### PR TITLE
human-readable low-weight Paulis

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -765,9 +765,9 @@ class Pauli(BasePauli):
         z_qubits = np.array(z_qubits)
 
         # Convert allowed negative indices to positive, then check for duplicates:
-        x_qubits[-num_qubits <= x_qubits < 0] %= num_qubits
-        y_qubits[-num_qubits <= y_qubits < 0] %= num_qubits
-        z_qubits[-num_qubits <= z_qubits < 0] %= num_qubits
+        x_qubits[np.logical_and(-num_qubits <= x_qubits, x_qubits < 0)] %= num_qubits
+        y_qubits[np.logical_and(-num_qubits <= y_qubits, y_qubits < 0)] %= num_qubits
+        z_qubits[np.logical_and(-num_qubits <= z_qubits, z_qubits < 0)] %= num_qubits
         
         num_x = len(x_qubits)
         num_y = len(y_qubits)

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -466,6 +466,28 @@ class Pauli(BasePauli):
         circuit.append(gate, range(self.num_qubits))
         return circuit.to_instruction()
 
+    def to_xyz_qubits(self):
+        """
+        Output `xyz` can be used as `Pauli.from_xyz_qubits(*xyz)`.
+
+        Returns:
+            x_qubits (array of ints)
+            y_qubits (array of ints)
+            z_qubits (array of ints)
+            phase (int)
+            num_qubits (int)
+        """
+
+        y_array = np.logical_and(self.x, self.z)
+
+        x_qubits = np.where(np.logical_xor(self.x, y_array))[0]
+        y_qubits = np.where(y_array)[0]
+        z_qubits = np.where(np.logical_xor(self.z, y_array))[0]
+        phase = self.phase
+        num_qubits = len(self.x)
+
+        return x_qubits, y_qubits, z_qubits, num_qubits, phase
+
     # ---------------------------------------------------------------------
     # BaseOperator methods
     # ---------------------------------------------------------------------
@@ -720,6 +742,35 @@ class Pauli(BasePauli):
                     qargs = [instr.find_bit(tup).index for tup in inner.qubits]
                     ret = ret.compose(next_instr, qargs=qargs)
         return ret._z, ret._x, ret._phase
+
+    @classmethod
+    def from_xyz_qubits(cls, x_qubits, y_qubits, z_qubits, num_qubits, phase=0):
+        """Concise way of defining a low-weight (mostly 'I') Pauli.
+        Args:
+            x_qubits (iterable of ints)
+            y_qubits (iterable of ints)
+            z_qubits (iterable of ints)
+            num_qubits (int)
+            phase (int)
+
+        Returns:
+            Pauli
+        """
+        num_x = len(x_qubits)
+        num_y = len(y_qubits)
+        num_z = len(z_qubits)
+        if num_x + num_y + num_z > len(set(x_qubits) | set(y_qubits) | set(z_qubits)):
+            raise ValueError("Sparse qubit lists must not contain duplicates.")
+
+        x_array = np.zeros(num_qubits)
+        x_array[list(x_qubits)] += 1
+        x_array[list(y_qubits)] += 1
+
+        z_array = np.zeros(num_qubits)
+        z_array[list(z_qubits)] += 1
+        z_array[list(y_qubits)] += 1
+
+        return cls((z_array, x_array, phase))
 
 
 # Update docstrings for API docs

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -759,7 +759,7 @@ class Pauli(BasePauli):
         Raises:
             ValueError: if any qubit is specified more than once.
         """
-        
+
         x_qubits = np.array(x_qubits)
         y_qubits = np.array(y_qubits)
         z_qubits = np.array(z_qubits)
@@ -768,7 +768,7 @@ class Pauli(BasePauli):
         x_qubits[np.logical_and(-num_qubits <= x_qubits, x_qubits < 0)] %= num_qubits
         y_qubits[np.logical_and(-num_qubits <= y_qubits, y_qubits < 0)] %= num_qubits
         z_qubits[np.logical_and(-num_qubits <= z_qubits, z_qubits < 0)] %= num_qubits
-        
+
         num_x = len(x_qubits)
         num_y = len(y_qubits)
         num_z = len(z_qubits)

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -480,9 +480,9 @@ class Pauli(BasePauli):
 
         y_array = np.logical_and(self.x, self.z)
 
-        x_qubits = np.where(np.logical_xor(self.x, y_array))[0]
-        y_qubits = np.where(y_array)[0]
-        z_qubits = np.where(np.logical_xor(self.z, y_array))[0]
+        x_qubits = tuple(np.where(np.logical_xor(self.x, y_array))[0])
+        y_qubits = tuple(np.where(y_array)[0])
+        z_qubits = tuple(np.where(np.logical_xor(self.z, y_array))[0])
         phase = self.phase
         num_qubits = len(self.x)
 

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -755,8 +755,11 @@ class Pauli(BasePauli):
 
         Returns:
             Pauli
-        """
 
