### PR TITLE
Pin rust compiler version to 1.73 for wheel builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,9 +18,9 @@ jobs:
         with:
           python-version: '3.10'
       - uses: dtolnay/rust-toolchain@stable
-        if: runner.os != "macOS"
+        if: runner.os != 'macOS'
       - uses: dtolnay/rust-toolchain@1.73
-        if: runner.os == "macOS"
+        if: runner.os == 'macOS'
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.13.0
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,7 +19,7 @@ jobs:
         name: Install Python
         with:
           python-version: '3.10'
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.73
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.13.0
       - uses: actions/upload-artifact@v3
@@ -40,7 +40,7 @@ jobs:
         name: Install Python
         with:
           python-version: '3.10'
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.73
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.13.0
         env:
@@ -85,7 +85,7 @@ jobs:
         name: Install Python
         with:
           python-version: '3.10'
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.73
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
@@ -118,7 +118,7 @@ jobs:
         name: Install Python
         with:
           python-version: '3.10'
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.73
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
@@ -151,7 +151,7 @@ jobs:
         name: Install Python
         with:
           python-version: '3.10'
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.73
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,9 +17,10 @@ jobs:
         name: Install Python
         with:
           python-version: '3.10'
+      - uses: dtolnay/rust-toolchain@stable
+        if: runner.os != "macOS"
       - uses: dtolnay/rust-toolchain@1.73
-        with:
-          targets: i686-pc-windows-msvc
+        if: runner.os == "macOS"
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.13.0
       - uses: actions/upload-artifact@v3
@@ -39,7 +40,7 @@ jobs:
         name: Install Python
         with:
           python-version: '3.10'
-      - uses: dtolnay/rust-toolchain@1.73
+      - uses: dtolnay/rust-toolchain@stable
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.13.0
         env:
@@ -67,7 +68,7 @@ jobs:
         name: Install Python
         with:
           python-version: '3.10'
-      - uses: dtolnay/rust-toolchain@1.73
+      - uses: dtolnay/rust-toolchain@stable
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
@@ -95,7 +96,7 @@ jobs:
         name: Install Python
         with:
           python-version: '3.10'
-      - uses: dtolnay/rust-toolchain@1.73
+      - uses: dtolnay/rust-toolchain@stable
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
@@ -123,7 +124,7 @@ jobs:
         name: Install Python
         with:
           python-version: '3.10'
-      - uses: dtolnay/rust-toolchain@1.73
+      - uses: dtolnay/rust-toolchain@stable
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           python-version: '3.10'
       - uses: dtolnay/rust-toolchain@1.73
+        with:
+          targets: i686-pc-windows-msvc
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.13.0
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,12 +1,14 @@
 ---
 name: Wheel Builds
 on:
-  pull_request:
-    branches: ['stable/0.45']
+  push:
+    tags:
+      - '*'
 jobs:
   build_wheels:
     name: Build wheels
     runs-on: ${{ matrix.os }}
+    environment: release
     strategy:
       fail-fast: false
       matrix:
@@ -30,6 +32,7 @@ jobs:
   build_wheels_macos_arm:
     name: Build wheels on macOS arm
     runs-on: ${{ matrix.os }}
+    environment: release
     strategy:
       fail-fast: false
       matrix:
@@ -53,9 +56,26 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
           name: shared-wheel-builds
+  upload_shared_wheels:
+    name: Upload shared build wheels
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    needs: ["build_wheels", "build_wheels_macos_arm"]
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: shared-wheel-builds
+          path: deploy
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: deploy
   build_wheels_s390x:
     name: Build wheels on s390x
     runs-on: ${{ matrix.os }}
+    environment: release
     permissions:
       id-token: write
     strategy:
@@ -81,9 +101,14 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wheelhouse/
   build_wheels_ppc64le:
     name: Build wheels on ppc64le
     runs-on: ${{ matrix.os }}
+    environment: release
     permissions:
       id-token: write
     strategy:
@@ -109,9 +134,14 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wheelhouse/
   build_wheels_aarch64:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    environment: release
     permissions:
       id-token: write
     strategy:
@@ -136,3 +166,58 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wheelhouse/
+  sdist:
+    name: Build and publish terra sdist
+    runs-on: ${{ matrix.os }}
+    needs: ["upload_shared_wheels"]
+    environment: release
+    permissions:
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: '3.10'
+      - name: Install deps
+        run: pip install -U twine setuptools-rust wheel build
+      - name: Build sdist
+        run: python -m build . --sdist
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+  metapackage:
+    name: Build and publish terra sdist
+    runs-on: ${{ matrix.os }}
+    needs: ["sdist"]
+    environment: release
+    permissions:
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: '3.10'
+      - name: Install deps
+        run: pip install -U twine setuptools-rust wheel build
+      - name: Build packages
+        run: |
+          set -e
+          cd qiskit_pkg
+          python -m build .
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: qiskit_pkg/dist

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,14 +1,12 @@
 ---
 name: Wheel Builds
 on:
-  push:
-    tags:
-      - '*'
+  pull_request:
+    branches: ['stable/0.45']
 jobs:
   build_wheels:
     name: Build wheels
     runs-on: ${{ matrix.os }}
-    environment: release
     strategy:
       fail-fast: false
       matrix:
@@ -29,7 +27,6 @@ jobs:
   build_wheels_macos_arm:
     name: Build wheels on macOS arm
     runs-on: ${{ matrix.os }}
