### PR TITLE
Optimize UnrollCustomDefinitions pass

### DIFF
--- a/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
+++ b/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
@@ -97,10 +97,8 @@ class UnrollCustomDefinitions(TransformationPass):
                     "and no rule found to expand." % (str(self._basis_gates), node.op.name)
                 )
 
-            decomposition = circuit_to_dag(unrolled)
-            unrolled_dag = UnrollCustomDefinitions(
-                self._equiv_lib, self._basis_gates, target=self._target
-            ).run(decomposition)
+            decomposition = circuit_to_dag(unrolled, copy_operations=False)
+            unrolled_dag = self.run(decomposition)
             dag.substitute_node_with_dag(node, unrolled_dag)
 
         return dag


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit makes some small tweaks to the UnrollCustomDefinitions pass to optimize it's runtime performance. It makes 2 primary changes to improve the efficiency. First, when calling `circuit_to_dag()` the copy_operations flag is set to False. This eliminates an inner deep copy from the conversion which will make the conversion operate more efficiently. The second is previously on every recursive call to run the pass we were previously reconstructing the pass on every execution. Instead this just reuses the existing instance. This will have less measurable of an impact as the pass construction is relatively fast, but it was unecessary work as we already have a pass object that can reused.

### Details and comments