### PR TITLE
Remove workaround for abi3 BigUint -> Python int conversio

### DIFF
--- a/crates/accelerate/src/results/marginalization.rs
+++ b/crates/accelerate/src/results/marginalization.rs
@@ -152,24 +152,19 @@ pub fn marginal_memory(
             .collect()
     };
     if return_int {
-        // Replace with:
-        //
-        // .iter()
-        // .map(|x| BigUint::parse_bytes(x.as_bytes(), 2).unwrap())
-        // .collect::<Vec<BigUint>>()
-        // .to_object(py))
-        //
-        // (also this can be done in parallel, see
-        // https://github.com/Qiskit/qiskit-terra/pull/10120 for more
-        // details)
-        //
-        // After PyO3/pyo3#3198 is included in a pyo3 release.
-        let int_pyobject = py.import("builtins")?.getattr("int")?;
-        Ok(out_mem
-            .iter()
-            .map(|x| int_pyobject.call1((x, 2u8)).unwrap())
-            .collect::<Vec<_>>()
-            .to_object(py))
+        if out_mem.len() < parallel_threshold || !run_in_parallel {
+            Ok(out_mem
+                .iter()
+                .map(|x| BigUint::parse_bytes(x.as_bytes(), 2).unwrap())
+                .collect::<Vec<BigUint>>()
+                .to_object(py))
+        } else {
+            Ok(out_mem
+                .par_iter()
+                .map(|x| BigUint::parse_bytes(x.as_bytes(), 2).unwrap())
+                .collect::<Vec<BigUint>>()
+                .to_object(py))
+        }
     } else {
         Ok(out_mem.to_object(py))
     }


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #10120 we moved to using the Python stable C API for the qiskit binaries we build. In that PR we encountered a limitation with PyO3 at the time when using abi3 it was unable to convert a BigUInt into a Python int directly. To workaround this we side stepped the issue by generating a string representation of the integer converting that to python and then having python go from a string to a int. This has some performance penalty and also prevented parallelism because a GIL handle was needed to do the conversion. In PyO3 0.19.1 this limitation was fixed and the library can handle the conversion directly now with abi3 and this commit restores the code that existed in the marginalization module prior to #10120.

### Details and comments