### PR TITLE
Remove unused optional requirements

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -24,14 +24,8 @@ seaborn>=0.9.0
 qiskit-aer
 qiskit-qasm3-import
 python-constraint>=1.4
-cplex; python_version < '3.11'
 cvxpy
-docplex
-jax; platform_system != 'Windows'
-jaxlib; platform_system != 'Windows'
 scikit-learn>=0.20.0
-scikit-quant<=0.7; platform_system != 'Windows'
-SQSnobFit
 z3-solver>=4.7
 # Tweedledum is unmaintained and its existing Mac wheels are unreliable. If you
 # manage to get a working install on a Mac the functionality should still work,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

With the removal of algorithms and opflow in #11324, #11111, and #11086
along with the removal of the BIPMapping transpiler pass in #10526
several optional test dependencies are no longer used in the code base.
This commit removes them from requirements-optional.txt as several have
compatibility issues with Python 3.12 and are causing failures in the
nightly builds. Since they're no longer used we shouldn't bother
installing them anymore.


### Details and comments