### PR TITLE
Deprecate dense Operator Estimator observables

### DIFF
--- a/qiskit/primitives/utils.py
+++ b/qiskit/primitives/utils.py
@@ -59,6 +59,14 @@ def init_observable(observable: BaseOperator | str) -> SparsePauliOp:
     if isinstance(observable, SparsePauliOp):
         return observable
     elif isinstance(observable, BaseOperator) and not isinstance(observable, BasePauli):
+        warnings.warn(
+            "Implicit conversion from a BaseOperator to a SparsePauliOp in estimator"
+            " observable arguments is deprecated as of Qiskit 0.46 and will be"
+            " in Qiskit 1.0. You should explicitly convert to a SparsePauli op using"
+            " `SparsePauliOp.from_operator(op)` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return SparsePauliOp.from_operator(observable)
     else:
         if isinstance(observable, PauliList):

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -266,10 +266,28 @@ class TestEstimator(QiskitTestCase):
                 [0.1809312, 0.0, 0.0, -1.06365335],
             ]
         )
+        obs = SparsePauliOp.from_operator(matrix)
         est = Estimator()
-        result = est.run([circuit], [matrix]).result()
+        result = est.run([circuit], [obs]).result()
         self.assertIsInstance(result, EstimatorResult)
         np.testing.assert_allclose(result.values, [-1.284366511861733])
+
+    def test_run_with_operator_deprecated(self):
+        """test for run with Operator as an observable"""
+        circuit = self.ansatz.assign_parameters([0, 1, 1, 2, 3, 5])
+        matrix = Operator(
+            [
+                [-1.06365335, 0.0, 0.0, 0.1809312],
+                [0.0, -1.83696799, 0.1809312, 0.0],
+                [0.0, 0.1809312, -0.24521829, 0.0],
+                [0.1809312, 0.0, 0.0, -1.06365335],
+            ]
+        )
+        est = Estimator()
+        with self.assertRaises(DeprecationWarning):
+            result = est.run([circuit], [matrix]).result()
+            self.assertIsInstance(result, EstimatorResult)
+            np.testing.assert_allclose(result.values, [-1.284366511861733])
 
     def test_run_with_shots_option(self):
         """test with shots option."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This deprecates passing Operator and other dense `BaseOperator` subclasses as observables in `Estimator.run`. These were implicitly converted to SparsePauliOps by the Estimator, so now should be explicitly converted to `SparsePauliOps` by the user instead.

### Details and comments


