### PR TITLE
Track Sabre decay heuristic on physical qubits

### DIFF
--- a/crates/accelerate/src/sabre_swap/mod.rs
+++ b/crates/accelerate/src/sabre_swap/mod.rs
@@ -416,8 +416,8 @@ fn swap_map_trial(
                 qubits_decay.fill(1.);
                 num_search_steps = 0;
             } else {
-                qubits_decay[best_swap[0].index()] += DECAY_RATE;
-                qubits_decay[best_swap[1].index()] += DECAY_RATE;
+                qubits_decay[best_swap[0].to_phys(&layout).index()] += DECAY_RATE;
+                qubits_decay[best_swap[1].to_phys(&layout).index()] += DECAY_RATE;
             }
         }
         // If we exceeded the number of allowed attempts without successfully routing a node, we
@@ -717,7 +717,8 @@ fn choose_best_swap(
                     + EXTENDED_SET_WEIGHT * extended_set.score(swap, layout, dist)
             }
             Heuristic::Decay => {
-                qubits_decay[swap[0].index()].max(qubits_decay[swap[1].index()])
+                qubits_decay[swap[0].to_phys(layout).index()]
+                    .max(qubits_decay[swap[1].to_phys(layout).index()])
                     * (absolute_score
                         + layer.score(swap, layout, dist)
                         + EXTENDED_SET_WEIGHT * extended_set.score(swap, layout, dist))

--- a/releasenotes/notes/sabre-decay-physical-ad2f470cd45d69f3.yaml
+++ b/releasenotes/notes/sabre-decay-physical-ad2f470cd45d69f3.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The ``"decay"`` heuristic of :class:`.SabreSwap` and :class:`.SabreLayout` now tracks the depth
+    correctly on physical qubits rather than mistakenly tracking the "depth" of swaps on virtual
+    qubits.

--- a/test/python/transpiler/test_sabre_layout.py
+++ b/test/python/transpiler/test_sabre_layout.py
@@ -60,7 +60,7 @@ class TestSabreLayout(QiskitTestCase):
         pass_.run(dag)
 
         layout = pass_.property_set["layout"]
-        self.assertEqual([layout[q] for q in circuit.qubits], [11, 10, 16, 5, 17])
+        self.assertEqual([layout[q] for q in circuit.qubits], [16, 7, 11, 12, 13])
 
     def test_6q_circuit_20q_coupling(self):
         """Test finds layout for 6q circuit on 20q device."""


### PR DESCRIPTION
### Summary

The custom `decay` heuristic is supposed to penalise increases in depth in the output.  The output space of qubits are the physical qubits, so the depth is defined in relation to those.  Since its introduction in gh-4537, this heuristic has instead been tracking the depth on the virtual qubits, which due to the swaps is not necessarily related to the depth in the output.

Notably, this commit actually makes the depth for routing large volumetric circuits slightly _worse_ on average (at least for heavy-hex topologies).  This may be because the effect on the heuristic is overweighted, or that the depth tracking resets after each gate is routed (and occasionally in between) to be flat across all qubits, rather than reflecting the actual depth each qubit is subject to.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Copying in some data/comments of mine from a Slack thread:

Using a setup of:
```python
from qiskit import transpile
from qiskit.circuit.library import QuantumVolume
from qiskit.converters import circuit_to_dag
from qiskit.transpiler import CouplingMap
from qiskit.transpiler.passes import SabreSwap
cm115 = CouplingMap.from_heavy_hex(7)
qc = circuit_to_dag(QuantumVolume(115, seed=0).decompose(), copy_operations=False)
```
I ran
```
[SabreSwap(cm115, heuristic="decay", seed=i, trials=4).run(qc).depth() for i in range(100)]
```
and found that the current implementation results in a distribution of depths with mean 6172(15), and switching it over results in a distribution of depths with mean 6289(15), where the uncertainties are the standard error of the mean.  Both distributions have a standard deviation consistent with 150.

I also ran my statistics on `QuantumVolume` seeds `range(20)` and 20 single-trial Sabre passes and the total means went from the current implementation’s 6281(8) to the physical-decay form’s 6379(9), so it wasn’t just a function of one particular QV pattern.  Note that the means are higher since there’s only one trial per run now (which is somewhat encouraging - we select the trial result based on swap size not depth, but the depth mean increasing at least hints that they _are_ correlated).