### PR TITLE
Fix flaky `BackendSampler` and `BackendEstimator` test

### DIFF
--- a/test/python/primitives/test_backend_estimator.py
+++ b/test/python/primitives/test_backend_estimator.py
@@ -13,6 +13,7 @@
 """Tests for Estimator."""
 
 import unittest
+from unittest.mock import patch
 from multiprocessing import Manager
 
 from test import combine
@@ -363,7 +364,7 @@ class TestBackendEstimator(QiskitTestCase):
                 # to keep track of the callback calls for num_circuits > 1
                 messages = manager.list()
 
-                def callback(msg):
+                def callback(msg):  # pylint: disable=function-redefined
                     messages.append(msg)
 
                 bound_counter = CallbackPass("bound_pass_manager", callback)

--- a/test/python/primitives/test_backend_estimator.py
+++ b/test/python/primitives/test_backend_estimator.py
@@ -341,32 +341,6 @@ class TestBackendEstimator(QiskitTestCase):
         op = SparsePauliOp.from_list([("II", 1)])
 
         with self.subTest("Test single circuit"):
-
-            dummy_pass = DummyTP()
-
-            with patch.object(DummyTP, "run", wraps=dummy_pass.run) as mock_pass:
-                bound_pass = PassManager(dummy_pass)
-                estimator = BackendEstimator(backend=FakeNairobi(), bound_pass_manager=bound_pass)
-                _ = estimator.run(qc, op).result()
-                self.assertEqual(mock_pass.call_count, 1)
-
-        with self.subTest("Test circuit batch"):
-
-            dummy_pass = DummyTP()
-
-            with patch.object(DummyTP, "run", wraps=dummy_pass.run) as mock_pass:
-                bound_pass = PassManager(dummy_pass)
-                estimator = BackendEstimator(backend=FakeNairobi(), bound_pass_manager=bound_pass)
-                _ = estimator.run([qc, qc], [op, op]).result()
-                self.assertEqual(mock_pass.call_count, 2)
-
-    def test_bound_pass_manager(self):
-        """Test bound pass manager."""
-
-        qc = QuantumCircuit(2)
-        op = SparsePauliOp.from_list([("II", 1)])
-
-        with self.subTest("Test single circuit"):
             messages = []
 
             def callback(msg):

--- a/test/python/primitives/test_backend_sampler.py
+++ b/test/python/primitives/test_backend_sampler.py
@@ -14,6 +14,7 @@
 
 import math
 import unittest
+from unittest.mock import patch
 from multiprocessing import Manager
 
 from test import combine
@@ -421,7 +422,7 @@ class TestBackendSampler(QiskitTestCase):
                 # to keep track of the callback calls for num_circuits > 1
                 messages = manager.list()
 
-                def callback(msg):
+                def callback(msg):  # pylint: disable=function-redefined
                     messages.append(msg)
 
                 bound_counter = CallbackPass("bound_pass_manager", callback)

--- a/test/python/primitives/test_backend_sampler.py
+++ b/test/python/primitives/test_backend_sampler.py
@@ -14,9 +14,10 @@
 
 import math
 import unittest
-from unittest.mock import patch
+from multiprocessing import Manager
+
 from test import combine
-from test.python.transpiler._dummy_passes import DummyTP
+from test.python.transpiler._dummy_passes import DummyAP
 
 import numpy as np
 from ddt import ddt
@@ -32,6 +33,18 @@ from qiskit.transpiler import PassManager
 from qiskit.utils import optionals
 
 BACKENDS = [FakeNairobi(), FakeNairobiV2()]
+
+
+class CallbackPass(DummyAP):
+    """A dummy analysis pass that calls a callback when executed"""
+
+    def __init__(self, message, callback):
+        super().__init__()
+        self.message = message
+        self.callback = callback
+
+    def run(self, dag):
+        self.callback(self.message)
 
 
 @ddt
@@ -386,24 +399,40 @@ class TestBackendSampler(QiskitTestCase):
         """Test bound pass manager."""
 
         with self.subTest("Test single circuit"):
+            messages = []
 
-            dummy_pass = DummyTP()
+            def callback(msg):
+                messages.append(msg)
 
-            with patch.object(DummyTP, "run", wraps=dummy_pass.run) as mock_pass:
-                bound_pass = PassManager(dummy_pass)
-                sampler = BackendSampler(backend=FakeNairobi(), bound_pass_manager=bound_pass)
-                _ = sampler.run(self._circuit[0]).result()
-                self.assertEqual(mock_pass.call_count, 1)
+            bound_counter = CallbackPass("bound_pass_manager", callback)
+            bound_pass = PassManager(bound_counter)
+            sampler = BackendSampler(backend=FakeNairobi(), bound_pass_manager=bound_pass)
+            _ = sampler.run([self._circuit[0]]).result()
+            expected = [
+                "bound_pass_manager",
+            ]
+            self.assertEqual(messages, expected)
 
         with self.subTest("Test circuit batch"):
+            with Manager() as manager:
+                # The multiprocessing manager is used to share data
+                # between different processes. Pass Managers parallelize
+                # execution for batches of circuits, so this is necessary
+                # to keep track of the callback calls for num_circuits > 1
+                messages = manager.list()
 
-            dummy_pass = DummyTP()
+                def callback(msg):
+                    messages.append(msg)
 
-            with patch.object(DummyTP, "run", wraps=dummy_pass.run) as mock_pass:
-                bound_pass = PassManager(dummy_pass)
+                bound_counter = CallbackPass("bound_pass_manager", callback)
+                bound_pass = PassManager(bound_counter)
                 sampler = BackendSampler(backend=FakeNairobi(), bound_pass_manager=bound_pass)
                 _ = sampler.run([self._circuit[0], self._circuit[0]]).result()
-                self.assertEqual(mock_pass.call_count, 2)
+                expected = [
+                    "bound_pass_manager",
+                    "bound_pass_manager",
+                ]
+                self.assertEqual(list(messages), expected)
 
 
 if __name__ == "__main__":

--- a/test/python/primitives/test_backend_sampler.py
+++ b/test/python/primitives/test_backend_sampler.py
@@ -14,7 +14,6 @@
 
 import math
 import unittest
-from unittest.mock import patch
 from multiprocessing import Manager
 
 from test import combine


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes the flaky behavior of the bound pass manager tests on the backend primitives. This behavior was caused by the paralelization of pass manager runs on certain platforms (linux). When [`parallel_map` is called](https://github.com/Qiskit/qiskit/blob/main/qiskit/passmanager/passmanager.py#L239), the pass manager gets serialized and deserialized using `dill`. The deserialization process creates a new instance of the pass manager, which "resets" the call count of the mock object that we were trying to check in the test. Instead, the test now uses a dummy transpiler pass that sends a message to a callback, and stores the message history in a multiprocessing-compatible list. 

### Details and comments
I tried to find a workaround using `logging`, but the behavior of `logging` is also affected by differences in multiprocessing, so the callback alternative looked more straightforward.

This should hopefully fix the long-lasting failures in the nightly tests: https://github.com/Qiskit/qiskit/issues/7864

Thanks @mrossinek for the help debugging :)

