### PR TITLE
Add singleton lookup-key logic

### DIFF
--- a/qiskit/circuit/library/standard_gates/dcx.py
+++ b/qiskit/circuit/library/standard_gates/dcx.py
@@ -12,7 +12,7 @@
 
 """Double-CNOT gate."""
 
-from qiskit.circuit.singleton import SingletonGate
+from qiskit.circuit.singleton import SingletonGate, stdlib_singleton_key
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit._utils import with_gate_array
 
@@ -51,6 +51,8 @@ class DCXGate(SingletonGate):
     def __init__(self, label=None, *, duration=None, unit="dt"):
         """Create new DCX gate."""
         super().__init__("dcx", 2, [], label=label, duration=duration, unit=unit)
+
+    _singleton_lookup_key = stdlib_singleton_key()
 
     def _define(self):
         """

--- a/qiskit/circuit/library/standard_gates/ecr.py
+++ b/qiskit/circuit/library/standard_gates/ecr.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from qiskit.circuit._utils import with_gate_array
 from qiskit.circuit.quantumregister import QuantumRegister
-from qiskit.circuit.singleton import SingletonGate
+from qiskit.circuit.singleton import SingletonGate, stdlib_singleton_key
 from .rzx import RZXGate
 from .x import XGate
 
@@ -87,6 +87,8 @@ class ECRGate(SingletonGate):
     def __init__(self, label=None, *, duration=None, unit="dt"):
         """Create new ECR gate."""
         super().__init__("ecr", 2, [], label=label, duration=duration, unit=unit)
+
+    _singleton_lookup_key = stdlib_singleton_key()
 
     def _define(self):
         """

--- a/qiskit/circuit/library/standard_gates/h.py
+++ b/qiskit/circuit/library/standard_gates/h.py
@@ -14,7 +14,7 @@
 from math import sqrt, pi
 from typing import Optional, Union
 import numpy
-from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate
+from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate, stdlib_singleton_key
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit._utils import with_gate_array, with_controlled_gate_array
 
@@ -54,6 +54,8 @@ class HGate(SingletonGate):
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
         """Create new H gate."""
         super().__init__("h", 1, [], label=label, duration=duration, unit=unit)
+
+    _singleton_lookup_key = stdlib_singleton_key()
 
     def _define(self):
         """
@@ -180,6 +182,8 @@ class CHGate(SingletonControlledGate):
             unit=unit,
             _base_label=_base_label,
         )
+
+    _singleton_lookup_key = stdlib_singleton_key(num_ctrl_qubits=1)
 
     def _define(self):
         """

--- a/qiskit/circuit/library/standard_gates/i.py
+++ b/qiskit/circuit/library/standard_gates/i.py
@@ -13,7 +13,7 @@
 """Identity gate."""
 
 from typing import Optional
-from qiskit.circuit.singleton import SingletonGate
+from qiskit.circuit.singleton import SingletonGate, stdlib_singleton_key
 from qiskit.circuit._utils import with_gate_array
 
 
@@ -48,6 +48,8 @@ class IGate(SingletonGate):
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
         """Create new Identity gate."""
         super().__init__("id", 1, [], label=label, duration=duration, unit=unit)
+
+    _singleton_lookup_key = stdlib_singleton_key()
 
     def inverse(self):
         """Invert this gate."""

--- a/qiskit/circuit/library/standard_gates/iswap.py
+++ b/qiskit/circuit/library/standard_gates/iswap.py
@@ -16,7 +16,7 @@ from typing import Optional
 
 import numpy as np
 
-from qiskit.circuit.singleton import SingletonGate
+from qiskit.circuit.singleton import SingletonGate, stdlib_singleton_key
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit._utils import with_gate_array
 
@@ -88,6 +88,8 @@ class iSwapGate(SingletonGate):
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
         """Create new iSwap gate."""
         super().__init__("iswap", 2, [], label=label, duration=duration, unit=unit)
+
+    _singleton_lookup_key = stdlib_singleton_key()
 
     def _define(self):
         """

--- a/qiskit/circuit/library/standard_gates/s.py
+++ b/qiskit/circuit/library/standard_gates/s.py
@@ -17,7 +17,7 @@ from typing import Optional, Union
 
 import numpy
 
-from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate
+from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate, stdlib_singleton_key
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit._utils import with_gate_array, with_controlled_gate_array
 
@@ -60,6 +60,8 @@ class SGate(SingletonGate):
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
         """Create new S gate."""
         super().__init__("s", 1, [], label=label, duration=None, unit="dt")
+
+    _singleton_lookup_key = stdlib_singleton_key()
 
     def _define(self):
         """
