### PR TITLE
Remove Optimize1qGatesDecomposition from init stage

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -106,7 +106,6 @@ class DefaultInitPassManager(PassManagerStagePlugin):
                     pass_manager_config.unitary_synthesis_plugin_config,
                     pass_manager_config.hls_config,
                 )
-            init.append(Optimize1qGatesDecomposition())
             init.append(
                 InverseCancellation(
                     [
@@ -137,7 +136,6 @@ class DefaultInitPassManager(PassManagerStagePlugin):
             )
             init.append(OptimizeSwapBeforeMeasure())
             init.append(RemoveDiagonalGatesBeforeMeasure())
-            init.append(Optimize1qGatesDecomposition())
             init.append(
                 InverseCancellation(
                     [


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #11354 we added more logical optimization passes to the preset pass managers for level 1, 2, and 3 which included the
Optimize1qGatesDecomposition pass. However, this had the the unintended side effect of tending to normalize circuits to use parameterized gates. This becomes an issue for discrete basis targets as the basis translator doesn't always know how to work with those. To avoid issues this commit removes the pass from the init stage and just saves it for the optimization loop. If we want to do 1q gate simplification during init in the future we can develop a different pass that does it in a manner that wouldn't interfere with discrete basis targets like Optimize1qGatesDecomposition.

### Details and comments