### PR TITLE
Fix pickling of conditioned custom gates from OpenQASM 2 import

### DIFF
--- a/qiskit/qasm2/parse.py
+++ b/qiskit/qasm2/parse.py
@@ -324,14 +324,15 @@ class _DefinedGate(Gate):
     # to pickle ourselves, we just eagerly create the definition and pickle that.
 
     def __getstate__(self):
-        return (self.name, self.num_qubits, self.params, self.definition)
+        return (self.name, self.num_qubits, self.params, self.definition, self.condition)
 
     def __setstate__(self, state):
-        name, num_qubits, params, definition = state
+        name, num_qubits, params, definition, condition = state
         super().__init__(name, num_qubits, params)
         self._gates = ()
         self._bytecode = ()
         self._definition = definition
+        self._condition = condition
 
 
 def _gate_builder(name, num_qubits, known_gates, bytecode):

--- a/releasenotes/notes/fix-qasm2-deepcopy-conditioned-gate-2fa75fee622c1fc0.yaml
+++ b/releasenotes/notes/fix-qasm2-deepcopy-conditioned-gate-2fa75fee622c1fc0.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Conditioned custom gates imported from OpenQASM 2 will now correctly retain their conditions
+    when pickled and deep-copied.  Previously, any conditional custom gate (defined by a ``gate``
+    statement in an OpenQASM 2 file) would lose its condition when copied or pickled.

--- a/test/python/qasm2/test_structure.py
+++ b/test/python/qasm2/test_structure.py
@@ -12,6 +12,7 @@
 
 # pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
 
+import copy
 import io
 import math
 import os
@@ -695,6 +696,32 @@ class TestGateDefinition(QiskitTestCase):
             fptr.seek(0)
             loaded = qpy.load(fptr)[0]
         self.assertEqual(loaded, qc)
+
+    def test_deepcopy_conditioned_defined_gate(self):
+        program = """
+            include "qelib1.inc";
+            gate my_gate a {
+                x a;
+            }
+            qreg q[1];
+            creg c[1];
+            if (c == 1) my_gate q[0];
+        """
+        parsed = qiskit.qasm2.loads(program)
+        my_gate = parsed.data[0].operation
+
+        self.assertEqual(my_gate.name, "my_gate")
+        self.assertEqual(my_gate.condition, (parsed.cregs[0], 1))
+
+        copied = copy.deepcopy(parsed)
+        copied_gate = copied.data[0].operation
+        self.assertEqual(copied_gate.name, "my_gate")
+        self.assertEqual(copied_gate.condition, (copied.cregs[0], 1))
+
+        pickled = pickle.loads(pickle.dumps(parsed))
+        pickled_gate = pickled.data[0].operation
+        self.assertEqual(pickled_gate.name, "my_gate")
+        self.assertEqual(pickled_gate.condition, (pickled.cregs[0], 1))
 
 
 class TestOpaque(QiskitTestCase):


### PR DESCRIPTION
### Summary

The condition of a gate defined by a `gate` statement in an OpenQASM 2 program was not previously exported as part of its state during pickling, causing pickle roundtrips or deepcopies to lose the condition on the new copy.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Fix #11174.
