### PR TITLE
Allow `BaseEstimator` to accept a `PauliList` as a sequence of `observables`

### DIFF
--- a/qiskit/primitives/base/base_estimator.py
+++ b/qiskit/primitives/base/base_estimator.py
@@ -270,7 +270,7 @@ class BaseEstimator(BasePrimitive):
     def _validate_observables(
         observables: Sequence[BaseOperator | PauliSumOp | str] | BaseOperator | PauliSumOp | str,
     ) -> tuple[SparsePauliOp, ...]:
-        if isinstance(observables, str) or not isinstance(observables, Sequence):
+        if isinstance(observables, str) or not isinstance(observables, (Sequence, PauliList)):
             observables = (observables,)
         if len(observables) == 0:
             raise ValueError("No observables were provided.")

--- a/qiskit/primitives/base/base_estimator.py
+++ b/qiskit/primitives/base/base_estimator.py
@@ -92,7 +92,7 @@ from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.circuit.parametertable import ParameterView
 from qiskit.opflow import PauliSumOp
 from qiskit.providers import JobV1 as Job
-from qiskit.quantum_info.operators import SparsePauliOp
+from qiskit.quantum_info.operators import SparsePauliOp, PauliList
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.utils.deprecation import deprecate_arguments, deprecate_function
 
@@ -218,6 +218,17 @@ class BaseEstimator(BasePrimitive):
         """
         # Singular validation
         circuits = self._validate_circuits(circuits)
+        if len(circuits) == 1 and len(observables) > 1 and isinstance(observables, PauliList):
+            warn(
+                "BaseEstimator's implicit conversion of a single PauliList to a "
+                "SparsePauliOp is deprecated as of Qiskit Terra 0.24.0 and will be "
+                "removed no sooner than 3 months after the release date.  If a single "
+                "observable is desired from a ``PauliList`` with multiple elements, "
+                "convert it to a SparsePauliOp before calling the Estimator.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            observables = SparsePauliOp(observables)
         observables = self._validate_observables(observables)
         parameter_values = self._validate_parameter_values(
             parameter_values,

--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -14,6 +14,7 @@ Optimized list of Pauli operators
 """
 
 from collections import defaultdict
+from collections.abc import Sequence
 
 import numpy as np
 import rustworkx as rx
@@ -1181,3 +1182,6 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         for idx, color in coloring_dict.items():
             groups[color].append(idx)
         return [self[group] for group in groups.values()]
+
+
+Sequence.register(PauliList)

