### PR TITLE
Relax CI pin on Numpy < 1.25

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -2,11 +2,6 @@
 # 4.0+. The pin can be removed after nbformat is updated.
 jsonschema==3.2.0
 
-# Numpy 1.25 deprecated some behaviours that we used, and caused the isometry
-# tests to flake. See https://github.com/Qiskit/qiskit-terra/issues/10305,
-# remove pin when resolving that.
-numpy<1.25; python_version<'3.12'
-
 # Scipy 1.11 seems to have caused an instability in the Weyl coordinates
 # eigensystem code for one of the test cases.  See
 # https://github.com/Qiskit/qiskit-terra/issues/10345 for current details.


### PR DESCRIPTION
The release of Numpy 1.26.1 included an upstream patch to fix a bug in the compiled SIMD versions of complex multiplication loops on macOS, and we have fixed the deprecation warnings and new CI flakiness on our side caused by it, so it should now be safe to relax the pin.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


