### PR TITLE
Remove Qobj input to `UnitarySimulatorPy.run`

### DIFF
--- a/qiskit/providers/basicaer/unitary_simulator.py
+++ b/qiskit/providers/basicaer/unitary_simulator.py
@@ -17,11 +17,11 @@ the simulator. It is exponential in the number of qubits.
 
 .. code-block:: python
 
-    UnitarySimulator().run(qobj)
+    UnitarySimulator().run(run_input)
 
-Where the input is a Qobj object and the output is a BasicAerJob object, which can
-later be queried for the Result object. The result will contain a 'unitary'
-data field, which is a 2**n x 2**n complex numpy array representing the
+Where the input is a either Qobj object (deprecated) or QuantumCircuit or a list of circuits and 
+the output is a BasicAerJob object, which can later be queried for the Result object. The result 
+will contain a 'unitary' data field, which is a 2**n x 2**n complex numpy array representing the
 circuit's unitary matrix.
 """
 import logging
@@ -32,7 +32,6 @@ import warnings
 
 import numpy as np
 
-from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.utils.multiprocessing import local_hardware_info
 from qiskit.providers.models import QasmBackendConfiguration
 from qiskit.providers.backend import BackendV1
@@ -203,11 +202,11 @@ class UnitarySimulatorPy(BackendV1):
         unitary[abs(unitary) < self._chop_threshold] = 0.0
         return unitary
 
-    def run(self, qobj, **backend_options):
-        """Run qobj asynchronously.
+    def run(self, run_input, **backend_options):
+        """Run experiments in run_input asynchronously.
 
         Args:
-            qobj (Qobj): payload of the experiment
+            run_input (Qobj, QuantumCircuit, list): payload of the experiment
             backend_options (dict): backend options
 
         Returns:
@@ -222,7 +221,7 @@ class UnitarySimulatorPy(BackendV1):
             The "initial_unitary" option specifies a custom initial unitary
             matrix for the simulator to be used instead of the identity
             matrix. This size of this matrix must be correct for the number
-            of qubits inall experiments in the qobj.
+            of qubits in all experiments in the run_input.
 
             The "chop_threshold" option specifies a truncation value for
             setting small values to zero in the output unitary. The default
@@ -238,21 +237,19 @@ class UnitarySimulatorPy(BackendV1):
                     "chop_threshold": 1e-15
                 }
         """
-        if isinstance(qobj, (QuantumCircuit, list)):
-            from qiskit.compiler import assemble
+        from qiskit.compiler import assemble
 
-            out_options = {}
-            for key in backend_options:
-                if not hasattr(self.options, key):
-                    warnings.warn(
-                        "Option %s is not used by this backend" % key, UserWarning, stacklevel=2
-                    )
-                else:
-                    out_options[key] = backend_options[key]
-            qobj = assemble(qobj, self, **out_options)
-            qobj_options = qobj.config
-        else:
-            qobj_options = None
+        out_options = {}
+        for key in backend_options:
+            if not hasattr(self.options, key):
+                warnings.warn(
+                    "Option %s is not used by this backend" % key, UserWarning, stacklevel=2
+                )
+            else:
+                out_options[key] = backend_options[key]
+        qobj = assemble(run_input, self, **out_options)
+        qobj_options = qobj.config
+
         self._set_options(qobj_config=qobj_options, backend_options=backend_options)
         job_id = str(uuid.uuid4())
         job = BasicAerJob(self, job_id, self._run_job(job_id, qobj))

--- a/releasenotes/notes/remove-qobj-input-in-UnitarySimulatorPy-436c3a7c0dcc5eb6.yaml
+++ b/releasenotes/notes/remove-qobj-input-in-UnitarySimulatorPy-436c3a7c0dcc5eb6.yaml
@@ -1,0 +1,20 @@
+---
+
+upgrade:
+  - |
+    It is no longer allowed to pass a :class:`~qiskit.qobj.QasmQobj` as the first input to
+    The :meth:`~qiskit.providers.basicaer.UnitarySimulatorPy.run`. This functionality was 
+    deprecated in Qiskit 0.46 and has now been removed.
+
+    Example usage:
+
+      from qiskit import transpile, QuantumCircuit
+      from qiskit.providers.basicaer import BasicAer
+
+      backend = BasicAer.get_backend('unitary_simulator')
+      circuit = QuantumCircuit(2)
+      qc.h(0)
+      qc.cx(0, 1)
+      qc.measure_all()
+      tqc = transpile(circuit, backend)
+      result = backend.run(tqc).result()


### PR DESCRIPTION

### Summary
[`qiskit.providers.basicaer.UnitarySimulatorPy.run()`](https://github.com/Qiskit/qiskit/blob/main/qiskit/providers/basicaer/unitary_simulator.py#L206) never deprecated a `qiskit.qobj.QasmQobj` input and will still support it while the qasm simulator and statevector simulator will not. 

#11394 deprecates this functionality in a PR to `stable/0.46`. This PR to `main` removes this functionality. Fixes #11046 