### PR TITLE
Improving MCXRecursive

### DIFF
--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -1093,22 +1093,8 @@ class MCXRecursive(MCXGate):
             qc._append(C4XGate(), q[:], [])
             self.definition = qc
         else:
-            num_ctrl_qubits = len(q) - 1
-            q_ancilla = q[-1]
-            q_target = q[-2]
-            middle = ceil(num_ctrl_qubits / 2)
-            first_half = [*q[:middle]]
-            second_half = [*q[middle:num_ctrl_qubits - 1], q_ancilla]
-
-            qc._append(MCXVChain(num_ctrl_qubits=len(first_half), dirty_ancillas=True), \
-                        [*first_half, q_ancilla, *q[middle:middle + len(first_half) - 2]], [])
-            qc._append(MCXVChain(num_ctrl_qubits=len(second_half), dirty_ancillas=True), \
-                        [*second_half, q_target, *q[:len(second_half) - 2]], [])
-            qc._append(MCXVChain(num_ctrl_qubits=len(first_half), dirty_ancillas=True), \
-                        [*first_half, q_ancilla, *q[middle:middle + len(first_half) - 2]], [])
-            qc._append(MCXVChain(num_ctrl_qubits=len(second_half), dirty_ancillas=True), \
-                        [*second_half, q_target, *q[:len(second_half) - 2]], [])
-
+            for instr, qargs, cargs in self._recurse(q[:-1], q_ancilla=q[-1]):
+                qc._append(instr, qargs, cargs)
             self.definition = qc
 
     def _recurse(self, q, q_ancilla=None):

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -1098,41 +1098,30 @@ class MCXRecursive(MCXGate):
             q_target = q[-2]
             middle = ceil(num_ctrl_qubits / 2)
             first_half = [*q[:middle]]
-            second_half = [*q[middle:num_ctrl_qubits - 1], q_ancilla]
+            second_half = [*q[middle : num_ctrl_qubits - 1], q_ancilla]
 
-            qc._append(MCXVChain(num_ctrl_qubits=len(first_half), dirty_ancillas=True), \
-                        [*first_half, q_ancilla, *q[middle:middle + len(first_half) - 2]], [])
-            qc._append(MCXVChain(num_ctrl_qubits=len(second_half), dirty_ancillas=True), \
-                        [*second_half, q_target, *q[:len(second_half) - 2]], [])
-            qc._append(MCXVChain(num_ctrl_qubits=len(first_half), dirty_ancillas=True), \
-                        [*first_half, q_ancilla, *q[middle:middle + len(first_half) - 2]], [])
-            qc._append(MCXVChain(num_ctrl_qubits=len(second_half), dirty_ancillas=True), \
-                        [*second_half, q_target, *q[:len(second_half) - 2]], [])
+            qc._append(
+                MCXVChain(num_ctrl_qubits=len(first_half), dirty_ancillas=True),
+                qargs=[*first_half, q_ancilla, *q[middle : middle + len(first_half) - 2]],
+                cargs=[],
+            )
+            qc._append(
+                MCXVChain(num_ctrl_qubits=len(second_half), dirty_ancillas=True),
+                qargs=[*second_half, q_target, *q[: len(second_half) - 2]],
+                cargs=[],
+            )
+            qc._append(
+                MCXVChain(num_ctrl_qubits=len(first_half), dirty_ancillas=True),
+                qargs=[*first_half, q_ancilla, *q[middle : middle + len(first_half) - 2]],
+                cargs=[],
+            )
+            qc._append(
+                MCXVChain(num_ctrl_qubits=len(second_half), dirty_ancillas=True),
+                qargs=[*second_half, q_target, *q[: len(second_half) - 2]],
+                cargs=[],
+            )
 
             self.definition = qc
