### PR TITLE
Remove use of dtype aliases to be removed in Numpy 2

### DIFF
--- a/qiskit/pulse/library/continuous.py
+++ b/qiskit/pulse/library/continuous.py
@@ -28,7 +28,7 @@ def constant(times: np.ndarray, amp: complex) -> np.ndarray:
         times: Times to output pulse for.
         amp: Complex pulse amplitude.
     """
-    return np.full(len(times), amp, dtype=np.complex_)
+    return np.full(len(times), amp, dtype=np.complex128)
 
 
 def zero(times: np.ndarray) -> np.ndarray:
@@ -50,7 +50,7 @@ def square(times: np.ndarray, amp: complex, freq: float, phase: float = 0) -> np
         phase: Pulse phase.
     """
     x = times * freq + phase / np.pi
-    return amp * (2 * (2 * np.floor(x) - np.floor(2 * x)) + 1).astype(np.complex_)
+    return amp * (2 * (2 * np.floor(x) - np.floor(2 * x)) + 1).astype(np.complex128)
 
 
 def sawtooth(times: np.ndarray, amp: complex, freq: float, phase: float = 0) -> np.ndarray:
@@ -63,7 +63,7 @@ def sawtooth(times: np.ndarray, amp: complex, freq: float, phase: float = 0) -> 
         phase: Pulse phase.
     """
     x = times * freq + phase / np.pi
-    return amp * 2 * (x - np.floor(1 / 2 + x)).astype(np.complex_)
+    return amp * 2 * (x - np.floor(1 / 2 + x)).astype(np.complex128)
 
 
 def triangle(times: np.ndarray, amp: complex, freq: float, phase: float = 0) -> np.ndarray:
@@ -76,7 +76,7 @@ def triangle(times: np.ndarray, amp: complex, freq: float, phase: float = 0) -> 
         phase: Pulse phase.
     """
     return amp * (-2 * np.abs(sawtooth(times, 1, freq, phase=(phase - np.pi / 2) / 2)) + 1).astype(
-        np.complex_
+        np.complex128
     )
 
 
@@ -89,7 +89,7 @@ def cos(times: np.ndarray, amp: complex, freq: float, phase: float = 0) -> np.nd
         freq: Pulse frequency, units of 1/dt.
         phase: Pulse phase.
     """
-    return amp * np.cos(2 * np.pi * freq * times + phase).astype(np.complex_)
+    return amp * np.cos(2 * np.pi * freq * times + phase).astype(np.complex128)
 
 
 def sin(times: np.ndarray, amp: complex, freq: float, phase: float = 0) -> np.ndarray:
@@ -101,7 +101,7 @@ def sin(times: np.ndarray, amp: complex, freq: float, phase: float = 0) -> np.nd
         freq: Pulse frequency, units of 1/dt.
         phase: Pulse phase.
     """
