### PR TITLE
Add pointer to qiskit/documentation issues for docs issues outside of API references

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Non-API docs issues
     url: https://github.com/Qiskit/documentation/issues/new/choose
-    about: Open a documentation issue about pages that do not have /api/ in the url (e.g., docs in the Build, Run, Transpile etc. sections)
+    about: Open an issue about documentation in the Start, Build, Transpile, Verify, Run, or Migration guides sections (non-API documentation)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Non-API docs issues
+    url: https://github.com/Qiskit/documentation/issues/new/choose
+    about: Open a documentation issue about pages that do not have /api/ in the url (e.g., docs in the Build, Run, Transpile etc. sections)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Non-API docs issues
     url: https://github.com/Qiskit/documentation/issues/new/choose
-    about: Open an issue about documentation in the Start, Build, Transpile, Verify, Run, or Migration guides sections (non-API documentation)
+    about: Open an issue about documentation in the Start, Build, Transpile, Verify, Run, or Migration guides sections of docs.quantum.ibm.com (non-API documentation)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ community in this goal.
 * [Choose an issue to work on](#Choose-an-issue-to-work-on)
 * [Set up Python virtual development environment](#set-up-python-virtual-development-environment)
 * [Installing Qiskit from source](#installing-qiskit-from-source)
-* [Pull requests](#pull-requests)
+* [Issues and pull requests](#issues-and-pull-requests)
 * [Contributor Licensing Agreement](#contributor-licensing-agreement)
 * [Changelog generation](#changelog-generation)
 * [Release notes](#release-notes)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,8 @@ the code. It also lets the community know what you're working on, and if you
 need help, you can reference the issue when discussing it with other community
 and team members.
 
+Please note that the repo for any docs page that does not have `/api/` in its url is [https://github.com/Qiskit/documentation](https://github.com/Qiskit/documentation) and you can open an issue [here](https://github.com/Qiskit/documentation/issues/new/choose) for any non-API docs fixes or suggestions.
+
 If you've written some code but need help finishing it, want to get initial
 feedback on it prior to finishing it, or want to share it and discuss prior
 to finishing the implementation, you can open a *Draft* pull request and prepend

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ the code. It also lets the community know what you're working on, and if you
 need help, you can reference the issue when discussing it with other community
 and team members.
 
-* For documentation issues relating to pages in the Start, Build, Transpile, Verify, Run, and Migration guides sections of docs.quantum.ibm.com, please open an issue in the [Qiskit/documentation repo](https://github.com/Qiskit/documentation/issues/new/choose) rather than the Qiskit/qiskit repo. In other words, any page that DOES NOT have `/api/` in the url should be addressed in the Qiskit/documentation repo. (Exception: the Migration guide urls contain `/api/` but are managed in the Qiskit/documentation repo.)
+* For documentation issues relating to pages in the Start, Build, Transpile, Verify, Run, and Migration guides sections of [docs.quantum.ibm.com](https://docs.quantum.ibm.com/), please open an issue in the [Qiskit/documentation repo](https://github.com/Qiskit/documentation/issues/new/choose) rather than the Qiskit/qiskit repo. In other words, any page that DOES NOT have `/api/` in the url should be addressed in the Qiskit/documentation repo. (Exception: the Migration guide urls contain `/api/` but are managed in the Qiskit/documentation repo.)
 * For issues relating to API reference pages (any page that contains /api/ in the url), please open an issue in the repo specific to that API reference.
 
 If you've written some code but need help finishing it, want to get initial

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,8 @@ the code. It also lets the community know what you're working on, and if you
 need help, you can reference the issue when discussing it with other community
 and team members.
 
-Please note that the repo for any docs page that does not have `/api/` in its url is [https://github.com/Qiskit/documentation](https://github.com/Qiskit/documentation) and you can open an issue [here](https://github.com/Qiskit/documentation/issues/new/choose) for any non-API docs fixes or suggestions.
+* For documentation issues relating to pages in the Start, Build, Transpile, Verify, Run, and Migration guides sections, please open an issue in the [Qiskit/documentation repo](https://github.com/Qiskit/documentation/issues/new/choose) rather than the Qiskit/qiskit repo. In other words, any page that DOES NOT have `/api/` in the url should be addressed in the Qiskit/documentation repo. (Exception: the Migration guide urls contain `/api/` but are managed in the Qiskit/documentation repo.)
+* For issues relating to API reference pages (any page that contains /api/ in the url), please open an issue in the repo specific to that API reference.
 
 If you've written some code but need help finishing it, want to get initial
 feedback on it prior to finishing it, or want to share it and discuss prior

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ the code. It also lets the community know what you're working on, and if you
 need help, you can reference the issue when discussing it with other community
 and team members.
 
-* For documentation issues relating to pages in the Start, Build, Transpile, Verify, Run, and Migration guides sections, please open an issue in the [Qiskit/documentation repo](https://github.com/Qiskit/documentation/issues/new/choose) rather than the Qiskit/qiskit repo. In other words, any page that DOES NOT have `/api/` in the url should be addressed in the Qiskit/documentation repo. (Exception: the Migration guide urls contain `/api/` but are managed in the Qiskit/documentation repo.)
+* For documentation issues relating to pages in the Start, Build, Transpile, Verify, Run, and Migration guides sections of docs.quantum.ibm.com, please open an issue in the [Qiskit/documentation repo](https://github.com/Qiskit/documentation/issues/new/choose) rather than the Qiskit/qiskit repo. In other words, any page that DOES NOT have `/api/` in the url should be addressed in the Qiskit/documentation repo. (Exception: the Migration guide urls contain `/api/` but are managed in the Qiskit/documentation repo.)
 * For issues relating to API reference pages (any page that contains /api/ in the url), please open an issue in the repo specific to that API reference.
 
 If you've written some code but need help finishing it, want to get initial

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ need help, you can reference the issue when discussing it with other community
 and team members.
 
 * For documentation issues relating to pages in the Start, Build, Transpile, Verify, Run, and Migration guides sections of [docs.quantum.ibm.com](https://docs.quantum.ibm.com/), please open an issue in the [Qiskit/documentation repo](https://github.com/Qiskit/documentation/issues/new/choose) rather than the Qiskit/qiskit repo. In other words, any page that DOES NOT have `/api/` in the url should be addressed in the Qiskit/documentation repo. (Exception: the [Migration guide](https://docs.quantum.ibm.com/api/migration-guides) urls contain `/api/` but are managed in the Qiskit/documentation repo.)
-* For issues relating to API reference pages (any page that contains /api/ in the url), please open an issue in the repo specific to that API reference, for example [Qiskit/qiskit](https://github.com/Qiskit/qiskit/issues/new/choose), [Qiskit/qiskit-aer](https://github.com/Qiskit/qiskit-aer/issues/new/choose), or [Qiskit/qiskit-ibm-runtime](https://github.com/Qiskit/qiskit-ibm-runtime/issues/new/choose).
+* For issues relating to API reference pages (any page that contains `/api/` in the url), please open an issue in the repo specific to that API reference, for example [Qiskit/qiskit](https://github.com/Qiskit/qiskit/issues/new/choose), [Qiskit/qiskit-aer](https://github.com/Qiskit/qiskit-aer/issues/new/choose), or [Qiskit/qiskit-ibm-runtime](https://github.com/Qiskit/qiskit-ibm-runtime/issues/new/choose).
 
 If you've written some code but need help finishing it, want to get initial
 feedback on it prior to finishing it, or want to share it and discuss prior

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ need help, you can reference the issue when discussing it with other community
 and team members.
 
 * For documentation issues relating to pages in the Start, Build, Transpile, Verify, Run, and Migration guides sections of [docs.quantum.ibm.com](https://docs.quantum.ibm.com/), please open an issue in the [Qiskit/documentation repo](https://github.com/Qiskit/documentation/issues/new/choose) rather than the Qiskit/qiskit repo. In other words, any page that DOES NOT have `/api/` in the url should be addressed in the Qiskit/documentation repo. (Exception: the Migration guide urls contain `/api/` but are managed in the Qiskit/documentation repo.)
-* For issues relating to API reference pages (any page that contains /api/ in the url), please open an issue in the repo specific to that API reference.
+* For issues relating to API reference pages (any page that contains /api/ in the url), please open an issue in the repo specific to that API reference, for example [Qiskit/qiskit](https://github.com/Qiskit/qiskit/issues/new/choose), [Qiskit/qiskit-aer](https://github.com/Qiskit/qiskit-aer/issues/new/choose) or [Qiskit/qiskit-ibm-runtime](https://github.com/Qiskit/qiskit-ibm-runtime/issues/new/choose).
 
 If you've written some code but need help finishing it, want to get initial
 feedback on it prior to finishing it, or want to share it and discuss prior

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ dependency packages installed in your environment, which are listed in the
 `pyproject.toml` file under the `[build-system]` section.
 
 
-## Pull requests
+## Issues and pull requests
 
 We use [GitHub pull requests](https://help.github.com/articles/about-pull-requests) to accept
 contributions.
@@ -148,8 +148,8 @@ the code. It also lets the community know what you're working on, and if you
 need help, you can reference the issue when discussing it with other community
 and team members.
 
-* For documentation issues relating to pages in the Start, Build, Transpile, Verify, Run, and Migration guides sections of [docs.quantum.ibm.com](https://docs.quantum.ibm.com/), please open an issue in the [Qiskit/documentation repo](https://github.com/Qiskit/documentation/issues/new/choose) rather than the Qiskit/qiskit repo. In other words, any page that DOES NOT have `/api/` in the url should be addressed in the Qiskit/documentation repo. (Exception: the Migration guide urls contain `/api/` but are managed in the Qiskit/documentation repo.)
-* For issues relating to API reference pages (any page that contains /api/ in the url), please open an issue in the repo specific to that API reference, for example [Qiskit/qiskit](https://github.com/Qiskit/qiskit/issues/new/choose), [Qiskit/qiskit-aer](https://github.com/Qiskit/qiskit-aer/issues/new/choose) or [Qiskit/qiskit-ibm-runtime](https://github.com/Qiskit/qiskit-ibm-runtime/issues/new/choose).
+* For documentation issues relating to pages in the Start, Build, Transpile, Verify, Run, and Migration guides sections of [docs.quantum.ibm.com](https://docs.quantum.ibm.com/), please open an issue in the [Qiskit/documentation repo](https://github.com/Qiskit/documentation/issues/new/choose) rather than the Qiskit/qiskit repo. In other words, any page that DOES NOT have `/api/` in the url should be addressed in the Qiskit/documentation repo. (Exception: the [Migration guide](https://docs.quantum.ibm.com/api/migration-guides) urls contain `/api/` but are managed in the Qiskit/documentation repo.)
+* For issues relating to API reference pages (any page that contains /api/ in the url), please open an issue in the repo specific to that API reference, for example [Qiskit/qiskit](https://github.com/Qiskit/qiskit/issues/new/choose), [Qiskit/qiskit-aer](https://github.com/Qiskit/qiskit-aer/issues/new/choose), or [Qiskit/qiskit-ibm-runtime](https://github.com/Qiskit/qiskit-ibm-runtime/issues/new/choose).
 
 If you've written some code but need help finishing it, want to get initial
 feedback on it prior to finishing it, or want to share it and discuss prior


### PR DESCRIPTION
### Summary

With the unification of the Qiskit docs and IBM Quantum Platform docs, we want to make it clear where to open an issue, depending on what page you're on when you identify a problem/suggestion to report.

### Details and comments

Issues about documentation in the Start, Build, Transpile, Verify, Run, or Migration guides sections should be opened here: https://github.com/Qiskit/documentation/issues/new/choose
