### PR TITLE
Slot standard library gates

### DIFF
--- a/qiskit/circuit/library/standard_gates/dcx.py
+++ b/qiskit/circuit/library/standard_gates/dcx.py
@@ -47,6 +47,17 @@ class DCXGate(Gate):
             \end{pmatrix}
     """
 
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
+
     def __init__(self):
         """Create new DCX gate."""
         super().__init__("dcx", 2, [])

--- a/qiskit/circuit/library/standard_gates/ecr.py
+++ b/qiskit/circuit/library/standard_gates/ecr.py
@@ -80,6 +80,17 @@ class ECRGate(Gate):
                 \end{pmatrix}
     """
 
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
+
     def __init__(self):
         """Create new ECR gate."""
         super().__init__("ecr", 2, [])

--- a/qiskit/circuit/library/standard_gates/h.py
+++ b/qiskit/circuit/library/standard_gates/h.py
@@ -51,6 +51,17 @@ class HGate(Gate):
             \end{pmatrix}
     """
 
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
+
     def __init__(self, label: Optional[str] = None):
         """Create new H gate."""
         super().__init__("h", 1, [], label=label)
@@ -161,6 +172,20 @@ class CHGate(ControlledGate):
                     0 & 0 & \frac{1}{\sqrt{2}} & -\frac{1}{\sqrt{2}}
                 \end{pmatrix}
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
+
     # Define class constants. This saves future allocation time.
     _sqrt2o2 = 1 / sqrt(2)
     _matrix1 = numpy.array(

--- a/qiskit/circuit/library/standard_gates/i.py
+++ b/qiskit/circuit/library/standard_gates/i.py
@@ -43,6 +43,16 @@ class IGate(Gate):
         q_0: ┤ I ├
              └───┘
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(self, label: Optional[str] = None):
         """Create new Identity gate."""

--- a/qiskit/circuit/library/standard_gates/iswap.py
+++ b/qiskit/circuit/library/standard_gates/iswap.py
@@ -82,6 +82,16 @@ class iSwapGate(Gate):
                 0 & 0 & 0 & 1
             \end{pmatrix}
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(self, label: Optional[str] = None):
         """Create new iSwap gate."""

--- a/qiskit/circuit/library/standard_gates/p.py
+++ b/qiskit/circuit/library/standard_gates/p.py
@@ -73,6 +73,16 @@ class PhaseGate(Gate):
         Reference for virtual Z gate implementation:
         `1612.00858 <https://arxiv.org/abs/1612.00858>`_
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(self, theta: ParameterValueType, label: Optional[str] = None):
         """Create new Phase gate."""
@@ -170,6 +180,20 @@ class CPhaseGate(ControlledGate):
         of Phase and RZ, CPhase and CRZ are different gates with a relative
         phase difference.
     """
