### PR TITLE
Improved Documentation and Error-Signaling of VF2PostLayout

### DIFF
--- a/qiskit/transpiler/passes/layout/vf2_post_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_post_layout.py
@@ -35,6 +35,7 @@ class VF2PostLayoutStopReason(Enum):
     """Stop reasons for VF2PostLayout pass."""
 
     SOLUTION_FOUND = "solution found"
+    NO_BETTER_SOLUTION_FOUND = "no better solution found"
     NO_SOLUTION_FOUND = "nonexistent solution"
     MORE_THAN_2Q = ">2q gates in basis"
 
@@ -66,15 +67,16 @@ class VF2PostLayout(AnalysisPass):
 
     If a solution is found that means there is a lower error layout available for the
     circuit. If a solution is found the layout will be set in the property set as
-    ``property_set['post_layout']``. However, if no solution is found, no
+    ``property_set['post_layout']``. However, if no solution or no better solution is found, no
     ``property_set['post_layout']`` is set. The stopping reason is
     set in ``property_set['VF2PostLayout_stop_reason']`` in all the cases and will be
     one of the values enumerated in ``VF2PostLayoutStopReason`` which has the
     following values:
 
         * ``"solution found"``: If a solution was found.
+        * ``"no better solution found"``: If the initial layout of the circuit is the best solution.
         * ``"nonexistent solution"``: If no solution was found.
-        * ``">2q gates in basis"``: If VF2PostLayout can't work with basis
+        * ``">2q gates in basis"``: If VF2PostLayout can't work with the basis of the circuit.
 
     By default this pass will construct a heuristic scoring map based on the
     the error rates in the provided ``target`` (or ``properties`` if ``target``
@@ -339,7 +341,10 @@ class VF2PostLayout(AnalysisPass):
                 )
                 break
         if chosen_layout is None:
-            stop_reason = VF2PostLayoutStopReason.NO_SOLUTION_FOUND
+            if initial_layout is not None:
+                stop_reason = VF2PostLayoutStopReason.NO_BETTER_SOLUTION_FOUND
+            else:
+                stop_reason = VF2PostLayoutStopReason.NO_SOLUTION_FOUND
         else:
             chosen_layout = vf2_utils.map_free_qubits(
                 free_nodes,

--- a/qiskit/transpiler/passes/layout/vf2_post_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_post_layout.py
@@ -52,7 +52,7 @@ def _target_match(node_a, node_b):
 
 
 class VF2PostLayout(AnalysisPass):
-    """A pass for choosing a Layout after transpilation of a circuit onto a
+    """A pass for improving an existing Layout after transpilation of a circuit onto a
     Coupling graph, as a subgraph isomorphism problem, solved by VF2++.
 
     Unlike the :class:`~.VF2Layout` transpiler pass which is designed to find an

--- a/releasenotes/notes/vf2postlayout-no-better-solution-eb5ced3c8a60ea23.yaml
+++ b/releasenotes/notes/vf2postlayout-no-better-solution-eb5ced3c8a60ea23.yaml
@@ -1,6 +1,7 @@
 ---
 features:
   - |
-    VF2PostLayout no distinguishes between 'no solution' and 'no better solution' when determining a
-    Layout for a given quantum circuit. 'no better solution' is set when the initial layout of a quantum
-    circuit is also the optimal one, i.e. incurs the least cost in terms of error rates.
+    :class:`.VF2PostLayout` now distinguishes between 'no solution' and 'no better solution' when
+    determining a :class:`.Layout` for a given quantum circuit. 'no better solution' is set when the
+    initial layout of a quantum circuit is also the optimal one, i.e. incurs the least cost in terms of
+    error rates.

--- a/releasenotes/notes/vf2postlayout-no-better-solution-eb5ced3c8a60ea23.yaml
+++ b/releasenotes/notes/vf2postlayout-no-better-solution-eb5ced3c8a60ea23.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    VF2PostLayout no distinguishes between 'no solution' and 'no better solution' when determining a
+    Layout for a given quantum circuit. 'no better solution' is set when the initial layout of a quantum
+    circuit is also the optimal one, i.e. incurs the least cost in terms of error rates.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
Fixes #11089 as discussed with @mtreinish  

### Details and comments

VF2PostLayout does not return a solution when presented with an already ideal initial layout for a quantum circuit. This PR extends the VF2PostLayout pass by a 'no better solution found' error code for these situations and changes the documentation accordingly.

