### PR TITLE
Fix a bug is StabilizerState repr

### DIFF
--- a/qiskit/quantum_info/states/stabilizerstate.py
+++ b/qiskit/quantum_info/states/stabilizerstate.py
@@ -95,7 +95,7 @@ class StabilizerState(QuantumState):
         return (self._data.stab == other._data.stab).all()
 
     def __repr__(self):
-        return f"StabilizerState({self._data.stabilizer})"
+        return f"StabilizerState({self._data.to_labels(mode='S')})"
 
     @property
     def clifford(self):

--- a/releasenotes/notes/fix-stabilizerstate-repr-908c830028b1f868.yaml
+++ b/releasenotes/notes/fix-stabilizerstate-repr-908c830028b1f868.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a bug in the :class:`.StabilizerState` string representation.

--- a/test/python/quantum_info/states/test_stabilizerstate.py
+++ b/test/python/quantum_info/states/test_stabilizerstate.py
@@ -980,6 +980,12 @@ class TestStabilizerStateExpectationValue(QiskitTestCase):
         self.assertFalse(cliff1.equiv(cliff3))
         self.assertFalse(cliff2.equiv(cliff4))
 
+    def test_visualize_does_not_throw_error(self):
+        """Test to verify that drawing StabilizerState does not throw an error"""
+        clifford = random_clifford(3, seed=0)
+        stab = StabilizerState(clifford)
+        _ = repr(stab)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Currently, printing `StabilizerState(qc)` raises the following error, since the Clifford class API has been changed.
`AttributeError: 'Clifford' object has no attribute 'stabilizer'`

This PR fixes this bug, and adds a test to check that the printing does not raise an error.

### Details and comments


