### PR TITLE
Add support for DAGCircuit io to PassManger

### DIFF
--- a/qiskit/converters/circuit_to_dag.py
+++ b/qiskit/converters/circuit_to_dag.py
@@ -71,4 +71,15 @@ def circuit_to_dag(circuit, copy_operations=True):
 
     dagcircuit.duration = circuit.duration
     dagcircuit.unit = circuit.unit
+
+    # Set attributes hardcoded by RunningPassManager
+    for attr in [
+        "_layout",
+        "_clbit_write_latency",
+        "_conditional_latency",
+        "_op_start_times",
+    ]:
+        if hasattr(circuit, attr):
+            setattr(dagcircuit, attr, getattr(circuit, attr))
+
     return dagcircuit

--- a/qiskit/converters/dag_to_circuit.py
+++ b/qiskit/converters/dag_to_circuit.py
@@ -74,4 +74,15 @@ def dag_to_circuit(dag, copy_operations=True):
 
     circuit.duration = dag.duration
     circuit.unit = dag.unit
+
+    # Set attributes hardcoded by RunningPassManager
+    for attr in [
+        "_layout",
+        "_clbit_write_latency",
+        "_conditional_latency",
+        "_op_start_times",
+    ]:
+        if hasattr(dag, attr):
+            setattr(circuit, attr, getattr(dag, attr))
+
     return circuit

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -238,7 +238,7 @@ class PassManager:
             return [
                 self._run_single_circuit(circuits[0], output_name, callback, return_dag=return_dag)
             ]
-        return self._run_several_circuits(circuits, output_name, callback)
+        return self._run_several_circuits(circuits, output_name, callback, return_dag=return_dag)
 
     def _create_running_passmanager(self) -> RunningPassManager:
         running_passmanager = RunningPassManager(self.max_iteration)

--- a/releasenotes/notes/pass-manager-dag-circuit-2ec863b39899431f.yaml
+++ b/releasenotes/notes/pass-manager-dag-circuit-2ec863b39899431f.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Adds support for working direclty with :class:`.DAGCircuit` inputs and
+    outputs to :class:`.PassManager`. :meth:`.PassManager.run` may now be called
+    directly with :class:`.DAGCircuit` input inputs to bypass conversion from a
+    :class:`.QauntumCircuit`, and can optionally can return :class:`.DAGCircuit`
+    outputs instead of converting to :class:`.QuantumCircuits` by calling with
+    ``return_dag=True`` kwarg.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

* Adds support for calling `PassManager.run` with DAGCircuit or QuantumCircuit inputs to optionally avoid conversion from QuantumCircuit to DAGCircuit.
* Adds `return_dag` kwarg to `PassManager.run` to optionally return DAGCircuit outputs to avoid conversion back to QauntumCircuit

### Details and comments

This is intended for workflows where someone might want to call multiple pass managers or individual passes on DAGs without having to always convert back and forth from circuits to dag circuits. `PassManager.run` can support the following types:
* QuantumCircuit | DAGCircuit -> QuantumCircuit (default, `return_dag=False`)
* QuantumCircuit | DAGCircuit -> DAGCircuit (optional, `return_dag=True`)

