### PR TITLE
Fix asv installation configuration

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -4,20 +4,19 @@
     "project_url": "https://qiskit.org",
     "repo": ".",
     "install_command": [
-        "in-dir={env_dir} python -mpip install {wheel_file}[all] python-constraint qiskit-experiments==0.3.0"
+        "in-dir={env_dir} python -m pip install {wheel_file}[all] python-constraint qiskit-experiments==0.3.0"
       ],
     "uninstall_command": [
-        "return-code=any python -mpip uninstall -y {project}"
+        "return-code=any python -m pip uninstall -y qiskit qiskit-terra"
     ],
     "build_command": [
-        "pip install -U setuptools-rust",
-        "python setup.py build_rust --release",
-        "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+        "python -m pip install -U build",
+        "python -m build --outdir {build_cache_dir} --wheel {build_dir}"
     ],
     "branches": ["main"],
     "dvcs": "git",
     "environment_type": "virtualenv",
-    "show_commit_url": "http://github.com/Qiskit/qiskit-terra/commit/",
+    "show_commit_url": "http://github.com/Qiskit/qiskit/commit/",
     "pythons": ["3.8", "3.9", "3.10", "3.11"],
     "benchmark_dir": "test/benchmarks",
     "env_dir": ".asv/env",


### PR DESCRIPTION
### Summary

Previously, the `uninstall` component of the asv configuration was attempting to uninstall the package `qiskit`.  This _is_ the name of the project, but it's not the name of the relevant Python package, and so was not being uninstalled correctly.  This meant that asv's managed environments would retain the previous build, unless the updating the commit changed the version number of the package.

This behaviour caused our tracking bot to be benchmarking the state of the package only at the commit points that bump version numbers on `main`.  Typically, this means it was only ever benchmarking the release-candidate versions of the package since we migrated from the metapackage.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

I was able to use this locally to correctly detect changes in the `time_circuit_copy` benchmark between #10314 and #11040, with the uninstall working correctly:
```text
Benchmarks that have improved:

       before           after         ratio
     [bcf5ce49]       [a8812159]
     <0.45.0rc1~33>       <0.45.0rc1~13>
-         418±6μs          117±3μs     0.28  circuit_construction.CircuitConstructionBench.time_circuit_copy(14, 128)
-        462±30ms          110±1ms     0.24  circuit_construction.CircuitConstructionBench.time_circuit_copy(14, 131072)
-      6.80±0.3ms      1.66±0.04ms     0.24  circuit_construction.CircuitConstructionBench.time_circuit_copy(14, 2048)
-         114±3ms         33.3±3ms     0.29  circuit_construction.CircuitConstructionBench.time_circuit_copy(14, 32768)
-        99.5±9μs        36.4±10μs     0.37  circuit_construction.CircuitConstructionBench.time_circuit_copy(14, 8)
-      27.0±0.8ms       6.88±0.2ms     0.26  circuit_construction.CircuitConstructionBench.time_circuit_copy(14, 8192)
-        342±20μs          112±6μs     0.33  circuit_construction.CircuitConstructionBench.time_circuit_copy(2, 128)
-         355±6ms          122±3ms     0.34  circuit_construction.CircuitConstructionBench.time_circuit_copy(2, 131072)
-     4.97±0.08ms      1.69±0.02ms     0.34  circuit_construction.CircuitConstructionBench.time_circuit_copy(2, 2048)
-      82.5±0.8ms       30.9±0.2ms     0.37  circuit_construction.CircuitConstructionBench.time_circuit_copy(2, 32768)
-      32.2±0.3μs         18.8±1μs     0.58  circuit_construction.CircuitConstructionBench.time_circuit_copy(2, 8)
-      21.4±0.2ms       7.32±0.5ms     0.34  circuit_construction.CircuitConstructionBench.time_circuit_copy(2, 8192)
-         486±5μs          132±4μs     0.27  circuit_construction.CircuitConstructionBench.time_circuit_copy(20, 128)
-         437±3ms          122±3ms     0.28  circuit_construction.CircuitConstructionBench.time_circuit_copy(20, 131072)
-      6.94±0.5ms      1.75±0.08ms     0.25  circuit_construction.CircuitConstructionBench.time_circuit_copy(20, 2048)
-       109±0.8ms         28.1±1ms     0.26  circuit_construction.CircuitConstructionBench.time_circuit_copy(20, 32768)
-         133±6μs       40.1±0.5μs     0.30  circuit_construction.CircuitConstructionBench.time_circuit_copy(20, 8)
-      26.4±0.2ms       7.54±0.2ms     0.29  circuit_construction.CircuitConstructionBench.time_circuit_copy(20, 8192)
-         430±5μs          124±4μs     0.29  circuit_construction.CircuitConstructionBench.time_circuit_copy(5, 128)
-        432±20ms          110±2ms     0.25  circuit_construction.CircuitConstructionBench.time_circuit_copy(5, 131072)
-      6.63±0.5ms      1.70±0.05ms     0.26  circuit_construction.CircuitConstructionBench.time_circuit_copy(5, 2048)
-         103±3ms         27.1±1ms     0.26  circuit_construction.CircuitConstructionBench.time_circuit_copy(5, 32768)
-        41.4±2μs       17.8±0.4μs     0.43  circuit_construction.CircuitConstructionBench.time_circuit_copy(5, 8)
-      25.2±0.4ms       6.79±0.4ms     0.27  circuit_construction.CircuitConstructionBench.time_circuit_copy(5, 8192)
-        457±80μs          121±7μs     0.27  circuit_construction.CircuitConstructionBench.time_circuit_copy(8, 128)
-        439±30ms          112±5ms     0.25  circuit_construction.CircuitConstructionBench.time_circuit_copy(8, 131072)
-      7.08±0.5ms      1.70±0.02ms     0.24  circuit_construction.CircuitConstructionBench.time_circuit_copy(8, 2048)
-         108±8ms         27.5±1ms     0.26  circuit_construction.CircuitConstructionBench.time_circuit_copy(8, 32768)
-        59.1±2μs       22.5±0.8μs     0.38  circuit_construction.CircuitConstructionBench.time_circuit_copy(8, 8)
-        27.2±2ms       6.84±0.2ms     0.25  circuit_construction.CircuitConstructionBench.time_circuit_copy(8, 8192)

Benchmarks that have stayed the same:

       before           after         ratio
     [bcf5ce49]       [a8812159]
     <0.45.0rc1~33>       <0.45.0rc1~13>
          127±8μs          109±2μs    ~0.86  circuit_construction.CircuitConstructionBench.time_circuit_copy(1, 128)
          113±5ms          112±4ms     0.99  circuit_construction.CircuitConstructionBench.time_circuit_copy(1, 131072)
      1.78±0.09ms      1.69±0.03ms     0.95  circuit_construction.CircuitConstructionBench.time_circuit_copy(1, 2048)
       26.2±0.8ms       26.7±0.9ms     1.02  circuit_construction.CircuitConstructionBench.time_circuit_copy(1, 32768)
       16.9±0.7μs       16.0±0.2μs     0.95  circuit_construction.CircuitConstructionBench.time_circuit_copy(1, 8)
         7.33±1ms       6.80±0.2ms     0.93  circuit_construction.CircuitConstructionBench.time_circuit_copy(1, 8192)
```
