### PR TITLE
Update `Instruction.condition_bits` for runtime classical expressions

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -618,12 +618,11 @@ class Instruction(Operation):
     @property
     def condition_bits(self) -> List[Clbit]:
         """Get Clbits in condition."""
+        from qiskit.circuit.controlflow import condition_resources  # pylint: disable=cyclic-import
+
         if self.condition is None:
             return []
-        if isinstance(self.condition[0], Clbit):
-            return [self.condition[0]]
-        else:  # ClassicalRegister
-            return list(self.condition[0])
+        return list(condition_resources(self.condition).clbits)
 
     @property
     def name(self):

--- a/releasenotes/notes/fix-instruction-condition-bits-17694f98628b30ad.yaml
+++ b/releasenotes/notes/fix-instruction-condition-bits-17694f98628b30ad.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The property :attr:`.Instruction.condition_bits` will now correctly handle runtime classical
+    expressions (:mod:`qiskit.circuit.classical`).


### PR DESCRIPTION
### Summary

I didn't even know this property existed and it wasn't tested directly, but the IBM provider uses it during its custom scheduling passes, so until removal, it should be kept updated.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


