### PR TITLE
Deprecate the ordered_parameters attribute in NLocal

### DIFF
--- a/qiskit/circuit/library/n_local/n_local.py
+++ b/qiskit/circuit/library/n_local/n_local.py
@@ -791,6 +791,8 @@ class NLocal(BlueprintCircuit):
                              if isinstance(param, ParameterExpression))
             dest._parameters = set(param for param in new_params
                                    if isinstance(param, ParameterExpression))
+        elif isinstance(parameters, ParameterVector):
+            dest._parameters = parameters
         else:
             dest._parameters = set(param for param in parameters
                                    if isinstance(param, ParameterExpression))

--- a/releasenotes/notes/deprecate-ordered-parameters-f7150eec246cd814.yaml
+++ b/releasenotes/notes/deprecate-ordered-parameters-f7150eec246cd814.yaml
@@ -1,0 +1,5 @@
+---
+deprecations:
+  - |
+    Deprecated the ``NLocal.ordered_parameters`` method in favor of simply calling
+    ``NLocal.parameters``, since all unbound circuit parameters are now ordered.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Since parameters are now ordered and we can assign by array, the `NLocal.ordered_parameters` attribute is no longer needed and can be deprecated.

### Details and comments

Instead of `NLocal.ordered_parameters` users can now just call `NLocal.parameters`.
