### PR TITLE
Lightweight Schedule

### DIFF
--- a/qiskit/providers/models/pulsedefaults.py
+++ b/qiskit/providers/models/pulsedefaults.py
@@ -202,11 +202,13 @@ class PulseDefaults:
         self.instruction_schedule_map = InstructionScheduleMap()
 
         self.converter = QobjToInstructionConverter(pulse_library)
-        for inst in cmd_def:
-            pulse_insts = [self.converter(inst) for inst in inst.sequence]
-            schedule = Schedule(*pulse_insts, name=inst.name)
+        for command in cmd_def:
+            schedule = Schedule(name=command.name)
+            for qobj_inst in command.sequence:
+                t0, pulse_inst = self.converter(qobj_inst)
+                schedule.insert(t0, pulse_inst, inplace=True, validate=False)
             schedule.metadata["publisher"] = CalibrationPublisher.BACKEND_PROVIDER
-            self.instruction_schedule_map.add(inst.name, inst.qubits, schedule)
+            self.instruction_schedule_map.add(command.name, command.qubits, schedule)
 
         if meas_kernel is not None:
             self.meas_kernel = meas_kernel

--- a/qiskit/pulse/filters.py
+++ b/qiskit/pulse/filters.py
@@ -56,7 +56,7 @@ def filter_instructions(
 
     filter_schedule = Schedule.initialize_from(sched)
     for time, inst in time_inst_tuples[valid_insts]:
-        filter_schedule.insert(time, inst, inplace=True)
+        filter_schedule.insert(time, inst, inplace=True, validate=False)
 
     return filter_schedule
 

--- a/qiskit/pulse/timeslot_manager.py
+++ b/qiskit/pulse/timeslot_manager.py
@@ -1,0 +1,132 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+from typing import Tuple, Dict, Union, Iterator, List, Sequence, Optional, TYPE_CHECKING
+
+from collections import defaultdict
+import numpy as np
+
+from qiskit.pulse.exceptions import PulseError
+
+if TYPE_CHECKING:
+    from qiskit.pulse.instructions import Instruction
+    from qiskit.pulse.schedule import Schedule
+    from qiskit.pulse.channels import Channel
+
+
+class TimeslotManager:
+
+    def __init__(self):
+        self._timeslots = defaultdict(list)
+        self._idle_after = None
+
+    def __len__(self):
+        return sum(len(slots) for slots in self._timeslots.values())
+
+    @property
+    def timeslots(self) -> Dict["Channel", List[Tuple[int, int]]]:
+        return self._timeslots
+
+    @property
+    def channels(self) -> Tuple["Channel"]:
+        return tuple(self._timeslots.keys())
+
+    @property
+    def duration(self) -> int:
+        if self._idle_after is None:
+            self._idle_after = self.find_idle_after()
+
+        return self._idle_after
+
+    def regenerate(self, t0_inst_tups: Iterator[Tuple[int, Union["Instruction", "Schedule"]]]):
+        self.clear()
+        self._idle_after = None
+
+        for t0, inst in t0_inst_tups:
+            if not np.issubdtype(type(t0), np.integer):
+                raise PulseError("Schedule start time must be an integer.")
+            if t0 < 0:
+                PulseError(f"An instruction on {inst.channels} has a negative starting time.")
+
+            if hasattr(inst, "timeslots"):
+                # TODO Cleaner logic is needed here
+                from qiskit.pulse.transforms import flatten
+                flat_sched = flatten(inst)
+                reservation = {
+                    chan: (t0 + ts, t0 + tf) for chan, (ts, tf) in flat_sched.timeslots.items()
+                }
+            else:
+                reservation = {chan: (t0, t0 + inst.duration) for chan in inst.channels}
+
+            overlaps = set(reservation.keys() & self._timeslots.keys())
+            while overlaps:
+                chan = overlaps.pop()
+                interval = reservation.pop(chan)
+                self._check_overlap(inst_name=inst.name, chan=chan, interval=interval, t0=t0)
+                self._timeslots[chan].append(interval)
+
+            self._timeslots.update(reservation)
+
+    def add(self, inst_name: str, channels: Sequence["Channel"], interval: Tuple[int, int]):
+        for chan in channels:
+            self._check_overlap(inst_name=inst_name, chan=chan, interval=interval)
+            self._timeslots[chan].append(interval)
+
+    def _check_overlap(
+        self,
+        inst_name: str,
+        chan: "Channel",
+        interval: Tuple[int, int],
+        t0: Optional[int] = None,
+    ):
+        def _check_overlap(occupied: Tuple[int, int]):
+            return max(interval[0], occupied[0]) < min(interval[1], occupied[1])
+        if any(_check_overlap(occupied) for occupied in self._timeslots[chan]):
+            t0 = t0 if t0 is not None else interval[0]
+            raise PulseError(
+                f"Schedule(name={inst_name}) cannot be inserted at time {t0} "
+                f"because its instruction on channel {chan} scheduled from time "
+                f"{interval[0]} to {interval[1]} overlaps with an existing instruction."
+            )
+
+    def find_idle_after(self, channels: Optional[Sequence["Channel"]] = None) -> int:
+        if channels is not None:
+            channels = list(self._timeslots.keys())
+
+        if all(chan not in self._timeslots for chan in channels):
+            return 0
+
+        idle_after = 0
+        for chan in channels:
+            if chan not in self._timeslots:
+                continue
+            chan_idle_after = max(interval[1] for interval in self._timeslots[chan])
+            idle_after = max(idle_after, chan_idle_after)
+        return idle_after
+
+    def find_start_at(self, channels: Optional[Sequence["Channel"]] = None) -> int:
+        if channels is not None:
+            channels = list(self._timeslots.keys())
+
+        if all(chan not in self._timeslots for chan in channels):
+            return 0
+
+        start_at = self.duration
+        for chan in channels:
+            if chan not in self._timeslots:
+                continue
+            chan_start_at = min(interval[0] for interval in self._timeslots[chan])
+            start_at = min(start_at, chan_start_at)
+        return start_at
+
+    def clear(self):
+        self._timeslots.clear()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Loading instruction schedule map from a backend becomes significant overhead as the qubit size increases. Currently it constructs `Schedule` instance from `CmdDef` entries, and the schedule evaluates timeslots per every `.insert` call. This is inefficient because schedules in the command definition have been already scheduled on the backend. This PR allows user to create a schedule without creating the timeslot.

### Details and comments

Currently the main user interface of Qiskit pulse programming is the pulse builder, in which a schedule is created as a `ScheduleBlock` instance with relative-timing representation with alignment context. The scheduling is done behind the scene at run time with these pulse transform passes.
https://github.com/Qiskit/qiskit-terra/blob/cffbb849344a501be624a75e64dcf757a41a6921/qiskit/pulse/transforms/base_transforms.py#L25-L28
This means user doesn't need to schedule the instructions by oneself, and in principle we can drop most of functionalities to control timeslots on `Schedule` (currently it supports `shift`, `append`, `replace`, `insert`). To create `Schedule`s we only need `insert` method taking an absolute timing t0, that the transform pass may provide. Thus, eventually the schedule can be just a data container to store the list of (`t0, instruction`) pair -- end-user will only deal with `ScheduleBlock` through the builder, rather than directly constructing `Schedules`s by manually calculating instruction timings. Schedule is then only instantiated by drawer, simulator, and qobj converters (if still supported). Validation of schedule timeslot could be delegated to transpiler passes, or even to backend (if backend can receive schedule block), when we completely migrate to from schedule to the pulse gate execution model. 

Note that still there could be many users who use `Schedule` because of [this paper](https://arxiv.org/abs/2004.06755). 

---
This PR does some simplification of `Schedule` as a first step. Here is some performance comparison.
- separate timeslots from `Schedule`
- add validate option to insert method

```python
backend = FakeWashingtonV2()  # no cache
backend.target
``` 

Current main: 3.51 s ± 222 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
This branch: 885 ms ± 36.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)