### PR TITLE
Use `SmallVec` in `NeighborTable` for cache locality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,7 @@ dependencies = [
  "rand_pcg",
  "rayon",
  "rustworkx-core",
+ "smallvec",
 ]
 
 [[package]]

--- a/crates/accelerate/Cargo.toml
+++ b/crates/accelerate/Cargo.toml
@@ -25,6 +25,10 @@ num-complex = "0.4"
 num-bigint = "0.4"
 rustworkx-core = "0.13"
 
+[dependencies.smallvec]
+version = "1.11"
+features = ["union"]
+
 [dependencies.pyo3]
 workspace = true
 features = ["hashbrown", "indexmap", "num-complex", "num-bigint"]


### PR DESCRIPTION
### Summary

A reasonable chunk of our time in Sabre is spent reading through the `NeighborTable` to find the candidate swaps for a given layout.  Most coupling maps that we care about have a relatively low number of edges between qubits, yet we needed to redirect to the heap for each individual physical-qubit lookup currently.

This switches from using a `Vec` (which is always a fat pointer to heap memory) to `SmallVec` with an inline buffer space of four qubits. With the qubit type being `u32`, the `SmallVec` now takes up the same stack size as a `Vec` but can store (usually) all the swaps directly inline in the outer `Vec` of qubits.  This means that most lookups of the available swaps are looking in the same (up to relatively small offsets) in memory, which makes the access patterns much easier for prefetching to optimise for.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

This is a less pronounced effect than either #10782 or #10783, but is still a measurable performance improvement - the example in #10782 went from 2.08(4)s on `main` to 1.96(3)s with this PR (again - the numbers are bigger because Webex is using some of my CPU cycles haha).