### PR TITLE
Emit a descriptive error when the QPY version is too new

### DIFF
--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -231,6 +231,12 @@ def load(
     version = struct.unpack("!6sB", file_obj.read(7))[1]
     file_obj.seek(0)
 
+    if version > common.QPY_VERSION:
+        raise QiskitError(
+            f"The QPY format version being read, {version}, isn't supported by "
+            "this Qiskit version. Please upgrade your version of Qiskit to load this QPY payload"
+        )
+
     if version < 10:
         data = formats.FILE_HEADER._make(
             struct.unpack(

--- a/releasenotes/notes/fix-error-message-qpy-version-cf0763da22ce2224.yaml
+++ b/releasenotes/notes/fix-error-message-qpy-version-cf0763da22ce2224.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed an issue with :func:`.qpy.load` when attempting to load a QPY format
+    version that is not supported by this version of Qiskit it will now display
+    a descriptive error message. Previously, it would raise an internal error
+    because of the incompatibility between the formats which was difficult to
+    debug. If the QPY format verison is not supported that indicates the Qiskit
+    version will need to be upgraded to read the QPY payload.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the qpy load() function to ensure we are raising a descriptive error message when a user attempts to load a qpy version that's not supported by this version of qiskit. Previously it would fail but with a hard to understand internal error message which was just confusing and not helpful. For example, when trying to load a QPY version 10 payload with qiskit 0.25.2 (which only supported up to version 9) it would raise an error message like:

```
Invalid payload format data kind 'b'p''."
```

which doesn't tell you anything meaningful unless you are intimately familiar with the QPY file format and how the load() function works. With this commit it now checks if the version number is supported immediately and if it's too new it will raise an error message that says exactly that. So in the above scenario instead of that error message it will say:

```
The QPY format version being read, 10, isn't supported by this Qiskit
version. Please upgrade your version of Qiskit to load this QPY payload.
```

### Details and comments