### PR TITLE
Use a more efficient formulation for fidelity

### DIFF
--- a/qiskit/quantum_info/states/measures.py
+++ b/qiskit/quantum_info/states/measures.py
@@ -22,7 +22,6 @@ from qiskit.quantum_info.states.utils import (
     partial_trace,
     shannon_entropy,
     _format_state,
-    _funm_svd,
 )
 
 
@@ -72,9 +71,7 @@ def state_fidelity(
         fid = arr2.conj().dot(arr1).dot(arr2)
     else:
         # Fidelity of two DensityMatrices
-        s1sq = _funm_svd(arr1, np.sqrt)
-        s2sq = _funm_svd(arr2, np.sqrt)
-        fid = np.linalg.norm(s1sq.dot(s2sq), ord="nuc") ** 2
+        fid = np.sum(np.sqrt(np.linalg.eigvals(arr1.dot(arr2)))) ** 2
     # Convert to py float rather than return np.float
     return float(np.real(fid))
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes. -> no new tests required
- [ ] I have updated the documentation accordingly. -> no documentation update required (as of now)
- [x] I have read the CONTRIBUTING document.
-->

### Summary
There is a more efficient way to calculate the quantum fidelity for two mixed states, using only one eigendecomposition instead of three SVDs.

### Details and comments
For a more detailed analysis see [arxiv:2309.10565](https://arxiv.org/abs/2309.10565).

