### PR TITLE
Fix deprecation warning of unscheduled circuits in timeline drawer

### DIFF
--- a/qiskit/transpiler/passes/scheduling/dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/dynamical_decoupling.py
@@ -53,6 +53,20 @@ class DynamicalDecoupling(TransformationPass):
         from qiskit.transpiler import PassManager, InstructionDurations
         from qiskit.transpiler.passes import ALAPSchedule, DynamicalDecoupling
         from qiskit.visualization import timeline_drawer
+
+        # Because the legacy passes do not propagate the scheduling information correctly, it is
+        # necessary to run a no-op "re-schedule" before the output circuits can be drawn.
+        def draw(circuit):
+            from qiskit import transpile
+
+            scheduled = transpile(
+                circuit,
+                optimization_level=0,
+                instruction_durations=InstructionDurations(),
+                scheduling_method="alap",
+            )
+            return timeline_drawer(scheduled)
+
         circ = QuantumCircuit(4)
         circ.h(0)
         circ.cx(0, 1)
@@ -69,7 +83,7 @@ class DynamicalDecoupling(TransformationPass):
         pm = PassManager([ALAPSchedule(durations),
                           DynamicalDecoupling(durations, dd_sequence)])
         circ_dd = pm.run(circ)
-        timeline_drawer(circ_dd)
+        draw(circ_dd)
 
         # Uhrig sequence on qubit 0
         n = 8
@@ -87,7 +101,7 @@ class DynamicalDecoupling(TransformationPass):
             ]
         )
         circ_dd = pm.run(circ)
-        timeline_drawer(circ_dd)
+        draw(circ_dd)
     """
 
     @deprecate_func(

--- a/qiskit/visualization/timeline/core.py
+++ b/qiskit/visualization/timeline/core.py
@@ -159,6 +159,7 @@ class DrawerCanvas:
                 "This circuit should be transpiled with scheduler though it consists of "
                 "instructions with explicit durations.",
                 DeprecationWarning,
+                stacklevel=3,
             )
 
             try:

--- a/releasenotes/notes/fix-timeline-draw-unscheduled-warning-873f7a24c6b51e2c.yaml
+++ b/releasenotes/notes/fix-timeline-draw-unscheduled-warning-873f7a24c6b51e2c.yaml
@@ -1,0 +1,22 @@
+---
+deprecations:
+  - |
+    Passing a circuit to :func:`qiskit.visualization.timeline_drawer` that does not have scheduled
+    node start-time information is deprecated.  Only circuits that have gone through one of the
+    scheduling analysis passes (for example :class:`.ALAPScheduleAnalysis` or
+    :class:`.ASAPScheduleAnalysis`) can be visualised.  If you have used one of the old-style
+    scheduling passes (for example :class:`.ALAPSchedule` or :class:`.ASAPSchedule`), you can
+    propagate the scheduling information by running::
+
+      from qiskit import transpile
+      from qiskit.transpiler import InstructionDurations
+
+      scheduled = transpile(
+        my_old_style_circuit,
+        optimization_level=0,
+        scheduling_method="alap",
+        instruction_durations=InstructionDurations(),
+      )
+
+    This behaviour was previously intended to be deprecated in Qiskit 0.37, but due to a bug in the
+    warning, it was not displayed to users until now.  The behaviour will be removed in Qiskit 1.0.


### PR DESCRIPTION
### Summary

The warning was previously emitted with a `stacklevel` that blamed the caller of `warnings.warn`, which would not be shown to users with the default warning filters.  This moves the stack level up to blame the caller of `timeline_drawer`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments


I updated some documentation still using the old paths here, but in looking at it, I'm not 100% sure that:
- the new `PadDynamicalDecoupling` also adds node start times to anything new it inserts in a way that the visualiser will understand
- we shouldn't just make the old-style schedulers save this information as well so the ugly `draw` wrapper in the (legacy) `DynamicalDecoupling` pass is unnecessary.

I'm not at all familiar with this code though, so I don't know what's best on it.