### PR TITLE
fix_prov_opt_upd: fix update of provider options

### DIFF
--- a/qiskit/providers/options.py
+++ b/qiskit/providers/options.py
@@ -166,19 +166,22 @@ class Options:
         """Update options with kwargs"""
         for field in fields:
             field_validator = self.validator.get(field, None)
-            if isinstance(field, tuple):
-                if fields[field] > field_validator[1] or fields[field] < field_validator[0]:
-                    raise ValueError(
-                        f"Specified value for '{field}' is not a valid value, "
-                        f"must be >={field_validator[0]} or <={field_validator[1]}"
-                    )
-            elif isinstance(field, list):
+            if isinstance(field_validator, tuple):
+                try:
+                    if fields[field] > field_validator[1] or fields[field] < field_validator[0]:
+                        raise ValueError(
+                            f"Specified value for '{field}' is not a valid value, "
+                            f"must be >={field_validator[0]} or <={field_validator[1]}"
+                        )
+                except:
+                    pass
+            elif isinstance(field_validator, list):
                 if fields[field] not in field_validator:
                     raise ValueError(
                         f"Specified value for {field} is not a valid choice, "
                         f"must be one of {field_validator}"
                     )
-            elif isinstance(field, type):
+            elif isinstance(field_validator, type):
                 if not isinstance(fields[field], field_validator):
                     raise TypeError(
                         f"Specified value for {field} is not of required type {field_validator}"

--- a/qiskit/providers/options.py
+++ b/qiskit/providers/options.py
@@ -166,15 +166,12 @@ class Options:
         """Update options with kwargs"""
         for field in fields:
             field_validator = self.validator.get(field, None)
-            if isinstance(field_validator, tuple):
-                try:
-                    if fields[field] > field_validator[1] or fields[field] < field_validator[0]:
-                        raise ValueError(
-                            f"Specified value for '{field}' is not a valid value, "
-                            f"must be >={field_validator[0]} or <={field_validator[1]}"
-                        )
-                except:
-                    pass
+            if isinstance(field_validator, tuple) and fields[field] is not None:
+                if fields[field] > field_validator[1] or fields[field] < field_validator[0]:
+                    raise ValueError(
+                        f"Specified value for '{field}' is not a valid value, "
+                        f"must be >={field_validator[0]} or <={field_validator[1]}"
+                    )
             elif isinstance(field_validator, list):
                 if fields[field] not in field_validator:
                     raise ValueError(

--- a/qiskit/providers/options.py
+++ b/qiskit/providers/options.py
@@ -166,19 +166,19 @@ class Options:
         """Update options with kwargs"""
         for field in fields:
             field_validator = self.validator.get(field, None)
-            if isinstance(field_validator, tuple):
+            if isinstance(field, tuple):
                 if fields[field] > field_validator[1] or fields[field] < field_validator[0]:
                     raise ValueError(
                         f"Specified value for '{field}' is not a valid value, "
                         f"must be >={field_validator[0]} or <={field_validator[1]}"
                     )
-            elif isinstance(field_validator, list):
+            elif isinstance(field, list):
                 if fields[field] not in field_validator:
                     raise ValueError(
                         f"Specified value for {field} is not a valid choice, "
                         f"must be one of {field_validator}"
                     )
-            elif isinstance(field_validator, type):
+            elif isinstance(field, type):
                 if not isinstance(fields[field], field_validator):
                     raise TypeError(
                         f"Specified value for {field} is not of required type {field_validator}"


### PR DESCRIPTION
The instance tests must be done with the input `fields` and not the
`field_validators` which can be `None` leading to crashes.

-------

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Change `field_validators` by `fields` in the `isinstance` switch of `update_options`.

### Details and comments
The problem was found when try to set options for real backends from qiskit runtime service.