### PR TITLE
Typos flagged by the IBM Quantum Platform automatic spellchecker

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -26,7 +26,7 @@ For example:
     num_processes = 15
 
 By default this file lives in ``~/.qiskit/settings.conf`` but the path used
-can be overriden with the ``QISKIT_SETTINGS`` environment variable. If
+can be overridden with the ``QISKIT_SETTINGS`` environment variable. If
 ``QISKIT_SETTINGS`` is set its value will used as the path to the user config
 file.
 
@@ -61,12 +61,12 @@ Available options:
    `Python multiprocessing <https://docs.python.org/3/library/multiprocessing.html>`__
    is enabled for operations that support running in parallel (for example
    transpilation of multiple :class:`~qiskit.circuit.QuantumCircuit` objects).
-   The default setting in the user config file can be overriden by
+   The default setting in the user config file can be overridden by
    the ``QISKIT_PARALLEL`` environment variable.
  * ``num_processes``: This option takes an integer value (> 0) that is used
    to specify the maximum number of parallel processes to launch for parallel
    operations if parallel execution is enabled. The default setting in the
-   user config file can be overriden by the ``QISKIT_NUM_PROCS`` environment
+   user config file can be overridden by the ``QISKIT_NUM_PROCS`` environment
    variable.
 
 Environment Variables

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -28253,7 +28253,7 @@ New Features
   for users who are only running qiskit-terra (or just not qiskit-aer and/or
   qiskit-ibmq-provider) and the warnings are not an indication of a potential
   packaging problem. If the user config file is set to disable the warnings
-  this can be overriden by setting the ``QISKIT_SUPPRESS_PACKAGING_WARNINGS``
+  this can be overridden by setting the ``QISKIT_SUPPRESS_PACKAGING_WARNINGS``
   to ``N`` or ``n``
 
 - :func:`qiskit.compiler.transpile()` has two new kwargs, ``layout_method``

--- a/qiskit/circuit/controlflow/if_else.py
+++ b/qiskit/circuit/controlflow/if_else.py
@@ -148,7 +148,7 @@ class IfElseOp(ControlFlowOp):
 
         Args:
             blocks: Iterable of circuits for "if" and "else" condition. If there is no "else"
-                circuit it may be set to None or ommited.
+                circuit it may be set to None or omitted.
 
         Returns:
             New IfElseOp with replaced blocks.

--- a/qiskit/circuit/library/data_preparation/pauli_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/pauli_feature_map.py
@@ -160,7 +160,7 @@ class PauliFeatureMap(NLocal):
     def _parameter_generator(
         self, rep: int, block: int, indices: List[int]
     ) -> Optional[List[Parameter]]:
-        """If certain blocks should use certain parameters this method can be overriden."""
+        """If certain blocks should use certain parameters this method can be overridden."""
         params = [self.ordered_parameters[i] for i in indices]
         return params
 

--- a/qiskit/circuit/library/n_local/n_local.py
+++ b/qiskit/circuit/library/n_local/n_local.py
@@ -961,7 +961,7 @@ class NLocal(BlueprintCircuit):
 
     # pylint: disable=unused-argument
     def _parameter_generator(self, rep: int, block: int, indices: list[int]) -> Parameter | None:
-        """If certain blocks should use certain parameters this method can be overriden."""
+        """If certain blocks should use certain parameters this method can be overridden."""
         return None
 
 

--- a/qiskit/circuit/parametertable.py
+++ b/qiskit/circuit/parametertable.py
@@ -18,7 +18,7 @@ from collections.abc import MappingView, MutableMapping, MutableSet
 class ParameterReferences(MutableSet):
     """A set of instruction parameter slot references.
     Items are expected in the form ``(instruction, param_index)``. Membership
-    testing is overriden such that items that are otherwise value-wise equal
+    testing is overridden such that items that are otherwise value-wise equal
     are still considered distinct if their ``instruction``\\ s are referentially
     distinct.
     """

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -352,7 +352,7 @@ class QuantumCircuit:
 
     @property
     def layout(self) -> Optional[TranspileLayout]:
