### PR TITLE
Fix warning on `__qiskit_version__`

### DIFF
--- a/qiskit/version.py
+++ b/qiskit/version.py
@@ -93,14 +93,6 @@ class QiskitVersion(Mapping):
     __slots__ = ["_version_dict", "_loaded"]
 
     def __init__(self):
-        warnings.warn(
-            "qiskit.__qiskit_version__ is deprecated since "
-            "Qiskit Terra 0.25.0, and will be removed 3 months or more later. "
-            "Instead, you should use qiskit.__version__. The other packages listed in "
-            "former qiskit.__qiskit_version__ have their own __version__ module level dunder, "
-            "as standard in PEP 8.",
-            category=DeprecationWarning,
-        )
         self._version_dict = {
             "qiskit-terra": __version__,
             "qiskit": None,
@@ -108,6 +100,16 @@ class QiskitVersion(Mapping):
         self._loaded = False
 
     def _load_versions(self):
+        warnings.warn(
+            "qiskit.__qiskit_version__ is deprecated since "
+            "Qiskit Terra 0.25.0, and will be removed 3 months or more later. "
+            "Instead, you should use qiskit.__version__. The other packages listed in the"
+            "former qiskit.__qiskit_version__ have their own __version__ module level dunder, "
+            "as standard in PEP 8.",
+            category=DeprecationWarning,
+            stacklevel=3,
+        )
+
         from importlib.metadata import version
 
         try:

--- a/test/python/test_version.py
+++ b/test/python/test_version.py
@@ -22,4 +22,5 @@ class TestVersion(QiskitTestCase):
 
     def test_qiskit_version(self):
         """Test qiskit-version sets the correct version for terra."""
-        self.assertEqual(__version__, __qiskit_version__["qiskit-terra"])
+        with self.assertWarnsRegex(DeprecationWarning, "__qiskit_version__"):
+            self.assertEqual(__version__, __qiskit_version__["qiskit-terra"])


### PR DESCRIPTION
### Summary

The warning emitted by the `QiskitVersion` class that backs the `__qiskit_version__` variable was previously set to warn on instantiation, not usage.  This caused the warning to trigger during library import, rather than at the site of usage.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Originally introduced in #10242.
