### PR TITLE
Use new OpenQASM 2 export paths in randomised testing

### DIFF
--- a/test/randomized/test_transpiler_equivalence.py
+++ b/test/randomized/test_transpiler_equivalence.py
@@ -56,7 +56,7 @@ from hypothesis.stateful import Bundle, RuleBasedStateMachine
 
 import hypothesis.strategies as st
 
-from qiskit import transpile, Aer
+from qiskit import transpile, Aer, qasm2
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit.circuit import Measure, Reset, Gate, Barrier
 from qiskit.providers.fake_provider import (
@@ -338,7 +338,7 @@ class QCircuitMachine(RuleBasedStateMachine):
     @invariant()
     def qasm(self):
         """After each circuit operation, it should be possible to build QASM."""
-        self.qc.qasm()
+        qasm2.dumps(self.qc)
 
     @precondition(lambda self: any(isinstance(d[0], Measure) for d in self.qc.data))
     @rule(kwargs=transpiler_conf())
@@ -357,7 +357,7 @@ class QCircuitMachine(RuleBasedStateMachine):
             + ", ".join(f"{key:s}={value!r}" for key, value in kwargs.items() if value is not None)
             + ")"
         )
-        print(f"Evaluating {call} for:\n{self.qc.qasm()}")
+        print(f"Evaluating {call} for:\n{qasm2.dumps(self.qc)}")
 
         shots = 4096
 
@@ -368,7 +368,9 @@ class QCircuitMachine(RuleBasedStateMachine):
         try:
             xpiled_qc = transpile(self.qc, **kwargs)
         except Exception as e:
-            failed_qasm = f"Exception caught during transpilation of circuit: \n{self.qc.qasm()}"
+            failed_qasm = (
+                f"Exception caught during transpilation of circuit: \n{qasm2.dumps(self.qc)}"
+            )
             raise RuntimeError(failed_qasm) from e
 
         xpiled_aer_counts = self.backend.run(xpiled_qc, shots=shots).result().get_counts()
@@ -378,7 +380,7 @@ class QCircuitMachine(RuleBasedStateMachine):
         assert (
             count_differences == ""
         ), "Counts not equivalent: {}\nFailing QASM Input:\n{}\n\nFailing QASM Output:\n{}".format(
-            count_differences, self.qc.qasm(), xpiled_qc.qasm()
+            count_differences, qasm2.dumps(self.qc), qasm2.dumps(xpiled_qc)
         )
 
 


### PR DESCRIPTION
### Summary

With `QuantumCircuit.qasm` deprecated / removed, the randomised tests need to be using the `qasm2.dumps` path.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


Fixes the recent randomised testing failures (see #2645).