### PR TITLE
Remove `requires_qe_access`, deprecated in 0.17

### DIFF
--- a/qiskit/test/__init__.py
+++ b/qiskit/test/__init__.py
@@ -13,6 +13,6 @@
 """Functionality and helpers for testing Qiskit."""
 
 from .base import QiskitTestCase
-from .decorators import requires_aer_provider, online_test, slow_test, requires_qe_access
+from .decorators import requires_aer_provider, online_test, slow_test
 from .reference_circuits import ReferenceCircuits
 from .utils import Path

--- a/qiskit/test/decorators.py
+++ b/qiskit/test/decorators.py
@@ -22,7 +22,6 @@ from typing import Union, Callable, Type, Iterable
 import unittest
 
 from qiskit.utils import wrap_method
-from qiskit.utils.deprecation import deprecate_func
 from .testing_options import get_test_options
 
 HAS_NET_CONNECTION = None
@@ -139,24 +138,6 @@ def _get_credentials():
     raise unittest.SkipTest(
         "No IBMQ credentials found for running the test. This is required for running online tests."
     )
-
-
-@deprecate_func(additional_msg="Instead, use ``online_test``", since="0.17.0")
-def requires_qe_access(func):
-    """Deprecated in favor of `online_test`"""
-
-    @functools.wraps(func)
-    def _wrapper(self, *args, **kwargs):
-        if TEST_OPTIONS["skip_online"]:
-            raise unittest.SkipTest("Skipping online tests")
-
-        credentials = _get_credentials()
-        self.using_ibmq_credentials = credentials.is_ibmq()
-        kwargs.update({"qe_token": credentials.token, "qe_url": credentials.url})
-
-        return func(self, *args, **kwargs)
-
-    return _wrapper
 
 
 def online_test(func):

--- a/releasenotes/notes/deprecate_func-25c04f94964cffb2.yaml
+++ b/releasenotes/notes/deprecate_func-25c04f94964cffb2.yaml
@@ -1,5 +1,0 @@
----
-upgrade:
-  - |
-    The decorator `requires_qe_access` was deprecated in qiskit-terra 0.17 (released on April 2021)
-    and now is it being removed. The decorator :func:`.online_test` is a one-to-one replacement of it.

--- a/releasenotes/notes/deprecate_func-25c04f94964cffb2.yaml
+++ b/releasenotes/notes/deprecate_func-25c04f94964cffb2.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    The decorator `requires_qe_access` was deprecated in qiskit-terra 0.17 (released on April 2021)
+    and now is it being removed. The decorator :func:`.online_test` is a one-to-one replacement of it.


### PR DESCRIPTION
In 0.17 (released on April 01, 2021), the decorator `requires_qe_access` was deprecated. Time to remove it.