### PR TITLE
Remove tox version cap

### DIFF
--- a/tools/install_ubuntu_docs_dependencies.sh
+++ b/tools/install_ubuntu_docs_dependencies.sh
@@ -5,7 +5,7 @@
 set -e
 
 python -m pip install --upgrade pip setuptools wheel
-python -m pip install --upgrade "tox<4.4.0"
+python -m pip install --upgrade tox
 
 sudo apt-get update
 sudo apt-get install -y graphviz pandoc


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The recent release of pyproject-api 1.6.x seems to have broken compatibility with older versions of tox. We had capped the tox version at < 4.4.0 for some time to avoid other issues in tox. This commit removes that cap to test if it is fixed and we can use the latest versions of tox and pyproject-api together. If this fails CI then the alternative approach will be to use the constraints file to cap pyproject-api to < 1.6.0.

### Details and comments


