### PR TITLE
Improved MCXVChain with dirty auxiliary qubits

### DIFF
--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -1517,123 +1517,87 @@ class MCXVChain(MCXGate):
                                         (
                                             CXGate(),
                                             [q_ancillas[num_ancillas - i - 1], targets[i]],
-                                            []
+                                            [],
                                         )
                                     )
-                                    definition.append(
-                                        (U1Gate(pi / 4), [targets[i]], [])      # T gate
-                                    )
+                                    definition.append((U1Gate(pi / 4), [targets[i]], []))  # T gate
                                     definition.append(
                                         (
                                             CXGate(),
                                             [q_controls[self.num_ctrl_qubits - i - 1], targets[i]],
-                                            []
+                                            [],
                                         )
                                     )
                                     definition.append(
-                                        (U1Gate(-pi / 4), [targets[i]], [])     # inverse T gate
+                                        (U1Gate(-pi / 4), [targets[i]], [])  # inverse T gate
                                     )
-                                    definition.append(
-                                        (U2Gate(0, pi), [targets[i]], [])       # H gate
-                                    )
+                                    definition.append((U2Gate(0, pi), [targets[i]], []))  # H gate
                                 else:
-                                    definition.append(
-                                        (U2Gate(0, pi), [targets[i]], [])       # H gate
-                                    )
-                                    definition.append(
-                                        (U1Gate(pi / 4), [targets[i]], [])      # T gate
-                                    )
+                                    definition.append((U2Gate(0, pi), [targets[i]], []))  # H gate
+                                    definition.append((U1Gate(pi / 4), [targets[i]], []))  # T gate
                                     definition.append(
                                         (
                                             CXGate(),
                                             [q_controls[self.num_ctrl_qubits - i - 1], targets[i]],
-                                            []
+                                            [],
                                         )
                                     )
                                     definition.append(
-                                        (U1Gate(-pi / 4), [targets[i]], [])     # inverse T gate
+                                        (U1Gate(-pi / 4), [targets[i]], [])  # inverse T gate
                                     )
                                     definition.append(
                                         (
                                             CXGate(),
                                             [q_ancillas[num_ancillas - i - 1], targets[i]],
-                                            []
+                                            [],
                                         )
                                     )
                             else:
                                 controls = [
                                     q_controls[self.num_ctrl_qubits - i - 1],
-                                    q_ancillas[num_ancillas - i - 1]
+                                    q_ancillas[num_ancillas - i - 1],
                                 ]
 
                                 definition.append((CCXGate(), [*controls, targets[i]], []))
                         else:
-                            definition.append(
-                                (U2Gate(0, pi), [targets[i]], [])       # H gate
-                            )
-                            definition.append(
-                                (U1Gate(pi / 4), [targets[i]], [])      # T gate
-                            )
+                            definition.append((U2Gate(0, pi), [targets[i]], []))  # H gate
+                            definition.append((U1Gate(pi / 4), [targets[i]], []))  # T gate
                             definition.append(
                                 (
                                     CXGate(),
                                     [q_controls[self.num_ctrl_qubits - i - 2], targets[i]],
-                                    []
+                                    [],
                                 )
                             )
-                            definition.append(
-                                (U1Gate(-pi / 4), [targets[i]], [])     # inverse T gate
-                            )
+                            definition.append((U1Gate(-pi / 4), [targets[i]], []))  # inverse T gate
                             definition.append(
                                 (
                                     CXGate(),
                                     [q_controls[self.num_ctrl_qubits - i - 1], targets[i]],
-                                    []
+                                    [],
                                 )
                             )
-                            definition.append(
-                                (U1Gate(pi / 4), [targets[i]], [])      # T gate
-                            )
+                            definition.append((U1Gate(pi / 4), [targets[i]], []))  # T gate
                             definition.append(
                                 (
                                     CXGate(),
                                     [q_controls[self.num_ctrl_qubits - i - 2], targets[i]],
-                                    []
+                                    [],
                                 )
                             )
