### PR TITLE
Avoid useless deepcopy of target with custom pulse gates in transpile 

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -300,7 +300,7 @@ def transpile(  # pylint: disable=too-many-return-statements
         )
 
     _skip_target = False
-    _given_inst_map = False if inst_map is None else True
+    _given_inst_map = bool(inst_map)  # check before inst_map is overwritten
     # If a target is specified have it override any implicit selections from a backend
     if target is not None:
         if coupling_map is None:

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -300,6 +300,7 @@ def transpile(  # pylint: disable=too-many-return-statements
         )
 
     _skip_target = False
+    _given_inst_map = False if inst_map is None else True
     # If a target is specified have it override any implicit selections from a backend
     if target is not None:
         if coupling_map is None:
@@ -335,7 +336,7 @@ def transpile(  # pylint: disable=too-many-return-statements
 
     timing_constraints = _parse_timing_constraints(backend, timing_constraints)
 
-    if inst_map is not None and inst_map.has_custom_gate() and target is not None:
+    if _given_inst_map and inst_map.has_custom_gate() and target is not None:
         # Do not mutate backend target
         target = copy.deepcopy(target)
         target.update_from_instruction_schedule_map(inst_map)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Improve transpilation time of circuits for a target with custom pulse gates by avoiding unnecessary deepcopy of the target object.
The time to build pulse schedules with circuit instructions is also improved since `transpile` function is internally called for each circuit instruction call. 

### Details and comments
When both `inst_map` and `target` are supplied, `transpile` function internally deepcopy the target object and update calibrations in it with ones in `inst_map` only if `inst_map` contains custom calibrations. However, the check was incorrect for the case when only the `target` (that contains custom calibrations) is supplied. In that case, the target object was deepcopied unnecessarily. This commit avoids it to improve the performance of transpilation with a custom target and hence building pulse schedules with circuit instructions. For instance, building 200 pulse schedules took 2 minutes while it takes 7 seconds with this commit.