+        Raises:
+            ValueError: if any qubit is specified more than once.
+        """
+        
         x_qubits = np.array(x_qubits)
         y_qubits = np.array(y_qubits)
         z_qubits = np.array(z_qubits)

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -756,6 +756,16 @@ class Pauli(BasePauli):
         Returns:
             Pauli
         """
+
+        x_qubits = np.array(x_qubits)
+        y_qubits = np.array(y_qubits)
+        z_qubits = np.array(z_qubits)
+
+        # Convert allowed negative indices to positive, then check for duplicates:
+        x_qubits[-num_qubits <= x_qubits < 0] %= num_qubits
+        y_qubits[-num_qubits <= y_qubits < 0] %= num_qubits
+        z_qubits[-num_qubits <= z_qubits < 0] %= num_qubits
+        
         num_x = len(x_qubits)
         num_y = len(y_qubits)
         num_z = len(z_qubits)


### PR DESCRIPTION
Opening this PR for discussion following #9933. This PR proposes some convenience functions for working with a human-readable representation of low-weight Paulis.

It's increasingly common to work with low-weight Paulis. Examples include sparse noise models for error mitigation containing all weight-1 and weight-2 Paulis on a device, or observables obtained by measuring a small subset of qubits.

For large devices, existing string representations of low-weight Paulis (labels) are no longer human readable (`IIIIIIIIIII...`), and inconvenient to construct.

It would be nice to have a standard human readable representation. This would have to include:
- the non-identity (XYZ) Paulis
- the qubits on which those Paulis act
- the length of the Pauli (total number of qubits)
- an optional Pauli phase

There are two natural choices:
1. (string of non-identity paulis, qubits, num_qubits, phase)
2. (x_qubits, y_qubits, z_qubits, num_qubits, phase)

I'm leaning towards the latter, which is less obvious but has some advantages:
- Readability: For Pauli weight `W`, the length of the human-readable representation grows as `W` instead of `2W`.
- Simplicity: No string parsing (avoids endianness ambiguity that IMO is problematic in [SparsePauliOp.from_sparse_list()](https://qiskit.org/documentation/stubs/qiskit.quantum_info.SparsePauliOp.html))

Plot headers in [this figure](https://www.nature.com/articles/s41586-023-06096-3/figures/3) are examples of using a similar format to briefly indicate a measured observable.

If we would like to work with this representation, it would be helpful to have Pauli methods converting to/from it. 

Currently, this PR adds Pauli methods `from_xyz_qubits()` and `to_xyz_qubits()`. The names are a little clunky but tell the user how to read the output/input (avoids confusion with alternative ordering z,x,y that is sometimes used).

I was not sure how to relate this to the other symplectic classes (`BasePauli`, `PauliList`, `SparsePauliOp`), so just added this to `Pauli` to start. 

Happy to work on tests/release note if there is support for moving forward.
