### PR TITLE
Constrain `python-subunit==1.4.2` in CI

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -11,3 +11,7 @@ numpy<1.25
 # eigensystem code for one of the test cases.  See
 # https://github.com/Qiskit/qiskit-terra/issues/10345 for current details.
 scipy<1.11
+
+# python-subunit 1.4.3 caused a problem with `stestr` failing to detect
+# the subcommands like `run` with the latest `stestr` 4.0.1.
+python-subunit==1.4.2


### PR DESCRIPTION
### Summary

The latest release (1.4.3) of `python-subunit` appears to have made `stestr` as of 4.0.1 fail to locate all its meaningful run commands in our CI.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


