### PR TITLE
Ensure metapackage is installed during CI and tox

### DIFF
--- a/.azure/lint-linux.yml
+++ b/.azure/lint-linux.yml
@@ -26,7 +26,10 @@ jobs:
             -c constraints.txt \
             -r requirements.txt \
             -r requirements-dev.txt \
+            -e ./qiskit_pkg \
             -e .
+          # Build and install both qiskit and qiskit-terra so that any optionals
+          # depending on `qiskit` will resolve correctly.
         displayName: 'Install dependencies'
         env:
           SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"

--- a/.azure/lint-linux.yml
+++ b/.azure/lint-linux.yml
@@ -26,7 +26,7 @@ jobs:
             -c constraints.txt \
             -r requirements.txt \
             -r requirements-dev.txt \
-            -e ./qiskit_pkg \
+            ./qiskit_pkg \
             -e .
           # Build and install both qiskit and qiskit-terra so that any optionals
           # depending on `qiskit` will resolve correctly.

--- a/.azure/test-linux.yml
+++ b/.azure/test-linux.yml
@@ -70,15 +70,18 @@ jobs:
             # Use stable Rust, rather than MSRV, to spot-check that stable builds properly.
             rustup override set stable
             source test-job/bin/activate
-            python -m pip install -U pip setuptools wheel
+            python -m pip install -U pip setuptools wheel build
             # Install setuptools-rust for building sdist
             python -m pip install -U -c constraints.txt setuptools-rust
-            python setup.py sdist
+            python build --sdist .
+            python build --sdist qiskit_pkg
             python -m pip install -U \
               -c constraints.txt \
               -r requirements.txt \
               -r requirements-dev.txt \
-              dist/qiskit-terra*.tar.gz
+              dist/qiskit*.tar.gz
+            # Build and install both qiskit and qiskit-terra so that any optionals
+            # depending on `qiskit` will resolve correctly.
           displayName: "Install Terra from sdist"
 
       - ${{ if eq(parameters.installFromSdist, false) }}:
@@ -89,7 +92,10 @@ jobs:
               -c constraints.txt \
               -r requirements.txt \
               -r requirements-dev.txt \
+              -e ./qiskit_pkg \
               -e .
+            # Build and install both qiskit and qiskit-terra so that any optionals
+            # depending on `qiskit` will resolve correctly.
           displayName: "Install Terra directly"
           env:
             SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"

--- a/.azure/test-linux.yml
+++ b/.azure/test-linux.yml
@@ -70,9 +70,8 @@ jobs:
             # Use stable Rust, rather than MSRV, to spot-check that stable builds properly.
             rustup override set stable
             source test-job/bin/activate
-            python -m pip install -U pip setuptools wheel build
-            # Install setuptools-rust for building sdist
-            python -m pip install -U -c constraints.txt setuptools-rust
+            python -m pip install -U pip
+            python -m pip install -U build
             python -m build --sdist .
             python -m build --sdist qiskit_pkg
             python -m pip install -U \

--- a/.azure/test-linux.yml
+++ b/.azure/test-linux.yml
@@ -73,8 +73,8 @@ jobs:
             python -m pip install -U pip setuptools wheel build
             # Install setuptools-rust for building sdist
             python -m pip install -U -c constraints.txt setuptools-rust
-            python build --sdist .
-            python build --sdist qiskit_pkg
+            python -m build --sdist .
+            python -m build --sdist qiskit_pkg
             python -m pip install -U \
               -c constraints.txt \
               -r requirements.txt \

--- a/.azure/test-linux.yml
+++ b/.azure/test-linux.yml
@@ -92,7 +92,7 @@ jobs:
               -c constraints.txt \
               -r requirements.txt \
               -r requirements-dev.txt \
-              -e ./qiskit_pkg \
+              ./qiskit_pkg \
               -e .
             # Build and install both qiskit and qiskit-terra so that any optionals
             # depending on `qiskit` will resolve correctly.