-    environment: release
     strategy:
       fail-fast: false
       matrix:
@@ -53,26 +50,9 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
           name: shared-wheel-builds
-  upload_shared_wheels:
-    name: Upload shared build wheels
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      id-token: write
-    needs: ["build_wheels", "build_wheels_macos_arm"]
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: shared-wheel-builds
-          path: deploy
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: deploy
   build_wheels_s390x:
     name: Build wheels on s390x
     runs-on: ${{ matrix.os }}
-    environment: release
     permissions:
       id-token: write
     strategy:
@@ -98,14 +78,9 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: wheelhouse/
   build_wheels_ppc64le:
     name: Build wheels on ppc64le
     runs-on: ${{ matrix.os }}
-    environment: release
     permissions:
       id-token: write
     strategy:
@@ -131,14 +106,9 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: wheelhouse/
   build_wheels_aarch64:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    environment: release
     permissions:
       id-token: write
     strategy:
@@ -163,58 +133,3 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: wheelhouse/
-  sdist:
-    name: Build and publish terra sdist
-    runs-on: ${{ matrix.os }}
-    needs: ["upload_shared_wheels"]
-    environment: release
-    permissions:
-      id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        name: Install Python
-        with:
-          python-version: '3.10'
-      - name: Install deps
-        run: pip install -U twine setuptools-rust wheel build
-      - name: Build sdist
-        run: python -m build . --sdist
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-  metapackage:
-    name: Build and publish terra sdist
-    runs-on: ${{ matrix.os }}
-    needs: ["sdist"]
-    environment: release
-    permissions:
-      id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        name: Install Python
-        with:
-          python-version: '3.10'
-      - name: Install deps
-        run: pip install -U twine setuptools-rust wheel build
-      - name: Build packages
-        run: |
-          set -e
-          cd qiskit_pkg
-          python -m build .
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: qiskit_pkg/dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ test-command = "python {project}/examples/python/stochastic_swap.py"
 # Numpy 1.22 there are no i686 wheels, so we force pip to use older ones without
 # restricting any dependencies that Numpy and Scipy might have.
 before-test = "pip install --only-binary=numpy,scipy numpy scipy"
-environment = 'RUSTUP_TOOLCHAIN="1.73"'
+environment = 'RUSTUP_TOOLCHAIN="stable"'
 
 [tool.cibuildwheel.linux]
 before-all = "yum install -y wget && {package}/tools/install_rust.sh"
@@ -26,6 +26,7 @@ repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} && pipx run abi3
 
 [tool.cibuildwheel.macos]
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} && pipx run abi3audit --strict --report {wheel}"
+environment = 'RUSTUP_TOOLCHAIN="1.73"'
 
 [tool.cibuildwheel.windows]
 repair-wheel-command = "cp {wheel} {dest_dir}/. && pipx run abi3audit --strict --report {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,11 @@ test-command = "python {project}/examples/python/stochastic_swap.py"
 # Numpy 1.22 there are no i686 wheels, so we force pip to use older ones without
 # restricting any dependencies that Numpy and Scipy might have.
 before-test = "pip install --only-binary=numpy,scipy numpy scipy"
-environment = 'RUSTUP_TOOLCHAIN="stable"'
+environment = 'RUSTUP_TOOLCHAIN="1.73"'
 
 [tool.cibuildwheel.linux]
 before-all = "yum install -y wget && {package}/tools/install_rust.sh"
-environment = 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true" RUSTUP_TOOLCHAIN="stable"'
+environment = 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true" RUSTUP_TOOLCHAIN="1.73"'
 repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} && pipx run abi3audit --strict --report {wheel}"
 
 [tool.cibuildwheel.macos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ environment = 'RUSTUP_TOOLCHAIN="stable"'
 
 [tool.cibuildwheel.linux]
 before-all = "yum install -y wget && {package}/tools/install_rust.sh"
-environment = 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true" RUSTUP_TOOLCHAIN="1.73"'
+environment = 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true" RUSTUP_TOOLCHAIN="stable"'
 repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} && pipx run abi3audit --strict --report {wheel}"
 
 [tool.cibuildwheel.macos]

--- a/tools/install_rust.sh
+++ b/tools/install_rust.sh
@@ -2,5 +2,5 @@
 if [ ! -d rust-installer ]; then
     mkdir rust-installer
     wget https://sh.rustup.rs -O rust-installer/rustup.sh
-    sh rust-installer/rustup.sh -y --default-toolchain 1.73
+    sh rust-installer/rustup.sh -y
 fi

--- a/tools/install_rust.sh
+++ b/tools/install_rust.sh
@@ -2,5 +2,5 @@
 if [ ! -d rust-installer ]; then
     mkdir rust-installer
     wget https://sh.rustup.rs -O rust-installer/rustup.sh
-    sh rust-installer/rustup.sh -y
+    sh rust-installer/rustup.sh -y --default-toolchain 1.73
 fi


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

With the release 1.74 on 11-16-2023 the minimum supported macOS version by the Rust compiler is 10.12. For the 0.45.x release series we still support macOS 10.9 (this will change in 1.0 see #10902). To facilitate still publishing wheels that will support macOS 10.9 for any future bugfix releases on 0.45.x release series (and 0.46.x too) this commit pins the rust toolchain version we use to 1.73 which is the last release that support 10.9.

### Details and comments