### PR TITLE
Use BasisTranslator for unroll 3q or more

### DIFF
--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -95,7 +95,7 @@ class BasisTranslator(TransformationPass):
     :ref:`custom_basis_gates` for details on adding custom equivalence rules.
     """
 
-    def __init__(self, equivalence_library, target_basis, target=None):
+    def __init__(self, equivalence_library, target_basis, target=None, min_qubits=0):
         """Initialize a BasisTranslator instance.
 
         Args:
@@ -104,6 +104,8 @@ class BasisTranslator(TransformationPass):
                 this library will not be unrolled by this pass.)
             target_basis (list[str]): Target basis names to unroll to, e.g. `['u3', 'cx']`.
             target (Target): The backend compilation target
+            min_qubits (int): The minimum number of qubits for operations in the input
+                dag to translate.
         """
 
         super().__init__()
@@ -112,6 +114,7 @@ class BasisTranslator(TransformationPass):
         self._target = target
         self._non_global_operations = None
         self._qargs_with_non_global_operation = {}
+        self._min_qubits = min_qubits
         if target is not None:
             self._non_global_operations = self._target.get_non_global_operation_names()
             self._qargs_with_non_global_operation = defaultdict(set)
@@ -237,7 +240,7 @@ class BasisTranslator(TransformationPass):
             for node in dag.op_nodes():
                 node_qargs = tuple(wire_map[bit] for bit in node.qargs)
                 qubit_set = frozenset(node_qargs)
-                if node.name in target_basis:
+                if node.name in target_basis or len(node.qargs) < self._min_qubits:
                     if isinstance(node.op, ControlFlowOp):
                         flow_blocks = []
                         for block in node.op.blocks:
@@ -327,7 +330,7 @@ class BasisTranslator(TransformationPass):
     @_extract_basis.register
     def _(self, dag: DAGCircuit):
         for node in dag.op_nodes():
-            if not dag.has_calibration_for(node):
+            if not dag.has_calibration_for(node) and len(node.qargs) >= self._min_qubits:
                 yield (node.name, node.op.num_qubits)
             if isinstance(node.op, ControlFlowOp):
                 for block in node.op.blocks:
@@ -337,7 +340,10 @@ class BasisTranslator(TransformationPass):
     def _(self, circ: QuantumCircuit):
         for instruction in circ.data:
             operation = instruction.operation
-            if not circ.has_calibration_for(instruction):
+            if (
+                not circ.has_calibration_for(instruction)
+                and len(instruction.qubits) >= self._min_qubits
+            ):
                 yield (operation.name, operation.num_qubits)
             if isinstance(operation, ControlFlowOp):
                 for block in operation.blocks:
@@ -352,7 +358,7 @@ class BasisTranslator(TransformationPass):
             qargs_local_source_basis = defaultdict(set)
         for node in dag.op_nodes():
             qargs = tuple(qarg_indices[bit] for bit in node.qargs)
-            if dag.has_calibration_for(node):
+            if dag.has_calibration_for(node) or len(node.qargs) < self._min_qubits:
                 continue
             # Treat the instruction as on an incomplete basis if the qargs are in the
             # qargs_with_non_global_operation dictionary or if any of the qubits in qargs

--- a/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
+++ b/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
@@ -22,7 +22,7 @@ from qiskit.converters.circuit_to_dag import circuit_to_dag
 class UnrollCustomDefinitions(TransformationPass):
     """Unrolls instructions with custom definitions."""
 
-    def __init__(self, equivalence_library, basis_gates=None, target=None):
+    def __init__(self, equivalence_library, basis_gates=None, target=None, min_qubits=0):
         """Unrolls instructions with custom definitions.
 
         Args:
@@ -33,12 +33,15 @@ class UnrollCustomDefinitions(TransformationPass):
                 Ignored if ``target`` is also specified.
             target (Optional[Target]): The :class:`~.Target` object corresponding to the compilation
                 target. When specified, any argument specified for ``basis_gates`` is ignored.
+             min_qubits (int): The minimum number of qubits for operations in the input
+                 dag to translate.
         """
 
         super().__init__()
         self._equiv_lib = equivalence_library
         self._basis_gates = basis_gates
         self._target = target
+        self._min_qubits = min_qubits
 
     def run(self, dag):
         """Run the UnrollCustomDefinitions pass on `dag`.
@@ -69,7 +72,7 @@ class UnrollCustomDefinitions(TransformationPass):
             if getattr(node.op, "_directive", False):
                 continue
 
-            if dag.has_calibration_for(node):
+            if dag.has_calibration_for(node) or len(node.qargs) < self._min_qubits:
                 continue
 
             controlled_gate_open_ctrl = isinstance(node.op, ControlledGate) and node.op._open_ctrl

--- a/qiskit/transpiler/preset_passmanagers/common.py
+++ b/qiskit/transpiler/preset_passmanagers/common.py
@@ -222,7 +222,15 @@ def generate_unroll_3q(
             hls_config=hls_config, coupling_map=None, target=target, use_qubit_indices=False
         )
     )
