### PR TITLE
adding an option to CouplingMap.reduce to allow disconnected coupling maps

### DIFF
--- a/qiskit/transpiler/coupling.py
+++ b/qiskit/transpiler/coupling.py
@@ -22,7 +22,6 @@ onto a device with this coupling.
 import math
 from typing import List
 
-import numpy as np
 import rustworkx as rx
 from rustworkx.visualization import graphviz_draw
 
@@ -252,14 +251,16 @@ class CouplingMap:
         """
         return self.graph.is_symmetric()
 
-    def reduce(self, mapping):
+    def reduce(self, mapping, check_if_connected=True):
         """Returns a reduced coupling map that
         corresponds to the subgraph of qubits
         selected in the mapping.
 
         Args:
             mapping (list): A mapping of reduced qubits to device
-                            qubits.
+                qubits.
+            check_if_connected (bool): if True, checks that the reduced
+                coupling map is connected.
 
         Returns:
             CouplingMap: A reduced coupling_map for the selected qubits.
@@ -268,9 +269,6 @@ class CouplingMap:
             CouplingError: Reduced coupling map must be connected.
         """
 
-        from scipy.sparse import coo_matrix, csgraph
-
-        reduced_qubits = len(mapping)
         inv_map = [None] * (max(mapping) + 1)
         for idx, val in enumerate(mapping):
             inv_map[val] = idx
@@ -281,17 +279,17 @@ class CouplingMap:
             if edge[0] in mapping and edge[1] in mapping:
                 reduced_cmap.append([inv_map[edge[0]], inv_map[edge[1]]])
 
-        # Verify coupling_map is connected
-        rows = np.array([edge[0] for edge in reduced_cmap], dtype=int)
-        cols = np.array([edge[1] for edge in reduced_cmap], dtype=int)
-        data = np.ones_like(rows)
+        # Note: using reduced_coupling_map.graph is significantly faster
+        # than calling add_physical_qubit / add_edge.
+        reduced_coupling_map = CouplingMap()
+        for node in range(len(mapping)):
+            reduced_coupling_map.graph.add_node(node)
+        reduced_coupling_map.graph.extend_from_edge_list([tuple(x) for x in reduced_cmap])
 
-        mat = coo_matrix((data, (rows, cols)), shape=(reduced_qubits, reduced_qubits)).tocsr()
-
-        if csgraph.connected_components(mat)[0] != 1:
+        if check_if_connected and not reduced_coupling_map.is_connected():
             raise CouplingError("coupling_map must be connected.")
 
-        return CouplingMap(reduced_cmap)
+        return reduced_coupling_map
 
     @classmethod
     def from_full(cls, num_qubits, bidirectional=True) -> "CouplingMap":

--- a/releasenotes/notes/extend-coupling-map-reduce-bb19e35ec939570d.yaml
+++ b/releasenotes/notes/extend-coupling-map-reduce-bb19e35ec939570d.yaml
@@ -4,6 +4,6 @@ features:
     The method :meth:`~qiskit.transpiler.CouplingMap.reduce` now accepts an
     additional argument ``check_if_connected``, defaulted to ``True``. This
     corresponds to the previous behavior, checking whether the reduced coupling
-    map remains connected and raising a ``CouplingError`` if so. When set to
+    map remains connected and raising a ``CouplingError`` if not so. When set to
     ``False``, the check is skipped, allowing disconnected reduced coupling maps.
 

--- a/releasenotes/notes/extend-coupling-map-reduce-bb19e35ec939570d.yaml
+++ b/releasenotes/notes/extend-coupling-map-reduce-bb19e35ec939570d.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    The method :meth:`~qiskit.transpiler.CouplingMap.reduce` now accepts an
+    additional argument ``check_if_connected``, defaulted to ``True``. This
+    corresponds to the previous behavior, checking whether the reduced coupling
+    map remains connected and raising a ``CouplingError`` if so. When set to
+    ``False``, the check is skipped, allowing disconnected reduced coupling maps.
+

--- a/test/python/transpiler/test_coupling.py
+++ b/test/python/transpiler/test_coupling.py
@@ -111,13 +111,25 @@ class CouplingTest(QiskitTestCase):
         ans = [(1, 2), (3, 2), (0, 1)]
         self.assertEqual(set(out), set(ans))
 
-    def test_failed_reduced_map(self):
-        """Generate a bad disconnected reduced map"""
+    def test_bad_reduced_map(self):
+        """Generate disconnected reduced map"""
         fake = FakeRueschlikon()
         cmap = fake.configuration().coupling_map
         coupling_map = CouplingMap(cmap)
         with self.assertRaises(CouplingError):
             coupling_map.reduce([12, 11, 10, 3])
+
+    def test_disconnected_reduced_map_allowed(self):
+        """Generate disconnected reduced map but do not error"""
+        fake = FakeRueschlikon()
+        cmap = fake.configuration().coupling_map
+        coupling_map = CouplingMap(cmap)
+        reduced_map = coupling_map.reduce([12, 11, 10, 3], check_if_connected=False)
+        reduced_edges = reduced_map.get_edges()
+        qubits_expected = [0, 1, 2, 3]
+        edges_expected = [(0, 1), (1, 2)]
+        self.assertEqual(qubits_expected, reduced_map.physical_qubits)
+        self.assertEqual(set(reduced_edges), set(edges_expected))
 
     def test_symmetric_small_true(self):
         coupling_list = [[0, 1], [1, 0]]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This PR adds an option ``check_if_connected`` to ``CouplingMap.reduce``, defaulted to ``True``. This corresponds to the previous behavior, checking whether the reduced coupling map remains connected and raising a ``CouplingError`` if not so. When set to ``False``, the check is skipped, allowing disconnected reduced coupling maps. This is useful for synthesis plugins (in particular for #10657) where no connectivity assumptions are necessary (for example, we may want to collect and to resynthesize blocks of consecutive swap gates). 


### Details and comments

This blocks #10657.

The check whether the reduced coupling map is (weakly) connected is now performed only when the option ``check_if_connected`` is set to ``True``.

The actual check now uses the `CouplingMap`'s method `is_connected` instead of scipy. There was no noticeable change in performance.

One additional minor point is that the reduced coupling map should have the correct number of vertices and either `coupling_map.add_physical_qubit` or `coupling_map.graph.add_node` should be used. Previously nodes with no edges would not have been added.