### PR TITLE
add CommuteMinimumDepth transpiler pass

### DIFF
--- a/qiskit/converters/dagdependency_to_circuit.py
+++ b/qiskit/converters/dagdependency_to_circuit.py
@@ -32,11 +32,12 @@ def dagdependency_to_circuit(dagdependency):
         *dagdependency.cregs.values(),
         name=name,
     )
+
     circuit.metadata = dagdependency.metadata
 
     circuit.calibrations = dagdependency.calibrations
-
-    for node in dagdependency.topological_nodes():
-        circuit._append(CircuitInstruction(node.op.copy(), node.qargs, node.cargs))
+    depths = sorted(dagdependency.node_depths().items(), key=lambda x: x[1])
+    for node in depths:
+        circuit._append(CircuitInstruction(node[0].op.copy(), node[0].qargs, node[0].cargs))
 
     return circuit

--- a/qiskit/converters/dagdependency_to_dag.py
+++ b/qiskit/converters/dagdependency_to_dag.py
@@ -37,10 +37,12 @@ def dagdependency_to_dag(dagdependency):
     for register in dagdependency.cregs.values():
         dagcircuit.add_creg(register)
 
-    for node in dagdependency.topological_nodes():
+    depths = sorted(dagdependency.node_depths().items(), key=lambda x: x[1])
+
+    for node in depths:
         # Get arguments for classical control (if any)
-        inst = node.op.copy()
-        dagcircuit.apply_operation_back(inst, node.qargs, node.cargs)
+        inst = node[0].op.copy()
+        dagcircuit.apply_operation_back(inst, node[0].qargs, node[0].cargs)
 
     # copy metadata
     dagcircuit.global_phase = dagdependency.global_phase

--- a/qiskit/dagcircuit/dagdependency.py
+++ b/qiskit/dagcircuit/dagdependency.py
@@ -173,6 +173,31 @@ class DAGDependency:
         depth = rx.dag_longest_path_length(self._multi_graph)
         return depth if depth >= 0 else 0
 
+    def node_depths(self):
+        """Get the depth of each node in the dag.
+
+        Returns:
+            A dictionary of (DAGDepNode,int)
+        """
+        depths = [0] * self.size()
+
+        def dfs(nd, p):
+            # print((nd,p))
+            if depths[p] + 1 > depths[nd]:
+                depths[nd] = max(depths[nd], depths[p] + 1)
+                for c in self.direct_successors(nd):
+                    dfs(c, nd)
+
+        sources = [
+            nd.node_id
+            for nd in list(self.get_nodes())
+            if len(self.direct_predecessors(nd.node_id)) == 0
+        ]
+        for i in sources:
+            for c in self.direct_successors(i):
+                dfs(c, i)
+        return dict(zip(list(self.get_nodes()), depths))
+
     def add_qubits(self, qubits):
         """Add individual qubit wires."""
         if any(not isinstance(qubit, Qubit) for qubit in qubits):

