### PR TITLE
Hardcode missing names in QPY backwards-compat tests

### DIFF
--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -632,7 +632,7 @@ def generate_control_flow_expr():
     body1.x(0)
     qr1 = QuantumRegister(2, "q1")
     cr1 = ClassicalRegister(2, "c1")
-    qc1 = QuantumCircuit(qr1, cr1)
+    qc1 = QuantumCircuit(qr1, cr1, name="cf-expr1")
     qc1.if_test(expr.equal(cr1, 3), body1.copy(), [0], [])
     qc1.while_loop(expr.logic_not(cr1[1]), body1.copy(), [0], [])
 
@@ -643,7 +643,7 @@ def generate_control_flow_expr():
     qr2 = QuantumRegister(2, "q2")
     cr1_2 = ClassicalRegister(3, "c1")
     cr2_2 = ClassicalRegister(3, "c2")
-    qc2 = QuantumCircuit(qr2, cr1_2, cr2_2)
+    qc2 = QuantumCircuit(qr2, cr1_2, cr2_2, name="cf-expr2")
     qc2.if_test(expr.logic_or(expr.less(cr1_2, cr2_2), cr1_2[1]), outer2, [1], [1])
 
     inner3 = QuantumCircuit(1)
@@ -653,7 +653,7 @@ def generate_control_flow_expr():
     qr3 = QuantumRegister(2, "q2")
     cr1_3 = ClassicalRegister(3, "c1")
     cr2_3 = ClassicalRegister(3, "c2")
-    qc3 = QuantumCircuit(qr3, cr1_3, cr2_3)
+    qc3 = QuantumCircuit(qr3, cr1_3, cr2_3, name="cf-expr3")
     qc3.switch(expr.bit_xor(cr1_3, cr2_3), [(0, outer2)], [1], [1])
 
     cr1_4 = ClassicalRegister(256, "c1")
@@ -679,7 +679,9 @@ def generate_control_flow_expr():
         [],
     )
     qc4_loose = Clbit()
-    qc4 = QuantumCircuit(QuantumRegister(2, "qr4"), cr1_4, cr2_4, cr3_4, [qc4_loose])
+    qc4 = QuantumCircuit(
+        QuantumRegister(2, "qr4"), cr1_4, cr2_4, cr3_4, [qc4_loose], name="cf-expr4"
+    )
     qc4.rz(np.pi, 0)
     qc4.switch(
         expr.logic_and(


### PR DESCRIPTION
### Summary

The newest control-flow QPY tests do not have hard-coded names on the outer circuits, which trips assertion errors if the library import causes any more circuits to be instantiated during build (since the generated names are circuit-count dependent).

Inner circuits do not need naming in the same way, since these are not used in the assertion; nested circuits' names would be tested separately. The control-flow builder interface, for example, does not assign these circuits names at all.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


