### PR TITLE
Added additional check related to SymbolicPulse disable_validation

### DIFF
--- a/qiskit/pulse/parameter_manager.py
+++ b/qiskit/pulse/parameter_manager.py
@@ -219,7 +219,8 @@ class ParameterSetter(NodeVisitor):
                 if isinstance(pval, ParameterExpression):
                     new_val = self._assign_parameter_expression(pval)
                     node._params[name] = new_val
-            node.validate_parameters()
+            if not node.disable_validation:
+                node.validate_parameters()
 
         return node
 

--- a/releasenotes/notes/symbolic-pulse-disable-validation-19cd8506b3a839b6.yaml
+++ b/releasenotes/notes/symbolic-pulse-disable-validation-19cd8506b3a839b6.yaml
@@ -5,7 +5,12 @@ upgrade:
     the class attribute :attr:`qiskit.pulse.SymbolicPulse.disable_validation` to ``False``
     the method :meth:`validate_parameters` will not be triggered for all `SymbolicPulse` objects.
     The automatic validation hindered JAX compatibility of the symbolic pulse library, and this
-    upgrade will make it easier to use Qiskit Pulse with JAX.
+    upgrade will make it easier to use Qiskit Pulse with JAX. Moreover, the parameter validation will also be
+    deactivated when using the :meth:`qiskit.pulse.Schedule.assign_parameters` and
+    :meth:`qiskit.pulse.ScheduleBlock.assign_parameters` methods. This constitutes a first
+    step towards a more general parameter validation mechanism, which will be implemented in the future to enable
+    JAX compatibility of the `ParameterExpression` class, such that parametrized schedules can be generated within a
+    JAX framework.
 
     Note that all library pulses automatically called :meth:`validate_parameters`. However, as part
     of the upgrade the call was moved directly to the initialization process of

--- a/test/python/pulse/test_parameter_manager.py
+++ b/test/python/pulse/test_parameter_manager.py
@@ -18,7 +18,6 @@ from copy import deepcopy
 from unittest.mock import patch
 
 import numpy as np
-from qiskit.pulse.library import Gaussian
 
 from qiskit import pulse
 from qiskit.circuit import Parameter
@@ -427,14 +426,25 @@ class TestParameterSetter(ParameterTestBase):
         """
         sig = Parameter("sigma")
         test_sched = pulse.ScheduleBlock()
-        test_sched.append(pulse.Play(pulse.Gaussian(duration=100,amp=0.5, sigma= sig, angle=0.),
-                                     pulse.DriveChannel(0)), inplace=True)
+        test_sched.append(
+            pulse.Play(
+                pulse.Gaussian(duration=100, amp=0.5, sigma=sig, angle=0.0), pulse.DriveChannel(0)
+            ),
+            inplace=True,
+        )
         with self.assertRaises(PulseError):
             test_sched.assign_parameters({sig: -1.0}, inplace=False)
-        with patch("qiskit.pulse.library.symbolic_pulses.SymbolicPulse.disable_validation", new=True):
+        with patch(
+            "qiskit.pulse.library.symbolic_pulses.SymbolicPulse.disable_validation", new=True
+        ):
             test_sched = pulse.ScheduleBlock()
-            test_sched.append(pulse.Play(pulse.Gaussian(duration=100, amp=0.5, sigma=sig, angle=0.),
-                                         pulse.DriveChannel(0)), inplace=True)
+            test_sched.append(
+                pulse.Play(
+                    pulse.Gaussian(duration=100, amp=0.5, sigma=sig, angle=0.0),
+                    pulse.DriveChannel(0),
+                ),
+                inplace=True,
+            )
             binded_sched = test_sched.assign_parameters({sig: -1.0}, inplace=False)
             self.assertLess(binded_sched.instructions[0][1].pulse.sigma, 0)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
We add here an additional check for validating parameters of the parameter_manager for the pulse level for the specific case of SymbolicPulse, which now has a class attribute disable_validation (check this PR: https://github.com/Qiskit/qiskit/pull/11029)



### Details and comments

This PR aims to bring consistency in the effort of enabling the user to choose if parameter validation should be performed. This would also constitute a first step towards enabling pulse parameter assignment within a JAX framework, to enable faster simulations of pulse schedules with Qiskit Dynamics for example.
