### PR TITLE
Remove sphinx-design from docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,6 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_autodoc_typehints",
     "reno.sphinxext",
-    "sphinx_design",
     "matplotlib.sphinxext.plot_directive",
 ]
 templates_path = ["_templates"]

--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -57,194 +57,185 @@ defined as:
 Supplementary Information
 =========================
 
-.. dropdown:: Quantum Circuit with conditionals
-   :animate: fade-in-slide-down
+Quantum Circuit with conditionals
+---------------------------------
 
-   When building a quantum circuit, there can be interest in applying a certain gate only
-   if a classical register has a specific value. This can be done with the
-   :meth:`InstructionSet.c_if` method.
+When building a quantum circuit, there can be interest in applying a certain gate only
+if a classical register has a specific value. This can be done with the
+:meth:`InstructionSet.c_if` method.
 
-   In the following example, we start with a single-qubit circuit formed by only a Hadamard gate
-   (:class:`~.HGate`), in which we expect to get :math:`|0\\rangle` and :math:`|1\\rangle`
-   with equal probability.
+In the following example, we start with a single-qubit circuit formed by only a Hadamard gate
+(:class:`~.HGate`), in which we expect to get :math:`|0\\rangle` and :math:`|1\\rangle`
+with equal probability.
 
-   .. plot::
-      :include-source:
+.. plot::
+   :include-source:
 
-      from qiskit import BasicAer, transpile, QuantumRegister, ClassicalRegister, QuantumCircuit
+   from qiskit import BasicAer, transpile, QuantumRegister, ClassicalRegister, QuantumCircuit
 
-      qr = QuantumRegister(1)
-      cr = ClassicalRegister(1)
-      qc = QuantumCircuit(qr, cr)
-      qc.h(0)
-      qc.measure(0, 0)
-      qc.draw('mpl')
+   qr = QuantumRegister(1)
+   cr = ClassicalRegister(1)
+   qc = QuantumCircuit(qr, cr)
+   qc.h(0)
+   qc.measure(0, 0)
+   qc.draw('mpl')
 
-   .. code-block::
+.. code-block::
 
-      backend = BasicAer.get_backend('qasm_simulator')
-      tqc = transpile(qc, backend)
-      counts = backend.run(tqc).result().get_counts()
+   backend = BasicAer.get_backend('qasm_simulator')
+   tqc = transpile(qc, backend)
+   counts = backend.run(tqc).result().get_counts()
 
-      print(counts)
+   print(counts)
 
-   .. parsed-literal::
+.. parsed-literal::
 
-      {'0': 524, '1': 500}
+   {'0': 524, '1': 500}
 
-   Now, we add an :class:`~.XGate` only if the value of the :class:`~.ClassicalRegister` is 0.
-   That way, if the state is :math:`|0\\rangle`, it will be changed to :math:`|1\\rangle` and
-   if the state is :math:`|1\\rangle`, it will not be changed at all, so the final state will
-   always be :math:`|1\\rangle`.
+Now, we add an :class:`~.XGate` only if the value of the :class:`~.ClassicalRegister` is 0.
+That way, if the state is :math:`|0\\rangle`, it will be changed to :math:`|1\\rangle` and
+if the state is :math:`|1\\rangle`, it will not be changed at all, so the final state will
+always be :math:`|1\\rangle`.
 
-   .. plot::
-      :include-source:
+.. plot::
+   :include-source:
 
-      from qiskit import BasicAer, transpile, QuantumRegister, ClassicalRegister, QuantumCircuit
+   from qiskit import BasicAer, transpile, QuantumRegister, ClassicalRegister, QuantumCircuit
 
-      qr = QuantumRegister(1)
-      cr = ClassicalRegister(1)
-      qc = QuantumCircuit(qr, cr)
-      qc.h(0)
-      qc.measure(0, 0)
+   qr = QuantumRegister(1)
+   cr = ClassicalRegister(1)
+   qc = QuantumCircuit(qr, cr)
+   qc.h(0)
+   qc.measure(0, 0)
 
-      qc.x(0).c_if(cr, 0)
-      qc.measure(0, 0)
+   qc.x(0).c_if(cr, 0)
+   qc.measure(0, 0)
 
-      qc.draw('mpl')
+   qc.draw('mpl')
 
