### PR TITLE
Fix `MergeAdjacentBarriers` to scale with number of barriers

### DIFF
--- a/qiskit/transpiler/passes/utils/merge_adjacent_barriers.py
+++ b/qiskit/transpiler/passes/utils/merge_adjacent_barriers.py
@@ -72,7 +72,9 @@ class MergeAdjacentBarriers(TransformationPass):
         for barrier in barriers:
             if barrier in node_to_barrier_qubits:
                 barrier_to_add, nodes = node_to_barrier_qubits[barrier]
-                dag.replace_block_with_op(nodes, barrier_to_add, wire_pos_map=indices, cycle_check=False)
+                dag.replace_block_with_op(
+                    nodes, barrier_to_add, wire_pos_map=indices, cycle_check=False
+                )
 
         return dag
 

--- a/qiskit/transpiler/passes/utils/merge_adjacent_barriers.py
+++ b/qiskit/transpiler/passes/utils/merge_adjacent_barriers.py
@@ -72,7 +72,7 @@ class MergeAdjacentBarriers(TransformationPass):
         for barrier in barriers:
             if barrier in node_to_barrier_qubits:
                 barrier_to_add, nodes = node_to_barrier_qubits[barrier]
-                dag.replace_block_with_op(nodes, barrier_to_add, wire_pos_map=indices)
+                dag.replace_block_with_op(nodes, barrier_to_add, wire_pos_map=indices, cycle_check=False)
 
         return dag
 

--- a/qiskit/transpiler/passes/utils/merge_adjacent_barriers.py
+++ b/qiskit/transpiler/passes/utils/merge_adjacent_barriers.py
@@ -71,13 +71,12 @@ class MergeAdjacentBarriers(TransformationPass):
         if not node_to_barrier_qubits:
             return dag
 
-        new_dag = copy.copy(dag)
         for barrier in barriers:
             if barrier in node_to_barrier_qubits:
                 barrier_to_add, nodes = node_to_barrier_qubits[barrier]
-                new_dag.replace_block_with_op(nodes, barrier_to_add, wire_pos_map=indices)
+                dag.replace_block_with_op(nodes, barrier_to_add, wire_pos_map=indices)
 
-        return new_dag
+        return dag
 
     @staticmethod
     def _collect_potential_merges(dag, barriers):

--- a/qiskit/transpiler/passes/utils/merge_adjacent_barriers.py
+++ b/qiskit/transpiler/passes/utils/merge_adjacent_barriers.py
@@ -12,6 +12,8 @@
 
 """Return a circuit with any adjacent barriers merged together."""
 
+import copy
+
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.circuit.barrier import Barrier
 
@@ -69,29 +71,21 @@ class MergeAdjacentBarriers(TransformationPass):
         if not node_to_barrier_qubits:
             return dag
 
-        # add the merged barriers to a new DAG
-        new_dag = dag.copy_empty_like()
+        new_dag = copy.copy(dag)
+        for barrier in barriers:
+            if barrier in node_to_barrier_qubits:
+                barrier_to_add, nodes = node_to_barrier_qubits[barrier]
+                new_dag.replace_block_with_op(nodes, barrier_to_add, wire_pos_map=indices)
 
-        # go over current nodes, and add them to the new dag
-        for node in dag.topological_op_nodes():
-            if node.name == "barrier":
-                if node in node_to_barrier_qubits:
-                    qubits = node_to_barrier_qubits[node]
-                    # qubits are stored as a set, need to convert to a list
-                    new_dag.apply_operation_back(
-                        Barrier(len(qubits)), qargs=sorted(qubits, key=indices.get), check=False
-                    )
-            else:
-                # copy the condition over too
-                new_dag.apply_operation_back(node.op, node.qargs, node.cargs, check=False)
         return new_dag
 
     @staticmethod
     def _collect_potential_merges(dag, barriers):
         """Return the potential merges.
 
-        Returns a dict of DAGOpNode: Barrier objects, where the barrier needs to be
-        inserted where the corresponding DAGOpNode appears in the main DAG.
+        Returns a dict of DAGOpNode: (Barrier, [DAGOpNode]) objects, where the barrier needs to be
+        inserted where the corresponding index DAGOpNode appears in the main DAG, in replacement of
+        the listed DAGOpNodes.
         """
         # if only got 1 or 0 barriers then can't merge
         if len(barriers) < 2:
