### PR TITLE
Add base-gate callback to `CUGate.params` return

### DIFF
--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -243,11 +243,11 @@ class ControlledGate(Gate):
         else:
             raise CircuitError("Controlled gate does not define base gate for extracting params")
 
-    def __deepcopy__(self, _memo=None):
+    def __deepcopy__(self, memo=None):
         cpy = copy.copy(self)
         cpy.base_gate = self.base_gate.copy()
         if self._definition:
-            cpy._definition = copy.deepcopy(self._definition, _memo)
+            cpy._definition = copy.deepcopy(self._definition, memo)
         return cpy
 
     @property

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -497,11 +497,11 @@ class Instruction(Operation):
             cpy.name = name
         return cpy
 
-    def __deepcopy__(self, _memo=None):
+    def __deepcopy__(self, memo=None):
         cpy = copy.copy(self)
         cpy._params = copy.copy(self._params)
         if self._definition:
-            cpy._definition = copy.deepcopy(self._definition, _memo)
+            cpy._definition = copy.deepcopy(self._definition, memo)
         return cpy
 
     def _qasmif(self, string):

--- a/qiskit/circuit/library/standard_gates/equivalence_library.py
+++ b/qiskit/circuit/library/standard_gates/equivalence_library.py
@@ -1210,6 +1210,7 @@ phi = Parameter("phi")
 lam = Parameter("lam")
 cu3_to_cu = QuantumCircuit(q)
 cu3_to_cu.cu(theta, phi, lam, 0, 0, 1)
+_sel.add_equivalence(CU3Gate(theta, phi, lam), cu3_to_cu)
 
 # XGate
 #

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Two-pulse single-qubit gate."""
+import copy
 import math
 from cmath import exp
 from typing import Optional, Union
@@ -19,7 +20,6 @@ from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit.circuit.quantumregister import QuantumRegister
-from qiskit.circuit.exceptions import CircuitError
 
 
 class UGate(Gate):
@@ -126,6 +126,35 @@ class UGate(Gate):
             ],
             dtype=dtype,
         )
+
+
+class _CUGateParams(list):
+    # This awful class is to let `CUGate.params` have its keys settable (as
+    # `QuantumCircuit.assign_parameters` requires), while accounting for the problem that `CUGate`
+    # was defined to have a different number of parameters to its `base_gate`, which breaks
+    # `ControlledGate`'s assumptions, and would make most parametric `CUGate`s invalid.
+    #
+    # It's constructed only as part of the `CUGate.params` getter, and given that the general
+    # circuit model assumes that that's a directly mutable list that _must_ be kept in sync with the
+    # gate's requirements, we don't need this to support arbitrary mutation, just enough for
+    # `QuantumCircuit.assign_parameters` to work.
+
+    __slots__ = ("_gate",)
+
+    def __init__(self, gate):
+        super().__init__(gate._params)
+        self._gate = gate
+
+    def __setitem__(self, key, value):
+        if isinstance(key, slice):
+            raise TypeError("'CUGate' only supports setting parameters by single index")
+        super().__setitem__(key, value)
+        self._gate._params[key] = value
+        # Magic numbers: CUGate has 4 parameters, UGate has 3.
+        if key < 0:
+            key = 4 + key
+        if key < 3:
+            self._gate.base_gate.params[key] = value
 
 
 class CUGate(ControlledGate):
@@ -273,33 +302,20 @@ class CUGate(ControlledGate):
 
     @property
     def params(self):
-        """Get parameters from base_gate.
-
-        Returns:
-            list: List of gate parameters.
-
-        Raises:
-            CircuitError: Controlled gate does not define a base gate
-        """
-        if self.base_gate:
-            # CU has one additional parameter to the U base gate
-            return self.base_gate.params + self._params
-        else:
-            raise CircuitError("Controlled gate does not define base gate for extracting params")
+        return _CUGateParams(self)
 
     @params.setter
     def params(self, parameters):
-        """Set base gate parameters.
+        # We need to skip `ControlledGate` in the inheritance tree, since it defines
+        # that all controlled gates are `(1-|c><c|).1 + |c><c|.base` for control-state `c`, which
+        # this class does _not_ satisfy (so it shouldn't really be a `ControlledGate`).
+        super(ControlledGate, type(self)).params.fset(self, parameters)
+        self.base_gate.params = parameters[:-1]
 
