### PR TITLE
fix Primitives (Estimator) documentation typo

### DIFF
--- a/qiskit/primitives/base/base_estimator.py
+++ b/qiskit/primitives/base/base_estimator.py
@@ -36,8 +36,8 @@ with the following parameters
   (list of list of float).
 
 The method returns a :class:`~qiskit.providers.JobV1` object, calling
-:meth:`qiskit.providers.JobV1.result()` yields a list of expectation values plus optional metadata like confidence intervals for
-the estimation.
+:meth:`qiskit.providers.JobV1.result()` yields a list of expectation values plus optional metadata
+like confidence intervals for the estimation.
 
 .. math::
 

--- a/qiskit/primitives/base/base_estimator.py
+++ b/qiskit/primitives/base/base_estimator.py
@@ -36,8 +36,7 @@ with the following parameters
   (list of list of float).
 
 The method returns a :class:`~qiskit.providers.JobV1` object, calling
-:meth:`qiskit.providers.JobV1.result()` yields the
-a list of expectation values plus optional metadata like confidence intervals for
+:meth:`qiskit.providers.JobV1.result()` yields a list of expectation values plus optional metadata like confidence intervals for
 the estimation.
 
 .. math::


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
I was reading the overview of Estimator class and I found a typo in the documentation " ... yields **the a** list of expectation values plus optional..." (the two articles before "list" word).


### Details and comments
I fixed the bug to make reading the textbook as clear and smooth as possible for readers.

