### PR TITLE
Add global-phase support to control-flow builders

### DIFF
--- a/qiskit/circuit/controlflow/_builder_utils.py
+++ b/qiskit/circuit/controlflow/_builder_utils.py
@@ -168,7 +168,9 @@ def _unify_circuit_resources_rebuild(  # pylint: disable=invalid-name  # (it's t
     # We use the inner `_append` method because everything is already resolved in the builders.
     out_circuits = []
     for circuit in circuits:
-        out = QuantumCircuit(qubits, clbits, *circuit.qregs, *circuit.cregs)
+        out = QuantumCircuit(
+            qubits, clbits, *circuit.qregs, *circuit.cregs, global_phase=circuit.global_phase
+        )
         for instruction in circuit.data:
             out._append(instruction)
         out_circuits.append(out)

--- a/qiskit/circuit/controlflow/builder.py
+++ b/qiskit/circuit/controlflow/builder.py
@@ -203,6 +203,7 @@ class ControlFlowBuilderBlock:
         "qubits",
         "clbits",
         "registers",
+        "global_phase",
         "_allow_jumps",
         "_resource_requester",
         "_built",
@@ -254,6 +255,7 @@ class ControlFlowBuilderBlock:
         self.qubits = set(qubits)
         self.clbits = set(clbits)
         self.registers = set(registers)
+        self.global_phase = 0.0
         self._allow_jumps = allow_jumps
         self._resource_requester = resource_requester
         self._built = False
@@ -417,7 +419,9 @@ class ControlFlowBuilderBlock:
 
         # We start off by only giving the QuantumCircuit the qubits we _know_ it will need, and add
         # more later as needed.
-        out = QuantumCircuit(list(self.qubits), list(self.clbits), *self.registers)
+        out = QuantumCircuit(
+            list(self.qubits), list(self.clbits), *self.registers, global_phase=self.global_phase
+        )
 
         for instruction in self.instructions:
             if isinstance(instruction.operation, InstructionPlaceholder):
@@ -482,6 +486,7 @@ class ControlFlowBuilderBlock:
         out.qubits = self.qubits.copy()
         out.clbits = self.clbits.copy()
         out.registers = self.registers.copy()
+        out.global_phase = self.global_phase
         out._allow_jumps = self._allow_jumps
         out._forbidden_message = self._forbidden_message
         return out

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2435,25 +2435,25 @@ class QuantumCircuit:
 
     @property
     def global_phase(self) -> ParameterValueType:
-        """Return the global phase of the circuit in radians."""
+        """Return the global phase of the current circuit scope in radians."""
+        if self._control_flow_scopes:
+            return self._control_flow_scopes[-1].global_phase
         return self._global_phase
 
     @global_phase.setter
     def global_phase(self, angle: ParameterValueType):
-        """Set the phase of the circuit.
+        """Set the phase of the current circuit scope.
 
         Args:
             angle (float, ParameterExpression): radians
         """
-        if isinstance(angle, ParameterExpression) and angle.parameters:
-            self._global_phase = angle
-        else:
+        if not (isinstance(angle, ParameterExpression) and angle.parameters):
             # Set the phase to the [0, 2π) interval
-            angle = float(angle)
-            if not angle:
-                self._global_phase = 0
-            else:
-                self._global_phase = angle % (2 * np.pi)
+            angle = float(angle) % (2 * np.pi)
+        if self._control_flow_scopes:
+            self._control_flow_scopes[-1].global_phase = angle
+        else:
+            self._global_phase = angle
 
     @property
     def parameters(self) -> ParameterView:

--- a/releasenotes/notes/fix-global-phase-control-flow-builders-38302f41302be928.yaml
+++ b/releasenotes/notes/fix-global-phase-control-flow-builders-38302f41302be928.yaml
@@ -1,0 +1,33 @@
+---
+fixes:
+  - |
+    The control-flow builder interface (the context-manager forms of
+    :meth:`.QuantumCircuit.if_test`, :meth:`~.QuantumCircuit.while_loop`,
+    :meth:`~.QuantumCircuit.for_loop` and :meth:`~.QuantumCircuit.switch`) will now correctly track
+    a separate global-phase advancement within that block.  You can add a global-phase advancement
+    to an inner block by assigning to :attr:`.QuantumCircuit.global_phase` within a builder scope::
+
+      from math import pi
+      from qiskit import QuantumCircuit
+
+      qc = QuantumCircuit(3, 3)
+      qc.global_phase = pi / 2  # Set the outer circuit's global phase.
+
+      with qc.if_test((qc.clbits[0], False)) as else_:
+        # The global phase advancement in a control-flow block begins at 0,
+        # because it represents how much the phase will be advanced by an
+        # execution of the block.  The defined phase of the outer scope is not
+        # affected by this set.
+        qc.global_phase = pi
+      with else_:
+        # Similarly, the `else` block may induce a different global-phase
+        # advancement to the `if`, so it can also be set separately.
+        qc.global_phase = 1.5 * pi
+
+      # The phase advancement caused directly by the outer scope is independent
+      # of the phase advancement conditionally caused by each control-flow path.
+      assert qc.global_phase == pi / 2
+
+    The meaning of :attr:`.QuantumCircuit.global_phase` is taken to be the global-phase advancement
+    that is inherent to a single execution of the block.  It is still a *global* phase advancement,
+    in that if the block is entered, the phase of all qubits in the entire program will be advanced.


### PR DESCRIPTION
### Summary

This formalises the concept of global phase within control-flow scopes, and teaches the control-flow builders to treat modifications to the global phase as being conditional on the control-flow block being entered.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

I turned this up during trying to write #10786, and felt like we needed a formalisation of what we treat "global phase" as during control-flow scopes.

This PR defines the "global phase" of a block as "the amount by which the phase of all program qubits will be advanced if this block is taken", which I think is consistent with how we have been de facto treating this via basis-translator recursion into control-flow blocks.  For the most part, this shouldn't be observable in an actual execution of a quantum program, but you could say take a single shot of a statevector simulation, and this interpretation would cause the resultant statevector to have a well-defined global phase consistent with our existent conventions.