### PR TITLE
Deprecate leftover algorithm/opflow utils

### DIFF
--- a/qiskit/utils/arithmetic.py
+++ b/qiskit/utils/arithmetic.py
@@ -16,8 +16,15 @@ Arithmetic Utilities
 
 from typing import List, Tuple
 import numpy as np
+from qiskit.utils.deprecation import deprecate_func
 
 
+@deprecate_func(
+    since="0.46.0",
+    package_name="qiskit",
+    additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
+    "two modules deprecated since Qiskit Terra 0.24.0.",
+)
 def normalize_vector(vector):
     """
     Normalize the input state vector.
@@ -25,6 +32,12 @@ def normalize_vector(vector):
     return vector / np.linalg.norm(vector)
 
 
+@deprecate_func(
+    since="0.46.0",
+    package_name="qiskit",
+    additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
+    "two modules deprecated since Qiskit Terra 0.24.0.",
+)
 def is_power_of_2(num):
     """
     Check if the input number is a power of 2.
@@ -32,6 +45,12 @@ def is_power_of_2(num):
     return num != 0 and ((num & (num - 1)) == 0)
 
 
+@deprecate_func(
+    since="0.46.0",
+    package_name="qiskit",
+    additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
+    "two modules deprecated since Qiskit Terra 0.24.0.",
+)
 def log2(num):
     """
     Compute the log2 of the input number. Use bit operation if the input is a power of 2.
@@ -47,6 +66,12 @@ def log2(num):
         return np.log2(num)
 
 
+@deprecate_func(
+    since="0.46.0",
+    package_name="qiskit",
+    additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
+    "two modules deprecated since Qiskit Terra 0.24.0.",
+)
 def is_power(num, return_decomposition=False):
     """
     Check if num is a perfect power in O(n^3) time, n=ceil(logN)
@@ -80,6 +105,12 @@ def is_power(num, return_decomposition=False):
         return False
 
 
+@deprecate_func(
+    since="0.46.0",
+    package_name="qiskit",
+    additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
+    "two modules deprecated since Qiskit Terra 0.24.0.",
+)
 def next_power_of_2_base(n):
     """
     Return the base of the smallest power of 2 no less than the input number
@@ -95,6 +126,12 @@ def next_power_of_2_base(n):
     return base
 
 
+@deprecate_func(
+    since="0.46.0",
+    package_name="qiskit",
+    additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
+    "two modules deprecated since Qiskit Terra 0.24.0.",
+)
 def transpositions(permutation: List[int]) -> List[Tuple[int, int]]:
     """Return a sequence of transpositions, corresponding to the permutation.
 
@@ -132,6 +169,12 @@ def transpositions(permutation: List[int]) -> List[Tuple[int, int]]:
     return res
 
 
+@deprecate_func(
+    since="0.46.0",
+    package_name="qiskit",
+    additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
+    "two modules deprecated since Qiskit Terra 0.24.0.",
+)
 def triu_to_dense(triu: np.ndarray) -> np.ndarray:
     """Converts upper triangular part of matrix to dense matrix.
 

--- a/qiskit/utils/arithmetic.py
+++ b/qiskit/utils/arithmetic.py
@@ -23,7 +23,7 @@ from qiskit.utils.deprecation import deprecate_func
     since="0.46.0",
     package_name="qiskit",
     additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
-    "two modules deprecated since Qiskit Terra 0.24.0.",
+    "two modules deprecated and planned to be removed in Qiskit 1.0.",
 )
 def normalize_vector(vector):
     """
@@ -36,7 +36,7 @@ def normalize_vector(vector):
     since="0.46.0",
     package_name="qiskit",
     additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
-    "two modules deprecated since Qiskit Terra 0.24.0.",
+    "two modules deprecated and planned to be removed in Qiskit 1.0.",
 )
 def is_power_of_2(num):
     """
@@ -49,7 +49,7 @@ def is_power_of_2(num):
     since="0.46.0",
     package_name="qiskit",
     additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
-    "two modules deprecated since Qiskit Terra 0.24.0.",
+    "two modules deprecated and planned to be removed in Qiskit 1.0.",
 )
 def log2(num):
     """
