### PR TITLE
Raise error eagerly on bad unitary synthesis method

### DIFF
--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -333,9 +333,8 @@ class UnitarySynthesis(TransformationPass):
                 set for ``basis_gates``, ``coupling_map``, and ``backend_props``.
 
         Raises:
-            TranspilerError: if ``method`` was specified for the class and is not
-                found in the installed plugins list. The list of installed
-                plugins can be queried with
+            TranspilerError: if ``method`` was specified but is not found in the
+                installed plugins list. The list of installed plugins can be queried with
                 :func:`~qiskit.transpiler.passes.synthesis.plugin.unitary_synthesis_plugin_names`
         """
         super().__init__()

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -331,6 +331,12 @@ class UnitarySynthesis(TransformationPass):
             target: The optional :class:`~.Target` for the target device the pass
                 is compiling for. If specified this will supersede the values
                 set for ``basis_gates``, ``coupling_map``, and ``backend_props``.
+
+        Raises:
+            TranspilerError: if ``method`` was specified for the class and is not
+                found in the installed plugins list. The list of installed
+                plugins can be queried with
+                :func:`~qiskit.transpiler.passes.synthesis.plugin.unitary_synthesis_plugin_names`
         """
         super().__init__()
         self._basis_gates = set(basis_gates or ())
@@ -358,6 +364,9 @@ class UnitarySynthesis(TransformationPass):
 
         self._synth_gates = set(self._synth_gates) - self._basis_gates
 
+        if self.method != "default" and self.method not in self.plugins.ext_plugins:
+            raise TranspilerError("Specified methodd: %s not found in plugin list" % self.method)
+
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         """Run the UnitarySynthesis pass on ``dag``.
 
@@ -373,8 +382,6 @@ class UnitarySynthesis(TransformationPass):
                 plugins can be queried with
                 :func:`~qiskit.transpiler.passes.synthesis.plugin.unitary_synthesis_plugin_names`
         """
-        if self.method != "default" and self.method not in self.plugins.ext_plugins:
-            raise TranspilerError("Specified method: %s not found in plugin list" % self.method)
 
         # If there aren't any gates to synthesize in the circuit we can skip all the iteration
         # and just return.

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -364,7 +364,7 @@ class UnitarySynthesis(TransformationPass):
         self._synth_gates = set(self._synth_gates) - self._basis_gates
 
         if self.method != "default" and self.method not in self.plugins.ext_plugins:
-            raise TranspilerError("Specified methodd: %s not found in plugin list" % self.method)
+            raise TranspilerError(f"Specified method '{self.method}' not found in plugin list")
 
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         """Run the UnitarySynthesis pass on ``dag``.

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -375,12 +375,6 @@ class UnitarySynthesis(TransformationPass):
 
         Returns:
             Output dag with UnitaryGates synthesized to target basis.
-
-        Raises:
-            TranspilerError: if ``method`` was specified for the class and is not
-                found in the installed plugins list. The list of installed
-                plugins can be queried with
-                :func:`~qiskit.transpiler.passes.synthesis.plugin.unitary_synthesis_plugin_names`
         """
 
         # If there aren't any gates to synthesize in the circuit we can skip all the iteration

--- a/releasenotes/notes/move-synthesis-plugin-error-61e3683bf5a0c225.yaml
+++ b/releasenotes/notes/move-synthesis-plugin-error-61e3683bf5a0c225.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    fixes issue #11355. If a nonexistent synthesis plugin is passed, `generate_preset_pass_manager` now raises an error 
+    the pass manager is created, not when it is run.

--- a/releasenotes/notes/move-synthesis-plugin-error-61e3683bf5a0c225.yaml
+++ b/releasenotes/notes/move-synthesis-plugin-error-61e3683bf5a0c225.yaml
@@ -1,5 +1,6 @@
 ---
 fixes:
   - |
-    fixes issue #11355. If a nonexistent synthesis plugin is passed, `generate_preset_pass_manager` now raises an error 
-    when the pass manager is created, not when it is run.
+    The :class:`.UnitarySynthesis` transpiler pass will now generate an error on initialization when
+    a nonexistent sythesis plugin is specified, rather than waiting until runtime to raise.  Fixed
+    `#11355 <https://github.com/Qiskit/qiskit/issues/11355>`__.

--- a/releasenotes/notes/move-synthesis-plugin-error-61e3683bf5a0c225.yaml
+++ b/releasenotes/notes/move-synthesis-plugin-error-61e3683bf5a0c225.yaml
@@ -2,4 +2,4 @@
 fixes:
   - |
     fixes issue #11355. If a nonexistent synthesis plugin is passed, `generate_preset_pass_manager` now raises an error 
-    the pass manager is created, not when it is run.
+    when the pass manager is created, not when it is run.

--- a/test/python/transpiler/test_stage_plugin.py
+++ b/test/python/transpiler/test_stage_plugin.py
@@ -123,5 +123,7 @@ class TestBuiltinPlugins(QiskitTestCase):
         backend = QasmSimulatorPy()
         with self.assertRaises(TranspilerError):
             _ = generate_preset_pass_manager(
-                optimization_level=optimization_level, backend=backend, unitary_synthesis_method="a"
+                optimization_level=optimization_level,
+                backend=backend,
+                unitary_synthesis_method="not a method",
             )

--- a/test/python/transpiler/test_stage_plugin.py
+++ b/test/python/transpiler/test_stage_plugin.py
@@ -22,6 +22,7 @@ from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.compiler.transpiler import transpile
 from qiskit.test import QiskitTestCase
 from qiskit.transpiler import PassManager, PassManagerConfig, CouplingMap
+from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit.transpiler.preset_passmanagers.builtin_plugins import BasicSwapPassManager
 from qiskit.transpiler.preset_passmanagers.plugin import (
     PassManagerStagePluginManager,
@@ -113,3 +114,14 @@ class TestBuiltinPlugins(QiskitTestCase):
         backend = QasmSimulatorPy()
         counts = backend.run(tqc, shots=1000).result().get_counts()
         self.assertDictAlmostEqual(counts, {"0000": 500, "1111": 500}, delta=100)
+
+    @combine(
+        optimization_level=list(range(4)),
+    )
+    def test_unitary_synthesis_plugins(self, optimization_level):
+        """Test unitary synthesis plugins"""
+        backend = QasmSimulatorPy()
+        with self.assertRaises(TranspilerError):
+            _ = generate_preset_pass_manager(
+                optimization_level=optimization_level, backend=backend, unitary_synthesis_method="a"
+            )


### PR DESCRIPTION
### Summary
`generate_preset_pass_manager` now raises an error the pass manager is created, not when it is run.

Fixes #11355 

