### PR TITLE
fixed issue 10920 by adding list support to the preset pass manager for

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/__init__.py
+++ b/qiskit/transpiler/preset_passmanagers/__init__.py
@@ -61,6 +61,7 @@ import warnings
 
 from qiskit.transpiler.passmanager_config import PassManagerConfig
 from qiskit.transpiler.target import target_to_backend_properties
+from qiskit.transpiler import CouplingMap
 
 from .level0 import level_0_pass_manager
 from .level1 import level_1_pass_manager
@@ -130,7 +131,7 @@ def generate_preset_pass_manager(
             circuit, transpiler attaches the custom gate definition to the circuit.
             This enables one to flexibly override the low-level instruction
             implementation.
-        coupling_map (CouplingMap): Directed graph represented a coupling
+        coupling_map (CouplingMap or list): Directed graph represented a coupling
             map.
         instruction_durations (InstructionDurations): Dictionary of duration
             (in dt) for each instruction.
@@ -212,6 +213,13 @@ def generate_preset_pass_manager(
             DeprecationWarning,
             stacklevel=2,
         )
+
+    if (
+        coupling_map
+        and isinstance(coupling_map, list)
+        and all(isinstance(sublist, list) for sublist in coupling_map)
+    ):
+        coupling_map = CouplingMap(coupling_map)
 
     if target is not None:
         if coupling_map is None:

--- a/qiskit/transpiler/preset_passmanagers/__init__.py
+++ b/qiskit/transpiler/preset_passmanagers/__init__.py
@@ -59,6 +59,7 @@ Stage Generator Functions
 
 from qiskit.transpiler.passmanager_config import PassManagerConfig
 from qiskit.transpiler.target import target_to_backend_properties
+from qiskit.transpiler import CouplingMap
 
 from .level0 import level_0_pass_manager
 from .level1 import level_1_pass_manager
@@ -128,7 +129,7 @@ def generate_preset_pass_manager(
             circuit, transpiler attaches the custom gate definition to the circuit.
             This enables one to flexibly override the low-level instruction
             implementation.
-        coupling_map (CouplingMap): Directed graph represented a coupling
+        coupling_map (CouplingMap or list): Directed graph represented a coupling
             map.
         instruction_durations (InstructionDurations): Dictionary of duration
             (in dt) for each instruction.
@@ -202,6 +203,13 @@ def generate_preset_pass_manager(
     Raises:
         ValueError: if an invalid value for ``optimization_level`` is passed in.
     """
+    if (
+        coupling_map
+        and isinstance(coupling_map, list)
+        and all(isinstance(sublist, list) for sublist in coupling_map)
+    ):
+        coupling_map = CouplingMap(coupling_map)
+
     if target is not None:
         if coupling_map is None:
             coupling_map = target.build_coupling_map()

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -1256,7 +1256,7 @@ class TestOptimizationOnSize(QiskitTestCase):
 
 
 @ddt
-class TestGeenratePresetPassManagers(QiskitTestCase):
+class TestGeneratePresetPassManagers(QiskitTestCase):
     """Test generate_preset_pass_manager function."""
 
     @data(0, 1, 2, 3)
@@ -1428,6 +1428,37 @@ class TestGeenratePresetPassManagers(QiskitTestCase):
             for y in x["passes"]
         ]
         self.assertIn("RemoveResetInZeroState", post_translation_pass_list)
+
+    def test_generate_preset_pass_manager_with_list_coupling_map(self):
+        """Test that generate_preset_pass_manager can handle list-based coupling_map."""
+
+        # Define the coupling map as a list
+        coupling_map_list = [[0, 1]]
+        coupling_map_object = CouplingMap(coupling_map_list)
+
+        # Circuit that doesn't fit in the coupling map
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.cx(1, 0)
+        qc.measure_all()
+
+        pm_list = generate_preset_pass_manager(optimization_level=0, coupling_map=coupling_map_list)
+        pm_object = generate_preset_pass_manager(
+            optimization_level=0, coupling_map=coupling_map_object
+        )
+
+        transpiled_circuit_list = pm_list.run(qc)
+        transpiled_circuit_object = pm_object.run(qc)
+
+        # Convert the transpiled circuits to DAGs to compare the states
+        dag_list = circuit_to_dag(transpiled_circuit_list)
+        dag_object = circuit_to_dag(transpiled_circuit_object)
+
+        # Assert that the circuits produced by both pass managers are the same and that both transpiled circuits fit
+        self.assertIsInstance(pm_list, PassManager)
+        self.assertIsInstance(pm_object, PassManager)
+        self.assertEqual(dag_list, dag_object)
 
 
 @ddt

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -1272,7 +1272,7 @@ class TestOptimizationOnSize(QiskitTestCase):
 
 
 @ddt
-class TestGeenratePresetPassManagers(QiskitTestCase):
+class TestGeneratePresetPassManagers(QiskitTestCase):
     """Test generate_preset_pass_manager function."""
 
     @data(0, 1, 2, 3)
@@ -1444,6 +1444,39 @@ class TestGeenratePresetPassManagers(QiskitTestCase):
             for y in x["passes"]
         ]
         self.assertIn("RemoveResetInZeroState", post_translation_pass_list)
+
+    def test_generate_preset_pass_manager_with_list_coupling_map(self):
+        """Test that generate_preset_pass_manager can handle list-based coupling_map."""
+
+        # Define the coupling map as a list
+        coupling_map_list = [[0, 1]]
+        coupling_map_object = CouplingMap(coupling_map_list)
+
+        # Circuit that doesn't fit in the coupling map
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.cx(1, 0)
+        qc.measure_all()
+
+        pm_list = generate_preset_pass_manager(optimization_level=0, coupling_map=coupling_map_list)
+        pm_object = generate_preset_pass_manager(
+            optimization_level=0, coupling_map=coupling_map_object
+        )
+
+        transpiled_circuit_list = pm_list.run(qc)
+        transpiled_circuit_object = pm_object.run(qc)
+
+        # Convert the transpiled circuits to DAGs to compare the states
+        dag_list = circuit_to_dag(transpiled_circuit_list)
+        dag_object = circuit_to_dag(transpiled_circuit_object)
+
+        # Check if both are instances of PassManager
+        self.assertIsInstance(pm_list, PassManager)
+        self.assertIsInstance(pm_object, PassManager)
+
+        # Ensure that the coupling map is the same
+        self.assertEqual(dag_list, dag_object)
 
 
 @ddt


### PR DESCRIPTION
coupling map

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #10920 

### Details and comments

The preset pass manager previously only allowed the user to provide a coupling map as an object, not as a list. Since the creation of a coupling map is typically a straightforward process, it makes sense to allow users to directly input the list into the preset pass manager generator. This is what this PR is about.

Example : 
pm =  generate_preset_pass_manager(basis_gates = ['cz', 'sx', 'rz'],  coupling_map =[[0,1], [1,2]], optimization_level=3)