@@ -70,7 +70,7 @@ def log2(num):
     since="0.46.0",
     package_name="qiskit",
     additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
-    "two modules deprecated since Qiskit Terra 0.24.0.",
+    "two modules deprecated and planned to be removed in Qiskit 1.0.",
 )
 def is_power(num, return_decomposition=False):
     """
@@ -109,7 +109,7 @@ def is_power(num, return_decomposition=False):
     since="0.46.0",
     package_name="qiskit",
     additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
-    "two modules deprecated since Qiskit Terra 0.24.0.",
+    "two modules deprecated and planned to be removed in Qiskit 1.0.",
 )
 def next_power_of_2_base(n):
     """
@@ -130,7 +130,7 @@ def next_power_of_2_base(n):
     since="0.46.0",
     package_name="qiskit",
     additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
-    "two modules deprecated since Qiskit Terra 0.24.0.",
+    "two modules deprecated and planned to be removed in Qiskit 1.0.",
 )
 def transpositions(permutation: List[int]) -> List[Tuple[int, int]]:
     """Return a sequence of transpositions, corresponding to the permutation.
@@ -173,7 +173,7 @@ def transpositions(permutation: List[int]) -> List[Tuple[int, int]]:
     since="0.46.0",
     package_name="qiskit",
     additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
-    "two modules deprecated since Qiskit Terra 0.24.0.",
+    "two modules deprecated and planned to be removed in Qiskit 1.0.",
 )
 def triu_to_dense(triu: np.ndarray) -> np.ndarray:
     """Converts upper triangular part of matrix to dense matrix.

--- a/qiskit/utils/circuit_utils.py
+++ b/qiskit/utils/circuit_utils.py
@@ -13,8 +13,15 @@
 """Circuit utility functions"""
 
 import numpy as np
+from qiskit.utils.deprecation import deprecate_func
 
 
+@deprecate_func(
+    since="0.46.0",
+    package_name="qiskit",
+    additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
+    "two modules deprecated since Qiskit Terra 0.24.0.",
+)
 def summarize_circuits(circuits):
     """Summarize circuits based on QuantumCircuit, and five metrics are summarized.
         - Number of qubits

--- a/qiskit/utils/circuit_utils.py
+++ b/qiskit/utils/circuit_utils.py
@@ -20,7 +20,7 @@ from qiskit.utils.deprecation import deprecate_func
     since="0.46.0",
     package_name="qiskit",
     additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
-    "two modules deprecated since Qiskit Terra 0.24.0.",
+    "two modules deprecated and planned to be removed in Qiskit 1.0.",
 )
 def summarize_circuits(circuits):
     """Summarize circuits based on QuantumCircuit, and five metrics are summarized.

--- a/qiskit/utils/entangler_map.py
+++ b/qiskit/utils/entangler_map.py
@@ -21,7 +21,7 @@ from qiskit.utils.deprecation import deprecate_func
     since="0.46.0",
     package_name="qiskit",
     additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
-    "two modules deprecated since Qiskit Terra 0.24.0.",
+    "two modules deprecated and planned to be removed in Qiskit 1.0.",
 )
 def get_entangler_map(map_type, num_qubits, offset=0):
     """Utility method to get an entangler map among qubits.
@@ -78,7 +78,7 @@ def get_entangler_map(map_type, num_qubits, offset=0):
     since="0.46.0",
     package_name="qiskit",
     additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
-    "two modules deprecated since Qiskit Terra 0.24.0.",
+    "two modules deprecated and planned to be removed in Qiskit 1.0.",
 )
 def validate_entangler_map(entangler_map, num_qubits, allow_double_entanglement=False):
     """Validate a user supplied entangler map and converts entries to ints.

