### PR TITLE
Add save_signs argument for qDRIFT synthesis

### DIFF
--- a/releasenotes/notes/qdrift-save-signs-beb6a9db9e255251.yaml
+++ b/releasenotes/notes/qdrift-save-signs-beb6a9db9e255251.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Added `save_signs` arguement to qdrift synthesis to perserve signs from
+    the original evolution operator
+    


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ X] I have updated the documentation accordingly.
- [ X] I have read the CONTRIBUTING document.
-->

### Summary
Add `save_signs` argument for qDRIFT synthesis so user can decide whether to preserve the signs of the original evolution operator in the qDRIFT Trotter synthesis.


### Details and comments
In the original formulation of qDRIFT (https://arxiv.org/abs/1811.08017) the coefficients of each of the terms in the Hamiltonian was assumed to be positive. The current way that `qdrift` handles this restriction is by arbitrarily taking the absolute value of each of the coefficients. However, it is useful to preserve the signs of the original Hamiltonian, such keeping gradient directionality intact. This change will aim to allow to user to decide how to handle negative coeffients. The default behavior is consistent with the original code.


