### PR TITLE
Relax opflow CODEOWNERS regex

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,7 @@
 
 # Qiskit folders (also their corresponding tests)
 algorithms/           @Qiskit/terra-core @woodsp-ibm @ElePT
-opflow/               @Qiskit/terra-core @woodsp-ibm @ikkoham
+opflow                @Qiskit/terra-core @woodsp-ibm @ikkoham
 qiskit/utils/         @Qiskit/terra-core @woodsp-ibm
 providers/            @Qiskit/terra-core @jyu00
 quantum_info/         @Qiskit/terra-core @ikkoham


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the CODEOWNERS regex for the opflow module. Previously it was set to `opflow/` which will match any path with "opflow" as a directory in it. However, there are several documentation files that have opflow in the name. This commit updates the regex to just be the string "opflow" which will match any file or path that contains "opflow" so that the CODEOWNERS for opflow can merge PRs that touch this documentation too.

### Details and comments