-        r"""Return any associated layout information anout the circuit
+        r"""Return any associated layout information about the circuit
 
         This attribute contains an optional :class:`~.TranspileLayout`
         object. This is typically set on the output from :func:`~.transpile`

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2591,7 +2591,7 @@ class QuantumCircuit:
                 >>> circuit.parameters  # sorted alphabetically!
                 ParameterView([Parameter(a), Parameter(b), Parameter(elephant)])
 
-            Bear in mind that alphabetical sorting might be unituitive when it comes to numbers.
+            Bear in mind that alphabetical sorting might be unintuitive when it comes to numbers.
             The literal "10" comes before "2" in strict alphabetical sorting.
 
             .. code-block:: python

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -914,7 +914,7 @@ class DAGCircuit:
 
     def depth(self, *, recurse: bool = False):
         """Return the circuit depth.  If there is control flow present, this count may only be an
-        estimate, as the complete control-flow path cannot be staticly known.
+        estimate, as the complete control-flow path cannot be statically known.
 
         Args:
             recurse: if ``True``, then recurse into control-flow operations.  For loops

--- a/qiskit/primitives/backend_estimator.py
+++ b/qiskit/primitives/backend_estimator.py
@@ -108,7 +108,7 @@ class BackendEstimator(BaseEstimator[PrimitiveJob[EstimatorResult]]):
         bound_pass_manager: PassManager | None = None,
         skip_transpilation: bool = False,
     ):
-        """Initalize a new BackendEstimator instance
+        """Initialize a new BackendEstimator instance
 
         Args:
             backend: Required: the backend to run the primitive on

--- a/qiskit/providers/__init__.py
+++ b/qiskit/providers/__init__.py
@@ -626,7 +626,7 @@ post-processing, batching, caching, error mitigation, etc. The concept of
 the :mod:`qiskit.primitives` module is to explicitly enable this as the
 primitive objects are higher level abstractions to produce processed higher
 level outputs (such as probability distributions and expectation values)
-that abstract away the mechanics of getting the best result efficienctly, to
+that abstract away the mechanics of getting the best result efficiently, to
 concentrate on higher level applications using these outputs.
 
 For example, if your backends were well suited to leverage

--- a/qiskit/providers/options.py
+++ b/qiskit/providers/options.py
@@ -48,7 +48,7 @@ class Options(Mapping):
 
     Runtime validators can be registered. See `set_validator`.
     Updates through `update_options` and indexing (`__setitem__`) validate
-    the new value before peforming the update and raise `ValueError` if
+    the new value before performing the update and raise `ValueError` if
     the new value is invalid.
 
     >>> options.set_validator("opt1", (1, 5))

--- a/qiskit/providers/options.py
+++ b/qiskit/providers/options.py
@@ -191,7 +191,7 @@ class Options(Mapping):
         In this case whenever the ``"shots"`` option is updated by the user
         it will enforce that the value is >=1 and <=4096. A ``ValueError`` will
         be raised if it's outside those bounds. If a validator is already present
-        for the specified field it will be silently overriden.
+        for the specified field it will be silently overridden.
 
         Args:
             field (str): The field name to set the validator on

--- a/qiskit/qasm2/__init__.py
+++ b/qiskit/qasm2/__init__.py
@@ -442,7 +442,7 @@ def loads(
 
     Args:
         string: The OpenQASM 2 program in a string.
-        include_path: order of directories to search when evluating ``include`` statements.
+        include_path: order of directories to search when evaluating ``include`` statements.
         custom_instructions: any custom constructors that should be used for specific gates or
             opaque instructions during circuit construction.  See :ref:`qasm2-custom-instructions`
             for more.
@@ -483,7 +483,7 @@ def load(
 
     Args:
         filename: The OpenQASM 2 program in a string.
-        include_path: order of directories to search when evluating ``include`` statements.
+        include_path: order of directories to search when evaluating ``include`` statements.
         include_input_directory: Whether to add the directory of the input file to the
             ``include_path``, and if so, whether to *append* it to search last, or *prepend* it to
             search first.  Pass ``None`` to suppress adding this directory entirely.

--- a/qiskit/qasm2/__init__.py
+++ b/qiskit/qasm2/__init__.py
@@ -280,10 +280,10 @@ In particular, in the legacy importers:
       The four-parameter version of a controlled-:math:`U`, corresponding to :class:`.CUGate`.
 
     ``rxx(theta) a, b``
-      Two-qubit rotation arond the :math:`XX` axis, corresponding to :class:`.RXXGate`.
+      Two-qubit rotation around the :math:`XX` axis, corresponding to :class:`.RXXGate`.
 
     ``rzz(theta) a, b``
-      Two-qubit rotation arond the :math:`ZZ` axis, corresponding to :class:`.RZZGate`.
+      Two-qubit rotation around the :math:`ZZ` axis, corresponding to :class:`.RZZGate`.
 
     ``rccx a, b, c``
       The double-controlled :math:`X` gate, but with relative phase differences over the standard

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -134,7 +134,7 @@ circuits in the data.
 Version 9
 =========
 
-Version 9 addds support for classical :class:`~.expr.Expr` nodes and their associated
+Version 9 adds support for classical :class:`~.expr.Expr` nodes and their associated
 :class:`~.types.Type`\\ s.
 
 

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -791,7 +791,7 @@ A RANGE is a representation of a ``range`` object. It is defined as:
 SEQUENCE
 --------
 
-A SEQUENCE is a reprentation of a arbitrary sequence object. As sequence are just fixed length
+A SEQUENCE is a representation of an arbitrary sequence object. As sequence are just fixed length
 containers of arbitrary python objects their QPY can't fully represent any sequence,
 but as long as the contents in a sequence are other QPY serializable types for
 the INSTRUCTION_PARAM payload the ``sequence`` object can be serialized.

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -511,7 +511,7 @@ Each schedule instruction starts with ``char`` representing the instruction type
 followed by the :ref:`qpy_sequence` block representing the instruction
 :attr:`~qiskit.pulse.instructions.Instruction.operands`.
 Note that the data structure of pulse :class:`~qiskit.pulse.instructions.Instruction`
-is unified so that instance can be uniquely determied by the class and a tuple of operands.
+is unified so that instance can be uniquely determined by the class and a tuple of operands.
 The mapping of type char to the instruction subclass is defined as follows:
 
 - ``a``: :class:`~qiskit.pulse.instructions.Acquire` instruction

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -497,7 +497,7 @@ The context type char is mapped to each alignment subclass as follows:
 - ``s``: :class:`~.AlignSequential`
 - ``e``: :class:`~.AlignEquispaced`
 
-Note that :class:`~.AlignFunc` context is not supported becasue of the callback function
+Note that :class:`~.AlignFunc` context is not supported because of the callback function
 stored in the context parameters.
 
 .. _qpy_schedule_instructions:

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -667,7 +667,7 @@ The calibration definition header is then followed by ``name_size`` utf8 bytes o
 the gate name, ``num_qubits`` length of integers representing a sequence of qubits,
 and ``num_params`` length of INSTRUCTION_PARAM payload for parameters
 associated to the custom instruction.
-The ``type`` indicates the class of pulse program which is either, in pricinple,
+The ``type`` indicates the class of pulse program which is either, in principle,
 :class:`~.ScheduleBlock` or :class:`~.Schedule`. As of QPY Version 5,
 only :class:`~.ScheduleBlock` payload is supported.
 Finally, :ref:`qpy_schedule_block` payload is packed for each CALIBRATION_DEF entry.

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -321,7 +321,7 @@ with the bit). Following each ``INITIAL_LAYOUT_BIT`` struct is ``register_size``
 bytes for a ``utf8`` encoded string for the register name.
 
 Following the initial layout there is ``input_mapping_size`` array of
-``uint32_t`` integers representing the positions of the phyiscal bit from the
+``uint32_t`` integers representing the positions of the physical bit from the
 initial layout. This enables constructing a list of virtual bits where the
 array index is its input mapping position.
 

--- a/qiskit/quantum_info/operators/custom_iterator.py
+++ b/qiskit/quantum_info/operators/custom_iterator.py
@@ -27,7 +27,7 @@ class CustomIterator(ABC):
     @abstractmethod
     def __getitem__(self, key):
         """Get next item"""
-        # This method should be overriden for lazy conversion of
+        # This method should be overridden for lazy conversion of
         # iterator only at a given key value
         pass
 

--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -421,7 +421,7 @@ class Clifford(BaseOperator, AdjointMixin, Operation):
 
     @property
     def stab_phase(self):
-        """Return phase of stablizer with boolean representation."""
+        """Return phase of stabilizer with boolean representation."""
         return self.tableau[self.num_qubits :, -1]
 
     @stab_phase.setter
@@ -874,8 +874,8 @@ class Clifford(BaseOperator, AdjointMixin, Operation):
         Args:
             array (bool): return a Numpy array if True, otherwise
                           return a list (Default: False).
-            mode (Literal["S", "D", "B"]): return both stabilizer and destablizer if "B",
-                return only stabilizer if "S" and return only destablizer if "D".
+            mode (Literal["S", "D", "B"]): return both stabilizer and destabilizer if "B",
+                return only stabilizer if "S" and return only destabilizer if "D".
 
         Returns:
             list or array: The rows of the StabilizerTable in label form.

--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -385,7 +385,7 @@ class Clifford(BaseOperator, AdjointMixin, Operation):
 
     @property
     def destab_phase(self):
-        """Return phase of destaibilizer with boolean representation."""
+        """Return phase of destabilizer with boolean representation."""
         return self.tableau[: self.num_qubits, -1]
 
     @destab_phase.setter

--- a/qiskit/quantum_info/states/stabilizerstate.py
+++ b/qiskit/quantum_info/states/stabilizerstate.py
@@ -151,7 +151,7 @@ class StabilizerState(QuantumState):
         return ret
 
     def tensor(self, other: StabilizerState) -> StabilizerState:
-        """Return the tensor product stabilzier state self ⊗ other.
+        """Return the tensor product stabilizer state self ⊗ other.
 
         Args:
             other (StabilizerState): a stabilizer state object.
@@ -169,7 +169,7 @@ class StabilizerState(QuantumState):
         return ret
 
     def expand(self, other: StabilizerState) -> StabilizerState:
-        """Return the tensor product stabilzier state other ⊗ self.
+        """Return the tensor product stabilizer state other ⊗ self.
 
         Args:
             other (StabilizerState): a stabilizer state object.

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -393,7 +393,7 @@ class TwoQubitWeylDecomposition:
     def _weyl_gate(self, simplify, circ: QuantumCircuit, atol):
         """Appends Ud(a, b, c) to the circuit.
 
