### PR TITLE
Handle final comments with no terminating newline in OpenQASM 2

### DIFF
--- a/crates/qasm2/src/lex.rs
+++ b/crates/qasm2/src/lex.rs
@@ -665,8 +665,11 @@ impl TokenStream {
             b'}' => TokenType::RBrace,
             b'/' => {
                 if let Some(b'/') = self.peek_byte()? {
-                    self.advance_line()?;
-                    return self.next(context);
+                    return if self.advance_line()? == 0 {
+                        Ok(None)
+                    } else {
+                        self.next(context)
+                    }
                 } else {
                     TokenType::Slash
                 }

--- a/crates/qasm2/src/lex.rs
+++ b/crates/qasm2/src/lex.rs
@@ -669,7 +669,7 @@ impl TokenStream {
                         Ok(None)
                     } else {
                         self.next(context)
-                    }
+                    };
                 } else {
                     TokenType::Slash
                 }

--- a/releasenotes/notes/fix-qasm2-final-comment-f0904c3e13215a00.yaml
+++ b/releasenotes/notes/fix-qasm2-final-comment-f0904c3e13215a00.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    OpenQASM 2 programs that end in comments with no terminating newline character will now parse
+    successfully.  Fixed `#10770 <https://github.com/Qiskit/qiskit/issues/10770>`__.

--- a/test/python/qasm2/test_structure.py
+++ b/test/python/qasm2/test_structure.py
@@ -39,9 +39,21 @@ from qiskit.test import QiskitTestCase
 from . import gate_builder
 
 
-class TestEmpty(QiskitTestCase):
+@ddt.ddt
+class TestWhitespace(QiskitTestCase):
     def test_allows_empty(self):
         self.assertEqual(qiskit.qasm2.loads(""), QuantumCircuit())
+
+    @ddt.data("", "\n", "\r\n", "\n  ")
+    def test_empty_except_comment(self, terminator):
+        program = "// final comment" + terminator
+        self.assertEqual(qiskit.qasm2.loads(program), QuantumCircuit())
+
+    @ddt.data("", "\n", "\r\n", "\n  ")
+    def test_final_comment(self, terminator):
+        # This is similar to the empty-circuit test, except that we also have an instruction.
+        program = "qreg q[2]; // final comment" + terminator
+        self.assertEqual(qiskit.qasm2.loads(program), QuantumCircuit(QuantumRegister(2, "q")))
 
 
 class TestVersion(QiskitTestCase):

--- a/test/python/qasm2/test_structure.py
+++ b/test/python/qasm2/test_structure.py
@@ -44,7 +44,7 @@ class TestWhitespace(QiskitTestCase):
     def test_allows_empty(self):
         self.assertEqual(qiskit.qasm2.loads(""), QuantumCircuit())
 
-    @ddt.data("", "\n", "\r\n", "\n  ")
+    @ddt.data("", "\n", "\r\n", "\n  ", "\n\t", "\r\n\t")
     def test_empty_except_comment(self, terminator):
         program = "// final comment" + terminator
         self.assertEqual(qiskit.qasm2.loads(program), QuantumCircuit())


### PR DESCRIPTION
### Summary

Previously, if an OpenQASM 2 program to be parsed ended in a comment with no terminating '\n', the lexer would fail to notice the end of the file and would instead attempt to emit the second '/' of the comment introduction as a 'Slash` token.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #10770.
