### PR TITLE
Fix Sabre extended set population order

### DIFF
--- a/crates/accelerate/src/sabre_swap/mod.rs
+++ b/crates/accelerate/src/sabre_swap/mod.rs
@@ -172,21 +172,30 @@ fn populate_extended_set(
         IndexMap::with_hasher(ahash::RandomState::default());
     let mut i = 0;
     while i < to_visit.len() && extended_set.len() < EXTENDED_SET_SIZE {
-        for edge in dag.dag.edges_directed(to_visit[i], Direction::Outgoing) {
-            let successor_node = edge.target();
-            let successor_index = successor_node.index();
-            *decremented.entry(successor_index).or_insert(0) += 1;
-            required_predecessors[successor_index] -= 1;
-            if required_predecessors[successor_index] == 0 {
-                if !dag.dag[successor_node].directive
-                    && !dag.node_blocks.contains_key(&successor_index)
-                {
-                    if let [a, b] = dag.dag[successor_node].qubits[..] {
-                        extended_set.push([a.to_phys(layout), b.to_phys(layout)]);
+        // Visit runs of non-2Q gates fully before moving on to children
+        // of 2Q gates. This way, traversal order is a BFS of 2Q gates rather
+        // than of all gates.
+        let mut visit_now = vec![to_visit[i]];
+        let mut j = 0;
+        while let Some(node) = visit_now.get(j) {
+            for edge in dag.dag.edges_directed(*node, Direction::Outgoing) {
+                let successor_node = edge.target();
+                let successor_index = successor_node.index();
+                *decremented.entry(successor_index).or_insert(0) += 1;
+                required_predecessors[successor_index] -= 1;
+                if required_predecessors[successor_index] == 0 {
+                    if !dag.dag[successor_node].directive
+		        && !dag.node_blocks.contains_key(&successor_index) {
+                        if let [a, b] = dag.dag[successor_node].qubits[..] {
+                            extended_set.push([a.to_phys(layout), b.to_phys(layout)]);
+                            to_visit.push(successor_node);
+                            continue;
+                        }
                     }
+                    visit_now.push(successor_node);
                 }
-                to_visit.push(successor_node);
             }
+            j += 1;
         }
         i += 1;
     }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
When building the extended set, the current traversal order uses a BFS of _all_ nodes as they become unblocked. This means that the order in which we encounter 2Q operations isn't necessarily the ones closest to inclusion in the front layer first. Since we limit the size of the extended set, operations that are closer to the front layer might not actually be included.

To fix this, we change the traversal order to visit non-2Q nodes (namely, 1Q gates and control flow ops) as soon as they're unblocked. Otherwise, we do the original BFS. This way, we get a BFS specifically of 2Q nodes as they become unblocked.


### Details and comments
Here's an example of the traversal orders before and after this PR for a 4 qubit circuit with a run of 1Q H gates, where the extended set is limited to size 4.

The magenta arrows show the traversal orders, and the numbers (1., 2., 3., 4.) denote the nodes that make up the extended set after traversal. Notice that the extended set on `main` doesn't contain the ECR gate that happens on `q0` and `q1`, even though it is closer to being pulled into the front layer than the latter 2 ECR gates on `q2` and `q3`.

![extended-set-traversal(1)](https://github.com/Qiskit/qiskit-terra/assets/1374024/36ed51fe-eaeb-4cba-8532-4870845e4251)
