### PR TITLE
Add Qiskit 0.44.1 to release version table

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -20,6 +20,7 @@ This table tracks the metapackage versions and the version of each legacy Qiskit
 ==========================  ============  ==========  ============  ====================  ===========  ============
 Qiskit Metapackage Version  qiskit-terra  qiskit-aer  qiskit-ignis  qiskit-ibmq-provider  qiskit-aqua  Release Date
 ==========================  ============  ==========  ============  ====================  ===========  ============
+0.44.1                      0.25.1                                                                     2023-08-17
 0.44.0                      0.25.0                                                                     2023-07-27
 0.43.3                      0.24.2        0.12.2                    0.20.2                             2023-07-19
 0.43.2                      0.24.1        0.12.1                    0.20.2                             2023-06-28


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

As part of the Qiskit 0.44.1 release notes we neglected to add the version information for the release to the version history table. This was mainly overlooked because historically when we had a separate metapackage handle the release notes as in that model there was a custom sphinx extensions that built the version table. But as we migrated away from the metapackage we need to handle this manually with a hardcoded table.

### Details and comments