-    return amp * np.sin(2 * np.pi * freq * times + phase).astype(np.complex_)
+    return amp * np.sin(2 * np.pi * freq * times + phase).astype(np.complex128)
 
 
 def _fix_gaussian_width(
@@ -171,9 +171,9 @@ def gaussian(
         ret_x: Return centered and standard deviation normalized pulse location.
                $x=(times-center)/sigma.
     """
-    times = np.asarray(times, dtype=np.complex_)
+    times = np.asarray(times, dtype=np.complex128)
     x = (times - center) / sigma
-    gauss = amp * np.exp(-(x**2) / 2).astype(np.complex_)
+    gauss = amp * np.exp(-(x**2) / 2).astype(np.complex128)
 
     if zeroed_width is not None:
         gauss = _fix_gaussian_width(
@@ -295,9 +295,9 @@ def sech(
         ret_x: Return centered and standard deviation normalized pulse location.
             $x=(times-center)/sigma$.
     """
-    times = np.asarray(times, dtype=np.complex_)
+    times = np.asarray(times, dtype=np.complex128)
     x = (times - center) / sigma
-    sech_out = amp * sech_fn(x).astype(np.complex_)
+    sech_out = amp * sech_fn(x).astype(np.complex128)
 
     if zeroed_width is not None:
         sech_out = _fix_sech_width(
@@ -384,7 +384,7 @@ def gaussian_square(
         functools.partial(constant, amp=amp),
     ]
     condlist = [times <= square_start, times >= square_stop]
-    return np.piecewise(times.astype(np.complex_), condlist, funclist)
+    return np.piecewise(times.astype(np.complex128), condlist, funclist)
 
 
 def drag(

--- a/qiskit/pulse/library/samplers/decorators.py
+++ b/qiskit/pulse/library/samplers/decorators.py
@@ -239,7 +239,7 @@ def sampler(sample_function: Callable) -> Callable:
             """Replace the call to the continuous function with a call to the sampler applied
             to the analytic pulse function."""
             sampled_pulse = sample_function(continuous_pulse, duration, *args, **kwargs)
-            return np.asarray(sampled_pulse, dtype=np.complex_)
+            return np.asarray(sampled_pulse, dtype=np.complex128)
 
         # Update type annotations for wrapped continuous function to be discrete
         call_sampler = _update_annotations(call_sampler)

--- a/qiskit/pulse/library/waveform.py
+++ b/qiskit/pulse/library/waveform.py
@@ -44,7 +44,7 @@ class Waveform(Pulse):
         """
 
         super().__init__(duration=len(samples), name=name, limit_amplitude=limit_amplitude)
-        samples = np.asarray(samples, dtype=np.complex_)
+        samples = np.asarray(samples, dtype=np.complex128)
         self.epsilon = epsilon
         self._samples = self._clip(samples, epsilon=epsilon)
 
@@ -78,7 +78,7 @@ class Waveform(Pulse):
             # first try normalizing by the abs value
             clip_where = np.argwhere(to_clip)
             clip_angle = np.angle(samples[clip_where])
-            clipped_samples = np.exp(1j * clip_angle, dtype=np.complex_)
+            clipped_samples = np.exp(1j * clip_angle, dtype=np.complex128)
 
             # if norm still exceed one subtract epsilon
             # required for some platforms
@@ -87,7 +87,7 @@ class Waveform(Pulse):
             if np.any(to_clip_epsilon):
                 clip_where_epsilon = np.argwhere(to_clip_epsilon)
                 clipped_samples_epsilon = (1 - epsilon) * np.exp(
-                    1j * clip_angle[clip_where_epsilon], dtype=np.complex_
+                    1j * clip_angle[clip_where_epsilon], dtype=np.complex128
                 )
                 clipped_samples[clip_where_epsilon] = clipped_samples_epsilon
 

--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -363,7 +363,7 @@ class QuantumState:
 
         if string_labels:
             max_dim = max(dims)
-            char_kets = np.asarray(kets, dtype=np.unicode_)
+            char_kets = np.asarray(kets, dtype=np.str_)
             str_kets = char_kets[0]
             for row in char_kets[1:]:
                 if max_dim > 10:

--- a/qiskit/result/postprocess.py
+++ b/qiskit/result/postprocess.py
@@ -86,7 +86,7 @@ def _list_to_complex_array(complex_list):
     Raises:
         QiskitError: If inner most array of input nested list is not of length 2.
     """
-    arr = np.asarray(complex_list, dtype=np.complex_)
+    arr = np.asarray(complex_list, dtype=np.complex128)
     if not arr.shape[-1] == 2:
         raise QiskitError("Inner most nested list is not of length 2.")
 

--- a/qiskit/transpiler/synthesis/aqc/fast_gradient/fast_gradient.py
+++ b/qiskit/transpiler/synthesis/aqc/fast_gradient/fast_gradient.py
@@ -54,16 +54,16 @@ class FastCNOTUnitObjective(CNOTUnitObjective):
         # array of F-layers:
         self._f_layers = np.asarray([object()] * num_qubits, dtype=LayerBase)
         # 4x4 C-gate matrices:
-        self._c_gates = np.full((self.num_cnots, 4, 4), fill_value=0, dtype=np.cfloat)
+        self._c_gates = np.full((self.num_cnots, 4, 4), fill_value=0, dtype=np.complex128)
         # derivatives of 4x4 C-gate matrices:
-        self._c_dervs = np.full((self.num_cnots, 4, 4, 4), fill_value=0, dtype=np.cfloat)
+        self._c_dervs = np.full((self.num_cnots, 4, 4, 4), fill_value=0, dtype=np.complex128)
         # 4x4 F-gate matrices:
-        self._f_gates = np.full((num_qubits, 2, 2), fill_value=0, dtype=np.cfloat)
+        self._f_gates = np.full((num_qubits, 2, 2), fill_value=0, dtype=np.complex128)
         # derivatives of 4x4 F-gate matrices:
-        self._f_dervs = np.full((num_qubits, 3, 2, 2), fill_value=0, dtype=np.cfloat)
+        self._f_dervs = np.full((num_qubits, 3, 2, 2), fill_value=0, dtype=np.complex128)
         # temporary NxN matrices:
-        self._tmp1 = np.full((dim, dim), fill_value=0, dtype=np.cfloat)
-        self._tmp2 = np.full((dim, dim), fill_value=0, dtype=np.cfloat)
+        self._tmp1 = np.full((dim, dim), fill_value=0, dtype=np.complex128)
+        self._tmp2 = np.full((dim, dim), fill_value=0, dtype=np.complex128)
 
         # Create layers of 2-qubit gates.
         for q in range(self.num_cnots):

--- a/qiskit/transpiler/synthesis/aqc/fast_gradient/layer.py
+++ b/qiskit/transpiler/synthesis/aqc/fast_gradient/layer.py
@@ -73,7 +73,7 @@ class Layer1Q(LayerBase):
         super().__init__()
 
         # 2x2 gate matrix (1-qubit gate).
-        self._gmat = np.full((2, 2), fill_value=0, dtype=np.cfloat)
+        self._gmat = np.full((2, 2), fill_value=0, dtype=np.complex128)
         if isinstance(g2x2, np.ndarray):
             np.copyto(self._gmat, g2x2)
 
@@ -114,7 +114,7 @@ class Layer2Q(LayerBase):
         super().__init__()
 
         # 4x4 gate matrix (2-qubit gate).
-        self._gmat = np.full((4, 4), fill_value=0, dtype=np.cfloat)
+        self._gmat = np.full((4, 4), fill_value=0, dtype=np.complex128)
         if isinstance(g4x4, np.ndarray):
             np.copyto(self._gmat, g4x4)
 
@@ -151,7 +151,7 @@ def init_layer1q_matrices(thetas: np.ndarray, dst: np.ndarray) -> np.ndarray:
         Returns the "dst" array.
     """
     n = thetas.shape[0]
-    tmp = np.full((4, 2, 2), fill_value=0, dtype=np.cfloat)
+    tmp = np.full((4, 2, 2), fill_value=0, dtype=np.complex128)
     for k in range(n):
         th = thetas[k]
         a = make_rz(th[0], out=tmp[0])
@@ -176,9 +176,9 @@ def init_layer1q_deriv_matrices(thetas: np.ndarray, dst: np.ndarray) -> np.ndarr
         Returns the "dst" array.
     """
     n = thetas.shape[0]
-    y = np.asarray([[0, -0.5], [0.5, 0]], dtype=np.cfloat)
-    z = np.asarray([[-0.5j, 0], [0, 0.5j]], dtype=np.cfloat)
-    tmp = np.full((5, 2, 2), fill_value=0, dtype=np.cfloat)
+    y = np.asarray([[0, -0.5], [0.5, 0]], dtype=np.complex128)
+    z = np.asarray([[-0.5j, 0], [0, 0.5j]], dtype=np.complex128)
+    tmp = np.full((5, 2, 2), fill_value=0, dtype=np.complex128)
     for k in range(n):
         th = thetas[k]
         a = make_rz(th[0], out=tmp[0])

--- a/qiskit/transpiler/synthesis/aqc/fast_gradient/pmatrix.py
+++ b/qiskit/transpiler/synthesis/aqc/fast_gradient/pmatrix.py
@@ -35,18 +35,18 @@ class PMatrix:
         dim = 2**num_qubits
         self._mat = np.empty(0)
         self._dim = dim
-        self._temp_g2x2 = np.zeros((2, 2), dtype=np.cfloat)
-        self._temp_g4x4 = np.zeros((4, 4), dtype=np.cfloat)
+        self._temp_g2x2 = np.zeros((2, 2), dtype=np.complex128)
+        self._temp_g4x4 = np.zeros((4, 4), dtype=np.complex128)
         self._temp_2x2 = self._temp_g2x2.copy()
         self._temp_4x4 = self._temp_g4x4.copy()
         self._identity_perm = np.arange(dim, dtype=np.int64)
         self._left_perm = self._identity_perm.copy()
         self._right_perm = self._identity_perm.copy()
         self._temp_perm = self._identity_perm.copy()
-        self._temp_slice_dim_x_2 = np.zeros((dim, 2), dtype=np.cfloat)
-        self._temp_slice_dim_x_4 = np.zeros((dim, 4), dtype=np.cfloat)
+        self._temp_slice_dim_x_2 = np.zeros((dim, 2), dtype=np.complex128)
+        self._temp_slice_dim_x_4 = np.zeros((dim, 4), dtype=np.complex128)
         self._idx_mat = self._init_index_matrix(dim)
-        self._temp_block_diag = np.zeros(self._idx_mat.shape, dtype=np.cfloat)
+        self._temp_block_diag = np.zeros(self._idx_mat.shape, dtype=np.complex128)
 
     def set_matrix(self, mat: np.ndarray):
         """
@@ -222,7 +222,7 @@ class PMatrix:
         # Update left permutation:
         self._left_perm[:] = inv_perm
 
-    def product_q1(self, layer: Layer1Q, tmp1: np.ndarray, tmp2: np.ndarray) -> np.cfloat:
+    def product_q1(self, layer: Layer1Q, tmp1: np.ndarray, tmp2: np.ndarray) -> np.complex128:
         """
         Computes and returns: ``Trace(mat @ C) = Trace(mat @ P^T @ gmat @ P) =
         Trace((P @ mat @ P^T) @ gmat) = Trace(C @ (P @ mat @ P^T)) =
@@ -254,9 +254,9 @@ class PMatrix:
             tmp3[:, :] = tmp2[i : i + 2, i : i + 2]
             _sum += np.dot(gmat_t.ravel(), tmp3.ravel())
 
-        return np.cfloat(_sum)
+        return np.complex128(_sum)
 
-    def product_q2(self, layer: Layer2Q, tmp1: np.ndarray, tmp2: np.ndarray) -> np.cfloat:
+    def product_q2(self, layer: Layer2Q, tmp1: np.ndarray, tmp2: np.ndarray) -> np.complex128:
         """
         Computes and returns: ``Trace(mat @ C) = Trace(mat @ P^T @ gmat @ P) =
         Trace((P @ mat @ P^T) @ gmat) = Trace(C @ (P @ mat @ P^T)) =
@@ -287,7 +287,7 @@ class PMatrix:
         bldia = self._temp_block_diag
         np.take(tmp2.ravel(), self._idx_mat.ravel(), axis=0, out=bldia.ravel())
         bldia *= gmat.reshape(-1, gmat.size)
-        return np.cfloat(np.sum(bldia))
+        return np.complex128(np.sum(bldia))
 
     def finalize(self, temp_mat: np.ndarray) -> np.ndarray:
         """

--- a/test/python/pulse/test_builder.py
+++ b/test/python/pulse/test_builder.py
@@ -343,7 +343,7 @@ class TestInstructions(TestBuilder):
     def test_play_array_pulse(self):
         """Test play instruction on an array directly."""
         d0 = pulse.DriveChannel(0)
-        test_array = np.array([0.0, 0.0], dtype=np.complex_)
+        test_array = np.array([0.0, 0.0], dtype=np.complex128)
 
         with pulse.build() as schedule:
             pulse.play(test_array, d0)

--- a/test/python/pulse/test_continuous_pulses.py
+++ b/test/python/pulse/test_continuous_pulses.py
@@ -30,7 +30,7 @@ class TestContinuousPulses(QiskitTestCase):
 
         constant_arr = continuous.constant(times, amp=amp)
 
-        self.assertEqual(constant_arr.dtype, np.complex_)
+        self.assertEqual(constant_arr.dtype, np.complex128)
         np.testing.assert_equal(constant_arr, amp)
         self.assertEqual(len(constant_arr), samples)
 
@@ -39,7 +39,7 @@ class TestContinuousPulses(QiskitTestCase):
         times = np.linspace(0, 10, 50)
         zero_arr = continuous.zero(times)
 
-        self.assertEqual(zero_arr.dtype, np.complex_)
+        self.assertEqual(zero_arr.dtype, np.complex128)
         np.testing.assert_equal(zero_arr, 0.0)
         self.assertEqual(len(zero_arr), 50)
 
@@ -53,7 +53,7 @@ class TestContinuousPulses(QiskitTestCase):
         # with new phase
         square_arr_phased = continuous.square(times, amp=amp, freq=freq, phase=np.pi / 2)
 
-        self.assertEqual(square_arr.dtype, np.complex_)
+        self.assertEqual(square_arr.dtype, np.complex128)
 
         self.assertAlmostEqual(square_arr[0], amp)
         # test constant
@@ -74,7 +74,7 @@ class TestContinuousPulses(QiskitTestCase):
         # with new phase
         sawtooth_arr_phased = continuous.sawtooth(times, amp=amp, freq=freq, phase=np.pi / 2)
 
-        self.assertEqual(sawtooth_arr.dtype, np.complex_)
+        self.assertEqual(sawtooth_arr.dtype, np.complex128)
 
         self.assertAlmostEqual(sawtooth_arr[0], 0.0)
         # test slope
@@ -97,7 +97,7 @@ class TestContinuousPulses(QiskitTestCase):
         # with new phase
         triangle_arr_phased = continuous.triangle(times, amp=amp, freq=freq, phase=np.pi / 2)
 
-        self.assertEqual(triangle_arr.dtype, np.complex_)
+        self.assertEqual(triangle_arr.dtype, np.complex128)
 
         self.assertAlmostEqual(triangle_arr[0], 0.0)
         # test slope
@@ -121,7 +121,7 @@ class TestContinuousPulses(QiskitTestCase):
         # with new phase
         cos_arr_phased = continuous.cos(times, amp=amp, freq=freq, phase=np.pi / 2)
 
-        self.assertEqual(cos_arr.dtype, np.complex_)
+        self.assertEqual(cos_arr.dtype, np.complex128)
 
         # Assert starts at 1
         self.assertAlmostEqual(cos_arr[0], amp)
@@ -144,7 +144,7 @@ class TestContinuousPulses(QiskitTestCase):
         # with new phase
         sin_arr_phased = continuous.sin(times, amp=0.5, freq=1 / 5, phase=np.pi / 2)
 
-        self.assertEqual(sin_arr.dtype, np.complex_)
+        self.assertEqual(sin_arr.dtype, np.complex128)
 
         # Assert starts at 1
         self.assertAlmostEqual(sin_arr[0], 0.0)
@@ -173,7 +173,7 @@ class TestContinuousPulses(QiskitTestCase):
             rescale_amp=True,
         )
 
-        self.assertEqual(gaussian_arr.dtype, np.complex_)
+        self.assertEqual(gaussian_arr.dtype, np.complex128)
 
         center_time = np.argmax(gaussian_arr)
         self.assertAlmostEqual(times[center_time], center)
@@ -196,7 +196,7 @@ class TestContinuousPulses(QiskitTestCase):
         gaussian_deriv_arr = continuous.gaussian_deriv(times, amp, center, sigma)
         gaussian_arr = gaussian_deriv_arr * deriv_prefactor
 
-        self.assertEqual(gaussian_deriv_arr.dtype, np.complex_)
+        self.assertEqual(gaussian_deriv_arr.dtype, np.complex128)
 
         self.assertAlmostEqual(
             continuous.gaussian_deriv(np.array([0]), amp, center, sigma)[0], 0, places=5
@@ -215,7 +215,7 @@ class TestContinuousPulses(QiskitTestCase):
         sech_arr = continuous.sech(times, amp, center, sigma)
         sech_arr_zeroed = continuous.sech(np.array([-1, center, duration + 1]), amp, center, sigma)
 
-        self.assertEqual(sech_arr.dtype, np.complex_)
+        self.assertEqual(sech_arr.dtype, np.complex128)
 
         center_time = np.argmax(sech_arr)
         self.assertAlmostEqual(times[center_time], center)
@@ -234,7 +234,7 @@ class TestContinuousPulses(QiskitTestCase):
 
         sech_deriv_arr = continuous.sech_deriv(times, amp, center, sigma)
 
-        self.assertEqual(sech_deriv_arr.dtype, np.complex_)
+        self.assertEqual(sech_deriv_arr.dtype, np.complex128)
 
         self.assertAlmostEqual(
             continuous.sech_deriv(np.array([0]), amp, center, sigma)[0], 0, places=3
@@ -249,7 +249,7 @@ class TestContinuousPulses(QiskitTestCase):
         times, dt = np.linspace(0, 20, 2001, retstep=True)
         gaussian_square_arr = continuous.gaussian_square(times, amp, center, width, sigma)
 
-        self.assertEqual(gaussian_square_arr.dtype, np.complex_)
+        self.assertEqual(gaussian_square_arr.dtype, np.complex128)
 
         self.assertEqual(gaussian_square_arr[1000], amp)
         # test half gaussian rise/fall
@@ -302,6 +302,6 @@ class TestContinuousPulses(QiskitTestCase):
             times, amp, center, sigma, beta=beta, zeroed_width=2 * (center + 1), rescale_amp=True
         )
 
-        self.assertEqual(drag_arr.dtype, np.complex_)
+        self.assertEqual(drag_arr.dtype, np.complex128)
 
         np.testing.assert_equal(drag_arr, gaussian_arr)

--- a/test/python/result/test_result.py
+++ b/test/python/result/test_result.py
@@ -479,7 +479,7 @@ class TestResultOperations(QiskitTestCase):
         """Test measurement level 1 average result."""
         # 3 qubits
         raw_memory = [[0.0, 1.0], [1.0, 0.0], [0.5, 0.5]]
-        processed_memory = np.array([1.0j, 1.0, 0.5 + 0.5j], dtype=np.complex_)
+        processed_memory = np.array([1.0j, 1.0, 0.5 + 0.5j], dtype=np.complex128)
         data = models.ExperimentResultData(memory=raw_memory)
         exp_result = models.ExperimentResult(
             shots=2, success=True, meas_level=1, meas_return="avg", data=data
@@ -488,7 +488,7 @@ class TestResultOperations(QiskitTestCase):
         memory = result.get_memory(0)
 
         self.assertEqual(memory.shape, (3,))
-        self.assertEqual(memory.dtype, np.complex_)
+        self.assertEqual(memory.dtype, np.complex128)
         np.testing.assert_almost_equal(memory, processed_memory)
 
     def test_meas_level_1_single(self):
@@ -496,7 +496,7 @@ class TestResultOperations(QiskitTestCase):
         # 3 qubits
         raw_memory = [[[0.0, 1.0], [1.0, 0.0], [0.5, 0.5]], [[0.5, 0.5], [1.0, 0.0], [0.0, 1.0]]]
         processed_memory = np.array(
-            [[1.0j, 1.0, 0.5 + 0.5j], [0.5 + 0.5j, 1.0, 1.0j]], dtype=np.complex_
+            [[1.0j, 1.0, 0.5 + 0.5j], [0.5 + 0.5j, 1.0, 1.0j]], dtype=np.complex128
         )
         data = models.ExperimentResultData(memory=raw_memory)
         exp_result = models.ExperimentResult(
@@ -506,14 +506,14 @@ class TestResultOperations(QiskitTestCase):
         memory = result.get_memory(0)
 
         self.assertEqual(memory.shape, (2, 3))
-        self.assertEqual(memory.dtype, np.complex_)
+        self.assertEqual(memory.dtype, np.complex128)
         np.testing.assert_almost_equal(memory, processed_memory)
 
     def test_meas_level_0_avg(self):
         """Test measurement level 0 average result."""
         # 3 qubits
         raw_memory = [[[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]], [[1.0, 0.0], [1.0, 0.0], [1.0, 0.0]]]
-        processed_memory = np.array([[1.0j, 1.0j, 1.0j], [1.0, 1.0, 1.0]], dtype=np.complex_)
+        processed_memory = np.array([[1.0j, 1.0j, 1.0j], [1.0, 1.0, 1.0]], dtype=np.complex128)
         data = models.ExperimentResultData(memory=raw_memory)
         exp_result = models.ExperimentResult(
             shots=2, success=True, meas_level=0, meas_return="avg", data=data
@@ -522,7 +522,7 @@ class TestResultOperations(QiskitTestCase):
         memory = result.get_memory(0)
 
         self.assertEqual(memory.shape, (2, 3))
-        self.assertEqual(memory.dtype, np.complex_)
+        self.assertEqual(memory.dtype, np.complex128)
         np.testing.assert_almost_equal(memory, processed_memory)
 
     def test_meas_level_0_single(self):
@@ -534,7 +534,7 @@ class TestResultOperations(QiskitTestCase):
         ]
         processed_memory = np.array(
             [[[1.0j, 1.0j, 1.0j], [1.0, 1.0, 1.0]], [[1.0j, 1.0j, 1.0j], [1.0, 1.0, 1.0]]],
-            dtype=np.complex_,
+            dtype=np.complex128,
         )
         data = models.ExperimentResultData(memory=raw_memory)
         exp_result = models.ExperimentResult(
@@ -544,7 +544,7 @@ class TestResultOperations(QiskitTestCase):
         memory = result.get_memory(0)
 
         self.assertEqual(memory.shape, (2, 2, 3))
-        self.assertEqual(memory.dtype, np.complex_)
+        self.assertEqual(memory.dtype, np.complex128)
         np.testing.assert_almost_equal(memory, processed_memory)
 
     def test_circuit_statevector_repr_without_decimal(self):
@@ -560,7 +560,7 @@ class TestResultOperations(QiskitTestCase):
                 0.35355339 + 0.0j,
                 0.35355339 + 0.0j,
             ],
-            dtype=np.complex_,
+            dtype=np.complex128,
         )
         processed_sv = np.array(
             [
@@ -573,14 +573,14 @@ class TestResultOperations(QiskitTestCase):
                 0.35355339 + 0.0j,
                 0.35355339 + 0.0j,
             ],
-            dtype=np.complex_,
+            dtype=np.complex128,
         )
         data = models.ExperimentResultData(statevector=raw_statevector)
         exp_result = models.ExperimentResult(shots=1, success=True, data=data)
         result = Result(results=[exp_result], **self.base_result_args)
         statevector = result.get_statevector()
         self.assertEqual(statevector.shape, (8,))
-        self.assertEqual(statevector.dtype, np.complex_)
+        self.assertEqual(statevector.dtype, np.complex128)
         np.testing.assert_almost_equal(statevector, processed_sv)
 
     def test_circuit_statevector_repr_decimal(self):
@@ -596,7 +596,7 @@ class TestResultOperations(QiskitTestCase):
                 0.35355339 + 0.0j,
                 0.35355339 + 0.0j,
             ],
-            dtype=np.complex_,
+            dtype=np.complex128,
         )
         processed_sv = np.array(
             [
@@ -609,14 +609,14 @@ class TestResultOperations(QiskitTestCase):
                 0.354 + 0.0j,
                 0.354 + 0.0j,
             ],
-            dtype=np.complex_,
+            dtype=np.complex128,
         )
         data = models.ExperimentResultData(statevector=raw_statevector)
         exp_result = models.ExperimentResult(shots=1, success=True, data=data)
         result = Result(results=[exp_result], **self.base_result_args)
         statevector = result.get_statevector(decimals=3)
         self.assertEqual(statevector.shape, (8,))
-        self.assertEqual(statevector.dtype, np.complex_)
+        self.assertEqual(statevector.dtype, np.complex128)
         np.testing.assert_almost_equal(statevector, processed_sv)
 
     def test_circuit_unitary_repr_without_decimal(self):
@@ -626,21 +626,21 @@ class TestResultOperations(QiskitTestCase):
                 [0.70710678 + 0.00000000e00j, 0.70710678 - 8.65956056e-17j],
                 [0.70710678 + 0.00000000e00j, -0.70710678 + 8.65956056e-17j],
             ],
-            dtype=np.complex_,
+            dtype=np.complex128,
         )
         processed_unitary = np.array(
             [
                 [0.70710678 + 0.00000000e00j, 0.70710678 - 8.65956056e-17j],
                 [0.70710678 + 0.00000000e00j, -0.70710678 + 8.65956056e-17j],
             ],
-            dtype=np.complex_,
+            dtype=np.complex128,
         )
         data = models.ExperimentResultData(unitary=raw_unitary)
         exp_result = models.ExperimentResult(shots=1, success=True, data=data)
         result = Result(results=[exp_result], **self.base_result_args)
         unitary = result.get_unitary()
         self.assertEqual(unitary.shape, (2, 2))
-        self.assertEqual(unitary.dtype, np.complex_)
+        self.assertEqual(unitary.dtype, np.complex128)
         np.testing.assert_almost_equal(unitary, processed_unitary)
 
     def test_circuit_unitary_repr_decimal(self):
@@ -650,17 +650,17 @@ class TestResultOperations(QiskitTestCase):
                 [0.70710678 + 0.00000000e00j, 0.70710678 - 8.65956056e-17j],
                 [0.70710678 + 0.00000000e00j, -0.70710678 + 8.65956056e-17j],
             ],
