### PR TITLE
Better align 1q euler decomposition output to multiples of π/2

### DIFF
--- a/crates/accelerate/src/euler_one_qubit_decomposer.rs
+++ b/crates/accelerate/src/euler_one_qubit_decomposer.rs
@@ -683,12 +683,12 @@ fn mod_2pi(angle: f64, atol: f64) -> f64 {
 }
 
 fn params_zyz_inner(mat: ArrayView2<Complex64>) -> [f64; 4] {
-    let det = det_one_qubit(mat);
-    let phase = 0.5 * det.arg();
+    let det_arg = det_one_qubit(mat).arg();
+    let phase = 0.5 * det_arg;
     let theta = 2. * mat[[1, 0]].abs().atan2(mat[[0, 0]].abs());
     let ang1 = mat[[1, 1]].arg();
     let ang2 = mat[[1, 0]].arg();
-    let phi = ang1 + ang2 - det.arg();
+    let phi = ang1 + ang2 - det_arg;
     let lam = ang1 - ang2;
     [theta, phi, lam, phase]
 }

--- a/crates/accelerate/src/euler_one_qubit_decomposer.rs
+++ b/crates/accelerate/src/euler_one_qubit_decomposer.rs
@@ -688,15 +688,16 @@ fn mod_2pi(angle: f64, atol: f64) -> f64 {
 }
 
 fn params_zyz_inner(mat: ArrayView2<Complex64>) -> [f64; 4] {
-    let coeff: Complex64 = 1. / det_one_qubit(mat).sqrt();
+    let det = det_one_qubit(mat);
+    let coeff: Complex64 = 1. / det.sqrt();
     let phase = -complex_phase(coeff);
     let tmp_1_0 = (coeff * mat[[1, 0]]).abs();
     let tmp_0_0 = (coeff * mat[[0, 0]]).abs();
     let theta = 2. * tmp_1_0.atan2(tmp_0_0);
-    let phiplambda2 = complex_phase(coeff * mat[[1, 1]]);
-    let phimlambda2 = complex_phase(coeff * mat[[1, 0]]);
-    let phi = phiplambda2 + phimlambda2;
-    let lam = phiplambda2 - phimlambda2;
+    let ang1 = complex_phase(mat[[1, 1]]);
+    let ang2 = complex_phase(mat[[1, 0]]);
+    let phi = ang1 + ang2 - complex_phase(det);
+    let lam = ang1 - ang2;
     [theta, phi, lam, phase]
 }
 

--- a/crates/accelerate/src/euler_one_qubit_decomposer.rs
+++ b/crates/accelerate/src/euler_one_qubit_decomposer.rs
@@ -668,11 +668,6 @@ fn det_one_qubit(mat: ArrayView2<Complex64>) -> Complex64 {
     mat[[0, 0]] * mat[[1, 1]] - mat[[0, 1]] * mat[[1, 0]]
 }
 
