### PR TITLE
Update DAGCircuit.draw() docstring with current requirements

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -2085,8 +2085,8 @@ class DAGCircuit:
         This function needs `Graphviz <https://www.graphviz.org/>`_ to be
         installed. Graphviz is not a python package and can't be pip installed
         (the ``graphviz`` package on PyPI is a Python interface library for
-        Graphviz and does not actually install Graphviz`) you can refer to
-        the Graphviz `documentation <https://www.graphviz.org/download/>`__ on
+        Graphviz and does not actually install Graphviz). You can refer to
+        `the Graphviz documentation <https://www.graphviz.org/download/>`__ on
         how to install it.
 
         Args:

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -2082,8 +2082,12 @@ class DAGCircuit:
         """
         Draws the dag circuit.
 
-        This function needs `pydot <https://github.com/erocarrera/pydot>`_, which in turn needs
-        `Graphviz <https://www.graphviz.org/>`_ to be installed.
+        This function needs `Graphviz <https://www.graphviz.org/>`_ to be
+        installed. Graphviz is not a python package and can't be pip installed
+        (the ``graphviz`` package on PyPI is a Python interface library for
+        Graphviz and does not actually install Graphviz`) you can refer to
+        the Graphviz `documentation <https://www.graphviz.org/download/>`__ on
+        how to install it.
 
         Args:
             scale (float): scaling factor


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Since #8162 the dag drawer hasn't required pydot to run. It now uses rustworkx's graphviz_draw() function which directly calls graphviz. However, in #8162 the docstring for the DAGCircuit.draw() method was not updated to reflect this and the method documentation still said that pydot was required. This commit fixes this oversight and updates the docstring to correctly state that only graphviz is required (as rustworkx is a hard dependency for Qiskit it's not anything that needs to be documented). It also includes more details on how to install graphviz as this is often a potential source of confusion for users.

### Details and comments