### PR TITLE
Remove opflow classes from primitives

### DIFF
--- a/qiskit/primitives/backend_estimator.py
+++ b/qiskit/primitives/backend_estimator.py
@@ -15,7 +15,6 @@ Expectation value class
 
 from __future__ import annotations
 
-import typing
 from collections.abc import Sequence
 from itertools import accumulate
 
@@ -40,9 +39,6 @@ from qiskit.transpiler.passes import (
 from .base import BaseEstimator, EstimatorResult
 from .primitive_job import PrimitiveJob
 from .utils import _circuit_key, _observable_key, init_observable
-
-if typing.TYPE_CHECKING:
-    from qiskit.opflow import PauliSumOp
 
 
 def _run_circuits(
@@ -269,7 +265,7 @@ class BackendEstimator(BaseEstimator[PrimitiveJob[EstimatorResult]]):
     def _run(
         self,
         circuits: tuple[QuantumCircuit, ...],
-        observables: tuple[BaseOperator | PauliSumOp, ...],
+        observables: tuple[BaseOperator, ...],
         parameter_values: tuple[tuple[float, ...], ...],
         **run_options,
     ):

--- a/qiskit/primitives/base/base_estimator.py
+++ b/qiskit/primitives/base/base_estimator.py
@@ -85,7 +85,6 @@ from abc import abstractmethod
 from collections.abc import Sequence
 from copy import copy
 from typing import Generic, TypeVar
-import typing
 
 from qiskit.utils.deprecation import deprecate_func
 from qiskit.circuit import QuantumCircuit
@@ -96,9 +95,6 @@ from qiskit.quantum_info.operators.base_operator import BaseOperator
 
 from .base_primitive import BasePrimitive
 from . import validation
-
-if typing.TYPE_CHECKING:
-    from qiskit.opflow import PauliSumOp
 
 T = TypeVar("T", bound=Job)
 
@@ -149,7 +145,7 @@ class BaseEstimator(BasePrimitive, Generic[T]):
     def run(
         self,
         circuits: Sequence[QuantumCircuit] | QuantumCircuit,
-        observables: Sequence[BaseOperator | PauliSumOp | str] | BaseOperator | PauliSumOp | str,
+        observables: Sequence[BaseOperator | str] | BaseOperator | str,
         parameter_values: Sequence[Sequence[float]] | Sequence[float] | float | None = None,
         **run_options,
     ) -> T:
@@ -218,14 +214,14 @@ class BaseEstimator(BasePrimitive, Generic[T]):
     @staticmethod
     @deprecate_func(since="0.46.0")
     def _validate_observables(
-        observables: Sequence[BaseOperator | PauliSumOp | str] | BaseOperator | PauliSumOp | str,
+        observables: Sequence[BaseOperator | str] | BaseOperator | str,
     ) -> tuple[SparsePauliOp, ...]:
         return validation._validate_observables(observables)
 
     @staticmethod
     @deprecate_func(since="0.46.0")
     def _cross_validate_circuits_observables(
-        circuits: tuple[QuantumCircuit, ...], observables: tuple[BaseOperator | PauliSumOp, ...]
+        circuits: tuple[QuantumCircuit, ...], observables: tuple[BaseOperator, ...]
     ) -> None:
         return validation._cross_validate_circuits_observables(circuits, observables)
 

--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from typing import Any
-import typing
 
 import numpy as np
 
@@ -34,9 +33,6 @@ from .utils import (
     bound_circuit_to_instruction,
     init_observable,
 )
-
-if typing.TYPE_CHECKING:
-    from qiskit.opflow import PauliSumOp
 
 
 class Estimator(BaseEstimator[PrimitiveJob[EstimatorResult]]):
@@ -130,7 +126,7 @@ class Estimator(BaseEstimator[PrimitiveJob[EstimatorResult]]):
     def _run(
         self,
         circuits: tuple[QuantumCircuit, ...],
-        observables: tuple[BaseOperator | PauliSumOp, ...],
+        observables: tuple[BaseOperator, ...],
         parameter_values: tuple[tuple[float, ...], ...],
         **run_options,
     ):

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -20,7 +20,6 @@ from ddt import data, ddt, unpack
 from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.exceptions import QiskitError
-from qiskit.opflow import PauliSumOp
 from qiskit.primitives import Estimator, EstimatorResult
 from qiskit.primitives.base import validation
 from qiskit.primitives.utils import _observable_key
@@ -350,7 +349,7 @@ class TestObservableValidation(QiskitTestCase):
         ("IXYZ", (SparsePauliOp("IXYZ"),)),
         (Pauli("IXYZ"), (SparsePauliOp("IXYZ"),)),
         (SparsePauliOp("IXYZ"), (SparsePauliOp("IXYZ"),)),
-        (PauliSumOp(SparsePauliOp("IXYZ")), (SparsePauliOp("IXYZ"),)),
+        (SparsePauliOp(SparsePauliOp("IXYZ")), (SparsePauliOp("IXYZ"),)),
         (
             ["IXYZ", "ZYXI"],
             (SparsePauliOp("IXYZ"), SparsePauliOp("ZYXI")),
@@ -364,7 +363,7 @@ class TestObservableValidation(QiskitTestCase):
             (SparsePauliOp("IXYZ"), SparsePauliOp("ZYXI")),
         ),
         (
-            [PauliSumOp(SparsePauliOp("IXYZ")), PauliSumOp(SparsePauliOp("ZYXI"))],
+            [SparsePauliOp(SparsePauliOp("IXYZ")), SparsePauliOp(SparsePauliOp("ZYXI"))],
             (SparsePauliOp("IXYZ"), SparsePauliOp("ZYXI")),
         ),
     )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
`PauliSumOp` class has been deprecated since `0.24.0`. This PR removes `PauliSumOp` support from the primitives.


### Details and comments
Updated the tests accordingly.