-
-    def _recurse(self, q, q_ancilla=None):
-        # recursion stop
-        if len(q) == 4:
-            return [(C3XGate(), q[:], [])]
-        if len(q) == 5:
-            return [(C4XGate(), q[:], [])]
-        if len(q) < 4:
-            raise AttributeError("Something went wrong in the recursion, have less than 4 qubits.")
-
-        # recurse
-        num_ctrl_qubits = len(q) - 1
-        middle = ceil(num_ctrl_qubits / 2)
-        first_half = [*q[:middle], q_ancilla]
-        second_half = [*q[middle:num_ctrl_qubits], q_ancilla, q[num_ctrl_qubits]]
-
-        rule = []
-        rule += self._recurse(first_half, q_ancilla=q[middle])
-        rule += self._recurse(second_half, q_ancilla=q[middle - 1])
-        rule += self._recurse(first_half, q_ancilla=q[middle])
-        rule += self._recurse(second_half, q_ancilla=q[middle - 1])
-
-        return rule
 
 
 class MCXVChain(MCXGate):

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -1093,8 +1093,22 @@ class MCXRecursive(MCXGate):
             qc._append(C4XGate(), q[:], [])
             self.definition = qc
         else:
-            for instr, qargs, cargs in self._recurse(q[:-1], q_ancilla=q[-1]):
-                qc._append(instr, qargs, cargs)
+            num_ctrl_qubits = len(q) - 1
+            q_ancilla = q[-1]
+            q_target = q[-2]
+            middle = ceil(num_ctrl_qubits / 2)
+            first_half = [*q[:middle]]
+            second_half = [*q[middle:num_ctrl_qubits - 1], q_ancilla]
+
+            qc._append(MCXVChain(num_ctrl_qubits=len(first_half), dirty_ancillas=True), \
+                        [*first_half, q_ancilla, *q[middle:middle + len(first_half) - 2]], [])
+            qc._append(MCXVChain(num_ctrl_qubits=len(second_half), dirty_ancillas=True), \
+                        [*second_half, q_target, *q[:len(second_half) - 2]], [])
+            qc._append(MCXVChain(num_ctrl_qubits=len(first_half), dirty_ancillas=True), \
+                        [*first_half, q_ancilla, *q[middle:middle + len(first_half) - 2]], [])
+            qc._append(MCXVChain(num_ctrl_qubits=len(second_half), dirty_ancillas=True), \
+                        [*second_half, q_target, *q[:len(second_half) - 2]], [])
+
             self.definition = qc
 
     def _recurse(self, q, q_ancilla=None):

--- a/test/python/circuit/test_circuit_qasm.py
+++ b/test/python/circuit/test_circuit_qasm.py
@@ -270,6 +270,8 @@ nG0(pi,pi/2) q[0],r[0];\n"""
         qc = QuantumCircuit(4)
         qc.mcx([0, 1, 2], 3)
 
+        print(qc.decompose().draw())
+
         # qasm output doesn't support parameterized gate yet.
         # param0 for "gate mcuq(param0) is not used inside the definition
         expected_qasm = """OPENQASM 2.0;
@@ -288,20 +290,23 @@ mcx q[0],q[1],q[2],q[3];\n"""
         qc.append(cl.MCXGrayCode(n), range(n + 1))
         qc.append(cl.MCXRecursive(n), range(n + 2))
         qc.append(cl.MCXVChain(n), range(2 * n - 1))
+        mcx_vchain_id = id(qc.data[-1].operation)
 
         # qasm output doesn't support parameterized gate yet.
         # param0 for "gate mcuq(param0) is not used inside the definition
         expected_qasm = """OPENQASM 2.0;
 include "qelib1.inc";