-            dtype=np.complex_,
+            dtype=np.complex128,
         )
         processed_unitary = np.array(
-            [[0.707 + 0.0j, 0.707 - 0.0j], [0.707 + 0.0j, -0.707 + 0.0j]], dtype=np.complex_
+            [[0.707 + 0.0j, 0.707 - 0.0j], [0.707 + 0.0j, -0.707 + 0.0j]], dtype=np.complex128
         )
         data = models.ExperimentResultData(unitary=raw_unitary)
         exp_result = models.ExperimentResult(shots=1, success=True, data=data)
         result = Result(results=[exp_result], **self.base_result_args)
         unitary = result.get_unitary(decimals=3)
         self.assertEqual(unitary.shape, (2, 2))
-        self.assertEqual(unitary.dtype, np.complex_)
+        self.assertEqual(unitary.dtype, np.complex128)
         np.testing.assert_almost_equal(unitary, processed_unitary)
 
     def test_additional_result_data(self):

--- a/test/python/transpiler/aqc/fast_gradient/test_layer1q.py
+++ b/test/python/transpiler/aqc/fast_gradient/test_layer1q.py
@@ -94,7 +94,7 @@ class TestLayer1q(QiskitTestCase):
         for n in range(2, self.max_num_qubits + 1):
 
             dim = 2**n
