### PR TITLE
Constrain `qiskit-aer==0.12.2`

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -11,3 +11,8 @@ numpy<1.25
 # eigensystem code for one of the test cases.  See
 # https://github.com/Qiskit/qiskit-terra/issues/10345 for current details.
 scipy<1.11
+
+# Aer 0.13 causes several randomised tests to begin failing, and some
+# `QuantumInstance` use of noise models to raise exceptions.  These need fixes
+# on Terra.
+qiskit-aer==0.12.2


### PR DESCRIPTION
### Summary

The 0.13.0 release of qiskit-aer causes several test failures, some of which look like changes in the randomisation, and some of which look like true failures.  These need a proper resolution, but it's more work than can be easily attached to a PR that's just meant to get CI rolling again.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Aer 0.13.0 caused several problems for Terra CI, several of which appear to be real problems that we need to fix.  #11119 is one of these, but adding to this, there are new test failures from simulator randomness changes, new exceptions coming from noise-model construction (in `QuantumInstance`, by the looks of things), and some of Terra's automated tests are wildly overzealous in attempting to discover `Gate` and `ControlledGate` subclasses to run over.