-                            definition.append(
-                                (U1Gate(-pi / 4), [targets[i]], [])     # inverse T gate
-                            )
-                            definition.append(
-                                (U2Gate(0, pi), [targets[i]], [])       # H gate
-                            )
+                            definition.append((U1Gate(-pi / 4), [targets[i]], []))  # inverse T gate
+                            definition.append((U2Gate(0, pi), [targets[i]], []))  # H gate
 
                             break
 
                     for i in range(num_ancillas - 1):  # reset part
+                        definition.append((CXGate(), [q_ancillas[i], q_ancillas[i + 1]], []))
+                        definition.append((U1Gate(pi / 4), [q_ancillas[i + 1]], []))  # T gate
+                        definition.append((CXGate(), [q_controls[2 + i], q_ancillas[i + 1]], []))
                         definition.append(
-                            (
-                                CXGate(),
-                                [q_ancillas[i], q_ancillas[i + 1]],
-                                []
-                            )
+                            (U1Gate(-pi / 4), [q_ancillas[i + 1]], [])  # inverse T gate
                         )
-                        definition.append(
-                            (U1Gate(pi / 4), [q_ancillas[i + 1]], [])      # T gate
-                        )
-                        definition.append(
-                            (
-                                CXGate(),
-                                [q_controls[2 + i], q_ancillas[i + 1]],
-                                []
-                            )
-                        )
-                        definition.append(
-                            (U1Gate(-pi / 4), [q_ancillas[i + 1]], [])     # inverse T gate
-                        )
-                        definition.append(
-                            (U2Gate(0, pi), [q_ancillas[i + 1]], [])       # H gate
-                        )
+                        definition.append((U2Gate(0, pi), [q_ancillas[i + 1]], []))  # H gate
 
                     if self._action_only:
                         definition.append(
@@ -1645,13 +1609,17 @@ class MCXVChain(MCXGate):
             definition.append((RCCXGate(), [q_controls[0], q_controls[1], q_ancillas[0]], []))
             i = 0
             for j in range(2, self.num_ctrl_qubits - 1):
-                definition.append((RCCXGate(), [q_controls[j], q_ancillas[i], q_ancillas[i + 1]], []))
+                definition.append(
+                    (RCCXGate(), [q_controls[j], q_ancillas[i], q_ancillas[i + 1]], [])
+                )
                 i += 1
 
             definition.append((CCXGate(), [q_controls[-1], q_ancillas[i], q_target], []))
 
             for j in reversed(range(2, self.num_ctrl_qubits - 1)):
-                definition.append((RCCXGate(), [q_controls[j], q_ancillas[i - 1], q_ancillas[i]], []))
+                definition.append(
+                    (RCCXGate(), [q_controls[j], q_ancillas[i - 1], q_ancillas[i]], [])
+                )
                 i -= 1
             definition.append((RCCXGate(), [q_controls[0], q_controls[1], q_ancillas[i]], []))
 

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -1444,13 +1444,14 @@ class MCXVChain(MCXGate):
             dirty_ancillas: when set to ``True``, the method applies an optimized multicontrolled-X gate
                 up to a relative phase using dirty ancillary qubits with the properties of lemmas 7 and 8
                 from arXiv:1501.06911, with at most 8*k - 6 CNOT gates.
-                For k within the range {1, ..., ceil(n/2)}. And for n representing the total number of qubits.
-
-            relative_phase: when set to ``True``, the method applies the optimized multicontrolled-X gate up to a
-                relative phase, in a way that, by lemma 7 of arXiv:1501.06911, the relative
+                For k within the range {1, ..., ceil(n/2)}. And for n representing the total number of
+                qubits.
+            relative_phase: when set to ``True``, the method applies the optimized multicontrolled-X gate
+                up to a relative phase, in a way that, by lemma 7 of arXiv:1501.06911, the relative
                 phases of the ``action part`` cancel out with the phases of the ``reset part``.
 
-            action_only: when set to ``True``, the method applies only the action part of lemma 8 from arXiv:1501.06911.
+            action_only: when set to ``True``, the method applies only the action part of lemma 8
+                from arXiv:1501.06911.
 
         """
         super().__init__(

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -1409,8 +1409,8 @@ class MCXVChain(MCXGate):
         duration=None,
         unit="dt",
         _base_label=None,
-        relative_phase: bool = False,
-        action_only: bool = False,
+        relative_phase: bool = False, # pylint: disable=unused-argument
+        action_only: bool = False, # pylint: disable=unused-argument
     ):
         """Create a new MCX instance.
 
@@ -1451,6 +1451,8 @@ class MCXVChain(MCXGate):
         self._dirty_ancillas = dirty_ancillas
         self._relative_phase = relative_phase
         self._action_only = action_only
+        super().__init__(num_ctrl_qubits, label=label, ctrl_state=ctrl_state, _name="mcx_vchain")
+
 
 
     def inverse(self, annotated: bool = False):
@@ -1496,7 +1498,7 @@ class MCXVChain(MCXGate):
         if self._dirty_ancillas:
             if self.num_ctrl_qubits < 3:
                 definition.append(
-                    (MCXGate(self.num_ctrl_qubits, mode="noancilla"), [*q_controls, q_target], [])
+                    (MCXGate(self.num_ctrl_qubits), [*q_controls, q_target], [])
                 )
             elif not self._relative_phase and self.num_ctrl_qubits == 3:
                 definition.append((C3XGate(), [*q_controls, q_target], []))

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -1409,8 +1409,8 @@ class MCXVChain(MCXGate):
         duration=None,
         unit="dt",
         _base_label=None,
-        relative_phase: bool = False, # pylint: disable=unused-argument
-        action_only: bool = False, # pylint: disable=unused-argument
+        relative_phase: bool = False,  # pylint: disable=unused-argument
+        action_only: bool = False,  # pylint: disable=unused-argument
     ):
         """Create a new MCX instance.
 
@@ -1452,8 +1452,6 @@ class MCXVChain(MCXGate):
         self._relative_phase = relative_phase
         self._action_only = action_only
         super().__init__(num_ctrl_qubits, label=label, ctrl_state=ctrl_state, _name="mcx_vchain")
-
-
 
     def inverse(self, annotated: bool = False):
         """Invert this gate. The MCX is its own inverse.
