### PR TITLE
Do not deepcopy operations in Unroll3qOrMore

### DIFF
--- a/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
+++ b/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
@@ -80,7 +80,7 @@ class Unroll3qOrMore(TransformationPass):
                     "Cannot unroll all 3q or more gates. "
                     "No rule to expand instruction %s." % node.op.name
                 )
-            decomposition = circuit_to_dag(node.op.definition)
+            decomposition = circuit_to_dag(node.op.definition, copy_operations=False)
             decomposition = self.run(decomposition)  # recursively unroll
             dag.substitute_node_with_dag(node, decomposition)
         return dag


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the Unroll3qOrMore pass internally is quite simple it iterates over every operation in the circuit and for any operation that uses >= 3 qubits and recursively decompsing it into all 1 and 2 qubit operations, converting it to a DAGCircuit and substituting the >=3 qubit gates with the equivalent circuit. However, during this DAGCircuit conversion step we're spending a large amount deep copying the operation objects. However, we don't need to do this because nothing in the circuit will be reused with shared references so we can skip the copying and just pass the operation objects by reference onto the DAG (as that's all we need). This commit makes that change by using the `copy_operations` flag we introduced in #9848 on circuit_to_dag() to disable the internal copying.

### Details and comments
