### PR TITLE
Pin `z3-solver` on macOS VMs

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -6,3 +6,10 @@ jsonschema==3.2.0
 # eigensystem code for one of the test cases.  See
 # https://github.com/Qiskit/qiskit-terra/issues/10345 for current details.
 scipy<1.11; python_version<'3.12'
+
+# z3-solver from 4.12.3 onwards upped the minimum macOS API version for its
+# wheels to 11.7. The Azure VM images contain pre-built CPythons, of which at
+# least CPython 3.8 was compiled for an older macOS, so does not match a
+# `macos_11_7` platform tag.  This should be purely a CI artefact, and not
+# affect local usage.
+z3-solver==4.12.2.0; platform_system=="Darwin"


### PR DESCRIPTION
### Summary

We currently use macOS 11.7 images in our CI and CPython 3.8 for the all-optionals test run.  `z3-solver` recently released 4.12.3.0, which upped the macOS platform version from 10.16 to 11.7.  This in theory should be fine for our VM image, but the pre-built version of CPython 3.8 we have access to was built for an older macOS, so does not match a `macos_11_7_x86_64` platform tag, and forces us to build Z3 from source, often timing out the job.

This should have no effect on user machines, which will be typically be using newer versions of Python, or will be able to install from source if required.

This CI-only constraint can be relaxed when the version of CPython we use on the macOS VMs supports the 11.7 macOS API version.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments


