### PR TITLE
Fixed typo in transpiler.py

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -522,7 +522,7 @@ def _parse_instruction_durations(backend, inst_durations, dt, circuit):
     """Create a list of ``InstructionDuration``s. If ``inst_durations`` is provided,
     the backend will be ignored, otherwise, the durations will be populated from the
     backend. If any circuits have gate calibrations, those calibration durations would
-    take precedence over backend durations, but be superceded by ``inst_duration``s.
+    take precedence over backend durations, but be superseded by ``inst_duration``s.
     """
     if not inst_durations:
         backend_version = getattr(backend, "version", 0)


### PR DESCRIPTION
superceded -> superseded