### PR TITLE
Fix calling backend.name() for backendV2 (#11065) (#11076)

### DIFF
--- a/qiskit/utils/backend_utils.py
+++ b/qiskit/utils/backend_utils.py
@@ -181,16 +181,21 @@ def is_statevector_backend(backend):
     Returns:
         bool: True is statevector
     """
+    if backend is None:
+        return False
+    backend_interface_version = _get_backend_interface_version(backend)
     if has_aer():
         from qiskit.providers.aer.backends import AerSimulator, StatevectorSimulator
 
         if isinstance(backend, StatevectorSimulator):
             return True
-        if isinstance(backend, AerSimulator) and "aer_simulator_statevector" in backend.name():
-            return True
-    if backend is None:
-        return False
-    backend_interface_version = _get_backend_interface_version(backend)
+        if isinstance(backend, AerSimulator):
+            if backend_interface_version <= 1:
+                name = backend.name()
+            else:
+                name = backend.name
+            if "aer_simulator_statevector" in name:
+                return True
     if backend_interface_version <= 1:
         return backend.name().startswith("statevector")
     else:

--- a/releasenotes/notes/fix_backend_name-e84661707058b529.yaml
+++ b/releasenotes/notes/fix_backend_name-e84661707058b529.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed an issue in the :class:`.QuantumInstance` class where it was assuming
+    all ``AerSimulator`` backends were always :class:`.BackendV1`. This would cause
+    combatibility issues with the 0.13.0 release of ``qiskit-aer`` which is starting to
+    use :class:`.BackendV2` for `AerSimulator`` backends.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

* add check for backend version to get backend name

* move backend_interface_version

* check backend is None before get version

* Update qiskit/utils/backend_utils.py

Co-authored-by: Matthew Treinish <mtreinish@kortar.org>

* Update releasenotes/notes/fix_backend_name-e84661707058b529.yaml

Co-authored-by: Matthew Treinish <mtreinish@kortar.org>

### Details and comments

Backported from #11076 

Co-authored-by: Matthew Treinish <mtreinish@kortar.org>
(cherry picked from commit d781dcc09b0c19098de35da56c15b2602e2e0385)

Co-authored-by: Jun Doi <doichan@jp.ibm.com>
(cherry picked from commit 2f76ef0de9bf9004db2a2560e5153fb394d33e19)