-            tmp1 = np.ndarray((dim, dim), dtype=np.cfloat)
+            tmp1 = np.ndarray((dim, dim), dtype=np.complex128)
             tmp2 = tmp1.copy()
             for _ in range(self.num_repeats):
                 k0 = randint(0, n - 1)
@@ -129,7 +129,7 @@ class TestLayer1q(QiskitTestCase):
                 err1 = tut.relative_error(alt_ttmtt, ttmtt)
                 self.assertLess(err1, _eps, "relative error: {:f}".format(err1))
 
-                prod = np.cfloat(np.trace(ttmtt @ t4))
+                prod = np.complex128(np.trace(ttmtt @ t4))
                 alt_prod = pmat.product_q1(layer=c4, tmp1=tmp1, tmp2=tmp2)
                 err2 = abs(alt_prod - prod) / abs(prod)
                 self.assertLess(err2, _eps, "relative error: {:f}".format(err2))

--- a/test/python/transpiler/aqc/fast_gradient/test_layer2q.py
+++ b/test/python/transpiler/aqc/fast_gradient/test_layer2q.py
@@ -97,7 +97,7 @@ class TestLayer2q(QiskitTestCase):
         for n in range(2, self.max_num_qubits + 1):
 
             dim = 2**n
-            tmp1 = np.ndarray((dim, dim), dtype=np.cfloat)
+            tmp1 = np.ndarray((dim, dim), dtype=np.complex128)
             tmp2 = tmp1.copy()
             for _ in range(self.num_repeats):
                 j0 = randint(0, n - 1)
