### PR TITLE
swap_cancellation pass

### DIFF
--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -68,6 +68,7 @@ Optimizations
    Collect2qBlocks
    ConsolidateBlocks
    CXCancellation
+   SWAPCancellation
    CommutationAnalysis
    CommutativeCancellation
    RemoveDiagonalGatesBeforeMeasure
@@ -156,6 +157,7 @@ from .optimization import ConsolidateBlocks
 from .optimization import CommutationAnalysis
 from .optimization import CommutativeCancellation
 from .optimization import CXCancellation
+from .optimization import SWAPCancellation
 from .optimization import OptimizeSwapBeforeMeasure
 from .optimization import RemoveResetInZeroState
 from .optimization import RemoveDiagonalGatesBeforeMeasure

--- a/qiskit/transpiler/passes/optimization/__init__.py
+++ b/qiskit/transpiler/passes/optimization/__init__.py
@@ -19,6 +19,7 @@ from .consolidate_blocks import ConsolidateBlocks
 from .commutation_analysis import CommutationAnalysis
 from .commutative_cancellation import CommutativeCancellation
 from .cx_cancellation import CXCancellation
+from .swap_cancellation import SWAPCancellation
 from .optimize_swap_before_measure import OptimizeSwapBeforeMeasure
 from .remove_reset_in_zero_state import RemoveResetInZeroState
 from .remove_diagonal_gates_before_measure import RemoveDiagonalGatesBeforeMeasure

--- a/qiskit/transpiler/passes/optimization/swap_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/swap_cancellation.py
@@ -19,7 +19,7 @@ class SWAPCancellation(TransformationPass):
     """Cancel back-to-back `swap` gates in dag."""
 
     def run(self, dag):
-        """Run the CXCancellation pass on `dag`.
+        """Run the SWAPCancellation pass on `dag`.
 
         Args:
             dag (DAGCircuit): the directed acyclic graph to run on.

--- a/qiskit/transpiler/passes/optimization/swap_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/swap_cancellation.py
@@ -1,0 +1,54 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Cancel back-to-back `swap` gates in dag."""
+
+from qiskit.transpiler.basepasses import TransformationPass
+
+
+class SWAPCancellation(TransformationPass):
+    """Cancel back-to-back `swap` gates in dag."""
+
+    def run(self, dag):
+        """Run the CXCancellation pass on `dag`.
+
+        Args:
+            dag (DAGCircuit): the directed acyclic graph to run on.
+
+        Returns:
+            DAGCircuit: Transformed DAG.
+        """
+        swap_runs = dag.collect_runs(["swap"])
+        for swap_run in swap_runs:
+            # Partition the swap_run into chunks with equal gate arguments
+            partition = []
+            chunk = []
+            for i in range(len(swap_run) - 1):
+                chunk.append(swap_run[i])
+
+                qargs0 = swap_run[i].qargs
+                qargs1 = swap_run[i + 1].qargs
+
+                if qargs0 != qargs1:
+                    partition.append(chunk)
+                    chunk = []
+            chunk.append(swap_run[-1])
+            partition.append(chunk)
+            # Simplify each chunk in the partition
+            for chunk in partition:
+                if len(chunk) % 2 == 0:
+                    for n in chunk:
+                        dag.remove_op_node(n)
+                else:
+                    for n in chunk[1:]:
+                        dag.remove_op_node(n)
+        return dag

--- a/qiskit/transpiler/passes/optimization/swap_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/swap_cancellation.py
@@ -38,7 +38,7 @@ class SWAPCancellation(TransformationPass):
                 qargs0 = swap_run[i].qargs
                 qargs1 = swap_run[i + 1].qargs
 
-                if qargs0 != qargs1:
+                if set(qargs0) != set(qargs1):
                     partition.append(chunk)
                     chunk = []
             chunk.append(swap_run[-1])

--- a/test/python/transpiler/test_swap_cancellation.py
+++ b/test/python/transpiler/test_swap_cancellation.py
@@ -21,7 +21,21 @@ from qiskit.test import QiskitTestCase
 class TestSWAPCancellation(QiskitTestCase):
     """Test the SWAPCancellation pass."""
 
-    def test_pass_swap_cancellation(self):
+    def test_pass_swap_cancellation_simple(self):
+        """Test a simple swap cancellation pass, symmetric wires """
+        qr = QuantumRegister(2)
+        circuit = QuantumCircuit(qr)
+        circuit.swap(qr[0], qr[1])
+        circuit.swap(qr[1], qr[2])
+
+        pass_manager = PassManager()
+        pass_manager.append(SWAPCancellation())
+        out_circuit = pass_manager.run(circuit)
+        resources_after = out_circuit.count_ops()
+
+        self.assertNotIn('swap', resources_after)
+
+    def test_pass_swap_cancellation_many(self):
         """Test the swap cancellation pass.
 
         It should cancel consecutive swap pairs on same qubits.
@@ -42,4 +56,4 @@ class TestSWAPCancellation(QiskitTestCase):
         out_circuit = pass_manager.run(circuit)
         resources_after = out_circuit.count_ops()
 