--- a/qiskit/utils/entangler_map.py
+++ b/qiskit/utils/entangler_map.py
@@ -14,8 +14,15 @@
 This module contains the definition of creating and validating entangler map
 based on the number of qubits.
 """
+from qiskit.utils.deprecation import deprecate_func
 
 
+@deprecate_func(
+    since="0.46.0",
+    package_name="qiskit",
+    additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
+    "two modules deprecated since Qiskit Terra 0.24.0.",
+)
 def get_entangler_map(map_type, num_qubits, offset=0):
     """Utility method to get an entangler map among qubits.
 
@@ -67,6 +74,12 @@ def get_entangler_map(map_type, num_qubits, offset=0):
     return ret
 
 
+@deprecate_func(
+    since="0.46.0",
+    package_name="qiskit",
+    additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
+    "two modules deprecated since Qiskit Terra 0.24.0.",
+)
 def validate_entangler_map(entangler_map, num_qubits, allow_double_entanglement=False):
     """Validate a user supplied entangler map and converts entries to ints.
 

--- a/qiskit/utils/name_unnamed_args.py
+++ b/qiskit/utils/name_unnamed_args.py
@@ -20,7 +20,7 @@ from qiskit.utils.deprecation import deprecate_func
     since="0.46.0",
     package_name="qiskit",
     additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
-    "two modules deprecated since Qiskit Terra 0.24.0.",
+    "two modules deprecated and planned to be removed in Qiskit 1.0.",
 )
 def name_args(mapping, skip=0):
     """Decorator to convert unnamed arguments to named ones.

--- a/qiskit/utils/name_unnamed_args.py
+++ b/qiskit/utils/name_unnamed_args.py
@@ -13,8 +13,15 @@
 """Tool to name unnamed arguments."""
 
 import functools
