### PR TITLE
Singletonized `Measure` and `Reset` instructions

### DIFF
--- a/qiskit/circuit/measure.py
+++ b/qiskit/circuit/measure.py
@@ -14,11 +14,11 @@
 Quantum measurement in the computational basis.
 """
 
-from qiskit.circuit.instruction import Instruction
+from qiskit.circuit.singleton import SingletonInstruction
 from qiskit.circuit.exceptions import CircuitError
 
 
-class Measure(Instruction):
+class Measure(SingletonInstruction):
     """Quantum measurement in the computational basis."""
 
     def __init__(self, label=None, *, duration=None, unit="dt"):

--- a/qiskit/circuit/measure.py
+++ b/qiskit/circuit/measure.py
@@ -14,7 +14,7 @@
 Quantum measurement in the computational basis.
 """
 
-from qiskit.circuit.singleton import SingletonInstruction
+from qiskit.circuit.singleton import SingletonInstruction, stdlib_singleton_key
 from qiskit.circuit.exceptions import CircuitError
 
 
@@ -24,6 +24,8 @@ class Measure(SingletonInstruction):
     def __init__(self, label=None, *, duration=None, unit="dt"):
         """Create new measurement instruction."""
         super().__init__("measure", 1, 1, [], label=label, duration=duration, unit=unit)
+
+    _singleton_lookup_key = stdlib_singleton_key()
 
     def broadcast_arguments(self, qargs, cargs):
         qarg = qargs[0]

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -59,8 +59,6 @@ from .register import Register
 from .bit import Bit
 from .quantumcircuitdata import QuantumCircuitData, CircuitInstruction
 from .delay import Delay
-from .measure import Measure
-from .reset import Reset
 
 if typing.TYPE_CHECKING:
     import qiskit  # pylint: disable=cyclic-import
@@ -2180,6 +2178,8 @@ class QuantumCircuit:
         Returns:
             qiskit.circuit.InstructionSet: handle to the added instruction.
         """
+        from .reset import Reset
+
         return self.append(Reset(), [qubit], [])
 
     def measure(self, qubit: QubitSpecifier, cbit: ClbitSpecifier) -> InstructionSet:
@@ -2255,6 +2255,8 @@ class QuantumCircuit:
                 circuit.measure(qreg[1], creg[1])
 
         """
+        from .measure import Measure
+
         return self.append(Measure(), [qubit], [cbit])
 
     def measure_active(self, inplace: bool = True) -> Optional["QuantumCircuit"]:

--- a/qiskit/circuit/reset.py
+++ b/qiskit/circuit/reset.py
@@ -14,7 +14,7 @@
 Qubit reset to computational zero.
 """
 
-from qiskit.circuit.singleton import SingletonInstruction
+from qiskit.circuit.singleton import SingletonInstruction, stdlib_singleton_key
 
 
 class Reset(SingletonInstruction):
@@ -23,6 +23,8 @@ class Reset(SingletonInstruction):
     def __init__(self, label=None, *, duration=None, unit="dt"):
         """Create new reset instruction."""
         super().__init__("reset", 1, 0, [], label=label, duration=duration, unit=unit)
+
+    _singleton_lookup_key = stdlib_singleton_key()
 
     def broadcast_arguments(self, qargs, cargs):
         for qarg in qargs[0]:

--- a/qiskit/circuit/reset.py
+++ b/qiskit/circuit/reset.py
@@ -14,10 +14,10 @@
 Qubit reset to computational zero.
 """
 
-from qiskit.circuit.instruction import Instruction
+from qiskit.circuit.singleton import SingletonInstruction
 
 
-class Reset(Instruction):
+class Reset(SingletonInstruction):
     """Qubit reset."""
 
     def __init__(self, label=None, *, duration=None, unit="dt"):

--- a/qiskit/qasm2/parse.py
+++ b/qiskit/qasm2/parse.py
@@ -234,15 +234,13 @@ def from_bytecode(bytecode, custom_instructions: Iterable[CustomInstruction]):
             qc._append(CircuitInstruction(Measure(), (qubits[qubit],), (clbits[clbit],)))
         elif opcode == OpCode.ConditionedMeasure:
             qubit, clbit, creg, value = op.operands
-            measure = Measure()
-            measure.condition = (qc.cregs[creg], value)
+            measure = Measure().c_if(qc.cregs[creg], value)
             qc._append(CircuitInstruction(measure, (qubits[qubit],), (clbits[clbit],)))
         elif opcode == OpCode.Reset:
             qc._append(CircuitInstruction(Reset(), (qubits[op.operands[0]],)))
         elif opcode == OpCode.ConditionedReset:
             qubit, creg, value = op.operands
-            reset = Reset()
-            reset.condition = (qc.cregs[creg], value)
+            reset = Reset().c_if(qc.cregs[creg], value)
             qc._append(CircuitInstruction(reset, (qubits[qubit],)))
         elif opcode == OpCode.Barrier:
             op_qubits = op.operands[0]

