### PR TITLE
Copy-in rather than copy-out in transpiler

### DIFF
--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -65,7 +65,7 @@ class PassManager(BasePassManager):
         input_program: QuantumCircuit,
         **kwargs,
     ) -> DAGCircuit:
-        return circuit_to_dag(input_program, copy_operations=False)
+        return circuit_to_dag(input_program, copy_operations=True)
 
     def _passmanager_backend(
         self,
@@ -73,7 +73,7 @@ class PassManager(BasePassManager):
         in_program: QuantumCircuit,
         **kwargs,
     ) -> QuantumCircuit:
-        out_program = dag_to_circuit(passmanager_ir)
+        out_program = dag_to_circuit(passmanager_ir, copy_operations=False)
 
         out_name = kwargs.get("output_name", None)
         if out_name is not None:


### PR DESCRIPTION
### Summary

This shifts the deepcopy of instructions in the transpiler to be at the input stage, rather than the output stage.  This more closely matches our behaviour before the passmanager refactoring, but also has a performance benefit for circuits that require significant routing and is typically safer for transpiler passes.  Output circuits are typically larger than input ones, so copy-in means less copying, and also makes the ownership model for tranpsiler passes clearer: a pass can assume the input operations are entirely owned by the circuit it receives, and that a pass must output a circuit that entirely owns its operations.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

The behaviour before #10127 was copy-in, as this PR reinstates, and I think it just got mistakenly swapped over in that - I didn't notice during the review either.

Ideally this goes into 0.45.0, so the behavioural change from #10127 doesn't get released, but it's not a big deal if it goes into 0.45.1 instead, I think.
