### PR TITLE
Add representation of storage-owning `Var` nodes

### DIFF
--- a/qiskit/circuit/classical/expr/__init__.py
+++ b/qiskit/circuit/classical/expr/__init__.py
@@ -39,8 +39,8 @@ The expression system is based on tree representation.  All nodes in the tree ar
 
 These objects are mutable and should not be reused in a different location without a copy.
 
-The entry point from general circuit objects to the expression system is by wrapping the object
-in a :class:`Var` node and associating a :class:`~.types.Type` with it.
+The base for dynamic variables is the :class:`Var`, which can be either an arbitrarily typed runtime
+variable, or a wrapper around an old-style :class:`.Clbit` or :class:`.ClassicalRegister`.
 
 .. autoclass:: Var
 
@@ -86,9 +86,17 @@ suitable :class:`Cast` nodes.
 The functions and methods described in this section are a more user-friendly way to build the
 expression tree, while staying close to the internal representation.  All these functions will
 automatically lift valid Python scalar values into corresponding :class:`Var` or :class:`Value`
-objects, and will resolve any required implicit casts on your behalf.
+objects, and will resolve any required implicit casts on your behalf.  If you want to directly use
+some scalar value as an :class:`Expr` node, you can manually lift it yourself.
 
 .. autofunction:: lift
+
+Typically you should create memory-owning :class:`Var` instances by using the
+:meth:`.QuantumCircuit.add_var` method to declare them in some circuit context, since a
+:class:`.QuantumCircuit` will not accept an :class:`Expr` that contains variables that are not
+already declared in it, since it needs to know how to allocate the storage and how the variable will
+be initialised.  However, should you want to do this manually, you should use the low-level
+:meth:`Var.new` call to safely generate a named variable for usage.
 
 You can manually specify casts in cases where the cast is allowed in explicit form, but may be
 lossy (such as the cast of a higher precision :class:`~.types.Uint` to a lower precision one).

--- a/qiskit/circuit/classical/expr/__init__.py
+++ b/qiskit/circuit/classical/expr/__init__.py
@@ -40,9 +40,10 @@ The expression system is based on tree representation.  All nodes in the tree ar
 These objects are mutable and should not be reused in a different location without a copy.
 
 The base for dynamic variables is the :class:`Var`, which can be either an arbitrarily typed runtime
-variable, or a wrapper around an old-style :class:`.Clbit` or :class:`.ClassicalRegister`.
+variable, or a wrapper around a :class:`.Clbit` or :class:`.ClassicalRegister`.
 
 .. autoclass:: Var
+    :members: var, name
 
 Similarly, literals used in comparison (such as integers) should be lifted to :class:`Value` nodes
 with associated types.
@@ -87,7 +88,7 @@ The functions and methods described in this section are a more user-friendly way
 expression tree, while staying close to the internal representation.  All these functions will
 automatically lift valid Python scalar values into corresponding :class:`Var` or :class:`Value`
 objects, and will resolve any required implicit casts on your behalf.  If you want to directly use
-some scalar value as an :class:`Expr` node, you can manually lift it yourself.
+some scalar value as an :class:`Expr` node, you can manually :func:`lift` it yourself.
 
 .. autofunction:: lift
 
@@ -95,7 +96,7 @@ Typically you should create memory-owning :class:`Var` instances by using the
 :meth:`.QuantumCircuit.add_var` method to declare them in some circuit context, since a
 :class:`.QuantumCircuit` will not accept an :class:`Expr` that contains variables that are not
 already declared in it, since it needs to know how to allocate the storage and how the variable will
-be initialised.  However, should you want to do this manually, you should use the low-level
+be initialized.  However, should you want to do this manually, you should use the low-level
 :meth:`Var.new` call to safely generate a named variable for usage.
 
 You can manually specify casts in cases where the cast is allowed in explicit form, but may be


### PR DESCRIPTION
### Summary

This adds the representation of `expr.Var` nodes that own their own storage locations, and consequently are not backed by existing Qiskit objects (`Clbit` or `ClassicalRegister`).  This is the base of the ability for Qiskit to represent manual classical-value storage in `QuantumCircuit`, and the base for how manual storage will be implemented.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Close #10923.

The release note will be added as part of closing epic #10922.