### PR TITLE
Compose multiple final_layout attributes in routing

### DIFF
--- a/qiskit/transpiler/layout.py
+++ b/qiskit/transpiler/layout.py
@@ -283,21 +283,6 @@ class Layout:
 
         return order
 
-    def compose(self, other: Layout, qubits: List[Qubit]) -> Layout:
-        """Compose this dag onto an existing layout.
-
-        Args:
-            other: The existing :class:`.Layout` to compose this :class:`.Layout` onto
-            qubits: A list of :class:`.Qubit` objects that is used to establish the
-                position of qubits.
-        Return:
-            A new layout object the represents this layout composed onto ``other``.
-
-
-        """
-        other_v2p = other.get_virtual_bits()
-        return Layout({virt: other_v2p[qubits[phys]] for virt, phys in self._v2p.items()})
-
     @staticmethod
     def generate_trivial_layout(*regs):
         """Creates a trivial ("one-to-one") Layout with the registers and qubits in `regs`.
@@ -382,6 +367,76 @@ class Layout:
         for qreg in qregs:
             out.add_register(qreg)
         return out
+
+    def compose(self, other: Layout, qubits: List[Qubit]) -> Layout:
+        """Compose this layout with another layout.
+
+        If this layout represents a mapping from the P-qubits to the positions of the Q-qubits,
+        and the other layout represents a mapping from the Q-qubits to the positions of
+        the R-qubits, then the composed layout represents a mapping from the P-qubits to the
+        positions of the R-qubits.
+
+        Args:
+            other: The existing :class:`.Layout` to compose this :class:`.Layout` with.
+            qubits: A list of :class:`.Qubit` objects over which ``other`` is defined,
+                used to establish the correspondence between the positions of the ``other``
+                qubits and the actual qubits.
+
+        Returns:
+            A new layout object the represents this layout composed with the ``other`` layout.
+        """
+        other_v2p = other.get_virtual_bits()
+        return Layout({virt: other_v2p[qubits[phys]] for virt, phys in self._v2p.items()})
+
+    def inverse(self, source_qubits: List[Qubit], target_qubits: List[Qubit]):
+        """Finds the inverse of this layout.
+
+        This is possible when the layout is a bijective mapping, however the input
+        and the output qubits may be different (in particular, this layout may be
+        the mapping from the extended-with-ancillas virtual qubits to physical qubits).
+        Thus, if this layout represents a mapping from the P-qubits to the positions
+        of the Q-qubits, the inverse layout represents a mapping from the Q-qubits
+        to the positions of the P-qubits.
+
+        Args:
+            source_qubits: A list of :class:`.Qubit` objects representing the domain
+                of the layout.
+            target_qubits: A list of :class:`.Qubit` objects representing the image
+                of the layout.
+
+        Returns:
+            A new layout object the represents the inverse of this layout.
+        """
+        source_qubit_to_position = {q: p for p, q in enumerate(source_qubits)}
+        return Layout(
+            {
+                target_qubits[pos_phys]: source_qubit_to_position[virt]
+                for virt, pos_phys in self._v2p.items()
+            }
+        )
+
+    def to_permutation(self, qubits: List[Qubit]):
+        """Creates a permutation corresponding to this layout.
+
+        This is possible when the layout is a bijective mapping with the same
+        source and target qubits (for instance, a "final_layout" corresponds
+        to a permutation of the physical circuit qubits). If this layout is
+        a mapping from qubits to their new positions, the resulting permutation
+        describes which qubits occupy the positions 0, 1, 2, etc. after
+        applying the permutation.
+
+        For example, suppose that the list of qubits is ``[qr_0, qr_1, qr_2]``,
+        and the layout maps ``qr_0`` to ``2``, ``qr_1`` to ``0``, and
+        ``qr_2`` to ``1``. In terms of positions in ``qubits``, this maps ``0``
+        to ``2``, ``1`` to ``0`` and ``2`` to ``1``, with the corresponding
+        permutation being ``[1, 2, 0]``.
+        """
+
+        perm = [None] * len(qubits)
+        for i, q in enumerate(qubits):
+            pos = self._v2p[q]
+            perm[pos] = i
+        return perm
 
 
 @dataclass

--- a/qiskit/transpiler/layout.py
+++ b/qiskit/transpiler/layout.py
@@ -283,6 +283,21 @@ class Layout:
 
         return order
 
+    def compose(self, other: Layout, qubits: List[Qubit]) -> Layout:
+        """Compose this dag onto an existing layout.
+
+        Args:
+            other: The existing :class:`.Layout` to compose this :class:`.Layout` onto
+            qubits: A list of :class:`.Qubit` objects that is used to establish the
+                position of qubits.
+        Return:
+            A new layout object the represents this layout composed onto ``other``.
+
+
+        """
+        other_v2p = other.get_virtual_bits()
+        return Layout({virt: other_v2p[qubits[phys]] for virt, phys in self._v2p.items()})
+
     @staticmethod
     def generate_trivial_layout(*regs):
         """Creates a trivial ("one-to-one") Layout with the registers and qubits in `regs`.

