### PR TITLE
Add QuantumCircuit.{q,c}regs as properties to sync with {q,c}bits.

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -52,7 +52,7 @@ from .parametervector import ParameterVector, ParameterVectorElement
 from .instructionset import InstructionSet
 from .register import Register
 from .bit import Bit
-from .quantumcircuitdata import QuantumCircuitData
+from .quantumcircuitdata import QuantumCircuitData, QuantumCircuitQregs, QuantumCircuitCregs
 from .delay import Delay
 from .measure import Measure
 from .reset import Reset
@@ -417,7 +417,7 @@ class QuantumCircuit:
                  └──────────┘
         """
         reverse_circ = QuantumCircuit(
-            self.qubits, self.clbits, *self.qregs, *self.cregs, name=self.name + "_reverse"
+            self.qubits, self.clbits, *self._qregs, *self._cregs, name=self.name + "_reverse"
         )
 
         for inst, qargs, cargs in reversed(self.data):
@@ -1240,6 +1240,26 @@ class QuantumCircuit:
             if spec[0] is instruction and spec[1] == param_index:
                 return True
         return False
+
+    @property
+    def qregs(self):
+        """Returns a list of QuantumRegisters attached to the circuit."""
+        return QuantumCircuitQregs(self)
+
+    @qregs.setter
+    def qregs(self, regs):
+        self._qregs = []
+        self.add_register(*regs)
+
+    @property
+    def cregs(self):
+        """Returns a list of ClassicalRegisters attached to the circuit."""
+        return QuantumCircuitCregs(self)
+
+    @cregs.setter
+    def cregs(self, regs):
+        self._cregs = []
+        self.add_register(*regs)
 
     def add_register(self, *regs: Union[Register, int, Sequence[Bit]]) -> None:
         """Add registers."""

--- a/qiskit/circuit/quantumcircuitdata.py
+++ b/qiskit/circuit/quantumcircuitdata.py
@@ -13,21 +13,95 @@
 """A wrapper class for the purposes of validating modifications to
 QuantumCircuit.data while maintaining the interface of a python list."""
 
+from abc import abstractmethod
 from collections.abc import MutableSequence
 
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.instruction import Instruction
 
 
-class QuantumCircuitData(MutableSequence):
+class ValidatedMutableSequence(MutableSequence):
+    """A wrapper for validating and acting upon modifications to an
+    underlying List.
+
+    Intended to be used when an underlying list structure, owned by
+    the QuantumCircuit (such as QuantumCircuit._data), is fetched by a
+    user (through e.g. the QuantumCircuit.data property) and may be
+    subsequently updated, such that updates through the returned
+    ValidatedMutableSequence are checked to ensure consistency with
+    the QuantumCircuit instance.
+    """
+
+    def __init__(self, list_):
+        self._list = list_
+
+    def __getitem__(self, i):
+        return self._list[i]
+
+    @abstractmethod
+    def __delitem__(self, i):
+        pass
+
+    @abstractmethod
+    def __setitem__(self, index, value):
+        pass
+
+    @abstractmethod
+    def insert(self, index, value):
+        pass
+
+    def __len__(self):
+        return len(self._list)
+
+    def __cast(self, other):
+        return other._list if isinstance(other, type(self)) else other
+
+    def __repr__(self):
+        return repr(self._list)
+
+    def __lt__(self, other):
+        return self._list < self.__cast(other)
+
+    def __le__(self, other):
+        return self._list <= self.__cast(other)
+
+    def __eq__(self, other):
+        return self._list == self.__cast(other)
+
+    def __gt__(self, other):
+        return self._list > self.__cast(other)
+
+    def __ge__(self, other):
+        return self._list >= self.__cast(other)
+
+    def __add__(self, other):
+        return self._list + self.__cast(other)
+
+    def __radd__(self, other):
+        return self.__cast(other) + self._list
+
+    def __mul__(self, n):
+        return self._list * n
+
+    def __rmul__(self, n):
+        return n * self._list
+
+    def sort(self, *args, **kwargs):
+        """In-place stable sort. Accepts arguments of list.sort."""
+        self._list.sort(*args, **kwargs)
+
+    def copy(self):
+        """Returns a shallow copy of instruction list."""
+        return self._list.copy()
+
+
+class QuantumCircuitData(ValidatedMutableSequence):
     """A wrapper class for the purposes of validating modifications to
     QuantumCircuit.data while maintaining the interface of a python list."""
 
     def __init__(self, circuit):
         self._circuit = circuit
-
-    def __getitem__(self, i):
-        return self._circuit._data[i]
+        super().__init__(circuit._data)
 
     def __setitem__(self, key, value):
         instruction, qargs, cargs = value
@@ -59,52 +133,71 @@ class QuantumCircuitData(MutableSequence):
         self._circuit._update_parameter_table(instruction)
 
     def insert(self, index, value):
-        self._circuit._data.insert(index, None)
-        self[index] = value
+        try:
+            # To consolidate validation to __setitem__, insert None and overwrite.
+            self._list.insert(index, None)
+            self[index] = value
+        except CircuitError as err:
+            del self._list[index]
+            raise err
 
-    def __delitem__(self, i):
-        del self._circuit._data[i]
+    def __delitem__(self, index):
+        del self._list[index]
 
-    def __len__(self):
-        return len(self._circuit._data)
 
-    def __cast(self, other):
-        return other._circuit._data if isinstance(other, QuantumCircuitData) else other
+class QuantumCircuitQregs(ValidatedMutableSequence):
+    """A wrapper class for the purposes of validating modifications to
+    QuantumCircuit.qregs while maintaining the interface of a python list."""
 
-    def __repr__(self):
-        return repr(self._circuit._data)
+    def __init__(self, circuit):
+        self._circuit = circuit
+        super().__init__(circuit._qregs)
 
-    def __lt__(self, other):
-        return self._circuit._data < self.__cast(other)
+    def __setitem__(self, key, value):
+        self._circuit.add_register(value)
+        self._list[key] = value
+        del self._list[-1]
 
-    def __le__(self, other):
-        return self._circuit._data <= self.__cast(other)
+    def insert(self, index, value):
+        self._circuit.add_register(value)
+        self._list.insert(index, self._list[-1])
+        del self._list[-1]
 
-    def __eq__(self, other):
-        return self._circuit._data == self.__cast(other)
+    def __delitem__(self, index):
+        del self._list[index]
 
-    def __gt__(self, other):
-        return self._circuit._data > self.__cast(other)
+    def reverse(self):
+        # Override MutableSequence.reverse which uses repeated pairwise
+        # calls to __setitem__ that do not maintain uniqueness of registers
+        # in _list throughout, and so raises a "CircuitError: register name
+        # ... already exists"
+        self._list.reverse()
 
-    def __ge__(self, other):
-        return self._circuit._data >= self.__cast(other)
 
-    def __add__(self, other):
-        return self._circuit._data + self.__cast(other)
+class QuantumCircuitCregs(ValidatedMutableSequence):
+    """A wrapper class for the purposes of validating modifications to
+    QuantumCircuit.cregs while maintaining the interface of a python list."""
 
-    def __radd__(self, other):
-        return self.__cast(other) + self._circuit._data
+    def __init__(self, circuit):
+        self._circuit = circuit
+        super().__init__(circuit._cregs)
 
-    def __mul__(self, n):
-        return self._circuit._data * n
+    def __setitem__(self, key, value):
+        self._circuit.add_register(value)
+        self._list[key] = value
+        del self._list[-1]
 
-    def __rmul__(self, n):
-        return n * self._circuit._data
+    def insert(self, index, value):
+        self._circuit.add_register(value)
+        self._list.insert(index, self._list[-1])
+        del self._list[-1]
 
-    def sort(self, *args, **kwargs):
-        """In-place stable sort. Accepts arguments of list.sort."""
-        self._circuit._data.sort(*args, **kwargs)
+    def __delitem__(self, index):
+        del self._list[index]
 
-    def copy(self):
-        """Returns a shallow copy of instruction list."""
-        return self._circuit._data.copy()
+    def reverse(self):
+        # Override MutableSequence.reverse which uses repeated pairwise
+        # calls to __setitem__ that do not maintain uniqueness of registers
+        # in _list throughout, and so raises a "CircuitError: register name
+        # ... already exists"
+        self._list.reverse()


### PR DESCRIPTION
Adds two new classes, QuantumCircuitQregs and
QuantumCircuitCregs, which, in the spirit of QuantumCircuitData,
provide validated list-like interfaces for circuit.qregs and
circuit.cregs.  Resolves #7009 .

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

WIP for comments from @jakelishman in https://github.com/Qiskit/qiskit-terra/pull/6621#pullrequestreview-714790219 .

