### PR TITLE
[WIP] Skip registering u gates to inst map when creating defaults

### DIFF
--- a/qiskit/providers/models/pulsedefaults.py
+++ b/qiskit/providers/models/pulsedefaults.py
@@ -204,6 +204,8 @@ class PulseDefaults:
         self.converter = QobjToInstructionConverter(pulse_library)
 
         for inst in cmd_def:
+            if inst.name in {"u1", "u2", "u3"}:
+                continue
             entry = PulseQobjDef(converter=self.converter, name=inst.name)
             entry.define(inst.sequence, user_provided=False)
             self.instruction_schedule_map._add(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR aims to address an issue that arose while working on [the PR](https://github.com/Qiskit/qiskit/pull/10564). 

The IBM provider used to offer `u1`, `u2`, `u3` gates as the basis gates, which have now been replaced by sx and gates.
However, when creating or updating the instruction schedule map, these `u1`, `u2`, and `u3` gates are still being added. 

Allowing this behavior could have implications for target creation and updates, which might not be favorable in the long run. While it's a provisional solution, this PR seeks to resolve this problem through the changes proposed.


### Details and comments


