### PR TITLE
Remove redundant closure / anonymous function

### DIFF
--- a/crates/accelerate/src/sabre_swap/neighbor_table.rs
+++ b/crates/accelerate/src/sabre_swap/neighbor_table.rs
@@ -89,12 +89,12 @@ impl NeighborTable {
                     adj_mat
                         .axis_iter(Axis(0))
                         .into_par_iter()
-                        .map(|row| build_neighbors(row))
+                        .map(build_neighbors)
                         .collect::<PyResult<_>>()?
                 } else {
                     adj_mat
                         .axis_iter(Axis(0))
-                        .map(|row| build_neighbors(row))
+                        .map(build_neighbors)
                         .collect::<PyResult<_>>()?
                 }
             }


### PR DESCRIPTION
Replace `map(|x| f(x))` with `map(f)`

Actually here:

https://github.com/Qiskit/qiskit/blob/df9eae42c4959e4d0f218f331102cb3e8f4e14f4/crates/accelerate/src/sabre_swap/neighbor_table.rs#L92-L97
