### PR TITLE
Track `QuantumCircuit.global_phase` in `ParameterTable`

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2930,6 +2930,7 @@ class QuantumCircuit:
         """Efficiently get all parameters in the circuit, without any sorting overhead.
 
         .. warning::
+
             The returned object may directly view onto the ``ParameterTable`` internals, and so
             should not be mutated.  This is an internal performance detail.  Code outside of this
             package should not use this method.

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -437,7 +437,10 @@ class QuantumCircuit:
         else:
             data_input = list(data_input)
         self._data.clear()
+        self._parameters = None
         self._parameter_table = ParameterTable()
+        # Repopulate the parameter table with any global-phase entries.
+        self.global_phase = self.global_phase
         if not data_input:
             return
         if isinstance(data_input[0], CircuitInstruction):
@@ -2411,6 +2414,9 @@ class QuantumCircuit:
         operation_copies = {
             id(instruction.operation): instruction.operation.copy() for instruction in self._data
         }
+        # The special global-phase sentinel doesn't need copying, but this ensures that it'll get
+        # recognised.  The global phase itself was already copied over in 'copy_empty_like`.
+        operation_copies[id(ParameterTable.GLOBAL_PHASE)] = ParameterTable.GLOBAL_PHASE
 
         cpy._parameter_table = ParameterTable(
             {
@@ -2473,6 +2479,10 @@ class QuantumCircuit:
         cpy._vars_capture = self._vars_capture.copy()
 
         cpy._parameter_table = ParameterTable()
+        for parameter in getattr(cpy.global_phase, "parameters", ()):
+            cpy._parameter_table[parameter] = ParameterReferences(
+                [(ParameterTable.GLOBAL_PHASE, None)]
+            )
         cpy._data = CircuitData(self._data.qubits, self._data.clbits)
 
         cpy._calibrations = copy.deepcopy(self._calibrations)
@@ -2489,6 +2499,8 @@ class QuantumCircuit:
         """
         self._data.clear()
         self._parameter_table.clear()
+        # Repopulate the parameter table with any phase symbols.
+        self.global_phase = self.global_phase
 
     def _create_creg(self, length: int, name: str) -> ClassicalRegister:
         """Creates a creg, checking if ClassicalRegister with same name exists"""
