### PR TITLE
Revert "Relax CI constraint on `numpy<1.25` (#11020)"

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -2,6 +2,11 @@
 # 4.0+. The pin can be removed after nbformat is updated.
 jsonschema==3.2.0
 
+# Numpy 1.25 deprecated some behaviours that we used, and caused the isometry
+# tests to flake. See https://github.com/Qiskit/qiskit-terra/issues/10305,
+# remove pin when resolving that.
+numpy<1.25
+
 # Scipy 1.11 seems to have caused an instability in the Weyl coordinates
 # eigensystem code for one of the test cases.  See
 # https://github.com/Qiskit/qiskit-terra/issues/10345 for current details.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Removing the restriction on the numpy version has introduced some non-determinism to some of the unitary synthesis tests that is causing a flaky failure in CI. This commit reverts the version cap removal to unblock CI. In parallel we should debug the source of the instability causing the test to fail so we can run CI using the latest version of numpy.

### Details and comments

This reverts commit fb8a69df2ffa99bd399b4c0365f875ae4b9f70f6.