### PR TITLE
Expire deprecation on `qargs=None` in DAG appends

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -23,7 +23,6 @@ directly from the graph.
 from collections import OrderedDict, defaultdict, deque, namedtuple
 import copy
 import math
-import warnings
 from typing import Dict, Generator, Any, List
 
 import numpy as np
@@ -657,16 +656,8 @@ class DAGCircuit:
             DAGCircuitError: if a leaf node is connected to multiple outputs
 
         """
-        if qargs is None:
-            _warn_none_args()
-            qargs = ()
-        else:
-            qargs = tuple(qargs)
-        if cargs is None:
-            _warn_none_args()
-            cargs = ()
-        else:
-            cargs = tuple(cargs)
+        qargs = tuple(qargs)
+        cargs = tuple(cargs)
 
         if self._operation_may_have_bits(op):
             # This is the slow path; most of the time, this won't happen.
@@ -710,16 +701,8 @@ class DAGCircuit:
         Raises:
             DAGCircuitError: if initial nodes connected to multiple out edges
         """
-        if qargs is None:
-            _warn_none_args()
-            qargs = ()
-        else:
-            qargs = tuple(qargs)
-        if cargs is None:
-            _warn_none_args()
-            cargs = ()
-        else:
-            cargs = tuple(cargs)
+        qargs = tuple(qargs)
+        cargs = tuple(cargs)
 
         if self._operation_may_have_bits(op):
             # This is the slow path; most of the time, this won't happen.
@@ -2116,12 +2099,3 @@ class DAGCircuit:
         from qiskit.visualization.dag_visualization import dag_drawer
 
         return dag_drawer(dag=self, scale=scale, filename=filename, style=style)
-
-
-def _warn_none_args():
-    warnings.warn(
-        "Passing 'None' as the qubits or clbits of an operation to 'DAGCircuit' methods"
-        " is deprecated since Qiskit 0.45 and will be removed in Qiskit 1.0.  Instead, pass '()'.",
-        DeprecationWarning,
-        stacklevel=3,
-    )

--- a/releasenotes/notes/remove-dag-none-be220777dc246803.yaml
+++ b/releasenotes/notes/remove-dag-none-be220777dc246803.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    It is no longer allowable to pass ``None`` as the ``qargs`` or ``cargs`` parameters in
+    :meth:`.DAGCircuit.apply_operation_back` and :meth:`~.DAGCircuit.apply_operation_front`.  If you
+    want to explicitly pass an empty argument, use the empty tuple ``()`` instead.

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -487,18 +487,6 @@ class TestDagApplyOperation(QiskitTestCase):
         self.assertEqual(len(list(self.dag.nodes())), 16)
         self.assertEqual(len(list(self.dag.edges())), 17)
 
-    def test_apply_operation_rejects_none(self):
-        """Test that the ``apply_operation_*`` methods warn when given ``None``."""
-        noop = Instruction("noop", 0, 0, [])
-        with self.assertWarnsRegex(DeprecationWarning, "Passing 'None'"):
-            self.dag.apply_operation_back(noop, None, ())
-        with self.assertWarnsRegex(DeprecationWarning, "Passing 'None'"):
-            self.dag.apply_operation_back(noop, (), None)
-        with self.assertWarnsRegex(DeprecationWarning, "Passing 'None'"):
-            self.dag.apply_operation_front(noop, None, ())
-        with self.assertWarnsRegex(DeprecationWarning, "Passing 'None'"):
-            self.dag.apply_operation_front(noop, (), None)
-
     def test_edges(self):
         """Test that DAGCircuit.edges() behaves as expected with ops."""
         x_gate = XGate().c_if(*self.condition)


### PR DESCRIPTION
### Summary

This removes the warnings converting explicit `None`s into empty tuples, following its deprecation in 0.45.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
### Details and comments

Originally deprecated in #10752.