--- a/.azure/test-macos.yml
+++ b/.azure/test-macos.yml
@@ -43,7 +43,7 @@ jobs:
             -c constraints.txt \
             -r requirements.txt \
             -r requirements-dev.txt \
-            -e ./qiskit_pkg \
+            ./qiskit_pkg \
             -e .
             # Build and install both qiskit and qiskit-terra so that any optionals
             # depending on `qiskit` will resolve correctly.

--- a/.azure/test-macos.yml
+++ b/.azure/test-macos.yml
@@ -43,7 +43,10 @@ jobs:
             -c constraints.txt \
             -r requirements.txt \
             -r requirements-dev.txt \
+            -e ./qiskit_pkg \
             -e .
+            # Build and install both qiskit and qiskit-terra so that any optionals
+            # depending on `qiskit` will resolve correctly.
           pip check
         displayName: 'Install dependencies'
         env:

--- a/.azure/test-windows.yml
+++ b/.azure/test-windows.yml
@@ -42,7 +42,10 @@ jobs:
             -c constraints.txt \
             -r requirements.txt \
             -r requirements-dev.txt \
+            -e ./qiskit_pkg \
             -e .
+          # Build and install both qiskit and qiskit-terra so that any optionals
+          # depending on `qiskit` will resolve correctly.
           pip check
         displayName: 'Install dependencies'
         env:

--- a/.azure/test-windows.yml
+++ b/.azure/test-windows.yml
@@ -42,7 +42,7 @@ jobs:
             -c constraints.txt \
             -r requirements.txt \
             -r requirements-dev.txt \
-            -e ./qiskit_pkg \
+            ./qiskit_pkg \
             -e .
           # Build and install both qiskit and qiskit-terra so that any optionals
           # depending on `qiskit` will resolve correctly.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,7 +42,7 @@ jobs:
         run: python -m pip install -c constraints.txt --upgrade pip setuptools wheel
 
       - name: Build and install qiskit-terra
-        run: python -m pip install -c constraints.txt -e . -e ./qiskit_pkg
+        run: python -m pip install -c constraints.txt -e . ./qiskit_pkg
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-Cinstrument-coverage"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,7 +42,7 @@ jobs:
         run: python -m pip install -c constraints.txt --upgrade pip setuptools wheel
 
       - name: Build and install qiskit-terra
-        run: python -m pip install -c constraints.txt -e .
+        run: python -m pip install -c constraints.txt -e . -e ./qiskit_pkg
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-Cinstrument-coverage"

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -19,7 +19,7 @@ jobs:
           python -m pip install -U pip setuptools wheel
           python -m pip install -U -r requirements.txt -c constraints.txt
           python -m pip install -U -r requirements-dev.txt -c constraints.txt
-          python -m pip install -c constraints.txt -e . -e ./qiskit_pkg
+          python -m pip install -c constraints.txt -e . ./qiskit_pkg
           python -m pip install "qiskit-aer" "z3-solver" "cplex" -c constraints.txt
         env:
           SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -19,7 +19,7 @@ jobs:
           python -m pip install -U pip setuptools wheel
           python -m pip install -U -r requirements.txt -c constraints.txt
           python -m pip install -U -r requirements-dev.txt -c constraints.txt
-          python -m pip install -c constraints.txt -e .
+          python -m pip install -c constraints.txt -e . -e ./qiskit_pkg
           python -m pip install "qiskit-aer" "z3-solver" "cplex" -c constraints.txt
         env:
           SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,10 @@ envlist = py38, py39, py310, py311, lint-incr
 isolated_build = true
 
 [testenv]
-usedevelop = True
+# We pretend that we're not actually installing the package, because we need tox to let us have two
+# packages ('qiskit' and 'qiskit-terra') under test at the same time.  For that, we have to stuff
+# them into 'deps'.
+skip_install = true
 install_command = pip install -c{toxinidir}/constraints.txt -U {opts} {packages}
 setenv =
   VIRTUAL_ENV={envdir}
