### PR TITLE
[WIP] Aligning amplitude rescaling of `Gaussian` and `Drag` pulses

### DIFF
--- a/qiskit/pulse/library/symbolic_pulses.py
+++ b/qiskit/pulse/library/symbolic_pulses.py
@@ -809,7 +809,7 @@ class Gaussian(metaclass=_PulseType):
         valid_amp_conditions_expr = sym.Abs(_amp) <= 1.0
 
         return ScalableSymbolicPulse(
-            pulse_type=cls.alias,
+            pulse_type=cls.alias + ("_Rescaled" if rescale_amplitude else ""),
             duration=duration,
             amp=amp,
             angle=angle,


### PR DESCRIPTION
### Summary
This draft PR presents a possible approach in aligning the pulse definitions of `Gaussian` and `Drag` with the backend.

### Details and comments
The envelope of both `pulse.Gaussian` and `pulse.Drag` are defined with an amplitude rescaling - after the gaussian is lifted (so that it will zero on the edges), the amplitude is then rescaled to preserve the user specified amplitude in the center of the pulse. The shorter the pulse is (compared to the width of the gaussian) the more prominent the effect becomes. For typical durations and widths used on IBM backends, the difference between rescaling and not rescaling could easily come out to a few percent, which is easily noticeable in the measured results.

Unfortunately, while Qiskit uses the rescaling convention, IBM backends do not. This has caused [confusion](https://github.com/Qiskit/qiskit-ibm-runtime/issues/1174) as seemingly identical `SymbolicPulse` and the `Waveform` defined by it produce different results - because the former is sampled on the backend (without rescaling) and the latter is sampled on the frontend (with rescaling).

As the choice whether or not to rescale is simply one of convention, and no convention holds a clear advantage, it seems reasonable to remove the rescaling, and align with IBM backends. Other providers can obviously create their own `SymbolicPulse` library and define the pulses as they see fit.

This PR demonstrates the option of adding an optional argument `rescale_amplitude` with a default value `False` to the `Gaussian` pulse. Using the optional flag, we can demonstrate the difference compared to the backend. Consider the circuit:

```python
  qc = circuit.QuantumCircuit(1, 1)
  qc.x(0)
  qc.measure(0, 0)
  qc.add_calibration("x",(0,), cali)
```
If we set:
```python
with pulse.build() as cali:
    pulse.play(pulse.Gaussian(160, 0.2, 50), pulse.DriveChannel(0))
```
the sampling is done on the backend, and we get `0` on `318/20000` shots.

However, if we sample on the frontend and set `rescale_amplitude=True` using
```python
with pulse.build() as cali:
    pulse.play(pulse.Gaussian(160, 0.2, 50, rescale_amplitude=True).get_waveform(), pulse.DriveChannel(0))
```
we get `0` on `4986/20000` shots.

If we set `rescale_amplitude=False` using
```python
with pulse.build() as cali:
    pulse.play(pulse.Gaussian(160, 0.2, 50, rescale_amplitude=False).get_waveform(), pulse.DriveChannel(0))
```
we get `0` on `247/20000` shots, like the backend sampled pulse.

By changing the `pulse_type` when `rescale_amplitude==True` we make sure that this version of the pulse is sampled on the frontend, and hopefully avoid issues with QPY roundtrips.

For example:
```python
with pulse.build() as cali:
    pulse.play(pulse.Gaussian(160, 0.2, 50, rescale_amplitude=True), pulse.DriveChannel(0))
```
Leads again to `0` on `4948/20000` like with the waveform example above.

### Issues
- What should be set when loading old QPY files?

This will be a breaking change and a follow-up PR will be added to the 0.46 branch to warn users of the upcoming change.