### PR TITLE
Fix `Channel.__hash__` in multiprocessing contexts

### DIFF
--- a/qiskit/pulse/channels.py
+++ b/qiskit/pulse/channels.py
@@ -96,7 +96,6 @@ class Channel(metaclass=ABCMeta):
         """
         self._validate_index(index)
         self._index = index
-        self._hash = hash((self.__class__.__name__, self._index))
 
     @property
     def index(self) -> Union[int, ParameterExpression]:
@@ -156,7 +155,7 @@ class Channel(metaclass=ABCMeta):
         return type(self) is type(other) and self._index == other._index
 
     def __hash__(self):
-        return self._hash
+        return hash((type(self), self._index))
 
 
 class PulseChannel(Channel, metaclass=ABCMeta):

--- a/qiskit/pulse/instructions/instruction.py
+++ b/qiskit/pulse/instructions/instruction.py
@@ -53,7 +53,6 @@ class Instruction(ABC):
         """
         self._operands = operands
         self._name = name
-        self._hash = None
         self._validate()
 
     def _validate(self):
@@ -301,9 +300,7 @@ class Instruction(ABC):
         return isinstance(other, type(self)) and self.operands == other.operands
 
     def __hash__(self) -> int:
-        if self._hash is None:
-            self._hash = hash((type(self), self.operands, self.name))
-        return self._hash
+        return hash((type(self), self.operands, self.name))
 
     def __add__(self, other):
         """Return a new schedule with `other` inserted within `self` at `start_time`.

--- a/qiskit/pulse/model/frames.py
+++ b/qiskit/pulse/model/frames.py
@@ -33,28 +33,6 @@ class Frame(ABC):
     The default initial phase for every frame is 0.
     """
 
-    def __init__(self, identifier):
-        """Create ``Frame``.
-
-        Args:
-            identifier: A unique identifier used to hash the Frame.
-        """
-        self._hash = hash((type(self), identifier))
-
-    def __eq__(self, other: "Frame") -> bool:
-        """Return True iff self and other are equal, specifically, iff they have the same type and hash.
-
-        Args:
-            other: The frame to compare to this one.
-
-        Returns:
-            True iff equal.
-        """
-        return type(self) is type(other) and self._hash == other._hash
-
-    def __hash__(self) -> int:
-        return self._hash
-
 
 class GenericFrame(Frame):
     """Pulse module GenericFrame.
@@ -74,7 +52,6 @@ class GenericFrame(Frame):
             name: A unique identifier used to identify the frame.
         """
         self._name = name
-        super().__init__(name)
 
     @property
     def name(self) -> str:
@@ -83,6 +60,12 @@ class GenericFrame(Frame):
 
     def __repr__(self) -> str:
         return f"GenericFrame({self._name})"
+
+    def __eq__(self, other):
+        return type(self) is type(other) and self._name == other._name
+
+    def __hash__(self):
+        return hash((type(self), self._name))
 
 
 class QubitFrame(Frame):
@@ -102,7 +85,6 @@ class QubitFrame(Frame):
         """
         self._validate_index(index)
         self._index = index
-        super().__init__("QubitFrame" + str(index))
 
     @property
     def index(self) -> int:
@@ -121,6 +103,12 @@ class QubitFrame(Frame):
 
     def __repr__(self) -> str:
         return f"QubitFrame({self._index})"
+
+    def __eq__(self, other):
+        return type(self) is type(other) and self._index == other._index
+
+    def __hash__(self):
+        return hash((type(self), self._index))
 
 
 class MeasurementFrame(Frame):
@@ -141,7 +129,6 @@ class MeasurementFrame(Frame):
         """
         self._validate_index(index)
         self._index = index
-        super().__init__("MeasurementFrame" + str(index))
 
     @property
     def index(self) -> int:
@@ -160,3 +147,9 @@ class MeasurementFrame(Frame):
 
     def __repr__(self) -> str:
         return f"MeasurementFrame({self._index})"
+
+    def __eq__(self, other):
+        return type(self) is type(other) and self._index == other._index
+
+    def __hash__(self):
+        return hash((type(self), self._index))

--- a/qiskit/pulse/model/mixed_frames.py
+++ b/qiskit/pulse/model/mixed_frames.py
@@ -47,7 +47,6 @@ class MixedFrame:
         """
         self._pulse_target = pulse_target
         self._frame = frame
-        self._hash = hash((self._pulse_target, self._frame, type(self)))
 
     @property
     def pulse_target(self) -> PulseTarget:
@@ -75,4 +74,4 @@ class MixedFrame:
         return self._pulse_target == other._pulse_target and self._frame == other._frame
 
     def __hash__(self) -> int:
-        return self._hash
+        return hash((self._pulse_target, self._frame, type(self)))

--- a/qiskit/pulse/model/pulse_target.py
+++ b/qiskit/pulse/model/pulse_target.py
@@ -59,7 +59,6 @@ class Port(PulseTarget):
             name: A string identifying the port.
         """
         self._name = name
-        self._hash = hash((name, type(self)))
 
     @property
     def name(self) -> str:
@@ -78,11 +77,11 @@ class Port(PulseTarget):
         """
         return type(self) is type(other) and self._name == other._name
 
+    def __hash__(self) -> int:
+        return hash((self._name, type(self)))
+
     def __repr__(self) -> str:
         return f"Port({self._name})"
-
-    def __hash__(self) -> int:
-        return self._hash
 
 
 class LogicalElement(PulseTarget, ABC):
@@ -104,7 +103,6 @@ class LogicalElement(PulseTarget, ABC):
         """
         self._validate_index(index)
         self._index = index
-        self._hash = hash((index, type(self)))
 
     @property
     def index(self) -> Tuple[int, ...]:
@@ -132,12 +130,12 @@ class LogicalElement(PulseTarget, ABC):
         """
         return type(self) is type(other) and self._index == other._index
 
+    def __hash__(self) -> int:
+        return hash((self._index, type(self)))
+
     def __repr__(self) -> str:
         ind_str = str(self._index) if len(self._index) > 1 else f"({self._index[0]})"
         return type(self).__name__ + ind_str
-
-    def __hash__(self) -> int:
-        return self._hash
 
 
 class Qubit(LogicalElement):

--- a/releasenotes/notes/fix-pulse-channel-hash-549a8fb5d8738c4d.yaml
+++ b/releasenotes/notes/fix-pulse-channel-hash-549a8fb5d8738c4d.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed the :func:`hash` of Qiskit Pulse ``Channel`` objects (such as :class:`.DriveChannel`) in
+    cases where the channel was transferred from one Python process to another that used a different
+    hash seed.


### PR DESCRIPTION
### Summary

Storing an explicit hash key is fragile in cases that a channel might be created in a different process to where it might be compared or the hash used, because the hash seeding can vary depending on how the new interpreter process was created, especially if it's not done by `fork`.

In this case, transmitting the stored `_hash` over pickle meant that a `DriveChannel(0)` created in the main process of a macOS runner could compare equal to a `DriveChannel(0)` created in a separate process (standard start method `spawn`) and pickled over the wire to the main process, but have different hashes, violating the Python data model.

Instead, we can just use the standard Python behaviour of creating the hash on demand when requested; this should typically be preferred unless absolutely necessary for critical performance reasons, because it will generally fail safe.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

This fixes a test failure that appears on Mac and Windows runners locally (but for some reason not in CI) in `test.python.compiler.test_transpiler.TestTranspileParallel.test_parallel_dispatch_lazy_cal_loading`.
