### PR TITLE
Replaced references to master with references to main in docs/maintainers_guide.rst

### DIFF
--- a/docs/maintainers_guide.rst
+++ b/docs/maintainers_guide.rst
@@ -11,7 +11,7 @@ Stable Branch Policy
 ====================
 
 The stable branch is intended to be a safe source of fixes for high-impact
-bugs and security issues that have been fixed on master since a
+bugs and security issues that have been fixed on ``main`` since a
 release. When reviewing a stable branch PR, we must balance the risk
 of any given patch with the value that it will provide to users of the
 stable branch. Only a limited class of changes are appropriate for
@@ -29,8 +29,8 @@ change:
     also refactors a lot of code, it's probably worth thinking about
     what a less risky fix might look like.
 -   Whether the fix is already on ``main``: a change must be a backport of
-    a change already merged onto master, unless the change simply does
-    not make sense on master.
+    a change already merged onto ``main``, unless the change simply does
+    not make sense on ``main``.
 
 
 Backporting


### PR DESCRIPTION
Replaced references to master with references to main in docs/maintainers_guide.rst (#11196)

* Added a release notes file

* Substituted mentions of the master branch with mentions to main in the file docs/maintainers_guide.rst

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
fixes #11196 (occurrences of master are replaced with occurrences of main)


### Details and comments
There is currently only a main branch, so mentions of master seem to intend to refer to the main branch. The text in docs/maintainers_guide.rst has been adjusted accordingly so that all mentions of master are now mentions of main.

