### PR TITLE
Support new-style Bit in Pauli convertor from QuantumCircuit

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -157,7 +157,12 @@ class Pauli(BasePauli):
     _CANONICAL_PHASE_LABEL = {"": 0, "-i": 1, "-": 2, "i": 3}
 
     def __init__(
-        self, data: str | tuple | Pauli | ScalarOp | None = None, x=None, *, z=None, label=None
+        self,
+        data: str | tuple | Pauli | ScalarOp | QuantumCircuit | None = None,
+        x=None,
+        *,
+        z=None,
+        label=None,
     ):
         """Initialize the Pauli.
 

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -712,7 +712,7 @@ class Pauli(BasePauli):
             if not isinstance(inner.operation, (Barrier, Delay)):
                 next_instr = BasePauli(*cls._from_circuit(inner.operation))
                 if next_instr is not None:
-                    qargs = [tup.index for tup in inner.qubits]
+                    qargs = [instr.find_bit(tup).index for tup in inner.qubits]
                     ret = ret.compose(next_instr, qargs=qargs)
         return ret._z, ret._x, ret._phase
 

--- a/releasenotes/notes/fix_pauli_new_style_bit-0704933127b4debe.yaml
+++ b/releasenotes/notes/fix_pauli_new_style_bit-0704933127b4debe.yaml
@@ -2,4 +2,4 @@
 fixes:
   - |
     The class :class:`.Pauli` now support creation from :class:`.QuantumCircuit`
-    that use new-style :class:`Bit`.
+    that use new-style :class:`.Bit`.

--- a/releasenotes/notes/fix_pauli_new_style_bit-0704933127b4debe.yaml
+++ b/releasenotes/notes/fix_pauli_new_style_bit-0704933127b4debe.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The class :class:`.Pauli` now support creation from :class:`.QuantumCircuit`
+    that use new-style :class:`Bit`.

--- a/test/python/quantum_info/operators/symplectic/test_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli.py
@@ -23,6 +23,7 @@ import numpy as np
 from ddt import ddt, data, unpack
 
 from qiskit import QuantumCircuit
+from qiskit.circuit import Qubit
 from qiskit.exceptions import QiskitError
 from qiskit.circuit.library import (
     IGate,
@@ -483,6 +484,15 @@ class TestPauli(QiskitTestCase):
         expected.phase = phase
         test = Pauli(label)
         self.assertEqual(expected, test)
+
+    def test_circuit_with_bit(self):
+        """Test new-style Bit support when converting from QuantumCircuit"""
+        circ = QuantumCircuit([Qubit()])
+        circ.x(0)
+        value = Pauli(circ)
+        target = Pauli("X")
+
+        self.assertEqual(value, target)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Internal dunder code in  quantum_info/operators/symplectic/pauli.py was still using Bit.index access, which is deprecated since 0.17 (see #10744). 

Because `tup` is coming from a QuantumCircuit in scope (`instr`), it is easy to fix with `find_bit`.