### PR TITLE
[WIP] Add iterator peel

### DIFF
--- a/qiskit/utils/__init__.py
+++ b/qiskit/utils/__init__.py
@@ -27,6 +27,7 @@ Utilities (:mod:`qiskit.utils`)
    is_main_process
    apply_prefix
    detach_prefix
+   peel
 
 Algorithm Utilities
 ===================
@@ -64,6 +65,7 @@ from .deprecation import deprecate_function
 from .multiprocessing import local_hardware_info
 from .multiprocessing import is_main_process
 from .units import apply_prefix, detach_prefix
+form .peel import peel
 
 from .circuit_utils import summarize_circuits
 from .entangler_map import get_entangler_map, validate_entangler_map
@@ -86,4 +88,5 @@ __all__ = [
     "local_hardware_info",
     "is_main_process",
     "apply_prefix",
+    "peel"
 ]

--- a/qiskit/utils/peel.py
+++ b/qiskit/utils/peel.py
@@ -1,0 +1,21 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""An iterator that returns the first item and an iterator over the remaining items of an iterable."""
+
+def peel(iterable):
+    """Return a tuple containing the first item in iterable and an iterator
+    over the remaining items.
+    """
+    iterator = iter(iterable)
+    first = next(iterator)
+    return  first, iterator


### PR DESCRIPTION
This iterator replaces a common idiom with an iterator that is a bit more elegant and performant.
It returns the first item in an iterable and an iterator over the remaining
items. Something like the following occurs many times in qiskit
```python
first = items[0]
for x in items[1:]:
    compare(x, first)
```
This would be replaced by
```python
from qiskit.utils import peel

first, rest = peel(items)
for x in rest:
     compare(x, first)
    ...
```

Here is an example in a new PR https://github.com/Qiskit/qiskit-terra/pull/7202
```python
        for other in ops[1:]:
            ops[0]._op_shape._validate_add(other._op_shape)
```

I searched for a while for this iterator in external libraries, but didn't find anything.
I have not begun to replace instances of this idiom in qiskit with calls to `peel`.

* This signals intent by putting the peeling procedure in one place. Often the two uses are separated. You might ask "why `items[1:]`", and then find several lines further that `items[0]` is treated specially.
*  It may be more efficient especially for large lists because `items[1:]` creates a new list, at least of references.
