### PR TITLE
Improve performance of barrier()

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3329,7 +3329,11 @@ class QuantumCircuit:
             if qargs
             else self.qubits.copy()
         )
-        return self.append(Barrier(len(qubits), label=label), qubits, [])
+        if qargs:
+            return self.append(Barrier(len(qubits), label=label), qubits, [])
+        else:
+            return self._append(Barrier(len(qubits), label=label), qubits, [])
+            
 
     def delay(
         self,

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3333,7 +3333,6 @@ class QuantumCircuit:
             return self.append(Barrier(len(qubits), label=label), qubits, [])
         else:
             return self._append(Barrier(len(qubits), label=label), qubits, [])
-            
 
     def delay(
         self,

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3329,8 +3329,9 @@ class QuantumCircuit:
             return self.append(CircuitInstruction(Barrier(len(qubits), label=label), qubits, ()))
         else:
             qubits = self.qubits.copy()
-            return self._current_scope().append(CircuitInstruction(Barrier(len(qubits)), qubits, ()))
-
+            return self._current_scope().append(
+                CircuitInstruction(Barrier(len(qubits)), qubits, ())
+            )
 
     def delay(
         self,

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3330,7 +3330,7 @@ class QuantumCircuit:
         else:
             qubits = self.qubits.copy()
             return self._current_scope().append(
-                CircuitInstruction(Barrier(len(qubits)), qubits, ())
+                CircuitInstruction(Barrier(len(qubits), label=label), qubits, ())
             )
 
     def delay(

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3323,16 +3323,14 @@ class QuantumCircuit:
         """
         from .barrier import Barrier
 
-        qubits = (
-            # This uses a `dict` not a `set` to guarantee a deterministic order to the arguments.
-            list({q: None for qarg in qargs for q in self.qbit_argument_conversion(qarg)})
-            if qargs
-            else self.qubits.copy()
-        )
         if qargs:
-            return self.append(Barrier(len(qubits), label=label), qubits, [])
+            # This uses a `dict` not a `set` to guarantee a deterministic order to the arguments.
+            qubits = tuple({q: None for qarg in qargs for q in self.qbit_argument_conversion(qarg)})
+            return self.append(CircuitInstruction(Barrier(len(qubits), label=label), qubits, ()))
         else:
-            return self._append(Barrier(len(qubits), label=label), qubits, [])
+            qubits = self.qubits.copy()
+            return self._current_scope().append(CircuitInstruction(Barrier(len(qubits)), qubits, ()))
+
 
     def delay(
         self,

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -559,7 +559,7 @@ class TestCircuitOperations(QiskitTestCase):
             qc.barrier()
 
         operation_names = [c.operation.name for c in qc]
-        assert "barrier" not in operation_names
+        self.assertNotIn("barrier", operation_names)
 
     def test_measure_active(self):
         """Test measure_active

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -551,7 +551,7 @@ class TestCircuitOperations(QiskitTestCase):
         self.assertEqual(qc, expected)
 
     def test_barrier_in_context(self):
-        """Test barrier statement in context, see gh-11345 """
+        """Test barrier statement in context, see gh-11345"""
         qc = QuantumCircuit(2, 2)
         qc.h(0)
         with qc.if_test((qc.clbits[0], False)):
@@ -559,7 +559,7 @@ class TestCircuitOperations(QiskitTestCase):
             qc.barrier()
 
         operation_names = [c.operation.name for c in qc]
-        assert 'barrier' not in operation_names
+        assert "barrier" not in operation_names
 
     def test_measure_active(self):
         """Test measure_active

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -550,6 +550,17 @@ class TestCircuitOperations(QiskitTestCase):
 
         self.assertEqual(qc, expected)
 
+    def test_barrier_in_context(self):
+        """Test barrier statement in context, see gh-11345 """
+        qc = QuantumCircuit(2, 2)
+        qc.h(0)
+        with qc.if_test((qc.clbits[0], False)):
+            qc.h(0)
+            qc.barrier()
+
+        operation_names = [c.operation.name for c in qc]
+        assert 'barrier' not in operation_names
+
     def test_measure_active(self):
         """Test measure_active
         Applies measurements only to non-idle qubits. Creates a ClassicalRegister of size equal to


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

 Improve performance of `barrier()` by using the `_append` when possible.

### Details and comments

Benchmark:
```
import time
from qiskit.circuit import QuantumCircuit
def g():
    qc=QuantumCircuit(2)
    qc.measure_all()

x=[]
for ii in range(20):
    t0=time.time()
    for ii in range(1000):
        g()
    dt=time.time()-t0
    #print(dt)
    x.append(dt)
    
print(f'total: {sum(x):.2f} seconds')
```
Results:
```
main: total: 2.08 seconds
PR: total: 1.72 seconds
```

This is an alternative to #10949 @jakelishman 

