### PR TITLE
Cleanup venvs if new qpy payloads are created in backwards compat tests

### DIFF
--- a/test/qpy_compat/process_version.sh
+++ b/test/qpy_compat/process_version.sh
@@ -34,7 +34,5 @@ else
 fi
 echo "Loading qpy files from $version with dev qiskit-terra"
 ../qiskit_venv/bin/python ../test_qpy.py load --version=$version
-if [[ ! -d qpy_$version ]] ; then
-    rm -rf ./$version
-fi
+rm -rf ./$version
 popd

--- a/test/qpy_compat/process_version.sh
+++ b/test/qpy_compat/process_version.sh
@@ -34,5 +34,5 @@ else
 fi
 echo "Loading qpy files from $version with dev qiskit-terra"
 ../qiskit_venv/bin/python ../test_qpy.py load --version=$version
-rm -rf ./$version
 popd
+rm -rf ./$version

--- a/test/qpy_compat/process_version.sh
+++ b/test/qpy_compat/process_version.sh
@@ -34,4 +34,7 @@ else
 fi
 echo "Loading qpy files from $version with dev qiskit-terra"
 ../qiskit_venv/bin/python ../test_qpy.py load --version=$version
+if [[ ! -d qpy_$version ]] ; then
+    rm -rf ./$version
+fi
 popd


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a cleanup step to the qpy backwards compatibility tests. If we need to regenerate the QPY payloads because of a change to the underlying python tests we end up building a venv for each historical release with qpy support and just leaving them on disk. This is an issue for disk space in CI as we have increasing number of historical releases with qpy support that will not get any smaller (at least potentially until Python 3.9 goes EoL when the oldest release, 0.18.0, no longer has a version of Python with upstream support) and we only have 10GB of local disk storage available in CI. To combat this disk space limitation this commit updates the tests to delete the venv after we've successfully finished executing the compatibility tests. They're left around if we fail because for local development having the environment available on failure is useful for debugging and for CI in the case of failure we don't need to worry about disk space anymore because the VM will be destroyed shortly after the failure.

### Details and comments