### PR TITLE
Do not create dag when no passes scheduled

### DIFF
--- a/qiskit/transpiler/_transpiler.py
+++ b/qiskit/transpiler/_transpiler.py
@@ -90,6 +90,9 @@ def _transpilation(circuit, backend=None, basis_gates=None, coupling_map=None,
     Raises:
         TranspilerError: if args are not complete for transpiler to function.
     """
+    if pass_manager and not pass_manager.working_list:
+        return circuit
+
     dag = circuit_to_dag(circuit)
     if not backend and not initial_layout:
         raise TranspilerError('initial layout not supplied, and cannot '


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is a performance improvement for the case when the pass_manager is empty (when the user wants to run the circuit as is). In this case, there is no need to go to dag and back.

@jaygambetta mentioned this before but I held off for code consistency and for delegating things to the pass manager. But now I see that the speed improvement is worth the explicit check.