### PR TITLE
Emit a descriptive error when the QPY version is too new

### DIFF
--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -225,6 +225,11 @@ def load(
             file_obj.read(formats.FILE_HEADER_SIZE),
         )
     )
+    if data.version > common.QPY_VERSION:
+        raise QiskitError(
+            f"The QPY format version being read, {data.version}, isn't supported by "
+            "this Qiskit version. Please upgrade your version of Qiskit to load this QPY payload"
+        )
     if data.preface.decode(common.ENCODE) != "QISKIT":
         raise QiskitError("Input file is not a valid QPY file")
     version_match = VERSION_PATTERN_REGEX.search(__version__)

--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -225,9 +225,9 @@ def load(
             file_obj.read(formats.FILE_HEADER_SIZE),
         )
     )
-    if data.version > common.QPY_VERSION:
+    if data.qpy_version > common.QPY_VERSION:
         raise QiskitError(
-            f"The QPY format version being read, {data.version}, isn't supported by "
+            f"The QPY format version being read, {data.qpy_version}, isn't supported by "
             "this Qiskit version. Please upgrade your version of Qiskit to load this QPY payload"
         )
     if data.preface.decode(common.ENCODE) != "QISKIT":

--- a/releasenotes/notes/fix-error-message-qpy-version-cf0763da22ce2224.yaml
+++ b/releasenotes/notes/fix-error-message-qpy-version-cf0763da22ce2224.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed an issue with :func:`.qpy.load` when attempting to load a QPY format
+    version that is not supported by this version of Qiskit it will now display
+    a descriptive error message. Previously, it would raise an internal error
+    because of the incompatibility between the formats which was difficult to
+    debug. If the QPY format verison is not supported that indicates the Qiskit
+    version will need to be upgraded to read the QPY payload.

--- a/test/qpy_compat/process_version.sh
+++ b/test/qpy_compat/process_version.sh
@@ -18,7 +18,7 @@ version=$1
 parts=( ${version//./ } )
 if [[ ${parts[1]} -lt 18 ]] ; then
     exit 0
-elif [[[[ ${parts[1]} -gt 25 ]] ; then
+elif [[ ${parts[1]} -gt 25 ]] ; then
     exit 0
 fi
 

--- a/test/qpy_compat/process_version.sh
+++ b/test/qpy_compat/process_version.sh
@@ -18,6 +18,8 @@ version=$1
 parts=( ${version//./ } )
 if [[ ${parts[1]} -lt 18 ]] ; then
     exit 0
+elif [[[[ ${parts[1]} -gt 25 ]] ; then
+    exit 0
 fi
 
 if [[ ! -d qpy_$version ]] ; then


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the qpy load() function to ensure we are raising a descriptive error message when a user attempts to load a qpy version that's not supported by this version of qiskit. Previously it would fail but with a hard to understand internal error message which was just confusing and not helpful. For example, when trying to load a QPY version 10 payload (the version used by Qiskit 0.45.x) with qiskit-terra 0.25.2 (which only supported up to version 9) it would raise an error message like:

```
Invalid payload format data kind 'b'p''."
```

which doesn't tell you anything meaningful unless you are intimately familiar with the QPY file format and how the load() function works. With this commit it now checks if the version number is supported immediately and if it's too new it will raise an error message that says exactly that. So in the above scenario instead of that error message it will say:

```
The QPY format version being read, 10, isn't supported by this Qiskit
version. Please upgrade your version of Qiskit to load this QPY payload.
```

In addition to fix CI on the stable/0.25 branch this commit puts a hard cap on the versions we test backwards compatibility with. Previously the script ran with all tagged releases of Qiskit, but with the recent release of the 0.45.0rc1 tag we no longer can do that. The QPY format emitted by 0.45.0rc1 is not something that the 0.25.x release series can read.

### Details and comments