### PR TITLE
Renyi entropy

### DIFF
--- a/qiskit/quantum_info/__init__.py
+++ b/qiskit/quantum_info/__init__.py
@@ -168,6 +168,7 @@ from .states import (
     concurrence,
     entanglement_of_formation,
     entropy,
+    renyi_entropy,
     mutual_information,
     partial_trace,
     purity,

--- a/qiskit/quantum_info/states/__init__.py
+++ b/qiskit/quantum_info/states/__init__.py
@@ -20,6 +20,7 @@ from .measures import (
     state_fidelity,
     purity,
     entropy,
+    renyi_entropy,
     concurrence,
     mutual_information,
     entanglement_of_formation,

--- a/qiskit/quantum_info/states/measures.py
+++ b/qiskit/quantum_info/states/measures.py
@@ -160,9 +160,13 @@ def renyi_entropy(state, alpha, qbits=None):
     Raises:
         QiskitError: if alpha is < 0.
         QiskitError: if the input state is not a valid QuantumState.
+        QiskitError: if the passed qbits are invalid
     """
     if alpha < 0:
         raise QiskitError("The Renyi order alpha must be greater than or equal to 0.")
+
+    if qbits is not None and len([q for q in qbits if q < 0 or q > state.num_qubits]):
+        raise QiskitError("One or more of the passed qubits is not valid.")
 
     if isinstance(state, StabilizerState):
         # Renyi entropy of a stabilizer state does not depend on alpha
@@ -205,7 +209,7 @@ def renyi_entropy(state, alpha, qbits=None):
     state = _format_state(state, validate=True)
 
     if isinstance(state, Statevector):
-        # Full state is pure, so has no entropy
+        # full Statevector is pure, so has no entropy
         if qbits is None:
             return 0.0
 
@@ -224,10 +228,10 @@ def renyi_entropy(state, alpha, qbits=None):
             state_entropy = np.log2(np.linalg.matrix_rank(rho_a))
         elif alpha == 1:  # Shannon entropy
             state_entropy = entropy(rho_a, base=2)
-        else:
+        else: # General case
             from scipy.linalg import fractional_matrix_power
 
-            state_entropy = (1 / (1 - alpha)) * np.log2(
+            state_entropy = (1. / (1. - alpha)) * np.log2(
                 np.real(np.trace(fractional_matrix_power(rho_a, alpha)))
             )
 

--- a/qiskit/quantum_info/states/measures.py
+++ b/qiskit/quantum_info/states/measures.py
@@ -214,7 +214,10 @@ def renyi_entropy(state, alpha, qbits=None):
 
     else:  # Density matrix case
         state = _format_state(state, validate=True)
-        subsystem_b = [q for q in range(state.num_qubits) if q not in qbits]
+        if qbits is None:
+            subsystem_b = []
+        else:
+            subsystem_b = [q for q in range(state.num_qubits) if q not in qbits]
         rho_a = partial_trace(state, subsystem_b)
 
         if alpha == 0:  # Hartley entropy

--- a/qiskit/quantum_info/states/measures.py
+++ b/qiskit/quantum_info/states/measures.py
@@ -16,6 +16,7 @@ Quantum information measures, metrics, and related functions for states.
 import numpy as np
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.states.statevector import Statevector
+from qiskit.quantum_info.states.stabilizerstate import StabilizerState
 from qiskit.quantum_info.states.densitymatrix import DensityMatrix
 from qiskit.quantum_info.states.utils import (
     partial_trace,
@@ -127,6 +128,84 @@ def entropy(state, base=2):
     evals = np.maximum(np.real(la.eigvals(state.data)), 0.0)
     return shannon_entropy(evals, base=base)
 
+def renyi_entropy(state, qargs, alpha=2.):
+    r"""Calculate the bipartite Renyi entropy of entanglement of a subsystem
+    
+    The Renyi entanglement entropy :math:`S_\alpha` is given by
+    
+    .. math::
+    
+        S_\alpha = \frac{1}{1 - \alpha} \log \left( \rho_A^\alpha \right)
+    
+    where :math:`\rho_A = Tr_B[\rho_{AB}]` is the reduced density matrix of the 
+    subsystem :math:`A`. For StabilizerStates, the Renyi entanglement is independent 
+    of :math:`\alpha` and can be calculated as the binary rank of the stabilizer tableau 
+    truncated to the subsystem :math:`A`:
+    
+    .. math::
+        S_\alpha = \text{rank}_2(T_A) - N_A
+    
+    where :math:`N_A` is the number of qubits in :math:`A` and :math:`T_A` is the
+    stabilizer tableau truncated to :math:`A`. 
+    
+    Args:
+        state (Statevector, DensityMatrix or StabilizerState): A quantum state.
+        qargs (list): The list of qubits which define the subsystem A.
+        alpha (float): The Renyi order. [Default: 2.0]
+        
+    Returns:
+        float: The Renyi entanglement entropy :math:`S_\alpha`.
+        
+    Raises:
+        QiskitError: if the input state is not a valid QuantumState.
+        QiskitError: if alpha is < 0. 
+    """
+    if alpha < 0:
+        raise QiskitError("The Renyi order alpha must be greater than or equal to 0.")
+    
+    if len(qargs) == 0 or len(qargs) == state.num_qubits:
+        return 0.
+    
+    if isinstance(state, StabilizerState):
+        if not state.is_valid():
+            raise QiskitError("Input StabilizerState is not valid.")
+
+        tableau = state._data.tableau.astype(int)
+        
+        # Truncate tableau
+        idx_x = np.array(qargs)
+        idx_z = idx_x + state.num_qubits
+
+        tableau = tableau[len(tableau)//2:, np.concatenate((idx_x, idx_z))]
+        # Convert each row of bits to an int 
+        tableau_int = [int(''.join(str(b) for b in row), 2) for row in tableau]
+
+        
+        # Binary row reduction to compute binary rank
+        rank = 0
+        j = 0
+        while j < len(tableau_int):
+            p = tableau_int[j]
+            j += 1
+            if p:
+                rank += 1
+                lsb = p & -p
+                for i,r in enumerate(tableau_int[j:]):
+                    if r & lsb:
+                        tableau_int[i]= r ^ p
+        
+        return rank - len(qargs)
+    else:
+        state = _format_state(state, validate=True)
+        rho_a = partial_trace(state, list([q for q in range(state.num_qubits) if q not in qargs])) # TODO revisit
+
+        if alpha == 0: # Hartley entropy
+            return np.log2(np.linalg.matrix_rank(rho_a)) # Counts number of nonzero eigenvalues
+        elif alpha == 1: # Shannon entropy
+            return entropy(rho_a, base=2)
+        else:
+            from scipy.linalg import fractional_matrix_power
+            return np.real((1/(1 - alpha))*np.log2(np.trace(fractional_matrix_power(rho_a, alpha))))
 
 def mutual_information(state, base=2):
     r"""Calculate the mutual information of a bipartite state.

--- a/releasenotes/notes/added-renyi-entropy-bee724fea3a8288b.yaml
+++ b/releasenotes/notes/added-renyi-entropy-bee724fea3a8288b.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Added the function :func:`~qiskit.quantum_info.states.measures.renyi_entropy` which 
+    computes the Renyi entropy with arbitrary index :math:`\alpha` of an optionally specified 
+    subsystem. By default, the subsystem is taken to be the entire system. For inputs of 
+    :class:`~.quantum_info.StabilizerState`, the entropy is computed efficiently in terms of 
+    the binary rank of the reduced stabilizer tableau. 

--- a/releasenotes/notes/added-renyi-entropy-bee724fea3a8288b.yaml
+++ b/releasenotes/notes/added-renyi-entropy-bee724fea3a8288b.yaml
@@ -2,7 +2,8 @@
 features:
   - |
     Added the function :func:`~qiskit.quantum_info.states.measures.renyi_entropy` which 
-    computes the Renyi entropy with arbitrary index :math:`\alpha` of an optionally specified 
+    computes the Renyi entropy of a state with arbitrary index :math:`\alpha` of an optionally specified 
     subsystem. By default, the subsystem is taken to be the entire system. For inputs of 
     :class:`~.quantum_info.StabilizerState`, the entropy is computed efficiently in terms of 
-    the binary rank of the reduced stabilizer tableau. 
+    the binary rank of the reduced stabilizer tableau. See 
+    `10114 <https://https://github.com/Qiskit/qiskit-terra/issues/10114>` for more details.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Addresses #10114 

### Details and comments
Added function `renyi_entropy` to `quantum_info.states.measures` which computes the Rényi entropy with index $\alpha$ of a quantum state:

$$S_\alpha(\rho) = \frac{1}{1 - \alpha}\log_2\text{Tr}\left(\rho^\alpha\right)$$

where $\lim_{\alpha \rightarrow 1} S_\alpha$ is the Shannon entropy. 

The input state can be a `Statevector`, `DensityMatrix`, or `StabilizerState`. In the latter case, an efficient algorithm is used to compute the entropy in terms of the stabilizer tableau (according to Appendix A of [arxiv.org/abs/2203.07510](https://arxiv.org/abs/2203.07510)). 

Optionally, a list of qubit indices can be passed which serve as the definition of a subsystem, tracing out the remaining qubits before returning the entropy of the reduced system. If no qubits are passed, the Rényi entropy of the entire state is returned. That is, if a list of qubits $A$ is passed, $S_\alpha(\rho_{A})$ is returned, where $\rho_{A}$ is the reduced density matrix of $A$.

I have imported the new function to `__init__.py` in `quantum_info` and `quantum_info.states` and added tests to `python/test/quantum_info/states/test_measures` to check the correctness and equivalence of the new function on equivalent input states.