### PR TITLE
Fix typo in docs announcement banners

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,7 +133,7 @@ html_last_updated_fmt = "%Y/%m/%d"
 html_context = {
     # Enable segment analytics for qiskit.org/documentation
     "analytics_enabled": bool(os.getenv("QISKIT_ENABLE_ANALYTICS", "")),
-    "theme_announcement": "🎉 Starting on December 1, 2023, Qiskit Documentation will only live on IBM Quantum",
+    "theme_announcement": "🎉 Starting on November 29, 2023, Qiskit Documentation will only live on IBM Quantum",
     "announcement_url": "https://medium.com/qiskit/important-changes-to-qiskit-documentation-and-learning-resources-7f4e346b19ab",
     "announcement_url_text": "Learn More",
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ them on real quantum computers or classical simulators. Qiskit is already in use
 around the world by beginners, hobbyists, educators, researchers, and commercial companies.
 
 .. qiskit-card::
-  :header: Starting on December 1, 2023, Qiskit Documentation will only live on IBM Quantum. Learn more ->
+  :header: Starting on November 29, 2023, Qiskit Documentation will only live on IBM Quantum. Learn more →
   :card_description: We are reorganizing Qiskit documentation on IBM Quantum to better support your research and development workflows.
   :image: _static/images/1xp.png
   :link: https://medium.com/qiskit/important-changes-to-qiskit-documentation-and-learning-resources-7f4e346b19ab


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

I messed up the dates on the last PR to update the docs announcement banners. The dates should have been Nov 29, not Dec 1. This PR fixes that so the docs banners now match the dates on the banners on the rest of qiskit.org

### Details and comments


