### PR TITLE
Do not emit warnings from `opflow` initialisation

### DIFF
--- a/qiskit/opflow/operator_globals.py
+++ b/qiskit/opflow/operator_globals.py
@@ -14,6 +14,8 @@
 Operator Globals
 """
 
+import warnings
+
 from qiskit.quantum_info import Pauli
 from qiskit.circuit.library import CXGate, SGate, TGate, HGate, SwapGate, CZGate
 
@@ -48,22 +50,30 @@ def make_immutable(obj):
     return obj
 
 
-# 1-Qubit Paulis
-X = make_immutable(PauliOp(Pauli("X")))
-Y = make_immutable(PauliOp(Pauli("Y")))
-Z = make_immutable(PauliOp(Pauli("Z")))
-I = make_immutable(PauliOp(Pauli("I")))
+# All the deprecation warnings triggered by these object creations correctly blame `qiskit.opflow`
+# and so are not shown to users by default. However, since they are eagerly triggered at `import
+# qiskit.opflow`, they obscure the one "true" warning of the import when downstream testing code is
+# running with all warnings showing.  The true warning that really needs attention becomes easy to
+# overlook because there's so many that the downstream code didn't explicitly call.
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"qiskit\.opflow\.")
 
-# Clifford+T, and some other common non-parameterized gates
-CX = make_immutable(CircuitOp(CXGate()))
-S = make_immutable(CircuitOp(SGate()))
-H = make_immutable(CircuitOp(HGate()))
-T = make_immutable(CircuitOp(TGate()))
-Swap = make_immutable(CircuitOp(SwapGate()))
-CZ = make_immutable(CircuitOp(CZGate()))
+    # 1-Qubit Paulis
+    X = make_immutable(PauliOp(Pauli("X")))
+    Y = make_immutable(PauliOp(Pauli("Y")))
+    Z = make_immutable(PauliOp(Pauli("Z")))
+    I = make_immutable(PauliOp(Pauli("I")))
 
-# 1-Qubit states
-Zero = make_immutable(DictStateFn("0"))
-One = make_immutable(DictStateFn("1"))
-Plus = make_immutable(H.compose(Zero))
-Minus = make_immutable(H.compose(X).compose(Zero))
+    # Clifford+T, and some other common non-parameterized gates
+    CX = make_immutable(CircuitOp(CXGate()))
+    S = make_immutable(CircuitOp(SGate()))
+    H = make_immutable(CircuitOp(HGate()))
+    T = make_immutable(CircuitOp(TGate()))
+    Swap = make_immutable(CircuitOp(SwapGate()))
+    CZ = make_immutable(CircuitOp(CZGate()))
+
+    # 1-Qubit states
+    Zero = make_immutable(DictStateFn("0"))
+    One = make_immutable(DictStateFn("1"))
+    Plus = make_immutable(H.compose(Zero))
+    Minus = make_immutable(H.compose(X).compose(Zero))


### PR DESCRIPTION
### Summary

Opflow is completely deprecated, and `import qiskit.opflow` should and does raise a warning blaming the importer.  However, during the import, several opflow objects are initialised, which also trigger deprecation warnings.  These will correctly be blamed on internal Qiskit library code, and so will not be shown to users by default.

However, test suites running with all warnings treated as errors will also see these warnings, which will mask the one true warning that should be handled by the downstream code.  It would be valid for downstream code to filter out these internal warnings, but in order to make it easier for downstream code to do the correct thing immediately, this opts to silence the internal warnings during initialisation. Downstream code running with all warnings enabled will now _only_ see the warning from `import qiskit.opflow` which is the only actionable warning they should have to deal with anyway.

These warnings are only filtered during the initialisation and are targetted specifically at opflow-internal deprecation warnings.  In general, deprecated code will call other deprecated code and it is not necessary to filter every single usage.  This particular commit is a slight compromise to make it slightly easier for downstream libraries to do the right thing.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Mostly this is to help `qiskit-ibm-runtime` and other downstream libraries of the sort transition to processes where they treat all warnings as errors.
