### PR TITLE
Deprecate qpy loading of old library pulses with complex `amp`

### DIFF
--- a/qiskit/qpy/binary_io/schedules.py
+++ b/qiskit/qpy/binary_io/schedules.py
@@ -169,10 +169,10 @@ def _read_symbolic_pulse(file_obj, version):
 
         # And warn that this will change in future releases:
         warnings.warn(
-            "Complex amp support for symbolic library pulses will be deprecated. "
+            "Complex amp support for symbolic library pulses will be deprecated in Qiskit 1.0.0. "
             "Once deprecated, library pulses loaded from old QPY files (Terra version < 0.23),"
             " will be converted automatically to float (amp,angle) representation.",
-            PendingDeprecationWarning,
+            DeprecationWarning,
         )
         class_name = "ScalableSymbolicPulse"
 

--- a/qiskit/qpy/binary_io/schedules.py
+++ b/qiskit/qpy/binary_io/schedules.py
@@ -169,8 +169,8 @@ def _read_symbolic_pulse(file_obj, version):
 
         # And warn that this will change in future releases:
         warnings.warn(
-            "Complex amp support for symbolic library pulses will be deprecated in Qiskit 1.0.0. "
-            "Once deprecated, library pulses loaded from old QPY files (Terra version < 0.23),"
+            "Complex amp support for symbolic library pulses is deprecated. Once removed "
+            "in Qiskit 1.0.0, library pulses loaded from old QPY files (Terra version < 0.23),"
             " will be converted automatically to float (amp,angle) representation.",
             DeprecationWarning,
         )

--- a/releasenotes/notes/deprecate-complex-amp-old-qpy-d3d183e84c395d9c.yaml
+++ b/releasenotes/notes/deprecate-complex-amp-old-qpy-d3d183e84c395d9c.yaml
@@ -4,8 +4,8 @@ deprecations:
     Loading library :class:`~.qiskit.pulse.ScalableSymbolicPulse` objects with
     complex ``amp`` parameter from
     qpy files of version 5 or lower (Qiskit Terra < 0.23.0) is now deprecated.
-    Following the deprecation in Qiskit 1.0.0, complex `amp` will be automatically
-    converted to float (`amp`,`angle`). The change applies to the pulses:
+    Following the removal in Qiskit 1.0.0, complex ``amp`` will be automatically
+    converted to float (``amp``,``angle``). The change applies to the pulses:
 
     * :class:`~.qiskit.pulse.Constant`
     * :class:`~.qiskit.pulse.Drag`

--- a/releasenotes/notes/deprecate-complex-amp-old-qpy-d3d183e84c395d9c.yaml
+++ b/releasenotes/notes/deprecate-complex-amp-old-qpy-d3d183e84c395d9c.yaml
@@ -1,0 +1,13 @@
+---
+deprecations:
+  - |
+    Loading library :class:`~.qiskit.pulse.ScalableSymbolicPulse` objects with
+    complex ``amp`` parameter from
+    qpy files of version 5 or lower (Qiskit Terra < 0.23.0) is now deprecated.
+    Following the deprecation in Qiskit 1.0.0, complex `amp` will be automatically
+    converted to float (`amp`,`angle`). The change applies to the pulses:
+
+    * :class:`~.qiskit.pulse.Constant`
+    * :class:`~.qiskit.pulse.Drag`
+    * :class:`~.qiskit.pulse.Gaussian`
+    * :class:`~.qiskit.pulse.GaussianSquare`


### PR DESCRIPTION
### Summary
This PR completes #10357 and adds a deprecation warning when loading an old QPY file containing library symbolic pulses with complex amp.

### Details and comments
The deprecation process began in #9002, but #10357 neglected to promote this specific warning to a deprecation warning. The PR is meant for 0.46, while 1.0.0 will have the support removed.


