### PR TITLE
Add `QuantumCircuit.get_parameter` to retrieve by name

### DIFF
--- a/qiskit/circuit/parametertable.py
+++ b/qiskit/circuit/parametertable.py
@@ -13,6 +13,7 @@
 Look-up table for variable parameters in QuantumCircuit.
 """
 import operator
+import typing
 from collections.abc import MappingView, MutableMapping, MutableSet
 
 
@@ -124,7 +125,7 @@ class ParameterTable(MutableMapping):
             self._table = {}
 
         self._keys = set(self._table)
-        self._names = {x.name for x in self._table}
+        self._names = {x.name: x for x in self._table}
 
     def __getitem__(self, key):
         return self._table[key]
@@ -149,7 +150,7 @@ class ParameterTable(MutableMapping):
 
         self._table[parameter] = refs
         self._keys.add(parameter)
-        self._names.add(parameter.name)
+        self._names[parameter.name] = parameter
 
     def get_keys(self):
         """Return a set of all keys in the parameter table
@@ -165,7 +166,16 @@ class ParameterTable(MutableMapping):
         Returns:
             set: A set of all the names in the parameter table
         """
-        return self._names
+        return self._names.keys()
+
+    def parameter_from_name(self, name: str, default: typing.Any = None):
+        """Get a :class:`.Parameter` with references in this table by its string name, or return the
+        default if not present.
+
+        Args:
+            name: the name of the :class:`.Parameter`
+            default: the object that should be returned if the parameter is missing."""
+        return self._names.get(name, default)
 
     def discard_references(self, expression, key):
         """Remove all references to parameters contained within ``expression`` at the given table
@@ -181,7 +191,7 @@ class ParameterTable(MutableMapping):
     def __delitem__(self, key):
         del self._table[key]
         self._keys.discard(key)
-        self._names.discard(key.name)
+        del self._names[key.name]
 
     def __iter__(self):
         return iter(self._table)

--- a/qiskit/circuit/parametertable.py
+++ b/qiskit/circuit/parametertable.py
@@ -170,7 +170,7 @@ class ParameterTable(MutableMapping):
 
     def parameter_from_name(self, name: str, default: typing.Any = None):
         """Get a :class:`.Parameter` with references in this table by its string name.
-        
+
         If the parameter is not present, return the ``default`` value.
 
         Args:

--- a/qiskit/circuit/parametertable.py
+++ b/qiskit/circuit/parametertable.py
@@ -169,12 +169,14 @@ class ParameterTable(MutableMapping):
         return self._names.keys()
 
     def parameter_from_name(self, name: str, default: typing.Any = None):
-        """Get a :class:`.Parameter` with references in this table by its string name, or return the
-        default if not present.
+        """Get a :class:`.Parameter` with references in this table by its string name.
+        
+        If the parameter is not present, return the ``default`` value.
 
         Args:
-            name: the name of the :class:`.Parameter`
-            default: the object that should be returned if the parameter is missing."""
+            name: The name of the :class:`.Parameter`
+            default: The object that should be returned if the parameter is missing.
+        """
         return self._names.get(name, default)
 
     def discard_references(self, expression, key):

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1556,7 +1556,7 @@ class QuantumCircuit:
 
         See also:
             :meth:`QuantumCircuit.get_parameter`
-                Retrive the :class:`.Parameter` instance from this circuit by name.
+                Retrieve the :class:`.Parameter` instance from this circuit by name.
             :meth:`QuantumCircuit.has_var`
                 A similar method to this, but for run-time :class:`.expr.Var` variables instead of
                 compile-time :class:`.Parameter`\\ s.
@@ -1633,7 +1633,7 @@ class QuantumCircuit:
 
         See also:
             :meth:`QuantumCircuit.get_var`
-                Retrive the :class:`.expr.Var` instance from this circuit by name.
+                Retrieve the :class:`.expr.Var` instance from this circuit by name.
             :meth:`QuantumCircuit.has_parameter`
                 A similar method to this, but for compile-time :class:`.Parameter`\\ s instead of
                 run-time :class:`.expr.Var` variables.

--- a/releasenotes/notes/circuit-get-parameter-d33c08925b5c7d72.yaml
+++ b/releasenotes/notes/circuit-get-parameter-d33c08925b5c7d72.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    :class:`.QuantumCircuit` has two new methods, :meth:`~.QuantumCircuit.get_parameter` and
+    :meth:`~.QuantumCircuit.has_parameter`, which respectively retrieve a :class:`.Parameter`
+    instance used in the circuit by name, and return a Boolean of whether a parameter with a
+    matching name (or the exact instance given) are used in the circuit.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This allows `Parameter` instances to be retrieved from a circuit by string name.  The interface is a mirror of the same functionality already added for run-time variables (`get_var`), but for the compile-time `Parameter` class.  Similarly, a `has_parameter` method mirrors `has_var`.


### Details and comments

~Depends on #11428, which this PR currently includes.~  Now up to date.