@@ -1528,9 +1526,7 @@ class MCXVChain(MCXGate):
                                             [],
                                         )
                                     )
-                                    definition.append(
-                                        (TdgGate(), [targets[i]], [])
-                                    )
+                                    definition.append((TdgGate(), [targets[i]], []))
                                     definition.append((HGate(), [targets[i]], []))
                                 else:
                                     definition.append((HGate(), [targets[i]], []))
@@ -1542,9 +1538,7 @@ class MCXVChain(MCXGate):
                                             [],
                                         )
                                     )
-                                    definition.append(
-                                        (TdgGate(), [targets[i]], [])
-                                    )
+                                    definition.append((TdgGate(), [targets[i]], []))
                                     definition.append(
                                         (
                                             CXGate(),
@@ -1594,9 +1588,7 @@ class MCXVChain(MCXGate):
                         definition.append((CXGate(), [q_ancillas[i], q_ancillas[i + 1]], []))
                         definition.append((TGate(), [q_ancillas[i + 1]], []))
                         definition.append((CXGate(), [q_controls[2 + i], q_ancillas[i + 1]], []))
-                        definition.append(
-                            (TdgGate(), [q_ancillas[i + 1]], [])
-                        )
+                        definition.append((TdgGate(), [q_ancillas[i + 1]], []))
                         definition.append((HGate(), [q_ancillas[i + 1]], []))
 
                     if self._action_only:

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -1497,9 +1497,7 @@ class MCXVChain(MCXGate):
 
         if self._dirty_ancillas:
             if self.num_ctrl_qubits < 3:
-                definition.append(
-                    (MCXGate(self.num_ctrl_qubits), [*q_controls, q_target], [])
-                )
+                definition.append((MCXGate(self.num_ctrl_qubits), [*q_controls, q_target], []))
             elif not self._relative_phase and self.num_ctrl_qubits == 3:
                 definition.append((C3XGate(), [*q_controls, q_target], []))
             else:

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -1484,8 +1484,8 @@ class MCXVChain(MCXGate):
         """Define the MCX gate using a V-chain of CX gates."""
         # pylint: disable=cyclic-import
         from qiskit.circuit.quantumcircuit import QuantumCircuit
-        from .u1 import U1Gate
-        from .u2 import U2Gate
+        from .t import TGate, TdgGate
+        from .h import HGate
 
         q = QuantumRegister(self.num_qubits, name="q")
         qc = QuantumCircuit(q, name=self.name)
@@ -1520,7 +1520,7 @@ class MCXVChain(MCXGate):
                                             [],
                                         )
                                     )
