### PR TITLE
Remove deprecated `IntegerComparator.num_ancilla_qubits`

### DIFF
--- a/qiskit/circuit/library/arithmetic/integer_comparator.py
+++ b/qiskit/circuit/library/arithmetic/integer_comparator.py
@@ -14,7 +14,6 @@
 """Integer Comparator."""
 
 from __future__ import annotations
-import warnings
 import numpy as np
 
 from qiskit.circuit import QuantumCircuit, QuantumRegister, AncillaRegister
@@ -99,16 +98,6 @@ class IntegerComparator(BlueprintCircuit):
         if geq != self._geq:
             self._invalidate()
             self._geq = geq
-
-    @property
-    def num_ancilla_qubits(self):
-        """Deprecated. Use num_ancillas instead."""
-        warnings.warn(
-            "The IntegerComparator.num_ancilla_qubits property is deprecated "
-            "as of 0.16.0. It will be removed no earlier than 3 months after the release "
-            "date. You should use the num_ancillas property instead."
-        )
-        return self.num_ancillas
 
     @property
     def num_state_qubits(self) -> int:

--- a/releasenotes/notes/5079_IntegerComparator_num_ancilla_qubits-bd1cff3366c345ae.yaml
+++ b/releasenotes/notes/5079_IntegerComparator_num_ancilla_qubits-bd1cff3366c345ae.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    The property ``IntegerComparator.num_ancilla_qubits`` is removed, which was 
+    deprecated in Qiskit 0.23 (released on Oct 2020). Its functionality is fully covered
+    by :attr:`.IntegerComparator.num_ancilla`.


### PR DESCRIPTION
The property `IntegerComparator.num_ancilla_qubits` was deprecated in https://github.com/Qiskit/qiskit/pull/5079/files (released with Qiskit Terra 0.16.0 - Oct 2020) but it never raised a DeprecationWarning. I think it is safe to remove it tho.