### PR TITLE
qreg_creg_descending calls deprecated Bit.index

### DIFF
--- a/qiskit/visualization/circuit/latex.py
+++ b/qiskit/visualization/circuit/latex.py
@@ -536,7 +536,7 @@ class QCircuitImage:
             register = get_bit_register(self._circuit, node.cargs[0])
             if register is not None:
                 wire2 = self._wire_map[register]
-                idx_str = str(node.cargs[0].index)
+                idx_str = str(self._circuit.find_bit(node.cargs[0]).registers[0][1])
             else:
                 wire2 = self._wire_map[node.cargs[0]]
 

--- a/qiskit/visualization/circuit/latex.py
+++ b/qiskit/visualization/circuit/latex.py
@@ -536,7 +536,7 @@ class QCircuitImage:
             register = get_bit_register(self._circuit, node.cargs[0])
             if register is not None:
                 wire2 = self._wire_map[register]
-                idx_str = str(self._circuit.find_bit(node.cargs[0]).registers[0][1])
+                idx_str = str(node.cargs[0].index)
             else:
                 wire2 = self._wire_map[node.cargs[0]]
 

--- a/qiskit/visualization/timeline/layouts.py
+++ b/qiskit/visualization/timeline/layouts.py
@@ -111,8 +111,8 @@ def qreg_creg_descending(bits: List[types.Bits]) -> List[types.Bits]:
         else:
             raise VisualizationError(f"Unknown bit {bit} is provided.")
 
-    qregs = sorted(qregs, key=lambda x: x.index, reverse=True)
-    cregs = sorted(cregs, key=lambda x: x.index, reverse=True)
+    qregs.reverse()
+    cregs.reverse()
 
     return qregs + cregs
 

--- a/qiskit/visualization/timeline/layouts.py
+++ b/qiskit/visualization/timeline/layouts.py
@@ -48,14 +48,10 @@ The function signature of the layout is restricted to:
 
 Arbitrary layout function satisfying the above format can be accepted.
 """
-
-import warnings
-
 from typing import List, Tuple
 import numpy as np
 
 from qiskit import circuit
-from qiskit.visualization.exceptions import VisualizationError
 from qiskit.visualization.timeline import types
 
 
@@ -70,23 +66,9 @@ def qreg_creg_ascending(bits: List[types.Bits]) -> List[types.Bits]:
     Returns:
         Sorted bits.
     """
-    qregs = []
-    cregs = []
-
-    for bit in bits:
-        if isinstance(bit, circuit.Qubit):
-            qregs.append(bit)
-        elif isinstance(bit, circuit.Clbit):
-            cregs.append(bit)
-        else:
-            raise VisualizationError(f"Unknown bit {bit} is provided.")
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        qregs = sorted(qregs, key=lambda x: x.index, reverse=False)
-        cregs = sorted(cregs, key=lambda x: x.index, reverse=False)
-
-    return qregs + cregs
+    return [x for x in bits if isinstance(x, circuit.Qubit)] + [
+        x for x in bits if isinstance(x, circuit.Clbit)
+    ]
 
 
 def qreg_creg_descending(bits: List[types.Bits]) -> List[types.Bits]:
@@ -100,21 +82,9 @@ def qreg_creg_descending(bits: List[types.Bits]) -> List[types.Bits]:
     Returns:
         Sorted bits.
     """
-    qregs = []
-    cregs = []
-
-    for bit in bits:
-        if isinstance(bit, circuit.Qubit):
-            qregs.append(bit)
-        elif isinstance(bit, circuit.Clbit):
-            cregs.append(bit)
-        else:
-            raise VisualizationError(f"Unknown bit {bit} is provided.")
-
-    qregs.reverse()
-    cregs.reverse()
-
-    return qregs + cregs
+    return [x for x in bits[::-1] if isinstance(x, circuit.Qubit)] + [
+        x for x in bits[::-1] if isinstance(x, circuit.Clbit)
+    ]
 
 
 def time_map_in_dt(time_window: Tuple[int, int]) -> types.HorizontalAxis:


### PR DESCRIPTION
In #5121, @nkanazawa1989 introduced the function `qiskit.visualization.timeline.layouts.qreg_creg_descending` which is only called by `test.python.visualization.timeline.test_layouts.TestBitArrange.test_qreg_creg_descending`.

It seems to me that it could be removed, or replace by this PR (not sure if that preserves the semantic, because it is hard to me what was its original intention). I would be fine with removing it and have a `upgrade` reno, without deprecation process, as I dont think it was ever intended for external usage. `On hold` until a direction is decided.

At this point, this is the only function that still calls deprecated Bit.index and it is blocking its removal.