### PR TITLE
Fix build filter coupling map with mix ideal/physical targets

### DIFF
--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -1073,7 +1073,7 @@ class Target(Mapping):
             return None
 
     def _filter_coupling_graph(self):
-        has_operations = set(itertools.chain.from_iterable(self.qargs))
+        has_operations = set(itertools.chain.from_iterable(x for x in self.qargs if x is not None))
         graph = self._coupling_graph.copy()
         to_remove = set(graph.node_indices()).difference(has_operations)
         if to_remove:

--- a/releasenotes/notes/fix-handling-of-mixed-ideal-target-with-filter-qubits-171894cb758356ca.yaml
+++ b/releasenotes/notes/fix-handling-of-mixed-ideal-target-with-filter-qubits-171894cb758356ca.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed an issue in the :meth:`.Target.build_coupling_map` method when the
+    ``filter_idle_qubits`` argument was set to ``True`` and there was a mix
+    of fixed width ideal and physical instructions in the target. In these cases
+    previously the :meth:`.Target.build_coupling_map` would have raised an
+    exception because it was assuming all instructions in the target were
+    physical and defined over qubits.

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -1837,6 +1837,15 @@ class TestGlobalVariableWidthOperations(QiskitTestCase):
             set(self.ibm_target.build_coupling_map().get_edges()),
         )
 
+    def test_mixed_ideal_target_filtered_coupling_map(self):
+        target = Target(num_qubits=10)
+        target.add_instruction(XGate(), {(qubit,): InstructionProperties(error=0.5) for qubit in range(5)})
+        target.add_instruction(CXGate(), {edge: InstructionProperties(error=0.6) for edge in CouplingMap.from_line(5, bidirectional=False).get_edges()})
+        target.add_instruction(SXGate())
+        coupling_map = target.build_coupling_map(filter_idle_qubits=True)
+        self.assertEqual(max(coupling_map.physical_qubits), 4)
+        self.assertEqual(coupling_map.get_edges(), [(0,1), (1, 2), (2, 3), (3, 4)])
+
 
 class TestInstructionProperties(QiskitTestCase):
     def test_empty_repr(self):

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -1839,12 +1839,20 @@ class TestGlobalVariableWidthOperations(QiskitTestCase):
 
     def test_mixed_ideal_target_filtered_coupling_map(self):
         target = Target(num_qubits=10)
-        target.add_instruction(XGate(), {(qubit,): InstructionProperties(error=0.5) for qubit in range(5)})
-        target.add_instruction(CXGate(), {edge: InstructionProperties(error=0.6) for edge in CouplingMap.from_line(5, bidirectional=False).get_edges()})
+        target.add_instruction(
+            XGate(), {(qubit,): InstructionProperties(error=0.5) for qubit in range(5)}
+        )
+        target.add_instruction(
+            CXGate(),
+            {
+                edge: InstructionProperties(error=0.6)
+                for edge in CouplingMap.from_line(5, bidirectional=False).get_edges()
+            },
+        )
         target.add_instruction(SXGate())
         coupling_map = target.build_coupling_map(filter_idle_qubits=True)
         self.assertEqual(max(coupling_map.physical_qubits), 4)
-        self.assertEqual(coupling_map.get_edges(), [(0,1), (1, 2), (2, 3), (3, 4)])
+        self.assertEqual(coupling_map.get_edges(), [(0, 1), (1, 2), (2, 3), (3, 4)])
 
 
 class TestInstructionProperties(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes a small issue in the Target.build_coupling_map method with filter_idle_qubits=True. Previously the internal method used to filter the idle qubits from the coupling map's creation was not accounting for the case that an instruction in the target could be ideal. This was never caught because normally if you have an ideal fixed width instruction in the target that is modelling a simulator which doesn't have any connectivity constraints and the function would never be called. But in targets that have a mix of both ideal globally defined and physical gates the filter code couldn't handle the None used to represent an ideal globally available gate. This commit fixes that handling to just ignore the global gate like the normal coupling map construction does.

### Details and comments