### PR TITLE
Support passing empty lists to Pauli delete method

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -370,6 +370,8 @@ class Pauli(BasePauli):
             )
         if len(qubits) == self.num_qubits:
             raise QiskitError("Cannot delete all qubits of Pauli")
+        if len(qubits) == 0:
+            return Pauli((self._z, self._x, self.phase))
         z = np.delete(self._z, qubits, axis=1)
         x = np.delete(self._x, qubits, axis=1)
         return Pauli((z, x, self.phase))

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -363,6 +363,8 @@ class Pauli(BasePauli):
         """
         if isinstance(qubits, (int, np.integer)):
             qubits = [qubits]
+        if len(qubits) == 0:
+            return Pauli((self._z, self._x, self.phase))
         if max(qubits) > self.num_qubits - 1:
             raise QiskitError(
                 "Qubit index is larger than the number of qubits "
@@ -370,8 +372,6 @@ class Pauli(BasePauli):
             )
         if len(qubits) == self.num_qubits:
             raise QiskitError("Cannot delete all qubits of Pauli")
-        if len(qubits) == 0:
-            return Pauli((self._z, self._x, self.phase))
         z = np.delete(self._z, qubits, axis=1)
         x = np.delete(self._x, qubits, axis=1)
         return Pauli((z, x, self.phase))

--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -376,7 +376,8 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         """
         if isinstance(ind, int):
             ind = [ind]
-
+        if len(ind) == 0:
+            return PauliList.from_symplectic(self._z, self._x, self.phase)
         # Row deletion
         if not qubit:
             if max(ind) >= len(self):

--- a/qiskit/quantum_info/operators/symplectic/pauli_table.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_table.py
@@ -281,7 +281,8 @@ class PauliTable(BaseOperator, AdjointMixin):
         """
         if isinstance(ind, (int, np.integer)):
             ind = [ind]
-
+        if len(ind) == 0:
+            return PauliTable(self._array)
         # Row deletion
         if not qubit:
             if max(ind) >= self.size:

--- a/releasenotes/notes/support-empty-delete-for-pauli-16c5c5fae890c16c.yaml
+++ b/releasenotes/notes/support-empty-delete-for-pauli-16c5c5fae890c16c.yaml
@@ -1,4 +1,5 @@
 ---
 fixes:
   - |
-    Passing empty list to delete method of Pauli, PauliList, and PauliTable returns a copy of the original object instead of throwing an error.
+    Passing an empty list to the methods :meth:`.Pauli.delete`, :meth:`.PauliList.delete`,
+    and :meth:`.PauliTable.delete` now returns a copy of the original object instead of throwing an error.

--- a/releasenotes/notes/support-empty-delete-for-pauli-16c5c5fae890c16c.yaml
+++ b/releasenotes/notes/support-empty-delete-for-pauli-16c5c5fae890c16c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Passing empty list to delete method of Pauli, PauliList, and PauliTable returns a copy of the original object instead of throwing an error.

--- a/test/python/quantum_info/operators/symplectic/test_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli.py
@@ -224,6 +224,8 @@ class TestPauliProperties(QiskitTestCase):
     def test_delete(self):
         """Test delete method"""
         pauli = Pauli("IXYZ")
+        pauli = pauli.delete([])
+        self.assertEqual(str(pauli), "IXYZ")
         pauli = pauli.delete([0, 2])
         self.assertEqual(str(pauli), "IY")
 

--- a/test/python/quantum_info/operators/symplectic/test_pauli_list.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli_list.py
@@ -1495,6 +1495,10 @@ class TestPauliListMethods(QiskitTestCase):
 
     def test_delete(self):
         """Test delete method."""
+        with self.subTest(msg="no rows"):
+            pauli = PauliList(["XX", "ZZ"])
+            self.assertEqual(pauli.delete([]), pauli)
+
         with self.subTest(msg="single row"):
             for j in range(1, 6):
                 pauli = PauliList([j * "X", j * "Y"])
@@ -1507,6 +1511,10 @@ class TestPauliListMethods(QiskitTestCase):
                 self.assertEqual(pauli.delete([0, 2]), PauliList("-i" + j * "Y"))
                 self.assertEqual(pauli.delete([1, 2]), PauliList(j * "X"))
                 self.assertEqual(pauli.delete([0, 1]), PauliList(j * "Z"))
+
+        with self.subTest(msg="no qubits"):
+            pauli = PauliList(["XX", "ZZ"])
+            self.assertEqual(pauli.delete([], qubit=True), pauli)
 
         with self.subTest(msg="single qubit"):
             pauli = PauliList(["IIX", "iIYI", "ZII"])

--- a/test/python/quantum_info/operators/symplectic/test_pauli_table.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli_table.py
@@ -1136,6 +1136,10 @@ class TestPauliTableMethods(QiskitTestCase):
 
     def test_delete(self):
         """Test delete method."""
+        with self.subTest(msg="no rows"):
+            pauli = PauliTable.from_labels(["XX", "YY"])
+            self.assertEqual(pauli.delete([]), pauli)
+
         with self.subTest(msg="single row"):
             for j in range(1, 6):
                 with self.assertWarns(DeprecationWarning):
@@ -1150,6 +1154,10 @@ class TestPauliTableMethods(QiskitTestCase):
                     self.assertEqual(pauli.delete([0, 2]), PauliTable(j * "Y"))
                     self.assertEqual(pauli.delete([1, 2]), PauliTable(j * "X"))
                     self.assertEqual(pauli.delete([0, 1]), PauliTable(j * "Z"))
+
+        with self.subTest(msg="no rows"):
+            pauli = PauliTable.from_labels(["XX", "YY"])
+            self.assertEqual(pauli.delete([], qubit=True), pauli)
 
         with self.subTest(msg="single qubit"):
             with self.assertWarns(DeprecationWarning):


### PR DESCRIPTION
Fixes #10839

### Summary
This PR addresses this [issue](https://github.com/Qiskit/qiskit/issues/10839) where the Pauli operator's delete method does not gracefully handle an empty list parameter.

### Details and comments
For the Pauli, PauliList, and PauliTable classes, performing a delete with an empty list argument will return a copy of the calling object.

Side note: I get unrelated errors with tox and tests sometimes, so I'm submitting this as a draft for now.

