### PR TITLE
Pin `cvxpy` to known-good version

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -11,3 +11,9 @@ numpy<1.25
 # eigensystem code for one of the test cases.  See
 # https://github.com/Qiskit/qiskit-terra/issues/10345 for current details.
 scipy<1.11
+
+# cvxpy 1.4.0 caused an instability in some diamond-norm tests.  That's
+# likely to be an unreliable measure already given its nature, so this
+# pin may be relaxed by modifying the tests slightly to choose known-safe
+# operators.
+cvxpy==1.3.2


### PR DESCRIPTION
### Summary

Some diamond-norm tests are failing with the latest 1.4.0 release of cvxpy.  Given the complex optimisation problem that the dnorm represents, it's quite possible that randomised tests would already have had a low success rate, and this is just a case of some internal tweaks destabilising the particular operator choice in our test.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Hopefully should get CI running again.
