### PR TITLE
replace test_subgraph to test_reduce

### DIFF
--- a/test/python/transpiler/test_coupling.py
+++ b/test/python/transpiler/test_coupling.py
@@ -442,14 +442,13 @@ class CouplingTest(QiskitTestCase):
         ]
         self.assertEqual(set(edges), set(expected))
 
-    def test_subgraph(self):
+    def test_reduce(self):
         coupling = CouplingMap.from_line(6, bidirectional=False)
-        with self.assertWarns(DeprecationWarning):
-            subgraph = coupling.subgraph([4, 2, 3, 5])
+        subgraph = coupling.reduce([4, 2, 3, 5])
         self.assertEqual(subgraph.size(), 4)
         self.assertEqual([0, 1, 2, 3], subgraph.physical_qubits)
         edge_list = subgraph.get_edges()
-        expected = [(0, 1), (1, 2), (2, 3)]
+        expected = [(1, 2), (2, 0), (0, 3)]
         self.assertEqual(expected, edge_list, f"{edge_list} does not match {expected}")
 
     def test_implements_iter(self):


### PR DESCRIPTION
While reviewing https://github.com/Qiskit/qiskit/pull/10767 which, among other things,  `qiskit.transpiler.coupling.CouplingMap.subgraph` is removed. The deprecation warning for `subgraph` says `Instead, use reduce. It does the same thing, but preserves nodelist order`.

So, would it make sense to replace `test.python.transpiler.test_coupling.CouplingTest.test_subgraph` by `test.python.transpiler.test_coupling.CouplingTest.test_reduce`? Does the change in `edge_list` expected?

cc: @mtreinish 