+from qiskit.utils.deprecation import deprecate_func
 
 
+@deprecate_func(
+    since="0.46.0",
+    package_name="qiskit",
+    additional_msg="This function was only used in the context of qiskit.opflow/qiskit.algorithms, "
+    "two modules deprecated since Qiskit Terra 0.24.0.",
+)
 def name_args(mapping, skip=0):
     """Decorator to convert unnamed arguments to named ones.
 

--- a/releasenotes/notes/deprecate-leftover-algorithm-utils-d77253426257f41f.yaml
+++ b/releasenotes/notes/deprecate-leftover-algorithm-utils-d77253426257f41f.yaml
@@ -1,0 +1,13 @@
+---
+deprecations:
+  - |
+    The following tools in :mod:`qiskit.utils` have been deprecated:
+
+      * Utils in ``qiskit.utils.arithmetic.py``
+      * Utils in ``qiskit.utils.circuit_utils.py``
+      * Utils in ``qiskit.utils.entangler_map.py``
+      * Utils in ``qiskit.utils.name_unnamed_args.py``
+
+    These functions were used exclusively in the context of ``qiskit.algorithms`` and
+    ``qiskit.opflow``, and will be removed following the removals of
+    ``qiskit.algorithms`` and  ``qiskit.opflow`` in Qiskit 1.0.

--- a/releasenotes/notes/deprecate-leftover-algorithm-utils-d77253426257f41f.yaml
+++ b/releasenotes/notes/deprecate-leftover-algorithm-utils-d77253426257f41f.yaml
@@ -3,10 +3,10 @@ deprecations:
   - |
     The following tools in :mod:`qiskit.utils` have been deprecated:
 
-      * Utils in ``qiskit.utils.arithmetic.py``
-      * Utils in ``qiskit.utils.circuit_utils.py``
-      * Utils in ``qiskit.utils.entangler_map.py``
-      * Utils in ``qiskit.utils.name_unnamed_args.py``
+      * Utils in ``qiskit.utils.arithmetic``
+      * Utils in ``qiskit.utils.circuit_utils``
+      * Utils in ``qiskit.utils.entangler_map``
+      * Utils in ``qiskit.utils.name_unnamed_args``
 
     These functions were used exclusively in the context of ``qiskit.algorithms`` and
     ``qiskit.opflow``, and will be removed following the removals of

--- a/test/python/algorithms/test_entangler_map.py
+++ b/test/python/algorithms/test_entangler_map.py
@@ -24,7 +24,8 @@ class TestEntanglerMap(QiskitAlgorithmsTestCase):
     def test_map_type_linear(self):
         """,ap type linear test"""
         ref_map = [[0, 1], [1, 2], [2, 3]]
-        entangler_map = get_entangler_map("linear", 4)
+        with self.assertWarns(DeprecationWarning):
+            entangler_map = get_entangler_map("linear", 4)
 
         for (ref_src, ref_targ), (exp_src, exp_targ) in zip(ref_map, entangler_map):
             self.assertEqual(ref_src, exp_src)
@@ -33,7 +34,8 @@ class TestEntanglerMap(QiskitAlgorithmsTestCase):
     def test_map_type_full(self):
         """map type full test"""
         ref_map = [[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]]
-        entangler_map = get_entangler_map("full", 4)
+        with self.assertWarns(DeprecationWarning):
+            entangler_map = get_entangler_map("full", 4)
 
         for (ref_src, ref_targ), (exp_src, exp_targ) in zip(ref_map, entangler_map):
             self.assertEqual(ref_src, exp_src)
@@ -41,27 +43,29 @@ class TestEntanglerMap(QiskitAlgorithmsTestCase):
 
     def test_validate_entangler_map(self):
         """validate entangler map test"""
-        valid_map = [[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]]
-        self.assertTrue(validate_entangler_map(valid_map, 4))
+        with self.assertWarns(DeprecationWarning):
 
-        valid_map_2 = [[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3], [3, 2]]
-        self.assertTrue(validate_entangler_map(valid_map_2, 4, True))
+            valid_map = [[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]]
+            self.assertTrue(validate_entangler_map(valid_map, 4))
 
-        invalid_map = [[0, 4], [4, 2], [0, 3], [1, 2], [1, 3], [2, 3]]
-        with self.assertRaises(ValueError):
-            validate_entangler_map(invalid_map, 4)
+            valid_map_2 = [[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3], [3, 2]]
+            self.assertTrue(validate_entangler_map(valid_map_2, 4, True))
 
-        invalid_map_2 = [[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3], [3, 2]]
-        with self.assertRaises(ValueError):
-            validate_entangler_map(invalid_map_2, 4)
+            invalid_map = [[0, 4], [4, 2], [0, 3], [1, 2], [1, 3], [2, 3]]
+            with self.assertRaises(ValueError):
+                validate_entangler_map(invalid_map, 4)
 
-        wrong_type_map = {0: [1, 2, 3], 1: [2, 3]}
-        with self.assertRaises(TypeError):
-            validate_entangler_map(wrong_type_map, 4)
+            invalid_map_2 = [[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3], [3, 2]]
+            with self.assertRaises(ValueError):
+                validate_entangler_map(invalid_map_2, 4)
 
-        wrong_type_map_2 = [(0, 1), (0, 2), (0, 3)]
-        with self.assertRaises(TypeError):
-            validate_entangler_map(wrong_type_map_2, 4)
+            wrong_type_map = {0: [1, 2, 3], 1: [2, 3]}
+            with self.assertRaises(TypeError):
+                validate_entangler_map(wrong_type_map, 4)
+
+            wrong_type_map_2 = [(0, 1), (0, 2), (0, 3)]
+            with self.assertRaises(TypeError):
+                validate_entangler_map(wrong_type_map_2, 4)
 
 
 if __name__ == "__main__":

--- a/test/python/test_util.py
+++ b/test/python/test_util.py
@@ -40,5 +40,5 @@ class TestUtil(QiskitTestCase):
         symm = (m + m.T) / 2
 
         triu = [[symm[i, j] for i in range(j, n)] for j in range(n)]
-
-        self.assertTrue(np.array_equal(symm, triu_to_dense(triu)))
+        with self.assertWarns(DeprecationWarning):
+            self.assertTrue(np.array_equal(symm, triu_to_dense(triu)))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR deprecates a series of util functions that were only used in the context of algorithms/opflow, and are no longer necessary. These will be removed in 1.0.

### Details and comment

