### PR TITLE
Fix Clifford.from_operator to fail with non-Clifford diagonal operators

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -1004,9 +1004,10 @@ class Clifford(BaseOperator, AdjointMixin, Operation):
         """Generate a binary vector (a row of tableau representation) from a Pauli matrix.
         Return None if the non-Pauli matrix is supplied."""
         # pylint: disable=too-many-return-statements
+        decimals = 6
 
-        def find_one_index(x, decimals=6):
-            indices = np.where(np.round(np.abs(x), decimals) == 1)
+        def find_one_index(x):
+            indices = np.where(np.round(np.abs(x), decimals=decimals) == 1)
             return indices[0][0] if len(indices[0]) == 1 else None
 
         def bitvector(n, num_bits):
@@ -1027,7 +1028,9 @@ class Clifford(BaseOperator, AdjointMixin, Operation):
             expected = xint ^ i
             if index != expected:
                 return None
-            entries[i] = np.round(mat[i, index])
+            entries[i] = np.round(mat[i, index], decimals=decimals)
+            if entries[i] not in {1, -1, 1j, -1j}:
+                return None
 
         # compute z-bits
         zbits = np.empty(num_qubits, dtype=bool)

--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -1019,7 +1019,7 @@ class Clifford(BaseOperator, AdjointMixin, Operation):
             return None
         xbits = bitvector(xint, num_qubits)
 
-        # extract non-zero elements from matrix (rounded to 1, -1, 1j or -1j)
+        # extract non-zero elements from matrix (each must be 1, -1, 1j or -1j for Pauli matrix)
         entries = np.empty(len(mat), dtype=complex)
         for i, row in enumerate(mat):
             index = find_one_index(row)

--- a/releasenotes/notes/fix-clifford-from-diagonal-7708654373bd5b8b.yaml
+++ b/releasenotes/notes/fix-clifford-from-diagonal-7708654373bd5b8b.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a bug where :meth:`~.Clifford.from_matrix` and :meth:`~.Clifford.from_operator`
+    do not fail with non-Clifford diagonal operators (matrices) and return incorrect
+    Clifford objects. This has been corrected so that they raise an error in the cases.
+    Fixed `#10903 <https://github.com/Qiskit/qiskit-terra/issues/10903>`__

--- a/test/python/quantum_info/operators/symplectic/test_clifford.py
+++ b/test/python/quantum_info/operators/symplectic/test_clifford.py
@@ -1068,6 +1068,12 @@ class TestCliffordOperators(QiskitTestCase):
             actual = Clifford.from_matrix(expected.to_matrix())
             self.assertEqual(expected, actual)
 
+    def test_from_non_clifford_diagonal_operator(self):
+        """Test if failing with non-clifford diagonal operator.
+        See https://github.com/Qiskit/qiskit/issues/10903"""
+        with self.assertRaises(QiskitError):
+            Clifford.from_operator(Operator(RZZGate(0.2)))
+
     @combine(num_qubits=[1, 2, 3, 4])
     def test_from_operator_round_trip(self, num_qubits):
         """Test round trip conversion to and from operator"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fix a bug where `Clifford.from_operator` (`from_matrix`) does not fail with non-Clifford diagonal operators (matrices) and return incorrect Clifford objects. This commit corrects it to raise an error as expected.
Fix #10903

### Details and comments
Each non-zero element of the Pauli matrices computed during the conversion must be one of {1, -1, 1j, -1j} for valid input but that was not fully checked and failed to raise an error against invalid non-Clifford diagonal matrices.

