### PR TITLE
Deprecate provider-specific fake backends,FakeProvider class and related tools in 0.46

### DIFF
--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -33,6 +33,7 @@ from qiskit.utils import optionals as _optionals
 from qiskit.providers import basic_provider
 from qiskit.transpiler import Target
 from qiskit.providers.backend_compat import convert_to_target
+from qiskit.utils.deprecation import deprecate_func
 
 from .utils.json_decoder import (
     decode_backend_configuration,
@@ -71,6 +72,15 @@ class FakeBackendV2(BackendV2):
     defs_filename = None
     backend_name = None
 
+    @deprecate_func(
+        additional_msg="This class has been migrated to the `qiskit_ibm_runtime` package. "
+        "To migrate your code, run `pip install qiskit-ibm-runtime` and use "
+        "`from qiskit_ibm_runtime.fake_provider import FakeExample` "
+        "instead of `from qiskit.providers.fake_provider import FakeExample`. ",
+        since="0.46.0",
+        removal_timeline="Qiskit 1.0",
+        package_name="qiskit",
+    )
     def __init__(self):
         """FakeBackendV2 initializer."""
         self._conf_dict = self._get_conf_dict_from_json()
@@ -88,20 +98,6 @@ class FakeBackendV2(BackendV2):
 
         if "channels" in self._conf_dict:
             self._parse_channels(self._conf_dict["channels"])
-
-        # This is a deprecation warning for the subclasses.
-        # FakeBackendV2 is not deprecated.
-        warnings.warn(
-            message="All fake backend instances based on real device snapshots (`FakeVigo`,"
-            "`FakeSherbrooke`,...) have been migrated to the `qiskit_ibm_runtime` package. "
-            "These classes are deprecated as of qiskit 0.46.0 and will be removed in qiskit 1.0.0. "
-            "To migrate your code, run `pip install qiskit-ibm-runtime` and use "
-            "`from qiskit_ibm_runtime.fake_provider import FakeExample` "
-            "instead of `from qiskit.providers.fake_provider import FakeExample`. "
-            "If you are using a custom fake backend implementation, you don't need to take any action.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
 
     def _parse_channels(self, channels):
         type_map = {

--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -56,7 +56,7 @@ class FakeBackendV2(BackendV2):
 
     The class inherits :class:`~qiskit.providers.BackendV2` class. This version
     differs from earlier :class:`~qiskit.providers.fake_provider.FakeBackend` (V1) class in a
-    few aspects. Firstly, configuration attribute no longer exsists. Instead,
+    few aspects. Firstly, configuration attribute no longer exists. Instead,
     attributes exposing equivalent required immutable properties of the backend
     device are added. For example ``fake_backend.configuration().n_qubits`` is
     accessible from ``fake_backend.num_qubits`` now. Secondly, this version
@@ -73,9 +73,12 @@ class FakeBackendV2(BackendV2):
 
     def __init__(self):
         """FakeBackendV2 initializer."""
+        # This is a deprecation warning for the subclasses.
+        # FakeBackendV2 is not deprecated.
         warnings.warn(
-            message="Device-specific fake backends have been migrated to the `qiskit_ibm_runtime` package. "
-            "These classes are deprecated as of qiskit 0.46.0 and will be removed in qiskit 1.0.0. "
+            message="Device-specific fake backends have been migrated to the "
+            "`qiskit_ibm_runtime` package. These classes are deprecated "
+            "as of qiskit 0.46.0 and will be removed in qiskit 1.0.0. "
             "You should migrate your code to use "
             "`from qiskit_ibm_runtime.fake_provider import FakeExample` "
             "instead of `from qiskit.providers.fake_provider import FakeExample`.",

--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -73,6 +73,15 @@ class FakeBackendV2(BackendV2):
 
     def __init__(self):
         """FakeBackendV2 initializer."""
+        warnings.warn(
+            message="Device-specific fake backends have been migrated to the `qiskit_ibm_runtime` package. "
+            "These classes are deprecated as of qiskit 0.46.0 and will be removed in qiskit 1.0.0. "
+            "You should migrate your code to use "
+            "`from qiskit_ibm_runtime.fake_provider import FakeExample` "
+            "instead of `from qiskit.providers.fake_provider import FakeExample`.",
+            category=DeprecationWarning,
+            stacklevel=3,
+        )
         self._conf_dict = self._get_conf_dict_from_json()
         self._props_dict = None
         self._defs_dict = None

--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -73,7 +73,9 @@ class FakeBackendV2(BackendV2):
     backend_name = None
 
     @deprecate_func(
-        additional_msg="This class has been migrated to the `qiskit_ibm_runtime` package. "
+        additional_msg="All fake backend instances based on real device snapshots "
+        "(`FakeVigo`,`FakeSherbrooke`,...) have been migrated to the "
+        "`qiskit_ibm_runtime` package. "
         "To migrate your code, run `pip install qiskit-ibm-runtime` and use "
         "`from qiskit_ibm_runtime.fake_provider import FakeExample` "
         "instead of `from qiskit.providers.fake_provider import FakeExample`. ",

--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -80,8 +80,7 @@ class FakeBackendV2(BackendV2):
         "`from qiskit_ibm_runtime.fake_provider import FakeExample` "
         "instead of `from qiskit.providers.fake_provider import FakeExample`. ",
         since="0.46.0",
-        removal_timeline="Qiskit 1.0",
-        package_name="qiskit",
+        removal_timeline="in qiskit 1.0",
     )
     def __init__(self):
         """FakeBackendV2 initializer."""

--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2023.
+# (C) Copyright IBM 2019, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -73,18 +73,6 @@ class FakeBackendV2(BackendV2):
 
     def __init__(self):
         """FakeBackendV2 initializer."""
-        # This is a deprecation warning for the subclasses.
-        # FakeBackendV2 is not deprecated.
-        warnings.warn(
-            message="Device-specific fake backends have been migrated to the "
-            "`qiskit_ibm_runtime` package. These classes are deprecated "
-            "as of qiskit 0.46.0 and will be removed in qiskit 1.0.0. "
-            "You should migrate your code to use "
-            "`from qiskit_ibm_runtime.fake_provider import FakeExample` "
-            "instead of `from qiskit.providers.fake_provider import FakeExample`.",
-            category=DeprecationWarning,
-            stacklevel=3,
-        )
         self._conf_dict = self._get_conf_dict_from_json()
         self._props_dict = None
         self._defs_dict = None
@@ -100,6 +88,18 @@ class FakeBackendV2(BackendV2):
 
         if "channels" in self._conf_dict:
             self._parse_channels(self._conf_dict["channels"])
+
+        # This is a deprecation warning for the subclasses.
+        # FakeBackendV2 is not deprecated.
+        warnings.warn(
+            message="Device-specific fake backends have been migrated to the `qiskit_ibm_runtime` package. "
+            "These classes are deprecated as of qiskit 0.46.0 and will be removed in qiskit 1.0.0. "
+            "You should migrate your code to use "
+            "`from qiskit_ibm_runtime.fake_provider import FakeExample` "
+            "instead of `from qiskit.providers.fake_provider import FakeExample`.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
 
     def _parse_channels(self, channels):
         type_map = {

--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -92,11 +92,13 @@ class FakeBackendV2(BackendV2):
         # This is a deprecation warning for the subclasses.
         # FakeBackendV2 is not deprecated.
         warnings.warn(
-            message="Device-specific fake backends have been migrated to the `qiskit_ibm_runtime` package. "
+            message="All fake backend instances based on real device snapshots (`FakeVigo`,"
+            "`FakeSherbrooke`,...) have been migrated to the `qiskit_ibm_runtime` package. "
             "These classes are deprecated as of qiskit 0.46.0 and will be removed in qiskit 1.0.0. "
-            "You should migrate your code to use "
+            "To migrate your code, run `pip install qiskit-ibm-runtime` and use "
             "`from qiskit_ibm_runtime.fake_provider import FakeExample` "
-            "instead of `from qiskit.providers.fake_provider import FakeExample`.",
+            "instead of `from qiskit.providers.fake_provider import FakeExample`. "
+            "If you are using a custom fake backend implementation, you don't need to take any action.",
             category=DeprecationWarning,
             stacklevel=2,
         )

--- a/qiskit/providers/fake_provider/fake_backend_v2.py
+++ b/qiskit/providers/fake_provider/fake_backend_v2.py
@@ -32,11 +32,19 @@ from qiskit.providers.backend import BackendV2, QubitProperties
 from qiskit.providers.options import Options
 from qiskit.transpiler import Target, InstructionProperties
 from qiskit.providers.basic_provider.basic_simulator import BasicSimulator
+from qiskit.utils.deprecation import deprecate_func
 
 
 class FakeBackendV2(BackendV2):
     """A mock backend that doesn't implement run() to test compatibility with Terra internals."""
 
+    @deprecate_func(
+        additional_msg="Use the `qiskit.providers.basic_provider.GenericBackendV2` "
+        "class instead.",
+        since="0.46.0",
+        removal_timeline="Qiskit 1.0",
+        package_name="qiskit",
+    )
     def __init__(self):
         super().__init__(
             None,
@@ -111,6 +119,13 @@ class FakeBackendV2LegacyQubitProps(FakeBackendV2):
 class FakeBackend5QV2(BackendV2):
     """A mock backend that doesn't implement run() to test compatibility with Terra internals."""
 
+    @deprecate_func(
+        additional_msg="Use the `qiskit.providers.basic_provider.GenericBackendV2` "
+        "class instead.",
+        since="0.46.0",
+        removal_timeline="Qiskit 1.0",
+        package_name="qiskit",
+    )
     def __init__(self, bidirectional=True):
         super().__init__(
             None,
@@ -183,6 +198,13 @@ class FakeBackend5QV2(BackendV2):
 class FakeBackendSimple(BackendV2):
     """A fake simple backend that wraps BasicSimulator to implement run()."""
 
+    @deprecate_func(
+        additional_msg="Use the `qiskit.providers.basic_provider.GenericBackendV2` "
+        "class instead.",
+        since="0.46.0",
+        removal_timeline="Qiskit 1.0",
+        package_name="qiskit",
+    )
     def __init__(self):
         super().__init__(
             None,

--- a/qiskit/providers/fake_provider/fake_backend_v2.py
+++ b/qiskit/providers/fake_provider/fake_backend_v2.py
@@ -42,7 +42,7 @@ class FakeBackendV2(BackendV2):
         additional_msg="Use the `qiskit.providers.basic_provider.GenericBackendV2` "
         "class instead.",
         since="0.46.0",
-        removal_timeline="Qiskit 1.0",
+        removal_timeline="in qiskit 1.0",
         package_name="qiskit",
     )
     def __init__(self):
@@ -123,7 +123,7 @@ class FakeBackend5QV2(BackendV2):
         additional_msg="Use the `qiskit.providers.basic_provider.GenericBackendV2` "
         "class instead.",
         since="0.46.0",
-        removal_timeline="Qiskit 1.0",
+        removal_timeline="in qiskit 1.0",
         package_name="qiskit",
     )
     def __init__(self, bidirectional=True):
@@ -202,7 +202,7 @@ class FakeBackendSimple(BackendV2):
         additional_msg="Use the `qiskit.providers.basic_provider.GenericBackendV2` "
         "class instead.",
         since="0.46.0",
-        removal_timeline="Qiskit 1.0",
+        removal_timeline="in qiskit 1.0",
         package_name="qiskit",
     )
     def __init__(self):

--- a/qiskit/providers/fake_provider/fake_job.py
+++ b/qiskit/providers/fake_provider/fake_job.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019.
+# (C) Copyright IBM 2019, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -28,7 +28,7 @@ class FakeJob(JobV1):
     _executor = futures.ThreadPoolExecutor()
 
     @deprecate_func(
-        additional_msg="Use the `qiskit.providers.JobV1` class instead.",
+        additional_msg="Use the `qiskit.providers.JobV1` class directly instead.",
         since="0.46.0",
         removal_timeline="Qiskit 1.0",
         package_name="qiskit",

--- a/qiskit/providers/fake_provider/fake_job.py
+++ b/qiskit/providers/fake_provider/fake_job.py
@@ -30,7 +30,7 @@ class FakeJob(JobV1):
     @deprecate_func(
         additional_msg="Use the `qiskit.providers.JobV1` class directly instead.",
         since="0.46.0",
-        removal_timeline="Qiskit 1.0",
+        removal_timeline="in qiskit 1.0",
         package_name="qiskit",
     )
     def __init__(self, backend, job_id, fn):

--- a/qiskit/providers/fake_provider/fake_job.py
+++ b/qiskit/providers/fake_provider/fake_job.py
@@ -19,6 +19,7 @@ from concurrent import futures
 
 from qiskit.providers import JobV1
 from qiskit.providers.jobstatus import JobStatus
+from qiskit.utils.deprecation import deprecate_func
 
 
 class FakeJob(JobV1):
@@ -26,6 +27,12 @@ class FakeJob(JobV1):
 
     _executor = futures.ThreadPoolExecutor()
 
+    @deprecate_func(
+        additional_msg="Use the `qiskit.providers.JobV1` class instead.",
+        since="0.46.0",
+        removal_timeline="Qiskit 1.0",
+        package_name="qiskit",
+    )
     def __init__(self, backend, job_id, fn):
         super().__init__(backend, job_id)
         self._backend = backend

--- a/qiskit/providers/fake_provider/fake_mumbai_v2.py
+++ b/qiskit/providers/fake_provider/fake_mumbai_v2.py
@@ -40,7 +40,7 @@ class FakeMumbaiFractionalCX(BackendV2):
         additional_msg="Use the `qiskit.providers.basic_provider.GenericBackendV2` "
         "class instead.",
         since="0.46.0",
-        removal_timeline="Qiskit 1.0",
+        removal_timeline="in qiskit 1.0",
         package_name="qiskit",
     )
     def __init__(self):

--- a/qiskit/providers/fake_provider/fake_mumbai_v2.py
+++ b/qiskit/providers/fake_provider/fake_mumbai_v2.py
@@ -30,11 +30,19 @@ from qiskit.circuit.library.standard_gates import (
 from qiskit.providers.backend import BackendV2, QubitProperties
 from qiskit.providers.options import Options
 from qiskit.transpiler import Target, InstructionProperties
+from qiskit.utils.deprecation import deprecate_func
 
 
 class FakeMumbaiFractionalCX(BackendV2):
     """A fake mumbai backend."""
 
+    @deprecate_func(
+        additional_msg="Use the `qiskit.providers.basic_provider.GenericBackendV2` "
+        "class instead.",
+        since="0.46.0",
+        removal_timeline="Qiskit 1.0",
+        package_name="qiskit",
+    )
     def __init__(self):
         super().__init__(
             name="FakeMumbaiFractionalCX",

--- a/qiskit/providers/fake_provider/fake_provider.py
+++ b/qiskit/providers/fake_provider/fake_provider.py
@@ -31,7 +31,7 @@ class FakeProviderFactory:
 
     @deprecate_func(
         additional_msg="This class has been migrated to the `qiskit_ibm_runtime` package. "
-        "You should migrate your code to "
+        "To migrate your code, run `pip install qiskit-ibm-runtime` and "
         "use `from qiskit_ibm_runtime.fake_provider import FakeProviderExample` "
         "instead of `from qiskit.providers.fake_provider import FakeProviderExample`.",
         since="0.46.0",
@@ -98,10 +98,11 @@ class FakeProviderForBackendV2(ProviderV1):
 
     @deprecate_func(
         additional_msg="This class has been migrated to the `qiskit_ibm_runtime` package. "
-        "You should migrate your code to "
+        "To migrate your code, run `pip install qiskit-ibm-runtime` and "
         "use `from qiskit_ibm_runtime.fake_provider import FakeProviderExample` "
         "instead of `from qiskit.providers.fake_provider import FakeProviderExample`.",
         since="0.46.0",
+        removal_timeline="Qiskit 1.0",
         package_name="qiskit",
     )
     def __init__(self):
@@ -180,10 +181,11 @@ class FakeProvider(ProviderV1):
 
     @deprecate_func(
         additional_msg="This class has been migrated to the `qiskit_ibm_runtime` package. "
-        "You should migrate your code to "
+        "To migrate your code, run `pip install qiskit-ibm-runtime` and "
         "use `from qiskit_ibm_runtime.fake_provider import FakeProviderExample` "
         "instead of `from qiskit.providers.fake_provider import FakeProviderExample`.",
         since="0.46.0",
+        removal_timeline="Qiskit 1.0",
         package_name="qiskit",
     )
     def __init__(self):

--- a/qiskit/providers/fake_provider/fake_provider.py
+++ b/qiskit/providers/fake_provider/fake_provider.py
@@ -35,7 +35,7 @@ class FakeProviderFactory:
         "use `from qiskit_ibm_runtime.fake_provider import FakeProviderExample` "
         "instead of `from qiskit.providers.fake_provider import FakeProviderExample`.",
         since="0.46.0",
-        removal_timeline="Qiskit 1.0",
+        removal_timeline="in qiskit 1.0",
         package_name="qiskit",
     )
     def __init__(self):
@@ -102,7 +102,7 @@ class FakeProviderForBackendV2(ProviderV1):
         "use `from qiskit_ibm_runtime.fake_provider import FakeProviderExample` "
         "instead of `from qiskit.providers.fake_provider import FakeProviderExample`.",
         since="0.46.0",
-        removal_timeline="Qiskit 1.0",
+        removal_timeline="in qiskit 1.0",
         package_name="qiskit",
     )
     def __init__(self):
@@ -185,7 +185,7 @@ class FakeProvider(ProviderV1):
         "use `from qiskit_ibm_runtime.fake_provider import FakeProviderExample` "
         "instead of `from qiskit.providers.fake_provider import FakeProviderExample`.",
         since="0.46.0",
-        removal_timeline="Qiskit 1.0",
+        removal_timeline="in qiskit 1.0",
         package_name="qiskit",
     )
     def __init__(self):

--- a/qiskit/providers/fake_provider/fake_provider.py
+++ b/qiskit/providers/fake_provider/fake_provider.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019.
+# (C) Copyright IBM 2019, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -18,6 +18,7 @@ Fake provider class that provides access to fake backends.
 
 from qiskit.providers.provider import ProviderV1
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
+from qiskit.utils.deprecation import deprecate_func
 
 from .backends import *
 from .fake_qasm_simulator import FakeQasmSimulator
@@ -28,6 +29,15 @@ from .fake_openpulse_3q import FakeOpenPulse3Q
 class FakeProviderFactory:
     """Fake provider factory class."""
 
+    @deprecate_func(
+        additional_msg="This class has been migrated to the `qiskit_ibm_runtime` package. "
+        "You should migrate your code to "
+        "use `from qiskit_ibm_runtime.fake_provider import FakeProviderExample` "
+        "instead of `from qiskit.providers.fake_provider import FakeProviderExample`.",
+        since="0.46.0",
+        removal_timeline="Qiskit 1.0",
+        package_name="qiskit",
+    )
     def __init__(self):
         self.fake_provider = FakeProvider()
 
@@ -86,6 +96,14 @@ class FakeProviderForBackendV2(ProviderV1):
     def backends(self, name=None, **kwargs):
         return self._backends
 
+    @deprecate_func(
+        additional_msg="This class has been migrated to the `qiskit_ibm_runtime` package. "
+        "You should migrate your code to "
+        "use `from qiskit_ibm_runtime.fake_provider import FakeProviderExample` "
+        "instead of `from qiskit.providers.fake_provider import FakeProviderExample`.",
+        since="0.46.0",
+        package_name="qiskit",
+    )
     def __init__(self):
         self._backends = [
             FakeAlmadenV2(),
@@ -160,6 +178,14 @@ class FakeProvider(ProviderV1):
     def backends(self, name=None, **kwargs):
         return self._backends
 
+    @deprecate_func(
+        additional_msg="This class has been migrated to the `qiskit_ibm_runtime` package. "
+        "You should migrate your code to "
+        "use `from qiskit_ibm_runtime.fake_provider import FakeProviderExample` "
+        "instead of `from qiskit.providers.fake_provider import FakeProviderExample`.",
+        since="0.46.0",
+        package_name="qiskit",
+    )
     def __init__(self):
         self._backends = [
             FakeAlmaden(),

--- a/qiskit/providers/fake_provider/fake_provider.py
+++ b/qiskit/providers/fake_provider/fake_provider.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2023.
+# (C) Copyright IBM 2019, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit/providers/fake_provider/fake_pulse_backend.py
+++ b/qiskit/providers/fake_provider/fake_pulse_backend.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020.
+# (C) Copyright IBM 2020, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -29,6 +29,7 @@ class FakePulseBackend(FakeQasmBackend):
     defs_filename = None
 
     def __init__(self):
+        super().__init__()
         # This is a deprecation warning for the subclasses.
         # FakePulseBackend is not deprecated.
         warnings.warn(
@@ -41,7 +42,6 @@ class FakePulseBackend(FakeQasmBackend):
             category=DeprecationWarning,
             stacklevel=3,
         )
-        super().__init__()
 
     def defaults(self):
         """Returns a snapshot of device defaults"""

--- a/qiskit/providers/fake_provider/fake_pulse_backend.py
+++ b/qiskit/providers/fake_provider/fake_pulse_backend.py
@@ -33,14 +33,15 @@ class FakePulseBackend(FakeQasmBackend):
         # This is a deprecation warning for the subclasses.
         # FakePulseBackend is not deprecated.
         warnings.warn(
-            message="Device-specific fake backends have been migrated to the "
-            "`qiskit_ibm_runtime` package. These classes are deprecated "
-            "as of qiskit 0.46.0 and will be removed in qiskit 1.0.0. "
-            "You should migrate your code to use "
+            message="All fake backend instances based on real device snapshots (`FakeVigo`,"
+            "`FakeSherbrooke`,...) have been migrated to the `qiskit_ibm_runtime` package. "
+            "These classes are deprecated as of qiskit 0.46.0 and will be removed in qiskit 1.0.0. "
+            "To migrate your code, run `pip install qiskit-ibm-runtime` and use "
             "`from qiskit_ibm_runtime.fake_provider import FakeExample` "
-            "instead of `from qiskit.providers.fake_provider import FakeExample`.",
+            "instead of `from qiskit.providers.fake_provider import FakeExample`. "
+            "If you are using a custom fake backend implementation, you don't need to take any action.",
             category=DeprecationWarning,
-            stacklevel=3,
+            stacklevel=2,
         )
 
     def defaults(self):

--- a/qiskit/providers/fake_provider/fake_pulse_backend.py
+++ b/qiskit/providers/fake_provider/fake_pulse_backend.py
@@ -16,6 +16,7 @@ Fake backend abstract class for mock backends supporting OpenPulse.
 
 from qiskit.exceptions import QiskitError
 from qiskit.providers.models import PulseBackendConfiguration, PulseDefaults
+import warnings
 
 from .fake_qasm_backend import FakeQasmBackend
 from .utils.json_decoder import decode_pulse_defaults
@@ -25,6 +26,18 @@ class FakePulseBackend(FakeQasmBackend):
     """A fake pulse backend."""
 
     defs_filename = None
+
+    def __init__(self):
+        warnings.warn(
+            message="Device-specific fake backends have been migrated to the `qiskit_ibm_runtime` package. "
+            "These classes are deprecated as of qiskit 0.46.0 and will be removed in qiskit 1.0.0. "
+            "You should migrate your code to use "
+            "`from qiskit_ibm_runtime.fake_provider import FakeExample` "
+            "instead of `from qiskit.providers.fake_provider import FakeExample`.",
+            category=DeprecationWarning,
+            stacklevel=3,
+        )
+        super().__init__()
 
     def defaults(self):
         """Returns a snapshot of device defaults"""

--- a/qiskit/providers/fake_provider/fake_pulse_backend.py
+++ b/qiskit/providers/fake_provider/fake_pulse_backend.py
@@ -14,9 +14,10 @@
 Fake backend abstract class for mock backends supporting OpenPulse.
 """
 
+import warnings
+
 from qiskit.exceptions import QiskitError
 from qiskit.providers.models import PulseBackendConfiguration, PulseDefaults
-import warnings
 
 from .fake_qasm_backend import FakeQasmBackend
 from .utils.json_decoder import decode_pulse_defaults
@@ -28,9 +29,12 @@ class FakePulseBackend(FakeQasmBackend):
     defs_filename = None
 
     def __init__(self):
+        # This is a deprecation warning for the subclasses.
+        # FakePulseBackend is not deprecated.
         warnings.warn(
-            message="Device-specific fake backends have been migrated to the `qiskit_ibm_runtime` package. "
-            "These classes are deprecated as of qiskit 0.46.0 and will be removed in qiskit 1.0.0. "
+            message="Device-specific fake backends have been migrated to the "
+            "`qiskit_ibm_runtime` package. These classes are deprecated "
+            "as of qiskit 0.46.0 and will be removed in qiskit 1.0.0. "
             "You should migrate your code to use "
             "`from qiskit_ibm_runtime.fake_provider import FakeExample` "
             "instead of `from qiskit.providers.fake_provider import FakeExample`.",

--- a/qiskit/providers/fake_provider/fake_qasm_backend.py
+++ b/qiskit/providers/fake_provider/fake_qasm_backend.py
@@ -37,9 +37,12 @@ class FakeQasmBackend(FakeBackend):
     backend_name = None
 
     def __init__(self):
+        # This is a deprecation warning for the subclasses.
+        # FakeQasmBackend is not deprecated.
         warnings.warn(
-            message="Device-specific fake backends have been migrated to the `qiskit_ibm_runtime` package. "
-            "These classes are deprecated as of qiskit 0.46.0 and will be removed in qiskit 1.0.0. "
+            message="Device-specific fake backends have been migrated to the "
+            "`qiskit_ibm_runtime` package. These classes are deprecated "
+            "as of qiskit 0.46.0 and will be removed in qiskit 1.0.0. "
             "You should migrate your code to use "
             "`from qiskit_ibm_runtime.fake_provider import FakeExample` "
             "instead of `from qiskit.providers.fake_provider import FakeExample`.",

--- a/qiskit/providers/fake_provider/fake_qasm_backend.py
+++ b/qiskit/providers/fake_provider/fake_qasm_backend.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020.
+# (C) Copyright IBM 2020, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -16,6 +16,7 @@ Fake backend abstract class for mock backends.
 
 import json
 import os
+import warnings
 
 from qiskit.exceptions import QiskitError
 from qiskit.providers.models import BackendProperties, QasmBackendConfiguration
@@ -36,6 +37,15 @@ class FakeQasmBackend(FakeBackend):
     backend_name = None
 
     def __init__(self):
+        warnings.warn(
+            message="Device-specific fake backends have been migrated to the `qiskit_ibm_runtime` package. "
+            "These classes are deprecated as of qiskit 0.46.0 and will be removed in qiskit 1.0.0. "
+            "You should migrate your code to use "
+            "`from qiskit_ibm_runtime.fake_provider import FakeExample` "
+            "instead of `from qiskit.providers.fake_provider import FakeExample`.",
+            category=DeprecationWarning,
+            stacklevel=3,
+        )
         configuration = self._get_conf_from_json()
         self._defaults = None
         self._properties = None

--- a/qiskit/providers/fake_provider/fake_qasm_backend.py
+++ b/qiskit/providers/fake_provider/fake_qasm_backend.py
@@ -44,14 +44,15 @@ class FakeQasmBackend(FakeBackend):
         # This is a deprecation warning for the subclasses.
         # FakeQasmBackend is not deprecated.
         warnings.warn(
-            message="Device-specific fake backends have been migrated to the "
-            "`qiskit_ibm_runtime` package. These classes are deprecated "
-            "as of qiskit 0.46.0 and will be removed in qiskit 1.0.0. "
-            "You should migrate your code to use "
+            message="All fake backend instances based on real device snapshots (`FakeVigo`,"
+            "`FakeSherbrooke`,...) have been migrated to the `qiskit_ibm_runtime` package. "
+            "These classes are deprecated as of qiskit 0.46.0 and will be removed in qiskit 1.0.0. "
+            "To migrate your code, run `pip install qiskit-ibm-runtime` and use "
             "`from qiskit_ibm_runtime.fake_provider import FakeExample` "
-            "instead of `from qiskit.providers.fake_provider import FakeExample`.",
+            "instead of `from qiskit.providers.fake_provider import FakeExample`. "
+            "If you are using a custom fake backend implementation, you don't need to take any action.",
             category=DeprecationWarning,
-            stacklevel=3,
+            stacklevel=2,
         )
 
     def properties(self):

--- a/qiskit/providers/fake_provider/fake_qasm_backend.py
+++ b/qiskit/providers/fake_provider/fake_qasm_backend.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2023.
+# (C) Copyright IBM 2020, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -37,6 +37,10 @@ class FakeQasmBackend(FakeBackend):
     backend_name = None
 
     def __init__(self):
+        configuration = self._get_conf_from_json()
+        self._defaults = None
+        self._properties = None
+        super().__init__(configuration)
         # This is a deprecation warning for the subclasses.
         # FakeQasmBackend is not deprecated.
         warnings.warn(
@@ -49,10 +53,6 @@ class FakeQasmBackend(FakeBackend):
             category=DeprecationWarning,
             stacklevel=3,
         )
-        configuration = self._get_conf_from_json()
-        self._defaults = None
-        self._properties = None
-        super().__init__(configuration)
 
     def properties(self):
         """Returns a snapshot of device properties"""

--- a/qiskit/providers/fake_provider/fake_qasm_simulator.py
+++ b/qiskit/providers/fake_provider/fake_qasm_simulator.py
@@ -15,6 +15,7 @@ Fake OpenQASM simulator.
 """
 
 from qiskit.providers.models import GateConfig, QasmBackendConfiguration
+from qiskit.utils.deprecation import deprecate_func
 
 from .fake_backend import FakeBackend
 
@@ -22,6 +23,12 @@ from .fake_backend import FakeBackend
 class FakeQasmSimulator(FakeBackend):
     """A fake simulator backend."""
 
+    @deprecate_func(
+        additional_msg="Use the `qiskit.providers.basic_provider.BasicSimulator` " "class instead.",
+        since="0.46.0",
+        removal_timeline="Qiskit 1.0",
+        package_name="qiskit",
+    )
     def __init__(self):
         configuration = QasmBackendConfiguration(
             backend_name="fake_qasm_simulator",

--- a/qiskit/providers/fake_provider/fake_qasm_simulator.py
+++ b/qiskit/providers/fake_provider/fake_qasm_simulator.py
@@ -24,7 +24,7 @@ class FakeQasmSimulator(FakeBackend):
     """A fake simulator backend."""
 
     @deprecate_func(
-        additional_msg="Use the `qiskit.providers.basic_provider.BasicSimulator` " "class instead.",
+        additional_msg="Use the `qiskit.providers.basic_provider.BasicSimulator` class instead.",
         since="0.46.0",
         removal_timeline="Qiskit 1.0",
         package_name="qiskit",

--- a/qiskit/providers/fake_provider/fake_qasm_simulator.py
+++ b/qiskit/providers/fake_provider/fake_qasm_simulator.py
@@ -26,7 +26,7 @@ class FakeQasmSimulator(FakeBackend):
     @deprecate_func(
         additional_msg="Use the `qiskit.providers.basic_provider.BasicSimulator` class instead.",
         since="0.46.0",
-        removal_timeline="Qiskit 1.0",
+        removal_timeline="in qiskit 1.0",
         package_name="qiskit",
     )
     def __init__(self):

--- a/qiskit/providers/fake_provider/fake_qobj.py
+++ b/qiskit/providers/fake_provider/fake_qobj.py
@@ -23,6 +23,7 @@ from qiskit.qobj import (
     QasmQobjExperiment,
     QasmQobjConfig,
 )
+from qiskit.utils.deprecation import deprecate_func
 
 from .fake_qasm_simulator import FakeQasmSimulator
 
@@ -30,6 +31,12 @@ from .fake_qasm_simulator import FakeQasmSimulator
 class FakeQobj(QasmQobj):
     """A fake `Qobj` instance."""
 
+    @deprecate_func(
+        additional_msg="Use the `qiskit.qobj.QasmQobj` class instead.",
+        since="0.46.0",
+        removal_timeline="Qiskit 1.0",
+        package_name="qiskit",
+    )
     def __init__(self):
         qobj_id = "test_id"
         config = QasmQobjConfig(shots=1024, memory_slots=1)

--- a/qiskit/providers/fake_provider/fake_qobj.py
+++ b/qiskit/providers/fake_provider/fake_qobj.py
@@ -34,7 +34,7 @@ class FakeQobj(QasmQobj):
     @deprecate_func(
         additional_msg="Use the `qiskit.qobj.QasmQobj` class directly instead.",
         since="0.46.0",
-        removal_timeline="Qiskit 1.0",
+        removal_timeline="in qiskit 1.0",
         package_name="qiskit",
     )
     def __init__(self):

--- a/qiskit/providers/fake_provider/fake_qobj.py
+++ b/qiskit/providers/fake_provider/fake_qobj.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019.
+# (C) Copyright IBM 2019, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -32,7 +32,7 @@ class FakeQobj(QasmQobj):
     """A fake `Qobj` instance."""
 
     @deprecate_func(
-        additional_msg="Use the `qiskit.qobj.QasmQobj` class instead.",
+        additional_msg="Use the `qiskit.qobj.QasmQobj` class directly instead.",
         since="0.46.0",
         removal_timeline="Qiskit 1.0",
         package_name="qiskit",

--- a/qiskit/providers/fake_provider/utils/configurable_backend.py
+++ b/qiskit/providers/fake_provider/utils/configurable_backend.py
@@ -38,7 +38,7 @@ class ConfigurableFakeBackend(FakeBackend):
     @deprecate_func(
         since="0.46.0",
         additional_msg="Use a suitable FakeBackend instead.",
-        removal_timeline="Qiskit 1.0",
+        removal_timeline="in qiskit 1.0",
     )
     def __init__(
         self,

--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -261,10 +261,7 @@ class QiskitTestCase(BaseQiskitTestCase):
                 "default", category=DeprecationWarning, module="qiskit_aer.*", message=msg
             )
         # Ignore fake backend deprecation warnings to avoid over-crowding the test log
-        ignore_fake_backend_message = (
-            r"Device-specific fake backends have been migrated "
-            r"to the `qiskit_ibm_runtime` package.*"
-        )
+        ignore_fake_backend_message = r".*have been migrated to the `qiskit_ibm_runtime` package.*"
         warnings.filterwarnings(
             "ignore", category=DeprecationWarning, message=ignore_fake_backend_message
         )

--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -261,7 +261,10 @@ class QiskitTestCase(BaseQiskitTestCase):
                 "default", category=DeprecationWarning, module="qiskit_aer.*", message=msg
             )
         # Ignore fake backend deprecation warnings to avoid over-crowding the test log
-        ignore_fake_backend_message = r"Device-specific fake backends have been migrated to the `qiskit_ibm_runtime` package.*"
+        ignore_fake_backend_message = (
+            r"Device-specific fake backends have been migrated "
+            r"to the `qiskit_ibm_runtime` package.*"
+        )
         warnings.filterwarnings(
             "ignore", category=DeprecationWarning, message=ignore_fake_backend_message
         )

--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -261,7 +261,7 @@ class QiskitTestCase(BaseQiskitTestCase):
                 "default", category=DeprecationWarning, module="qiskit_aer.*", message=msg
             )
         # Ignore fake backend deprecation warnings to avoid over-crowding the test log
-        ignore_fake_backend_message = r".*been migrated to the `qiskit_ibm_runtime` package.*"
+        ignore_fake_backend_message = r".*have been migrated to the `qiskit_ibm_runtime` package.*"
         warnings.filterwarnings(
             "ignore", category=DeprecationWarning, message=ignore_fake_backend_message
         )

--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -245,7 +245,6 @@ class QiskitTestCase(BaseQiskitTestCase):
         ]
         for msg in allow_DeprecationWarning_message:
             warnings.filterwarnings("default", category=DeprecationWarning, message=msg)
-
         allow_aer_DeprecationWarning_message = [
             # This warning should be fixed once Qiskit/qiskit-aer#1761 is in a release version of Aer.
             "Setting metadata to None.*",
@@ -257,11 +256,15 @@ class QiskitTestCase(BaseQiskitTestCase):
             "The qiskit.extensions module is deprecated since Qiskit 0.46.0. It will be removed "
             "in the Qiskit 1.0 release.",
         ]
-
         for msg in allow_aer_DeprecationWarning_message:
             warnings.filterwarnings(
                 "default", category=DeprecationWarning, module="qiskit_aer.*", message=msg
             )
+        # Ignore fake backend deprecation warnings to avoid over-crowding the test log
+        ignore_fake_backend_message = r"Device-specific fake backends have been migrated to the `qiskit_ibm_runtime` package.*"
+        warnings.filterwarnings(
+            "ignore", category=DeprecationWarning, message=ignore_fake_backend_message
+        )
 
 
 class FullQiskitTestCase(QiskitTestCase):

--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -261,7 +261,7 @@ class QiskitTestCase(BaseQiskitTestCase):
                 "default", category=DeprecationWarning, module="qiskit_aer.*", message=msg
             )
         # Ignore fake backend deprecation warnings to avoid over-crowding the test log
-        ignore_fake_backend_message = r".*have been migrated to the `qiskit_ibm_runtime` package.*"
+        ignore_fake_backend_message = r".*been migrated to the `qiskit_ibm_runtime` package.*"
         warnings.filterwarnings(
             "ignore", category=DeprecationWarning, message=ignore_fake_backend_message
         )

--- a/releasenotes/notes/deprecate-fake-backends-4dd275cf9a30d41f.yaml
+++ b/releasenotes/notes/deprecate-fake-backends-4dd275cf9a30d41f.yaml
@@ -1,0 +1,50 @@
+---
+deprecations:
+  - |
+    The core functionality of the :mod:`qiskit.providers.fake_provider` module has been migrated to
+    the new ``qiskit_ibm_runtime.fake_provider`` module. For this reason, the following elements in
+    the :mod:`qiskit.providers.fake_provider` have been deprecated as of Qiskit 0.46 and will be
+    removed in Qiskit 1.0:
+
+      * :class:`qiskit.providers.fake_provider.FakeProvider`
+      * :class:`qiskit.providers.fake_provider.FakeProviderForBackendV2`
+      * :class:`qiskit.providers.fake_provider.FakeProviderFactory`
+      * any fake backend contained in :class:`qiskit.providers.fake_provider.backends`
+        (accesible through the provider)
+      * :class:`qiskit.providers.fake_provider.FakeQasmSimulator`
+      * :class:`qiskit.providers.fake_provider.FakeJob`
+      * :class:`qiskit.providers.fake_provider.FakeQobj`
+
+    Migration example to the new fake provider::
+
+      # Legacy path
+      from qiskit.providers.fake_provider import FakeProvider, FakeSherbrooke
+      backend1 = FakeProvider().get_backend("fake_ourense")
+      backend2 = FakeSherbrooke()
+
+      # New path
+      # run "pip install qiskit-ibm-runtime"
+      from qiskit_ibm_runtime.fake_provider import FakeProvider, FakeSherbrooke
+      backend1 = FakeProvider().get_backend("fake_ourense")
+      backend2 = FakeSherbrooke()
+
+    Additionally, the following fake backends designed for special testing purposes have been superseded
+    by the new :class:`.GenericBackendV2` class, and are also deprecated as of Qiskit 0.46:
+
+      * :class:`qiskit.providers.fake_provider.fake_backend_v2.FakeBackendV2`
+      * :class:`qiskit.providers.fake_provider.fake_backend_v2.FakeBackendV2LegacyQubitProps`
+      * :class:`qiskit.providers.fake_provider.fake_backend_v2.FakeBackend5QV2`
+      * :class:`qiskit.providers.fake_provider.fake_backend_v2.FakeBackendSimple`
+
+    Migration example to the new :class:`.GenericBackendV2` class::
+
+      # Legacy path
+      from qiskit.providers.fake_provider import FakeBackend5QV2
+      backend = FakeBackend5QV2()
+
+      # New path
+      from qiskit.providers.fake_provider import GenericBackendV2
+      backend = GenericBackendV2(num_qubits=5)
+      # note that this class will generate 5q backend with generic
+      # properties that serves the same purpose as FakeBackend5QV2
+      # but will generate different results

--- a/releasenotes/notes/deprecate-fake-backends-4dd275cf9a30d41f.yaml
+++ b/releasenotes/notes/deprecate-fake-backends-4dd275cf9a30d41f.yaml
@@ -9,6 +9,7 @@ deprecations:
       * :class:`qiskit.providers.fake_provider.FakeProvider`
       * :class:`qiskit.providers.fake_provider.FakeProviderForBackendV2`
       * :class:`qiskit.providers.fake_provider.FakeProviderFactory`
+      * :class:`qiskit.providers.fake_provider.fake_backends.FakeBackendV2`
       * any fake backend contained in :class:`qiskit.providers.fake_provider.backends`
         (accessible through the provider)
       * :class:`qiskit.providers.fake_provider.FakeQasmSimulator`

--- a/releasenotes/notes/deprecate-fake-backends-4dd275cf9a30d41f.yaml
+++ b/releasenotes/notes/deprecate-fake-backends-4dd275cf9a30d41f.yaml
@@ -1,8 +1,8 @@
 ---
 deprecations:
   - |
-    The core functionality of the :mod:`qiskit.providers.fake_provider` module has been migrated to
-    the new ``qiskit_ibm_runtime.fake_provider`` module. For this reason, the following elements in
+    The :mod:`qiskit.providers.fake_provider` module has been migrated to
+    the ``qiskit-ibm-runtime`` Python package. For this reason, the following elements in
     the :mod:`qiskit.providers.fake_provider` have been deprecated as of Qiskit 0.46 and will be
     removed in Qiskit 1.0:
 
@@ -10,7 +10,7 @@ deprecations:
       * :class:`qiskit.providers.fake_provider.FakeProviderForBackendV2`
       * :class:`qiskit.providers.fake_provider.FakeProviderFactory`
       * any fake backend contained in :class:`qiskit.providers.fake_provider.backends`
-        (accesible through the provider)
+        (accessible through the provider)
       * :class:`qiskit.providers.fake_provider.FakeQasmSimulator`
       * :class:`qiskit.providers.fake_provider.FakeJob`
       * :class:`qiskit.providers.fake_provider.FakeQobj`

--- a/releasenotes/notes/deprecate-fake-backends-4dd275cf9a30d41f.yaml
+++ b/releasenotes/notes/deprecate-fake-backends-4dd275cf9a30d41f.yaml
@@ -10,7 +10,7 @@ deprecations:
       * :class:`qiskit.providers.fake_provider.FakeProviderForBackendV2`
       * :class:`qiskit.providers.fake_provider.FakeProviderFactory`
       * :class:`qiskit.providers.fake_provider.fake_backends.FakeBackendV2`
-      * any fake backend contained in :class:`qiskit.providers.fake_provider.backends`
+      * any fake backend contained in :mod:`qiskit.providers.fake_provider.backends`
         (accessible through the provider)
       * :class:`qiskit.providers.fake_provider.FakeQasmSimulator`
       * :class:`qiskit.providers.fake_provider.FakeJob`

--- a/test/python/algorithms/test_backendv1.py
+++ b/test/python/algorithms/test_backendv1.py
@@ -31,7 +31,9 @@ class TestBackendV1(QiskitAlgorithmsTestCase):
 
     def setUp(self):
         super().setUp()
-        self._provider = FakeProvider()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            self._provider = FakeProvider()
         self._qasm = self._provider.get_backend("fake_qasm_simulator")
         self.seed = 50
 

--- a/test/python/algorithms/test_backendv2.py
+++ b/test/python/algorithms/test_backendv2.py
@@ -13,6 +13,7 @@
 """Test Providers that support BackendV2 interface"""
 
 import unittest
+import warnings
 from test.python.algorithms import QiskitAlgorithmsTestCase
 from qiskit import QuantumCircuit
 from qiskit.providers.fake_provider import FakeProvider
@@ -29,8 +30,10 @@ class TestBackendV2(QiskitAlgorithmsTestCase):
 
     def setUp(self):
         super().setUp()
-        self._provider = FakeProvider()
-        self._qasm = FakeBackendSimple()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            self._provider = FakeProvider()
+            self._qasm = FakeBackendSimple()
         self.seed = 50
 
     def test_vqe_qasm(self):

--- a/test/python/providers/test_backend_v2.py
+++ b/test/python/providers/test_backend_v2.py
@@ -14,6 +14,7 @@
 # pylint: disable=missing-module-docstring
 
 import math
+import warnings
 
 from test import combine
 
@@ -38,7 +39,9 @@ from qiskit.pulse import channels
 class TestBackendV2(QiskitTestCase):
     def setUp(self):
         super().setUp()
-        self.backend = FakeBackendV2()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            self.backend = FakeBackendV2()
 
     def assertMatchesTargetConstraints(self, tqc, target):
         qubit_indices = {qubit: index for index, qubit in enumerate(tqc.qubits)}
@@ -61,15 +64,19 @@ class TestBackendV2(QiskitTestCase):
 
     def test_legacy_qubit_properties(self):
         """Test that qubit props work for backends not using properties in target."""
-        props = FakeBackendV2LegacyQubitProps().qubit_properties([1, 0])
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            props = FakeBackendV2LegacyQubitProps().qubit_properties([1, 0])
         self.assertEqual([73.09352e-6, 63.48783e-6], [x.t1 for x in props])
         self.assertEqual([126.83382e-6, 112.23246e-6], [x.t2 for x in props])
         self.assertEqual([5.26722e9, 5.17538e9], [x.frequency for x in props])
 
     def test_no_qubit_properties_raises(self):
         """Ensure that if no qubit properties are defined we raise correctly."""
-        with self.assertRaises(NotImplementedError):
-            FakeBackendSimple().qubit_properties(0)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            with self.assertRaises(NotImplementedError):
+                FakeBackendSimple().qubit_properties(0)
 
     def test_option_bounds(self):
         """Test that option bounds are enforced."""
@@ -101,7 +108,9 @@ class TestBackendV2(QiskitTestCase):
         name="{gate}_level_{opt_level}_bidirectional_{bidirectional}",
     )
     def test_5q_ghz(self, opt_level, gate, bidirectional):
-        backend = FakeBackend5QV2(bidirectional)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            backend = FakeBackend5QV2(bidirectional)
         qc = QuantumCircuit(5)
         qc.h(0)
         getattr(qc, gate)(0, 1)
@@ -158,7 +167,9 @@ class TestBackendV2(QiskitTestCase):
 
     def test_transpile_mumbai_target(self):
         """Test that transpile respects a more involved target for a fake mumbai."""
-        backend = FakeMumbaiFractionalCX()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            backend = FakeMumbaiFractionalCX()
         qc = QuantumCircuit(2)
         qc.h(0)
         qc.cx(1, 0)

--- a/test/python/providers/test_backendconfiguration.py
+++ b/test/python/providers/test_backendconfiguration.py
@@ -27,7 +27,8 @@ class TestBackendConfiguration(QiskitTestCase):
 
     def setUp(self):
         super().setUp()
-        self.provider = FakeProvider()
+        with self.assertWarns(DeprecationWarning):
+            self.provider = FakeProvider()
         self.config = self.provider.get_backend("fake_openpulse_2q").configuration()
 
     def test_simple_config(self):

--- a/test/python/providers/test_backendproperties.py
+++ b/test/python/providers/test_backendproperties.py
@@ -27,7 +27,8 @@ class BackendpropertiesTestCase(QiskitTestCase):
 
     def setUp(self):
         super().setUp()
-        self.provider = FakeProvider()
+        with self.assertWarns(DeprecationWarning):
+            self.provider = FakeProvider()
         self.backend = self.provider.get_backend("fake_ourense")
         self.properties = self.backend.properties()
         self.ref_gate = next(

--- a/test/python/providers/test_fake_backends.py
+++ b/test/python/providers/test_fake_backends.py
@@ -17,6 +17,7 @@ import datetime
 import itertools
 import operator
 import unittest
+import warnings
 
 from test import combine
 from ddt import ddt, data
@@ -76,8 +77,10 @@ from qiskit.circuit.controlflow import (
     SwitchCaseOp,
 )
 
-FAKE_PROVIDER_FOR_BACKEND_V2 = FakeProviderForBackendV2()
-FAKE_PROVIDER = FakeProvider()
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    FAKE_PROVIDER_FOR_BACKEND_V2 = FakeProviderForBackendV2()
+    FAKE_PROVIDER = FakeProvider()
 
 
 @ddt

--- a/test/python/tools/monitor/test_backend_monitor.py
+++ b/test/python/tools/monitor/test_backend_monitor.py
@@ -61,7 +61,8 @@ class TestBackendOverview(QiskitTestCase):
             self.import_error = True
             qiskit.IBMQ = None
         self.ibmq_back = qiskit.IBMQ
-        qiskit.IBMQ = FakeProviderFactory()
+        with self.assertWarns(DeprecationWarning):
+            qiskit.IBMQ = FakeProviderFactory()
         self.addCleanup(self._restore_ibmq)
         if hasattr(providers, "ibmq"):
             self.prov_backup = providers.ibmq

--- a/test/python/transpiler/test_gates_in_basis_pass.py
+++ b/test/python/transpiler/test_gates_in_basis_pass.py
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Test GatesInBasis pass."""
+import warnings
 
 from qiskit.circuit import QuantumCircuit, ForLoopOp, IfElseOp, SwitchCaseOp, Clbit
 from qiskit.circuit.library import HGate, CXGate, UGate, XGate, ZGate
@@ -95,7 +96,9 @@ class TestGatesInBasisPass(QiskitTestCase):
 
     def test_all_gates_in_basis_with_target(self):
         """Test circuit with all gates in basis with target."""
-        target = FakeBackend5QV2().target
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            target = FakeBackend5QV2().target
         basis_gates = ["cx", "u"]  # not used
         property_set = {}
         analysis_pass = GatesInBasis(basis_gates, target=target)
@@ -108,7 +111,9 @@ class TestGatesInBasisPass(QiskitTestCase):
 
     def test_all_gates_not_in_basis_with_target(self):
         """Test circuit with not all gates in basis with target."""
-        target = FakeBackend5QV2().target
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            target = FakeBackend5QV2().target
         basis_gates = ["cx", "h"]
         property_set = {}
         analysis_pass = GatesInBasis(basis_gates, target=target)
@@ -121,7 +126,9 @@ class TestGatesInBasisPass(QiskitTestCase):
 
     def test_all_gates_in_basis_not_on_all_qubits_with_target(self):
         """Test circuit with gate in global basis but not local basis."""
-        target = FakeBackend5QV2().target
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            target = FakeBackend5QV2().target
         basis_gates = ["ecr", "cx", "h"]
         property_set = {}
         analysis_pass = GatesInBasis(basis_gates, target=target)
@@ -134,7 +141,9 @@ class TestGatesInBasisPass(QiskitTestCase):
 
     def test_all_gates_in_basis_empty_circuit_with_target(self):
         """Test circuit with no gates with target."""
-        target = FakeBackend5QV2().target
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            target = FakeBackend5QV2().target
         basis_gates = ["cx", "u"]
         property_set = {}
         analysis_pass = GatesInBasis(basis_gates, target=target)
@@ -187,7 +196,9 @@ class TestGatesInBasisPass(QiskitTestCase):
 
     def test_all_gates_in_basis_after_translation_with_target(self):
         """Test circuit with gates in basis after conditional translation."""
-        target = FakeBackend5QV2().target
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            target = FakeBackend5QV2().target
         basis_gates = ["cx", "u"]
         property_set = {}
         analysis_pass = GatesInBasis(basis_gates, target)

--- a/test/python/transpiler/test_high_level_synthesis.py
+++ b/test/python/transpiler/test_high_level_synthesis.py
@@ -16,6 +16,8 @@ Tests the interface for HighLevelSynthesis transpiler pass.
 
 
 import unittest.mock
+import warnings
+
 import numpy as np
 from qiskit.circuit import (
     QuantumCircuit,
@@ -463,17 +465,19 @@ class TestHighLevelSynthesisInterface(QiskitTestCase):
         qc.append(OpA(), [0])
 
         mock_plugin_manager = MockPluginManager
-        with unittest.mock.patch(
-            "qiskit.transpiler.passes.synthesis.high_level_synthesis.HighLevelSynthesisPluginManager",
-            wraps=mock_plugin_manager,
-        ):
-            hls_config = HLSConfig(op_a=["needs_coupling_map"])
-            pm_good = PassManager(
-                [HighLevelSynthesis(hls_config=hls_config, target=FakeBackend5QV2().target)]
-            )
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            with unittest.mock.patch(
+                "qiskit.transpiler.passes.synthesis.high_level_synthesis.HighLevelSynthesisPluginManager",
+                wraps=mock_plugin_manager,
+            ):
+                hls_config = HLSConfig(op_a=["needs_coupling_map"])
+                pm_good = PassManager(
+                    [HighLevelSynthesis(hls_config=hls_config, target=FakeBackend5QV2().target)]
+                )
 
-            # HighLevelSynthesis is initialized with target.
-            pm_good.run(qc)
+                # HighLevelSynthesis is initialized with target.
+                pm_good.run(qc)
 
     def test_qubits_get_passed_to_plugins(self):
         """Check that setting ``use_qubit_indices`` works correctly."""
@@ -855,7 +859,9 @@ class TestHighLevelSynthesisModifiers(QiskitTestCase):
         annotated_linear_function = AnnotatedOperation(linear_function, ControlModifier(1))
         qc = QuantumCircuit(3)
         qc.append(annotated_linear_function, [0, 1, 2])
-        backend = FakeBackend5QV2()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            backend = FakeBackend5QV2()
         qct = HighLevelSynthesis(target=backend.target)(qc)
         self.assertEqual(Operator(qc), Operator(qct))
 
@@ -868,7 +874,9 @@ class TestHighLevelSynthesisModifiers(QiskitTestCase):
         annotated_linear_function = AnnotatedOperation(linear_function, ControlModifier(1))
         qc = QuantumCircuit(3)
         qc.append(annotated_linear_function, [0, 1, 2])
-        backend = FakeBackend5QV2()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            backend = FakeBackend5QV2()
         qct = transpile(qc, target=backend.target)
         ops = qct.count_ops().keys()
         for op in ops:
@@ -883,7 +891,9 @@ class TestHighLevelSynthesisModifiers(QiskitTestCase):
         annotated_linear_function = AnnotatedOperation(linear_function, InverseModifier())
         qc = QuantumCircuit(3)
         qc.append(annotated_linear_function, [0, 1])
-        backend = FakeBackend5QV2()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            backend = FakeBackend5QV2()
         qct = HighLevelSynthesis(target=backend.target)(qc)
         self.assertEqual(Operator(qc), Operator(qct))
 
@@ -896,7 +906,9 @@ class TestHighLevelSynthesisModifiers(QiskitTestCase):
         annotated_linear_function = AnnotatedOperation(linear_function, InverseModifier())
         qc = QuantumCircuit(3)
         qc.append(annotated_linear_function, [0, 1])
-        backend = FakeBackend5QV2()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            backend = FakeBackend5QV2()
         qct = transpile(qc, target=backend.target)
         ops = qct.count_ops().keys()
         for op in ops:
@@ -911,7 +923,9 @@ class TestHighLevelSynthesisModifiers(QiskitTestCase):
         annotated_linear_function = AnnotatedOperation(linear_function, PowerModifier(3))
         qc = QuantumCircuit(3)
         qc.append(annotated_linear_function, [0, 1])
-        backend = FakeBackend5QV2()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            backend = FakeBackend5QV2()
         qct = HighLevelSynthesis(target=backend.target)(qc)
         self.assertEqual(Operator(qc), Operator(qct))
 
@@ -924,7 +938,9 @@ class TestHighLevelSynthesisModifiers(QiskitTestCase):
         annotated_linear_function = AnnotatedOperation(linear_function, PowerModifier(3))
         qc = QuantumCircuit(3)
         qc.append(annotated_linear_function, [0, 1])
-        backend = FakeBackend5QV2()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            backend = FakeBackend5QV2()
         qct = transpile(qc, target=backend.target)
         ops = qct.count_ops().keys()
         for op in ops:

--- a/test/python/transpiler/test_high_level_synthesis.py
+++ b/test/python/transpiler/test_high_level_synthesis.py
@@ -467,17 +467,18 @@ class TestHighLevelSynthesisInterface(QiskitTestCase):
         mock_plugin_manager = MockPluginManager
         with warnings.catch_warnings():
             warnings.filterwarnings(action="ignore", category=DeprecationWarning)
-            with unittest.mock.patch(
-                "qiskit.transpiler.passes.synthesis.high_level_synthesis.HighLevelSynthesisPluginManager",
-                wraps=mock_plugin_manager,
-            ):
-                hls_config = HLSConfig(op_a=["needs_coupling_map"])
-                pm_good = PassManager(
-                    [HighLevelSynthesis(hls_config=hls_config, target=FakeBackend5QV2().target)]
-                )
+            backend = FakeBackend5QV2()
+        with unittest.mock.patch(
+            "qiskit.transpiler.passes.synthesis.high_level_synthesis.HighLevelSynthesisPluginManager",
+            wraps=mock_plugin_manager,
+        ):
+            hls_config = HLSConfig(op_a=["needs_coupling_map"])
+            pm_good = PassManager(
+                [HighLevelSynthesis(hls_config=hls_config, target=backend.target)]
+            )
 
-                # HighLevelSynthesis is initialized with target.
-                pm_good.run(qc)
+            # HighLevelSynthesis is initialized with target.
+            pm_good.run(qc)
 
     def test_qubits_get_passed_to_plugins(self):
         """Check that setting ``use_qubit_indices`` works correctly."""

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -13,6 +13,7 @@
 # pylint: disable=missing-docstring
 
 import math
+import warnings
 
 from qiskit.circuit.library import (
     RZGate,
@@ -55,7 +56,9 @@ from qiskit.providers.fake_provider import (
 class TestTarget(QiskitTestCase):
     def setUp(self):
         super().setUp()
-        self.fake_backend = FakeBackendV2()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            self.fake_backend = FakeBackendV2()
         self.fake_backend_target = self.fake_backend.target
         self.theta = Parameter("theta")
         self.phi = Parameter("phi")
@@ -1052,7 +1055,9 @@ Instructions:
         self.assertFalse(self.ideal_sim_target.instruction_supported("cx", (0, 1, 2)))
 
     def test_instruction_supported_parameters(self):
-        mumbai = FakeMumbaiFractionalCX()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            mumbai = FakeMumbaiFractionalCX()
         self.assertTrue(
             mumbai.target.instruction_supported(
                 qargs=(0, 1), operation_class=RZXGate, parameters=[math.pi / 4]

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -15,6 +15,7 @@
 """
 Tests for the default UnitarySynthesis transpiler pass.
 """
+import warnings
 
 from test import combine
 import unittest
@@ -604,7 +605,9 @@ class TestUnitarySynthesis(QiskitTestCase):
         name="opt_level_{opt_level}_bidirectional_{bidirectional}",
     )
     def test_coupling_map_transpile_with_backendv2(self, opt_level, bidirectional):
-        backend = FakeBackend5QV2(bidirectional)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            backend = FakeBackend5QV2(bidirectional)
         qr = QuantumRegister(2)
         circ = QuantumCircuit(qr)
         circ.append(random_unitary(4, seed=1), [0, 1])
@@ -656,7 +659,9 @@ class TestUnitarySynthesis(QiskitTestCase):
         qr = QuantumRegister(2)
         circ = QuantumCircuit(qr)
         circ.append(random_unitary(4, seed=1), [1, 0])
-        backend = FakeBackend5QV2(bidirectional)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            backend = FakeBackend5QV2(bidirectional)
         tqc = transpile(
             circ,
             backend=backend,
@@ -681,7 +686,9 @@ class TestUnitarySynthesis(QiskitTestCase):
         qr = QuantumRegister(2)
         circ = QuantumCircuit(qr)
         circ.append(random_unitary(4, seed=1), [1, 0])
-        backend = FakeBackendV2()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            backend = FakeBackendV2()
         tqc = transpile(
             circ,
             backend=backend,
@@ -699,7 +706,9 @@ class TestUnitarySynthesis(QiskitTestCase):
         qr = QuantumRegister(2)
         circ = QuantumCircuit(qr)
         circ.append(random_unitary(4, seed=1), [0, 1])
-        backend = FakeMumbaiFractionalCX()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            backend = FakeMumbaiFractionalCX()
         synth_pass = UnitarySynthesis(target=backend.target)
         tqc = synth_pass(circ)
         tqc_index = {qubit: index for index, qubit in enumerate(tqc.qubits)}

--- a/test/python/visualization/test_gate_map.py
+++ b/test/python/visualization/test_gate_map.py
@@ -12,6 +12,7 @@
 
 """A test for visualizing device coupling maps"""
 import unittest
+import warnings
 
 from io import BytesIO
 from ddt import ddt, data
@@ -46,13 +47,15 @@ if optionals.HAS_PIL:
 class TestGateMap(QiskitVisualizationTestCase):
     """visual tests for plot_gate_map"""
 
-    backends = list(
-        filter(
-            lambda x: not x.configuration().simulator
-            and x.configuration().num_qubits in range(5, 21),
-            FakeProvider().backends(),
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        backends = list(
+            filter(
+                lambda x: not x.configuration().simulator
+                and x.configuration().num_qubits in range(5, 21),
+                FakeProvider().backends(),
+            )
         )
-    )
 
     @data(*backends)
     @unittest.skipIf(not optionals.HAS_MATPLOTLIB, "matplotlib not available.")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
**(1/2)** --> This is the first PR of the second step of the `FakeBackends` refactoring [epic](https://github.com/Qiskit/qiskit/issues/10954) in the main branch, it deprecates the snapshot-dependent fake backends as well as the fake provider. 

### Details and comments

This PR is blocked by:
- [x] #11670 (backport of #10266)
- [x] `qiskit-ibm-runtime` release including https://github.com/Qiskit/qiskit-ibm-runtime/pull/1270 -> to avoid deprecation warnings being raised when using the fake backends in `qiskit-ibm-runtime`, as this PR directly modifies the fake backend base classes currently shared with runtime. In principle people would use `qiskit-ibm-runtime` with `qiskit` 1.0, so it is unlikely that the warning would be raised, but it's a good safeguard to have. 

This PR is followed by:
- [ ] #11376 

Related PRs:
- [x] #10952
- [x] #10918 
