### PR TITLE
Fixed bug in OptimizeSwapBeforeMeasure

### DIFF
--- a/qiskit/transpiler/passes/optimization/optimize_swap_before_measure.py
+++ b/qiskit/transpiler/passes/optimization/optimize_swap_before_measure.py
@@ -43,7 +43,7 @@ class OptimizeSwapBeforeMeasure(TransformationPass):
             if getattr(swap.op, "condition", None) is not None:
                 continue
             final_successor = []
-            for successor in dag.successors(swap):
+            for successor in dag.descendants(swap):
                 final_successor.append(
                     isinstance(successor, DAGOutNode)
                     or (isinstance(successor, DAGOpNode) and isinstance(successor.op, Measure))
@@ -56,7 +56,7 @@ class OptimizeSwapBeforeMeasure(TransformationPass):
                     measure_layer.add_qreg(qreg)
                 for creg in dag.cregs.values():
                     measure_layer.add_creg(creg)
-                for successor in list(dag.successors(swap)):
+                for successor in list(dag.descendants(swap)):
                     if isinstance(successor, DAGOpNode) and isinstance(successor.op, Measure):
                         # replace measure node with a new one, where qargs is set with the "other"
                         # swap qarg.

--- a/releasenotes/notes/fix-optimize-swap-before-measure-67e8896da2215d49.yaml
+++ b/releasenotes/notes/fix-optimize-swap-before-measure-67e8896da2215d49.yaml
@@ -1,0 +1,44 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :class:`~.OptimizeSwapBeforeMeasure` pass where
+    it would incorrectly optimize circuits involving swap and measure 
+    instructions. This commit fixes the bug by changing `DAGCircuit.successors`
+    to `DAGCircuit.descendants`. Also, added a couple of extra tests to ensure 
+    that the bug is fixed. For example::
+
+        from qiskit import QuantumCircuit
+        from qiskit.transpiler.passes import OptimizeSwapBeforeMeasure
+        pass_ = OptimizeSwapBeforeMeasure()
+        qc = QuantumCircuit(2, 1)
+        qc.swap(0, 1)
+        qc.measure(0, 0)
+        qc.measure(0, 0)
+        print(qc.draw())
+        print(pass_(qc).draw())
+    
+    would previously print::
+
+                  ┌─┐┌─┐
+          q_0: ─X─┤M├┤M├
+                │ └╥┘└╥┘
+          q_1: ─X──╫──╫─
+                   ║  ║
+          c: 1/════╩══╩═
+                   0  0
+               ┌─┐
+          q_0: ┤M├───
+               └╥┘┌─┐
+          q_1: ─╫─┤M├
+                ║ └╥┘
+          c: 1/═╩══╩═
+                0  0
+    
+    and now the second ciruit is correctly optimized to::
+      
+          q_0: ──────
+               ┌─┐┌─┐
+          q_1: ┤M├┤M├
+               └╥┘└╥┘
+          c: 1/═╩══╩═
+                0  0

--- a/test/python/transpiler/test_optimize_swap_before_measure.py
+++ b/test/python/transpiler/test_optimize_swap_before_measure.py
@@ -73,6 +73,38 @@ class TestOptimizeSwapBeforeMeasure(QiskitTestCase):
 
         self.assertEqual(circuit_to_dag(expected), after)
 
+    def test_optimize_3swap_3measure(self):
+        """Remove three swaps affecting three measurements
+                ┌─┐         ┌─┐             ┌─┐   
+        q_0: ─X─┤M├────X──X─┤M├     q_0: ───┤M├───
+              │ └╥┘┌─┐ │  │ └╥┘          ┌─┐└╥┘┌─┐
+        q_1: ─X──╫─┤M├─┼──┼──╫─     q_1: ┤M├─╫─┤M├
+                 ║ └╥┘ │  │  ║  ==>      └╥┘ ║ └╥┘
+        q_2: ────╫──╫──X──X──╫─     q_2: ─╫──╫──╫─
+                 ║  ║        ║            ║  ║  ║ 
+        c: 2/════╩══╩════════╩═     c: 2/═╩══╩══╩═
+                 0  1        0            0  1  0 
+        """
+    
+        qc = QuantumCircuit(3, 2)
+        qc.swap(0, 1)
+        qc.measure(0, 0)
+        qc.swap(0, 2)
+        qc.measure(1, 1)
+        qc.swap(0, 2)
+        qc.measure(0, 0)
+        dag = circuit_to_dag(qc);
+        
+        expected = QuantumCircuit(3, 2)
+        expected.measure(1, 0);
+        expected.measure(0, 1);
+        expected.measure(1, 0);
+        
+        pass_ = OptimizeSwapBeforeMeasure()
+        after = pass_.run(dag)
+
+        self.assertEqual(circuit_to_dag(expected), after)
+
     def test_optimize_nswap_nmeasure(self):
         """Remove severals swap affecting multiple measurements
                             ┌─┐                                                   ┌─┐
@@ -134,6 +166,45 @@ class TestOptimizeSwapBeforeMeasure(QiskitTestCase):
         expected.measure(6, 5)
         expected.measure(7, 6)
 
+        pass_ = OptimizeSwapBeforeMeasure()
+        after = pass_.run(dag)
+
+        self.assertEqual(circuit_to_dag(expected), after)
+
+    def test_optimize_nswap_nmeasure_2(self):
+        """Remove multiple swaps affecting multiple measurements
+                   ┌─┐┌─┐                             ┌─┐┌─┐┌─┐┌─┐┌─┐
+        q_0: ─X──X─┤M├┤M├─X──────────────X─      q_0: ┤M├┤M├┤M├┤M├┤M├
+              │  │ └╥┘└╥┘ │       ┌─┐    │            └╥┘└╥┘└╥┘└╥┘└╥┘
+        q_1: ─X──X──╫──╫──┼─────X─┤M├─X──X─      q_1: ─╫──╫──╫──╫──╫─
+                    ║  ║  │ ┌─┐ │ └╥┘ │ ┌─┐  ==>       ║  ║  ║  ║  ║ 
+        q_2: ───────╫──╫──X─┤M├─X──╫──X─┤M├      q_2: ─╫──╫──╫──╫──╫─
+                    ║  ║    └╥┘    ║    └╥┘            ║  ║  ║  ║  ║ 
+        c: 1/═══════╩══╩═════╩═════╩═════╩═      c: 1/═╩══╩══╩══╩══╩═
+                    0  0     0     0     0             0  0  0  0  0
+        """
+    
+        qc = QuantumCircuit(3, 1)
+        qc.swap(0, 1)
+        qc.swap(0, 1)
+        qc.measure(0, 0)
+        qc.measure(0, 0)
+        qc.swap(2, 0)
+        qc.measure(2, 0)
+        qc.swap(1, 2)
+        qc.measure(1, 0)
+        qc.swap(1, 2)
+        qc.swap(0, 1)
+        qc.measure(2, 0)
+        dag = circuit_to_dag(qc);
+        
+        expected = QuantumCircuit(3, 1)
+        expected.measure(0, 0);
+        expected.measure(0, 0);
+        expected.measure(0, 0);
+        expected.measure(0, 0);
+        expected.measure(0, 0);
+        
         pass_ = OptimizeSwapBeforeMeasure()
         after = pass_.run(dag)
 

--- a/test/python/transpiler/test_optimize_swap_before_measure.py
+++ b/test/python/transpiler/test_optimize_swap_before_measure.py
@@ -75,17 +75,17 @@ class TestOptimizeSwapBeforeMeasure(QiskitTestCase):
 
     def test_optimize_3swap_3measure(self):
         """Remove three swaps affecting three measurements
-                ┌─┐         ┌─┐             ┌─┐   
+                ┌─┐         ┌─┐             ┌─┐
         q_0: ─X─┤M├────X──X─┤M├     q_0: ───┤M├───
               │ └╥┘┌─┐ │  │ └╥┘          ┌─┐└╥┘┌─┐
         q_1: ─X──╫─┤M├─┼──┼──╫─     q_1: ┤M├─╫─┤M├
                  ║ └╥┘ │  │  ║  ==>      └╥┘ ║ └╥┘
         q_2: ────╫──╫──X──X──╫─     q_2: ─╫──╫──╫─
-                 ║  ║        ║            ║  ║  ║ 
+                 ║  ║        ║            ║  ║  ║
         c: 2/════╩══╩════════╩═     c: 2/═╩══╩══╩═
-                 0  1        0            0  1  0 
+                 0  1        0            0  1  0
         """
-    
+
         qc = QuantumCircuit(3, 2)
         qc.swap(0, 1)
         qc.measure(0, 0)
@@ -93,13 +93,13 @@ class TestOptimizeSwapBeforeMeasure(QiskitTestCase):
         qc.measure(1, 1)
         qc.swap(0, 2)
         qc.measure(0, 0)
-        dag = circuit_to_dag(qc);
-        
+        dag = circuit_to_dag(qc)
+
         expected = QuantumCircuit(3, 2)
-        expected.measure(1, 0);
-        expected.measure(0, 1);
-        expected.measure(1, 0);
-        
+        expected.measure(1, 0)
+        expected.measure(0, 1)
+        expected.measure(1, 0)
+
         pass_ = OptimizeSwapBeforeMeasure()
         after = pass_.run(dag)
 
@@ -177,13 +177,13 @@ class TestOptimizeSwapBeforeMeasure(QiskitTestCase):
         q_0: ─X──X─┤M├┤M├─X──────────────X─      q_0: ┤M├┤M├┤M├┤M├┤M├
               │  │ └╥┘└╥┘ │       ┌─┐    │            └╥┘└╥┘└╥┘└╥┘└╥┘
         q_1: ─X──X──╫──╫──┼─────X─┤M├─X──X─      q_1: ─╫──╫──╫──╫──╫─
-                    ║  ║  │ ┌─┐ │ └╥┘ │ ┌─┐  ==>       ║  ║  ║  ║  ║ 
+                    ║  ║  │ ┌─┐ │ └╥┘ │ ┌─┐  ==>       ║  ║  ║  ║  ║
         q_2: ───────╫──╫──X─┤M├─X──╫──X─┤M├      q_2: ─╫──╫──╫──╫──╫─
-                    ║  ║    └╥┘    ║    └╥┘            ║  ║  ║  ║  ║ 
+                    ║  ║    └╥┘    ║    └╥┘            ║  ║  ║  ║  ║
         c: 1/═══════╩══╩═════╩═════╩═════╩═      c: 1/═╩══╩══╩══╩══╩═
                     0  0     0     0     0             0  0  0  0  0
         """
-    
+
         qc = QuantumCircuit(3, 1)
         qc.swap(0, 1)
         qc.swap(0, 1)
@@ -196,15 +196,15 @@ class TestOptimizeSwapBeforeMeasure(QiskitTestCase):
         qc.swap(1, 2)
         qc.swap(0, 1)
         qc.measure(2, 0)
-        dag = circuit_to_dag(qc);
-        
+        dag = circuit_to_dag(qc)
+
         expected = QuantumCircuit(3, 1)
-        expected.measure(0, 0);
-        expected.measure(0, 0);
-        expected.measure(0, 0);
-        expected.measure(0, 0);
-        expected.measure(0, 0);
-        
+        expected.measure(0, 0)
+        expected.measure(0, 0)
+        expected.measure(0, 0)
+        expected.measure(0, 0)
+        expected.measure(0, 0)
+
         pass_ = OptimizeSwapBeforeMeasure()
         after = pass_.run(dag)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixed an issue with the :class:`~.OptimizeSwapBeforeMeasure` pass where it would incorrectly optimize circuits involving swap and measure instructions. This commit fixes the bug by changing`DAGCircuit.successors`to`DAGCircuit.descendants`. Also, added a couple of extra tests to ensure that the bug is fixed.

### Details and comments
The original issue in https://github.com/Qiskit/qiskit/issues/11195 could not be reproduced after the fix as it produced a ValueError.
