### PR TITLE
transforms (pulses): compress_pulses() speedup

### DIFF
--- a/qiskit/pulse/transforms/canonicalization.py
+++ b/qiskit/pulse/transforms/canonicalization.py
@@ -85,7 +85,10 @@ def compress_pulses(schedules: List[Schedule]) -> List[Schedule]:
     Returns:
         Compressed schedules.
     """
-    existing_pulses = []
+    pulse_index = 0
+    existing_pulse_set = set()
+    pulse_index_map = dict()    # mapping pulse -> index
+    index_pulse_map = dict()    # mapping index -> pulse
     new_schedules = []
 
     for schedule in schedules:
@@ -93,16 +96,20 @@ def compress_pulses(schedules: List[Schedule]) -> List[Schedule]:
 
         for time, inst in schedule.instructions:
             if isinstance(inst, instructions.Play):
-                if inst.pulse in existing_pulses:
-                    idx = existing_pulses.index(inst.pulse)
-                    identical_pulse = existing_pulses[idx]
+                if inst.pulse in existing_pulse_set:
+                    idx = pulse_index_map[inst.pulse]
+                    identical_pulse = index_pulse_map[idx]
+
                     new_schedule.insert(
                         time,
                         instructions.Play(identical_pulse, inst.channel, inst.name),
                         inplace=True,
                     )
                 else:
-                    existing_pulses.append(inst.pulse)
+                    existing_pulse_set.add(inst.pulse)
+                    pulse_index_map[inst.pulse] = pulse_index
+                    index_pulse_map[pulse_index] = inst.pulse
+                    pulse_index += 1
                     new_schedule.insert(time, inst, inplace=True)
             else:
                 new_schedule.insert(time, inst, inplace=True)


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

-->

### Summary

﻿The previous implementation used list lookup, which is O(list length),
and increased as the number of items in the list increased.

This new method uses O(1) lookup for comparing pulses, while maintaining
the same functionality, for a dramatic speed improvement as the
number of pulses increases.


### Details and comments

- [x] I have added the tests to cover my changes. **The tests should already exist, no external functionality change.**
- [ ] I have updated the documentation accordingly. **Unsure if documentation needs to be changed, this is purely an internal speedup with no API changes.**
- [x] I have read the CONTRIBUTING document.
