### PR TITLE
Bump package version for post release

### DIFF
--- a/qiskit_pkg/setup.py
+++ b/qiskit_pkg/setup.py
@@ -26,7 +26,7 @@ README_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.m
 with open(README_PATH) as readme_file:
     README = readme_file.read()
 
-requirements = ["qiskit-terra==0.25.2.post0"]
+requirements = ["qiskit-terra==0.25.2.1"]
 
 setup(
     name="qiskit",

--- a/qiskit_pkg/setup.py
+++ b/qiskit_pkg/setup.py
@@ -26,7 +26,7 @@ README_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.m
 with open(README_PATH) as readme_file:
     README = readme_file.read()
 
-requirements = ["qiskit-terra==0.25.2"]
+requirements = ["qiskit-terra==0.25.2.post0"]
 
 setup(
     name="qiskit",

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ toqm_requirements = ["qiskit-toqm>=0.1.0"]
 
 setup(
     name="qiskit-terra",
-    version="0.25.2",
+    version="0.25.2.post0",
     description="Software for developing quantum computing programs",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ toqm_requirements = ["qiskit-toqm>=0.1.0"]
 
 setup(
     name="qiskit-terra",
-    version="0.25.2.post0",
+    version="0.25.2.1",
     description="Software for developing quantum computing programs",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The 0.25.2 release had a number of packaging issues relating to CI and versioning. This commit bumps the terra package version to 0.25.2.post0 which is a post-release notation that is pep440 compliant. The actual version.txt file is not updated in this PR because we still want it to show as 0.25.2 for `qiskit.__version__`, this is just a re-packaging of the 0.25.2 release.

### Details and comments