### PR TITLE
Apply layout inside estimator

### DIFF
--- a/qiskit/primitives/backend_estimator.py
+++ b/qiskit/primitives/backend_estimator.py
@@ -114,6 +114,8 @@ class BackendEstimator(BaseEstimator[PrimitiveJob[EstimatorResult]]):
         abelian_grouping: bool = True,
         bound_pass_manager: PassManager | None = None,
         skip_transpilation: bool = False,
+        *,
+        apply_layout: bool = True,
     ):
         """Initialize a new BackendEstimator instance
 
@@ -128,7 +130,7 @@ class BackendEstimator(BaseEstimator[PrimitiveJob[EstimatorResult]]):
                 of the input circuits is skipped and the circuit objects
                 will be directly executed when this object is called.
         """
-        super().__init__(options=options)
+        super().__init__(options=options, apply_layout=apply_layout)
 
         self._abelian_grouping = abelian_grouping
 

--- a/qiskit/primitives/base/base_primitive.py
+++ b/qiskit/primitives/base/base_primitive.py
@@ -51,15 +51,15 @@ class BasePrimitive(ABC):
     @staticmethod
     def _validate_circuits(
         circuits: Sequence[QuantumCircuit] | QuantumCircuit,
-    ) -> tuple[QuantumCircuit, ...]:
+    ) -> list[QuantumCircuit, ...]:
         if isinstance(circuits, QuantumCircuit):
-            circuits = (circuits,)
+            circuits = [circuits]
         elif not isinstance(circuits, Sequence) or not all(
             isinstance(cir, QuantumCircuit) for cir in circuits
         ):
             raise TypeError("Invalid circuits, expected Sequence[QuantumCircuit].")
-        elif not isinstance(circuits, tuple):
-            circuits = tuple(circuits)
+        elif not isinstance(circuits, list):
+            circuits = list(circuits)
         if len(circuits) == 0:
             raise ValueError("No circuits were provided.")
         return circuits
@@ -104,7 +104,7 @@ class BasePrimitive(ABC):
 
     @staticmethod
     def _cross_validate_circuits_parameter_values(
-        circuits: tuple[QuantumCircuit, ...], parameter_values: tuple[tuple[float, ...], ...]
+        circuits: list[QuantumCircuit, ...], parameter_values: tuple[tuple[float, ...], ...]
     ) -> None:
         if len(circuits) != len(parameter_values):
             raise ValueError(

--- a/qiskit/primitives/base/base_primitive.py
+++ b/qiskit/primitives/base/base_primitive.py
@@ -104,7 +104,7 @@ class BasePrimitive(ABC):
 
     @staticmethod
     def _cross_validate_circuits_parameter_values(
-        circuits: list[QuantumCircuit, ...], parameter_values: tuple[tuple[float, ...], ...]
+        circuits: list[QuantumCircuit], parameter_values: tuple[tuple[float, ...], ...]
     ) -> None:
         if len(circuits) != len(parameter_values):
             raise ValueError(

--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -15,9 +15,9 @@ Estimator class
 
 from __future__ import annotations
 
+import typing
 from collections.abc import Sequence
 from typing import Any
-import typing
 
 import numpy as np
 
@@ -28,12 +28,7 @@ from qiskit.quantum_info.operators.base_operator import BaseOperator
 
 from .base import BaseEstimator, EstimatorResult
 from .primitive_job import PrimitiveJob
-from .utils import (
-    _circuit_key,
-    _observable_key,
-    bound_circuit_to_instruction,
-    init_observable,
-)
+from .utils import _circuit_key, _observable_key, bound_circuit_to_instruction, init_observable
 
 if typing.TYPE_CHECKING:
     from qiskit.opflow import PauliSumOp
@@ -55,15 +50,16 @@ class Estimator(BaseEstimator[PrimitiveJob[EstimatorResult]]):
           this option is ignored.
     """
 
-    def __init__(self, *, options: dict | None = None):
+    def __init__(self, *, options: dict | None = None, apply_layout: bool = True):
         """
         Args:
             options: Default options.
+            apply_layout: if True, apply layout to observables.
 
         Raises:
             QiskitError: if some classical bits are not used for measurements.
         """
-        super().__init__(options=options)
+        super().__init__(options=options, apply_layout=apply_layout)
         self._circuit_ids = {}
         self._observable_ids = {}
 

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -492,7 +492,7 @@ class Statevector(QuantumState, TolerancesMixin):
 
     def expectation_value(
         self, oper: BaseOperator | QuantumCircuit | Instruction, qargs: None | list[int] = None
-    ) -> complex:
+    ) -> numpy.complex128:
         """Compute the expectation value of an operator.
 
         Args:

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -492,7 +492,7 @@ class Statevector(QuantumState, TolerancesMixin):
 
     def expectation_value(
         self, oper: BaseOperator | QuantumCircuit | Instruction, qargs: None | list[int] = None
-    ) -> numpy.complex128:
+    ) -> complex:
         """Compute the expectation value of an operator.
 
         Args:

--- a/test/python/primitives/test_primitive.py
+++ b/test/python/primitives/test_primitive.py
@@ -30,10 +30,10 @@ class TestCircuitValidation(QiskitTestCase):
     """Test circuits validation logic."""
 
     @data(
-        (random_circuit(2, 2, seed=0), (random_circuit(2, 2, seed=0),)),
+        (random_circuit(2, 2, seed=0), [random_circuit(2, 2, seed=0)]),
         (
             [random_circuit(2, 2, seed=0), random_circuit(2, 2, seed=1)],
-            (random_circuit(2, 2, seed=0), random_circuit(2, 2, seed=1)),
+            [random_circuit(2, 2, seed=0), random_circuit(2, 2, seed=1)],
         ),
     )
     @unpack

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -1065,7 +1065,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
         op = SparsePauliOp.from_list([("IIII", 1), ("IZZZ", 2), ("XXXI", 3)])
         backend = FakeNairobiV2()
         backend.set_options(seed_simulator=123)
-        estimator = BackendEstimator(backend=backend, skip_transpilation=True)
+        estimator = BackendEstimator(backend=backend, skip_transpilation=True, apply_layout=False)
         thetas = list(range(len(psi.parameters)))
         transpiled_psi = transpile(psi, backend, optimization_level=3)
         permuted_op = op.apply_layout(transpiled_psi.layout)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

`apply_layout` is called inside the estimator.
This PR enables the following code:

```python
n = 3
qc = QuantumCircuit(n)
qc.x(n - 1)
qc.h(range(n))
qc.cx(range(n - 1), n - 1)
qc.h(range(n - 1))

op = SparsePauliOp("IZI")

backend = FakeBelem()
trans_qc = transpile(qc, backend)

expval = Estimator().run(trans_qc, op).result().values[0]
```

Resolves https://github.com/Qiskit/qiskit-ibm-runtime/issues/338

### Details and comments

I'll rebase this PR after #10947 is merged.