### PR TITLE
Fixed concurrent preset manager race condition (fixes #10426 )

### DIFF
--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -466,6 +466,9 @@ class BasisSearchVisitor(rustworkx.visit.DijkstraVisitor):
         self._num_gates_remain_for_rule = {}
         save_index = -1
         for edata in self.graph.edges():
+            # We only care about edges with data.
+            if edata is None:
+                continue
             if save_index == edata.index:
                 continue
             self._num_gates_remain_for_rule[edata.index] = edata.num_gates
@@ -574,7 +577,10 @@ def _basis_search(equiv_lib, source_basis, target_basis):
     # their names and we need to have in addition the number of qubits they act on.
     target_basis_keys = [key for key in equiv_lib.keys() if key.name in target_basis]
 
-    graph = equiv_lib.graph
+    # Copy the equivalence library graph and add edges for the target basis gates.
+    # We copy the graph since we'll be modifying it in-place, and we don't want to modify
+    # the original graph, accessible throughout multiple threads.
+    graph = equiv_lib.graph.copy()
     vis = BasisSearchVisitor(graph, source_basis, target_basis_keys)
 
     # we add a dummy node and connect it with gates in the target basis.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [v] I have added the tests to cover my changes.
- [v] I have updated the documentation accordingly.
- [v] I have read the CONTRIBUTING document.
-->

### Summary

Addressing the issue #10426 

This fixes a race condition issue when running a `PresetPassManager` in multiple threads. This small pull request makes it so that the `EquivalenceLibrary`'s graph accessed in the `_basis_search` function is not shared across all the different threads but instead a local copy. This should not change anything performance wise as the graph is ultimately not changed (dummy node added, Dijkstra search algorithm, then dummy node removed).

### Details and comments

Fixes #10426 