@@ -123,6 +125,8 @@ class SdgGate(SingletonGate):
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
         """Create new Sdg gate."""
         super().__init__("sdg", 1, [], label=label, duration=None, unit="dt")
+
+    _singleton_lookup_key = stdlib_singleton_key()
 
     def _define(self):
         """
@@ -205,6 +209,8 @@ class CSGate(SingletonControlledGate):
             unit=unit,
         )
 
+    _singleton_lookup_key = stdlib_singleton_key(num_ctrl_qubits=1)
+
     def _define(self):
         """
         gate cs a,b { h b; cp(pi/2) a,b; h b; }
@@ -275,6 +281,8 @@ class CSdgGate(SingletonControlledGate):
             duration=duration,
             unit=unit,
         )
+
+    _singleton_lookup_key = stdlib_singleton_key(num_ctrl_qubits=1)
 
     def _define(self):
         """

--- a/qiskit/circuit/library/standard_gates/swap.py
+++ b/qiskit/circuit/library/standard_gates/swap.py
@@ -14,7 +14,7 @@
 
 from typing import Optional, Union
 import numpy
-from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate
+from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate, stdlib_singleton_key
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit._utils import with_gate_array, with_controlled_gate_array
 
@@ -61,6 +61,8 @@ class SwapGate(SingletonGate):
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
         """Create new SWAP gate."""
         super().__init__("swap", 2, [], label=label, duration=duration, unit=unit)
+
+    _singleton_lookup_key = stdlib_singleton_key()
 
     def _define(self):
         """
@@ -212,6 +214,8 @@ class CSwapGate(SingletonControlledGate):
             duration=duration,
             unit=unit,
         )
+
+    _singleton_lookup_key = stdlib_singleton_key(num_ctrl_qubits=1)
 
     def _define(self):
         """

--- a/qiskit/circuit/library/standard_gates/sx.py
+++ b/qiskit/circuit/library/standard_gates/sx.py
@@ -14,7 +14,7 @@
 
 from math import pi
 from typing import Optional, Union
-from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate
+from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate, stdlib_singleton_key
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit._utils import with_gate_array, with_controlled_gate_array
 
@@ -65,6 +65,8 @@ class SXGate(SingletonGate):
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
         """Create new SX gate."""
         super().__init__("sx", 1, [], label=label, duration=duration, unit=unit)
+
+    _singleton_lookup_key = stdlib_singleton_key()
 
     def _define(self):
         """
@@ -144,6 +146,8 @@ class SXdgGate(SingletonGate):
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
         """Create new SXdg gate."""
         super().__init__("sxdg", 1, [], label=label, duration=duration, unit=unit)
+
+    _singleton_lookup_key = stdlib_singleton_key()
 
     def _define(self):
         """
@@ -244,6 +248,8 @@ class CSXGate(SingletonControlledGate):
             duration=duration,
             unit=unit,
         )
+
+    _singleton_lookup_key = stdlib_singleton_key(num_ctrl_qubits=1)
 
     def _define(self):
         """

--- a/qiskit/circuit/library/standard_gates/t.py
+++ b/qiskit/circuit/library/standard_gates/t.py
@@ -17,7 +17,7 @@ from typing import Optional
 
 import numpy
 
-from qiskit.circuit.singleton import SingletonGate
+from qiskit.circuit.singleton import SingletonGate, stdlib_singleton_key
 from qiskit.circuit.library.standard_gates.p import PhaseGate
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit._utils import with_gate_array
@@ -58,6 +58,8 @@ class TGate(SingletonGate):
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
         """Create new T gate."""
         super().__init__("t", 1, [], label=label, duration=duration, unit=unit)
+
+    _singleton_lookup_key = stdlib_singleton_key()
 
     def _define(self):
         """
@@ -119,6 +121,8 @@ class TdgGate(SingletonGate):
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
         """Create new Tdg gate."""
         super().__init__("tdg", 1, [], label=label, duration=duration, unit=unit)
+
+    _singleton_lookup_key = stdlib_singleton_key()
 
     def _define(self):
         """

--- a/qiskit/circuit/library/standard_gates/y.py
+++ b/qiskit/circuit/library/standard_gates/y.py
@@ -16,7 +16,7 @@ from math import pi
 from typing import Optional, Union
 
 # pylint: disable=cyclic-import
