### PR TITLE
Issue warning on known-bad combinations for `UCGate` synthesis

### DIFF
--- a/qiskit/extensions/quantum_initializer/uc.py
+++ b/qiskit/extensions/quantum_initializer/uc.py
@@ -47,6 +47,7 @@ from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.synthesis import OneQubitEulerDecomposer
+from qiskit.extensions.quantum_initializer import _warn_if_bad_numpy
 
 _EPS = 1e-10  # global variable used to chop very small numbers to zero
 _DECOMPOSER1Q = OneQubitEulerDecomposer("U3")
@@ -134,6 +135,8 @@ class UCGate(Gate):
         up_to_diagonal=True, the circuit implements the gate up to a diagonal gate and
         the diagonal gate is also returned.
         """
+        _warn_if_bad_numpy("synthesis of multiplexed gates")
+
         diag = np.ones(2**self.num_qubits).tolist()
         q = QuantumRegister(self.num_qubits)
         q_controls = q[1:]

--- a/releasenotes/notes/numpy-avx2-cmul-ucgate-6c8708fb30f42f3f.yaml
+++ b/releasenotes/notes/numpy-avx2-cmul-ucgate-6c8708fb30f42f3f.yaml
@@ -1,0 +1,18 @@
+---
+issues:
+  - |
+    The PyPI versions of the NumPy 1.25 series and the current most recent release 1.26.0 are known
+    to have inconsistent behaviour with the complex `multiply` ufunc when running on Intel Macs with
+    AVX2 CPU extensions.  This bug destabilises the synthesis of :class:`.UCGate`, which is used by
+    :class:`.Isometry` and :meth:`.UnitaryGate.control`, to the degree of it returning completely
+    invalid results.
+
+    This bug only affects Intel Macs with AVX2 CPU extensions enabled with certain versions of NumPy.
+    If the bad code paths are used, a :exc:`RuntimeWarning` will be issued.  If you are affected,
+    you can install an older version of NumPy (the 1.24 series is known good), or you can disable
+    NumPy's use of AVX2 extensions by setting the environment variable
+    `NPY_DISABLE_CPU_FEATURES=AVX2` while importing `numpy`.  See
+    https://qisk.it/cmul-avx2-numpy-bug for more detail.
+
+    This bug also affects all prior versions of Qiskit with :class:`.UCGate` if the bad combination
+    of OS, CPU and NumPy version are present, but this is the first version that issues a warning.

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -78,6 +78,7 @@ from qiskit.circuit._utils import _compute_control_matrix
 import qiskit.circuit.library.standard_gates as allGates
 from qiskit.extensions import UnitaryGate
 from qiskit.circuit.library.standard_gates.multi_control_rotation_gates import _mcsu2_real_diagonal
+from qiskit.extensions.quantum_initializer import _IS_BAD_NUMPY
 
 from .gate_utils import _get_free_params
 
@@ -843,6 +844,7 @@ class TestControlledGate(QiskitTestCase):
         self.assertTrue(matrix_equal(cop_mat, test_op.data))
 
     @data(1, 2, 3, 4, 5)
+    @unittest.skipIf(_IS_BAD_NUMPY, "known-bad OS+NumPy combination for Isometry")
     def test_controlled_random_unitary(self, num_ctrl_qubits):
         """Test the matrix data of an Operator based on a random UnitaryGate."""
         num_target = 2

--- a/test/python/circuit/test_isometry.py
+++ b/test/python/circuit/test_isometry.py
@@ -25,10 +25,12 @@ from qiskit import execute
 from qiskit.test import QiskitTestCase
 from qiskit.compiler import transpile
 from qiskit.quantum_info import Operator
+from qiskit.extensions.quantum_initializer import _IS_BAD_NUMPY
 from qiskit.extensions.quantum_initializer.isometry import Isometry
 
 
 @ddt
+@unittest.skipIf(_IS_BAD_NUMPY, "known-bad OS+NumPy combination for Isometry")
 class TestIsometry(QiskitTestCase):
     """Qiskit isometry tests."""
 

--- a/test/python/circuit/test_uc.py
+++ b/test/python/circuit/test_uc.py
@@ -23,6 +23,7 @@ from test import combine  # pylint: disable=wrong-import-order
 import numpy as np
 from scipy.linalg import block_diag
 
+from qiskit.extensions.quantum_initializer import _IS_BAD_NUMPY
 from qiskit.extensions.quantum_initializer.uc import UCGate
 
 from qiskit import QuantumCircuit, QuantumRegister, BasicAer, execute
@@ -37,6 +38,7 @@ _not = np.matrix([[0, 1], [1, 0]])
 
 
 @ddt
+@unittest.skipIf(_IS_BAD_NUMPY, "known-bad OS+NumPy combination for UCGate")
 class TestUCGate(QiskitTestCase):
     """Qiskit UCGate tests."""
 

--- a/test/python/circuit/test_unitary.py
+++ b/test/python/circuit/test_unitary.py
@@ -13,10 +13,13 @@
 """UnitaryGate tests"""
 
 import json
+import unittest
+
 import numpy
 from numpy.testing import assert_allclose
 
 import qiskit
+from qiskit.extensions.quantum_initializer import _IS_BAD_NUMPY
 from qiskit.extensions.unitary import UnitaryGate
 from qiskit.test import QiskitTestCase
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
@@ -303,6 +306,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         mat = numpy.array([[0, 0, 1, 0], [0, 0, 0, -1], [1, 0, 0, 0], [0, -1, 0, 0]])
         self.assertTrue(numpy.allclose(Operator(UnitaryGate(mat).definition).data, mat))
 
+    @unittest.skipIf(_IS_BAD_NUMPY, "known-bad OS+NumPy combination for Isometry")
     def test_unitary_control(self):
         """Test parameters of controlled - unitary."""
         mat = numpy.array([[0, 1], [1, 0]])


### PR DESCRIPTION
### Summary

The combination of AVX2-enabled Intel Macs with versions of NumPy compiled with Apple clang 14.0.0 has problems with the complex128 `multiply` ufunc that makes it non-deterministic.  The PyPI releases of the entire NumPy 1.25 series and the current newest 1.26.0 are all known to have this issue.

This causes a severe instability in the `UCGate` synthesis code, to the degree of the returned results being (non-deterministically) completely invalid.  This commit causes Qiskit to query the host platform and runtime NumPy features to guess if the bug is likely to be present; the results are so incorrect that we need to warn users so they can work around them.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

See #10305 for more detail, including the link to discussions on NumPy and the current set of known work-arounds for affected users.

If #10901 merges before this commit, I should be able to update this PR to relax the `numpy<1.25` constraint in CI, which in turn would mean #10305 could be resolved.

The https://qisk.it/cmul-avx2-numpy-bug shortlink used in the warning and the release note currently points to https://github.com/Qiskit/qiskit/issues/10305#issuecomment-1737769709.