### PR TITLE
Add helper to detect nested control-flow writes to variables

### DIFF
--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -280,6 +280,7 @@ Gates and Instructions
    Operation
    EquivalenceLibrary
    SingletonGate
+   Store
 
 Control Flow Operations
 -----------------------
@@ -375,6 +376,7 @@ from .barrier import Barrier
 from .delay import Delay
 from .measure import Measure
 from .reset import Reset
+from .store import Store
 from .parameter import Parameter
 from .parametervector import ParameterVector
 from .parameterexpression import ParameterExpression

--- a/qiskit/circuit/classical/expr/__init__.py
+++ b/qiskit/circuit/classical/expr/__init__.py
@@ -159,6 +159,11 @@ between two different circuits.  In this case, one can use :func:`structurally_e
 suitable "key" functions to do the comparison.
 
 .. autofunction:: structurally_equivalent
+
+Some expressions have associated memory locations with them, and some may be purely temporaries.
+You can use :func:`is_lvalue` to determine whether an expression has such a memory backing.
+
+.. autofunction:: is_lvalue
 """
 
 __all__ = [
@@ -171,6 +176,7 @@ __all__ = [
     "ExprVisitor",
     "iter_vars",
     "structurally_equivalent",
+    "is_lvalue",
     "lift",
     "cast",
     "bit_not",
@@ -190,7 +196,7 @@ __all__ = [
 ]
 
 from .expr import Expr, Var, Value, Cast, Unary, Binary
-from .visitors import ExprVisitor, iter_vars, structurally_equivalent
+from .visitors import ExprVisitor, iter_vars, structurally_equivalent, is_lvalue
 from .constructors import (
     lift,
     cast,

--- a/qiskit/circuit/classical/expr/__init__.py
+++ b/qiskit/circuit/classical/expr/__init__.py
@@ -39,8 +39,8 @@ The expression system is based on tree representation.  All nodes in the tree ar
 
 These objects are mutable and should not be reused in a different location without a copy.
 
-The entry point from general circuit objects to the expression system is by wrapping the object
-in a :class:`Var` node and associating a :class:`~.types.Type` with it.
+The base for dynamic variables is the :class:`Var`, which can be either an arbitrarily typed runtime
+variable, or a wrapper around an old-style :class:`.Clbit` or :class:`.ClassicalRegister`.
 
 .. autoclass:: Var
 
@@ -86,9 +86,17 @@ suitable :class:`Cast` nodes.
 The functions and methods described in this section are a more user-friendly way to build the
 expression tree, while staying close to the internal representation.  All these functions will
 automatically lift valid Python scalar values into corresponding :class:`Var` or :class:`Value`
-objects, and will resolve any required implicit casts on your behalf.
+objects, and will resolve any required implicit casts on your behalf.  If you want to directly use
+some scalar value as an :class:`Expr` node, you can manually lift it yourself.
 
 .. autofunction:: lift
+
+Typically you should create memory-owning :class:`Var` instances by using the
+:meth:`.QuantumCircuit.add_var` method to declare them in some circuit context, since a
+:class:`.QuantumCircuit` will not accept an :class:`Expr` that contains variables that are not
+already declared in it, since it needs to know how to allocate the storage and how the variable will
+be initialised.  However, should you want to do this manually, you should use the low-level
+:meth:`Var.new` call to safely generate a named variable for usage.
 
 You can manually specify casts in cases where the cast is allowed in explicit form, but may be
 lossy (such as the cast of a higher precision :class:`~.types.Uint` to a lower precision one).

--- a/qiskit/circuit/classical/expr/expr.py
+++ b/qiskit/circuit/classical/expr/expr.py
@@ -115,9 +115,23 @@ class Var(Expr):
     associated name; and an old-style variable that wraps a :class:`.Clbit` or
     :class:`.ClassicalRegister` instance that is owned by some containing circuit.  In general,
     construction of variables for use in programs should use :meth:`Var.new` or
-    :meth:`.QuantumCircuit.add_var`."""
+    :meth:`.QuantumCircuit.add_var`.
+
+    Variables are immutable after construction, so they can be used as dictionary keys."""
 
     __slots__ = ("var", "name")
+
+    var: qiskit.circuit.Clbit | qiskit.circuit.ClassicalRegister | uuid.UUID
+    """A reference to the backing data storage of the :class:`Var` instance.  When lifting
+    old-style :class:`.Clbit` or :class:`.ClassicalRegister` instances into a :class:`Var`,
+    this is exactly the :class:`.Clbit` or :class:`.ClassicalRegister`.  If the variable is a
+    new-style classical variable (one that owns its own storage separate to the old
+    :class:`.Clbit`/:class:`.ClassicalRegister` model), this field will be a :class:`~uuid.UUID`
+    to uniquely identify it."""
+    name: str | None
+    """The name of the variable.  This is required to exist if the backing :attr:`var` attribute
+    is a :class:`~uuid.UUID`, i.e. if it is a new-style variable, and must be ``None`` if it is
+    an old-style variable."""
 
     def __init__(
         self,
@@ -126,26 +140,31 @@ class Var(Expr):
         *,
         name: str | None = None,
     ):
-        self.type = type
-        self.var = var
-        """A reference to the backing data storage of the :class:`Var` instance.  When lifting
-        old-style :class:`.Clbit` or :class:`.ClassicalRegister` instances into a :class:`Var`,
-        this is exactly the :class:`.Clbit` or :class:`.ClassicalRegister`.  If the variable is a
-        new-style classical variable (one that owns its own storage separate to the old
-        :class:`.Clbit`/:class:`.ClassicalRegister` model), this field will be a :class:`~uuid.UUID`
-        to uniquely identify it."""
-        self.name = name
-        """The name of the variable.  This is required to exist if the backing :attr:`var` attribute
-        is a :class:`~uuid.UUID`, i.e. if it is a new-style variable, and must be ``None`` if it is
-        an old-style variable."""
+        super().__setattr__("type", type)
+        super().__setattr__("var", var)
+        super().__setattr__("name", name)
 
     @classmethod
     def new(cls, name: str, type: types.Type) -> typing.Self:
         """Generate a new named variable that owns its own backing storage."""
         return cls(uuid.uuid4(), type, name=name)
 
+    @property
+    def standalone(self) -> bool:
+        """Whether this :class:`Var` is a standalone variable that owns its storage location.  If
+        false, this is a wrapper :class:`Var` around some pre-existing circuit object."""
+        return isinstance(self.var, uuid.UUID)
+
     def accept(self, visitor, /):
         return visitor.visit_var(self)
+
+    def __setattr__(self, key, value):
+        if hasattr(self, key):
+            raise AttributeError(f"'Var' object attribute '{key}' is read-only")
+        raise AttributeError(f"'Var' object has no attribute '{key}'")
+
+    def __hash__(self):
+        return hash((self.type, self.var, self.name))
 
     def __eq__(self, other):
         return (
@@ -159,6 +178,23 @@ class Var(Expr):
         if self.name is None:
             return f"Var({self.var}, {self.type})"
         return f"Var({self.var}, {self.type}, name='{self.name}')"
+
+    def __getstate__(self):
+        return (self.var, self.type, self.name)
+
+    def __setstate__(self, state):
+        var, type, name = state
+        super().__setattr__("type", type)
+        super().__setattr__("var", var)
+        super().__setattr__("name", name)
+
+    def __copy__(self):
+        # I am immutable...
+        return self
+
+    def __deepcopy__(self, memo):
+        # ... as are all my consituent parts.
+        return self
 
 
 @typing.final

--- a/qiskit/circuit/classical/types/__init__.py
+++ b/qiskit/circuit/classical/types/__init__.py
@@ -15,6 +15,8 @@
 Typing (:mod:`qiskit.circuit.classical.types`)
 ==============================================
 
+Representation
+==============
 
 The type system of the expression tree is exposed through this module.  This is inherently linked to
 the expression system in the :mod:`~.classical.expr` module, as most expressions can only be
@@ -41,10 +43,17 @@ literals ``True`` and ``False``), and unsigned integers (corresponding to
 Note that :class:`Uint` defines a family of types parametrised by their width; it is not one single
 type, which may be slightly different to the 'classical' programming languages you are used to.
 
+
+Working with types
+==================
+
 There are some functions on these types exposed here as well.  These are mostly expected to be used
 only in manipulations of the expression tree; users who are building expressions using the
 :ref:`user-facing construction interface <circuit-classical-expressions-expr-construction>` should
 not need to use these.
+
+Partial ordering of types
+-------------------------
 
 The type system is equipped with a partial ordering, where :math:`a < b` is interpreted as
 ":math:`a` is a strict subtype of :math:`b`".  Note that the partial ordering is a subset of the
@@ -66,6 +75,20 @@ Some helper methods are then defined in terms of this low-level :func:`order` pr
 .. autofunction:: is_subtype
 .. autofunction:: is_supertype
 .. autofunction:: greater
+
+
+Casting between types
+---------------------
+
+It is common to need to cast values of one type to another type.  The casting rules for this are
+embedded into the :mod:`types` module.  You can query the casting kinds using :func:`cast_kind`:
+
+.. autofunction:: cast_kind
+
+The return values from this function are an enumeration explaining the types of cast that are
+allowed from the left type to the right type.
+
+.. autoclass:: CastKind
 """
 
 __all__ = [
@@ -77,7 +100,9 @@ __all__ = [
     "is_subtype",
     "is_supertype",
     "greater",
+    "CastKind",
+    "cast_kind",
 ]
 
 from .types import Type, Bool, Uint
-from .ordering import Ordering, order, is_subtype, is_supertype, greater
+from .ordering import Ordering, order, is_subtype, is_supertype, greater, CastKind, cast_kind

--- a/qiskit/circuit/classical/types/types.py
+++ b/qiskit/circuit/classical/types/types.py
@@ -89,6 +89,9 @@ class Bool(Type, metaclass=_Singleton):
     def __repr__(self):
         return "Bool()"
 
+    def __hash__(self):
+        return hash(self.__class__)
+
     def __eq__(self, other):
         return isinstance(other, Bool)
 
@@ -106,6 +109,9 @@ class Uint(Type):
 
     def __repr__(self):
         return f"Uint({self.width})"
+
+    def __hash__(self):
+        return hash((self.__class__, self.width))
 
     def __eq__(self, other):
         return isinstance(other, Uint) and self.width == other.width

--- a/qiskit/circuit/controlflow/__init__.py
+++ b/qiskit/circuit/controlflow/__init__.py
@@ -14,7 +14,7 @@
 
 
 from ._builder_utils import condition_resources, node_resources, LegacyResources
-from .control_flow import ControlFlowOp
+from .control_flow import ControlFlowOp, VarUsage
 from .continue_loop import ContinueLoopOp
 from .break_loop import BreakLoopOp
 

--- a/qiskit/circuit/controlflow/_builder_utils.py
+++ b/qiskit/circuit/controlflow/_builder_utils.py
@@ -15,14 +15,16 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Iterable, Tuple, Set, Union, TypeVar
+from typing import Iterable, Tuple, Set, Union, TypeVar, TYPE_CHECKING
 
 from qiskit.circuit.classical import expr, types
 from qiskit.circuit.exceptions import CircuitError
-from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit.register import Register
 from qiskit.circuit.classicalregister import ClassicalRegister, Clbit
 from qiskit.circuit.quantumregister import QuantumRegister
+
+if TYPE_CHECKING:
+    from qiskit.circuit import QuantumCircuit
 
 _ConditionT = TypeVar(
     "_ConditionT", bound=Union[Tuple[ClassicalRegister, int], Tuple[Clbit, int], expr.Expr]
@@ -159,6 +161,9 @@ def _unify_circuit_resources_rebuild(  # pylint: disable=invalid-name  # (it's t
 
     This function will always rebuild the objects into new :class:`.QuantumCircuit` instances.
     """
+    # pylint: disable=cyclic-import
+    from qiskit.circuit import QuantumCircuit
+
     qubits, clbits = set(), set()
     for circuit in circuits:
         qubits.update(circuit.qubits)

--- a/qiskit/circuit/controlflow/builder.py
+++ b/qiskit/circuit/controlflow/builder.py
@@ -33,7 +33,7 @@ from qiskit.circuit.register import Register
 from ._builder_utils import condition_resources, node_resources
 
 if typing.TYPE_CHECKING:
-    import qiskit  # pylint: disable=cyclic-import
+    import qiskit
 
 
 class InstructionResources(typing.NamedTuple):
@@ -401,6 +401,7 @@ class ControlFlowBuilderBlock:
             and using the minimal set of resources necessary to support them, within the enclosing
             scope.
         """
+        # pylint: disable=cyclic-import
         from qiskit.circuit import QuantumCircuit, SwitchCaseOp
 
         # There's actually no real problem with building a scope more than once.  This flag is more

--- a/qiskit/circuit/controlflow/control_flow.py
+++ b/qiskit/circuit/controlflow/control_flow.py
@@ -14,14 +14,29 @@
 
 from __future__ import annotations
 
+import dataclasses
 import typing
 from abc import ABC, abstractmethod
 
 from qiskit.circuit.instruction import Instruction
+from qiskit.circuit.store import Store
 from qiskit.circuit.exceptions import CircuitError
+from qiskit.circuit.classical import expr
 
 if typing.TYPE_CHECKING:
     from qiskit.circuit import QuantumCircuit
+
+
+@dataclasses.dataclass
+class VarUsage:
+    """Used in the return value of :meth:`.ControlFlowOp.captured_var_usage` to store information
+    about how variables are used.
+
+    This is an attribute-based dataclass to allow backwards compatibility should the returned
+    information need to expand in the future."""
+
+    written: bool = dataclasses.field(default=False)
+    """Whether the variable is written to in any path through the control-flow operation."""
 
 
 class ControlFlowOp(Instruction, ABC):
@@ -50,3 +65,44 @@ class ControlFlowOp(Instruction, ABC):
         Returns:
             New ControlFlowOp with replaced blocks.
         """
+
+    def captured_var_usage(self) -> dict[expr.Var, VarUsage]:
+        """Get information about the variables captured in the blocks of this operation."""
+
+        # This is very inefficient to do on the tree structure, but until our graph-based circuits
+        # represent control flow better, we need a way to query the operations for this information.
+        # A better graph-based structure will let us chase def-use chains through to find
+        # redefinitions of the variables, rather than needing an iteration through every operation.
+        #
+        # Using this while constructing separate DAGCircuit blocks for each part of the control-flow
+        # op is also quadratic in the depth of the nested control-flow, since it examines nested
+        # structure, but the construction would itself need to recurse into those blocks.  This is
+        # again indicative in deficiencies in our graph-based IR in the presence of control flow.
+
+        return _captured_var_usage_recurse(
+            self, {var: VarUsage() for block in self.blocks for var in block.iter_captured_vars()}
+        )
+
+
+def _captured_var_usage_recurse(operation, usages):
+    for block in operation.blocks:
+        to_check = {
+            var: usage
+            for var in block.iter_captured_vars()
+            # No need to do expensive checks of this block if we know there's a write.
+            if not (usage := usages[var]).written
+        }
+        if not to_check:
+            continue
+        for instruction in block.data:
+            if isinstance(instruction.operation, ControlFlowOp):
+                usages = _captured_var_usage_recurse(instruction.operation, usages)
+            elif isinstance(instruction.operation, Store):
+                memory_location = instruction.operation.lvalue
+                if (usage := to_check.get(memory_location)) is None:
+                    continue
+                usage.written = True
+                to_check.pop(memory_location)
+                if not to_check:
+                    break
+    return usages

--- a/qiskit/circuit/controlflow/control_flow.py
+++ b/qiskit/circuit/controlflow/control_flow.py
@@ -13,14 +13,25 @@
 "Container to encapsulate all control flow operations."
 
 from __future__ import annotations
-from abc import ABC, abstractmethod
-from typing import Iterable
 
-from qiskit.circuit import QuantumCircuit, Instruction
+import typing
+from abc import ABC, abstractmethod
+
+from qiskit.circuit.instruction import Instruction
+from qiskit.circuit.exceptions import CircuitError
+
+if typing.TYPE_CHECKING:
+    from qiskit.circuit import QuantumCircuit
 
 
 class ControlFlowOp(Instruction, ABC):
     """Abstract class to encapsulate all control flow operations."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for block in self.blocks:
+            if block.num_input_vars:
+                raise CircuitError("control-flow blocks cannot contain input variables")
 
     @property
     @abstractmethod
@@ -29,10 +40,9 @@ class ControlFlowOp(Instruction, ABC):
         execution of this ControlFlowOp. May be parameterized by a loop
         parameter to be resolved at run time.
         """
-        pass
 
     @abstractmethod
-    def replace_blocks(self, blocks: Iterable[QuantumCircuit]) -> "ControlFlowOp":
+    def replace_blocks(self, blocks: typing.Iterable[QuantumCircuit]) -> ControlFlowOp:
         """Replace blocks and return new instruction.
         Args:
             blocks: Tuple of QuantumCircuits to replace in instruction.
@@ -40,4 +50,3 @@ class ControlFlowOp(Instruction, ABC):
         Returns:
             New ControlFlowOp with replaced blocks.
         """
-        pass

--- a/qiskit/circuit/controlflow/for_loop.py
+++ b/qiskit/circuit/controlflow/for_loop.py
@@ -10,15 +10,19 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"Circuit operation representing a ``for`` loop."
+"""Circuit operation representing a ``for`` loop."""
+
+from __future__ import annotations
 
 import warnings
-from typing import Iterable, Optional, Union
+from typing import Iterable, Optional, Union, TYPE_CHECKING
 
 from qiskit.circuit.parameter import Parameter
 from qiskit.circuit.exceptions import CircuitError
-from qiskit.circuit.quantumcircuit import QuantumCircuit
 from .control_flow import ControlFlowOp
+
+if TYPE_CHECKING:
+    from qiskit.circuit import QuantumCircuit
 
 
 class ForLoopOp(ControlFlowOp):
@@ -69,6 +73,9 @@ class ForLoopOp(ControlFlowOp):
 
     @params.setter
     def params(self, parameters):
+        # pylint: disable=cyclic-import
+        from qiskit.circuit import QuantumCircuit
+
         indexset, loop_parameter, body = parameters
 
         if not isinstance(loop_parameter, (Parameter, type(None))):

--- a/qiskit/circuit/controlflow/if_else.py
+++ b/qiskit/circuit/controlflow/if_else.py
@@ -14,10 +14,10 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union, Iterable
+from typing import Optional, Union, Iterable, TYPE_CHECKING
 import itertools
 
-from qiskit.circuit import ClassicalRegister, Clbit, QuantumCircuit
+from qiskit.circuit.classicalregister import ClassicalRegister, Clbit
 from qiskit.circuit.classical import expr
 from qiskit.circuit.instructionset import InstructionSet
 from qiskit.circuit.exceptions import CircuitError
@@ -30,6 +30,9 @@ from ._builder_utils import (
     validate_condition,
     condition_resources,
 )
+
+if TYPE_CHECKING:
+    from qiskit.circuit import QuantumCircuit
 
 
 # This is just an indication of what's actually meant to be the public API.
@@ -82,6 +85,9 @@ class IfElseOp(ControlFlowOp):
         false_body: QuantumCircuit | None = None,
         label: str | None = None,
     ):
+        # pylint: disable=cyclic-import
+        from qiskit.circuit import QuantumCircuit
+
         # Type checking generally left to @params.setter, but required here for
         # finding num_qubits and num_clbits.
         if not isinstance(true_body, QuantumCircuit):
@@ -103,6 +109,9 @@ class IfElseOp(ControlFlowOp):
 
     @params.setter
     def params(self, parameters):
+        # pylint: disable=cyclic-import
+        from qiskit.circuit import QuantumCircuit
+
         true_body, false_body = parameters
 
         if not isinstance(true_body, QuantumCircuit):

--- a/qiskit/circuit/controlflow/switch_case.py
+++ b/qiskit/circuit/controlflow/switch_case.py
@@ -17,15 +17,18 @@ from __future__ import annotations
 __all__ = ("SwitchCaseOp", "CASE_DEFAULT")
 
 import contextlib
-from typing import Union, Iterable, Any, Tuple, Optional, List, Literal
+from typing import Union, Iterable, Any, Tuple, Optional, List, Literal, TYPE_CHECKING
 
-from qiskit.circuit import ClassicalRegister, Clbit, QuantumCircuit
+from qiskit.circuit.classicalregister import ClassicalRegister, Clbit
 from qiskit.circuit.classical import expr, types
 from qiskit.circuit.exceptions import CircuitError
 
 from .builder import InstructionPlaceholder, InstructionResources, ControlFlowBuilderBlock
 from .control_flow import ControlFlowOp
 from ._builder_utils import unify_circuit_resources, partition_registers, node_resources
+
+if TYPE_CHECKING:
+    from qiskit.circuit import QuantumCircuit
 
 
 class _DefaultCaseType:
@@ -71,6 +74,9 @@ class SwitchCaseOp(ControlFlowOp):
         *,
         label: Optional[str] = None,
     ):
+        # pylint: disable=cyclic-import
+        from qiskit.circuit import QuantumCircuit
+
         if isinstance(target, expr.Expr):
             if target.type.kind not in (types.Uint, types.Bool):
                 raise CircuitError(

--- a/qiskit/circuit/controlflow/while_loop.py
+++ b/qiskit/circuit/controlflow/while_loop.py
@@ -14,11 +14,16 @@
 
 from __future__ import annotations
 
-from qiskit.circuit import Clbit, ClassicalRegister, QuantumCircuit
+from typing import TYPE_CHECKING
+
+from qiskit.circuit.classicalregister import Clbit, ClassicalRegister
 from qiskit.circuit.classical import expr
 from qiskit.circuit.exceptions import CircuitError
 from ._builder_utils import validate_condition, condition_resources
 from .control_flow import ControlFlowOp
+
+if TYPE_CHECKING:
+    from qiskit.circuit import QuantumCircuit
 
 
 class WhileLoopOp(ControlFlowOp):
@@ -70,6 +75,9 @@ class WhileLoopOp(ControlFlowOp):
 
     @params.setter
     def params(self, parameters):
+        # pylint: disable=cyclic-import
+        from qiskit.circuit import QuantumCircuit
+
         (body,) = parameters
 
         if not isinstance(body, QuantumCircuit):

--- a/qiskit/circuit/store.py
+++ b/qiskit/circuit/store.py
@@ -1,0 +1,87 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""The 'Store' operation."""
+
+from __future__ import annotations
+
+import typing
+
+from .exceptions import CircuitError
+from .classical import expr, types
+from .instruction import Instruction
+
+
+def _handle_equal_types(lvalue: expr.Expr, rvalue: expr.Expr, /) -> tuple[expr.Expr, expr.Expr]:
+    return lvalue, rvalue
+
+
+def _handle_implicit_cast(lvalue: expr.Expr, rvalue: expr.Expr, /) -> tuple[expr.Expr, expr.Expr]:
+    return lvalue, expr.Cast(rvalue, lvalue.type, implicit=True)
+
+
+def _requires_lossless_cast(lvalue: expr.Expr, rvalue: expr.Expr, /) -> typing.NoReturn:
+    raise CircuitError(f"an explicit cast is required from '{rvalue.type}' to '{lvalue.type}'")
+
+
+def _requires_dangerous_cast(lvalue: expr.Expr, rvalue: expr.Expr, /) -> typing.NoReturn:
+    raise CircuitError(
+        f"an explicit cast is required from '{rvalue.type}' to '{lvalue.type}', which may be lossy"
+    )
+
+
+def _no_cast_possible(lvalue: expr.Expr, rvalue: expr.Expr) -> typing.NoReturn:
+    raise CircuitError(f"no cast is possible from '{rvalue.type}' to '{lvalue.type}'")
+
+
+_HANDLE_CAST = {
+    types.CastKind.EQUAL: _handle_equal_types,
+    types.CastKind.IMPLICIT: _handle_implicit_cast,
+    types.CastKind.LOSSLESS: _requires_lossless_cast,
+    types.CastKind.DANGEROUS: _requires_dangerous_cast,
+    types.CastKind.NONE: _no_cast_possible,
+}
+
+
+class Store(Instruction):
+    """A manual storage of some classical value to a classical memory location.
+
+    This is a low-level primitive of the classical-expression handling (similar to how
+    :class:`~.circuit.Measure` is a primitive for quantum measurement), and is not safe for
+    subclassing.  It is likely to become a special-case instruction in later versions of Qiskit
+    circuit and compiler internal representations."""
+
+    def __init__(self, lvalue: expr.Expr, rvalue: expr.Expr):
+        if not expr.is_lvalue(lvalue):
+            raise CircuitError(f"'{lvalue}' is not an l-value")
+
+        cast_kind = types.cast_kind(rvalue.type, lvalue.type)
+        if (handler := _HANDLE_CAST.get(cast_kind)) is None:
+            raise RuntimeError(f"unhandled cast kind required: {cast_kind}")
+        lvalue, rvalue = handler(lvalue, rvalue)
+
+        super().__init__("store", 0, 0, [lvalue, rvalue])
+
+    @property
+    def lvalue(self):
+        """Get the l-value :class:`~.expr.Expr` node that is being stored to."""
+        return self.params[0]
+
+    @property
+    def rvalue(self):
+        """Get the r-value :class:`~.expr.Expr` node that is being written into the l-value."""
+        return self.params[1]
+
+    def c_if(self, classical, val):
+        raise NotImplementedError(
+            "stores cannot be conditioned with `c_if`; use a full `if_test` context instead"
+        )

--- a/releasenotes/notes/expr-hashable-var-types-7cf2aaa00b201ae6.yaml
+++ b/releasenotes/notes/expr-hashable-var-types-7cf2aaa00b201ae6.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Classical types (subclasses of :class:`~classical.types.Type`) and variables (:class:`~.expr.Var`)
+    are now hashable.

--- a/releasenotes/notes/expr-var-standalone-2c1116583a2be9fd.yaml
+++ b/releasenotes/notes/expr-var-standalone-2c1116583a2be9fd.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    :class:`~.expr.Var` nodes now have a :attr:`.Var.standalone` property to quickly query whether
+    they are new-style memory-owning variables, or whether they wrap old-style classical memory in
+    the form of a :class:`.Clbit` or :class:`.ClassicalRegister`.

--- a/test/python/circuit/classical/test_expr_helpers.py
+++ b/test/python/circuit/classical/test_expr_helpers.py
@@ -115,3 +115,30 @@ class TestStructurallyEquivalent(QiskitTestCase):
         # ``True`` instead.
         self.assertFalse(expr.structurally_equivalent(left, right, not_handled, not_handled))
         self.assertTrue(expr.structurally_equivalent(left, right, always_equal, always_equal))
+
+
+@ddt.ddt
+class TestIsLValue(QiskitTestCase):
+    @ddt.data(
+        expr.Var.new("a", types.Bool()),
+        expr.Var.new("b", types.Uint(8)),
+        expr.Var(Clbit(), types.Bool()),
+        expr.Var(ClassicalRegister(8, "cr"), types.Uint(8)),
+    )
+    def test_happy_cases(self, lvalue):
+        self.assertTrue(expr.is_lvalue(lvalue))
+
+    @ddt.data(
+        expr.Value(3, types.Uint(2)),
+        expr.Value(False, types.Bool()),
+        expr.Cast(expr.Var.new("a", types.Uint(2)), types.Uint(8)),
+        expr.Unary(expr.Unary.Op.LOGIC_NOT, expr.Var.new("a", types.Bool()), types.Bool()),
+        expr.Binary(
+            expr.Binary.Op.LOGIC_AND,
+            expr.Var.new("a", types.Bool()),
+            expr.Var.new("b", types.Bool()),
+            types.Bool(),
+        ),
+    )
+    def test_bad_cases(self, not_an_lvalue):
+        self.assertFalse(expr.is_lvalue(not_an_lvalue))

--- a/test/python/circuit/classical/test_types_ordering.py
+++ b/test/python/circuit/classical/test_types_ordering.py
@@ -58,3 +58,13 @@ class TestTypesOrdering(QiskitTestCase):
         self.assertEqual(types.greater(types.Bool(), types.Bool()), types.Bool())
         with self.assertRaisesRegex(TypeError, "no ordering"):
             types.greater(types.Bool(), types.Uint(8))
+
+
+class TestTypesCastKind(QiskitTestCase):
+    def test_basic_examples(self):
+        """This is used extensively throughout the expression construction functions, but since it
+        is public API, it should have some direct unit tests as well."""
+        self.assertIs(types.cast_kind(types.Bool(), types.Bool()), types.CastKind.EQUAL)
+        self.assertIs(types.cast_kind(types.Uint(8), types.Bool()), types.CastKind.IMPLICIT)
+        self.assertIs(types.cast_kind(types.Bool(), types.Uint(8)), types.CastKind.LOSSLESS)
+        self.assertIs(types.cast_kind(types.Uint(16), types.Uint(8)), types.CastKind.DANGEROUS)

--- a/test/python/circuit/test_circuit_vars.py
+++ b/test/python/circuit/test_circuit_vars.py
@@ -25,11 +25,19 @@ class TestCircuitVars(QiskitTestCase):
         vars_ = [expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Uint(16))]
         qc = QuantumCircuit(inputs=vars_)
         self.assertEqual(set(vars_), set(qc.iter_vars()))
+        self.assertEqual(qc.num_vars, len(vars_))
+        self.assertEqual(qc.num_input_vars, len(vars_))
+        self.assertEqual(qc.num_captured_vars, 0)
+        self.assertEqual(qc.num_declared_vars, 0)
 
     def test_initialise_captures(self):
         vars_ = [expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Uint(16))]
         qc = QuantumCircuit(captures=vars_)
         self.assertEqual(set(vars_), set(qc.iter_vars()))
+        self.assertEqual(qc.num_vars, len(vars_))
+        self.assertEqual(qc.num_input_vars, 0)
+        self.assertEqual(qc.num_captured_vars, len(vars_))
+        self.assertEqual(qc.num_declared_vars, 0)
 
     def test_initialise_declarations_iterable(self):
         vars_ = [
@@ -39,6 +47,10 @@ class TestCircuitVars(QiskitTestCase):
         qc = QuantumCircuit(declarations=vars_)
 
         self.assertEqual({var for var, _initialiser in vars_}, set(qc.iter_vars()))
+        self.assertEqual(qc.num_vars, len(vars_))
+        self.assertEqual(qc.num_input_vars, 0)
+        self.assertEqual(qc.num_captured_vars, 0)
+        self.assertEqual(qc.num_declared_vars, len(vars_))
         operations = [
             (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
             for instruction in qc.data
@@ -88,6 +100,10 @@ class TestCircuitVars(QiskitTestCase):
         self.assertEqual({a}, set(qc.iter_input_vars()))
         self.assertEqual({b}, set(qc.iter_declared_vars()))
         self.assertEqual({a, b}, set(qc.iter_vars()))
+        self.assertEqual(qc.num_vars, 2)
+        self.assertEqual(qc.num_input_vars, 1)
+        self.assertEqual(qc.num_captured_vars, 0)
+        self.assertEqual(qc.num_declared_vars, 1)
         operations = [
             (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
             for instruction in qc.data
@@ -103,6 +119,10 @@ class TestCircuitVars(QiskitTestCase):
         self.assertEqual({a}, set(qc.iter_captured_vars()))
         self.assertEqual({b}, set(qc.iter_declared_vars()))
         self.assertEqual({a, b}, set(qc.iter_vars()))
+        self.assertEqual(qc.num_vars, 2)
+        self.assertEqual(qc.num_input_vars, 0)
+        self.assertEqual(qc.num_captured_vars, 1)
+        self.assertEqual(qc.num_declared_vars, 1)
         operations = [
             (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
             for instruction in qc.data

--- a/test/python/circuit/test_circuit_vars.py
+++ b/test/python/circuit/test_circuit_vars.py
@@ -1,0 +1,366 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
+
+from qiskit.test import QiskitTestCase
+from qiskit.circuit import QuantumCircuit, CircuitError, Clbit, ClassicalRegister
+from qiskit.circuit.classical import expr, types
+
+
+class TestCircuitVars(QiskitTestCase):
+    """Tests for variable-manipulation routines on circuits.  More specific functionality is likely
+    tested in the suites of the specific methods."""
+
+    def test_initialise_inputs(self):
+        vars_ = [expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Uint(16))]
+        qc = QuantumCircuit(inputs=vars_)
+        self.assertEqual(set(vars_), set(qc.iter_vars()))
+
+    def test_initialise_captures(self):
+        vars_ = [expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Uint(16))]
+        qc = QuantumCircuit(captures=vars_)
+        self.assertEqual(set(vars_), set(qc.iter_vars()))
+
+    def test_initialise_declarations_iterable(self):
+        vars_ = [
+            (expr.Var.new("a", types.Bool()), expr.lift(True)),
+            (expr.Var.new("b", types.Uint(16)), expr.lift(0xFFFF)),
+        ]
+        qc = QuantumCircuit(declarations=vars_)
+
+        self.assertEqual({var for var, _initialiser in vars_}, set(qc.iter_vars()))
+        operations = [
+            (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
+            for instruction in qc.data
+        ]
+        self.assertEqual(operations, [("store", lvalue, rvalue) for lvalue, rvalue in vars_])
+
+    def test_initialise_declarations_mapping(self):
+        # Dictionary iteration order is guaranteed to be insertion order.
+        vars_ = {
+            expr.Var.new("a", types.Bool()): expr.lift(True),
+            expr.Var.new("b", types.Uint(16)): expr.lift(0xFFFF),
+        }
+        qc = QuantumCircuit(declarations=vars_)
+
+        self.assertEqual(set(vars_), set(qc.iter_vars()))
+        operations = [
+            (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
+            for instruction in qc.data
+        ]
+        self.assertEqual(
+            operations, [("store", lvalue, rvalue) for lvalue, rvalue in vars_.items()]
+        )
+
+    def test_initialise_declarations_dependencies(self):
+        """Test that the cirucit initialiser can take in declarations with dependencies between
+        them, provided they're specified in a suitable order."""
+        a = expr.Var.new("a", types.Bool())
+        vars_ = [
+            (a, expr.lift(True)),
+            (expr.Var.new("b", types.Bool()), a),
+        ]
+        qc = QuantumCircuit(declarations=vars_)
+
+        self.assertEqual({var for var, _initialiser in vars_}, set(qc.iter_vars()))
+        operations = [
+            (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
+            for instruction in qc.data
+        ]
+        self.assertEqual(operations, [("store", lvalue, rvalue) for lvalue, rvalue in vars_])
+
+    def test_initialise_inputs_declarations(self):
+        a = expr.Var.new("a", types.Uint(16))
+        b = expr.Var.new("b", types.Uint(16))
+        b_init = expr.bit_and(a, 0xFFFF)
+        qc = QuantumCircuit(inputs=[a], declarations={b: b_init})
+
+        self.assertEqual({a}, set(qc.iter_input_vars()))
+        self.assertEqual({b}, set(qc.iter_declared_vars()))
+        self.assertEqual({a, b}, set(qc.iter_vars()))
+        operations = [
+            (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
+            for instruction in qc.data
+        ]
+        self.assertEqual(operations, [("store", b, b_init)])
+
+    def test_initialise_captures_declarations(self):
+        a = expr.Var.new("a", types.Uint(16))
+        b = expr.Var.new("b", types.Uint(16))
+        b_init = expr.bit_and(a, 0xFFFF)
+        qc = QuantumCircuit(captures=[a], declarations={b: b_init})
+
+        self.assertEqual({a}, set(qc.iter_captured_vars()))
+        self.assertEqual({b}, set(qc.iter_declared_vars()))
+        self.assertEqual({a, b}, set(qc.iter_vars()))
+        operations = [
+            (instruction.operation.name, instruction.operation.lvalue, instruction.operation.rvalue)
+            for instruction in qc.data
+        ]
+        self.assertEqual(operations, [("store", b, b_init)])
+
+    def test_add_var_returns_good_var(self):
+        qc = QuantumCircuit()
+        a = qc.add_var("a", expr.lift(True))
+        self.assertEqual(a.name, "a")
+        self.assertEqual(a.type, types.Bool())
+
+        b = qc.add_var("b", expr.Value(0xFF, types.Uint(8)))
+        self.assertEqual(b.name, "b")
+        self.assertEqual(b.type, types.Uint(8))
+
+    def test_add_var_returns_input(self):
+        """Test that the `Var` returned by `add_var` is the same as the input if `Var`."""
+        a = expr.Var.new("a", types.Bool())
+        qc = QuantumCircuit()
+        a_other = qc.add_var(a, expr.lift(True))
+        self.assertIs(a, a_other)
+
+    def test_add_input_returns_good_var(self):
+        qc = QuantumCircuit()
+        a = qc.add_input("a", types.Bool())
+        self.assertEqual(a.name, "a")
+        self.assertEqual(a.type, types.Bool())
+
+        b = qc.add_input("b", types.Uint(8))
+        self.assertEqual(b.name, "b")
+        self.assertEqual(b.type, types.Uint(8))
+
+    def test_add_input_returns_input(self):
+        """Test that the `Var` returned by `add_input` is the same as the input if `Var`."""
+        a = expr.Var.new("a", types.Bool())
+        qc = QuantumCircuit()
+        a_other = qc.add_input(a)
+        self.assertIs(a, a_other)
+
+    def test_cannot_have_both_inputs_and_captures(self):
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+
+        with self.assertRaisesRegex(CircuitError, "circuits with input.*cannot be closures"):
+            QuantumCircuit(inputs=[a], captures=[b])
+
+        qc = QuantumCircuit(inputs=[a])
+        with self.assertRaisesRegex(CircuitError, "circuits with input.*cannot be closures"):
+            qc.add_capture(b)
+
+        qc = QuantumCircuit(captures=[a])
+        with self.assertRaisesRegex(CircuitError, "circuits to be enclosed.*cannot have input"):
+            qc.add_input(b)
+
+    def test_cannot_add_cyclic_declaration(self):
+        a = expr.Var.new("a", types.Bool())
+        with self.assertRaisesRegex(CircuitError, "not present in this circuit"):
+            QuantumCircuit(declarations=[(a, a)])
+
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "not present in this circuit"):
+            qc.add_var(a, a)
+
+    def test_initialise_inputs_equal_to_add_input(self):
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Uint(16))
+
+        qc_init = QuantumCircuit(inputs=[a, b])
+        qc_manual = QuantumCircuit()
+        qc_manual.add_input(a)
+        qc_manual.add_input(b)
+        self.assertEqual(list(qc_init.iter_vars()), list(qc_manual.iter_vars()))
+
+        qc_manual = QuantumCircuit()
+        a = qc_manual.add_input("a", types.Bool())
+        b = qc_manual.add_input("b", types.Uint(16))
+        qc_init = QuantumCircuit(inputs=[a, b])
+        self.assertEqual(list(qc_init.iter_vars()), list(qc_manual.iter_vars()))
+
+    def test_initialise_captures_equal_to_add_capture(self):
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Uint(16))
+
+        qc_init = QuantumCircuit(captures=[a, b])
+        qc_manual = QuantumCircuit()
+        qc_manual.add_capture(a)
+        qc_manual.add_capture(b)
+        self.assertEqual(list(qc_init.iter_vars()), list(qc_manual.iter_vars()))
+
+    def test_initialise_declarations_equal_to_add_var(self):
+        a = expr.Var.new("a", types.Bool())
+        a_init = expr.lift(False)
+        b = expr.Var.new("b", types.Uint(16))
+        b_init = expr.lift(0xFFFF)
+
+        qc_init = QuantumCircuit(declarations=[(a, a_init), (b, b_init)])
+        qc_manual = QuantumCircuit()
+        qc_manual.add_var(a, a_init)
+        qc_manual.add_var(b, b_init)
+        self.assertEqual(list(qc_init.iter_vars()), list(qc_manual.iter_vars()))
+        self.assertEqual(qc_init.data, qc_manual.data)
+
+        qc_manual = QuantumCircuit()
+        a = qc_manual.add_var("a", a_init)
+        b = qc_manual.add_var("b", b_init)
+        qc_init = QuantumCircuit(declarations=[(a, a_init), (b, b_init)])
+        self.assertEqual(list(qc_init.iter_vars()), list(qc_manual.iter_vars()))
+        self.assertEqual(qc_init.data, qc_manual.data)
+
+    def test_cannot_shadow_vars(self):
+        """Test that exact duplicate ``Var`` nodes within different combinations of the inputs are
+        detected and rejected."""
+        a = expr.Var.new("a", types.Bool())
+        a_init = expr.lift(True)
+        with self.assertRaisesRegex(CircuitError, "already present"):
+            QuantumCircuit(inputs=[a, a])
+        with self.assertRaisesRegex(CircuitError, "already present"):
+            QuantumCircuit(captures=[a, a])
+        with self.assertRaisesRegex(CircuitError, "already present"):
+            QuantumCircuit(declarations=[(a, a_init), (a, a_init)])
+        with self.assertRaisesRegex(CircuitError, "already present"):
+            QuantumCircuit(inputs=[a], declarations=[(a, a_init)])
+        with self.assertRaisesRegex(CircuitError, "already present"):
+            QuantumCircuit(captures=[a], declarations=[(a, a_init)])
+
+    def test_cannot_shadow_names(self):
+        """Test that exact duplicate ``Var`` nodes within different combinations of the inputs are
+        detected and rejected."""
+        a_bool1 = expr.Var.new("a", types.Bool())
+        a_bool2 = expr.Var.new("a", types.Bool())
+        a_uint = expr.Var.new("a", types.Uint(16))
+        a_bool_init = expr.lift(True)
+        a_uint_init = expr.lift(0xFFFF)
+
+        tests = [
+            ((a_bool1, a_bool_init), (a_bool2, a_bool_init)),
+            ((a_bool1, a_bool_init), (a_uint, a_uint_init)),
+        ]
+        for (left, left_init), (right, right_init) in tests:
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                QuantumCircuit(inputs=(left, right))
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                QuantumCircuit(captures=(left, right))
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                QuantumCircuit(declarations=[(left, left_init), (right, right_init)])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                QuantumCircuit(inputs=[left], declarations=[(right, right_init)])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                QuantumCircuit(captures=[left], declarations=[(right, right_init)])
+
+            qc = QuantumCircuit(inputs=[left])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                qc.add_input(right)
+            qc = QuantumCircuit(inputs=[left])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                qc.add_var(right, right_init)
+
+            qc = QuantumCircuit(captures=[left])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                qc.add_capture(right)
+            qc = QuantumCircuit(captures=[left])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                qc.add_var(right, right_init)
+
+            qc = QuantumCircuit(inputs=[left])
+            with self.assertRaisesRegex(CircuitError, "its name shadows"):
+                qc.add_var(right, right_init)
+
+        qc = QuantumCircuit()
+        qc.add_var("a", expr.lift(True))
+        with self.assertRaisesRegex(CircuitError, "its name shadows"):
+            qc.add_var("a", expr.lift(True))
+        with self.assertRaisesRegex(CircuitError, "its name shadows"):
+            qc.add_var("a", expr.lift(0xFF))
+
+    def test_cannot_add_vars_wrapping_clbits(self):
+        a = expr.Var(Clbit(), types.Bool())
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            QuantumCircuit(inputs=[a])
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            qc.add_input(a)
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            QuantumCircuit(captures=[a])
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            qc.add_capture(a)
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            QuantumCircuit(declarations=[(a, expr.lift(True))])
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            qc.add_var(a, expr.lift(True))
+
+    def test_cannot_add_vars_wrapping_cregs(self):
+        a = expr.Var(ClassicalRegister(8, "cr"), types.Uint(8))
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            QuantumCircuit(inputs=[a])
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            qc.add_input(a)
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            QuantumCircuit(captures=[a])
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            qc.add_capture(a)
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            QuantumCircuit(declarations=[(a, expr.lift(0xFF))])
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "cannot add variables that wrap"):
+            qc.add_var(a, expr.lift(0xFF))
+
+    def test_get_var_success(self):
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Uint(8))
+
+        qc = QuantumCircuit(inputs=[a], declarations={b: expr.Value(0xFF, types.Uint(8))})
+        self.assertIs(qc.get_var("a"), a)
+        self.assertIs(qc.get_var("b"), b)
+
+        qc = QuantumCircuit(captures=[a, b])
+        self.assertIs(qc.get_var("a"), a)
+        self.assertIs(qc.get_var("b"), b)
+
+        qc = QuantumCircuit(declarations={a: expr.lift(True), b: expr.Value(0xFF, types.Uint(8))})
+        self.assertIs(qc.get_var("a"), a)
+        self.assertIs(qc.get_var("b"), b)
+
+    def test_get_var_missing(self):
+        qc = QuantumCircuit()
+        with self.assertRaises(KeyError):
+            qc.get_var("a")
+
+        a = expr.Var.new("a", types.Bool())
+        qc.add_input(a)
+        with self.assertRaises(KeyError):
+            qc.get_var("b")
+
+    def test_get_var_default(self):
+        qc = QuantumCircuit()
+        self.assertIs(qc.get_var("a", None), None)
+
+        missing = "default"
+        a = expr.Var.new("a", types.Bool())
+        qc.add_input(a)
+        self.assertIs(qc.get_var("b", missing), missing)
+        self.assertIs(qc.get_var("b", a), a)
+
+    def test_has_var(self):
+        a = expr.Var.new("a", types.Bool())
+        self.assertFalse(QuantumCircuit().has_var("a"))
+        self.assertTrue(QuantumCircuit(inputs=[a]).has_var("a"))
+        self.assertTrue(QuantumCircuit(captures=[a]).has_var("a"))
+        self.assertTrue(QuantumCircuit(declarations={a: expr.lift(True)}).has_var("a"))
+        self.assertTrue(QuantumCircuit(inputs=[a]).has_var(a))
+        self.assertTrue(QuantumCircuit(captures=[a]).has_var(a))
+        self.assertTrue(QuantumCircuit(declarations={a: expr.lift(True)}).has_var(a))
+
+        # When giving an `Var`, the match must be exact, not just the name.
+        self.assertFalse(QuantumCircuit(inputs=[a]).has_var(expr.Var.new("a", types.Uint(8))))
+        self.assertFalse(QuantumCircuit(inputs=[a]).has_var(expr.Var.new("a", types.Bool())))

--- a/test/python/circuit/test_control_flow.py
+++ b/test/python/circuit/test_control_flow.py
@@ -510,6 +510,49 @@ class TestCreatingControlFlowOperations(QiskitTestCase):
         with self.assertRaisesRegex(CircuitError, "cases after the default are unreachable"):
             SwitchCaseOp(creg, [(CASE_DEFAULT, case1), (1, case2)])
 
+    def test_if_else_rejects_input_vars(self):
+        """Bodies must not contain input variables."""
+        cond = (Clbit(), False)
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+        bad_body = QuantumCircuit(inputs=[a])
+        good_body = QuantumCircuit(captures=[a], declarations=[(b, expr.lift(False))])
+
+        with self.assertRaisesRegex(CircuitError, "cannot contain input variables"):
+            IfElseOp(cond, bad_body, None)
+        with self.assertRaisesRegex(CircuitError, "cannot contain input variables"):
+            IfElseOp(cond, bad_body, good_body)
+        with self.assertRaisesRegex(CircuitError, "cannot contain input variables"):
+            IfElseOp(cond, good_body, bad_body)
+
+    def test_while_rejects_input_vars(self):
+        """Bodies must not contain input variables."""
+        cond = (Clbit(), False)
+        a = expr.Var.new("a", types.Bool())
+        bad_body = QuantumCircuit(inputs=[a])
+        with self.assertRaisesRegex(CircuitError, "cannot contain input variables"):
+            WhileLoopOp(cond, bad_body)
+
+    def test_for_rejects_input_vars(self):
+        """Bodies must not contain input variables."""
+        a = expr.Var.new("a", types.Bool())
+        bad_body = QuantumCircuit(inputs=[a])
+        with self.assertRaisesRegex(CircuitError, "cannot contain input variables"):
+            ForLoopOp(range(3), None, bad_body)
+
+    def test_switch_rejects_input_vars(self):
+        """Bodies must not contain input variables."""
+        target = ClassicalRegister(3, "cr")
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+        bad_body = QuantumCircuit(inputs=[a])
+        good_body = QuantumCircuit(captures=[a], declarations=[(b, expr.lift(False))])
+
+        with self.assertRaisesRegex(CircuitError, "cannot contain input variables"):
+            SwitchCaseOp(target, [(0, bad_body)])
+        with self.assertRaisesRegex(CircuitError, "cannot contain input variables"):
+            SwitchCaseOp(target, [(0, good_body), (1, bad_body)])
+
 
 @ddt
 class TestAddingControlFlowOperations(QiskitTestCase):
@@ -874,3 +917,148 @@ class TestAddingControlFlowOperations(QiskitTestCase):
             )
 
             self.assertEqual(assigned, expected)
+
+    def test_can_add_op_with_captures_of_inputs(self):
+        """Test circuit methods can capture input variables."""
+        outer = QuantumCircuit(1, 1)
+        a = outer.add_input("a", types.Bool())
+
+        inner = QuantumCircuit(1, 1, captures=[a])
+
+        outer.if_test((outer.clbits[0], False), inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "if_else")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+
+        outer.if_else((outer.clbits[0], False), inner.copy(), inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "if_else")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+        self.assertEqual(set(added.blocks[1].iter_captured_vars()), {a})
+
+        outer.while_loop((outer.clbits[0], False), inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "while_loop")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+
+        outer.for_loop(range(3), None, inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "for_loop")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+
+        outer.switch(outer.clbits[0], [(False, inner.copy()), (True, inner.copy())], [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "switch_case")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+        self.assertEqual(set(added.blocks[1].iter_captured_vars()), {a})
+
+    def test_can_add_op_with_captures_of_captures(self):
+        """Test circuit methods can capture captured variables."""
+        outer = QuantumCircuit(1, 1)
+        a = expr.Var.new("a", types.Bool())
+        outer.add_capture(a)
+
+        inner = QuantumCircuit(1, 1, captures=[a])
+
+        outer.if_test((outer.clbits[0], False), inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "if_else")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+
+        outer.if_else((outer.clbits[0], False), inner.copy(), inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "if_else")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+        self.assertEqual(set(added.blocks[1].iter_captured_vars()), {a})
+
+        outer.while_loop((outer.clbits[0], False), inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "while_loop")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+
+        outer.for_loop(range(3), None, inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "for_loop")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+
+        outer.switch(outer.clbits[0], [(False, inner.copy()), (True, inner.copy())], [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "switch_case")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+        self.assertEqual(set(added.blocks[1].iter_captured_vars()), {a})
+
+    def test_can_add_op_with_captures_of_locals(self):
+        """Test circuit methods can capture declared variables."""
+        outer = QuantumCircuit(1, 1)
+        a = outer.add_var("a", expr.lift(True))
+
+        inner = QuantumCircuit(1, 1, captures=[a])
+
+        outer.if_test((outer.clbits[0], False), inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "if_else")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+
+        outer.if_else((outer.clbits[0], False), inner.copy(), inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "if_else")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+        self.assertEqual(set(added.blocks[1].iter_captured_vars()), {a})
+
+        outer.while_loop((outer.clbits[0], False), inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "while_loop")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+
+        outer.for_loop(range(3), None, inner.copy(), [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "for_loop")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+
+        outer.switch(outer.clbits[0], [(False, inner.copy()), (True, inner.copy())], [0], [0])
+        added = outer.data[-1].operation
+        self.assertEqual(added.name, "switch_case")
+        self.assertEqual(set(added.blocks[0].iter_captured_vars()), {a})
+        self.assertEqual(set(added.blocks[1].iter_captured_vars()), {a})
+
+    def test_cannot_capture_unknown_variables_methods(self):
+        """Control-flow operations should not be able to capture variables that don't exist in the
+        outer circuit."""
+        outer = QuantumCircuit(1, 1)
+
+        a = expr.Var.new("a", types.Bool())
+        inner = QuantumCircuit(1, 1, captures=[a])
+
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.if_test((outer.clbits[0], False), inner.copy(), [0], [0])
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.if_else((outer.clbits[0], False), inner.copy(), inner.copy(), [0], [0])
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.while_loop((outer.clbits[0], False), inner.copy(), [0], [0])
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.for_loop(range(3), None, inner.copy(), [0], [0])
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.switch(outer.clbits[0], [(False, inner.copy()), (True, inner.copy())], [0], [0])
+
+    def test_cannot_capture_unknown_variables_append(self):
+        """Control-flow operations should not be able to capture variables that don't exist in the
+        outer circuit."""
+        outer = QuantumCircuit(1, 1)
+
+        a = expr.Var.new("a", types.Bool())
+        inner = QuantumCircuit(1, 1, captures=[a])
+
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.append(IfElseOp((outer.clbits[0], False), inner.copy(), None), [0], [0])
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.append(IfElseOp((outer.clbits[0], False), inner.copy(), inner.copy()), [0], [0])
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.append(WhileLoopOp((outer.clbits[0], False), inner.copy()), [0], [0])
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.append(ForLoopOp(range(3), None, inner.copy()), [0], [0])
+        with self.assertRaisesRegex(CircuitError, "not in this circuit"):
+            outer.append(
+                SwitchCaseOp(outer.clbits[0], [(False, inner.copy()), (True, inner.copy())]),
+                [0],
+                [0],
+            )

--- a/test/python/circuit/test_store.py
+++ b/test/python/circuit/test_store.py
@@ -13,7 +13,7 @@
 # pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
 
 from qiskit.test import QiskitTestCase
-from qiskit.circuit import Store, Clbit, CircuitError
+from qiskit.circuit import Store, Clbit, CircuitError, QuantumCircuit, ClassicalRegister
 from qiskit.circuit.classical import expr, types
 
 
@@ -60,3 +60,140 @@ class TestStoreInstruction(QiskitTestCase):
         instruction = Store(expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Bool()))
         with self.assertRaises(NotImplementedError):
             instruction.c_if(Clbit(), False)
+
+
+class TestStoreCircuit(QiskitTestCase):
+    """Tests of the `QuantumCircuit.store` method and appends of `Store`."""
+
+    def test_produces_expected_operation(self):
+        a = expr.Var.new("a", types.Bool())
+        value = expr.Value(True, types.Bool())
+
+        qc = QuantumCircuit(inputs=[a])
+        qc.store(a, value)
+        self.assertEqual(qc.data[-1].operation, Store(a, value))
+
+        qc = QuantumCircuit(captures=[a])
+        qc.store(a, value)
+        self.assertEqual(qc.data[-1].operation, Store(a, value))
+
+        qc = QuantumCircuit(declarations=[(a, expr.lift(False))])
+        qc.store(a, value)
+        self.assertEqual(qc.data[-1].operation, Store(a, value))
+
+    def test_allows_stores_with_clbits(self):
+        clbits = [Clbit(), Clbit()]
+        a = expr.Var.new("a", types.Bool())
+        qc = QuantumCircuit(clbits, inputs=[a])
+        qc.store(clbits[0], True)
+        qc.store(expr.Var(clbits[1], types.Bool()), a)
+        qc.store(clbits[0], clbits[1])
+        qc.store(expr.lift(clbits[0]), expr.lift(clbits[1]))
+        qc.store(a, expr.lift(clbits[1]))
+
+        expected = [
+            Store(expr.lift(clbits[0]), expr.lift(True)),
+            Store(expr.lift(clbits[1]), a),
+            Store(expr.lift(clbits[0]), expr.lift(clbits[1])),
+            Store(expr.lift(clbits[0]), expr.lift(clbits[1])),
+            Store(a, expr.lift(clbits[1])),
+        ]
+        actual = [instruction.operation for instruction in qc.data]
+        self.assertEqual(actual, expected)
+
+    def test_allows_stores_with_cregs(self):
+        cregs = [ClassicalRegister(8, "cr1"), ClassicalRegister(8, "cr2")]
+        a = expr.Var.new("a", types.Uint(8))
+        qc = QuantumCircuit(*cregs, captures=[a])
+        qc.store(cregs[0], 0xFF)
+        qc.store(expr.Var(cregs[1], types.Uint(8)), a)
+        qc.store(cregs[0], cregs[1])
+        qc.store(expr.lift(cregs[0]), expr.lift(cregs[1]))
+        qc.store(a, cregs[1])
+
+        expected = [
+            Store(expr.lift(cregs[0]), expr.lift(0xFF)),
+            Store(expr.lift(cregs[1]), a),
+            Store(expr.lift(cregs[0]), expr.lift(cregs[1])),
+            Store(expr.lift(cregs[0]), expr.lift(cregs[1])),
+            Store(a, expr.lift(cregs[1])),
+        ]
+        actual = [instruction.operation for instruction in qc.data]
+        self.assertEqual(actual, expected)
+
+    def test_lifts_values(self):
+        a = expr.Var.new("a", types.Bool())
+        qc = QuantumCircuit(captures=[a])
+        qc.store(a, True)
+        self.assertEqual(qc.data[-1].operation, Store(a, expr.lift(True)))
+
+        b = expr.Var.new("b", types.Uint(16))
+        qc.add_capture(b)
+        qc.store(b, 0xFFFF)
+        self.assertEqual(qc.data[-1].operation, Store(b, expr.lift(0xFFFF)))
+
+    def test_rejects_vars_not_in_circuit(self):
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(CircuitError, "'a'.*not present"):
+            qc.store(expr.Var.new("a", types.Bool()), True)
+
+        # Not the same 'a'
+        qc.add_input(a)
+        with self.assertRaisesRegex(CircuitError, "'a'.*not present"):
+            qc.store(expr.Var.new("a", types.Bool()), True)
+        with self.assertRaisesRegex(CircuitError, "'b'.*not present"):
+            qc.store(a, b)
+
+    def test_rejects_bits_not_in_circuit(self):
+        a = expr.Var.new("a", types.Bool())
+        clbit = Clbit()
+        qc = QuantumCircuit(captures=[a])
+        with self.assertRaisesRegex(CircuitError, "not present"):
+            qc.store(clbit, False)
+        with self.assertRaisesRegex(CircuitError, "not present"):
+            qc.store(clbit, a)
+        with self.assertRaisesRegex(CircuitError, "not present"):
+            qc.store(a, clbit)
+
+    def test_rejects_cregs_not_in_circuit(self):
+        a = expr.Var.new("a", types.Uint(8))
+        creg = ClassicalRegister(8, "cr1")
+        qc = QuantumCircuit(captures=[a])
+        with self.assertRaisesRegex(CircuitError, "not present"):
+            qc.store(creg, 0xFF)
+        with self.assertRaisesRegex(CircuitError, "not present"):
+            qc.store(creg, a)
+        with self.assertRaisesRegex(CircuitError, "not present"):
+            qc.store(a, creg)
+
+    def test_rejects_non_lvalue(self):
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+        qc = QuantumCircuit(inputs=[a, b])
+        not_an_lvalue = expr.logic_and(a, b)
+        with self.assertRaisesRegex(CircuitError, "not an l-value"):
+            qc.store(not_an_lvalue, expr.lift(False))
+
+    def test_rejects_explicit_cast(self):
+        lvalue = expr.Var.new("a", types.Uint(16))
+        rvalue = expr.Var.new("b", types.Uint(8))
+        qc = QuantumCircuit(inputs=[lvalue, rvalue])
+        with self.assertRaisesRegex(CircuitError, "an explicit cast is required"):
+            qc.store(lvalue, rvalue)
+
+    def test_rejects_dangerous_cast(self):
+        lvalue = expr.Var.new("a", types.Uint(8))
+        rvalue = expr.Var.new("b", types.Uint(16))
+        qc = QuantumCircuit(inputs=[lvalue, rvalue])
+        with self.assertRaisesRegex(CircuitError, "an explicit cast is required.*may be lossy"):
+            qc.store(lvalue, rvalue)
+
+    def test_rejects_c_if(self):
+        a = expr.Var.new("a", types.Bool())
+        qc = QuantumCircuit([Clbit()], inputs=[a])
+        instruction_set = qc.store(a, True)
+        with self.assertRaises(NotImplementedError):
+            instruction_set.c_if(qc.clbits[0], False)

--- a/test/python/circuit/test_store.py
+++ b/test/python/circuit/test_store.py
@@ -1,0 +1,62 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
+
+from qiskit.test import QiskitTestCase
+from qiskit.circuit import Store, Clbit, CircuitError
+from qiskit.circuit.classical import expr, types
+
+
+class TestStoreInstruction(QiskitTestCase):
+    """Tests of the properties of the ``Store`` instruction itself."""
+
+    def test_happy_path_construction(self):
+        lvalue = expr.Var.new("a", types.Bool())
+        rvalue = expr.lift(Clbit())
+        constructed = Store(lvalue, rvalue)
+        self.assertIsInstance(constructed, Store)
+        self.assertEqual(constructed.lvalue, lvalue)
+        self.assertEqual(constructed.rvalue, rvalue)
+
+    def test_implicit_cast(self):
+        lvalue = expr.Var.new("a", types.Bool())
+        rvalue = expr.Var.new("b", types.Uint(8))
+        constructed = Store(lvalue, rvalue)
+        self.assertIsInstance(constructed, Store)
+        self.assertEqual(constructed.lvalue, lvalue)
+        self.assertEqual(constructed.rvalue, expr.Cast(rvalue, types.Bool(), implicit=True))
+
+    def test_rejects_non_lvalue(self):
+        not_an_lvalue = expr.logic_and(
+            expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Bool())
+        )
+        rvalue = expr.lift(False)
+        with self.assertRaisesRegex(CircuitError, "not an l-value"):
+            Store(not_an_lvalue, rvalue)
+
+    def test_rejects_explicit_cast(self):
+        lvalue = expr.Var.new("a", types.Uint(16))
+        rvalue = expr.Var.new("b", types.Uint(8))
+        with self.assertRaisesRegex(CircuitError, "an explicit cast is required"):
+            Store(lvalue, rvalue)
+
+    def test_rejects_dangerous_cast(self):
+        lvalue = expr.Var.new("a", types.Uint(8))
+        rvalue = expr.Var.new("b", types.Uint(16))
+        with self.assertRaisesRegex(CircuitError, "an explicit cast is required.*may be lossy"):
+            Store(lvalue, rvalue)
+
+    def test_rejects_c_if(self):
+        instruction = Store(expr.Var.new("a", types.Bool()), expr.Var.new("b", types.Bool()))
+        with self.assertRaises(NotImplementedError):
+            instruction.c_if(Clbit(), False)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary


This helper function is intended for use during the `DAGCircuit`
construction in the near term, where it will need to distinguish whether
a control-flow operation reads or writes a variable.

This is not an efficient operation on the `QuantumCircuit` tree
representation, and in general is something that should instead be
calculated by data-flow analysis (or similar) on a graph-based
representation of the program, or cached.  However, `DAGCircuit`
currently does not represent control-flow well enough to do anything
like this across the circuit, so the helper method is necessary in the
short term, despite the effective quadratic complexity on the
control-flow depth of a circuit during complete recursive conversion of
blocks to `DAGCircuit`s.




### Details and comments

Depends on #10974 

Close #10940.

It might be preferable to store the number of writes to variables within `QuantumCircuit`, but the only way to reliably keep this number up-to-date is to add an extra check within `QuantumCircuit._append`, and I'm wary of affecting the performance of that inner-loop function for a feature that most circuits will not use.  `DAGCircuit` is already very inefficient with regards to classical handling at the moment and needs a more complete rework, so this feels like a reasonable compromise; performance is poorer than it _could_ be for control-flow ops in `DAGCircuit` (it's already poor), but circuits that don't use it aren't affected.