-from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate
+from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate, stdlib_singleton_key
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit._utils import with_gate_array, with_controlled_gate_array
 
@@ -73,6 +73,8 @@ class YGate(SingletonGate):
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
         """Create new Y gate."""
         super().__init__("y", 1, [], label=label, duration=duration, unit=unit)
+
+    _singleton_lookup_key = stdlib_singleton_key()
 
     def _define(self):
         # pylint: disable=cyclic-import
@@ -194,6 +196,8 @@ class CYGate(SingletonControlledGate):
             duration=duration,
             unit=unit,
         )
+
+    _singleton_lookup_key = stdlib_singleton_key(num_ctrl_qubits=1)
 
     def _define(self):
         """

--- a/qiskit/circuit/library/standard_gates/z.py
+++ b/qiskit/circuit/library/standard_gates/z.py
@@ -18,7 +18,7 @@ from typing import Optional, Union
 import numpy
 
 from qiskit.circuit._utils import with_gate_array, with_controlled_gate_array
-from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate
+from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate, stdlib_singleton_key
 from qiskit.circuit.quantumregister import QuantumRegister
 
 from .p import PhaseGate
@@ -76,6 +76,8 @@ class ZGate(SingletonGate):
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
         """Create new Z gate."""
         super().__init__("z", 1, [], label=label, duration=duration, unit=unit)
+
+    _singleton_lookup_key = stdlib_singleton_key()
 
     def _define(self):
         # pylint: disable=cyclic-import
@@ -180,6 +182,8 @@ class CZGate(SingletonControlledGate):
             unit=unit,
         )
 
+    _singleton_lookup_key = stdlib_singleton_key(num_ctrl_qubits=1)
+
     def _define(self):
         """
         gate cz a,b { h b; cx a,b; h b; }
@@ -264,6 +268,8 @@ class CCZGate(SingletonControlledGate):
             duration=duration,
             unit=unit,
         )
+
+    _singleton_lookup_key = stdlib_singleton_key(num_ctrl_qubits=2)
 
     def _define(self):
         """

--- a/qiskit/circuit/singleton.py
+++ b/qiskit/circuit/singleton.py
@@ -250,7 +250,6 @@ same anyway.
 from __future__ import annotations
 
 import functools
-import typing
 
 from .instruction import Instruction
 from .gate import Gate
@@ -399,9 +398,6 @@ class _SingletonMeta(type(Instruction)):
             # The logic can be extended to have an LRU cache for key requests that are absent,
             # to allow things like parametric gates to have reusable singletons as well.
         return super().__call__(*args, **kwargs)
-
-
-_InstructionT = typing.TypeVar("_InstructionT", bound=Instruction)
 
 
 class _SingletonBase(metaclass=_SingletonMeta):

--- a/qiskit/circuit/singleton.py
+++ b/qiskit/circuit/singleton.py
@@ -196,7 +196,7 @@ We do this in a three-step procedure:
 
 1. Before creating any singletons, we separately define the overrides needed to make an
    :class:`~.circuit.Instruction` and a :class:`.Gate` immutable.  This is
-   ``_SingletonInstructionOverrides`` the other ``_*Overrides``.
+   ``_SingletonInstructionOverrides`` and the other ``_*Overrides`` classes.
 
 2. While we are creating the ``XGate`` type object, we dynamically *also* create a subclass of it
    that has the immutable overrides in its method-resolution order in the correct place. These
@@ -234,16 +234,16 @@ the base class, but still able to call :class:`super`.  It's more convenient to 
 closing over the desired class variable and using the two-argument form of :class:`super`, since the
 zero-argument form does magic introspection based on where its containing function was defined.
 
-Handling multiple singletons requires storing the initialisation arguments in some form, to allow
+Handling multiple singletons requires storing the initialization arguments in some form, to allow
 the :meth:`~.Instruction.to_mutable` method and pickling to be defined.  We do this as a lookup
 dictionary on the singleton *type object*.  This is logically an instance attribute, but because we
 need to dynamically switch in the dynamic `_Singleton` type onto an instance of the base type, that
-gets rather hairy; either we have to require that the base already has an instance dictionary, or we
+gets rather complex; either we have to require that the base already has an instance dictionary, or we
 risk breaking the ``__slots__`` layout during the switch.  Since the singletons have lifetimes that
 last until garbage collection of their base class's type object, we can fake out this instance
 dictionary using a type-object dictionary that maps instance pointers to the data we want to store.
 An alternative would be to build a new type object for each individual singleton that closes over
-(or stores) the initialiser arguments, but type objects are quite heavy and the principle is largely
+(or stores) the initializer arguments, but type objects are quite heavy and the principle is largely
 same anyway.
 """
 

