### PR TITLE
[WIP] Fix issue #6185

### DIFF
--- a/qiskit/circuit/library/n_local/two_local.py
+++ b/qiskit/circuit/library/n_local/two_local.py
@@ -214,7 +214,7 @@ class TwoLocal(NLocal):
         if isinstance(layer, (str, type)):
             instance = self._get_gate_instance(layer)
             if instance is None:
-                raise ValueError(f"Unknown layer `{layer}`.")
+                raise ValueError(f"Layer `{layer}` is not supported.")
             layer = instance
 
         if isinstance(layer, Instruction):
@@ -249,9 +249,6 @@ class TwoLocal(NLocal):
                 if hasattr(gate, "num_params"):
                     for i in range(gate.num_params):
                         params.append(Parameter(f"θ{i}"))
-                if hasattr(gate, "num_int_params"):
-                    for _ in range(gate.num_int_params):
-                        params.append(1)
                 # instantiate gate with appropriate params
                 try:
                     instance = gate(*params)

--- a/test/python/circuit/library/test_nlocal.py
+++ b/test/python/circuit/library/test_nlocal.py
@@ -795,7 +795,7 @@ class TestTwoLocal(QiskitTestCase):
             TwoLocal(3, "ry", standard_gates.MSGate, "linear", reps=2)
 
     def test_all_standard_gates(self):
-        """Test TwoLocal works with every standard gate"""
+        """Test TwoLocal works with every supported standard gate"""
         gates_dict = {
             cls_name: cls
             for (cls_name, cls) in standard_gates.__dict__.items()

--- a/test/python/circuit/library/test_nlocal.py
+++ b/test/python/circuit/library/test_nlocal.py
@@ -37,6 +37,7 @@ from qiskit.circuit.library import (
     RXXGate,
     RYYGate,
     CXGate,
+    standard_gates,
 )
 from qiskit.circuit.random.utils import random_circuit
 from qiskit.converters.circuit_to_dag import circuit_to_dag
@@ -782,6 +783,33 @@ class TestTwoLocal(QiskitTestCase):
 
         self.assertEqual(two_np32.decompose().count_ops()["cx"], expected_cx)
         self.assertEqual(two_np64.decompose().count_ops()["cx"], expected_cx)
+
+    def test_unknown_layer_error(self):
+        """Test if TwoLocal throws error with unknown layer name"""
+        with self.assertRaisesRegex(ValueError, "Unknown layer `abc`"):
+            TwoLocal(3, "ry", "abc", "linear", reps=2)
+
+    def test_unsupported_layer_error(self):
+        """Test if TwoLocal throws error with unsupported gate"""
+        with self.assertRaisesRegex(ValueError, f"Unable to instantiate {standard_gates.MSGate}"):
+            TwoLocal(3, "ry", standard_gates.MSGate, "linear", reps=2)
+
+    def test_all_standard_gates(self):
+        """Test TwoLocal works with every standard gate"""
+        gates_dict = {
+            cls_name: cls
+            for (cls_name, cls) in standard_gates.__dict__.items()
+            if isinstance(cls, type)
+        }
+        unsupported_gates = ["MSGate", "MCXGate", "MCXGrayCode", "MCXRecursive", "MCXVChain"]
+
+        for key in unsupported_gates:
+            del gates_dict[key]
+
+        for gate in gates_dict.values():
+            two = TwoLocal(4, "ry", gate, "linear", reps=2)
+            print(gate)
+            self.assertIsInstance(two.entanglement_blocks[0].data[0][0], gate)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

fixes #6185, depends on #6883  

Replaces `valid_layers` with a `_get_gate_instance` function that iterates over all gates in standard library

### Details and comments

To do:
- [x] ~~twolocal should throw error for multi-controlled gates~~
- [ ] should the rotation layer blocks only support single qubit gates? The two_local docstring says The rotation layers are single qubit gates applied on all qubits but even in main branch you can set rotation_blocks="cx" and it will work