### PR TITLE
Fix build ordering of `BlueprintCircuit._append`

### DIFF
--- a/qiskit/circuit/library/blueprintcircuit.py
+++ b/qiskit/circuit/library/blueprintcircuit.py
@@ -119,10 +119,10 @@ class BlueprintCircuit(QuantumCircuit, ABC):
             self._build()
         return super().qasm(formatted, filename, encoding)
 
-    def append(self, instruction, qargs=None, cargs=None):
+    def _append(self, instruction, _qargs=None, _cargs=None):
         if not self._is_built:
             self._build()
-        return super().append(instruction, qargs, cargs)
+        return super()._append(instruction, _qargs, _cargs)
 
     def compose(self, other, qubits=None, clbits=None, front=False, inplace=False, wrap=False):
         if not self._is_built:

--- a/releasenotes/notes/fix-blueprint-circuit-_append-b4d6c9c41db860f5.yaml
+++ b/releasenotes/notes/fix-blueprint-circuit-_append-b4d6c9c41db860f5.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    :class:`.BlueprintCircuit` subclasses will now behave correctly when the semi-public method
+    :meth:`.QuantumCircuit._append` is used with the blueprint in an unbuilt state, *i.e.* the
+    circuit will be built before attempting the append.


### PR DESCRIPTION
### Summary

`QuantumCircuit._append` is the actual append primitive and is allowed in inner-loop appends (and for `QuantumCircuit` to assume that it's callable from other methods), so it's important that the "ensure built" check happens there, not in `append`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #11180.
