### PR TITLE
Remove deprecated qiskit.IBMQ alias object

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -137,57 +137,7 @@ class AerWrapper:
         return getattr(self.aer, attr)
 
 
-class IBMQWrapper:
-    """Lazy loading wrapper for IBMQ provider."""
-
-    def __init__(self):
-        self.ibmq = None
-
-    def __bool__(self):
-        if self.ibmq is None:
-            try:
-                from qiskit.providers import ibmq
-
-                self.ibmq = ibmq.IBMQ
-                warnings.warn(
-                    "The qiskit.IBMQ entrypoint and the qiskit-ibmq-provider package ("
-                    "accessible from 'qiskit.providers.ibmq`) are deprecated and will be removed "
-                    "in a future release. Instead you should use the qiskit-ibm-provider package "
-                    "which is accessible from 'qiskit_ibm_provider'. You can install it with "
-                    "'pip install qiskit_ibm_provider'",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-
-            except ImportError:
-                return False
-        return True
-
-    def __getattr__(self, attr):
-        if not self.ibmq:
-            try:
-                from qiskit.providers import ibmq
-
-                self.ibmq = ibmq.IBMQ
-                warnings.warn(
-                    "The qiskit.IBMQ entrypoint and the qiskit-ibmq-provider package ("
-                    "accessible from 'qiskit.providers.ibmq`) are deprecated and will be removed "
-                    "in a future release. Instead you should use the qiskit-ibm-provider package "
-                    "which is accessible from 'qiskit_ibm_provider'. You can install it with "
-                    "'pip install qiskit_ibm_provider'. Just replace 'qiskit.IBMQ' with "
-                    "'qiskit_ibm_provider.IBMProvider'",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-            except ImportError as ex:
-                raise MissingOptionalLibraryError(
-                    "qiskit-ibmq-provider", "IBMQ provider", "pip install qiskit-ibmq-provider"
-                ) from ex
-        return getattr(self.ibmq, attr)
-
-
 Aer = AerWrapper()
-IBMQ = IBMQWrapper()
 
 __all__ = [
     "Aer",

--- a/qiskit/providers/__init__.py
+++ b/qiskit/providers/__init__.py
@@ -461,7 +461,7 @@ is used to actually submit circuits to a device or simulator. The run method
 handles submitting the circuits to the backend to be executed and returning a
 :class:`~qiskit.providers.Job` object. Depending on the type of backend this
 typically involves serializing the circuit object into the API format used by a
-backend. For example, on IBMQ backends from the ``qiskit-ibmq-provider``
+backend. For example, on IBM Quantum backends from the ``qiskit-ibm-provider``
 package this involves converting from a quantum circuit and options into a
 `qobj <https://arxiv.org/abs/1809.03452>`__ JSON payload and submitting
 that to the IBM Quantum API. Since every backend interface is different (and

--- a/releasenotes/notes/remove-deprecated-aliases-73eedaa4c610c4cf.yaml
+++ b/releasenotes/notes/remove-deprecated-aliases-73eedaa4c610c4cf.yaml
@@ -1,0 +1,13 @@
+---
+upgrade:
+  - |
+    The deprecated ``qiskit.IBMQ`` object hase been removed. The object  was marked
+    as deprecated. This alias object was marked as deprecated in the 0.23.0 release.
+    This alias object lazily redirected attribute access to ``qiskit.providers.ibmq.IBMQ``. As the
+    ``qiskit-ibmq-provider`` package has now been retired and superseded by
+    ``qiskit-ibm-provider`` package which maintains its own namespace
+    maintaining this alias is no longer relevant. If you
+    were relying on the ``qiskit.IBMQ`` alias you should migrate your usage to
+    the ``qiskit-ibm-provider`` package, see the
+    `migration guide <https://qiskit.org/ecosystem/ibm-provider/tutorials/Migration_Guide_from_qiskit-ibmq-provider.html>`__
+    for more details.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit removes the depercated qiskit.IBMQ alias object. It was marked as deprecated in 0.23.0 and now that the qiskit-ibmq-provider package has been retired and is no longer supported it truly has no more meaning. Realistically it probably should have been removed as part of 0.25.0 which corresponded with the retirement of the qiskit-ibmq-provider library, but this was forgotten as part of the 0.25.0 release so we'll have to do it as part of 0.45.0.

### Details and comments