@@ -137,7 +137,7 @@ class TestLayer2q(QiskitTestCase):
                 err1 = tut.relative_error(alt_ttmtt, ttmtt)
                 self.assertLess(err1, _eps, "relative error: {:f}".format(err1))
 
-                prod = np.cfloat(np.trace(ttmtt @ t4))
+                prod = np.complex128(np.trace(ttmtt @ t4))
                 alt_prod = pmat.product_q2(layer=c4, tmp1=tmp1, tmp2=tmp2)
                 err2 = abs(alt_prod - prod) / abs(prod)
                 self.assertLess(err2, _eps, "relative error: {:f}".format(err2))

--- a/test/python/transpiler/aqc/fast_gradient/test_utils.py
+++ b/test/python/transpiler/aqc/fast_gradient/test_utils.py
@@ -164,7 +164,7 @@ class TestUtils(QiskitTestCase):
         """
 
         tol = np.finfo(np.float64).eps * 2.0
-        out = np.full((2, 2), fill_value=0, dtype=np.cfloat)
+        out = np.full((2, 2), fill_value=0, dtype=np.complex128)
         for test in range(self.num_repeats_gates2x2):  # pylint: disable=unused-variable
             phi = random.random() * 2.0 * np.pi
             self.assertTrue(np.allclose(myu.make_rx(phi, out=out), _rx(phi), atol=tol, rtol=tol))

--- a/test/python/transpiler/aqc/fast_gradient/utils_for_testing.py
+++ b/test/python/transpiler/aqc/fast_gradient/utils_for_testing.py
@@ -86,8 +86,8 @@ def rand_matrix(dim: int, kind: str = "complex") -> np.ndarray:
     """
     if kind == "complex":
         return (
-            np.random.rand(dim, dim).astype(np.cfloat)
-            + np.random.rand(dim, dim).astype(np.cfloat) * 1j
+            np.random.rand(dim, dim).astype(np.complex128)
+            + np.random.rand(dim, dim).astype(np.complex128) * 1j
         )
     else:
         return np.random.randint(low=1, high=100, size=(dim, dim), dtype=np.int64)

--- a/test/python/transpiler/aqc/test_aqc.py
+++ b/test/python/transpiler/aqc/test_aqc.py
@@ -75,7 +75,7 @@ class TestAqc(QiskitTestCase):
 
         # Make multi-control CNOT gate matrix.
         # Another option: target_matrix = ORIGINAL_CIRCUIT
-        target_matrix = np.eye(2**num_qubits, dtype=np.cfloat)
+        target_matrix = np.eye(2**num_qubits, dtype=np.complex128)
         target_matrix[-2:, -2:] = [[0, 1], [1, 0]]
 
         circ = CNOTUnitCircuit(num_qubits, cnots)


### PR DESCRIPTION
### Summary

All of these are direct substitutions; the forms changed in this commit are just straight aliases, and Numpy 2 will remove them.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