--- a/qiskit/dagcircuit/dagdependency.py
+++ b/qiskit/dagcircuit/dagdependency.py
@@ -179,7 +179,7 @@ class DAGDependency:
         Returns:
             A dictionary of (DAGDepNode,int)
         """
-        depths = [0] * self.size()
+        depths = {k.node_id: 0 for k in self.get_nodes()}
 
         def dfs(nd, p):
             # print((nd,p))
@@ -195,7 +195,7 @@ class DAGDependency:
         ]
         for i in sources:
             dfs(i, i)
-        return dict(zip(list(self.get_nodes()), depths))
+        return {self.get_node(nd): v for nd, v in zip(depths.keys(), depths.values())}
 
     def add_qubits(self, qubits):
         """Add individual qubit wires."""

--- a/qiskit/dagcircuit/dagdependency.py
+++ b/qiskit/dagcircuit/dagdependency.py
@@ -194,7 +194,7 @@ class DAGDependency:
             if len(self.direct_predecessors(nd.node_id)) == 0
         ]
         for i in sources:
-            dfs(i,i)
+            dfs(i, i)
         return dict(zip(list(self.get_nodes()), depths))
 
     def add_qubits(self, qubits):

--- a/qiskit/dagcircuit/dagdependency.py
+++ b/qiskit/dagcircuit/dagdependency.py
@@ -194,8 +194,7 @@ class DAGDependency:
             if len(self.direct_predecessors(nd.node_id)) == 0
         ]
         for i in sources:
-            for c in self.direct_successors(i):
-                dfs(c, i)
+            dfs(i,i)
         return dict(zip(list(self.get_nodes()), depths))
 
     def add_qubits(self, qubits):

--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -90,6 +90,7 @@ Optimizations
    ResetAfterMeasureSimplification
    OptimizeCliffords
    NormalizeRXAngle
+   CommuteMinimumDepth
 
 Calibration
 =============
@@ -236,6 +237,7 @@ from .optimization import CollectCliffords
 from .optimization import ResetAfterMeasureSimplification
 from .optimization import OptimizeCliffords
 from .optimization import NormalizeRXAngle
+from .optimization import CommuteMinimumDepth
 
 # circuit analysis
 from .analysis import ResourceEstimation

--- a/qiskit/transpiler/passes/optimization/__init__.py
+++ b/qiskit/transpiler/passes/optimization/__init__.py
@@ -20,6 +20,7 @@ from .consolidate_blocks import ConsolidateBlocks
 from .commutation_analysis import CommutationAnalysis
 from .commutative_cancellation import CommutativeCancellation
 from .commutative_inverse_cancellation import CommutativeInverseCancellation
+from .commute_minimum_depth import CommuteMinimumDepth
 from .cx_cancellation import CXCancellation
 from .optimize_1q_commutation import Optimize1qGatesSimpleCommutation
 from .optimize_swap_before_measure import OptimizeSwapBeforeMeasure

--- a/qiskit/transpiler/passes/optimization/commute_minimum_depth.py
+++ b/qiskit/transpiler/passes/optimization/commute_minimum_depth.py
@@ -22,7 +22,7 @@ class CommuteMinimumDepth(TransformationPass):
     and then back to a class:`~DagCircuit`.
 
     The optimization is done in the conversion from the class:`~DagDependency`
-    to the class:`~DagCircuit
+    to the class:`~DagCircuit`.
     """
 
     def run(self, dag):

--- a/qiskit/transpiler/passes/optimization/commute_minimum_depth.py
+++ b/qiskit/transpiler/passes/optimization/commute_minimum_depth.py
@@ -1,0 +1,38 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+
+"""Commute gates to reduce circuit depth."""
+
+from qiskit import converters
+from qiskit.transpiler.basepasses import TransformationPass
+
+
+class CommuteMinimumDepth(TransformationPass):
+    r"""This pass converts a class:`~DagCircuit` to a class:`~DagDependency`
+    and then back to a class:`~DagCircuit`.
+
+    The optimization is done in the conversion from the class:`~DagDependency`
+    to the class:`~DagCircuit
+    """
+
+    def run(self, dag):
+        """Run the CommuteMinimumDepth pass on `dag`.
+
+        Args:
+            dag (DAGCircuit): the DAG to be optimized.
+        
+        Returns:
+            DAGCircuit: the optimized DAG.
+        """
+        return converters.dagdependency_to_circuit(converters.circuit_to_dagdependency(dag))
+        

--- a/qiskit/transpiler/passes/optimization/commute_minimum_depth.py
+++ b/qiskit/transpiler/passes/optimization/commute_minimum_depth.py
@@ -30,9 +30,8 @@ class CommuteMinimumDepth(TransformationPass):
 
         Args:
             dag (DAGCircuit): the DAG to be optimized.
