### PR TITLE
Fix pickle handling for SingletonGate class

### DIFF
--- a/qiskit/circuit/singleton_gate.py
+++ b/qiskit/circuit/singleton_gate.py
@@ -80,6 +80,25 @@ class SingletonGate(Gate):
         super().__init__(*args, **kwargs)
         self._condition = _condition
 
+    def __setstate__(self, state):
+        if state is not None:
+            self.label = state[0]
+            self._condition = state[1]
+            self.duration = state[2]
+            self.unit = state[3]
+
+    def __reduce__(self):
+        if not self.mutable:
+            return (self.__class__, (), None)
+        # Argument list is set twice to force instantiation via __setstate__
+        # the first arg list is only passed to __new__ to create a mutable
+        # object
+        return (
+            self.__class__,
+            (self.label, self._condition, self.duration, self.unit),
+            (self.label, self._condition, self.duration, self.unit),
+        )
+
     def c_if(self, classical, val):
         if not isinstance(classical, (ClassicalRegister, Clbit)):
             raise CircuitError("c_if must be used with a classical register or classical bit")

--- a/qiskit/circuit/singleton_gate.py
+++ b/qiskit/circuit/singleton_gate.py
@@ -80,24 +80,10 @@ class SingletonGate(Gate):
         super().__init__(*args, **kwargs)
         self._condition = _condition
 
-    def __setstate__(self, state):
-        if state is not None:
-            self.label = state[0]
-            self._condition = state[1]
-            self.duration = state[2]
-            self.unit = state[3]
-
-    def __reduce__(self):
+    def __getnewargs_ex__(self):
         if not self.mutable:
-            return (self.__class__, (), None)
-        # Argument list is set twice to force instantiation via __setstate__
-        # the first arg list is only passed to __new__ to create a mutable
-        # object
-        return (
-            self.__class__,
-            (self.label, self._condition, self.duration, self.unit),
-            (self.label, self._condition, self.duration, self.unit),
-        )
+            return ((), {})
+        return ((self.label, self._condition, self.duration, self.unit), {})
 
     def c_if(self, classical, val):
         if not isinstance(classical, (ClassicalRegister, Clbit)):

--- a/test/python/circuit/test_singleton_gate.py
+++ b/test/python/circuit/test_singleton_gate.py
@@ -262,6 +262,7 @@ class TestSingletonGate(QiskitTestCase):
             fd.seek(0)
             copied = pickle.load(fd)
         self.assertFalse(copied.mutable)
+        self.assertIs(copied, gate)
 
     def test_mutable_pickle(self):
         gate = SXGate()

--- a/test/python/circuit/test_singleton_gate.py
+++ b/test/python/circuit/test_singleton_gate.py
@@ -18,6 +18,8 @@ Tests for singleton gate behavior
 """
 
 import copy
+import io
+import pickle
 
 from qiskit.circuit.library import HGate, SXGate
 from qiskit.circuit import Clbit, QuantumCircuit, QuantumRegister, ClassicalRegister
@@ -251,3 +253,26 @@ class TestSingletonGate(QiskitTestCase):
         label_gate = SXGate("I am a little label")
         self.assertIsNot(gate, label_gate)
         self.assertEqual(label_gate.label, "I am a little label")
+
+    def test_immutable_pickle(self):
+        gate = SXGate()
+        self.assertFalse(gate.mutable)
+        with io.BytesIO() as fd:
+            pickle.dump(gate, fd)
+            fd.seek(0)
+            copied = pickle.load(fd)
+        self.assertFalse(copied.mutable)
+
+    def test_mutable_pickle(self):
+        gate = SXGate()
+        clbit = Clbit()
+        condition_gate = gate.c_if(clbit, 0)
+        self.assertIsNot(gate, condition_gate)
+        self.assertEqual(condition_gate.condition, (clbit, 0))
+        self.assertTrue(condition_gate.mutable)
+        with io.BytesIO() as fd:
+            pickle.dump(condition_gate, fd)
+            fd.seek(0)
+            copied = pickle.load(fd)
+        self.assertEqual(copied, condition_gate)
+        self.assertTrue(copied.mutable)

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -2174,6 +2174,20 @@ class TestTranspileParallel(QiskitTestCase):
             self.assertEqual(added_cal, ref_cal)
 
     @data(0, 1, 2, 3)
+    def test_parallel_singleton_conditional_gate(self, opt_level):
+        """Test that singleton mutable instance doesn't lose state in parallel."""
+        backend = FakeNairobiV2()
+        circ = QuantumCircuit(2, 1)
+        circ.h(0)
+        circ.measure(0, circ.clbits[0])
+        circ.z(1).c_if(circ.clbits[0], 1)
+        res = transpile(
+            [circ, circ], backend, optimization_level=opt_level, seed_transpiler=123456769
+        )
+        self.assertTrue(res[0].data[-1].operation.mutable)
+        self.assertEqual(res[0].data[-1].operation.condition, (res[0].clbits[0], 1))
+
+    @data(0, 1, 2, 3)
     def test_backendv2_and_basis_gates(self, opt_level):
         """Test transpile() with BackendV2 and basis_gates set."""
         backend = FakeNairobiV2()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an oversight in #10314 where the handling of pickle wasn't done correctly. Because the SingletonGate class defines __new__ and based on the parameters to the gate.__class__() call determines whether we get a new mutable copy or a shared singleton immutable instance we need special handling in pickle. By default pickle will call __new__() without any arguments and then rely on __setstate__ to update the state in the new object. This works fine if the original instance was a singleton but in the case of mutable copies this will create a singleton object instead of a mutable copy. To fix this a __reduce__ method is added to ensure arguments get passed to __new__ forcing a mutable object to be created in deserialization. Then a __setstate__ method is defined to correctly update the mutable object post creation.

### Details and comments