@@ -15,9 +18,12 @@ setenv =
   QISKIT_TEST_CAPTURE_STREAMS=1
   QISKIT_PARALLEL=FALSE
 passenv = RAYON_NUM_THREADS, OMP_NUM_THREADS, QISKIT_PARALLEL, RUST_BACKTRACE, SETUPTOOLS_ENABLE_FEATURES, QISKIT_TESTS, QISKIT_IN_PARALLEL
-deps = setuptools_rust  # This is work around for the bug of tox 3 (see #8606 for more details.)
-       -r{toxinidir}/requirements.txt
-       -r{toxinidir}/requirements-dev.txt
+deps =
+    setuptools_rust  # This is work around for the bug of tox 3 (see #8606 for more details.)
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements-dev.txt
+    -e .
+    -e ./qiskit_pkg
 commands =
   stestr run {posargs}
 
@@ -50,6 +56,9 @@ commands =
   reno lint
 
 [testenv:black]
+skip_install = true
+deps =
+    -r requirements-dev.txt
 commands = black {posargs} qiskit test tools examples setup.py qiskit_pkg
 
 [testenv:coverage]
@@ -57,17 +66,15 @@ basepython = python3
 setenv =
   {[testenv]setenv}
   PYTHON=coverage3 run --source qiskit --parallel-mode
-deps = -r{toxinidir}/requirements.txt
-       -r{toxinidir}/requirements-dev.txt
-       -r{toxinidir}/requirements-optional.txt
+deps =
+  {[testenv]deps}
+  -r{toxinidir}/requirements-optional.txt
 commands =
   stestr run {posargs}
   coverage3 combine
   coverage3 report
 
 [testenv:docs]
-# Editable mode breaks macOS: https://github.com/sphinx-doc/sphinx/issues/10943
-usedevelop = False
 basepython = python3
 setenv =
   {[testenv]setenv}
@@ -75,15 +82,9 @@ setenv =
   RUST_DEBUG=1  # Faster to compile.
 passenv = {[testenv]passenv}, QISKIT_DOCS_BUILD_TUTORIALS, QISKIT_CELL_TIMEOUT, DOCS_PROD_BUILD
 deps =
-  setuptools_rust  # This is work around for the bug of tox 3 (see #8606 for more details.)
-  -r{toxinidir}/requirements-dev.txt
+  {[testenv]deps}
   -r{toxinidir}/requirements-optional.txt
   -r{toxinidir}/requirements-tutorials.txt
-  # Some optionals depend on Terra. We want to make sure pip satisfies that requirement from a local
-  # installation, not from PyPI. But Tox normally doesn't install the local installation until
-  # after `deps` is installed. So, instead, we tell pip to do the local installation at the same
-  # time as the optionals. See https://github.com/Qiskit/qiskit-terra/pull/9477.
-  .
 commands =
   sphinx-build -W -j auto -T --keep-going -b html docs/ docs/_build/html {posargs}
 


### PR DESCRIPTION
### Summary

This ensures that the local version of the metapackage is also built and installed on all CI runs (and in `tox`, where it's overridden) so that dependencies on the metapackage in our optionals (e.g. Aer) will not cause the older released version of Terra to be installed.

`tox` does not like having two local packages under test simultaneously through its default configuration, so this fakes things out by putting the two packages in the run dependencies and setting `skip_install`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

This should (hopefully) get CI moving again.  The necessary changes to `tox` are indicative of larger developer (but not user) pain, though - installing any downstream Qiskit project on top of an editable install of Terra is liable to reinstall the current release version of Terra via a pin from the `qiskit` metapackage.  To work around this, developers should ensure that they have done `pip install ./qiskit_pkg` in their dev env, and they may need to rerun that when Terra bumps its version number (editable mode won't affect pip's version resolution).