### PR TITLE
Deprecate importing provider-specific fake backends from `qiskit.providers`

### DIFF
--- a/qiskit/providers/fake_provider/backends/__init__.py
+++ b/qiskit/providers/fake_provider/backends/__init__.py
@@ -14,6 +14,7 @@
 """
 Mocked versions of real quantum backends.
 """
+import warnings
 
 # BackendV2 Backends
 from .almaden import FakeAlmadenV2
@@ -108,3 +109,12 @@ from .valencia import FakeValencia
 from .vigo import FakeVigo
 from .washington import FakeWashington
 from .yorktown import FakeYorktown
+
+warnings.warn(
+    "This import path is deprecated as of qiskit 0.45.0, please import "
+    "device-specific fake backends using "
+    "``from qiskit_ibm_provider.fake_provider import FakeExample`` "
+    "instead of ``from qiskit.providers.fake_provider import FakeExample``.",
+    category=DeprecationWarning,
+    stacklevel=2,
+)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR is blocked by https://github.com/Qiskit/qiskit-ibm-provider/pull/740, as well as #10918. While the base classes have also been copied over to the provider, I believe the plan for the moment is to just deprecate the provider-specific fake backends (those under `backends`).


### Details and comments


