### PR TITLE
#10360 New sign feature in parameterexpression.py

### DIFF
--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -451,6 +451,17 @@ class ParameterExpression:
 
             return self._call(_log)
 
+    def sign(self):
+        """Sign of a ParameterExpression"""
+        if _optionals.HAS_SYMENGINE:
+            import symengine
+
+            return self._call(symengine.sign)
+        else:
+            from sympy import sign as _sign
+
+            return self._call(_sign)
+
     def __repr__(self):
         return f"{self.__class__.__name__}({str(self)})"
 

--- a/releasenotes/notes/added-sign-feature-parameterexpression-57693dd69103dc8c.yaml
+++ b/releasenotes/notes/added-sign-feature-parameterexpression-57693dd69103dc8c.yaml
@@ -2,7 +2,7 @@
 features:
   - |
     Added support for expressing the sign of a :class:`.ParameterExpression`
-    Instead of assigning a concrete value and using ''numpy.sign'' or other library functions, the user can use the instance of the ParameterExpression
+    Instead of assigning a concrete value and using :data:`numpy.sign` or other library functions, the user can use the instance of the :class:`.ParameterExpression`
     class to calculate the sign and can work with the sign before the expression is fully assigned.
 
     It can be used as follows::

--- a/releasenotes/notes/added-sign-feature-parameterexpression-57693dd69103dc8c.yaml
+++ b/releasenotes/notes/added-sign-feature-parameterexpression-57693dd69103dc8c.yaml
@@ -14,5 +14,5 @@ features:
       print("sign of an unassigned Parameter is: ", sign_value)
       print("Sign of a Parameter assigned to -3 is: ", sign_value.assign(b,-3))
 
-    Refer to ' #10360<https://github.com/Qiskit/qiskit-terra/issues/10360>'__ for more details.
+    Refer to `#10360 <https://github.com/Qiskit/qiskit-terra/issues/10360>`__ for more details.
 

--- a/releasenotes/notes/added-sign-feature-parameterexpression-57693dd69103dc8c.yaml
+++ b/releasenotes/notes/added-sign-feature-parameterexpression-57693dd69103dc8c.yaml
@@ -1,0 +1,18 @@
+---
+features:
+  - |
+    Added support for expressing the sign of a :class: 'ParameterExpression'
+    Instead of assigning a concrete value and using ''numpy.sign'' or other library functions, the user can use the instance of the ParameterExpression
+    class to calculate the sign and can work with the sign before the expression is fully assigned.
+
+    It can be used as follows::
+
+      from qiskit.circuit import Parameter
+
+      b = Parameter("phi")
+      sign_value = b.sign()
+      print("sign of an unassigned Parameter is: ", sign_value)
+      print("Sign of a Parameter assigned to -3 is: ", sign_value.assign(b,-3))
+
+    Refer to ' #10360<https://github.com/Qiskit/qiskit-terra/issues/10360>'__ for more details.
+

--- a/releasenotes/notes/added-sign-feature-parameterexpression-57693dd69103dc8c.yaml
+++ b/releasenotes/notes/added-sign-feature-parameterexpression-57693dd69103dc8c.yaml
@@ -1,7 +1,7 @@
 ---
 features:
   - |
-    Added support for expressing the sign of a :class: 'ParameterExpression'
+    Added support for expressing the sign of a :class:`.ParameterExpression`
     Instead of assigning a concrete value and using ''numpy.sign'' or other library functions, the user can use the instance of the ParameterExpression
     class to calculate the sign and can work with the sign before the expression is fully assigned.
 

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -950,6 +950,15 @@ class TestParameters(QiskitTestCase):
                 self.assertEqual(expected1, output1)
                 self.assertEqual(expected2, output2)
 
+    def test_sign_of_parameter(self):
+        """Test returning the sign of the value of the parameter"""
+
+        b = Parameter("phi")
+        sign_of_parameter = b.sign()
+        self.assertEqual(sign_of_parameter.assign(b, -3), -1)
+        self.assertEqual(sign_of_parameter.assign(b, 2), 1)
+        self.assertEqual(sign_of_parameter.assign(b, 0), 0)
+
     @combine(target_type=["gate", "instruction"], parameter_type=["numbers", "parameters"])
     def test_decompose_propagates_bound_parameters(self, target_type, parameter_type):
         """Verify bind-before-decompose preserves bound values."""


### PR DESCRIPTION
Added a new feature in parameterexpression.py to display the sign of an expression

…the expression inputted

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.
r4
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

I've added a feature that allows a user to display the sign of an inputted expression using an object of the Parameter class.

### Details and comments


