### PR TITLE
[WIP] Fix the broken links in qiskit.pulse API doc

### DIFF
--- a/docs/api_redirects.txt
+++ b/docs/api_redirects.txt
@@ -148,6 +148,7 @@ qiskit.pulse.builder.qubit_channels pulse
 qiskit.pulse.builder.samples_to_seconds pulse
 qiskit.pulse.builder.seconds_to_samples pulse
 
+qiskit.pulse.library.Constant_class pulse
 qiskit.pulse.library.constant pulse
 qiskit.pulse.library.zero pulse
 qiskit.pulse.library.square pulse

--- a/docs/api_redirects.txt
+++ b/docs/api_redirects.txt
@@ -149,6 +149,15 @@ qiskit.pulse.builder.samples_to_seconds pulse
 qiskit.pulse.builder.seconds_to_samples pulse
 
 qiskit.pulse.library.Constant_class pulse
+qiskit.pulse.library.Sawtooth_class pulse
+qiskit.pulse.library.Triangle_class pulse
+qiskit.pulse.library.Cos_class pulse
+qiskit.pulse.library.Sin_class pulse
+qiskit.pulse.library.Gaussian_class pulse
+qiskit.pulse.library.Drag_class pulse
+qiskit.pulse.library.Square_fun pulse
+qiskit.pulse.library.Sech_fun pulse
+
 qiskit.pulse.library.constant pulse
 qiskit.pulse.library.zero pulse
 qiskit.pulse.library.square pulse


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

**Work in progress**

This PR aims to fix the broken links in qiskit.pulse API doc.

This is the first attempt to fix the following links:

- qiskit.pulse.library.Constant_class.rst
- qiskit.pulse.library.Sawtooth_class.rst
- qiskit.pulse.library.Triangle_class.rst
- qiskit.pulse.library.Cos_class.rst
- qiskit.pulse.library.Sin_class.rst
- qiskit.pulse.library.Gaussian_class.rst
- qiskit.pulse.library.Drag_class.rst
- qiskit.pulse.library.Square_fun.rst
- qiskit.pulse.library.Sech_fun.rst