### PR TITLE
[WIP] Improve speed of `sample_counts` from O(N) to O(1)

### DIFF
--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -298,10 +298,9 @@ class QuantumState:
             np.arange(len(probs)), self.dims(qargs), string_labels=True
         )
 
-        counts_pairs = [
+        return Counts(
             (labels[i], counts_array[i]) for i in range(len(counts_array)) if counts_array[i] > 0
-        ]
-        return Counts(counts_pairs)
+        )
 
     def measure(self, qargs=None):
         """Measure subsystems and return outcome and post-measure state.

--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -290,12 +290,18 @@ class QuantumState:
             The seed for random number generator used for sampling can be
             set to a fixed value by using the stats :meth:`seed` method.
         """
-        # Sample list of outcomes
-        samples = self.sample_memory(shots, qargs=qargs)
 
-        # Combine all samples into a counts dictionary
-        inds, counts = np.unique(samples, return_counts=True)
-        return Counts(zip(inds, counts))
+        probs = self.probabilities(qargs)
+
+        counts_array = self._rng.multinomial(shots, probs)
+        labels = self._index_to_ket_array(
+            np.arange(len(probs)), self.dims(qargs), string_labels=True
+        )
+
+        counts_pairs = [
+            (labels[i], counts_array[i]) for i in range(len(counts_array)) if counts_array[i] > 0
+        ]
+        return Counts(counts_pairs)
 
     def measure(self, qargs=None):
         """Measure subsystems and return outcome and post-measure state.

--- a/releasenotes/notes/multinomial-in-sample-counts-eef7ca66f39155f0.yaml
+++ b/releasenotes/notes/multinomial-in-sample-counts-eef7ca66f39155f0.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    The performance of the method :meth:`quantum_info.QuantumState.sample_counts`
+    has been improved from O(n) to O(1). Before, we sampled n shots from the
+    state and then counted the number of shots for each basis state. Now, we
+    instead sample directly from the distribution of the number of shots for
+    each basis state.

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -596,8 +596,8 @@ class TestDensityMatrix(QiskitTestCase):
     def test_sample_counts_ghz(self):
         """Test sample_counts method for GHZ state"""
 
-        shots = 2000
-        threshold = 0.02 * shots
+        shots = 10_000_000
+        threshold = 0.001 * shots
         state = DensityMatrix(
             (Statevector.from_label("000") + Statevector.from_label("111")) / np.sqrt(2)
         )
@@ -629,8 +629,8 @@ class TestDensityMatrix(QiskitTestCase):
 
     def test_sample_counts_w(self):
         """Test sample_counts method for W state"""
-        shots = 3000
-        threshold = 0.02 * shots
+        shots = 10_000_000
+        threshold = 0.001 * shots
         state = DensityMatrix(
             (
                 Statevector.from_label("001")
@@ -666,9 +666,9 @@ class TestDensityMatrix(QiskitTestCase):
 
     def test_sample_counts_qutrit(self):
         """Test sample_counts method for qutrit state"""
+        shots = 10_000_000
+        threshold = 0.001 * shots
         p = 0.3
-        shots = 1000
-        threshold = 0.03 * shots
         state = DensityMatrix(np.diag([p, 0, 1 - p]))
         state.seed(100)
 

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -670,8 +670,8 @@ class TestStatevector(QiskitTestCase):
 
     def test_sample_counts_w(self):
         """Test sample_counts method for W state"""
-        shots = 3000
-        threshold = 0.02 * shots
+        shots = 10_000_000
+        threshold = 0.001 * shots
         state = (
             Statevector.from_label("001")
             + Statevector.from_label("010")
@@ -705,8 +705,8 @@ class TestStatevector(QiskitTestCase):
     def test_sample_counts_qutrit(self):
         """Test sample_counts method for qutrit state"""
         p = 0.3
-        shots = 1000
-        threshold = 0.03 * shots
+        shots = 10_000_000
+        threshold = 0.001 * shots
         state = Statevector([np.sqrt(p), 0, np.sqrt(1 - p)])
         state.seed(100)
 

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -633,34 +633,40 @@ class TestStatevector(QiskitTestCase):
     def test_sample_counts_ghz(self):
         """Test sample_counts method for GHZ state"""
 
-        shots = 2000
-        threshold = 0.02 * shots
+        shots = 100_000_000
+        threshold = 0.001 * shots
+        seeds = [3786, 5497, 7826, 5528, 7453, 6162, 9044]
         state = (Statevector.from_label("000") + Statevector.from_label("111")) / np.sqrt(2)
-        state.seed(100)
 
         # 3-qubit qargs
         target = {"000": shots / 2, "111": shots / 2}
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
 
             with self.subTest(msg=f"counts (qargs={qargs})"):
-                counts = state.sample_counts(shots, qargs=qargs)
-                self.assertDictAlmostEqual(counts, target, threshold)
+                for _seed in seeds:
+                    state.seed(_seed)
+                    counts = state.sample_counts(shots, qargs=qargs)
+                    self.assertDictAlmostEqual(counts, target, threshold)
 
         # 2-qubit qargs
         target = {"00": shots / 2, "11": shots / 2}
         for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
 
             with self.subTest(msg=f"counts (qargs={qargs})"):
-                counts = state.sample_counts(shots, qargs=qargs)
-                self.assertDictAlmostEqual(counts, target, threshold)
+                for _seed in seeds:
+                    state.seed(_seed)
+                    counts = state.sample_counts(shots, qargs=qargs)
+                    self.assertDictAlmostEqual(counts, target, threshold)
 
         # 1-qubit qargs
         target = {"0": shots / 2, "1": shots / 2}
         for qargs in [[0], [1], [2]]:
 
             with self.subTest(msg=f"counts (qargs={qargs})"):
-                counts = state.sample_counts(shots, qargs=qargs)
-                self.assertDictAlmostEqual(counts, target, threshold)
+                for _seed in seeds:
+                    state.seed(_seed)
+                    counts = state.sample_counts(shots, qargs=qargs)
+                    self.assertDictAlmostEqual(counts, target, threshold)
 
     def test_sample_counts_w(self):
         """Test sample_counts method for W state"""


### PR DESCRIPTION
Use `numpy.random.multinomial` with parameter N rather than actually generating N counts in `QuantumState.sample_counts`. This is an $O(1)$ method, whereas the current one is $O(N)$.

- [x] I have added the tests to cover my changes.
- [x] (NA, no API change) I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] reno release note

### Summary

Use a more efficient algorithm for `QuantumState.sample_counts`.
Fixes #8535.

### Details and comments

In #8535 a solution using `numpy.random.multinomial` was proposed. This PR implements it.

* The test has been updated. It now uses $10^7$ shots rather than $2000$, and a tolerance of $0.001$.
   Furthermore, we run the tests for 7 different seeds, rather than just one. The time to run all tests has
   decreased from $>6$ ms to $<6$ ms (one one machine.)
* In the following, I use a plain-python generator
    ```python
        return Counts(
            (labels[i], counts_array[i]) for i in range(len(counts_array)) if counts_array[i] > 0
        )
    ```
    Both `labels` and `counts_array` are numpy arrays. So it make sense to instead filter the indices and then build new arrays
    indexing into the two arrays. I latter is slower if the vector of probabilities is not too long. But, it would be probably faster for
    large arrays. I suppose optimizing for the larger arrays is best. We could do both with a length cutoff, but that addes
    complexity, and I think it's premature optimization at this point. 