### PR TITLE
Migrate init stage to plugins

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -27,10 +27,52 @@ from qiskit.transpiler.passes import TrivialLayout
 from qiskit.transpiler.passes import NoiseAdaptiveLayout
 from qiskit.transpiler.passes import CheckMap
 from qiskit.transpiler.passes import BarrierBeforeFinalMeasurements
+from qiskit.transpiler.passes import RemoveResetInZeroState
+from qiskit.transpiler.passes import OptimizeSwapBeforeMeasure
+from qiskit.transpiler.passes import RemoveDiagonalGatesBeforeMeasure
 from qiskit.transpiler.preset_passmanagers import common
 from qiskit.transpiler.preset_passmanagers.plugin import PassManagerStagePlugin
 from qiskit.transpiler.timing_constraints import TimingConstraints
 from qiskit.transpiler.passes.layout.vf2_layout import VF2LayoutStopReason
+
+
+class DefaultInitPassManager(PassManagerStagePlugin):
+    """Plugin class for default init stage."""
+
+    def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
+        if optimization_level in {1, 2, 0}:
+            init = None
+            if (
+                pass_manager_config.initial_layout
+                or pass_manager_config.coupling_map
+                or (
+                    pass_manager_config.target is not None
+                    and pass_manager_config.target.build_coupling_map() is not None
+                )
+            ):
+                init = common.generate_unroll_3q(
+                    pass_manager_config.target,
+                    pass_manager_config.basis_gates,
+                    pass_manager_config.approximation_degree,
+                    pass_manager_config.unitary_synthesis_method,
+                    pass_manager_config.unitary_synthesis_plugin_config,
+                    pass_manager_config.hls_config,
+                )
+        elif optimization_level == 3:
+            init = common.generate_unroll_3q(
+                pass_manager_config.target,
+                pass_manager_config.basis_gates,
+                pass_manager_config.approximation_degree,
+                pass_manager_config.unitary_synthesis_method,
+                pass_manager_config.unitary_synthesis_plugin_config,
+                pass_manager_config.hls_config,
+            )
+            init.append(RemoveResetInZeroState())
+            init.append(OptimizeSwapBeforeMeasure())
+            init.append(RemoveDiagonalGatesBeforeMeasure())
+        else:
+            return TranspilerError(f"Invalid optimization level {optimization_level}")
+        return init
 
 
 class BasisTranslatorPassManager(PassManagerStagePlugin):

--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -46,34 +46,21 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     basis_gates = pass_manager_config.basis_gates
     coupling_map = pass_manager_config.coupling_map
     initial_layout = pass_manager_config.initial_layout
-    init_method = pass_manager_config.init_method
+    init_method = pass_manager_config.init_method or "default"
     layout_method = pass_manager_config.layout_method or "default"
     routing_method = pass_manager_config.routing_method or "stochastic"
     translation_method = pass_manager_config.translation_method or "translator"
     optimization_method = pass_manager_config.optimization_method
     scheduling_method = pass_manager_config.scheduling_method or "default"
-    approximation_degree = pass_manager_config.approximation_degree
-    unitary_synthesis_method = pass_manager_config.unitary_synthesis_method
-    unitary_synthesis_plugin_config = pass_manager_config.unitary_synthesis_plugin_config
     target = pass_manager_config.target
-    hls_config = pass_manager_config.hls_config
 
     # Choose routing pass
     routing_pm = plugin_manager.get_passmanager_stage(
         "routing", routing_method, pass_manager_config, optimization_level=0
     )
 
-    unroll_3q = None
     # Build pass manager
     if coupling_map or initial_layout:
-        unroll_3q = common.generate_unroll_3q(
-            target,
-            basis_gates,
-            approximation_degree,
-            unitary_synthesis_method,
-            unitary_synthesis_plugin_config,
-            hls_config,
-        )
         layout = plugin_manager.get_passmanager_stage(
             "layout", layout_method, pass_manager_config, optimization_level=0
         )
@@ -98,7 +85,7 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
         "scheduling", scheduling_method, pass_manager_config, optimization_level=0
     )
 