-        
+
         Returns:
             DAGCircuit: the optimized DAG.
         """
-        return converters.dagdependency_to_circuit(converters.circuit_to_dagdependency(dag))
-        
+        return converters.dagdependency_to_dag(converters.dag_to_dagdependency(dag))

--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -40,6 +40,7 @@ from qiskit.transpiler.passes.optimization import (
     Collect2qBlocks,
     ConsolidateBlocks,
     InverseCancellation,
+    CommuteMinimumDepth
 )
 from qiskit.transpiler.passes import Depth, Size, FixedPoint, MinimumPoint
 from qiskit.transpiler.passes.utils.gates_basis import GatesInBasis
@@ -591,6 +592,7 @@ class OptimizationPassManager(PassManagerStagePlugin):
                         basis=pass_manager_config.basis_gates, target=pass_manager_config.target
                     ),
                     CommutativeCancellation(target=pass_manager_config.target),
+                    CommuteMinimumDepth()
                 ]
 
                 def _opt_control(property_set):

--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -40,7 +40,7 @@ from qiskit.transpiler.passes.optimization import (
     Collect2qBlocks,
     ConsolidateBlocks,
     InverseCancellation,
-    CommuteMinimumDepth
+    CommuteMinimumDepth,
 )
 from qiskit.transpiler.passes import Depth, Size, FixedPoint, MinimumPoint
 from qiskit.transpiler.passes.utils.gates_basis import GatesInBasis
@@ -592,7 +592,7 @@ class OptimizationPassManager(PassManagerStagePlugin):
                         basis=pass_manager_config.basis_gates, target=pass_manager_config.target
                     ),
                     CommutativeCancellation(target=pass_manager_config.target),
-                    CommuteMinimumDepth()
+                    CommuteMinimumDepth(),
                 ]
 
                 def _opt_control(property_set):

--- a/releasenotes/notes/add-commute-minimum-depth-c965fa6a7812e85b.yaml
+++ b/releasenotes/notes/add-commute-minimum-depth-c965fa6a7812e85b.yaml
@@ -1,0 +1,22 @@
+---
+prelude: >
+    Add CommuteMinimumDepth transpiler pass
+features:
+  - |
+    Updated :meth:`~.converters.dagdependency_to_circuit() to return the circuit with
+    minimum depth. It traverses the DAG, sorts each node by it's
+    depth, and converts the DAG back into a circuit with optimal depth.
+
+  - |
+    Introduced a new transpiler pass CommuteMinimumDepth as proposed in `#7387 <https://github.com/Qiskit/qiskit/issues/7387>`, 
+    this optimizes the depth of circuits by commuting gates. It converts the 
+    circuit to a dagdependency and back. This can possiby improve performance 
+    of other TransformationPasses. This pass was added to the preset pass 
+    manager for optimization level 3 (I have no idea if I did this correctly 
+    so please feel free to advise).
+
+other:
+  - |
+    The :meth:`~.converters.dagdependency_to_circuit() uses DFS, which is done
+    with python instead of rustworkx. This was done because the same edge may
+    need to be traversed multiple times, which I am not sure rustworkx supports.

--- a/releasenotes/notes/add-commute-minimum-depth-c965fa6a7812e85b.yaml
+++ b/releasenotes/notes/add-commute-minimum-depth-c965fa6a7812e85b.yaml
@@ -3,7 +3,7 @@ prelude: >
     Add CommuteMinimumDepth transpiler pass
 features:
   - |
-    Updated :meth:`~.converters.dagdependency_to_circuit() to return the circuit with
+    Updated :meth:`~.converters.dagdependency_to_circuit()` to return the circuit with
     minimum depth. It traverses the DAG, sorts each node by it's
     depth, and converts the DAG back into a circuit with optimal depth.
 
@@ -17,6 +17,6 @@ features:
 
 other:
   - |
-    The :meth:`~.converters.dagdependency_to_circuit() uses DFS, which is done
+    The :meth:`~.converters.dagdependency_to_circuit()` uses DFS, which is done
     with python instead of rustworkx. This was done because the same edge may
     need to be traversed multiple times, which I am not sure rustworkx supports.

--- a/test/python/transpiler/test_commute_minimum_depth.py
+++ b/test/python/transpiler/test_commute_minimum_depth.py
@@ -117,12 +117,12 @@ class TestCommuteMinimumDepth(QiskitTestCase):
         new_circuit = passmanager.run(circuit)
 
         expected = QuantumCircuit(4)
-        circuit.cx(3, 2)
-        circuit.cx(1, 3)
-        circuit.cx(2, 0)
-        circuit.cx(1, 2)
-        circuit.cx(2, 1)
-        circuit.cx(1, 0)
+        expected.cx(3, 2)
+        expected.cx(1, 3)
+        expected.cx(2, 0)
+        expected.cx(1, 2)
+        expected.cx(2, 1)
+        expected.cx(1, 0)
         self.assertEqual(expected, new_circuit)
 
 

--- a/test/python/transpiler/test_commute_minimum_depth.py
+++ b/test/python/transpiler/test_commute_minimum_depth.py
@@ -79,7 +79,8 @@ class TestElideSwaps(QiskitTestCase):
         res = self.swap_pass(qc)
         self.assertEqual(res, expected)
 
-  # This code is part of Qiskit.
+
+# This code is part of Qiskit.
 #
 # (C) Copyright IBM 2022.
 #
@@ -96,7 +97,7 @@ class TestElideSwaps(QiskitTestCase):
 import unittest
 from qiskit.test import QiskitTestCase
 
-from qiskit.circuit import  QuantumCircuit
+from qiskit.circuit import QuantumCircuit
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.passes import CommuteMinimumDepth
 
@@ -132,32 +133,34 @@ class TestCommutativeMinimumDepth(QiskitTestCase):
         expected.cx(2, 3)
         expected.cx(2, 1)
         self.assertEqual(expected, new_circuit)
-    def  test_non_commutative_gates(self):
+
+    def test_non_commutative_gates(self):
         """A simple circuit where the depth can not be reduced.
 
         0: --.-----(+)--------         0: --.-----(+)--------
              |      |                       |      |
