### PR TITLE
Add definition of `Store` instruction

### DIFF
--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -279,6 +279,7 @@ Gates and Instructions
    InstructionSet
    Operation
    EquivalenceLibrary
+   Store
 
 Control Flow Operations
 -----------------------
@@ -375,6 +376,7 @@ from .barrier import Barrier
 from .delay import Delay
 from .measure import Measure
 from .reset import Reset
+from .store import Store
 from .parameter import Parameter
 from .parametervector import ParameterVector
 from .parameterexpression import ParameterExpression

--- a/qiskit/circuit/classical/expr/__init__.py
+++ b/qiskit/circuit/classical/expr/__init__.py
@@ -160,6 +160,11 @@ between two different circuits.  In this case, one can use :func:`structurally_e
 suitable "key" functions to do the comparison.
 
 .. autofunction:: structurally_equivalent
+
+Some expressions have associated memory locations with them, and some may be purely temporaries.
+You can use :func:`is_lvalue` to determine whether an expression has such a memory backing.
+
+.. autofunction:: is_lvalue
 """
 
 __all__ = [
@@ -172,6 +177,7 @@ __all__ = [
     "ExprVisitor",
     "iter_vars",
     "structurally_equivalent",
+    "is_lvalue",
     "lift",
     "cast",
     "bit_not",
@@ -191,7 +197,7 @@ __all__ = [
 ]
 
 from .expr import Expr, Var, Value, Cast, Unary, Binary
-from .visitors import ExprVisitor, iter_vars, structurally_equivalent
+from .visitors import ExprVisitor, iter_vars, structurally_equivalent, is_lvalue
 from .constructors import (
     lift,
     cast,

--- a/qiskit/circuit/classical/types/__init__.py
+++ b/qiskit/circuit/classical/types/__init__.py
@@ -15,6 +15,8 @@
 Typing (:mod:`qiskit.circuit.classical.types`)
 ==============================================
 
+Representation
+==============
 
 The type system of the expression tree is exposed through this module.  This is inherently linked to
 the expression system in the :mod:`~.classical.expr` module, as most expressions can only be
@@ -41,10 +43,17 @@ literals ``True`` and ``False``), and unsigned integers (corresponding to
 Note that :class:`Uint` defines a family of types parametrised by their width; it is not one single
 type, which may be slightly different to the 'classical' programming languages you are used to.
 
+
+Working with types
+==================
+
 There are some functions on these types exposed here as well.  These are mostly expected to be used
 only in manipulations of the expression tree; users who are building expressions using the
 :ref:`user-facing construction interface <circuit-classical-expressions-expr-construction>` should
 not need to use these.
+
+Partial ordering of types
+-------------------------
 
 The type system is equipped with a partial ordering, where :math:`a < b` is interpreted as
 ":math:`a` is a strict subtype of :math:`b`".  Note that the partial ordering is a subset of the
@@ -66,6 +75,20 @@ Some helper methods are then defined in terms of this low-level :func:`order` pr
 .. autofunction:: is_subtype
 .. autofunction:: is_supertype
 .. autofunction:: greater
+
+
+Casting between types
+---------------------
+
+It is common to need to cast values of one type to another type.  The casting rules for this are
+embedded into the :mod:`types` module.  You can query the casting kinds using :func:`cast_kind`:
+
+.. autofunction:: cast_kind
+
+The return values from this function are an enumeration explaining the types of cast that are
+allowed from the left type to the right type.
+
+.. autoclass:: CastKind
 """
 
 __all__ = [
@@ -77,7 +100,9 @@ __all__ = [
     "is_subtype",
     "is_supertype",
     "greater",
+    "CastKind",
+    "cast_kind",
 ]
 
 from .types import Type, Bool, Uint
-from .ordering import Ordering, order, is_subtype, is_supertype, greater
+from .ordering import Ordering, order, is_subtype, is_supertype, greater, CastKind, cast_kind

--- a/qiskit/circuit/store.py
+++ b/qiskit/circuit/store.py
@@ -1,0 +1,87 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""The 'Store' operation."""
+
+from __future__ import annotations
+
+import typing
+
+from .exceptions import CircuitError
+from .classical import expr, types
+from .instruction import Instruction
+
+
+def _handle_equal_types(lvalue: expr.Expr, rvalue: expr.Expr, /) -> tuple[expr.Expr, expr.Expr]:
+    return lvalue, rvalue
+
+
+def _handle_implicit_cast(lvalue: expr.Expr, rvalue: expr.Expr, /) -> tuple[expr.Expr, expr.Expr]:
+    return lvalue, expr.Cast(rvalue, lvalue.type, implicit=True)
+
+
+def _requires_lossless_cast(lvalue: expr.Expr, rvalue: expr.Expr, /) -> typing.NoReturn:
+    raise CircuitError(f"an explicit cast is required from '{rvalue.type}' to '{lvalue.type}'")
+
+
+def _requires_dangerous_cast(lvalue: expr.Expr, rvalue: expr.Expr, /) -> typing.NoReturn:
+    raise CircuitError(
+        f"an explicit cast is required from '{rvalue.type}' to '{lvalue.type}', which may be lossy"
+    )
+
+
+def _no_cast_possible(lvalue: expr.Expr, rvalue: expr.Expr) -> typing.NoReturn:
+    raise CircuitError(f"no cast is possible from '{rvalue.type}' to '{lvalue.type}'")
+
+
+_HANDLE_CAST = {
+    types.CastKind.EQUAL: _handle_equal_types,
+    types.CastKind.IMPLICIT: _handle_implicit_cast,
+    types.CastKind.LOSSLESS: _requires_lossless_cast,
+    types.CastKind.DANGEROUS: _requires_dangerous_cast,
+    types.CastKind.NONE: _no_cast_possible,
+}
+
+
+class Store(Instruction):
+    """A manual storage of some classical value to a classical memory location.
+
+    This is a low-level primitive of the classical-expression handling (similar to how
+    :class:`~.circuit.Measure` is a primitive for quantum measurement), and is not safe for
+    subclassing.  It is likely to become a special-case instruction in later versions of Qiskit
+    circuit and compiler internal representations."""
+
+    def __init__(self, lvalue: expr.Expr, rvalue: expr.Expr):
+        if not expr.is_lvalue(lvalue):
+            raise CircuitError(f"'{lvalue}' is not an l-value")
+
+        cast_kind = types.cast_kind(rvalue.type, lvalue.type)
+        if (handler := _HANDLE_CAST.get(cast_kind)) is None:
+            raise RuntimeError(f"unhandled cast kind required: {cast_kind}")
+        lvalue, rvalue = handler(lvalue, rvalue)
+
+        super().__init__("store", 0, 0, [lvalue, rvalue])
+
+    @property
+    def lvalue(self):
+        """Get the l-value :class:`~.expr.Expr` node that is being stored to."""
+        return self.params[0]
+
+    @property
+    def rvalue(self):
+        """Get the r-value :class:`~.expr.Expr` node that is being written into the l-value."""
+        return self.params[1]
+
+    def c_if(self, classical, val):
+        raise NotImplementedError(
+            "stores cannot be conditioned with `c_if`; use a full `if_test` context instead"
+        )

--- a/test/python/circuit/classical/test_expr_helpers.py
+++ b/test/python/circuit/classical/test_expr_helpers.py
@@ -115,3 +115,30 @@ class TestStructurallyEquivalent(QiskitTestCase):
         # ``True`` instead.
         self.assertFalse(expr.structurally_equivalent(left, right, not_handled, not_handled))
         self.assertTrue(expr.structurally_equivalent(left, right, always_equal, always_equal))
+
+
+@ddt.ddt
+class TestIsLValue(QiskitTestCase):
+    @ddt.data(
+        expr.Var.new("a", types.Bool()),
+        expr.Var.new("b", types.Uint(8)),
+        expr.Var(Clbit(), types.Bool()),
+        expr.Var(ClassicalRegister(8, "cr"), types.Uint(8)),
+    )
+    def test_happy_cases(self, lvalue):
+        self.assertTrue(expr.is_lvalue(lvalue))
+
+    @ddt.data(
+        expr.Value(3, types.Uint(2)),
+        expr.Value(False, types.Bool()),
+        expr.Cast(expr.Var.new("a", types.Uint(2)), types.Uint(8)),
+        expr.Unary(expr.Unary.Op.LOGIC_NOT, expr.Var.new("a", types.Bool()), types.Bool()),
+        expr.Binary(
+            expr.Binary.Op.LOGIC_AND,
+            expr.Var.new("a", types.Bool()),
+            expr.Var.new("b", types.Bool()),
+            types.Bool(),
+        ),
+    )
+    def test_bad_cases(self, not_an_lvalue):
+        self.assertFalse(expr.is_lvalue(not_an_lvalue))

--- a/test/python/circuit/classical/test_types_ordering.py
+++ b/test/python/circuit/classical/test_types_ordering.py
@@ -58,3 +58,13 @@ class TestTypesOrdering(QiskitTestCase):
         self.assertEqual(types.greater(types.Bool(), types.Bool()), types.Bool())
         with self.assertRaisesRegex(TypeError, "no ordering"):
             types.greater(types.Bool(), types.Uint(8))
+
+
+class TestTypesCastKind(QiskitTestCase):
+    def test_basic_examples(self):
+        """This is used extensively throughout the expression construction functions, but since it
+        is public API, it should have some direct unit tests as well."""
+        self.assertIs(types.cast_kind(types.Bool(), types.Bool()), types.CastKind.EQUAL)
+        self.assertIs(types.cast_kind(types.Uint(8), types.Bool()), types.CastKind.IMPLICIT)
+        self.assertIs(types.cast_kind(types.Bool(), types.Uint(8)), types.CastKind.LOSSLESS)
+        self.assertIs(types.cast_kind(types.Uint(16), types.Uint(8)), types.CastKind.DANGEROUS)

--- a/test/python/circuit/test_store.py
+++ b/test/python/circuit/test_store.py
@@ -1,0 +1,62 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
+
+from qiskit.test import QiskitTestCase
+from qiskit.circuit import Store, Clbit, CircuitError
+from qiskit.circuit.classical import expr, types
+
+
+class TestStoreInstruction(QiskitTestCase):
+    """Tests of the properties of the ``Store`` instruction itself."""
+
+    def test_happy_path_construction(self):
+        lvalue = expr.Var.new("a", types.Bool())
+        rvalue = expr.lift(Clbit())
+        constructed = Store(lvalue, rvalue)
+        self.assertIsInstance(constructed, Store)
+        self.assertEqual(constructed.lvalue, lvalue)
+        self.assertEqual(constructed.rvalue, rvalue)
+
+    def test_implicit_cast(self):
+        lvalue = expr.Var.new("a", types.Bool())
+        rvalue = expr.Var.new("b", types.Uint(8))
+        constructed = Store(lvalue, rvalue)
+        self.assertIsInstance(constructed, Store)
+        self.assertEqual(constructed.lvalue, lvalue)
+        self.assertEqual(constructed.rvalue, expr.Cast(rvalue, types.Bool(), implicit=True))
+
+    def test_rejects_non_lvalue(self):
+        not_an_lvalue = expr.logic_and(
+            expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Bool())
+        )
+        rvalue = expr.lift(False)
+        with self.assertRaisesRegex(CircuitError, "not an l-value"):
+            Store(not_an_lvalue, rvalue)
+
+    def test_rejects_explicit_cast(self):
+        lvalue = expr.Var.new("a", types.Uint(16))
+        rvalue = expr.Var.new("b", types.Uint(8))
+        with self.assertRaisesRegex(CircuitError, "an explicit cast is required"):
+            Store(lvalue, rvalue)
+
+    def test_rejects_dangerous_cast(self):
+        lvalue = expr.Var.new("a", types.Uint(8))
+        rvalue = expr.Var.new("b", types.Uint(16))
+        with self.assertRaisesRegex(CircuitError, "an explicit cast is required.*may be lossy"):
+            Store(lvalue, rvalue)
+
+    def test_rejects_c_if(self):
+        instruction = Store(expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Bool()))
+        with self.assertRaises(NotImplementedError):
+            instruction.c_if(Clbit(), False)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This does not yet add the implementation of `QuantumCircuit.store`, which will come later as part of expanding the full API of `QuantumCircuit` to be able to support these runtime variables.

The `is_lvalue` helper is added generally to the `classical.expr` module because it's generally useful, while `types.cast_kind` is moved from being a private method in `expr` to a public-API function so `Store` can use it.  These now come with associated unit tests.



### Details and comments

Depends on #10944.

Close #10939.

Release note to be added when closing #10922.