### PR TITLE
Optionally remove argument inputs in passmanager.draw

### DIFF
--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -294,7 +294,7 @@ class PassManager(BasePassManager):
             output_name=output_name,
         )
 
-    def draw(self, filename=None, style=None, raw=False):
+    def draw(self, filename=None, style=None, raw=False, inputs=True):
         """Draw the pass manager.
 
         This function needs `pydot <https://github.com/erocarrera/pydot>`__, which in turn needs
@@ -318,7 +318,7 @@ class PassManager(BasePassManager):
         """
         from qiskit.visualization import pass_manager_drawer
 
-        return pass_manager_drawer(self, filename=filename, style=style, raw=raw)
+        return pass_manager_drawer(self, filename=filename, style=style, raw=raw, inputs=inputs)
 
     def passes(self) -> list[dict[str, BasePass]]:
         """Return a list structure of the appended passes and its options.
@@ -531,11 +531,13 @@ class StagedPassManager(PassManager):
         self._update_passmanager()
         return super().run(circuits, output_name, callback)
 
-    def draw(self, filename=None, style=None, raw=False):
+    def draw(self, filename=None, style=None, raw=False, inputs=True):
         """Draw the staged pass manager."""
         from qiskit.visualization import staged_pass_manager_drawer
 
-        return staged_pass_manager_drawer(self, filename=filename, style=style, raw=raw)
+        return staged_pass_manager_drawer(
+            self, filename=filename, style=style, raw=raw, inputs=inputs
+        )
 
 
 # A temporary error handling with slight overhead at class loading.


### PR DESCRIPTION
This is an alternative to https://github.com/Qiskit/qiskit/pull/11268

I was trying to document the passes used in different optimization levels and I realized that `passmanger.draw` is getting hard to read:
```
from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
generate_preset_pass_manager(3).draw()
```
![image](https://github.com/Qiskit/qiskit/assets/766693/505517ba-d3d3-48da-8971-6cce309f3596)

So, what do you think if we optionally remove the argument nodes? Something like this:

```
generate_preset_pass_manager(3).draw(inputs=False)
```
![image](https://github.com/Qiskit/qiskit/assets/766693/55bfc47f-6b93-41fb-80bd-511c33f324bb)