-        1: -(+)-----.-----(+)-    =    1: -(+)-----.-----(+)- 
+        1: -(+)-----.-----(+)-    =    1: -(+)-----.-----(+)-
                            |                              |
         2: ----------------.--         2: ----------------.--
-        
+
         """
         circuit = QuantumCircuit(3)
-        circuit.cx(0,1)
-        circuit.cx(1,0)
-        circuit.cx(2,1)
+        circuit.cx(0, 1)
+        circuit.cx(1, 0)
+        circuit.cx(2, 1)
         passmanager = PassManager(CommuteMinimumDepth())
         new_circuit = passmanager.run(circuit)
 
         expected = QuantumCircuit(3)
-        circuit.cx(0,1)
-        circuit.cx(1,0)
-        circuit.cx(2,1)
-        self.assertEqual(expected,new_circuit)
+        circuit.cx(0, 1)
+        circuit.cx(1, 0)
+        circuit.cx(2, 1)
+        self.assertEqual(expected, new_circuit)
+
     def test_dfs_edges_multiple_times(self):
         """A simple circuit where the same edge has to tested more than once
         to confirm the proper depth and avoid doing impossible commutations.
-        
+
         0:--.-------------------------
             |
         1:-(+)------------(+)------.--
@@ -165,48 +168,47 @@ class TestCommutativeMinimumDepth(QiskitTestCase):
         2:-(+)------.------.------(+)-
             |       |
         3:--.------(+)----------------
-   
+
         """
         circuit = QuantumCircuit(4)
-        circuit.cx(0,1)
-        circuit.cx(3,2)
-        circuit.cx(2,3)
-        circuit.cx(1,2)
-        circuit.cx(2,1)
+        circuit.cx(0, 1)
+        circuit.cx(3, 2)
+        circuit.cx(2, 3)
+        circuit.cx(1, 2)
+        circuit.cx(2, 1)
         passmanager = PassManager(CommuteMinimumDepth())
         new_circuit = passmanager.run(circuit)
 
         expected = QuantumCircuit(4)
-        expected.cx(0,1)
-        expected.cx(3,2)
-        expected.cx(2,3)
-        expected.cx(1,2)
-        expected.cx(2,1)
-        self.assertEqual(expected,new_circuit)
-    
+        expected.cx(0, 1)
+        expected.cx(3, 2)
+        expected.cx(2, 3)
+        expected.cx(1, 2)
+        expected.cx(2, 1)
+        self.assertEqual(expected, new_circuit)
+
     def single_source_dfs_edges_multiple_times(self):
-        """A circuit where within the same source an edge is tested multiple 
+        """A circuit where within the same source an edge is tested multiple
         times to find the proper depth."""
 
         circuit = QuantumCircuit(4)