-                                    definition.append((U1Gate(pi / 4), [targets[i]], []))  # T gate
+                                    definition.append((TGate(), [targets[i]], []))
                                     definition.append(
                                         (
                                             CXGate(),
@@ -1529,12 +1529,12 @@ class MCXVChain(MCXGate):
                                         )
                                     )
                                     definition.append(
-                                        (U1Gate(-pi / 4), [targets[i]], [])  # inverse T gate
+                                        (TdgGate(), [targets[i]], [])
                                     )
-                                    definition.append((U2Gate(0, pi), [targets[i]], []))  # H gate
+                                    definition.append((HGate(), [targets[i]], []))
                                 else:
-                                    definition.append((U2Gate(0, pi), [targets[i]], []))  # H gate
-                                    definition.append((U1Gate(pi / 4), [targets[i]], []))  # T gate
+                                    definition.append((HGate(), [targets[i]], []))
+                                    definition.append((TGate(), [targets[i]], []))
                                     definition.append(
                                         (
                                             CXGate(),
@@ -1543,7 +1543,7 @@ class MCXVChain(MCXGate):
                                         )
                                     )
                                     definition.append(
-                                        (U1Gate(-pi / 4), [targets[i]], [])  # inverse T gate
+                                        (TdgGate(), [targets[i]], [])
                                     )
                                     definition.append(
                                         (
@@ -1560,8 +1560,8 @@ class MCXVChain(MCXGate):
 
                                 definition.append((CCXGate(), [*controls, targets[i]], []))
                         else:
-                            definition.append((U2Gate(0, pi), [targets[i]], []))  # H gate
-                            definition.append((U1Gate(pi / 4), [targets[i]], []))  # T gate
+                            definition.append((HGate(), [targets[i]], []))
+                            definition.append((TGate(), [targets[i]], []))
                             definition.append(
                                 (
                                     CXGate(),
@@ -1569,7 +1569,7 @@ class MCXVChain(MCXGate):
                                     [],
                                 )
                             )
-                            definition.append((U1Gate(-pi / 4), [targets[i]], []))  # inverse T gate
+                            definition.append((TdgGate(), [targets[i]], []))
                             definition.append(
                                 (
                                     CXGate(),
@@ -1577,7 +1577,7 @@ class MCXVChain(MCXGate):
                                     [],
                                 )
                             )
-                            definition.append((U1Gate(pi / 4), [targets[i]], []))  # T gate
+                            definition.append((TGate(), [targets[i]], []))
                             definition.append(
                                 (
                                     CXGate(),
@@ -1585,19 +1585,19 @@ class MCXVChain(MCXGate):
                                     [],
                                 )
                             )
-                            definition.append((U1Gate(-pi / 4), [targets[i]], []))  # inverse T gate
-                            definition.append((U2Gate(0, pi), [targets[i]], []))  # H gate
+                            definition.append((TdgGate(), [targets[i]], []))
+                            definition.append((HGate(), [targets[i]], []))
 
                             break
 
                     for i in range(num_ancillas - 1):  # reset part
                         definition.append((CXGate(), [q_ancillas[i], q_ancillas[i + 1]], []))
-                        definition.append((U1Gate(pi / 4), [q_ancillas[i + 1]], []))  # T gate
+                        definition.append((TGate(), [q_ancillas[i + 1]], []))
                         definition.append((CXGate(), [q_controls[2 + i], q_ancillas[i + 1]], []))
                         definition.append(
-                            (U1Gate(-pi / 4), [q_ancillas[i + 1]], [])  # inverse T gate
+                            (TdgGate(), [q_ancillas[i + 1]], [])
                         )
-                        definition.append((U2Gate(0, pi), [q_ancillas[i + 1]], []))  # H gate
+                        definition.append((HGate(), [q_ancillas[i + 1]], []))
 
                     if self._action_only:
                         definition.append(

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -1493,7 +1493,7 @@ class MCXVChain(MCXGate):
             if self.num_ctrl_qubits < 3:
                 qc.mcx(q_controls, q_target)
             elif not self._relative_phase and self.num_ctrl_qubits == 3:
-                qc.mcx(q_controls, q_target)
+                qc._append(C3XGate(), [*q_controls, q_target], [])
             else:
                 num_ancillas = self.num_ctrl_qubits - 2
                 targets = [q_target] + q_ancillas[:num_ancillas][::-1]

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -1439,6 +1439,20 @@ class MCXVChain(MCXGate):
         relative_phase: bool = False,
         action_only: bool = False,
     ):
+        """
+        Args:
+            dirty_ancillas: when set to ``True``, the method applies an optimized multicontrolled-X gate
+                up to a relative phase using dirty ancillary qubits with the properties of lemmas 7 and 8
+                from arXiv:1501.06911, with at most 8*k - 6 CNOT gates.
+                For k within the range {1, ..., ceil(n/2)}. And for n representing the total number of qubits.
+
+            relative_phase: when set to ``True``, the method applies the optimized multicontrolled-X gate up to a
+                relative phase, in a way that, by lemma 7 of arXiv:1501.06911, the relative
+                phases of the ``action part`` cancel out with the phases of the ``reset part``.
+
+            action_only: when set to ``True``, the method applies only the action part of lemma 8 from arXiv:1501.06911.
+
+        """
         super().__init__(
             num_ctrl_qubits,
             label=label,
@@ -1526,6 +1540,8 @@ class MCXVChain(MCXGate):
 
                                 qc.ccx(controls[0], controls[1], targets[i])
                         else:
+                            # implements an optimized toffoli operation
+                            # up to a diagonal gate, akin to lemma 6 of arXiv:1501.06911
                             qc.h(targets[i])
                             qc.t(targets[i])
                             qc.cx(q_controls[self.num_ctrl_qubits - i - 2], targets[i])

--- a/releasenotes/notes/mcxvchain_dirty_auxiliary-5ea4037557209f6e.yaml
+++ b/releasenotes/notes/mcxvchain_dirty_auxiliary-5ea4037557209f6e.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    :class:`.MCXVChain` has two new Boolean parameters `relative_phase` and `action_only`.
+    If `action_only` the circuit does not clean the dirty qubits. If `relative_phase`
+    the gate is implemented up to a global phase. Both parameters are used to optimize the
+    decomposition of MCXVChain.
+fixes:
+  - |
+    :class:`.MCXVChain` with k controls and k-2 dirty auxiliary qubits now requires 8k-6 cx gates.

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -20,7 +20,6 @@ from numpy import pi
 from ddt import ddt, data, unpack
 
 from qiskit import QuantumRegister, QuantumCircuit, QiskitError, transpile
-from qiskit.test import QiskitTestCase
 from qiskit.circuit import ControlledGate, Parameter, Gate
 from qiskit.circuit.annotated_operation import AnnotatedOperation
 from qiskit.circuit.singleton import SingletonControlledGate, _SingletonControlledGateOverrides

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -19,7 +19,7 @@ import numpy as np
 from numpy import pi
 from ddt import ddt, data, unpack
 
-from qiskit import QuantumRegister, QuantumCircuit, QiskitError, transpile
+from qiskit import QuantumRegister, QuantumCircuit, QiskitError
 from qiskit.circuit import ControlledGate, Parameter, Gate
 from qiskit.circuit.annotated_operation import AnnotatedOperation
 from qiskit.circuit.singleton import SingletonControlledGate, _SingletonControlledGateOverrides
@@ -802,6 +802,7 @@ class TestControlledGate(QiskitTestCase):
     def test_mcxvchain_dirty_ancilla_cx_count(self, num_ctrl_qubits):
         """Test if cx count of the v-chain mcx with dirty ancilla
         is less than upper bound."""
+        from qiskit import transpile
 
         mcx_vchain = MCXVChain(num_ctrl_qubits, dirty_ancillas=True)
         qc = QuantumCircuit(mcx_vchain.num_qubits)

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -814,8 +814,8 @@ class TestControlledGate(QiskitTestCase):
 
         self.assertLessEqual(cx_count, 8 * num_ctrl_qubits - 6)
 
-    @data(5, 6, 7)
-    def test_mcxvchain_dirty_ancilla_action_only(self, num_ctrl_qubits):
+    def test_mcxvchain_dirty_ancilla_action_only(self):
+        num_ctrl_qubits = 5
         """Test the v-chain mcx with dirty auxiliary qubits
         with gate cancelling with mirrored circuit."""
 
@@ -836,8 +836,8 @@ class TestControlledGate(QiskitTestCase):
 
         self.assertTrue(matrix_equal(Operator(circuit).data, Operator(ref_circuit).data))
 
-    @data(5, 6, 7)
-    def test_mcxvchain_dirty_ancilla_relative_phase(self, num_ctrl_qubits):
+    def test_mcxvchain_dirty_ancilla_relative_phase(self):
+        num_ctrl_qubits = 5
         """Test the v-chain mcx with dirty auxiliary qubits
         with only relative phase Toffoli gates."""
 
@@ -855,6 +855,8 @@ class TestControlledGate(QiskitTestCase):
         circuit.append(gate_relative_phase, list(range(num_qubits - 1)), [])
         circuit.h(num_qubits - 1)
         circuit.append(gate_relative_phase.inverse(), list(range(num_qubits - 1)), [])
+
+        self.assertTrue(matrix_equal(Operator(circuit).data, Operator(ref_circuit).data))
 
     @data(1, 2, 3, 4)
     def test_inverse_x(self, num_ctrl_qubits):

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -815,9 +815,10 @@ class TestControlledGate(QiskitTestCase):
         self.assertLessEqual(cx_count, 8 * num_ctrl_qubits - 6)
 
     def test_mcxvchain_dirty_ancilla_action_only(self):
-        num_ctrl_qubits = 5
         """Test the v-chain mcx with dirty auxiliary qubits
         with gate cancelling with mirrored circuit."""
+
+        num_ctrl_qubits = 5
 
         gate = MCXVChain(num_ctrl_qubits, dirty_ancillas=True)
         gate_with_cancelling = MCXVChain(num_ctrl_qubits, dirty_ancillas=True, action_only=True)
@@ -837,9 +838,9 @@ class TestControlledGate(QiskitTestCase):
         self.assertTrue(matrix_equal(Operator(circuit).data, Operator(ref_circuit).data))
 
     def test_mcxvchain_dirty_ancilla_relative_phase(self):
-        num_ctrl_qubits = 5
         """Test the v-chain mcx with dirty auxiliary qubits
         with only relative phase Toffoli gates."""
+        num_ctrl_qubits = 5
 
         gate = MCXVChain(num_ctrl_qubits, dirty_ancillas=True)
         gate_relative_phase = MCXVChain(num_ctrl_qubits, dirty_ancillas=True, relative_phase=True)

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -798,27 +798,27 @@ class TestControlledGate(QiskitTestCase):
                         corrected[i] += statevector_amplitude
                     statevector = corrected
                 np.testing.assert_array_almost_equal(statevector.real, reference)
-    
+
     @data(5, 10, 15)
     def test_mcxvchain_dirty_ancilla_cx_count(self, num_ctrl_qubits):
         """Test if cx count of the v-chain mcx with dirty ancilla
         is less than upper bound."""
-        
+
         mcx_vchain = MCXVChain(num_ctrl_qubits, dirty_ancillas=True)
         qc = QuantumCircuit(mcx_vchain.num_qubits)
 
         qc.append(mcx_vchain, list(range(mcx_vchain.num_qubits)))
-        
-        tr_mcx_vchain = transpile(qc, basis_gates=['u', 'cx'])
-        cx_count = tr_mcx_vchain.count_ops()['cx']
-        
+
+        tr_mcx_vchain = transpile(qc, basis_gates=["u", "cx"])
+        cx_count = tr_mcx_vchain.count_ops()["cx"]
+
         self.assertLessEqual(cx_count, 8 * num_ctrl_qubits - 6)
-    
+
     @data(5, 6, 7)
     def test_mcxvchain_dirty_ancilla_action_only(self, num_ctrl_qubits):
         """Test the v-chain mcx with dirty auxiliary qubits
         with gate cancelling with mirrored circuit."""
-        
+
         gate = MCXVChain(num_ctrl_qubits, dirty_ancillas=True)
         gate_with_cancelling = MCXVChain(num_ctrl_qubits, dirty_ancillas=True, action_only=True)
 
@@ -829,18 +829,18 @@ class TestControlledGate(QiskitTestCase):
         ref_circuit.append(gate, list(range(num_qubits)), [])
         ref_circuit.h(num_ctrl_qubits)
         ref_circuit.append(gate, list(range(num_qubits)), [])
-        
+
         circuit.append(gate_with_cancelling, list(range(num_qubits)), [])
         circuit.h(num_ctrl_qubits)
         circuit.append(gate_with_cancelling.inverse(), list(range(num_qubits)), [])
 
         self.assertTrue(matrix_equal(Operator(circuit).data, Operator(ref_circuit).data))
-    
+
     @data(5, 6, 7)
     def test_mcxvchain_dirty_ancilla_relative_phase(self, num_ctrl_qubits):
         """Test the v-chain mcx with dirty auxiliary qubits
         with only relative phase Toffoli gates."""
-        
+
         gate = MCXVChain(num_ctrl_qubits, dirty_ancillas=True)
         gate_relative_phase = MCXVChain(num_ctrl_qubits, dirty_ancillas=True, relative_phase=True)
 
@@ -851,7 +851,7 @@ class TestControlledGate(QiskitTestCase):
         ref_circuit.append(gate, list(range(num_qubits - 1)), [])
         ref_circuit.h(num_qubits - 1)
         ref_circuit.append(gate, list(range(num_qubits - 1)), [])
-        
+
         circuit.append(gate_relative_phase, list(range(num_qubits - 1)), [])
         circuit.h(num_qubits - 1)
         circuit.append(gate_relative_phase.inverse(), list(range(num_qubits - 1)), [])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Implementation of MCX with $k$ controls and $k - 2$ dirty auxiliary qubits following the optimizations described by Iten et al. in [1].

[1] http://arxiv.org/abs/1501.06911

### Details and comments

The changes made to the MCXVChain class only affect the dirty_ancilla mode. This implementation produces MCX circuits with at most $8k - 6$ CNOTs with $k$ control qubits. It also addresses issue #5872 and is a necessary step to further improve PR #8710.