-   .. code-block::
+.. code-block::
 
-      backend = BasicAer.get_backend('qasm_simulator')
-      tqc = transpile(qc, backend)
-      counts = backend.run(tqc).result().get_counts()
+   backend = BasicAer.get_backend('qasm_simulator')
+   tqc = transpile(qc, backend)
+   counts = backend.run(tqc).result().get_counts()
 
-      print(counts)
+   print(counts)
 
-   .. parsed-literal::
+.. parsed-literal::
 
-      {'1': 1024}
+   {'1': 1024}
 
-.. dropdown:: Quantum Circuit Properties
-   :animate: fade-in-slide-down
+Quantum Circuit Properties
+--------------------------
 
-   When constructing quantum circuits, there are several properties that help quantify
-   the "size" of the circuits, and their ability to be run on a noisy quantum device.
-   Some of these, like number of qubits, are straightforward to understand, while others
-   like depth and number of tensor components require a bit more explanation.  Here we will
-   explain all of these properties, and, in preparation for understanding how circuits change
-   when run on actual devices, highlight the conditions under which they change.
+When constructing quantum circuits, there are several properties that help quantify
+the "size" of the circuits, and their ability to be run on a noisy quantum device.
+Some of these, like number of qubits, are straightforward to understand, while others
+like depth and number of tensor components require a bit more explanation.  Here we will
+explain all of these properties, and, in preparation for understanding how circuits change
+when run on actual devices, highlight the conditions under which they change.
 
-   Consider the following circuit:
+Consider the following circuit:
 
-   .. plot::
-      :include-source:
+.. plot::
+   :include-source:
 
-      from qiskit import QuantumCircuit
-      qc = QuantumCircuit(12)
-      for idx in range(5):
-         qc.h(idx)
-         qc.cx(idx, idx+5)
+   from qiskit import QuantumCircuit
+   qc = QuantumCircuit(12)
+   for idx in range(5):
+      qc.h(idx)
+      qc.cx(idx, idx+5)
 
-      qc.cx(1, 7)
-      qc.x(8)
-      qc.cx(1, 9)
-      qc.x(7)
-      qc.cx(1, 11)
-      qc.swap(6, 11)
-      qc.swap(6, 9)
-      qc.swap(6, 10)
-      qc.x(6)
-      qc.draw('mpl')
+   qc.cx(1, 7)
+   qc.x(8)
+   qc.cx(1, 9)
+   qc.x(7)
+   qc.cx(1, 11)
+   qc.swap(6, 11)
+   qc.swap(6, 9)
+   qc.swap(6, 10)
+   qc.x(6)
+   qc.draw('mpl')
 
-   From the plot, it is easy to see that this circuit has 12 qubits, and a collection of
-   Hadamard, CNOT, X, and SWAP gates.  But how to quantify this programmatically? Because we
-   can do single-qubit gates on all the qubits simultaneously, the number of qubits in this
-   circuit is equal to the **width** of the circuit:
+From the plot, it is easy to see that this circuit has 12 qubits, and a collection of
+Hadamard, CNOT, X, and SWAP gates.  But how to quantify this programmatically? Because we
+can do single-qubit gates on all the qubits simultaneously, the number of qubits in this
+circuit is equal to the **width** of the circuit:
 
-   .. code-block::
+.. code-block::
 
-      qc.width()
+   qc.width()
 
-   .. parsed-literal::
+.. parsed-literal::
 
-      12
+   12
 
-   We can also just get the number of qubits directly:
+We can also just get the number of qubits directly:
 
-   .. code-block::
+.. code-block::
 
-      qc.num_qubits
+   qc.num_qubits
 
-   .. parsed-literal::
+.. parsed-literal::
 
-      12
+   12
 
-   .. important::
+.. important::
 
-      For a quantum circuit composed from just qubits, the circuit width is equal
-      to the number of qubits. This is the definition used in quantum computing. However,
-      for more complicated circuits with classical registers, and classically controlled gates,
-      this equivalence breaks down. As such, from now on we will not refer to the number of
-      qubits in a quantum circuit as the width.
+   For a quantum circuit composed from just qubits, the circuit width is equal
+   to the number of qubits. This is the definition used in quantum computing. However,
+   for more complicated circuits with classical registers, and classically controlled gates,
+   this equivalence breaks down. As such, from now on we will not refer to the number of
+   qubits in a quantum circuit as the width.
 
 
-   It is also straightforward to get the number and type of the gates in a circuit using
-   :meth:`QuantumCircuit.count_ops`:
+It is also straightforward to get the number and type of the gates in a circuit using
+:meth:`QuantumCircuit.count_ops`:
 