-gate mcx q0,q1,q2,q3 { h q3; p(pi/8) q0; p(pi/8) q1; p(pi/8) q2; p(pi/8) q3; cx q0,q1; p(-pi/8) q1; cx q0,q1; cx q1,q2; p(-pi/8) q2; cx q0,q2; p(pi/8) q2; cx q1,q2; p(-pi/8) q2; cx q0,q2; cx q2,q3; p(-pi/8) q3; cx q1,q3; p(pi/8) q3; cx q2,q3; p(-pi/8) q3; cx q0,q3; p(pi/8) q3; cx q2,q3; p(-pi/8) q3; cx q1,q3; p(pi/8) q3; cx q2,q3; p(-pi/8) q3; cx q0,q3; h q3; }
-gate mcu1(param0) q0,q1,q2,q3,q4,q5 { cu1(pi/16) q4,q5; cx q4,q3; cu1(-pi/16) q3,q5; cx q4,q3; cu1(pi/16) q3,q5; cx q3,q2; cu1(-pi/16) q2,q5; cx q4,q2; cu1(pi/16) q2,q5; cx q3,q2; cu1(-pi/16) q2,q5; cx q4,q2; cu1(pi/16) q2,q5; cx q2,q1; cu1(-pi/16) q1,q5; cx q4,q1; cu1(pi/16) q1,q5; cx q3,q1; cu1(-pi/16) q1,q5; cx q4,q1; cu1(pi/16) q1,q5; cx q2,q1; cu1(-pi/16) q1,q5; cx q4,q1; cu1(pi/16) q1,q5; cx q3,q1; cu1(-pi/16) q1,q5; cx q4,q1; cu1(pi/16) q1,q5; cx q1,q0; cu1(-pi/16) q0,q5; cx q4,q0; cu1(pi/16) q0,q5; cx q3,q0; cu1(-pi/16) q0,q5; cx q4,q0; cu1(pi/16) q0,q5; cx q2,q0; cu1(-pi/16) q0,q5; cx q4,q0; cu1(pi/16) q0,q5; cx q3,q0; cu1(-pi/16) q0,q5; cx q4,q0; cu1(pi/16) q0,q5; cx q1,q0; cu1(-pi/16) q0,q5; cx q4,q0; cu1(pi/16) q0,q5; cx q3,q0; cu1(-pi/16) q0,q5; cx q4,q0; cu1(pi/16) q0,q5; cx q2,q0; cu1(-pi/16) q0,q5; cx q4,q0; cu1(pi/16) q0,q5; cx q3,q0; cu1(-pi/16) q0,q5; cx q4,q0; cu1(pi/16) q0,q5; }
-gate mcx_gray q0,q1,q2,q3,q4,q5 { h q5; mcu1(pi) q0,q1,q2,q3,q4,q5; h q5; }
-gate mcx_recursive q0,q1,q2,q3,q4,q5,q6 { mcx q0,q1,q2,q6; mcx q3,q4,q6,q5; mcx q0,q1,q2,q6; mcx q3,q4,q6,q5; }
-gate mcx_vchain q0,q1,q2,q3,q4,q5,q6,q7,q8 { rccx q0,q1,q6; rccx q2,q6,q7; rccx q3,q7,q8; ccx q4,q8,q5; rccx q3,q7,q8; rccx q2,q6,q7; rccx q0,q1,q6; }
+gate mcx_vchain q0,q1,q2,q3,q4 {{ u2(0,pi) q3; cx q3,q4; u1(-pi/4) q4; cx q2,q4; u1(pi/4) q4; cx q3,q4; u1(-pi/4) q4; cx q2,q4; u1(pi/4) q4; rccx q0,q1,q4; u1(-pi/4) q4; cx q2,q4; u1(pi/4) q4; cx q3,q4; u1(-pi/4) q4; cx q2,q4; u1(pi/4) q4; cx q3,q4; u2(0,pi) q3; rccx q0,q1,q4; }}
+gate mcu1(param0) q0,q1,q2,q3,q4,q5 {{ cu1(pi/16) q4,q5; cx q4,q3; cu1(-pi/16) q3,q5; cx q4,q3; cu1(pi/16) q3,q5; cx q3,q2; cu1(-pi/16) q2,q5; cx q4,q2; cu1(pi/16) q2,q5; cx q3,q2; cu1(-pi/16) q2,q5; cx q4,q2; cu1(pi/16) q2,q5; cx q2,q1; cu1(-pi/16) q1,q5; cx q4,q1; cu1(pi/16) q1,q5; cx q3,q1; cu1(-pi/16) q1,q5; cx q4,q1; cu1(pi/16) q1,q5; cx q2,q1; cu1(-pi/16) q1,q5; cx q4,q1; cu1(pi/16) q1,q5; cx q3,q1; cu1(-pi/16) q1,q5; cx q4,q1; cu1(pi/16) q1,q5; cx q1,q0; cu1(-pi/16) q0,q5; cx q4,q0; cu1(pi/16) q0,q5; cx q3,q0; cu1(-pi/16) q0,q5; cx q4,q0; cu1(pi/16) q0,q5; cx q2,q0; cu1(-pi/16) q0,q5; cx q4,q0; cu1(pi/16) q0,q5; cx q3,q0; cu1(-pi/16) q0,q5; cx q4,q0; cu1(pi/16) q0,q5; cx q1,q0; cu1(-pi/16) q0,q5; cx q4,q0; cu1(pi/16) q0,q5; cx q3,q0; cu1(-pi/16) q0,q5; cx q4,q0; cu1(pi/16) q0,q5; cx q2,q0; cu1(-pi/16) q0,q5; cx q4,q0; cu1(pi/16) q0,q5; cx q3,q0; cu1(-pi/16) q0,q5; cx q4,q0; cu1(pi/16) q0,q5; }}
+gate mcx_gray q0,q1,q2,q3,q4,q5 {{ h q5; mcu1(pi) q0,q1,q2,q3,q4,q5; h q5; }}
+gate mcx_recursive q0,q1,q2,q3,q4,q5,q6 {{ mcx_vchain q0,q1,q2,q6,q3; mcx_vchain q3,q4,q6,q5,q0; mcx_vchain q0,q1,q2,q6,q3; mcx_vchain q3,q4,q6,q5,q0; }}
+gate mcx_vchain_{0} q0,q1,q2,q3,q4,q5,q6,q7,q8 {{ rccx q0,q1,q6; rccx q2,q6,q7; rccx q3,q7,q8; ccx q4,q8,q5; rccx q3,q7,q8; rccx q2,q6,q7; rccx q0,q1,q6; }}
 qreg q[9];
 mcx_gray q[0],q[1],q[2],q[3],q[4],q[5];
 mcx_recursive q[0],q[1],q[2],q[3],q[4],q[5],q[6];
-mcx_vchain q[0],q[1],q[2],q[3],q[4],q[5],q[6],q[7],q[8];\n"""
+mcx_vchain_{0} q[0],q[1],q[2],q[3],q[4],q[5],q[6],q[7],q[8];\n""".format(
+            mcx_vchain_id
+        )
 
         self.assertEqual(qc.qasm(), expected_qasm)
 

--- a/test/python/circuit/test_circuit_qasm.py
+++ b/test/python/circuit/test_circuit_qasm.py
@@ -270,8 +270,6 @@ nG0(pi,pi/2) q[0],r[0];\n"""
         qc = QuantumCircuit(4)
         qc.mcx([0, 1, 2], 3)
 
-        print(qc.decompose().draw())
-
         # qasm output doesn't support parameterized gate yet.
         # param0 for "gate mcuq(param0) is not used inside the definition
         expected_qasm = """OPENQASM 2.0;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
Issue #5872 
Change the recursive method for the Lemma 9 of arXiv:1501.06911, first shown in Lemma 7.3 of https://link.aps.org/doi/10.1103/PhysRevA.52.3457

### Details and comments
For the case of num_qubits>5 we changed the recursion method for a method which divides the control qubits in two groups, and them apply the MCXVChain gate alternating between the two groups.