-#[inline]
-fn complex_phase(x: Complex64) -> f64 {
-    x.im.atan2(x.re)
-}
-
 /// Wrap angle into interval [-π,π). If within atol of the endpoint, clamp to -π
 #[inline]
 fn mod_2pi(angle: f64, atol: f64) -> f64 {
@@ -689,11 +684,11 @@ fn mod_2pi(angle: f64, atol: f64) -> f64 {
 
 fn params_zyz_inner(mat: ArrayView2<Complex64>) -> [f64; 4] {
     let det = det_one_qubit(mat);
-    let phase = 0.5 * complex_phase(det);
-    let theta = 2. * mat[[1, 0]].abs().atan2(mat[[0,0]].abs());
-    let ang1 = complex_phase(mat[[1, 1]]);
-    let ang2 = complex_phase(mat[[1, 0]]);
-    let phi = ang1 + ang2 - complex_phase(det);
+    let phase = 0.5 * det.arg();
+    let theta = 2. * mat[[1, 0]].abs().atan2(mat[[0, 0]].abs());
+    let ang1 = mat[[1, 1]].arg();
+    let ang2 = mat[[1, 0]].arg();
+    let phi = ang1 + ang2 - det.arg();
     let lam = ang1 - ang2;
     [theta, phi, lam, phase]
 }

--- a/crates/accelerate/src/euler_one_qubit_decomposer.rs
+++ b/crates/accelerate/src/euler_one_qubit_decomposer.rs
@@ -689,11 +689,8 @@ fn mod_2pi(angle: f64, atol: f64) -> f64 {
 
 fn params_zyz_inner(mat: ArrayView2<Complex64>) -> [f64; 4] {
     let det = det_one_qubit(mat);
-    let coeff: Complex64 = 1. / det.sqrt();
-    let phase = -complex_phase(coeff);
-    let tmp_1_0 = (coeff * mat[[1, 0]]).abs();
-    let tmp_0_0 = (coeff * mat[[0, 0]]).abs();
-    let theta = 2. * tmp_1_0.atan2(tmp_0_0);
+    let phase = 0.5 * complex_phase(det);
+    let theta = 2. * mat[[1, 0]].abs().atan2(mat[[0,0]].abs());
     let ang1 = complex_phase(mat[[1, 1]]);
     let ang2 = complex_phase(mat[[1, 0]]);
     let phi = ang1 + ang2 - complex_phase(det);

--- a/test/python/circuit/test_circuit_qasm.py
+++ b/test/python/circuit/test_circuit_qasm.py
@@ -368,8 +368,8 @@ unitary q[0];
             r"""OPENQASM 2.0;
 include "qelib1.inc";
 gate unitary q0 { u\(0,0,0\) q0; }
-gate (?P<u1>unitary_[0-9]*) q0 { u\(pi,-pi/2,pi/2\) q0; }
-gate (?P<u2>unitary_[0-9]*) q0 { u\(0,pi/2,pi/2\) q0; }
+gate (?P<u1>unitary_[0-9]*) q0 { u\(pi,-pi,0\) q0; }
+gate (?P<u2>unitary_[0-9]*) q0 { u\(0,0,pi\) q0; }
 gate custom q0 { (?P=u2) q0; }
 qreg q\[2\];
 unitary q\[0\];

--- a/test/python/qasm2/test_export.py
+++ b/test/python/qasm2/test_export.py
@@ -354,8 +354,8 @@ unitary q[0];"""
             r"""OPENQASM 2.0;
 include "qelib1.inc";
 gate unitary q0 { u\(0,0,0\) q0; }
-gate (?P<u1>unitary_[0-9]*) q0 { u\(pi,-pi/2,pi/2\) q0; }
-gate (?P<u2>unitary_[0-9]*) q0 { u\(0,pi/2,pi/2\) q0; }
+gate (?P<u1>unitary_[0-9]*) q0 { u\(pi,-pi,0\) q0; }
+gate (?P<u2>unitary_[0-9]*) q0 { u\(0,0,pi\) q0; }
 gate custom q0 { (?P=u2) q0; }
 qreg q\[2\];
 unitary q\[0\];

--- a/test/python/transpiler/test_dynamical_decoupling.py
+++ b/test/python/transpiler/test_dynamical_decoupling.py
@@ -438,7 +438,7 @@ class TestPadDynamicalDecoupling(QiskitTestCase):
 
         midmeas_dd = pm.run(self.midmeas)
 
-        combined_u = UGate(0, -pi / 2, pi / 2)
+        combined_u = UGate(0, 0, 0)
 
         expected = QuantumCircuit(3, 1)
         expected.cx(0, 1)
@@ -453,7 +453,7 @@ class TestPadDynamicalDecoupling(QiskitTestCase):
         expected.cx(1, 2)
         expected.cx(0, 1)
         expected.delay(700, 2)
-        expected.global_phase = pi / 2
+        expected.global_phase = pi
 
         self.assertEqual(midmeas_dd, expected)
         # check the absorption into U was done correctly

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -536,7 +536,6 @@ def generate_controlled_gates():
     custom_gate = Gate("black_box", 1, [])
     custom_definition = QuantumCircuit(1)
     custom_definition.h(0)
-    custom_definition.rz(1.5, 0)
     custom_definition.sdg(0)
     custom_gate.definition = custom_definition
     nested_qc = QuantumCircuit(3, name="nested_qc")
@@ -562,7 +561,6 @@ def generate_open_controlled_gates():
     custom_gate = Gate("black_box", 1, [])
     custom_definition = QuantumCircuit(1)
     custom_definition.h(0)
-    custom_definition.rz(1.5, 0)
     custom_definition.sdg(0)
     custom_gate.definition = custom_definition
     nested_qc = QuantumCircuit(3, name="open_controls_nested")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the euler decomposer to better align the parameter outputs to be multiples of π/2 when possible to enable output circuits to be run with a Clifford simulator.

Previously the angle was calculated as:

```
phi = angle(u11 * (det**(-0.5))) + angle(u10 * (det**(-0.5)))
```

which has been replaced with:

```
phi = angle(u11) + angle(u10) - angle(det)
```

The algebra to get the new expression is:

```
phi = angle(u11 * (det**(-0.5))) + angle(u10 * (det**(-0.5)))
    # assumes particular phase convention so not guaranteed to be the
    # valid interpretation (though it probably is).
    = angle(u11) - 0.5*angle(det) + angle(u10) - 0.5*angle(det)
    = angle(u11) + angle(u10) - angle(det)
```

A couple of tests are updated as they were testing for exact circuit outputs and the synthesis is returning equivalent by different results in those cases.

### Details and comments

Co-authored-by: aeddins-ibm <60495383+aeddins-ibm@users.noreply.github.com>