-   .. code-block::
+.. code-block::
 
-      qc.count_ops()
+   qc.count_ops()
 
-   .. parsed-literal::
+.. parsed-literal::
 
-      OrderedDict([('cx', 8), ('h', 5), ('x', 3), ('swap', 3)])
+   OrderedDict([('cx', 8), ('h', 5), ('x', 3), ('swap', 3)])
 
-   We can also get just the raw count of operations by computing the circuits
-   :meth:`QuantumCircuit.size`:
+We can also get just the raw count of operations by computing the circuits
+:meth:`QuantumCircuit.size`:
 
-   .. code-block::
+.. code-block::
 
-      qc.size()
+   qc.size()
 
-   .. parsed-literal::
+.. parsed-literal::
 
-      19
+   19
 
-   A particularly important circuit property is known as the circuit **depth**.  The depth
-   of a quantum circuit is a measure of how many "layers" of quantum gates, executed in
-   parallel, it takes to complete the computation defined by the circuit.  Because quantum
-   gates take time to implement, the depth of a circuit roughly corresponds to the amount of
-   time it takes the quantum computer to execute the circuit.  Thus, the depth of a circuit
-   is one important quantity used to measure if a quantum circuit can be run on a device.
+A particularly important circuit property is known as the circuit **depth**.  The depth
+of a quantum circuit is a measure of how many "layers" of quantum gates, executed in
+parallel, it takes to complete the computation defined by the circuit.  Because quantum
+gates take time to implement, the depth of a circuit roughly corresponds to the amount of
+time it takes the quantum computer to execute the circuit.  Thus, the depth of a circuit
+is one important quantity used to measure if a quantum circuit can be run on a device.
 
-   The depth of a quantum circuit has a mathematical definition as the longest path in a
-   directed acyclic graph (DAG).  However, such a definition is a bit hard to grasp, even for
-   experts.  Fortunately, the depth of a circuit can be easily understood by anyone familiar
-   with playing `Tetris <https://en.wikipedia.org/wiki/Tetris>`_.  Lets see how to compute this
-   graphically:
+The depth of a quantum circuit has a mathematical definition as the longest path in a
+directed acyclic graph (DAG).  However, such a definition is a bit hard to grasp, even for
+experts.  Fortunately, the depth of a circuit can be easily understood by anyone familiar
+with playing `Tetris <https://en.wikipedia.org/wiki/Tetris>`_.  Lets see how to compute this
+graphically:
 
-   .. image:: /source_images/depth.gif
+.. image:: /source_images/depth.gif
 
 
-   .. raw:: html
+We can verify our graphical result using :meth:`QuantumCircuit.depth`:
 
-      <br><br>
+.. code-block::
 
+   qc.depth()
 
-   We can verify our graphical result using :meth:`QuantumCircuit.depth`:
+.. parsed-literal::
 
-   .. code-block::
-
-      qc.depth()
-
-   .. parsed-literal::
-
-      9
-
-   .. raw:: html
-
-      <br>
+   9
 
 Quantum Circuit API
 ===================

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,6 @@ reno>=3.4.0
 Sphinx>=3.0.0
 qiskit-sphinx-theme>=1.6
 sphinx-autodoc-typehints==1.21.1  # revert to >=1.18 once the incompatibilities are fixed
-sphinx-design>=0.2.0
 pygments>=2.4
 scikit-learn>=0.20.0
 scikit-quant<=0.7;platform_system != 'Windows'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit removes the last two usages of the dropdown directive and removes sphinx-design from our docs build. In general we've been moving away from the formatting features that sphinx design provides because it doesn't always integrate cleanly into the docs theme. The sphinx-design package also forces us on an older release of sphinx because it is incompatible with newer version. By removing this dependency we're no longer capped on the sphinx version we're using in builds.

### Details and comments