### PR TITLE
[WIP] Add getter of minimal attributes necessary for pulse simulation in FakeBackendV2

### DIFF
--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -85,7 +85,7 @@ class FakeBackendV2(BackendV2):
         self.sim = None
 
     def __getattr__(self, name: str) -> Any:
-        """Getter of minimal hidden attributes necessary for pulse-level simulation."""
+        """Getter of minimal custom attributes necessary for pulse-level simulation."""
         if name not in {"hamiltonian", "u_channel_lo"}:
             raise AttributeError(
                 "'{}' object has no attribute '{}'".format(self.__class__.__name__, name)

--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -85,8 +85,20 @@ class FakeBackendV2(BackendV2):
         self.sim = None
 
     def __getattr__(self, name: str) -> Any:
-        """Gets attribute from configuration if self does not yet have it."""
+        """Getter of minimal hidden attributes necessary for pulse-level simulation."""
+        if name not in {"hamiltonian", "u_channel_lo"}:
+            raise AttributeError(
+                "'{}' object has no attribute '{}'".format(self.__class__.__name__, name)
+            )
+
         if self._conf_dict and name in self._conf_dict:
+            if name == "u_channel_lo":
+                from qiskit.providers.models import UchannelLO
+
+                return [
+                    [UchannelLO.from_dict(x) for x in channel] for channel in self._conf_dict[name]
+                ]
+
             return self._conf_dict[name]
 
         raise AttributeError(

--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -20,7 +20,7 @@ import warnings
 import json
 import os
 
-from typing import List
+from typing import List, Any
 
 from qiskit import circuit
 from qiskit.providers.models import BackendProperties
@@ -84,6 +84,15 @@ class FakeBackendV2(BackendV2):
         self._target = None
         self.sim = None
 
+    def __getattr__(self, name: str) -> Any:
+        """Gets attribute from configuration if self does not yet have it."""
+        if self._conf_dict and name in self._conf_dict:
+            return self._conf_dict[name]
+
+        raise AttributeError(
+            "'{}' object has no attribute '{}'".format(self.__class__.__name__, name)
+        )
+
     def _setup_sim(self):
         if _optionals.HAS_AER:
             from qiskit.providers import aer
@@ -131,7 +140,6 @@ class FakeBackendV2(BackendV2):
         :rtype: Target
         """
         if self._target is None:
-            self._get_conf_dict_from_json()
             if self._props_dict is None:
                 self._set_props_dict_from_json()
             if self._defs_dict is None:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Exceptionally add getter function of two custom attributes `hamiltonian` and `u_channel_lo` to `FakeBackendV2`. Those attributes are necessary for pulse simulation. They were in `configuration()` in BackendV1 but they disappear in BackendV2.

### Details and comments
Currently, `FakeManila().configuration().hamiltonian` (`u_channel_lo`) returns Hamiltonian string (list of u channels info) while the counterpart `FakeManilaV2().hamiltonian` (`u_channel_lo`) fails with `AttributeError`. This commit enables to get those two attributes without failing by adding `FakeBackendV2.__getattr__()` function.