### PR TITLE
Decomposition of single R gate in RR basis should be one R gate, not two

### DIFF
--- a/crates/accelerate/src/euler_one_qubit_decomposer.rs
+++ b/crates/accelerate/src/euler_one_qubit_decomposer.rs
@@ -380,22 +380,26 @@ fn circuit_rr(
     if !simplify {
         atol = -1.0;
     }
-    if theta.abs() < atol && phi.abs() < atol && lam.abs() < atol {
-        return OneQubitGateSequence {
-            gates: circuit,
-            global_phase: phase,
-        };
-    }
-    if (theta - PI).abs() > atol {
+
+    if mod_2pi((phi + lam) / 2., atol).abs() < atol {
+        // This can be expressed as a single R gate
+        if theta.abs() > atol {
+            circuit.push((String::from("r"), vec![theta, mod_2pi(PI / 2. + phi, atol)]));
+        }
+    } else {
+        // General case: use two R gates
+        if (theta - PI).abs() > atol {
+            circuit.push((
+                String::from("r"),
+                vec![theta - PI, mod_2pi(PI / 2. - lam, atol)],
+            ));
+        }
         circuit.push((
             String::from("r"),
-            vec![theta - PI, mod_2pi(PI / 2. - lam, atol)],
+            vec![PI, mod_2pi(0.5 * (phi - lam + PI), atol)],
         ));
     }
-    circuit.push((
-        String::from("r"),
-        vec![PI, mod_2pi(0.5 * (phi - lam + PI), atol)],
-    ));
+
     OneQubitGateSequence {
         gates: circuit,
         global_phase: phase,

--- a/releasenotes/notes/rr-decomposition-synthesis-70eb88ada9305916.yaml
+++ b/releasenotes/notes/rr-decomposition-synthesis-70eb88ada9305916.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed an issue in :func:`.unitary_to_gate_sequence` which caused unitary
+    decomposition in RR basis to emit two R gates in some cases where the
+    matrix can be expressed as a single R gate. Previously, in those cases you
+    would get two R gates with the same phi parameter. Now, they are combined
+    into one.

--- a/test/python/quantum_info/test_synthesis.py
+++ b/test/python/quantum_info/test_synthesis.py
@@ -30,6 +30,7 @@ from qiskit.converters import dag_to_circuit, circuit_to_dag
 from qiskit.circuit.library import (
     HGate,
     IGate,
+    RGate,
     SdgGate,
     SGate,
     U3Gate,
@@ -446,6 +447,8 @@ class TestOneQubitEulerSpecial(CheckDecompositions):
         self.check_oneq_special_cases(U3Gate(-np.pi, 0.2, 0.0).to_matrix(), "RR", {"r": 1})
         self.check_oneq_special_cases(U3Gate(np.pi, 0.0, 0.2).to_matrix(), "RR", {"r": 1})
         self.check_oneq_special_cases(U3Gate(0.1, 0.2, 0.3).to_matrix(), "RR", {"r": 2})
+        self.check_oneq_special_cases(U3Gate(0.1, 0.2, -0.2).to_matrix(), "RR", {"r": 1})
+        self.check_oneq_special_cases(RGate(0.1, 0.2).to_matrix(), "RR", {"r": 1})
 
     def test_special_U1X(self):
         """Special cases of U1X"""


### PR DESCRIPTION
### Summary

Currently, a single R gate may come out of RR-decomposition as two R gates, which is obviously not ideal.

This PR adds test cases for when this happens and contains the code changes to only emit one R gate when possible.

### Details and comments

For example, `RGate(0.1, 0.2)` is currently decomposed (in RR basis) as

```
   ┌────────────────┐┌──────────┐
0: ┤ R(-3.0416,0.2) ├┤ R(π,0.2) ├
   └────────────────┘└──────────┘
```

Two `R(𝜗, 𝜑)` gates with the same 𝜑 parameter can be combined into one by simply adding up the 𝜗 values (giving us `R(0.1, 0.2)`, unsurprisingly).

In terms of `U(𝜗, 𝜑, 𝜆)`, it is the case when `𝜑 = -𝜆` that the two R-gates we construct have the same second parameter and therefore should be expressed as a single R gate. For example, `U3Gate(0.1, 0.2, -0.2)` currently produces this RR-decomposition:

```
   ┌───────────────────┐┌─────────────┐
0: ┤ R(-3.0416,1.7708) ├┤ R(π,1.7708) ├
   └───────────────────┘└─────────────┘
```

which also unnecessarily consists of two R gates instead of just one.

This commit adds the two examples above as unit tests, ensuring they RR-decompose two just one R gate, as well as the code changes to make these two new tests pass, along with all existing tests, of course.

The condition for this special case is that the 𝜑 parameters of the two R-gates we would emit are the same (thus `mod_2pi(PI / 2. - lam)=mod_2pi(0.5 * (phi - lam + PI)`, simplified as `mod_2pi((phi + lam) / 2)=0`).

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly. (added a release note)
- [X] I have read the CONTRIBUTING document.
-->






