### PR TITLE
Fix test suite to account for beta numpy versions

### DIFF
--- a/test/python/algorithms/optimizers/test_optimizers_scikitquant.py
+++ b/test/python/algorithms/optimizers/test_optimizers_scikitquant.py
@@ -69,7 +69,8 @@ class TestOptimizers(QiskitAlgorithmsTestCase):
             self.skipTest(str(ex))
 
     @unittest.skipIf(
-        tuple(map(int, numpy.__version__.split("."))) >= (1, 24, 0),
+        # NB: numpy.__version__ may contain letters, e.g. "1.26.0b1"
+        tuple(map(int, numpy.__version__.split(".")[:2])) >= (1, 24),
         "scikit's SnobFit currently incompatible with NumPy 1.24.0.",
     )
     def test_snobfit(self):
@@ -81,7 +82,8 @@ class TestOptimizers(QiskitAlgorithmsTestCase):
             self.skipTest(str(ex))
 
     @unittest.skipIf(
-        tuple(map(int, numpy.__version__.split("."))) >= (1, 24, 0),
+        # NB: numpy.__version__ may contain letters, e.g. "1.26.0b1"
+        tuple(map(int, numpy.__version__.split(".")[:2])) >= (1, 24),
         "scikit's SnobFit currently incompatible with NumPy 1.24.0.",
     )
     @data((None,), ([(-1, 1), (None, None)],))


### PR DESCRIPTION
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.

### Summary

Fix the numpy version check in the test suite to account for the possibility that `numpy.__version__` may contain letters.

### Details and comments

Prior to this change, running tests on numpy 1.26.0b1 would result in the following error:

```
test/python/algorithms/optimizers/test_optimizers_scikitquant.py:72: in TestOptimizers
    tuple(map(int, numpy.__version__.split("."))) >= (1, 24, 0),
E   ValueError: invalid literal for int() with base 10: '0b1'
```

Since the third component is matched against zero, the simplest solution is to check only the first two components, since we can expect that the first two split elements will be integers.