-        circuit.cx(3,2)
-        circuit.cx(1,3)
-        circuit.cx(2,0)
-        circuit.cx(1,2)
-        circuit.cx(2,1)
-        circuit.cx(1,0)
+        circuit.cx(3, 2)
+        circuit.cx(1, 3)
+        circuit.cx(2, 0)
+        circuit.cx(1, 2)
+        circuit.cx(2, 1)
+        circuit.cx(1, 0)
         passmanager = PassManager(CommuteMinimumDepth())
         new_circuit = passmanager.run(circuit)
 
         expected = QuantumCircuit(4)
-        circuit.cx(3,2)
-        circuit.cx(1,3)
-        circuit.cx(2,0)
-        circuit.cx(1,2)
-        circuit.cx(2,1)
-        circuit.cx(1,0)
-        self.assertEqual(expected,new_circuit)
-
+        circuit.cx(3, 2)
+        circuit.cx(1, 3)
+        circuit.cx(2, 0)
+        circuit.cx(1, 2)
+        circuit.cx(2, 1)
+        circuit.cx(1, 0)
+        self.assertEqual(expected, new_circuit)
 
 
 if __name__ == "__main__":

--- a/test/python/transpiler/test_commute_minimum_depth.py
+++ b/test/python/transpiler/test_commute_minimum_depth.py
@@ -67,9 +67,9 @@ class TestCommuteMinimumDepth(QiskitTestCase):
         new_circuit = passmanager.run(circuit)
 
         expected = QuantumCircuit(3)
-        circuit.cx(0, 1)
-        circuit.cx(1, 0)
-        circuit.cx(2, 1)
+        expected.cx(0, 1)
+        expected.cx(1, 0)
+        expected.cx(2, 1)
         self.assertEqual(expected, new_circuit)
 
     def test_dfs_edges_multiple_times(self):

