### PR TITLE
Use final_layout_index in BackendEstimator

### DIFF
--- a/qiskit/primitives/backend_estimator.py
+++ b/qiskit/primitives/backend_estimator.py
@@ -201,25 +201,18 @@ class BackendEstimator(BaseEstimator[PrimitiveJob[EstimatorResult]]):
             # 1. transpile a common circuit
             if self._skip_transpilation:
                 transpiled_circuit = common_circuit.copy()
-                perm_pattern = list(range(common_circuit.num_qubits))
+                final_index_layout = list(range(common_circuit.num_qubits))
             else:
                 transpiled_circuit = transpile(
                     common_circuit, self.backend, **self.transpile_options.__dict__
                 )
                 if transpiled_circuit.layout is not None:
-                    layout = transpiled_circuit.layout
-                    virtual_bit_map = layout.initial_layout.get_virtual_bits()
-                    perm_pattern = [virtual_bit_map[v] for v in common_circuit.qubits]
-                    if layout.final_layout is not None:
-                        final_mapping = dict(
-                            enumerate(layout.final_layout.get_virtual_bits().values())
-                        )
-                        perm_pattern = [final_mapping[i] for i in perm_pattern]
+                    final_index_layout = transpiled_circuit.layout.final_index_layout()
                 else:
-                    perm_pattern = list(range(transpiled_circuit.num_qubits))
+                    final_index_layout = list(range(transpiled_circuit.num_qubits))
 
             # 2. transpile diff circuits
-            passmanager = _passmanager_for_measurement_circuits(perm_pattern, self.backend)
+            passmanager = _passmanager_for_measurement_circuits(final_index_layout, self.backend)
             diff_circuits = passmanager.run(diff_circuits)
             # 3. combine
             transpiled_circuits = []


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Just code refactoring.
I used `final_layout_index` introduced from 0.45 instead of complex workaround.

### Details and comments


