### PR TITLE
Fix bug in qs_decomposition

### DIFF
--- a/qiskit/quantum_info/synthesis/qsd.py
+++ b/qiskit/quantum_info/synthesis/qsd.py
@@ -243,7 +243,11 @@ def _apply_a2(circ):
     for i, instruction in enumerate(ccirc.data):
         if instruction.operation.name == "qsd2q":
             ind2q.append(i)
-    if not ind2q:
+    if len(ind2q) == 0:
+        return ccirc
+    elif len(ind2q) == 1:
+        # No neighbors to merge diagonal into; revert name
+        ccirc.data[ind2q[0]].operation.name = "Unitary"
         return ccirc
     # rolling over diagonals
     ind2 = None  # lint

--- a/releasenotes/notes/10787-078d7caa70fc7de8.yaml
+++ b/releasenotes/notes/10787-078d7caa70fc7de8.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix the Quantum Shannon Decomposition implemented in :func:`.qs_decomposition`. When a unitary
+    could not take advantage of the diagonal commutation optimization, it used to error.
+    Now, it leaves it as undecomposed 2-qubit unitary gate.
+    Fixes `#10787 <https://github.com/Qiskit/qiskit/issues/10787>`__

--- a/test/python/quantum_info/test_synthesis.py
+++ b/test/python/quantum_info/test_synthesis.py
@@ -1548,6 +1548,105 @@ class TestQuantumShannonDecomposer(QiskitTestCase):
         elif nqubits == 2:
             self.assertLessEqual(ccirc.count_ops().get("cx", 0), 3)
 
+    def test_a2_opt_single_2q(self):
+        """
+        Test a2_opt when a unitary causes a single final 2-qubit unitary for which this optimization
+        won't help. This came up in issue 10787.
+        """
+        # this somewhat unique signed permutation matrix seems to cause the issue
+        mat = np.array(
+            [
+                [
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    1.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                ],
+                [
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    1.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                ],
+                [
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    -1.0 + 0.0j,
+                    0.0 + 0.0j,
+                ],
+                [
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    -1.0 + 0.0j,
+                ],
+                [
+                    1.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                ],
+                [
+                    0.0 + 0.0j,
+                    1.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                ],
+                [
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    -1.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                ],
+                [
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    -1.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                    0.0 + 0.0j,
+                ],
+            ]
+        )
+
+        gate = UnitaryGate(mat)
+        qc = QuantumCircuit(3)
+        qc.append(gate, range(3))
+        try:
+            qc.to_gate().control(1)
+        except UnboundLocalError as uerr:
+            self.fail(str(uerr))
+
 
 class TestTwoQubitDecomposeUpToDiagonal(QiskitTestCase):
     """test TwoQubitDecomposeUpToDiagonal class"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
fixes #10787


### Details and comments
The unitary described in this issue was causing a single 2q unitary to be generated in the quantum shannon decomposition, when opt_a2==True, which couldn't take advantage of this diagonal commutation optimization and would error. The fix instead leaves this as an undecomposed 2-qubit unitary gate.

