### PR TITLE
Remove `print` calls from test suite

### DIFF
--- a/test/python/circuit/library/test_functional_pauli_rotations.py
+++ b/test/python/circuit/library/test_functional_pauli_rotations.py
@@ -84,7 +84,7 @@ class TestFunctionalPauliRotations(QiskitTestCase):
 
         with self.subTest(msg="missing number of state qubits"):
             with self.assertRaises(AttributeError):  # no state qubits set
-                print(polynomial_rotations.draw())
+                _ = str(polynomial_rotations.draw())
 
         with self.subTest(msg="default setup, just setting number of state qubits"):
             polynomial_rotations.num_state_qubits = 2
@@ -121,7 +121,7 @@ class TestFunctionalPauliRotations(QiskitTestCase):
 
         with self.subTest(msg="missing number of state qubits"):
             with self.assertRaises(AttributeError):  # no state qubits set
-                print(linear_rotation.draw())
+                _ = str(linear_rotation.draw())
 
         with self.subTest(msg="default setup, just setting number of state qubits"):
             linear_rotation.num_state_qubits = 2
@@ -171,7 +171,7 @@ class TestFunctionalPauliRotations(QiskitTestCase):
 
         with self.subTest(msg="missing number of state qubits"):
             with self.assertRaises(AttributeError):  # no state qubits set
-                print(pw_linear_rotations.draw())
+                _ = str(pw_linear_rotations.draw())
 
         with self.subTest(msg="default setup, just setting number of state qubits"):
             pw_linear_rotations.num_state_qubits = 2

--- a/test/python/circuit/library/test_integer_comparator.py
+++ b/test/python/circuit/library/test_integer_comparator.py
@@ -71,13 +71,13 @@ class TestIntegerComparator(QiskitTestCase):
 
         with self.subTest(msg="missing num state qubits and value"):
             with self.assertRaises(AttributeError):
-                print(comp.draw())
+                _ = str(comp.draw())
 
         comp.num_state_qubits = 2
 
         with self.subTest(msg="missing value"):
             with self.assertRaises(AttributeError):
-                print(comp.draw())
+                _ = str(comp.draw())
 
         comp.value = 0
         comp.geq = True

--- a/test/python/circuit/library/test_nlocal.py
+++ b/test/python/circuit/library/test_nlocal.py
@@ -378,7 +378,7 @@ class TestNLocal(QiskitTestCase):
 
         # pairwise entanglement is only defined if the entangling gate has 2 qubits
         with self.assertRaises(ValueError):
-            print(nlocal.draw())
+            _ = str(nlocal.draw())
 
     def test_entanglement_by_list(self):
         """Test setting the entanglement by list.

--- a/test/python/circuit/library/test_permutation.py
+++ b/test/python/circuit/library/test_permutation.py
@@ -170,7 +170,6 @@ class TestPermutationGatesOnCircuit(QiskitTestCase):
         circuit.cx(0, 1)
         circuit.append(PermutationGate([1, 2, 0]), [2, 4, 5])
         circuit.h(4)
-        print(circuit)
 
         qpy_file = io.BytesIO()
         dump(circuit, qpy_file)

--- a/test/python/circuit/library/test_piecewise_chebyshev.py
+++ b/test/python/circuit/library/test_piecewise_chebyshev.py
@@ -103,7 +103,7 @@ class TestPiecewiseChebyshev(QiskitTestCase):
 
         with self.subTest(msg="missing number of state qubits"):
             with self.assertRaises(AttributeError):  # no state qubits set
-                print(pw_approximation.draw())
+                _ = str(pw_approximation.draw())
 
         with self.subTest(msg="default setup, just setting number of state qubits"):
             pw_approximation.num_state_qubits = 2

--- a/test/python/circuit/library/test_weighted_adder.py
+++ b/test/python/circuit/library/test_weighted_adder.py
@@ -67,7 +67,7 @@ class TestWeightedAdder(QiskitTestCase):
 
         with self.subTest(msg="missing number of state qubits"):
             with self.assertRaises(AttributeError):
-                print(adder.draw())
+                _ = str(adder.draw())
 
         with self.subTest(msg="default weights"):
             adder.num_state_qubits = 3
@@ -81,7 +81,7 @@ class TestWeightedAdder(QiskitTestCase):
         with self.subTest(msg="mismatching number of state qubits and weights"):
             with self.assertRaises(ValueError):
                 adder.weights = [0, 1, 2, 3]
-                print(adder.draw())
+                _ = str(adder.draw())
 
         with self.subTest(msg="change all attributes"):
             adder.num_state_qubits = 4

--- a/test/python/circuit/test_piecewise_polynomial.py
+++ b/test/python/circuit/test_piecewise_polynomial.py
@@ -101,7 +101,7 @@ class TestPiecewisePolynomialRotations(QiskitTestCase):
 
         with self.subTest(msg="missing number of state qubits"):
             with self.assertRaises(AttributeError):  # no state qubits set
-                print(pw_polynomial_rotations.draw())
+                _ = str(pw_polynomial_rotations.draw())
 
         with self.subTest(msg="default setup, just setting number of state qubits"):
             pw_polynomial_rotations.num_state_qubits = 2

--- a/test/python/primitives/test_backend_sampler.py
+++ b/test/python/primitives/test_backend_sampler.py
@@ -117,7 +117,6 @@ class TestBackendSampler(QiskitTestCase):
         bell = self._circuit[1]
         sampler = BackendSampler(backend=backend)
         result = sampler.run([bell, bell, bell]).result()
-        # print([q.binary_probabilities() for q in result.quasi_dists])
         self._compare_probs(result.quasi_dists[0], self._target[1])
         self._compare_probs(result.quasi_dists[1], self._target[1])
         self._compare_probs(result.quasi_dists[2], self._target[1])

--- a/test/python/primitives/test_sampler.py
+++ b/test/python/primitives/test_sampler.py
@@ -93,7 +93,6 @@ class TestSampler(QiskitTestCase):
         self.assertIsInstance(job, JobV1)
         result = job.result()
         self.assertIsInstance(result, SamplerResult)
-        # print([q.binary_probabilities() for q in result.quasi_dists])
         self._compare_probs(result.quasi_dists, self._target[1])
 
     def test_sample_run_multiple_circuits(self):
@@ -103,7 +102,6 @@ class TestSampler(QiskitTestCase):
         bell = self._circuit[1]
         sampler = Sampler()
         result = sampler.run([bell, bell, bell]).result()
-        # print([q.binary_probabilities() for q in result.quasi_dists])
         self._compare_probs(result.quasi_dists[0], self._target[1])
         self._compare_probs(result.quasi_dists[1], self._target[1])
         self._compare_probs(result.quasi_dists[2], self._target[1])

--- a/test/python/quantum_info/operators/symplectic/test_clifford.py
+++ b/test/python/quantum_info/operators/symplectic/test_clifford.py
@@ -1044,7 +1044,8 @@ class TestCliffordOperators(QiskitTestCase):
         # An error may be thrown if visualization code calls op.condition instead
         # of getattr(op, "condition", None)
         clifford = random_clifford(3, seed=0)
-        print(clifford)
+        _ = str(clifford)
+        _ = repr(clifford)
 
     @combine(num_qubits=[1, 2, 3, 4])
     def test_from_matrix_round_trip(self, num_qubits):


### PR DESCRIPTION
### Summary

This removes some debugging `print` statements from the test suite, to avoid noise in the test-runner output.  In some cases, the `print` was only part of an assertion that the conversion to string fails, and these were converted to explicit calls to `str`.  This isn't strictly necessary, it's just trying to get the test suite out of the habit of using `print`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments


