### PR TITLE
Ensure `QuantumCircuit.append` validates captures in control-flow

### DIFF
--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -279,6 +279,7 @@ Gates and Instructions
    InstructionSet
    Operation
    EquivalenceLibrary
+   Store
 
 Control Flow Operations
 -----------------------
@@ -375,6 +376,7 @@ from .barrier import Barrier
 from .delay import Delay
 from .measure import Measure
 from .reset import Reset
+from .store import Store
 from .parameter import Parameter
 from .parametervector import ParameterVector
 from .parameterexpression import ParameterExpression

--- a/qiskit/circuit/classical/expr/__init__.py
+++ b/qiskit/circuit/classical/expr/__init__.py
@@ -161,8 +161,8 @@ suitable "key" functions to do the comparison.
 
 .. autofunction:: structurally_equivalent
 
-Some expressions have associated memory locations with them, and some may be purely temporaries.
-You can use :func:`is_lvalue` to determine whether an expression has such a memory backing.
+Some expressions have associated memory locations, and others may be purely temporary.
+You can use :func:`is_lvalue` to determine whether an expression has an associated memory location.
 
 .. autofunction:: is_lvalue
 """

--- a/qiskit/circuit/classical/expr/__init__.py
+++ b/qiskit/circuit/classical/expr/__init__.py
@@ -160,6 +160,11 @@ between two different circuits.  In this case, one can use :func:`structurally_e
 suitable "key" functions to do the comparison.
 
 .. autofunction:: structurally_equivalent
+
+Some expressions have associated memory locations with them, and some may be purely temporaries.
+You can use :func:`is_lvalue` to determine whether an expression has such a memory backing.
+
+.. autofunction:: is_lvalue
 """
 
 __all__ = [
@@ -172,6 +177,7 @@ __all__ = [
     "ExprVisitor",
     "iter_vars",
     "structurally_equivalent",
+    "is_lvalue",
     "lift",
     "cast",
     "bit_not",
@@ -191,7 +197,7 @@ __all__ = [
 ]
 
 from .expr import Expr, Var, Value, Cast, Unary, Binary
-from .visitors import ExprVisitor, iter_vars, structurally_equivalent
+from .visitors import ExprVisitor, iter_vars, structurally_equivalent, is_lvalue
 from .constructors import (
     lift,
     cast,

--- a/qiskit/circuit/classical/expr/expr.py
+++ b/qiskit/circuit/classical/expr/expr.py
@@ -115,9 +115,23 @@ class Var(Expr):
     associated name; and an old-style variable that wraps a :class:`.Clbit` or
     :class:`.ClassicalRegister` instance that is owned by some containing circuit.  In general,
     construction of variables for use in programs should use :meth:`Var.new` or
-    :meth:`.QuantumCircuit.add_var`."""
+    :meth:`.QuantumCircuit.add_var`.
+
+    Variables are immutable after construction, so they can be used as dictionary keys."""
 
     __slots__ = ("var", "name")
+
+    var: qiskit.circuit.Clbit | qiskit.circuit.ClassicalRegister | uuid.UUID
+    """A reference to the backing data storage of the :class:`Var` instance.  When lifting
+    old-style :class:`.Clbit` or :class:`.ClassicalRegister` instances into a :class:`Var`,
+    this is exactly the :class:`.Clbit` or :class:`.ClassicalRegister`.  If the variable is a
+    new-style classical variable (one that owns its own storage separate to the old
+    :class:`.Clbit`/:class:`.ClassicalRegister` model), this field will be a :class:`~uuid.UUID`
+    to uniquely identify it."""
+    name: str | None
+    """The name of the variable.  This is required to exist if the backing :attr:`var` attribute
+    is a :class:`~uuid.UUID`, i.e. if it is a new-style variable, and must be ``None`` if it is
+    an old-style variable."""
 
     def __init__(
         self,
@@ -126,26 +140,31 @@ class Var(Expr):
         *,
         name: str | None = None,
     ):
-        self.type = type
-        self.var = var
-        """A reference to the backing data storage of the :class:`Var` instance.  When lifting
-        old-style :class:`.Clbit` or :class:`.ClassicalRegister` instances into a :class:`Var`,
-        this is exactly the :class:`.Clbit` or :class:`.ClassicalRegister`.  If the variable is a
-        new-style classical variable (one that owns its own storage separate to the old
-        :class:`.Clbit`/:class:`.ClassicalRegister` model), this field will be a :class:`~uuid.UUID`
-        to uniquely identify it."""
-        self.name = name
-        """The name of the variable.  This is required to exist if the backing :attr:`var` attribute
-        is a :class:`~uuid.UUID`, i.e. if it is a new-style variable, and must be ``None`` if it is
-        an old-style variable."""
+        super().__setattr__("type", type)
+        super().__setattr__("var", var)
+        super().__setattr__("name", name)
 
     @classmethod
     def new(cls, name: str, type: types.Type) -> typing.Self:
         """Generate a new named variable that owns its own backing storage."""
         return cls(uuid.uuid4(), type, name=name)
 
+    @property
+    def standalone(self) -> bool:
+        """Whether this :class:`Var` is a standalone variable that owns its storage location.  If
+        false, this is a wrapper :class:`Var` around some pre-existing circuit object."""
+        return isinstance(self.var, uuid.UUID)
+
     def accept(self, visitor, /):
         return visitor.visit_var(self)
+
+    def __setattr__(self, key, value):
+        if hasattr(self, key):
+            raise AttributeError(f"'Var' object attribute '{key}' is read-only")
+        raise AttributeError(f"'Var' object has no attribute '{key}'")
+
+    def __hash__(self):
+        return hash((self.type, self.var, self.name))
 
     def __eq__(self, other):
         return (
@@ -159,6 +178,23 @@ class Var(Expr):
         if self.name is None:
             return f"Var({self.var}, {self.type})"
         return f"Var({self.var}, {self.type}, name='{self.name}')"
+
+    def __getstate__(self):
+        return (self.var, self.type, self.name)
+
+    def __setstate__(self, state):
+        var, type, name = state
+        super().__setattr__("type", type)
+        super().__setattr__("var", var)
+        super().__setattr__("name", name)
+
+    def __copy__(self):
+        # I am immutable...
+        return self
+
+    def __deepcopy__(self, memo):
+        # ... as are all my consituent parts.
+        return self
 
 
 @typing.final

--- a/qiskit/circuit/classical/expr/expr.py
+++ b/qiskit/circuit/classical/expr/expr.py
@@ -152,7 +152,7 @@ class Var(Expr):
     @property
     def standalone(self) -> bool:
         """Whether this :class:`Var` is a standalone variable that owns its storage location.  If
-        false, this is a wrapper :class:`Var` around some pre-existing circuit object."""
+        false, this is a wrapper :class:`Var` around a pre-existing circuit object."""
         return isinstance(self.var, uuid.UUID)
 
     def accept(self, visitor, /):

--- a/qiskit/circuit/classical/types/__init__.py
+++ b/qiskit/circuit/classical/types/__init__.py
@@ -15,6 +15,8 @@
 Typing (:mod:`qiskit.circuit.classical.types`)
 ==============================================
 
+Representation
+==============
 
 The type system of the expression tree is exposed through this module.  This is inherently linked to
 the expression system in the :mod:`~.classical.expr` module, as most expressions can only be
@@ -41,10 +43,17 @@ literals ``True`` and ``False``), and unsigned integers (corresponding to
 Note that :class:`Uint` defines a family of types parametrised by their width; it is not one single
 type, which may be slightly different to the 'classical' programming languages you are used to.
 
+
+Working with types
+==================
+
 There are some functions on these types exposed here as well.  These are mostly expected to be used
 only in manipulations of the expression tree; users who are building expressions using the
 :ref:`user-facing construction interface <circuit-classical-expressions-expr-construction>` should
 not need to use these.
+
+Partial ordering of types
+-------------------------
 
 The type system is equipped with a partial ordering, where :math:`a < b` is interpreted as
 ":math:`a` is a strict subtype of :math:`b`".  Note that the partial ordering is a subset of the
@@ -66,6 +75,20 @@ Some helper methods are then defined in terms of this low-level :func:`order` pr
 .. autofunction:: is_subtype
 .. autofunction:: is_supertype
 .. autofunction:: greater
+
+
+Casting between types
+---------------------
+
+It is common to need to cast values of one type to another type.  The casting rules for this are
+embedded into the :mod:`types` module.  You can query the casting kinds using :func:`cast_kind`:
+
+.. autofunction:: cast_kind
+
+The return values from this function are an enumeration explaining the types of cast that are
+allowed from the left type to the right type.
+
+.. autoclass:: CastKind
 """
 
 __all__ = [
@@ -77,7 +100,9 @@ __all__ = [
     "is_subtype",
     "is_supertype",
     "greater",
+    "CastKind",
+    "cast_kind",
 ]
 
 from .types import Type, Bool, Uint
-from .ordering import Ordering, order, is_subtype, is_supertype, greater
+from .ordering import Ordering, order, is_subtype, is_supertype, greater, CastKind, cast_kind

--- a/qiskit/circuit/classical/types/types.py
+++ b/qiskit/circuit/classical/types/types.py
@@ -89,6 +89,9 @@ class Bool(Type, metaclass=_Singleton):
     def __repr__(self):
         return "Bool()"
 
+    def __hash__(self):
+        return hash(self.__class__)
+
     def __eq__(self, other):
         return isinstance(other, Bool)
 
@@ -106,6 +109,9 @@ class Uint(Type):
 
     def __repr__(self):
         return f"Uint({self.width})"
+
+    def __hash__(self):
+        return hash((self.__class__, self.width))
 
     def __eq__(self, other):
         return isinstance(other, Uint) and self.width == other.width

--- a/qiskit/circuit/controlflow/_builder_utils.py
+++ b/qiskit/circuit/controlflow/_builder_utils.py
@@ -15,14 +15,16 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Iterable, Tuple, Set, Union, TypeVar
+from typing import Iterable, Tuple, Set, Union, TypeVar, TYPE_CHECKING
 
 from qiskit.circuit.classical import expr, types
 from qiskit.circuit.exceptions import CircuitError
-from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit.register import Register
 from qiskit.circuit.classicalregister import ClassicalRegister, Clbit
 from qiskit.circuit.quantumregister import QuantumRegister
+
+if TYPE_CHECKING:
+    from qiskit.circuit import QuantumCircuit
 
 _ConditionT = TypeVar(
     "_ConditionT", bound=Union[Tuple[ClassicalRegister, int], Tuple[Clbit, int], expr.Expr]
@@ -159,6 +161,9 @@ def _unify_circuit_resources_rebuild(  # pylint: disable=invalid-name  # (it's t
 
     This function will always rebuild the objects into new :class:`.QuantumCircuit` instances.
     """
+    # pylint: disable=cyclic-import
+    from qiskit.circuit import QuantumCircuit
+
     qubits, clbits = set(), set()
     for circuit in circuits:
         qubits.update(circuit.qubits)

--- a/qiskit/circuit/controlflow/builder.py
+++ b/qiskit/circuit/controlflow/builder.py
@@ -33,7 +33,7 @@ from qiskit.circuit.register import Register
 from ._builder_utils import condition_resources, node_resources
 
 if typing.TYPE_CHECKING:
-    import qiskit  # pylint: disable=cyclic-import
+    import qiskit
 
 
 class InstructionResources(typing.NamedTuple):
@@ -403,6 +403,7 @@ class ControlFlowBuilderBlock:
             and using the minimal set of resources necessary to support them, within the enclosing
             scope.
         """
+        # pylint: disable=cyclic-import
         from qiskit.circuit import QuantumCircuit, SwitchCaseOp
 
         # There's actually no real problem with building a scope more than once.  This flag is more

--- a/qiskit/circuit/controlflow/control_flow.py
+++ b/qiskit/circuit/controlflow/control_flow.py
@@ -13,14 +13,25 @@
 "Container to encapsulate all control flow operations."
 
 from __future__ import annotations
-from abc import ABC, abstractmethod
-from typing import Iterable
 
-from qiskit.circuit import QuantumCircuit, Instruction
+import typing
+from abc import ABC, abstractmethod
+
+from qiskit.circuit.instruction import Instruction
+from qiskit.circuit.exceptions import CircuitError
+
+if typing.TYPE_CHECKING:
+    from qiskit.circuit import QuantumCircuit
 
 
 class ControlFlowOp(Instruction, ABC):
     """Abstract class to encapsulate all control flow operations."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for block in self.blocks:
+            if block.num_input_vars:
+                raise CircuitError("control-flow blocks cannot contain input variables")
 
     @property
     @abstractmethod
@@ -29,10 +40,9 @@ class ControlFlowOp(Instruction, ABC):
         execution of this ControlFlowOp. May be parameterized by a loop
         parameter to be resolved at run time.
         """
-        pass
 
     @abstractmethod
-    def replace_blocks(self, blocks: Iterable[QuantumCircuit]) -> "ControlFlowOp":
+    def replace_blocks(self, blocks: typing.Iterable[QuantumCircuit]) -> ControlFlowOp:
         """Replace blocks and return new instruction.
         Args:
             blocks: Tuple of QuantumCircuits to replace in instruction.
@@ -40,4 +50,3 @@ class ControlFlowOp(Instruction, ABC):
         Returns:
             New ControlFlowOp with replaced blocks.
         """
-        pass

--- a/qiskit/circuit/controlflow/for_loop.py
+++ b/qiskit/circuit/controlflow/for_loop.py
@@ -10,15 +10,19 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"Circuit operation representing a ``for`` loop."
+"""Circuit operation representing a ``for`` loop."""
+
+from __future__ import annotations
 
 import warnings
-from typing import Iterable, Optional, Union
+from typing import Iterable, Optional, Union, TYPE_CHECKING
 
 from qiskit.circuit.parameter import Parameter
 from qiskit.circuit.exceptions import CircuitError
-from qiskit.circuit.quantumcircuit import QuantumCircuit
 from .control_flow import ControlFlowOp
+
+if TYPE_CHECKING:
+    from qiskit.circuit import QuantumCircuit
 
 
 class ForLoopOp(ControlFlowOp):
@@ -69,6 +73,9 @@ class ForLoopOp(ControlFlowOp):
 
     @params.setter
     def params(self, parameters):
+        # pylint: disable=cyclic-import
+        from qiskit.circuit import QuantumCircuit
+
         indexset, loop_parameter, body = parameters
 
         if not isinstance(loop_parameter, (Parameter, type(None))):

--- a/qiskit/circuit/controlflow/if_else.py
+++ b/qiskit/circuit/controlflow/if_else.py
@@ -14,10 +14,10 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union, Iterable
+from typing import Optional, Union, Iterable, TYPE_CHECKING
 import itertools
 
-from qiskit.circuit import ClassicalRegister, Clbit, QuantumCircuit
+from qiskit.circuit.classicalregister import ClassicalRegister, Clbit
 from qiskit.circuit.classical import expr
 from qiskit.circuit.instructionset import InstructionSet
 from qiskit.circuit.exceptions import CircuitError
@@ -30,6 +30,9 @@ from ._builder_utils import (
     validate_condition,
     condition_resources,
 )
+
+if TYPE_CHECKING:
+    from qiskit.circuit import QuantumCircuit
 
 
 # This is just an indication of what's actually meant to be the public API.
@@ -82,6 +85,9 @@ class IfElseOp(ControlFlowOp):
         false_body: QuantumCircuit | None = None,
         label: str | None = None,
     ):
+        # pylint: disable=cyclic-import
+        from qiskit.circuit import QuantumCircuit
+
         # Type checking generally left to @params.setter, but required here for
         # finding num_qubits and num_clbits.
         if not isinstance(true_body, QuantumCircuit):
@@ -103,6 +109,9 @@ class IfElseOp(ControlFlowOp):
 
     @params.setter
     def params(self, parameters):
+        # pylint: disable=cyclic-import
+        from qiskit.circuit import QuantumCircuit
+
         true_body, false_body = parameters
 
         if not isinstance(true_body, QuantumCircuit):

--- a/qiskit/circuit/controlflow/switch_case.py
+++ b/qiskit/circuit/controlflow/switch_case.py
@@ -17,15 +17,18 @@ from __future__ import annotations
 __all__ = ("SwitchCaseOp", "CASE_DEFAULT")
 
 import contextlib
-from typing import Union, Iterable, Any, Tuple, Optional, List, Literal
+from typing import Union, Iterable, Any, Tuple, Optional, List, Literal, TYPE_CHECKING
 
-from qiskit.circuit import ClassicalRegister, Clbit, QuantumCircuit
+from qiskit.circuit.classicalregister import ClassicalRegister, Clbit
 from qiskit.circuit.classical import expr, types
 from qiskit.circuit.exceptions import CircuitError
 
 from .builder import InstructionPlaceholder, InstructionResources, ControlFlowBuilderBlock
 from .control_flow import ControlFlowOp
 from ._builder_utils import unify_circuit_resources, partition_registers, node_resources
+
+if TYPE_CHECKING:
+    from qiskit.circuit import QuantumCircuit
 
 
 class _DefaultCaseType:
@@ -71,6 +74,9 @@ class SwitchCaseOp(ControlFlowOp):
         *,
         label: Optional[str] = None,
     ):
+        # pylint: disable=cyclic-import
+        from qiskit.circuit import QuantumCircuit
+
         if isinstance(target, expr.Expr):
             if target.type.kind not in (types.Uint, types.Bool):
                 raise CircuitError(

--- a/qiskit/circuit/controlflow/while_loop.py
+++ b/qiskit/circuit/controlflow/while_loop.py
@@ -14,11 +14,16 @@
 
 from __future__ import annotations
 
-from qiskit.circuit import Clbit, ClassicalRegister, QuantumCircuit
+from typing import TYPE_CHECKING
+
+from qiskit.circuit.classicalregister import Clbit, ClassicalRegister
 from qiskit.circuit.classical import expr
 from qiskit.circuit.exceptions import CircuitError
 from ._builder_utils import validate_condition, condition_resources
 from .control_flow import ControlFlowOp
+
+if TYPE_CHECKING:
+    from qiskit.circuit import QuantumCircuit
 
 
 class WhileLoopOp(ControlFlowOp):
@@ -70,6 +75,9 @@ class WhileLoopOp(ControlFlowOp):
 
     @params.setter
     def params(self, parameters):
+        # pylint: disable=cyclic-import
+        from qiskit.circuit import QuantumCircuit
+
         (body,) = parameters
 
         if not isinstance(body, QuantumCircuit):

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 import copy
+import itertools
 import multiprocessing as mp
 import warnings
 import typing
@@ -47,7 +48,7 @@ from qiskit.circuit.exceptions import CircuitError
 from qiskit.utils.deprecation import deprecate_func
 from . import _classical_resource_map
 from ._utils import sort_parameters
-from .classical import expr
+from .classical import expr, types
 from .parameterexpression import ParameterExpression, ParameterValueType
 from .quantumregister import QuantumRegister, Qubit, AncillaRegister, AncillaQubit
 from .classicalregister import ClassicalRegister, Clbit
@@ -59,6 +60,7 @@ from .register import Register
 from .bit import Bit
 from .quantumcircuitdata import QuantumCircuitData, CircuitInstruction
 from .delay import Delay
+from .store import Store
 
 if typing.TYPE_CHECKING:
     import qiskit  # pylint: disable=cyclic-import
@@ -136,6 +138,23 @@ class QuantumCircuit:
             circuit. This gets stored as free-form data in a dict in the
             :attr:`~qiskit.circuit.QuantumCircuit.metadata` attribute. It will
             not be directly used in the circuit.
+        inputs: any variables to declare as ``input`` runtime variables for this circuit.  These
+            should already be existing :class:`.expr.Var` nodes that you build from somewhere else;
+            if you need to create the inputs as well, use :meth:`QuantumCircuit.add_input`.  The
+            variables given in this argument will be passed directly to :meth:`add_input`.  A
+            circuit cannot have both ``inputs`` and ``captures``.
+        captures: any variables that that this circuit scope should capture from a containing scope.
+            The variables given here will be passed directly to :meth:`add_capture`.  A circuit
+            cannot have both ``inputs`` and ``captures``.
+        declarations: any variables that this circuit should declare and initialize immediately.
+            You can order this input so that later declarations depend on earlier ones (including
+            inputs or captures). If you need to depend on values that will be computed later at
+            runtime, use :meth:`add_var` at an appropriate point in the circuit execution.
+
+            This argument is intended for convenient circuit initialization when you already have a
+            set of created variables.  The variables used here will be directly passed to
+            :meth:`add_var`, which you can use directly if this is the first time you are creating
+            the variable.
 
     Raises:
         CircuitError: if the circuit name, if given, is not valid.
@@ -198,6 +217,9 @@ class QuantumCircuit:
         name: str | None = None,
         global_phase: ParameterValueType = 0,
         metadata: dict | None = None,
+        inputs: Iterable[expr.Var] = (),
+        captures: Iterable[expr.Var] = (),
+        declarations: Mapping[expr.Var, expr.Expr] | Iterable[Tuple[expr.Var, expr.Expr]] = (),
     ):
         if any(not isinstance(reg, (list, QuantumRegister, ClassicalRegister)) for reg in regs):
             # check if inputs are integers, but also allow e.g. 2.0
@@ -266,6 +288,20 @@ class QuantumCircuit:
         self._layout = None
         self._global_phase: ParameterValueType = 0
         self.global_phase = global_phase
+
+        # Add classical variables.  Resolve inputs and captures first because they can't depend on
+        # anything, but declarations might depend on them.
+        self._vars_input: dict[str, expr.Var] = {}
+        self._vars_capture: dict[str, expr.Var] = {}
+        self._vars_local: dict[str, expr.Var] = {}
+        for input_ in inputs:
+            self.add_input(input_)
+        for capture in captures:
+            self.add_capture(capture)
+        if isinstance(declarations, Mapping):
+            declarations = declarations.items()
+        for var, initial in declarations:
+            self.add_var(var, initial)
 
         self.duration = None
         self.unit = "dt"
@@ -1110,6 +1146,33 @@ class QuantumCircuit:
         """
         return self._ancillas
 
+    def iter_vars(self) -> typing.Iterable[expr.Var]:
+        """Get an iterable over all runtime classical variables in scope within this circuit.
+
+        This method will iterate over all variables in scope.  For more fine-grained iterators, see
+        :meth:`iter_declared_vars`, :meth:`iter_input_vars` and :meth:`iter_captured_vars`."""
+        return itertools.chain(
+            self._vars_input.values(), self._vars_capture.values(), self._vars_local.values()
+        )
+
+    def iter_declared_vars(self) -> typing.Iterable[expr.Var]:
+        """Get an iterable over all runtime classical variables that are declared with automatic
+        storage duration in this scope.  This excludes input variables (see :meth:`iter_input_vars`)
+        and captured variables (see :meth:`iter_captured_vars`)."""
+        return self._vars_local.values()
+
+    def iter_input_vars(self) -> typing.Iterable[expr.Var]:
+        """Get an iterable over all runtime classical variables that are declared as inputs to this
+        circuit scope.  This excludes locally declared variables (see :meth:`iter_declared_vars`)
+        and captured variables (see :meth:`iter_captured_vars`)."""
+        return self._vars_input.values()
+
+    def iter_captured_vars(self) -> typing.Iterable[expr.Var]:
+        """Get an iterable over all runtime classical variables that are captured by this circuit
+        scope from a containing scope.  This excludes input variables (see :meth:`iter_input_vars`)
+        and locally declared variables (see :meth:`iter_declared_vars`)."""
+        return self._vars_capture.values()
+
     def __and__(self, rhs: "QuantumCircuit") -> "QuantumCircuit":
         """Overload & to implement self.compose."""
         return self.compose(rhs)
@@ -1224,12 +1287,17 @@ class QuantumCircuit:
 
     def _validate_expr(self, node: expr.Expr) -> expr.Expr:
         for var in expr.iter_vars(node):
-            if isinstance(var.var, Clbit):
+            if var.standalone:
+                if not self.has_var(var):
+                    raise CircuitError(f"Variable '{var}' is not present in this circuit.")
+            elif isinstance(var.var, Clbit):
                 if var.var not in self._clbit_indices:
                     raise CircuitError(f"Clbit {var.var} is not present in this circuit.")
             elif isinstance(var.var, ClassicalRegister):
                 if var.var not in self.cregs:
                     raise CircuitError(f"Register {var.var} is not present in this circuit.")
+            else:
+                raise RuntimeError(f"unhandled Var inner type in '{var}'")
         return node
 
     def append(
@@ -1287,8 +1355,12 @@ class QuantumCircuit:
                 )
 
         # Make copy of parameterized gate instances
-        if hasattr(operation, "params"):
-            is_parameter = any(isinstance(param, Parameter) for param in operation.params)
+        if params := getattr(operation, "params", ()):
+            is_parameter = False
+            for param in params:
+                is_parameter = is_parameter or isinstance(param, Parameter)
+                if isinstance(param, expr.Expr):
+                    self._validate_expr(param)
             if is_parameter:
                 operation = copy.deepcopy(operation)
 
@@ -1405,6 +1477,243 @@ class QuantumCircuit:
 
                     # clear cache if new parameter is added
                     self._parameters = None
+
+    @typing.overload
+    def get_var(self, name: str, default: T) -> Union[expr.Var, T]:
+        ...
+
+    # The builtin `types` module has `EllipsisType`, but only from 3.10+!
+    @typing.overload
+    def get_var(self, name: str, default: type(...) = ...) -> expr.Var:
+        ...
+
+    # We use a _literal_ `Ellipsis` as the marker value to leave `None` available as a default.
+    def get_var(self, name: str, default: typing.Any = ...):
+        """Retrieve a variable that is accessible in this circuit scope by name.
+
+        Args:
+            name: the name of the variable to retrieve.
+            default: if given, this value will be returned if the variable is not present.  If it
+                is not given, a :exc:`KeyError` is raised instead.
+
+        Returns:
+            The corresponding variable.
+
+        Raises:
+            KeyError: if no default is given, but the variable does not exist.
+
+        Examples:
+            Retrieve a variable by name from a circuit::
+
+                from qiskit.circuit import QuantumCircuit
+
+                # Create a circuit and create a variable in it.
+                qc = QuantumCircuit()
+                my_var = qc.add_var("my_var", False)
+
+                # We can use 'my_var' as a variable, but let's say we've lost the Python object and
+                # need to retrieve it.
+                my_var_again = qc.get_var("my_var")
+
+                assert my_var is my_var_again
+
+            Get a variable from a circuit by name, returning some default if it is not present::
+
+                assert qc.get_var("my_var", None) is my_var
+                assert qc.get_var("unknown_variable", None) is None
+        """
+
+        if (out := self._vars_local.get(name)) is not None:
+            return out
+        if (out := self._vars_capture.get(name)) is not None:
+            return out
+        if (out := self._vars_input.get(name)) is not None:
+            return out
+        if default is Ellipsis:
+            raise KeyError(f"no variable named '{name}' is present")
+        return default
+
+    def has_var(self, name_or_var: str | expr.Var, /) -> bool:
+        """Check whether a variable is defined in this scope.
+
+        Args:
+            name_or_var: the variable, or name of a variable to check.  If this is a
+                :class:`.expr.Var` node, the variable must be exactly the given one for this
+                function to return ``True``.
+
+        Returns:
+            whether a matching variable is present.
+
+        See also:
+            :meth:`QuantumCircuit.get_var`: retrieve a named variable from a circuit.
+        """
+        if isinstance(name_or_var, str):
+            return self.get_var(name_or_var, None) is not None
+        return self.get_var(name_or_var.name, None) == name_or_var
+
+    def _prepare_new_var(
+        self, name_or_var: str | expr.Var, type_: types.Type | None, /
+    ) -> expr.Var:
+        """The common logic for preparing and validating a new :class:`~.expr.Var` for the circuit.
+
+        The given ``type_`` can be ``None`` if the variable specifier is already a :class:`.Var`,
+        and must be a :class:`~.types.Type` if it is a string.  The argument is ignored if the given
+        first argument is a :class:`.Var` already.
+
+        Returns the validated variable, which is guaranteed to be safe to add to the circuit."""
+        if isinstance(name_or_var, str):
+            var = expr.Var.new(name_or_var, type_)
+        else:
+            var = name_or_var
+            if not var.standalone:
+                raise CircuitError(
+                    "cannot add variables that wrap `Clbit` or `ClassicalRegister` instances."
+                    " Use `add_bits` or `add_register` as appropriate."
+                )
+
+        # The `var` is guaranteed to have a name because we already excluded the cases where it's
+        # wrapping a bit/register.
+        if (previous := self.get_var(var.name, default=None)) is not None:
+            if previous == var:
+                raise CircuitError(f"'{var}' is already present in the circuit")
+            raise CircuitError(f"cannot add '{var}' as its name shadows the existing '{previous}'")
+        return var
+
+    def add_var(self, name_or_var: str | expr.Var, /, initial: typing.Any) -> expr.Var:
+        """Add a classical variable with automatic storage and scope to this circuit.
+
+        The variable is considered to have been "declared" at the beginning of the circuit, but it
+        only becomes initialized at the point of the circuit that you call this method, so it can
+        depend on variables defined before it.
+
+        Args:
+            name_or_var: either a string of the variable name, or an existing instance of
+                :class:`~.expr.Var` to re-use.  Variables cannot shadow names that are already in
+                use within the circuit.
+            initial: the value to initialize this variable with.  If the first argument was given
+                as a string name, the type of the resulting variable is inferred from the initial
+                expression; to control this more manually, either use :meth:`.Var.new` to manually
+                construct a new variable with the desired type, or use :func:`.expr.cast` to cast
+                the initializer to the desired type.
+
+                This must be either a :class:`~.expr.Expr` node, or a value that can be lifted to
+                one using :class:`.expr.lift`.
+
+        Returns:
+            The created variable.  If a :class:`~.expr.Var` instance was given, the exact same
+            object will be returned.
+
+        Raises:
+            CircuitError: if the variable cannot be created due to shadowing an existing variable.
+
+        Examples:
+            Define a new variable given just a name and an initializer expression::
+
+                from qiskit.circuit import QuantumCircuit
+
+                qc = QuantumCircuit(2)
+                my_var = qc.add_var("my_var", False)
+
+            Reuse a variable that may have been taking from a related circuit, or otherwise
+            constructed manually, and initialize it to some more complicated expression::
+
+                from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister
+                from qiskit.circuit.classical import expr, types
+
+                my_var = expr.Var.new("my_var", types.Uint(8))
+
+                cr1 = ClassicalRegister(8, "cr1")
+                cr2 = ClassicalRegister(8, "cr2")
+                qc = QuantumCircuit(QuantumRegister(8), cr1, cr2)
+
+                # Get some measurement results into each register.
+                qc.h(0)
+                for i in range(1, 8):
+                    qc.cx(0, i)
+                qc.measure(range(8), cr1)
+
+                qc.reset(range(8))
+                qc.h(0)
+                for i in range(1, 8):
+                    qc.cx(0, i)
+                qc.measure(range(8), cr2)
+
+                # Now when we add the variable, it is initialized using the runtime state of the two
+                # classical registers we measured into above.
+                qc.add_var(my_var, expr.bit_and(cr1, cr2))
+        """
+        # Validate the initialiser first to catch cases where the variable to be declared is being
+        # used in the initialiser.
+        initial = self._validate_expr(expr.lift(initial))
+        var = self._prepare_new_var(name_or_var, initial.type)
+        # Store is responsible for ensuring the type safety of the initialisation.  We build this
+        # before actually modifying any of our own state, so we don't get into an inconsistent state
+        # if an exception is raised later.
+        store = Store(var, initial)
+
+        self._vars_local[var.name] = var
+        self._append(CircuitInstruction(store, (), ()))
+        return var
+
+    def add_capture(self, var: expr.Var):
+        """Add a variable to the circuit that it should capture from a scope it will be contained
+        within.
+
+        This method requires a :class:`~.expr.Var` node to enforce that you've got a handle to one,
+        because you will need to declare the same variable using the same object into the outer
+        circuit.
+
+        This is a low-level method.  You typically will not need to call this method, assuming you
+        are using the builder interface for control-flow scopes (``with`` context-manager statements
+        for :meth:`if_test` and the other scoping constructs).  The builder interface will
+        automatically make the inner scopes closures on your behalf by capturing any variables that
+        are used within them.
+
+        Args:
+            var: the variable to capture from an enclosing scope.
+
+        Raises:
+            CircuitError: if the variable cannot be created due to shadowing an existing variable.
+        """
+        if self._vars_input:
+            raise CircuitError(
+                "circuits with input variables cannot be enclosed, so cannot be closures"
+            )
+        self._vars_capture[var.name] = self._prepare_new_var(var, None)
+
+    @typing.overload
+    def add_input(self, name_or_var: str, type_: types.Type, /) -> expr.Var:
+        ...
+
+    @typing.overload
+    def add_input(self, name_or_var: expr.Var, type_: None = None, /) -> expr.Var:
+        ...
+
+    def add_input(  # pylint: disable=missing-raises-doc
+        self, name_or_var: str | expr.Var, type_: types.Type | None = None, /
+    ) -> expr.Var:
+        """Register a variable as an input to the circuit.
+
+        Args:
+            name_or_var: either a string name, or an existing :class:`~.expr.Var` node to use as the
+                input variable.
+            type_: if the name is given as a string, then this must be a :class:`~.types.Type` to
+                use for the variable.  If the variable is given as an existing :class:`~.expr.Var`,
+                then this must not be given, and will instead be read from the object itself.
+
+        Returns:
+            the variable created, or the same variable as was passed in.
+
+        Raises:
+            CircuitError: if the variable cannot be created due to shadowing an existing variable.
+        """
+        if self._vars_capture:
+            raise CircuitError("circuits to be enclosed with captures cannot have input variables")
+        if isinstance(name_or_var, expr.Var) and type_ is not None:
+            raise ValueError("cannot give an explicit type with an existing Var")
+        var = self._prepare_new_var(name_or_var, type_)
+        self._vars_input[var.name] = var
+        return var
 
     def add_register(self, *regs: Register | int | Sequence[Bit]) -> None:
         """Add registers."""
@@ -2147,6 +2456,27 @@ class QuantumCircuit:
         from .reset import Reset
 
         return self.append(Reset(), [qubit], [])
+
+    def store(self, lvalue: typing.Any, rvalue: typing.Any, /) -> InstructionSet:
+        """Store the result of the given runtime classical expression ``rvalue`` in the memory
+        location defined by ``lvalue``.
+
+        Typically ``lvalue`` will be a :class:`~.expr.Var` node and ``rvalue`` will be some
+        :class:`~.expr.Expr` to write into it, but anything that :func:`.expr.lift` can raise to an
+        :class:`~.expr.Expr` is permissible in both places, and it will be called on them.
+
+        Args:
+            lvalue: a valid specifier for a memory location in the circuit.  This will typically be
+                a :class:`~.expr.Var` node, but you can also write to :class:`.Clbit` or
+                :class:`.ClassicalRegister` memory locations if your hardware supports it.
+            rvalue: a runtime classical expression whose result should be written into the given
+                memory location.
+
+        .. seealso::
+            :class:`~.circuit.Store`
+                the backing :class:`~.circuit.Instruction` class that represents this operation.
+        """
+        return self.append(Store(expr.lift(lvalue), expr.lift(rvalue)), (), ())
 
     def measure(self, qubit: QubitSpecifier, cbit: ClbitSpecifier) -> InstructionSet:
         r"""Measure a quantum bit (``qubit``) in the Z basis into a classical bit (``cbit``).

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -48,6 +48,13 @@ from qiskit.circuit.exceptions import CircuitError
 from qiskit.utils.deprecation import deprecate_func
 from . import _classical_resource_map
 from ._utils import sort_parameters
+from .controlflow import ControlFlowOp
+from .controlflow.break_loop import BreakLoopOp, BreakLoopPlaceholder
+from .controlflow.continue_loop import ContinueLoopOp, ContinueLoopPlaceholder
+from .controlflow.for_loop import ForLoopOp, ForLoopContext
+from .controlflow.if_else import IfElseOp, IfContext
+from .controlflow.switch_case import SwitchCaseOp, SwitchContext
+from .controlflow.while_loop import WhileLoopOp, WhileLoopContext
 from .classical import expr, types
 from .parameterexpression import ParameterExpression, ParameterValueType
 from .quantumregister import QuantumRegister, Qubit, AncillaRegister, AncillaQubit
@@ -922,8 +929,6 @@ class QuantumCircuit:
                 lcr_1: 0 ═══════════                           lcr_1: 0 ═══════════════════════
 
         """
-        # pylint: disable=cyclic-import
-        from qiskit.circuit.controlflow.switch_case import SwitchCaseOp
 
         if inplace and front and self._control_flow_scopes:
             # If we're composing onto ourselves while in a stateful control-flow builder context,
@@ -1146,6 +1151,38 @@ class QuantumCircuit:
         """
         return self._ancillas
 
+    @property
+    def num_vars(self) -> int:
+        """The number of runtime classical variables in the circuit.
+
+        This is the length of the :meth:`iter_vars` iterable."""
+        return self.num_input_vars + self.num_captured_vars + self.num_declared_vars
+
+    @property
+    def num_input_vars(self) -> int:
+        """The number of runtime classical variables in the circuit marked as circuit inputs.
+
+        This is the length of the :meth:`iter_input_vars` iterable.  If this is non-zero,
+        :attr:`num_captured_vars` must be zero."""
+        return len(self._vars_input)
+
+    @property
+    def num_captured_vars(self) -> int:
+        """The number of runtime classical variables in the circuit marked as captured from an
+        enclosing scope.
+
+        This is the length of the :meth:`iter_captured_vars` iterable.  If this is non-zero,
+        :attr:`num_input_vars` must be zero."""
+        return len(self._vars_capture)
+
+    @property
+    def num_declared_vars(self) -> int:
+        """The number of runtime classical variables in the circuit that are declared by this
+        circuit scope, excluding inputs or captures.
+
+        This is the length of the :meth:`iter_declared_vars` iterable."""
+        return len(self._vars_local)
+
     def iter_vars(self) -> typing.Iterable[expr.Var]:
         """Get an iterable over all runtime classical variables in scope within this circuit.
 
@@ -1363,6 +1400,20 @@ class QuantumCircuit:
                     self._validate_expr(param)
             if is_parameter:
                 operation = copy.deepcopy(operation)
+        if isinstance(operation, ControlFlowOp):
+            # Verify that any variable bindings are valid.  Control-flow ops are already compelled
+            # by the class not to contain 'input' variables.
+            if bad_captures := {
+                var
+                for var in itertools.chain.from_iterable(
+                    block.iter_captured_vars() for block in operation.blocks
+                )
+                if not self.has_var(var)
+            }:
+                raise CircuitError(
+                    f"control-flow op attempts to capture '{bad_captures}'"
+                    " which are not in this circuit"
+                )
 
         expanded_qargs = [self.qbit_argument_conversion(qarg) for qarg in qargs or []]
         expanded_cargs = [self.cbit_argument_conversion(carg) for carg in cargs or []]
@@ -5239,7 +5290,7 @@ class QuantumCircuit:
         clbits: None,
         *,
         label: str | None,
-    ) -> "qiskit.circuit.controlflow.while_loop.WhileLoopContext":
+    ) -> WhileLoopContext:
         ...
 
     @typing.overload
@@ -5297,9 +5348,6 @@ class QuantumCircuit:
         Raises:
             CircuitError: if an incorrect calling convention is used.
         """
-        # pylint: disable=cyclic-import
-        from qiskit.circuit.controlflow.while_loop import WhileLoopOp, WhileLoopContext
-
         if isinstance(condition, expr.Expr):
             condition = self._validate_expr(condition)
         else:
@@ -5329,7 +5377,7 @@ class QuantumCircuit:
         clbits: None,
         *,
         label: str | None,
-    ) -> "qiskit.circuit.controlflow.for_loop.ForLoopContext":
+    ) -> ForLoopContext:
         ...
 
     @typing.overload
@@ -5397,9 +5445,6 @@ class QuantumCircuit:
         Raises:
             CircuitError: if an incorrect calling convention is used.
         """
-        # pylint: disable=cyclic-import
-        from qiskit.circuit.controlflow.for_loop import ForLoopOp, ForLoopContext
-
         if body is None:
             if qubits is not None or clbits is not None:
                 raise CircuitError(
@@ -5422,7 +5467,7 @@ class QuantumCircuit:
         clbits: None,
         *,
         label: str | None,
-    ) -> "qiskit.circuit.controlflow.if_else.IfContext":
+    ) -> IfContext:
         ...
 
     @typing.overload
@@ -5505,9 +5550,6 @@ class QuantumCircuit:
         Returns:
             A handle to the instruction created.
         """
-        # pylint: disable=cyclic-import
-        from qiskit.circuit.controlflow.if_else import IfElseOp, IfContext
-
         if isinstance(condition, expr.Expr):
             condition = self._validate_expr(condition)
         else:
@@ -5574,9 +5616,6 @@ class QuantumCircuit:
         Returns:
             A handle to the instruction created.
         """
-        # pylint: disable=cyclic-import
-        from qiskit.circuit.controlflow.if_else import IfElseOp
-
         if isinstance(condition, expr.Expr):
             condition = self._validate_expr(condition)
         else:
@@ -5593,7 +5632,7 @@ class QuantumCircuit:
         clbits: None,
         *,
         label: Optional[str],
-    ) -> "qiskit.circuit.controlflow.switch_case.SwitchContext":
+    ) -> SwitchContext:
         ...
 
     @typing.overload
@@ -5659,8 +5698,6 @@ class QuantumCircuit:
         Raises:
             CircuitError: if an incorrect calling convention is used.
         """
-        # pylint: disable=cyclic-import
-        from qiskit.circuit.controlflow.switch_case import SwitchCaseOp, SwitchContext
 
         if isinstance(target, expr.Expr):
             target = self._validate_expr(target)
@@ -5699,9 +5736,6 @@ class QuantumCircuit:
             CircuitError: if this method was called within a builder context, but not contained
                 within a loop.
         """
-        # pylint: disable=cyclic-import
-        from qiskit.circuit.controlflow.break_loop import BreakLoopOp, BreakLoopPlaceholder
-
         if self._control_flow_scopes:
             operation = BreakLoopPlaceholder()
             resources = operation.placeholder_resources()
@@ -5729,9 +5763,6 @@ class QuantumCircuit:
             CircuitError: if this method was called within a builder context, but not contained
                 within a loop.
         """
-        # pylint: disable=cyclic-import
-        from qiskit.circuit.controlflow.continue_loop import ContinueLoopOp, ContinueLoopPlaceholder
-
         if self._control_flow_scopes:
             operation = ContinueLoopPlaceholder()
             resources = operation.placeholder_resources()

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1614,6 +1614,8 @@ class QuantumCircuit:
 
         Returns the validated variable, which is guaranteed to be safe to add to the circuit."""
         if isinstance(name_or_var, str):
+            if type_ is None:
+                raise CircuitError("the type must be known when creating a 'Var' from a string")
             var = expr.Var.new(name_or_var, type_)
         else:
             var = name_or_var

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1655,6 +1655,36 @@ class QuantumCircuit:
         self._append(CircuitInstruction(store, (), ()))
         return var
 
+    def add_uninitialized_var(self, var: expr.Var, /):
+        """Add a variable with no initializer.
+
+        In most cases, you should use :meth:`add_var` to initialize the variable.  To use this
+        function, you must already hold a :class:`~.expr.Var` instance, as the use of the function
+        typically only makes sense in copying contexts.
+
+        .. warning::
+
+            Qiskit makes no assertions about what an uninitialized variable will evaluate to at
+            runtime, and some hardware may reject this as an error.
+
+            You should treat this function with caution, and as a low-level primitive that is useful
+            only in special cases of programmatically rebuilding two like circuits.
+
+        Args:
+            var: the variable to add.
+        """
+        # This function is deliberately meant to be a bit harder to find, to have a long descriptive
+        # name, and to be a bit less ergonomic than `add_var` (i.e. not allowing the (name, type)
+        # overload) to discourage people from using it when they should use `add_var`.
+        #
+        # This function exists so that there is a method to emulate `copy_empty_like`'s behaviour of
+        # adding uninitialised variables, which there's no obvious way around.  We need to be sure
+        # that _some_ sort of handling of uninitialised variables is taken into account in our
+        # structures, so that doesn't become a huge edge case, even though we make no assertions
+        # about the _meaning_ if such an expression was run on hardware.
+        var = self._prepare_new_var(var, None)
+        self._vars_local[var.name] = var
+
     def add_capture(self, var: expr.Var):
         """Add a variable to the circuit that it should capture from a scope it will be contained
         within.
@@ -2386,6 +2416,14 @@ class QuantumCircuit:
             * global phase
             * all the qubits and clbits, including the registers
 
+        .. warning::
+
+            If the circuit contains any local variable declarations (those added by the
+            ``declarations`` argument to the circuit constructor, or using :meth:`add_var`), they
+            will be **uninitialized** in the output circuit.  You will need to manually add store
+            instructions for them (see :class:`.Store` and :meth:`.QuantumCircuit.store`) to
+            initialize them.
+
         Args:
             name (str): Name for the copied circuit. If None, then the name stays the same.
 
@@ -2403,6 +2441,13 @@ class QuantumCircuit:
         cpy._ancillas = self._ancillas.copy()
         cpy._qubit_indices = self._qubit_indices.copy()
         cpy._clbit_indices = self._clbit_indices.copy()
+
+        # Note that this causes the local variables to be uninitialised, because the stores are not
+        # copied.  This can leave the circuit in a potentially dangerous state for users if they
+        # don't re-add initialiser stores.
+        cpy._vars_local = self._vars_local.copy()
+        cpy._vars_input = self._vars_input.copy()
+        cpy._vars_capture = self._vars_capture.copy()
 
         cpy._parameter_table = ParameterTable()
         cpy._data = CircuitData(self._data.qubits, self._data.clbits)

--- a/qiskit/circuit/store.py
+++ b/qiskit/circuit/store.py
@@ -1,0 +1,87 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""The 'Store' operation."""
+
+from __future__ import annotations
+
+import typing
+
+from .exceptions import CircuitError
+from .classical import expr, types
+from .instruction import Instruction
+
+
+def _handle_equal_types(lvalue: expr.Expr, rvalue: expr.Expr, /) -> tuple[expr.Expr, expr.Expr]:
+    return lvalue, rvalue
+
+
+def _handle_implicit_cast(lvalue: expr.Expr, rvalue: expr.Expr, /) -> tuple[expr.Expr, expr.Expr]:
+    return lvalue, expr.Cast(rvalue, lvalue.type, implicit=True)
+
+
+def _requires_lossless_cast(lvalue: expr.Expr, rvalue: expr.Expr, /) -> typing.NoReturn:
+    raise CircuitError(f"an explicit cast is required from '{rvalue.type}' to '{lvalue.type}'")
+
+
+def _requires_dangerous_cast(lvalue: expr.Expr, rvalue: expr.Expr, /) -> typing.NoReturn:
+    raise CircuitError(
+        f"an explicit cast is required from '{rvalue.type}' to '{lvalue.type}', which may be lossy"
+    )
+
+
+def _no_cast_possible(lvalue: expr.Expr, rvalue: expr.Expr) -> typing.NoReturn:
+    raise CircuitError(f"no cast is possible from '{rvalue.type}' to '{lvalue.type}'")
+
+
+_HANDLE_CAST = {
+    types.CastKind.EQUAL: _handle_equal_types,
+    types.CastKind.IMPLICIT: _handle_implicit_cast,
+    types.CastKind.LOSSLESS: _requires_lossless_cast,
+    types.CastKind.DANGEROUS: _requires_dangerous_cast,
+    types.CastKind.NONE: _no_cast_possible,
+}
+
+
+class Store(Instruction):
+    """A manual storage of some classical value to a classical memory location.
+
+    This is a low-level primitive of the classical-expression handling (similar to how
+    :class:`~.circuit.Measure` is a primitive for quantum measurement), and is not safe for
+    subclassing.  It is likely to become a special-case instruction in later versions of Qiskit
+    circuit and compiler internal representations."""
+
+    def __init__(self, lvalue: expr.Expr, rvalue: expr.Expr):
+        if not expr.is_lvalue(lvalue):
+            raise CircuitError(f"'{lvalue}' is not an l-value")
+
+        cast_kind = types.cast_kind(rvalue.type, lvalue.type)
+        if (handler := _HANDLE_CAST.get(cast_kind)) is None:
+            raise RuntimeError(f"unhandled cast kind required: {cast_kind}")
+        lvalue, rvalue = handler(lvalue, rvalue)
+
+        super().__init__("store", 0, 0, [lvalue, rvalue])
+
+    @property
+    def lvalue(self):
+        """Get the l-value :class:`~.expr.Expr` node that is being stored to."""
+        return self.params[0]
+
+    @property
+    def rvalue(self):
+        """Get the r-value :class:`~.expr.Expr` node that is being written into the l-value."""
+        return self.params[1]
+
+    def c_if(self, classical, val):
+        raise NotImplementedError(
+            "stores cannot be conditioned with `c_if`; use a full `if_test` context instead"
+        )

--- a/releasenotes/notes/classical-store-e64ee1286219a862.yaml
+++ b/releasenotes/notes/classical-store-e64ee1286219a862.yaml
@@ -1,0 +1,56 @@
+---
+features:
+  - |
+    A :class:`.QuantumCircuit` can now contain typed classical variables::
+
+        from qiskit.circuit import QuantumCircuit, ClassicalRegister, QuantumRegister
+        from qiskit.circuit.classical import expr, types
+
+        qr = QuantumRegister(2, "q")
+        cr = ClassicalRegister(2, "c")
+        qc = QuantumCircuit(qr, cr)
+        # Add two input variables to the circuit with different types.
+        a = qc.add_input("a", types.Bool())
+        mask = qc.add_input("mask", types.Uint(2))
+
+        # Test whether the input variable was true at runtime.
+        with qc.if_test(a) as else_:
+            qc.x(0)
+        with else_:
+            qc.h(0)
+
+        qc.cx(0, 1)
+        qc.measure(qr, cr)
+
+        # Add a typed variable manually, initialized to the same value as the classical register.
+        b = qc.add_var("b", expr.lift(cr))
+
+        qc.reset([0, 1])
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.measure(qr, cr)
+
+        # Store some calculated value into the `b` variable.
+        qc.store(b, expr.bit_and(b, cr))
+        # Test whether we had equality, up to a mask.
+        with qc.if_test(expr.equal(expr.bit_and(b, mask), mask)):
+            qc.x(0)
+
+    These variables can be specified either as *inputs* to the circuit, or as scoped variables.
+    The circuit object does not yet have support for representing typed classical-variable *outputs*,
+    but this will be added later when hardware and the result interfaces are in more of a position
+    to support it.  Circuits that represent a block of an inner scope may also capture variables
+    from outer scopes.
+
+    A variable is a :class:`.Var` node, which can now contain an arbitrary type, and represents a
+    unique memory location within its live range when added to a circuit.  These can be constructed
+    in a circuit using :meth:`.QuantumCircuit.add_var` and :meth:`~.QuantumCircuit.add_input`, or
+    at a lower level using :meth:`.Var.new`.
+
+    Variables can be manually stored to, using the :class:`.Store` instruction and its corresponding
+    circuit method :meth:`.QuantumCircuit.store`.  This includes writing to :class:`.Clbit` and
+    :class:`.ClassicalRegister` instances wrapped in :class:`.Var` nodes.
+
+    Variables can be used wherever classical expressions (see :mod:`qiskit.circuit.classical.expr`)
+    are valid.  Currently this is the target expressions of control-flow operations, though we plan
+    to expand this to gate parameters in the future, as the type and expression system are expanded.

--- a/releasenotes/notes/expr-hashable-var-types-7cf2aaa00b201ae6.yaml
+++ b/releasenotes/notes/expr-hashable-var-types-7cf2aaa00b201ae6.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Classical types (subclasses of :class:`~classical.types.Type`) and variables (:class:`~.expr.Var`)
+    are now hashable.

--- a/releasenotes/notes/expr-var-standalone-2c1116583a2be9fd.yaml
+++ b/releasenotes/notes/expr-var-standalone-2c1116583a2be9fd.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    :class:`~.expr.Var` nodes now have a :attr:`.Var.standalone` property to quickly query whether
+    they are new-style memory-owning variables, or whether they wrap old-style classical memory in
+    the form of a :class:`.Clbit` or :class:`.ClassicalRegister`.

--- a/test/python/circuit/classical/test_expr_helpers.py
+++ b/test/python/circuit/classical/test_expr_helpers.py
@@ -115,3 +115,30 @@ class TestStructurallyEquivalent(QiskitTestCase):
         # ``True`` instead.
         self.assertFalse(expr.structurally_equivalent(left, right, not_handled, not_handled))
         self.assertTrue(expr.structurally_equivalent(left, right, always_equal, always_equal))
+
+
+@ddt.ddt
+class TestIsLValue(QiskitTestCase):
+    @ddt.data(
+        expr.Var.new("a", types.Bool()),
+        expr.Var.new("b", types.Uint(8)),
+        expr.Var(Clbit(), types.Bool()),
+        expr.Var(ClassicalRegister(8, "cr"), types.Uint(8)),
+    )
+    def test_happy_cases(self, lvalue):
+        self.assertTrue(expr.is_lvalue(lvalue))
+
+    @ddt.data(
+        expr.Value(3, types.Uint(2)),
+        expr.Value(False, types.Bool()),
+        expr.Cast(expr.Var.new("a", types.Uint(2)), types.Uint(8)),
+        expr.Unary(expr.Unary.Op.LOGIC_NOT, expr.Var.new("a", types.Bool()), types.Bool()),
+        expr.Binary(
+            expr.Binary.Op.LOGIC_AND,
+            expr.Var.new("a", types.Bool()),
+            expr.Var.new("b", types.Bool()),
+            types.Bool(),
+        ),
+    )
+    def test_bad_cases(self, not_an_lvalue):
+        self.assertFalse(expr.is_lvalue(not_an_lvalue))

--- a/test/python/circuit/classical/test_types_ordering.py
+++ b/test/python/circuit/classical/test_types_ordering.py
@@ -58,3 +58,13 @@ class TestTypesOrdering(QiskitTestCase):
         self.assertEqual(types.greater(types.Bool(), types.Bool()), types.Bool())
         with self.assertRaisesRegex(TypeError, "no ordering"):
             types.greater(types.Bool(), types.Uint(8))
+
+
+class TestTypesCastKind(QiskitTestCase):
+    def test_basic_examples(self):
+        """This is used extensively throughout the expression construction functions, but since it
+        is public API, it should have some direct unit tests as well."""
+        self.assertIs(types.cast_kind(types.Bool(), types.Bool()), types.CastKind.EQUAL)
+        self.assertIs(types.cast_kind(types.Uint(8), types.Bool()), types.CastKind.IMPLICIT)
+        self.assertIs(types.cast_kind(types.Bool(), types.Uint(8)), types.CastKind.LOSSLESS)
+        self.assertIs(types.cast_kind(types.Uint(16), types.Uint(8)), types.CastKind.DANGEROUS)

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -19,6 +19,7 @@ from ddt import data, ddt
 from qiskit import BasicAer, ClassicalRegister, QuantumCircuit, QuantumRegister, execute
 from qiskit.circuit import Gate, Instruction, Measure, Parameter, Barrier
 from qiskit.circuit.bit import Bit
+from qiskit.circuit.classical import expr, types
 from qiskit.circuit.classicalregister import Clbit
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.controlflow import IfElseOp
@@ -390,6 +391,77 @@ class TestCircuitOperations(QiskitTestCase):
 
         copied = qc.copy_empty_like("copy")
         self.assertEqual(copied.name, "copy")
+
+    def test_copy_variables(self):
+        """Test that a full copy of circuits including variables copies them across."""
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Uint(8))
+        c = expr.Var.new("c", types.Bool())
+        d = expr.Var.new("d", types.Uint(8))
+
+        qc = QuantumCircuit(inputs=[a], declarations=[(c, expr.lift(False))])
+        copied = qc.copy()
+        self.assertEqual({a}, set(copied.iter_input_vars()))
+        self.assertEqual({c}, set(copied.iter_declared_vars()))
+        self.assertEqual(
+            [instruction.operation for instruction in qc],
+            [instruction.operation for instruction in copied.data],
+        )
+
+        # Check that the original circuit is not mutated.
+        copied.add_input(b)
+        copied.add_var(d, 0xFF)
+        self.assertEqual({a, b}, set(copied.iter_input_vars()))
+        self.assertEqual({c, d}, set(copied.iter_declared_vars()))
+        self.assertEqual({a}, set(qc.iter_input_vars()))
+        self.assertEqual({c}, set(qc.iter_declared_vars()))
+
+        qc = QuantumCircuit(captures=[b], declarations=[(a, expr.lift(False)), (c, a)])
+        copied = qc.copy()
+        self.assertEqual({b}, set(copied.iter_captured_vars()))
+        self.assertEqual({a, c}, set(copied.iter_declared_vars()))
+        self.assertEqual(
+            [instruction.operation for instruction in qc],
+            [instruction.operation for instruction in copied.data],
+        )
+
+        # Check that the original circuit is not mutated.
+        copied.add_capture(d)
+        self.assertEqual({b, d}, set(copied.iter_captured_vars()))
+        self.assertEqual({b}, set(qc.iter_captured_vars()))
+
+    def test_copy_empty_variables(self):
+        """Test that an empty copy of circuits including variables copies them across, but does not
+        initialise them."""
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Uint(8))
+        c = expr.Var.new("c", types.Bool())
+        d = expr.Var.new("d", types.Uint(8))
+
+        qc = QuantumCircuit(inputs=[a], declarations=[(c, expr.lift(False))])
+        copied = qc.copy_empty_like()
+        self.assertEqual({a}, set(copied.iter_input_vars()))
+        self.assertEqual({c}, set(copied.iter_declared_vars()))
+        self.assertEqual([], list(copied.data))
+
+        # Check that the original circuit is not mutated.
+        copied.add_input(b)
+        copied.add_var(d, 0xFF)
+        self.assertEqual({a, b}, set(copied.iter_input_vars()))
+        self.assertEqual({c, d}, set(copied.iter_declared_vars()))
+        self.assertEqual({a}, set(qc.iter_input_vars()))
+        self.assertEqual({c}, set(qc.iter_declared_vars()))
+
+        qc = QuantumCircuit(captures=[b], declarations=[(a, expr.lift(False)), (c, a)])
+        copied = qc.copy_empty_like()
+        self.assertEqual({b}, set(copied.iter_captured_vars()))
+        self.assertEqual({a, c}, set(copied.iter_declared_vars()))
+        self.assertEqual([], list(copied.data))
+
+        # Check that the original circuit is not mutated.
+        copied.add_capture(d)
+        self.assertEqual({b, d}, set(copied.iter_captured_vars()))
+        self.assertEqual({b}, set(qc.iter_captured_vars()))
 
     def test_circuit_copy_rejects_invalid_types(self):
         """Test copy method rejects argument with type other than 'string' and 'None' type."""

--- a/test/python/circuit/test_circuit_vars.py
+++ b/test/python/circuit/test_circuit_vars.py
@@ -25,11 +25,19 @@ class TestCircuitVars(QiskitTestCase):
         vars_ = [expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Uint(16))]
         qc = QuantumCircuit(inputs=vars_)
         self.assertEqual(set(vars_), set(qc.iter_vars()))
+        self.assertEqual(qc.num_vars, len(vars_))
+        self.assertEqual(qc.num_input_vars, len(vars_))
+        self.assertEqual(qc.num_captured_vars, 0)
+        self.assertEqual(qc.num_declared_vars, 0)
 
     def test_initialise_captures(self):
         vars_ = [expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Uint(16))]
         qc = QuantumCircuit(captures=vars_)
         self.assertEqual(set(vars_), set(qc.iter_vars()))
+        self.assertEqual(qc.num_vars, len(vars_))
+        self.assertEqual(qc.num_input_vars, 0)
+        self.assertEqual(qc.num_captured_vars, len(vars_))
+        self.assertEqual(qc.num_declared_vars, 0)
 
     def test_initialise_declarations_iterable(self):
         vars_ = [
@@ -39,6 +47,10 @@ class TestCircuitVars(QiskitTestCase):
         qc = QuantumCircuit(declarations=vars_)
 
         self.assertEqual({var for var, _initialiser in vars_}, set(qc.iter_vars()))
+        self.assertEqual(qc.num_vars, len(vars_))
+        self.assertEqual(qc.num_input_vars, 0)
+        self.assertEqual(qc.num_captured_vars, 0)
+        self.assertEqual(qc.num_declared_vars, len(vars_))
         operations = [
             (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
             for instruction in qc.data
@@ -88,6 +100,10 @@ class TestCircuitVars(QiskitTestCase):
         self.assertEqual({a}, set(qc.iter_input_vars()))
         self.assertEqual({b}, set(qc.iter_declared_vars()))
         self.assertEqual({a, b}, set(qc.iter_vars()))
+        self.assertEqual(qc.num_vars, 2)
+        self.assertEqual(qc.num_input_vars, 1)
+        self.assertEqual(qc.num_captured_vars, 0)
+        self.assertEqual(qc.num_declared_vars, 1)
         operations = [
             (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
             for instruction in qc.data
@@ -103,6 +119,10 @@ class TestCircuitVars(QiskitTestCase):
         self.assertEqual({a}, set(qc.iter_captured_vars()))
         self.assertEqual({b}, set(qc.iter_declared_vars()))
         self.assertEqual({a, b}, set(qc.iter_vars()))
+        self.assertEqual(qc.num_vars, 2)
+        self.assertEqual(qc.num_input_vars, 0)
+        self.assertEqual(qc.num_captured_vars, 1)
+        self.assertEqual(qc.num_declared_vars, 1)
         operations = [
             (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
             for instruction in qc.data

--- a/test/python/circuit/test_circuit_vars.py
+++ b/test/python/circuit/test_circuit_vars.py
@@ -1,0 +1,366 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
+
+from qiskit.test import QiskitTestCase
+from qiskit.circuit import QuantumCircuit, CircuitError, Clbit, ClassicalRegister
+from qiskit.circuit.classical import expr, types
+
+
+class TestCircuitVars(QiskitTestCase):
+    """Tests for variable-manipulation routines on circuits.  More specific functionality is likely
+    tested in the suites of the specific methods."""
+
+    def test_initialise_inputs(self):
+        vars_ = [expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Uint(16))]
+        qc = QuantumCircuit(inputs=vars_)
+        self.assertEqual(set(vars_), set(qc.iter_vars()))
+
+    def test_initialise_captures(self):
+        vars_ = [expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Uint(16))]
+        qc = QuantumCircuit(captures=vars_)
+        self.assertEqual(set(vars_), set(qc.iter_vars()))
+
+    def test_initialise_declarations_iterable(self):
+        vars_ = [
+            (expr.Var.new("a", types.Bool()), expr.lift(True)),
+            (expr.Var.new("b", types.Uint(16)), expr.lift(0xFFFF)),
+        ]
+        qc = QuantumCircuit(declarations=vars_)
+
+        self.assertEqual({var for var, _initialiser in vars_}, set(qc.iter_vars()))
+        operations = [
+            (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
+            for instruction in qc.data
+        ]
+        self.assertEqual(operations, [("store", lvalue, rvalue) for lvalue, rvalue in vars_])
+
+    def test_initialise_declarations_mapping(self):
+        # Dictionary iteration order is guaranteed to be insertion order.
+        vars_ = {
+            expr.Var.new("a", types.Bool()): expr.lift(True),
+            expr.Var.new("b", types.Uint(16)): expr.lift(0xFFFF),
+        }
+        qc = QuantumCircuit(declarations=vars_)
+
+        self.assertEqual(set(vars_), set(qc.iter_vars()))
+        operations = [
+            (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
+            for instruction in qc.data
+        ]
+        self.assertEqual(
+            operations, [("store", lvalue, rvalue) for lvalue, rvalue in vars_.items()]
+        )
+
+    def test_initialise_declarations_dependencies(self):
+        """Test that the cirucit initialiser can take in declarations with dependencies between
+        them, provided they're specified in a suitable order."""
+        a = expr.Var.new("a", types.Bool())
+        vars_ = [
+            (a, expr.lift(True)),
+            (expr.Var.new("b", types.Bool()), a),
+        ]
+        qc = QuantumCircuit(declarations=vars_)
+
+        self.assertEqual({var for var, _initialiser in vars_}, set(qc.iter_vars()))
+        operations = [
+            (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
+            for instruction in qc.data
+        ]
+        self.assertEqual(operations, [("store", lvalue, rvalue) for lvalue, rvalue in vars_])
+
+    def test_initialise_inputs_declarations(self):
+        a = expr.Var.new("a", types.Uint(16))
+        b = expr.Var.new("b", types.Uint(16))
+        b_init = expr.bit_and(a, 0xFFFF)
+        qc = QuantumCircuit(inputs=[a], declarations={b: b_init})
+
+        self.assertEqual({a}, set(qc.iter_input_vars()))
+        self.assertEqual({b}, set(qc.iter_declared_vars()))
+        self.assertEqual({a, b}, set(qc.iter_vars()))
+        operations = [
+            (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
+            for instruction in qc.data
+        ]
+        self.assertEqual(operations, [("store", b, b_init)])
+
+    def test_initialise_captures_declarations(self):
+        a = expr.Var.new("a", types.Uint(16))
+        b = expr.Var.new("b", types.Uint(16))
+        b_init = expr.bit_and(a, 0xFFFF)
+        qc = QuantumCircuit(captures=[a], declarations={b: b_init})
+
+        self.assertEqual({a}, set(qc.iter_captured_vars()))
+        self.assertEqual({b}, set(qc.iter_declared_vars()))
+        self.assertEqual({a, b}, set(qc.iter_vars()))
+        operations = [
+            (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
+            for instruction in qc.data
+        ]
+        self.assertEqual(operations, [("store", b, b_init)])
+
+    def test_add_var_returns_good_var(self):
+        qc = QuantumCircuit()
+        a = qc.add_var("a", expr.lift(True))
+        self.assertEqual(a.name, "a")
+        self.assertEqual(a.type, types.Bool())
+
+        b = qc.add_var("b", expr.Value(0xFF, types.Uint(8)))
+        self.assertEqual(b.name, "b")
+        self.assertEqual(b.type, types.Uint(8))
+
+    def test_add_var_returns_input(self):
+        """Test that the `Var` returned by `add_var` is the same as the input if `Var`."""
+        a = expr.Var.new("a", types.Bool())
+        qc = QuantumCircuit()
+        a_other = qc.add_var(a, expr.lift(True))
+        self.assertIs(a, a_other)
+
+    def test_add_input_returns_good_var(self):
+        qc = QuantumCircuit()
+        a = qc.add_input("a", types.Bool())
+        self.assertEqual(a.name, "a")
+        self.assertEqual(a.type, types.Bool())
+
+        b = qc.add_input("b", types.Uint(8))
+        self.assertEqual(b.name, "b")
+        self.assertEqual(b.type, types.Uint(8))
+
+    def test_add_input_returns_input(self):
+        """Test that the `Var` returned by `add_input` is the same as the input if `Var`."""
+        a = expr.Var.new("a", types.Bool())
+        qc = QuantumCircuit()
+        a_other = qc.add_input(a)
+        self.assertIs(a, a_other)
+
+    def test_cannot_have_both_inputs_and_captures(self):
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+
+        with self.assertRaisesRegex(CircuitError, "circuits with input.*cannot be closures"):
+            QuantumCircuit(inputs=[a], captures=[b])
+
+        qc = QuantumCircuit(inputs=[a])
+        with self.assertRaisesRegex(CircuitError, "circuits with input.*cannot be closures"):
+            qc.add_capture(b)
+
+        qc = QuantumCircuit(captures=[a])
+        with self.assertRaisesRegex(CircuitError, "circuits to be enclosed.*cannot have input"):
+            qc.add_input(b)
+
+    def test_cannot_add_cyclic_declaration(self):
+        a = expr.Var.new("a", types.Bool())
+        with self.assertRaisesRegex(CircuitError, "not present in this circuit"):
+            QuantumCircuit(declarations=[(a, a)])
+
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "not present in this circuit"):
+            qc.add_var(a, a)
+
+    def test_initialise_inputs_equal_to_add_input(self):
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Uint(16))
+
+        qc_init = QuantumCircuit(inputs=[a, b])
+        qc_manual = QuantumCircuit()
+        qc_manual.add_input(a)
+        qc_manual.add_input(b)
+        self.assertEqual(list(qc_init.iter_vars()), list(qc_manual.iter_vars()))
+
+        qc_manual = QuantumCircuit()
+        a = qc_manual.add_input("a", types.Bool())
+        b = qc_manual.add_input("b", types.Uint(16))
+        qc_init = QuantumCircuit(inputs=[a, b])
+        self.assertEqual(list(qc_init.iter_vars()), list(qc_manual.iter_vars()))
+
+    def test_initialise_captures_equal_to_add_capture(self):
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Uint(16))
+
+        qc_init = QuantumCircuit(captures=[a, b])
+        qc_manual = QuantumCircuit()
+        qc_manual.add_capture(a)
+        qc_manual.add_capture(b)
+        self.assertEqual(list(qc_init.iter_vars()), list(qc_manual.iter_vars()))
+
+    def test_initialise_declarations_equal_to_add_var(self):
+        a = expr.Var.new("a", types.Bool())
+        a_init = expr.lift(False)
+        b = expr.Var.new("b", types.Uint(16))
+        b_init = expr.lift(0xFFFF)
+
+        qc_init = QuantumCircuit(declarations=[(a, a_init), (b, b_init)])
+        qc_manual = QuantumCircuit()
+        qc_manual.add_var(a, a_init)
+        qc_manual.add_var(b, b_init)
+        self.assertEqual(list(qc_init.iter_vars()), list(qc_manual.iter_vars()))
+        self.assertEqual(qc_init.data, qc_manual.data)
+
+        qc_manual = QuantumCircuit()
+        a = qc_manual.add_var("a", a_init)
+        b = qc_manual.add_var("b", b_init)
+        qc_init = QuantumCircuit(declarations=[(a, a_init), (b, b_init)])
+        self.assertEqual(list(qc_init.iter_vars()), list(qc_manual.iter_vars()))
+        self.assertEqual(qc_init.data, qc_manual.data)
+
+    def test_cannot_shadow_vars(self):
+        """Test that exact duplicate ``Var`` nodes within different combinations of the inputs are
+        detected and rejected."""
+        a = expr.Var.new("a", types.Bool())
+        a_init = expr.lift(True)
+        with self.assertRaisesRegex(CircuitError, "already present"):
+            QuantumCircuit(inputs=[a, a])
+        with self.assertRaisesRegex(CircuitError, "already present"):
+            QuantumCircuit(captures=[a, a])
+        with self.assertRaisesRegex(CircuitError, "already present"):
+            QuantumCircuit(declarations=[(a, a_init), (a, a_init)])
+        with self.assertRaisesRegex(CircuitError, "already present"):
+            QuantumCircuit(inputs=[a], declarations=[(a, a_init)])
+        with self.assertRaisesRegex(CircuitError, "already present"):
+            QuantumCircuit(captures=[a], declarations=[(a, a_init)])
+
+    def test_cannot_shadow_names(self):
+        """Test that exact duplicate ``Var`` nodes within different combinations of the inputs are
+        detected and rejected."""
+        a_bool1 = expr.Var.new("a", types.Bool())
+        a_bool2 = expr.Var.new("a", types.Bool())
+        a_uint = expr.Var.new("a", types.Uint(16))
+        a_bool_init = expr.lift(True)
+        a_uint_init = expr.lift(0xFFFF)
+
+        tests = [
+            ((a_bool1, a_bool_init), (a_bool2, a_bool_init)),
+            ((a_bool1, a_bool_init), (a_uint, a_uint_init)),
+        ]
+        for (left, left_init), (right, right_init) in tests:
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                QuantumCircuit(inputs=(left, right))
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                QuantumCircuit(captures=(left, right))
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                QuantumCircuit(declarations=[(left, left_init), (right, right_init)])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                QuantumCircuit(inputs=[left], declarations=[(right, right_init)])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                QuantumCircuit(captures=[left], declarations=[(right, right_init)])
+
+            qc = QuantumCircuit(inputs=[left])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                qc.add_input(right)
+            qc = QuantumCircuit(inputs=[left])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                qc.add_var(right, right_init)
+
+            qc = QuantumCircuit(captures=[left])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                qc.add_capture(right)
+            qc = QuantumCircuit(captures=[left])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                qc.add_var(right, right_init)
+
+            qc = QuantumCircuit(inputs=[left])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                qc.add_var(right, right_init)
+
+        qc = QuantumCircuit()
+        qc.add_var("a", expr.lift(True))
+        with self.assertRaisesRegex(CircuitError, "its name shadows"):
+            qc.add_var("a", expr.lift(True))
+        with self.assertRaisesRegex(CircuitError, "its name shadows"):
+            qc.add_var("a", expr.lift(0xFF))
+
+    def test_cannot_add_vars_wrapping_clbits(self):
+        a = expr.Var(Clbit(), types.Bool())
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            QuantumCircuit(inputs=[a])
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            qc.add_input(a)
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            QuantumCircuit(captures=[a])
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            qc.add_capture(a)
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            QuantumCircuit(declarations=[(a, expr.lift(True))])
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            qc.add_var(a, expr.lift(True))
+
+    def test_cannot_add_vars_wrapping_cregs(self):
+        a = expr.Var(ClassicalRegister(8, "cr"), types.Uint(8))
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            QuantumCircuit(inputs=[a])
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            qc.add_input(a)
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            QuantumCircuit(captures=[a])
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            qc.add_capture(a)
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            QuantumCircuit(declarations=[(a, expr.lift(0xFF))])
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            qc.add_var(a, expr.lift(0xFF))
+
+    def test_get_var_success(self):
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Uint(8))
+
+        qc = QuantumCircuit(inputs=[a], declarations={b: expr.Value(0xFF, types.Uint(8))})
+        self.assertIs(qc.get_var("a"), a)
+        self.assertIs(qc.get_var("b"), b)
+
+        qc = QuantumCircuit(captures=[a, b])
+        self.assertIs(qc.get_var("a"), a)
+        self.assertIs(qc.get_var("b"), b)
+
+        qc = QuantumCircuit(declarations={a: expr.lift(True), b: expr.Value(0xFF, types.Uint(8))})
+        self.assertIs(qc.get_var("a"), a)
+        self.assertIs(qc.get_var("b"), b)
+
+    def test_get_var_missing(self):
+        qc = QuantumCircuit()
+        with self.assertRaises(KeyError):
+            qc.get_var("a")
+
+        a = expr.Var.new("a", types.Bool())
+        qc.add_input(a)
+        with self.assertRaises(KeyError):
+            qc.get_var("b")
+
+    def test_get_var_default(self):
+        qc = QuantumCircuit()
+        self.assertIs(qc.get_var("a", None), None)
+
+        missing = "default"
+        a = expr.Var.new("a", types.Bool())
+        qc.add_input(a)
+        self.assertIs(qc.get_var("b", missing), missing)
+        self.assertIs(qc.get_var("b", a), a)
+
+    def test_has_var(self):
+        a = expr.Var.new("a", types.Bool())
+        self.assertFalse(QuantumCircuit().has_var("a"))
+        self.assertTrue(QuantumCircuit(inputs=[a]).has_var("a"))
+        self.assertTrue(QuantumCircuit(captures=[a]).has_var("a"))
+        self.assertTrue(QuantumCircuit(declarations={a: expr.lift(True)}).has_var("a"))
+        self.assertTrue(QuantumCircuit(inputs=[a]).has_var(a))
+        self.assertTrue(QuantumCircuit(captures=[a]).has_var(a))
+        self.assertTrue(QuantumCircuit(declarations={a: expr.lift(True)}).has_var(a))
+
+        # When giving an `Var`, the match must be exact, not just the name.
+        self.assertFalse(QuantumCircuit(inputs=[a]).has_var(expr.Var.new("a", types.Uint(8))))
+        self.assertFalse(QuantumCircuit(inputs=[a]).has_var(expr.Var.new("a", types.Bool())))

--- a/test/python/circuit/test_circuit_vars.py
+++ b/test/python/circuit/test_circuit_vars.py
@@ -109,6 +109,13 @@ class TestCircuitVars(QiskitTestCase):
         ]
         self.assertEqual(operations, [("store", b, b_init)])
 
+    def test_add_uninitialized_var(self):
+        a = expr.Var.new("a", types.Bool())
+        qc = QuantumCircuit()
+        qc.add_uninitialized_var(a)
+        self.assertEqual({a}, set(qc.iter_vars()))
+        self.assertEqual([], list(qc.data))
+
     def test_add_var_returns_good_var(self):
         qc = QuantumCircuit()
         a = qc.add_var("a", expr.lift(True))

--- a/test/python/circuit/test_control_flow.py
+++ b/test/python/circuit/test_control_flow.py
@@ -510,6 +510,49 @@ class TestCreatingControlFlowOperations(QiskitTestCase):
         with self.assertRaisesRegex(CircuitError, "cases after the default are unreachable"):
             SwitchCaseOp(creg, [(CASE_DEFAULT, case1), (1, case2)])
 
+    def test_if_else_rejects_input_vars(self):
+        """Bodies must not contain input variables."""
+        cond = (Clbit(), False)
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+        bad_body = QuantumCircuit(inputs=[a])
+        good_body = QuantumCircuit(captures=[a], declarations=[(b, expr.lift(False))])
+
+        with self.assertRaisesRegex(CircuitError, "cannot contain input variables"):
+            IfElseOp(cond, bad_body, None)
+        with self.assertRaisesRegex(CircuitError, "cannot contain input variables"):
+            IfElseOp(cond, bad_body, good_body)
+        with self.assertRaisesRegex(CircuitError, "cannot contain input variables"):
+            IfElseOp(cond, good_body, bad_body)
+
+    def test_while_rejects_input_vars(self):
+        """Bodies must not contain input variables."""
+        cond = (Clbit(), False)
+        a = expr.Var.new("a", types.Bool())
+        bad_body = QuantumCircuit(inputs=[a])
+        with self.assertRaisesRegex(CircuitError, "cannot contain input variables"):
+            WhileLoopOp(cond, bad_body)
+
+    def test_for_rejects_input_vars(self):
+        """Bodies must not contain input variables."""
+        a = expr.Var.new("a", types.Bool())
+        bad_body = QuantumCircuit(inputs=[a])
+        with self.assertRaisesRegex(CircuitError, "cannot contain input variables"):
+            ForLoopOp(range(3), None, bad_body)
+
+    def test_switch_rejects_input_vars(self):
+        """Bodies must not contain input variables."""
+        target = ClassicalRegister(3, "cr")
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+        bad_body = QuantumCircuit(inputs=[a])
+        good_body = QuantumCircuit(captures=[a], declarations=[(b, expr.lift(False))])
+
+        with self.assertRaisesRegex(CircuitError, "cannot contain input variables"):
+            SwitchCaseOp(target, [(0, bad_body)])
+        with self.assertRaisesRegex(CircuitError, "cannot contain input variables"):
+            SwitchCaseOp(target, [(0, good_body), (1, bad_body)])
+
 
 @ddt
 class TestAddingControlFlowOperations(QiskitTestCase):
@@ -874,3 +917,148 @@ class TestAddingControlFlowOperations(QiskitTestCase):
             )
 
             self.assertEqual(assigned, expected)
