### PR TITLE
Fix error in plot_state_city that negative value in real is not displayed

### DIFF
--- a/qiskit/visualization/state_visualization.py
+++ b/qiskit/visualization/state_visualization.py
@@ -516,9 +516,6 @@ def plot_state_city(
     min_dzi = np.min(dzi)
     max_dzi = np.max(dzi)
 
-    # There seems to be a rounding error in which some zero bars are negative
-    dzr = np.clip(dzr, 0, None)
-
     if ax1 is not None:
         fc1 = generate_facecolors(xpos, ypos, zpos, dx, dy, dzr, color[0])
         for idx, cur_zpos in enumerate(zpos):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix an error that the negative value is not displayed when a state with a real negative value is used as input for the `plot_state_city` method.

### Details and comments

A simple example that shows the original problem:

```
from qiskit import QuantumCircuit, transpile
from qiskit.tools.jupyter import *
from qiskit.visualization import *
from ibm_quantum_widgets import *
from qiskit_ibm_runtime import QiskitRuntimeService, Sampler, Estimator, Session, Options
from qiskit.quantum_info import DensityMatrix

service = QiskitRuntimeService(channel="ibm_quantum")

circ = QuantumCircuit(2)

circ.x(0)
circ.h(0)
circ.cx(0, 1)

dm = DensityMatrix.from_instruction(circ)

plot_state_city(dm, title='Density Matrix')
```

<img width="154" alt="dm" src="https://github.com/Qiskit/qiskit/assets/49875430/e23d3ce4-c98a-4e44-99f8-302bad31bcf0">

![dm_issue](https://github.com/Qiskit/qiskit/assets/49875430/0b9c7c78-3961-44a8-af90-ec1725781b71)

After fixing `plot_state_city` method:

![dm_fix](https://github.com/Qiskit/qiskit/assets/49875430/bf2f03ba-e16e-4048-b7b7-d89123e543fa)


