### PR TITLE
Handle packaging split in qpy tests

### DIFF
--- a/test/qpy_compat/process_version.sh
+++ b/test/qpy_compat/process_version.sh
@@ -39,7 +39,11 @@ fi
 if [[ ! -d qpy_$version ]] ; then
     echo "Building venv for qiskit-terra $version"
     python -m venv $version
-    ./$version/bin/pip install "qiskit-terra==$version"
+    if [[ ${parts[0]} -eq 0 ]] ; then
+        ./$version/bin/pip install "qiskit-terra==$version"
+    else
+        ./$version/bin/pip install "qiskit==$version"
+    fi
     mkdir qpy_$version
     pushd qpy_$version
     echo "Generating qpy files with qiskit-terra $version"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Starting in Qiskit 1.* the qiskit-terra package isn't beijg used anymore. The qpy backwards compatibility tests were previously hard coded to install historical versiojs of qiskit-terra. Now that we have a tag which doesn't exist for qiskit-terra we can no longer do thid anf need to install the qiskit package instead. Thid commit fixes this by setting a version cap on the use of the qiskit-terra package and then installing qiskit for other versions.

### Details and comments