### PR TITLE
 Removed 2pi wrapping for global phase parameter

### DIFF
--- a/qiskit/transpiler/passes/scheduling/dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/dynamical_decoupling.py
@@ -24,7 +24,6 @@ from qiskit.transpiler.passes.optimization import Optimize1qGates
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.utils.deprecation import deprecate_func
-from qiskit.circuit.parameterexpression import ParameterExpression
 
 
 class DynamicalDecoupling(TransformationPass):
@@ -275,10 +274,7 @@ class DynamicalDecoupling(TransformationPass):
                 if gate is not None:
                     new_dag.apply_operation_back(gate, [dag_qubit], check=False)
 
-            if isinstance(new_dag.global_phase, ParameterExpression):
-                new_dag.global_phase = new_dag.global_phase + sequence_gphase
-            else:
-                new_dag.global_phase = _mod_2pi(new_dag.global_phase + sequence_gphase)
+            new_dag.global_phase = new_dag.global_phase + sequence_gphase
 
         return new_dag
 
@@ -287,11 +283,3 @@ class DynamicalDecoupling(TransformationPass):
         if self._target is None or self._target.instruction_supported(gate.name, qargs=(qarg,)):
             return True
         return False
-
-
-def _mod_2pi(angle: float, atol: float = 0):
-    """Wrap angle into interval [-π,π). If within atol of the endpoint, clamp to -π"""
-    wrapped = (angle + np.pi) % (2 * np.pi) - np.pi
-    if abs(wrapped - np.pi) < atol:
-        wrapped = -np.pi
-    return wrapped

--- a/qiskit/transpiler/passes/scheduling/dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/dynamical_decoupling.py
@@ -274,7 +274,10 @@ class DynamicalDecoupling(TransformationPass):
                 if gate is not None:
                     new_dag.apply_operation_back(gate, [dag_qubit], check=False)
 
-            new_dag.global_phase = (new_dag.global_phase + sequence_gphase)
+            if isinstance(angle, ParameterExpression):
+                new_dag.global_phase = new_dag.global_phase + sequence_gphase
+            else:
+                new_dag.global_phase = _mod_2pi(new_dag.global_phase + sequence_gphase)
 
         return new_dag
 
@@ -285,3 +288,9 @@ class DynamicalDecoupling(TransformationPass):
         return False
 
 
+def _mod_2pi(angle: float, atol: float = 0):
+    """Wrap angle into interval [-π,π). If within atol of the endpoint, clamp to -π"""
+    wrapped = (angle + np.pi) % (2 * np.pi) - np.pi
+    if abs(wrapped - np.pi) < atol:
+        wrapped = -np.pi
+    return wrapped

--- a/qiskit/transpiler/passes/scheduling/dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/dynamical_decoupling.py
@@ -274,7 +274,7 @@ class DynamicalDecoupling(TransformationPass):
                 if gate is not None:
                     new_dag.apply_operation_back(gate, [dag_qubit], check=False)
 
-            new_dag.global_phase = _mod_2pi(new_dag.global_phase + sequence_gphase)
+            new_dag.global_phase = (new_dag.global_phase + sequence_gphase)
 
         return new_dag
 
@@ -285,9 +285,3 @@ class DynamicalDecoupling(TransformationPass):
         return False
 
 
-def _mod_2pi(angle: float, atol: float = 0):
-    """Wrap angle into interval [-π,π). If within atol of the endpoint, clamp to -π"""
-    wrapped = (angle + np.pi) % (2 * np.pi) - np.pi
-    if abs(wrapped - np.pi) < atol:
-        wrapped = -np.pi
-    return wrapped

--- a/qiskit/transpiler/passes/scheduling/dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/dynamical_decoupling.py
@@ -24,6 +24,7 @@ from qiskit.transpiler.passes.optimization import Optimize1qGates
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.utils.deprecation import deprecate_func
+from qiskit.circuit.parameterexpression import ParameterExpression
 
 
 class DynamicalDecoupling(TransformationPass):
@@ -274,7 +275,7 @@ class DynamicalDecoupling(TransformationPass):
                 if gate is not None:
                     new_dag.apply_operation_back(gate, [dag_qubit], check=False)
 
-            if isinstance(angle, ParameterExpression):
+            if isinstance(new_dag.global_phase, ParameterExpression):
                 new_dag.global_phase = new_dag.global_phase + sequence_gphase
             else:
                 new_dag.global_phase = _mod_2pi(new_dag.global_phase + sequence_gphase)

