### PR TITLE
Add `ParameterExpression.numeric` to cast to number

### DIFF
--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -507,7 +507,7 @@ class ParameterExpression:
         when they are involved.  If you want to assert that all floating-point calculations *were*
         carried out at infinite precision (i.e. :class:`float` could represent every intermediate
         value exactly), you can use :meth:`float.is_integer` to check if the return float represents
-        and integer and cast it using :class:`int` if so.  This would be an unusual pattern;
+        an integer and cast it using :class:`int` if so.  This would be an unusual pattern;
         typically one requires this by only ever using explicitly :class:`~numbers.Rational` objects
         while working with symbolic expressions.
 
@@ -524,7 +524,7 @@ class ParameterExpression:
         """
         if self._parameter_symbols:
             raise TypeError(
-                f"expression with unbound parameters '{self.parameters}' is not numeric"
+                f"Expression with unbound parameters '{self.parameters}' is not numeric"
             )
         if self._symbol_expr.is_integer:
             # Integer evaluation is reliable, as far as we know.

--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -495,6 +495,52 @@ class ParameterExpression:
             return False
         return symbol_expr.is_real
 
+    def numeric(self) -> int | float | complex:
+        """Return a Python number representing this object, using the most restrictive of
+        :class:`int`, :class:`float` and :class:`complex` that is valid for this object.
+
+        In general, an :class:`int` is only returned if the expression only involved symbolic
+        integers.  If floating-point values were used during the evaluation, the return value will
+        be a :class:`float` regardless of whether the represented value is an integer.  This is
+        because floating-point values "infect" symbolic computations by their inexact nature, and
+        symbolic libraries will use inexact floating-point semantics not exact real-number semantics
+        when they are involved.  If you want to assert that all floating-point calculations *were*
+        carried out at infinite precision (i.e. :class:`float` could represent every intermediate
+        value exactly), you can use :meth:`float.is_integer` to check if the return float represents
+        and integer and cast it using :class:`int` if so.  This would be an unusual pattern;
+        typically one requires this by only ever using explicitly :class:`~numbers.Rational` objects
+        while working with symbolic expressions.
+
+        This is more reliable and performant than using :meth:`is_real` followed by calling
+        :class:`float` or :class:`complex`, as in some cases :meth:`is_real` needs to force a
+        floating-point evaluation to determine an accurate result to work around bugs in the
+        upstream symbolic libraries.
+
+        Returns:
+            A Python number representing the object.
+
+        Raises:
+            TypeError: if there are unbound parameters.
+        """
+        if self._parameter_symbols:
+            raise TypeError(
+                f"expression with unbound parameters '{self.parameters}' is not numeric"
+            )
+        if self._symbol_expr.is_integer:
+            # Integer evaluation is reliable, as far as we know.
+            return int(self._symbol_expr)
+        # We've come across several ways in which symengine's general-purpose evaluators
+        # introduce spurious imaginary components can get involved in the output.  The most
+        # reliable strategy "try it and see" while forcing real floating-point evaluation.
+        try:
+            real_expr = self._symbol_expr.evalf(real=True)
+        except RuntimeError:
+            # Symengine returns `complex` if any imaginary floating-point enters at all, even if
+            # the result is zero.  The best we can do is detect that and decay to a float.
+            out = complex(self._symbol_expr)
+            return out.real if out.imag == 0.0 else out
+        return float(real_expr)
+
     def sympify(self):
         """Return symbolic expression as a raw Sympy or Symengine object.
 

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3124,7 +3124,7 @@ class QuantumCircuit:
                 if not parameter.parameters:
                     parameter = parameter.numeric()
                     if isinstance(parameter, complex):
-                        raise TypeError(f"calibration cannot use complex number: '{parameter}'")
+                        raise TypeError(f"Calibration cannot use complex number: '{parameter}'")
                 new_parameters[i] = parameter
                 modified = True
             if modified:

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3081,15 +3081,7 @@ class QuantumCircuit:
                             target._parameter_table[parameter] = ParameterReferences(())
                         target._parameter_table[parameter].add((operation, index))
                     if not new_parameter.parameters:
