### PR TITLE
Bump metapackage versions

### DIFF
--- a/qiskit_pkg/setup.py
+++ b/qiskit_pkg/setup.py
@@ -26,11 +26,11 @@ README_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.m
 with open(README_PATH) as readme_file:
     README = readme_file.read()
 
-requirements = ["qiskit-terra==0.25.1"]
+requirements = ["qiskit-terra==0.25.2"]
 
 setup(
     name="qiskit",
-    version="0.44.1",
+    version="0.44.2",
     description="Software for developing quantum computing programs",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

As part of the recently released bugfix release for terra 0.25.2, the metapackage version numbers in qiskit_pkg/setup.py was accidentally overlooked. This means we're unable to publish a 0.44.2 package using the state of the repo as of the 0.25.2 tag. This commit corrects the oversight by bumping the version numbers on the stable/0.25 branch. To release 0.44.2 after this merges we have 2 choices, either we can push a 0.25.2post0 tag as a post-release for the 0.25.2 and this will trigger the publish of 0.44.2 with the correct versions. The alternative is we can just push a disposable branch that manually triggers just the qiskit package publish job with this commit applied. The latter might be preferable because it only runs one CI job, at the cost of the 0.25.2 not reflecting the state of the qiskit 0.44.2 release.

### Details and comments