-    init = common.generate_control_flow_options_check(
+    pre_init = common.generate_control_flow_options_check(
         layout_method=layout_method,
         routing_method=routing_method,
         translation_method=translation_method,
@@ -107,12 +94,9 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
         basis_gates=basis_gates,
         target=target,
     )
-    if init_method is not None:
-        init += plugin_manager.get_passmanager_stage(
-            "init", init_method, pass_manager_config, optimization_level=0
-        )
-    elif unroll_3q is not None:
-        init += unroll_3q
+    init = plugin_manager.get_passmanager_stage(
+        "init", init_method, pass_manager_config, optimization_level=0
+    )
     optimization = None
     if optimization_method is not None:
         optimization = plugin_manager.get_passmanager_stage(
@@ -120,6 +104,7 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
         )
 
     return StagedPassManager(
+        pre_init=pre_init,
         init=init,
         layout=layout,
         routing=routing,

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -60,17 +60,13 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     basis_gates = pass_manager_config.basis_gates
     coupling_map = pass_manager_config.coupling_map
     initial_layout = pass_manager_config.initial_layout
-    init_method = pass_manager_config.init_method
+    init_method = pass_manager_config.init_method or "default"
     layout_method = pass_manager_config.layout_method or "default"
     routing_method = pass_manager_config.routing_method or "sabre"
     translation_method = pass_manager_config.translation_method or "translator"
     optimization_method = pass_manager_config.optimization_method
     scheduling_method = pass_manager_config.scheduling_method or "default"
-    approximation_degree = pass_manager_config.approximation_degree
-    unitary_synthesis_method = pass_manager_config.unitary_synthesis_method
-    unitary_synthesis_plugin_config = pass_manager_config.unitary_synthesis_plugin_config
     target = pass_manager_config.target
-    hls_config = pass_manager_config.hls_config
 
     # Choose routing pass
     routing_pm = plugin_manager.get_passmanager_stage(
@@ -90,17 +86,8 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
         CommutativeCancellation(basis_gates=basis_gates, target=target),
     ]
 
-    unroll_3q = None
     # Build pass manager
     if coupling_map or initial_layout:
-        unroll_3q = common.generate_unroll_3q(
-            target,
-            basis_gates,
-            approximation_degree,
-            unitary_synthesis_method,
-            unitary_synthesis_plugin_config,
-            hls_config,
-        )
         layout = plugin_manager.get_passmanager_stage(
             "layout", layout_method, pass_manager_config, optimization_level=2
         )
@@ -142,7 +129,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
         "scheduling", scheduling_method, pass_manager_config, optimization_level=2
     )
 
-    init = common.generate_control_flow_options_check(
+    pre_init = common.generate_control_flow_options_check(
         layout_method=layout_method,
         routing_method=routing_method,
         translation_method=translation_method,
@@ -151,14 +138,12 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
         basis_gates=basis_gates,
         target=target,
     )
-    if init_method is not None:
-        init += plugin_manager.get_passmanager_stage(
-            "init", init_method, pass_manager_config, optimization_level=2
-        )
-    elif unroll_3q is not None:
-        init += unroll_3q
+    init = plugin_manager.get_passmanager_stage(
+        "init", init_method, pass_manager_config, optimization_level=2
+    )
 
     return StagedPassManager(
+        pre_init=pre_init,
         init=init,
         layout=layout,
         routing=routing,

--- a/qiskit/transpiler/preset_passmanagers/plugin.py
+++ b/qiskit/transpiler/preset_passmanagers/plugin.py
@@ -47,7 +47,7 @@ load external plugins via corresponding entry points.
      - Description and expectations
    * - ``init``
      - ``qiskit.transpiler.init``
-     - No reserved names
+     - ``default``
      - This stage runs first and is typically used for any initial logical optimization. Because most
        layout and routing algorithms are only designed to work with 1 and 2 qubit gates, this stage
        is also used to translate any gates that operate on more than 2 qubits into gates that only

--- a/releasenotes/notes/default-reserved-plugin-name-3825c2000a579e38.yaml
+++ b/releasenotes/notes/default-reserved-plugin-name-3825c2000a579e38.yaml
@@ -2,7 +2,7 @@
 upgrade:
   - |
     The plugin name ``default`` is reserved for the :ref:`stage_table`
-    ``layout`` and ``scheduling``. These stages previously did not reserve this
+    ``init``, ``layout`` and ``scheduling``. These stages previously did not reserve this
     plugin name, but the ``default`` name is now used to represent Qiskit's
     built-in default method for these stages. If you were using these names
     for plugins on these stages these will conflict with Qiskit's usage and

--- a/setup.py
+++ b/setup.py
@@ -134,6 +134,9 @@ setup(
             "permutation.basic = qiskit.transpiler.passes.synthesis.high_level_synthesis:BasicSynthesisPermutation",
             "permutation.acg = qiskit.transpiler.passes.synthesis.high_level_synthesis:ACGSynthesisPermutation",
         ],
+        "qiskit.transpiler.init": [
+            "default = qiskit.transpiler.preset_passmanagers.builtin_plugins:DefaultInitPassManager",
+        ],
         "qiskit.transpiler.translation": [
             "translator = qiskit.transpiler.preset_passmanagers.builtin_plugins:BasisTranslatorPassManager",
             "unroller = qiskit.transpiler.preset_passmanagers.builtin_plugins:UnrollerPassManager",

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -69,6 +69,8 @@ def mock_get_passmanager_stage(
             ]
         )
         return pm
+    elif stage_name == "init":
+        return PassManager([])
     elif stage_name == "routing":
         return PassManager([])
     elif stage_name == "layout":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the preset pass manager construction to only use plugins for the init stage. To accomplish this the previously hard coded built-in pass manager used for each optimization level are refactored to be in a plugin named "default". One thing that is changed in this PR is that the use of `generate_control_flow_options_check()` is moved to the `pre_init` stage. The reason for this is because the way the init stage was being constructed in the preset pass managers was to do initial checking of any methods, and this was unconditionally being run. This is a more logical fit for pre_init stage because it should run before any specified plugin.

### Details and comments

Fixes: #10687
Fixes: #8661