### PR TITLE
Speed up synthesis passes when there is nothing to synthesize

### DIFF
--- a/qiskit/circuit/controlflow/__init__.py
+++ b/qiskit/circuit/controlflow/__init__.py
@@ -22,3 +22,6 @@ from .if_else import IfElseOp
 from .while_loop import WhileLoopOp
 from .for_loop import ForLoopOp
 from .switch_case import SwitchCaseOp, CASE_DEFAULT
+
+
+CONTROL_FLOW_OP_NAMES = frozenset(("for_loop", "while_loop", "if_else", "switch_case"))

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -37,7 +37,7 @@ from qiskit.circuit import (
     SwitchCaseOp,
     _classical_resource_map,
 )
-from qiskit.circuit.controlflow import condition_resources, node_resources
+from qiskit.circuit.controlflow import condition_resources, node_resources, CONTROL_FLOW_OP_NAMES
 from qiskit.circuit.quantumregister import QuantumRegister, Qubit
 from qiskit.circuit.classicalregister import ClassicalRegister, Clbit
 from qiskit.circuit.gate import Gate
@@ -890,9 +890,7 @@ class DAGCircuit:
         """
         length = len(self._multi_graph) - 2 * len(self._wires)
         if not recurse:
-            if any(
-                x in self._op_names for x in ("for_loop", "while_loop", "if_else", "switch_case")
-            ):
+            if any(x in self._op_names for x in CONTROL_FLOW_OP_NAMES):
                 raise DAGCircuitError(
                     "Size with control flow is ambiguous."
                     " You may use `recurse=True` to get a result,"
@@ -954,9 +952,7 @@ class DAGCircuit:
                 return node_lookup.get(target, 1)
 
         else:
-            if any(
-                x in self._op_names for x in ("for_loop", "while_loop", "if_else", "switch_case")
-            ):
+            if any(x in self._op_names for x in CONTROL_FLOW_OP_NAMES):
                 raise DAGCircuitError(
                     "Depth with control flow is ambiguous."
                     " You may use `recurse=True` to get a result,"
@@ -1952,9 +1948,7 @@ class DAGCircuit:
         Returns:
             Mapping[str, int]: a mapping of operation names to the number of times it appears.
         """
-        if not recurse or not {"for_loop", "while_loop", "if_else", "switch_case"}.intersection(
-            self._op_names
-        ):
+        if not recurse or not CONTROL_FLOW_OP_NAMES.intersection(self._op_names):
             return self._op_names.copy()
 
         # pylint: disable=cyclic-import

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1952,7 +1952,9 @@ class DAGCircuit:
         Returns:
             Mapping[str, int]: a mapping of operation names to the number of times it appears.
         """
-        if not recurse:
+        if not recurse or not {"for_loop", "while_loop", "if_else", "switch_case"}.intersection(
+            self._op_names
+        ):
             return self._op_names.copy()
 
         # pylint: disable=cyclic-import

--- a/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
@@ -169,6 +169,10 @@ class HighLevelSynthesis(TransformationPass):
         Raises:
             TranspilerError: when the specified synthesis method is not available.
         """
