### PR TITLE
Fix `qpy` for multiple controlled parametrized gates

### DIFF
--- a/qiskit/qpy/binary_io/circuits.py
+++ b/qiskit/qpy/binary_io/circuits.py
@@ -540,13 +540,17 @@ def _write_instruction(file_obj, instruction, custom_operations, index_map):
         )
         or gate_class_name == "Gate"
         or gate_class_name == "Instruction"
-        or gate_class_name == "ControlledGate"
         or isinstance(instruction.operation, library.BlueprintCircuit)
     ):
         if instruction.operation.name not in custom_operations:
             custom_operations[instruction.operation.name] = instruction.operation
             custom_operations_list.append(instruction.operation.name)
         gate_class_name = instruction.operation.name
+
+    elif gate_class_name == "ControlledGate":
+        gate_class_name = instruction.operation.name + "_" + str(uuid.uuid4())
+        custom_operations[gate_class_name] = instruction.operation
+        custom_operations_list.append(gate_class_name)
 
     elif isinstance(instruction.operation, library.PauliEvolutionGate):
         gate_class_name = r"###PauliEvolutionGate_" + str(uuid.uuid4())

--- a/releasenotes/notes/fix-qpy-repeated-controlled-gates-e19fc4ee65a22756.yaml
+++ b/releasenotes/notes/fix-qpy-repeated-controlled-gates-e19fc4ee65a22756.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed a bug in QPY serialization (:mod:`qiskit.qpy`) where if a circuit contained
+    multiple instances of parametrized controlled gates of the same class (not custom),
+    the parameter values from the first instance were used to build the gate definitions
+    of subsequent instances. The gates were rendered correctly despite this bug because
+    the correct parameter values were stored, but not used to build the gates. Fixed
+    `#10735 <https://github.com/Qiskit/qiskit-terra/issues/10735>`__.

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -29,6 +29,7 @@ from qiskit.circuit.random import random_circuit
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.library import (
     XGate,
+    RYGate,
     QFT,
     QAOAAnsatz,
     PauliEvolutionGate,
@@ -1302,6 +1303,25 @@ class TestLoadFromQPY(QiskitTestCase):
 
         qc = QuantumCircuit(2)
         qc.append(CustomCXGate(), [0, 1])
+        qpy_file = io.BytesIO()
+        dump(qc, qpy_file)
+        qpy_file.seek(0)
+        new_circ = load(qpy_file)[0]
+        self.assertEqual(qc, new_circ)
+        self.assertEqual(qc.decompose(), new_circ.decompose())
+        self.assertDeprecatedBitProperties(qc, new_circ)
+
+    def test_multiple_controlled_gates(self):
+        """Test multiple controlled gates with same name but different
+        parameter values.
+
+        Reproduce from: https://github.com/Qiskit/qiskit-terra/issues/10735
+        """
+
+        qc = QuantumCircuit(3)
+        for i in range(3):
+            c2ry = RYGate(i + 1).control(2)
+            qc.append(c2ry, [i % 3, (i + 1) % 3, (i + 2) % 3])
         qpy_file = io.BytesIO()
         dump(qc, qpy_file)
         qpy_file.seek(0)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
I have recently found out that if a circuit contains multiple instances of parametrized controlled gates of the same class 
(not custom, for example, multiple ccrx, ccry....), the parameter values from the first instance were used to build the gate definitions of subsequent instances. This happened because they were all detected as the same `custom_operation` because of the shared gate class name. 

The "fast" way I have found to address the issue has been to modify `_write_instruction` to account for the `uuid`s of all controlled gates, to make sure they are not lumped into the same definition even if their parameter values are different. This is, however, not ideal because we might (will) be unnecessarily storing identical controlled gate definitions. 

Given that the parameter values are actually correctly stored in the controlled gate payload (they are just never used because the definition is already bound to the values of the first gate), I think that an alternative could be to store an "unbound" version of the operation definition during `write`, and then assign the right parameter values to every instance during `read`, or keep it as-is and replace the incorrect values with the correct values. However, it looked a bit artificial and couldn't come up with a nice implementation.

### Details and comments
Fixes #10735. Let me know if you think I should reconsider the implementation, as you can see, I am not too sure.

