### PR TITLE
Pylint: enable modified-iterating-list and bugfix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,6 @@ disable = [
     "consider-using-enumerate",
     "consider-using-f-string",
     "consider-using-from-import",
-    "modified-iterating-list",
     "nested-min-max",
     "no-member",
     "no-value-for-parameter",

--- a/qiskit/transpiler/passes/optimization/template_matching/forward_match.py
+++ b/qiskit/transpiler/passes/optimization/template_matching/forward_match.py
@@ -148,7 +148,7 @@ class ForwardMatch:
 
         if self.template_dag_dep.direct_successors(node_id_t):
             maximal_index = self.template_dag_dep.direct_successors(node_id_t)[-1]
-            for elem in pred:
+            for elem in matches:
                 if elem > maximal_index:
                     pred.remove(elem)
 
@@ -268,7 +268,6 @@ class ForwardMatch:
         """
 
         if isinstance(node_circuit.op, ControlledGate):
-
             c_template = node_template.op.num_ctrl_qubits
 
             if c_template == 1:
@@ -279,7 +278,6 @@ class ForwardMatch:
                 control_qubits_circuit = self.qarg_indices[:c_template]
 
                 if set(control_qubits_circuit) == set(control_qubits_template):
-
                     target_qubits_template = node_template.qindices[c_template::]
                     target_qubits_circuit = self.qarg_indices[c_template::]
 
@@ -347,7 +345,6 @@ class ForwardMatch:
 
         # While the list of matched nodes is not empty
         while self.matched_nodes_list:
-
             # Return first element of the matched_nodes_list and removes it from the list
             v_first = self._get_node_forward(0)
             self._remove_node_forward(0)
@@ -386,7 +383,6 @@ class ForwardMatch:
 
             # For loop over the candidates (template) to find a match.
             for i in self.candidates:
-
                 # Break the for loop if a match is found.
                 if match:
                     break
@@ -411,7 +407,6 @@ class ForwardMatch:
                     and self._is_same_c_conf(node_circuit, node_template)
                     and self._is_same_op(node_circuit, node_template)
                 ):
-
                     v[1].matchedwith = [i]
 
                     self.template_dag_dep.get_node(i).matchedwith = [label]


### PR DESCRIPTION
Turned on the `modified-iterating-list` pylint check and used it to find a bug.
The iteration would fail to remove matching list elements if they along came two-in-a-row.
Here's a simplified illustration of the problematic idiom:

```python
In [38]: l=[1,12,13,14,5,6,7,8,9]
    ...: for i in l:
    ...:     if i >=10:
    ...:         l.remove(i)
    ...: l
Out[38]: [1, 13, 5, 6, 7, 8, 9]
```
Notice that `13` makes it through despite the filter.

For this PR I put a minimal change to fix the issue, but the rest of that routine does smell a bit funny to me and it would likely benefit from a rewrite. Eg, I'm not sure what was the intention with the superfluous conditional here:

```python
        if len(pred) > 1:
            pred.sort()
```

Anyway, this all relates to #9614 