+        # If there aren't any high level operations to synthesize return fast
+        hls_names = set(self.hls_plugin_manager.plugins_by_op)
+        if not hls_names.intersection(dag.count_ops()):
+            return dag
         for node in dag.op_nodes():
             if node.name in self.hls_config.methods.keys():
                 # the operation's name appears in the user-provided config,

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -375,6 +375,12 @@ class UnitarySynthesis(TransformationPass):
         """
         if self.method != "default" and self.method not in self.plugins.ext_plugins:
             raise TranspilerError("Specified method: %s not found in plugin list" % self.method)
+
+        # If there aren't any gates to synthesize in the circuit we can skip all the iteration
+        # and just return.
+        if not set(self._synth_gates).intersection(dag.count_ops()):
+            return dag
+
         # Return fast if we have no synth gates (ie user specified an empty
         # list or the synth gates are all in the basis
         if not self._synth_gates:

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -381,10 +381,6 @@ class UnitarySynthesis(TransformationPass):
         if not set(self._synth_gates).intersection(dag.count_ops()):
             return dag
 
-        # Return fast if we have no synth gates (ie user specified an empty
-        # list or the synth gates are all in the basis
-        if not self._synth_gates:
-            return dag
         if self.plugins:
             plugin_method = self.plugins.ext_plugins[self.method].obj
         else:

--- a/qiskit/transpiler/preset_passmanagers/common.py
+++ b/qiskit/transpiler/preset_passmanagers/common.py
@@ -17,6 +17,7 @@ import collections
 from typing import Optional
 
 from qiskit.circuit.equivalence_library import SessionEquivalenceLibrary as sel
+from qiskit.circuit.controlflow import CONTROL_FLOW_OP_NAMES
 from qiskit.utils.deprecation import deprecate_func
 
 from qiskit.transpiler.passmanager import PassManager
@@ -53,7 +54,6 @@ from qiskit.transpiler.passes.layout.vf2_post_layout import VF2PostLayoutStopRea
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.layout import Layout
 
-_CONTROL_FLOW_OP_NAMES = {"for_loop", "if_else", "while_loop", "switch_case"}
 
 _ControlFlowState = collections.namedtuple("_ControlFlowState", ("working", "not_working"))
 
@@ -76,11 +76,11 @@ _CONTROL_FLOW_STATES = {
 
 
 def _has_control_flow(property_set):
-    return any(property_set[f"contains_{x}"] for x in _CONTROL_FLOW_OP_NAMES)
+    return any(property_set[f"contains_{x}"] for x in CONTROL_FLOW_OP_NAMES)
 
 
 def _without_control_flow(property_set):
-    return not any(property_set[f"contains_{x}"] for x in _CONTROL_FLOW_OP_NAMES)
+    return not any(property_set[f"contains_{x}"] for x in CONTROL_FLOW_OP_NAMES)
 
 
 class _InvalidControlFlowForBackend:
@@ -88,10 +88,10 @@ class _InvalidControlFlowForBackend:
 
     def __init__(self, basis_gates=(), target=None):
         if target is not None:
-            self.unsupported = [op for op in _CONTROL_FLOW_OP_NAMES if op not in target]
+            self.unsupported = [op for op in CONTROL_FLOW_OP_NAMES if op not in target]
         else:
             basis_gates = set(basis_gates) if basis_gates is not None else set()
-            self.unsupported = [op for op in _CONTROL_FLOW_OP_NAMES if op not in basis_gates]
+            self.unsupported = [op for op in CONTROL_FLOW_OP_NAMES if op not in basis_gates]
 
     def message(self, property_set):
         """Create an error message for the given property set."""
@@ -147,7 +147,7 @@ def generate_control_flow_options_check(
                 )
             bad_options.append(option)
     out = PassManager()
-    out.append(ContainsInstruction(_CONTROL_FLOW_OP_NAMES, recurse=False))
+    out.append(ContainsInstruction(CONTROL_FLOW_OP_NAMES, recurse=False))
     if bad_options:
         out.append(Error(message), condition=_has_control_flow)
     backend_control = _InvalidControlFlowForBackend(basis_gates, target)
@@ -159,7 +159,7 @@ def generate_error_on_control_flow(message):
     """Get a pass manager that always raises an error if control flow is present in a given
     circuit."""
     out = PassManager()
-    out.append(ContainsInstruction(_CONTROL_FLOW_OP_NAMES, recurse=False))
+    out.append(ContainsInstruction(CONTROL_FLOW_OP_NAMES, recurse=False))
     out.append(Error(message), condition=_has_control_flow)
     return out
 
@@ -172,7 +172,7 @@ def if_has_control_flow_else(if_present, if_absent):
     if isinstance(if_absent, PassManager):
         if_absent = if_absent.to_flow_controller()
     out = PassManager()
-    out.append(ContainsInstruction(_CONTROL_FLOW_OP_NAMES, recurse=False))
+    out.append(ContainsInstruction(CONTROL_FLOW_OP_NAMES, recurse=False))
     out.append(if_present, condition=_has_control_flow)
     out.append(if_absent, condition=_without_control_flow)
     return out


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit makes a small optimization to the UnitarySynthesis and HighLevelSynthesis synthesis passes when there are no gates to synthesize. Previously these passes would iterate over the entire DAG and check every gate to determine that None needed to be synthesized. While this is relatively quick for very large circuits this can take 100s of ms. However, this was wasted work because the DAG carries a dictionary of op names in the circuit so we can determine in constant time whether any of the operations to synthesize are present up front and skip the bulk of the iteration. To improve the impact here the DAGCircuit.count_ops() method is updated to skip the recursion if no control flow operations are present. Otherwise we'd still be iterating over the DAG (in a faster manner) which would limit the improvement from this commit. This isn't the best approach for that as it uses a hardcoded list of control flow operations which doesn't seem super general purpose, but as this hard coded set of instructions is already used elsewhere in the DAGCircuit this isn't making the situation any worse. If/when we expand recursive objects this can be revisited (and we'll likely not be able to avoid the iteration in count ops). With these changes the time these passes take when there are no operations to synthesize only takes ~10-20 microseconds.

A similar optimization should be considered for UnrollCustomDefinitions as this takes an even longer amount of time to iterate when there is nothing to translate. However, it wasn't done as part of this PR as to check the equivalence library has an entry we need to work with gate objects (well actually name and number of qubits as that's all that's used from the object for a lookup) and the name from the op count dictionary is not sufficient for a lookup. So this will need to be handled independently in a separate PR.

### Details and comments