### PR TITLE
Remove deprecated functions in pulse qobj converter

### DIFF
--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -30,7 +30,6 @@ from qiskit.pulse.parser import parse_string_expr
 from qiskit.pulse.schedule import Schedule
 from qiskit.qobj import QobjMeasurementOption, PulseLibraryItem, PulseQobjInstruction
 from qiskit.qobj.utils import MeasLevel
-from qiskit.utils.deprecation import deprecate_func
 
 
 class ParametricPulseShapes(Enum):
@@ -63,18 +62,10 @@ class ParametricPulseShapes(Enum):
         Raises:
             QiskitError: When pulse instance is not recognizable type.
         """
-        if isinstance(instance, library.SymbolicPulse):
+        try:
             return cls(instance.pulse_type)
-        if isinstance(instance, library.parametric_pulses.Gaussian):
-            return ParametricPulseShapes.gaussian
-        if isinstance(instance, library.parametric_pulses.GaussianSquare):
-            return ParametricPulseShapes.gaussian_square
-        if isinstance(instance, library.parametric_pulses.Drag):
-            return ParametricPulseShapes.drag
-        if isinstance(instance, library.parametric_pulses.Constant):
-            return ParametricPulseShapes.constant
-
-        raise QiskitError(f"'{instance}' is not valid pulse type.")
+        except ValueError as ex:
+            raise QiskitError(f"'{instance}' is not valid pulse type.") from ex
 
     @classmethod
     def to_type(cls, name: str) -> library.SymbolicPulse:
@@ -502,78 +493,6 @@ class InstructionToQobjConverter:
 
         return self._qobj_model(**command_dict)
 
-    @deprecate_func(
-        additional_msg="Instead, call converter instance directory.",
-        since="0.23.0",
-        package_name="qiskit-terra",
-    )
-    def convert_acquire(self, shift, instruction):
-        return self._convert_instruction(instruction, shift)
-
-    @deprecate_func(
-        additional_msg="Instead, call converter instance directory.",
-        since="0.23.0",
-        package_name="qiskit-terra",
-    )
-    def convert_bundled_acquires(self, shift, instructions_):
-        return self._convert_bundled_acquire(instructions_, shift)
-
-    @deprecate_func(
-        additional_msg="Instead, call converter instance directory.",
-        since="0.23.0",
-        package_name="qiskit-terra",
-    )
-    def convert_set_frequency(self, shift, instruction):
-        return self._convert_instruction(instruction, shift)
-
-    @deprecate_func(
-        additional_msg="Instead, call converter instance directory.",
-        since="0.23.0",
-        package_name="qiskit-terra",
-    )
-    def convert_shift_frequency(self, shift, instruction):
-        return self._convert_instruction(instruction, shift)
-
-    @deprecate_func(
-        additional_msg="Instead, call converter instance directory.",
-        since="0.23.0",
-        package_name="qiskit-terra",
-    )
-    def convert_set_phase(self, shift, instruction):
-        return self._convert_instruction(instruction, shift)
-
-    @deprecate_func(
-        additional_msg="Instead, call converter instance directory.",
-        since="0.23.0",
-        package_name="qiskit-terra",
-    )
-    def convert_shift_phase(self, shift, instruction):
-        return self._convert_instruction(instruction, shift)
-
-    @deprecate_func(
-        additional_msg="Instead, call converter instance directory.",
-        since="0.23.0",
-        package_name="qiskit-terra",
-    )
-    def convert_delay(self, shift, instruction):
-        return self._convert_instruction(instruction, shift)
-
-    @deprecate_func(
-        additional_msg="Instead, call converter instance directory.",
-        since="0.23.0",
-        package_name="qiskit-terra",
-    )
-    def convert_play(self, shift, instruction):
-        return self._convert_instruction(instruction, shift)
-
-    @deprecate_func(
-        additional_msg="Instead, call converter instance directory.",
-        since="0.23.0",
-        package_name="qiskit-terra",
-    )
-    def convert_snapshot(self, shift, instruction):
-        return self._convert_instruction(instruction, shift)
-
 
 class QobjToInstructionConverter:
     """Converts Qobj data into Qiskit Pulse in-memory representation.
@@ -963,108 +882,3 @@ class QobjToInstructionConverter:
                 f"Instruction {instruction.name} on qubit {instruction.qubits} is not found  "
                 "in Qiskit namespace. This instruction cannot be deserialized."
             )
