### PR TITLE
Fix depreciation warning in matplotlib circuit drawer

### DIFF
--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -1450,7 +1450,7 @@ class MatplotlibDrawer:
         self.ax = self.figure.add_subplot(111)
         self.ax.axis('off')
         self.ax.set_aspect('equal')
-        self.ax.tick_params(labelbottom='off', labeltop='off', labelleft='off', labelright='off')
+        self.ax.tick_params(labelbottom=False, labeltop=False, labelleft=False, labelright=False)
 
     def load_qasm_file(self, filename):
         circuit = load_qasm_file(filename, name='draw', basis_gates=self._basis)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix a depreciation warning in the matplotlib circuit drawer.


### Details and comments


