### PR TITLE
Remove patching of `SwapGate.__new__` from Sabre test

### DIFF
--- a/test/python/transpiler/test_sabre_swap.py
+++ b/test/python/transpiler/test_sabre_swap.py
@@ -230,18 +230,9 @@ class TestSabreSwap(QiskitTestCase):
         coupling_map = CouplingMap.from_line(qc.num_qubits)
         routing_pass = PassManager(SabreSwap(coupling_map, method))
 
-        n_swap_gates = 0
-
-        def leak_number_of_swaps(cls, *args, **kwargs):
-            nonlocal n_swap_gates
-            n_swap_gates += 1
-            if n_swap_gates > 1_000:
-                raise Exception("SabreSwap seems to be stuck in a loop")
-            # pylint: disable=bad-super-call
-            return super(SwapGate, cls).__new__(cls, *args, **kwargs)
-
-        with unittest.mock.patch.object(SwapGate, "__new__", leak_number_of_swaps):
-            routed = routing_pass.run(qc)
+        # Since all the logic happens in Rust space these days, the best we'll really see here is
+        # the test hanging.
+        routed = routing_pass.run(qc)
 
         routed_ops = routed.count_ops()
         del routed_ops["swap"]


### PR DESCRIPTION
### Summary

This made sense as a way of tracking the progress of Sabre back when our implementation was pure-Python and generated the swaps on-the-fly, but ever since it moved to Rust, the infinite loop would have happened before any swaps were constructed at all.

With the move to singleton gates, this test can cause problems; the restoration after the patching can cause issues with the singleton-return apparatus.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments
