### PR TITLE
Draft: Improve performance of QuantumCircuit.measure_all and QuantumCircuit.barrier by using _append fast path

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2848,11 +2848,11 @@ class QuantumCircuit:
         """
         from .barrier import Barrier
 
-        qubits: list[QubitSpecifier] = []
 
         if not qargs:  # None
-            qubits.extend(self.qubits)
+            self._append(Barrier(len(self.qubits), label=label), self.qubits, [])
 
+        qubits: list[QubitSpecifier] = []
         for qarg in qargs:
             if isinstance(qarg, QuantumRegister):
                 qubits.extend([qarg[j] for j in range(qarg.size)])
@@ -2865,7 +2865,7 @@ class QuantumCircuit:
             else:
                 qubits.append(qarg)
 
-        return self._append(Barrier(len(qubits), label=label), qubits, [])
+        return self.append(Barrier(len(qubits), label=label), qubits, [])
 
     def delay(
         self,

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2312,7 +2312,7 @@ class QuantumCircuit:
             new_creg = circ._create_creg(len(circ.qubits), "meas")
             circ.add_register(new_creg)
             circ.barrier()
-            circ.measure(circ.qubits, new_creg)
+            self._append(Measure(), circ.qubits, new_creg)
         else:
             if len(circ.clbits) < len(circ.qubits):
                 raise CircuitError(
@@ -2320,7 +2320,7 @@ class QuantumCircuit:
                     "the number of qubits."
                 )
             circ.barrier()
-            circ.measure(circ.qubits, circ.clbits[0 : len(circ.qubits)])
+            self._append(Measure(), circ.qubits, circ.clbits[0 : len(circ.qubits)])
 
         if not inplace:
             return circ
@@ -2865,7 +2865,7 @@ class QuantumCircuit:
             else:
                 qubits.append(qarg)
 
-        return self.append(Barrier(len(qubits), label=label), qubits, [])
+        return self._append(Barrier(len(qubits), label=label), qubits, [])
 
     def delay(
         self,


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Improve performance of QuantumCircuit.measure_all and QuantumCircuit.barrier by using _append fast path

### Details and comments

The register argument are obtained from the QuantumCircuit directly, so do not need to be validated.

