### PR TITLE
Add qubit count and basis gate checks to fake_backend

### DIFF
--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -571,7 +571,7 @@ class FakeBackend(BackendV1):
                                     set(self.configuration().basis_gates),
                                 )
                             )
-        elif not isinstance(circuits, QasmQobj):
+        elif not isinstance(circuits, QasmQobj) and not isinstance(circuits, pulse.ScheduleBlock):
             if not circuits.num_qubits <= self.configuration().n_qubits:
                 raise QiskitError(
                     "Invalid number of qubits, %s, attempted be run on "

--- a/releasenotes/notes/add-fake-backend-checks-5624e5927607991c.yaml
+++ b/releasenotes/notes/add-fake-backend-checks-5624e5927607991c.yaml
@@ -4,3 +4,4 @@ fixes:
     This release fixes the fake backend and makes it check that the 
     number of qubits is compatible with the simulated provider and it 
     ensures that the basis gates used are supported by the provider.
+    Fixed `#8590 <https://github.com/Qiskit/qiskit/issues/8509>`__

--- a/releasenotes/notes/add-fake-backend-checks-5624e5927607991c.yaml
+++ b/releasenotes/notes/add-fake-backend-checks-5624e5927607991c.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    This release fixes the fake backend and makes it check that the 
+    number of qubits is compatible with the simulated provider and it 
+    ensures that the basis gates used are supported by the provider.


### PR DESCRIPTION
Fixes #8509

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.

### Summary
This PR adds sanity checks to the fake_backend provider to ensure that it does not run tasks using a greater than supported qubit count or unsupported basis gate for a given provider e.g. FakeLima()