-        Args:
-            parameters (list): The list of parameters to set.
-
-        Raises:
-            CircuitError: If controlled gate does not define a base gate.
-        """
-        # CU has one additional parameter to the U base gate
-        self._params = [parameters[-1]]
-        if self.base_gate:
-            self.base_gate.params = parameters[:-1]
-        else:
-            raise CircuitError("Controlled gate does not define base gate for extracting params")
+    def __deepcopy__(self, memo=None):
+        # We have to override this because `ControlledGate` doesn't copy the `_params` list,
+        # assuming that `params` will be a view onto the base gate's `_params`.
+        memo = memo if memo is not None else {}
+        out = super().__deepcopy__(memo)
+        out._params = copy.deepcopy(out._params, memo)
+        return out

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -146,15 +146,23 @@ class _CUGateParams(list):
         self._gate = gate
 
     def __setitem__(self, key, value):
-        if isinstance(key, slice):
-            raise TypeError("'CUGate' only supports setting parameters by single index")
         super().__setitem__(key, value)
         self._gate._params[key] = value
-        # Magic numbers: CUGate has 4 parameters, UGate has 3.
-        if key < 0:
-            key = 4 + key
-        if key < 3:
-            self._gate.base_gate.params[key] = value
+        # Magic numbers: CUGate has 4 parameters, UGate has 3, with the last of CUGate's missing.
+        if isinstance(key, slice):
+            # We don't need to worry about the case of the slice being used to insert extra / remove
+            # elements because that would be "undefined behaviour" in a gate already, so we're
+            # within our rights to do anything at all.
+            for i, base_key in enumerate(range(*key.indices(4))):
+                if base_key < 0:
+                    base_key = 4 + base_key
+                if base_key < 3:
+                    self._gate.base_gate.params[base_key] = value[i]
+        else:
+            if key < 0:
+                key = 4 + key
+            if key < 3:
+                self._gate.base_gate.params[key] = value
 
 
 class CUGate(ControlledGate):

--- a/releasenotes/notes/fix-cu-assign-parameters-fbf6f21d3e0c8c0b.yaml
+++ b/releasenotes/notes/fix-cu-assign-parameters-fbf6f21d3e0c8c0b.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    :class:`.CUGate` will now behave correctly during calls to :meth:`.QuantumCircuit.assign_parameters`.
+    Previously, it would cause various odd errors, often some time after the initial circuit assignment.
+    See `#7326 <https://github.com/Qiskit/qiskit/issues/7326>`__, `#7410 <https://github.com/Qiskit/qiskit/issues/7410>`__,
+    `#9627 <https://github.com/Qiskit/qiskit/issues/9627>`__, `#10002 <https://github.com/Qiskit/qiskit/issues/10002>`__,
+    and `#10131 <https://github.com/Qiskit/qiskit/issues/10131>`__.

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -1193,6 +1193,31 @@ class TestControlledGate(QiskitTestCase):
         self.assertEqual(assigned.data[0].operation.base_gate, expected.data[0].operation.base_gate)
         self.assertEqual(assigned, expected)
 
+    def test_modify_cugate_params_slice(self):
+        """Test that CUGate.params can be modified by a standard slice (without changing the number
+        of elements) and changes propagate to the base gate.  This is only needed for as long as
+        CUGate's `base_gate` is `UGate`, which has the "wrong" number of parameters."""
+        cu = CUGate(0.1, 0.2, 0.3, 0.4)
+        self.assertEqual(cu.params, [0.1, 0.2, 0.3, 0.4])
+        self.assertEqual(cu.base_gate.params, [0.1, 0.2, 0.3])
+
+        cu.params[0:4] = [0.5, 0.4, 0.3, 0.2]
+        self.assertEqual(cu.params, [0.5, 0.4, 0.3, 0.2])
+        self.assertEqual(cu.base_gate.params, [0.5, 0.4, 0.3])
+
+        cu.params[:] = [0.1, 0.2, 0.3, 0.4]
+        self.assertEqual(cu.params, [0.1, 0.2, 0.3, 0.4])
+        self.assertEqual(cu.base_gate.params, [0.1, 0.2, 0.3])
+
+        cu.params[:3] = [0.5, 0.4, 0.3]
+        self.assertEqual(cu.params, [0.5, 0.4, 0.3, 0.4])
+        self.assertEqual(cu.base_gate.params, [0.5, 0.4, 0.3])
+
+        # indices (3, 2, 1, 0), note that the assignment is in reverse.
+        cu.params[-1::-1] = [0.1, 0.2, 0.3, 0.4]
+        self.assertEqual(cu.params, [0.4, 0.3, 0.2, 0.1])
+        self.assertEqual(cu.base_gate.params, [0.4, 0.3, 0.2])
+
     def test_assign_nested_controlled_cu(self):
         """Test assignment of an arbitrary controlled parametrised gate that appears through the
         `Gate.control()` method on an already-controlled gate."""


### PR DESCRIPTION
### Summary

This causes item-setting in `CUGate.params` to forward those sets on to the `UGate` in its `base_gate` unless they are setting the `gamma` parameter, which is not shared.

`CUGate` breaks several assumptions and components of the `ControlledGate` interface, including by having more parameters than its `base_gate`; `ControlledGate` assumes that its subclasses will not have a separate `_params` field, but instead will always just view onto their `base_gate._params`.  This commit changes the behaviour of the `params` getter to create a temporary list that backreferences to the base gate, satisfying the requirement.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

This is a replacement PR for #9118, as enough of Terra had moved on since that PR that the workaround in it was no longer sufficient for most test cases.  This commit builds on the work from that PR and I've credited @rrodenbusch as a co-author on it, since they solved the initial problem, and it's just my fault that the PR then staled due to lack of review.

This commit is by no means ideal, but the root problem is that `CUGate` simply does not follow the `ControlledGate` interface; it does _not_ satisfy $C[U] = \bigl(I - \lvert\psi\rangle\langle\psi\rvert\bigr)I + \lvert\psi\rangle\langle\psi\rvert U$ where $\lvert\psi\rangle$ is `ctrl_state` and $U$ is `base_gate`.  Unfortunately, the class is probably a bit too heavily used for it to be easy to make the existing `CUGate` a new `CU4Gate` or so that _doesn't_ subclass `ControlledGate` (although making a special `_U4Gate` that includes a global phase in its definition to use as the `base_gate` is a possibility).

Fix #7326 
Fix #7410 
Fix #9627 
Fix #10002 
Fix #10131 

Close #9118 (replaces it).