### PR TITLE
Fix a bug of missing pulse library entry in PulseQobj parsing

### DIFF
--- a/qiskit/pulse/calibration_entries.py
+++ b/qiskit/pulse/calibration_entries.py
@@ -13,6 +13,7 @@
 """Internal format of calibration data in target."""
 from __future__ import annotations
 import inspect
+import warnings
 from abc import ABCMeta, abstractmethod
 from collections.abc import Sequence, Callable
 from enum import IntEnum
@@ -327,9 +328,13 @@ class PulseQobjDef(ScheduleDef):
                     schedule.insert(qobj_inst.t0, qiskit_inst, inplace=True)
             self._definition = schedule
             self._parse_argument()
-        except QiskitError:
+        except QiskitError as ex:
             # When the play waveform data is missing in pulse_lib we cannot build schedule.
             # Instead of raising an error, get_schedule should return None.
+            warnings.warn(
+                f"Pulse calibration cannot be built and the entry is ignored: {ex.message}.",
+                UserWarning,
+            )
             self._definition = IncompletePulseQobj
 
     def define(

--- a/qiskit/pulse/calibration_entries.py
+++ b/qiskit/pulse/calibration_entries.py
@@ -22,6 +22,11 @@ from qiskit.pulse.exceptions import PulseError
 from qiskit.pulse.schedule import Schedule, ScheduleBlock
 from qiskit.qobj.converters import QobjToInstructionConverter
 from qiskit.qobj.pulse_qobj import PulseQobjInstruction
+from qiskit.exceptions import QiskitError
+
+
+IncompletePulseQobj = object()
+"""A None-like constant that represents the PulseQobj is incomplete."""
 
 
 class CalibrationPublisher(IntEnum):
@@ -316,11 +321,16 @@ class PulseQobjDef(ScheduleDef):
     def _build_schedule(self):
         """Build pulse schedule from cmd-def sequence."""
         schedule = Schedule(name=self._name)
-        for qobj_inst in self._source:
-            for qiskit_inst in self._converter._get_sequences(qobj_inst):
-                schedule.insert(qobj_inst.t0, qiskit_inst, inplace=True)
-        self._definition = schedule
-        self._parse_argument()
+        try:
+            for qobj_inst in self._source:
+                for qiskit_inst in self._converter._get_sequences(qobj_inst):
+                    schedule.insert(qobj_inst.t0, qiskit_inst, inplace=True)
+            self._definition = schedule
+            self._parse_argument()
+        except QiskitError:
+            # When the play waveform data is missing in pulse_lib we cannot build schedule.
+            # Instead of raising an error, get_schedule should return None.
+            self._definition = IncompletePulseQobj
 
     def define(
         self,
@@ -336,9 +346,11 @@ class PulseQobjDef(ScheduleDef):
             self._build_schedule()
         return super().get_signature()
 
-    def get_schedule(self, *args, **kwargs) -> Schedule | ScheduleBlock:
+    def get_schedule(self, *args, **kwargs) -> Schedule | ScheduleBlock | None:
         if self._definition is None:
             self._build_schedule()
+        if self._definition is IncompletePulseQobj:
+            return None
         return super().get_schedule(*args, **kwargs)
 
     def __eq__(self, other):
@@ -356,4 +368,6 @@ class PulseQobjDef(ScheduleDef):
         if self._definition is None:
             # Avoid parsing schedule for pretty print.
             return "PulseQobj"
+        if self._definition is IncompletePulseQobj:
+            return "None"
         return super().__str__()

--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -959,8 +959,12 @@ class QobjToInstructionConverter:
 
             yield instructions.Play(waveform, channel)
         else:
+            if qubits := getattr(instruction, "qubits", None):
+                msg = f"qubits {qubits}"
+            else:
+                msg = f"channel {instruction.ch}"
             raise QiskitError(
-                f"Instruction {instruction.name} on qubit {instruction.qubits} is not found  "
+                f"Instruction {instruction.name} on {msg} is not found "
                 "in Qiskit namespace. This instruction cannot be deserialized."
             )
 

--- a/releasenotes/notes/fix-missing-pulse-lib-c370f5b9393d0df6.yaml
+++ b/releasenotes/notes/fix-missing-pulse-lib-c370f5b9393d0df6.yaml
@@ -3,9 +3,10 @@ fixes:
   - |
     Fixed a bug that results in an error when a user tries to load .calibration
     data of a gate in :class:`.Target` in a particular situation.
-    This occurs when the backend doesn't support pulse waveform payload, while
-    Qiskit doesn't have corresponding parametric pulse definition.
-    In this situation, Qiskit pulse object cannot be built, resulting in the failure in
-    parsing PulseQobj and the user encounters a meaningless error.
-    This error was suppressed, and the .calibration now returns None value instead,
-    which implies the calibration data is not properly supplied.
+    This occurs when the backend reports only partial calibration data, for
+    example referencing a waveform pulse in a command definition but not
+    including that waveform pulse in the pulse library. In this situation, the
+    Qiskit pulse object cannot be built, resulting in a failure to build the pulse
+    schedule for the calibration. Now when calibration data is incomplete
+    the :class:`.Target` treats it as equivalent to no calibration being reported
+    at all and does not raise an exception.

--- a/releasenotes/notes/fix-missing-pulse-lib-c370f5b9393d0df6.yaml
+++ b/releasenotes/notes/fix-missing-pulse-lib-c370f5b9393d0df6.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixed a bug that results in an error when a user tries to load .calibration
+    data of a gate in :class:`.Target` in a particular situation.
+    This occurs when the backend doesn't support pulse waveform payload, while
+    Qiskit doesn't have corresponding parametric pulse definition.
+    In this situation, Qiskit pulse object cannot be built, resulting in the failure in
+    parsing PulseQobj and the user encounters a meaningless error.
+    This error was suppressed, and the .calibration now returns None value instead,
+    which implies the calibration data is not properly supplied.

--- a/test/python/pulse/test_calibration_entries.py
+++ b/test/python/pulse/test_calibration_entries.py
@@ -326,6 +326,30 @@ class TestPulseQobj(QiskitTestCase):
         )
         self.assertEqual(schedule_to_test, schedule_ref)
 
+    def test_missing_waveform(self):
+        """Test incomplete Qobj should raise warning and calibration returns None."""
+        serialized_program = [
+            PulseQobjInstruction(
+                name="waveform_123456",
+                t0=20,
+                ch="d0",
+            ),
+        ]
+        entry = PulseQobjDef(converter=self.converter, name="my_gate")
+        entry.define(serialized_program)
+
+        with self.assertWarns(
+            UserWarning,
+            msg=(
+                "Pulse calibration cannot be built and the entry is ignored: "
+                "Instruction waveform_123456 on channel d0 is not found in Qiskit namespace. "
+                "This instruction cannot be deserialized."
+            ),
+        ):
+            out = entry.get_schedule()
+
+        self.assertIsNone(out)
+
     def test_parameterized_qobj(self):
         """Test adding and managing parameterized qobj.
 

--- a/test/python/pulse/test_calibration_entries.py
+++ b/test/python/pulse/test_calibration_entries.py
@@ -434,3 +434,37 @@ class TestPulseQobj(QiskitTestCase):
         entry2.define(program)
 
         self.assertEqual(entry1, entry2)
+
+    def test_calibration_missing_waveform(self):
+        """Test that calibration with missing waveform should become None.
+
+        When a hardware doesn't support waveform payload and Qiskit doesn't have
+        the corresponding parametric pulse definition, CmdDef with missing waveform
+        might be input to the QobjConverter. This fails in loading the calibration data
+        because necessary pulse object cannot be built.
+
+        In this situation, parsed calibration data must become None,
+        instead of raising an error.
+        """
+        serialized_program = [
+            PulseQobjInstruction(
+                name="SomeMissingPulse",
+                t0=0,
+                ch="d0",
+            )
+        ]
+        entry = PulseQobjDef(name="qobj_entry")
+        entry.define(serialized_program)
+
+        # This is pulse qobj before parsing it
+        self.assertEqual(str(entry), "PulseQobj")
+
+        # Actual calibration value is None
+        parsed_output = entry.get_schedule()
+        self.assertIsNone(parsed_output)
+
+        # Repr becomes None-like after it finds calibration is incomplete
+        self.assertEqual(str(entry), "None")
+
+        # Signature is also None
+        self.assertIsNone(entry.get_signature())


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

When a user tries to get calibration data from Target, it may fail because of partly missing calibration data, e.g.

```python
backend.target["some_gate"][(0, 1)].calibration
```

This may occur when the backend doesn't support waveform payload, while Qiskit doesn't have definition of the corresponding parametric pulse that the backend uses. 

### Details and comments

This PR adds exception handling for this case. Namely, `None` value is returned instead of raising an error.