--- a/test/python/transpiler/test_commute_minimum_depth.py
+++ b/test/python/transpiler/test_commute_minimum_depth.py
@@ -1,0 +1,213 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test ElideSwap pass"""
+
+import unittest
+
+from qiskit import QuantumCircuit
+from qiskit.transpiler.passes import CommuteMinimumDepth
+from qiskit.test import QiskitTestCase
+
+
+class TestElideSwaps(QiskitTestCase):
+    """Test swap elision logical optimization pass."""
+
+    def setUp(self):
+        super().setUp()
+        self.swap_pass = CommuteMinimumDepth()
+
+    def test_no_swap(self):
+        """Test no swap means no transform."""
+        qc = QuantumCircuit(4)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.measure_all()
+        res = self.swap_pass(qc)
+        self.assertEqual(res, qc)
+
+    def test_swap_in_middle(self):
+        """Test swap in middle of bell is elided."""
+        qc = QuantumCircuit(3, 3)
+        qc.h(0)
+        qc.swap(0, 1)
+        qc.cx(1, 2)
+        qc.barrier(0, 1, 2)
+        qc.measure(0, 0)
+        qc.measure(1, 1)
+        qc.measure(2, 2)
+
+        expected = QuantumCircuit(3, 3)
+        expected.h(0)
+        expected.cx(0, 2)
+        expected.barrier(0, 1, 2)
+        expected.measure(1, 0)
+        expected.measure(0, 1)
+        expected.measure(2, 2)
+
+        res = self.swap_pass(qc)
+        self.assertEqual(res, expected)
+
+    def test_swap_at_beginning(self):
+        """Test swap in beginning of bell is elided."""
+        qc = QuantumCircuit(3, 3)
+        qc.swap(0, 1)
+        qc.h(0)
+        qc.cx(1, 2)
+        qc.barrier(0, 1, 2)
+        qc.measure(0, 0)
+        qc.measure(1, 1)
+        qc.measure(2, 2)
+
+        expected = QuantumCircuit(3, 3)
+        expected.h(1)
+        expected.cx(0, 2)
+        expected.barrier(0, 1, 2)
+        expected.measure(1, 0)
+        expected.measure(0, 1)
+        expected.measure(2, 2)
+
+        res = self.swap_pass(qc)
+        self.assertEqual(res, expected)
+
+  # This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test transpiler pass that cancels inverse gates while exploiting the commutation relations."""
+
+import unittest
+from qiskit.test import QiskitTestCase
+
+from qiskit.circuit import  QuantumCircuit
+from qiskit.transpiler import PassManager
+from qiskit.transpiler.passes import CommuteMinimumDepth
+
+
+class TestCommutativeMinimumDepth(QiskitTestCase):
+    """Test the CommutativeInverseCancellation pass."""
+
+    # The first suite of tests is adapted from CommutativeCancellation,
+    # excluding/modifying the tests the combine rotations gates or do
+    # basis priority change.
+
+    def test_commutative_circuit(self):
+        """A simple circuit where the last cnot commutes to the left.
+
+        0:---(+)----------------       0:---(+)--------
+              |                              |
+        1:----.------(x)--------   =   1:----.-----(x)-
+                      |                             |
+        2:------------.------.--       2:----.------.--
+                             |               |
+        3:------------------(+)-       3:---(+)--------
+        """
+        circuit = QuantumCircuit(4)
+        circuit.cx(1, 0)
+        circuit.cx(2, 1)
+        circuit.cx(2, 3)
+
+        passmanager = PassManager(CommuteMinimumDepth())
+        new_circuit = passmanager.run(circuit)
+
+        expected = QuantumCircuit(4)
+        expected.cx(1, 0)
+        expected.cx(2, 3)
+        expected.cx(2, 1)
+        self.assertEqual(expected, new_circuit)
+    def  test_non_commutative_gates(self):
+        """A simple circuit where the depth can not be reduced.
+
+        0: --.-----(+)--------         0: --.-----(+)--------
+             |      |                       |      |
+        1: -(+)-----.-----(+)-    =    1: -(+)-----.-----(+)- 
+                           |                              |
+        2: ----------------.--         2: ----------------.--
+        
+        """
+        circuit = QuantumCircuit(3)
+        circuit.cx(0,1)
+        circuit.cx(1,0)
+        circuit.cx(2,1)
+        passmanager = PassManager(CommuteMinimumDepth())
+        new_circuit = passmanager.run(circuit)
+
+        expected = QuantumCircuit(3)
+        circuit.cx(0,1)
+        circuit.cx(1,0)
+        circuit.cx(2,1)
+        self.assertEqual(expected,new_circuit)
+    def test_dfs_edges_multiple_times(self):
+        """A simple circuit where the same edge has to tested more than once
+        to confirm the proper depth and avoid doing impossible commutations.
+        
+        0:--.-------------------------
+            |
+        1:-(+)------------(+)------.--
+                           |       |
+        2:-(+)------.------.------(+)-
+            |       |
+        3:--.------(+)----------------
+   
+        """
+        circuit = QuantumCircuit(4)
+        circuit.cx(0,1)
+        circuit.cx(3,2)
+        circuit.cx(2,3)
+        circuit.cx(1,2)
+        circuit.cx(2,1)
+        passmanager = PassManager(CommuteMinimumDepth())
+        new_circuit = passmanager.run(circuit)
+
+        expected = QuantumCircuit(4)
+        expected.cx(0,1)
+        expected.cx(3,2)
+        expected.cx(2,3)
+        expected.cx(1,2)
+        expected.cx(2,1)
+        self.assertEqual(expected,new_circuit)
+    
+    def single_source_dfs_edges_multiple_times(self):
+        """A circuit where within the same source an edge is tested multiple 
+        times to find the proper depth."""
+
+        circuit = QuantumCircuit(4)
+        circuit.cx(3,2)
+        circuit.cx(1,3)
+        circuit.cx(2,0)
+        circuit.cx(1,2)
+        circuit.cx(2,1)
+        circuit.cx(1,0)
+        passmanager = PassManager(CommuteMinimumDepth())
+        new_circuit = passmanager.run(circuit)
+
+        expected = QuantumCircuit(4)
+        circuit.cx(3,2)
+        circuit.cx(1,3)
+        circuit.cx(2,0)
+        circuit.cx(1,2)
+        circuit.cx(2,1)
+        circuit.cx(1,0)
+        self.assertEqual(expected,new_circuit)
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/transpiler/test_commute_minimum_depth.py
+++ b/test/python/transpiler/test_commute_minimum_depth.py
@@ -1,87 +1,5 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2023
-#
-# This code is licensed under the Apache License, Version 2.0. You may
-# obtain a copy of this license in the LICENSE.txt file in the root directory
-# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
-#
-# Any modifications or derivative works of this code must retain this
-# copyright notice, and modified files need to carry a notice indicating
-# that they have been altered from the originals.
-
-"""Test ElideSwap pass"""
-
-import unittest
-
-from qiskit import QuantumCircuit
-from qiskit.transpiler.passes import CommuteMinimumDepth
-from qiskit.test import QiskitTestCase
-
-
-class TestElideSwaps(QiskitTestCase):
-    """Test swap elision logical optimization pass."""
-
-    def setUp(self):
-        super().setUp()
-        self.swap_pass = CommuteMinimumDepth()
-
-    def test_no_swap(self):
-        """Test no swap means no transform."""
-        qc = QuantumCircuit(4)
-        qc.h(0)
-        qc.cx(0, 1)
-        qc.measure_all()
-        res = self.swap_pass(qc)
-        self.assertEqual(res, qc)
-
-    def test_swap_in_middle(self):
-        """Test swap in middle of bell is elided."""
-        qc = QuantumCircuit(3, 3)
-        qc.h(0)
-        qc.swap(0, 1)
-        qc.cx(1, 2)
-        qc.barrier(0, 1, 2)
-        qc.measure(0, 0)
-        qc.measure(1, 1)
-        qc.measure(2, 2)
-
-        expected = QuantumCircuit(3, 3)
-        expected.h(0)
-        expected.cx(0, 2)
-        expected.barrier(0, 1, 2)
-        expected.measure(1, 0)
-        expected.measure(0, 1)
-        expected.measure(2, 2)
-
-        res = self.swap_pass(qc)
-        self.assertEqual(res, expected)
-
-    def test_swap_at_beginning(self):
-        """Test swap in beginning of bell is elided."""
-        qc = QuantumCircuit(3, 3)
-        qc.swap(0, 1)
-        qc.h(0)
-        qc.cx(1, 2)
-        qc.barrier(0, 1, 2)
-        qc.measure(0, 0)
-        qc.measure(1, 1)
-        qc.measure(2, 2)
-
-        expected = QuantumCircuit(3, 3)
-        expected.h(1)
-        expected.cx(0, 2)
-        expected.barrier(0, 1, 2)
-        expected.measure(1, 0)
-        expected.measure(0, 1)
-        expected.measure(2, 2)
-
-        res = self.swap_pass(qc)
-        self.assertEqual(res, expected)
-
-
-# This code is part of Qiskit.
-#
 # (C) Copyright IBM 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
