### PR TITLE
Add new transpiler exception class for too many qubits

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -28,7 +28,7 @@ from qiskit.providers.models import BackendProperties
 from qiskit.pulse import Schedule, InstructionScheduleMap
 from qiskit.transpiler import Layout, CouplingMap, PropertySet
 from qiskit.transpiler.basepasses import BasePass
-from qiskit.transpiler.exceptions import TranspilerError
+from qiskit.transpiler.exceptions import TranspilerError, CircuitToWideForTarget
 from qiskit.transpiler.instruction_durations import InstructionDurations, InstructionDurationsType
 from qiskit.transpiler.passes.synthesis.high_level_synthesis import HLSConfig
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
@@ -455,7 +455,7 @@ def _check_circuits_coupling_map(circuits, cmap, backend):
         # If coupling_map is not None or num_qubits == 1
         num_qubits = len(circuit.qubits)
         if max_qubits is not None and (num_qubits > max_qubits):
-            raise TranspilerError(
+            raise CircuitToWideForTarget(
                 f"Number of qubits ({num_qubits}) in {circuit.name} "
                 f"is greater than maximum ({max_qubits}) in the coupling_map"
             )

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -28,7 +28,7 @@ from qiskit.providers.models import BackendProperties
 from qiskit.pulse import Schedule, InstructionScheduleMap
 from qiskit.transpiler import Layout, CouplingMap, PropertySet
 from qiskit.transpiler.basepasses import BasePass
-from qiskit.transpiler.exceptions import TranspilerError, CircuitToWideForTarget
+from qiskit.transpiler.exceptions import TranspilerError, CircuitTooWideForTarget
 from qiskit.transpiler.instruction_durations import InstructionDurations, InstructionDurationsType
 from qiskit.transpiler.passes.synthesis.high_level_synthesis import HLSConfig
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
@@ -455,7 +455,7 @@ def _check_circuits_coupling_map(circuits, cmap, backend):
         # If coupling_map is not None or num_qubits == 1
         num_qubits = len(circuit.qubits)
         if max_qubits is not None and (num_qubits > max_qubits):
-            raise CircuitToWideForTarget(
+            raise CircuitTooWideForTarget(
                 f"Number of qubits ({num_qubits}) in {circuit.name} "
                 f"is greater than maximum ({max_qubits}) in the coupling_map"
             )

--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -1251,7 +1251,7 @@ Exceptions
 .. autoexception:: TranspilerAccessError
 .. autoexception:: CouplingError
 .. autoexception:: LayoutError
-.. autoexception:: CircuitToWideForTarget
+.. autoexception:: CircuitTooWideForTarget
 
 """
 
@@ -1270,7 +1270,7 @@ from .exceptions import (
     TranspilerAccessError,
     CouplingError,
     LayoutError,
-    CircuitToWideForTarget,
+    CircuitTooWideForTarget,
 )
 from .fencedobjs import FencedDAGCircuit, FencedPropertySet
 from .basepasses import AnalysisPass, TransformationPass

--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -1251,6 +1251,8 @@ Exceptions
 .. autoexception:: TranspilerAccessError
 .. autoexception:: CouplingError
 .. autoexception:: LayoutError
+.. autoexception:: CircuitToWideForTarget
+
 """
 
 # For backward compatibility
@@ -1263,7 +1265,13 @@ from qiskit.passmanager import (
 from .passmanager import PassManager, StagedPassManager
 from .passmanager_config import PassManagerConfig
 from .propertyset import PropertySet  # pylint: disable=no-name-in-module
-from .exceptions import TranspilerError, TranspilerAccessError, CouplingError, LayoutError
+from .exceptions import (
+    TranspilerError,
+    TranspilerAccessError,
+    CouplingError,
+    LayoutError,
+    CircuitToWideForTarget,
+)
 from .fencedobjs import FencedDAGCircuit, FencedPropertySet
 from .basepasses import AnalysisPass, TransformationPass
 from .coupling import CouplingMap

--- a/qiskit/transpiler/exceptions.py
+++ b/qiskit/transpiler/exceptions.py
@@ -51,5 +51,5 @@ class LayoutError(QiskitError):
         return repr(self.msg)
 
 
-class CircuitToWideForTarget(TranspilerError):
+class CircuitTooWideForTarget(TranspilerError):
     """Error raised if the circuit is too wide for the target."""

--- a/qiskit/transpiler/exceptions.py
+++ b/qiskit/transpiler/exceptions.py
@@ -49,3 +49,7 @@ class LayoutError(QiskitError):
     def __str__(self):
         """Return the message."""
         return repr(self.msg)
+
+
+class CircuitToWideForTarget(TranspilerError):
+    """Error raised if the circuit is too wide for the target."""

--- a/releasenotes/notes/new-exception-too-wide-3231c1df15952445.yaml
+++ b/releasenotes/notes/new-exception-too-wide-3231c1df15952445.yaml
@@ -1,9 +1,9 @@
 ---
 features:
   - |
-    Added a new exception class :class:`.CircuitToWideForTarget` which
-    subclasses :class:`.TranspilerError`. It's used in places where a
-    :class:`.TranspilerError` was previously raised when the error was that
+    Added a new exception class :exc:`.CircuitToWideForTarget` which
+    subclasses :exc:`.TranspilerError`. It's used in places where a
+    :exc:`.TranspilerError` was previously raised when the error was that
     the number of circuit qubits was larger than the target backend's qubits.
     The new class enables more differentiating between this error condition and
-    other :class:`.TranspilerError`\s.
+    other :exc:`.TranspilerError`\s.

--- a/releasenotes/notes/new-exception-too-wide-3231c1df15952445.yaml
+++ b/releasenotes/notes/new-exception-too-wide-3231c1df15952445.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Added a new exception class :class:`.CircuitToWideForTarget` which
+    subclasses :class:`.TranspilerError`. It's used in places where a
+    :class:`.TranspilerError` was previously raised when the error was that
+    the number of circuit qubits was larger than the target backend's qubits.
+    The new class enables more differentiating between this error condition and
+    other :class:`.TranspilerError`\s.

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -87,7 +87,7 @@ from qiskit.quantum_info import Operator, random_unitary
 from qiskit.test import QiskitTestCase, slow_test
 from qiskit.tools import parallel
 from qiskit.transpiler import CouplingMap, Layout, PassManager, TransformationPass
-from qiskit.transpiler.exceptions import TranspilerError
+from qiskit.transpiler.exceptions import TranspilerError, CircuitTooWideForTarget
 from qiskit.transpiler.passes import BarrierBeforeFinalMeasurements, GateDirection, VF2PostLayout
 from qiskit.transpiler.passmanager_config import PassManagerConfig
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager, level_0_pass_manager
@@ -987,7 +987,7 @@ class TestTranspile(QiskitTestCase):
 
         qc = QuantumCircuit(15, 15)
 
-        with self.assertRaises(TranspilerError):
+        with self.assertRaises(CircuitTooWideForTarget):
             transpile(qc, coupling_map=cmap)
 
     @data(0, 1, 2, 3)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new exception class for when the transpiler is given a circuit too many qubits for a given backend. Previously the generic TranspilerError was raised for this, but it made it difficult for downstream users to catch as it wasn't easy to differentiate this error condition from other TranspilerError exceptions. There isn't any backwards compatibility issues with this because the new CircuitToWideForTarget class is a subclass of TranspilerError so any of the previous catches for TranspilerError will still catch this.

### Details and comments


