### PR TITLE
Use singleton `SwapGate` in Sabre reconstruction

### DIFF
--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -347,6 +347,10 @@ def _apply_sabre_result(
             :class:`.DAGCircuit` that represents the same thing.
     """
 
+    # The swap gate is a singleton instance, so we don't need to waste time reconstructing it each
+    # time we need to use it.
+    swap_singleton = SwapGate()
+
     def empty_dag(block):
         empty = DAGCircuit()
         empty.add_qubits(out_dag.qubits)
@@ -362,7 +366,7 @@ def _apply_sabre_result(
         for a, b in swaps:
             qubits = (physical_qubits[a], physical_qubits[b])
             layout.swap_physical(a, b)
-            dest_dag.apply_operation_back(SwapGate(), qubits, (), check=False)
+            dest_dag.apply_operation_back(swap_singleton, qubits, (), check=False)
 
     def recurse(dest_dag, source_dag, result, root_logical_map, layout):
         """The main recursive worker.  Mutates ``dest_dag`` and ``layout`` and returns them.


### PR DESCRIPTION
### Summary

Since `SwapGate` is now a singleton instance in most cases, we can directly reuse the same instance during Sabre reconstruction rather than wasting cycles re-retrieving the singleton instance.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

See #10314 for the root of this.
