### PR TITLE
Docstring only: Fix math parsing error for Pauli docstring

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -110,7 +110,7 @@ class Pauli(BasePauli):
 
         P = (-i)^{q + z\cdot x} Z^z \cdot X^x.
 
-    The :math:`k`th qubit corresponds to the :math:`k`th entry in the
+    The :math:`k`-th qubit corresponds to the :math:`k`-th entry in the
     :math:`z` and :math:`x` arrays
 
     .. math::


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes. N/A
- [ x] I have updated the documentation accordingly.
- [ x] I have read the CONTRIBUTING document.
-->

### Summary

``:math:`k`th`` in docstring (or generally math directly followed by a letter) results in parsing error, see [qiskit.quantum_info.Pauli](https://qiskit.org/documentation/stubs/qiskit.quantum_info.Pauli.html#qiskit.quantum_info.Pauli) under section 'Array Representation'. Assuming this is a Sphinx bug, but as a simple fix replaced by ``:math:`k`-th``. (:class:`qiskit.quantum_info.Pauli` seems the only place where this issue occurs.)

(Since this is a simple typo fix in the docstring only, I directly opened the PR without filing a bug report first and without adding release notes. Please let me know if this is improper procedure.)



