### PR TITLE
Add support for feature/* branches

### DIFF
--- a/.github/workflows/neko.yml
+++ b/.github/workflows/neko.yml
@@ -2,7 +2,7 @@ name: Qiskit Neko Integration Tests
 on:
   push:
   pull_request:
-    branches: ['main', 'stable/*']
+    branches: ['main', 'stable/*', 'feature/*']
 concurrency:
   group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}
   # Only cancel in PR mode.  In push mode, don't cancel so we don't see spurious test "failures".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -601,6 +601,12 @@ that minor version on pypi. For example, stable/0.8 contains the code for the
 0.8.2 release on pypi. The API on these branches are stable and the only changes
 merged to it are bugfixes.
 
+* `feature/*` branches:
+Branches under `feature/*` are used to implement epic-level experimental features without 
+guarantee for any backward compatibility and deprecation policy.
+Branch name must be descriptive of the ongoing development, and the branch 
+must be closed after the code is merged back in the main branch.
+
 ### Release cycle
 
 In the lead up to a release there are a few things to keep in mind. Prior to

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,7 @@ trigger:
       - 'main'
       - 'stable/*'
       - 'gh-readonly-queue/*'
+      - 'feature/*'
 
 pr:
   autoCancel: true
@@ -205,7 +206,7 @@ stages:
 
   # Push to main or the stable branches.  The triggering branches also need to
   # be in the triggers at the top of this file.
-  - ${{ if and(eq(variables['Build.Reason'], 'IndividualCI'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/stable/'))) }}:
+  - ${{ if and(eq(variables['Build.Reason'], 'IndividualCI'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/stable/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/'))) }}:
     - stage: "Push"
       jobs:
         - template: ".azure/test-linux.yml"

--- a/tools/docs_exclude.txt
+++ b/tools/docs_exclude.txt
@@ -1,3 +1,4 @@
 /stable/**
 /locale/**
 /dev/**
+/feature/**

--- a/tools/docs_exclude.txt
+++ b/tools/docs_exclude.txt
@@ -1,4 +1,3 @@
 /stable/**
 /locale/**
 /dev/**
-/feature/**


### PR DESCRIPTION
### Summary

Qiskit is going to release the first major version, and post-1.0 development requires more strict stability policy as described in https://github.com/Qiskit/documentation/pull/366. However, we still want a pattern for experimental feature development, which must be agile and can be fail-fast (easily reverted) as we expect to quickly gain practice and confidence during more integration tests. One possible solution is an `experimental` decorator that emits user warning and hacks API document, but this doesn't fit in with epic level development that would introduce many classes and public methods during development. We may prefer feature branches rather than the decorator in some situation.

### Details and comments

This PR lets our CI recognize `feature/*` branch.

