### PR TITLE
Add dag_drawer to visualization init

### DIFF
--- a/qiskit/tools/visualization/__init__.py
+++ b/qiskit/tools/visualization/__init__.py
@@ -21,6 +21,7 @@ from qiskit.tools.visualization._state_visualization import (plot_state_hinton,
 
 from ._circuit_visualization import circuit_drawer, plot_circuit, generate_latex_source, \
     latex_circuit_drawer, matplotlib_circuit_drawer, _text_circuit_drawer, qx_color_scheme
+from .dag_visualization import dag_drawer
 from ._error import VisualizationError
 from ._matplotlib import HAS_MATPLOTLIB
 


### PR DESCRIPTION
So we can do `from qiskit.tools.visualization import circuit_drawer, dag_drawer`

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


