### PR TITLE
Add a pulse macro to split gaussian square pulse into multiple chunks

### DIFF
--- a/qiskit/pulse/__init__.py
+++ b/qiskit/pulse/__init__.py
@@ -140,6 +140,8 @@ from qiskit.pulse.library import (
     Constant,
     Drag,
     Gaussian,
+    GaussianFallEdge,
+    GaussianRiseEdge,
     GaussianSquare,
     ParametricPulse,
     SymbolicPulse,

--- a/qiskit/pulse/library/__init__.py
+++ b/qiskit/pulse/library/__init__.py
@@ -91,6 +91,8 @@ Parametric Pulse Representation
    Constant
    Drag
    Gaussian
+   GaussianFallEdge
+   GaussianRiseEdge
    GaussianSquare
 
 """
@@ -111,6 +113,14 @@ from .discrete import (
     drag,
 )
 from .parametric_pulses import ParametricPulse
-from .symbolic_pulses import SymbolicPulse, Gaussian, GaussianSquare, Drag, Constant
+from .symbolic_pulses import (
+    SymbolicPulse,
+    Gaussian,
+    GaussianSquare,
+    Drag,
+    Constant,
+    GaussianFallEdge,
+    GaussianRiseEdge,
+)
 from .pulse import Pulse
 from .waveform import Waveform

--- a/qiskit/pulse/library/symbolic_pulses.py
+++ b/qiskit/pulse/library/symbolic_pulses.py
@@ -1141,7 +1141,7 @@ def GaussianFallEdge(
     )
 
     instance = SymbolicPulse(
-        pulse_type="GaussianRiseEdge",
+        pulse_type="GaussianFallEdge",
         duration=duration,
         parameters={"amp": amp, "angle": angle, "sigma": sigma, "risefall": risefall_sigma_ratio},
         name=name,

--- a/qiskit/pulse/macros.py
+++ b/qiskit/pulse/macros.py
@@ -12,11 +12,19 @@
 
 """Module for common pulse programming macros."""
 
-from typing import Dict, List, Optional, Union
+import math
+import warnings
+from typing import Dict, List, Union, Optional
 
+from qiskit import pulse
+from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit.pulse import channels, exceptions, instructions, utils
+from qiskit.pulse.library.symbolic_pulses import GaussianRiseEdge, GaussianFallEdge
+from qiskit.pulse.channels import PulseChannel
+from qiskit.pulse.exceptions import PulseError
 from qiskit.pulse.instruction_schedule_map import InstructionScheduleMap
-from qiskit.pulse.schedule import Schedule
+from qiskit.pulse.schedule import Schedule, ScheduleBlock
+from qiskit.pulse.transforms import AlignSequential
 
 
 def measure(
@@ -104,3 +112,173 @@ def measure_all(backend) -> Schedule:
         A schedule corresponding to the inputs provided.
     """
     return measure(qubits=list(range(backend.configuration().n_qubits)), backend=backend)
+
+
+def chunking_gaussian_square(
+    duration: int,
+    amp: ParameterValueType,
+    angle: ParameterValueType,
+    sigma: ParameterValueType,
+    risefall_sigma_ratio: ParameterValueType,
+    channel: PulseChannel,
+    granularity: int,
+    name: Optional[str] = None,
+    limit_amplitude: Optional[bool] = None,
+    chunk_size: int = 256,
+    min_chunk_number: int = 10,
+) -> ScheduleBlock:
+    """A macro to build long GaussianSquare pulse in the chunk divided fashion.
+
+    When we play a very long Gaussian Square pulse, such a pulse may quickly consume
+    the waveform memory resource of the waveform generator of the corresponding channel,
+    depending on how the microarchitecture of the pulse controller is designed.
+
+    This macro will provide a memory-efficient encoding of the pulse envelope, in other words,
+    it splits the flat-top part of the pulse into multiple short constant envelopes,
+    and concatenates all of them together with the rise and fall edges to
+    express the entire pulse envelope. This chunking allows the pulse controller to compress
+    the very long flat-top part into a single short constant pulse in the waveform memory,
+    and thus it can reduce waveform memory footprint for a single job.
+
+    Chunked pulse can be parameterized except for the `duration`.
+
+    .. note::
+
+        A chunked pulse may increase the payload size because rising and falling edges
+        are expressed by the raw samples rather than in the parametric form.
+        When required chunk, i.e. number of repeated constant pulse, is less than the
+        `min_chunk_number` limit, this macro function plays a single
+        :class:`.GaussianSquare` pulse instead of generating a chunked pulse schedule.
+
+    .. see_also::
+        :class:`.GaussianSquare` for definition of the pulse envelope.
+
+    Args:
+        duration: Pulse length in terms of the sampling period `dt`.
+            This duration must be an integer numer. Parameterization is not acceptable.
+            Duration may be rounded to match the chunk size and ramp durations
+            with the device timing constraint of the pulse granularity.
+        amp: The magnitude of the amplitude of the Gaussian and square pulse.
+            Complex amp support will be deprecated.
+        angle: The angle of the complex amplitude of the pulse.
+        sigma: A measure of how wide or narrow the Gaussian risefall is.
+        risefall_sigma_ratio: The ratio of each risefall duration to sigma.
+        channel: A pulse channel to play this pulse.
+        granularity: A device timing constraint for the pulse granularity.
+        name: Display name for this pulse envelope.
+        limit_amplitude: If ``True``, then limit the amplitude of the
+            waveform to 1. The default is ``True`` and the amplitude is constrained to 1.
+        chunk_size: Size of a single chunk in units of dt. This must satisfy the
+            device timing constraint for the pulse granularity.
+        min_chunk_number: Minimum chunk number to enable the chunk division.
+            This macro plays a single :class:`.GaussianSquare` pulse when
+            the pulse duration is sufficiently short.
+
+    Returns:
+        ScheduleBlock of the chunked GaussianSquare pulse sequence.
+
+    Raises:
+        PulseError: When duration is parameterized.
+    """
+    # TODO this must be called from proper pulse compiler once implemented.
+    #  i.e. Standard GaussianSquare is implicitly replaced with this based on a compiler option.
+    #  Experimentalist doesn't need to take care of chunking like this.
+
+    if not isinstance(duration, int):
+        raise PulseError(
+            "Parameterized duration cannot be applied to the chunked pulse. "
+            "Specify an integer duration in units of dt."
+        )
+
+    if chunk_size % granularity != 0:
+        _new_size = granularity * int(chunk_size / granularity)
+        warnings.warn(
+            f"Chunk size of {chunk_size} dt doesn't match with the device timing constraint. "
+            f"The value is rounded to the nearest valid size of {_new_size} dt.",
+            UserWarning,
+        )
+        chunk_size = _new_size
+    width = duration - 2 * sigma * risefall_sigma_ratio
+    n_chunks = int(width / chunk_size)
+
+    schedule = ScheduleBlock(name=name, alignment_context=AlignSequential())
+
+    if n_chunks < min_chunk_number:
+        # Pulse is very short. No need to apply chunk division.
+        # Usually chunk division increases payload size because rising and falling edges
+        # are submitted down to the device in the waveform format.
+        # Switch back to the standard GaussianSquare pulse to compress payload.
+        valid_duration = granularity * int(duration / granularity)
+        schedule.append(
+            instructions.Play(
+                pulse.GaussianSquare(
+                    duration=valid_duration,
+                    amp=amp,
+                    sigma=sigma,
+                    risefall_sigma_ratio=risefall_sigma_ratio,
+                    name=name,
+                    limit_amplitude=limit_amplitude,
+                ),
+                channel=channel,
+            ),
+            inplace=True,
+        )
+    else:
+        # Extra flat-top duration absorbed by ramps, i.e. waveform
+        chunked_flat_top_size = n_chunks * chunk_size
+        total_slack = width - chunked_flat_top_size
+
+        # Effective pulse edge duration
+        # This must guarantee the duration > sigma * risefall_sigma_ratio
+        # It rounds up duration rather than truncating.
+        edge_size = granularity * math.ceil(
+            (sigma * risefall_sigma_ratio + total_slack / 2) / granularity
+        )
+
+        # Rising edge
+        schedule.append(
+            instructions.Play(
+                GaussianRiseEdge(
+                    amp=amp,
+                    angle=angle,
+                    duration=edge_size,
+                    sigma=sigma,
+                    risefall_sigma_ratio=risefall_sigma_ratio,
+                    limit_amplitude=limit_amplitude,
+                    name=name + "_rise" if name else None,
+                ),
+                channel=channel,
+            ),
+            inplace=True,
+        )
+        # Flat-top part
+        flat_top_pulse = pulse.Constant(
+            duration=chunk_size,
+            amp=amp,
+            angle=angle,
+            limit_amplitude=limit_amplitude,
+            name=name + "_flat" if name else None,
+        )
+        for _ in range(n_chunks):
+            schedule.append(
+                instructions.Play(flat_top_pulse, channel=channel),
+                inplace=True,
+            )
+        # Falling edge
+        schedule.append(
+            instructions.Play(
+                GaussianFallEdge(
+                    amp=amp,
+                    angle=angle,
+                    duration=edge_size,
+                    sigma=sigma,
+                    risefall_sigma_ratio=risefall_sigma_ratio,
+                    limit_amplitude=limit_amplitude,
+                    name=name + "_fall" if name else None,
+                ),
+                channel=channel,
+            ),
+            inplace=True,
+        )
+
+    return schedule

--- a/releasenotes/notes/add-chunked-gaussian-macro-a861111f80859860.yaml
+++ b/releasenotes/notes/add-chunked-gaussian-macro-a861111f80859860.yaml
@@ -1,0 +1,14 @@
+---
+features:
+  - |
+    Two symbolic pulse factories :func:`.GaussianFallEdge` and :func:`.GaussianRiseEdge`
+    have been added to the pulse library. These pulses are expected to
+    be used by the pulse chunking macros.
+  - |
+    A pulse macro function :func:`~.qiskit.pulse.macros.chunking_gaussian_square`
+    has been added. This function generates a pulse schedule of a single
+    Gaussian square pulse which is divided into multiple pieces.
+    This representation may allow the backend pulse controller to efficiently store
+    the full waveform of very long Gaussian square pulse in its waveform memory,
+    and may enable experimentalists to efficiently write a particular experiment program
+    requiring long pulse irradiation, such as resonator spectroscopy.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR adds a macro function `chunking_gaussian_square` that splits a very long Gaussian square into multiple chunks. The split pulse is represented by a `ScheduleBlock` rather than a single `Play` instruction as follows:

![image](https://user-images.githubusercontent.com/39517270/211068923-c14ff4b5-1824-472b-919e-9fe8eb22f45f.png)

This representation effectively compresses the waveform memory data that is loaded to a standard IBM pulse controller. This pulse representation may save an experimentalist from the annoying `waveform memory limit` error, especially when the experimental program attempts to scan a parameter of the very long pulse, e.g. resonator spectroscopy.


### Details and comments

Two symbolic pulses `GaussianRiseEdge` and `GaussianFallEdge` are added to the library. These are the intermediate pulse representation that are expected to be converted into waveform representation in the Qobj payload. This parametric representation allows a user to parameterize pulse program while apply chunking technique (except for duration).

