### PR TITLE
Assert properties not specifics of `DenseLayout` results

### DIFF
--- a/test/python/transpiler/test_dense_layout.py
+++ b/test/python/transpiler/test_dense_layout.py
@@ -12,6 +12,7 @@
 
 """Test the DenseLayout pass"""
 
+import itertools
 import unittest
 
 import numpy as np
@@ -43,6 +44,30 @@ class TestDenseLayout(QiskitTestCase):
         }
         self.target_19.add_instruction(CXGate(), instruction_props)
 
+    def test_finds_densest_component(self):
+        """Test that `DenseLayout` finds precisely the densest subcomponent of a coupling graph, not
+        just _any_ connected component."""
+        circuit = QuantumCircuit(5)
+        for a, b in itertools.permutations(circuit.qubits, 2):
+            circuit.cx(a, b)
+
+        # The map is a big long sparse line, except the middle 5 physical qubits are all completely
+        # connected, so `DenseLayout` should always choose those.
+        left_edge_qubits = range(0, 7)
+        middle_qubits = range(7, 12)
+        right_edge_qubits = range(12, 20)
+        cm = CouplingMap(
+            [(q, q + 1) for q in left_edge_qubits]
+            + [(q - 1, q) for q in right_edge_qubits]
+            + list(itertools.permutations(middle_qubits, 2))
+        )
+        cm.make_symmetric()
+        pass_ = DenseLayout(cm)
+        pass_(circuit)
+        layout = pass_.property_set["layout"]
+        used_qubits = {layout[q] for q in circuit.qubits}
+        self.assertEqual(used_qubits, set(middle_qubits))
+
     def test_5q_circuit_20q_coupling(self):
         """Test finds dense 5q corner in 20q coupling map."""
         qr = QuantumRegister(5, "q")
@@ -53,15 +78,14 @@ class TestDenseLayout(QiskitTestCase):
         circuit.cx(qr[0], qr[2])
 
         dag = circuit_to_dag(circuit)
-        pass_ = DenseLayout(CouplingMap(self.cmap20))
+        cm = CouplingMap(self.cmap20)
+        pass_ = DenseLayout(cm)
         pass_.run(dag)
 
         layout = pass_.property_set["layout"]
-        self.assertEqual(layout[qr[0]], 11)
-        self.assertEqual(layout[qr[1]], 10)
-        self.assertEqual(layout[qr[2]], 6)
-        self.assertEqual(layout[qr[3]], 5)
-        self.assertEqual(layout[qr[4]], 0)
+        actual = [layout[q] for q in circuit.qubits]
+        sub_map = cm.reduce(actual, check_if_connected=False)
+        self.assertTrue(sub_map.is_connected(), msg=f"chosen layout is not dense: {actual}")
 
     def test_6q_circuit_20q_coupling(self):
         """Test finds dense 5q corner in 20q coupling map."""
@@ -72,17 +96,14 @@ class TestDenseLayout(QiskitTestCase):
         circuit.cx(qr1[1], qr0[2])
 
         dag = circuit_to_dag(circuit)
-        pass_ = DenseLayout(CouplingMap(self.cmap20))
+        cm = CouplingMap(self.cmap20)
+        pass_ = DenseLayout(cm)
         pass_.run(dag)
 
         layout = pass_.property_set["layout"]
-
-        self.assertEqual(layout[qr0[0]], 11)
-        self.assertEqual(layout[qr0[1]], 10)
-        self.assertEqual(layout[qr0[2]], 6)
-        self.assertEqual(layout[qr1[0]], 5)
-        self.assertEqual(layout[qr1[1]], 1)
-        self.assertEqual(layout[qr1[2]], 0)
+        actual = [layout[q] for q in circuit.qubits]
+        sub_map = cm.reduce(actual, check_if_connected=False)
+        self.assertTrue(sub_map.is_connected(), msg=f"chosen layout is not dense: {actual}")
 
     def test_5q_circuit_19q_target_with_noise(self):
         """Test layout works finds a dense 5q subgraph in a 19q heavy hex target."""
@@ -96,11 +117,9 @@ class TestDenseLayout(QiskitTestCase):
         pass_ = DenseLayout(target=self.target_19)
         pass_.run(dag)
         layout = pass_.property_set["layout"]
