### PR TITLE
Convert PassManager.passes to property

### DIFF
--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -328,7 +328,7 @@ class PassManager:
                 warn("The `PassManager.passes()` method is deprecated as of 0.22.0, and "
                     "will be removed no earlier than 3 months after that "
                     "release date. You should use the `PassManager.passes` property instead.",
-                    DeprecationWarning, stacklevel=2)
+                    PendingDeprecationWarning, stacklevel=2)
                 return self
 
         return CallableList(ret)

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -323,14 +323,15 @@ class PassManager:
                 item["flow_controllers"] = {}
             ret.append(item)
 
-        def call(self):
-            warn("The `PassManager.passes()` method is deprecated as of 0.22.0, and "
-                  "will be removed no earlier than 3 months after that "
-                  "release date. You should use the `PassManager.passes` property instead.", DeprecationWarning, stacklevel=2)
-            return self
+        class CallableList(list):
+            def __call__(self) -> List:
+                warn("The `PassManager.passes()` method is deprecated as of 0.22.0, and "
+                    "will be removed no earlier than 3 months after that "
+                    "release date. You should use the `PassManager.passes` property instead.",
+                    DeprecationWarning, stacklevel=2)
+                return self
 
-        ret.__call__ = call
-        return ret
+        return CallableList(ret)
 
 
 class StagedPassManager(PassManager):

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -321,10 +321,13 @@ class PassManager:
 
         class CallableList(list):
             def __call__(self) -> List:
-                warn("The `PassManager.passes()` method is deprecated as of 0.22.0, and "
+                warn(
+                    "The `PassManager.passes()` method is deprecated as of 0.22.0, and "
                     "will be removed no earlier than 3 months after that "
                     "release date. You should use the `PassManager.passes` property instead.",
-                    PendingDeprecationWarning, stacklevel=2)
+                    PendingDeprecationWarning,
+                    stacklevel=2,
+                )
                 return self
 
         return CallableList(ret)

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -319,7 +319,7 @@ class PassManager:
                 item["flow_controllers"] = {}
             ret.append(item)
 
-        class CallableList(list):
+        class CallableList(list):  # pylint: disable=C0115
             def __call__(self) -> List:
                 warn(
                     "The `PassManager.passes()` method is deprecated as of 0.22.0, and "

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -309,11 +309,7 @@ class PassManager:
 
     @property
     def passes(self) -> List[Dict[str, BasePass]]:
-        """List structure of the appended passes and its options.
-
-        Returns:
-            A list of pass sets, as defined in ``append()``.
-        """
+        """List structure of the appended passes and its options"""
         ret = []
         for pass_set in self._pass_sets:
             item = {"passes": pass_set["passes"]}

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -15,6 +15,7 @@
 import io
 import re
 from typing import Union, List, Callable, Dict, Any
+from warnings import warn
 
 import dill
 
@@ -306,8 +307,9 @@ class PassManager:
 
         return pass_manager_drawer(self, filename=filename, style=style, raw=raw)
 
+    @property
     def passes(self) -> List[Dict[str, BasePass]]:
-        """Return a list structure of the appended passes and its options.
+        """List structure of the appended passes and its options.
 
         Returns:
             A list of pass sets, as defined in ``append()``.
@@ -320,6 +322,14 @@ class PassManager:
             else:
                 item["flow_controllers"] = {}
             ret.append(item)
+
+        def call(self):
+            warn("The `PassManager.passes()` method is deprecated as of 0.22.0, and "
+                  "will be removed no earlier than 3 months after that "
+                  "release date. You should use the `PassManager.passes` property instead.", DeprecationWarning, stacklevel=2)
+            return self
+
+        ret.__call__ = call
         return ret
 
 
@@ -491,9 +501,10 @@ class StagedPassManager(PassManager):
         self._update_passmanager()
         return super()._create_running_passmanager()
 
+    @property
     def passes(self) -> List[Dict[str, BasePass]]:
         self._update_passmanager()
-        return super().passes()
+        return super().passes
 
     def run(
         self,

--- a/releasenotes/notes/passmanager-passes-154f9b23b7101192.yaml
+++ b/releasenotes/notes/passmanager-passes-154f9b23b7101192.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    * Convert `PassManager.passes()` to a property.
+deprecations:
+  - |
+    * Pending deprecation of method call `PassManager.passes()`.

--- a/test/python/transpiler/test_passmanager.py
+++ b/test/python/transpiler/test_passmanager.py
@@ -118,7 +118,7 @@ class TestPassManager(QiskitTestCase):
     def test_passes_deprecation_warning(self):
         passmanager = PassManager()
         passmanager.append(CommutativeCancellation(basis_gates=["u1", "u2", "u3", "cx"]))
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarns(PendingDeprecationWarning):
             passes = passmanager.passes()
         self.assertIsInstance(passes, list)
         self.assertIsInstance(passmanager.passes, list)

--- a/test/python/transpiler/test_passmanager.py
+++ b/test/python/transpiler/test_passmanager.py
@@ -114,3 +114,12 @@ class TestPassManager(QiskitTestCase):
         self.assertIsInstance(calls[0]["time"], float)
         self.assertIsInstance(calls[0]["property_set"], PropertySet)
         self.assertEqual("MyCircuit", calls[1]["dag"].name)
+
+    def test_passes_deprecation_warning(self):
+        passmanager = PassManager()
+        passmanager.append(CommutativeCancellation(basis_gates=["u1", "u2", "u3", "cx"]))
+        with self.assertWarns(DeprecationWarning):
+            passes = passmanager.passes()
+        self.assertIsInstance(passes, list)
+        self.assertIsInstance(passmanager.passes, list)
+        self.assertEqual(passes, passmanager.passes)

--- a/test/python/transpiler/test_passmanager.py
+++ b/test/python/transpiler/test_passmanager.py
@@ -116,6 +116,7 @@ class TestPassManager(QiskitTestCase):
         self.assertEqual("MyCircuit", calls[1]["dag"].name)
 
     def test_passes_deprecation_warning(self):
+        """Test deprecation logic for passes callable"""
         passmanager = PassManager()
         passmanager.append(CommutativeCancellation(basis_gates=["u1", "u2", "u3", "cx"]))
         with self.assertWarns(PendingDeprecationWarning):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Convert `PassManager.passes` to property and introduce deprecation warning when called

Breaking change
Closes #8239 
Changelog: New Feature
Changelog: Deprecation

<!-- ### Details and comments -->


