### PR TITLE
Run logical optimization passes in init stage

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1900,10 +1900,10 @@ class DAGCircuit:
                 isinstance(node, DAGOpNode)
                 and len(node.qargs) == 1
                 and len(node.cargs) == 0
-                and getattr(node.op, "condition", None) is None
-                and not node.op.is_parameterized()
                 and isinstance(node.op, Gate)
                 and hasattr(node.op, "__array__")
+                and getattr(node.op, "condition", None) is None
+                and not node.op.is_parameterized()
             )
 
         return rx.collect_runs(self._multi_graph, filter_fn)

--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -70,7 +70,7 @@ class DefaultInitPassManager(PassManagerStagePlugin):
     """Plugin class for default init stage."""
 
     def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
-        if optimization_level in {1, 2, 0}:
+        if optimization_level == 0:
             init = None
             if (
                 pass_manager_config.initial_layout
@@ -88,6 +88,44 @@ class DefaultInitPassManager(PassManagerStagePlugin):
                     pass_manager_config.unitary_synthesis_plugin_config,
                     pass_manager_config.hls_config,
                 )
+        elif optimization_level in {1, 2}:
+            init = PassManager()
+            if (
+                pass_manager_config.initial_layout
+                or pass_manager_config.coupling_map
+                or (
+                    pass_manager_config.target is not None
+                    and pass_manager_config.target.build_coupling_map() is not None
+                )
+            ):
+                init += common.generate_unroll_3q(
+                    pass_manager_config.target,
+                    pass_manager_config.basis_gates,
+                    pass_manager_config.approximation_degree,
+                    pass_manager_config.unitary_synthesis_method,
+                    pass_manager_config.unitary_synthesis_plugin_config,
+                    pass_manager_config.hls_config,
+                )
+            init.append(Optimize1qGatesDecomposition())
+            init.append(
+                InverseCancellation(
+                    [
+                        CXGate(),
+                        ECRGate(),
+                        CZGate(),
+                        CYGate(),
+                        XGate(),
+                        YGate(),
+                        ZGate(),
+                        HGate(),
+                        SwapGate(),
+                        (TGate(), TdgGate()),
+                        (SGate(), SdgGate()),
+                        (SXGate(), SXdgGate()),
+                    ]
+                )
+            )
+
         elif optimization_level == 3:
             init = common.generate_unroll_3q(
                 pass_manager_config.target,
@@ -99,6 +137,26 @@ class DefaultInitPassManager(PassManagerStagePlugin):
             )
             init.append(OptimizeSwapBeforeMeasure())
             init.append(RemoveDiagonalGatesBeforeMeasure())
+            init.append(Optimize1qGatesDecomposition())
+            init.append(
+                InverseCancellation(
+                    [
+                        CXGate(),
+                        ECRGate(),
+                        CZGate(),
+                        CYGate(),
+                        XGate(),
+                        YGate(),
+                        ZGate(),
+                        HGate(),
+                        SwapGate(),
+                        (TGate(), TdgGate()),
+                        (SGate(), SdgGate()),
+                        (SXGate(), SXdgGate()),
+                    ]
+                )
+            )
+
         else:
             return TranspilerError(f"Invalid optimization level {optimization_level}")
         return init

--- a/test/python/transpiler/test_sabre_layout.py
+++ b/test/python/transpiler/test_sabre_layout.py
@@ -423,13 +423,15 @@ class TestSabrePreLayout(QiskitTestCase):
     def test_integration_with_pass_manager(self):
         """Tests SabrePreLayoutIntegration with the rest of PassManager pipeline."""
         backend = FakeAlmadenV2()
-        pm = generate_preset_pass_manager(1, backend, seed_transpiler=0)
+        pm = generate_preset_pass_manager(
+            0, backend, layout_method="sabre", routing_method="sabre", seed_transpiler=0
+        )
         pm.pre_layout = PassManager([SabrePreLayout(backend.target)])
         qct = pm.run(self.circuit)
         qct_initial_layout = qct.layout.initial_layout
         self.assertEqual(
             [qct_initial_layout[q] for q in self.circuit.qubits],
-            [1, 6, 5, 10, 11, 12, 16, 17, 18, 13, 14, 9, 8, 3, 2, 0],
+            [3, 8, 7, 12, 13, 14, 18, 17, 16, 11, 10, 5, 6, 1, 2, 4],
         )
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds Optimize1qGatesDecomposition and InverseCancellation to the init stage for optimization levels 1, 2, and 3. The optimizations these passes run are completely valid on abstract circuits and do not require target qubits to be selected to run
(`Optimize1qGatesDecomposition` is noise aware and will perform target aware optimizations if one is provided, but if no target information is reported it will operate correctly for any circuit)

### Details and comments