--- a/qiskit/transpiler/passes/optimization/hoare_opt.py
+++ b/qiskit/transpiler/passes/optimization/hoare_opt.py
@@ -214,7 +214,7 @@ class HoareOptimizer(TransformationPass):
             if remove_ctrl:
                 dag.substitute_node_with_dag(node, new_dag)
                 gate = gate.base_gate
-                node.op = gate
+                node.op = gate.to_mutable()
                 node.name = gate.name
                 node.qargs = tuple((ctrlqb + trgtqb)[qi] for qi in qb_idx)
                 _, ctrlvar, trgtqb, trgtvar = self._seperate_ctrl_trgt(node)

--- a/test/python/circuit/test_singleton.py
+++ b/test/python/circuit/test_singleton.py
@@ -20,8 +20,22 @@ Tests for singleton gate behavior
 import copy
 import io
 import pickle
+import sys
+import types
+import unittest.mock
+import uuid
 
-from qiskit.circuit.library import HGate, SXGate, CXGate, CZGate, CSwapGate, CHGate, CCXGate, XGate
+from qiskit.circuit.library import (
+    HGate,
+    SXGate,
+    CXGate,
+    CZGate,
+    CSwapGate,
+    CHGate,
+    CCXGate,
+    XGate,
+    C4XGate,
+)
 from qiskit.circuit import Clbit, QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit.circuit.singleton import SingletonGate, SingletonInstruction
 from qiskit.converters import dag_to_circuit, circuit_to_dag
@@ -326,6 +340,137 @@ class TestSingletonGate(QiskitTestCase):
         self.assertIs(base.base_class, Measure)
         self.assertIs(esp.base_class, ESPMeasure)
 
