### PR TITLE
Speed up InverseCancellation when there's nothing to cancel

### DIFF
--- a/qiskit/transpiler/passes/optimization/inverse_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/inverse_cancellation.py
@@ -111,7 +111,13 @@ class InverseCancellation(TransformationPass):
                 partitions = []
                 chunk = []
                 for i in range(len(gate_cancel_run) - 1):
-                    chunk.append(gate_cancel_run[i])
+                    if gate_cancel_run[i].op == gate:
+                        chunk.append(gate_cancel_run[i])
+                    else:
+                        if chunk:
+                            partitions.append(chunk)
+                            chunk = []
+                        continue
                     if gate_cancel_run[i].qargs != gate_cancel_run[i + 1].qargs:
                         partitions.append(chunk)
                         chunk = []

--- a/qiskit/transpiler/passes/optimization/inverse_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/inverse_cancellation.py
@@ -81,12 +81,12 @@ class InverseCancellation(TransformationPass):
             DAGCircuit: Transformed DAG.
         """
         if self.self_inverse_gates:
-            dag = self._run_on_self_inverse(dag, self.self_inverse_gates)
+            dag = self._run_on_self_inverse(dag)
         if self.inverse_gate_pairs:
-            dag = self._run_on_inverse_pairs(dag, self.inverse_gate_pairs)
+            dag = self._run_on_inverse_pairs(dag)
         return dag
 
-    def _run_on_self_inverse(self, dag: DAGCircuit, self_inverse_gates: List[Gate]):
+    def _run_on_self_inverse(self, dag: DAGCircuit):
         """
         Run self-inverse gates on `dag`.
 
@@ -97,11 +97,16 @@ class InverseCancellation(TransformationPass):
         Returns:
             DAGCircuit: Transformed DAG.
         """
-        if not self.self_inverse_gate_names.intersection(dag.count_ops()):
+        op_counts = dag.count_ops()
+        if not self.self_inverse_gate_names.intersection(op_counts):
             return dag
         # Sets of gate runs by name, for instance: [{(H 0, H 0), (H 1, H 1)}, {(X 0, X 0}]
-        gate_runs_sets = [dag.collect_runs([gate.name]) for gate in self_inverse_gates]
-        for gate_runs in gate_runs_sets:
+        for gate in self.self_inverse_gates:
+            gate_name = gate.name
+            gate_count = op_counts.get(gate_name, 0)
+            if gate_count <= 1:
+                continue
+            gate_runs = dag.collect_runs([gate_name])
             for gate_cancel_run in gate_runs:
                 partitions = []
                 chunk = []
@@ -120,7 +125,7 @@ class InverseCancellation(TransformationPass):
                         dag.remove_op_node(node)
         return dag
 
-    def _run_on_inverse_pairs(self, dag: DAGCircuit, inverse_gate_pairs: List[Tuple[Gate, Gate]]):
+    def _run_on_inverse_pairs(self, dag: DAGCircuit):
         """
         Run inverse gate pairs on `dag`.
 
@@ -131,11 +136,16 @@ class InverseCancellation(TransformationPass):
         Returns:
             DAGCircuit: Transformed DAG.
         """
-        if not self.inverse_gate_pairs_names.intersection(dag.count_ops()):
+        op_counts = dag.count_ops()
+        if not self.inverse_gate_pairs_names.intersection(op_counts):
             return dag
 
-        for pair in inverse_gate_pairs:
-            gate_cancel_runs = dag.collect_runs([pair[0].name, pair[1].name])
+        for pair in self.inverse_gate_pairs:
+            gate_0_name = pair[0].name
+            gate_1_name = pair[1].name
+            if gate_0_name not in op_counts or gate_1_name not in op_counts:
+                continue
+            gate_cancel_runs = dag.collect_runs([gate_0_name, gate_1_name])
             for dag_nodes in gate_cancel_runs:
                 i = 0
                 while i < len(dag_nodes) - 1:

--- a/releasenotes/notes/fix-parameterized-self-inverse-7cb2d68b273640f8.yaml
+++ b/releasenotes/notes/fix-parameterized-self-inverse-7cb2d68b273640f8.yaml
@@ -1,0 +1,22 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :class:`~.InverseCancellation` pass where it would
+    incorrectly cancel gates passed in as self inverses with a parameter
+    value, if a run of gates had a different parameter value. For example::
+
+        from math import pi
+
+        from qiskit.circuit.library import RZGate
+        from qiskit.circuit import QuantumCircuit
+        from qiskit.transpiler.passes import InverseCancellation
+
+        inverse_pass = InverseCancellation([RZGate(0)])
+
+        qc = QuantumCircuit(1)
+        qc.rz(0, 0)
+        qc.rz(pi, 0)
+
+        inverse_pass(qc)
+
+    would previously have incorrectly cancelled the two rz gates.

--- a/test/python/transpiler/test_inverse_cancellation.py
+++ b/test/python/transpiler/test_inverse_cancellation.py
@@ -329,6 +329,16 @@ class TestInverseCancellation(QiskitTestCase):
         self.assertNotIn("t", new_circ.count_ops())
         self.assertNotIn("tdg", new_circ.count_ops())
 
+    def test_half_of_an_inverse_pair(self):
+        """Test that half of an inverse pair doesn't do anything."""
+        qc = QuantumCircuit(1)
+        qc.t(0)
+        qc.t(0)
+        qc.t(0)
+        inverse_pass = InverseCancellation([(TGate(), TdgGate())])
+        new_circ = inverse_pass(qc)
+        self.assertEqual(new_circ, qc)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the cases when there is nothing to cancel in the DAGCircuit the InverseCancellation pass would iterate over the entire circuit twice, once to search for self inverse gates and then a second time to search for other inverse pairs. This is typically fairly fast because the actual search is done in rust, but there is a python callback function that is called for each node. Depending on the size of the circuit this could add up to a significant amount of time. This commit updates the logic in the pass to first check if there are any operations being asked to cancel for either stage, and if there are then only do the iteration if there are any gates in the circuit in the set of instructions that will be cancelled, which means we'll need to do an iteration. These checks are all O(1) for any sized dag, so they're much lower overhead and will mean the pass executes much faster in the case when there isn't anything to cancel.

### Details and comments