### PR TITLE
reintroducing GeneratedFakeBackendsTest

### DIFF
--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -348,7 +348,7 @@ def _parse_common_args(
     qubit_lo_range = qubit_lo_range or getattr(backend_config, "qubit_lo_range", None)
     meas_lo_range = meas_lo_range or getattr(backend_config, "meas_lo_range", None)
 
-    # check that LO frequencies are in the perscribed range
+    # check that LO frequencies are in the prescribed range
     _check_lo_freqs(qubit_lo_freq, qubit_lo_range, "qubit")
     _check_lo_freqs(meas_lo_freq, meas_lo_range, "meas")
 
@@ -388,7 +388,7 @@ def _check_lo_freqs(
     lo_range: Union[List[float], None],
     lo_type: str,
 ):
-    """Check that LO frequencies are within the perscribed LO range.
+    """Check that LO frequencies are within the prescribed LO range.
 
     NOTE: Only checks if frequency/range lists have equal length. And does not check that the lists
     have length ``n_qubits``. This is because some backends, like simulator backends, do not

--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -56,7 +56,7 @@ class FakeBackendV2(BackendV2):
 
     The class inherits :class:`~qiskit.providers.BackendV2` class. This version
     differs from earlier :class:`~qiskit.providers.fake_provider.FakeBackend` (V1) class in a
-    few aspects. Firstly, configuration attribute no longer exsists. Instead,
+    few aspects. Firstly, configuration attribute no longer exists. Instead,
     attributes exposing equivalent required immutable properties of the backend
     device are added. For example ``fake_backend.configuration().n_qubits`` is
     accessible from ``fake_backend.num_qubits`` now. Secondly, this version
@@ -459,7 +459,7 @@ class FakeBackend(BackendV1):
 
             self.sim = aer.AerSimulator()
             if self.properties():
-                noise_model = NoiseModel.from_backend(self, warnings=False)
+                noise_model = NoiseModel.from_backend(self)
                 self.sim.set_options(noise_model=noise_model)
                 # Update fake backend default options too to avoid overwriting
                 # it when run() is called

--- a/qiskit/providers/fake_provider/utils/configurable_backend.py
+++ b/qiskit/providers/fake_provider/utils/configurable_backend.py
@@ -101,7 +101,7 @@ class ConfigurableFakeBackend(FakeBackend):
             dt = 1.33
 
         self.backend_name = name
-        self.version = version
+        self.backend_version = version
         self.basis_gates = basis_gates
         self.qubit_t1 = qubit_t1
         self.qubit_t2 = qubit_t2
@@ -198,7 +198,7 @@ class ConfigurableFakeBackend(FakeBackend):
 
         return BackendProperties(
             backend_name=self.backend_name,
-            backend_version=self.version,
+            backend_version=self.backend_version,
             last_update_date=self.now,
             qubits=qubits,
             gates=gates,
@@ -232,12 +232,12 @@ class ConfigurableFakeBackend(FakeBackend):
 
         meas_map = [list(range(self.n_qubits))]
         qubit_lo_range = [[freq - 0.5, freq + 0.5] for freq in self.qubit_frequency]
-        meas_lo_range = [[6.5, 7.5] for _ in range(self.n_qubits)]
+        meas_lo_range = [[6.3, 7.5] for _ in range(self.n_qubits)]
         u_channel_lo = [[UchannelLO(q=i, scale=1.0 + 0.0j)] for i in range(len(self.coupling_map))]
 
         return PulseBackendConfiguration(
             backend_name=self.backend_name,
-            backend_version=self.version,
+            backend_version=self.backend_version,
             n_qubits=self.n_qubits,
             meas_levels=[0, 1, 2],
             basis_gates=self.basis_gates,

--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017--2022
+# (C) Copyright IBM 2017-2022
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory


### PR DESCRIPTION
Fixes #7438, maybe.

Fixing #7438 is, indeed, kinda hard. There were some problems of confusing the backend version with the `backend_version`. And, on top, the FakeBackend has deprecated `u3` in the basis. Plus `qobj`. I think this PR is the closes to reintroduce the test. Maybe `ConfigurableFakeBackend` needs an update. 
