### PR TITLE
Extend error message when target disjoint connectivity

### DIFF
--- a/qiskit/transpiler/passes/layout/disjoint_utils.py
+++ b/qiskit/transpiler/passes/layout/disjoint_utils.py
@@ -165,9 +165,10 @@ def require_layout_isolated_to_component(
                 break
         if dag.find_bit(inst.qargs[1]).index not in component_sets[component_index]:
             raise TranspilerError(
-                f"The qubit {inst.qargs[1].register.name}[{inst.qargs[1].index}] is "
-                f"mapped to physical qubit {dag.find_bit(inst.qargs[1]).index} which "
-                f"is in a disconnected component with respect to other interacting qubits."
+                "The circuit has an invalid layout as two qubits need to interact in disconnected "
+                "components of the coupling map. The physical qubit "
+                f"{dag.find_bit(inst.qargs[1]).index} needs to interact with the "
+                f"qubit {dag.find_bit(inst.qargs[0]).index} and they belong to different components"
             )
 
 

--- a/qiskit/transpiler/passes/layout/disjoint_utils.py
+++ b/qiskit/transpiler/passes/layout/disjoint_utils.py
@@ -165,9 +165,9 @@ def require_layout_isolated_to_component(
                 break
         if dag.find_bit(inst.qargs[1]).index not in component_sets[component_index]:
             raise TranspilerError(
-                f"The qubit {inst.qargs[1].register.name}[{inst.qargs[1].index}] laid "
-                f"out in the physical qubit {dag.find_bit(inst.qargs[1]).index} is "
-                f"in a disconnected component with respect to other necessary qubits."
+                f"The qubit {inst.qargs[1].register.name}[{inst.qargs[1].index}] is "
+                f"mapped to physical qubit {dag.find_bit(inst.qargs[1]).index} which "
+                f"is in a disconnected component with respect to other interacting qubits."
             )
 
 

--- a/qiskit/transpiler/passes/layout/disjoint_utils.py
+++ b/qiskit/transpiler/passes/layout/disjoint_utils.py
@@ -164,7 +164,11 @@ def require_layout_isolated_to_component(
                 component_index = i
                 break
         if dag.find_bit(inst.qargs[1]).index not in component_sets[component_index]:
-            raise TranspilerError("Chosen layout is not valid for the target disjoint connectivity")
+            raise TranspilerError(
+                f"The qubit {inst.qargs[1].register.name}[{inst.qargs[1].index}] laid "
+                f"out in the physical qubit {dag.find_bit(inst.qargs[1]).index} is "
+                f"in a component disjoined to the qubits."
+            )
 
 
 def separate_dag(dag: DAGCircuit) -> List[DAGCircuit]:

--- a/qiskit/transpiler/passes/layout/disjoint_utils.py
+++ b/qiskit/transpiler/passes/layout/disjoint_utils.py
@@ -167,7 +167,7 @@ def require_layout_isolated_to_component(
             raise TranspilerError(
                 f"The qubit {inst.qargs[1].register.name}[{inst.qargs[1].index}] laid "
                 f"out in the physical qubit {dag.find_bit(inst.qargs[1]).index} is "
-                f"in a component disjoined to the qubits."
+                f"in a disconnected component with respect to other necessary qubits."
             )
 
 


### PR DESCRIPTION
Closes #10731 

In optimization level 0, the default layout strategy is `trivial`. In the context of a disjoined coupling map, trivial might lay the circuit in an incompatible setting. `qiskit.transpiler.passes.layout.disjoint_utils.require_layout_isolated_to_component` checks for that imcompatibility and currently raises `Chosen layout is not valid for the target disjoint connectivity`. However, the user might not actively choose any layout.

This PR adds more details to the error. For example: `The qubit q[2] laid out in the physical qubit 2 is in a disconnected component with respect to other necessary qubits.` 