### PR TITLE
change the url for the pip metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     description="Software for developing quantum computing programs",
     long_description=README,
     long_description_content_type="text/markdown",
-    url="https://github.com/Qiskit/qiskit-terra",
+    url="https://github.com/Qiskit/qiskit",
     author="Qiskit Development Team",
     author_email="hello@qiskit.org",
     license="Apache 2.0",


### PR DESCRIPTION
@yurivict noticed in https://github.com/Qiskit/qiskit/issues/10716#issue-1869022087 that pip metadata still points to the previous name of the repo. Fixing that.