### PR TITLE
Remove namespace packaging hooks

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -14,7 +14,6 @@
 
 """Main Qiskit public functionality."""
 
-import pkgutil
 import sys
 import warnings
 
@@ -68,14 +67,6 @@ from qiskit import user_config as _user_config
 
 import qiskit.circuit.measure
 import qiskit.circuit.reset
-
-# Allow extending this namespace. Please note that currently this line needs
-# to be placed *before* the wrapper imports or any non-import code AND *before*
-# importing the package you want to allow extensions for (in this case `backends`).
-
-# Support for the deprecated extending this namespace.
-# Remove this after 0.46.0 release
-__path__ = pkgutil.extend_path(__path__, __name__)
 
 # Please note these are global instances, not modules.
 from qiskit.providers.basicaer import BasicAer

--- a/qiskit/providers/__init__.py
+++ b/qiskit/providers/__init__.py
@@ -750,8 +750,6 @@ There is also a :class:`~.BackendV2Converter` class available that enables you
 to wrap a :class:`~.BackendV1` object with a :class:`~.BackendV2` interface.
 """
 
-import pkgutil
-
 # Providers interface
 from qiskit.providers.provider import Provider
 from qiskit.providers.provider import ProviderV1
@@ -773,8 +771,3 @@ from qiskit.providers.exceptions import (
     BackendConfigurationError,
 )
 from qiskit.providers.jobstatus import JobStatus
-
-
-# Support for the deprecated extending this namespace.
-# Remove this after 0.46.0 release
-__path__ = pkgutil.extend_path(__path__, __name__)

--- a/releasenotes/notes/remove-namespace-hooks-995bdb7515a9fe35.yaml
+++ b/releasenotes/notes/remove-namespace-hooks-995bdb7515a9fe35.yaml
@@ -1,0 +1,14 @@
+---
+upgrade:
+  - |
+    Support for extensions of the ``qiskit`` and ``qiskit.providers`` namespaces
+    by external packages has been removed. Support for doing this was deprecated
+    in the Qiskit 0.44.0 release. In the past, the Qiskit project was composed
+    of elements that extended a shared namespace and hook points were added
+    to enable doing that. However, it was not intended for these interfaces to
+    ever be used by other packages. Now that the overall Qiskit package is no
+    longer using that packaging model, leaving the possibility for these
+    extensions carry more risk than benefits and has therefore been removed.
+    If you’re maintaining a package that extends the Qiskit namespace (i.e.
+    your users import from ``qiskit.x`` or ``qiskit.providers.y``) you should
+    transition to using a standalone Python namespace for your package.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit removes the pkgutil namespace hooks that are used for extending the `qiskit.*` and `qiskit.providers.*` namespaces from external packages. These were previously used to enable the elements packaging model where different parts of qiskit lived in separate python packages under a shared namespace. This is no longer being used and leaving the namespace extendable by external packages carries a risk of issues or other accidental cross-interactions when an external package gets loaded as part of Qiskit.

### Details and comments