### PR TITLE
Fix Barrier broadcast arguments

### DIFF
--- a/qiskit/circuit/barrier.py
+++ b/qiskit/circuit/barrier.py
@@ -47,8 +47,5 @@ class Barrier(Instruction):
         """Special case. Return self."""
         return Barrier(self.num_qubits)
 
-    def broadcast_arguments(self, qargs, cargs):
-        yield [qarg for sublist in qargs for qarg in sublist], []
-
     def c_if(self, classical, val):
         raise QiskitError("Barriers are compiler directives and cannot be conditional.")

--- a/releasenotes/notes/fix-barrier-arg-list-check-ff69f37ede6bdf6c.yaml
+++ b/releasenotes/notes/fix-barrier-arg-list-check-ff69f37ede6bdf6c.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :class:`.Barrier` class. When adding a
+    :class:`.Barrier` instance to a :class:`.QuantumCircuit` with the
+    :meth:`.QuantumCircuit.append` method previously there was no validation
+    that the size of the barrier matched the qargs specified.

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -17,7 +17,7 @@ import numpy as np
 from ddt import data, ddt
 
 from qiskit import BasicAer, ClassicalRegister, QuantumCircuit, QuantumRegister, execute
-from qiskit.circuit import Gate, Instruction, Measure, Parameter
+from qiskit.circuit import Gate, Instruction, Measure, Parameter, Barrier
 from qiskit.circuit.bit import Bit
 from qiskit.circuit.classicalregister import Clbit
 from qiskit.circuit.exceptions import CircuitError
@@ -156,6 +156,8 @@ class TestCircuitOperations(QiskitTestCase):
             qc.append(inst, bad_arg, [0, 1])
         with self.assertRaisesRegex(CircuitError, "The amount of clbit arguments"):
             qc.append(inst, [0, 1], bad_arg)
+        with self.assertRaisesRegex(CircuitError, "The amount of qubit arguments"):
+            qc.append(Barrier(4), bad_arg)
 
     def test_anding_self(self):
         """Test that qc &= qc finishes, which can be prone to infinite while-loops.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue with the Barrier class's broadcast_arguments() method. Previously the Barrier class was overriding broadcast_arguments(), however this custom implementation resulted in an identical output to the Instruction's implementation (its parent class) but stripped out all the error checking to determine if the arguments aligned with the size of the instruction. This could result in creating a corrupt circuit that had a mismatch between the barrier width and the number of qargs. For example:

```
circuit = QuantumCircuit(1)
circuit.append(Barrier(42), [0])
```

would not error despite trying to add a 42 qubit barrier on qubit 0. This would result in weird errors such as invalid qpy generation that are confusing to debug. This commit fixes this by deleting the broadcast_arguments() implementation for Barrier so it will just depend on the inherited implementation from Instruction which will return an identical result but check the instruction is valid.

### Details and comments