### PR TITLE
Always run vf2 scoring serially

### DIFF
--- a/qiskit/transpiler/passes/layout/vf2_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_layout.py
@@ -12,7 +12,6 @@
 
 
 """VF2Layout pass to find a layout using subgraph isomorphism"""
-import os
 from enum import Enum
 import itertools
 import logging
@@ -172,10 +171,6 @@ class VF2Layout(AnalysisPass):
         chosen_layout_score = None
         start_time = time.time()
         trials = 0
-        run_in_parallel = (
-            os.getenv("QISKIT_IN_PARALLEL", "FALSE").upper() != "TRUE"
-            or os.getenv("QISKIT_FORCE_THREADS", "FALSE").upper() == "TRUE"
-        )
 
         def mapping_to_layout(layout_mapping):
             return Layout({reverse_im_graph_node_map[k]: v for k, v in layout_mapping.items()})
@@ -204,7 +199,6 @@ class VF2Layout(AnalysisPass):
                 reverse_im_graph_node_map,
                 im_graph,
                 self.strict_direction,
-                run_in_parallel,
             )
             # If the layout score is 0 we can't do any better and we'll just
             # waste time finding additional mappings that will at best match

--- a/qiskit/transpiler/passes/layout/vf2_post_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_post_layout.py
@@ -12,7 +12,6 @@
 
 
 """VF2PostLayout pass to find a layout after transpile using subgraph isomorphism"""
-import os
 from enum import Enum
 import logging
 import inspect
@@ -253,10 +252,6 @@ class VF2PostLayout(AnalysisPass):
                 call_limit=self.call_limit,
             )
         chosen_layout = None
-        run_in_parallel = (
-            os.getenv("QISKIT_IN_PARALLEL", "FALSE").upper() != "TRUE"
-            or os.getenv("QISKIT_FORCE_THREADS", "FALSE").upper() == "TRUE"
-        )
         try:
             if self.strict_direction:
                 initial_layout = Layout({bit: index for index, bit in enumerate(dag.qubits)})
@@ -276,7 +271,6 @@ class VF2PostLayout(AnalysisPass):
                     reverse_im_graph_node_map,
                     im_graph,
                     self.strict_direction,
-                    run_in_parallel,
                 )
         # Circuit not in basis so we have nothing to compare against return here
         except KeyError:
@@ -309,7 +303,6 @@ class VF2PostLayout(AnalysisPass):
                     reverse_im_graph_node_map,
                     im_graph,
                     self.strict_direction,
-                    run_in_parallel,
                 )
             logger.debug("Trial %s has score %s", trials, layout_score)
             if layout_score < chosen_layout_score:

--- a/qiskit/transpiler/passes/layout/vf2_utils.py
+++ b/qiskit/transpiler/passes/layout/vf2_utils.py
@@ -102,7 +102,7 @@ def score_layout(
     _reverse_bit_map,
     im_graph,
     strict_direction=False,
-    run_in_parallel=True,
+    run_in_parallel=False,
 ):
     """Score a layout given an average error map."""
     if layout_mapping:

--- a/releasenotes/notes/vf2-threading-b778a36de5b8832a.yaml
+++ b/releasenotes/notes/vf2-threading-b778a36de5b8832a.yaml
@@ -1,0 +1,8 @@
+---
+other:
+  - |
+    The :class:`.VF2Layout` and :class:`.VF2PostLayout` transpiler passes previously would
+    potentially run their internal scoring using multithreading if the input
+    circuit's were sufficiently large. However, the multithreading usage has
+    been removed from the passes as it was shown to cause a performance
+    regression instead of an improvement like originally intended.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The VF2Layout and VF2PostLayout passes' Rust scoring function has the option to use a parallel iterator for computing the score of a layout given a sufficiently large circuit (both in number of 2q interactions or qubits). Previously the scoring would be multithreaded if there were > 50 qubits or > 50 2q interactions in the circuit. However, as recent testing has shown in most cases the performance of doing this operation in parallel is much worse than serial execution. To address this issue, this commit just always uses the serial version. The parallel option is left in place for now just in case someone was manually calling the scoring function with the parallel option set to ``True``.


### Details and comments