### PR TITLE
Use `circuit_drawer` for circuit drawer tests

### DIFF
--- a/qiskit/visualization/circuit/matplotlib.py
+++ b/qiskit/visualization/circuit/matplotlib.py
@@ -17,7 +17,6 @@
 import collections
 import itertools
 import re
-from warnings import warn
 from io import StringIO
 
 import numpy as np
@@ -135,28 +134,7 @@ class MatplotlibDrawer:
         self._global_phase = self._circuit.global_phase
         self._calibrations = self._circuit.calibrations
         self._expr_len = expr_len
-
-        def check_clbit_in_inst(circuit, cregbundle):
-            if cregbundle is False:
-                return False
-            for inst in circuit.data:
-                if isinstance(inst.operation, ControlFlowOp):
-                    for block in inst.operation.blocks:
-                        if check_clbit_in_inst(block, cregbundle) is False:
-                            return False
-                elif inst.clbits and not isinstance(inst.operation, Measure):
-                    if cregbundle is not False:
-                        warn(
-                            "Cregbundle set to False since an instruction needs to refer"
-                            " to individual classical wire",
-                            RuntimeWarning,
-                            3,
-                        )
-                    return False
-
-            return True
-
-        self._cregbundle = check_clbit_in_inst(circuit, cregbundle)
+        self._cregbundle = cregbundle
 
         self._lwidth1 = 1.0
         self._lwidth15 = 1.5

--- a/qiskit/visualization/circuit/text.py
+++ b/qiskit/visualization/circuit/text.py
@@ -735,28 +735,7 @@ class TextDrawing:
             raise ValueError("Vertical compression can only be 'high', 'medium', or 'low'")
         self.vertical_compression = vertical_compression
         self._wire_map = {}
-
-        def check_clbit_in_inst(circuit, cregbundle):
-            if cregbundle is False:
-                return False
-            for inst in circuit.data:
-                if isinstance(inst.operation, ControlFlowOp):
-                    for block in inst.operation.blocks:
-                        if check_clbit_in_inst(block, cregbundle) is False:
-                            return False
-                elif inst.clbits and not isinstance(inst.operation, Measure):
-                    if cregbundle is not False:
-                        warn(
-                            "Cregbundle set to False since an instruction needs to refer"
-                            " to individual classical wire",
-                            RuntimeWarning,
-                            3,
-                        )
-                    return False
-
-            return True
-
-        self.cregbundle = check_clbit_in_inst(circuit, cregbundle)
+        self.cregbundle = cregbundle
 
         if encoding:
             self.encoding = encoding

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -27,11 +27,11 @@ from qiskit.quantum_info.operators import SuperOp
 from qiskit.quantum_info.random import random_unitary
 from qiskit.test import QiskitTestCase
 from qiskit.transpiler.layout import Layout, TranspileLayout
+from qiskit.visualization.circuit.circuit_visualization import _text_circuit_drawer
 from qiskit.visualization import circuit_drawer
 from qiskit.visualization.circuit import text as elements
-from qiskit.extensions import UnitaryGate, HamiltonianGate
-from qiskit.extensions.quantum_initializer import UCGate
 from qiskit.providers.fake_provider import FakeBelemV2
+from qiskit.circuit.classical import expr
 from qiskit.circuit.library import (
     HGate,
     U2Gate,
@@ -46,6 +46,9 @@ from qiskit.circuit.library import (
     CU3Gate,
     CU1Gate,
     CPhaseGate,
+    UnitaryGate,
+    HamiltonianGate,
+    UCGate,
 )
 from qiskit.transpiler.passes import ApplyLayout
 from qiskit.utils.optionals import HAS_TWEEDLEDUM
@@ -5680,7 +5683,7 @@ class TestCircuitVisualizationImplementation(QiskitVisualizationTestCase):
         circuit.tdg(qr[0])
         circuit.sx(qr[0])
         circuit.sxdg(qr[0])
-        circuit.i(qr[0])
+        circuit.id(qr[0])
         circuit.reset(qr[0])
         circuit.rx(pi, qr[0])
         circuit.ry(pi, qr[0])
@@ -5708,9 +5711,8 @@ class TestCircuitVisualizationImplementation(QiskitVisualizationTestCase):
         """Test that text drawer handles utf8 encoding."""
         filename = "current_textplot_utf8.txt"
         qc = self.sample_circuit()
-        output = circuit_drawer(
+        output = _text_circuit_drawer(
             qc,
-            output="text",
             filename=filename,
             fold=-1,
             initial_state=True,
@@ -5728,9 +5730,8 @@ class TestCircuitVisualizationImplementation(QiskitVisualizationTestCase):
         """Test that text drawer handles cp437 encoding."""
         filename = "current_textplot_cp437.txt"
         qc = self.sample_circuit()
-        output = circuit_drawer(
+        output = _text_circuit_drawer(
             qc,
-            output="text",
             filename=filename,
             fold=-1,
             initial_state=True,
@@ -6169,6 +6170,137 @@ class TestCircuitControlFlowOps(QiskitVisualizationTestCase):
         circuit.if_else((cr[1], 1), qc2, None, [0, 1, 2], [0, 1, 2])
         self.assertEqual(
             str(circuit_drawer(circuit, output="text", initial_state=False, cregbundle=False)),
+            expected,
+        )
+
+    def test_if_with_expr(self):
+        """Test an IfElseOp with an expression"""
+        expected = "\n".join(
+            [
+                "       ┌───┐┌─────────────────────────────── ┌───┐ ───────┐ ",
+                " qr_0: ┤ H ├┤ If-0 (cr1 & (cr2 & cr3)) == 3  ┤ Z ├  End-0 ├─",
+                "       └───┘└───────────────╥─────────────── └───┘ ───────┘ ",
+                " qr_1: ─────────────────────╫───────────────────────────────",
+                "                            ║                               ",
+                " qr_2: ─────────────────────╫───────────────────────────────",
+                "                            ║                               ",
+                " cr: 3/═════════════════════╬═══════════════════════════════",
+                "                        ┌───╨────┐                          ",
+                "cr1: 3/═════════════════╡ [expr] ╞══════════════════════════",
+                "                        ├───╨────┤                          ",
+                "cr2: 3/═════════════════╡ [expr] ╞══════════════════════════",
+                "                        ├───╨────┤                          ",
+                "cr3: 3/═════════════════╡ [expr] ╞══════════════════════════",
+                "                        └────────┘                          ",
+            ]
+        )
+        qr = QuantumRegister(3, "qr")
+        cr = ClassicalRegister(3, "cr")
+        cr1 = ClassicalRegister(3, "cr1")
+        cr2 = ClassicalRegister(3, "cr2")
+        cr3 = ClassicalRegister(3, "cr3")
+        circuit = QuantumCircuit(qr, cr, cr1, cr2, cr3)
+
+        circuit.h(0)
+        with circuit.if_test(expr.equal(expr.bit_and(cr1, expr.bit_and(cr2, cr3)), 3)):
+            circuit.z(0)
+
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=False)),
+            expected,
+        )
+
+    def test_if_with_expr_nested(self):
+        """Test an IfElseOp with an expression for nested"""
+        expected = "\n".join(
+            [
+                "       ┌───┐┌─────────────────────── ┌───┐                                 ───────┐ ",
+                " qr_0: ┤ H ├┤                        ┤ X ├────────────────────────────────        ├─",
+                "       └───┘│ If-0 (cr2 & cr3) == 3  └───┘┌─────────────── ┌───┐ ───────┐   End-0 │ ",
+                " qr_1: ─────┤                        ─────┤ If-1 cr2 == 5  ┤ Z ├  End-1 ├─        ├─",
+                "            └───────────╥───────────      └───────╥─────── └───┘ ───────┘  ───────┘ ",
+                " qr_2: ─────────────────╫─────────────────────────╫─────────────────────────────────",
+                "                        ║                         ║                                 ",
+                " cr: 3/═════════════════╬═════════════════════════╬═════════════════════════════════",
+                "                        ║                         ║                                 ",
+                "cr1: 3/═════════════════╬═════════════════════════╬═════════════════════════════════",
+                "                    ┌───╨────┐                ┌───╨────┐                            ",
+                "cr2: 3/═════════════╡ [expr] ╞════════════════╡ [expr] ╞════════════════════════════",
+                "                    ├───╨────┤                └────────┘                            ",
+                "cr3: 3/═════════════╡ [expr] ╞══════════════════════════════════════════════════════",
+                "                    └────────┘                                                      ",
+            ]
+        )
+        qr = QuantumRegister(3, "qr")
+        cr = ClassicalRegister(3, "cr")
+        cr1 = ClassicalRegister(3, "cr1")
+        cr2 = ClassicalRegister(3, "cr2")
+        cr3 = ClassicalRegister(3, "cr3")
+        circuit = QuantumCircuit(qr, cr, cr1, cr2, cr3)
+
+        circuit.h(0)
+        with circuit.if_test(expr.equal(expr.bit_and(cr2, cr3), 3)):
+            circuit.x(0)
+            with circuit.if_test(expr.equal(cr2, 5)):
+                circuit.z(1)
+
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=False, fold=120)),
+            expected,
+        )
+
+    def test_switch_with_expression(self):
+        """Test an SwitchcaseOp with an expression"""
+        expected = "\n".join(
+            [
+                "       ┌───┐┌──────────────────────────── ┌───────────────────── ┌───┐»",
+                " qr_0: ┤ H ├┤                             ┤                      ┤ X ├»",
+                "       └───┘│ Switch-0 cr1 & (cr2 & cr3)  │ Case-0 (0, 1, 2, 3)  └───┘»",
+                " qr_1: ─────┤                             ┤                      ─────»",
+                "            └─────────────╥────────────── └─────────────────────      »",
+                " qr_2: ───────────────────╫───────────────────────────────────────────»",
+                "                          ║                                           »",
+                " cr: 3/═══════════════════╬═══════════════════════════════════════════»",
+                "                      ┌───╨────┐                                      »",
+                "cr1: 3/═══════════════╡ [expr] ╞══════════════════════════════════════»",
+                "                      ├───╨────┤                                      »",
+                "cr2: 3/═══════════════╡ [expr] ╞══════════════════════════════════════»",
+                "                      ├───╨────┤                                      »",
+                "cr3: 3/═══════════════╡ [expr] ╞══════════════════════════════════════»",
+                "                      └────────┘                                      »",
+                "«       ┌────────────────       ───────┐ ",
+                "« qr_0: ┤                 ──■──        ├─",
+                "«       │ Case-0 default  ┌─┴─┐  End-0 │ ",
+                "« qr_1: ┤                 ┤ X ├        ├─",
+                "«       └──────────────── └───┘ ───────┘ ",
+                "« qr_2: ─────────────────────────────────",
+                "«                                        ",
+                "« cr: 3/═════════════════════════════════",
+                "«                                        ",
+                "«cr1: 3/═════════════════════════════════",
+                "«                                        ",
+                "«cr2: 3/═════════════════════════════════",
+                "«                                        ",
+                "«cr3: 3/═════════════════════════════════",
+                "«                                        ",
+            ]
+        )
+        qr = QuantumRegister(3, "qr")
+        cr = ClassicalRegister(3, "cr")
+        cr1 = ClassicalRegister(3, "cr1")
+        cr2 = ClassicalRegister(3, "cr2")
+        cr3 = ClassicalRegister(3, "cr3")
+        circuit = QuantumCircuit(qr, cr, cr1, cr2, cr3)
+
+        circuit.h(0)
+        with circuit.switch(expr.bit_and(cr1, expr.bit_and(cr2, cr3))) as case:
+            with case(0, 1, 2, 3):
+                circuit.x(0)
+            with case(case.DEFAULT):
+                circuit.cx(0, 1)
+
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", fold=80, initial_state=False)),
             expected,
         )
 

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""`_text_circuit_drawer` draws a circuit in ascii art"""
+"""circuit_drawer with output="text" draws a circuit in ascii art"""
 
 import pathlib
 import os
@@ -29,9 +29,9 @@ from qiskit.test import QiskitTestCase
 from qiskit.transpiler.layout import Layout, TranspileLayout
 from qiskit.visualization import circuit_drawer
 from qiskit.visualization.circuit import text as elements
-from qiskit.visualization.circuit.circuit_visualization import _text_circuit_drawer
+from qiskit.extensions import UnitaryGate, HamiltonianGate
+from qiskit.extensions.quantum_initializer import UCGate
 from qiskit.providers.fake_provider import FakeBelemV2
-from qiskit.circuit.classical import expr
 from qiskit.circuit.library import (
     HGate,
     U2Gate,
@@ -46,9 +46,6 @@ from qiskit.circuit.library import (
     CU3Gate,
     CU1Gate,
     CPhaseGate,
-    UnitaryGate,
-    HamiltonianGate,
-    UCGate,
 )
 from qiskit.transpiler.passes import ApplyLayout
 from qiskit.utils.optionals import HAS_TWEEDLEDUM
@@ -112,7 +109,7 @@ class TestTextDrawerElement(QiskitTestCase):
         """The empty circuit."""
         expected = ""
         circuit = QuantumCircuit()
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_pager(self):
         """The pager breaks the circuit when the drawing does not fit in the console."""
@@ -153,7 +150,9 @@ class TestTextDrawerElement(QiskitTestCase):
         circuit.measure(qr[0], cr[0])
         circuit.cx(qr[1], qr[0])
         circuit.cx(qr[0], qr[1])
-        self.assertEqual(str(_text_circuit_drawer(circuit, fold=20)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, fold=20)), expected
+        )
 
     def test_text_no_pager(self):
         """The pager can be disable."""
@@ -161,7 +160,9 @@ class TestTextDrawerElement(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         for _ in range(100):
             circuit.h(qr[0])
-        amount_of_lines = str(_text_circuit_drawer(circuit, fold=-1)).count("\n")
+        amount_of_lines = str(
+            circuit_drawer(circuit, output="text", initial_state=True, fold=-1)
+        ).count("\n")
         self.assertEqual(amount_of_lines, 2)
 
 
@@ -188,7 +189,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         cr = ClassicalRegister(3, "c")
         circuit = QuantumCircuit(qr, cr)
         circuit.measure(qr, cr)
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=True)),
+            expected,
+        )
 
     def test_text_measure_cregbundle_2(self):
         """The measure operator, using 2 classical registers with cregbundle=True."""
@@ -212,7 +216,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr, cr_a, cr_b)
         circuit.measure(qr[0], cr_a[0])
         circuit.measure(qr[1], cr_b[0])
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=True)),
+            expected,
+        )
 
     def test_text_measure_1(self):
         """The measure operator, using 3-bit-length registers."""
@@ -238,7 +245,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         cr = ClassicalRegister(3, "c")
         circuit = QuantumCircuit(qr, cr)
         circuit.measure(qr, cr)
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=False)),
+            expected,
+        )
 
     def test_text_measure_1_reverse_bits(self):
         """The measure operator, using 3-bit-length registers, with reverse_bits"""
@@ -260,7 +270,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         cr = ClassicalRegister(3, "c")
         circuit = QuantumCircuit(qr, cr)
         circuit.measure(qr, cr)
-        self.assertEqual(str(_text_circuit_drawer(circuit, reverse_bits=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, reverse_bits=True)),
+            expected,
+        )
 
     def test_text_measure_2(self):
         """The measure operator, using some registers."""
@@ -288,7 +301,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         cr2 = ClassicalRegister(2, "c2")
         circuit = QuantumCircuit(qr1, qr2, cr1, cr2)
         circuit.measure(qr2, cr2)
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_measure_2_reverse_bits(self):
         """The measure operator, using some registers, with reverse_bits"""
@@ -316,7 +329,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         cr2 = ClassicalRegister(2, "c2")
         circuit = QuantumCircuit(qr1, qr2, cr1, cr2)
         circuit.measure(qr2, cr2)
-        self.assertEqual(str(_text_circuit_drawer(circuit, reverse_bits=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, reverse_bits=True)),
+            expected,
+        )
 
     def test_wire_order(self):
         """Test the wire_order option"""
@@ -356,8 +372,12 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit.x(3).c_if(cr, 10)
         self.assertEqual(
             str(
-                _text_circuit_drawer(
-                    circuit, cregbundle=False, wire_order=[2, 1, 3, 0, 6, 8, 9, 5, 4, 7]
+                circuit_drawer(
+                    circuit,
+                    output="text",
+                    initial_state=True,
+                    cregbundle=False,
+                    wire_order=[2, 1, 3, 0, 6, 8, 9, 5, 4, 7],
                 )
             ),
             expected,
@@ -383,7 +403,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         qr2 = QuantumRegister(2, "q2")
         circuit = QuantumCircuit(qr1, qr2)
         circuit.swap(qr1, qr2)
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_swap_reverse_bits(self):
         """Swap drawing with reverse_bits."""
@@ -405,7 +425,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         qr2 = QuantumRegister(2, "q2")
         circuit = QuantumCircuit(qr1, qr2)
         circuit.swap(qr1, qr2)
-        self.assertEqual(str(_text_circuit_drawer(circuit, reverse_bits=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, reverse_bits=True)),
+            expected,
+        )
 
     def test_text_reverse_bits_read_from_config(self):
         """Swap drawing with reverse_bits set in the configuration file."""
@@ -473,7 +496,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit.cswap(qr[0], qr[1], qr[2])
         circuit.cswap(qr[1], qr[0], qr[2])
         circuit.cswap(qr[2], qr[1], qr[0])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_cswap_reverse_bits(self):
         """CSwap drawing with reverse_bits."""
@@ -494,7 +517,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit.cswap(qr[0], qr[1], qr[2])
         circuit.cswap(qr[1], qr[0], qr[2])
         circuit.cswap(qr[2], qr[1], qr[0])
-        self.assertEqual(str(_text_circuit_drawer(circuit, reverse_bits=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, reverse_bits=True)),
+            expected,
+        )
 
     def test_text_cu3(self):
         """cu3 drawing."""
@@ -514,7 +540,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.append(CU3Gate(pi / 2, pi / 2, pi / 2), [qr[0], qr[1]])
         circuit.append(CU3Gate(pi / 2, pi / 2, pi / 2), [qr[2], qr[0]])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_cu3_reverse_bits(self):
         """cu3 drawing with reverse_bits"""
@@ -534,7 +560,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.append(CU3Gate(pi / 2, pi / 2, pi / 2), [qr[0], qr[1]])
         circuit.append(CU3Gate(pi / 2, pi / 2, pi / 2), [qr[2], qr[0]])
-        self.assertEqual(str(_text_circuit_drawer(circuit, reverse_bits=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, reverse_bits=True)),
+            expected,
+        )
 
     def test_text_crz(self):
         """crz drawing."""
@@ -553,7 +582,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.crz(pi / 2, qr[0], qr[1])
         circuit.crz(pi / 2, qr[2], qr[0])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_cry(self):
         """cry drawing."""
@@ -572,7 +601,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.cry(pi / 2, qr[0], qr[1])
         circuit.cry(pi / 2, qr[2], qr[0])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_crx(self):
         """crx drawing."""
@@ -591,7 +620,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.crx(pi / 2, qr[0], qr[1])
         circuit.crx(pi / 2, qr[2], qr[0])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_cx(self):
         """cx drawing."""
@@ -610,7 +639,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.cx(qr[0], qr[1])
         circuit.cx(qr[2], qr[0])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_cy(self):
         """cy drawing."""
@@ -629,7 +658,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.cy(qr[0], qr[1])
         circuit.cy(qr[2], qr[0])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_cz(self):
         """cz drawing."""
@@ -648,7 +677,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.cz(qr[0], qr[1])
         circuit.cz(qr[2], qr[0])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_ch(self):
         """ch drawing."""
@@ -667,7 +696,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.ch(qr[0], qr[1])
         circuit.ch(qr[2], qr[0])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_rzz(self):
         """rzz drawing. See #1957"""