--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -14,7 +14,6 @@ Optimized list of Pauli operators
 """
 
 from collections import defaultdict
-from collections.abc import Sequence
 
 import numpy as np
 import rustworkx as rx
@@ -1182,6 +1181,3 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         for idx, color in coloring_dict.items():
             groups[color].append(idx)
         return [self[group] for group in groups.values()]
-
-
-Sequence.register(PauliList)

--- a/releasenotes/notes/baseestimator-paulilist-observables-5fddffc11b9b581e.yaml
+++ b/releasenotes/notes/baseestimator-paulilist-observables-5fddffc11b9b581e.yaml
@@ -1,0 +1,21 @@
+---
+features:
+  - |
+    ``BaseEstimator`` can now accept multiple observables in the form
+    of a ``PauliList``.  Previously, it was necessary to convert the
+    ``PauliList`` to a ``list`` before passing it to a
+    ``BaseEstimator`` subclass; otherwise it would be interpreted as a
+    single ``SparsePauliOp`` observable.
+deprecations:
+  - |
+    ``BaseEstimator``'s implicit conversion of ``observables`` in the
+    form of a ``PauliList`` with multiple elements to a single
+    ``SparsePauliOp`` is deprecated as of Qiskit Terra 0.24.0 and will
+    be removed no sooner than 3 months after the release date.  If a
+    single observable is desired from a ``PauliList`` with multiple
+    elements, convert it to a ``SparsePauliOp`` before calling the
+    ``Estimator``.
+other:
+  - |
+    ``PauliList`` is now registered with ``collections.abc`` as a
+    ``Sequence``.

--- a/releasenotes/notes/baseestimator-paulilist-observables-5fddffc11b9b581e.yaml
+++ b/releasenotes/notes/baseestimator-paulilist-observables-5fddffc11b9b581e.yaml
@@ -15,7 +15,3 @@ deprecations:
     single observable is desired from a ``PauliList`` with multiple
     elements, convert it to a ``SparsePauliOp`` before calling the
     ``Estimator``.
-other:
-  - |
-    ``PauliList`` is now registered with ``collections.abc`` as a
-    ``Sequence``.

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -705,14 +705,20 @@ class TestObservableValidation(QiskitTestCase):
         self.assertEqual(BaseEstimator._validate_observables(obsevables), expected)
 
     def test_deprecated_paulilist_multiple_as_single_observable(self):
+        """Test deprecated interpretation of PauliList as single observable."""
         observables = PauliList(["IXYZ", "ZYXI"])
         expected = (SparsePauliOp(["IXYZ", "ZYXI"]),)
+        self_ = self
 
         class MockEstimator(BaseEstimator):
-            def _run(self_, circuits, observables, parameter_values, **run_options):
-                self.assertEqual(observables, expected)
+            """Mock Estimator for testing deprecated PauliList as single observable."""
 
-            def _call(self_, circuits, observables, parameters_values, **run_options):
+            def _run(self, circuits, observables, parameter_values, **run_options):
+                """Override _run for the test."""
+                self_.assertEqual(observables, expected)
+
+            def _call(self, circuits, observables, parameter_values, **run_options):
+                """Override _call so abstract base class does not complain."""
                 pass
 
         qc = QuantumCircuit(4)

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -712,7 +712,7 @@ class TestObservableValidation(QiskitTestCase):
             def _run(self_, circuits, observables, parameter_values, **run_options):
                 self.assertEqual(observables, expected)
 
-            def _call():
+            def _call(self_, circuits, observables, parameters_values, **run_options):
                 pass
 
         qc = QuantumCircuit(4)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Currently, if a `PauliList` of multiple elements is passed to an Estimator in the `observables` argument, it will be converted to a single `SparsePauliOp` with multiple terms and interpreted as a single observable.  This PR deprecates that behavior and instead makes the default be to interpret it as a _sequence_ of observables, which I feel is more consistent with the documentation.

### Details and comments

~~I felt that the cleanest way to achieve this is to register `PauliList` as a `Sequence`, as it implements all the `Sequence` methods.  (All tests continue to pass with this change.)  However, if this is considered too radical, I could achieve the same result as far as this PR is concerned by replacing `Sequence` with `(Sequence, PauliList)` on [this line](https://github.com/Qiskit/qiskit-terra/blob/5a62949dd086ccdd530959539d67da473a07cded/qiskit/primitives/base/base_estimator.py#L262).~~ EDIT: I removed the registration with `Sequence` in 3d4a22ddc981b88e97f65ee85738c47d63c079b1.

I should mention that some of the existing tests ensured that if `observables` is a _list_ of `PauliList`s, each such `PauliList` is converted to a `SparsePauliOp`, so perhaps the original intention was to do this conversion always.  However, none of the tests considered `PauliList`s of more than one element prior to this PR, and doing an implicit conversion on a toplevel `PauliList` with many elements seems counter to the documentation, to me at least.  (If `observables` is "one or more observable objects", then I would expect a `PauliList` of multiple elements to be interpreted as multiple observables.)  I see three potential solutions:

1. Keep it such that a `PauliList` passed as `observables` is implicitly concerted to a `SparsePauliOp` always. (status quo, seems unintuitive and should be better documented if this route is chosen)
2. Change it so a `PauliList` passed as `observables` is treated as a sequence of observables. (this PR)
3. Infer, from `len(circuits)`, whether a `PauliList` with multiple elements passed as `observables` should be treated as a single observable or multiple observables. (this PR, but remove the deprecation warning)