### PR TITLE
enable inverse of classically conditioned gate

### DIFF
--- a/qiskit/circuit/classicalfunction/classical_function_visitor.py
+++ b/qiskit/circuit/classicalfunction/classical_function_visitor.py
@@ -14,10 +14,10 @@
 This module is used internally by ``qiskit.transpiler.classicalfunction.ClassicalFunction``.
 """
 
-from tweedledum.classical import LogicNetwork
-
 import ast
 import _ast
+
+from tweedledum.classical import LogicNetwork
 
 from .exceptions import ClassicalFunctionParseError, ClassicalFunctionCompilerTypeError
 

--- a/qiskit/circuit/classicalfunction/classical_function_visitor.py
+++ b/qiskit/circuit/classicalfunction/classical_function_visitor.py
@@ -14,10 +14,10 @@
 This module is used internally by ``qiskit.transpiler.classicalfunction.ClassicalFunction``.
 """
 
+from tweedledum.classical import LogicNetwork
+
 import ast
 import _ast
-
-from tweedledum.classical import LogicNetwork
 
 from .exceptions import ClassicalFunctionParseError, ClassicalFunctionCompilerTypeError
 

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -37,7 +37,7 @@ class ControlledGate(Gate):
         definition: Optional["QuantumCircuit"] = None,
         ctrl_state: Optional[Union[int, str]] = None,
         base_gate: Optional[Gate] = None,
-        condition: Optional[Tuple] = None,
+        condition: Optional[Tuple[Union["ClassicalRegister", "Clbit"], int]] = None
     ):
         """Create a new ControlledGate. In the new gate the first ``num_ctrl_qubits``
         of the gate are the controls.

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -13,7 +13,7 @@
 """Controlled unitary gate."""
 
 import copy
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Tuple
 
 from qiskit.circuit.exceptions import CircuitError
 
@@ -37,6 +37,7 @@ class ControlledGate(Gate):
         definition: Optional["QuantumCircuit"] = None,
         ctrl_state: Optional[Union[int, str]] = None,
         base_gate: Optional[Gate] = None,
+        condition: Optional[Tuple] = None,
     ):
         """Create a new ControlledGate. In the new gate the first ``num_ctrl_qubits``
         of the gate are the controls.
@@ -55,6 +56,8 @@ class ControlledGate(Gate):
                 must equal num_ctrl_qubits, MSB on left. If None, use
                 2**num_ctrl_qubits-1.
             base_gate: Gate object to be controlled.
+            condition: tuple (ClassicalRegister, int), tuple (Clbit, bool) or
+                tuple (Clbit, int) for classically conditioned gate.
 
         Raises:
             CircuitError: If ``num_ctrl_qubits`` >= ``num_qubits``.

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -23,8 +23,8 @@ from .gate import Gate
 from .quantumregister import QuantumRegister
 from ._utils import _ctrl_state_to_int
 
-if TYPE_CHECKING:
-    import qiskit.circuit.classicalregister as classicalregister
+# pylint: disable=cyclic-import
+from .classicalregister import ClassicalRegister, Clbit
 
 
 class ControlledGate(Gate):
@@ -40,9 +40,7 @@ class ControlledGate(Gate):
         definition: Optional["QuantumCircuit"] = None,
         ctrl_state: Optional[Union[int, str]] = None,
         base_gate: Optional[Gate] = None,
-        condition: Optional[
-            Tuple[Union["classicalregister.ClassicalRegister", "classicalregister.Clbit"], int]
-        ] = None,
+        condition: Optional[Tuple[Union["ClassicalRegister", "Clbit"], int]] = None,
     ):
         """Create a new ControlledGate. In the new gate the first ``num_ctrl_qubits``
         of the gate are the controls.

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -13,7 +13,7 @@
 """Controlled unitary gate."""
 
 import copy
-from typing import List, Optional, Union, Tuple
+from typing import List, Optional, Union, Tuple, TYPE_CHECKING
 
 from qiskit.circuit.exceptions import CircuitError
 
@@ -21,7 +21,8 @@ from qiskit.circuit.exceptions import CircuitError
 from .quantumcircuit import QuantumCircuit
 from .gate import Gate
 from .quantumregister import QuantumRegister
-import classicalregister
+if TYPE_CHECKING:
+    import qiskit.circuit.classicalregister as classicalregister
 from ._utils import _ctrl_state_to_int
 
 

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -21,10 +21,10 @@ from qiskit.circuit.exceptions import CircuitError
 from .quantumcircuit import QuantumCircuit
 from .gate import Gate
 from .quantumregister import QuantumRegister
+from ._utils import _ctrl_state_to_int
 
 if TYPE_CHECKING:
     import qiskit.circuit.classicalregister as classicalregister
-from ._utils import _ctrl_state_to_int
 
 
 class ControlledGate(Gate):

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -21,6 +21,7 @@ from qiskit.circuit.exceptions import CircuitError
 from .quantumcircuit import QuantumCircuit
 from .gate import Gate
 from .quantumregister import QuantumRegister
+
 if TYPE_CHECKING:
     import qiskit.circuit.classicalregister as classicalregister
 from ._utils import _ctrl_state_to_int
@@ -39,8 +40,9 @@ class ControlledGate(Gate):
         definition: Optional["QuantumCircuit"] = None,
         ctrl_state: Optional[Union[int, str]] = None,
         base_gate: Optional[Gate] = None,
-        condition: Optional[Tuple[Union["classicalregister.ClassicalRegister",
-                                        "classicalregister.Clbit"], int]] = None,
+        condition: Optional[
+            Tuple[Union["classicalregister.ClassicalRegister", "classicalregister.Clbit"], int]
+        ] = None,
     ):
         """Create a new ControlledGate. In the new gate the first ``num_ctrl_qubits``
         of the gate are the controls.

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -21,6 +21,7 @@ from qiskit.circuit.exceptions import CircuitError
 from .quantumcircuit import QuantumCircuit
 from .gate import Gate
 from .quantumregister import QuantumRegister
+import classicalregister
 from ._utils import _ctrl_state_to_int
 
 
@@ -37,7 +38,8 @@ class ControlledGate(Gate):
         definition: Optional["QuantumCircuit"] = None,
         ctrl_state: Optional[Union[int, str]] = None,
         base_gate: Optional[Gate] = None,
-        condition: Optional[Tuple[Union["ClassicalRegister", "Clbit"], int]] = None,
+        condition: Optional[Tuple[Union["classicalregister.ClassicalRegister",
+                                        "classicalregister.Clbit"], int]] = None,
     ):
         """Create a new ControlledGate. In the new gate the first ``num_ctrl_qubits``
         of the gate are the controls.

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -37,7 +37,7 @@ class ControlledGate(Gate):
         definition: Optional["QuantumCircuit"] = None,
         ctrl_state: Optional[Union[int, str]] = None,
         base_gate: Optional[Gate] = None,
-        condition: Optional[Tuple[Union["ClassicalRegister", "Clbit"], int]] = None
+        condition: Optional[Tuple[Union["ClassicalRegister", "Clbit"], int]] = None,
     ):
         """Create a new ControlledGate. In the new gate the first ``num_ctrl_qubits``
         of the gate are the controls.
@@ -56,8 +56,8 @@ class ControlledGate(Gate):
                 must equal num_ctrl_qubits, MSB on left. If None, use
                 2**num_ctrl_qubits-1.
             base_gate: Gate object to be controlled.