@@ -686,7 +715,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.rzz(0, qr[0], qr[1])
         circuit.rzz(pi / 2, qr[2], qr[1])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_cu1(self):
         """cu1 drawing."""
@@ -705,7 +734,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.append(CU1Gate(pi / 2), [qr[0], qr[1]])
         circuit.append(CU1Gate(pi / 2), [qr[2], qr[0]])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_cp(self):
         """cp drawing."""
@@ -724,7 +753,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.append(CPhaseGate(pi / 2), [qr[0], qr[1]])
         circuit.append(CPhaseGate(pi / 2), [qr[2], qr[0]])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_cu1_condition(self):
         """Test cu1 with condition"""
@@ -745,7 +774,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         cr = ClassicalRegister(3, "c")
         circuit = QuantumCircuit(qr, cr)
         circuit.append(CU1Gate(pi / 2), [qr[0], qr[1]]).c_if(cr[1], 1)
-        self.assertEqual(str(_text_circuit_drawer(circuit, initial_state=False)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=False)), expected)
 
     def test_text_rzz_condition(self):
         """Test rzz with condition"""
@@ -766,7 +795,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         cr = ClassicalRegister(3, "c")
         circuit = QuantumCircuit(qr, cr)
         circuit.append(RZZGate(pi / 2), [qr[0], qr[1]]).c_if(cr[1], 1)
-        self.assertEqual(str(_text_circuit_drawer(circuit, initial_state=False)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=False)), expected)
 
     def test_text_cp_condition(self):
         """Test cp with condition"""
@@ -787,7 +816,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         cr = ClassicalRegister(3, "c")
         circuit = QuantumCircuit(qr, cr)
         circuit.append(CPhaseGate(pi / 2), [qr[0], qr[1]]).c_if(cr[1], 1)
-        self.assertEqual(str(_text_circuit_drawer(circuit, initial_state=False)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=False)), expected)
 
     def test_text_cu1_reverse_bits(self):
         """cu1 drawing with reverse_bits"""
@@ -806,7 +835,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.append(CU1Gate(pi / 2), [qr[0], qr[1]])
         circuit.append(CU1Gate(pi / 2), [qr[2], qr[0]])
-        self.assertEqual(str(_text_circuit_drawer(circuit, reverse_bits=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, reverse_bits=True)),
+            expected,
+        )
 
     def test_text_ccx(self):
         """cx drawing."""
@@ -826,7 +858,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit.ccx(qr[0], qr[1], qr[2])
         circuit.ccx(qr[2], qr[0], qr[1])
         circuit.ccx(qr[2], qr[1], qr[0])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_reset(self):
         """Reset drawing."""
@@ -849,7 +881,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr1, qr2)
         circuit.reset(qr1)
         circuit.reset(qr2[1])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_single_gate(self):
         """Single Qbit gate drawing."""
@@ -872,7 +904,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr1, qr2)
         circuit.h(qr1)
         circuit.h(qr2[1])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_id(self):
         """Id drawing."""
@@ -895,7 +927,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr1, qr2)
         circuit.id(qr1)
         circuit.id(qr2[1])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_barrier(self):
         """Barrier drawing."""
@@ -918,7 +950,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr1, qr2)
         circuit.barrier(qr1)
         circuit.barrier(qr2[1])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_no_barriers(self):
         """Drawing without plotbarriers."""
@@ -943,7 +975,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit.barrier(qr1)
         circuit.barrier(qr2[1])
         circuit.h(qr2)
-        self.assertEqual(str(_text_circuit_drawer(circuit, plot_barriers=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, plot_barriers=False)),
+            expected,
+        )
 
     def test_text_measure_html(self):
         """The measure operator. HTML representation."""
@@ -965,7 +1000,9 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         cr = ClassicalRegister(1, "c")
         circuit = QuantumCircuit(qr, cr)
         circuit.measure(qr, cr)
-        self.assertEqual(_text_circuit_drawer(circuit)._repr_html_(), expected)
+        self.assertEqual(
+            circuit_drawer(circuit, output="text", initial_state=True)._repr_html_(), expected
+        )
 
     def test_text_repr(self):
         """The measure operator. repr."""
@@ -982,7 +1019,9 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         cr = ClassicalRegister(1, "c")
         circuit = QuantumCircuit(qr, cr)
         circuit.measure(qr, cr)
-        self.assertEqual(_text_circuit_drawer(circuit).__repr__(), expected)
+        self.assertEqual(
+            circuit_drawer(circuit, output="text", initial_state=True).__repr__(), expected
+        )
 
     def test_text_justify_left(self):
         """Drawing with left justify"""
@@ -1004,7 +1043,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit.x(qr1[0])
         circuit.h(qr1[1])
         circuit.measure(qr1[1], cr1[1])
-        self.assertEqual(str(_text_circuit_drawer(circuit, justify="left")), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, justify="left")),
+            expected,
+        )
 
     def test_text_justify_right(self):
         """Drawing with right justify"""
@@ -1026,7 +1068,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit.x(qr1[0])
         circuit.h(qr1[1])
         circuit.measure(qr1[1], cr1[1])
-        self.assertEqual(str(_text_circuit_drawer(circuit, justify="right")), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, justify="right")),
+            expected,
+        )
 
     def test_text_justify_none(self):
         """Drawing with none justify"""
@@ -1048,7 +1093,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit.x(qr1[0])
         circuit.h(qr1[1])
         circuit.measure(qr1[1], cr1[1])
-        self.assertEqual(str(_text_circuit_drawer(circuit, justify="none")), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, justify="none")),
+            expected,
+        )
 
     def test_text_justify_left_barrier(self):
         """Left justify respects barriers"""
@@ -1067,7 +1115,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit.h(qr1[0])
         circuit.barrier(qr1)
         circuit.h(qr1[1])
-        self.assertEqual(str(_text_circuit_drawer(circuit, justify="left")), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, justify="left")),
+            expected,
+        )
 
     def test_text_justify_right_barrier(self):
         """Right justify respects barriers"""
@@ -1086,7 +1137,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit.h(qr1[0])
         circuit.barrier(qr1)
         circuit.h(qr1[1])
-        self.assertEqual(str(_text_circuit_drawer(circuit, justify="right")), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, justify="right")),
+            expected,
+        )
 
     def test_text_barrier_label(self):
         """Show barrier label"""
@@ -1108,7 +1162,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit.y(0)
         circuit.x(1)
         circuit.barrier(label="End Y/X")
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_overlap_cx(self):
         """Overlapping CX gates are drawn not overlapping"""
@@ -1130,7 +1184,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr1)
         circuit.cx(qr1[0], qr1[3])
         circuit.cx(qr1[1], qr1[2])
-        self.assertEqual(str(_text_circuit_drawer(circuit, justify="left")), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, justify="left")),
+            expected,
+        )
 
     def test_text_overlap_measure(self):
         """Measure is drawn not overlapping"""
@@ -1151,7 +1208,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr1, cr1)
         circuit.measure(qr1[0], cr1[0])
         circuit.x(qr1[1])
-        self.assertEqual(str(_text_circuit_drawer(circuit, justify="left")), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, justify="left")),
+            expected,
+        )
 
     def test_text_overlap_swap(self):
         """Swap is drawn in 2 separate columns"""
@@ -1173,7 +1233,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         qr2 = QuantumRegister(2, "q2")
         circuit = QuantumCircuit(qr1, qr2)
         circuit.swap(qr1, qr2)
-        self.assertEqual(str(_text_circuit_drawer(circuit, justify="left")), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, justify="left")),
+            expected,
+        )
 
     def test_text_justify_right_measure_resize(self):
         """Measure gate can resize if necessary"""
@@ -1194,7 +1257,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr1, cr1)
         circuit.x(qr1[0])
         circuit.measure(qr1[1], cr1[1])
-        self.assertEqual(str(_text_circuit_drawer(circuit, justify="right")), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, justify="right")),
+            expected,
+        )
 
     def test_text_box_length(self):
         """The length of boxes is independent of other boxes in the layer
@@ -1216,7 +1282,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit.h(qr[0])
         circuit.h(qr[0])
         circuit.rz(0.0000001, qr[2])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_spacing_2378(self):
         """Small gates in the same layer as long gates.
@@ -1236,7 +1302,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.swap(qr[0], qr[1])
         circuit.rz(11111, qr[2])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     @unittest.skipUnless(HAS_TWEEDLEDUM, "Tweedledum is required for these tests.")
     def test_text_synth_no_registerless(self):
@@ -1261,7 +1327,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
             return a and b and not c
 
         circuit = grover_oracle.synth(registerless=False)
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
 
 class TestTextDrawerLabels(QiskitTestCase):
@@ -1277,7 +1343,7 @@ class TestTextDrawerLabels(QiskitTestCase):
         circuit = QuantumCircuit(1)
         circuit.append(HGate(label="an H gate"), [0])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_controlled_gate_with_label(self):
         """Test a controlled gate-with-a-label."""
@@ -1293,7 +1359,7 @@ class TestTextDrawerLabels(QiskitTestCase):
         circuit = QuantumCircuit(2)
         circuit.append(HGate(label="an H gate").control(1), [0, 1])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_label_on_controlled_gate(self):
         """Test a controlled gate with a label (as a as a whole)."""
@@ -1310,7 +1376,7 @@ class TestTextDrawerLabels(QiskitTestCase):
         circuit = QuantumCircuit(2)
         circuit.append(HGate().control(1, label="a controlled H gate"), [0, 1])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_rzz_on_wide_layer(self):
         """Test a labeled gate (RZZ) in a wide layer.
@@ -1330,7 +1396,7 @@ class TestTextDrawerLabels(QiskitTestCase):
         circuit.rzz(pi / 2, 0, 1)
         circuit.x(2, label="This is a really long long long box")
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_cu1_on_wide_layer(self):
         """Test a labeled gate (CU1) in a wide layer.
@@ -1350,7 +1416,7 @@ class TestTextDrawerLabels(QiskitTestCase):
         circuit.append(CU1Gate(pi / 2), [0, 1])
         circuit.x(2, label="This is a really long long long box")
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
 
 class TestTextDrawerMultiQGates(QiskitTestCase):