-        Can be overriden in subclasses for special cases"""
+        Can be overridden in subclasses for special cases"""
         if not simplify or abs(self.a) > atol:
             circ.rxx(-self.a * 2, 0, 1)
         if not simplify or abs(self.b) > atol:

--- a/qiskit/result/mitigation/base_readout_mitigator.py
+++ b/qiskit/result/mitigation/base_readout_mitigator.py
@@ -43,7 +43,7 @@ class BaseReadoutMitigator(ABC):
                 be calculated as the sum of all counts.
 
         Returns:
-            QuasiDistibution: A dictionary containing pairs of [output, mean] where "output"
+            QuasiDistribution: A dictionary containing pairs of [output, mean] where "output"
                 is the key in the dictionaries,
                 which is the length-N bitstring of a measured standard basis state,
                 and "mean" is the mean of non-zero quasi-probability estimates.

--- a/qiskit/result/mitigation/correlated_readout_mitigator.py
+++ b/qiskit/result/mitigation/correlated_readout_mitigator.py
@@ -145,7 +145,7 @@ class CorrelatedReadoutMitigator(BaseReadoutMitigator):
                 be calculated as the sum of all counts.
 
         Returns:
-            QuasiDistibution: A dictionary containing pairs of [output, mean] where "output"
+            QuasiDistribution: A dictionary containing pairs of [output, mean] where "output"
                 is the key in the dictionaries,
                 which is the length-N bitstring of a measured standard basis state,
                 and "mean" is the mean of non-zero quasi-probability estimates.

