### PR TITLE
Update FakeMelbourne to 15 qubits

### DIFF
--- a/qiskit/providers/fake_provider/backends/melbourne/fake_melbourne.py
+++ b/qiskit/providers/fake_provider/backends/melbourne/fake_melbourne.py
@@ -23,7 +23,7 @@ from qiskit.providers.fake_provider import fake_backend
 
 
 class FakeMelbourneV2(fake_backend.FakeBackendV2):
-    """A fake 14 qubit backend."""
+    """A fake 15 qubit backend."""
 
     dirname = os.path.dirname(__file__)
     conf_filename = "conf_melbourne.json"
@@ -32,16 +32,16 @@ class FakeMelbourneV2(fake_backend.FakeBackendV2):
 
 
 class FakeMelbourne(FakeBackend):
-    """A fake 14 qubit backend."""
+    """A fake 15 qubit backend."""
 
     def __init__(self):
         """
 
         .. code-block:: text
 
-            0 ← 1 →  2 →  3 ←  4 ← 5 → 6
-                ↑    ↑    ↑    ↓   ↓   ↓
-               13 → 12 ← 11 → 10 ← 9 → 8 ← 7
+             0  ← 1 →  2 →  3 ←  4 ← 5 → 6
+             ↑    ↑    ↑    ↑    ↓   ↓   ↓
+            14 → 13 → 12 ← 11 → 10 ← 9 → 8 ← 7
         """
         cmap = [
             [1, 0],
@@ -62,12 +62,14 @@ class FakeMelbourne(FakeBackend):
             [12, 2],
             [13, 1],
             [13, 12],
+            [0, 14],
+            [14, 13],
         ]
 
         configuration = QasmBackendConfiguration(
             backend_name="fake_melbourne",
             backend_version="0.0.0",
-            n_qubits=14,
+            n_qubits=15,
             basis_gates=["u1", "u2", "u3", "cx", "id"],
             simulator=False,
             local=True,


### PR DESCRIPTION
### Summary

Fixes #7677 

### Details and comments

`FakeMelbourne` has an inconsistency between its properties and its configuration. While reporting 14 qubits, the calibration data is for 15 qubits.As the 15-qubit configuration seems to be the one that the saved calibration data (fetch on March 12th, 2021) reported, this PR extends the coupling map to cover this case. Based on the asymmetry in the `cx` gates, I deduced the gate direction.