### PR TITLE
Bump version in toplevel setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ csp_requirements = ["python-constraint>=1.4"]
 
 setup(
     name="qiskit-terra",
-    version="0.45.0rc1",
+    version="1.0.0",
     description="Software for developing quantum computing programs",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Pull request #11059 bumped the version on `main` to `1.0.0`, but it missed the version in the toplevel `setup.py`.  This PR fixes that oversight.



### Details and comments

In the current state, the `qiskit` and `qiskit-terra` python packages cannot be simultaneously installed from `main`.  This led to a CI failure for us in the circuit knitting toolbox, which can be seen here: https://github.com/Qiskit-Extensions/circuit-knitting-toolbox/actions/runs/6582190865/job/17883338486