-    unroll_3q.append(Unroll3qOrMore(target=target, basis_gates=basis_gates))
+    # If there are no target instructions revert to using unroll3qormore so
+    # routing works.
+    if basis_gates is None and target is None:
+        unroll_3q.append(Unroll3qOrMore(target, basis_gates))
+    else:
+        unroll_3q.append(
+            UnrollCustomDefinitions(sel, basis_gates=basis_gates, target=target, min_qubits=3)
+        )
+        unroll_3q.append(BasisTranslator(sel, basis_gates, target=target, min_qubits=3))
     return unroll_3q
 
 

--- a/releasenotes/notes/min-qubits-basis-translation-09380145f3cf97fc.yaml
+++ b/releasenotes/notes/min-qubits-basis-translation-09380145f3cf97fc.yaml
@@ -1,0 +1,17 @@
+---
+features:
+  - |
+    Added a new keyword argument, ``min_qubits``, to the constructor of the
+    :class:`.BasisTranslator` transpiler pass. When set to a non-zero value this
+    is used to set a minimum number of qubits to filter operations to translate
+    in the circuit. For example, if ``min_qubits=3`` is set the
+    :class:`.BasisTranslator` instance will only translate gates in the circuit
+    that operate on 3 or more qubits.
+  - |
+    Added a new keyword argument, ``min_qubits``, to the constructor of the
+    :class:`.UnrollCustomDefinitions` transpiler pass. When set to a non-zero
+    value this is used to set a minimum number of qubits to filter operations
+    to translate in the circuit. For example, if ``min_qubits=3`` is set the
+    :class:`.UnrollCustomDefinitions` instance will only translate gates in the
+    circuit that operate on 3 or more qubits.
+

--- a/test/python/transpiler/test_basis_translator.py
+++ b/test/python/transpiler/test_basis_translator.py
@@ -514,6 +514,37 @@ class TestUnrollerCompatability(QiskitTestCase):
         for node in op_nodes:
             self.assertIn(node.name, ["h", "t", "tdg", "cx"])
 
+    def test_basic_unroll_min_qubits(self):
+        """Test decompose a single H into u2."""
+        qr = QuantumRegister(1, "qr")
+        circuit = QuantumCircuit(qr)
+        circuit.h(qr[0])
+        dag = circuit_to_dag(circuit)
+        pass_ = UnrollCustomDefinitions(std_eqlib, ["u2"], min_qubits=3)
+        dag = pass_.run(dag)
+        pass_ = BasisTranslator(std_eqlib, ["u2"], min_qubits=3)
+        unrolled_dag = pass_.run(dag)
+        op_nodes = unrolled_dag.op_nodes()
+        self.assertEqual(len(op_nodes), 1)
+        self.assertEqual(op_nodes[0].name, "h")
+
+    def test_unroll_toffoli_min_qubits(self):
+        """Test unroll toffoli on multi regs to h, t, tdg, cx."""
+        qr1 = QuantumRegister(2, "qr1")
+        qr2 = QuantumRegister(1, "qr2")
+        circuit = QuantumCircuit(qr1, qr2)
+        circuit.ccx(qr1[0], qr1[1], qr2[0])
+        circuit.sx(qr1[0])
+        dag = circuit_to_dag(circuit)
+        pass_ = UnrollCustomDefinitions(std_eqlib, ["h", "t", "tdg", "cx"], min_qubits=3)
+        dag = pass_.run(dag)
+        pass_ = BasisTranslator(std_eqlib, ["h", "t", "tdg", "cx"], min_qubits=3)
+        unrolled_dag = pass_.run(dag)
+        op_nodes = unrolled_dag.op_nodes()
+        self.assertEqual(len(op_nodes), 16)
+        for node in op_nodes:
+            self.assertIn(node.name, ["h", "t", "tdg", "cx", "sx"])
+
     def test_unroll_1q_chain_conditional(self):
         """Test unroll chain of 1-qubit gates interrupted by conditional."""
 

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -1546,7 +1546,6 @@ class TestIntegrationControlFlow(QiskitTestCase):
         self.assertIn("Unroller", calls)
         self.assertNotIn("DenseLayout", calls)
         self.assertNotIn("SabreLayout", calls)
-        self.assertNotIn("BasisTranslator", calls)
 
     @data(0, 1, 2, 3)
     def test_invalid_methods_raise_on_control_flow(self, optimization_level):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit modifies the the preset pass manager construction to by default use the UnrollCustomDefinitions and BasisTranslator passes to perform the unrolling of operations that operate on >= 3 qubits. This is done by leveraging the min_qubits argument added to those passes in this commit which lets you set a minimum number of qubit arguments to translate operations for.

Previously, this was handled by the Unroll3qOrMore pass which works by iterating over the DAG and finding all operations with >= 3 qubits and recursively unrolling them until the output is all in terms of 1 or 2 qubit operations. This works fine, but has undesireable runtime performance characteristics because standard gates repeatedly have to build new DAGs to substitute in. For example, if you had a circuit with 50k CCXGates that would result in 50k new DAGs being created from scratch for each instance of CCXGate. A previous attempt was made to add a translation cache to that pass in #10703 but as was discussed in code review caching the circuit is unsound as it's possible for a custom gate object to be constructed such that it would be cached and return an invalid substitution circuit. By leveraging the basis translator we only build as many substition DAGs as needed.

### Details and comments