### PR TITLE
Fix flakiness in pulse-optimal `UnitarySynthesis` test

### DIFF
--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -344,25 +344,36 @@ class TestUnitarySynthesis(QiskitTestCase):
         backend = FakeVigo()
         conf = backend.configuration()
         qr = QuantumRegister(2)
-        coupling_map = CouplingMap([[0, 1], [1, 2], [1, 3], [3, 4]])
-        triv_layout_pass = TrivialLayout(coupling_map)
         qc = QuantumCircuit(qr)
         qc.unitary(random_unitary(4, seed=12), [0, 1])
-        unisynth_pass = UnitarySynthesis(
-            basis_gates=conf.basis_gates,
-            coupling_map=coupling_map,
-            backend_props=backend.properties(),
-            pulse_optimize=False,
-            natural_direction=True,
+        coupling_map = CouplingMap([[0, 1]])
+        pm_nonoptimal = PassManager(
+            [
+                TrivialLayout(coupling_map),
+                UnitarySynthesis(
+                    basis_gates=conf.basis_gates,
+                    coupling_map=coupling_map,
+                    backend_props=backend.properties(),
+                    pulse_optimize=False,
+                    natural_direction=True,
+                ),
+            ]
         )
-        pm = PassManager([triv_layout_pass, unisynth_pass])
-        qc_out = pm.run(qc)
-        if isinstance(qc_out, QuantumCircuit):
-            num_ops = qc_out.count_ops()
-        else:
-            num_ops = qc_out[0].count_ops()
-        self.assertIn("sx", num_ops)
-        self.assertGreaterEqual(num_ops["sx"], 16)
+        pm_optimal = PassManager(
+            [
+                TrivialLayout(coupling_map),
+                UnitarySynthesis(
+                    basis_gates=conf.basis_gates,
+                    coupling_map=coupling_map,
+                    backend_props=backend.properties(),
+                    pulse_optimize=True,
+                    natural_direction=True,
+                ),
+            ]
+        )
+        qc_nonoptimal = pm_nonoptimal.run(qc)
+        qc_optimal = pm_optimal.run(qc)
+        self.assertGreater(qc_nonoptimal.count_ops()["sx"], qc_optimal.count_ops()["sx"])
 
     def test_two_qubit_pulse_optimal_true_raises(self):
         """Verify raises if pulse optimal==True but cx is not in the backend basis."""


### PR DESCRIPTION
### Summary

The previous iteration of this test asserted that the `sx` count for non-optimal synthesis was higher than a certain particular value.  This value did not have any fundamental properties, it was just the value that happened to be returned for some time.  Recent OpenBLAS support for x86_64 instructions from the AVX512 SkylakeX set meant that supporting processors can now return slightly fewer `sx` gates in the non-optimal path, despite the pulse-optimal synthesis still not being in use.  This caused flaky CI, when we were allocated an Azure VM that had access to the new instructions.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #11287.

Unblocks #11262 and lets us reinstate #11020.
