### PR TITLE
Cache DAGOpNode sort keys

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -73,6 +73,9 @@ class DAGCircuit:
         # Circuit metadata
         self.metadata = {}
 
+        # Cache of dag op node sort keys
+        self._key_cache = {}
+
         # Set of wires (Register,idx) in the dag
         self._wires = set()
 
@@ -632,6 +635,7 @@ class DAGCircuit:
         target_dag.duration = self.duration
         target_dag.unit = self.unit
         target_dag.metadata = self.metadata
+        target_dag._key_cache = self._key_cache
 
         target_dag.add_qubits(self.qubits)
         target_dag.add_clbits(self.clbits)

--- a/qiskit/dagcircuit/dagnode.py
+++ b/qiskit/dagcircuit/dagnode.py
@@ -251,7 +251,6 @@ class DAGOpNode(DAGNode):
     """Object to represent an Instruction at a node in the DAGCircuit."""
 
     __slots__ = ["op", "qargs", "cargs", "sort_key"]
-    _key_cache = {}
 
     def __init__(self, op, qargs: Iterable[Qubit] = (), cargs: Iterable[Clbit] = (), dag=None):
         """Create an Instruction node"""
@@ -260,13 +259,15 @@ class DAGOpNode(DAGNode):
         self.qargs = tuple(qargs)
         self.cargs = tuple(cargs)
         if dag is not None:
-            qargs = tuple(itertools.chain(self.qargs, self.cargs))
-            key = self._key_cache.get(qargs, None)
+            qargs = (self.qargs, self.cargs)
+            key = dag._key_cache.get(qargs, None)
             if key is not None:
                 self.sort_key = key
             else:
-                self.sort_key = ",".join(f"{dag.find_bit(q).index:04d}" for q in qargs)
-                self._key_cache[qargs] = self.sort_key
+                self.sort_key = ",".join(
+                    f"{dag.find_bit(q).index:04d}" for q in itertools.chain(*qargs)
+                )
+                dag._key_cache[qargs] = self.sort_key
         else:
             self.sort_key = str(self.qargs)
 

--- a/qiskit/dagcircuit/dagnode.py
+++ b/qiskit/dagcircuit/dagnode.py
@@ -259,15 +259,15 @@ class DAGOpNode(DAGNode):
         self.qargs = tuple(qargs)
         self.cargs = tuple(cargs)
         if dag is not None:
-            qargs = (self.qargs, self.cargs)
-            key = dag._key_cache.get(qargs, None)
+            cache_key = (self.qargs, self.cargs)
+            key = dag._key_cache.get(cache_key, None)
             if key is not None:
                 self.sort_key = key
             else:
                 self.sort_key = ",".join(
-                    f"{dag.find_bit(q).index:04d}" for q in itertools.chain(*qargs)
+                    f"{dag.find_bit(q).index:04d}" for q in itertools.chain(*cache_key)
                 )
-                dag._key_cache[qargs] = self.sort_key
+                dag._key_cache[cache_key] = self.sort_key
         else:
             self.sort_key = str(self.qargs)
 

--- a/qiskit/dagcircuit/dagnode.py
+++ b/qiskit/dagcircuit/dagnode.py
@@ -251,6 +251,7 @@ class DAGOpNode(DAGNode):
     """Object to represent an Instruction at a node in the DAGCircuit."""
 
     __slots__ = ["op", "qargs", "cargs", "sort_key"]
+    _key_cache = {}
 
     def __init__(self, op, qargs: Iterable[Qubit] = (), cargs: Iterable[Clbit] = (), dag=None):
         """Create an Instruction node"""
@@ -259,9 +260,13 @@ class DAGOpNode(DAGNode):
         self.qargs = tuple(qargs)
         self.cargs = tuple(cargs)
         if dag is not None:
-            self.sort_key = ",".join(
-                f"{dag.find_bit(q).index:04d}" for q in itertools.chain(self.qargs, self.cargs)
-            )
+            qargs = tuple(itertools.chain(self.qargs, self.cargs))
+            key = self._key_cache.get(qargs, None)
+            if key is not None:
+                self.sort_key = key
+            else:
+                self.sort_key = ",".join(f"{dag.find_bit(q).index:04d}" for q in qargs)
+                self._key_cache[qargs] = self.sort_key
         else:
             self.sort_key = str(self.qargs)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In a typical circuit there are only certain numbers of qargs that are used regularly. The best examples are 1q gates on each qubit in the target, or 2q gates on each edge in the connectivity graph. As the qargs will be repeated many times in a typical circuit then for most operations the sort key attribute is also not-unique (as it's just composed of the positional indices of each qarg and carg). In very large circuit compilation we spend a non-insignificant amount of time constructing the sort key strings on nodes during the lifecycle of the DAGCircuit as it gets transformed. This commit caches the sort keys so that they're not rebuilt for every new DAGNode. This does add some extra overhead to the construction the first time a DAGNode is created because it has to do an additional qarg tuple construction and a dict lookup. But this is worth it because in most circutis the cache hit rate will be very high and we'll avoid the more expensive string construction for most gates in a circuit.

~There is also a potential shared state issue here if any qubit or clbit objects are present in >1 DAGCircuit and the relative positions of those bits differ between the circuits the sort key will not be the same as before because the earlier qubit combinations. This is because the cache is stored as a class attribute on the DAGOpNode class and will be reused between circuits. In practice this is unlikely to come up very frequently. But also it's impact is mitigated by these keys just being used for sorting and the sorting hasn't always been 100% deterministic anyway as long as it's consistent for the life of the DAGCircuit being exactly the same between multiple DAGCircuit objects has never been a guarantee (although we tried to improve it in #9569).~ This is addressed by: https://github.com/Qiskit/qiskit/pull/10729/commits/c57207d38a1e4fd38dc52829c20a920349903b46

### Details and comments


