### PR TITLE
Fix incorrect list of parameters in PauliTwoDesign documentation 

### DIFF
--- a/qiskit/circuit/library/n_local/pauli_two_design.py
+++ b/qiskit/circuit/library/n_local/pauli_two_design.py
@@ -75,6 +75,16 @@ class PauliTwoDesign(TwoLocal):
         insert_barriers: bool = False,
         name: str = "PauliTwoDesign",
     ):
+        """
+        Args:
+            num_qubits: The number of qubits of the Pauli Two-Design circuit.
+            reps: Specifies how often a block consisting of a rotation layer and entanglement
+                layer is repeated.
+            seed: The seed for randomly choosing the axes of the Pauli rotations.
+            insert_barriers: If ``True``, barriers are inserted in between each layer. If ``False``,
+                no barriers are inserted. Defaults to ``False``.
+
+        """
         from qiskit.circuit.library import RYGate  # pylint: disable=cyclic-import
 
         # store a random number generator


### PR DESCRIPTION
- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.

### Summary
Add an Args docstring to the `init` function in `PauliTwoDesign.py` to fix the incorrect list of parameters in the documentation.

### Details and comments
The list of parameters in the `parameter` section for the [PauliTwoDesign circuit](https://docs.quantum.ibm.com/api/qiskit/qiskit.circuit.library.PauliTwoDesign) appears to be the one for the [TwoLocal circuit](https://docs.quantum.ibm.com/api/qiskit/qiskit.circuit.library.TwoLocal). 
This PR adds an Args docstring with the correct parameters for the PauliTwoDesign function.

Since the `name` parameter is not in the list for `TwoLocal`, I assumed this was done on purpose and did not include `name` in the docstring for `PauliTwoDesign`.

Fixes #11423

