### PR TITLE
Optimize Quantumcircuit.decompose

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1592,7 +1592,7 @@ class QuantumCircuit:
         pass_ = Decompose(gates_to_decompose)
         for _ in range(reps):
             dag = pass_.run(dag)
-        return dag_to_circuit(dag)
+        return dag_to_circuit(dag, copy_operations=True)
 
     def qasm(
         self,

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1586,7 +1586,8 @@ class QuantumCircuit:
         from qiskit.converters.circuit_to_dag import circuit_to_dag
         from qiskit.converters.dag_to_circuit import dag_to_circuit
 
-        dag = circuit_to_dag(self)
+        # do not copy operations, this is done in the conversion from dag_to_circuit
+        dag = circuit_to_dag(self,copy_operations=False)
         dag = HighLevelSynthesis().run(dag)
         pass_ = Decompose(gates_to_decompose)
         for _ in range(reps):

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1587,7 +1587,7 @@ class QuantumCircuit:
         from qiskit.converters.dag_to_circuit import dag_to_circuit
 
         # do not copy operations, this is done in the conversion from dag_to_circuit
-        dag = circuit_to_dag(self,copy_operations=False)
+        dag = circuit_to_dag(self, copy_operations=False)
         dag = HighLevelSynthesis().run(dag)
         pass_ = Decompose(gates_to_decompose)
         for _ in range(reps):

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1586,13 +1586,13 @@ class QuantumCircuit:
         from qiskit.converters.circuit_to_dag import circuit_to_dag
         from qiskit.converters.dag_to_circuit import dag_to_circuit
 
-        # do not copy operations, this is done in the conversion from dag_to_circuit
-        dag = circuit_to_dag(self, copy_operations=False)
+        dag = circuit_to_dag(self, copy_operations=True)
         dag = HighLevelSynthesis().run(dag)
         pass_ = Decompose(gates_to_decompose)
         for _ in range(reps):
             dag = pass_.run(dag)
-        return dag_to_circuit(dag, copy_operations=True)
+        # do not copy operations, this is done in the conversion with circuit_to_dag
+        return dag_to_circuit(dag, copy_operations=False)
 
     def qasm(
         self,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Optimize `Quantumcircuit.decompose` by avoiding unnecessary copies of instructions.

### Details and comments

The instructions in the circuit are copied (at least) twice. We skip the first copy of instructions by passing `copy_operations=False` to `circuit_to_dag`. This results in a 20% speedup of circuit decompositions.

