### PR TITLE
Remove unnecessary installation of build requirements

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -185,7 +185,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install deps
-        run: pip install -U twine setuptools-rust wheel build
+        run: pip install -U build
       - name: Build sdist
         run: python -m build . --sdist
       - name: Publish package distributions to PyPI
@@ -208,7 +208,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install deps
-        run: pip install -U twine setuptools-rust wheel build
+        run: pip install -U build
       - name: Build packages
         run: |
           set -e


### PR DESCRIPTION
### Summary

Since we are using `build`, a basic PEP 517 builder, we do not need to manually install the build requirements; our `pyproject.toml` specifies them, and they'll be automatically pulled in.

With the pivot to PyPI trusted publishers in gh-10999, we no longer use `twine` manually either.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


Related to similar work in https://github.com/Qiskit/qiskit/pull/11119#discussion_r1394117522.