### PR TITLE
fixed issue 8438 PauliList.evolve raises exception

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -689,5 +689,5 @@ def _count_y(x, z, dtype=None):
     """Count the number of I Pauli's"""
     axis = 1
     if dtype is None:
-        dtype = np.min_scalar_type(x.shape[axis])
+        dtype = np.int64(x.shape[axis])
     return (x & z).sum(axis=axis, dtype=dtype)

--- a/releasenotes/notes/fix_evolve_raises_exception_in_Cliffordcircuits-46453dfbef7ac2e2.yaml
+++ b/releasenotes/notes/fix_evolve_raises_exception_in_Cliffordcircuits-46453dfbef7ac2e2.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed an issue with the a bug in the BasePauli/Pauli classes where the phase vector is sometimes set as 
+    dtype uint8 instead of int64 leading to errors when calling the evolve function for circuits containing 
+    gates that modify the pauli phase vector.
+    The dtype of the phase vector should always be the same, so that evolution and other methods that attempt
+    to inplace modify the vector don't cause exceptions for mismatched dtypes.
+    Fixed #8438 <https://github.com/Qiskit/qiskit-terra/issues/8438>

--- a/test/python/quantum_info/operators/symplectic/test_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli.py
@@ -42,7 +42,6 @@ from qiskit.test import QiskitTestCase
 from qiskit.quantum_info.random import random_clifford, random_pauli
 from qiskit.quantum_info.operators import Pauli, Operator
 from qiskit.quantum_info.operators.symplectic.pauli import _split_pauli_label, _phase_from_label
-import qiskit.quantum_info as qi
 
 
 @lru_cache(maxsize=8)

--- a/test/python/quantum_info/operators/symplectic/test_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli.py
@@ -440,7 +440,7 @@ class TestPauli(QiskitTestCase):
         qc.cz(0, 1)
         op = Operator(qc)
 
-        pauli = qi.random_pauli(2, seed=123)
+        pauli = random_pauli(2, seed=123)
 
         value = Operator(pauli.evolve(qc))
         target = op.adjoint().dot(pauli).dot(op)

--- a/test/python/quantum_info/operators/symplectic/test_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli.py
@@ -42,6 +42,7 @@ from qiskit.test import QiskitTestCase
 from qiskit.quantum_info.random import random_clifford, random_pauli
 from qiskit.quantum_info.operators import Pauli, Operator
 from qiskit.quantum_info.operators.symplectic.pauli import _split_pauli_label, _phase_from_label
+import qiskit.quantum_info as qi
 
 
 @lru_cache(maxsize=8)
@@ -432,6 +433,19 @@ class TestPauli(QiskitTestCase):
         circ.barrier([0, 1])
         circ.y(1)
         value = Pauli(circ)
+        self.assertEqual(value, target)
+
+    def test_evolve_clifford_with_phase(self):
+        """Create circuit with gate that modifies Pauli phase"""
+        qc = QuantumCircuit(2)
+        qc.cz(0, 1)
+        op = Operator(qc)
+
+        pauli = qi.random_pauli(2, seed=123)
+
+        value = Operator(pauli.evolve(qc))
+        target = op.adjoint().dot(pauli).dot(op)
+
         self.assertEqual(value, target)
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This pull request is fix for issue #8438 
Title
PauliList.evolve raises exception when evolving certain Clifford circuits


### Details and comments

changed in file base_pauli.py

if dtype is None:
    dtype = np.min_scalar_type(x.shape[axis])