@@ -1374,7 +1440,10 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         my_gate2 = Gate(name="twoQ", num_qubits=2, params=[], label="twoQ")
         circuit.append(my_gate2, [qr[0], qr[1]])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, reverse_bits=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, reverse_bits=True)),
+            expected,
+        )
 
     def test_2Qgate_cross_wires(self):
         """2Q no params, with cross wires"""
@@ -1394,7 +1463,10 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         my_gate2 = Gate(name="twoQ", num_qubits=2, params=[], label="twoQ")
         circuit.append(my_gate2, [qr[1], qr[0]])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, reverse_bits=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, reverse_bits=True)),
+            expected,
+        )
 
     def test_3Qgate_cross_wires(self):
         """3Q no params, with cross wires"""
@@ -1416,7 +1488,10 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         my_gate3 = Gate(name="threeQ", num_qubits=3, params=[], label="threeQ")
         circuit.append(my_gate3, [qr[1], qr[2], qr[0]])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, reverse_bits=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, reverse_bits=True)),
+            expected,
+        )
 
     def test_2Qgate_nottogether(self):
         """2Q that are not together"""
@@ -1437,7 +1512,10 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         my_gate2 = Gate(name="twoQ", num_qubits=2, params=[], label="twoQ")
         circuit.append(my_gate2, [qr[0], qr[2]])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, reverse_bits=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, reverse_bits=True)),
+            expected,
+        )
 
     def test_2Qgate_nottogether_across_4(self):
         """2Q that are 2 bits apart"""
@@ -1461,7 +1539,10 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         my_gate2 = Gate(name="twoQ", num_qubits=2, params=[], label="twoQ")
         circuit.append(my_gate2, [qr[0], qr[3]])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, reverse_bits=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, reverse_bits=True)),
+            expected,
+        )
 
     def test_unitary_nottogether_across_4(self):
         """unitary that are 2 bits apart"""
@@ -1484,7 +1565,7 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
 
         qc.append(random_unitary(4, seed=42), [qr[0], qr[3]])
 
-        self.assertEqual(str(_text_circuit_drawer(qc)), expected)
+        self.assertEqual(str(circuit_drawer(qc, initial_state=True, output="text")), expected)
 
     def test_kraus(self):
         """Test Kraus.
@@ -1499,7 +1580,7 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         qc = QuantumCircuit(qr)
         qc.append(error, [qr[0]])
 
-        self.assertEqual(str(_text_circuit_drawer(qc)), expected)
+        self.assertEqual(str(circuit_drawer(qc, output="text", initial_state=True)), expected)
 
     def test_multiplexer(self):
         """Test Multiplexer.
@@ -1520,7 +1601,7 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         qc = QuantumCircuit(qr)
         qc.append(cx_multiplexer, [qr[0], qr[1]])
 
-        self.assertEqual(str(_text_circuit_drawer(qc)), expected)
+        self.assertEqual(str(circuit_drawer(qc, output="text", initial_state=True)), expected)
 
     def test_label_over_name_2286(self):
         """If there is a label, it should be used instead of the name
@@ -1540,7 +1621,7 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         circ.append(XGate(label="alt-X"), [qr[0]])
         circ.append(UnitaryGate(numpy.eye(4), label="iswap"), [qr[0], qr[1]])
 
-        self.assertEqual(str(_text_circuit_drawer(circ)), expected)
+        self.assertEqual(str(circuit_drawer(circ, output="text", initial_state=True)), expected)
 
     def test_label_turns_to_box_2286(self):
         """If there is a label, non-boxes turn into boxes
@@ -1560,7 +1641,7 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         circ.append(CZGate(), [qr[0], qr[1]])
         circ.append(CZGate(label="cz label"), [qr[0], qr[1]])
 
-        self.assertEqual(str(_text_circuit_drawer(circ)), expected)
+        self.assertEqual(str(circuit_drawer(circ, output="text", initial_state=True)), expected)
 
     def test_control_gate_with_base_label_4361(self):
         """Control gate has a label and a base gate with a label
@@ -1582,7 +1663,7 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         circ.append(controlh, [0, 1])
         circ.append(controlh, [1, 0])
 
-        self.assertEqual(str(_text_circuit_drawer(circ)), expected)
+        self.assertEqual(str(circuit_drawer(circ, output="text", initial_state=True)), expected)
 
     def test_control_gate_label_with_cond_1_low(self):
         """Control gate has a label and a conditional (compression=low)
@@ -1608,7 +1689,12 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         controlh = hgate.control(label="my ch").c_if(cr, 1)
         circ.append(controlh, [0, 1])
 
-        self.assertEqual(str(_text_circuit_drawer(circ, vertical_compression="low")), expected)
+        self.assertEqual(
+            str(
+                circuit_drawer(circ, output="text", initial_state=True, vertical_compression="low")
+            ),
+            expected,
+        )
 
     def test_control_gate_label_with_cond_1_low_cregbundle(self):
         """Control gate has a label and a conditional (compression=low) with cregbundle
@@ -1635,7 +1721,16 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         circ.append(controlh, [0, 1])
 
         self.assertEqual(
-            str(_text_circuit_drawer(circ, vertical_compression="low", cregbundle=True)), expected
+            str(
+                circuit_drawer(
+                    circ,
+                    output="text",
+                    initial_state=True,
+                    vertical_compression="low",
+                    cregbundle=True,
+                )
+            ),
+            expected,
         )
 
     def test_control_gate_label_with_cond_1_med(self):
@@ -1661,7 +1756,15 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         circ.append(controlh, [0, 1])
 
         self.assertEqual(
-            str(_text_circuit_drawer(circ, cregbundle=False, vertical_compression="medium")),
+            str(
+                circuit_drawer(
+                    circ,
+                    output="text",
+                    initial_state=True,
+                    cregbundle=False,
+                    vertical_compression="medium",
+                )
+            ),
             expected,
         )
 
@@ -1689,7 +1792,15 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         circ.append(controlh, [0, 1])
 
         self.assertEqual(
-            str(_text_circuit_drawer(circ, vertical_compression="medium", cregbundle=True)),
+            str(
+                circuit_drawer(
+                    circ,
+                    output="text",
+                    initial_state=True,
+                    cregbundle=True,
+                    vertical_compression="medium",
+                )
+            ),
             expected,
         )
 
@@ -1716,7 +1827,16 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         circ.append(controlh, [0, 1])
 
         self.assertEqual(
-            str(_text_circuit_drawer(circ, cregbundle=False, vertical_compression="high")), expected
+            str(
+                circuit_drawer(
+                    circ,
+                    output="text",
+                    initial_state=True,
+                    cregbundle=False,
+                    vertical_compression="high",
+                )
+            ),
+            expected,
         )
 
     def test_control_gate_label_with_cond_1_high_cregbundle(self):
@@ -1742,7 +1862,16 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         circ.append(controlh, [0, 1])
 
         self.assertEqual(
-            str(_text_circuit_drawer(circ, vertical_compression="high", cregbundle=True)), expected
+            str(
+                circuit_drawer(
+                    circ,
+                    output="text",
+                    initial_state=True,
+                    cregbundle=True,
+                    vertical_compression="high",
+                )
+            ),
+            expected,
         )
 
     def test_control_gate_label_with_cond_2_med_space(self):
@@ -1768,7 +1897,14 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         controlh = hgate.control(label="my ch").c_if(cr, 1)
         circ.append(controlh, [1, 0])
 
-        self.assertEqual(str(_text_circuit_drawer(circ, vertical_compression="medium")), expected)
+        self.assertEqual(
+            str(
+                circuit_drawer(
+                    circ, output="text", initial_state=True, vertical_compression="medium"
+                )
+            ),
+            expected,
+        )
 
     def test_control_gate_label_with_cond_2_med(self):
         """Control gate has a label and a conditional (on label, compression=med)
@@ -1794,7 +1930,15 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         circ.append(controlh, [1, 0])
 
         self.assertEqual(
-            str(_text_circuit_drawer(circ, cregbundle=False, vertical_compression="medium")),
+            str(
+                circuit_drawer(
+                    circ,
+                    output="text",
+                    initial_state=True,
+                    cregbundle=False,
+                    vertical_compression="medium",
+                )
+            ),
             expected,
         )
 
@@ -1822,7 +1966,15 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         circ.append(controlh, [1, 0])
 
         self.assertEqual(
-            str(_text_circuit_drawer(circ, vertical_compression="medium", cregbundle=True)),
+            str(
+                circuit_drawer(
+                    circ,
+                    output="text",
+                    initial_state=True,
+                    cregbundle=True,
+                    vertical_compression="medium",
+                )
+            ),
             expected,
         )
 
@@ -1851,7 +2003,16 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         circ.append(controlh, [1, 0])
 
         self.assertEqual(
-            str(_text_circuit_drawer(circ, cregbundle=False, vertical_compression="low")), expected
+            str(
+                circuit_drawer(
+                    circ,
+                    output="text",
+                    initial_state=True,
+                    cregbundle=False,
+                    vertical_compression="low",
+                )
+            ),
+            expected,
         )
 
     def test_control_gate_label_with_cond_2_low_cregbundle(self):
@@ -1879,7 +2040,16 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         circ.append(controlh, [1, 0])
 
         self.assertEqual(
-            str(_text_circuit_drawer(circ, vertical_compression="low", cregbundle=True)), expected
+            str(
+                circuit_drawer(
+                    circ,
+                    output="text",
+                    initial_state=True,
+                    cregbundle=True,
+                    vertical_compression="low",
+                )
+            ),
+            expected,
         )
 
 
@@ -1899,7 +2069,7 @@ class TestTextDrawerParams(QiskitTestCase):
         qr = QuantumRegister(1, "q")
         circuit = QuantumCircuit(qr)
         circuit.x(0)
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_parameters_mix(self):
         """cu3 drawing with parameters"""