@@ -92,7 +10,8 @@ class TestElideSwaps(QiskitTestCase):
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Test transpiler pass that cancels inverse gates while exploiting the commutation relations."""
+"""Test transpiler pass that optimizes depth of quantum circuits by commuting
+gates to the left when possible."""
 
 import unittest
 from qiskit.test import QiskitTestCase
@@ -102,12 +21,8 @@ from qiskit.transpiler import PassManager
 from qiskit.transpiler.passes import CommuteMinimumDepth
 
 
-class TestCommutativeMinimumDepth(QiskitTestCase):
-    """Test the CommutativeInverseCancellation pass."""
-
-    # The first suite of tests is adapted from CommutativeCancellation,
-    # excluding/modifying the tests the combine rotations gates or do
-    # basis priority change.
+class TestCommuteMinimumDepth(QiskitTestCase):
+    """Test the CommuteMinimumDepth pass."""
 
     def test_commutative_circuit(self):
         """A simple circuit where the last cnot commutes to the left.


### PR DESCRIPTION


### Summary

Optimizes conversion from DagDependency to a DagCircuit to have as little depth as possible. A new transpiler pass, named CommuteMinimumDepth, is also introduced.

fixes #7387 



### Details and comments

This optimization is done by finding the depth of each node in the DagDependency via a depth-first-search, and then adding each node to the resulting circuit in order of it's depth from least to greatest. This DFS is done through python and not rustworkx because the DFS in some cases has to test the same edge multiple times, which I'm not sure if rustworkx supports.

The transpiler pass just converts a DagCircuit into a DagDependency and then back into a DagCircuit.

Please let me know any fixes I have to make as this is my first time contributing to this repository.


