### PR TITLE
Allow barriers in overlap circuit inputs

### DIFF
--- a/qiskit/circuit/library/overlap.py
+++ b/qiskit/circuit/library/overlap.py
@@ -15,6 +15,7 @@
 from qiskit.circuit import QuantumCircuit, Gate
 from qiskit.circuit.parametervector import ParameterVector
 from qiskit.circuit.exceptions import CircuitError
+from qiskit.circuit.library import Barrier
 
 
 class UnitaryOverlap(QuantumCircuit):
@@ -101,7 +102,7 @@ def _check_unitary(circuit):
     """Check a circuit is unitary by checking if all operations are of type ``Gate``."""
 
     for instruction in circuit.data:
-        if not isinstance(instruction.operation, Gate):
+        if not isinstance(instruction.operation, [Gate, Barrier]):
             raise CircuitError(
                 (
                     "One or more instructions cannot be converted to"

--- a/qiskit/circuit/library/overlap.py
+++ b/qiskit/circuit/library/overlap.py
@@ -15,7 +15,7 @@
 from qiskit.circuit import QuantumCircuit, Gate
 from qiskit.circuit.parametervector import ParameterVector
 from qiskit.circuit.exceptions import CircuitError
-from qiskit.circuit.library import Barrier
+from qiskit.circuit import Barrier
 
 
 class UnitaryOverlap(QuantumCircuit):
@@ -102,7 +102,7 @@ def _check_unitary(circuit):
     """Check a circuit is unitary by checking if all operations are of type ``Gate``."""
 
     for instruction in circuit.data:
-        if not isinstance(instruction.operation, [Gate, Barrier]):
+        if not isinstance(instruction.operation, (Gate, Barrier)):
             raise CircuitError(
                 (
                     "One or more instructions cannot be converted to"

--- a/releasenotes/notes/overlap-circuit-barriers-63b9b1be9c1da100.yaml
+++ b/releasenotes/notes/overlap-circuit-barriers-63b9b1be9c1da100.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed a bug which caused :class:`~qiskit.circuit.library.UnitaryOverlap` to error upon initialization if given an input circuit containing a barrier.

--- a/test/python/circuit/library/test_overlap.py
+++ b/test/python/circuit/library/test_overlap.py
@@ -82,6 +82,15 @@ class TestUnitaryOverlap(QiskitTestCase):
         overlap = UnitaryOverlap(unitary1, unitary2)
         self.assertEqual(overlap.num_parameters, unitary1.num_parameters)
 
+    def test_barrier(self):
+        """Test that barriers on input circuits are well handled"""
+        unitary1 = EfficientSU2(1, reps=0)
+        unitary1.barrier()
+        unitary2 = EfficientSU2(1, reps=1)
+        unitary2.barrier()
+        overlap = UnitaryOverlap(unitary1, unitary2)
+        self.assertEqual(overlap.num_parameters, unitary1.num_parameters + unitary2.num_parameters)
+
     def test_measurements(self):
         """Test that exception is thrown for measurements"""
         unitary1 = EfficientSU2(2)
@@ -121,15 +130,6 @@ class TestUnitaryOverlap(QiskitTestCase):
 
         with self.assertRaises(CircuitError):
             _ = UnitaryOverlap(unitary1, unitary2)
-
-    def test_barrier(self):
-        """Test that barriers on input circuits are well handled"""
-        unitary1 = EfficientSU2(1, reps=0)
-        unitary1.barrier()
-        unitary2 = EfficientSU2(1, reps=1)
-        unitary2.barrier()
-        overlap = UnitaryOverlap(unitary1, unitary2)
-        self.assertEqual(overlap.num_parameters, unitary1.num_parameters + unitary2.num_parameters)
 
 
 if __name__ == "__main__":

--- a/test/python/circuit/library/test_overlap.py
+++ b/test/python/circuit/library/test_overlap.py
@@ -122,6 +122,16 @@ class TestUnitaryOverlap(QiskitTestCase):
         with self.assertRaises(CircuitError):
             _ = UnitaryOverlap(unitary1, unitary2)
 
+    def test_barrier(self):
+        """Test that barriers on input circuits are well handled"""
+        unitary1 = EfficientSU2(1, reps=0)
+        unitary1.barrier()
+        unitary2 = EfficientSU2(1, reps=1)
+        unitary2.barrier()
+
+        _ = UnitaryOverlap(unitary1, unitary2)
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/circuit/library/test_overlap.py
+++ b/test/python/circuit/library/test_overlap.py
@@ -128,9 +128,8 @@ class TestUnitaryOverlap(QiskitTestCase):
         unitary1.barrier()
         unitary2 = EfficientSU2(1, reps=1)
         unitary2.barrier()
-
-        _ = UnitaryOverlap(unitary1, unitary2)
-
+        overlap = UnitaryOverlap(unitary1, unitary2)
+        self.assertEqual(overlap.num_parameters, unitary1.num_parameters + unitary2.num_parameters)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #11177 

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR allows the inputs to `UnitaryOverlap` to contain barriers.


### Details and comments
When checking the circuit to ensure all instructions are unitary operations, we should ignore barriers.

