### PR TITLE
Fix calling backend.name() for backendV2

### DIFF
--- a/qiskit/utils/backend_utils.py
+++ b/qiskit/utils/backend_utils.py
@@ -181,6 +181,7 @@ def is_statevector_backend(backend):
     Returns:
         bool: True is statevector
     """
+    backend_interface_version = _get_backend_interface_version(backend)
     if has_aer():
         from qiskit.providers.aer.backends import AerSimulator, StatevectorSimulator
 
@@ -194,7 +195,6 @@ def is_statevector_backend(backend):
                 return True
     if backend is None:
         return False
-    backend_interface_version = _get_backend_interface_version(backend)
     if backend_interface_version <= 1:
         return backend.name().startswith("statevector")
     else:

--- a/qiskit/utils/backend_utils.py
+++ b/qiskit/utils/backend_utils.py
@@ -186,8 +186,12 @@ def is_statevector_backend(backend):
 
         if isinstance(backend, StatevectorSimulator):
             return True
-        if isinstance(backend, AerSimulator) and "aer_simulator_statevector" in backend.name():
-            return True
+        if backend_interface_version <= 1:
+            if isinstance(backend, AerSimulator) and "aer_simulator_statevector" in backend.name():
+                return True
+        else:
+            if isinstance(backend, AerSimulator) and "aer_simulator_statevector" in backend.name:
+                return True
     if backend is None:
         return False
     backend_interface_version = _get_backend_interface_version(backend)

--- a/qiskit/utils/backend_utils.py
+++ b/qiskit/utils/backend_utils.py
@@ -181,6 +181,8 @@ def is_statevector_backend(backend):
     Returns:
         bool: True is statevector
     """
+    if backend is None:
+        return False
     backend_interface_version = _get_backend_interface_version(backend)
     if has_aer():
         from qiskit.providers.aer.backends import AerSimulator, StatevectorSimulator
@@ -193,8 +195,6 @@ def is_statevector_backend(backend):
         else:
             if isinstance(backend, AerSimulator) and "aer_simulator_statevector" in backend.name:
                 return True
-    if backend is None:
-        return False
     if backend_interface_version <= 1:
         return backend.name().startswith("statevector")
     else:

--- a/qiskit/utils/backend_utils.py
+++ b/qiskit/utils/backend_utils.py
@@ -189,11 +189,12 @@ def is_statevector_backend(backend):
 
         if isinstance(backend, StatevectorSimulator):
             return True
-        if backend_interface_version <= 1:
-            if isinstance(backend, AerSimulator) and "aer_simulator_statevector" in backend.name():
-                return True
-        else:
-            if isinstance(backend, AerSimulator) and "aer_simulator_statevector" in backend.name:
+        if isinstance(backend, AerSimulator):
+            if backend_interface_version <= 1:
+                name = backend.name()
+            else:
+                name = backend.name
+            if "aer_simulator_statevector" in name:
                 return True
     if backend_interface_version <= 1:
         return backend.name().startswith("statevector")

--- a/releasenotes/notes/fix_backend_name-e84661707058b529.yaml
+++ b/releasenotes/notes/fix_backend_name-e84661707058b529.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    In utils/backend_utils.py there is name() function call without checking
+    backend version. This fix adds check of backend version and get property
+    name for V2

--- a/releasenotes/notes/fix_backend_name-e84661707058b529.yaml
+++ b/releasenotes/notes/fix_backend_name-e84661707058b529.yaml
@@ -1,6 +1,7 @@
 ---
 fixes:
   - |
-    In utils/backend_utils.py there is name() function call without checking
-    backend version. This fix adds check of backend version and get property
-    name for V2
+    Fixed an issue in the :class:`.QuantumInstance` class where it was assuming
+    all ``AerSimulator`` backends were always :class:`.BackendV1`. This would cause
+    combatibility issues with the 0.13.0 release of ``qiskit-aer`` which is starting to
+    use :class:`.BackendV2` for `AerSimulator`` backends.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
In utils/backend_utils.py we have to check backend's version if we call name() function for V1 and get property name for V2, but calling name() function without checking version


### Details and comments
This issue causes Neko test error in Qiskit Aer if we upgrade backend from V1 to V2 and we can not release Qiskit Aer without this fix.