--- a/qiskit/result/mitigation/local_readout_mitigator.py
+++ b/qiskit/result/mitigation/local_readout_mitigator.py
@@ -181,7 +181,7 @@ class LocalReadoutMitigator(BaseReadoutMitigator):
                 be calculated as the sum of all counts.
 
         Returns:
-            QuasiDistibution: A dictionary containing pairs of [output, mean] where "output"
+            QuasiDistribution: A dictionary containing pairs of [output, mean] where "output"
                 is the key in the dictionaries,
                 which is the length-N bitstring of a measured standard basis state,
                 and "mean" is the mean of non-zero quasi-probability estimates.

--- a/qiskit/synthesis/clifford/clifford_decompose_greedy.py
+++ b/qiskit/synthesis/clifford/clifford_decompose_greedy.py
@@ -36,7 +36,7 @@ def synth_clifford_greedy(clifford):
     greedy Clifford compiler that is described in Appendix A of
     Bravyi, Hu, Maslov and Shaydulin.
 
-    This method typically yields better CX cost compared to the Aaronson-Gottesma method.
+    This method typically yields better CX cost compared to the Aaronson-Gottesman method.
 
     Args:
         clifford (Clifford): a clifford operator.

--- a/qiskit/synthesis/evolution/lie_trotter.py
+++ b/qiskit/synthesis/evolution/lie_trotter.py
@@ -64,7 +64,7 @@ class LieTrotter(ProductFormula):
                 "chain", where next neighbor connections are used, or "fountain", where all
                 qubits are connected to one.
             atomic_evolution: A function to construct the circuit for the evolution of single
