### PR TITLE
Fix virtual/physical-qubit distinction in Sabre

### DIFF
--- a/crates/accelerate/src/sabre_layout.rs
+++ b/crates/accelerate/src/sabre_layout.rs
@@ -12,8 +12,7 @@
 #![allow(clippy::too_many_arguments)]
 
 use ndarray::prelude::*;
-use numpy::IntoPyArray;
-use numpy::PyReadonlyArray2;
+use numpy::{IntoPyArray, PyArray, PyReadonlyArray2};
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use pyo3::Python;
@@ -39,7 +38,7 @@ pub fn sabre_layout_and_routing(
     num_swap_trials: usize,
     num_layout_trials: usize,
     seed: Option<u64>,
-) -> (NLayout, Vec<usize>, (SwapMap, PyObject, NodeBlockResults)) {
+) -> (NLayout, PyObject, (SwapMap, PyObject, NodeBlockResults)) {
     let run_in_parallel = getenv_use_multiple_threads();
     let outer_rng = match seed {
         Some(seed) => Pcg64Mcg::seed_from_u64(seed),
@@ -97,7 +96,7 @@ pub fn sabre_layout_and_routing(
     };
     (
         res.0,
-        res.1,
+        PyArray::from_vec(py, res.1).into(),
         (
             res.2.map,
             res.2.node_order.into_pyarray(py).into(),

--- a/crates/accelerate/src/sabre_layout.rs
+++ b/crates/accelerate/src/sabre_layout.rs
@@ -39,7 +39,7 @@ pub fn sabre_layout_and_routing(
     num_swap_trials: usize,
     num_layout_trials: usize,
     seed: Option<u64>,
-) -> ([NLayout; 2], (SwapMap, PyObject, NodeBlockResults)) {
+) -> (NLayout, Vec<usize>, (SwapMap, PyObject, NodeBlockResults)) {
     let run_in_parallel = getenv_use_multiple_threads();
     let outer_rng = match seed {
         Some(seed) => Pcg64Mcg::seed_from_u64(seed),
@@ -69,7 +69,7 @@ pub fn sabre_layout_and_routing(
                     ),
                 )
             })
-            .min_by_key(|(index, (_, result))| {
+            .min_by_key(|(index, (_, _, result))| {
                 (
                     result.map.map.values().map(|x| x.len()).sum::<usize>(),
                     *index,
@@ -92,15 +92,16 @@ pub fn sabre_layout_and_routing(
                     run_in_parallel,
                 )
             })
-            .min_by_key(|(_, result)| result.map.map.values().map(|x| x.len()).sum::<usize>())
+            .min_by_key(|(_, _, result)| result.map.map.values().map(|x| x.len()).sum::<usize>())
             .unwrap()
     };
     (
         res.0,
+        res.1,
         (
-            res.1.map,
-            res.1.node_order.into_pyarray(py).into(),
-            res.1.node_block_results,
+            res.2.map,
+            res.2.node_order.into_pyarray(py).into(),
+            res.2.node_block_results,
         ),
     )
 }
@@ -114,113 +115,72 @@ fn layout_trial(
     max_iterations: usize,
     num_swap_trials: usize,
     run_swap_in_parallel: bool,
-) -> ([NLayout; 2], SabreResult) {
-    // Pick a random initial layout and fully populate ancillas in that layout too
+) -> (NLayout, Vec<usize>, SabreResult) {
     let num_physical_qubits = distance_matrix.shape()[0];
     let mut rng = Pcg64Mcg::seed_from_u64(seed);
-    let mut physical_qubits: Vec<usize> = (0..num_physical_qubits).collect();
-    physical_qubits.shuffle(&mut rng);
-    let mut initial_layout = NLayout::from_logical_to_physical(physical_qubits);
-    let new_dag_fn = |nodes| {
-        // Because the current implementation of Sabre swap doesn't permute
-        // the layout when placing control flow ops, there's no need to
-        // recurse into blocks. We remove them here, but still map control
-        // flow node IDs to an empty block list so Sabre treats these ops
-        // as control flow nodes, but doesn't route their blocks.
-        let node_blocks_empty = dag
-            .node_blocks
-            .iter()
-            .map(|(node_index, _)| (*node_index, Vec::with_capacity(0)));
-        SabreDAG::new(
-            dag.num_qubits,
-            dag.num_clbits,
-            nodes,
-            node_blocks_empty.collect(),
-        )
-        .unwrap()
+
+    // Pick a random initial layout including a full ancilla allocation.
+    let mut initial_layout = {
+        let mut physical_qubits: Vec<usize> = (0..num_physical_qubits).collect();
+        physical_qubits.shuffle(&mut rng);
+        NLayout::from_logical_to_physical(physical_qubits)
     };
 
-    // Create forward and reverse dags (without node blocks).
-    // Once we've settled on a layout, we recursively apply it to the original
-    // DAG and its node blocks.
-    let mut dag_forward: SabreDAG = new_dag_fn(dag.nodes.clone());
-    let mut dag_reverse: SabreDAG = new_dag_fn(dag.nodes.iter().rev().cloned().collect());
+    // Sabre routing currently enforces that control-flow blocks return to their starting layout,
+    // which means they don't actually affect any heuristics that affect our layout choice.
+    let dag_no_control_forward = SabreDAG {
+        num_qubits: dag.num_qubits,
+        num_clbits: dag.num_clbits,
+        dag: dag.dag.clone(),
+        nodes: dag.nodes.clone(),
+        first_layer: dag.first_layer.clone(),
+        node_blocks: dag
+            .node_blocks
+            .keys()
+            .map(|index| (*index, Vec::new()))
+            .collect(),
+    };
+    let dag_no_control_reverse = SabreDAG::new(
+        dag_no_control_forward.num_qubits,
+        dag_no_control_forward.num_clbits,
+        dag_no_control_forward.nodes.iter().rev().cloned().collect(),
+        dag_no_control_forward.node_blocks.clone(),
+    );
+
     for _iter in 0..max_iterations {
-        // forward and reverse
-        for _direction in 0..2 {
-            let layout_dag = apply_layout(&dag_forward, &initial_layout);
-            let mut pass_final_layout = NLayout::generate_trivial_layout(num_physical_qubits);
-            build_swap_map_inner(
+        for dag in [&dag_no_control_forward, &dag_no_control_reverse] {
+            let (_result, final_layout) = build_swap_map_inner(
                 num_physical_qubits,
-                &layout_dag,
+                dag,
                 neighbor_table,
                 distance_matrix,
                 heuristic,
                 Some(seed),
-                &mut pass_final_layout,
+                &initial_layout,
                 num_swap_trials,
                 Some(run_swap_in_parallel),
             );
-            let final_layout = compose_layout(&initial_layout, &pass_final_layout);
             initial_layout = final_layout;
-            std::mem::swap(&mut dag_forward, &mut dag_reverse);
         }
     }
 
-    // Apply the layout to the original DAG.
-    let layout_dag = apply_layout(dag, &initial_layout);
-
-    let mut final_layout = NLayout::generate_trivial_layout(num_physical_qubits);
-    let sabre_result = build_swap_map_inner(
+    let (sabre_result, final_layout) = build_swap_map_inner(
         num_physical_qubits,
-        &layout_dag,
+        dag,
         neighbor_table,
         distance_matrix,
         heuristic,
         Some(seed),
-        &mut final_layout,
+        &initial_layout,
         num_swap_trials,
         Some(run_swap_in_parallel),
     );
-    ([initial_layout, final_layout], sabre_result)
-}
-
-fn apply_layout(dag: &SabreDAG, layout: &NLayout) -> SabreDAG {
-    let layout_nodes = dag.nodes.iter().map(|(node_index, qargs, cargs)| {
-        let new_qargs: Vec<usize> = qargs.iter().map(|n| layout.logic_to_phys[*n]).collect();
-        (*node_index, new_qargs, cargs.clone())
-    });
-    let node_blocks = dag.node_blocks.iter().map(|(node_index, blocks)| {
-        (
-            *node_index,
-            blocks.iter().map(|d| apply_layout(d, layout)).collect(),
-        )
-    });
-    SabreDAG::new(
-        dag.num_qubits,
-        dag.num_clbits,
-        layout_nodes.collect(),
-        node_blocks.collect(),
-    )
-    .unwrap()
-}
-
-fn compose_layout(initial_layout: &NLayout, final_layout: &NLayout) -> NLayout {
-    let logic_to_phys = initial_layout
-        .logic_to_phys
-        .iter()
-        .map(|n| final_layout.logic_to_phys[*n])
-        .collect();
-    let phys_to_logic = final_layout
+    let final_permutation = initial_layout
         .phys_to_logic
         .iter()
-        .map(|n| initial_layout.phys_to_logic[*n])
+        .map(|initial| final_layout.logic_to_phys[*initial])
         .collect();
-
-    NLayout {
-        logic_to_phys,
-        phys_to_logic,
-    }
+    (initial_layout, final_permutation, sabre_result)
 }
 
 #[pymodule]

--- a/crates/accelerate/src/sabre_swap/mod.rs
+++ b/crates/accelerate/src/sabre_swap/mod.rs
@@ -181,7 +181,7 @@ fn populate_extended_set(
             required_predecessors[successor_index] -= 1;
             if required_predecessors[successor_index] == 0 {
                 if !dag.node_blocks.contains_key(&successor_index) {
-                    if let [a, b] = dag.dag[successor_node].1[..] {
+                    if let [a, b] = dag.dag[successor_node].qubits[..] {
                         extended_set.insert(successor_node, &[a, b]);
                     }
                 }
@@ -208,10 +208,12 @@ fn cmap_from_neighor_table(neighbor_table: &NeighborTable) -> DiGraph<(), ()> {
 /// Run sabre swap on a circuit
 ///
 /// Returns:
-///     (SwapMap, gate_order, node_block_results): A tuple where the first element is a mapping of
-///     DAGCircuit node ids to a list of virtual qubit swaps that should be
-///     added before that operation. The second element is a numpy array of
-///     node ids that represents the traversal order used by sabre.
+///     (SwapMap, gate_order, node_block_results, final_permutation): A tuple where the first
+///     element is a mapping of DAGCircuit node ids to a list of virtual qubit swaps that should be
+///     added before that operation. The second element is a numpy array of node ids that
+///     represents the traversal order used by sabre.  The third is inner results for the blocks of
+///     control flow, and the fourth is a permutation, where `final_permution[i]` is the final
+///     logical position of the qubit that began in position `i`.
 #[pyfunction]
 pub fn build_swap_map(
     py: Python,
@@ -220,20 +222,20 @@ pub fn build_swap_map(
     neighbor_table: &NeighborTable,
     distance_matrix: PyReadonlyArray2<f64>,
     heuristic: &Heuristic,
-    layout: &mut NLayout,
+    initial_layout: &NLayout,
     num_trials: usize,
     seed: Option<u64>,
     run_in_parallel: Option<bool>,
-) -> (SwapMap, PyObject, NodeBlockResults) {
+) -> (SwapMap, PyObject, NodeBlockResults, Vec<usize>) {
     let dist = distance_matrix.as_array();
-    let res = build_swap_map_inner(
+    let (res, final_layout) = build_swap_map_inner(
         num_qubits,
         dag,
         neighbor_table,
         &dist,
         heuristic,
         seed,
-        layout,
+        initial_layout,
         num_trials,
         run_in_parallel,
     );
@@ -241,6 +243,11 @@ pub fn build_swap_map(
         res.map,
         res.node_order.into_pyarray(py).into(),
         res.node_block_results,
+        initial_layout
+            .phys_to_logic
+            .iter()
+            .map(|initial| final_layout.logic_to_phys[*initial])
+            .collect(),
     )
 }
 
@@ -251,10 +258,10 @@ pub fn build_swap_map_inner(
     dist: &ArrayView2<f64>,
     heuristic: &Heuristic,
     seed: Option<u64>,
-    layout: &mut NLayout,
+    initial_layout: &NLayout,
     num_trials: usize,
     run_in_parallel: Option<bool>,
-) -> SabreResult {
+) -> (SabreResult, NLayout) {
     let run_in_parallel = match run_in_parallel {
         Some(run_in_parallel) => run_in_parallel,
         None => getenv_use_multiple_threads() && num_trials > 1,
@@ -268,7 +275,7 @@ pub fn build_swap_map_inner(
         .sample_iter(&rand::distributions::Standard)
         .take(num_trials)
         .collect();
-    let (result, final_layout) = if run_in_parallel {
+    if run_in_parallel {
         seed_vec
             .into_par_iter()
             .enumerate()
@@ -283,7 +290,7 @@ pub fn build_swap_map_inner(
                         &coupling_graph,
                         heuristic,
                         seed_trial,
-                        layout.clone(),
+                        initial_layout,
                     ),
                 )
             })
@@ -307,14 +314,12 @@ pub fn build_swap_map_inner(
                     &coupling_graph,
                     heuristic,
                     seed_trial,
-                    layout.clone(),
+                    initial_layout,
                 )
             })
             .min_by_key(|(result, _)| result.map.map.values().map(|x| x.len()).sum::<usize>())
             .unwrap()
-    };
-    *layout = final_layout;
-    result
+    }
 }
 
 fn swap_map_trial(
@@ -325,7 +330,7 @@ fn swap_map_trial(
     coupling_graph: &DiGraph<(), ()>,
     heuristic: &Heuristic,
     seed: u64,
-    mut layout: NLayout,
+    initial_layout: &NLayout,
 ) -> (SabreResult, NLayout) {
     let max_iterations_without_progress = 10 * neighbor_table.neighbors.len();
     let mut out_map: HashMap<usize, Vec<[usize; 2]>> = HashMap::new();
@@ -333,6 +338,7 @@ fn swap_map_trial(
     let mut front_layer = FrontLayer::new(num_qubits);
     let mut extended_set = ExtendedSet::new(num_qubits, EXTENDED_SET_SIZE);
     let mut required_predecessors: Vec<u32> = vec![0; dag.dag.node_count()];
+    let mut layout = initial_layout.clone();
     let mut num_search_steps: u8 = 0;
     let mut qubits_decay: Vec<f64> = vec![1.; num_qubits];
     let mut rng = Pcg64Mcg::seed_from_u64(seed);
@@ -348,7 +354,7 @@ fn swap_map_trial(
     // This closure is used to curry parameters so we can avoid passing
     // everything and the kitchen sink to update_routes and
     // route_reachable_nodes.
-    let route_block_dag = |block_dag: &SabreDAG, current_layout: NLayout| {
+    let route_block_dag = |block_dag: &SabreDAG, current_layout: &NLayout| {
         swap_map_trial(
             num_qubits,
             block_dag,
@@ -474,12 +480,11 @@ fn update_route<F>(
     node_block_results: &mut HashMap<usize, Vec<BlockResult>>,
     route_block_dag: &F,
 ) where
-    F: Fn(&SabreDAG, NLayout) -> (SabreResult, NLayout),
+    F: Fn(&SabreDAG, &NLayout) -> (SabreResult, NLayout),
 {
     // First node gets the swaps attached.  We don't add to the `gate_order` here because
     // `route_reachable_nodes` is responsible for that part.
-    let py_node = dag.dag[nodes[0]].0;
-    out_map.insert(py_node, swaps);
+    out_map.insert(dag.dag[nodes[0]].py_node_id, swaps);
     for node in nodes {
         front_layer.remove(node);
     }
@@ -560,24 +565,22 @@ fn route_reachable_nodes<F>(
     node_block_results: &mut HashMap<usize, Vec<BlockResult>>,
     route_block_dag: &F,
 ) where
-    F: Fn(&SabreDAG, NLayout) -> (SabreResult, NLayout),
+    F: Fn(&SabreDAG, &NLayout) -> (SabreResult, NLayout),
 {
     let mut to_visit = to_visit.to_vec();
     let mut i = 0;
     // Iterate through `to_visit`, except we often push new nodes onto the end of it.
     while i < to_visit.len() {
-        let node = to_visit[i];
+        let node_id = to_visit[i];
+        let node = &dag.dag[node_id];
         i += 1;
-        let (py_node, qubits) = &dag.dag[node];
 
-        match dag.node_blocks.get(py_node) {
+        match dag.node_blocks.get(&node.py_node_id) {
             Some(blocks) => {
                 // Control flow op. Route all blocks for current layout.
                 let mut block_results: Vec<BlockResult> = Vec::with_capacity(blocks.len());
                 for inner_dag in blocks {
-                    let (inner_dag_routed, inner_final_layout) =
-                        route_block_dag(inner_dag, layout.copy());
-
+                    let (inner_dag_routed, inner_final_layout) = route_block_dag(inner_dag, layout);
                     // For now, we always append a swap circuit that gets the inner block
                     // back to the parent's layout.
                     let swap_epilogue =
@@ -588,9 +591,9 @@ fn route_reachable_nodes<F>(
                     };
                     block_results.push(block_result);
                 }
-                node_block_results.insert_unique_unchecked(*py_node, block_results);
+                node_block_results.insert_unique_unchecked(node.py_node_id, block_results);
             }
-            None => match qubits[..] {
+            None => match node.qubits[..] {
                 // A gate op whose connectivity must match the device to be
                 // placed in the gate order.
                 [a, b]
@@ -601,15 +604,15 @@ fn route_reachable_nodes<F>(
                 {
                     // 2Q op that cannot be placed. Add it to the front layer
                     // and move on.
-                    front_layer.insert(node, [a, b]);
+                    front_layer.insert(node_id, [a, b]);
                     continue;
                 }
                 _ => {}
             },
         }
 
-        gate_order.push(*py_node);
-        for edge in dag.dag.edges_directed(node, Direction::Outgoing) {
+        gate_order.push(node.py_node_id);
+        for edge in dag.dag.edges_directed(node_id, Direction::Outgoing) {
             let successor_node = edge.target();
             let successor_index = successor_node.index();
             required_predecessors[successor_index] -= 1;

--- a/crates/accelerate/src/sabre_swap/mod.rs
+++ b/crates/accelerate/src/sabre_swap/mod.rs
@@ -22,7 +22,7 @@ use std::cmp::Ordering;
 use hashbrown::HashMap;
 use ndarray::prelude::*;
 use numpy::PyReadonlyArray2;
-use numpy::{IntoPyArray, ToPyArray};
+use numpy::{IntoPyArray, PyArray, ToPyArray};
 use pyo3::exceptions::PyIndexError;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
@@ -226,7 +226,7 @@ pub fn build_swap_map(
     num_trials: usize,
     seed: Option<u64>,
     run_in_parallel: Option<bool>,
-) -> (SwapMap, PyObject, NodeBlockResults, Vec<usize>) {
+) -> (SwapMap, PyObject, NodeBlockResults, PyObject) {
     let dist = distance_matrix.as_array();
     let (res, final_layout) = build_swap_map_inner(
         num_qubits,
@@ -243,11 +243,14 @@ pub fn build_swap_map(
         res.map,
         res.node_order.into_pyarray(py).into(),
         res.node_block_results,
-        initial_layout
-            .phys_to_logic
-            .iter()
-            .map(|initial| final_layout.logic_to_phys[*initial])
-            .collect(),
+        PyArray::from_iter(
+            py,
+            initial_layout
+                .phys_to_logic
+                .iter()
+                .map(|initial| final_layout.logic_to_phys[*initial]),
+        )
+        .into(),
     )
 }
 

--- a/qiskit/transpiler/passes/layout/sabre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_layout.py
@@ -391,5 +391,5 @@ class _DisjointComponent:
     coupling_map: CouplingMap
     initial_layout: NLayout
     final_permutation: "list[int]"
-    sabre_result: "SabreResult"
+    sabre_result: "tuple[SwapMap, Sequence[int], NodeBlockResults]"
     circuit_to_dag_dict: "dict[int, DAGCircuit]"

--- a/qiskit/transpiler/passes/layout/sabre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_layout.py
@@ -387,6 +387,15 @@ class SabreLayout(TransformationPass):
 
 @dataclasses.dataclass
 class _DisjointComponent:
+    __slots__ = (
+        "dag",
+        "coupling_map",
+        "initial_layout",
+        "final_permutation",
+        "sabre_result",
+        "circuit_to_dag_dict",
+    )
+
     dag: DAGCircuit
     coupling_map: CouplingMap
     initial_layout: NLayout

--- a/qiskit/transpiler/passes/layout/sabre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_layout.py
@@ -14,11 +14,14 @@
 """
 
 import copy
+import dataclasses
 import logging
 import numpy as np
 import rustworkx as rx
 
 from qiskit.converters import dag_to_circuit
+from qiskit.circuit import QuantumRegister
+from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.passes.layout.set_layout import SetLayout
 from qiskit.transpiler.passes.layout.full_ancilla_allocation import FullAncillaAllocation
 from qiskit.transpiler.passes.layout.enlarge_with_ancilla import EnlargeWithAncilla
@@ -227,59 +230,84 @@ class SabreLayout(TransformationPass):
             target.make_symmetric()
         else:
             target = self.coupling_map
-        layout_components = disjoint_utils.run_pass_over_connected_components(
-            dag,
-            target,
-            self._inner_run,
+
+        components = disjoint_utils.run_pass_over_connected_components(dag, target, self._inner_run)
+        self.property_set["layout"] = Layout(
+            {
+                component.dag.qubits[logic]: component.coupling_map.graph[phys]
+                for component in components
+                for logic, phys in component.initial_layout.layout_mapping()
+                # A physical component of the coupling map might be wider than the DAG that we're
+                # laying out onto it.  We shouldn't include these implicit ancillas right now as the
+                # ancilla-allocation pass will run on the whole map in one go.
+                if logic < len(component.dag.qubits)
+            }
         )
-        initial_layout_dict = {}
-        final_layout_dict = {}
-        for (
-            layout_dict,
-            final_dict,
-            component_map,
-            _sabre_result,
-            _circuit_to_dag_dict,
-            local_dag,
-        ) in layout_components:
-            initial_layout_dict.update({k: component_map[v] for k, v in layout_dict.items()})
-            final_layout_dict.update({component_map[k]: component_map[v] for k, v in final_dict})
-        self.property_set["layout"] = Layout(initial_layout_dict)
+
         # If skip_routing is set then return the layout in the property set
         # and throwaway the extra work we did to compute the swap map.
         # We also skip routing here if there is more than one connected
         # component we ran layout on. We can only reliably route the full dag
         # in this case if there is any dependency between the components
         # (typically shared classical data or barriers).
-        if self.skip_routing or len(layout_components) > 1:
+        if self.skip_routing or len(components) > 1:
             return dag
-        # After this point the pass is no longer an analysis pass and the
-        # output circuit returned is transformed with the layout applied
-        # and swaps inserted
-        dag = self._apply_layout_no_pass_manager(dag)
-        mapped_dag = dag.copy_empty_like()
+
+        # At this point, we become a transformation pass, and apply the layout and the routing to
+        # the DAG directly.  This includes filling in the `property_set` data of the embed passes.
+
+        dag = self._ancilla_allocation_no_pass_manager(dag)
+        # The ancilla-allocation pass has expanded this since we set it above.
+        full_initial_layout = self.property_set["layout"]
+
+        # Set up a physical DAG to apply the Sabre result onto.  We do not need to run the
+        # `ApplyLayout` transpiler pass (which usually does this step), because we're about to apply
+        # the layout and routing together as part of resolving the Sabre result.
+        physical_qubits = QuantumRegister(self.coupling_map.size(), "q")
+        mapped_dag = DAGCircuit()
+        mapped_dag.add_qreg(physical_qubits)
+        mapped_dag.add_clbits(dag.clbits)
+        for creg in dag.cregs.values():
+            mapped_dag.add_creg(creg)
+        mapped_dag._global_phase = dag._global_phase
+        self.property_set["original_qubit_indices"] = {
+            bit: index for index, bit in enumerate(dag.qubits)
+        }
         self.property_set["final_layout"] = Layout(
-            {dag.qubits[k]: v for (k, v) in final_layout_dict.items()}
+            {
+                mapped_dag.qubits[
+                    component.coupling_map.graph[initial]
+                ]: component.coupling_map.graph[final]
+                for component in components
+                for initial, final in enumerate(component.final_permutation)
+            }
         )
-        canonical_register = dag.qregs["q"]
-        original_layout = NLayout.generate_trivial_layout(self.coupling_map.size())
-        for (
-            _layout_dict,
-            _final_layout_dict,
-            component_map,
-            sabre_result,
-            circuit_to_dag_dict,
-            local_dag,
-        ) in layout_components:
-            _apply_sabre_result(
+        for component in components:
+            # Sabre routing still returns all its swaps as on virtual qubits, so we need to expand
+            # each component DAG with the virtual ancillas that were allocated to it, so the layout
+            # application can succeed.  This is the last thing we do with the component DAG, so it's
+            # ok for us to modify it.
+            component_size = component.coupling_map.size()
+            dag_size = component.dag.num_qubits()
+            if component_size > dag_size:
+                used_physical = {full_initial_layout[logic] for logic in component.dag.qubits}
+                component.dag.add_qubits(
+                    [
+                        full_initial_layout[component.coupling_map.graph[phys]]
+                        for phys in range(component.dag.num_qubits(), component_size)
+                        if component.coupling_map.graph[phys] not in used_physical
+                    ]
+                )
+            mapped_dag = _apply_sabre_result(
                 mapped_dag,
-                local_dag,
-                initial_layout_dict,
-                canonical_register,
-                original_layout,
-                sabre_result,
-                circuit_to_dag_dict,
-                component_map,
+                component.dag,
+                component.sabre_result,
+                component.initial_layout,
+                [
+                    mapped_dag.qubits[component.coupling_map.graph[phys]]
+                    for phys in range(component_size)
+                ],
+                component.circuit_to_dag_dict,
             )
         disjoint_utils.combine_barriers(mapped_dag, retain_uuid=False)
         return mapped_dag
@@ -293,13 +321,10 @@ class SabreLayout(TransformationPass):
             coupling_map.make_symmetric()
         neighbor_table = NeighborTable(rx.adjacency_matrix(coupling_map.graph))
         dist_matrix = coupling_map.distance_matrix
-        original_qubit_indices = {bit: index for index, bit in enumerate(dag.qubits)}
         sabre_dag, circuit_to_dag_dict = _build_sabre_dag(
-            dag,
-            coupling_map.size(),
-            original_qubit_indices,
+            dag, coupling_map.size(), {bit: index for index, bit in enumerate(dag.qubits)}
         )
-        ((initial_layout, final_layout), sabre_result) = sabre_layout_and_routing(
+        (initial_layout, final_permutation, sabre_result) = sabre_layout_and_routing(
             sabre_dag,
             neighbor_table,
             dist_matrix,
@@ -309,37 +334,25 @@ class SabreLayout(TransformationPass):
             self.layout_trials,
             self.seed,
         )
-
-        # Apply initial layout selected.
-        layout_dict = {}
-        num_qubits = len(dag.qubits)
-        for k, v in initial_layout.layout_mapping():
-            if k < num_qubits:
-                layout_dict[dag.qubits[k]] = v
-        final_layout_dict = final_layout.layout_mapping()
-        component_mapping = {x: coupling_map.graph[x] for x in coupling_map.graph.node_indices()}
-        return (
-            layout_dict,
-            final_layout_dict,
-            component_mapping,
+        return _DisjointComponent(
+            dag,
+            coupling_map,
+            initial_layout,
+            final_permutation,
             sabre_result,
             circuit_to_dag_dict,
-            dag,
         )
 
-    def _apply_layout_no_pass_manager(self, dag):
-        """Apply and embed a layout into a dagcircuit without using a ``PassManager`` to
-        avoid circuit<->dag conversion.
-        """
+    def _ancilla_allocation_no_pass_manager(self, dag):
+        """Run the ancilla-allocation and -enlargment passes on the DAG chained onto our
+        ``property_set``, skipping the DAG-to-circuit conversion cost of using a ``PassManager``."""
         ancilla_pass = FullAncillaAllocation(self.coupling_map)
         ancilla_pass.property_set = self.property_set
         dag = ancilla_pass.run(dag)
         enlarge_pass = EnlargeWithAncilla()
         enlarge_pass.property_set = ancilla_pass.property_set
         dag = enlarge_pass.run(dag)
-        apply_pass = ApplyLayout()
-        apply_pass.property_set = enlarge_pass.property_set
-        dag = apply_pass.run(dag)
+        self.property_set = enlarge_pass.property_set
         return dag
 
     def _layout_and_route_passmanager(self, initial_layout):
@@ -370,3 +383,13 @@ class SabreLayout(TransformationPass):
         qubit_map = Layout.combine_into_edge_map(initial_layout, trivial_layout)
         final_layout = {v: pass_final_layout._v2p[qubit_map[v]] for v in initial_layout._v2p}
         return Layout(final_layout)
+
+
+@dataclasses.dataclass
+class _DisjointComponent:
+    dag: DAGCircuit
+    coupling_map: CouplingMap
+    initial_layout: NLayout
+    final_permutation: "list[int]"
+    sabre_result: "SabreResult"
+    circuit_to_dag_dict: "dict[int, DAGCircuit]"

--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -331,10 +331,10 @@ def _apply_sabre_result(
     Args:
         out_dag (DAGCircuit): the physical DAG that the output should be written to.
         in_dag (DAGCircuit): the source of the nodes that are being routed.
-        sabre_result (SabreResult): the result object from the Rust run of the Sabre routing
-            algorithm.
+        sabre_result (tuple[SwapMap, Sequence[int], NodeBlockResults]): the result object from the
+            Rust run of the Sabre routing algorithm.
         initial_layout (NLayout): a Rust-space mapping of virtual indices (i.e. those of the qubits
-            in ``source_dag``) to physical ones.
+            in ``in_dag``) to physical ones.
         physical_qubits (list[Qubit]): an indexable sequence of :class:`.Qubit` objects representing
             the physical qubits of the circuit.  Note that disjoint-coupling handling can mean that
             these are not strictly a "canonical physical register" in order.

--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -13,7 +13,7 @@
 """Routing via SWAP insertion using the SABRE method from Li et al."""
 
 import logging
-from copy import copy, deepcopy
+from copy import deepcopy
 
 import rustworkx
 
@@ -27,7 +27,7 @@ from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.target import Target
 from qiskit.transpiler.passes.layout import disjoint_utils
-from qiskit.dagcircuit import DAGOpNode, DAGCircuit
+from qiskit.dagcircuit import DAGCircuit
 from qiskit.tools.parallel import CPU_COUNT
 
 from qiskit._accelerate.sabre_swap import (
@@ -230,41 +230,35 @@ class SabreSwap(TransformationPass):
         layout_mapping = {
             self._qubit_indices[k]: v for k, v in current_layout.get_virtual_bits().items()
         }
-        layout = NLayout(layout_mapping, len(dag.qubits), self.coupling_map.size())
-        original_layout = layout.copy()
+        initial_layout = NLayout(layout_mapping, len(dag.qubits), self.coupling_map.size())
 
         sabre_dag, circuit_to_dag_dict = _build_sabre_dag(
             dag,
             self.coupling_map.size(),
             self._qubit_indices,
         )
-        sabre_result = build_swap_map(
+        *sabre_result, final_permutation = build_swap_map(
             len(dag.qubits),
             sabre_dag,
             self._neighbor_table,
             self.dist_matrix,
             heuristic,
-            layout,
+            initial_layout,
             self.trials,
             self.seed,
         )
 
-        layout_mapping = layout.layout_mapping()
-        output_layout = Layout({dag.qubits[k]: v for (k, v) in layout_mapping})
-        self.property_set["final_layout"] = output_layout
-        if not self.fake_run:
-            mapped_dag = dag.copy_empty_like()
-            _apply_sabre_result(
-                mapped_dag,
-                dag,
-                self._qubit_indices,
-                canonical_register,
-                original_layout,
-                sabre_result,
-                circuit_to_dag_dict,
-            )
-            return mapped_dag
-        return dag
+        self.property_set["final_layout"] = Layout(dict(zip(dag.qubits, final_permutation)))
+        if self.fake_run:
+            return dag
+        return _apply_sabre_result(
+            dag.copy_empty_like(),
+            dag,
+            sabre_result,
+            initial_layout,
+            dag.qubits,
+            circuit_to_dag_dict,
+        )
 
 
 def _build_sabre_dag(dag, num_physical_qubits, qubit_indices):
@@ -319,159 +313,114 @@ def _build_sabre_dag(dag, num_physical_qubits, qubit_indices):
 
 
 def _apply_sabre_result(
-    mapped_dag,
-    root_dag,
-    qubit_indices,
-    canonical_register,
-    initial_layout,
+    out_dag,
+    in_dag,
     sabre_result,
+    initial_layout,
+    physical_qubits,
     circuit_to_dag_dict,
-    component_map=None,
 ):
-    bit_to_qreg_idx = {bit: idx for idx, bit in enumerate(canonical_register)}
+    """Apply the ``SabreResult`` to ``out_dag``, mutating it in place.  This function in effect
+    performs the :class:`.ApplyLayout` transpiler pass with ``initial_layout`` and the Sabre routing
+    simultaneously, though it assumes that ``out_dag`` has already been prepared as containing the
+    right physical qubits.
 
-    def empty_dag(node, block):
-        out = DAGCircuit()
-        for qreg in mapped_dag.qregs.values():
-            out.add_qreg(qreg)
-        out.add_clbits(node.cargs)
+    Mutates ``out_dag`` in place and returns it.  Mutates ``initial_layout`` in place as scratch
+    space.
+
+    Args:
+        out_dag (DAGCircuit): the physical DAG that the output should be written to.
+        in_dag (DAGCircuit): the source of the nodes that are being routed.
+        sabre_result (SabreResult): the result object from the Rust run of the Sabre routing
+            algorithm.
+        initial_layout (NLayout): a Rust-space mapping of virtual indices (i.e. those of the qubits
+            in ``source_dag``) to physical ones.
+        physical_qubits (list[Qubit]): an indexable sequence of :class:`.Qubit` objects representing
+            the physical qubits of the circuit.  Note that disjoint-coupling handling can mean that
+            these are not strictly a "canonical physical register" in order.
+        circuit_to_dag_dict (Mapping[int, DAGCircuit]): a mapping of the Python object identity
+            (as returned by :func:`id`) of a control-flow block :class:`.QuantumCircuit` to a
+            :class:`.DAGCircuit` that represents the same thing.
+    """
+
+    def empty_dag(block):
+        empty = DAGCircuit()
+        empty.add_qubits(out_dag.qubits)
+        for qreg in out_dag.qregs.values():
+            empty.add_qreg(qreg)
+        empty.add_clbits(block.clbits)
         for creg in block.cregs:
-            out.add_creg(creg)
-        out._global_phase = block.global_phase
-        return out
+            empty.add_creg(creg)
+        empty._global_phase = block.global_phase
+        return empty
 
-    def apply_inner(out_dag, current_layout, qubit_indices_inner, result, id_to_node):
-        node_order = result[1]
-        swap_map = result[0]
-        node_block_results = result[2]
+    def apply_swaps(dest_dag, swaps, layout):
+        for a, b in swaps:
+            # The swaps that come out of Sabre are already in terms of the virtual qubits of the
+            # outermost DAG, since the scope binding occurred as the `SabreDAG` objects were built
+            # up; they're all provided to Sabre routing as full-width already.
+            qubits = (
+                physical_qubits[layout.logical_to_physical(a)],
+                physical_qubits[layout.logical_to_physical(b)],
+            )
+            layout.swap_logical(a, b)
+            dest_dag.apply_operation_back(SwapGate(), qubits, ())
+
+    def recurse(dest_dag, source_dag, result, root_logical_map, layout):
+        """The main recursive worker.  Mutates ``dest_dag`` and ``layout`` and returns them.
+
+        ``root_virtual_map`` is a mapping of the (virtual) qubit in ``source_dag`` to the index of
+        the virtual qubit in the root source DAG that it is bound to."""
+        swap_map, node_order, node_block_results = result
         for node_id in node_order:
-            node = id_to_node[node_id]
-            if isinstance(node.op, ControlFlowOp):
-                # Handle control flow op and continue.
-                block_results = node_block_results[node_id]
-                mapped_block_dags = []
-                idle_qubits = set(out_dag.qubits)
-                for block, block_result in zip(node.op.blocks, block_results):
-                    block_id_to_node = circuit_to_dag_dict[id(block)]._multi_graph
-                    mapped_block_dag = empty_dag(node, block)
-                    mapped_block_layout = current_layout.copy()
-                    block_qubit_indices = {
-                        inner: qubit_indices_inner[outer]
-                        for inner, outer in zip(block.qubits, node.qargs)
-                    }
-                    apply_inner(
-                        mapped_block_dag,
-                        mapped_block_layout,
-                        block_qubit_indices,
-                        (
-                            block_result.result.map,
-                            block_result.result.node_order,
-                            block_result.result.node_block_results,
-                        ),
-                        block_id_to_node,
-                    )
-
-                    # Apply swap epilogue to bring each block to the same
-                    # final layout.
-                    process_swaps(
-                        block_result.swap_epilogue,
-                        mapped_block_dag,
-                        mapped_block_layout,
-                        canonical_register,
-                        False,
-                        bit_to_qreg_idx,
-                        component_map,
-                    )
-
-                    # If the swap epilogue didn't return us to the initial layout,
-                    # there's a bug.
-                    # assert mapped_block_layout.layout_mapping() == current_layout.layout_mapping()
-
-                    mapped_block_dags.append(mapped_block_dag)
-                    idle_qubits.intersection_update(mapped_block_dag.idle_wires())
-
-                mapped_blocks = []
-                for mapped_block_dag in mapped_block_dags:
-                    # Remove wires that are idle in all blocks.
-                    mapped_block_dag.remove_qubits(*idle_qubits)
-                    mapped_blocks.append(dag_to_circuit(mapped_block_dag))
-
-                # Apply the control flow gate to the dag.
-                mapped_node = node.op.replace_blocks(mapped_blocks)
-                mapped_node_qargs = mapped_blocks[0].qubits
-                out_dag.apply_operation_back(mapped_node, mapped_node_qargs, node.cargs)
+            node = source_dag._multi_graph[node_id]
+            if node_id in swap_map:
+                apply_swaps(dest_dag, swap_map[node_id], layout)
+            if not isinstance(node.op, ControlFlowOp):
+                dest_dag.apply_operation_back(
+                    node.op,
+                    [
+                        physical_qubits[layout.logical_to_physical(root_logical_map[q])]
+                        for q in node.qargs
+                    ],
+                    node.cargs,
+                )
                 continue
 
-            # If we get here, the node isn't a control-flow gate.
-            if node_id in swap_map:
-                process_swaps(
-                    swap_map[node_id],
-                    out_dag,
-                    current_layout,
-                    canonical_register,
-                    False,
-                    bit_to_qreg_idx,
-                    component_map,
+            # At this point, we have to handle a control-flow node.
+            block_results = node_block_results[node_id]
+            mapped_block_dags = []
+            idle_qubits = set(dest_dag.qubits)
+            for block, block_result in zip(node.op.blocks, block_results):
+                block_root_logical_map = {
+                    inner: root_logical_map[outer] for inner, outer in zip(block.qubits, node.qargs)
+                }
+                block_dag, block_layout = recurse(
+                    empty_dag(block),
+                    circuit_to_dag_dict[id(block)],
+                    (
+                        block_result.result.map,
+                        block_result.result.node_order,
+                        block_result.result.node_block_results,
+                    ),
+                    block_root_logical_map,
+                    layout.copy(),
                 )
-            apply_gate(
-                out_dag,
-                node,
-                current_layout,
-                canonical_register,
-                False,
-                qubit_indices_inner,
-            )
+                apply_swaps(block_dag, block_result.swap_epilogue, block_layout)
+                mapped_block_dags.append(block_dag)
+                idle_qubits.intersection_update(block_dag.idle_wires())
 
-    apply_inner(mapped_dag, initial_layout, qubit_indices, sabre_result, root_dag._multi_graph)
+            mapped_blocks = []
+            for mapped_block_dag in mapped_block_dags:
+                # Remove wires that are idle in all blocks.
+                mapped_block_dag.remove_qubits(*idle_qubits)
+                mapped_blocks.append(dag_to_circuit(mapped_block_dag))
 
+            # Apply the control flow gate to the dag.
+            mapped_node = node.op.replace_blocks(mapped_blocks)
+            mapped_node_qargs = mapped_blocks[0].qubits if mapped_blocks else ()
+            dest_dag.apply_operation_back(mapped_node, mapped_node_qargs, node.cargs)
+        return dest_dag, layout
 
-def process_swaps(
-    swap_list,
-    mapped_dag,
-    current_layout,
-    canonical_register,
-    fake_run,
-    qubit_indices,
-    component_map=None,
-):
-    """
-    Applies each swap in ``swap_list`` sequentially and updates
-    ``current_layout`` accordingly.
-    """
-    for swap in swap_list:
-        if component_map:
-            swap_qargs = [
-                canonical_register[component_map[swap[0]]],
-                canonical_register[component_map[swap[1]]],
-            ]
-        else:
-            swap_qargs = [canonical_register[swap[0]], canonical_register[swap[1]]]
-        apply_gate(
-            mapped_dag,
-            DAGOpNode(op=SwapGate(), qargs=swap_qargs),
-            current_layout,
-            canonical_register,
-            fake_run,
-            qubit_indices,
-        )
-        if component_map:
-            current_layout.swap_logical(component_map[swap[0]], component_map[swap[1]])
-        else:
-            current_layout.swap_logical(*swap)
-
-
-def apply_gate(mapped_dag, node, current_layout, canonical_register, fake_run, qubit_indices):
-    """Apply gate given the current layout."""
-    new_node = transform_gate_for_layout(node, current_layout, canonical_register, qubit_indices)
-    if fake_run:
-        return new_node
-    return mapped_dag.apply_operation_back(new_node.op, new_node.qargs, new_node.cargs)
-
-
-def transform_gate_for_layout(op_node, layout, device_qreg, qubit_indices):
-    """Return node implementing a virtual op on given layout."""
-    mapped_op_node = copy(op_node)
-    mapped_op_node.qargs = tuple(
-        device_qreg[layout.logical_to_physical(qubit_indices[x])] for x in op_node.qargs
-    )
-    return mapped_op_node
+    root_logical_map = {bit: index for index, bit in enumerate(in_dag.qubits)}
+    return recurse(out_dag, in_dag, sabre_result, root_logical_map, initial_layout)[0]


### PR DESCRIPTION
### Summary

`SabreLayout` in particular previously had a very confused notion of virtual and physical qubits in Rust space; on each iteration, it rewrote the `SabreDAG` to "apply" a layout.  This is not logically what `SabreDAG` represents, though; that defines the circuit purely in terms of virtual qubits, which by definition do not change as the mapping of
them to physical qubits changes.

This commit modifies that internal logic so that there is a clear distinction between the virtual DAG and the changing layout.  This significantly simplies the logic within the Sabre layout Rust component.  This commit is RNG-compatible with its parent.

The Python entry points to the Rust components of both layout and routing are modified to return a final permutation, rather than a final layout, as this is what `TranspileLayout.final_layout` actually is.

The application of the Sabre result to a DAG is also updated to reflect the correct virtual/physical relationship.  With the roles of everything clarified, this now means that in the Sabre layout case, it automatically does the job of `ApplyLayout` _and_ the subsequent swap-mapping in one iteration, rather than rewriting the DAG once with `ApplyLayout` only to rewrite it immediately after with the swap-mapped form; the initial layout is after all only valid as far as the first inserted swap.

The Sabre routing inputs are slightly tweaked, so the clone of the layout that the routing pass mutates to track its state as it progresses happens internally.  _Technically_, there could have been situations where it was preferable for the caller in Rust-space to give the output object (if it didn't care about losing the initial layout), but in practice, we always cloned on entry.  The cost of the layout clone is not high even in the worst case, and this makes the ownership, mutation and return-value interfaces clearer.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

I came across this when trying to move more of the layout application behaviour from Sabre into Rust space; at the moment, there's a lot of quite split logic that means that the Rust component of the Sabre algorithm doesn't have all the information it needs, despite appearances.  This refactor now means that a call to `build_swap_map_inner` supplies it with all the information needed to apply the layout to the original DAG as well, and simplifies a lot of the data.

In practice, it would be _far_ easier for reconstruction if the Rust Sabre components output its swaps in terms of physical qubits rather than virtual ones - we're applying swaps to the physical circuit not the virtual one.  This would avoid a lot of faffing around that we have to do during the reconstruction at the moment to handle the ancilla allocations correctly; there's no reason in principle that `SabreSwap` actually needs its input DAG to be full width other than it's difficult to apply the virtual swaps without it.  This especially hurts `SabreLayout` on disjoint coupling maps, since the ancilla allocation doesn't happen until after the disjoint layout has been done, so we have to run around trying to work out which ancillas were _effectively_ mapped to each component.


**Performance**:
- Technically there's now quite a bit less data cloning / rewriting in the Sabre layout algorithm, though in practice I don't expect it to have a notable impact
- We now elide the call to `ApplyLayout` from `SabreLayout` when doing both the layout and routing together, which may be a small performance boost for large circuits that are already close to routed (the relative impact is smaller if we insert many swaps)
- The `DAGOpNode` transforming logic in the Sabre reconstruction is now simpler and involves less copying just to throw a node away again, so there might be a little win there.

I'll run some actual benchmarks a bit later, but I'm not worried if this has a neutral effect on performance; this PR is just meant to be clarifying all the logic ahead of a _complete_ rewrite of the Sabre routing reconstruction that's actually intended to be more performant, and to reduce memory usage in the output. *edit*: I ran the whole suite, and it was neutral in benchmarking.