### PR TITLE
Fix release jobs post-0.25.1 release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -260,6 +260,7 @@ stages:
                     versionSpec: ${{ version }}
                     architecture: x64
     - stage: "sdist"
+      dependsOn: "Deploy"
       jobs:
         - job: 'sdist'
           pool: {vmImage: 'ubuntu-latest'}
@@ -281,7 +282,6 @@ stages:
                 TWINE_PASSWORD: $(TWINE_PASSWORD)
         - job: 'qiskit_pkg'
           pool: {vmImage: 'ubuntu-latest'}
-          dependsOn: "Deploy"
           steps:
             - task: UsePythonVersion@0
             - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -259,7 +259,8 @@ stages:
                   inputs:
                     versionSpec: ${{ version }}
                     architecture: x64
-
+    - stage: "sdist"
+      jobs:
         - job: 'sdist'
           pool: {vmImage: 'ubuntu-latest'}
           steps:
@@ -278,8 +279,9 @@ stages:
               env:
                 TWINE_USERNAME: "qiskit"
                 TWINE_PASSWORD: $(TWINE_PASSWORD)
-        - job: 'qiskit-pkg'
+        - job: 'qiskit_pkg'
           pool: {vmImage: 'ubuntu-latest'}
+          dependsOn: "Deploy"
           steps:
             - task: UsePythonVersion@0
             - bash: |
@@ -288,11 +290,11 @@ stages:
                 cd qiskit_pkg
                 python -m build .
             - task: PublishBuildArtifacts@1
-              inputs: {pathtoPublish: 'dist'}
+              inputs: {pathtoPublish: 'qiskit_pkg/dist'}
               condition: succeededOrFailed()
             - bash: |
                 python -m pip install --upgrade twine
-                twine upload dist/*
+                twine upload qiskit_pkg/dist/*
               env:
                 TWINE_USERNAME: "qiskit"
                 TWINE_PASSWORD: $(TWINE_PASSWORD)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes 3 issues identified during the 0.25.1 release. The first is that the name of the qiskit package build/publish job was invalid in azure pipelines. The `-` character is not valid and throws an error when the release is triggered. The second issue is that the qiskit package job is triggered at the same time as all the qiskit-terra package build/publish jobs. However, the qiskit package is very quick to build while the qiskit-terra jobs take some time so qiskit will be published first and qiskit-terra second. This will result in a small period when `qiskit` is uninstallable because it depends on a yet unpublished release of qiskit-terra. To address this the build artifact deployment is split into 2 stages, the first builds the qiskit-terra precompiled binary wheels and publishes those to pypi first. The second stage builds the qiskit-terra sdist and the qiskit package. This means users will always have a working install when they do `pip install qiskit`. The final fix is the path for the qiskit package's build artifacts was incorrect. This caused the job to fail because it could not upload the artifacts for local download or to pypi.

### Details and comments