-                Pauli string. Per default, a single Pauli evolution is decomopsed in a CX chain
+                Pauli string. Per default, a single Pauli evolution is decomposed in a CX chain
                 and a single qubit Z rotation.
         """
         super().__init__(1, reps, insert_barriers, cx_structure, atomic_evolution)

--- a/qiskit/synthesis/evolution/product_formula.py
+++ b/qiskit/synthesis/evolution/product_formula.py
@@ -47,7 +47,7 @@ class ProductFormula(EvolutionSynthesis):
                 "chain", where next neighbor connections are used, or "fountain", where all
                 qubits are connected to one.
             atomic_evolution: A function to construct the circuit for the evolution of single
-                Pauli string. Per default, a single Pauli evolution is decomopsed in a CX chain
+                Pauli string. Per default, a single Pauli evolution is decomposed in a CX chain
                 and a single qubit Z rotation.
         """
         super().__init__()

--- a/qiskit/synthesis/evolution/qdrift.py
+++ b/qiskit/synthesis/evolution/qdrift.py
@@ -49,7 +49,7 @@ class QDrift(ProductFormula):
                 "chain", where next neighbor connections are used, or "fountain", where all
                 qubits are connected to one.
             atomic_evolution: A function to construct the circuit for the evolution of single
-                Pauli string. Per default, a single Pauli evolution is decomopsed in a CX chain
+                Pauli string. Per default, a single Pauli evolution is decomposed in a CX chain
                 and a single qubit Z rotation.
         """
         super().__init__(1, reps, insert_barriers, cx_structure, atomic_evolution)

--- a/qiskit/synthesis/evolution/suzuki_trotter.py
+++ b/qiskit/synthesis/evolution/suzuki_trotter.py
@@ -81,7 +81,7 @@ class SuzukiTrotter(ProductFormula):
                 where next neighbor connections are used, or "fountain", where all qubits are
                 connected to one.
             atomic_evolution: A function to construct the circuit for the evolution of single
-                Pauli string. Per default, a single Pauli evolution is decomopsed in a CX chain
+                Pauli string. Per default, a single Pauli evolution is decomposed in a CX chain
                 and a single qubit Z rotation.
         """
         # TODO replace deprecation warning by the following error and add unit test for odd