--- a/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
@@ -394,8 +394,7 @@ class PadDynamicalDecoupling(BasePadding):
                 gate_length = self._dd_sequence_lengths[qubit][dd_ind]
                 self._apply_scheduled_op(dag, idle_after, gate, qubit)
                 idle_after += gate_length
-
-        dag.global_phase = self._mod_2pi(dag.global_phase + sequence_gphase)
+        dag.global_phase = dag.global_phase + sequence_gphase
 
     @staticmethod
     def _resolve_params(gate: Gate) -> tuple:
@@ -407,11 +406,3 @@ class PadDynamicalDecoupling(BasePadding):
             else:
                 params.append(p)
         return tuple(params)
-
-    @staticmethod
-    def _mod_2pi(angle: float, atol: float = 0):
-        """Wrap angle into interval [-π,π). If within atol of the endpoint, clamp to -π"""
-        wrapped = (angle + np.pi) % (2 * np.pi) - np.pi
-        if abs(wrapped - np.pi) < atol:
-            wrapped = -np.pi
-        return wrapped

--- a/releasenotes/notes/fix-param-global-phase-31547267f6124552.yaml
+++ b/releasenotes/notes/fix-param-global-phase-31547267f6124552.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    2pi wrapping cannot be applied on a parameterized global phase.Use the 
+    DAGCircuit global_phase setter to wrap the phase for floats only.Refer to
+    `#10569 <https://github.com/Qiskit/qiskit-terra/issues/10569>` for more
+    details.

--- a/releasenotes/notes/fix-param-global-phase-31547267f6124552.yaml
+++ b/releasenotes/notes/fix-param-global-phase-31547267f6124552.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    Fixed compatibility of :class:`.DynamicalDecoupling` and 
-    :class:`.PadDynamicalDecoupling` with circuits that have a parameterized 
-    global phase. 
+    Fixed compatibility of :class:`.DynamicalDecoupling` and
+    :class:`.PadDynamicalDecoupling` with circuits that have a parameterized
+    global phase.
     Fixed `#10569 <https://github.com/Qiskit/qiskit-terra/issues/10569>`__.

--- a/releasenotes/notes/fix-param-global-phase-31547267f6124552.yaml
+++ b/releasenotes/notes/fix-param-global-phase-31547267f6124552.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    2pi wrapping cannot be applied on a parameterized global phase.Use the 
-    DAGCircuit global_phase setter to wrap the phase for floats only.Refer to
-    `#10569 <https://github.com/Qiskit/qiskit-terra/issues/10569>` for more
-    details.
+    Fixed compatibility of :class:`.DynamicalDecoupling` and 
+    :class:`.PadDynamicalDecoupling` with circuits that have a parameterized 
+    global phase. 
+    Fixed `#10569 <https://github.com/Qiskit/qiskit-terra/issues/10569>`__.

--- a/test/python/transpiler/test_dynamical_decoupling.py
+++ b/test/python/transpiler/test_dynamical_decoupling.py
@@ -1047,11 +1047,8 @@ class TestPadDynamicalDecoupling(QiskitTestCase):
                 PadDynamicalDecoupling(self.durations, dd_sequence),
             ]
         )
-        try:
-            pm.run(qc)
-        except TypeError:
-            print("test_paramaterized_global_phase fails")
-            raise
+
+        self.assertEqual(qc.global_phase + np.pi, pm.run(qc).global_phase)
 
 
 if __name__ == "__main__":

--- a/test/python/transpiler/test_dynamical_decoupling.py
+++ b/test/python/transpiler/test_dynamical_decoupling.py
@@ -1031,6 +1031,28 @@ class TestPadDynamicalDecoupling(QiskitTestCase):
         expected.delay(200, [0])
         self.assertEqual(expected, scheduled)
 
+    def test_paramaterized_global_phase(self):
+        """Test paramaterized global phase in DD circuit.
+        See:https://github.com/Qiskit/qiskit-terra/issues/10569
+        """
+        dd_sequence = [XGate(), YGate()] * 2
+        qc = QuantumCircuit(1, 1)
+        qc.h(0)
+        qc.delay(1700, 0)
+        qc.y(0)
+        qc.global_phase = Parameter("a")
+        pm = PassManager(
+            [
+                ALAPScheduleAnalysis(self.durations),
+                PadDynamicalDecoupling(self.durations, dd_sequence),
+            ]
+        )
+        try:
+            pm.run(qc)
+        except TypeError:
+            print("test_paramaterized_global_phase fails")
+            raise
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
It fixes #10569
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Removed `_mod_2pi` function.


### Details and comments
It is similiar to Qiskit/qiskit-ibm-provider#689


