### PR TITLE
Fix deprecated Numpy logic in `NormalizeRXAngles`

### DIFF
--- a/qiskit/transpiler/passes/optimization/normalize_rx_angle.py
+++ b/qiskit/transpiler/passes/optimization/normalize_rx_angle.py
@@ -85,7 +85,7 @@ class NormalizeRXAngle(TransformationPass):
         if similar_angles.size == 0:
             self.already_generated[qubit] = np.append(angles, original_angle)
             return original_angle
-        return float(angles[0])
+        return float(similar_angles[0])
 
     def run(self, dag):
         """Run the NormalizeRXAngle pass on ``dag``.

--- a/qiskit/transpiler/passes/optimization/normalize_rx_angle.py
+++ b/qiskit/transpiler/passes/optimization/normalize_rx_angle.py
@@ -76,25 +76,16 @@ class NormalizeRXAngle(TransformationPass):
             float: Quantized angle.
         """
 
-        # check if there is already a calibration for a simliar angle
-        try:
-            angles = self.already_generated[qubit]  # 1d ndarray of already generated angles
-            similar_angle = angles[
-                np.isclose(angles, original_angle, atol=self.resolution_in_radian / 2)
-            ]
-            quantized_angle = (
-                float(similar_angle[0]) if len(similar_angle) > 1 else float(similar_angle)
-            )
-        except KeyError:
-            quantized_angle = original_angle
-            self.already_generated[qubit] = np.array([quantized_angle])
-        except TypeError:
-            quantized_angle = original_angle
-            self.already_generated[qubit] = np.append(
-                self.already_generated[qubit], quantized_angle
-            )
-
-        return quantized_angle
+        if (angles := self.already_generated.get(qubit)) is None:
+            self.already_generated[qubit] = np.array([original_angle])
+            return original_angle
+        similar_angles = angles[
+            np.isclose(angles, original_angle, atol=self.resolution_in_radian / 2)
+        ]
+        if similar_angles.size == 0:
+            self.already_generated[qubit] = np.append(angles, original_angle)
+            return original_angle
+        return float(angles[0])
 
     def run(self, dag):
         """Run the NormalizeRXAngle pass on ``dag``.


### PR DESCRIPTION
### Summary

This new pass added in gh-10634 uses some deprecated Numpy properties and has some slightly fragile exception-based logic when the required properties can be directly tested.  This code issues warnings with Numpy 1.25+, which is currently not used by CI due to gh-10305.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

This should fix the common errors in #11020.  There's still a Linux / Numpy 1.26.1 failure in unitary synthesis that's new, and it's not immediately clear to me if that's related or not.

I submitted this as a separate PR to #11020 because I'd like the history / CI to record that we're not sacrificing compatibility with Numpy 1.24 to add compatibility with 1.26.