@@ -2825,9 +2837,20 @@ class QuantumCircuit:
         Args:
             angle (float, ParameterExpression): radians
         """
-        if not (isinstance(angle, ParameterExpression) and angle.parameters):
-            # Set the phase to the [0, 2π) interval
-            angle = float(angle) % (2 * np.pi)
+        # If we're currently parametric, we need to throw away the references.  This setter is
+        # called by some subclasses before the inner `_global_phase` is initialised.
+        global_phase_reference = (ParameterTable.GLOBAL_PHASE, None)
+        if isinstance(previous := getattr(self, "_global_phase", None), ParameterExpression):
+            self._parameter_table.discard_references(previous, global_phase_reference)
+
+        if isinstance(angle, ParameterExpression) and angle.parameters:
+            for parameter in angle.parameters:
+                if parameter not in self._parameter_table:
+                    self._parameters = None
+                    self._parameter_table[parameter] = ParameterReferences(())
+                self._parameter_table[parameter].add(global_phase_reference)
+        else:
+            angle = _normalize_global_phase(angle)
         if self._control_flow_scopes:
             self._control_flow_scopes[-1].global_phase = angle
         else:
@@ -2901,27 +2924,11 @@ class QuantumCircuit:
     @property
     def num_parameters(self) -> int:
         """The number of parameter objects in the circuit."""
-        # Avoid a (potential) object creation if we can.
-        if self._parameters is not None:
-            return len(self._parameters)
-        return len(self._unsorted_parameters())
+        return len(self._parameter_table)
 
     def _unsorted_parameters(self) -> set[Parameter]:
-        """Efficiently get all parameters in the circuit, without any sorting overhead.
-
-        .. warning::
-
-            The returned object may directly view onto the ``ParameterTable`` internals, and so
-            should not be mutated.  This is an internal performance detail.  Code outside of this
-            package should not use this method.
-        """
-        # This should be free, by accessing the actual backing data structure of the table, but that
-        # means that we need to copy it if adding keys from the global phase.
-        parameters = self._parameter_table.get_keys()
-        if isinstance(self.global_phase, ParameterExpression):
-            # Deliberate copy.
-            parameters = parameters | self.global_phase.parameters
-        return parameters
+        """Efficiently get all parameters in the circuit, without any sorting overhead."""
+        return self._parameter_table.get_keys()
 
     @overload
     def assign_parameters(
@@ -3038,7 +3045,6 @@ class QuantumCircuit:
         # 'target' so we can take advantage of any caching we might be doing.
         if isinstance(parameters, dict):
             raw_mapping = parameters if flat_input else self._unroll_param_dict(parameters)
-            # Remember that we _must not_ mutate the output of `_unsorted_parameters`.
             our_parameters = self._unsorted_parameters()
             if strict and (extras := raw_mapping.keys() - our_parameters):
                 raise CircuitError(
@@ -3073,7 +3079,12 @@ class QuantumCircuit:
             )
             for operation, index in references:
                 seen_operations[id(operation)] = operation
-                assignee = operation.params[index]
+                if operation is ParameterTable.GLOBAL_PHASE:
+                    assignee = target.global_phase
+                    validate = _normalize_global_phase
+                else:
+                    assignee = operation.params[index]
+                    validate = operation.validate_parameter
                 if isinstance(assignee, ParameterExpression):
                     new_parameter = assignee.assign(to_bind, bound_value)
                     for parameter in update_parameters:
@@ -3081,7 +3092,7 @@ class QuantumCircuit:
                             target._parameter_table[parameter] = ParameterReferences(())
                         target._parameter_table[parameter].add((operation, index))
                     if not new_parameter.parameters:
-                        new_parameter = operation.validate_parameter(new_parameter.numeric())
+                        new_parameter = validate(new_parameter.numeric())
                 elif isinstance(assignee, QuantumCircuit):
                     new_parameter = assignee.assign_parameters(
                         {to_bind: bound_value}, inplace=False, flat_input=True
@@ -3091,7 +3102,12 @@ class QuantumCircuit:
                         f"Saw an unknown type during symbolic binding: {assignee}."
                         " This may indicate an internal logic error in symbol tracking."
                     )
-                operation.params[index] = new_parameter
+                if operation is ParameterTable.GLOBAL_PHASE:
+                    # We've already handled parameter table updates in bulk, so we need to skip the
+                    # public setter trying to do it again.
+                    target._global_phase = new_parameter
+                else:
+                    operation.params[index] = new_parameter
 
         # After we've been through everything at the top level, make a single visit to each
         # operation we've seen, rebinding its definition if necessary.
@@ -3102,12 +3118,6 @@ class QuantumCircuit:
                 definition.assign_parameters(
                     parameter_binds.mapping, inplace=True, flat_input=True, strict=False
                 )
-
-        if isinstance(target.global_phase, ParameterExpression):
-            new_phase = target.global_phase
-            for parameter in new_phase.parameters & parameter_binds.mapping.keys():
-                new_phase = new_phase.assign(parameter, parameter_binds.mapping[parameter])
-            target.global_phase = new_phase
 
         # Finally, assign the parameters inside any of the calibrations.  We don't track these in
         # the `ParameterTable`, so we manually reconstruct things.
@@ -6064,3 +6074,11 @@ def _bit_argument_conversion_scalar(specifier, bit_sequence, bit_set, type_):
         else f"Invalid bit index: '{specifier}' of type '{type(specifier)}'"
     )
     raise CircuitError(message)
+
+
+def _normalize_global_phase(angle):
+    """Return the normalized form of an angle for use in the global phase.  This coerces to float if
+    possible, and fixes to the interval :math:`[0, 2\\pi)`."""
+    if isinstance(angle, ParameterExpression) and angle.parameters:
+        return angle
+    return float(angle) % (2.0 * np.pi)

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -370,6 +370,25 @@ class TestCircuitOperations(QiskitTestCase):
         self.assertEqual(len(qc.cregs), 1)
         self.assertEqual(len(copied.cregs), 2)
 
+    def test_copy_handles_global_phase(self):
+        """Test that the global phase is included in the copy, including parameters."""
+        a, b = Parameter("a"), Parameter("b")
+
+        nonparametric = QuantumCircuit(global_phase=1.0).copy()
+        self.assertEqual(nonparametric.global_phase, 1.0)
+        self.assertEqual(set(nonparametric.parameters), set())
+
+        parameter_phase = QuantumCircuit(global_phase=a).copy()
+        self.assertEqual(parameter_phase.global_phase, a)
+        self.assertEqual(set(parameter_phase.parameters), {a})
+        # The `assign_parameters` is an indirect test that the `ParameterTable` is fully valid.
+        self.assertEqual(parameter_phase.assign_parameters({a: 1.0}).global_phase, 1.0)
+
+        expression_phase = QuantumCircuit(global_phase=a - b).copy()
+        self.assertEqual(expression_phase.global_phase, a - b)
+        self.assertEqual(set(expression_phase.parameters), {a, b})
+        self.assertEqual(expression_phase.assign_parameters({a: 3, b: 2}).global_phase, 1.0)
+
     def test_copy_empty_like_circuit(self):
         """Test copy_empty_like method makes a clear copy."""
         qr = QuantumRegister(2)
@@ -462,6 +481,24 @@ class TestCircuitOperations(QiskitTestCase):
         copied.add_capture(d)
         self.assertEqual({b, d}, set(copied.iter_captured_vars()))
         self.assertEqual({b}, set(qc.iter_captured_vars()))
+
+    def test_copy_empty_like_parametric_phase(self):
+        """Test that the parameter table of an empty circuit remains valid after copying a circuit
+        with a parametric global phase."""
+        a, b = Parameter("a"), Parameter("b")
+
+        single = QuantumCircuit(global_phase=a).copy_empty_like()
+        self.assertEqual(single.global_phase, a)
+        self.assertEqual(set(single.parameters), {a})
+        # The `assign_parameters` is an indirect test that the `ParameterTable` is fully valid.
+        self.assertEqual(single.assign_parameters({a: 1.0}).global_phase, 1.0)
+
+        stripped_instructions = QuantumCircuit(1, global_phase=a - b)
+        stripped_instructions.rz(a, 0)
+        stripped_instructions = stripped_instructions.copy_empty_like()
+        self.assertEqual(stripped_instructions.global_phase, a - b)
+        self.assertEqual(set(stripped_instructions.parameters), {a, b})
+        self.assertEqual(stripped_instructions.assign_parameters({a: 3, b: 2}).global_phase, 1.0)
 
     def test_circuit_copy_rejects_invalid_types(self):
         """Test copy method rejects argument with type other than 'string' and 'None' type."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

We have previously always had a split where circuit parameters used in instructions were tracked in the `ParameterTable`, but any parameters used in the global phase were not.  Any method that influenced the parameters needed to separately check the global phase, and merge that information with that in the `ParameterTable`.  This made it easy to forget, or easy for the handling of it to become out of sync.

This commit now tracks the global phase as part of the `ParameterTable`, so this object is now the canonical source of parameter information for the circuit (outside the context of calibrations, which are handled entirely separately).  The `ParameterTable` is an internal detail, and only accessible through private attributes, so is not part of the public interface.



### Details and comments

Dependent on #11109, which this PR currently includes.  I'll rebase it after that merges, but I'm putting this up a little early just to have things to link to in the dependency chain of #7107.

No changelog because it's a dev-only internal detail (in theory).