### PR TITLE
Relax CI pin on Aer <0.13

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -11,8 +11,3 @@ numpy<1.25; python_version<'3.12'
 # eigensystem code for one of the test cases.  See
 # https://github.com/Qiskit/qiskit-terra/issues/10345 for current details.
 scipy<1.11; python_version<'3.12'
-
-# Aer 0.13 causes several randomised tests to begin failing, and some
-# `QuantumInstance` use of noise models to raise exceptions.  These need fixes
-# on Terra.
-qiskit-aer==0.12.2


### PR DESCRIPTION
Now that Aer 0.13.1 is released, we expect that all the bugs and issues we had Qiskit-side are resolved.  This releases the pin on the lower version of Aer to get us testing properly in CI again.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments
