### PR TITLE
Hardcode register name in timeline/test_generators.py to remove deprecated attribute

### DIFF
--- a/qiskit/visualization/timeline/generators.py
+++ b/qiskit/visualization/timeline/generators.py
@@ -129,17 +129,15 @@ def gen_sched_gate(
     except AttributeError:
         label = "n/a"
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        meta = {
-            "name": gate.operand.name,
-            "label": label,
-            "bits": ", ".join([bit.register.name for bit in gate.bits]),
-            "t0": gate.t0,
-            "duration": gate.duration,
-            "unitary": unitary,
-            "parameters": ", ".join(map(str, gate.operand.params)),
-        }
+    meta = {
+        "name": gate.operand.name,
+        "label": label,
+        "bits": gate.bits,
+        "t0": gate.t0,
+        "duration": gate.duration,
+        "unitary": unitary,
+        "parameters": ", ".join(map(str, gate.operand.params)),
+    }
 
     # find color
     color = formatter["color.gates"].get(gate.operand.name, formatter["color.default_gate"])

--- a/test/python/visualization/timeline/test_generators.py
+++ b/test/python/visualization/timeline/test_generators.py
@@ -206,7 +206,7 @@ class TestTimeslot(QiskitTestCase):
         """Setup."""
         super().setUp()
 
-        self.qubit = list(qiskit.QuantumRegister(1))[0]
+        self.qubit = list(qiskit.QuantumRegister(1, "bar"))[0]
 
         style = stylesheet.QiskitTimelineStyle()
         self.formatter = style.formatter
@@ -244,10 +244,8 @@ class TestTimeslot(QiskitTestCase):
         self.assertListEqual(list(drawing_obj.xvals), [types.AbstractCoordinate.LEFT])
         self.assertListEqual(list(drawing_obj.yvals), [0])
         self.assertListEqual(drawing_obj.bits, [self.qubit])
-        self.assertEqual(drawing_obj.text, str(self.qubit.register.name))
-        ref_latex = r"{{\rm {register}}}_{{{index}}}".format(
-            register=self.qubit.register.prefix, index=self.qubit.index
-        )
+        self.assertEqual(drawing_obj.text, "bar")
+        ref_latex = r"{{\rm {register}}}_{{{index}}}".format(register="q", index="0")
         self.assertEqual(drawing_obj.latex, ref_latex)
 
         ref_styles = {

--- a/test/python/visualization/timeline/test_generators.py
+++ b/test/python/visualization/timeline/test_generators.py
@@ -58,7 +58,7 @@ class TestGates(QiskitTestCase):
         ref_meta = {
             "name": "u3",
             "label": "n/a",
-            "bits": "foo",
+            "bits": [self.qubit],
             "t0": 100,
             "duration": 20,
             "unitary": "[[1.+0.j 0.-0.j]\n [0.+0.j 1.+0.j]]",

--- a/test/python/visualization/timeline/test_generators.py
+++ b/test/python/visualization/timeline/test_generators.py
@@ -27,7 +27,7 @@ class TestGates(QiskitTestCase):
         """Setup."""
         super().setUp()
 
-        self.qubit = list(qiskit.QuantumRegister(1))[0]
+        self.qubit = list(qiskit.QuantumRegister(1, name="foo"))[0]
 
         self.u1 = types.ScheduledGate(
             t0=100, operand=library.U1Gate(0), duration=0, bits=[self.qubit], bit_position=0
@@ -58,7 +58,7 @@ class TestGates(QiskitTestCase):
         ref_meta = {
             "name": "u3",
             "label": "n/a",
-            "bits": str(self.qubit.register.name),
+            "bits": "foo",
             "t0": 100,
             "duration": 20,
             "unitary": "[[1.+0.j 0.-0.j]\n [0.+0.j 1.+0.j]]",


### PR DESCRIPTION
I got 5 mins between meetings and I removed this "the property qiskit.circuit.bit.Bit.index is deprecated" by hardcoding the name of a register in a test.

it's not much but it's honest work

Related to #10749