### PR TITLE
Add Target methods to query the target for instruction properties

### DIFF
--- a/releasenotes/notes/add-target-lookup-methods-5a3170e90bb5015b.yaml
+++ b/releasenotes/notes/add-target-lookup-methods-5a3170e90bb5015b.yaml
@@ -1,0 +1,24 @@
+---
+features:
+  - |
+    Added 3 new lookup methods, :meth:`~.Target.get_instruction_properties`,
+    :meth:~.Target.get_instruction_error`, and :meth:`~.Target.get_instruction_duration`
+    to the :class:`~.Target` class. These methods are used to query the target
+    for the :class:`~.InstructionProperties`, error rate, or duration of a given
+    instruction in the target. Previously this was possible using the mapping protocol
+    (i.e. ``target[op_name][qargs]``) however it resulted in a great deal of duplicated
+    logic to handle edge cases around ideal and/or global gates which depending on the
+    type of operation are represented with ``None`` at various levels in a
+    :class:`~.Target`. THese methods provide a simple entry point that will either return
+    the desired result, ``None`` if the instruction doesn't have the property defined, or raise
+    a ``KeyError`` if the instruction isn't supported by the :class:`~.Target`.
+  - |
+    Added 3 new lookup methods, :meth:`~.Target.get_instruction_properties_by_class`,
+    :meth:~.Target.get_instruction_errors_by_class`, and :meth:`~.Target.get_instruction_durations_by_class`
+    to the :class:`~.Target` class. These methods are used to query the target
+    for the :class:`~.InstructionProperties`, error rate, or duration of a given
+    instruction in the target by the operation class instead of the canonical name for the
+    operation. These methods provide a simple entry point that will either return
+    a dictionary mapping the canonical operation names which match the input parameters
+    to desired result, ``None`` if the instruction doesn't have the property defined, or raise
+    a ``KeyError`` if the instruction isn't supported by the :class:`~.Target`.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds 6 new helper methods to the Target class. These methods are used  to query the target by either name or class to extract the InstructionProperties (or attributes of them) for a given instruction. Previously doing this by name was possible using the mapping protocol, but handling the combination of ideal gates with ``None`` at different levels in the internal dictionaries was cumbersome and error prone. These methods give a simple entry point to do the query which abstracts away the internal structure of the target.

For the methods which use a class based lookup this wasn't easily accomplishable before, the closest available method would just return a boolean about whether the class was supported on the target or not.

### Details and comments

Implements #8892