### PR TITLE
Deprecate `ParametricPulse` (0.46)

### DIFF
--- a/qiskit/pulse/library/parametric_pulses.py
+++ b/qiskit/pulse/library/parametric_pulses.py
@@ -56,8 +56,8 @@ class ParametricPulse(Pulse):
 
     .. warning::
 
-        This class is superseded by :class:`.SymbolicPulse` and will be deprecated
-        and eventually removed in the future because of the poor flexibility
+        This class was superseded by :class:`.SymbolicPulse` and is deprecated.
+        It will be removed in Qiskit 1.0 because of the poor flexibility
         for defining a new waveform type and serializing it through the :mod:`qiskit.qpy` framework.
 
     """
@@ -68,9 +68,9 @@ class ParametricPulse(Pulse):
             "Instead, use SymbolicPulse because of QPY serialization support. See "
             "qiskit.pulse.library.symbolic_pulses for details."
         ),
-        since="0.22",
+        since="0.46",
         package_name="qiskit-terra",
-        pending=True,
+        removal_timeline="in Qiskit 1.0",
     )
     def __init__(
         self,
@@ -138,9 +138,9 @@ class Gaussian(ParametricPulse):
             "Instead, use Gaussian from qiskit.pulse.library.symbolic_pulses because of "
             "QPY serialization support."
         ),
-        since="0.22",
+        since="0.46",
         package_name="qiskit-terra",
-        pending=True,
+        removal_timeline="in Qiskit 1.0",
     )
     def __init__(
         self,
@@ -251,9 +251,9 @@ class GaussianSquare(ParametricPulse):
             "Instead, use GaussianSquare from qiskit.pulse.library.symbolic_pulses because of "
             "QPY serialization support."
         ),
-        since="0.22",
+        since="0.46",
         package_name="qiskit-terra",
-        pending=True,
+        removal_timeline="in Qiskit 1.0",
     )
     def __init__(
         self,
@@ -422,9 +422,9 @@ class Drag(ParametricPulse):
             "Instead, use Drag from qiskit.pulse.library.symbolic_pulses because of "
             "QPY serialization support."
         ),
-        since="0.22",
+        since="0.46",
         package_name="qiskit-terra",
-        pending=True,
+        removal_timeline="in Qiskit 1.0",
     )
     def __init__(
         self,
@@ -546,9 +546,9 @@ class Constant(ParametricPulse):
             "Instead, use Constant from qiskit.pulse.library.symbolic_pulses because of "
             "QPY serialization support."
         ),
-        since="0.22",
+        since="0.46",
         package_name="qiskit-terra",
-        pending=True,
+        removal_timeline="in Qiskit 1.0",
     )
     def __init__(
         self,

--- a/releasenotes/notes/deprecate-parametric-pulse-0a692c1fa6b46d7f.yaml
+++ b/releasenotes/notes/deprecate-parametric-pulse-0a692c1fa6b46d7f.yaml
@@ -1,0 +1,14 @@
+---
+deprecations:
+  - |
+    The :class:`~qiskit.pulse.library.parametric_pulses.ParametricPulse` base class and pulses are now
+    deprecated, and will be removed in Qiskit 1.0. This includes:
+
+    * :class:`~qiskit.pulse.library.parametric_pulses.ParametricPulse`
+    * :class:`~qiskit.pulse.library.parametric_pulses.Constant`
+    * :class:`~qiskit.pulse.library.parametric_pulses.Drag`
+    * :class:`~qiskit.pulse.library.parametric_pulses.Gaussian`
+    * :class:`~qiskit.pulse.library.parametric_pulses.GaussianSquare`
+
+    The class has been superseded by :class:`~qiskit.pulse.SymbolicPulse` and the corresponding pulse library.
+    :class:`~qiskit.pulse.SymbolicPulse` provides better performance, flexibility and QPY support.


### PR DESCRIPTION
### Summary
This PR deprecates the `ParametricPulse` base class and pulse library.


### Details and comments
The `ParametricPulse` library has been superseded by the `SymbolicPulse` library which provides QPY support and some performance improvements. It has been pending deprecation since Terra 0.22, and is now promoted to deprecation in Qiskit 0.46, ahead of removal in Qiskit 1.0. This PR adds the deprecation to the 0.46 branch.