+    def test_singleton_with_default(self):
+        # Explicitly setting the label to its default.
+        gate = HGate(label=None)
+        self.assertIs(gate, HGate())
+        self.assertIsNot(gate, HGate(label="label"))
+
+    def test_additional_singletons(self):
+        additional_inputs = [
+            ((1,), {}),
+            ((2,), {"label": "x"}),
+        ]
+
+        class Discrete(SingletonGate, additional_singletons=additional_inputs):
+            def __init__(self, n=0, label=None):
+                super().__init__("discrete", 1, [], label=label)
+                self.n = n
+
+            @staticmethod
+            def _singleton_lookup_key(n=0, label=None):  # pylint: disable=arguments-differ
+                # This is an atypical usage - in Qiskit standard gates, the `label` being set
+                # not-None should not generate a singleton, so should return a mutable instance.
+                return (n, label)
+
+        default = Discrete()
+        self.assertIs(default, Discrete())
+        self.assertIs(default, Discrete(0, label=None))
+        self.assertEqual(default.n, 0)
+        self.assertIsNot(default, Discrete(1))
+
+        one = Discrete(1)
+        self.assertIs(one, Discrete(1))
+        self.assertIs(one, Discrete(1, label=None))
+        self.assertEqual(one.n, 1)
+        self.assertIs(one.label, None)
+
+        two = Discrete(2, label="x")
+        self.assertIs(two, Discrete(2, label="x"))
+        self.assertIsNot(two, Discrete(2))
+        self.assertEqual(two.n, 2)
+        self.assertEqual(two.label, "x")
+
+        # This doesn't match any of the defined singletons, and we're checking that it's not
+        # spuriously cached without us asking for it.
+        self.assertIsNot(Discrete(2), Discrete(2))
+
+    def test_additional_singletons_copy(self):
+        additional_inputs = [
+            ((1,), {}),
+            ((2,), {"label": "x"}),
+        ]
+
+        class Discrete(SingletonGate, additional_singletons=additional_inputs):
+            def __init__(self, n=0, label=None):
+                super().__init__("discrete", 1, [], label=label)
+                self.n = n
+
+            @staticmethod
+            def _singleton_lookup_key(n=0, label=None):  # pylint: disable=arguments-differ
+                return (n, label)
+
+        default = Discrete()
+        one = Discrete(1)
+        two = Discrete(2, "x")
+        mutable = Discrete(3)
+
+        self.assertIsNot(default, default.to_mutable())
+        self.assertEqual(default.n, default.to_mutable().n)
+        self.assertIsNot(one, one.to_mutable())
+        self.assertEqual(one.n, one.to_mutable().n)
+        self.assertIsNot(two, two.to_mutable())
+        self.assertEqual(two.n, two.to_mutable().n)
+        self.assertIsNot(mutable, mutable.to_mutable())
+        self.assertEqual(mutable.n, mutable.to_mutable().n)
+
+        # The equality assertions in the middle are sanity checks that nothing got overwritten.
+
+        self.assertIs(default, copy.copy(default))
+        self.assertEqual(default.n, 0)
+        self.assertIs(one, copy.copy(one))
+        self.assertEqual(one.n, 1)
+        self.assertIs(two, copy.copy(two))
+        self.assertEqual(two.n, 2)
+        self.assertIsNot(mutable, copy.copy(mutable))
+
+        self.assertIs(default, copy.deepcopy(default))
+        self.assertEqual(default.n, 0)
+        self.assertIs(one, copy.deepcopy(one))
+        self.assertEqual(one.n, 1)
+        self.assertIs(two, copy.deepcopy(two))
+        self.assertEqual(two.n, 2)
+        self.assertIsNot(mutable, copy.deepcopy(mutable))
+
+    def test_additional_singletons_pickle(self):
+        additional_inputs = [
+            ((1,), {}),
+            ((2,), {"label": "x"}),
+        ]
+
+        class Discrete(SingletonGate, additional_singletons=additional_inputs):
+            def __init__(self, n=0, label=None):
+                super().__init__("discrete", 1, [], label=label)
+                self.n = n
+
+            @staticmethod
+            def _singleton_lookup_key(n=0, label=None):  # pylint: disable=arguments-differ
+                return (n, label)
+
+        # Pickle needs the class to be importable.  We want the class to only be instantiated inside
+        # the test, which means we need a little magic to make it pretend-importable.
+        dummy_module = types.ModuleType("_QISKIT_DUMMY_" + str(uuid.uuid4()).replace("-", "_"))
+        dummy_module.Discrete = Discrete
+        Discrete.__module__ = dummy_module.__name__
+        Discrete.__qualname__ = Discrete.__name__
+
+        default = Discrete()
+        one = Discrete(1)
+        two = Discrete(2, "x")
+        mutable = Discrete(3)
+
+        with unittest.mock.patch.dict(sys.modules, {dummy_module.__name__: dummy_module}):
+            # The singletons in `additional_singletons` are statics; their lifetimes should be tied
+            # to the type object itself, so if we don't delete it, it should be eligible to be
+            # reloaded from and produce the exact instances.
+            self.assertIs(default, pickle.loads(pickle.dumps(default)))
+            self.assertEqual(default.n, 0)
+            self.assertIs(one, pickle.loads(pickle.dumps(one)))
+            self.assertEqual(one.n, 1)
+            self.assertIs(two, pickle.loads(pickle.dumps(two)))
+            self.assertEqual(two.n, 2)
+            self.assertIsNot(mutable, pickle.loads(pickle.dumps(mutable)))
+
 
 class TestSingletonControlledGate(QiskitTestCase):
     """Qiskit SingletonGate tests."""
@@ -415,7 +560,6 @@ class TestSingletonControlledGate(QiskitTestCase):
         self.assertEqual(gate, copied)
         self.assertEqual(copied.label, "special")
         self.assertTrue(copied.mutable)
-        self.assertIsNot(gate.base_gate, copied.base_gate)
         self.assertIsNot(copied, singleton_gate)
         self.assertEqual(singleton_gate, copied)
         self.assertNotEqual(singleton_gate.label, copied.label)
@@ -597,3 +741,22 @@ class TestSingletonControlledGate(QiskitTestCase):
         self.assertTrue(copied.mutable)
         self.assertEqual("my h gate", copied.base_gate.label)
         self.assertEqual("foo", copied.label)
+
+    def test_singleton_with_defaults(self):
+        self.assertIs(CXGate(), CXGate(label=None))
+        self.assertIs(CXGate(), CXGate(duration=None, unit="dt"))
+        self.assertIs(CXGate(), CXGate(_base_label=None))
+        self.assertIs(CXGate(), CXGate(label=None, ctrl_state=None))
+
+    def test_singleton_with_equivalent_ctrl_state(self):
+        self.assertIs(CXGate(), CXGate(ctrl_state=None))
+        self.assertIs(CXGate(), CXGate(ctrl_state=1))
+        self.assertIs(CXGate(), CXGate(label=None, ctrl_state=1))
+        self.assertIs(CXGate(), CXGate(ctrl_state="1"))
+        self.assertIsNot(CXGate(), CXGate(ctrl_state=0))
+        self.assertIsNot(CXGate(), CXGate(ctrl_state="0"))
+
+        self.assertIs(C4XGate(), C4XGate(ctrl_state=None))
+        self.assertIs(C4XGate(), C4XGate(ctrl_state=15))
+        self.assertIs(C4XGate(), C4XGate(ctrl_state="1111"))
+        self.assertIsNot(C4XGate(), C4XGate(ctrl_state=0))