--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -658,7 +658,7 @@ a heuristic pass that tries to find the best layout to use if a perfect layout c
 For the first stage there are 2 passes typically used for this:
 
 - :class:`~.VF2Layout`: Models layout selection as a subgraph isomorphism problem and tries
-  to find a subgraph of the connectivity graph that is isomporphic to the
+  to find a subgraph of the connectivity graph that is isomorphic to the
   graph of 2 qubit interactions in the circuit. If more than one isomorphic mapping is found a
   scoring heuristic is run to select the mapping which would result in the lowest average error
   when executing the circuit.

--- a/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
+++ b/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
@@ -26,7 +26,7 @@ class Unroll3qOrMore(TransformationPass):
         """Initialize the Unroll3qOrMore pass
 
         Args:
-            target (Target): The target object reprsenting the compilation
+            target (Target): The target object representing the compilation
                 target. If specified any multiqubit instructions in the
                 circuit when the pass is run that are supported by the target
                 device will be left in place. If both this and ``basis_gates``

--- a/qiskit/transpiler/passes/optimization/collect_multiqubit_blocks.py
+++ b/qiskit/transpiler/passes/optimization/collect_multiqubit_blocks.py
@@ -33,7 +33,7 @@ class CollectMultiQBlocks(AnalysisPass):
     Some gates may not be present in any block (e.g. if the number
     of operands is greater than max_block_size)
 
-    A Disjont Set Union data structure (DSU) is used to maintain blocks as
+    A Disjoint Set Union data structure (DSU) is used to maintain blocks as
     gates are processed. This data structure points each qubit to a set at all
     times and the sets correspond to current blocks. These change over time
     and the data structure allows these changes to be done quickly.

--- a/qiskit/transpiler/passes/optimization/crosstalk_adaptive_schedule.py
+++ b/qiskit/transpiler/passes/optimization/crosstalk_adaptive_schedule.py
@@ -224,7 +224,7 @@ class CrosstalkAdaptiveSchedule(TransformationPass):
         """
         Gate A, B are overlapping if
         A is neither a descendant nor an ancestor of B.
-        Currenty overlaps (A,B) are considered when A is a 2q gate and
+        Currently overlaps (A,B) are considered when A is a 2q gate and
         B is either 2q or 1q gate.
         """
         for gate in dag.two_qubit_ops():

--- a/qiskit/transpiler/passes/optimization/inverse_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/inverse_cancellation.py
@@ -33,7 +33,7 @@ class InverseCancellation(TransformationPass):
 
         Raises:
             TranspilerError:
-                Initalization raises an error when the input is not a self-inverse gate
+                Initialization raises an error when the input is not a self-inverse gate
                 or a two-tuple of inverse gates.
         """
 