-        self.assertNotIn('cx', resources_after)
+        self.assertNotIn('swap', resources_after)

--- a/test/python/transpiler/test_swap_cancellation.py
+++ b/test/python/transpiler/test_swap_cancellation.py
@@ -26,7 +26,7 @@ class TestSWAPCancellation(QiskitTestCase):
         qr = QuantumRegister(2)
         circuit = QuantumCircuit(qr)
         circuit.swap(qr[0], qr[1])
-        circuit.swap(qr[1], qr[2])
+        circuit.swap(qr[1], qr[0])
 
         pass_manager = PassManager()
         pass_manager.append(SWAPCancellation())

--- a/test/python/transpiler/test_swap_cancellation.py
+++ b/test/python/transpiler/test_swap_cancellation.py
@@ -1,0 +1,45 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for pass cancelling 2 consecutive SWAPs on the same qubits."""
+
+from qiskit import QuantumRegister, QuantumCircuit
+from qiskit.transpiler import PassManager
+from qiskit.transpiler.passes import SWAPCancellation
+from qiskit.test import QiskitTestCase
+
+
+class TestSWAPCancellation(QiskitTestCase):
+    """Test the SWAPCancellation pass."""
+
+    def test_pass_swap_cancellation(self):
+        """Test the swap cancellation pass.
+
+        It should cancel consecutive swap pairs on same qubits.
+        """
+        qr = QuantumRegister(2)
+        circuit = QuantumCircuit(qr)
+        circuit.h(qr[0])
+        circuit.h(qr[0])
+        circuit.swap(qr[0], qr[1])
+        circuit.swap(qr[0], qr[1])
+        circuit.swap(qr[0], qr[1])
+        circuit.swap(qr[0], qr[1])
+        circuit.swap(qr[1], qr[0])
+        circuit.swap(qr[1], qr[0])
+
+        pass_manager = PassManager()
+        pass_manager.append(SWAPCancellation())
+        out_circuit = pass_manager.run(circuit)
+        resources_after = out_circuit.count_ops()
+
+        self.assertNotIn('cx', resources_after)

--- a/test/python/transpiler/test_swap_cancellation.py
+++ b/test/python/transpiler/test_swap_cancellation.py
@@ -12,8 +12,7 @@
 
 """Tests for pass cancelling 2 consecutive SWAPs on the same qubits."""
 
-from qiskit import QuantumRegister, QuantumCircuit
-from qiskit.transpiler import PassManager
+from qiskit import QuantumCircuit
 from qiskit.transpiler.passes import SWAPCancellation
 from qiskit.test import QiskitTestCase
 
@@ -23,14 +22,11 @@ class TestSWAPCancellation(QiskitTestCase):
 
     def test_pass_swap_cancellation_simple(self):
         """Test a simple swap cancellation pass, symmetric wires """
-        qr = QuantumRegister(2)
-        circuit = QuantumCircuit(qr)
-        circuit.swap(qr[0], qr[1])
-        circuit.swap(qr[1], qr[0])
+        circuit = QuantumCircuit(2)
+        circuit.swap(0, 1)
+        circuit.swap(1, 0)
 
-        pass_manager = PassManager()
-        pass_manager.append(SWAPCancellation())
-        out_circuit = pass_manager.run(circuit)
+        out_circuit = SWAPCancellation()(circuit)
         resources_after = out_circuit.count_ops()
 
         self.assertNotIn('swap', resources_after)
@@ -40,20 +36,17 @@ class TestSWAPCancellation(QiskitTestCase):
 
         It should cancel consecutive swap pairs on same qubits.
         """
-        qr = QuantumRegister(2)
-        circuit = QuantumCircuit(qr)
-        circuit.h(qr[0])
-        circuit.h(qr[0])
-        circuit.swap(qr[0], qr[1])
-        circuit.swap(qr[0], qr[1])
-        circuit.swap(qr[0], qr[1])
-        circuit.swap(qr[0], qr[1])
-        circuit.swap(qr[1], qr[0])
-        circuit.swap(qr[1], qr[0])
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.h(0)
+        circuit.swap(0, 1)
+        circuit.swap(0, 1)
+        circuit.swap(0, 1)
+        circuit.swap(0, 1)
+        circuit.swap(1, 0)
+        circuit.swap(1, 0)
 
-        pass_manager = PassManager()
-        pass_manager.append(SWAPCancellation())
-        out_circuit = pass_manager.run(circuit)
+        out_circuit = SWAPCancellation()(circuit)
         resources_after = out_circuit.count_ops()
 
         self.assertNotIn('swap', resources_after)


### PR DESCRIPTION
As part of preserving unitary during transpilation, some swap gates are inserted with https://github.com/Qiskit/qiskit-terra/pull/5280. 

These swaps might be adjacent to swap gates introduced by the routing passes. Pairs of swaps can be cancelled as pairs of cnots. 

This pass is a copy of the `cx_cancellation` pass, but for swap gates.