### PR DESCRIPTION
### Summary

This adds overridable logic for singleton classes to define a "key" function, which takes the same arguments as its `__init__` and returns a lookup key that is used as a comparison for returning singletons.  This lets the standard singleton gates easily return the singleton instance even when `label` is explicitly set to the default, such as happens using the idiomatic `QuantumCircuit` methods like `x`.

This keying logic has a simple logical extension to allow more than one singleton to exist for a single base class.  This functionality is not yet used by the Qiskit standard library, but can easily be used to make both closed- and open-controlled versions of gates singletons, or to allow specific hard-coded parameters for (e.g.) `RZGate` singletons.

The decision on which gates to extend this to can be done in follow-up commits later.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

The most notable change here is that idiomatic circuit construction now produces singleton instances.  For example, `QuantumCircuit.x(0)` previously would produce a _mutable_ `XGate` because internally it constructed it as `XGate(label=None)` due to a default argument to `label` in the `x` method.  This commit makes explicit defaults correctly resolve to the same singleton instance.  As a side effect, this causes the `base_gate` in controlled gate subclasses to become a singleton if (as default) the `_base_label` is not overridden.

The key machinery logically immediately allows multiple singletons to exist for any given class, as they can now be simply distinguished.  I didn't implement that in this commit for any of the standard-library operations, but in principle this allows `SingletonControlledGate` subclasses to make both open- and closed-control states singletons, and lays the groundwork for parametric gates like `RZGate` to have special parameter values that are singletons (though these will need an extension to the standard-library gate key function).

Using an extension to the timing script from #11014:
```python
from qiskit.circuit import QuantumCircuit
from qiskit.circuit.library import XGate, CXGate

immutable = QuantumCircuit(127)
for q in immutable.qubits:
    for _ in [None]*1_000:
        immutable.append(XGate(), [q], [])
for (q1, q2) in zip(immutable.qubits[:-1], immutable.qubits[1:]):
    for _ in [None]*100:
         immutable.append(CXGate(), [q1, q2], [])

idiomatic = QuantumCircuit(127)
for q in idiomatic.qubits:
    for _ in [None]*1_000:
        idiomatic.x(q)
for (q1, q2) in zip(idiomatic.qubits[:-1], idiomatic.qubits[1:]):
    for _ in [None]*100:
         idiomatic.cx(q1, q2)


%timeit XGate()
%timeit XGate(label="x")
%timeit CXGate()
%timeit CXGate(ctrl_state=1)
%timeit CXGate(label="x")
%timeit immutable.copy()
%timeit idiomatic.copy()
```

Note that before this commit, `idiomatic` contained only mutable gate objects.  The new timings compared to `main` at the parent b18faa3 are:

|   | main | PR |
|:-:|------|----|
| X() /µs        | 0.121(1) | 0.122(1) |
| X(label) /µs   | 1.89(1)  | 2.10(4)  |
| CX() /µs       | 0.120(1) | 0.123(5) |
| CX(ctrl) /µs   | 9.4(1)   | 0.895(6) |
| CX(label) /µs  | 9.3(1)   | 5.55(6)  |
| copy /ms       | 111(1)   | 113(1)   |
| copy idiom /ms | 504(10)  | 115(1)   |

To explain timing differences:
- `X(label="x")` is ~10% slower because of the additional indirection through the key lookup.
- `CX(ctrl_state=1)` is faster now because that `ctrl_state` is a default value.  It's not quite as fast as `CX()` because the zero-arguments case gets a fast path so that the construction idioms for high-performance inner loops are as fast as possible (no key lookup).
- `CX(label)` is faster despite _not_ returning a default because the `.base_gate` object of the `CXGate` now _does_ get generated as a singleton, whereas before it didn't even though it was eligible to be because it constructs `XGate(label=_base_label)` where `_base_label` defaults to `None`.
- The "idiomatic" circuit copy time now matches the "fast-path" copy time because the idiomatic one now creates singleton instances.