@@ -1917,7 +2087,7 @@ class TestTextDrawerParams(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.cu(pi / 2, Parameter("theta"), pi, 0, qr[0], qr[1])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_bound_parameters(self):
         """Bound parameters
@@ -1937,7 +2107,7 @@ class TestTextDrawerParams(QiskitTestCase):
         circuit.append(my_u2, [qr[0]])
         circuit = circuit.assign_parameters({phi: 3.141592653589793, lam: 3.141592653589793})
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_pi_param_expr(self):
         """Text pi in circuit with parameter expression."""
@@ -1976,7 +2146,7 @@ class TestTextDrawerParams(QiskitTestCase):
         qr = QuantumRegister(1, "q")
         circuit = QuantumCircuit(qr)
         circuit.unitary(numpy.array([[0, 1], [1, 0]]), 0)
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_qc_parameters(self):
         """Test that if params are type QuantumCircuit, params are not displayed."""
@@ -1997,7 +2167,7 @@ class TestTextDrawerParams(QiskitTestCase):
         qr = QuantumRegister(2, "q")
         circuit = QuantumCircuit(qr)
         circuit.append(inst, [0, 1])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
 
 class TestTextDrawerVerticalCompressionLow(QiskitTestCase):
@@ -2030,7 +2200,15 @@ class TestTextDrawerVerticalCompressionLow(QiskitTestCase):
 
         circuit = QuantumCircuit.from_qasm_str(qasm_string)
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, cregbundle=False, vertical_compression="low")),
+            str(
+                circuit_drawer(
+                    circuit,
+                    output="text",
+                    initial_state=True,
+                    cregbundle=False,
+                    vertical_compression="low",
+                )
+            ),
             expected,
         )
 
@@ -2061,7 +2239,15 @@ class TestTextDrawerVerticalCompressionLow(QiskitTestCase):
 
         circuit = QuantumCircuit.from_qasm_str(qasm_string)
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, vertical_compression="low", cregbundle=True)),
+            str(
+                circuit_drawer(
+                    circuit,
+                    output="text",
+                    initial_state=True,
+                    vertical_compression="low",
+                    cregbundle=True,
+                )
+            ),
             expected,
         )
 
@@ -2104,8 +2290,13 @@ class TestTextDrawerVerticalCompressionLow(QiskitTestCase):
 
         self.assertEqual(
             str(
-                _text_circuit_drawer(
-                    circuit, vertical_compression="low", cregbundle=False, reverse_bits=True
+                circuit_drawer(
+                    circuit,
+                    output="text",
+                    initial_state=True,
+                    cregbundle=False,
+                    reverse_bits=True,
+                    vertical_compression="low",
                 )
             ),
             expected,
@@ -2150,8 +2341,13 @@ class TestTextDrawerVerticalCompressionLow(QiskitTestCase):
 
         self.assertEqual(
             str(
-                _text_circuit_drawer(
-                    circuit, vertical_compression="low", cregbundle=False, reverse_bits=False
+                circuit_drawer(
+                    circuit,
+                    output="text",
+                    initial_state=True,
+                    vertical_compression="low",
+                    cregbundle=False,
+                    reverse_bits=False,
                 )
             ),
             expected,
@@ -2180,7 +2376,15 @@ class TestTextDrawerVerticalCompressionLow(QiskitTestCase):
         circuit.h(qr1[1])
         circuit.measure(qr1[1], cr1[1])
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, justify="right", vertical_compression="low")),
+            str(
+                circuit_drawer(
+                    circuit,
+                    output="text",
+                    initial_state=True,
+                    justify="right",
+                    vertical_compression="low",
+                )
+            ),
             expected,
         )
 
@@ -2212,7 +2416,15 @@ class TestTextDrawerVerticalCompressionMedium(QiskitTestCase):
         )
         circuit = QuantumCircuit.from_qasm_str(qasm_string)
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, cregbundle=False, vertical_compression="medium")),
+            str(
+                circuit_drawer(
+                    circuit,
+                    output="text",
+                    initial_state=True,
+                    cregbundle=False,
+                    vertical_compression="medium",
+                )
+            ),
             expected,
         )
 
@@ -2242,7 +2454,15 @@ class TestTextDrawerVerticalCompressionMedium(QiskitTestCase):
 
         circuit = QuantumCircuit.from_qasm_str(qasm_string)
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, vertical_compression="medium", cregbundle=True)),
+            str(
+                circuit_drawer(
+                    circuit,
+                    output="text",
+                    initial_state=True,
+                    vertical_compression="medium",
+                    cregbundle=True,
+                )
+            ),
             expected,
         )
 
@@ -2275,7 +2495,15 @@ class TestTextDrawerVerticalCompressionMedium(QiskitTestCase):
         )
         circuit = QuantumCircuit.from_qasm_str(qasm_string)
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, cregbundle=False, vertical_compression="medium")),
+            str(
+                circuit_drawer(
+                    circuit,
+                    output="text",
+                    initial_state=True,
+                    cregbundle=False,
+                    vertical_compression="medium",
+                )
+            ),
             expected,
         )
 
@@ -2305,7 +2533,15 @@ class TestTextDrawerVerticalCompressionMedium(QiskitTestCase):
         )
         circuit = QuantumCircuit.from_qasm_str(qasm_string)
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, vertical_compression="medium", cregbundle=True)),
+            str(
+                circuit_drawer(
+                    circuit,
+                    output="text",
+                    initial_state=True,
+                    vertical_compression="medium",
+                    cregbundle=True,
+                )
+            ),
             expected,
         )
 
@@ -2332,7 +2568,15 @@ class TestTextDrawerVerticalCompressionMedium(QiskitTestCase):
         )
 
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, vertical_compression="medium", cregbundle=False)),
+            str(
+                circuit_drawer(
+                    circuit,
+                    output="text",
+                    initial_state=True,
+                    vertical_compression="medium",
+                    cregbundle=False,
+                )
+            ),
             expected,
         )
 
@@ -2360,7 +2604,15 @@ class TestTextDrawerVerticalCompressionMedium(QiskitTestCase):
         )
 
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, vertical_compression="medium", cregbundle=False)),
+            str(
+                circuit_drawer(
+                    circuit,
+                    output="text",
+                    initial_state=True,
+                    vertical_compression="medium",
+                    cregbundle=False,
+                )
+            ),
             expected,
         )
 
@@ -2391,8 +2643,10 @@ class TestTextDrawerVerticalCompressionMedium(QiskitTestCase):
 
         self.assertEqual(
             str(
-                _text_circuit_drawer(
+                circuit_drawer(
                     circuit,
+                    output="text",
+                    initial_state=True,
                     vertical_compression="medium",
                     wire_order=[0, 1, 3, 4, 2],
                     cregbundle=False,
@@ -2429,7 +2683,18 @@ class TestTextConditional(QiskitTestCase):
         )
 
         circuit = QuantumCircuit.from_qasm_str(qasm_string)
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=True)), expected)
+        self.assertEqual(
+            str(
+                circuit_drawer(
+                    circuit,
+                    output="text",
+                    initial_state=True,
+                    cregbundle=True,
+                    vertical_compression="high",
+                )
+            ),
+            expected,
+        )
 
     def test_text_conditional_1(self):
         """Conditional drawing with 1-bit-length regs."""
@@ -2455,7 +2720,10 @@ class TestTextConditional(QiskitTestCase):
         )
 
         circuit = QuantumCircuit.from_qasm_str(qasm_string)
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=False)),
+            expected,
+        )
 
     def test_text_conditional_2_cregbundle(self):
         """Conditional drawing with 2-bit-length regs with cregbundle"""
@@ -2480,7 +2748,18 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
         circuit = QuantumCircuit.from_qasm_str(qasm_string)
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=True)), expected)
+        self.assertEqual(
+            str(
+                circuit_drawer(
+                    circuit,
+                    output="text",
+                    initial_state=True,
+                    cregbundle=True,
+                    vertical_compression="high",
+                )
+            ),
+            expected,
+        )
 
     def test_text_conditional_2(self):
         """Conditional drawing with 2-bit-length regs."""
@@ -2509,7 +2788,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
         circuit = QuantumCircuit.from_qasm_str(qasm_string)
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=False)),
+            expected,
+        )
 
     def test_text_conditional_3_cregbundle(self):
         """Conditional drawing with 3-bit-length regs with cregbundle."""
@@ -2534,7 +2816,18 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
         circuit = QuantumCircuit.from_qasm_str(qasm_string)
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=True)), expected)
+        self.assertEqual(
+            str(
+                circuit_drawer(
+                    circuit,
+                    output="text",
+                    initial_state=True,
+                    cregbundle=True,
+                    vertical_compression="high",
+                )
+            ),
+            expected,
+        )
 
     def test_text_conditional_3(self):
         """Conditional drawing with 3-bit-length regs."""
@@ -2567,7 +2860,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
         circuit = QuantumCircuit.from_qasm_str(qasm_string)
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=False)),
+            expected,
+        )
 
     def test_text_conditional_4(self):
         """Conditional drawing with 4-bit-length regs."""
@@ -2592,7 +2888,14 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
         circuit = QuantumCircuit.from_qasm_str(qasm_string)
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(
+            str(
+                circuit_drawer(
+                    circuit, output="text", initial_state=True, vertical_compression="high"
+                )
+            ),
+            expected,
+        )
 
     def test_text_conditional_5(self):
         """Conditional drawing with 5-bit-length regs."""
@@ -2633,7 +2936,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
         circuit = QuantumCircuit.from_qasm_str(qasm_string)
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=False)),
+            expected,
+        )
 
     def test_text_conditional_cz_no_space_cregbundle(self):
         """Conditional CZ without space"""
@@ -2654,7 +2960,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=True)),
+            expected,
+        )
 
     def test_text_conditional_cz_no_space(self):
         """Conditional CZ without space"""
@@ -2675,7 +2984,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=False)),
+            expected,
+        )
 
     def test_text_conditional_cz_cregbundle(self):
         """Conditional CZ with a wire in the middle"""
@@ -2698,7 +3010,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=True)),
+            expected,
+        )
 
     def test_text_conditional_cz(self):
         """Conditional CZ with a wire in the middle"""
@@ -2721,7 +3036,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=False)),
+            expected,
+        )
 
     def test_text_conditional_cx_ct_cregbundle(self):
         """Conditional CX (control-target) with a wire in the middle"""
@@ -2744,7 +3062,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=True)),
+            expected,
+        )
 
     def test_text_conditional_cx_ct(self):
         """Conditional CX (control-target) with a wire in the middle"""
@@ -2767,7 +3088,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=False)),
+            expected,
+        )
 
     def test_text_conditional_cx_tc_cregbundle(self):
         """Conditional CX (target-control) with a wire in the middle with cregbundle."""
@@ -2790,7 +3114,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=True)),
+            expected,
+        )
 
     def test_text_conditional_cx_tc(self):
         """Conditional CX (target-control) with a wire in the middle"""
@@ -2813,7 +3140,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=False)),
+            expected,
+        )
 
     def test_text_conditional_cu3_ct_cregbundle(self):
         """Conditional Cu3 (control-target) with a wire in the middle with cregbundle"""
@@ -2836,7 +3166,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=True)),
+            expected,
+        )
 
     def test_text_conditional_cu3_ct(self):
         """Conditional Cu3 (control-target) with a wire in the middle"""
@@ -2859,7 +3192,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=False)),
+            expected,
+        )
 
     def test_text_conditional_cu3_tc_cregbundle(self):
         """Conditional Cu3 (target-control) with a wire in the middle with cregbundle"""
@@ -2882,7 +3218,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=True)),
+            expected,
+        )
 
     def test_text_conditional_cu3_tc(self):
         """Conditional Cu3 (target-control) with a wire in the middle"""
@@ -2905,7 +3244,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=False)),
+            expected,
+        )
 
     def test_text_conditional_ccx_cregbundle(self):
         """Conditional CCX with a wire in the middle with cregbundle"""
@@ -2930,7 +3272,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=True)),
+            expected,
+        )
 
     def test_text_conditional_ccx(self):
         """Conditional CCX with a wire in the middle"""
@@ -2955,7 +3300,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=False)),
+            expected,
+        )
 
     def test_text_conditional_ccx_no_space_cregbundle(self):
         """Conditional CCX without space with cregbundle"""
@@ -2978,7 +3326,18 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=True)), expected)
+        self.assertEqual(
+            str(
+                circuit_drawer(
+                    circuit,
+                    output="text",
+                    initial_state=True,
+                    cregbundle=True,
+                    vertical_compression="high",
+                )
+            ),
+            expected,
+        )
 
     def test_text_conditional_ccx_no_space(self):
         """Conditional CCX without space"""
@@ -3001,7 +3360,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=False)),
+            expected,
+        )
 
     def test_text_conditional_h_cregbundle(self):
         """Conditional H with a wire in the middle with cregbundle"""
@@ -3022,7 +3384,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=True)),
+            expected,
+        )
 
     def test_text_conditional_h(self):
         """Conditional H with a wire in the middle"""
@@ -3043,7 +3408,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=False)),
+            expected,
+        )
 
     def test_text_conditional_swap_cregbundle(self):
         """Conditional SWAP with cregbundle"""
@@ -3066,7 +3434,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=True)),
+            expected,
+        )
 
     def test_text_conditional_swap(self):
         """Conditional SWAP"""
@@ -3089,7 +3460,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=False)),
+            expected,
+        )
 
     def test_text_conditional_cswap_cregbundle(self):
         """Conditional CSwap with cregbundle"""
@@ -3114,7 +3488,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=True)),
+            expected,
+        )
 
     def test_text_conditional_cswap(self):
         """Conditional CSwap"""
@@ -3139,7 +3516,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=False)),
+            expected,
+        )
 
     def test_conditional_reset_cregbundle(self):
         """Reset drawing with cregbundle."""
@@ -3161,7 +3541,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=True)),
+            expected,
+        )
 
     def test_conditional_reset(self):
         """Reset drawing."""
@@ -3183,7 +3566,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=False)),
+            expected,
+        )
 
     def test_conditional_multiplexer_cregbundle(self):
         """Test Multiplexer with cregbundle."""
@@ -3207,7 +3593,9 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(qc, cregbundle=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(qc, output="text", initial_state=True, cregbundle=True)), expected
+        )
 
     def test_conditional_multiplexer(self):
         """Test Multiplexer."""
@@ -3231,7 +3619,9 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(qc, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(qc, output="text", initial_state=True, cregbundle=False)), expected
+        )
 
     def test_text_conditional_measure_cregbundle(self):
         """Conditional with measure on same clbit with cregbundle"""
@@ -3254,7 +3644,18 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=True)), expected)
+        self.assertEqual(
+            str(
+                circuit_drawer(
+                    circuit,
+                    output="text",
+                    initial_state=True,
+                    cregbundle=True,
+                    vertical_compression="high",
+                )
+            ),
+            expected,
+        )
 
     def test_text_conditional_measure(self):
         """Conditional with measure on same clbit"""
@@ -3278,7 +3679,10 @@ class TestTextConditional(QiskitTestCase):
                 "                  0x1 ",
             ]
         )
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=False)),
+            expected,
+        )
 
     def test_text_bit_conditional(self):
         """Test bit conditions on gates"""
@@ -3303,7 +3707,10 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=False)),
+            expected,
+        )
 
     def test_text_bit_conditional_cregbundle(self):
         """Test bit conditions on gates when cregbundle=True"""
@@ -3328,7 +3735,15 @@ class TestTextConditional(QiskitTestCase):
         )
 
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, cregbundle=True, vertical_compression="medium")),
+            str(
+                circuit_drawer(
+                    circuit,
+                    output="text",
+                    initial_state=True,
+                    cregbundle=True,
+                    vertical_compression="medium",
+                )
+            ),
             expected,
         )
 
@@ -3362,7 +3777,8 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, cregbundle=True, initial_state=False)), expected
+            str(circuit_drawer(circuit, output="text", cregbundle=True, initial_state=False)),
+            expected,
         )
 
     def test_text_condition_measure_bits_false(self):
@@ -3401,7 +3817,8 @@ class TestTextConditional(QiskitTestCase):
             ]
         )
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, cregbundle=False, initial_state=False)), expected
+            str(circuit_drawer(circuit, output="text", cregbundle=False, initial_state=False)),
+            expected,
         )
 
     def test_text_conditional_reverse_bits_1(self):
@@ -3428,7 +3845,12 @@ class TestTextConditional(QiskitTestCase):
         )
 
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, cregbundle=False, reverse_bits=True)), expected
+            str(
+                circuit_drawer(
+                    circuit, output="text", initial_state=True, cregbundle=False, reverse_bits=True
+                )
+            ),
+            expected,
         )
 
     def test_text_conditional_reverse_bits_2(self):
@@ -3460,7 +3882,12 @@ class TestTextConditional(QiskitTestCase):
         )
 
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, cregbundle=False, reverse_bits=True)), expected
+            str(
+                circuit_drawer(
+                    circuit, output="text", initial_state=True, cregbundle=False, reverse_bits=True
+                )
+            ),
+            expected,
         )
 
     def test_text_condition_bits_reverse(self):
@@ -3493,8 +3920,8 @@ class TestTextConditional(QiskitTestCase):
         )
         self.assertEqual(
             str(
-                _text_circuit_drawer(
-                    circuit, cregbundle=True, initial_state=False, reverse_bits=True
+                circuit_drawer(
+                    circuit, output="text", cregbundle=True, initial_state=False, reverse_bits=True
                 )
             ),
             expected,
@@ -3514,7 +3941,10 @@ class TestTextIdleWires(QiskitTestCase):
         qr1 = QuantumRegister(3, "q1")
         circuit = QuantumCircuit(qr1)
         circuit.h(qr1[1])
-        self.assertEqual(str(_text_circuit_drawer(circuit, idle_wires=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, idle_wires=False)),
+            expected,
+        )
 
     def test_text_measure(self):
         """Remove QuWires and ClWires."""
@@ -3535,13 +3965,19 @@ class TestTextIdleWires(QiskitTestCase):
         cr2 = ClassicalRegister(2, "c2")
         circuit = QuantumCircuit(qr1, qr2, cr1, cr2)
         circuit.measure(qr2, cr2)
-        self.assertEqual(str(_text_circuit_drawer(circuit, idle_wires=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, idle_wires=False)),
+            expected,
+        )
 
     def test_text_empty_circuit(self):
         """Remove everything in an empty circuit."""
         expected = ""
         circuit = QuantumCircuit()
-        self.assertEqual(str(_text_circuit_drawer(circuit, idle_wires=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, idle_wires=False)),
+            expected,
+        )
 
     def test_text_barrier(self):
         """idle_wires should ignore barrier
@@ -3555,7 +3991,10 @@ class TestTextIdleWires(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.h(qr[1])
         circuit.barrier(qr[1], qr[2])
-        self.assertEqual(str(_text_circuit_drawer(circuit, idle_wires=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, idle_wires=False)),
+            expected,
+        )
 
     def test_text_barrier_delay(self):
         """idle_wires should ignore delay"""
@@ -3569,7 +4008,10 @@ class TestTextIdleWires(QiskitTestCase):
         circuit.h(qr[1])
         circuit.barrier()
         circuit.delay(100, qr[2])
-        self.assertEqual(str(_text_circuit_drawer(circuit, idle_wires=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, idle_wires=False)),
+            expected,
+        )
 
     def test_does_not_mutate_circuit(self):
         """Using 'idle_wires=False' should not mutate the circuit.  Regression test of gh-8739."""
@@ -3594,7 +4036,7 @@ class TestTextNonRational(QiskitTestCase):
         qr = QuantumRegister(1, "q")
         circuit = QuantumCircuit(qr)
         circuit.u(pi, -5 * pi / 8, 0, qr[0])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_complex(self):
         """Complex numbers show up in the text
@@ -3671,7 +4113,7 @@ class TestTextInstructionWithBothWires(QiskitTestCase):
         circuit = QuantumCircuit(qr1, cr1)
         circuit.append(inst, qr1[:], cr1[:])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_all_2q_2c(self):
         """Test q0-q1-c0-c1 in q0-q1-c0-c1"""
@@ -3695,7 +4137,7 @@ class TestTextInstructionWithBothWires(QiskitTestCase):
         circuit = QuantumCircuit(qr2, cr2)
         circuit.append(inst, qr2[:], cr2[:])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_all_2q_2c_cregbundle(self):
         """Test q0-q1-c0-c1 in q0-q1-c0-c1. Ignore cregbundle=True"""
@@ -3719,7 +4161,10 @@ class TestTextInstructionWithBothWires(QiskitTestCase):
         circuit = QuantumCircuit(qr2, cr2)
         circuit.append(inst, qr2[:], cr2[:])
         with self.assertWarns(RuntimeWarning):
-            self.assertEqual(str(_text_circuit_drawer(circuit, cregbundle=True)), expected)
+            self.assertEqual(
+                str(circuit_drawer(circuit, output="text", initial_state=True, cregbundle=True)),
+                expected,
+            )
 
     def test_text_4q_2c(self):
         """Test q1-q2-q3-q4-c1-c2 in q0-q1-q2-q3-q4-q5-c0-c1-c2-c3-c4-c5"""
@@ -3761,7 +4206,7 @@ class TestTextInstructionWithBothWires(QiskitTestCase):
         circuit = QuantumCircuit(qr6, cr6)
         circuit.append(inst, qr6[1:5], cr6[1:3])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_2q_1c(self):
         """Test q0-c0 in q0-q1-c0
@@ -3784,7 +4229,7 @@ class TestTextInstructionWithBothWires(QiskitTestCase):
         inst = QuantumCircuit(1, 1, name="Name").to_instruction()
         circuit.append(inst, [qr[0]], [cr[0]])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_3q_3c_qlabels_inverted(self):
         """Test q3-q0-q1-c0-c1-c_10 in q0-q1-q2-q3-c0-c1-c2-c_10-c_11
@@ -3820,7 +4265,7 @@ class TestTextInstructionWithBothWires(QiskitTestCase):
         inst = QuantumCircuit(3, 3, name="Name").to_instruction()
         circuit.append(inst, [qr[3], qr[0], qr[1]], [cr[0], cr[1], cr1[0]])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_3q_3c_clabels_inverted(self):
         """Test q0-q1-q3-c_11-c0-c_10 in q0-q1-q2-q3-c0-c1-c2-c_10-c_11
@@ -3856,7 +4301,7 @@ class TestTextInstructionWithBothWires(QiskitTestCase):
         inst = QuantumCircuit(3, 3, name="Name").to_instruction()
         circuit.append(inst, [qr[0], qr[1], qr[3]], [cr1[1], cr[0], cr1[0]])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_3q_3c_qclabels_inverted(self):
         """Test q3-q1-q2-c_11-c0-c_10 in q0-q1-q2-q3-c0-c1-c2-c_10-c_11
@@ -3892,7 +4337,7 @@ class TestTextInstructionWithBothWires(QiskitTestCase):
         inst = QuantumCircuit(3, 3, name="Name").to_instruction()
         circuit.append(inst, [qr[3], qr[1], qr[2]], [cr1[1], cr[0], cr1[0]])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
 
 class TestTextDrawerAppendedLargeInstructions(QiskitTestCase):
@@ -3934,7 +4379,7 @@ class TestTextDrawerAppendedLargeInstructions(QiskitTestCase):
         inst = QuantumCircuit(11, name="Name").to_instruction()
         circuit.append(inst, qr)
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_text_11q_1c(self):
         """Test q0-...-q10-c0 in q0-...-q10-c0"""
@@ -3974,7 +4419,7 @@ class TestTextDrawerAppendedLargeInstructions(QiskitTestCase):
         inst = QuantumCircuit(11, 1, name="Name").to_instruction()
         circuit.append(inst, qr, cr)
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
 
 class TestTextControlledGate(QiskitTestCase):
@@ -3996,7 +4441,7 @@ class TestTextControlledGate(QiskitTestCase):
         qr = QuantumRegister(3, "q")
         circuit = QuantumCircuit(qr)
         circuit.append(HGate().control(2), [qr[0], qr[1], qr[2]])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_cch_mid(self):
         """Controlled CH (middle)"""
@@ -4014,7 +4459,7 @@ class TestTextControlledGate(QiskitTestCase):
         qr = QuantumRegister(3, "q")
         circuit = QuantumCircuit(qr)
         circuit.append(HGate().control(2), [qr[0], qr[2], qr[1]])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_cch_top(self):
         """Controlled CH"""
@@ -4032,7 +4477,7 @@ class TestTextControlledGate(QiskitTestCase):
         qr = QuantumRegister(3, "q")
         circuit = QuantumCircuit(qr)
         circuit.append(HGate().control(2), [qr[2], qr[1], qr[0]])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_c3h(self):
         """Controlled Controlled CH"""
@@ -4052,7 +4497,7 @@ class TestTextControlledGate(QiskitTestCase):
         qr = QuantumRegister(4, "q")
         circuit = QuantumCircuit(qr)
         circuit.append(HGate().control(3), [qr[0], qr[1], qr[2], qr[3]])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_c3h_middle(self):
         """Controlled Controlled CH (middle)"""
@@ -4072,7 +4517,7 @@ class TestTextControlledGate(QiskitTestCase):
         qr = QuantumRegister(4, "q")
         circuit = QuantumCircuit(qr)
         circuit.append(HGate().control(3), [qr[0], qr[3], qr[2], qr[1]])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_c3u2(self):
         """Controlled Controlled U2"""
@@ -4092,7 +4537,7 @@ class TestTextControlledGate(QiskitTestCase):
         qr = QuantumRegister(4, "q")
         circuit = QuantumCircuit(qr)
         circuit.append(U2Gate(pi, -5 * pi / 8).control(3), [qr[0], qr[3], qr[2], qr[1]])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_controlled_composite_gate_edge(self):
         """Controlled composite gates (edge)
@@ -4119,7 +4564,7 @@ class TestTextControlledGate(QiskitTestCase):
         circuit = QuantumCircuit(4)
         circuit.append(cghz, [1, 0, 2, 3])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_controlled_composite_gate_top(self):
         """Controlled composite gates (top)"""
@@ -4145,7 +4590,7 @@ class TestTextControlledGate(QiskitTestCase):
         circuit = QuantumCircuit(4)
         circuit.append(cghz, [0, 1, 3, 2])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_controlled_composite_gate_bot(self):
         """Controlled composite gates (bottom)"""
@@ -4171,7 +4616,7 @@ class TestTextControlledGate(QiskitTestCase):
         circuit = QuantumCircuit(4)
         circuit.append(cghz, [3, 1, 0, 2])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_controlled_composite_gate_top_bot(self):
         """Controlled composite gates (top and bottom)"""
@@ -4199,7 +4644,7 @@ class TestTextControlledGate(QiskitTestCase):
         circuit = QuantumCircuit(5)
         circuit.append(ccghz, [4, 0, 1, 2, 3])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_controlled_composite_gate_all(self):
         """Controlled composite gates (top, bot, and edge)"""
@@ -4229,7 +4674,7 @@ class TestTextControlledGate(QiskitTestCase):
         circuit = QuantumCircuit(6)
         circuit.append(ccghz, [0, 2, 5, 1, 3, 4])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_controlled_composite_gate_even_label(self):
         """Controlled composite gates (top and bottom) with a even label length"""
@@ -4257,7 +4702,7 @@ class TestTextControlledGate(QiskitTestCase):
         circuit = QuantumCircuit(5)
         circuit.append(ccghz, [4, 0, 1, 2, 3])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
 
 class TestTextOpenControlledGate(QiskitTestCase):
@@ -4277,7 +4722,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         qr = QuantumRegister(2, "q")
         circuit = QuantumCircuit(qr)
         circuit.append(HGate().control(1, ctrl_state=0), [qr[0], qr[1]])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_cz_bot(self):
         """Open controlled Z (bottom)"""
@@ -4291,7 +4736,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         qr = QuantumRegister(2, "q")
         circuit = QuantumCircuit(qr)
         circuit.append(ZGate().control(1, ctrl_state=0), [qr[0], qr[1]])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_ccz_bot(self):
         """Closed-Open controlled Z (bottom)"""
@@ -4309,7 +4754,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         qr = QuantumRegister(3, "q")
         circuit = QuantumCircuit(qr)
         circuit.append(ZGate().control(2, ctrl_state="01"), [qr[0], qr[1], qr[2]])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_cccz_conditional(self):
         """Closed-Open controlled Z (with conditional)"""
@@ -4334,7 +4779,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         circuit.append(
             ZGate().control(3, ctrl_state="101").c_if(cr, 1), [qr[0], qr[1], qr[2], qr[3]]
         )
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_cch_bot(self):
         """Controlled CH (bottom)"""
@@ -4352,7 +4797,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         qr = QuantumRegister(3, "q")
         circuit = QuantumCircuit(qr)
         circuit.append(HGate().control(2, ctrl_state="10"), [qr[0], qr[1], qr[2]])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_cch_mid(self):
         """Controlled CH (middle)"""
@@ -4370,7 +4815,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         qr = QuantumRegister(3, "q")
         circuit = QuantumCircuit(qr)
         circuit.append(HGate().control(2, ctrl_state="10"), [qr[0], qr[2], qr[1]])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_cch_top(self):
         """Controlled CH"""
@@ -4388,7 +4833,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         qr = QuantumRegister(3, "q")
         circuit = QuantumCircuit(qr)
         circuit.append(HGate().control(2, ctrl_state="10"), [qr[1], qr[2], qr[0]])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_c3h(self):
         """Controlled Controlled CH"""
@@ -4408,7 +4853,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         qr = QuantumRegister(4, "q")
         circuit = QuantumCircuit(qr)
         circuit.append(HGate().control(3, ctrl_state="100"), [qr[0], qr[1], qr[2], qr[3]])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_c3h_middle(self):
         """Controlled Controlled CH (middle)"""
@@ -4428,7 +4873,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         qr = QuantumRegister(4, "q")
         circuit = QuantumCircuit(qr)
         circuit.append(HGate().control(3, ctrl_state="010"), [qr[0], qr[3], qr[2], qr[1]])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_c3u2(self):
         """Controlled Controlled U2"""
@@ -4450,7 +4895,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         circuit.append(
             U2Gate(pi, -5 * pi / 8).control(3, ctrl_state="100"), [qr[0], qr[3], qr[2], qr[1]]
         )
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_controlled_composite_gate_edge(self):
         """Controlled composite gates (edge)
@@ -4477,7 +4922,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         circuit = QuantumCircuit(4)
         circuit.append(cghz, [1, 0, 2, 3])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_controlled_composite_gate_top(self):
         """Controlled composite gates (top)"""
@@ -4503,7 +4948,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         circuit = QuantumCircuit(4)
         circuit.append(cghz, [0, 1, 3, 2])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_controlled_composite_gate_bot(self):
         """Controlled composite gates (bottom)"""
@@ -4529,7 +4974,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         circuit = QuantumCircuit(4)
         circuit.append(cghz, [3, 1, 0, 2])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_controlled_composite_gate_top_bot(self):
         """Controlled composite gates (top and bottom)"""
@@ -4557,7 +5002,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         circuit = QuantumCircuit(5)
         circuit.append(ccghz, [4, 0, 1, 2, 3])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_controlled_composite_gate_all(self):
         """Controlled composite gates (top, bot, and edge)"""
@@ -4587,7 +5032,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         circuit = QuantumCircuit(6)
         circuit.append(ccghz, [0, 2, 5, 1, 3, 4])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_open_controlled_x(self):
         """Controlled X gates.
@@ -4620,7 +5065,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         control3 = XGate().control(4, ctrl_state="0101")
         circuit.append(control3, [0, 1, 4, 2, 3])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_open_controlled_y(self):
         """Controlled Y gates.
@@ -4653,7 +5098,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         control3 = YGate().control(4, ctrl_state="0101")
         circuit.append(control3, [0, 1, 4, 2, 3])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_open_controlled_z(self):
         """Controlled Z gates."""
@@ -4685,7 +5130,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         control3 = ZGate().control(4, ctrl_state="0101")
         circuit.append(control3, [0, 1, 4, 2, 3])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_open_controlled_u1(self):
         """Controlled U1 gates."""
@@ -4717,7 +5162,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         control3 = U1Gate(0.5).control(4, ctrl_state="0101")
         circuit.append(control3, [0, 1, 4, 2, 3])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_open_controlled_swap(self):
         """Controlled SWAP gates."""
@@ -4747,7 +5192,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         control3 = SwapGate().control(3, ctrl_state="010")
         circuit.append(control3, [0, 1, 2, 3, 4])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_open_controlled_rzz(self):
         """Controlled RZZ gates."""
@@ -4777,7 +5222,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         control3 = RZZGate(1).control(3, ctrl_state="010")
         circuit.append(control3, [0, 1, 2, 3, 4])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_open_out_of_order(self):
         """Out of order CXs
@@ -4801,7 +5246,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.append(XGate().control(3, ctrl_state="101"), [qr[0], qr[3], qr[1], qr[2]])
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
 
 class TestTextWithLayout(QiskitTestCase):
@@ -4823,7 +5268,7 @@ class TestTextWithLayout(QiskitTestCase):
         qr = QuantumRegister(3, "q")
         circuit = QuantumCircuit(qr)
         circuit.h(qr[1])
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_mixed_layout(self):
         """With a mixed layout."""
@@ -4849,7 +5294,9 @@ class TestTextWithLayout(QiskitTestCase):
         pass_.property_set["layout"] = Layout({qr[0]: 0, ancilla[1]: 1, ancilla[0]: 2, qr[1]: 3})
         circuit_with_layout = pass_(circuit)
 
-        self.assertEqual(str(_text_circuit_drawer(circuit_with_layout)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit_with_layout, output="text", initial_state=True)), expected
+        )
 
     def test_partial_layout(self):
         """With a partial layout.
@@ -4878,7 +5325,7 @@ class TestTextWithLayout(QiskitTestCase):
         )
         circuit._layout.initial_layout.add_register(qr)
 
-        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_with_classical_regs(self):
         """Involving classical registers"""
@@ -4909,7 +5356,9 @@ class TestTextWithLayout(QiskitTestCase):
         pass_.property_set["layout"] = Layout({qr1[0]: 0, qr1[1]: 1, qr2[0]: 2, qr2[1]: 3})
         circuit_with_layout = pass_(circuit)
 
-        self.assertEqual(str(_text_circuit_drawer(circuit_with_layout)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit_with_layout, output="text", initial_state=True)), expected
+        )
 
     def test_with_layout_but_disable(self):
         """With parameter without_layout=False"""
@@ -4936,7 +5385,10 @@ class TestTextWithLayout(QiskitTestCase):
         circuit._layout = Layout({qr1[0]: 0, qr1[1]: 1, qr2[0]: 2, qr2[1]: 3})
         circuit.measure(pqr[2], cr[0])
         circuit.measure(pqr[3], cr[1])
-        self.assertEqual(str(_text_circuit_drawer(circuit, with_layout=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, with_layout=False)),
+            expected,
+        )
 
     def test_after_transpile(self):
         """After transpile, the drawing should include the layout"""
@@ -5079,7 +5531,9 @@ class TestTextInitialValue(QiskitTestCase):
             ]
         )
 
-        self.assertEqual(str(_text_circuit_drawer(self.circuit, initial_state=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(self.circuit, output="text", initial_state=False)), expected
+        )
 
 
 class TestTextHamiltonianGate(QiskitTestCase):
@@ -5226,7 +5680,7 @@ class TestCircuitVisualizationImplementation(QiskitVisualizationTestCase):
         circuit.tdg(qr[0])
         circuit.sx(qr[0])
         circuit.sxdg(qr[0])
-        circuit.id(qr[0])
+        circuit.i(qr[0])
         circuit.reset(qr[0])
         circuit.rx(pi, qr[0])
         circuit.ry(pi, qr[0])
@@ -5254,8 +5708,14 @@ class TestCircuitVisualizationImplementation(QiskitVisualizationTestCase):
         """Test that text drawer handles utf8 encoding."""
         filename = "current_textplot_utf8.txt"
         qc = self.sample_circuit()
-        output = _text_circuit_drawer(
-            qc, filename=filename, fold=-1, initial_state=True, cregbundle=False, encoding="utf8"
+        output = circuit_drawer(
+            qc,
+            output="text",
+            filename=filename,
+            fold=-1,
+            initial_state=True,
+            cregbundle=False,
+            encoding="utf8",
         )
         try:
             encode(str(output), encoding="utf8")
@@ -5268,14 +5728,20 @@ class TestCircuitVisualizationImplementation(QiskitVisualizationTestCase):
         """Test that text drawer handles cp437 encoding."""
         filename = "current_textplot_cp437.txt"
         qc = self.sample_circuit()
-        output = _text_circuit_drawer(
-            qc, filename=filename, fold=-1, initial_state=True, cregbundle=False, encoding="cp437"
+        output = circuit_drawer(
+            qc,
+            output="text",
+            filename=filename,
+            fold=-1,
+            initial_state=True,
+            cregbundle=False,
+            encoding="cp437",
         )
         try:
             encode(str(output), encoding="cp437")
         except UnicodeEncodeError:
             self.fail("_text_circuit_drawer() should be cp437.")
-        self.assertFilesAreEqual(filename, self.text_reference_cp437, "cp437")
+        self.assertFilesAreEqual("current_textplot_cp437.txt", self.text_reference_cp437, "cp437")
         os.remove(filename)
 
 
@@ -5310,7 +5776,8 @@ class TestCircuitControlFlowOps(QiskitVisualizationTestCase):
             circuit.h(0)
             circuit.cx(0, 1)
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, initial_state=False, cregbundle=False)), expected
+            str(circuit_drawer(circuit, output="text", initial_state=False, cregbundle=False)),
+            expected,
         )
 
     def test_if_op_bundle_true(self):
@@ -5338,7 +5805,10 @@ class TestCircuitControlFlowOps(QiskitVisualizationTestCase):
         with circuit.if_test((cr[1], 1)):
             circuit.h(0)
             circuit.cx(0, 1)
-        self.assertEqual(str(_text_circuit_drawer(circuit, initial_state=False)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=False)),
+            expected,
+        )
 
     def test_if_else_with_body_specified(self):
         """Test an IfElseOp where the body is directly specified."""
@@ -5382,7 +5852,8 @@ class TestCircuitControlFlowOps(QiskitVisualizationTestCase):
         circuit.if_else((cr[1], 1), circuit2, None, [0, 1, 2], [0, 1, 2])
         circuit.x(0, label="X1i")
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, initial_state=False, cregbundle=False)), expected
+            str(circuit_drawer(circuit, output="text", initial_state=False, cregbundle=False)),
+            expected,
         )
 
     def test_if_op_nested_wire_order(self):
@@ -5464,8 +5935,9 @@ class TestCircuitControlFlowOps(QiskitVisualizationTestCase):
         circuit.x(0)
         self.assertEqual(
             str(
-                _text_circuit_drawer(
+                circuit_drawer(
                     circuit,
+                    output="text",
                     fold=77,
                     initial_state=False,
                     wire_order=[2, 0, 3, 1, 4, 5, 6],
@@ -5509,7 +5981,8 @@ class TestCircuitControlFlowOps(QiskitVisualizationTestCase):
             with circuit.if_test((cr[2], 1)):
                 circuit.x(0)
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, initial_state=False, cregbundle=False)), expected
+            str(circuit_drawer(circuit, output="text", initial_state=False, cregbundle=False)),
+            expected,
         )
 
     def test_for_loop(self):
@@ -5548,7 +6021,11 @@ class TestCircuitControlFlowOps(QiskitVisualizationTestCase):
             with circuit.if_test((cr[2], 1)):
                 circuit.z(0)
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, fold=-1, initial_state=False, cregbundle=False)),
+            str(
+                circuit_drawer(
+                    circuit, output="text", fold=-1, initial_state=False, cregbundle=False
+                )
+            ),
             expected,
         )
 
@@ -5604,7 +6081,11 @@ class TestCircuitControlFlowOps(QiskitVisualizationTestCase):
                 circuit.cx(0, 1)
         circuit.h(0)
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, fold=78, initial_state=False, cregbundle=False)),
+            str(
+                circuit_drawer(
+                    circuit, output="text", fold=78, initial_state=False, cregbundle=False
+                )
+            ),
             expected,
         )
 
@@ -5644,7 +6125,11 @@ class TestCircuitControlFlowOps(QiskitVisualizationTestCase):
 
         circuit = transpile(qc, backend, optimization_level=2, seed_transpiler=671_42)
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, fold=78, initial_state=False, cregbundle=False)),
+            str(
+                circuit_drawer(
+                    circuit, output="text", fold=78, initial_state=False, cregbundle=False
+                )
+            ),
             expected,
         )
 
@@ -5683,132 +6168,9 @@ class TestCircuitControlFlowOps(QiskitVisualizationTestCase):
 
         circuit.if_else((cr[1], 1), qc2, None, [0, 1, 2], [0, 1, 2])
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, initial_state=False, cregbundle=False)), expected
+            str(circuit_drawer(circuit, output="text", initial_state=False, cregbundle=False)),
+            expected,
         )
-
-    def test_if_with_expr(self):
-        """Test an IfElseOp with an expression"""
-        expected = "\n".join(
-            [
-                "       ┌───┐┌─────────────────────────────── ┌───┐ ───────┐ ",
-                " qr_0: ┤ H ├┤ If-0 (cr1 & (cr2 & cr3)) == 3  ┤ Z ├  End-0 ├─",
-                "       └───┘└───────────────╥─────────────── └───┘ ───────┘ ",
-                " qr_1: ─────────────────────╫───────────────────────────────",
-                "                            ║                               ",
-                " qr_2: ─────────────────────╫───────────────────────────────",
-                "                            ║                               ",
-                " cr: 3/═════════════════════╬═══════════════════════════════",
-                "                        ┌───╨────┐                          ",
-                "cr1: 3/═════════════════╡ [expr] ╞══════════════════════════",
-                "                        ├───╨────┤                          ",
-                "cr2: 3/═════════════════╡ [expr] ╞══════════════════════════",
-                "                        ├───╨────┤                          ",
-                "cr3: 3/═════════════════╡ [expr] ╞══════════════════════════",
-                "                        └────────┘                          ",
-            ]
-        )
-        qr = QuantumRegister(3, "qr")
-        cr = ClassicalRegister(3, "cr")
-        cr1 = ClassicalRegister(3, "cr1")
-        cr2 = ClassicalRegister(3, "cr2")
-        cr3 = ClassicalRegister(3, "cr3")
-        circuit = QuantumCircuit(qr, cr, cr1, cr2, cr3)
-
-        circuit.h(0)
-        with circuit.if_test(expr.equal(expr.bit_and(cr1, expr.bit_and(cr2, cr3)), 3)):
-            circuit.z(0)
-
-        self.assertEqual(str(_text_circuit_drawer(circuit, initial_state=False)), expected)
-
-    def test_if_with_expr_nested(self):
-        """Test an IfElseOp with an expression for nested"""
-        expected = "\n".join(
-            [
-                "       ┌───┐┌─────────────────────── ┌───┐                                 ───────┐ ",
-                " qr_0: ┤ H ├┤                        ┤ X ├────────────────────────────────        ├─",
-                "       └───┘│ If-0 (cr2 & cr3) == 3  └───┘┌─────────────── ┌───┐ ───────┐   End-0 │ ",
-                " qr_1: ─────┤                        ─────┤ If-1 cr2 == 5  ┤ Z ├  End-1 ├─        ├─",
-                "            └───────────╥───────────      └───────╥─────── └───┘ ───────┘  ───────┘ ",
-                " qr_2: ─────────────────╫─────────────────────────╫─────────────────────────────────",
-                "                        ║                         ║                                 ",
-                " cr: 3/═════════════════╬═════════════════════════╬═════════════════════════════════",
-                "                        ║                         ║                                 ",
-                "cr1: 3/═════════════════╬═════════════════════════╬═════════════════════════════════",
-                "                    ┌───╨────┐                ┌───╨────┐                            ",
-                "cr2: 3/═════════════╡ [expr] ╞════════════════╡ [expr] ╞════════════════════════════",
-                "                    ├───╨────┤                └────────┘                            ",
-                "cr3: 3/═════════════╡ [expr] ╞══════════════════════════════════════════════════════",
-                "                    └────────┘                                                      ",
-            ]
-        )
-        qr = QuantumRegister(3, "qr")
-        cr = ClassicalRegister(3, "cr")
-        cr1 = ClassicalRegister(3, "cr1")
-        cr2 = ClassicalRegister(3, "cr2")
-        cr3 = ClassicalRegister(3, "cr3")
-        circuit = QuantumCircuit(qr, cr, cr1, cr2, cr3)
-
-        circuit.h(0)
-        with circuit.if_test(expr.equal(expr.bit_and(cr2, cr3), 3)):
-            circuit.x(0)
-            with circuit.if_test(expr.equal(cr2, 5)):
-                circuit.z(1)
-
-        self.assertEqual(
-            str(_text_circuit_drawer(circuit, initial_state=False, fold=120)), expected
-        )
-
-    def test_switch_with_expression(self):
-        """Test an SwitchcaseOp with an expression"""
-        expected = "\n".join(
-            [
-                "       ┌───┐┌──────────────────────────── ┌───────────────────── ┌───┐»",
-                " qr_0: ┤ H ├┤                             ┤                      ┤ X ├»",
-                "       └───┘│ Switch-0 cr1 & (cr2 & cr3)  │ Case-0 (0, 1, 2, 3)  └───┘»",
-                " qr_1: ─────┤                             ┤                      ─────»",
-                "            └─────────────╥────────────── └─────────────────────      »",
-                " qr_2: ───────────────────╫───────────────────────────────────────────»",
-                "                          ║                                           »",
-                " cr: 3/═══════════════════╬═══════════════════════════════════════════»",
-                "                      ┌───╨────┐                                      »",
-                "cr1: 3/═══════════════╡ [expr] ╞══════════════════════════════════════»",
-                "                      ├───╨────┤                                      »",
-                "cr2: 3/═══════════════╡ [expr] ╞══════════════════════════════════════»",
-                "                      ├───╨────┤                                      »",
-                "cr3: 3/═══════════════╡ [expr] ╞══════════════════════════════════════»",
-                "                      └────────┘                                      »",
-                "«       ┌────────────────       ───────┐ ",
-                "« qr_0: ┤                 ──■──        ├─",
-                "«       │ Case-0 default  ┌─┴─┐  End-0 │ ",
-                "« qr_1: ┤                 ┤ X ├        ├─",
-                "«       └──────────────── └───┘ ───────┘ ",
-                "« qr_2: ─────────────────────────────────",
-                "«                                        ",
-                "« cr: 3/═════════════════════════════════",
-                "«                                        ",
-                "«cr1: 3/═════════════════════════════════",
-                "«                                        ",
-                "«cr2: 3/═════════════════════════════════",
-                "«                                        ",
-                "«cr3: 3/═════════════════════════════════",
-                "«                                        ",
-            ]
-        )
-        qr = QuantumRegister(3, "qr")
-        cr = ClassicalRegister(3, "cr")
-        cr1 = ClassicalRegister(3, "cr1")
-        cr2 = ClassicalRegister(3, "cr2")
-        cr3 = ClassicalRegister(3, "cr3")
-        circuit = QuantumCircuit(qr, cr, cr1, cr2, cr3)
-
-        circuit.h(0)
-        with circuit.switch(expr.bit_and(cr1, expr.bit_and(cr2, cr3))) as case:
-            with case(0, 1, 2, 3):
-                circuit.x(0)
-            with case(case.DEFAULT):
-                circuit.cx(0, 1)
-
-        self.assertEqual(str(_text_circuit_drawer(circuit, fold=80, initial_state=False)), expected)
 
 
 if __name__ == "__main__":

--- a/test/visual/mpl/circuit/test_circuit_matplotlib_drawer.py
+++ b/test/visual/mpl/circuit/test_circuit_matplotlib_drawer.py
@@ -23,8 +23,8 @@ from numpy import pi
 
 from qiskit.test import QiskitTestCase
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister, transpile
-from qiskit.providers.fake_provider import FakeTenerife, FakeBelemV2
-from qiskit.visualization.circuit.circuit_visualization import _matplotlib_circuit_drawer
+from qiskit.providers.fake_provider import FakeTenerife
+from qiskit.visualization.circuit.circuit_visualization import circuit_drawer
 from qiskit.circuit.library import (
     XGate,
     MCXGate,
@@ -36,13 +36,11 @@ from qiskit.circuit.library import (
     SGate,
     U1Gate,
     CPhaseGate,
-    HamiltonianGate,
-    Isometry,
 )
 from qiskit.circuit.library import MCXVChain
-from qiskit.circuit import Parameter, Qubit, Clbit, SwitchCaseOp, IfElseOp
+from qiskit.extensions import HamiltonianGate
+from qiskit.circuit import Parameter, Qubit, Clbit
 from qiskit.circuit.library import IQP
-from qiskit.circuit.classical import expr
 from qiskit.quantum_info.random import random_unitary
 from qiskit.utils import optionals
 
@@ -64,7 +62,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
     def setUp(self):
         super().setUp()
         self.circuit_drawer = VisualTestUtilities.save_data_wrap(
-            _matplotlib_circuit_drawer, str(self), RESULT_DIR
+            circuit_drawer, str(self), RESULT_DIR
         )
 
         if not os.path.exists(FAILURE_DIFF_DIR):
@@ -90,7 +88,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit = QuantumCircuit()
 
         fname = "empty_circut.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -119,7 +117,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.add_calibration("h", [0], h_q0)
 
         fname = "calibrations.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -156,7 +154,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.add_calibration("ch", [0, 1], ch_q01)
 
         fname = "calibrations_with_control_gates.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -193,7 +191,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.add_calibration("reset", [0], reset_q0)
 
         fname = "calibrations_with_swap_and_reset.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -229,7 +227,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.add_calibration("rxx", [0, 1], rxx_q01)
 
         fname = "calibrations_with_rzz_and_rxx.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -246,7 +244,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit = QuantumCircuit(2, 3)
 
         fname = "no_op_circut.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -274,7 +272,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.h(qr)
 
         fname = "long_name.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -294,7 +292,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit = QuantumCircuit(q_reg1, q_reg3, c_reg1, c_reg3)
 
         fname = "multi_underscore_true.png"
-        self.circuit_drawer(circuit, cregbundle=True, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", cregbundle=True, filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -304,7 +302,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_PREFIX,
         )
         fname2 = "multi_underscore_false.png"
-        self.circuit_drawer(circuit, cregbundle=False, filename=fname2)
+        self.circuit_drawer(circuit, output="mpl", cregbundle=False, filename=fname2)
 
         ratio2 = VisualTestUtilities._save_diff(
             self._image_path(fname2),
@@ -329,7 +327,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.h(qr[0]).c_if(cr, 2)
 
         fname = "reg_conditional.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -353,7 +351,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.x(qr[1]).c_if(cr[1], 0)
 
         fname = "bit_conditional_bundle.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -377,7 +375,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.x(qr[1]).c_if(cr[1], 0)
 
         fname = "bit_conditional_no_bundle.png"
-        self.circuit_drawer(circuit, filename=fname, cregbundle=False)
+        self.circuit_drawer(circuit, output="mpl", filename=fname, cregbundle=False)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -402,7 +400,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.h(q[0])
 
         fname = "plot_partial_barrier.png"
-        self.circuit_drawer(circuit, filename=fname, plot_barriers=True)
+        self.circuit_drawer(circuit, output="mpl", filename=fname, plot_barriers=True)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -432,12 +430,11 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         # this import appears to be unused, but is actually needed to get snapshot instruction
         import qiskit.extensions.simulator  # pylint: disable=unused-import
 
-        with self.assertWarns(DeprecationWarning):
-            circuit.snapshot("1")
+        circuit.snapshot("1")
 
         # check the barriers plot properly when plot_barriers= True
         fname = "plot_barriers_true.png"
-        self.circuit_drawer(circuit, filename=fname, plot_barriers=True)
+        self.circuit_drawer(circuit, output="mpl", filename=fname, plot_barriers=True)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -447,7 +444,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_PREFIX,
         )
         fname2 = "plot_barriers_false.png"
-        self.circuit_drawer(circuit, filename=fname2, plot_barriers=False)
+        self.circuit_drawer(circuit, output="mpl", filename=fname2, plot_barriers=False)
 
         ratio2 = VisualTestUtilities._save_diff(
             self._image_path(fname2),
@@ -470,7 +467,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.h(q1[1])
 
         fname = "no_barriers.png"
-        self.circuit_drawer(circuit, filename=fname, plot_barriers=False)
+        self.circuit_drawer(circuit, output="mpl", filename=fname, plot_barriers=False)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -491,7 +488,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             circuit.x(0)
 
         fname = "fold_minus1.png"
-        self.circuit_drawer(circuit, fold=-1, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", fold=-1, filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -512,7 +509,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             circuit.x(0)
 
         fname = "fold_4.png"
-        self.circuit_drawer(circuit, fold=4, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", fold=4, filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -546,10 +543,10 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         theta = Parameter("theta")
         circuit.append(HamiltonianGate(matrix, theta), [qr[1], qr[2]])
         circuit = circuit.assign_parameters({theta: 1})
-        circuit.append(Isometry(np.eye(4, 4), 0, 0), list(range(3, 5)))
+        circuit.isometry(np.eye(4, 4), list(range(3, 5)), [])
 
         fname = "big_gates.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -572,7 +569,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.append(MCXVChain(3, dirty_ancillas=True), [qr[0], qr[1], qr[2], qr[3], qr[5]])
 
         fname = "cnot.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -594,7 +591,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.append(ZGate().control(1, ctrl_state="0", label="CZ Gate"), [2, 3])
 
         fname = "cz.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -624,7 +621,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.dcx(3, 4)
 
         fname = "pauli_clifford.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -645,7 +642,9 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.x(1)
 
         fname = "creg_initial_true.png"
-        self.circuit_drawer(circuit, filename=fname, cregbundle=True, initial_state=True)
+        self.circuit_drawer(
+            circuit, output="mpl", filename=fname, cregbundle=True, initial_state=True
+        )
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -655,7 +654,9 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_PREFIX,
         )
         fname2 = "creg_initial_false.png"
-        self.circuit_drawer(circuit, filename=fname2, cregbundle=False, initial_state=False)
+        self.circuit_drawer(
+            circuit, output="mpl", filename=fname2, cregbundle=False, initial_state=False
+        )
 
         ratio2 = VisualTestUtilities._save_diff(
             self._image_path(fname2),
@@ -682,7 +683,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.rzz(pi / 2, 2, 3)
 
         fname = "r_gates.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -706,7 +707,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         )
 
         fname = "ctrl_labels.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -725,7 +726,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.append(RZZGate(3 * pi / 4).control(3, ctrl_state="010"), [2, 1, 4, 3, 0])
 
         fname = "cswap_rzz.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -749,7 +750,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.append(ccghz, [4, 0, 1, 3, 2])
 
         fname = "ghz_to_gate.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -767,7 +768,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.unitary(random_unitary(2**5), circuit.qubits)
 
         fname = "scale_default.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -777,7 +778,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_PREFIX,
         )
         fname2 = "scale_half.png"
-        self.circuit_drawer(circuit, filename=fname2, scale=0.5)
+        self.circuit_drawer(circuit, output="mpl", filename=fname2, scale=0.5)
 
         ratio2 = VisualTestUtilities._save_diff(
             self._image_path(fname2),
@@ -788,7 +789,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         )
 
         fname3 = "scale_double.png"
-        self.circuit_drawer(circuit, filename=fname3, scale=2)
+        self.circuit_drawer(circuit, output="mpl", filename=fname3, scale=2)
 
         ratio3 = VisualTestUtilities._save_diff(
             self._image_path(fname3),
@@ -809,7 +810,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.rx((pi - x) * (pi - y), 0)
 
         fname = "pi_in_param_expr.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -835,7 +836,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         )
 
         fname = "partial_layout.png"
-        self.circuit_drawer(transpiled, filename=fname)
+        self.circuit_drawer(transpiled, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -854,7 +855,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.initialize([0, 1, 0, 0], [0, 1])
 
         fname = "init_reset.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -871,7 +872,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.h(range(3))
 
         fname = "global_phase.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -885,7 +886,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
     def test_alternative_colors(self):
         """Tests alternative color schemes"""
         ratios = []
-        for style in ["iqp", "iqp-dark", "iqx", "iqx-dark", "textbook", "clifford"]:
+        for style in ["iqx", "iqx-dark", "textbook"]:
             with self.subTest(style=style):
                 circuit = QuantumCircuit(7)
                 circuit.h(0)
@@ -893,7 +894,6 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
                 circuit.cx(0, 1)
                 circuit.ccx(0, 1, 2)
                 circuit.swap(0, 1)
-                circuit.iswap(2, 3)
                 circuit.cswap(0, 1, 2)
                 circuit.append(SwapGate().control(2), [0, 1, 2, 3])
                 circuit.dcx(0, 1)
@@ -907,28 +907,19 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
                 circuit.p(pi / 2, 4)
                 circuit.cz(5, 6)
                 circuit.cp(pi / 2, 5, 6)
-                circuit.mcp(pi / 5, [0, 1, 2, 3], 4)
                 circuit.y(5)
                 circuit.rx(pi / 3, 5)
-                circuit.rz(pi / 6, 6)
                 circuit.rzx(pi / 2, 5, 6)
-                circuit.rzz(pi / 4, 5, 6)
                 circuit.u(pi / 2, pi / 2, pi / 2, 5)
                 circuit.barrier(5, 6)
                 circuit.reset(5)
 
                 fname = f"{style}_color.png"
-                # IQX has the same reference filename as IQP
-                if style[:3] == "iqx":
-                    ref_fname = "iqp" + style[3:] + "_color.png"
-                else:
-                    ref_fname = fname
-
-                self.circuit_drawer(circuit, style={"name": style}, filename=fname)
+                self.circuit_drawer(circuit, output="mpl", style={"name": style}, filename=fname)
 
                 ratio = VisualTestUtilities._save_diff(
                     self._image_path(fname),
-                    self._reference_path(ref_fname),
+                    self._reference_path(fname),
                     fname,
                     FAILURE_DIFF_DIR,
                     FAILURE_PREFIX,
@@ -946,7 +937,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.ccx(2, 1, 0)
 
         fname = "reverse_bits.png"
-        self.circuit_drawer(circuit, reverse_bits=True, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", reverse_bits=True, filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -969,7 +960,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.measure_all()
 
         fname = "bw.png"
-        self.circuit_drawer(circuit, style={"name": "bw"}, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", style={"name": "bw"}, filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1012,6 +1003,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         fname = "user_style.png"
         self.circuit_drawer(
             circuit,
+            output="mpl",
             style={
                 "name": "user_style",
                 "displaytext": {"H2": "H_2"},
@@ -1039,7 +1031,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         style = {"name": "iqx", "subfontsize": 11}
 
         fname = "subfont.png"
-        self.circuit_drawer(circuit, style=style, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", style=style, filename=fname)
         self.assertEqual(style, {"name": "iqx", "subfontsize": 11})  # check does not change style
 
         ratio = VisualTestUtilities._save_diff(
@@ -1061,7 +1053,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.h(qr[1]).c_if(cr, 1)
 
         fname = "meas_condition.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1087,7 +1079,9 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.x(2).c_if(cr, 2)
 
         fname = "reverse_bits_cond_true.png"
-        self.circuit_drawer(circuit, cregbundle=False, reverse_bits=True, filename=fname)
+        self.circuit_drawer(
+            circuit, output="mpl", cregbundle=False, reverse_bits=True, filename=fname
+        )
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1097,7 +1091,9 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_PREFIX,
         )
         fname2 = "reverse_bits_cond_false.png"
-        self.circuit_drawer(circuit, cregbundle=False, reverse_bits=False, filename=fname2)
+        self.circuit_drawer(
+            circuit, output="mpl", cregbundle=False, reverse_bits=False, filename=fname2
+        )
 
         ratio2 = VisualTestUtilities._save_diff(
             self._image_path(fname2),
@@ -1115,8 +1111,8 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
 
         def cnotnot(gate_label):
             gate_circuit = QuantumCircuit(3, name=gate_label)
-            gate_circuit.cx(0, 1)
-            gate_circuit.cx(0, 2)
+            gate_circuit.cnot(0, 1)
+            gate_circuit.cnot(0, 2)
             gate = gate_circuit.to_gate()
             return gate
 
@@ -1131,6 +1127,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         fname = "style_custom_gates.png"
         self.circuit_drawer(
             circuit,
+            output="mpl",
             style={
                 "displaycolor": {"CNOTNOT": ("#000000", "#FFFFFF"), "h": ("#A1A1A1", "#043812")},
                 "displaytext": {"CNOTNOT_PRIME": "$\\mathrm{CNOTNOT}'$"},
@@ -1157,6 +1154,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         fname = "6095.png"
         self.circuit_drawer(
             circuit,
+            output="mpl",
             style={"displaycolor": {"cp": ("#A27486", "#000000"), "h": ("#A27486", "#000000")}},
             filename=fname,
         )
@@ -1179,7 +1177,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.append(inst, [qr[0]], [cr[0]])
 
         fname = "instruction_1q_1c.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1200,7 +1198,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.append(inst, [qr[0], qr[1], qr[2]], [cr2[0], cr[0], cr[1]])
 
         fname = "instruction_3q_3c_circ1.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1221,7 +1219,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.append(inst, [qr[3], qr[0], qr[2]], [cr[0], cr[1], cr2[0]])
 
         fname = "instruction_3q_3c_circ2.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1243,7 +1241,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.append(inst, [qr[3], qr[1], qr[2]], [cr3[1], cr[1], cr3[0]])
 
         fname = "instruction_3q_3c_circ3.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1262,7 +1260,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.initialize(initial_state)
 
         fname = "wide_params.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1284,7 +1282,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.measure(0, 0)
 
         fname = "one_bit_regs.png"
-        self.circuit_drawer(circuit, cregbundle=False, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", cregbundle=False, filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1313,7 +1311,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         plt.close(fig)
 
         fname = "user_ax.png"
-        self.circuit_drawer(circuit, ax=ax2, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", ax=ax2, filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1334,7 +1332,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.x(2)
 
         fname = "figwidth.png"
-        self.circuit_drawer(circuit, style={"figwidth": 5}, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", style={"figwidth": 5}, filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1353,7 +1351,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit = QuantumCircuit(qrx, [Qubit(), Qubit()], qry, [Clbit(), Clbit()], crx)
 
         fname = "registerless_one_bit.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1377,7 +1375,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.h(0).c_if(cr2, 3)
 
         fname = "measure_cond_false.png"
-        self.circuit_drawer(circuit, cregbundle=False, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", cregbundle=False, filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1387,7 +1385,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_PREFIX,
         )
         fname2 = "measure_cond_true.png"
-        self.circuit_drawer(circuit, cregbundle=True, filename=fname2)
+        self.circuit_drawer(circuit, output="mpl", cregbundle=True, filename=fname2)
 
         ratio2 = VisualTestUtilities._save_diff(
             self._image_path(fname2),
@@ -1410,7 +1408,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.measure(0, bits[3])
 
         fname = "measure_cond_bits_false.png"
-        self.circuit_drawer(circuit, cregbundle=False, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", cregbundle=False, filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1420,7 +1418,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_PREFIX,
         )
         fname2 = "measure_cond_bits_true.png"
-        self.circuit_drawer(circuit, cregbundle=True, filename=fname2)
+        self.circuit_drawer(circuit, output="mpl", cregbundle=True, filename=fname2)
 
         ratio2 = VisualTestUtilities._save_diff(
             self._image_path(fname2),
@@ -1444,7 +1442,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.h(qr[2]).c_if(cr[0], 0)
 
         fname = "measure_cond_bits_right.png"
-        self.circuit_drawer(circuit, cregbundle=False, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", cregbundle=False, filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1464,7 +1462,9 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.x(0).c_if(bits[3], 0)
 
         fname = "cond_bits_reverse.png"
-        self.circuit_drawer(circuit, cregbundle=False, reverse_bits=True, filename=fname)
+        self.circuit_drawer(
+            circuit, output="mpl", cregbundle=False, reverse_bits=True, filename=fname
+        )
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1483,7 +1483,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.append(CPhaseGate(pi / 2), [qr[0], qr[1]]).c_if(cr[1], 1)
 
         fname = "sidetext_condition.png"
-        self.circuit_drawer(circuit, cregbundle=False, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", cregbundle=False, filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1496,8 +1496,8 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
 
     def test_fold_with_conditions(self):
         """Test that gates with conditions draw correctly when folding"""
-        qr = QuantumRegister(3, "qr")
-        cr = ClassicalRegister(5, "cr")
+        qr = QuantumRegister(3)
+        cr = ClassicalRegister(5)
         circuit = QuantumCircuit(qr, cr)
 
         circuit.append(U1Gate(0).control(1), [1, 0]).c_if(cr, 1)
@@ -1518,7 +1518,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.append(U1Gate(0).control(1), [1, 0]).c_if(cr, 31)
 
         fname = "fold_with_conditions.png"
-        self.circuit_drawer(circuit, cregbundle=False, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", cregbundle=False, filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1536,7 +1536,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.barrier()
 
         fname = "idle_wires_barrier.png"
-        self.circuit_drawer(circuit, cregbundle=False, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", cregbundle=False, filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1561,6 +1561,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         fname = "wire_order.png"
         self.circuit_drawer(
             circuit,
+            output="mpl",
             cregbundle=False,
             wire_order=[2, 1, 3, 0, 6, 8, 9, 5, 4, 7],
             filename=fname,
@@ -1586,7 +1587,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.barrier(label="End Y/X")
 
         fname = "barrier_label.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1608,7 +1609,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             circuit.cx(0, 1)
 
         fname = "if_op.png"
-        self.circuit_drawer(circuit, cregbundle=False, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1619,8 +1620,8 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         )
         self.assertGreaterEqual(ratio, 0.9999)
 
-    def test_if_else_op_bundle_false(self):
-        """Test the IfElseOp with else with cregbundle False"""
+    def test_if_else_op(self):
+        """Test the IfElseOp with else"""
         qr = QuantumRegister(4, "q")
         cr = ClassicalRegister(2, "cr")
         circuit = QuantumCircuit(qr, cr)
@@ -1631,33 +1632,8 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         with _else:
             circuit.cx(0, 1)
 
-        fname = "if_else_op_false.png"
-        self.circuit_drawer(circuit, cregbundle=False, filename=fname)
-
-        ratio = VisualTestUtilities._save_diff(
-            self._image_path(fname),
-            self._reference_path(fname),
-            fname,
-            FAILURE_DIFF_DIR,
-            FAILURE_PREFIX,
-        )
-        self.assertGreaterEqual(ratio, 0.9999)
-
-    def test_if_else_op_bundle_true(self):
-        """Test the IfElseOp with else with cregbundle True"""
-        qr = QuantumRegister(4, "q")
-        cr = ClassicalRegister(2, "cr")
-        circuit = QuantumCircuit(qr, cr)
-
-        circuit.h(0)
-        with circuit.if_test((cr[1], 1)) as _else:
-            circuit.h(0)
-            circuit.cx(0, 1)
-        with _else:
-            circuit.cx(0, 1)
-
-        fname = "if_else_op_true.png"
-        self.circuit_drawer(circuit, filename=fname)
+        fname = "if_else_op.png"
+        self.circuit_drawer(circuit, output="mpl", cregbundle=False, filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1681,7 +1657,9 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             circuit.cx(0, 1)
 
         fname = "if_else_op_textbook.png"
-        self.circuit_drawer(circuit, style="textbook", cregbundle=False, filename=fname)
+        self.circuit_drawer(
+            circuit, output="mpl", style="textbook", cregbundle=True, filename=fname
+        )
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1715,7 +1693,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.x(0, label="X1i")
 
         fname = "if_else_body.png"
-        self.circuit_drawer(circuit, cregbundle=False, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", cregbundle=False, filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1756,7 +1734,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.x(0)
 
         fname = "if_else_op_nested.png"
-        self.circuit_drawer(circuit, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", cregbundle=True, filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1797,7 +1775,13 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.x(0)
 
         fname = "if_else_op_wire_order.png"
-        self.circuit_drawer(circuit, wire_order=[2, 0, 3, 1, 4, 5, 6], filename=fname)
+        self.circuit_drawer(
+            circuit,
+            output="mpl",
+            cregbundle=False,
+            wire_order=[2, 0, 3, 1, 4, 5, 6],
+            filename=fname,
+        )
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1838,7 +1822,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.x(0)
 
         fname = "if_else_op_fold.png"
-        self.circuit_drawer(circuit, fold=7, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", fold=7, filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1865,7 +1849,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
                 circuit.x(0)
 
         fname = "while_loop.png"
-        self.circuit_drawer(circuit, cregbundle=False, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", cregbundle=False, filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1894,64 +1878,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
                 circuit.z(0)
 
         fname = "for_loop.png"
-        self.circuit_drawer(circuit, cregbundle=False, filename=fname)
-
-        ratio = VisualTestUtilities._save_diff(
-            self._image_path(fname),
-            self._reference_path(fname),
-            fname,
-            FAILURE_DIFF_DIR,
-            FAILURE_PREFIX,
-        )
-        self.assertGreaterEqual(ratio, 0.9999)
-
-    def test_for_loop_op_range(self):
-        """Test the ForLoopOp with a range"""
-        qr = QuantumRegister(4, "q")
-        cr = ClassicalRegister(3, "cr")
-        circuit = QuantumCircuit(qr, cr)
-
-        a = Parameter("a")
-        circuit.h(0)
-        circuit.measure(0, 2)
-        with circuit.for_loop(range(10, 20), loop_parameter=a):
-            circuit.h(0)
-            circuit.cx(0, 1)
-            circuit.rx(pi / a, 1)
-            circuit.measure(0, 0)
-            with circuit.if_test((cr[2], 1)):
-                circuit.z(0)
-
-        fname = "for_loop_range.png"
-        self.circuit_drawer(circuit, cregbundle=False, filename=fname)
-
-        ratio = VisualTestUtilities._save_diff(
-            self._image_path(fname),
-            self._reference_path(fname),
-            fname,
-            FAILURE_DIFF_DIR,
-            FAILURE_PREFIX,
-        )
-        self.assertGreaterEqual(ratio, 0.9999)
-
-    def test_for_loop_op_1_qarg(self):
-        """Test the ForLoopOp with 1 qarg"""
-        qr = QuantumRegister(4, "q")
-        cr = ClassicalRegister(3, "cr")
-        circuit = QuantumCircuit(qr, cr)
-
-        a = Parameter("a")
-        circuit.h(0)
-        circuit.measure(0, 2)
-        with circuit.for_loop((2, 4, 8, 16), loop_parameter=a):
-            circuit.h(0)
-            circuit.rx(pi / a, 0)
-            circuit.measure(0, 0)
-            with circuit.if_test((cr[2], 1)):
-                circuit.z(0)
-
-        fname = "for_loop_1_qarg.png"
-        self.circuit_drawer(circuit, cregbundle=False, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1983,7 +1910,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.h(0)
 
         fname = "switch_case.png"
-        self.circuit_drawer(circuit, cregbundle=False, filename=fname)
+        self.circuit_drawer(circuit, output="mpl", filename=fname)
 
         ratio = VisualTestUtilities._save_diff(
             self._image_path(fname),
@@ -1993,196 +1920,6 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_PREFIX,
         )
         self.assertGreaterEqual(ratio, 0.9999)
-
-    def test_switch_case_op_1_qarg(self):
-        """Test the SwitchCaseOp with 1 qarg"""
-        qreg = QuantumRegister(3, "q")
-        creg = ClassicalRegister(3, "cr")
-        circuit = QuantumCircuit(qreg, creg)
-
-        circuit.h([0, 1, 2])
-        circuit.measure([0, 1, 2], [0, 1, 2])
-
-        with circuit.switch(creg) as case:
-            with case(0, 1, 2):
-                circuit.x(0)
-            with case(case.DEFAULT):
-                circuit.y(0)
-        circuit.h(0)
-
-        fname = "switch_case_1_qarg.png"
-        self.circuit_drawer(circuit, cregbundle=False, filename=fname)
-
-        ratio = VisualTestUtilities._save_diff(
-            self._image_path(fname),
-            self._reference_path(fname),
-            fname,
-            FAILURE_DIFF_DIR,
-            FAILURE_PREFIX,
-        )
-        self.assertGreaterEqual(ratio, 0.9999)
-
-    def test_if_with_expression(self):
-        """Test the IfElseOp with an expression"""
-        qr = QuantumRegister(3, "qr")
-        cr = ClassicalRegister(3, "cr")
-        cr1 = ClassicalRegister(3, "cr1")
-        cr2 = ClassicalRegister(3, "cr2")
-        cr3 = ClassicalRegister(3, "cr3")
-        circuit = QuantumCircuit(qr, cr, cr1, cr2, cr3)
-
-        circuit.h(0)
-        with circuit.if_test(expr.equal(expr.bit_and(cr1, expr.bit_and(cr2, cr3)), 3)):
-            circuit.z(0)
-
-        fname = "if_op_expr.png"
-        self.circuit_drawer(circuit, filename=fname)
-
-        ratio = VisualTestUtilities._save_diff(
-            self._image_path(fname),
-            self._reference_path(fname),
-            fname,
-            FAILURE_DIFF_DIR,
-            FAILURE_PREFIX,
-        )
-        self.assertGreaterEqual(ratio, 0.9999)
-
-    def test_if_with_expression_nested(self):
-        """Test the IfElseOp with an expression for nested"""
-        qr = QuantumRegister(3, "qr")
-        cr = ClassicalRegister(3, "cr")
-        cr1 = ClassicalRegister(3, "cr1")
-        cr2 = ClassicalRegister(3, "cr2")
-        cr3 = ClassicalRegister(3, "cr3")
-        circuit = QuantumCircuit(qr, cr, cr1, cr2, cr3)
-
-        circuit.h(0)
-        with circuit.if_test(expr.equal(expr.bit_and(cr1, expr.bit_and(cr2, cr3)), 3)):
-            circuit.x(0)
-            with circuit.if_test(expr.equal(expr.bit_and(cr3, expr.bit_and(cr1, cr2)), 5)):
-                circuit.z(1)
-
-        fname = "if_op_expr_nested.png"
-        self.circuit_drawer(circuit, filename=fname)
-
-        ratio = VisualTestUtilities._save_diff(
-            self._image_path(fname),
-            self._reference_path(fname),
-            fname,
-            FAILURE_DIFF_DIR,
-            FAILURE_PREFIX,
-        )
-        self.assertGreaterEqual(ratio, 0.9999)
-
-    def test_switch_with_expression(self):
-        """Test the SwitchCaseOp with an expression"""
-        qr = QuantumRegister(3, "qr")
-        cr = ClassicalRegister(3, "cr")
-        cr1 = ClassicalRegister(3, "cr1")
-        cr2 = ClassicalRegister(3, "cr2")
-        cr3 = ClassicalRegister(3, "cr3")
-        circuit = QuantumCircuit(qr, cr, cr1, cr2, cr3)
-
-        circuit.h(0)
-        with circuit.switch(expr.bit_and(cr1, expr.bit_and(cr2, cr3))) as case:
-            with case(0, 1, 2, 3):
-                circuit.x(0)
-            with case(case.DEFAULT):
-                circuit.cx(0, 1)
-
-        fname = "switch_expr.png"
-        self.circuit_drawer(circuit, filename=fname)
-
-        ratio = VisualTestUtilities._save_diff(
-            self._image_path(fname),
-            self._reference_path(fname),
-            fname,
-            FAILURE_DIFF_DIR,
-            FAILURE_PREFIX,
-        )
-        self.assertGreaterEqual(ratio, 0.9999)
-
-    def test_control_flow_layout(self):
-        """Test control flow with a layout set."""
-        qreg = QuantumRegister(2, "qr")
-        creg = ClassicalRegister(2, "cr")
-        qc = QuantumCircuit(qreg, creg)
-        qc.h([0, 1])
-        qc.h([0, 1])
-        qc.h([0, 1])
-        qc.measure([0, 1], [0, 1])
-        with qc.switch(creg) as case:
-            with case(0):
-                qc.z(0)
-            with case(1, 2):
-                qc.cx(0, 1)
-            with case(case.DEFAULT):
-                qc.h(0)
-        backend = FakeBelemV2()
-        backend.target.add_instruction(SwitchCaseOp, name="switch_case")
-        tqc = transpile(qc, backend, optimization_level=2, seed_transpiler=671_42)
-        fname = "layout_control_flow.png"
-        self.circuit_drawer(tqc, filename=fname)
-        ratio = VisualTestUtilities._save_diff(
-            self._image_path(fname),
-            self._reference_path(fname),
-            fname,
-            FAILURE_DIFF_DIR,
-            FAILURE_PREFIX,
-        )
-        self.assertGreaterEqual(ratio, 0.9999)
-
-    def test_control_flow_nested_layout(self):
-        """Test nested control flow with a layout set."""
-        qreg = QuantumRegister(2, "qr")
-        creg = ClassicalRegister(2, "cr")
-        qc = QuantumCircuit(qreg, creg)
-        qc.h([0, 1])
-        qc.h([0, 1])
-        qc.h([0, 1])
-        qc.measure([0, 1], [0, 1])
-        with qc.switch(creg) as case:
-            with case(0):
-                qc.z(0)
-            with case(1, 2):
-                with qc.if_test((creg[0], 0)):
-                    qc.cx(0, 1)
-            with case(case.DEFAULT):
-                with qc.if_test((creg[1], 0)):
-                    qc.h(0)
-        backend = FakeBelemV2()
-        backend.target.add_instruction(SwitchCaseOp, name="switch_case")
-        backend.target.add_instruction(IfElseOp, name="if_else")
-        tqc = transpile(qc, backend, optimization_level=2, seed_transpiler=671_42)
-        fname = "nested_layout_control_flow.png"
-        self.circuit_drawer(tqc, filename=fname)
-        ratio = VisualTestUtilities._save_diff(
-            self._image_path(fname),
-            self._reference_path(fname),
-            fname,
-            FAILURE_DIFF_DIR,
-            FAILURE_PREFIX,
-        )
-        self.assertGreaterEqual(ratio, 0.9999)
-
-    def test_default_futurewarning(self):
-        """Test using the default scheme emits a future warning."""
-        qc = QuantumCircuit(1)
-
-        with self.assertWarnsRegex(
-            FutureWarning, "To silence this warning, specify the current default explicitly"
-        ):
-            qc.draw("mpl")
-
-    def test_iqx_pendingdeprecation(self):
-        """Test using the IQX schemes emits a pending deprecation warning."""
-        qc = QuantumCircuit(1)
-
-        for style in ["iqx", "iqx-dark"]:
-            with self.assertWarnsRegex(
-                PendingDeprecationWarning, 'Instead, use "iqp" and "iqp-dark"'
-            ):
-                qc.draw("mpl", style=style)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Switches to using `circuit_drawer` for circuit drawer tests.

### Details and comments

Previously the 'text' and 'mpl' circuit drawer tests used the 'private' functions, `_text_circuit_drawer` and `_matplotlib_circuit_drawer`, respectively, instead of the public API function `circuit_drawer`, which is the function called by `QuantumCircuit.draw`.

Since `circuit_drawer` performs several checks - for wire_order, reverse_bits, and cregbundle - before calling the 'private' functions, these checks were not being tested as part of the specific drawer tests. This PR now uses `circuit_drawer` for all these tests.
