### PR TITLE
Show DeprecationWarning on first access to implicit register.

### DIFF
--- a/releasenotes/notes/quantumcircuit-deprecate-implicit-register-c665aa7d7ce648a5.yaml
+++ b/releasenotes/notes/quantumcircuit-deprecate-implicit-register-c665aa7d7ce648a5.yaml
@@ -1,0 +1,9 @@
+---
+deprecations:
+  - |
+    Initializing a QuantumCircuit with only the number of qubits and clbits previously
+    implicitly created a QuantumRegister("q") and optionally ClassicalRegister("c")
+    and added them to the circuit. This behavior has been deprecated and will be
+    removed in a future release. Instead, the circuit will be created with the correct
+    number of registerless qubits and clbits.
+

--- a/test/python/circuit/test_registerless_circuit.py
+++ b/test/python/circuit/test_registerless_circuit.py
@@ -104,6 +104,22 @@ class TestAddingBitsWithoutRegisters(QiskitTestCase):
 
         self.assertEqual(qc.qubits, [anc, qb])
 
+    def test_deprecation_warn_on_first_register_access(self):
+        """Verify we warn when accessing implicitly created register."""
+
+        # Unset show-once flag in case triggered by other test.
+        QuantumCircuit._implicit_register_deprecation_shown = False
+
+        qc = QuantumCircuit(5, 2)
+        with self.assertWarns(DeprecationWarning):
+            _ = qc.qregs
+        self.assertTrue(QuantumCircuit._implicit_register_deprecation_shown)
+
+        QuantumCircuit._implicit_register_deprecation_shown = False
+        with self.assertWarns(DeprecationWarning):
+            _ = qc.cregs
+        self.assertTrue(QuantumCircuit._implicit_register_deprecation_shown)
+
 
 class TestGatesOnWires(QiskitTestCase):
     """Test gates on wires."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Addresses #6496 by raising a `DeprecationWarning` on first access to `QuantumCircuit.qregs` or `QuantumCircuit.cregs` from a circuit created using `QuantumCircuit(num_qubits, num_clbits)`.

### Details and comments

WIP to check and resolve cases where we internally and in tests use `.qregs`/`.cregs` on what will become registerless circuits.

