### PR TITLE
Use InverseCancellation in opt level 1 instead of CXCancellation

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -39,7 +39,7 @@ from qiskit.transpiler.passes.optimization import (
     CommutativeCancellation,
     Collect2qBlocks,
     ConsolidateBlocks,
-    CXCancellation,
+    InverseCancellation,
 )
 from qiskit.transpiler.passes import Depth, Size, FixedPoint, MinimumPoint
 from qiskit.transpiler.passes.utils.gates_basis import GatesInBasis
@@ -47,6 +47,21 @@ from qiskit.transpiler.passes.synthesis.unitary_synthesis import UnitarySynthesi
 from qiskit.passmanager.flow_controllers import ConditionalController
 from qiskit.transpiler.timing_constraints import TimingConstraints
 from qiskit.transpiler.passes.layout.vf2_layout import VF2LayoutStopReason
+from qiskit.circuit.library.standard_gates import (
+    CXGate,
+    ECRGate,
+    CZGate,
+    XGate,
+    YGate,
+    ZGate,
+    TGate,
+    TdgGate,
+    SwapGate,
+    SGate,
+    SdgGate,
+    HGate,
+    CYGate,
+)
 
 
 class DefaultInitPassManager(PassManagerStagePlugin):
@@ -468,7 +483,21 @@ class OptimizationPassManager(PassManagerStagePlugin):
                     Optimize1qGatesDecomposition(
                         basis=pass_manager_config.basis_gates, target=pass_manager_config.target
                     ),
-                    CXCancellation(),
+                    InverseCancellation(
+                        [
+                            CXGate(),
+                            ECRGate(),
+                            CZGate(),
+                            CYGate(),
+                            XGate(),
+                            YGate(),
+                            ZGate(),
+                            HGate(),
+                            SwapGate(),
+                            (TGate(), TdgGate()),
+                            (SGate(), SdgGate()),
+                        ]
+                    ),
                 ]
             elif optimization_level == 2:
                 # Steps for optimization level 2

--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -61,6 +61,8 @@ from qiskit.circuit.library.standard_gates import (
     SdgGate,
     HGate,
     CYGate,
+    SXGate,
+    SXdgGate,
 )
 
 
@@ -496,6 +498,7 @@ class OptimizationPassManager(PassManagerStagePlugin):
                             SwapGate(),
                             (TGate(), TdgGate()),
                             (SGate(), SdgGate()),
+                            (SXGate(), SXdgGate()),
                         ]
                     ),
                 ]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the default optimization stage plugin to use the InverseCancellation pass instead of CXCancellation for optimization level 1. The CXCancellation pass was hard coded to only cancel runs of CX gates on the same qubits. This was fine when CX is the target, but for other targets which aren't using CX the pass had no value. An alternative, more general, inverse cancellation pass was added in #6855 that enables defining arbitrary inverse cancellation rules and simplifying a dag based on it. This commit updates the default optimization plugin at optimization level 1 to use this with some common inverse rules from the standard gate library.

### Details and comments

Closes #6576
Closes #7016
Related-to: #7112