### PR TITLE
fix typo in files of `qiskit/circuit/`  folder

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -215,7 +215,7 @@ class Instruction(Operation):
         return True
 
     def __repr__(self) -> str:
-        """Generates a representation of the Intruction object instance
+        """Generates a representation of the Instruction object instance
         Returns:
             str: A representation of the Instruction instance with the name,
                  number of qubits, classical bits and params( if any )

--- a/qiskit/circuit/library/overlap.py
+++ b/qiskit/circuit/library/overlap.py
@@ -62,7 +62,7 @@ class UnitaryOverlap(QuantumCircuit):
     ):
         """
         Args:
-            unitary1: Unitary acting on the key vector.
+            unitary1: Unitary acting on the ket vector.
             unitary2: Unitary whose inverse operates on the bra vector.
             prefix1: The name of the parameter vector associated to ``unitary1``,
                 if it is parameterized. Defaults to ``"p1"``.

--- a/qiskit/circuit/library/overlap.py
+++ b/qiskit/circuit/library/overlap.py
@@ -62,7 +62,7 @@ class UnitaryOverlap(QuantumCircuit):
     ):
         """
         Args:
-            unitary1: Unitary acting on the ket vector.
+            unitary1: Unitary acting on the key vector.
             unitary2: Unitary whose inverse operates on the bra vector.
             prefix1: The name of the parameter vector associated to ``unitary1``,
                 if it is parameterized. Defaults to ``"p1"``.

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -640,7 +640,7 @@ class C3XGate(SingletonControlledGate):
 
     _singleton_lookup_key = stdlib_singleton_key(num_ctrl_qubits=3)
 
-    # seems like open controls not hapening?
+    # seems like open controls not happening?
     def _define(self):
         """
         gate c3x a,b,c,d

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1188,7 +1188,7 @@ class QuantumCircuit:
         if isinstance(specifier, ClassicalRegister):
             # This is linear complexity for something that should be constant, but QuantumCircuit
             # does not currently keep a hashmap of registers, and requires non-trivial changes to
-            # how it exposes its registers publically before such a map can be safely stored so it
+            # how it exposes its registers publicly before such a map can be safely stored so it
             # doesn't miss updates. (Jake, 2021-11-10).
             if specifier not in self.cregs:
                 raise CircuitError(f"Register {specifier} is not present in this circuit.")

--- a/qiskit/circuit/singleton.py
+++ b/qiskit/circuit/singleton.py
@@ -156,7 +156,7 @@ definition::
 
 there will be two singleton instances instantiated.  One corresponds to ``n=1`` and ``label=None``,
 and the other to ``n=2`` and ``label="two"``.  Whenever ``MySingleton`` is constructed with
-arguments consistent with one of those two cases, the relavent singleton will be returned.  For
+arguments consistent with one of those two cases, the relevent singleton will be returned.  For
 example::
 
     assert MySingleton() is MySingleton(1, label=None)

--- a/qiskit/circuit/singleton.py
+++ b/qiskit/circuit/singleton.py
@@ -156,7 +156,7 @@ definition::
 
 there will be two singleton instances instantiated.  One corresponds to ``n=1`` and ``label=None``,
 and the other to ``n=2`` and ``label="two"``.  Whenever ``MySingleton`` is constructed with
-arguments consistent with one of those two cases, the relevent singleton will be returned.  For
+arguments consistent with one of those two cases, the relevant singleton will be returned.  For
 example::
 
     assert MySingleton() is MySingleton(1, label=None)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
This PR fix the typo that were present in the files inside `qiskit/circuit/`  folder


### Details and comments

```pseudo
Intruction > Instruction
hapening > happening
publically > publicly
relavent > relevent
```

