### PR TITLE
Allow string keys in `QuantumCircuit.assign_parameters`

### DIFF
--- a/releasenotes/notes/assign-by-name-305f2bbf89099174.yaml
+++ b/releasenotes/notes/assign-by-name-305f2bbf89099174.yaml
@@ -1,0 +1,14 @@
+---
+features:
+  - |
+    :meth:`.QuantumCircuit.assign_parameters` now accepts string keys in the mapping form of input.
+    These names are used to look up the corresponding :class:`.Parameter` instance using
+    :meth:`~.QuantumCircuit.get_parameter`.  This lets you do::
+
+      from qiskit.circuit import QuantumCircuit, Parameter
+
+      a = Parameter("a")
+      qc = QuantumCircuit(1)
+      qc.rx(a, 0)
+
+      qc.assign_parameters({"a": 1}) == qc.assign_parameters({a: 1})

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -244,6 +244,18 @@ class TestParameters(QiskitTestCase):
         c = a.bind({a: 1, b: 1}, allow_unknown_parameters=True)
         self.assertEqual(c, a.bind({a: 1}))
 
+    def test_assign_parameters_by_name(self):
+        """Test that parameters can be assigned by name as well as value."""
+        a = Parameter("a")
+        b = Parameter("b")
+        c = Parameter("c")
+        qc = QuantumCircuit(2, global_phase=a * 2)
+        qc.rx(b + 0.125 * c, 0)
+
+        self.assertEqual(
+            qc.assign_parameters({a: 1, b: 2, c: 3}), qc.assign_parameters({"a": 1, "b": 2, "c": 3})
+        )
+
     def test_bind_parameters_custom_definition_global_phase(self):
         """Test that a custom gate with a parametrised `global_phase` is assigned correctly."""
         x = Parameter("x")
@@ -536,7 +548,7 @@ class TestParameters(QiskitTestCase):
         with self.assertRaises(CircuitError):
             qc.assign_parameters({z: [3, 4, 5]})
         with self.assertRaises(CircuitError):
-            qc.assign_parameters({"a_str": 6})
+            qc.assign_parameters({6: 6})
         with self.assertRaises(CircuitError):
             qc.assign_parameters({None: 7})
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

These are looked up using the new `get_parameter` method to convert them into an actual `Parameter` instance.  This is not available in the fast path (which is allowed to assume that the caller has taken care of providing the most efficient inputs).


### Details and comments

~Depends on #11431, which this PR currently contains.~ *edit*: now rebased.

Close #7107.
