### PR TITLE
Add memoization to StagedPassmanager

### DIFF
--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -18,7 +18,7 @@ import re
 try:
     from functools import cached_property
 except ImportError:  # Below python 3.8
-    cached_property = property
+    cached_property = property  # pylint: disable=invalid-name
 
 from typing import Union, List, Tuple, Callable, Dict, Any, Optional, Iterator, Iterable
 
@@ -424,7 +424,7 @@ class StagedPassManager(PassManager):
 
     def _validate_init_kwargs(self, kwargs: Dict[str, Any]) -> None:
         expanded_stages = set(self.expanded_stages)
-        for stage in kwargs.keys():
+        for stage in kwargs:
             if stage not in expanded_stages:
                 raise AttributeError(f"{stage} is not a valid stage.")
 

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -17,8 +17,9 @@ import re
 
 try:
     from functools import cached_property
-except ImportError:
+except ImportError:  # Below python 3.8
     cached_property = property
+
 from typing import Union, List, Tuple, Callable, Dict, Any, Optional, Iterator, Iterable
 
 import dill

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -14,6 +14,7 @@
 
 import io
 import re
+from functools import cached_property
 from typing import Union, List, Tuple, Callable, Dict, Any, Optional, Iterator, Iterable
 
 import dill
@@ -379,7 +380,7 @@ class StagedPassManager(PassManager):
             stages (Iterable[str]): An optional list of stages to use for this
                 instance. If this is not specified the default stages list
                 ``['init', 'layout', 'routing', 'translation', 'optimization', 'scheduling']`` is
-                used. After instantiation, the final list will be immutable and stored as tuple.
+                used. After instantiation, the final list will be immutable and stored as a tuple.
             kwargs: The initial :class:`~.PassManager` values for any stages
                 defined in ``stages``. If a argument is not defined the
                 stages will default to ``None`` indicating an empty/undefined
@@ -398,9 +399,7 @@ class StagedPassManager(PassManager):
             "scheduling",
         ]
         self._validate_stages(stages)
-        # Set through parent class since `__setattr__` requieres `expanded_stages` to be defined
-        super().__setattr__("_stages", tuple(stages))
-        super().__setattr__("_expanded_stages", tuple(self._generate_expanded_stages()))
+        self._stages = tuple(stages)
         super().__init__()
         self._validate_init_kwargs(kwargs)
         for stage in self.expanded_stages:
@@ -427,12 +426,12 @@ class StagedPassManager(PassManager):
     @property
     def stages(self) -> Tuple[str, ...]:
         """Pass manager stages"""
-        return self._stages  # pylint: disable=no-member
+        return self._stages
 
-    @property
+    @cached_property
     def expanded_stages(self) -> Tuple[str, ...]:
         """Expanded Pass manager stages including ``pre_`` and ``post_`` phases."""
-        return self._expanded_stages  # pylint: disable=no-member
+        return tuple(self._generate_expanded_stages())
 
     def _generate_expanded_stages(self) -> Iterator[str]:
         for stage in self.stages:

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -14,7 +14,10 @@
 
 import io
 import re
-from functools import cached_property
+try:
+    from functools import cached_property
+except ImportError:
+    cached_property = property
 from typing import Union, List, Tuple, Callable, Dict, Any, Optional, Iterator, Iterable
 
 import dill

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -18,7 +18,9 @@ import re
 try:
     from functools import cached_property
 
-    class immutable_cached_property(cached_property):
+    class immutable_cached_property(cached_property):  # pylint: disable=invalid-name
+        """Immutable cached_property memoization descriptor"""
+
         def __set__(self, instance, value):
             raise AttributeError("can't set attribute")
 
@@ -26,18 +28,7 @@ try:
             raise AttributeError("can't delete attribute")
 
 except ImportError:  # Below python 3.8
-
-    class immutable_cached_property(property):
-        def __init__(self, func):
-            self.func = func
-
-        def __call__(self, *args, **kwargs):
-            try:
-                return self.cache
-            except AttributeError:
-                self.cache = self.func(*args, **kwargs)
-                return self.cache
-
+    immutable_cached_property = property  # pylint: disable=invalid-name
 
 from typing import Union, List, Tuple, Callable, Dict, Any, Optional, Iterator, Iterable
 

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -14,6 +14,7 @@
 
 import io
 import re
+
 try:
     from functools import cached_property
 except ImportError:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Simplifies code and improves readability by introducing memoization for `expanded_stages` in `StagedPassmanager`  through the `cached_property` decorator in functools. @mtreinish @jakelishman 


### Details and comments
1. Removes need to call parent class `__setattr__`.
2. Removes pylint ignores.
3. Removes need to set `self._expanded_stages` attribute.
4. Maintains efficiency and functionality thanks to `self.expanded_stages` immutability.