### PR TITLE
Add missing variable width operations to standard_gate_name_mapping()

### DIFF
--- a/qiskit/circuit/library/standard_gates/__init__.py
+++ b/qiskit/circuit/library/standard_gates/__init__.py
@@ -117,7 +117,7 @@ def get_standard_gate_name_mapping():
     from qiskit.circuit.measure import Measure
     from qiskit.circuit.delay import Delay
     from qiskit.circuit.reset import Reset
-    from qiskit.circuit.controlflow import IfElseOp, WhileLoop, ForLoop
+    from qiskit.circuit.controlflow import IfElseOp, WhileLoopOp, ForLoopOp
 
     # Standard gates library mapping, multicontrolled gates not included since they're
     # variable width.
@@ -179,9 +179,9 @@ def get_standard_gate_name_mapping():
     name_mapping = {gate.name: gate for gate in gates}
     # Add variable width gates as a mapping between names and classes
     # since an instance requires knowing how many qubits are being operated on
-    name_mapping["if_else"] = IFElseOp
-    name_mapping["for_loop"] = ForLoop
-    name_mapping["while_loop"] = WhileLoop
+    name_mapping["if_else"] = IfElseOp
+    name_mapping["for_loop"] = ForLoopOp
+    name_mapping["while_loop"] = WhileLoopOP
     name_mapping["mcx"] = MCXGate
     name_mapping["mcx_gray"] = MCXGrayCode
     name_mapping["mcx_recursive"] = MCXRecursive

--- a/qiskit/circuit/library/standard_gates/__init__.py
+++ b/qiskit/circuit/library/standard_gates/__init__.py
@@ -107,14 +107,20 @@ from .multi_control_rotation_gates import mcrx, mcry, mcrz
 
 def get_standard_gate_name_mapping():
     """Return a dictionary mapping the name of standard gates and instructions to an object for
-    that name."""
+    that name.
+
+    For variadic operations (i.e. operations that operate on a variable
+    number of qubits), such as :class:`~.MCXGate`, the class for that
+    operation is returned and not an instance.
+    """
     from qiskit.circuit.parameter import Parameter
     from qiskit.circuit.measure import Measure
     from qiskit.circuit.delay import Delay
     from qiskit.circuit.reset import Reset
+    from qiskit.circuit.controlflow import IfElseOp, WhileLoop, ForLoop
 
     # Standard gates library mapping, multicontrolled gates not included since they're
-    # variable width
+    # variable width.
     gates = [
         IGate(),
         SXGate(),
@@ -171,4 +177,15 @@ def get_standard_gate_name_mapping():
         Measure(),
     ]
     name_mapping = {gate.name: gate for gate in gates}
+    # Add variable width gates as a mapping between names and classes
+    # since an instance requires knowing how many qubits are being operated on
+    name_mapping["if_else"] = IFElseOp
+    name_mapping["for_loop"] = ForLoop
+    name_mapping["while_loop"] = WhileLoop
+    name_mapping["mcx"] = MCXGate
+    name_mapping["mcx_gray"] = MCXGrayCode
+    name_mapping["mcx_recursive"] = MCXRecursive
+    name_mapping["mcx_vchain"] = MCXVChain
+    name_mapping["mcp"] = MCPhaseGate
+    name_mapping["mcu1"] = MCU1Gate
     return name_mapping


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #8852 we added support to the target class for representing variable width operations by using the class directly instead of an instance. Now that we have settled on a representation for these types of operations we can add them to the built in name mapping function (from which they were previously excluded. This commit adds the built-in variable width operations to the output of the function and returns just the class instead of an instance.

### Details and comments