### PR TITLE
Pin Numpy < 2 in requirements

### DIFF
--- a/releasenotes/notes/numpy-2-pin-f600328f24fab6dd.yaml
+++ b/releasenotes/notes/numpy-2-pin-f600328f24fab6dd.yaml
@@ -1,0 +1,10 @@
+---
+other:
+  - |
+    This version of Qiskit is explicitly pinned to the Numpy 1.x series, because it includes compiled
+    extensions that are not yet compiled against the as-yet-unreleased Numpy 2.x series.  We will
+    release a new version of Qiskit with Numpy 2.x support as soon as feasible.
+
+    We cannot prevent your package manager from resolving to older versions of Qiskit (which do not
+    have the same pin but are still likely to be incompatible) if you forcibly try to install Qiskit
+    alongside Numpy 2, before we have released a compatible version.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rustworkx>=0.13.0
-numpy>=1.17
+numpy>=1.17,<2
 ply>=3.10
 psutil>=5
 scipy>=1.5


### PR DESCRIPTION
### Summary

We have compiled extensions that are built against the Numpy C API.  The Numpy transition guide for developers of downstream packages[^1] encourages us to put in this pin until we have wheels built against the newer version, which is not expected to be fully ABI compatible (but extensions built against Numpy 2 _should_ work with older Numpys).

Note that this won't prevent package managers from resolving _older_ versions of Qiskit (which don't have the pin) along with Numpy 2, but there's not a vast amount we can do about that now.

[^1]: https://github.com/numpy/numpy/issues/24300

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


