### PR TITLE
Improve performance of measure_all by inlining calls to barrier 

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2285,7 +2285,7 @@ class QuantumCircuit:
         if add_bits:
             new_creg = circ._create_creg(len(circ.qubits), "meas")
             circ.add_register(new_creg)
-            # inline calls to barrier and measure
+            # inline call to barrier
             circ._append(Barrier(len(circ.qubits), label=None), circ.qubits, [])
             circ.measure(circ.qubits, new_creg)
         else:
@@ -2294,7 +2294,7 @@ class QuantumCircuit:
                     "The number of classical bits must be equal or greater than "
                     "the number of qubits."
                 )
-            # inline calls to barrier and measure
+            # inline call to barrier
             circ._append(Barrier(len(circ.qubits), label=None), circ.qubits, [])
             circ.measure(circ.qubits, circ.clbits[0 : len(circ.qubits)])
 

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2820,11 +2820,6 @@ class QuantumCircuit:
         Returns:
             qiskit.circuit.InstructionSet: handle to the added instructions.
         """
-        qubits: list[QubitSpecifier] = []
-
-        if not qargs:  # None
-            qubits.extend(self.qubits)
-
         qubits = (
             # This uses a `dict` not a `set` to guarantee a deterministic order to the arguments.
             list({q: None for qarg in qargs for q in self.qbit_argument_conversion(qarg)})

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -40,6 +40,7 @@ import numpy as np
 from qiskit._accelerate.quantum_circuit import CircuitData
 from qiskit.exceptions import QiskitError
 from qiskit.utils.multiprocessing import is_main_process
+from qiskit.circuit.barrier import Barrier
 from qiskit.circuit.instruction import Instruction
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.parameter import Parameter
@@ -2284,7 +2285,8 @@ class QuantumCircuit:
         if add_bits:
             new_creg = circ._create_creg(len(circ.qubits), "meas")
             circ.add_register(new_creg)
-            circ.barrier()
+            # inline calls to barrier and measure
+            circ._append(Barrier(len(circ.qubits), label=None), circ.qubits, [])
             circ.measure(circ.qubits, new_creg)
         else:
             if len(circ.clbits) < len(circ.qubits):
@@ -2292,7 +2294,8 @@ class QuantumCircuit:
                     "The number of classical bits must be equal or greater than "
                     "the number of qubits."
                 )
-            circ.barrier()
+            # inline calls to barrier and measure
+            circ._append(Barrier(len(circ.qubits), label=None), circ.qubits, [])
             circ.measure(circ.qubits, circ.clbits[0 : len(circ.qubits)])
 
         if not inplace:

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2825,18 +2825,13 @@ class QuantumCircuit:
         if not qargs:  # None
             qubits.extend(self.qubits)
 
-        for qarg in qargs:
-            if isinstance(qarg, QuantumRegister):
-                qubits.extend([qarg[j] for j in range(qarg.size)])
-            elif isinstance(qarg, list):
-                qubits.extend(qarg)
-            elif isinstance(qarg, range):
-                qubits.extend(list(qarg))
-            elif isinstance(qarg, slice):
-                qubits.extend(self.qubits[qarg])
-            else:
-                qubits.append(qarg)
-
+        qubits = (
+            # This uses a `dict` not a `set` to guarantee a deterministic order to the arguments.
+            list({q: None for qarg in qargs for q in self.qbit_argument_conversion(qarg)})
+            if qargs
+            else self.qubits.copy()
+        )
+ 
         return self.append(Barrier(len(qubits), label=label), qubits, [])
 
     def delay(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

 Improve performance of measure_all by inlining calls to barrier 

### Details and comments

Benchmark:
```
import time
from qiskit.circuit import QuantumCircuit
def g():
    qc=QuantumCircuit(2)
    qc.measure_all()

x=[]
for ii in range(20):
    t0=time.time()
    for ii in range(1000):
        g()
    dt=time.time()-t0
    #print(dt)
    x.append(dt)
    
print(f'total: {sum(x):.2f} seconds')
```
Results:
```
main: total: 2.04 seconds
PR: total: 1.80 seconds
```