-
-    @deprecate_func(
-        additional_msg="Instead, call converter instance directory.",
-        since="0.23.0",
-        package_name="qiskit-terra",
-    )
-    def convert_acquire(self, instruction):
-        t0 = instruction.t0
-        schedule = Schedule()
-        for inst in self._convert_acquire(instruction=instruction):
-            schedule.insert(t0, inst, inplace=True)
-        return schedule
-
-    @deprecate_func(
-        additional_msg="Instead, call converter instance directory.",
-        since="0.23.0",
-        package_name="qiskit-terra",
-    )
-    def convert_set_phase(self, instruction):
-        t0 = instruction.t0
-        schedule = Schedule()
-        for inst in self._convert_setp(instruction=instruction):
-            schedule.insert(t0, inst, inplace=True)
-        return schedule
-
-    @deprecate_func(
-        additional_msg="Instead, call converter instance directory.",
-        since="0.23.0",
-        package_name="qiskit-terra",
-    )
-    def convert_shift_phase(self, instruction):
-        t0 = instruction.t0
-        schedule = Schedule()
-        for inst in self._convert_fc(instruction=instruction):
-            schedule.insert(t0, inst, inplace=True)
-        return schedule
-
-    @deprecate_func(
-        additional_msg="Instead, call converter instance directory.",
-        since="0.23.0",
-        package_name="qiskit-terra",
-    )
-    def convert_set_frequency(self, instruction):
-        t0 = instruction.t0
-        schedule = Schedule()
-        for inst in self._convert_setf(instruction=instruction):
-            schedule.insert(t0, inst, inplace=True)
-        return schedule
-
-    @deprecate_func(
-        additional_msg="Instead, call converter instance directory.",
-        since="0.23.0",
-        package_name="qiskit-terra",
-    )
-    def convert_shift_frequency(self, instruction):
-        t0 = instruction.t0
-        schedule = Schedule()
-        for inst in self._convert_shiftf(instruction=instruction):
-            schedule.insert(t0, inst, inplace=True)
-        return schedule
-
-    @deprecate_func(
-        additional_msg="Instead, call converter instance directory.",
-        since="0.23.0",
-        package_name="qiskit-terra",
-    )
-    def convert_delay(self, instruction):
-        t0 = instruction.t0
-        schedule = Schedule()
-        for inst in self._convert_delay(instruction=instruction):
-            schedule.insert(t0, inst, inplace=True)
-        return schedule
-
-    @deprecate_func(
-        additional_msg="Instead, call converter instance directory.",
-        since="0.23.0",
-        package_name="qiskit-terra",
-    )
-    def bind_pulse(self, pulse):
-        if pulse.name not in self._pulse_library:
-            self._pulse_library[pulse.name] = pulse.samples
-
-    @deprecate_func(
-        additional_msg="Instead, call converter instance directory.",
-        since="0.23.0",
-        package_name="qiskit-terra",
-    )
-    def convert_parametric(self, instruction):
-        t0 = instruction.t0
-        schedule = Schedule()
-        for inst in self._convert_parametric_pulse(instruction=instruction):
-            schedule.insert(t0, inst, inplace=True)
-        return schedule
-
-    @deprecate_func(
-        additional_msg="Instead, call converter instance directory.",
-        since="0.23.0",
-        package_name="qiskit-terra",
-    )
-    def convert_snapshot(self, instruction):
-        t0 = instruction.t0
-        schedule = Schedule()
-        for inst in self._convert_snapshot(instruction=instruction):
-            schedule.insert(t0, inst, inplace=True)
-        return schedule

--- a/releasenotes/notes/remove-deprecated-funcs-in-qobj-converter-402408e84b3043bb.yaml
+++ b/releasenotes/notes/remove-deprecated-funcs-in-qobj-converter-402408e84b3043bb.yaml
@@ -1,7 +1,7 @@
 ---
 upgrade:
   - |
-    Removed deprecated functions in :class:`.InstructionToQobjConverter`
+    Removed deprecated methods in :class:`.InstructionToQobjConverter`
     and :class:`.QobjToInstructionConverter`. This includes
 
     * :meth:`.InstructionToQobjConverter.convert_acquire`
@@ -23,5 +23,5 @@ upgrade:
     * :meth:`.QobjToInstructionConverter.convert_parametric`
     * :meth:`.QobjToInstructionConverter.convert_snapshot`
 
-    These public functions are all replaced with protected ones which are implicitly called from
+    These public methods are all replaced with protected ones which are implicitly called from
     the single entry point, i.e. call dunder method of the classes.

--- a/releasenotes/notes/remove-deprecated-funcs-in-qobj-converter-402408e84b3043bb.yaml
+++ b/releasenotes/notes/remove-deprecated-funcs-in-qobj-converter-402408e84b3043bb.yaml
@@ -1,0 +1,27 @@
+---
+upgrade:
+  - |
+    Removed deprecated functions in :class:`.InstructionToQobjConverter`
+    and :class:`.QobjToInstructionConverter`. This includes
+
+    * :meth:`.InstructionToQobjConverter.convert_acquire`
+    * :meth:`.InstructionToQobjConverter.convert_bundled_acquires`
+    * :meth:`.InstructionToQobjConverter.convert_set_frequency`
+    * :meth:`.InstructionToQobjConverter.convert_shift_frequency`
+    * :meth:`.InstructionToQobjConverter.convert_set_phase`
+    * :meth:`.InstructionToQobjConverter.convert_shift_phase`
+    * :meth:`.InstructionToQobjConverter.convert_delay`
+    * :meth:`.InstructionToQobjConverter.convert_play`
+    * :meth:`.InstructionToQobjConverter.convert_snapshot`
+    * :meth:`.QobjToInstructionConverter.convert_acquire`
+    * :meth:`.QobjToInstructionConverter.convert_set_phase`
+    * :meth:`.QobjToInstructionConverter.convert_shift_phase`
+    * :meth:`.QobjToInstructionConverter.convert_set_frequency`
+    * :meth:`.QobjToInstructionConverter.convert_shift_frequency`
+    * :meth:`.QobjToInstructionConverter.convert_delay`
+    * :meth:`.QobjToInstructionConverter.bind_pulse`
+    * :meth:`.QobjToInstructionConverter.convert_parametric`
+    * :meth:`.QobjToInstructionConverter.convert_snapshot`
+
+    These public functions are all replaced with protected ones which are implicitly called from
+    the single entry point, i.e. call dunder method of the classes.


### PR DESCRIPTION
### Summary

This PR removes deprecated class methods in the pulse qobj converters.

### Details and comments

This also updates internals of `ParametricPulseShapes` mapping table, because parametric pulse is also removed in this release.