-            condition: tuple (ClassicalRegister, int), tuple (Clbit, bool) or
-                tuple (Clbit, int) for classically conditioned gate.
+            condition (tuple[ClassicalRegister or Clbit, int] or None: classical
+                condition of instruction.
 
         Raises:
             CircuitError: If ``num_ctrl_qubits`` >= ``num_qubits``.

--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -40,6 +40,8 @@ class Gate(Instruction):
             num_qubits: The number of qubits the gate acts on.
             params: A list of parameters.
             label: An optional label for the gate.
+            condition (tuple[ClassicalRegister or Clbit, int] or None: classical
+                condition of instruction.
         """
         self.definition = None
         super().__init__(name, num_qubits, 0, params, label=label, condition=condition)

--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -26,7 +26,12 @@ class Gate(Instruction):
     """Unitary gate."""
 
     def __init__(
-        self, name: str, num_qubits: int, params: List, label: Optional[str] = None
+        self,
+        name: str,
+        num_qubits: int,
+        params: List,
+        label: Optional[str] = None,
+        condition: Optional[Tuple] = None,
     ) -> None:
         """Create a new gate.
 
@@ -37,7 +42,7 @@ class Gate(Instruction):
             label: An optional label for the gate.
         """
         self.definition = None
-        super().__init__(name, num_qubits, 0, params, label=label)
+        super().__init__(name, num_qubits, 0, params, label=label, condition=condition)
 
     # Set higher priority than Numpy array and matrix classes
     __array_priority__ = 20

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -75,7 +75,7 @@ class Instruction:
             duration (int or float): instruction's duration. it must be integer if ``unit`` is 'dt'
             unit (str): time unit of duration
             label (str or None): An optional label for identifying the instruction.
-            condition (tupple[ClassicalRegister, int] or None: classical condition of instruction.
+            condition (tuple[ClassicalRegister, int] or None: classical condition of instruction.
 
         Raises:
             CircuitError: when the register is not in the correct format.

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -53,7 +53,17 @@ class Instruction:
     # NOTE: Using this attribute may change in the future (See issue # 5811)
     _directive = False
 
-    def __init__(self, name, num_qubits, num_clbits, params, duration=None, unit="dt", label=None):
+    def __init__(
+        self,
+        name,
+        num_qubits,
+        num_clbits,
+        params,
+        duration=None,
+        unit="dt",
+        label=None,
+        condition=None,
+    ):
         """Create a new instruction.
 
         Args:
@@ -65,6 +75,7 @@ class Instruction:
             duration (int or float): instruction's duration. it must be integer if ``unit`` is 'dt'
             unit (str): time unit of duration
             label (str or None): An optional label for identifying the instruction.
+            condition (tupple[ClassicalRegister, int] or None: classical condition of instruction.
 
         Raises:
             CircuitError: when the register is not in the correct format.
@@ -88,7 +99,7 @@ class Instruction:
             self._label = label
         # tuple (ClassicalRegister, int), tuple (Clbit, bool) or tuple (Clbit, int)
         # when the instruction has a conditional ("if")
-        self.condition = None
+        self.condition = condition
         # list of instructions (and their contexts) that this instruction is composed of
         # empty definition means opaque or fundamental instruction
         self._definition = None
@@ -108,13 +119,15 @@ class Instruction:
         Returns:
             bool: are self and other equal.
         """
-        if (
+        neq_cond = bool(
             type(self) is not type(other)
             or self.name != other.name
             or self.num_qubits != other.num_qubits
             or self.num_clbits != other.num_clbits
             or self.definition != other.definition
-        ):
+            or self.condition != other.condition
+        )
+        if neq_cond:
             return False
 
         for self_param, other_param in zip_longest(self.params, other.params):
@@ -376,6 +389,7 @@ class Instruction:
                 num_qubits=self.num_qubits,
                 num_clbits=self.num_clbits,
                 params=self.params.copy(),
+                condition=self.condition,
             )
 
         else:

--- a/qiskit/circuit/library/generalized_gates/gms.py
+++ b/qiskit/circuit/library/generalized_gates/gms.py
@@ -107,9 +107,9 @@ class MSGate(Gate):
     and is thus reduced to the RXXGate.
     """
 
-    def __init__(self, num_qubits, theta, label=None):
+    def __init__(self, num_qubits, theta, label=None, condition=None):
         """Create new MS gate."""
-        super().__init__("ms", num_qubits, [theta], label=label)
+        super().__init__("ms", num_qubits, [theta], label=label, condition=condition)
 
     def _define(self):
         theta = self.params[0]

--- a/qiskit/circuit/library/generalized_gates/mcmt.py
+++ b/qiskit/circuit/library/generalized_gates/mcmt.py
@@ -154,7 +154,9 @@ class MCMT(QuantumCircuit):
 
     def inverse(self):
         """Return the inverse MCMT circuit, which is itself."""
-        return MCMT(self.gate, self.num_ctrl_qubits, self.num_target_qubits)
+        return MCMT(
+            self.gate, self.num_ctrl_qubits, self.num_target_qubits
+        )
 
 
 class MCMTVChain(MCMT):
@@ -256,4 +258,6 @@ class MCMTVChain(MCMT):
             self.ccx(control_qubits[0], control_qubits[1], ancilla_qubits[0])
 
     def inverse(self):
-        return MCMTVChain(self.gate, self.num_ctrl_qubits, self.num_target_qubits)
+        return MCMTVChain(
+            self.gate, self.num_ctrl_qubits, self.num_target_qubits
+        )

--- a/qiskit/circuit/library/generalized_gates/mcmt.py
+++ b/qiskit/circuit/library/generalized_gates/mcmt.py
@@ -154,9 +154,7 @@ class MCMT(QuantumCircuit):
 
     def inverse(self):
         """Return the inverse MCMT circuit, which is itself."""
-        return MCMT(
-            self.gate, self.num_ctrl_qubits, self.num_target_qubits
-        )
+        return MCMT(self.gate, self.num_ctrl_qubits, self.num_target_qubits)
 
 
 class MCMTVChain(MCMT):
@@ -258,6 +256,4 @@ class MCMTVChain(MCMT):
             self.ccx(control_qubits[0], control_qubits[1], ancilla_qubits[0])
 
     def inverse(self):
-        return MCMTVChain(
-            self.gate, self.num_ctrl_qubits, self.num_target_qubits
-        )
+        return MCMTVChain(self.gate, self.num_ctrl_qubits, self.num_target_qubits)

--- a/qiskit/circuit/library/generalized_gates/pauli.py
+++ b/qiskit/circuit/library/generalized_gates/pauli.py
@@ -35,8 +35,8 @@ class PauliGate(Gate):
     the pauli gates sequentially using standard Qiskit gates
     """
 
-    def __init__(self, label):
-        super().__init__("pauli", len(label), [label])
+    def __init__(self, label, condition=None):
+        super().__init__("pauli", len(label), [label], condition=condition)
 
     def _define(self):
         """
@@ -55,7 +55,7 @@ class PauliGate(Gate):
 
     def inverse(self):
         r"""Return inverted pauli gate (itself)."""
-        return PauliGate(self.params[0])  # self-inverse
+        return PauliGate(self.params[0], condition=self.condition)  # self-inverse
 
     def __array__(self, dtype=None):
         """Return a Numpy.array for the pauli gate.

--- a/qiskit/circuit/library/generalized_gates/rv.py
+++ b/qiskit/circuit/library/generalized_gates/rv.py
@@ -42,7 +42,7 @@ class RVGate(Gate):
                 \end{pmatrix}
     """
 
-    def __init__(self, v_x, v_y, v_z, basis="U"):
+    def __init__(self, v_x, v_y, v_z, basis="U", condition=None):
         """Create new rv single-qubit gate.
 
         Args:
@@ -55,7 +55,7 @@ class RVGate(Gate):
         # pylint: disable=cyclic-import
         from qiskit.quantum_info.synthesis.one_qubit_decompose import OneQubitEulerDecomposer
 
-        super().__init__("rv", 1, [v_x, v_y, v_z])
+        super().__init__("rv", 1, [v_x, v_y, v_z], condition=condition)
         self._decomposer = OneQubitEulerDecomposer(basis=basis)
 
     def _define(self):
@@ -69,7 +69,7 @@ class RVGate(Gate):
     def inverse(self):
         """Invert this gate."""
         vx, vy, vz = self.params
-        return RVGate(-vx, -vy, -vz)
+        return RVGate(-vx, -vy, -vz, condition=self.condition)
 
     def to_matrix(self):
         """Return a numpy.array for the R(v) gate."""

--- a/qiskit/circuit/library/standard_gates/dcx.py
+++ b/qiskit/circuit/library/standard_gates/dcx.py
@@ -44,9 +44,9 @@ class DCXGate(Gate):
             \end{pmatrix}
     """
 
-    def __init__(self):
+    def __init__(self, condition=None):
         """Create new DCX gate."""
-        super().__init__("dcx", 2, [])
+        super().__init__("dcx", 2, [], condition=condition)
 
     def _define(self):
         """

--- a/qiskit/circuit/library/standard_gates/ecr.py
+++ b/qiskit/circuit/library/standard_gates/ecr.py
@@ -76,9 +76,9 @@ class ECRGate(Gate):
                 \end{pmatrix}
     """
 
-    def __init__(self):
+    def __init__(self, condition=None):
         """Create new ECR gate."""
-        super().__init__("ecr", 2, [])
+        super().__init__("ecr", 2, [], condition=condition)
 
     def _define(self):
         """

--- a/qiskit/circuit/library/standard_gates/h.py
+++ b/qiskit/circuit/library/standard_gates/h.py
@@ -47,9 +47,9 @@ class HGate(Gate):
             \end{pmatrix}
     """
 
-    def __init__(self, label=None):
+    def __init__(self, label=None, condition=None):
         """Create new H gate."""
-        super().__init__("h", 1, [], label=label)
+        super().__init__("h", 1, [], label=label, condition=condition)
 
     def _define(self):
         """
@@ -89,7 +89,7 @@ class HGate(Gate):
 
     def inverse(self):
         r"""Return inverted H gate (itself)."""
-        return HGate()  # self-inverse
+        return HGate(condition=self.condition)  # self-inverse
 
     def __array__(self, dtype=None):
         """Return a Numpy.array for the H gate."""
@@ -158,10 +158,17 @@ class CHGate(ControlledGate):
         dtype=complex,
     )
 
-    def __init__(self, label=None, ctrl_state=None):
+    def __init__(self, label=None, ctrl_state=None, condition=None):
         """Create new CH gate."""
         super().__init__(
-            "ch", 2, [], num_ctrl_qubits=1, label=label, ctrl_state=ctrl_state, base_gate=HGate()
+            "ch",
+            2,
+            [],
+            num_ctrl_qubits=1,
+            label=label,
+            ctrl_state=ctrl_state,
+            base_gate=HGate(),
+            condition=condition,
         )
 
     def _define(self):
@@ -198,7 +205,7 @@ class CHGate(ControlledGate):
 
     def inverse(self):
         """Return inverted CH gate (itself)."""
-        return CHGate(ctrl_state=self.ctrl_state)  # self-inverse
+        return CHGate(ctrl_state=self.ctrl_state, condition=self.condition)  # self-inverse
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the CH gate."""

--- a/qiskit/circuit/library/standard_gates/i.py
+++ b/qiskit/circuit/library/standard_gates/i.py
@@ -39,13 +39,13 @@ class IGate(Gate):
              └───┘
     """
 
-    def __init__(self, label=None):
+    def __init__(self, label=None, condition=None):
         """Create new Identity gate."""
-        super().__init__("id", 1, [], label=label)
+        super().__init__("id", 1, [], label=label, condition=condition)
 
     def inverse(self):
         """Invert this gate."""
-        return IGate()  # self-inverse
+        return IGate(condition=self.condition)  # self-inverse
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the identity gate."""

--- a/qiskit/circuit/library/standard_gates/ms.py
+++ b/qiskit/circuit/library/standard_gates/ms.py
@@ -30,7 +30,7 @@ class MSGate(Gate):
     and is thus reduced to the RXXGate.
     """
 
-    def __init__(self, num_qubits, theta, label=None):
+    def __init__(self, num_qubits, theta, label=None, condition=None):
         """Create new MS gate."""
         warnings.warn(
             "The qiskit.circuit.library.standard_gates.ms import "
@@ -40,7 +40,7 @@ class MSGate(Gate):
             DeprecationWarning,
             stacklevel=2,
         )
-        super().__init__("ms", num_qubits, [theta], label=label)
+        super().__init__("ms", num_qubits, [theta], label=label, condition=condition)
 
     def _define(self):
         # pylint: disable=cyclic-import

--- a/qiskit/circuit/library/standard_gates/p.py
+++ b/qiskit/circuit/library/standard_gates/p.py
@@ -69,9 +69,9 @@ class PhaseGate(Gate):
         `1612.00858 <https://arxiv.org/abs/1612.00858>`_
     """
 
-    def __init__(self, theta, label=None):
+    def __init__(self, theta, label=None, condition=None):
         """Create new Phase gate."""
-        super().__init__("p", 1, [theta], label=label)
+        super().__init__("p", 1, [theta], label=label, condition=condition)
 
     def _define(self):
         # pylint: disable=cyclic-import
@@ -108,7 +108,7 @@ class PhaseGate(Gate):
 
     def inverse(self):
         r"""Return inverted Phase gate (:math:`Phase(\lambda){\dagger} = Phase(-\lambda)`)"""
-        return PhaseGate(-self.params[0])
+        return PhaseGate(-self.params[0], condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the Phase gate."""
@@ -153,7 +153,7 @@ class CPhaseGate(ControlledGate):
         phase difference.
     """
 
-    def __init__(self, theta, label=None, ctrl_state=None):
+    def __init__(self, theta, label=None, ctrl_state=None, condition=None):
         """Create new CPhase gate."""
         super().__init__(
             "cp",
@@ -163,6 +163,7 @@ class CPhaseGate(ControlledGate):
             label=label,
             ctrl_state=ctrl_state,
             base_gate=PhaseGate(theta),
+            condition=condition,
         )
 
     def _define(self):
@@ -205,7 +206,7 @@ class CPhaseGate(ControlledGate):
 
     def inverse(self):
         r"""Return inverted CPhase gate (:math:`CPhase(\lambda){\dagger} = CPhase(-\lambda)`)"""
-        return CPhaseGate(-self.params[0], ctrl_state=self.ctrl_state)
+        return CPhaseGate(-self.params[0], ctrl_state=self.ctrl_state, condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the CPhase gate."""
@@ -242,7 +243,7 @@ class MCPhaseGate(ControlledGate):
         The singly-controlled-version of this gate.
     """
 
-    def __init__(self, lam, num_ctrl_qubits, label=None):
+    def __init__(self, lam, num_ctrl_qubits, label=None, condition=None):
         """Create new MCPhase gate."""
         super().__init__(
             "mcphase",
@@ -251,6 +252,7 @@ class MCPhaseGate(ControlledGate):
             num_ctrl_qubits=num_ctrl_qubits,
             label=label,
             base_gate=PhaseGate(lam),
+            condition=condition,
         )
 
     def _define(self):
@@ -295,4 +297,4 @@ class MCPhaseGate(ControlledGate):
 
     def inverse(self):
         r"""Return inverted MCU1 gate (:math:`MCU1(\lambda){\dagger} = MCU1(-\lambda)`)"""
-        return MCPhaseGate(-self.params[0], self.num_ctrl_qubits)
+        return MCPhaseGate(-self.params[0], self.num_ctrl_qubits, condition=self.condition)

--- a/qiskit/circuit/library/standard_gates/r.py
+++ b/qiskit/circuit/library/standard_gates/r.py
@@ -43,9 +43,9 @@ class RGate(Gate):
             \end{pmatrix}
     """
 
-    def __init__(self, theta, phi):
+    def __init__(self, theta, phi, *, condition=None):
         """Create new r single-qubit gate."""
-        super().__init__("r", 1, [theta, phi])
+        super().__init__("r", 1, [theta, phi], condition=condition)
 
     def _define(self):
         """
@@ -70,7 +70,7 @@ class RGate(Gate):
 
         r(θ, φ)^dagger = r(-θ, φ)
         """
-        return RGate(-self.params[0], self.params[1])
+        return RGate(-self.params[0], self.params[1], condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the R gate."""

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -44,9 +44,9 @@ class RXGate(Gate):
             \end{pmatrix}
     """
 
-    def __init__(self, theta, label=None):
+    def __init__(self, theta, label=None, condition=None):
         """Create new RX gate."""
-        super().__init__("rx", 1, [theta], label=label)
+        super().__init__("rx", 1, [theta], label=label, condition=condition)
 
     def _define(self):
         """
@@ -87,7 +87,7 @@ class RXGate(Gate):
 
         :math:`RX(\lambda)^{\dagger} = RX(-\lambda)`
         """
-        return RXGate(-self.params[0])
+        return RXGate(-self.params[0], condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the RX gate."""
@@ -151,7 +151,7 @@ class CRXGate(ControlledGate):
                 \end{pmatrix}
     """
 
-    def __init__(self, theta, label=None, ctrl_state=None):
+    def __init__(self, theta, label=None, ctrl_state=None, condition=None):
         """Create new CRX gate."""
         super().__init__(
             "crx",
@@ -161,6 +161,7 @@ class CRXGate(ControlledGate):
             label=label,
             ctrl_state=ctrl_state,
             base_gate=RXGate(theta),
+            condition=condition,
         )
 
     def _define(self):
@@ -195,7 +196,7 @@ class CRXGate(ControlledGate):
 
     def inverse(self):
         """Return inverse CRX gate (i.e. with the negative rotation angle)."""
-        return CRXGate(-self.params[0], ctrl_state=self.ctrl_state)
+        return CRXGate(-self.params[0], ctrl_state=self.ctrl_state, condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the CRX gate."""

--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -66,9 +66,9 @@ class RXXGate(Gate):
                                     \end{pmatrix}
     """
 
-    def __init__(self, theta):
+    def __init__(self, theta, condition=None):
         """Create new RXX gate."""
-        super().__init__("rxx", 2, [theta])
+        super().__init__("rxx", 2, [theta], condition=condition)
 
     def _define(self):
         """Calculate a subcircuit that implements this unitary."""
@@ -97,7 +97,7 @@ class RXXGate(Gate):
 
     def inverse(self):
         """Return inverse RXX gate (i.e. with the negative rotation angle)."""
-        return RXXGate(-self.params[0])
+        return RXXGate(-self.params[0], condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a Numpy.array for the RXX gate."""

--- a/qiskit/circuit/library/standard_gates/ry.py
+++ b/qiskit/circuit/library/standard_gates/ry.py
@@ -44,9 +44,9 @@ class RYGate(Gate):
             \end{pmatrix}
     """
 
-    def __init__(self, theta, label=None):
+    def __init__(self, theta, label=None, condition=None):
         """Create new RY gate."""
-        super().__init__("ry", 1, [theta], label=label)
+        super().__init__("ry", 1, [theta], label=label, condition=condition)
 
     def _define(self):
         """
@@ -87,7 +87,7 @@ class RYGate(Gate):
 
         :math:`RY(\lambda){\dagger} = RY(-\lambda)`
         """
-        return RYGate(-self.params[0])
+        return RYGate(-self.params[0], condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the RY gate."""
@@ -151,7 +151,7 @@ class CRYGate(ControlledGate):
                 \end{pmatrix}
     """
 
-    def __init__(self, theta, label=None, ctrl_state=None):
+    def __init__(self, theta, label=None, ctrl_state=None, condition=None):
         """Create new CRY gate."""
         super().__init__(
             "cry",
@@ -161,6 +161,7 @@ class CRYGate(ControlledGate):
             label=label,
             ctrl_state=ctrl_state,
             base_gate=RYGate(theta),
+            condition=condition,
         )
 
     def _define(self):
@@ -189,7 +190,7 @@ class CRYGate(ControlledGate):
 
     def inverse(self):
         """Return inverse CRY gate (i.e. with the negative rotation angle)."""
-        return CRYGate(-self.params[0], ctrl_state=self.ctrl_state)
+        return CRYGate(-self.params[0], ctrl_state=self.ctrl_state, condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the CRY gate."""

--- a/qiskit/circuit/library/standard_gates/ryy.py
+++ b/qiskit/circuit/library/standard_gates/ryy.py
@@ -67,9 +67,9 @@ class RYYGate(Gate):
                                     \end{pmatrix}
     """
 
-    def __init__(self, theta):
+    def __init__(self, theta, condition=None):
         """Create new RYY gate."""
-        super().__init__("ryy", 2, [theta])
+        super().__init__("ryy", 2, [theta], condition=condition)
 
     def _define(self):
         """Calculate a subcircuit that implements this unitary."""
@@ -98,7 +98,7 @@ class RYYGate(Gate):
 
     def inverse(self):
         """Return inverse RYY gate (i.e. with the negative rotation angle)."""
-        return RYYGate(-self.params[0])
+        return RYYGate(-self.params[0], condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the RYY gate."""

--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -54,9 +54,9 @@ class RZGate(Gate):
         `1612.00858 <https://arxiv.org/abs/1612.00858>`_
     """
 
-    def __init__(self, phi, label=None):
+    def __init__(self, phi, label=None, condition=None):
         """Create new RZ gate."""
-        super().__init__("rz", 1, [phi], label=label)
+        super().__init__("rz", 1, [phi], label=label, condition=condition)
 
     def _define(self):
         """
@@ -98,7 +98,7 @@ class RZGate(Gate):
 
         :math:`RZ(\lambda){\dagger} = RZ(-\lambda)`
         """
-        return RZGate(-self.params[0])
+        return RZGate(-self.params[0], condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the RZ gate."""
@@ -169,7 +169,7 @@ class CRZGate(ControlledGate):
         phase difference.
     """
 
-    def __init__(self, theta, label=None, ctrl_state=None):
+    def __init__(self, theta, label=None, ctrl_state=None, condition=None):
         """Create new CRZ gate."""
         super().__init__(
             "crz",
@@ -179,6 +179,7 @@ class CRZGate(ControlledGate):
             label=label,
             ctrl_state=ctrl_state,
             base_gate=RZGate(theta),
+            condition=condition,
         )
 
     def _define(self):
@@ -207,7 +208,7 @@ class CRZGate(ControlledGate):
 
     def inverse(self):
         """Return inverse CRZ gate (i.e. with the negative rotation angle)."""
-        return CRZGate(-self.params[0], ctrl_state=self.ctrl_state)
+        return CRZGate(-self.params[0], ctrl_state=self.ctrl_state, condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the CRZ gate."""

--- a/qiskit/circuit/library/standard_gates/rzx.py
+++ b/qiskit/circuit/library/standard_gates/rzx.py
@@ -112,9 +112,9 @@ class RZXGate(Gate):
                                     \end{pmatrix}
     """
 
-    def __init__(self, theta):
+    def __init__(self, theta, condition=None):
         """Create new RZX gate."""
-        super().__init__("rzx", 2, [theta])
+        super().__init__("rzx", 2, [theta], condition=condition)
 
     def _define(self):
         """
@@ -143,7 +143,7 @@ class RZXGate(Gate):
 
     def inverse(self):
         """Return inverse RZX gate (i.e. with the negative rotation angle)."""
-        return RZXGate(-self.params[0])
+        return RZXGate(-self.params[0], condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the RZX gate."""

--- a/qiskit/circuit/library/standard_gates/rzz.py
+++ b/qiskit/circuit/library/standard_gates/rzz.py
@@ -79,9 +79,9 @@ class RZZGate(Gate):
                                     \end{pmatrix}
     """
 
-    def __init__(self, theta):
+    def __init__(self, theta, condition=None):
         """Create new RZZ gate."""
-        super().__init__("rzz", 2, [theta])
+        super().__init__("rzz", 2, [theta], condition=condition)
 
     def _define(self):
         """
@@ -107,7 +107,7 @@ class RZZGate(Gate):
 
     def inverse(self):
         """Return inverse RZZ gate (i.e. with the negative rotation angle)."""
-        return RZZGate(-self.params[0])
+        return RZZGate(-self.params[0], condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the RZZ gate."""

--- a/qiskit/circuit/library/standard_gates/s.py
+++ b/qiskit/circuit/library/standard_gates/s.py
@@ -45,9 +45,9 @@ class SGate(Gate):
     Equivalent to a :math:`\pi/2` radian rotation about the Z axis.
     """
 
-    def __init__(self, label=None):
+    def __init__(self, label=None, condition=None):
         """Create new S gate."""
-        super().__init__("s", 1, [], label=label)
+        super().__init__("s", 1, [], label=label, condition=condition)
 
     def _define(self):
         """
@@ -67,7 +67,7 @@ class SGate(Gate):
 
     def inverse(self):
         """Return inverse of S (SdgGate)."""
-        return SdgGate()
+        return SdgGate(condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the S gate."""
@@ -101,9 +101,9 @@ class SdgGate(Gate):
     Equivalent to a :math:`\pi/2` radian rotation about the Z axis.
     """
 
-    def __init__(self, label=None):
+    def __init__(self, label=None, condition=None):
         """Create new Sdg gate."""
-        super().__init__("sdg", 1, [], label=label)
+        super().__init__("sdg", 1, [], label=label, condition=condition)
 
     def _define(self):
         """
@@ -123,7 +123,7 @@ class SdgGate(Gate):
 
     def inverse(self):
         """Return inverse of Sdg (SGate)."""
-        return SGate()
+        return SGate(condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the Sdg gate."""

--- a/qiskit/circuit/library/standard_gates/swap.py
+++ b/qiskit/circuit/library/standard_gates/swap.py
@@ -50,9 +50,9 @@ class SwapGate(Gate):
         |a, b\rangle \rightarrow |b, a\rangle
     """
 
-    def __init__(self, label=None):
+    def __init__(self, label=None, condition=None):
         """Create new SWAP gate."""
-        super().__init__("swap", 2, [], label=label)
+        super().__init__("swap", 2, [], label=label, condition=condition)
 
     def _define(self):
         """
@@ -96,7 +96,7 @@ class SwapGate(Gate):
 
     def inverse(self):
         """Return inverse Swap gate (itself)."""
-        return SwapGate()  # self-inverse
+        return SwapGate(condition=self.condition)  # self-inverse
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the SWAP gate."""
@@ -201,7 +201,7 @@ class CSwapGate(ControlledGate):
         ]
     )
 
-    def __init__(self, label=None, ctrl_state=None):
+    def __init__(self, label=None, ctrl_state=None, condition=None):
         """Create new CSWAP gate."""
         super().__init__(
             "cswap",
@@ -211,6 +211,7 @@ class CSwapGate(ControlledGate):
             label=label,
             ctrl_state=ctrl_state,
             base_gate=SwapGate(),
+            condition=condition,
         )
 
     def _define(self):
@@ -239,7 +240,7 @@ class CSwapGate(ControlledGate):
 
     def inverse(self):
         """Return inverse CSwap gate (itself)."""
-        return CSwapGate(ctrl_state=self.ctrl_state)  # self-inverse
+        return CSwapGate(ctrl_state=self.ctrl_state, condition=self.condition)  # self-inverse
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the Fredkin (CSWAP) gate."""

--- a/qiskit/circuit/library/standard_gates/sx.py
+++ b/qiskit/circuit/library/standard_gates/sx.py
@@ -54,9 +54,9 @@ class SXGate(Gate):
 
     """
 
-    def __init__(self, label=None):
+    def __init__(self, label=None, condition=None):
         """Create new SX gate."""
-        super().__init__("sx", 1, [], label=label)
+        super().__init__("sx", 1, [], label=label, condition=condition)
 
     def _define(self):
         """
@@ -75,7 +75,7 @@ class SXGate(Gate):
 
     def inverse(self):
         """Return inverse SX gate (i.e. SXdg)."""
-        return SXdgGate()
+        return SXdgGate(condition=self.condition)
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
         """Return a (multi-)controlled-SX gate.
@@ -128,9 +128,9 @@ class SXdgGate(Gate):
 
     """
 
-    def __init__(self, label=None):
+    def __init__(self, label=None, condition=None):
         """Create new SXdg gate."""
-        super().__init__("sxdg", 1, [], label=label)
+        super().__init__("sxdg", 1, [], label=label, condition=condition)
 
     def _define(self):
         """
@@ -149,7 +149,7 @@ class SXdgGate(Gate):
 
     def inverse(self):
         """Return inverse SXdg gate (i.e. SX)."""
-        return SXGate()
+        return SXGate(condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the SXdg gate."""
@@ -226,10 +226,17 @@ class CSXGate(ControlledGate):
         ]
     )
 
-    def __init__(self, label=None, ctrl_state=None):
+    def __init__(self, label=None, ctrl_state=None, condition=None):
         """Create new CSX gate."""
         super().__init__(
-            "csx", 2, [], num_ctrl_qubits=1, label=label, ctrl_state=ctrl_state, base_gate=SXGate()
+            "csx",
+            2,
+            [],
+            num_ctrl_qubits=1,
+            label=label,
+            ctrl_state=ctrl_state,
+            base_gate=SXGate(),
+            condition=condition,
         )
 
     def _define(self):

--- a/qiskit/circuit/library/standard_gates/t.py
+++ b/qiskit/circuit/library/standard_gates/t.py
@@ -46,9 +46,9 @@ class TGate(Gate):
     Equivalent to a :math:`\pi/4` radian rotation about the Z axis.
     """
 
-    def __init__(self, label=None):
+    def __init__(self, label=None, condition=None):
         """Create new T gate."""
-        super().__init__("t", 1, [], label=label)
+        super().__init__("t", 1, [], label=label, condition=condition)
 
     def _define(self):
         """
@@ -68,7 +68,7 @@ class TGate(Gate):
 
     def inverse(self):
         """Return inverse T gate (i.e. Tdg)."""
-        return TdgGate()
+        return TdgGate(condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the T gate."""
@@ -102,9 +102,9 @@ class TdgGate(Gate):
     Equivalent to a :math:`\pi/2` radian rotation about the Z axis.
     """
 
-    def __init__(self, label=None):
+    def __init__(self, label=None, condition=None):
         """Create new Tdg gate."""
-        super().__init__("tdg", 1, [], label=label)
+        super().__init__("tdg", 1, [], label=label, condition=condition)
 
     def _define(self):
         """
@@ -124,7 +124,7 @@ class TdgGate(Gate):
 
     def inverse(self):
         """Return inverse Tdg gate (i.e. T)."""
-        return TGate()
+        return TGate(condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the inverse T gate."""

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -59,16 +59,16 @@ class UGate(Gate):
         U(\theta, 0, 0) = RY(\theta)
     """
 
-    def __init__(self, theta, phi, lam, label=None):
+    def __init__(self, theta, phi, lam, label=None, condition=None):
         """Create new U gate."""
-        super().__init__("u", 1, [theta, phi, lam], label=label)
+        super().__init__("u", 1, [theta, phi, lam], label=label, condition=condition)
 
     def inverse(self):
         r"""Return inverted U gate.
 
         :math:`U(\theta,\phi,\lambda)^{\dagger} =U(-\theta,-\lambda,-\phi)`)
         """
-        return UGate(-self.params[0], -self.params[2], -self.params[1])
+        return UGate(-self.params[0], -self.params[2], -self.params[1], condition=self.condition)
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
         """Return a (multi-)controlled-U gate.
@@ -168,7 +168,7 @@ class CUGate(ControlledGate):
                 \end{pmatrix}
     """
 
-    def __init__(self, theta, phi, lam, gamma, label=None, ctrl_state=None):
+    def __init__(self, theta, phi, lam, gamma, label=None, ctrl_state=None, condition=None):
         """Create new CU gate."""
         super().__init__(
             "cu",
@@ -178,6 +178,7 @@ class CUGate(ControlledGate):
             label=label,
             ctrl_state=ctrl_state,
             base_gate=UGate(theta, phi, lam),
+            condition=condition,
         )
 
     def _define(self):
@@ -217,6 +218,7 @@ class CUGate(ControlledGate):
             -self.params[1],
             -self.params[3],
             ctrl_state=self.ctrl_state,
+            condition=self.condition,
         )
 
     def __array__(self, dtype=None):

--- a/qiskit/circuit/library/standard_gates/u1.py
+++ b/qiskit/circuit/library/standard_gates/u1.py
@@ -74,9 +74,9 @@ class U1Gate(Gate):
         `1612.00858 <https://arxiv.org/abs/1612.00858>`_
     """
 
-    def __init__(self, theta, label=None):
+    def __init__(self, theta, label=None, condition=None):
         """Create new U1 gate."""
-        super().__init__("u1", 1, [theta], label=label)
+        super().__init__("u1", 1, [theta], label=label, condition=condition)
 
     def _define(self):
         # pylint: disable=cyclic-import
@@ -116,7 +116,7 @@ class U1Gate(Gate):
 
     def inverse(self):
         r"""Return inverted U1 gate (:math:`U1(\lambda){\dagger} = U1(-\lambda)`)"""
-        return U1Gate(-self.params[0])
+        return U1Gate(-self.params[0], condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the U1 gate."""
@@ -161,7 +161,7 @@ class CU1Gate(ControlledGate):
         phase difference.
     """
 
-    def __init__(self, theta, label=None, ctrl_state=None):
+    def __init__(self, theta, label=None, ctrl_state=None, condition=None):
         """Create new CU1 gate."""
         super().__init__(
             "cu1",
@@ -171,6 +171,7 @@ class CU1Gate(ControlledGate):
             label=label,
             ctrl_state=ctrl_state,
             base_gate=U1Gate(theta),
+            condition=condition,
         )
 
     def _define(self):
@@ -219,7 +220,7 @@ class CU1Gate(ControlledGate):
 
     def inverse(self):
         r"""Return inverted CU1 gate (:math:`CU1(\lambda){\dagger} = CU1(-\lambda)`)"""
-        return CU1Gate(-self.params[0], ctrl_state=self.ctrl_state)
+        return CU1Gate(-self.params[0], ctrl_state=self.ctrl_state, condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the CU1 gate."""
@@ -259,7 +260,7 @@ class MCU1Gate(ControlledGate):
         The singly-controlled-version of this gate.
     """
 
-    def __init__(self, lam, num_ctrl_qubits, label=None, ctrl_state=None):
+    def __init__(self, lam, num_ctrl_qubits, label=None, ctrl_state=None, condition=None):
         """Create new MCU1 gate."""
         super().__init__(
             "mcu1",
@@ -269,6 +270,7 @@ class MCU1Gate(ControlledGate):
             label=label,
             ctrl_state=ctrl_state,
             base_gate=U1Gate(lam),
+            condition=condition,
         )
 
     def _define(self):
@@ -317,4 +319,4 @@ class MCU1Gate(ControlledGate):
 
     def inverse(self):
         r"""Return inverted MCU1 gate (:math:`MCU1(\lambda){\dagger} = MCU1(-\lambda)`)"""
-        return MCU1Gate(-self.params[0], self.num_ctrl_qubits)
+        return MCU1Gate(-self.params[0], self.num_ctrl_qubits, condition=self.condition)

--- a/qiskit/circuit/library/standard_gates/u2.py
+++ b/qiskit/circuit/library/standard_gates/u2.py
@@ -58,9 +58,9 @@ class U2Gate(Gate):
         using two X90 pulses.
     """
 
-    def __init__(self, phi, lam, label=None):
+    def __init__(self, phi, lam, label=None, condition=None):
         """Create new U2 gate."""
-        super().__init__("u2", 1, [phi, lam], label=label)
+        super().__init__("u2", 1, [phi, lam], label=label, condition=condition)
 
     def _define(self):
         # pylint: disable=cyclic-import
@@ -80,7 +80,7 @@ class U2Gate(Gate):
 
         :math:`U2(\phi, \lambda)^{\dagger} =U2(-\lambda-\pi, -\phi+\pi)`)
         """
-        return U2Gate(-self.params[1] - pi, -self.params[0] + pi)
+        return U2Gate(-self.params[1] - pi, -self.params[0] + pi, condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a Numpy.array for the U2 gate."""

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -58,16 +58,16 @@ class U3Gate(Gate):
         U3(\theta, 0, 0) = RY(\theta)
     """
 
-    def __init__(self, theta, phi, lam, label=None):
+    def __init__(self, theta, phi, lam, label=None, condition=None):
         """Create new U3 gate."""
-        super().__init__("u3", 1, [theta, phi, lam], label=label)
+        super().__init__("u3", 1, [theta, phi, lam], label=label, condition=condition)
 
     def inverse(self):
         r"""Return inverted U3 gate.
 
         :math:`U3(\theta,\phi,\lambda)^{\dagger} =U3(-\theta,-\lambda,-\phi)`)
         """
-        return U3Gate(-self.params[0], -self.params[2], -self.params[1])
+        return U3Gate(-self.params[0], -self.params[2], -self.params[1], condition=self.condition)
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
         """Return a (multi-)controlled-U3 gate.
@@ -169,7 +169,7 @@ class CU3Gate(ControlledGate):
                 \end{pmatrix}
     """
 
-    def __init__(self, theta, phi, lam, label=None, ctrl_state=None):
+    def __init__(self, theta, phi, lam, label=None, ctrl_state=None, condition=None):
         """Create new CU3 gate."""
         super().__init__(
             "cu3",
@@ -179,6 +179,7 @@ class CU3Gate(ControlledGate):
             label=label,
             ctrl_state=ctrl_state,
             base_gate=U3Gate(theta, phi, lam),
+            condition=condition,
         )
 
     def _define(self):
@@ -218,7 +219,11 @@ class CU3Gate(ControlledGate):
         :math:`CU3(\theta,\phi,\lambda)^{\dagger} =CU3(-\theta,-\phi,-\lambda)`)
         """
         return CU3Gate(
-            -self.params[0], -self.params[2], -self.params[1], ctrl_state=self.ctrl_state
+            -self.params[0],
+            -self.params[2],
+            -self.params[1],
+            ctrl_state=self.ctrl_state,
+            condition=self.condition,
         )
 
     def __array__(self, dtype=None):

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -70,9 +70,9 @@ class XGate(Gate):
         |1\rangle \rightarrow |0\rangle
     """
 
-    def __init__(self, label=None):
+    def __init__(self, label=None, condition=None):
         """Create new X gate."""
-        super().__init__("x", 1, [], label=label)
+        super().__init__("x", 1, [], label=label, condition=condition)
 
     def _define(self):
         """
@@ -110,7 +110,7 @@ class XGate(Gate):
 
     def inverse(self):
         r"""Return inverted X gate (itself)."""
-        return XGate()  # self-inverse
+        return XGate(condition=self.condition)  # self-inverse
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the X gate."""
@@ -176,10 +176,17 @@ class CXGate(ControlledGate):
         `|a, b\rangle \rightarrow |a, a \oplus b\rangle`
     """
 
-    def __init__(self, label=None, ctrl_state=None):
+    def __init__(self, label=None, ctrl_state=None, condition=None):
         """Create new CX gate."""
         super().__init__(
-            "cx", 2, [], num_ctrl_qubits=1, label=label, ctrl_state=ctrl_state, base_gate=XGate()
+            "cx",
+            2,
+            [],
+            num_ctrl_qubits=1,
+            label=label,
+            ctrl_state=ctrl_state,
+            base_gate=XGate(),
+            condition=condition,
         )
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
@@ -202,7 +209,7 @@ class CXGate(ControlledGate):
 
     def inverse(self):
         """Return inverted CX gate (itself)."""
-        return CXGate(ctrl_state=self.ctrl_state)  # self-inverse
+        return CXGate(ctrl_state=self.ctrl_state, condition=self.condition)  # self-inverse
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the CX gate."""
@@ -280,10 +287,17 @@ class CCXGate(ControlledGate):
 
     """
 
-    def __init__(self, label=None, ctrl_state=None):
+    def __init__(self, label=None, ctrl_state=None, condition=None):
         """Create new CCX gate."""
         super().__init__(
-            "ccx", 3, [], num_ctrl_qubits=2, label=label, ctrl_state=ctrl_state, base_gate=XGate()
+            "ccx",
+            3,
+            [],
+            num_ctrl_qubits=2,
+            label=label,
+            ctrl_state=ctrl_state,
+            base_gate=XGate(),
+            condition=condition,
         )
 
     def _define(self):
@@ -342,7 +356,7 @@ class CCXGate(ControlledGate):
 
     def inverse(self):
         """Return an inverted CCX gate (also a CCX)."""
-        return CCXGate(ctrl_state=self.ctrl_state)  # self-inverse
+        return CCXGate(ctrl_state=self.ctrl_state, condition=self.condition)  # self-inverse
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the CCX gate."""
@@ -367,9 +381,9 @@ class RCCXGate(Gate):
     of Fig. 3.
     """
 
-    def __init__(self, label=None):
+    def __init__(self, label=None, condition=None):
         """Create a new simplified CCX gate."""
-        super().__init__("rccx", 3, [], label=label)
+        super().__init__("rccx", 3, [], label=label, condition=condition)
 
     def _define(self):
         """
@@ -432,7 +446,7 @@ class C3SXGate(ControlledGate):
         [1] Barenco et al., 1995. https://arxiv.org/pdf/quant-ph/9503016.pdf
     """
 
-    def __init__(self, label=None, ctrl_state=None, *, angle=None):
+    def __init__(self, label=None, ctrl_state=None, condition=None, *, angle=None):
         """Create a new 3-qubit controlled sqrt-X gate.
 
         Args:
@@ -443,7 +457,14 @@ class C3SXGate(ControlledGate):
                 yields the sqrt(X) gates, an angle of π/4 the 3-qubit controlled X gate.
         """
         super().__init__(
-            "c3sx", 4, [], num_ctrl_qubits=3, label=label, ctrl_state=ctrl_state, base_gate=SXGate()
+            "c3sx",
+            4,
+            [],
+            num_ctrl_qubits=3,
+            label=label,
+            ctrl_state=ctrl_state,
+            base_gate=SXGate(),
+            condition=condition,
         )
 
         if angle is not None:
@@ -527,7 +548,7 @@ class C3SXGate(ControlledGate):
         else:
             angle = None
 
-        return C3SXGate(angle=angle, ctrl_state=self.ctrl_state)
+        return C3SXGate(angle=angle, ctrl_state=self.ctrl_state, condition=self.condition)
 
 
 class C3XGate(ControlledGate):
@@ -536,19 +557,26 @@ class C3XGate(ControlledGate):
     This implementation uses :math:`\sqrt{T}` and 14 CNOT gates.
     """
 
-    def __new__(cls, angle=None, label=None, ctrl_state=None):
+    def __new__(cls, angle=None, label=None, ctrl_state=None, condition=None):
         if angle is not None:
             return C3SXGate(label, ctrl_state, angle=angle)
 
         instance = super().__new__(cls)
-        instance.__init__(None, label, ctrl_state)
+        instance.__init__(None, label, ctrl_state, condition=condition)
         return instance
 
     # pylint: disable=unused-argument
-    def __init__(self, angle=None, label=None, ctrl_state=None):
+    def __init__(self, angle=None, label=None, ctrl_state=None, condition=None):
         """Create a new 3-qubit controlled X gate."""
         super().__init__(
-            "mcx", 4, [], num_ctrl_qubits=3, label=label, ctrl_state=ctrl_state, base_gate=XGate()
+            "mcx",
+            4,
+            [],
+            num_ctrl_qubits=3,
+            label=label,
+            ctrl_state=ctrl_state,
+            base_gate=XGate(),
+            condition=condition,
         )
 
     # seems like open controls not hapening?
@@ -644,7 +672,7 @@ class C3XGate(ControlledGate):
 
     def inverse(self):
         """Invert this gate. The C4X is its own inverse."""
-        return C3XGate(ctrl_state=self.ctrl_state)
+        return C3XGate(ctrl_state=self.ctrl_state, condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the C4X gate."""
@@ -667,9 +695,9 @@ class RC3XGate(Gate):
     of Fig. 4.
     """
 
-    def __init__(self, label=None):
+    def __init__(self, label=None, condition=None):
         """Create a new RC3X gate."""
-        super().__init__("rcccx", 4, [], label=label)
+        super().__init__("rcccx", 4, [], label=label, condition=condition)
 
     def _define(self):
         """
@@ -760,10 +788,17 @@ class C4XGate(ControlledGate):
         [2] Maslov, 2015. https://arxiv.org/abs/1508.03273
     """
 
-    def __init__(self, label=None, ctrl_state=None):
+    def __init__(self, label=None, ctrl_state=None, condition=None):
         """Create a new 4-qubit controlled X gate."""
         super().__init__(
-            "mcx", 5, [], num_ctrl_qubits=4, label=label, ctrl_state=ctrl_state, base_gate=XGate()
+            "mcx",
+            5,
+            [],
+            num_ctrl_qubits=4,
+            label=label,
+            ctrl_state=ctrl_state,
+            base_gate=XGate(),
+            condition=condition,
         )
 
     # seems like open controls not hapening?
@@ -836,7 +871,7 @@ class C4XGate(ControlledGate):
 
     def inverse(self):
         """Invert this gate. The C4X is its own inverse."""
-        return C4XGate(ctrl_state=self.ctrl_state)
+        return C4XGate(ctrl_state=self.ctrl_state, condition=self.condition)
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the C4X gate."""
@@ -851,7 +886,7 @@ class C4XGate(ControlledGate):
 class MCXGate(ControlledGate):
     """The general, multi-controlled X gate."""
 
-    def __new__(cls, num_ctrl_qubits=None, label=None, ctrl_state=None):
+    def __new__(cls, num_ctrl_qubits=None, label=None, ctrl_state=None, condition=None):
         """Create a new MCX instance.
 
         Depending on the number of controls and which mode of the MCX, this creates an
@@ -864,11 +899,11 @@ class MCXGate(ControlledGate):
             gate_class = explicit[num_ctrl_qubits]
             gate = gate_class.__new__(gate_class, label=label, ctrl_state=ctrl_state)
             # if __new__ does not return the same type as cls, init is not called
-            gate.__init__(label=label, ctrl_state=ctrl_state)
+            gate.__init__(label=label, ctrl_state=ctrl_state, condition=condition)
             return gate
         return super().__new__(cls)
 
-    def __init__(self, num_ctrl_qubits, label=None, ctrl_state=None, _name="mcx"):
+    def __init__(self, num_ctrl_qubits, label=None, ctrl_state=None, _name="mcx", condition=None):
         """Create new MCX gate."""
         num_ancilla_qubits = self.__class__.get_num_ancilla_qubits(num_ctrl_qubits)
         super().__init__(
@@ -879,11 +914,16 @@ class MCXGate(ControlledGate):
             label=label,
             ctrl_state=ctrl_state,
             base_gate=XGate(),
+            condition=condition,
         )
 
     def inverse(self):
         """Invert this gate. The MCX is its own inverse."""
-        return MCXGate(num_ctrl_qubits=self.num_ctrl_qubits, ctrl_state=self.ctrl_state)
+        return MCXGate(
+            num_ctrl_qubits=self.num_ctrl_qubits,
+            ctrl_state=self.ctrl_state,
+            condition=self.condition,
+        )
 
     @staticmethod
     def get_num_ancilla_qubits(num_ctrl_qubits, mode="noancilla"):
@@ -943,24 +983,36 @@ class MCXGrayCode(MCXGate):
     This delegates the implementation to the MCU1 gate, since :math:`X = H \cdot U1(\pi) \cdot H`.
     """
 
-    def __new__(cls, num_ctrl_qubits=None, label=None, ctrl_state=None):
+    def __new__(cls, num_ctrl_qubits=None, label=None, ctrl_state=None, condition=None):
         """Create a new MCXGrayCode instance"""
         # if 1 to 4 control qubits, create explicit gates
         explicit = {1: CXGate, 2: CCXGate, 3: C3XGate, 4: C4XGate}
         if num_ctrl_qubits in explicit.keys():
             gate_class = explicit[num_ctrl_qubits]
-            gate = gate_class.__new__(gate_class, label=label, ctrl_state=ctrl_state)
+            gate = gate_class.__new__(
+                gate_class, label=label, ctrl_state=ctrl_state, condition=condition
+            )
             # if __new__ does not return the same type as cls, init is not called
-            gate.__init__(label=label, ctrl_state=ctrl_state)
+            gate.__init__(label=label, ctrl_state=ctrl_state, condition=condition)
             return gate
         return super().__new__(cls)
 
-    def __init__(self, num_ctrl_qubits, label=None, ctrl_state=None):
-        super().__init__(num_ctrl_qubits, label=label, ctrl_state=ctrl_state, _name="mcx_gray")
+    def __init__(self, num_ctrl_qubits, label=None, ctrl_state=None, condition=None):
+        super().__init__(
+            num_ctrl_qubits,
+            label=label,
+            ctrl_state=ctrl_state,
+            _name="mcx_gray",
+            condition=condition,
+        )
 
     def inverse(self):
         """Invert this gate. The MCX is its own inverse."""
-        return MCXGrayCode(num_ctrl_qubits=self.num_ctrl_qubits, ctrl_state=self.ctrl_state)
+        return MCXGrayCode(
+            num_ctrl_qubits=self.num_ctrl_qubits,
+            ctrl_state=self.ctrl_state,
+            condition=self.condition,
+        )
 
     def _define(self):
         """Define the MCX gate using the Gray code."""
@@ -984,8 +1036,14 @@ class MCXRecursive(MCXGate):
     for these we have a concrete implementation that do not require ancillas.
     """
 
-    def __init__(self, num_ctrl_qubits, label=None, ctrl_state=None):
-        super().__init__(num_ctrl_qubits, label=label, ctrl_state=ctrl_state, _name="mcx_recursive")
+    def __init__(self, num_ctrl_qubits, label=None, ctrl_state=None, condition=None):
+        super().__init__(
+            num_ctrl_qubits,
+            label=label,
+            ctrl_state=ctrl_state,
+            _name="mcx_recursive",
+            condition=condition,
+        )
 
     @staticmethod
     def get_num_ancilla_qubits(num_ctrl_qubits, mode="recursion"):
@@ -994,7 +1052,11 @@ class MCXRecursive(MCXGate):
 
     def inverse(self):
         """Invert this gate. The MCX is its own inverse."""
-        return MCXRecursive(num_ctrl_qubits=self.num_ctrl_qubits, ctrl_state=self.ctrl_state)
+        return MCXRecursive(
+            num_ctrl_qubits=self.num_ctrl_qubits,
+            ctrl_state=self.ctrl_state,
+            condition=self.condition,
+        )
 
     def _define(self):
         """Define the MCX gate using recursion."""
@@ -1047,15 +1109,26 @@ class MCXVChain(MCXGate):
         dirty_ancillas=False,  # pylint: disable=unused-argument
         label=None,
         ctrl_state=None,
+        condition=None,
     ):
         """Create a new MCX instance.
 
         This must be defined anew to include the additional argument ``dirty_ancillas``.
         """
-        return super().__new__(cls, num_ctrl_qubits, label=label, ctrl_state=ctrl_state)
+        return super().__new__(
+            cls, num_ctrl_qubits, label=label, ctrl_state=ctrl_state, condition=condition
+        )
 
-    def __init__(self, num_ctrl_qubits, dirty_ancillas=False, label=None, ctrl_state=None):
-        super().__init__(num_ctrl_qubits, label=label, ctrl_state=ctrl_state, _name="mcx_vchain")
+    def __init__(
+        self, num_ctrl_qubits, dirty_ancillas=False, label=None, ctrl_state=None, condition=None
+    ):
+        super().__init__(
+            num_ctrl_qubits,
+            label=label,
+            ctrl_state=ctrl_state,
+            _name="mcx_vchain",
+            condition=condition,
+        )
         self._dirty_ancillas = dirty_ancillas
 
     def inverse(self):
@@ -1064,6 +1137,7 @@ class MCXVChain(MCXGate):
             num_ctrl_qubits=self.num_ctrl_qubits,
             dirty_ancillas=self._dirty_ancillas,
             ctrl_state=self.ctrl_state,
+            condition=self.condition,
         )
 
     @staticmethod

--- a/qiskit/circuit/library/standard_gates/y.py
+++ b/qiskit/circuit/library/standard_gates/y.py
@@ -64,9 +64,9 @@ class YGate(Gate):
         |1\rangle \rightarrow -i|0\rangle
     """
 
-    def __init__(self, label=None):
+    def __init__(self, label=None, condition=None):
         """Create new Y gate."""
-        super().__init__("y", 1, [], label=label)
+        super().__init__("y", 1, [], label=label, condition=condition)
 
     def _define(self):
         # pylint: disable=cyclic-import
@@ -103,7 +103,7 @@ class YGate(Gate):
 
     def inverse(self):
         r"""Return inverted Y gate (:math:`Y{\dagger} = Y`)"""
-        return YGate()  # self-inverse
+        return YGate(condition=self.condition)  # self-inverse
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the Y gate."""
@@ -166,10 +166,17 @@ class CYGate(ControlledGate):
     _matrix1 = numpy.array([[1, 0, 0, 0], [0, 0, 0, -1j], [0, 0, 1, 0], [0, 1j, 0, 0]])
     _matrix0 = numpy.array([[0, 0, -1j, 0], [0, 1, 0, 0], [1j, 0, 0, 0], [0, 0, 0, 1]])
 
-    def __init__(self, label=None, ctrl_state=None):
+    def __init__(self, label=None, ctrl_state=None, condition=None):
         """Create new CY gate."""
         super().__init__(
-            "cy", 2, [], num_ctrl_qubits=1, label=label, ctrl_state=ctrl_state, base_gate=YGate()
+            "cy",
+            2,
+            [],
+            num_ctrl_qubits=1,
+            label=label,
+            ctrl_state=ctrl_state,
+            base_gate=YGate(),
+            condition=condition,
         )
 
     def _define(self):
@@ -191,7 +198,7 @@ class CYGate(ControlledGate):
 
     def inverse(self):
         """Return inverted CY gate (itself)."""
-        return CYGate(ctrl_state=self.ctrl_state)  # self-inverse
+        return CYGate(ctrl_state=self.ctrl_state, condition=self.condition)  # self-inverse
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the CY gate."""

--- a/qiskit/circuit/library/standard_gates/z.py
+++ b/qiskit/circuit/library/standard_gates/z.py
@@ -62,9 +62,9 @@ class ZGate(Gate):
         |1\rangle \rightarrow -|1\rangle
     """
 
-    def __init__(self, label=None):
+    def __init__(self, label=None, condition=None):
         """Create new Z gate."""
-        super().__init__("z", 1, [], label=label)
+        super().__init__("z", 1, [], label=label, condition=condition)
 
     def _define(self):
         # pylint: disable=cyclic-import
@@ -101,7 +101,7 @@ class ZGate(Gate):
 
     def inverse(self):
         """Return inverted Z gate (itself)."""
-        return ZGate()  # self-inverse
+        return ZGate(condition=self.condition)  # self-inverse
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the Z gate."""
@@ -138,10 +138,17 @@ class CZGate(ControlledGate):
     the target qubit if the control qubit is in the :math:`|1\rangle` state.
     """
 
-    def __init__(self, label=None, ctrl_state=None):
+    def __init__(self, label=None, ctrl_state=None, condition=None):
         """Create new CZ gate."""
         super().__init__(
-            "cz", 2, [], label=label, num_ctrl_qubits=1, ctrl_state=ctrl_state, base_gate=ZGate()
+            "cz",
+            2,
+            [],
+            label=label,
+            num_ctrl_qubits=1,
+            ctrl_state=ctrl_state,
+            base_gate=ZGate(),
+            condition=condition,
         )
 
     def _define(self):
@@ -163,7 +170,7 @@ class CZGate(ControlledGate):
 
     def inverse(self):
         """Return inverted CZ gate (itself)."""
-        return CZGate(ctrl_state=self.ctrl_state)  # self-inverse
+        return CZGate(ctrl_state=self.ctrl_state, condition=self.condition)  # self-inverse
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the CZ gate."""

--- a/qiskit/circuit/reset.py
+++ b/qiskit/circuit/reset.py
@@ -20,9 +20,9 @@ from qiskit.circuit.instruction import Instruction
 class Reset(Instruction):
     """Qubit reset."""
 
-    def __init__(self):
+    def __init__(self, condition=None):
         """Create new reset instruction."""
-        super().__init__("reset", 1, 0, [])
+        super().__init__("reset", 1, 0, [], condition=condition)
 
     def broadcast_arguments(self, qargs, cargs):
         for qarg in qargs[0]:

--- a/qiskit/extensions/hamiltonian_gate.py
+++ b/qiskit/extensions/hamiltonian_gate.py
@@ -32,7 +32,7 @@ class HamiltonianGate(Gate):
     resolves to a UnitaryGate U(t) = exp(-1j * t * H), which can be decomposed into basis gates if
     it is 2 qubits or less, or simulated directly in Aer for more qubits."""
 
-    def __init__(self, data, time, label=None):
+    def __init__(self, data, time, label=None, condition=None):
         """Create a gate from a hamiltonian operator and evolution time parameter t
 
         Args:
@@ -66,7 +66,7 @@ class HamiltonianGate(Gate):
             raise ExtensionError("Input matrix is not an N-qubit operator.")
 
         # Store instruction params
-        super().__init__("hamiltonian", num_qubits, [data, time], label=label)
+        super().__init__("hamiltonian", num_qubits, [data, time], label=label, condition=condition)
 
     def __eq__(self, other):
         if not isinstance(other, HamiltonianGate):

--- a/qiskit/extensions/quantum_initializer/diagonal.py
+++ b/qiskit/extensions/quantum_initializer/diagonal.py
@@ -38,7 +38,7 @@ class DiagonalGate(Gate):
     least two entries.
     """
 
-    def __init__(self, diag):
+    def __init__(self, diag, condition=None):
         """Check types"""
         # Check if diag has type "list"
         if not isinstance(diag, list):
@@ -58,7 +58,7 @@ class DiagonalGate(Gate):
             if not np.abs(z) - 1 < _EPS:
                 raise QiskitError("A diagonal entry has not absolute value one.")
         # Create new gate.
-        super().__init__("diagonal", int(num_action_qubits), diag)
+        super().__init__("diagonal", int(num_action_qubits), diag, condition=condition)
 
     def _define(self):
         diag_circuit = self._dec_diag()

--- a/qiskit/extensions/quantum_initializer/initializer.py
+++ b/qiskit/extensions/quantum_initializer/initializer.py
@@ -42,7 +42,7 @@ class Initialize(Instruction):
     which is not unitary.
     """
 
-    def __init__(self, params, num_qubits=None):
+    def __init__(self, params, num_qubits=None, condition=None):
         """Create new initialize composite.
 
         params (str, list, int or Statevector):
@@ -93,7 +93,7 @@ class Initialize(Instruction):
 
             num_qubits = int(num_qubits)
 
-        super().__init__("initialize", num_qubits, 0, params)
+        super().__init__("initialize", num_qubits, 0, params, condition=condition)
 
     def _define(self):
         if self._from_label:

--- a/qiskit/extensions/quantum_initializer/isometry.py
+++ b/qiskit/extensions/quantum_initializer/isometry.py
@@ -65,7 +65,9 @@ class Isometry(Instruction):
     # finally, we convert the labels back to the qubit numbering used in Qiskit
     # (using: _get_qubits_by_label)
 
-    def __init__(self, isometry, num_ancillas_zero, num_ancillas_dirty, epsilon=_EPS):
+    def __init__(
+        self, isometry, num_ancillas_zero, num_ancillas_dirty, epsilon=_EPS, condition=None
+    ):
         # Convert to numpy array in case not already an array
         isometry = np.array(isometry, dtype=complex)
 
@@ -100,7 +102,7 @@ class Isometry(Instruction):
 
         num_qubits = int(n) + num_ancillas_zero + num_ancillas_dirty
 
-        super().__init__("isometry", num_qubits, 0, [isometry])
+        super().__init__("isometry", num_qubits, 0, [isometry], condition=condition)
 
     def _define(self):
         # TODO The inverse().inverse() is because there is code to uncompute (_gates_to_uncompute)

--- a/qiskit/extensions/quantum_initializer/mcg_up_to_diagonal.py
+++ b/qiskit/extensions/quantum_initializer/mcg_up_to_diagonal.py
@@ -38,7 +38,7 @@ class MCGupDiag(Gate):
     such that u=d.u'.
     """
 
-    def __init__(self, gate, num_controls, num_ancillas_zero, num_ancillas_dirty):
+    def __init__(self, gate, num_controls, num_ancillas_zero, num_ancillas_dirty, condition=None):
         """Initialize a multi controlled gate.
 
         Args:
@@ -62,7 +62,7 @@ class MCGupDiag(Gate):
             raise QiskitError("The controlled gate is not unitary.")
         # Create new gate.
         num_qubits = 1 + num_controls + num_ancillas_zero + num_ancillas_dirty
-        super().__init__("MCGupDiag", num_qubits, [gate])
+        super().__init__("MCGupDiag", num_qubits, [gate], condition=condition)
 
     def _define(self):
         mcg_up_diag_circuit, _ = self._dec_mcg_up_diag()

--- a/qiskit/extensions/quantum_initializer/squ.py
+++ b/qiskit/extensions/quantum_initializer/squ.py
@@ -44,7 +44,7 @@ class SingleQubitUnitary(Gate):
 
     # pylint: disable=unused-argument
     @deprecate_arguments({"u": "unitary_matrix"})
-    def __init__(self, unitary_matrix, mode="ZYZ", up_to_diagonal=False, u=None):
+    def __init__(self, unitary_matrix, mode="ZYZ", up_to_diagonal=False, u=None, condition=None):
         """Create a new single qubit gate based on the unitary ``u``."""
         if mode not in ["ZYZ"]:
             raise QiskitError("The decomposition mode is not known.")
@@ -59,7 +59,7 @@ class SingleQubitUnitary(Gate):
         self._diag = None
 
         # Create new gate
-        super().__init__("unitary", 1, [unitary_matrix])
+        super().__init__("unitary", 1, [unitary_matrix], condition=condition)
 
     def inverse(self):
         """Return the inverse.

--- a/qiskit/extensions/quantum_initializer/uc.py
+++ b/qiskit/extensions/quantum_initializer/uc.py
@@ -57,7 +57,7 @@ class UCGate(Gate):
     The decomposition is based on: https://arxiv.org/pdf/quant-ph/0410066.pdf.
     """
 
-    def __init__(self, gate_list, up_to_diagonal=False):
+    def __init__(self, gate_list, up_to_diagonal=False, condition=None):
         """UCGate Gate initializer.
 
         Args:
@@ -94,7 +94,7 @@ class UCGate(Gate):
                 raise QiskitError("A controlled gate is not unitary.")
 
         # Create new gate.
-        super().__init__("multiplexer", int(num_contr) + 1, gate_list)
+        super().__init__("multiplexer", int(num_contr) + 1, gate_list, condition=condition)
         self.up_to_diagonal = up_to_diagonal
 
     def inverse(self):

--- a/qiskit/extensions/quantum_initializer/uc_pauli_rot.py
+++ b/qiskit/extensions/quantum_initializer/uc_pauli_rot.py
@@ -45,7 +45,7 @@ class UCPauliRotGate(Gate):
                (currently, 'X', 'Y' and 'Z' are supported)
     """
 
-    def __init__(self, angle_list, rot_axis):
+    def __init__(self, angle_list, rot_axis, condition=None):
         self.rot_axes = rot_axis
         # Check if angle_list has type "list"
         if not isinstance(angle_list, list):
@@ -67,7 +67,7 @@ class UCPauliRotGate(Gate):
             raise QiskitError("Rotation axis is not supported.")
         # Create new gate.
         num_qubits = int(num_contr) + 1
-        super().__init__("ucr" + rot_axis.lower(), num_qubits, angle_list)
+        super().__init__("ucr" + rot_axis.lower(), num_qubits, angle_list, condition=condition)
 
     def _define(self):
         ucr_circuit = self._dec_ucrot()

--- a/qiskit/extensions/unitary.py
+++ b/qiskit/extensions/unitary.py
@@ -36,7 +36,7 @@ _DECOMPOSER1Q = OneQubitEulerDecomposer("U3")
 class UnitaryGate(Gate):
     """Class for representing unitary gates"""
 
-    def __init__(self, data, label=None):
+    def __init__(self, data, label=None, condition=None):
         """Create a gate from a numeric unitary matrix.
 
         Args:
@@ -69,7 +69,7 @@ class UnitaryGate(Gate):
         self._qasm_name = None
         self._qasm_definition = None
         # Store instruction params
-        super().__init__("unitary", num_qubits, [data], label=label)
+        super().__init__("unitary", num_qubits, [data], label=label, condition=condition)
 
     def __eq__(self, other):
         if not isinstance(other, UnitaryGate):

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -852,6 +852,22 @@ class TestCircuitOperations(QiskitTestCase):
 
         self.assertFalse(qc1 == qc2)
 
+    def test_circuit_inverse_c_if(self):
+        """Test inverse of classically conditioned circuit"""
+        qr = QuantumRegister(1)
+        cr = ClassicalRegister(1)
+        qc = QuantumCircuit(qr, cr)
+        qc.s(0).c_if(cr, 0)
+        qc.h(0)
+        qc.x(0).c_if(cr, 1)
+        qc_inv = qc.inverse()
+
+        qc_ref = QuantumCircuit(qr, cr)
+        qc_ref.x(0).c_if(cr, 1)
+        qc_ref.h(0)
+        qc_ref.sdg(0).c_if(cr, 0)
+        self.assertEqual(qc_inv, qc_ref)
+
 
 class TestCircuitBuilding(QiskitTestCase):
     """QuantumCircuit tests."""

--- a/test/python/circuit/test_extensions_standard.py
+++ b/test/python/circuit/test_extensions_standard.py
@@ -1377,7 +1377,7 @@ class TestStandardMethods(QiskitTestCase):
                 # gate_class is abstract
                 continue
             sig = signature(gate_class)
-            free_params = len(set(sig.parameters) - {"label"})
+            free_params = len(set(sig.parameters) - {"label", "condition"})
             try:
                 if gate_class == PauliGate:
                     # special case due to PauliGate using string parameters
@@ -1427,7 +1427,7 @@ class TestStandardMethods(QiskitTestCase):
                 # n_qubits argument is no longer supported.
                 free_params = 2
             else:
-                free_params = len(set(sig.parameters) - {"label"})
+                free_params = len(set(sig.parameters) - {"label", "condition"})
             try:
                 if gate_class == PauliGate:
                     # special case due to PauliGate using string parameters

--- a/test/python/circuit/test_instructions.py
+++ b/test/python/circuit/test_instructions.py
@@ -313,18 +313,11 @@ class TestInstructions(QiskitTestCase):
         inst = circ.to_instruction()
         self.assertRaises(CircuitError, inst.inverse)
 
-    def test_inverse_instruction_with_conditional(self):
-        """test inverting instruction with conditionals fails"""
-        q = QuantumRegister(4)
-        c = ClassicalRegister(4)
-        circ = QuantumCircuit(q, c, name="circ")
-        circ.t(q[1])
-        circ.u(0.1, 0.2, -0.2, q[0])
-        circ.barrier()
-        circ.measure(q[0], c[0])
-        circ.rz(0.8, q[0]).c_if(c, 6)
-        inst = circ.to_instruction()
-        self.assertRaises(CircuitError, inst.inverse)
+    def test_set_instruction_with_conditional_argument(self):
+        """test inverting instruction with conditional"""
+        cr = ClassicalRegister(1)
+        cif_instr = Instruction("c_if_instr", 1, 1, [], condition=(cr, 1))
+        self.assertEqual(cif_instr.condition, (cr, 1))
 
     def test_inverse_opaque(self):
         """test inverting opaque gate fails"""

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -1409,10 +1409,10 @@ class TestConditional(QiskitTestCase):
         self.circuit.h(self.qreg[0]).c_if(self.creg, 1)
         self.dag = circuit_to_dag(self.circuit)
         gate_node = self.dag.gate_nodes()[0]
-        self.assertEqual(gate_node.op, HGate())
+        self.assertEqual(gate_node.op, HGate(condition=(self.creg, 1)))
         self.assertEqual(gate_node.qargs, [self.qreg[0]])
         self.assertEqual(gate_node.cargs, [])
-        self.assertEqual(gate_node.condition, (self.creg, 1))
+        self.assertEqual(gate_node.op.condition, (self.creg, 1))
         self.assertEqual(
             sorted(self.dag._multi_graph.in_edges(gate_node._node_id)),
             sorted(
@@ -1441,7 +1441,7 @@ class TestConditional(QiskitTestCase):
         self.circuit.h(self.qreg[0]).c_if(self.creg[0], 1)
         self.dag = circuit_to_dag(self.circuit)
         gate_node = self.dag.gate_nodes()[0]
-        self.assertEqual(gate_node.op, HGate())
+        self.assertEqual(gate_node.op, HGate(condition=(self.creg[0], 1)))
         self.assertEqual(gate_node.qargs, [self.qreg[0]])
         self.assertEqual(gate_node.cargs, [])
         self.assertEqual(gate_node.condition, (self.creg[0], 1))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR enables the preservation of the classical condition for the inverse of a classically conditioned gate. 
Also added is the ability to initialize the classical condition during instruction instantiation which should help with progress toward issue #2439.
  
Fixes #6810 


### Details and comments

