### PR TITLE
Add pow as supported operation for ParameterExpression

### DIFF
--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -362,6 +362,12 @@ class ParameterExpression:
     def __rtruediv__(self, other):
         return self._apply_operation(operator.truediv, other, reflected=True)
 
+    def __pow__(self, other):
+        return self._apply_operation(pow, other)
+
+    def __rpow__(self, other):
+        return self._apply_operation(pow, other, reflected=True)
+
     def _call(self, ufunc):
         return ParameterExpression(self._parameter_symbols, ufunc(self._symbol_expr))
 

--- a/releasenotes/notes/add-parameter-pow-ff5f8d10813f5733.yaml
+++ b/releasenotes/notes/add-parameter-pow-ff5f8d10813f5733.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    :class:`~qiskit.circuit.ParameterExpression` (and thus also
+    :class:`~qiskit.circuit.Parameter`) now support powering: :code:`x**y`
+    where :code:`x` and :code:`y` can be any combination of
+    :class:`~qiskit.circuit.ParameterExpression` and number types.

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -1332,7 +1332,7 @@ def _paramvec_names(prefix, length):
 class TestParameterExpressions(QiskitTestCase):
     """Test expressions of Parameters."""
 
-    supported_operations = [add, sub, mul, truediv]
+    supported_operations = [add, sub, mul, truediv, pow]
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Adds powering for `qiskit.circuit.ParameterExpression` allowing to use `a**n`, `n**a`, `a**b`, `pow(a,b)` etc. for `ParameterExpression`s `a`, `b` and numbers `n`.

### Details and comments

Minimal change using default support of `pow` by Sympy/Symengine.
Also added `pow` to list of operators in `TestParameterExpressions` test case for unit testing.
Fixes #8959
Changelog: New Feature
