### PR TITLE
Add variable-handling methods to `QuantumCircuit`

### DIFF
--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -279,6 +279,7 @@ Gates and Instructions
    InstructionSet
    Operation
    EquivalenceLibrary
+   Store
 
 Control Flow Operations
 -----------------------
@@ -375,6 +376,7 @@ from .barrier import Barrier
 from .delay import Delay
 from .measure import Measure
 from .reset import Reset
+from .store import Store
 from .parameter import Parameter
 from .parametervector import ParameterVector
 from .parameterexpression import ParameterExpression

--- a/qiskit/circuit/classical/expr/__init__.py
+++ b/qiskit/circuit/classical/expr/__init__.py
@@ -159,6 +159,11 @@ between two different circuits.  In this case, one can use :func:`structurally_e
 suitable "key" functions to do the comparison.
 
 .. autofunction:: structurally_equivalent
+
+Some expressions have associated memory locations with them, and some may be purely temporaries.
+You can use :func:`is_lvalue` to determine whether an expression has such a memory backing.
+
+.. autofunction:: is_lvalue
 """
 
 __all__ = [
@@ -171,6 +176,7 @@ __all__ = [
     "ExprVisitor",
     "iter_vars",
     "structurally_equivalent",
+    "is_lvalue",
     "lift",
     "cast",
     "bit_not",
@@ -190,7 +196,7 @@ __all__ = [
 ]
 
 from .expr import Expr, Var, Value, Cast, Unary, Binary
-from .visitors import ExprVisitor, iter_vars, structurally_equivalent
+from .visitors import ExprVisitor, iter_vars, structurally_equivalent, is_lvalue
 from .constructors import (
     lift,
     cast,

--- a/qiskit/circuit/classical/expr/__init__.py
+++ b/qiskit/circuit/classical/expr/__init__.py
@@ -39,8 +39,8 @@ The expression system is based on tree representation.  All nodes in the tree ar
 
 These objects are mutable and should not be reused in a different location without a copy.
 
-The entry point from general circuit objects to the expression system is by wrapping the object
-in a :class:`Var` node and associating a :class:`~.types.Type` with it.
+The base for dynamic variables is the :class:`Var`, which can be either an arbitrarily typed runtime
+variable, or a wrapper around an old-style :class:`.Clbit` or :class:`.ClassicalRegister`.
 
 .. autoclass:: Var
 
@@ -86,9 +86,17 @@ suitable :class:`Cast` nodes.
 The functions and methods described in this section are a more user-friendly way to build the
 expression tree, while staying close to the internal representation.  All these functions will
 automatically lift valid Python scalar values into corresponding :class:`Var` or :class:`Value`
-objects, and will resolve any required implicit casts on your behalf.
+objects, and will resolve any required implicit casts on your behalf.  If you want to directly use
+some scalar value as an :class:`Expr` node, you can manually lift it yourself.
 
 .. autofunction:: lift
+
+Typically you should create memory-owning :class:`Var` instances by using the
+:meth:`.QuantumCircuit.add_var` method to declare them in some circuit context, since a
+:class:`.QuantumCircuit` will not accept an :class:`Expr` that contains variables that are not
+already declared in it, since it needs to know how to allocate the storage and how the variable will
+be initialised.  However, should you want to do this manually, you should use the low-level
+:meth:`Var.new` call to safely generate a named variable for usage.
 
 You can manually specify casts in cases where the cast is allowed in explicit form, but may be
 lossy (such as the cast of a higher precision :class:`~.types.Uint` to a lower precision one).

--- a/qiskit/circuit/classical/expr/expr.py
+++ b/qiskit/circuit/classical/expr/expr.py
@@ -115,9 +115,23 @@ class Var(Expr):
     associated name; and an old-style variable that wraps a :class:`.Clbit` or
     :class:`.ClassicalRegister` instance that is owned by some containing circuit.  In general,
     construction of variables for use in programs should use :meth:`Var.new` or
-    :meth:`.QuantumCircuit.add_var`."""
+    :meth:`.QuantumCircuit.add_var`.
+
+    Variables are immutable after construction, so they can be used as dictionary keys."""
 
     __slots__ = ("var", "name")
+
+    var: qiskit.circuit.Clbit | qiskit.circuit.ClassicalRegister | uuid.UUID
+    """A reference to the backing data storage of the :class:`Var` instance.  When lifting
+    old-style :class:`.Clbit` or :class:`.ClassicalRegister` instances into a :class:`Var`,
+    this is exactly the :class:`.Clbit` or :class:`.ClassicalRegister`.  If the variable is a
+    new-style classical variable (one that owns its own storage separate to the old
+    :class:`.Clbit`/:class:`.ClassicalRegister` model), this field will be a :class:`~uuid.UUID`
+    to uniquely identify it."""
+    name: str | None
+    """The name of the variable.  This is required to exist if the backing :attr:`var` attribute
+    is a :class:`~uuid.UUID`, i.e. if it is a new-style variable, and must be ``None`` if it is
+    an old-style variable."""
 
     def __init__(
         self,
@@ -126,26 +140,31 @@ class Var(Expr):
         *,
         name: str | None = None,
     ):
-        self.type = type
-        self.var = var
-        """A reference to the backing data storage of the :class:`Var` instance.  When lifting
-        old-style :class:`.Clbit` or :class:`.ClassicalRegister` instances into a :class:`Var`,
-        this is exactly the :class:`.Clbit` or :class:`.ClassicalRegister`.  If the variable is a
-        new-style classical variable (one that owns its own storage separate to the old
-        :class:`.Clbit`/:class:`.ClassicalRegister` model), this field will be a :class:`~uuid.UUID`
-        to uniquely identify it."""
-        self.name = name
-        """The name of the variable.  This is required to exist if the backing :attr:`var` attribute
-        is a :class:`~uuid.UUID`, i.e. if it is a new-style variable, and must be ``None`` if it is
-        an old-style variable."""
+        super().__setattr__("type", type)
+        super().__setattr__("var", var)
+        super().__setattr__("name", name)
 
     @classmethod
     def new(cls, name: str, type: types.Type) -> typing.Self:
         """Generate a new named variable that owns its own backing storage."""
         return cls(uuid.uuid4(), type, name=name)
 
+    @property
+    def standalone(self) -> bool:
+        """Whether this :class:`Var` is a standalone variable that owns its storage location.  If
+        false, this is a wrapper :class:`Var` around some pre-existing circuit object."""
+        return isinstance(self.var, uuid.UUID)
+
     def accept(self, visitor, /):
         return visitor.visit_var(self)
+
+    def __setattr__(self, key, value):
+        if hasattr(self, key):
+            raise AttributeError(f"'Var' object attribute '{key}' is read-only")
+        raise AttributeError(f"'Var' object has no attribute '{key}'")
+
+    def __hash__(self):
+        return hash((self.type, self.var, self.name))
 
     def __eq__(self, other):
         return (
@@ -159,6 +178,23 @@ class Var(Expr):
         if self.name is None:
             return f"Var({self.var}, {self.type})"
         return f"Var({self.var}, {self.type}, name='{self.name}')"
+
+    def __getstate__(self):
+        return (self.var, self.type, self.name)
+
+    def __setstate__(self, state):
+        var, type, name = state
+        super().__setattr__("type", type)
+        super().__setattr__("var", var)
+        super().__setattr__("name", name)
+
+    def __copy__(self):
+        # I am immutable...
+        return self
+
+    def __deepcopy__(self, memo):
+        # ... as are all my consituent parts.
+        return self
 
 
 @typing.final

--- a/qiskit/circuit/classical/types/__init__.py
+++ b/qiskit/circuit/classical/types/__init__.py
@@ -15,6 +15,8 @@
 Typing (:mod:`qiskit.circuit.classical.types`)
 ==============================================
 
+Representation
+==============
 
 The type system of the expression tree is exposed through this module.  This is inherently linked to
 the expression system in the :mod:`~.classical.expr` module, as most expressions can only be
@@ -41,10 +43,17 @@ literals ``True`` and ``False``), and unsigned integers (corresponding to
 Note that :class:`Uint` defines a family of types parametrised by their width; it is not one single
 type, which may be slightly different to the 'classical' programming languages you are used to.
 
+
+Working with types
+==================
+
 There are some functions on these types exposed here as well.  These are mostly expected to be used
 only in manipulations of the expression tree; users who are building expressions using the
 :ref:`user-facing construction interface <circuit-classical-expressions-expr-construction>` should
 not need to use these.
+
+Partial ordering of types
+-------------------------
 
 The type system is equipped with a partial ordering, where :math:`a < b` is interpreted as
 ":math:`a` is a strict subtype of :math:`b`".  Note that the partial ordering is a subset of the
@@ -66,6 +75,20 @@ Some helper methods are then defined in terms of this low-level :func:`order` pr
 .. autofunction:: is_subtype
 .. autofunction:: is_supertype
 .. autofunction:: greater
+
+
+Casting between types
+---------------------
+
+It is common to need to cast values of one type to another type.  The casting rules for this are
+embedded into the :mod:`types` module.  You can query the casting kinds using :func:`cast_kind`:
+
+.. autofunction:: cast_kind
+
+The return values from this function are an enumeration explaining the types of cast that are
+allowed from the left type to the right type.
+
+.. autoclass:: CastKind
 """
 
 __all__ = [
@@ -77,7 +100,9 @@ __all__ = [
     "is_subtype",
     "is_supertype",
     "greater",
+    "CastKind",
+    "cast_kind",
 ]
 
 from .types import Type, Bool, Uint
-from .ordering import Ordering, order, is_subtype, is_supertype, greater
+from .ordering import Ordering, order, is_subtype, is_supertype, greater, CastKind, cast_kind

--- a/qiskit/circuit/classical/types/types.py
+++ b/qiskit/circuit/classical/types/types.py
@@ -89,6 +89,9 @@ class Bool(Type, metaclass=_Singleton):
     def __repr__(self):
         return "Bool()"
 
+    def __hash__(self):
+        return hash(self.__class__)
+
     def __eq__(self, other):
         return isinstance(other, Bool)
 
@@ -106,6 +109,9 @@ class Uint(Type):
 
     def __repr__(self):
         return f"Uint({self.width})"
+
+    def __hash__(self):
+        return hash((self.__class__, self.width))
 
     def __eq__(self, other):
         return isinstance(other, Uint) and self.width == other.width

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 import copy
+import itertools
 import multiprocessing as mp
 import warnings
 import typing
@@ -48,7 +49,7 @@ from qiskit.utils import optionals as _optionals
 from qiskit.utils.deprecation import deprecate_func
 from . import _classical_resource_map
 from ._utils import sort_parameters
-from .classical import expr
+from .classical import expr, types
 from .parameterexpression import ParameterExpression, ParameterValueType
 from .quantumregister import QuantumRegister, Qubit, AncillaRegister, AncillaQubit
 from .classicalregister import ClassicalRegister, Clbit
@@ -60,6 +61,7 @@ from .register import Register
 from .bit import Bit
 from .quantumcircuitdata import QuantumCircuitData, CircuitInstruction
 from .delay import Delay
+from .store import Store
 
 if typing.TYPE_CHECKING:
     import qiskit  # pylint: disable=cyclic-import
@@ -137,6 +139,23 @@ class QuantumCircuit:
             circuit. This gets stored as free-form data in a dict in the
             :attr:`~qiskit.circuit.QuantumCircuit.metadata` attribute. It will
             not be directly used in the circuit.
+        inputs: any variables to declare as ``input`` runtime variables for this circuit.  These
+            should already be existing :class:`.expr.Var` nodes that you build from somewhere else;
+            if you need to create the inputs as well, use :meth:`QuantumCircuit.add_input`.  The
+            variables given in this argument will be passed directly to :meth:`add_input`.  A
+            circuit cannot have both ``inputs`` and ``captures``.
+        captures: any variables that that this circuit scope should capture from a containing scope.
+            The variables given here will be passed directly to :meth:`add_capture`.  A circuit
+            cannot have both ``inputs`` and ``captures``.
+        declarations: any variables that this circuit should declare and initialize immediately.
+            You can order this input so that later declarations depend on earlier ones (including
+            inputs or captures). If you need to depend on values that will be computed later at
+            runtime, use :meth:`add_var` at an appropriate point in the circuit execution.
+
+            This argument is intended for convenient circuit initialization when you already have a
+            set of created variables.  The variables used here will be directly passed to
+            :meth:`add_var`, which you can use directly if this is the first time you are creating
+            the variable.
 
     Raises:
         CircuitError: if the circuit name, if given, is not valid.
@@ -199,6 +218,9 @@ class QuantumCircuit:
         name: str | None = None,
         global_phase: ParameterValueType = 0,
         metadata: dict | None = None,
+        inputs: Iterable[expr.Var] = (),
+        captures: Iterable[expr.Var] = (),
+        declarations: Mapping[expr.Var, expr.Expr] | Iterable[Tuple[expr.Var, expr.Expr]] = (),
     ):
         if any(not isinstance(reg, (list, QuantumRegister, ClassicalRegister)) for reg in regs):
             # check if inputs are integers, but also allow e.g. 2.0
@@ -267,6 +289,20 @@ class QuantumCircuit:
         self._layout = None
         self._global_phase: ParameterValueType = 0
         self.global_phase = global_phase
+
+        # Add classical variables.  Resolve inputs and captures first because they can't depend on
+        # anything, but declarations might depend on them.
+        self._vars_input: dict[str, expr.Var] = {}
+        self._vars_capture: dict[str, expr.Var] = {}
+        self._vars_local: dict[str, expr.Var] = {}
+        for input_ in inputs:
+            self.add_input(input_)
+        for capture in captures:
+            self.add_capture(capture)
+        if isinstance(declarations, Mapping):
+            declarations = declarations.items()
+        for var, initial in declarations:
+            self.add_var(var, initial)
 
         self.duration = None
         self.unit = "dt"
@@ -1111,6 +1147,33 @@ class QuantumCircuit:
         """
         return self._ancillas
 
+    def iter_vars(self) -> typing.Iterable[expr.Var]:
+        """Get an iterable over all runtime classical variables in scope within this circuit.
+
+        This method will iterate over all variables in scope.  For more fine-grained iterators, see
+        :meth:`iter_declared_vars`, :meth:`iter_input_vars` and :meth:`iter_captured_vars`."""
+        return itertools.chain(
+            self._vars_input.values(), self._vars_capture.values(), self._vars_local.values()
+        )
+
+    def iter_declared_vars(self) -> typing.Iterable[expr.Var]:
+        """Get an iterable over all runtime classical variables that are declared with automatic
+        storage duration in this scope.  This excludes input variables (see :meth:`iter_input_vars`)
+        and captured variables (see :meth:`iter_captured_vars`)."""
+        return self._vars_local.values()
+
+    def iter_input_vars(self) -> typing.Iterable[expr.Var]:
+        """Get an iterable over all runtime classical variables that are declared as inputs to this
+        circuit scope.  This excludes locally declared variables (see :meth:`iter_declared_vars`)
+        and captured variables (see :meth:`iter_captured_vars`)."""
+        return self._vars_input.values()
+
+    def iter_captured_vars(self) -> typing.Iterable[expr.Var]:
+        """Get an iterable over all runtime classical variables that are captured by this circuit
+        scope from a containing scope.  This excludes input variables (see :meth:`iter_input_vars`)
+        and locally declared variables (see :meth:`iter_declared_vars`)."""
+        return self._vars_capture.values()
+
     def __and__(self, rhs: "QuantumCircuit") -> "QuantumCircuit":
         """Overload & to implement self.compose."""
         return self.compose(rhs)
@@ -1225,12 +1288,17 @@ class QuantumCircuit:
 
     def _validate_expr(self, node: expr.Expr) -> expr.Expr:
         for var in expr.iter_vars(node):
-            if isinstance(var.var, Clbit):
+            if var.standalone:
+                if not self.has_var(var):
+                    raise CircuitError(f"Variable '{var}' is not present in this circuit.")
+            elif isinstance(var.var, Clbit):
                 if var.var not in self._clbit_indices:
                     raise CircuitError(f"Clbit {var.var} is not present in this circuit.")
             elif isinstance(var.var, ClassicalRegister):
                 if var.var not in self.cregs:
                     raise CircuitError(f"Register {var.var} is not present in this circuit.")
+            else:
+                raise RuntimeError(f"unhandled Var inner type in '{var}'")
         return node
 
     def append(
@@ -1288,8 +1356,12 @@ class QuantumCircuit:
                 )
 
         # Make copy of parameterized gate instances
-        if hasattr(operation, "params"):
-            is_parameter = any(isinstance(param, Parameter) for param in operation.params)
+        if params := getattr(operation, "params", ()):
+            is_parameter = False
+            for param in params:
+                is_parameter = is_parameter or isinstance(param, Parameter)
+                if isinstance(param, expr.Expr):
+                    self._validate_expr(param)
             if is_parameter:
                 operation = copy.deepcopy(operation)
 
@@ -1406,6 +1478,243 @@ class QuantumCircuit:
 
                     # clear cache if new parameter is added
                     self._parameters = None
+
+    @typing.overload
+    def get_var(self, name: str, default: T) -> Union[expr.Var, T]:
+        ...
+
+    # The builtin `types` module has `EllipsisType`, but only from 3.10+!
+    @typing.overload
+    def get_var(self, name: str, default: type(...) = ...) -> expr.Var:
+        ...
+
+    # We use a _literal_ `Ellipsis` as the marker value to leave `None` available as a default.
+    def get_var(self, name: str, default: typing.Any = ...):
+        """Retrieve a variable that is accessible in this circuit scope by name.
+
+        Args:
+            name: the name of the variable to retrieve.
+            default: if given, this value will be returned if the variable is not present.  If it
+                is not given, a :exc:`KeyError` is raised instead.
+
+        Returns:
+            The corresponding variable.
+
+        Raises:
+            KeyError: if no default is given, but the variable does not exist.
+
+        Examples:
+            Retrieve a variable by name from a circuit::
+
+                from qiskit.circuit import QuantumCircuit
+
+                # Create a circuit and create a variable in it.
+                qc = QuantumCircuit()
+                my_var = qc.add_var("my_var", False)
+
+                # We can use 'my_var' as a variable, but let's say we've lost the Python object and
+                # need to retrieve it.
+                my_var_again = qc.get_var("my_var")
+
+                assert my_var is my_var_again
+
+            Get a variable from a circuit by name, returning some default if it is not present::
+
+                assert qc.get_var("my_var", None) is my_var
+                assert qc.get_var("unknown_variable", None) is None
+        """
+
+        if (out := self._vars_local.get(name)) is not None:
+            return out
+        if (out := self._vars_capture.get(name)) is not None:
+            return out
+        if (out := self._vars_input.get(name)) is not None:
+            return out
+        if default is Ellipsis:
+            raise KeyError(f"no variable named '{name}' is present")
+        return default
+
+    def has_var(self, name_or_var: str | expr.Var, /) -> bool:
+        """Check whether a variable is defined in this scope.
+
+        Args:
+            name_or_var: the variable, or name of a variable to check.  If this is a
+                :class:`.expr.Var` node, the variable must be exactly the given one for this
+                function to return ``True``.
+
+        Returns:
+            whether a matching variable is present.
+
+        See also:
+            :meth:`QuantumCircuit.get_var`: retrieve a named variable from a circuit.
+        """
+        if isinstance(name_or_var, str):
+            return self.get_var(name_or_var, None) is not None
+        return self.get_var(name_or_var.name, None) == name_or_var
+
+    def _prepare_new_var(
+        self, name_or_var: str | expr.Var, type_: types.Type | None, /
+    ) -> expr.Var:
+        """The common logic for preparing and validating a new :class:`~.expr.Var` for the circuit.
+
+        The given ``type_`` can be ``None`` if the variable specifier is already a :class:`.Var`,
+        and must be a :class:`~.types.Type` if it is a string.  The argument is ignored if the given
+        first argument is a :class:`.Var` already.
+
+        Returns the validated variable, which is guaranteed to be safe to add to the circuit."""
+        if isinstance(name_or_var, str):
+            var = expr.Var.new(name_or_var, type_)
+        else:
+            var = name_or_var
+            if not var.standalone:
+                raise CircuitError(
+                    "cannot add variables that wrap `Clbit` or `ClassicalRegister` instances."
+                    " Use `add_bits` or `add_register` as appropriate."
+                )
+
+        # The `var` is guaranteed to have a name because we already excluded the cases where it's
+        # wrapping a bit/register.
+        if (previous := self.get_var(var.name, default=None)) is not None:
+            if previous == var:
+                raise CircuitError(f"'{var}' is already present in the circuit")
+            raise CircuitError(f"cannot add '{var}' as its name shadows the existing '{previous}'")
+        return var
+
+    def add_var(self, name_or_var: str | expr.Var, /, initial: typing.Any) -> expr.Var:
+        """Add a classical variable with automatic storage and scope to this circuit.
+
+        The variable is considered to have been "declared" at the beginning of the circuit, but it
+        only becomes initialized at the point of the circuit that you call this method, so it can
+        depend on variables defined before it.
+
+        Args:
+            name_or_var: either a string of the variable name, or an existing instance of
+                :class:`~.expr.Var` to re-use.  Variables cannot shadow names that are already in
+                use within the circuit.
+            initial: the value to initialize this variable with.  If the first argument was given
+                as a string name, the type of the resulting variable is inferred from the initial
+                expression; to control this more manually, either use :meth:`.Var.new` to manually
+                construct a new variable with the desired type, or use :func:`.expr.cast` to cast
+                the initializer to the desired type.
+
+                This must be either a :class:`~.expr.Expr` node, or a value that can be lifted to
+                one using :class:`.expr.lift`.
+
+        Returns:
+            The created variable.  If a :class:`~.expr.Var` instance was given, the exact same
+            object will be returned.
+
+        Raises:
+            CircuitError: if the variable cannot be created due to shadowing an existing variable.
+
+        Examples:
+            Define a new variable given just a name and an initializer expression::
+
+                from qiskit.circuit import QuantumCircuit
+
+                qc = QuantumCircuit(2)
+                my_var = qc.add_var("my_var", False)
+
+            Reuse a variable that may have been taking from a related circuit, or otherwise
+            constructed manually, and initialize it to some more complicated expression::
+
+                from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister
+                from qiskit.circuit.classical import expr, types
+
+                my_var = expr.Var.new("my_var", types.Uint(8))
+
+                cr1 = ClassicalRegister(8, "cr1")
+                cr2 = ClassicalRegister(8, "cr2")
+                qc = QuantumCircuit(QuantumRegister(8), cr1, cr2)
+
+                # Get some measurement results into each register.
+                qc.h(0)
+                for i in range(1, 8):
+                    qc.cx(0, i)
+                qc.measure(range(8), cr1)
+
+                qc.reset(range(8))
+                qc.h(0)
+                for i in range(1, 8):
+                    qc.cx(0, i)
+                qc.measure(range(8), cr2)
+
+                # Now when we add the variable, it is initialized using the runtime state of the two
+                # classical registers we measured into above.
+                qc.add_var(my_var, expr.bit_and(cr1, cr2))
+        """
+        # Validate the initialiser first to catch cases where the variable to be declared is being
+        # used in the initialiser.
+        initial = self._validate_expr(expr.lift(initial))
+        var = self._prepare_new_var(name_or_var, initial.type)
+        # Store is responsible for ensuring the type safety of the initialisation.  We build this
+        # before actually modifying any of our own state, so we don't get into an inconsistent state
+        # if an exception is raised later.
+        store = Store(var, initial)
+
+        self._vars_local[var.name] = var
+        self._append(CircuitInstruction(store, (), ()))
+        return var
+
+    def add_capture(self, var: expr.Var):
+        """Add a variable to the circuit that it should capture from a scope it will be contained
+        within.
+
+        This method requires a :class:`~.expr.Var` node to enforce that you've got a handle to one,
+        because you will need to declare the same variable using the same object into the outer
+        circuit.
+
+        This is a low-level method.  You typically will not need to call this method, assuming you
+        are using the builder interface for control-flow scopes (``with`` context-manager statements
+        for :meth:`if_test` and the other scoping constructs).  The builder interface will
+        automatically make the inner scopes closures on your behalf by capturing any variables that
+        are used within them.
+
+        Args:
+            var: the variable to capture from an enclosing scope.
+
+        Raises:
+            CircuitError: if the variable cannot be created due to shadowing an existing variable.
+        """
+        if self._vars_input:
+            raise CircuitError(
+                "circuits with input variables cannot be enclosed, so cannot be closures"
+            )
+        self._vars_capture[var.name] = self._prepare_new_var(var, None)
+
+    @typing.overload
+    def add_input(self, name_or_var: str, type_: types.Type, /) -> expr.Var:
+        ...
+
+    @typing.overload
+    def add_input(self, name_or_var: expr.Var, type_: None = None, /) -> expr.Var:
+        ...
+
+    def add_input(  # pylint: disable=missing-raises-doc
+        self, name_or_var: str | expr.Var, type_: types.Type | None = None, /
+    ) -> expr.Var:
+        """Register a variable as an input to the circuit.
+
+        Args:
+            name_or_var: either a string name, or an existing :class:`~.expr.Var` node to use as the
+                input variable.
+            type_: if the name is given as a string, then this must be a :class:`~.types.Type` to
+                use for the variable.  If the variable is given as an existing :class:`~.expr.Var`,
+                then this must not be given, and will instead be read from the object itself.
+
+        Returns:
+            the variable created, or the same variable as was passed in.
+
+        Raises:
+            CircuitError: if the variable cannot be created due to shadowing an existing variable.
+        """
+        if self._vars_capture:
+            raise CircuitError("circuits to be enclosed with captures cannot have input variables")
+        if isinstance(name_or_var, expr.Var) and type_ is not None:
+            raise ValueError("cannot give an explicit type with an existing Var")
+        var = self._prepare_new_var(name_or_var, type_)
+        self._vars_input[var.name] = var
+        return var
 
     def add_register(self, *regs: Register | int | Sequence[Bit]) -> None:
         """Add registers."""
@@ -2207,6 +2516,27 @@ class QuantumCircuit:
         from .reset import Reset
 
         return self.append(Reset(), [qubit], [])
+
+    def store(self, lvalue: typing.Any, rvalue: typing.Any, /) -> InstructionSet:
+        """Store the result of the given runtime classical expression ``rvalue`` in the memory
+        location defined by ``lvalue``.
+
+        Typically ``lvalue`` will be a :class:`~.expr.Var` node and ``rvalue`` will be some
+        :class:`~.expr.Expr` to write into it, but anything that :func:`.expr.lift` can raise to an
+        :class:`~.expr.Expr` is permissible in both places, and it will be called on them.
+
+        Args:
+            lvalue: a valid specifier for a memory location in the circuit.  This will typically be
+                a :class:`~.expr.Var` node, but you can also write to :class:`.Clbit` or
+                :class:`.ClassicalRegister` memory locations if your hardware supports it.
+            rvalue: a runtime classical expression whose result should be written into the given
+                memory location.
+
+        .. seealso::
+            :class:`~.circuit.Store`
+                the backing :class:`~.circuit.Instruction` class that represents this operation.
+        """
+        return self.append(Store(expr.lift(lvalue), expr.lift(rvalue)), (), ())
 
     def measure(self, qubit: QubitSpecifier, cbit: ClbitSpecifier) -> InstructionSet:
         r"""Measure a quantum bit (``qubit``) in the Z basis into a classical bit (``cbit``).

--- a/qiskit/circuit/store.py
+++ b/qiskit/circuit/store.py
@@ -1,0 +1,87 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""The 'Store' operation."""
+
+from __future__ import annotations
+
+import typing
+
+from .exceptions import CircuitError
+from .classical import expr, types
+from .instruction import Instruction
+
+
+def _handle_equal_types(lvalue: expr.Expr, rvalue: expr.Expr, /) -> tuple[expr.Expr, expr.Expr]:
+    return lvalue, rvalue
+
+
+def _handle_implicit_cast(lvalue: expr.Expr, rvalue: expr.Expr, /) -> tuple[expr.Expr, expr.Expr]:
+    return lvalue, expr.Cast(rvalue, lvalue.type, implicit=True)
+
+
+def _requires_lossless_cast(lvalue: expr.Expr, rvalue: expr.Expr, /) -> typing.NoReturn:
+    raise CircuitError(f"an explicit cast is required from '{rvalue.type}' to '{lvalue.type}'")
+
+
+def _requires_dangerous_cast(lvalue: expr.Expr, rvalue: expr.Expr, /) -> typing.NoReturn:
+    raise CircuitError(
+        f"an explicit cast is required from '{rvalue.type}' to '{lvalue.type}', which may be lossy"
+    )
+
+
+def _no_cast_possible(lvalue: expr.Expr, rvalue: expr.Expr) -> typing.NoReturn:
+    raise CircuitError(f"no cast is possible from '{rvalue.type}' to '{lvalue.type}'")
+
+
+_HANDLE_CAST = {
+    types.CastKind.EQUAL: _handle_equal_types,
+    types.CastKind.IMPLICIT: _handle_implicit_cast,
+    types.CastKind.LOSSLESS: _requires_lossless_cast,
+    types.CastKind.DANGEROUS: _requires_dangerous_cast,
+    types.CastKind.NONE: _no_cast_possible,
+}
+
+
+class Store(Instruction):
+    """A manual storage of some classical value to a classical memory location.
+
+    This is a low-level primitive of the classical-expression handling (similar to how
+    :class:`~.circuit.Measure` is a primitive for quantum measurement), and is not safe for
+    subclassing.  It is likely to become a special-case instruction in later versions of Qiskit
+    circuit and compiler internal representations."""
+
+    def __init__(self, lvalue: expr.Expr, rvalue: expr.Expr):
+        if not expr.is_lvalue(lvalue):
+            raise CircuitError(f"'{lvalue}' is not an l-value")
+
+        cast_kind = types.cast_kind(rvalue.type, lvalue.type)
+        if (handler := _HANDLE_CAST.get(cast_kind)) is None:
+            raise RuntimeError(f"unhandled cast kind required: {cast_kind}")
+        lvalue, rvalue = handler(lvalue, rvalue)
+
+        super().__init__("store", 0, 0, [lvalue, rvalue])
+
+    @property
+    def lvalue(self):
+        """Get the l-value :class:`~.expr.Expr` node that is being stored to."""
+        return self.params[0]
+
+    @property
+    def rvalue(self):
+        """Get the r-value :class:`~.expr.Expr` node that is being written into the l-value."""
+        return self.params[1]
+
+    def c_if(self, classical, val):
+        raise NotImplementedError(
+            "stores cannot be conditioned with `c_if`; use a full `if_test` context instead"
+        )

--- a/releasenotes/notes/expr-hashable-var-types-7cf2aaa00b201ae6.yaml
+++ b/releasenotes/notes/expr-hashable-var-types-7cf2aaa00b201ae6.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Classical types (subclasses of :class:`~classical.types.Type`) and variables (:class:`~.expr.Var`)
+    are now hashable.

--- a/releasenotes/notes/expr-var-standalone-2c1116583a2be9fd.yaml
+++ b/releasenotes/notes/expr-var-standalone-2c1116583a2be9fd.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    :class:`~.expr.Var` nodes now have a :attr:`.Var.standalone` property to quickly query whether
+    they are new-style memory-owning variables, or whether they wrap old-style classical memory in
+    the form of a :class:`.Clbit` or :class:`.ClassicalRegister`.

--- a/test/python/circuit/classical/test_expr_helpers.py
+++ b/test/python/circuit/classical/test_expr_helpers.py
@@ -115,3 +115,30 @@ class TestStructurallyEquivalent(QiskitTestCase):
         # ``True`` instead.
         self.assertFalse(expr.structurally_equivalent(left, right, not_handled, not_handled))
         self.assertTrue(expr.structurally_equivalent(left, right, always_equal, always_equal))
+
+
+@ddt.ddt
+class TestIsLValue(QiskitTestCase):
+    @ddt.data(
+        expr.Var.new("a", types.Bool()),
+        expr.Var.new("b", types.Uint(8)),
+        expr.Var(Clbit(), types.Bool()),
+        expr.Var(ClassicalRegister(8, "cr"), types.Uint(8)),
+    )
+    def test_happy_cases(self, lvalue):
+        self.assertTrue(expr.is_lvalue(lvalue))
+
+    @ddt.data(
+        expr.Value(3, types.Uint(2)),
+        expr.Value(False, types.Bool()),
+        expr.Cast(expr.Var.new("a", types.Uint(2)), types.Uint(8)),
+        expr.Unary(expr.Unary.Op.LOGIC_NOT, expr.Var.new("a", types.Bool()), types.Bool()),
+        expr.Binary(
+            expr.Binary.Op.LOGIC_AND,
+            expr.Var.new("a", types.Bool()),
+            expr.Var.new("b", types.Bool()),
+            types.Bool(),
+        ),
+    )
+    def test_bad_cases(self, not_an_lvalue):
+        self.assertFalse(expr.is_lvalue(not_an_lvalue))

--- a/test/python/circuit/classical/test_types_ordering.py
+++ b/test/python/circuit/classical/test_types_ordering.py
@@ -58,3 +58,13 @@ class TestTypesOrdering(QiskitTestCase):
         self.assertEqual(types.greater(types.Bool(), types.Bool()), types.Bool())
         with self.assertRaisesRegex(TypeError, "no ordering"):
             types.greater(types.Bool(), types.Uint(8))
+
+
+class TestTypesCastKind(QiskitTestCase):
+    def test_basic_examples(self):
+        """This is used extensively throughout the expression construction functions, but since it
+        is public API, it should have some direct unit tests as well."""
+        self.assertIs(types.cast_kind(types.Bool(), types.Bool()), types.CastKind.EQUAL)
+        self.assertIs(types.cast_kind(types.Uint(8), types.Bool()), types.CastKind.IMPLICIT)
+        self.assertIs(types.cast_kind(types.Bool(), types.Uint(8)), types.CastKind.LOSSLESS)
+        self.assertIs(types.cast_kind(types.Uint(16), types.Uint(8)), types.CastKind.DANGEROUS)

--- a/test/python/circuit/test_circuit_vars.py
+++ b/test/python/circuit/test_circuit_vars.py
@@ -1,0 +1,366 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
+
+from qiskit.test import QiskitTestCase
+from qiskit.circuit import QuantumCircuit, CircuitError, Clbit, ClassicalRegister
+from qiskit.circuit.classical import expr, types
+
+
+class TestCircuitVars(QiskitTestCase):
+    """Tests for variable-manipulation routines on circuits.  More specific functionality is likely
+    tested in the suites of the specific methods."""
+
+    def test_initialise_inputs(self):
+        vars_ = [expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Uint(16))]
+        qc = QuantumCircuit(inputs=vars_)
+        self.assertEqual(set(vars_), set(qc.iter_vars()))
+
+    def test_initialise_captures(self):
+        vars_ = [expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Uint(16))]
+        qc = QuantumCircuit(captures=vars_)
+        self.assertEqual(set(vars_), set(qc.iter_vars()))
+
+    def test_initialise_declarations_iterable(self):
+        vars_ = [
+            (expr.Var.new("a", types.Bool()), expr.lift(True)),
+            (expr.Var.new("b", types.Uint(16)), expr.lift(0xFFFF)),
+        ]
+        qc = QuantumCircuit(declarations=vars_)
+
+        self.assertEqual({var for var, _initialiser in vars_}, set(qc.iter_vars()))
+        operations = [
+            (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
+            for instruction in qc.data
+        ]
+        self.assertEqual(operations, [("store", lvalue, rvalue) for lvalue, rvalue in vars_])
+
+    def test_initialise_declarations_mapping(self):
+        # Dictionary iteration order is guaranteed to be insertion order.
+        vars_ = {
+            expr.Var.new("a", types.Bool()): expr.lift(True),
+            expr.Var.new("b", types.Uint(16)): expr.lift(0xFFFF),
+        }
+        qc = QuantumCircuit(declarations=vars_)
+
+        self.assertEqual(set(vars_), set(qc.iter_vars()))
+        operations = [
+            (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
+            for instruction in qc.data
+        ]
+        self.assertEqual(
+            operations, [("store", lvalue, rvalue) for lvalue, rvalue in vars_.items()]
+        )
+
+    def test_initialise_declarations_dependencies(self):
+        """Test that the cirucit initialiser can take in declarations with dependencies between
+        them, provided they're specified in a suitable order."""
+        a = expr.Var.new("a", types.Bool())
+        vars_ = [
+            (a, expr.lift(True)),
+            (expr.Var.new("b", types.Bool()), a),
+        ]
+        qc = QuantumCircuit(declarations=vars_)
+
+        self.assertEqual({var for var, _initialiser in vars_}, set(qc.iter_vars()))
+        operations = [
+            (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
+            for instruction in qc.data
+        ]
+        self.assertEqual(operations, [("store", lvalue, rvalue) for lvalue, rvalue in vars_])
+
+    def test_initialise_inputs_declarations(self):
+        a = expr.Var.new("a", types.Uint(16))
+        b = expr.Var.new("b", types.Uint(16))
+        b_init = expr.bit_and(a, 0xFFFF)
+        qc = QuantumCircuit(inputs=[a], declarations={b: b_init})
+
+        self.assertEqual({a}, set(qc.iter_input_vars()))
+        self.assertEqual({b}, set(qc.iter_declared_vars()))
+        self.assertEqual({a, b}, set(qc.iter_vars()))
+        operations = [
+            (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
+            for instruction in qc.data
+        ]
+        self.assertEqual(operations, [("store", b, b_init)])
+
+    def test_initialise_captures_declarations(self):
+        a = expr.Var.new("a", types.Uint(16))
+        b = expr.Var.new("b", types.Uint(16))
+        b_init = expr.bit_and(a, 0xFFFF)
+        qc = QuantumCircuit(captures=[a], declarations={b: b_init})
+
+        self.assertEqual({a}, set(qc.iter_captured_vars()))
+        self.assertEqual({b}, set(qc.iter_declared_vars()))
+        self.assertEqual({a, b}, set(qc.iter_vars()))
+        operations = [
+            (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
+            for instruction in qc.data
+        ]
+        self.assertEqual(operations, [("store", b, b_init)])
+
+    def test_add_var_returns_good_var(self):
+        qc = QuantumCircuit()
+        a = qc.add_var("a", expr.lift(True))
+        self.assertEqual(a.name, "a")
+        self.assertEqual(a.type, types.Bool())
+
+        b = qc.add_var("b", expr.Value(0xFF, types.Uint(8)))
+        self.assertEqual(b.name, "b")
+        self.assertEqual(b.type, types.Uint(8))
+
+    def test_add_var_returns_input(self):
+        """Test that the `Var` returned by `add_var` is the same as the input if `Var`."""
+        a = expr.Var.new("a", types.Bool())
+        qc = QuantumCircuit()
+        a_other = qc.add_var(a, expr.lift(True))
+        self.assertIs(a, a_other)
+
+    def test_add_input_returns_good_var(self):
+        qc = QuantumCircuit()
+        a = qc.add_input("a", types.Bool())
+        self.assertEqual(a.name, "a")
+        self.assertEqual(a.type, types.Bool())
+
+        b = qc.add_input("b", types.Uint(8))
+        self.assertEqual(b.name, "b")
+        self.assertEqual(b.type, types.Uint(8))
+
+    def test_add_input_returns_input(self):
+        """Test that the `Var` returned by `add_input` is the same as the input if `Var`."""
+        a = expr.Var.new("a", types.Bool())
+        qc = QuantumCircuit()
+        a_other = qc.add_input(a)
+        self.assertIs(a, a_other)
+
+    def test_cannot_have_both_inputs_and_captures(self):
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+
+        with self.assertRaisesRegex(CircuitError, "circuits with input.*cannot be closures"):
+            QuantumCircuit(inputs=[a], captures=[b])
+
+        qc = QuantumCircuit(inputs=[a])
+        with self.assertRaisesRegex(CircuitError, "circuits with input.*cannot be closures"):
+            qc.add_capture(b)
+
+        qc = QuantumCircuit(captures=[a])
+        with self.assertRaisesRegex(CircuitError, "circuits to be enclosed.*cannot have input"):
+            qc.add_input(b)
+
+    def test_cannot_add_cyclic_declaration(self):
+        a = expr.Var.new("a", types.Bool())
+        with self.assertRaisesRegex(CircuitError, "not present in this circuit"):
+            QuantumCircuit(declarations=[(a, a)])
+
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "not present in this circuit"):
+            qc.add_var(a, a)
+
+    def test_initialise_inputs_equal_to_add_input(self):
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Uint(16))
+
+        qc_init = QuantumCircuit(inputs=[a, b])
+        qc_manual = QuantumCircuit()
+        qc_manual.add_input(a)
+        qc_manual.add_input(b)
+        self.assertEqual(list(qc_init.iter_vars()), list(qc_manual.iter_vars()))
+
+        qc_manual = QuantumCircuit()
+        a = qc_manual.add_input("a", types.Bool())
+        b = qc_manual.add_input("b", types.Uint(16))
+        qc_init = QuantumCircuit(inputs=[a, b])
+        self.assertEqual(list(qc_init.iter_vars()), list(qc_manual.iter_vars()))
+
+    def test_initialise_captures_equal_to_add_capture(self):
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Uint(16))
+
+        qc_init = QuantumCircuit(captures=[a, b])
+        qc_manual = QuantumCircuit()
+        qc_manual.add_capture(a)
+        qc_manual.add_capture(b)
+        self.assertEqual(list(qc_init.iter_vars()), list(qc_manual.iter_vars()))
+
+    def test_initialise_declarations_equal_to_add_var(self):
+        a = expr.Var.new("a", types.Bool())
+        a_init = expr.lift(False)
+        b = expr.Var.new("b", types.Uint(16))
+        b_init = expr.lift(0xFFFF)
+
+        qc_init = QuantumCircuit(declarations=[(a, a_init), (b, b_init)])
+        qc_manual = QuantumCircuit()
+        qc_manual.add_var(a, a_init)
+        qc_manual.add_var(b, b_init)
+        self.assertEqual(list(qc_init.iter_vars()), list(qc_manual.iter_vars()))
+        self.assertEqual(qc_init.data, qc_manual.data)
+
+        qc_manual = QuantumCircuit()
+        a = qc_manual.add_var("a", a_init)
+        b = qc_manual.add_var("b", b_init)
+        qc_init = QuantumCircuit(declarations=[(a, a_init), (b, b_init)])
+        self.assertEqual(list(qc_init.iter_vars()), list(qc_manual.iter_vars()))
+        self.assertEqual(qc_init.data, qc_manual.data)
+
+    def test_cannot_shadow_vars(self):
+        """Test that exact duplicate ``Var`` nodes within different combinations of the inputs are
+        detected and rejected."""
+        a = expr.Var.new("a", types.Bool())
+        a_init = expr.lift(True)
+        with self.assertRaisesRegex(CircuitError, "already present"):
+            QuantumCircuit(inputs=[a, a])
+        with self.assertRaisesRegex(CircuitError, "already present"):
+            QuantumCircuit(captures=[a, a])
+        with self.assertRaisesRegex(CircuitError, "already present"):
+            QuantumCircuit(declarations=[(a, a_init), (a, a_init)])
+        with self.assertRaisesRegex(CircuitError, "already present"):
+            QuantumCircuit(inputs=[a], declarations=[(a, a_init)])
+        with self.assertRaisesRegex(CircuitError, "already present"):
+            QuantumCircuit(captures=[a], declarations=[(a, a_init)])
+
+    def test_cannot_shadow_names(self):
+        """Test that exact duplicate ``Var`` nodes within different combinations of the inputs are
+        detected and rejected."""
+        a_bool1 = expr.Var.new("a", types.Bool())
+        a_bool2 = expr.Var.new("a", types.Bool())
+        a_uint = expr.Var.new("a", types.Uint(16))
+        a_bool_init = expr.lift(True)
+        a_uint_init = expr.lift(0xFFFF)
+
+        tests = [
+            ((a_bool1, a_bool_init), (a_bool2, a_bool_init)),
+            ((a_bool1, a_bool_init), (a_uint, a_uint_init)),
+        ]
+        for (left, left_init), (right, right_init) in tests:
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                QuantumCircuit(inputs=(left, right))
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                QuantumCircuit(captures=(left, right))
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                QuantumCircuit(declarations=[(left, left_init), (right, right_init)])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                QuantumCircuit(inputs=[left], declarations=[(right, right_init)])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                QuantumCircuit(captures=[left], declarations=[(right, right_init)])
+
+            qc = QuantumCircuit(inputs=[left])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                qc.add_input(right)
+            qc = QuantumCircuit(inputs=[left])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                qc.add_var(right, right_init)
+
+            qc = QuantumCircuit(captures=[left])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                qc.add_capture(right)
+            qc = QuantumCircuit(captures=[left])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                qc.add_var(right, right_init)
+
+            qc = QuantumCircuit(inputs=[left])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                qc.add_var(right, right_init)
+
+        qc = QuantumCircuit()
+        qc.add_var("a", expr.lift(True))
+        with self.assertRaisesRegex(CircuitError, "its name shadows"):
+            qc.add_var("a", expr.lift(True))
+        with self.assertRaisesRegex(CircuitError, "its name shadows"):
+            qc.add_var("a", expr.lift(0xFF))
+
+    def test_cannot_add_vars_wrapping_clbits(self):
+        a = expr.Var(Clbit(), types.Bool())
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            QuantumCircuit(inputs=[a])
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            qc.add_input(a)
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            QuantumCircuit(captures=[a])
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            qc.add_capture(a)
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            QuantumCircuit(declarations=[(a, expr.lift(True))])
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            qc.add_var(a, expr.lift(True))
+
+    def test_cannot_add_vars_wrapping_cregs(self):
+        a = expr.Var(ClassicalRegister(8, "cr"), types.Uint(8))
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            QuantumCircuit(inputs=[a])
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            qc.add_input(a)
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            QuantumCircuit(captures=[a])
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            qc.add_capture(a)
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            QuantumCircuit(declarations=[(a, expr.lift(0xFF))])
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            qc.add_var(a, expr.lift(0xFF))
+
+    def test_get_var_success(self):
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Uint(8))
+
+        qc = QuantumCircuit(inputs=[a], declarations={b: expr.Value(0xFF, types.Uint(8))})
+        self.assertIs(qc.get_var("a"), a)
+        self.assertIs(qc.get_var("b"), b)
+
+        qc = QuantumCircuit(captures=[a, b])
+        self.assertIs(qc.get_var("a"), a)
+        self.assertIs(qc.get_var("b"), b)
+
+        qc = QuantumCircuit(declarations={a: expr.lift(True), b: expr.Value(0xFF, types.Uint(8))})
+        self.assertIs(qc.get_var("a"), a)
+        self.assertIs(qc.get_var("b"), b)
+
+    def test_get_var_missing(self):
+        qc = QuantumCircuit()
+        with self.assertRaises(KeyError):
+            qc.get_var("a")
+
+        a = expr.Var.new("a", types.Bool())
+        qc.add_input(a)
+        with self.assertRaises(KeyError):
+            qc.get_var("b")
+
+    def test_get_var_default(self):
+        qc = QuantumCircuit()
+        self.assertIs(qc.get_var("a", None), None)
+
+        missing = "default"
+        a = expr.Var.new("a", types.Bool())
+        qc.add_input(a)
+        self.assertIs(qc.get_var("b", missing), missing)
+        self.assertIs(qc.get_var("b", a), a)
+
+    def test_has_var(self):
+        a = expr.Var.new("a", types.Bool())
+        self.assertFalse(QuantumCircuit().has_var("a"))
+        self.assertTrue(QuantumCircuit(inputs=[a]).has_var("a"))
+        self.assertTrue(QuantumCircuit(captures=[a]).has_var("a"))
+        self.assertTrue(QuantumCircuit(declarations={a: expr.lift(True)}).has_var("a"))
+        self.assertTrue(QuantumCircuit(inputs=[a]).has_var(a))
+        self.assertTrue(QuantumCircuit(captures=[a]).has_var(a))
+        self.assertTrue(QuantumCircuit(declarations={a: expr.lift(True)}).has_var(a))
+
+        # When giving an `Var`, the match must be exact, not just the name.
+        self.assertFalse(QuantumCircuit(inputs=[a]).has_var(expr.Var.new("a", types.Uint(8))))
+        self.assertFalse(QuantumCircuit(inputs=[a]).has_var(expr.Var.new("a", types.Bool())))

--- a/test/python/circuit/test_store.py
+++ b/test/python/circuit/test_store.py
@@ -13,7 +13,7 @@
 # pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
 
 from qiskit.test import QiskitTestCase
-from qiskit.circuit import Store, Clbit, CircuitError
+from qiskit.circuit import Store, Clbit, CircuitError, QuantumCircuit, ClassicalRegister
 from qiskit.circuit.classical import expr, types
 
 
@@ -60,3 +60,140 @@ class TestStoreInstruction(QiskitTestCase):
         instruction = Store(expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Bool()))
         with self.assertRaises(NotImplementedError):
             instruction.c_if(Clbit(), False)
+
+
+class TestStoreCircuit(QiskitTestCase):
+    """Tests of the `QuantumCircuit.store` method and appends of `Store`."""
+
+    def test_produces_expected_operation(self):
+        a = expr.Var.new("a", types.Bool())
+        value = expr.Value(True, types.Bool())
+
+        qc = QuantumCircuit(inputs=[a])
+        qc.store(a, value)
+        self.assertEqual(qc.data[-1].operation, Store(a, value))
+
+        qc = QuantumCircuit(captures=[a])
+        qc.store(a, value)
+        self.assertEqual(qc.data[-1].operation, Store(a, value))
+
+        qc = QuantumCircuit(declarations=[(a, expr.lift(False))])
+        qc.store(a, value)
+        self.assertEqual(qc.data[-1].operation, Store(a, value))
+
+    def test_allows_stores_with_clbits(self):
+        clbits = [Clbit(), Clbit()]
+        a = expr.Var.new("a", types.Bool())
+        qc = QuantumCircuit(clbits, inputs=[a])
+        qc.store(clbits[0], True)
+        qc.store(expr.Var(clbits[1], types.Bool()), a)
+        qc.store(clbits[0], clbits[1])
+        qc.store(expr.lift(clbits[0]), expr.lift(clbits[1]))
+        qc.store(a, expr.lift(clbits[1]))
+
+        expected = [
+            Store(expr.lift(clbits[0]), expr.lift(True)),
+            Store(expr.lift(clbits[1]), a),
+            Store(expr.lift(clbits[0]), expr.lift(clbits[1])),
+            Store(expr.lift(clbits[0]), expr.lift(clbits[1])),
+            Store(a, expr.lift(clbits[1])),
+        ]
+        actual = [instruction.operation for instruction in qc.data]
+        self.assertEqual(actual, expected)
+
+    def test_allows_stores_with_cregs(self):
+        cregs = [ClassicalRegister(8, "cr1"), ClassicalRegister(8, "cr2")]
+        a = expr.Var.new("a", types.Uint(8))
+        qc = QuantumCircuit(*cregs, captures=[a])
+        qc.store(cregs[0], 0xFF)
+        qc.store(expr.Var(cregs[1], types.Uint(8)), a)
+        qc.store(cregs[0], cregs[1])
+        qc.store(expr.lift(cregs[0]), expr.lift(cregs[1]))
+        qc.store(a, cregs[1])
+
+        expected = [
+            Store(expr.lift(cregs[0]), expr.lift(0xFF)),
+            Store(expr.lift(cregs[1]), a),
+            Store(expr.lift(cregs[0]), expr.lift(cregs[1])),
+            Store(expr.lift(cregs[0]), expr.lift(cregs[1])),
+            Store(a, expr.lift(cregs[1])),
+        ]
+        actual = [instruction.operation for instruction in qc.data]
+        self.assertEqual(actual, expected)
+
+    def test_lifts_values(self):
+        a = expr.Var.new("a", types.Bool())
+        qc = QuantumCircuit(captures=[a])
+        qc.store(a, True)
+        self.assertEqual(qc.data[-1].operation, Store(a, expr.lift(True)))
+
+        b = expr.Var.new("b", types.Uint(16))
+        qc.add_capture(b)
+        qc.store(b, 0xFFFF)
+        self.assertEqual(qc.data[-1].operation, Store(b, expr.lift(0xFFFF)))
+
+    def test_rejects_vars_not_in_circuit(self):
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "'a'.*not present"):
+            qc.store(expr.Var.new("a", types.Bool()), True)
+
+        # Not the same 'a'
+        qc.add_input(a)
+        with self.assertRaisesRegex(CircuitError, "'a'.*not present"):
+            qc.store(expr.Var.new("a", types.Bool()), True)
+        with self.assertRaisesRegex(CircuitError, "'b'.*not present"):
+            qc.store(a, b)
+
+    def test_rejects_bits_not_in_circuit(self):
+        a = expr.Var.new("a", types.Bool())
+        clbit = Clbit()
+        qc = QuantumCircuit(captures=[a])
+        with self.assertRaisesRegex(CircuitError, "not present"):
+            qc.store(clbit, False)
+        with self.assertRaisesRegex(CircuitError, "not present"):
+            qc.store(clbit, a)
+        with self.assertRaisesRegex(CircuitError, "not present"):
+            qc.store(a, clbit)
+
+    def test_rejects_cregs_not_in_circuit(self):
+        a = expr.Var.new("a", types.Uint(8))
+        creg = ClassicalRegister(8, "cr1")
+        qc = QuantumCircuit(captures=[a])
+        with self.assertRaisesRegex(CircuitError, "not present"):
+            qc.store(creg, 0xFF)
+        with self.assertRaisesRegex(CircuitError, "not present"):
+            qc.store(creg, a)
+        with self.assertRaisesRegex(CircuitError, "not present"):
+            qc.store(a, creg)
+
+    def test_rejects_non_lvalue(self):
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+        qc = QuantumCircuit(inputs=[a, b])
+        not_an_lvalue = expr.logic_and(a, b)
+        with self.assertRaisesRegex(CircuitError, "not an l-value"):
+            qc.store(not_an_lvalue, expr.lift(False))
+
+    def test_rejects_explicit_cast(self):
+        lvalue = expr.Var.new("a", types.Uint(16))
+        rvalue = expr.Var.new("b", types.Uint(8))
+        qc = QuantumCircuit(inputs=[lvalue, rvalue])
+        with self.assertRaisesRegex(CircuitError, "an explicit cast is required"):
+            qc.store(lvalue, rvalue)
+
+    def test_rejects_dangerous_cast(self):
+        lvalue = expr.Var.new("a", types.Uint(8))
+        rvalue = expr.Var.new("b", types.Uint(16))
+        qc = QuantumCircuit(inputs=[lvalue, rvalue])
+        with self.assertRaisesRegex(CircuitError, "an explicit cast is required.*may be lossy"):
+            qc.store(lvalue, rvalue)
+
+    def test_rejects_c_if(self):
+        a = expr.Var.new("a", types.Bool())
+        qc = QuantumCircuit([Clbit()], inputs=[a])
+        instruction_set = qc.store(a, True)
+        with self.assertRaises(NotImplementedError):
+            instruction_set.c_if(qc.clbits[0], False)

--- a/test/python/circuit/test_store.py
+++ b/test/python/circuit/test_store.py
@@ -1,0 +1,62 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
+
+from qiskit.test import QiskitTestCase
+from qiskit.circuit import Store, Clbit, CircuitError
+from qiskit.circuit.classical import expr, types
+
+
+class TestStoreInstruction(QiskitTestCase):
+    """Tests of the properties of the ``Store`` instruction itself."""
+
+    def test_happy_path_construction(self):
+        lvalue = expr.Var.new("a", types.Bool())
+        rvalue = expr.lift(Clbit())
+        constructed = Store(lvalue, rvalue)
+        self.assertIsInstance(constructed, Store)
+        self.assertEqual(constructed.lvalue, lvalue)
+        self.assertEqual(constructed.rvalue, rvalue)
+
+    def test_implicit_cast(self):
+        lvalue = expr.Var.new("a", types.Bool())
+        rvalue = expr.Var.new("b", types.Uint(8))
+        constructed = Store(lvalue, rvalue)
+        self.assertIsInstance(constructed, Store)
+        self.assertEqual(constructed.lvalue, lvalue)
+        self.assertEqual(constructed.rvalue, expr.Cast(rvalue, types.Bool(), implicit=True))
+
+    def test_rejects_non_lvalue(self):
+        not_an_lvalue = expr.logic_and(
+            expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Bool())
+        )
+        rvalue = expr.lift(False)
+        with self.assertRaisesRegex(CircuitError, "not an l-value"):
+            Store(not_an_lvalue, rvalue)
+
+    def test_rejects_explicit_cast(self):
+        lvalue = expr.Var.new("a", types.Uint(16))
+        rvalue = expr.Var.new("b", types.Uint(8))
+        with self.assertRaisesRegex(CircuitError, "an explicit cast is required"):
+            Store(lvalue, rvalue)
+
+    def test_rejects_dangerous_cast(self):
+        lvalue = expr.Var.new("a", types.Uint(8))
+        rvalue = expr.Var.new("b", types.Uint(16))
+        with self.assertRaisesRegex(CircuitError, "an explicit cast is required.*may be lossy"):
+            Store(lvalue, rvalue)
+
+    def test_rejects_c_if(self):
+        instruction = Store(expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Bool()))
+        with self.assertRaises(NotImplementedError):
+            instruction.c_if(Clbit(), False)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This adds all the new `QuantumCircuit` methods discussed in the variable-declaration RFC[^1], and threads the support for them through the methods that are called in turn, such as `QuantumCircuit.append`.  It does yet not add support to methods such as `copy` or `compose`, which will be done in a follow-up.

The APIs discussed in the RFC necessitated making `Var` nodes hashable.  This is done in this commit, as it is logically connected.  These nodes now have enforced immutability, which is technically a minor breaking change, but in practice required for the properties of such expressions to be tracked correctly through circuits.

A helper attribute `Var.standalone` is added to unify the handling of whether a variable is an old-style existing-memory wrapper, or a new "proper" variable with its own memory.

[^1]: https://github.com/Qiskit/RFCs/pull/50



### Details and comments

Depends on #10946

Close #10924 

Two changelog entries are added for the semi-orthogonal changes, but the main thrust will come as with most things at the end of the epic.