-                        if new_parameter.is_real():
-                            new_parameter = (
-                                int(new_parameter)
-                                if new_parameter._symbol_expr.is_integer
-                                else float(new_parameter)
-                            )
-                        else:
-                            new_parameter = complex(new_parameter)
-                        new_parameter = operation.validate_parameter(new_parameter)
+                        new_parameter = operation.validate_parameter(new_parameter.numeric())
                 elif isinstance(assignee, QuantumCircuit):
                     new_parameter = assignee.assign_parameters(
                         {to_bind: bound_value}, inplace=False, flat_input=True
@@ -3130,9 +3122,9 @@ class QuantumCircuit:
                 for to_bind in contained:
                     parameter = parameter.assign(to_bind, parameter_binds.mapping[to_bind])
                 if not parameter.parameters:
-                    parameter = (
-                        int(parameter) if parameter._symbol_expr.is_integer else float(parameter)
-                    )
+                    parameter = parameter.numeric()
+                    if isinstance(parameter, complex):
+                        raise TypeError(f"calibration cannot use complex number: '{parameter}'")
                 new_parameters[i] = parameter
                 modified = True
             if modified:

--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -319,16 +319,8 @@ class BasisTranslator(TransformationPass):
                                     new_value = new_value.assign(*x)
                             else:
                                 new_value = param.bind(bind_dict)
-                            # cast from ParameterExpression to number, if no parameters left
                             if not new_value.parameters:
-                                if new_value.is_real():
-                                    new_value = (
-                                        int(new_value)
-                                        if new_value._symbol_expr.is_integer
-                                        else float(new_value)
-                                    )
-                                else:
-                                    new_value = complex(new_value)
+                                new_value = new_value.numeric()
                             new_params.append(new_value)
                     new_op.params = new_params
                 else:
@@ -345,26 +337,9 @@ class BasisTranslator(TransformationPass):
                 else:
                     new_phase = old_phase.bind(bind_dict)
                 if not new_phase.parameters:
-                    if new_phase.is_real():
-                        new_phase = (
-                            int(new_phase)
-                            if new_phase._symbol_expr.is_integer
-                            else float(new_phase)
-                        )
-                    else:
-                        # If is_real() evals false try casting to a float
-                        # anyway in case there is a rounding error adding
-                        # a near 0 complex term
-                        try:
-                            new_phase = float(new_phase)
-                        except TypeError as exc:
-                            raise TranspilerError(
-                                f"Global phase: {new_phase} is complex which is invalid"
-                            ) from exc
-                try:
-                    new_phase = float(new_phase)
-                except TypeError:
-                    pass
+                    new_phase = new_phase.numeric()
+                    if isinstance(new_phase, complex):
+                        raise TranspilerError(f"global phase must be real, but got '{new_phase}'")
                 bound_target_dag.global_phase = new_phase
         else:
             bound_target_dag = target_dag

--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -339,7 +339,7 @@ class BasisTranslator(TransformationPass):
                 if not new_phase.parameters:
                     new_phase = new_phase.numeric()
                     if isinstance(new_phase, complex):
-                        raise TranspilerError(f"global phase must be real, but got '{new_phase}'")
+                        raise TranspilerError(f"Global phase must be real, but got '{new_phase}'")
                 bound_target_dag.global_phase = new_phase
         else:
             bound_target_dag = target_dag

--- a/releasenotes/notes/parameterexpression.numeric-958d365dadabfb81.yaml
+++ b/releasenotes/notes/parameterexpression.numeric-958d365dadabfb81.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    A new method :meth:`.ParameterExpression.numeric` is added, which converts a fully bound
+    parameter expression into the most restrictive builtin Python numeric type that accurately
+    describes the result of the symbolic evaluation.  For example, a symbolic integer will become an
+    :class:`int`, while a symbolic real number will become a :class:`float` and a complex number
+    will become a :class:`complex`.  This method includes several workarounds for peculiarities of
+    the evaluation contexts of ``symengine``, which can sometimes lead to spurious results when
+    calling :class:`complex` or :class:`float` on an expression directly.


### PR DESCRIPTION
### Summary

This is largely a wrap-up of the `if ParameterExpression.is_real(): ...` logic present in a few places across the library, but a bit more efficient for Symengine because it can re-use cases where it needed to force an evaluation to produce accurate results.  Mostly, though, it simplifies a few call sites.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Depends on #11107, because `.evalf(real=True)` is a symengine-specific extension, and when `TemplateOptimization` produces mismatched `ParameterExpression`s it breaks this handling.

The additional handling in `numeric` to reduce the impact of the spurious imaginary components makes this generally more reliable. I came across problems with global phases during binding in a PR built on top of this - at the moment, the type of the `global_phase` in `QuantumCircuit.assign_parameters` isn't validated in the same way, but in a unification PR I had it was, and some deeply nested (but completely valid) assignments were failing.