### PR TITLE
formating issues in schmidt_decomposition and diamond_norm

### DIFF
--- a/qiskit/quantum_info/operators/measures.py
+++ b/qiskit/quantum_info/operators/measures.py
@@ -263,8 +263,7 @@ def diamond_norm(choi: Choi | QuantumChannel, **kwargs) -> float:
         kwargs: optional arguments to pass to CVXPY solver.
 
     Returns:
-        float: The completely-bounded trace norm
-               :math:`\|\mathcal{E}\|_{\diamond}`.
+        float: The completely-bounded trace norm :math:`\|\mathcal{E}\|_{\diamond}`.
 
     Raises:
         QiskitError: if CVXPY package cannot be found.

--- a/qiskit/quantum_info/states/utils.py
+++ b/qiskit/quantum_info/states/utils.py
@@ -140,13 +140,13 @@ def schmidt_decomposition(state, qargs):
     orthonormal set of vectors in their respective spaces :math:`A` and :math:`B`,
     and the Schmidt coefficients :math:`\lambda_k` are positive real values.
 
-    ..note ::
-        In Qiskit, qubits are ordered using little endian notation, with the least significant
+    .. note::
+        In Qiskit, qubits are ordered using little-endian notation, with the least significant
         qubits having smaller indices. For example, a four-qubit system is represented as
-        :math:`|q_3q_2q_1q_0\rangle`. Using this convention, setting `qargs = [0]` will partition the
+        :math:`|q_3q_2q_1q_0\rangle`. Using this convention, setting ``qargs=[0]`` will partition the
         state as :math:`|q_3q_2q_1\rangle_A\otimes|q_0\rangle_B`. Furthermore, qubits will be organized
         in this notation regardless of the order they are passed. For instance, passing either
-        `qargs = [1,2]` or `qargs = [2,1]` will result in partitioning the state as
+        ``qargs=[1,2]`` or ``qargs=[2,1]`` will result in partitioning the state as
         :math:`|q_3q_0\rangle_A\otimes|q_2q_1\rangle_B`.
 
     Args:
@@ -155,8 +155,8 @@ def schmidt_decomposition(state, qargs):
 
     Returns:
         list: list of tuples ``(s, u, v)``, where ``s`` (float) are the Schmidt coefficients
-         :math:`\lambda_k`, and ``u`` (Statevector), ``v`` (Statevector) are the Schmidt vectors
-         :math:`|u_k\rangle_A`, :math:`|u_k\rangle_B`, respectively.
+        :math:`\lambda_k`, and ``u`` (Statevector), ``v`` (Statevector) are the Schmidt vectors
+        :math:`|u_k\rangle_A`, :math:`|u_k\rangle_B`, respectively.
 
     Raises:
         QiskitError: if Input qargs is not a list of positions of the Input state.

--- a/qiskit/quantum_info/states/utils.py
+++ b/qiskit/quantum_info/states/utils.py
@@ -140,20 +140,6 @@ def schmidt_decomposition(state, qargs):
     orthonormal set of vectors in their respective spaces :math:`A` and :math:`B`,
     and the Schmidt coefficients :math:`\lambda_k` are positive real values.
 
-    Args:
-        state (Statevector or DensityMatrix): the input state.
-        qargs (list): the list of Input state positions corresponding to subsystem :math:`B`.
-
-    Returns:
-        list: list of tuples ``(s, u, v)``, where ``s`` (float) are the
-              Schmidt coefficients :math:`\lambda_k`, and ``u`` (Statevector),
-              ``v`` (Statevector) are the Schmidt vectors
-              :math:`|u_k\rangle_A`, :math:`|u_k\rangle_B`, respectively.
-
-    Raises:
-        QiskitError: if Input qargs is not a list of positions of the Input state.
-        QiskitError: if Input qargs is not a proper subset of Input state.
-
     ..note ::
         In Qiskit, qubits are ordered using little endian notation, with the least significant
         qubits having smaller indices. For example, a four-qubit system is represented as