-        self.assertEqual(layout[qr[0]], 9)
-        self.assertEqual(layout[qr[1]], 3)
-        self.assertEqual(layout[qr[2]], 11)
-        self.assertEqual(layout[qr[3]], 15)
-        self.assertEqual(layout[qr[4]], 4)
+        actual = [layout[q] for q in circuit.qubits]
+        sub_map = self.target_19.build_coupling_map().reduce(actual, check_if_connected=False)
+        self.assertTrue(sub_map.is_connected(), msg=f"chosen layout is not dense: {actual}")
 
     def test_5q_circuit_19q_target_without_noise(self):
         """Test layout works finds a dense 5q subgraph in a 19q heavy hex target with no noise."""
@@ -117,11 +136,9 @@ class TestDenseLayout(QiskitTestCase):
         pass_ = DenseLayout(target=noiseless_target)
         pass_.run(dag)
         layout = pass_.property_set["layout"]
-        self.assertEqual(layout[qr[0]], 1)
-        self.assertEqual(layout[qr[1]], 13)
-        self.assertEqual(layout[qr[2]], 0)
-        self.assertEqual(layout[qr[3]], 9)
-        self.assertEqual(layout[qr[4]], 3)
+        actual = [layout[q] for q in circuit.qubits]
+        sub_map = noiseless_target.build_coupling_map().reduce(actual, check_if_connected=False)
+        self.assertTrue(sub_map.is_connected(), msg=f"chosen layout is not dense: {actual}")
 
     def test_ideal_target_no_coupling(self):
         """Test pass fails as expected if a target without edge constraints exists."""
@@ -217,14 +234,13 @@ class TestDenseLayout(QiskitTestCase):
         circuit.cx(0, 4)
 
         dag = circuit_to_dag(circuit)
-        pass_ = DenseLayout(CouplingMap(self.cmap20))
+        cm = CouplingMap(self.cmap20)
+        pass_ = DenseLayout(cm)
         pass_.run(dag)
         layout = pass_.property_set["layout"]
-        self.assertEqual(layout[qr[0]], 11)
-        self.assertEqual(layout[qr[1]], 10)
-        self.assertEqual(layout[qr[2]], 6)
-        self.assertEqual(layout[qr[3]], 5)
-        self.assertEqual(layout[qr[4]], 0)
+        actual = [layout[q] for q in circuit.qubits]
+        sub_map = cm.reduce(actual, check_if_connected=False)
+        self.assertTrue(sub_map.is_connected(), msg=f"chosen layout is not dense: {actual}")
 
     def test_loose_bit_circuit(self):
         """Test dense layout works with loose bits outside a register."""
@@ -237,14 +253,13 @@ class TestDenseLayout(QiskitTestCase):
         circuit.cx(3, 0)
         circuit.cx(3, 1)
         dag = circuit_to_dag(circuit)
-        pass_ = DenseLayout(CouplingMap(self.cmap20))
+        cm = CouplingMap(self.cmap20)
+        pass_ = DenseLayout(cm)
         pass_.run(dag)
         layout = pass_.property_set["layout"]
-        self.assertEqual(layout[bits[0]], 11)
-        self.assertEqual(layout[bits[1]], 10)
-        self.assertEqual(layout[bits[2]], 6)
-        self.assertEqual(layout[bits[3]], 5)
-        self.assertEqual(layout[bits[4]], 0)
+        actual = [layout[q] for q in circuit.qubits]
+        sub_map = cm.reduce(actual, check_if_connected=False)
+        self.assertTrue(sub_map.is_connected(), msg=f"chosen layout is not dense: {actual}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

`DenseLayout` is a deterministic pass, so there's no risk of RNG manipulations changing the output.  Internally, however, the use of the sparse-matrix bandwidth-reduction algorithm in Scipy's `reverse_cuthill_mckee` uses `numpy.argsort` internally with the unstable default sorting algorithm, which means the output _can_ be dependent on the way that sort is implemented.  The arrays that are sorted are directly related to the input coupling map, and are likely to include degeneracies, which pose problems when the implementation of the unstable sort changes.  This was the case moving from Numpy 1.24 to Numpy 1.25.

This commit instead changes the tests from asserting that a precise layout was returned to asserting that the returned layout contains only a connected subgraph of qubits.  The "most" connected component that `DenseLayout` finds must be _at least_ connected, though this assertion is not quite as strong as finding the _densest_.  The extra test accounts for this weakening.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

This is another case where our tests were incompatible with Numpy 1.25+ (see #10305), and a simpler one to fix than the others noted in that issue; it's not an unsoundness of the library, just a sort-method instability that we can make the tests more resilient against.