--- a/qiskit/transpiler/passes/scheduling/alignments/check_durations.py
+++ b/qiskit/transpiler/passes/scheduling/alignments/check_durations.py
@@ -19,7 +19,7 @@ from qiskit.transpiler.basepasses import AnalysisPass
 class InstructionDurationCheck(AnalysisPass):
     """Duration validation pass for reschedule.
 
-    This pass investigates the input quantum circuit and checks if the circuit requres
+    This pass investigates the input quantum circuit and checks if the circuit requires
     rescheduling for execution. Note that this pass can be triggered without scheduling.
     This pass only checks the duration of delay instructions and user defined pulse gates,
     which report duration values without pre-scheduling.

--- a/qiskit/transpiler/passes/scheduling/padding/base_padding.py
+++ b/qiskit/transpiler/passes/scheduling/padding/base_padding.py
@@ -93,7 +93,7 @@ class BasePadding(TransformationPass):
 
         # Update start time dictionary for the new_dag.
         # This information may be used for further scheduling tasks,
-        # but this is immediately invalidated becasue node id is updated in the new_dag.
+        # but this is immediately invalidated because node id is updated in the new_dag.
         self.property_set["node_start_time"].clear()
 
         new_dag.name = dag.name

--- a/qiskit/transpiler/passes/scheduling/scheduling/set_io_latency.py
+++ b/qiskit/transpiler/passes/scheduling/scheduling/set_io_latency.py
@@ -24,7 +24,7 @@ class SetIOLatency(AnalysisPass):
 
     Once these latencies are added to the property set, this information
     is also copied to the output circuit object as protected attributes,
-    so that it can be utilized outside the transilation,
+    so that it can be utilized outside the transpilation,
     for example, the timeline visualization can use latency to accurately show
     time occupation by instructions on the classical registers.
     """

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -466,7 +466,7 @@ class Target(Mapping):
             inst_name_map (dict): An optional dictionary that maps any
                 instruction name in ``inst_map`` to an instruction object.
                 If not provided, instruction is pulled from the standard Qiskit gates,
-                and finally custom gate instnace is created with schedule name.
+                and finally custom gate instance is created with schedule name.
             error_dict (dict): A dictionary of errors of the form::
 
                 {gate_name: {qarg: error}}

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -1292,7 +1292,7 @@ class Target(Mapping):
         Raises:
             TranspilerError: If the input basis gates contain > 2 qubits and ``coupling_map`` is
             specified.
-            KeyError: If no mappign is available for a specified ``basis_gate``.
+            KeyError: If no mapping is available for a specified ``basis_gate``.
         """
         granularity = 1
         min_length = 1

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -442,7 +442,7 @@ class Target(Mapping):
         Args:
             instruction (str): The instruction name to update
             qargs (tuple): The qargs to update the properties of
-            properties (InstructionProperties): The properties to set for this nstruction
+            properties (InstructionProperties): The properties to set for this instruction
         Raises:
             KeyError: If ``instruction`` or ``qarg`` are not in the target
         """

--- a/qiskit/utils/__init__.py
+++ b/qiskit/utils/__init__.py
@@ -53,7 +53,7 @@ are run on a device or simulator by passing a QuantumInstance setup with the des
 backend etc.
 
 
-Optional Depedency Checkers (:mod:`qiskit.utils.optionals`)
+Optional Dependency Checkers (:mod:`qiskit.utils.optionals`)
 ===========================================================
 
 .. automodule:: qiskit.utils.optionals

--- a/qiskit/utils/__init__.py
+++ b/qiskit/utils/__init__.py
@@ -54,7 +54,7 @@ backend etc.
 
 
 Optional Dependency Checkers (:mod:`qiskit.utils.optionals`)
-===========================================================
+============================================================
 
 .. automodule:: qiskit.utils.optionals
 """

--- a/releasenotes/notes/0.13/suppress-packaging-warnings-396b38feb6b3d52f.yaml
+++ b/releasenotes/notes/0.13/suppress-packaging-warnings-396b38feb6b3d52f.yaml
@@ -21,5 +21,5 @@ features:
     for users who are only running qiskit-terra (or just not qiskit-aer and/or
     qiskit-ibmq-provider) and the warnings are not an indication of a potential
     packaging problem. If the user config file is set to disable the warnings
-    this can be overriden by setting the ``QISKIT_SUPPRESS_PACKAGING_WARNINGS``
+    this can be overridden by setting the ``QISKIT_SUPPRESS_PACKAGING_WARNINGS``
     to ``N`` or ``n``


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

As part of its build, IQP now has an auto-spellchecker, and it flagged several minor typos in the API refs that are surfaced in IQP from the Qiskit/qiskit repo.  Fixing them in this PR; hope this is the best way to contribute this kind of fix!--feedback welcome! 

### Details and comments

🍎 "Low-hanging fruit" 🍎  


