### PR TITLE
Document how to use high level synthesis plugins

### DIFF
--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -146,6 +146,7 @@ Synthesis
    LinearFunctionsSynthesis
    LinearFunctionsToPermutations
    HighLevelSynthesis
+   HLSConfig
    SolovayKitaev
    SolovayKitaevSynthesis
 
@@ -253,6 +254,7 @@ from .synthesis import unitary_synthesis_plugin_names
 from .synthesis import LinearFunctionsSynthesis
 from .synthesis import LinearFunctionsToPermutations
 from .synthesis import HighLevelSynthesis
+from .synthesis import HLSConfig
 from .synthesis import SolovayKitaev
 from .synthesis import SolovayKitaevSynthesis
 

--- a/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
@@ -53,17 +53,23 @@ from .plugin import HighLevelSynthesisPluginManager, HighLevelSynthesisPlugin
 class HLSConfig:
     """The high-level-synthesis config allows to specify a list of "methods" used by
     :class:`~.HighLevelSynthesis` transformation pass to synthesize different types
-    of higher-level-objects. A higher-level object is an object of type
-    :class:`~.Operation` (e.g., "clifford", "linear_function", etc.), and the list
-    of applicable synthesis methods is strictly tied to the name of the operation.
-    In the config, each method is specified as a tuple consisting of the name of the
-    synthesis algorithm and of a dictionary providing additional arguments for this
-    algorithm. Additionally, a synthesis method can be specified as a tuple consisting
-    of an instance of :class:`.HighLevelSynthesisPlugin` and additional arguments.
-    Moreover, when there are no additional arguments, a synthesis
-    method can be specified simply by name or by an instance
-    of :class:`.HighLevelSynthesisPlugin`. The following example illustrates different
-    ways how a config file can be created::
+    of higher-level objects.
+
+    A higher-level object is an object of type :class:`~.Operation` (e.g., :class:`.Clifford` or
+    :class:`.LinearFunction`).  Each object is referred to by its :attr:`~.Operation.name` field
+    (e.g., ``"clifford"`` for :class:`.Clifford` objects), and the applicable synthesis methods are
+    tied to this name.
+
+    In the config, each method is specified in one of several ways:
+
+    1. a tuple consisting of the name of a known synthesis plugin and a dictionary providing
+       additional arguments for the algorithm.
+    2. a tuple consisting of an instance of :class:`.HighLevelSynthesisPlugin` and additional
+       arguments for the algorithm.
+    3. a single string of a known synthesis plugin
+    4. a single instance of :class:`.HighLevelSynthesisPlugin`.
+
+    The following example illustrates different ways how a config file can be created::
 
         from qiskit.transpiler.passes.synthesis.high_level_synthesis import HLSConfig
         from qiskit.transpiler.passes.synthesis.high_level_synthesis import ACGSynthesisPermutation
@@ -74,7 +80,7 @@ class HLSConfig:
         hls_config = HLSConfig(permutation=[(ACGSynthesisPermutation(), {})])
         hls_config = HLSConfig(permutation=[ACGSynthesisPermutation()])
 
-    The names of the synthesis algorithms should be declared in ``entry-points`` table for
+    The names of the synthesis plugins should be declared in ``entry-points`` table for
     ``qiskit.synthesis`` in ``pyproject.toml``, in the form
     <higher-level-object-name>.<synthesis-method-name>.
 
@@ -84,8 +90,11 @@ class HLSConfig:
 
     To avoid synthesizing a given higher-level-object, one can give it an empty list of methods.
 
-    For an explicit example of using such config files, refer to the
-    documentation for :class:`~.HighLevelSynthesis`.
+    For an explicit example of using such config files, refer to the documentation for
+    :class:`~.HighLevelSynthesis`.
+
+    For an overview of the complete process of using high-level synthesis, see
+    :ref:`using-high-level-synthesis-plugins`.
     """
 
     def __init__(self, use_default_on_unspecified=True, **kwargs):

