### PR TITLE
Replace use of `numpy.lib.scimath` with preferred `numpy.emath`

### DIFF
--- a/qiskit/quantum_info/synthesis/qsd.py
+++ b/qiskit/quantum_info/synthesis/qsd.py
@@ -175,7 +175,7 @@ def _demultiplex(um0, um1, opt_a1=False, opt_a2=False, *, _depth=0):
     else:
         evals, vmat = scipy.linalg.schur(um0um1, output="complex")
         eigvals = evals.diagonal()
-    dvals = np.lib.scimath.sqrt(eigvals)
+    dvals = np.emath.sqrt(eigvals)
     dmat = np.diag(dvals)
     wmat = dmat @ vmat.T.conjugate() @ um1
 


### PR DESCRIPTION
### Summary

`numpy.emath` is the preferred alias to `numpy.lib.scimath`, and direct access to the latter is scheduled for removal in Numpy 2.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments


