### PR TITLE
Collapse release notes for pre-releases

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -9,4 +9,9 @@ This page contains the release notes for Qiskit, starting from the point at whic
 "meta-package" structure of Qiskit, see :ref:`legacy-release-notes`.
 
 .. release-notes::
-   :earliest-version: 0.25.0rc1
+   :earliest-version: 0.45.0
+   :branch: stable/0.45
+
+.. release-notes::
+   :earliest-version: 0.25.0
+   :branch: stable/0.25

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -2,6 +2,7 @@
 encoding: utf8
 default_branch: main
 collapse_pre_releases: true
+pre_release_tag_re: (?P<pre_release>(?:[ab]|rc|pre)+\d*)$
 sections:
     - [features, New Features]
     - [features_algorithms, Algorithms Features]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit tweaks the reno sphinx directive usage to collapse the pre-releases. The big piece of this is splitting into using multiple directives for each minor stable release branch. Each directive explicitly sets the scanning branch to the stable branches. The underlying issue with a single directive was that the reno git scanner wasn't seeing the final release tags on main as the tags only exist on the stable branches. The extra benefit of this is that we also get the bugfix releases included now.

### Details and comments

This is pushed directly to stable/0.45 to handle that release and the published docs. We'll need to forward port this but also include an extra directive on main. I opted to push this in reverse to handle that on the main PR instead of removing it on a backport.