+
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __init__(
         self,
@@ -282,6 +306,20 @@ class MCPhaseGate(ControlledGate):
         :class:`~qiskit.circuit.library.standard_gates.CPhaseGate`:
         The singly-controlled-version of this gate.
     """
+
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __init__(self, lam: ParameterValueType, num_ctrl_qubits: int, label: Optional[str] = None):
         """Create new MCPhase gate."""

--- a/qiskit/circuit/library/standard_gates/r.py
+++ b/qiskit/circuit/library/standard_gates/r.py
@@ -48,6 +48,16 @@ class RGate(Gate):
                 -i e^{i \phi} \sin{\th} & \cos{\th}
             \end{pmatrix}
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(
         self, theta: ParameterValueType, phi: ParameterValueType, label: Optional[str] = None

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -49,6 +49,16 @@ class RXGate(Gate):
                 -i\sin{\th} & \cos{\th}
             \end{pmatrix}
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(self, theta: ParameterValueType, label: Optional[str] = None):
         """Create new RX gate."""
@@ -169,6 +179,20 @@ class CRXGate(ControlledGate):
                     0 & 0 & -i\sin{\th} & \cos{\th}
                 \end{pmatrix}
     """
+
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __init__(
         self,

--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -72,6 +72,17 @@ class RXXGate(Gate):
                                     \end{pmatrix}
     """
 
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
+
     def __init__(self, theta: ParameterValueType, label: Optional[str] = None):
         """Create new RXX gate."""
         super().__init__("rxx", 2, [theta], label=label)

--- a/qiskit/circuit/library/standard_gates/ry.py
+++ b/qiskit/circuit/library/standard_gates/ry.py
@@ -48,6 +48,16 @@ class RYGate(Gate):
                 \sin{\th} & \cos{\th}
             \end{pmatrix}
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(self, theta: ParameterValueType, label: Optional[str] = None):
         """Create new RY gate."""
@@ -168,6 +178,20 @@ class CRYGate(ControlledGate):
                     0 & 0 & \sin{\th} & \cos{\th}
                 \end{pmatrix}
     """
+
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __init__(
         self,

--- a/qiskit/circuit/library/standard_gates/ryy.py
+++ b/qiskit/circuit/library/standard_gates/ryy.py
@@ -71,6 +71,16 @@ class RYYGate(Gate):
                                         i & 0 & 0 & 1
                                     \end{pmatrix}
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(self, theta: ParameterValueType, label: Optional[str] = None):
         """Create new RYY gate."""

--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -59,6 +59,17 @@ class RZGate(Gate):
         `1612.00858 <https://arxiv.org/abs/1612.00858>`_
     """
 
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
+
     def __init__(self, phi: ParameterValueType, label: Optional[str] = None):
         """Create new RZ gate."""
         super().__init__("rz", 1, [phi], label=label)
@@ -186,6 +197,19 @@ class CRZGate(ControlledGate):
         of U1 and RZ, CU1 and CRZ are different gates with a relative
         phase difference.
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __init__(
         self,

--- a/qiskit/circuit/library/standard_gates/rzz.py
+++ b/qiskit/circuit/library/standard_gates/rzz.py
@@ -83,6 +83,16 @@ class RZZGate(Gate):
                                         0 & 0 & 0 & 1-i
                                     \end{pmatrix}
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(self, theta: ParameterValueType, label: Optional[str] = None):
         """Create new RZZ gate."""

--- a/qiskit/circuit/library/standard_gates/s.py
+++ b/qiskit/circuit/library/standard_gates/s.py
@@ -52,6 +52,16 @@ class SGate(Gate):
 
     Equivalent to a :math:`\pi/2` radian rotation about the Z axis.
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(self, label: Optional[str] = None):
         """Create new S gate."""
@@ -116,6 +126,16 @@ class SdgGate(Gate):
 
     Equivalent to a :math:`-\pi/2` radian rotation about the Z axis.
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(self, label: Optional[str] = None):
         """Create new Sdg gate."""
@@ -179,6 +199,20 @@ class CSGate(ControlledGate):
                 0 & 0 & 0 & i
             \end{pmatrix}
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
+
     # Define class constants. This saves future allocation time.
     _matrix1 = numpy.array(
         [
@@ -253,6 +287,19 @@ class CSdgGate(ControlledGate):
                 0 & 0 & 0 & -i
             \end{pmatrix}
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
     # Define class constants. This saves future allocation time.
     _matrix1 = numpy.array(
         [

--- a/qiskit/circuit/library/standard_gates/swap.py
+++ b/qiskit/circuit/library/standard_gates/swap.py
@@ -53,6 +53,16 @@ class SwapGate(Gate):
 
         |a, b\rangle \rightarrow |b, a\rangle
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(self, label: Optional[str] = None):
         """Create new SWAP gate."""
@@ -188,6 +198,19 @@ class CSwapGate(ControlledGate):
         |0, b, c\rangle \rightarrow |0, b, c\rangle
         |1, b, c\rangle \rightarrow |1, c, b\rangle
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
     # Define class constants. This saves future allocation time.
     _matrix1 = numpy.array(
         [

--- a/qiskit/circuit/library/standard_gates/sx.py
+++ b/qiskit/circuit/library/standard_gates/sx.py
@@ -57,6 +57,16 @@ class SXGate(Gate):
                     = e^{-i pi/4} \sqrt{X}
 
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(self, label: Optional[str] = None):
         """Create new SX gate."""
@@ -140,6 +150,16 @@ class SXdgGate(Gate):
                     = e^{-i pi/4} \sqrt{X}^{\dagger}
 
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(self, label: Optional[str] = None):
         """Create new SXdg gate."""
@@ -225,6 +245,19 @@ class CSXGate(ControlledGate):
                 \end{pmatrix}
 
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
     # Define class constants. This saves future allocation time.
     _matrix1 = numpy.array(
         [

--- a/qiskit/circuit/library/standard_gates/t.py
+++ b/qiskit/circuit/library/standard_gates/t.py
@@ -52,6 +52,16 @@ class TGate(Gate):
 
     Equivalent to a :math:`\pi/4` radian rotation about the Z axis.
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(self, label: Optional[str] = None):
         """Create new T gate."""
@@ -116,6 +126,16 @@ class TdgGate(Gate):
 
     Equivalent to a :math:`-\pi/4` radian rotation about the Z axis.
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(self, label: Optional[str] = None):
         """Create new Tdg gate."""

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -66,6 +66,16 @@ class UGate(Gate):
 
         U(\theta, 0, 0) = RY(\theta)
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(
         self,
@@ -188,6 +198,19 @@ class CUGate(ControlledGate):
                     0 & 0 & e^{i(\gamma + \phi)}\sin(\th) & e^{i(\gamma + \phi+\lambda)}\cos(\th)
                 \end{pmatrix}
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __init__(
         self,

--- a/qiskit/circuit/library/standard_gates/u1.py
+++ b/qiskit/circuit/library/standard_gates/u1.py
@@ -91,6 +91,16 @@ class U1Gate(Gate):
         Reference for virtual Z gate implementation:
         `1612.00858 <https://arxiv.org/abs/1612.00858>`_
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(self, theta: ParameterValueType, label: Optional[str] = None):
         """Create new U1 gate."""
@@ -183,6 +193,19 @@ class CU1Gate(ControlledGate):
         of U1 and RZ, CU1 and CRZ are different gates with a relative
         phase difference.
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __init__(
         self,
@@ -296,6 +319,19 @@ class MCU1Gate(ControlledGate):
         :class:`~qiskit.circuit.library.standard_gates.CU1Gate`:
         The singly-controlled-version of this gate.
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __init__(
         self,

--- a/qiskit/circuit/library/standard_gates/u2.py
+++ b/qiskit/circuit/library/standard_gates/u2.py
@@ -86,6 +86,16 @@ class U2Gate(Gate):
         U3 is a generalization of U2 that covers all single-qubit rotations,
         using two X90 pulses.
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(
         self, phi: ParameterValueType, lam: ParameterValueType, label: Optional[str] = None

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -78,6 +78,16 @@ class U3Gate(Gate):
 
         U3(\theta, 0, 0) = RY(\theta)
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(
         self,
@@ -200,6 +210,19 @@ class CU3Gate(ControlledGate):
                     0 & 0   & e^{i\phi}\sin(\th) & e^{i(\phi+\lambda)}\cos(\th)
                 \end{pmatrix}
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __init__(
         self,

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -72,6 +72,16 @@ class XGate(Gate):
         |0\rangle \rightarrow |1\rangle \\
         |1\rangle \rightarrow |0\rangle
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(self, label: Optional[str] = None):
         """Create new X gate."""
@@ -187,6 +197,19 @@ class CXGate(ControlledGate):
     .. math::
         `|a, b\rangle \rightarrow |a, a \oplus b\rangle`
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __init__(self, label: Optional[str] = None, ctrl_state: Optional[Union[str, int]] = None):
         """Create new CX gate."""
@@ -325,6 +348,19 @@ class CCXGate(ControlledGate):
                 \end{pmatrix}
 
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __init__(self, label: Optional[str] = None, ctrl_state: Optional[Union[str, int]] = None):
         """Create new CCX gate."""
@@ -428,6 +464,17 @@ class RCCXGate(Gate):
     with the :meth:`~qiskit.circuit.QuantumCircuit.rccx` method.
     """
 
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
+
     def __init__(self, label: Optional[str] = None):
         """Create a new simplified CCX gate."""
         super().__init__("rccx", 3, [], label=label)
@@ -492,6 +539,20 @@ class C3SXGate(ControlledGate):
     References:
         [1] Barenco et al., 1995. https://arxiv.org/pdf/quant-ph/9503016.pdf
     """
+
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __init__(
         self,
@@ -589,6 +650,19 @@ class C3XGate(ControlledGate):
 
     This implementation uses :math:`\sqrt{T}` and 14 CNOT gates.
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __init__(
         self,
@@ -724,6 +798,17 @@ class RC3XGate(Gate):
     with the :meth:`~qiskit.circuit.QuantumCircuit.rcccx` method.
     """
 
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
+
     def __init__(self, label: Optional[str] = None):
         """Create a new RC3X gate."""
         super().__init__("rcccx", 4, [], label=label)
@@ -816,6 +901,20 @@ class C4XGate(ControlledGate):
         [1] Barenco et al., 1995. https://arxiv.org/pdf/quant-ph/9503016.pdf
         [2] Maslov, 2015. https://arxiv.org/abs/1508.03273
     """
+
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __init__(self, label: Optional[str] = None, ctrl_state: Optional[Union[str, int]] = None):
         """Create a new 4-qubit controlled X gate."""
@@ -916,6 +1015,20 @@ class MCXGate(ControlledGate):
     Can be applied to a :class:`~qiskit.circuit.QuantumCircuit`
     with the :meth:`~qiskit.circuit.QuantumCircuit.mcx` method.
     """
+
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __new__(
         cls,
@@ -1024,6 +1137,19 @@ class MCXGrayCode(MCXGate):
 
     This delegates the implementation to the MCU1 gate, since :math:`X = H \cdot U1(\pi) \cdot H`.
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __new__(
         cls,
@@ -1075,6 +1201,20 @@ class MCXRecursive(MCXGate):
     four sub-registers. This is done until we reach the 3- or 4-controlled X gate since
     for these we have a concrete implementation that do not require ancillas.
     """
+
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __init__(
         self,
@@ -1137,6 +1277,20 @@ class MCXRecursive(MCXGate):
 
 class MCXVChain(MCXGate):
     """Implement the multi-controlled X gate using a V-chain of CX gates."""
+
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __new__(
         cls,

--- a/qiskit/circuit/library/standard_gates/xx_minus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_minus_yy.py
@@ -90,6 +90,16 @@ class XXMinusYYGate(Gate):
                     -i\sin\left(\th\right)e^{-i\beta} & 0 & 0 & \cos\left(\th\right)
                 \end{pmatrix}
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(
         self,

--- a/qiskit/circuit/library/standard_gates/xx_plus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_plus_yy.py
@@ -81,6 +81,16 @@ class XXPlusYYGate(Gate):
                 0 & 0                     & 0                    & 1
             \end{pmatrix}
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(
         self,

--- a/qiskit/circuit/library/standard_gates/y.py
+++ b/qiskit/circuit/library/standard_gates/y.py
@@ -67,6 +67,16 @@ class YGate(Gate):
         |0\rangle \rightarrow i|1\rangle \\
         |1\rangle \rightarrow -i|0\rangle
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(self, label: Optional[str] = None):
         """Create new Y gate."""
@@ -174,6 +184,19 @@ class CYGate(ControlledGate):
                 \end{pmatrix}
 
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
     # Define class constants. This saves future allocation time.
     _matrix1 = numpy.array([[1, 0, 0, 0], [0, 0, 0, -1j], [0, 0, 1, 0], [0, 1j, 0, 0]])
     _matrix0 = numpy.array([[0, 0, -1j, 0], [0, 1, 0, 0], [1j, 0, 0, 0], [0, 0, 0, 1]])

--- a/qiskit/circuit/library/standard_gates/z.py
+++ b/qiskit/circuit/library/standard_gates/z.py
@@ -70,6 +70,16 @@ class ZGate(Gate):
         |0\rangle \rightarrow |0\rangle \\
         |1\rangle \rightarrow -|1\rangle
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+    )
 
     def __init__(self, label: Optional[str] = None):
         """Create new Z gate."""
@@ -159,6 +169,19 @@ class CZGate(ControlledGate):
     In the computational basis, this gate flips the phase of
     the target qubit if the control qubit is in the :math:`|1\rangle` state.
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __init__(self, label: Optional[str] = None, ctrl_state: Optional[Union[str, int]] = None):
         """Create new CZ gate."""
@@ -238,6 +261,19 @@ class CCZGate(ControlledGate):
     In the computational basis, this gate flips the phase of
     the target qubit if the control qubits are in the :math:`|11\rangle` state.
     """
+    __slots__ = (
+        "_definition",
+        "_num_qubits",
+        "_num_clbits",
+        "_name",
+        "_params",
+        "condition",
+        "_duration",
+        "_unit",
+        "base_gate",
+        "_num_ctrl_qubits",
+        "_ctrl_state",
+    )
 
     def __init__(self, label: Optional[str] = None, ctrl_state: Optional[Union[str, int]] = None):
         """Create new CCZ gate."""

--- a/releasenotes/notes/slot-standard-library-gates-c8a7641dc59cc6cd.yaml
+++ b/releasenotes/notes/slot-standard-library-gates-c8a7641dc59cc6cd.yaml
@@ -1,0 +1,95 @@
+---
+upgrade:
+  - |
+    The standard library gate classes in :mod:`qiskit.circuit.library` no longer have a
+    ``__dict__`` attribute and no longer accept adding arbitrary attributes being added to
+    instances of the classes. The specific gate classes effected by this change are:
+
+      * :class:`~.DCXGate`
+      * :class:`~.ECRGate`
+      * :class:`~.HGate`
+      * :class:`~.CHGate`
+      * :class:`~.IGate`
+      * :class:`~.iSwapGate`
+      * :class:`~.PhaseGate`
+      * :class:`~.CPhaseGate`
+      * :class:`~.MCPhaseGate`
+      * :class:`~.RGate`
+      * :class:`~.RXGate`
+      * :class:`~.CRXGate`
+      * :class:`~.RXXGate`
+      * :class:`~.RYGate`
+      * :class:`~.CRYGate`
+      * :class:`~.RYYGate`
+      * :class:`~.RZGate`
+      * :class:`~.CRZGate`
+      * :class:`~.RZZGate`
+      * :class:`~.SGate`
+      * :class:`~.SdgGate`
+      * :class:`~.CSGate`
+      * :class:`~.CSdgGate`
+      * :class:`~.SwapGate`
+      * :class:`~.CSwapGate`
+      * :class:`~.SXGate`
+      * :class:`~.SXdgGate`
+      * :class:`~.CSXGate`
+      * :class:`~.TGate`
+      * :class:`~.TdgGate`
+      * :class:`~.UGate`
+      * :class:`~.CUGate`
+      * :class:`~.U1Gate`
+      * :class:`~.CU1Gate`
+      * :class:`~.MCU1Gate`
+      * :class:`~.U2Gate`
+      * :class:`~.U3Gate`
+      * :class:`~.CU3Gate`
+      * :class:`~.XGate`
+      * :class:`~.CXGate`
+      * :class:`~.CCXGate`
+      * :class:`~.RCCXGate`
+      * :class:`~.C3SXGate`
+      * :class:`~.C3XGate`
+      * :class:`~.RC3XGate`
+      * :class:`~.C4XGate`
+      * :class:`~.MCXGate`
+      * :class:`~.MCXGrayCode`
+      * :class:`~.MCXRecursive`
+      * :class:`~.MCXVChain`
+      * :class:`~.XXMinusYYGate`
+      * :class:`~.XXPlusYYGate`
+      * :class:`~.YGate`
+      * :class:`~.CYGate`
+      * :class:`~.ZGate`
+      * :class:`~.CZGate`
+      * :class:`~.CCZGate`
+
+    If you were using either ``__dict__`` or assigning extra attributes to instances of these
+    classes you can create a subclass to retrain this functionality. For example, if you were
+    previously doing something like::
+
+        from qiskit.circuit.library import CXGate
+
+        gate = CXGate()
+        gate.my_special_attribute = True
+
+    to perfrom the same task you will now have to do something like::
+
+      from qiskit.circuit.library import CXGate
+
+      class MySpecialCXGate(CXGate):
+
+          def __init__(self):
+              super().__init__()
+              self.my_special_attribute = True
+
+      gate = MySpecialCXGate()
+
+    or::
+
+      from qiskit.circuit.library import CXGate
+
+      class MySpecialCXGate(CXGate):
+          pass
+
+      gate = MySpecialCXGate()
+      gate.my_special_attribute = True


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit slots all the standard library gates. Adding the `__slots__` attribute to a class decreases the memory overhead of an isntance of a class and increases the access speed for attributes. This omes with the tradeoff of removing the __dict__ attribute meaning attributes not defined in __slots__ cannot be added to an instance of a class. For the standard library gates which we create a large number of objects during the typical qiskit usage (either in circuit construction or compilation) the overhead from creating this objects can end up in aggregate dominating the memory overhead and runtime performance of a program. We can't make this change more broadly with the lower level interface classes (Operation, Instruction, Gate, and ControlledGate) because by definition they support adding custom attributes to their definition (at least currently). But since in most use cases the standard library gates are used to build up all custom gates this will go very far to improve the performance of working with gates.

This commit ends up being the first step towards lighter weight QuantumCircuit objects as it will lower the overhead for circuits. In the future we'll look at larger refactors which will need to be taken with more care to avoid larget backwards compatibility changes.

### Details and comments