### PR TITLE
Relax tolerance of `UnitaryOverlap` tests

### DIFF
--- a/test/python/circuit/library/test_overlap.py
+++ b/test/python/circuit/library/test_overlap.py
@@ -30,7 +30,7 @@ class TestUnitaryOverlap(QiskitTestCase):
         unitary.assign_parameters(np.random.random(size=unitary.num_parameters), inplace=True)
 
         overlap = UnitaryOverlap(unitary, unitary)
-        self.assertTrue(abs(Statevector.from_instruction(overlap)[0] - 1) < 1e-15)
+        self.assertLess(abs(Statevector.from_instruction(overlap)[0] - 1), 1e-12)
 
     def test_parameterized_identity(self):
         """Test identity is returned"""
@@ -40,7 +40,7 @@ class TestUnitaryOverlap(QiskitTestCase):
         rands = np.random.random(size=unitary.num_parameters)
         double_rands = np.hstack((rands, rands))
         overlap.assign_parameters(double_rands, inplace=True)
-        self.assertTrue(abs(Statevector.from_instruction(overlap)[0] - 1) < 1e-15)
+        self.assertLess(abs(Statevector.from_instruction(overlap)[0] - 1), 1e-12)
 
     def test_two_parameterized_inputs(self):
         """Test two parameterized inputs"""


### PR DESCRIPTION
### Summary

The failure rate for the parametric identity tests was about 0.2%, which at our CI scale corresponds to approximately one spurious failure every two days.  The alternative to this is to fix the random seed of the test, but similar to other `quantum_info` tests, we would like some degree of extended coverage.  Lifting the tolerance by three orders of magnitude at this circuit size should ensure a zero false-positive rate.

This also changes the test to actually display the failure tolerance, so it's easier to tell from a CI run if a failure was real.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


