### PR TITLE
Add missing `expr.bit_xor` documentation

### DIFF
--- a/qiskit/circuit/classical/expr/__init__.py
+++ b/qiskit/circuit/classical/expr/__init__.py
@@ -104,6 +104,7 @@ Similarly, the binary operations and relations have helper functions defined.
 
 .. autofunction:: bit_and
 .. autofunction:: bit_or
+.. autofunction:: bit_xor
 .. autofunction:: logic_and
 .. autofunction:: logic_or
 .. autofunction:: equal


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Apparently I forgot to build this one function into the documentation, even though its docstring was already written.

### Details and comments


