### PR TITLE
Change cvxpy solver

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -11,9 +11,3 @@ numpy<1.25
 # eigensystem code for one of the test cases.  See
 # https://github.com/Qiskit/qiskit-terra/issues/10345 for current details.
 scipy<1.11
-
-# cvxpy 1.4.0 caused an instability in some diamond-norm tests.  That's
-# likely to be an unreliable measure already given its nature, so this
-# pin may be relaxed by modifying the tests slightly to choose known-safe
-# operators.
-cvxpy==1.3.2

--- a/qiskit/quantum_info/operators/measures.py
+++ b/qiskit/quantum_info/operators/measures.py
@@ -344,7 +344,7 @@ def diamond_norm(choi: Choi | QuantumChannel, **kwargs) -> float:
     # Objective function
     obj = cvxpy.Maximize(cvxpy.trace(choi_rt_r @ x_r) + cvxpy.trace(choi_rt_i @ x_i))
     prob = cvxpy.Problem(obj, cons)
-    sol = prob.solve(**kwargs)
+    sol = prob.solve(solver="SCS", **kwargs)
     return sol
 
 

--- a/qiskit/quantum_info/operators/measures.py
+++ b/qiskit/quantum_info/operators/measures.py
@@ -250,7 +250,7 @@ def gate_error(
     )
 
 
-def diamond_norm(choi: Choi | QuantumChannel, **kwargs) -> float:
+def diamond_norm(choi: Choi | QuantumChannel, solver: str = "SCS", **kwargs) -> float:
     r"""Return the diamond norm of the input quantum channel object.
 
     This function computes the completely-bounded trace-norm (often
@@ -260,6 +260,7 @@ def diamond_norm(choi: Choi | QuantumChannel, **kwargs) -> float:
     Args:
         choi(Choi or QuantumChannel): a quantum channel object or
                                       Choi-matrix array.
+        solver (str): The solver to use.
         kwargs: optional arguments to pass to CVXPY solver.
 
     Returns:
@@ -344,7 +345,7 @@ def diamond_norm(choi: Choi | QuantumChannel, **kwargs) -> float:
     # Objective function
     obj = cvxpy.Maximize(cvxpy.trace(choi_rt_r @ x_r) + cvxpy.trace(choi_rt_i @ x_i))
     prob = cvxpy.Problem(obj, cons)
-    sol = prob.solve(solver="SCS", **kwargs)
+    sol = prob.solve(solver=solver, **kwargs)
     return sol
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

CVXPY 1.4.0 has been released recently and it changed the default solver from SCS to CLARABEL.
https://www.cvxpy.org/updates/index.html#cvxpy-1-4

But the new solver took so long time to converge, and the following unit test fails.
`test.python.quantum_info.operators.test_measures.TestOperatorMeasures.test_diamond_norm_3`

CI log example https://dev.azure.com/qiskit-ci/qiskit/_build/results?buildId=50270&view=logs&j=047b33e0-32e5-58f1-0c38-5f1e11815a2c&t=0892c657-33d9-5456-4eb8-9e7ebbe33ddf

This PR specifies the old solver to pass the unit test.

### Details and comments