+
+    def test_can_add_op_with_captures_of_inputs(self):
+        """Test circuit methods can capture input variables."""
+        outer = QuantumCircuit(1, 1)
+        a = outer.add_input("a", types.Bool())
+
+        inner = QuantumCircuit(1, 1, captures=[a])
+
+        outer.if_test((outer.clbits[0], False), inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "if_else")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+
+        outer.if_else((outer.clbits[0], False), inner.copy(), inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "if_else")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+        self.assertEqual(set(added.blocks[1].iter_captured_vars()), {a})
+
+        outer.while_loop((outer.clbits[0], False), inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "while_loop")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+
+        outer.for_loop(range(3), None, inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "for_loop")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+
+        outer.switch(outer.clbits[0], [(False, inner.copy()), (True, inner.copy())], [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "switch_case")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+        self.assertEqual(set(added.blocks[1].iter_captured_vars()), {a})
+
+    def test_can_add_op_with_captures_of_captures(self):
+        """Test circuit methods can capture captured variables."""
+        outer = QuantumCircuit(1, 1)
+        a = expr.Var.new("a", types.Bool())
+        outer.add_capture(a)
+
+        inner = QuantumCircuit(1, 1, captures=[a])
+
+        outer.if_test((outer.clbits[0], False), inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "if_else")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+
+        outer.if_else((outer.clbits[0], False), inner.copy(), inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "if_else")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+        self.assertEqual(set(added.blocks[1].iter_captured_vars()), {a})
+
+        outer.while_loop((outer.clbits[0], False), inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "while_loop")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+
+        outer.for_loop(range(3), None, inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "for_loop")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+
+        outer.switch(outer.clbits[0], [(False, inner.copy()), (True, inner.copy())], [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "switch_case")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+        self.assertEqual(set(added.blocks[1].iter_captured_vars()), {a})
+
+    def test_can_add_op_with_captures_of_locals(self):
+        """Test circuit methods can capture declared variables."""
+        outer = QuantumCircuit(1, 1)
+        a = outer.add_var("a", expr.lift(True))
+
+        inner = QuantumCircuit(1, 1, captures=[a])
+
+        outer.if_test((outer.clbits[0], False), inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "if_else")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+
+        outer.if_else((outer.clbits[0], False), inner.copy(), inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "if_else")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+        self.assertEqual(set(added.blocks[1].iter_captured_vars()), {a})
+
+        outer.while_loop((outer.clbits[0], False), inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "while_loop")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+
+        outer.for_loop(range(3), None, inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "for_loop")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+
+        outer.switch(outer.clbits[0], [(False, inner.copy()), (True, inner.copy())], [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "switch_case")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+        self.assertEqual(set(added.blocks[1].iter_captured_vars()), {a})
+
+    def test_cannot_capture_unknown_variables_methods(self):
+        """Control-flow operations should not be able to capture variables that don't exist in the
+        outer circuit."""
+        outer = QuantumCircuit(1, 1)
+
+        a = expr.Var.new("a", types.Bool())
+        inner = QuantumCircuit(1, 1, captures=[a])
+
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.if_test((outer.clbits[0], False), inner.copy(), [0], [0])
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.if_else((outer.clbits[0], False), inner.copy(), inner.copy(), [0], [0])
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.while_loop((outer.clbits[0], False), inner.copy(), [0], [0])
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.for_loop(range(3), None, inner.copy(), [0], [0])
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.switch(outer.clbits[0], [(False, inner.copy()), (True, inner.copy())], [0], [0])
+
+    def test_cannot_capture_unknown_variables_append(self):
+        """Control-flow operations should not be able to capture variables that don't exist in the
+        outer circuit."""
+        outer = QuantumCircuit(1, 1)
+
+        a = expr.Var.new("a", types.Bool())
+        inner = QuantumCircuit(1, 1, captures=[a])
+
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.append(IfElseOp((outer.clbits[0], False), inner.copy(), None), [0], [0])
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.append(IfElseOp((outer.clbits[0], False), inner.copy(), inner.copy()), [0], [0])
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.append(WhileLoopOp((outer.clbits[0], False), inner.copy()), [0], [0])
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.append(ForLoopOp(range(3), None, inner.copy()), [0], [0])
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.append(
+                SwitchCaseOp(outer.clbits[0], [(False, inner.copy()), (True, inner.copy())]),
+                [0],
+                [0],
+            )

--- a/test/python/circuit/test_store.py
+++ b/test/python/circuit/test_store.py
@@ -13,7 +13,7 @@
 # pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
 
 from qiskit.test import QiskitTestCase
-from qiskit.circuit import Store, Clbit, CircuitError
+from qiskit.circuit import Store, Clbit, CircuitError, QuantumCircuit, ClassicalRegister
 from qiskit.circuit.classical import expr, types
 
 
@@ -60,3 +60,140 @@ class TestStoreInstruction(QiskitTestCase):
         instruction = Store(expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Bool()))
         with self.assertRaises(NotImplementedError):
             instruction.c_if(Clbit(), False)
+
+
+class TestStoreCircuit(QiskitTestCase):
+    """Tests of the `QuantumCircuit.store` method and appends of `Store`."""
+
+    def test_produces_expected_operation(self):
+        a = expr.Var.new("a", types.Bool())
+        value = expr.Value(True, types.Bool())
+
+        qc = QuantumCircuit(inputs=[a])
+        qc.store(a, value)
+        self.assertEqual(qc.data[-1].operation, Store(a, value))
+
+        qc = QuantumCircuit(captures=[a])
+        qc.store(a, value)
+        self.assertEqual(qc.data[-1].operation, Store(a, value))
+
+        qc = QuantumCircuit(declarations=[(a, expr.lift(False))])
+        qc.store(a, value)
+        self.assertEqual(qc.data[-1].operation, Store(a, value))
+
+    def test_allows_stores_with_clbits(self):
+        clbits = [Clbit(), Clbit()]
+        a = expr.Var.new("a", types.Bool())
+        qc = QuantumCircuit(clbits, inputs=[a])
+        qc.store(clbits[0], True)
+        qc.store(expr.Var(clbits[1], types.Bool()), a)
+        qc.store(clbits[0], clbits[1])
+        qc.store(expr.lift(clbits[0]), expr.lift(clbits[1]))
+        qc.store(a, expr.lift(clbits[1]))
+
+        expected = [
+            Store(expr.lift(clbits[0]), expr.lift(True)),
+            Store(expr.lift(clbits[1]), a),
+            Store(expr.lift(clbits[0]), expr.lift(clbits[1])),
+            Store(expr.lift(clbits[0]), expr.lift(clbits[1])),
+            Store(a, expr.lift(clbits[1])),
+        ]
+        actual = [instruction.operation for instruction in qc.data]
+        self.assertEqual(actual, expected)
+
+    def test_allows_stores_with_cregs(self):
+        cregs = [ClassicalRegister(8, "cr1"), ClassicalRegister(8, "cr2")]
+        a = expr.Var.new("a", types.Uint(8))
+        qc = QuantumCircuit(*cregs, captures=[a])
+        qc.store(cregs[0], 0xFF)
+        qc.store(expr.Var(cregs[1], types.Uint(8)), a)
+        qc.store(cregs[0], cregs[1])
+        qc.store(expr.lift(cregs[0]), expr.lift(cregs[1]))
+        qc.store(a, cregs[1])
+
+        expected = [
+            Store(expr.lift(cregs[0]), expr.lift(0xFF)),
+            Store(expr.lift(cregs[1]), a),
+            Store(expr.lift(cregs[0]), expr.lift(cregs[1])),
+            Store(expr.lift(cregs[0]), expr.lift(cregs[1])),
+            Store(a, expr.lift(cregs[1])),
+        ]
+        actual = [instruction.operation for instruction in qc.data]
+        self.assertEqual(actual, expected)
+
+    def test_lifts_values(self):
+        a = expr.Var.new("a", types.Bool())
+        qc = QuantumCircuit(captures=[a])
+        qc.store(a, True)
+        self.assertEqual(qc.data[-1].operation, Store(a, expr.lift(True)))
+
+        b = expr.Var.new("b", types.Uint(16))
+        qc.add_capture(b)
+        qc.store(b, 0xFFFF)
+        self.assertEqual(qc.data[-1].operation, Store(b, expr.lift(0xFFFF)))
+
+    def test_rejects_vars_not_in_circuit(self):
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "'a'.*not present"):
+            qc.store(expr.Var.new("a", types.Bool()), True)
+
+        # Not the same 'a'
+        qc.add_input(a)
+        with self.assertRaisesRegex(CircuitError, "'a'.*not present"):
+            qc.store(expr.Var.new("a", types.Bool()), True)
+        with self.assertRaisesRegex(CircuitError, "'b'.*not present"):
+            qc.store(a, b)
+
+    def test_rejects_bits_not_in_circuit(self):
+        a = expr.Var.new("a", types.Bool())
+        clbit = Clbit()
+        qc = QuantumCircuit(captures=[a])
+        with self.assertRaisesRegex(CircuitError, "not present"):
+            qc.store(clbit, False)
+        with self.assertRaisesRegex(CircuitError, "not present"):
+            qc.store(clbit, a)
+        with self.assertRaisesRegex(CircuitError, "not present"):
+            qc.store(a, clbit)
+
+    def test_rejects_cregs_not_in_circuit(self):
+        a = expr.Var.new("a", types.Uint(8))
+        creg = ClassicalRegister(8, "cr1")
+        qc = QuantumCircuit(captures=[a])
+        with self.assertRaisesRegex(CircuitError, "not present"):
+            qc.store(creg, 0xFF)
+        with self.assertRaisesRegex(CircuitError, "not present"):
+            qc.store(creg, a)
+        with self.assertRaisesRegex(CircuitError, "not present"):
+            qc.store(a, creg)
+
+    def test_rejects_non_lvalue(self):
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+        qc = QuantumCircuit(inputs=[a, b])
+        not_an_lvalue = expr.logic_and(a, b)
+        with self.assertRaisesRegex(CircuitError, "not an l-value"):
+            qc.store(not_an_lvalue, expr.lift(False))
+
+    def test_rejects_explicit_cast(self):
+        lvalue = expr.Var.new("a", types.Uint(16))
+        rvalue = expr.Var.new("b", types.Uint(8))
+        qc = QuantumCircuit(inputs=[lvalue, rvalue])
+        with self.assertRaisesRegex(CircuitError, "an explicit cast is required"):
+            qc.store(lvalue, rvalue)
+
+    def test_rejects_dangerous_cast(self):
+        lvalue = expr.Var.new("a", types.Uint(8))
+        rvalue = expr.Var.new("b", types.Uint(16))
+        qc = QuantumCircuit(inputs=[lvalue, rvalue])
+        with self.assertRaisesRegex(CircuitError, "an explicit cast is required.*may be lossy"):
+            qc.store(lvalue, rvalue)
+
+    def test_rejects_c_if(self):
+        a = expr.Var.new("a", types.Bool())
+        qc = QuantumCircuit([Clbit()], inputs=[a])
+        instruction_set = qc.store(a, True)
+        with self.assertRaises(NotImplementedError):
+            instruction_set.c_if(qc.clbits[0], False)

--- a/test/python/circuit/test_store.py
+++ b/test/python/circuit/test_store.py
@@ -1,0 +1,62 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
+
+from qiskit.test import QiskitTestCase
+from qiskit.circuit import Store, Clbit, CircuitError
+from qiskit.circuit.classical import expr, types
+
+
+class TestStoreInstruction(QiskitTestCase):
+    """Tests of the properties of the ``Store`` instruction itself."""
+
+    def test_happy_path_construction(self):
+        lvalue = expr.Var.new("a", types.Bool())
+        rvalue = expr.lift(Clbit())
+        constructed = Store(lvalue, rvalue)
+        self.assertIsInstance(constructed, Store)
+        self.assertEqual(constructed.lvalue, lvalue)
+        self.assertEqual(constructed.rvalue, rvalue)
+
+    def test_implicit_cast(self):
+        lvalue = expr.Var.new("a", types.Bool())
+        rvalue = expr.Var.new("b", types.Uint(8))
+        constructed = Store(lvalue, rvalue)
+        self.assertIsInstance(constructed, Store)
+        self.assertEqual(constructed.lvalue, lvalue)
+        self.assertEqual(constructed.rvalue, expr.Cast(rvalue, types.Bool(), implicit=True))
+
+    def test_rejects_non_lvalue(self):
+        not_an_lvalue = expr.logic_and(
+            expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Bool())
+        )
+        rvalue = expr.lift(False)
+        with self.assertRaisesRegex(CircuitError, "not an l-value"):
+            Store(not_an_lvalue, rvalue)
+
+    def test_rejects_explicit_cast(self):
+        lvalue = expr.Var.new("a", types.Uint(16))
+        rvalue = expr.Var.new("b", types.Uint(8))
+        with self.assertRaisesRegex(CircuitError, "an explicit cast is required"):
+            Store(lvalue, rvalue)
+
+    def test_rejects_dangerous_cast(self):
+        lvalue = expr.Var.new("a", types.Uint(8))
+        rvalue = expr.Var.new("b", types.Uint(16))
+        with self.assertRaisesRegex(CircuitError, "an explicit cast is required.*may be lossy"):
+            Store(lvalue, rvalue)
+
+    def test_rejects_c_if(self):
+        instruction = Store(expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Bool()))
+        with self.assertRaises(NotImplementedError):
+            instruction.c_if(Clbit(), False)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



This adds an inner check to the control-flow operations that their
blocks do not contain input variables, and to `QuantumCircuit.append`
that any captures within blocks are validate (in the sense of the
variables existing in the outer circuit).

In order to avoid an `import` on every call to `QuantumCircuit.append`
(especially since we're already eating the cost of an extra
`isinstance` check), this reorganises the import structure of
`qiskit.circuit.controlflow` to sit strictly _before_
`qiskit.circuit.quantumcircuit` in the import tree.  Since those are key
parts of the circuit data structure, that does make sense, although by
their nature the structures are of course recursive at runtime.



### Details and comments

Depends on #10962 

Close #10925

For CI efficiency reasons ahead of Summit, this is now being merged as the rollup of several PRs.  This PR now:
- closes #10946 
- closes #10962 
- closes #10963

See the additional summary fields of those PRs (which are just the commit messages of the components of this PR) for more detail on them.