--- a/qiskit/transpiler/passes/synthesis/plugin.py
+++ b/qiskit/transpiler/passes/synthesis/plugin.py
@@ -302,6 +302,7 @@ High-Level Synthesis Plugins
 """
 
 import abc
+from typing import List
 
 import stevedore
 

--- a/qiskit/transpiler/passes/synthesis/plugin.py
+++ b/qiskit/transpiler/passes/synthesis/plugin.py
@@ -258,7 +258,12 @@ For example::
 creates a high-level synthesis configuration that uses the ``acg`` plugin
 for synthesizing :class:`.PermutationGate` objects, the ``layers`` plugin
 for synthesizing :class:`.Clifford` objects, and the ``pmh`` plugin for synthesizing
-:class:`.LinearFunction` objects.
+:class:`.LinearFunction` objects.  The keyword arguments are the :attr:`.Operation.name` fields of
+the relevant objects.  For example, all :class:`.Clifford` operations have the
+:attr:`~.Operation.name` ``clifford``, so this is used as the keyword argument.  You can specify
+any keyword argument here that you have installed plugins to handle, including custom user objects
+if you have plugins installed for them.
+
 For each high-level object, the list of given plugins are tried in sequence until one of them
 succeeds (in the example above, each list only contains a single plugin). In addition to specifying
 a plugin by its name, you can instead pass a ``(name, options)`` tuple, where the second element of
@@ -268,13 +273,13 @@ Once created you then pass this :class:`.HLSConfig` object into the
 ``hls_config`` argument for :func:`.transpile` or :func:`.generate_preset_pass_manager`
 which will use the specified plugins as part of the larger compilation workflow.
 
-To get a list of installed high level synthesis plugins you can use the
-:func:`.high_level_synthesis_plugin_names` function to get the list of plugins
-for a given high level object. For example::
+To get a list of installed high level synthesis plugins for any given :attr:`.Operation.name`, you
+can use the :func:`.high_level_synthesis_plugin_names` function, passing the desired ``name`` as the
+argument::
 
     high_level_synthesis_plugin_names("clifford")
 
-will return a list of all the installed clifford synthesis plugins.
+will return a list of all the installed Clifford synthesis plugins.
 
 Plugin API
 ==========
@@ -639,6 +644,7 @@ def high_level_synthesis_plugin_names(op_name: str) -> List[str]:
         op_name: The operation name to find the installed plugins for. For example,
             if you provide ``"clifford"`` as the input it will find all the installed
             clifford synthesis plugins that can synthesize :class:`.Clifford` objects.
+            The name refers to the :attr:`.Operation.name` attribute of the relevant objects.
 
     Returns:
         A list of installed plugin names for the specified high level operation

--- a/qiskit/transpiler/passes/synthesis/plugin.py
+++ b/qiskit/transpiler/passes/synthesis/plugin.py
@@ -259,7 +259,10 @@ creates a high-level synthesis configuration that uses the ``acg`` plugin
 for synthesizing :class:`.PermutationGate` objects, the ``layers`` plugin
 for synthesizing :class:`.Clifford` objects, and the ``pmh`` plugin for synthesizing
 :class:`.LinearFunction` objects.
-For each high-level object, the list of given plugins are tried in sequence until one of them succeeds (in the example above, each list only contains a single plugin). In addition to specifying a plugin by its name, you can instead pass a ``(name, options)`` tuple, where the second element of the tuple is a dictionary containing options for the plugin.
+For each high-level object, the list of given plugins are tried in sequence until one of them
+succeeds (in the example above, each list only contains a single plugin). In addition to specifying
+a plugin by its name, you can instead pass a ``(name, options)`` tuple, where the second element of
+the tuple is a dictionary containing options for the plugin.
 
 Once created you then pass this :class:`.HLSConfig` object into the
 ``hls_config`` argument for :func:`.transpile` or :func:`.generate_preset_pass_manager`

--- a/qiskit/transpiler/passes/synthesis/plugin.py
+++ b/qiskit/transpiler/passes/synthesis/plugin.py
@@ -259,7 +259,7 @@ creates a high-level synthesis configuration that uses the ``acg`` plugin
 for synthesizing :class:`.PermutationGate` objects, the ``layers`` plugin
 for synthesizing :class:`.Clifford` objects, and the ``pmh`` plugin for synthesizing
 :class:`.LinearFunction` objects.
-For each high-level object, the list of given plugins are tried in sequence until one of them succeeds (in the example above, each list only contains a single plugin). In addition to specifying a plugin by its name, one can also instead pass a ``(name, options)`` tuple, where the second element of the tuple contains options for the plugin.
+For each high-level object, the list of given plugins are tried in sequence until one of them succeeds (in the example above, each list only contains a single plugin). In addition to specifying a plugin by its name, you can instead pass a ``(name, options)`` tuple, where the second element of the tuple is a dictionary containing options for the plugin.
 
 Once created you then pass this :class:`.HLSConfig` object into the
 ``hls_config`` argument for :func:`.transpile` or :func:`.generate_preset_pass_manager`

--- a/qiskit/transpiler/passes/synthesis/plugin.py
+++ b/qiskit/transpiler/passes/synthesis/plugin.py
@@ -246,23 +246,20 @@ To get the installed list of installed unitary synthesis plugins you can use the
 :func:`qiskit.transpiler.passes.synthesis.plugin.unitary_synthesis_plugin_names`
 function.
 
-High Level Synthesis Plugins
+High-level Synthesis Plugins
 ----------------------------
 
-To use a high level synthesis you leverage the :class:`.HLSConfig` class to
-create an input configuration for how to synthesize multiple high level
-plugins. For example::
+To use a high-level synthesis plugin, you first instantiate an :class:`.HLSConfig` to
+store the names of the plugins to use for various high-level objects.
+For example::
 
     HLSConfig(permutation=["acg"], clifford=["layers"], linear_function=["pmh"])
 
-will create a high level synthesis configuration that will use the ``acg`` plugin
+creates a high-level synthesis configuration that uses the ``acg`` plugin
 for synthesizing :class:`.PermutationGate` objects, the ``layers`` plugin
 for synthesizing :class:`.Clifford` objects, and the ``pmh`` plugin for synthesizing
-:class:`.LinearFunction` objects. The :class:`.HLSConfig` class
-has the flexibility to specify multiple plugins in sequence which will enable
-trying multiple synthesis plugins and using the first one that successsfully
-synthesizes the object and also to pass tuples of the plugin along with options
-to adjust the behavior of the synthesis plugin.
+:class:`.LinearFunction` objects.
+For each high-level object, the list of given plugins are tried in sequence until one of them succeeds (in the example above, each list only contains a single plugin). In addition to specifying a plugin by its name, one can also instead pass a ``(name, options)`` tuple, where the second element of the tuple contains options for the plugin.
 
 Once created you then pass this :class:`.HLSConfig` object into the
 ``hls_config`` argument for :func:`.transpile` or :func:`.generate_preset_pass_manager`

--- a/qiskit/transpiler/passes/synthesis/plugin.py
+++ b/qiskit/transpiler/passes/synthesis/plugin.py
@@ -246,6 +246,8 @@ To get the installed list of installed unitary synthesis plugins you can use the
 :func:`qiskit.transpiler.passes.synthesis.plugin.unitary_synthesis_plugin_names`
 function.
 
+.. _using-high-level-synthesis-plugins:
+
 High-level Synthesis Plugins
 ----------------------------
 
@@ -262,7 +264,8 @@ for synthesizing :class:`.Clifford` objects, and the ``pmh`` plugin for synthesi
 the relevant objects.  For example, all :class:`.Clifford` operations have the
 :attr:`~.Operation.name` ``clifford``, so this is used as the keyword argument.  You can specify
 any keyword argument here that you have installed plugins to handle, including custom user objects
-if you have plugins installed for them.
+if you have plugins installed for them.  See :class:`.HLSConfig` for more detail on alternate
+formats for configuring the plugins within each argument.
 
 For each high-level object, the list of given plugins are tried in sequence until one of them
 succeeds (in the example above, each list only contains a single plugin). In addition to specifying

--- a/releasenotes/notes/high-level-synthesis-plugin-list-beff523921c4c4eb.yaml
+++ b/releasenotes/notes/high-level-synthesis-plugin-list-beff523921c4c4eb.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Added a new function, :func:`.high_level_synthesis_plugin_names` that is
+    used to get the list of installed high level synthesis plugins for a given
+    operation name.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds missing documentation to the transpiler synthesis plugin page on how to use the high level synthesis plugin interface. There was existing documentation on how to write a high level synthesis plugin but not for how users can consume any installed plugins. This commit fills that documentation gap and also adds the HLSConfig class to the documentation as a stable defined interface. This was an oversight as we've not been treating the API interface as stable as it's the primary entrypoint for using high level synthesis plugins. Additionally, a new function high_level_synthesis_plugin_names is added in this PR to make querying the installed plugins a bit easier as to do this before you had to instantiate a plugin manager object to do this. This makes the querying interface similar to what exists for unitary synthesis.

### Details and comments

Fixes #11356
Fixes https://github.com/Qiskit/documentation/issues/505