### PR TITLE
Fix `QuantumCircuit.barrier` argument conversion

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2852,23 +2852,12 @@ class QuantumCircuit:
         """
         from .barrier import Barrier
 
-        qubits: list[QubitSpecifier] = []
-
-        if not qargs:  # None
-            qubits.extend(self.qubits)
-
-        for qarg in qargs:
-            if isinstance(qarg, QuantumRegister):
-                qubits.extend([qarg[j] for j in range(qarg.size)])
-            elif isinstance(qarg, list):
-                qubits.extend(qarg)
-            elif isinstance(qarg, range):
-                qubits.extend(list(qarg))
-            elif isinstance(qarg, slice):
-                qubits.extend(self.qubits[qarg])
-            else:
-                qubits.append(qarg)
-
+        qubits = (
+            # This uses a `dict` not a `set` to guarantee a deterministic order to the arguments.
+            list({q: None for qarg in qargs for q in self.qbit_argument_conversion(qarg)})
+            if qargs
+            else self.qubits.copy()
+        )
         return self.append(Barrier(len(qubits), label=label), qubits, [])
 
     def delay(

--- a/releasenotes/notes/fix-circuit-barrier-c696eabae1dcc6c2.yaml
+++ b/releasenotes/notes/fix-circuit-barrier-c696eabae1dcc6c2.yaml
@@ -4,3 +4,4 @@ fixes:
     :meth:`.QuantumCircuit.barrier` will now generate correct output when given a :class:`set` as
     one of its inputs.  Previously, it would append an invalid operation onto the circuit, though in
     practice this usually would not cause observable problems.
+    Fixed `#11208 <https://github.com/Qiskit/qiskit/issues/11208>`__

--- a/releasenotes/notes/fix-circuit-barrier-c696eabae1dcc6c2.yaml
+++ b/releasenotes/notes/fix-circuit-barrier-c696eabae1dcc6c2.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    :meth:`.QuantumCircuit.barrier` will now generate correct output when given a :class:`set` as
+    one of its inputs.  Previously, it would append an invalid operation onto the circuit, though in
+    practice this usually would not cause observable problems.

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -420,6 +420,27 @@ class TestCircuitOperations(QiskitTestCase):
         self.assertEqual(len(qc.data), 0)
         self.assertEqual(len(qc._parameter_table), 0)
 
+    def test_barrier(self):
+        """Test multiple argument forms of barrier."""
+        qr1, qr2 = QuantumRegister(3, "qr1"), QuantumRegister(4, "qr2")
+        qc = QuantumCircuit(qr1, qr2)
+        qc.barrier()  # All qubits.
+        qc.barrier(0, 1)
+        qc.barrier([4, 2])
+        qc.barrier(qr1)
+        qc.barrier(slice(3, 5))
+        qc.barrier({1, 4, 2}, range(5, 7))
+
+        expected = QuantumCircuit(qr1, qr2)
+        expected.append(Barrier(expected.num_qubits), expected.qubits.copy(), [])
+        expected.append(Barrier(2), [expected.qubits[0], expected.qubits[1]], [])
+        expected.append(Barrier(2), [expected.qubits[2], expected.qubits[4]], [])
+        expected.append(Barrier(3), expected.qubits[0:3], [])
+        expected.append(Barrier(2), [expected.qubits[3], expected.qubits[4]], [])
+        expected.append(Barrier(5), [expected.qubits[x] for x in [1, 2, 4, 5, 6]], [])
+
+        self.assertEqual(qc, expected)
+
     def test_measure_active(self):
         """Test measure_active
         Applies measurements only to non-idle qubits. Creates a ClassicalRegister of size equal to


### PR DESCRIPTION
### Summary

The manual argument conversion within `QuantumCircuit.barrier` made it inconsistent with the rest of the circuit methods, and it would silently generate invalid circuit output when given iterables outside an expected set.  This switches the method to use the standard argument conversion, bringing it inline with the rest of the circuit methods.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #11208.