@@ -144,14 +138,13 @@ class MergeAdjacentBarriers(TransformationPass):
 
                     end_of_barrier = next_barrier
                     current_barrier_nodes.append(end_of_barrier)
-
                     continue
 
             # Fallback if barriers are not adjacent or not mergeable.
 
             # store the previously made barrier
             if barrier_to_add:
-                node_to_barrier_qubits[end_of_barrier] = current_qubits
+                node_to_barrier_qubits[end_of_barrier] = (barrier_to_add, current_barrier_nodes)
 
             # reset the properties
             current_qubits = set(next_barrier.qargs)
@@ -165,6 +158,6 @@ class MergeAdjacentBarriers(TransformationPass):
             current_barrier_nodes.append(end_of_barrier)
 
         if barrier_to_add:
-            node_to_barrier_qubits[end_of_barrier] = current_qubits
+            node_to_barrier_qubits[end_of_barrier] = (barrier_to_add, current_barrier_nodes)
 
         return node_to_barrier_qubits

--- a/qiskit/transpiler/passes/utils/merge_adjacent_barriers.py
+++ b/qiskit/transpiler/passes/utils/merge_adjacent_barriers.py
@@ -12,8 +12,6 @@
 
 """Return a circuit with any adjacent barriers merged together."""
 
-import copy
-
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.circuit.barrier import Barrier
 

--- a/releasenotes/notes/improve-performance-merge-adjacent-barriers-pass-c0cd064bdd059811.yaml
+++ b/releasenotes/notes/improve-performance-merge-adjacent-barriers-pass-c0cd064bdd059811.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Performance improvement of the :class:`~.MergeAdjacentBarriers` transpiler pass, which used to
+    rebuild the complete DAG to merge the barriers. It now iterates over the barriers instead of
+    the full graph, and applies the :meth:`.`DAGCircuit.replace_block_with_op` method when necessary.

--- a/releasenotes/notes/improve-performance-merge-adjacent-barriers-pass-c0cd064bdd059811.yaml
+++ b/releasenotes/notes/improve-performance-merge-adjacent-barriers-pass-c0cd064bdd059811.yaml
@@ -2,5 +2,4 @@
 features:
   - |
     Performance improvement of the :class:`~.MergeAdjacentBarriers` transpiler pass, which used to
-    rebuild the complete DAG to merge the barriers. It now iterates over the barriers instead of
-    the full graph, and applies the :meth:`.`DAGCircuit.replace_block_with_op` method when necessary.
+    rebuild the complete DAG to merge the barriers.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Proposed fix for #10860. I found that the easiest path would be to return the nodes to be replaced in the `_collect_potential_merges` method, which I also modified to match the documented return type, as it can now return barriers directly (it was returning the barrier qubits before).

### Details and comments

I tried profiling the before/after with this circuit (modifying the number of hadamards):

```
qr = QuantumRegister(4, "q")

circuit = QuantumCircuit(qr)
for i in range(500000):
    circuit.h(0)
circuit.barrier([qr[0], qr[1]])
circuit.barrier([qr[1], qr[2]])
circuit.barrier(qr[3])
```
And the new version is faster in general but still scales linearly with the number of gates, I guess this is still somewhat expected?

```
Before Fix:

5 Hadamards Total: 0.007848978042602539
name                                  ncall  tsub      ttot      tavg
..rs.py:60 MergeAdjacentBarriers.run  1      0.000119  0.002610  0.002610

5000 H  Total: 1.225039005279541
name                                  ncall  tsub      ttot      tavg
..rs.py:60 MergeAdjacentBarriers.run  1      0.035354  0.629396  0.629396

500 000 H  Total: 119.47961711883545
name                                  ncall  tsub      ttot      tavg
..rs.py:60 MergeAdjacentBarriers.run  1      3.511733  62.77685  62.77685

——————————————————
After Fix:

5 Hadamards  Total: 0.007379055023193359
name                                  ncall  tsub      ttot      tavg
..rs.py:60 MergeAdjacentBarriers.run  1      0.000054  0.001563  0.001563

5000 H  Total: 0.6967248916625977
name                                  ncall  tsub      ttot      tavg
..rs.py:60 MergeAdjacentBarriers.run  1      0.000074  0.105973  0.105973

500 000 H  Total: 67.28817319869995
name                                  ncall  tsub      ttot      tavg
..rs.py:60 MergeAdjacentBarriers.run  1      0.004816  10.76225  10.76225
```