--- a/qiskit/transpiler/passes/layout/sabre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_layout.py
@@ -312,7 +312,7 @@ class SabreLayout(TransformationPass):
         self.property_set["original_qubit_indices"] = {
             bit: index for index, bit in enumerate(dag.qubits)
         }
-        self.property_set["final_layout"] = Layout(
+        final_layout = Layout(
             {
                 mapped_dag.qubits[
                     component.coupling_map.graph[initial]
@@ -321,6 +321,12 @@ class SabreLayout(TransformationPass):
                 for initial, final in enumerate(component.final_permutation)
             }
         )
+        if self.property_set["final_layout"] is None:
+            self.property_set["final_layout"] = final_layout
+        else:
+            self.property_set["final_layout"] = final_layout.compose(
+                self.property_set["final_layout"], dag.qubits
+            )
         for component in components:
             # Sabre routing still returns all its swaps as on virtual qubits, so we need to expand
             # each component DAG with the virtual ancillas that were allocated to it, so the layout

--- a/qiskit/transpiler/passes/routing/basic_swap.py
+++ b/qiskit/transpiler/passes/routing/basic_swap.py
@@ -114,7 +114,13 @@ class BasicSwap(TransformationPass):
             order = current_layout.reorder_bits(new_dag.qubits)
             new_dag.compose(subdag, qubits=order)
 
-        self.property_set["final_layout"] = current_layout
+        if self.property_set["final_layout"] is None:
+            self.property_set["final_layout"] = current_layout
+        else:
+            self.property_set["final_layout"] = current_layout.compose(
+                self.property_set["final_layout"], dag.qubits
+            )
+
         return new_dag
 
     def _fake_run(self, dag):
@@ -151,5 +157,10 @@ class BasicSwap(TransformationPass):
                     for swap in range(len(path) - 2):
                         current_layout.swap(path[swap], path[swap + 1])
 
-        self.property_set["final_layout"] = current_layout
+        if self.property_set["final_layout"] is None:
+            self.property_set["final_layout"] = current_layout
+        else:
+            self.property_set["final_layout"] = current_layout.compose(
+                self.property_set["final_layout"], dag.qubits
+            )
         return dag

--- a/qiskit/transpiler/passes/routing/lookahead_swap.py
+++ b/qiskit/transpiler/passes/routing/lookahead_swap.py
@@ -169,7 +169,13 @@ class LookaheadSwap(TransformationPass):
 
             mapped_gates.extend(gates_mapped)
 
-        self.property_set["final_layout"] = current_state.layout
+        if self.property_set["final_layout"] is None:
+            self.property_set["final_layout"] = current_state.layout
+        else:
+            self.property_set["final_layout"] = current_state.layout.compose(
+                self.property_set["final_layout"], dag.qubits
+            )
+
         if self.fake_run:
             return dag
 

--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -251,8 +251,13 @@ class SabreSwap(TransformationPass):
         )
         sabre_stop = time.perf_counter()
         logging.debug("Sabre swap algorithm execution complete in: %s", sabre_stop - sabre_start)
-
-        self.property_set["final_layout"] = Layout(dict(zip(dag.qubits, final_permutation)))
+        final_layout = Layout(dict(zip(dag.qubits, final_permutation)))
+        if self.property_set["final_layout"] is None:
+            self.property_set["final_layout"] = final_layout
+        else:
+            self.property_set["final_layout"] = final_layout.compose(
+                self.property_set["final_layout"], dag.qubits
+            )
         if self.fake_run:
             return dag
         return _apply_sabre_result(

--- a/qiskit/transpiler/passes/routing/stochastic_swap.py
+++ b/qiskit/transpiler/passes/routing/stochastic_swap.py
@@ -375,8 +375,13 @@ class StochasticSwap(TransformationPass):
         # any measurements that needed to be removed earlier.
         logger.debug("mapper: self.initial_layout = %s", self.initial_layout)
         logger.debug("mapper: layout = %s", layout)
+        if self.property_set["final_layout"] is None:
+            self.property_set["final_layout"] = layout
+        else:
+            self.property_set["final_layout"] = layout.compose(
+                self.property_set["final_layout"], circuit_graph.qubits
+            )
 
-        self.property_set["final_layout"] = layout
         if self.fake_run:
             return circuit_graph
         return dagcircuit_output

--- a/qiskit/transpiler/preset_passmanagers/plugin.py
+++ b/qiskit/transpiler/preset_passmanagers/plugin.py
@@ -68,7 +68,15 @@ load external plugins via corresponding entry points.
        connectivity constraints of the target backend. This does not necessarily
        need to match the directionality of the edges in the target as a later
        stage typically will adjust directional gates to match that constraint
-       (but there is no penalty for doing that in the ``routing`` stage).
+       (but there is no penalty for doing that in the ``routing`` stage). The output
+       of this stage is also expected to have the ``final_layout`` property set field
+       set with a :class:`~.Layout` object that maps the :class:`.Qubit` to the
+       output final position of that qubit in the circuit. If there is an
+       existing ``final_layout`` entry in the property set (such as might be set
+       by an optimization pass that introduces a permutation) it is expected
+       that the final layout will be the composition of the two layouts (this
+       can be computed using :meth:`.DAGCircuit.compose`, for example:
+       ``second_final_layout.compose(first_final_layout, dag.qubits)``).
    * - ``translation``
      - ``qiskit.transpiler.translation``
      - ``translator``, ``synthesis``, ``unroller``

--- a/releasenotes/notes/layout-compose-0b9a9a72359638d8.yaml
+++ b/releasenotes/notes/layout-compose-0b9a9a72359638d8.yaml
@@ -1,5 +1,9 @@
 ---
 features:
   - |
+    Added a new method :meth:`.Layout.inverse` which is used for taking
+    the inverse of a :class:`.Layout` object.
     Added a new method :meth:`.Layout.compose` which is used for composing
     two :class:`.Layout` objects together.
+    Added a new method :meth:`.Layout.to_permutation` which is used for
+    creating a permutation corresponding to a :class:`.Layout` object.

--- a/releasenotes/notes/layout-compose-0b9a9a72359638d8.yaml
+++ b/releasenotes/notes/layout-compose-0b9a9a72359638d8.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Added a new method :meth:`.Layout.compose` which is used for composing
+    two :class:`.Layout` objects together.

--- a/test/python/transpiler/test_layout.py
+++ b/test/python/transpiler/test_layout.py
@@ -428,6 +428,34 @@ class LayoutTest(QiskitTestCase):
         self.assertNotIn(qr[1], layout)
         self.assertNotIn(1, layout)
 
+    def test_compose(self):
+        """Test the compose method."""
+        qubits = [Qubit() for _ in range(4)]
+        first = [0, 3, 1, 2]
+        second = [2, 3, 1, 0]
+        first_layout = Layout(dict(zip(qubits, first)))
+        second_layout = Layout(dict(zip(qubits, second)))
+        expected = Layout({qubits[0]: 1, qubits[1]: 2, qubits[2]: 3, qubits[3]: 0})
+        self.assertEqual(second_layout.compose(first_layout, qubits), expected)
+
+    def test_compose_no_permutation_original(self):
+        """Test compose where the first doesn't permute anything."""
+        qubits = [Qubit() for _ in range(4)]
+        first = [0, 1, 2, 3]
+        second = [2, 3, 1, 0]
+        first_layout = Layout(dict(zip(qubits, first)))
+        second_layout = Layout(dict(zip(qubits, second)))
+        self.assertEqual(second_layout.compose(first_layout, qubits), second_layout)
+
+    def test_compose_no_permutation_second(self):
+        """Test compose where the second doesn't permute anything."""
+        qubits = [Qubit() for _ in range(4)]
+        second = [0, 1, 2, 3]
+        first = [2, 3, 1, 0]
+        first_layout = Layout(dict(zip(qubits, first)))
+        second_layout = Layout(dict(zip(qubits, second)))
+        self.assertEqual(second_layout.compose(first_layout, qubits), first_layout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/transpiler/test_layout.py
+++ b/test/python/transpiler/test_layout.py
@@ -438,6 +438,27 @@ class LayoutTest(QiskitTestCase):
         expected = Layout({qubits[0]: 1, qubits[1]: 2, qubits[2]: 3, qubits[3]: 0})
         self.assertEqual(second_layout.compose(first_layout, qubits), expected)
 
+    def test_compose_different_qubit_lists(self):
+        """Test the compose method when the lists of source qubits for the
+        two layouts are different.
+        """
+        qr1 = QuantumRegister(4, "qr1")
+        qr2 = QuantumRegister(4, "qr2")
+
+        qubits1 = [Qubit(qr1, 0), Qubit(qr1, 1), Qubit(qr1, 2), Qubit(qr1, 3)]
+        qubits2 = [Qubit(qr2, 0), Qubit(qr2, 1), Qubit(qr2, 2), Qubit(qr2, 3)]
+        positions1 = [1, 2, 3, 0]
+        positions2 = [0, 2, 1, 3]
+        layout1 = Layout(dict(zip(qubits1, positions1)))
+        layout2 = Layout(dict(zip(qubits2, positions2)))
+        # qr1[0] -> 1 <--> qr2[1] -> 2
+        # qr1[1] -> 2 <--> qr2[2] -> 1
+        # qr1[2] -> 3 <--> qr2[3] -> 3
+        # qr1[3] -> 0 <--> qr2[0] -> 0
+        expected = Layout({qubits1[0]: 2, qubits1[1]: 1, qubits1[2]: 3, qubits1[3]: 0})
+        composed = layout1.compose(layout2, qubits2)
+        self.assertEqual(composed, expected)
+
     def test_compose_no_permutation_original(self):
         """Test compose where the first doesn't permute anything."""
         qubits = [Qubit() for _ in range(4)]
@@ -455,6 +476,39 @@ class LayoutTest(QiskitTestCase):
         first_layout = Layout(dict(zip(qubits, first)))
         second_layout = Layout(dict(zip(qubits, second)))
         self.assertEqual(second_layout.compose(first_layout, qubits), first_layout)
+
+    def test_inverse(self):
+        """Test inverse method."""
+        qubits = [Qubit() for _ in range(4)]
+        layout = Layout({qubits[0]: 1, qubits[1]: 2, qubits[2]: 3, qubits[3]: 0})
+        inverse = layout.inverse(qubits, qubits)
+        expected = Layout({qubits[1]: 0, qubits[2]: 1, qubits[3]: 2, qubits[0]: 3})
+        self.assertEqual(inverse, expected)
+
+    def test_inverse_different_qubit_lists(self):
+        """Test inverse method when the source and target qubits are different."""
+        qr1 = QuantumRegister(4, "qr1")
+        qr2 = QuantumRegister(4, "qr2")
+
+        qubits1 = [Qubit(qr1, 0), Qubit(qr1, 1), Qubit(qr1, 2), Qubit(qr1, 3)]
+        qubits2 = [Qubit(qr2, 0), Qubit(qr2, 1), Qubit(qr2, 2), Qubit(qr2, 3)]
+
+        layout = Layout({qubits1[0]: 1, qubits1[1]: 2, qubits1[2]: 3, qubits1[3]: 0})
+        inverse = layout.inverse(qubits1, qubits2)
+
+        expected = Layout({qubits2[1]: 0, qubits2[2]: 1, qubits2[3]: 2, qubits2[0]: 3})
+        self.assertEqual(inverse, expected)
+
+        not_expected = Layout({qubits1[1]: 0, qubits1[2]: 1, qubits1[3]: 2, qubits1[0]: 3})
+        self.assertNotEqual(inverse, not_expected)
+
+    def test_to_permutation(self):
+        """Test to_permutation method."""
+        qubits = [Qubit() for _ in range(3)]
+        positions = [2, 0, 1]
+        layout = Layout(dict(zip(qubits, positions)))
+        permutation = layout.to_permutation(qubits)
+        self.assertEqual(permutation, [1, 2, 0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds several usability methods to the ``Layout`` class. The method ``compose`` is used to compose two layouts together, the method ``inverse`` is used to find the inverse of a layout, and the method ``to_permutation`` is used to create a permutation corresponding to the layout.

This commit also adds functionality to the built-in routing passes for composing an existing final layout with the routing permutation. 

In PRs #9523 and #11387 we're adding new passes that introduce a permutation prior to routing that needs to be tracked for the final output layout to be valid. The compose method introduced here can be used to combine the two layouts.
