### PR TITLE
Remove spurious `SXGate._ARRAY`

### DIFF
--- a/qiskit/circuit/library/standard_gates/sx.py
+++ b/qiskit/circuit/library/standard_gates/sx.py
@@ -146,10 +146,6 @@ class SXdgGate(SingletonGate):
                     = e^{-i pi/4} \sqrt{X}^{\dagger}
 
     """
-    _ARRAY = numpy.array(
-        [[0.5 - 0.5j, 0.5 + 0.5j], [0.5 + 0.5j, 0.5 - 0.5j]], dtype=numpy.complex128
-    )
-    _ARRAY.setflags(write=False)
 
     def __init__(self, label: Optional[str] = None, duration=None, unit=None, _condition=None):
         """Create new SXdg gate."""

--- a/qiskit/circuit/library/standard_gates/sx.py
+++ b/qiskit/circuit/library/standard_gates/sx.py
@@ -14,7 +14,6 @@
 
 from math import pi
 from typing import Optional, Union
-import numpy
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.singleton_gate import SingletonGate
 from qiskit.circuit.quantumregister import QuantumRegister


### PR DESCRIPTION
### Summary

This was left in only as a mistake during the writing of #10296; originally the `with_gate_array` decorator didn't exist and all classes had manual `_ARRAY` specifiers, but `SXGate`'s got left in accidentally when all the rest were removed in favour of the decorator.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->



### Details and comments