--- a/releasenotes/notes/singletonize-instructions-78723f68cd0ac03f.yaml
+++ b/releasenotes/notes/singletonize-instructions-78723f68cd0ac03f.yaml
@@ -1,0 +1,29 @@
+---
+features:
+  - |
+    The following standard library instructions are now instances of
+    :class:`~.SingletonInstruction`:
+    
+     * :class:`~.Measure`
+     * :class:`~.Reset`
+    
+    This means that if these classes are instantiated as (e.g.) ``Measure()`` using
+    all the constructor defaults, they will all share a single global
+    instance. This results in large reduction in the memory overhead for > 1
+    object of these types and significantly faster object construction time.
+upgrade:
+  - |
+    The following standard library instructions:
+    
+     * :class:`~.Measure`
+     * :class:`~.Reset`
+     
+    are immutable, unless the attributes ``label``, ``duration`` and ``unit`` are given as keyword 
+    arguments during class construction. 
+    The attributes :attr:`~.Instruction.label`, :attr:`~.Instruction.duration`, :attr:`~.Instruction.unit`, 
+    and :attr:`~.Instruction.condition` attributes are all not publicly accessible and setting these attributes
+    directly is not allowed and it will raise an exception. If they are needed for a particular
+    instance you must ensure you have a mutable instance using :meth:`.Instruction.to_mutable`
+    and use :meth:`.Instruction.c_if` for :attr:`~.Instruction.condition`
+    
+    

--- a/releasenotes/notes/singletonize-instructions-78723f68cd0ac03f.yaml
+++ b/releasenotes/notes/singletonize-instructions-78723f68cd0ac03f.yaml
@@ -25,5 +25,8 @@ upgrade:
     directly is not allowed and it will raise an exception. If they are needed for a particular
     instance you must ensure you have a mutable instance using :meth:`.Instruction.to_mutable`
     and use :meth:`.Instruction.c_if` for :attr:`~.Instruction.condition`
+    For the singleton variant of these instructions, there is a special attribute 
+    :attr:`~.SingletonInstruction._singleton_lookup_key`, that when called generates a key based on the input
+    arguments, which can be used for identifying and indexing these instructions within the framework. 
     
     

--- a/test/python/circuit/test_singleton.py
+++ b/test/python/circuit/test_singleton.py
@@ -328,19 +328,25 @@ class TestSingleton(QiskitTestCase):
 
     def test_return_type_singleton_instructions(self):
         measure = Measure()
-        self.assertEqual(measure.__class__.__name__, "_SingletonMeasure")
+        new_measure = Measure()
+        self.assertIs(measure, new_measure)
+        self.assertIs(measure.base_class, Measure)
+        self.assertIsInstance(measure, Measure)
 
         reset = Reset()
-        self.assertEqual(reset.__class__.__name__, "_SingletonReset")
+        new_reset = Reset()
+        self.assertIs(reset, new_reset)
+        self.assertIs(reset.base_class, Reset)
+        self.assertIsInstance(reset, Reset)
 
     def test_singleton_instruction_integration(self):
-        qc = QuantumCircuit(1, 1)
         measure = Measure()
         reset = Reset()
-        qc.append(measure, [0], [0])
-        qc.append(reset, [0])
-        self.assertEqual(qc.data[0].operation.__class__.__name__, "_SingletonMeasure")
-        self.assertEqual(qc.data[1].operation.__class__.__name__, "_SingletonReset")
+        qc = QuantumCircuit(1, 1)
+        qc.measure(0, 0)
+        qc.reset(0)
+        self.assertIs(qc.data[0].operation, measure)
+        self.assertIs(qc.data[1].operation, reset)
 
     def test_inherit_singleton_instructions(self):
         class ESPMeasure(Measure):
@@ -352,16 +358,6 @@ class TestSingleton(QiskitTestCase):
         self.assertIsNot(esp_measure, measure_base)
         self.assertIs(measure_base.base_class, Measure)
         self.assertIs(esp_measure.base_class, ESPMeasure)
-
-        class ESPReset(Reset):
-            pass
-
-        reset_base = Reset()
-        esp_reset = ESPReset()
-        self.assertIs(esp_reset, ESPReset())
-        self.assertIsNot(esp_reset, reset_base)
-        self.assertIs(reset_base.base_class, Reset)
-        self.assertIs(esp_reset.base_class, ESPReset)
 
     def test_singleton_with_default(self):
         # Explicitly setting the label to its default.


### PR DESCRIPTION
### Summary
  * Singletonized instructions `Measure` and `Reset`
  * Resolved circular import error during test run
  * Drafted release notes highlighting the features and upgrades

### Details and comments
This PR partially addresses the issue [#10953](https://github.com/Qiskit/qiskit/issues/10953). It involves singletonizing `Measure` and `Reset` instructions. However, `Barrier` is not singletonized after discussing with the maintainer, as the base singleton code needed some additional machinery to handle instructions like `Barrier`.
Running `tox` test suite resulted in circular import error, which also has been solved with the guidance of the maintainer.
Finally added the release notes, elaborating on the features and upgrades brought upon by this pull request.

