### PR TITLE
Do not ignore global phases when comparing unitary gates

### DIFF
--- a/qiskit/circuit/library/generalized_gates/unitary.py
+++ b/qiskit/circuit/library/generalized_gates/unitary.py
@@ -111,9 +111,7 @@ class UnitaryGate(Gate):
             return False
         if self.label != other.label:
             return False
-        # Should we match unitaries as equal if they are equal
-        # up to global phase?
-        return matrix_equal(self.params[0], other.params[0], ignore_phase=True)
+        return matrix_equal(self.params[0], other.params[0])
 
     def __array__(self, dtype=None):
         """Return matrix for the unitary."""

--- a/releasenotes/notes/fix-unitary-equal-eb828aca3aaa5e73.yaml
+++ b/releasenotes/notes/fix-unitary-equal-eb828aca3aaa5e73.yaml
@@ -4,5 +4,5 @@ fixes:
     Previously two objects of type :class:`~.UnitaryGate` class were considered equal
     even when they had different global phases. This could lead to transpiler
     passes not maintaining the global phase and, in theory, to incorrect optimizations.
-    This commit changes the :meth:`~.UnitaryGate.__eq__`` method not to ignore the global
+    This commit changes the :meth:`~.UnitaryGate.__eq__` method not to ignore the global
     phases in the comparison.

--- a/releasenotes/notes/fix-unitary-equal-eb828aca3aaa5e73.yaml
+++ b/releasenotes/notes/fix-unitary-equal-eb828aca3aaa5e73.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Previously two objects of type :class:`~.UnitaryGate` class were considered equal
+    even when they had different global phases. This could lead to transpiler
+    passes not maintaining the global phase and, in theory, to incorrect optimizations.
+    This commit changes the :meth:`~.UnitaryGate.__eq__`` method not to ignore the global
+    phases in the comparison.

--- a/test/python/circuit/test_hamiltonian_gate.py
+++ b/test/python/circuit/test_hamiltonian_gate.py
@@ -18,7 +18,7 @@ from numpy.testing import assert_allclose
 
 
 import qiskit
-from qiskit.circuit.library import HamiltonianGate, UnitaryGate
+from qiskit.circuit.library import HamiltonianGate
 from qiskit.test import QiskitTestCase
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.circuit import Parameter

--- a/test/python/circuit/test_hamiltonian_gate.py
+++ b/test/python/circuit/test_hamiltonian_gate.py
@@ -169,4 +169,4 @@ class TestHamiltonianCircuit(QiskitTestCase):
         qc.append(uni2q, [0, 1])
         qc = qc.assign_parameters({theta: -np.pi / 2}).decompose()
         decomposed_ham = qc.data[0].operation
-        self.assertEqual(decomposed_ham, UnitaryGate(Operator.from_label("XY")))
+        self.assertEqual(Operator(decomposed_ham), 1j * Operator.from_label("XY"))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Previously two objects of type ``UnitaryGate`` class were considered equal even when they had different global phases. This could lead to transpiler passes not maintaining the global phase and, in theory, to incorrect optimizations. This commit changes the ``UnitaryGate.__eq__`` method not to ignore the global phases in the comparison.

Fixes #10645.

### Details and comments

Thanks to @ShellyGarion and @Cryoris for understanding the math behind the failing test in `test_hamiltonian_gates.py`. The test had been modified to include the global phase.
