### PR TITLE
Run Rust tests with Miri

### DIFF
--- a/.azure/test-linux.yml
+++ b/.azure/test-linux.yml
@@ -49,14 +49,13 @@ jobs:
         displayName: "Cache stestr"
 
       - ${{ if eq(parameters.testRust, true) }}:
-        # We need to avoid linking our crates into full Python extension libraries during Rust-only
-        # testing because Rust/PyO3 can't handle finding a static CPython interpreter.
-        - bash: cargo test --no-default-features
-          env:
-            # On Linux we link against `libpython` dynamically, but it isn't written into the rpath
-            # of the test executable (I'm not 100% sure why ---Jake).  It's easiest just to forcibly
-            # include the correct place in the `dlopen` search path.
-            LD_LIBRARY_PATH: '$(usePython.pythonLocation)/lib:$LD_LIBRARY_PATH'
+        # Most tests in Rust space are for testing low-level unsafe code, using Miri to detect
+        # undefined/invalid behaviour.
+        - bash: |
+            set -e
+            rustup install nightly
+            rustup +nightly component add miri
+            cargo +nightly miri test
           displayName: "Run Rust tests"
 
       - bash: |


### PR DESCRIPTION
### Summary

This converts the small Rust test suite to be entirely within Miri, rather than the more minimal built-in cargo-test.  Most of our Rust code is tested from Python space, but the Rust tests are largely for inner internal details, which will include more and more `unsafe` blocks as we move more numerical code down into Rust.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments


