### PR TITLE
[WIP] Fix memory usage issues in `BasisTranslator`, `BarrierBeforeFinalMeasurements`, `DAGFixedPoint` and `Decompose` transpiler passes, fixes issue #7485

### DIFF
--- a/qiskit/transpiler/passes/basis/decompose.py
+++ b/qiskit/transpiler/passes/basis/decompose.py
@@ -78,7 +78,7 @@ class Decompose(TransformationPass):
         self._make_gate_lists()
 
     def _make_gate_lists(self):
-        """Make comparison lists for the gates"""
+        """Make comparison lists for the gate list"""
         if not isinstance(self.gates_to_decompose, list):
             gates = [self.gates_to_decompose]
         else:

--- a/qiskit/transpiler/passes/basis/decompose.py
+++ b/qiskit/transpiler/passes/basis/decompose.py
@@ -44,6 +44,7 @@ class Decompose(TransformationPass):
             self.gates_to_decompose = gate
         else:
             self.gates_to_decompose = gates_to_decompose
+        self._make_gate_lists()
 
     @property
     def gate(self) -> Gate:
@@ -74,6 +75,19 @@ class Decompose(TransformationPass):
             stacklevel=2,
         )
         self.gates_to_decompose = value
+        self._make_gate_lists()
+
+    def _make_gate_lists(self):
+        """Make comparison lists for the gates"""
+        if not isinstance(self.gates_to_decompose, list):
+            gates = [self.gates_to_decompose]
+        else:
+            gates = self.gates_to_decompose
+
+        self._strings_list, self._gate_type_list = [], []
+        if gates is not None:
+            self._strings_list = [s for s in gates if isinstance(s, str)]
+            self._gate_type_list = [g for g in gates if isinstance(g, type)]
 
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         """Run the Decompose pass on `dag`.
@@ -114,22 +128,19 @@ class Decompose(TransformationPass):
         else:
             gates = self.gates_to_decompose
 
-        strings_list = [s for s in gates if isinstance(s, str)]
-        gate_type_list = [g for g in gates if isinstance(g, type)]
-
         if hasattr(node.op, "label") and node.op.label is not None:
             has_label = True
 
         if has_label and (  # check if label or label wildcard is given
-            node.op.label in gates or any(fnmatch(node.op.label, p) for p in strings_list)
+            node.op.label in gates or any(fnmatch(node.op.label, p) for p in self._strings_list)
         ):
             return True
         elif not has_label and (  # check if name or name wildcard is given
-            node.name in gates or any(fnmatch(node.name, p) for p in strings_list)
+            node.name in gates or any(fnmatch(node.name, p) for p in self._strings_list)
         ):
             return True
         elif not has_label and (  # check if Gate type given
-            any(isinstance(node.op, op) for op in gate_type_list)
+            any(isinstance(node.op, op) for op in self._gate_type_list)
         ):
             return True
         else:

--- a/qiskit/transpiler/passes/utils/dag_fixed_point.py
+++ b/qiskit/transpiler/passes/utils/dag_fixed_point.py
@@ -32,5 +32,5 @@ class DAGFixedPoint(AnalysisPass):
         else:
             fixed_point_reached = self.property_set["_dag_fixed_point_previous_dag"] == dag
             self.property_set["dag_fixed_point"] = fixed_point_reached
-
+            del self.property_set["_dag_fixed_point_previous_dag"]
         self.property_set["_dag_fixed_point_previous_dag"] = deepcopy(dag)

--- a/qiskit/transpiler/passes/utils/merge_adjacent_barriers.py
+++ b/qiskit/transpiler/passes/utils/merge_adjacent_barriers.py
@@ -101,7 +101,7 @@ class MergeAdjacentBarriers(TransformationPass):
         # Start from the first barrier
         current_barrier = barriers[0]
         end_of_barrier = current_barrier
-        current_barrier_nodes = [current_barrier]
+        current_barrier_nodes = set([current_barrier])
 
         current_qubits = set(current_barrier.qargs)
         current_ancestors = dag.ancestors(current_barrier)
@@ -140,7 +140,7 @@ class MergeAdjacentBarriers(TransformationPass):
                     barrier_to_add = Barrier(len(current_qubits))
 
                     end_of_barrier = next_barrier
-                    current_barrier_nodes.append(end_of_barrier)
+                    current_barrier_nodes.add(end_of_barrier)
 
                     continue
 
@@ -156,10 +156,10 @@ class MergeAdjacentBarriers(TransformationPass):
             current_descendants = dag.descendants(next_barrier)
 
             barrier_to_add = Barrier(len(current_qubits))
-            current_barrier_nodes = []
+            current_barrier_nodes = set()
 
             end_of_barrier = next_barrier
-            current_barrier_nodes.append(end_of_barrier)
+            current_barrier_nodes.add(end_of_barrier)
 
         if barrier_to_add:
             node_to_barrier_qubits[end_of_barrier] = current_qubits


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fix memory usage issues in `BasisTranslator`, `DAGFixedPoint` and `Decompose` transpiler passes, fixes #7485 


### Details and comments
#### `Decompose` 
- The original `_should_decompose` method tried to make two variables `strings_list` and `gate_type_list` repeatedly during the call of the method. 
- This should not be the case as the lists only depend on the `gates_to_decompose` attribute of the pass, which is invariant during the call of the `run` method
- New attributes are introduced for the `strings_list` and the `gate_type_list` lists. 
- Although this may not have much effect on the memory usage of the pass, this should have some improvement in the run time of the pass. 
#### `BasisTranslator` - to do
#### `BarrierBeforeFinalMeasurements` 
- There is a dependency of `MergeAdjacentBarriers` in the above pass. 
- The variable `current_barrier_nodes` [here](https://github.com/Qiskit/qiskit-terra/blob/main/qiskit/transpiler/passes/utils/merge_adjacent_barriers.py#L104) was used only for membership checking
- A `set` would serve as a more optimal data structure here
- **Note** : Memory leakage is yet to be detected
#### `DAGFixedPoint` 
- There was a usage of `deepcopy`, for saving a copy of the `dag`, in the property set of the circuit.
-  This may have been a point of memory leakage and thus an explicit delete was introduced before the re-assignment.
