### PR TITLE
Add warning when qiskit package not installed

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -14,12 +14,25 @@
 
 """Main Qiskit public functionality."""
 
+from importlib.metadata import version, PackageNotFoundError
 import pkgutil
 import sys
 import warnings
 
 import qiskit._accelerate
 
+try:
+    version("qiskit")
+except PackageNotFoundError:
+    warnings.warn(
+        "The `qiskit` package is not installed, only `qiskit-terra` is installed. "
+        "Starting in Qiskit 1.0.0 only the `qiskit` package will be published. Migrate "
+        "any requirements files still using `qiskit-terra` to use `qiskit` instead. Also "
+        "when upgrading ensure you create a new venv instead of trying to "
+        "upgrade in place.",
+        FutureWarning,
+        stacklevel=2,
+    )
 
 # Globally define compiled submodules. The normal import mechanism will not find compiled submodules
 # in _accelerate because it relies on file paths, but PyO3 generates only one shared library file.

--- a/releasenotes/notes/warn-on-no-qiskit-56e1080842aa81b5.yaml
+++ b/releasenotes/notes/warn-on-no-qiskit-56e1080842aa81b5.yaml
@@ -1,0 +1,23 @@
+---
+deprecations:
+  - |
+    The ``qiskit-terra`` python package is deprecated and will no longer receive
+    updates starting in Qiskit 1.0.0. If you're installing ``qiskit-terra`` by
+    itself this will no longer be updated for Qiskit>=1.0.0. If you're running
+    qiskit without the ``qiskit`` package a ``FutureWarning`` will be emitted on
+    import of :mod:`qiskit` to indicate you're not using the ``qiskit`` package.
+critical:
+  - |
+    When updating Qiskit from ``0.46.x`` to ``1.0.0`` you will not be able to
+    update in place. For example, ``pip install -U qiskit`` or
+    ``pip install --upgrade qiskit`` is not supported and likely will **not**
+    work. To upgrade qiskit the recommended path is to create a new virtual
+    environment (:mod:`venv`) to build a new separate environment for
+    Qiskit>=1.0.0. For example::
+
+        python -m venv qiskit_1.0
+        source qiskit_1.0/bin/activate
+        pip install qiskit>=1
+
+    will create a new virtual environment named ``qiskit_1.0`` will contain the
+    new version of Qiskit.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Starting in Qiskit 1.0 the qiskit-terra package will no longer be published anymore. This is a major change in the packaging because since December 2018 users have been able rely on just the qiskit-terra package if they were only depending on the core functionality in qiskit. But as we're . This commit adds a warning on import of the `qiskit` namespace if the `qiskit` package is not installed to inform users that starting in 1.0.0 qiskit-terra will not recieve updates. There will still be releases for the 0.46.x release series (while it's still supported).

The other aspect with this migration is there is **not** a safe direct upgrade path from qiskit < 1.0.0 to qiskit>=1.0.0 due to limitations in `pip`. This means that users will not be able to upgrade the `qiskit` package in place. A `critical` section (the first time we've used it) release note is added to document the upgrade path for users.

### Details and comments