### PR TITLE
Add checks for presence of xypic, standalone, and qcircuit

### DIFF
--- a/qiskit/utils/optionals.py
+++ b/qiskit/utils/optionals.py
@@ -337,11 +337,27 @@ HAS_GRAPHVIZ = _LazySubprocessTester(
         " You must install the actual Graphviz software"
     ),
 )
+HAS_KPSEWHICH = _LazySubprocessTester(
+    ("kpsewhich", "-version"),
+    msg="Unable to find a minimal TeX installation on your path. To install see https://www.latex-project.org/get/ for installation instructions.",
+)
 HAS_PDFLATEX = _LazySubprocessTester(
     ("pdflatex", "-version"),
-    msg="You will likely need to install a full LaTeX distribution for your system",
+    msg="You will likely need to install a full LaTeX distribution for your system.",
+)
+HAS_XYPIC = _LazySubprocessTester(
+    ("kpsewhich", "xypic.sty"),
+    msg="Unable to find the LaTeX package xypic.",
+)
+HAS_QCIRCUIT = _LazySubprocessTester(
+    ("kpsewhich", "qcircuit.sty"),
+    msg="Unable to find the LaTeX package qcircuit.",
+)
+HAS_STANDALONE = _LazySubprocessTester(
+    ("kpsewhich", "standalone.cls"),
+    msg="Unable to find the LaTeX package standalone.",
 )
 HAS_PDFTOCAIRO = _LazySubprocessTester(
     ("pdftocairo", "-v"),
-    msg="This is part of the 'poppler' set of PDF utilities",
+    msg="This is part of the 'poppler' set of PDF utilities.",
 )

--- a/qiskit/visualization/circuit/circuit_visualization.py
+++ b/qiskit/visualization/circuit/circuit_visualization.py
@@ -446,6 +446,10 @@ def _text_circuit_drawer(
 # -----------------------------------------------------------------------------
 
 
+@_optionals.HAS_KPSEWHICH.require_in_call("LaTeX circuit drawing")
+@_optionals.HAS_XYPIC.require_in_call("LaTeX circuit drawing")
+@_optionals.HAS_QCIRCUIT.require_in_call("LaTeX circuit drawing")
+@_optionals.HAS_STANDALONE.require_in_call("LaTeX circuit drawing")
 @_optionals.HAS_PDFLATEX.require_in_call("LaTeX circuit drawing")
 @_optionals.HAS_PDFTOCAIRO.require_in_call("LaTeX circuit drawing")
 @_optionals.HAS_PIL.require_in_call("LaTeX circuit drawing")


### PR DESCRIPTION
This PR tests for the presence of the LaTeX packages `standalone`, `xypic`, and `qcircuit` when a function that requires them is called. It should print informative error messages if they are missing.

It remains to iron out the error messages that are printed. I currently use `_LazySubprocessTester`. Perhaps a new subclass with overrides is the right approach.

For example `kpsewhich` is the TeX program that finds resources in a `TeX` installation. It should be present in a minimal installation. Its absence indicates might indicate that there is no `LaTeX` installation or that the executables are not found on the `PATH`. But printing error messages about `kpsewhich` in particular is probably not useful.

Closes #7664

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


