### PR TITLE
[WIP] Implement `sort` method for `SparsePauliOp`

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -324,6 +324,27 @@ class SparsePauliOp(LinearOp):
             coeffs = np.array([0j])
         return SparsePauliOp(table, coeffs)
 
+    def sort(self, weight=False):
+        """Sort the terms in the operator.
+
+        The sort order is as specified in :meth:`~PauliTable.sort`. In particular,
+        the sort order is only determined by the Pauli strings in the table. The
+        coefficients are permuted according to the same order.
+
+        Before comparing two instances of `SparsePauliOp`, you might want to call the
+        :meth:`simplify` method followed by this method.
+
+        Args:
+            weight (bool): optionally sort by weight if True (Default: False).
+
+        Returns:
+            PauliTable: a sorted copy of the original sparse Pauli sum.
+        """
+        indices = self.table.argsort(weight=weight)
+        table = self.table[indices]
+        coeffs = self.coeffs[indices]
+        return SparsePauliOp(table, coeffs)
+
     # ---------------------------------------------------------------------
     # Additional conversions
     # ---------------------------------------------------------------------


### PR DESCRIPTION
This PR adds a method `sort` to `SparsePauliOp`.

The motivation is to allow easily checking for equality. Currently the `__eq__` method compares the data in `SparsePauliOp`, a table and array of coefficients, without regard to order, which may be different if the two operators are constructed in different ways. With this PR, one might call `sparse_pauli_op.simplify().sort()` on each instance before comparing them with `==`.

No test has been written yet.