### PR TITLE
Tune CODEOWNERS to prevent notifications

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,23 +1,22 @@
-# Default owners for everything in the repo. Further rules in the file may
-# (and should) override the notifications they get - but still be able to act
-# as code owners if needed
-* @jaygambetta @ismaelfaro
+# This file defines the persons that will be assigned as reviewers for PRs that
+# modify a particular file in the repo. Please note it is just a convention
+# for the GitHub interface, and any member of the QISKit team can (and should!)
+# review as well.
 
-# Files on root directory. This pattern is actually the one that will apply
-# unless specialized by a later rule
-/* @ajavadia @ewinston @atilag @diego-plan9
+# Real code owners.
+#* @jaygambetta @ismaelfaro
+
+# Generic rule for the repository. This pattern is actually the one that will
+# apply unless specialized by a later rule
+* @ajavadia @ewinston @atilag @delapuente @diego-plan9
 
 # Individual folders on root directory
-/cmake     @atilag
-/doc       @diego-plan9
-/examples  @jaygambetta
-/src       @chriseclectic
+/cmake     @ajavadia @atilag @diego-plan9
+/doc       @jaygambetta @ajavadia @atilag @diego-plan9
+/examples  @jaygambetta @ajavadia @atilag @diego-plan9
+/src       @chriseclectic @ajavadia @atilag @diego-plan9
 
-# qiskit folder
-qiskit/*             @ajavadia @ewinston @awcross1 @1ucian0 @atilag @diego-plan9 @delapuente
-qiskit/**/*.py       @ajavadia @ewinston @atilag @diego-plan9
-qiskit/mapper/*      @ajavadia
-qiskit/qasm/*        @1ucian0
-qiskit/tools/qcvv/*  @chriseclectic
-qiskit/tools/qi/*    @chriseclectic
-qiskit/tools/apps/*  @antoniomezzacapo
+# qiskit folders
+qiskit/qasm/*        @1ucian0 @ajavadia @ewinston @atilag @delapuente @diego-plan9
+qiskit/tools/*       @antoniomezzacapo @chriseclectic @ajavadia @ewinston @atilag @delapuente @diego-plan9
+qiskit/schemas/*     @jaygambetta @ajavadia @ewinston @atilag @delapuente @diego-plan9


### PR DESCRIPTION
Revise the `CODEOWNERS` file, as the previous set of rules were causing
extra notifications and issues with the defined set of code owners. The
rules do not "inherit" codeowners from previous rules - the file has
been rewritten to explicitly list codeowners for each section.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.