### PR TITLE
Upgrade TranspileLayout

### DIFF
--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -241,6 +241,7 @@ class Operator(LinearOp):
             layout = TranspileLayout(
                 initial_layout=layout,
                 input_qubit_mapping={qubit: index for index, qubit in enumerate(circuit.qubits)},
+                output_qubit_mapping={qubit: layout[qubit] for qubit in circuit.qubits},
             )
         if final_layout is None:
             if not ignore_set_layout and layout is not None:

--- a/qiskit/transpiler/basepasses.py
+++ b/qiskit/transpiler/basepasses.py
@@ -135,6 +135,7 @@ class BasePass(metaclass=MetaPass):
             result_circuit._layout = TranspileLayout(
                 initial_layout=self.property_set["layout"],
                 input_qubit_mapping=self.property_set["original_qubit_indices"],
+                output_qubit_mapping={qubit: index for index, qubit in enumerate(result_circuit)},
                 final_layout=self.property_set["final_layout"],
             )
         if self.property_set["clbit_write_latency"] is not None:

--- a/qiskit/transpiler/layout.py
+++ b/qiskit/transpiler/layout.py
@@ -374,4 +374,36 @@ class TranspileLayout:
 
     initial_layout: Layout
     input_qubit_mapping: Dict[Qubit, int]
+    output_qubit_mapping: Dict[Qubit, int]
     final_layout: Optional[Layout] = None
+
+    @property
+    def num_qubits(self) -> int:
+        """Number of qubits in the represented Layout."""
+        return len(self.input_qubit_mapping)
+
+    def get_initial_permutation(self) -> list[int]:
+        """Get initial permutation from initial layout."""
+        inverted_input_mapping = {i: q for q, i in self.input_qubit_mapping.items()}
+        input_qubits = tuple(inverted_input_mapping[i] for i in range(self.num_qubits))
+        return [self.initial_layout[q] for q in input_qubits]
+
+    def get_final_permutation(self) -> list[int]:
+        """Get final permutation from final layout."""
+        inverted_output_mapping = {i: q for q, i in self.output_qubit_mapping.items()}
+        output_qubits = tuple(inverted_output_mapping[i] for i in range(self.num_qubits))
+        final_layout = self.final_layout or Layout(self.output_qubit_mapping)
+        return [final_layout[q] for q in output_qubits]
+
+    def get_complete_permutation(self) -> list[int]:
+        """Get complete permutation by composing initial and final permutations."""
+        initial_permutation = self.get_initial_permutation(self)
+        final_permutation = self.get_final_permutation(self)
+        return [final_permutation[initial_permutation[i]] for i in range(self.num_qubits)]
+
+    def get_complete_layout(self) -> Layout:
+        """Get complete layout by composing initial and final layouts."""
+        permutation = self.get_complete_permutation(self)
+        inverted_input_mapping = {i: q for q, i in self.input_qubit_mapping.items()}
+        layout_dict = {inverted_input_mapping[i]: p for i, p in enumerate(permutation)}
+        return Layout(layout_dict)

--- a/qiskit/transpiler/runningpassmanager.py
+++ b/qiskit/transpiler/runningpassmanager.py
@@ -133,6 +133,7 @@ class RunningPassManager:
             circuit._layout = TranspileLayout(
                 initial_layout=self.property_set["layout"],
                 input_qubit_mapping=self.property_set["original_qubit_indices"],
+                output_qubit_mapping={qubit: index for index, qubit in enumerate(circuit)},
                 final_layout=self.property_set["final_layout"],
             )
         circuit._clbit_write_latency = self.property_set["clbit_write_latency"]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Upgrades `TranspileLayout` class adding one more field (i.e. `output_qubit_mapping`), a property, and a few convenience methods.


### Details and comments
Field:
- `output_qubit_mapping` is added in order to make `TranspileLayout` self contained; meaning that it will not need to know about the (transpiled) circuit that it as attached to in order to understand its `final_layout` field. This mimics the way `input_qubit_mapping` allows interpretation of `initial_layout`.

Property:
- `num_qubits` is added as a convenient way to assess the number of qubits involved in the layout. Notice that checking the size of a dictionary is an $\mathcal{O}(1)$ operation, which justifies making this a property instead of a regular method (no computation is performed, only retrieval).

Methods:
- `get_initial_permutation` allows retrieval of the permutation performed by `initial_layout`.
- `get_final_permutation` allows retrieval of the permutation performed by `final_layout`.
- `get_complete_permutation` allows retrieval of the composed permutation from `initial_layout` and `final_layout` (in order).
- `get_complete_layout` allows retrieval of the complete layout that results from composing `initial_layout` and `final_layout`.

#9486 should be updated accordingly