@@ -162,6 +148,19 @@ def schmidt_decomposition(state, qargs):
         in this notation regardless of the order they are passed. For instance, passing either
         `qargs = [1,2]` or `qargs = [2,1]` will result in partitioning the state as
         :math:`|q_3q_0\rangle_A\otimes|q_2q_1\rangle_B`.
+
+    Args:
+        state (Statevector or DensityMatrix): the input state.
+        qargs (list): the list of Input state positions corresponding to subsystem :math:`B`.
+
+    Returns:
+        list: list of tuples ``(s, u, v)``, where ``s`` (float) are the Schmidt coefficients
+         :math:`\lambda_k`, and ``u`` (Statevector), ``v`` (Statevector) are the Schmidt vectors
+         :math:`|u_k\rangle_A`, :math:`|u_k\rangle_B`, respectively.
+
+    Raises:
+        QiskitError: if Input qargs is not a list of positions of the Input state.
+        QiskitError: if Input qargs is not a proper subset of Input state.
     """
     state = _format_state(state, validate=False)
 

--- a/qiskit/quantum_info/states/utils.py
+++ b/qiskit/quantum_info/states/utils.py
@@ -140,15 +140,6 @@ def schmidt_decomposition(state, qargs):
     orthonormal set of vectors in their respective spaces :math:`A` and :math:`B`,
     and the Schmidt coefficients :math:`\lambda_k` are positive real values.
 
-    .. note::
-        In Qiskit, qubits are ordered using little-endian notation, with the least significant
-        qubits having smaller indices. For example, a four-qubit system is represented as
-        :math:`|q_3q_2q_1q_0\rangle`. Using this convention, setting ``qargs=[0]`` will partition the
-        state as :math:`|q_3q_2q_1\rangle_A\otimes|q_0\rangle_B`. Furthermore, qubits will be organized
-        in this notation regardless of the order they are passed. For instance, passing either
-        ``qargs=[1,2]`` or ``qargs=[2,1]`` will result in partitioning the state as
-        :math:`|q_3q_0\rangle_A\otimes|q_2q_1\rangle_B`.
-
     Args:
         state (Statevector or DensityMatrix): the input state.
         qargs (list): the list of Input state positions corresponding to subsystem :math:`B`.
@@ -161,6 +152,15 @@ def schmidt_decomposition(state, qargs):
     Raises:
         QiskitError: if Input qargs is not a list of positions of the Input state.
         QiskitError: if Input qargs is not a proper subset of Input state.
+
+    .. note::
+        In Qiskit, qubits are ordered using little-endian notation, with the least significant
+        qubits having smaller indices. For example, a four-qubit system is represented as
+        :math:`|q_3q_2q_1q_0\rangle`. Using this convention, setting ``qargs=[0]`` will partition the
+        state as :math:`|q_3q_2q_1\rangle_A\otimes|q_0\rangle_B`. Furthermore, qubits will be organized
+        in this notation regardless of the order they are passed. For instance, passing either
+        ``qargs=[1,2]`` or ``qargs=[2,1]`` will result in partitioning the state as
+        :math:`|q_3q_0\rangle_A\otimes|q_2q_1\rangle_B`.
     """
     state = _format_state(state, validate=False)
 


### PR DESCRIPTION
### Summary

There are some doc formatting issues in `schmidt_decomposition` and `diamond_norm`


https://qiskit.org/documentation/apidoc/quantum_info.html#qiskit.quantum_info.diamond_norm
![](https://github.com/Qiskit/qiskit/assets/766693/fa23546c-70fc-4ace-816d-5841aa855a43)


https://qiskit.org/documentation/apidoc/quantum_info.html#qiskit.quantum_info.schmidt_decomposition
![](https://github.com/Qiskit/qiskit/assets/766693/9796027e-4993-43fc-beb0-498588ae861d)
