### PR TITLE
Fix LaTeX equations for KaTeX

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,11 +40,11 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
-    "sphinx.ext.mathjax",
     "sphinx.ext.intersphinx",
     "sphinx.ext.doctest",
     "matplotlib.sphinxext.plot_directive",
     "reno.sphinxext",
+    "sphinxcontrib.katex",
 ]
 
 templates_path = ["_templates"]

--- a/qiskit/circuit/library/generalized_gates/rv.py
+++ b/qiskit/circuit/library/generalized_gates/rv.py
@@ -36,14 +36,14 @@ class RVGate(Gate):
 
     .. math::
 
-        \newcommand{\th}{|\vec{v}|}
+        \newcommand{\rotationangle}{|\vec{v}|}
         \newcommand{\sinc}{\text{sinc}}
             R(\vec{v}) = e^{-i \vec{v}\cdot\vec{\sigma}} =
                 \begin{pmatrix}
-                    \cos\left(\th\right) -i v_z \sinc\left(\th\right)
-                    & -(i v_x + v_y) \sinc\left(\th\right) \\
-                    -(i v_x - v_y) \sinc\left(\th\right)
-                    & \cos\left(\th\right) + i v_z \sinc\left(\th\right)
+                    \cos\left(\rotationangle\right) -i v_z \sinc\left(\rotationangle\right)
+                    & -(i v_x + v_y) \sinc\left(\rotationangle\right) \\
+                    -(i v_x - v_y) \sinc\left(\rotationangle\right)
+                    & \cos\left(\rotationangle\right) + i v_z \sinc\left(\rotationangle\right)
                 \end{pmatrix}
     """
 

--- a/qiskit/circuit/library/n_local/excitation_preserving.py
+++ b/qiskit/circuit/library/n_local/excitation_preserving.py
@@ -30,12 +30,12 @@ class ExcitationPreserving(TwoLocal):
 
     .. math::
 
-        \newcommand{\th}{\theta/2}
+        \newcommand{\rotationangle}{\theta/2}
 
         \begin{pmatrix}
         1 & 0 & 0 & 0 \\
-        0 & \cos\left(\th\right) & -i\sin\left(\th\right) & 0 \\
-        0 & -i\sin\left(\th\right) & \cos\left(\th\right) & 0 \\
+        0 & \cos\left(\rotationangle\right) & -i\sin\left(\rotationangle\right) & 0 \\
+        0 & -i\sin\left(\rotationangle\right) & \cos\left(\rotationangle\right) & 0 \\
         0 & 0 & 0 & e^{-i\phi}
         \end{pmatrix}
 

--- a/qiskit/circuit/library/standard_gates/r.py
+++ b/qiskit/circuit/library/standard_gates/r.py
@@ -40,12 +40,12 @@ class RGate(Gate):
 
     .. math::
 
-        \newcommand{\th}{\frac{\theta}{2}}
+        \newcommand{\rotationangle}{\frac{\theta}{2}}
 
-        R(\theta, \phi) = e^{-i \th \left(\cos{\phi} x + \sin{\phi} y\right)} =
+        R(\theta, \phi) = e^{-i \rotationangle \left(\cos{\phi} x + \sin{\phi} y\right)} =
             \begin{pmatrix}
-                \cos\left(\th\right) & -i e^{-i \phi} \sin\left(\th\right) \\
-                -i e^{i \phi} \sin\left(\th\right) & \cos\left(\th\right)
+                \cos\left(\rotationangle\right) & -i e^{-i \phi} \sin\left(\rotationangle\right) \\
+                -i e^{i \phi} \sin\left(\rotationangle\right) & \cos\left(\rotationangle\right)
             \end{pmatrix}
     """
 

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -41,12 +41,12 @@ class RXGate(Gate):
 
     .. math::
 
-        \newcommand{\th}{\frac{\theta}{2}}
+        \newcommand{\rotationangle}{\frac{\theta}{2}}
 
-        RX(\theta) = \exp\left(-i \th X\right) =
+        RX(\theta) = \exp\left(-i \rotationangle X\right) =
             \begin{pmatrix}
-                \cos\left(\th\right)   & -i\sin\left(\th\right) \\
-                -i\sin\left(\th\right) & \cos\left(\th\right)
+                \cos\left(\rotationangle\right)   & -i\sin\left(\rotationangle\right) \\
+                -i\sin\left(\rotationangle\right) & \cos\left(\rotationangle\right)
             \end{pmatrix}
     """
 
@@ -133,15 +133,15 @@ class CRXGate(ControlledGate):
 
     .. math::
 
-        \newcommand{\th}{\frac{\theta}{2}}
+        \newcommand{\rotationangle}{\frac{\theta}{2}}
 
         CRX(\theta)\ q_0, q_1 =
             I \otimes |0\rangle\langle 0| + RX(\theta) \otimes |1\rangle\langle 1| =
             \begin{pmatrix}
                 1 & 0 & 0 & 0 \\
-                0 & \cos\left(\th\right) & 0 & -i\sin\left(\th\right) \\
+                0 & \cos\left(\rotationangle\right) & 0 & -i\sin\left(\rotationangle\right) \\
                 0 & 0 & 1 & 0 \\
-                0 & -i\sin\left(\th\right) & 0 & \cos\left(\th\right)
+                0 & -i\sin\left(\rotationangle\right) & 0 & \cos\left(\rotationangle\right)
             \end{pmatrix}
 
     .. note::
@@ -160,15 +160,15 @@ class CRXGate(ControlledGate):
 
         .. math::
 
-            \newcommand{\th}{\frac{\theta}{2}}
+            \newcommand{\rotationangle}{\frac{\theta}{2}}
 
             CRX(\theta)\ q_1, q_0 =
             |0\rangle\langle0| \otimes I + |1\rangle\langle1| \otimes RX(\theta) =
                 \begin{pmatrix}
                     1 & 0 & 0 & 0 \\
                     0 & 1 & 0 & 0 \\
-                    0 & 0 & \cos\left(\th\right)   & -i\sin\left(\th\right) \\
-                    0 & 0 & -i\sin\left(\th\right) & \cos\left(\th\right)
+                    0 & 0 & \cos\left(\rotationangle\right)   & -i\sin\left(\rotationangle\right) \\
+                    0 & 0 & -i\sin\left(\rotationangle\right) & \cos\left(\rotationangle\right)
                 \end{pmatrix}
     """
 

--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -45,10 +45,10 @@ class RXXGate(Gate):
 
         R_{XX}(\theta) = \exp\left(-i \rotationangle X{\otimes}X\right) =
             \begin{pmatrix}
-                \cos\left(\rotationangle\right)   & 0           & 0           & -i\sin\left(\rotationangle\right) \\
-                0           & \cos\left(\rotationangle\right)   & -i\sin\left(\rotationangle\right) & 0 \\
-                0           & -i\sin\left(\rotationangle\right) & \cos\left(\rotationangle\right)   & 0 \\
-                -i\sin\left(\rotationangle\right) & 0           & 0           & \cos\left(\rotationangle\right)
+                \cos\left(\rotationangle\right) & 0 & 0 & -i\sin\left(\rotationangle\right) \\
+                0 & \cos\left(\rotationangle\right) & -i\sin\left(\rotationangle\right) & 0 \\
+                0 & -i\sin\left(\rotationangle\right) & \cos\left(\rotationangle\right) & 0 \\
+                -i\sin\left(\rotationangle\right) & 0 & 0 & \cos\left(\rotationangle\right)
             \end{pmatrix}
 
     **Examples:**

--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -41,14 +41,14 @@ class RXXGate(Gate):
 
     .. math::
 
-        \newcommand{\th}{\frac{\theta}{2}}
+        \newcommand{\rotationangle}{\frac{\theta}{2}}
 
-        R_{XX}(\theta) = \exp\left(-i \th X{\otimes}X\right) =
+        R_{XX}(\theta) = \exp\left(-i \rotationangle X{\otimes}X\right) =
             \begin{pmatrix}
-                \cos\left(\th\right)   & 0           & 0           & -i\sin\left(\th\right) \\
-                0           & \cos\left(\th\right)   & -i\sin\left(\th\right) & 0 \\
-                0           & -i\sin\left(\th\right) & \cos\left(\th\right)   & 0 \\
-                -i\sin\left(\th\right) & 0           & 0           & \cos\left(\th\right)
+                \cos\left(\rotationangle\right)   & 0           & 0           & -i\sin\left(\rotationangle\right) \\
+                0           & \cos\left(\rotationangle\right)   & -i\sin\left(\rotationangle\right) & 0 \\
+                0           & -i\sin\left(\rotationangle\right) & \cos\left(\rotationangle\right)   & 0 \\
+                -i\sin\left(\rotationangle\right) & 0           & 0           & \cos\left(\rotationangle\right)
             \end{pmatrix}
 
     **Examples:**

--- a/qiskit/circuit/library/standard_gates/ry.py
+++ b/qiskit/circuit/library/standard_gates/ry.py
@@ -40,12 +40,12 @@ class RYGate(Gate):
 
     .. math::
 
-        \newcommand{\th}{\frac{\theta}{2}}
+        \newcommand{\rotationangle}{\frac{\theta}{2}}
 
-        RY(\theta) = \exp\left(-i \th Y\right) =
+        RY(\theta) = \exp\left(-i \rotationangle Y\right) =
             \begin{pmatrix}
-                \cos\left(\th\right) & -\sin\left(\th\right) \\
-                \sin\left(\th\right) & \cos\left(\th\right)
+                \cos\left(\rotationangle\right) & -\sin\left(\rotationangle\right) \\
+                \sin\left(\rotationangle\right) & \cos\left(\rotationangle\right)
             \end{pmatrix}
     """
 
@@ -132,15 +132,15 @@ class CRYGate(ControlledGate):
 
     .. math::
 
-        \newcommand{\th}{\frac{\theta}{2}}
+        \newcommand{\rotationangle}{\frac{\theta}{2}}
 
         CRY(\theta)\ q_0, q_1 =
             I \otimes |0\rangle\langle 0| + RY(\theta) \otimes |1\rangle\langle 1| =
             \begin{pmatrix}
                 1 & 0         & 0 & 0 \\
-                0 & \cos\left(\th\right) & 0 & -\sin\left(\th\right) \\
+                0 & \cos\left(\rotationangle\right) & 0 & -\sin\left(\rotationangle\right) \\
                 0 & 0         & 1 & 0 \\
-                0 & \sin\left(\th\right) & 0 & \cos\left(\th\right)
+                0 & \sin\left(\rotationangle\right) & 0 & \cos\left(\rotationangle\right)
             \end{pmatrix}
 
     .. note::
@@ -159,15 +159,15 @@ class CRYGate(ControlledGate):
 
         .. math::
 
-            \newcommand{\th}{\frac{\theta}{2}}
+            \newcommand{\rotationangle}{\frac{\theta}{2}}
 
             CRY(\theta)\ q_1, q_0 =
             |0\rangle\langle 0| \otimes I + |1\rangle\langle 1| \otimes RY(\theta) =
                 \begin{pmatrix}
                     1 & 0 & 0 & 0 \\
                     0 & 1 & 0 & 0 \\
-                    0 & 0 & \cos\left(\th\right) & -\sin\left(\th\right) \\
-                    0 & 0 & \sin\left(\th\right) & \cos\left(\th\right)
+                    0 & 0 & \cos\left(\rotationangle\right) & -\sin\left(\rotationangle\right) \\
+                    0 & 0 & \sin\left(\rotationangle\right) & \cos\left(\rotationangle\right)
                 \end{pmatrix}
     """
 

--- a/qiskit/circuit/library/standard_gates/ryy.py
+++ b/qiskit/circuit/library/standard_gates/ryy.py
@@ -45,10 +45,10 @@ class RYYGate(Gate):
 
         R_{YY}(\theta) = \exp\left(-i \rotationangle Y{\otimes}Y\right) =
             \begin{pmatrix}
-                \cos\left(\rotationangle\right)   & 0           & 0           & i\sin\left(\rotationangle\right) \\
-                0           & \cos\left(\rotationangle\right)   & -i\sin\left(\rotationangle\right) & 0 \\
-                0           & -i\sin\left(\rotationangle\right) & \cos\left(\rotationangle\right)   & 0 \\
-                i\sin\left(\rotationangle\right)  & 0           & 0           & \cos\left(\rotationangle\right)
+                \cos\left(\rotationangle\right) & 0 & 0 & i\sin\left(\rotationangle\right) \\
+                0 & \cos\left(\rotationangle\right) & -i\sin\left(\rotationangle\right) & 0 \\
+                0 & -i\sin\left(\rotationangle\right) & \cos\left(\rotationangle\right) & 0 \\
+                i\sin\left(\rotationangle\right) & 0 & 0 & \cos\left(\rotationangle\right)
             \end{pmatrix}
 
     **Examples:**

--- a/qiskit/circuit/library/standard_gates/ryy.py
+++ b/qiskit/circuit/library/standard_gates/ryy.py
@@ -41,14 +41,14 @@ class RYYGate(Gate):
 
     .. math::
 
-        \newcommand{\th}{\frac{\theta}{2}}
+        \newcommand{\rotationangle}{\frac{\theta}{2}}
 
-        R_{YY}(\theta) = \exp\left(-i \th Y{\otimes}Y\right) =
+        R_{YY}(\theta) = \exp\left(-i \rotationangle Y{\otimes}Y\right) =
             \begin{pmatrix}
-                \cos\left(\th\right)   & 0           & 0           & i\sin\left(\th\right) \\
-                0           & \cos\left(\th\right)   & -i\sin\left(\th\right) & 0 \\
-                0           & -i\sin\left(\th\right) & \cos\left(\th\right)   & 0 \\
-                i\sin\left(\th\right)  & 0           & 0           & \cos\left(\th\right)
+                \cos\left(\rotationangle\right)   & 0           & 0           & i\sin\left(\rotationangle\right) \\
+                0           & \cos\left(\rotationangle\right)   & -i\sin\left(\rotationangle\right) & 0 \\
+                0           & -i\sin\left(\rotationangle\right) & \cos\left(\rotationangle\right)   & 0 \\
+                i\sin\left(\rotationangle\right)  & 0           & 0           & \cos\left(\rotationangle\right)
             \end{pmatrix}
 
     **Examples:**

--- a/qiskit/circuit/library/standard_gates/rzx.py
+++ b/qiskit/circuit/library/standard_gates/rzx.py
@@ -47,10 +47,10 @@ class RZXGate(Gate):
 
         R_{ZX}(\theta)\ q_0, q_1 = \exp\left(-i \frac{\theta}{2} X{\otimes}Z\right) =
             \begin{pmatrix}
-                \cos\left(\rotationangle\right)   & 0          & -i\sin\left(\rotationangle\right)  & 0          \\
-                0           & \cos\left(\rotationangle\right)  & 0            & i\sin\left(\rotationangle\right) \\
-                -i\sin\left(\rotationangle\right) & 0          & \cos\left(\rotationangle\right)    & 0          \\
-                0           & i\sin\left(\rotationangle\right) & 0            & \cos\left(\rotationangle\right)
+                \cos\left(\rotationangle\right) & 0 & -i\sin\left(\rotationangle\right) & 0 \\
+                0 & \cos\left(\rotationangle\right) & 0 & i\sin\left(\rotationangle\right) \\
+                -i\sin\left(\rotationangle\right) & 0 & \cos\left(\rotationangle\right) & 0 \\
+                0 & i\sin\left(\rotationangle\right) & 0 & \cos\left(\rotationangle\right)
             \end{pmatrix}
 
     .. note::

--- a/qiskit/circuit/library/standard_gates/rzx.py
+++ b/qiskit/circuit/library/standard_gates/rzx.py
@@ -43,14 +43,14 @@ class RZXGate(Gate):
 
     .. math::
 
-        \newcommand{\th}{\frac{\theta}{2}}
+        \newcommand{\rotationangle}{\frac{\theta}{2}}
 
         R_{ZX}(\theta)\ q_0, q_1 = \exp\left(-i \frac{\theta}{2} X{\otimes}Z\right) =
             \begin{pmatrix}
-                \cos\left(\th\right)   & 0          & -i\sin\left(\th\right)  & 0          \\
-                0           & \cos\left(\th\right)  & 0            & i\sin\left(\th\right) \\
-                -i\sin\left(\th\right) & 0          & \cos\left(\th\right)    & 0          \\
-                0           & i\sin\left(\th\right) & 0            & \cos\left(\th\right)
+                \cos\left(\rotationangle\right)   & 0          & -i\sin\left(\rotationangle\right)  & 0          \\
+                0           & \cos\left(\rotationangle\right)  & 0            & i\sin\left(\rotationangle\right) \\
+                -i\sin\left(\rotationangle\right) & 0          & \cos\left(\rotationangle\right)    & 0          \\
+                0           & i\sin\left(\rotationangle\right) & 0            & \cos\left(\rotationangle\right)
             \end{pmatrix}
 
     .. note::
@@ -71,14 +71,14 @@ class RZXGate(Gate):
 
         .. math::
 
-            \newcommand{\th}{\frac{\theta}{2}}
+            \newcommand{\rotationangle}{\frac{\theta}{2}}
 
             R_{ZX}(\theta)\ q_1, q_0 = exp(-i \frac{\theta}{2} Z{\otimes}X) =
                 \begin{pmatrix}
-                    \cos(\th)   & -i\sin(\th) & 0           & 0          \\
-                    -i\sin(\th) & \cos(\th)   & 0           & 0          \\
-                    0           & 0           & \cos(\th)   & i\sin(\th) \\
-                    0           & 0           & i\sin(\th)  & \cos(\th)
+                    \cos(\rotationangle)   & -i\sin(\rotationangle) & 0           & 0          \\
+                    -i\sin(\rotationangle) & \cos(\rotationangle)   & 0           & 0          \\
+                    0           & 0           & \cos(\rotationangle)   & i\sin(\rotationangle) \\
+                    0           & 0           & i\sin(\rotationangle)  & \cos(\rotationangle)
                 \end{pmatrix}
 
         This is a direct sum of RX rotations, so this gate is equivalent to a

--- a/qiskit/circuit/library/standard_gates/rzz.py
+++ b/qiskit/circuit/library/standard_gates/rzz.py
@@ -38,14 +38,14 @@ class RZZGate(Gate):
 
     .. math::
 
-        \newcommand{\th}{\frac{\theta}{2}}
+        \newcommand{\rotationangle}{\frac{\theta}{2}}
 
-        R_{ZZ}(\theta) = \exp\left(-i \th Z{\otimes}Z\right) =
+        R_{ZZ}(\theta) = \exp\left(-i \rotationangle Z{\otimes}Z\right) =
             \begin{pmatrix}
-                e^{-i \th} & 0 & 0 & 0 \\
-                0 & e^{i \th} & 0 & 0 \\
-                0 & 0 & e^{i \th} & 0 \\
-                0 & 0 & 0 & e^{-i \th}
+                e^{-i \rotationangle} & 0 & 0 & 0 \\
+                0 & e^{i \rotationangle} & 0 & 0 \\
+                0 & 0 & e^{i \rotationangle} & 0 \\
+                0 & 0 & 0 & e^{-i \rotationangle}
             \end{pmatrix}
 
     This is a direct sum of RZ rotations, so this gate is equivalent to a

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -40,12 +40,12 @@ class UGate(Gate):
 
     .. math::
 
-        \newcommand{\th}{\frac{\theta}{2}}
+        \newcommand{\rotationangle}{\frac{\theta}{2}}
 
         U(\theta, \phi, \lambda) =
             \begin{pmatrix}
-                \cos\left(\th\right)          & -e^{i\lambda}\sin\left(\th\right) \\
-                e^{i\phi}\sin\left(\th\right) & e^{i(\phi+\lambda)}\cos\left(\th\right)
+                \cos\left(\rotationangle\right)          & -e^{i\lambda}\sin\left(\rotationangle\right) \\
+                e^{i\phi}\sin\left(\rotationangle\right) & e^{i(\phi+\lambda)}\cos\left(\rotationangle\right)
             \end{pmatrix}
 
     .. note::
@@ -190,16 +190,16 @@ class CUGate(ControlledGate):
 
     .. math::
 
-        \newcommand{\th}{\frac{\theta}{2}}
+        \newcommand{\rotationangle}{\frac{\theta}{2}}
 
         CU(\theta, \phi, \lambda, \gamma)\ q_0, q_1 =
             I \otimes |0\rangle\langle 0| +
             e^{i\gamma} U(\theta,\phi,\lambda) \otimes |1\rangle\langle 1| =
             \begin{pmatrix}
                 1 & 0                           & 0 & 0 \\
-                0 & e^{i\gamma}\cos(\th)        & 0 & -e^{i(\gamma + \lambda)}\sin(\th) \\
+                0 & e^{i\gamma}\cos(\rotationangle)        & 0 & -e^{i(\gamma + \lambda)}\sin(\rotationangle) \\
                 0 & 0                           & 1 & 0 \\
-                0 & e^{i(\gamma+\phi)}\sin(\th) & 0 & e^{i(\gamma+\phi+\lambda)}\cos(\th)
+                0 & e^{i(\gamma+\phi)}\sin(\rotationangle) & 0 & e^{i(\gamma+\phi+\lambda)}\cos(\rotationangle)
             \end{pmatrix}
 
     .. note::
@@ -224,8 +224,8 @@ class CUGate(ControlledGate):
                 \begin{pmatrix}
                     1 & 0 & 0                             & 0 \\
                     0 & 1 & 0                             & 0 \\
-                    0 & 0 & e^{i\gamma} \cos(\th)         & -e^{i(\gamma + \lambda)}\sin(\th) \\
-                    0 & 0 & e^{i(\gamma + \phi)}\sin(\th) & e^{i(\gamma + \phi+\lambda)}\cos(\th)
+                    0 & 0 & e^{i\gamma} \cos(\rotationangle)         & -e^{i(\gamma + \lambda)}\sin(\rotationangle) \\
+                    0 & 0 & e^{i(\gamma + \phi)}\sin(\rotationangle) & e^{i(\gamma + \phi+\lambda)}\cos(\rotationangle)
                 \end{pmatrix}
     """
 

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -43,10 +43,10 @@ class UGate(Gate):
         \newcommand{\rotationangle}{\frac{\theta}{2}}
 
         U(\theta, \phi, \lambda) =
-            \begin{pmatrix}
-                \cos\left(\rotationangle\right)          & -e^{i\lambda}\sin\left(\rotationangle\right) \\
-                e^{i\phi}\sin\left(\rotationangle\right) & e^{i(\phi+\lambda)}\cos\left(\rotationangle\right)
-            \end{pmatrix}
+        \begin{pmatrix}
+            \cos\left(\rotationangle\right) & -e^{i\lambda}\sin\left(\rotationangle\right) \\
+            e^{i\phi}\sin\left(\rotationangle\right) & e^{i(\phi+\lambda)}\cos\left(\rotationangle\right)
+        \end{pmatrix}
 
     .. note::
 
@@ -196,10 +196,12 @@ class CUGate(ControlledGate):
             I \otimes |0\rangle\langle 0| +
             e^{i\gamma} U(\theta,\phi,\lambda) \otimes |1\rangle\langle 1| =
             \begin{pmatrix}
-                1 & 0                           & 0 & 0 \\
-                0 & e^{i\gamma}\cos(\rotationangle)        & 0 & -e^{i(\gamma + \lambda)}\sin(\rotationangle) \\
-                0 & 0                           & 1 & 0 \\
-                0 & e^{i(\gamma+\phi)}\sin(\rotationangle) & 0 & e^{i(\gamma+\phi+\lambda)}\cos(\rotationangle)
+                1 & 0 & 0 & 0 \\
+                0 & e^{i\gamma}\cos(\rotationangle) &
+                0 & -e^{i(\gamma + \lambda)}\sin(\rotationangle) \\
+                0 & 0 & 1 & 0 \\
+                0 & e^{i(\gamma+\phi)}\sin(\rotationangle) &
+                0 & e^{i(\gamma+\phi+\lambda)}\cos(\rotationangle)
             \end{pmatrix}
 
     .. note::
@@ -218,15 +220,17 @@ class CUGate(ControlledGate):
 
         .. math::
 
+            \newcommand{\rotationangle}{\frac{\theta}{2}}
             CU(\theta, \phi, \lambda, \gamma)\ q_1, q_0 =
-                |0\rangle\langle 0| \otimes I +
-                e^{i\gamma}|1\rangle\langle 1| \otimes U(\theta,\phi,\lambda) =
-                \begin{pmatrix}
-                    1 & 0 & 0                             & 0 \\
-                    0 & 1 & 0                             & 0 \\
-                    0 & 0 & e^{i\gamma} \cos(\rotationangle)         & -e^{i(\gamma + \lambda)}\sin(\rotationangle) \\
-                    0 & 0 & e^{i(\gamma + \phi)}\sin(\rotationangle) & e^{i(\gamma + \phi+\lambda)}\cos(\rotationangle)
-                \end{pmatrix}
+            |0\rangle\langle 0| \otimes I +
+            e^{i\gamma}|1\rangle\langle 1| \otimes U(\theta,\phi,\lambda) =
+            \begin{pmatrix}
+            1 & 0 & 0 & 0 \\
+            0 & 1 & 0 & 0 \\
+            0 & 0 & e^{i\gamma} \cos(\rotationangle) & -e^{i(\gamma + \lambda)}\sin(\rotationangle) \\
+            0 & 0 &
+            e^{i(\gamma + \phi)}\sin(\rotationangle) & e^{i(\gamma + \phi+\lambda)}\cos(\rotationangle)
+            \end{pmatrix}
     """
 
     def __init__(

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -49,12 +49,12 @@ class U3Gate(Gate):
 
     .. math::
 
-        \newcommand{\th}{\frac{\theta}{2}}
+        \newcommand{\rotationangle}{\frac{\theta}{2}}
 
         U3(\theta, \phi, \lambda) =
             \begin{pmatrix}
-                \cos\left(\th\right)          & -e^{i\lambda}\sin\left(\th\right) \\
-                e^{i\phi}\sin\left(\th\right) & e^{i(\phi+\lambda)}\cos\left(\th\right)
+                \cos\left(\rotationangle\right)          & -e^{i\lambda}\sin\left(\rotationangle\right) \\
+                e^{i\phi}\sin\left(\rotationangle\right) & e^{i(\phi+\lambda)}\cos\left(\rotationangle\right)
             \end{pmatrix}
 
     .. note::
@@ -165,16 +165,16 @@ class CU3Gate(ControlledGate):
 
     .. math::
 
-        \newcommand{\th}{\frac{\theta}{2}}
+        \newcommand{\rotationangle}{\frac{\theta}{2}}
 
         CU3(\theta, \phi, \lambda)\ q_0, q_1 =
             I \otimes |0\rangle\langle 0| +
             U3(\theta,\phi,\lambda) \otimes |1\rangle\langle 1| =
             \begin{pmatrix}
                 1 & 0                   & 0 & 0 \\
-                0 & \cos(\th)           & 0 & -e^{i\lambda}\sin(\th) \\
+                0 & \cos(\rotationangle)           & 0 & -e^{i\lambda}\sin(\rotationangle) \\
                 0 & 0                   & 1 & 0 \\
-                0 & e^{i\phi}\sin(\th)  & 0 & e^{i(\phi+\lambda)}\cos(\th)
+                0 & e^{i\phi}\sin(\rotationangle)  & 0 & e^{i(\phi+\lambda)}\cos(\rotationangle)
             \end{pmatrix}
 
     .. note::
@@ -199,8 +199,8 @@ class CU3Gate(ControlledGate):
                 \begin{pmatrix}
                     1 & 0   & 0                  & 0 \\
                     0 & 1   & 0                  & 0 \\
-                    0 & 0   & \cos(\th)          & -e^{i\lambda}\sin(\th) \\
-                    0 & 0   & e^{i\phi}\sin(\th) & e^{i(\phi+\lambda)}\cos(\th)
+                    0 & 0   & \cos(\rotationangle)          & -e^{i\lambda}\sin(\rotationangle) \\
+                    0 & 0   & e^{i\phi}\sin(\rotationangle) & e^{i(\phi+\lambda)}\cos(\rotationangle)
                 \end{pmatrix}
     """
 

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -53,8 +53,9 @@ class U3Gate(Gate):
 
         U3(\theta, \phi, \lambda) =
             \begin{pmatrix}
-                \cos\left(\rotationangle\right)          & -e^{i\lambda}\sin\left(\rotationangle\right) \\
-                e^{i\phi}\sin\left(\rotationangle\right) & e^{i(\phi+\lambda)}\cos\left(\rotationangle\right)
+                \cos\left(\rotationangle\right) & -e^{i\lambda}\sin\left(\rotationangle\right) \\
+                e^{i\phi}\sin\left(\rotationangle\right) &
+                e^{i(\phi+\lambda)}\cos\left(\rotationangle\right)
             \end{pmatrix}
 
     .. note::

--- a/qiskit/circuit/library/standard_gates/xx_minus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_minus_yy.py
@@ -54,9 +54,9 @@ class XXMinusYYGate(Gate):
         R_{XX-YY}(\theta, \beta) q_0, q_1 =
           RZ_1(\beta) \cdot \exp\left(-i \frac{\theta}{2} \frac{XX-YY}{2}\right) \cdot RZ_1(-\beta) =
             \begin{pmatrix}
-                \cos\left(\rotationangle\right)             & 0 & 0 & -i\sin\left(\rotationangle\right)e^{-i\beta}  \\
-                0                     & 1 & 0 & 0  \\
-                0                     & 0 & 1 & 0  \\
+                \cos\left(\rotationangle\right) & 0 & 0 & -i\sin\left(\rotationangle\right)e^{-i\beta} \\
+                0 & 1 & 0 & 0 \\
+                0 & 0 & 1 & 0 \\
                 -i\sin\left(\rotationangle\right)e^{i\beta} & 0 & 0 & \cos\left(\rotationangle\right)
             \end{pmatrix}
 
@@ -83,12 +83,12 @@ class XXMinusYYGate(Gate):
 
             R_{XX-YY}(\theta, \beta) q_1, q_0 =
             RZ_0(\beta) \cdot \exp\left(-i \frac{\theta}{2} \frac{XX-YY}{2}\right) \cdot RZ_0(-\beta) =
-                \begin{pmatrix}
-                    \cos\left(\rotationangle\right)             & 0 & 0 & -i\sin\left(\rotationangle\right)e^{i\beta}  \\
-                    0                     & 1 & 0 & 0  \\
-                    0                     & 0 & 1 & 0  \\
-                    -i\sin\left(\rotationangle\right)e^{-i\beta} & 0 & 0 & \cos\left(\rotationangle\right)
-                \end{pmatrix}
+            \begin{pmatrix}
+                \cos\left(\rotationangle\right) & 0 & 0 & -i\sin\left(\rotationangle\right)e^{i\beta} \\
+                0 & 1 & 0 & 0 \\
+                0 & 0 & 1 & 0 \\
+                -i\sin\left(\rotationangle\right)e^{-i\beta} & 0 & 0 & \cos\left(\rotationangle\right)
+            \end{pmatrix}
     """
 
     def __init__(

--- a/qiskit/circuit/library/standard_gates/xx_minus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_minus_yy.py
@@ -49,15 +49,15 @@ class XXMinusYYGate(Gate):
 
     .. math::
 
-        \newcommand{\th}{\frac{\theta}{2}}
+        \newcommand{\rotationangle}{\frac{\theta}{2}}
 
         R_{XX-YY}(\theta, \beta) q_0, q_1 =
           RZ_1(\beta) \cdot \exp\left(-i \frac{\theta}{2} \frac{XX-YY}{2}\right) \cdot RZ_1(-\beta) =
             \begin{pmatrix}
-                \cos\left(\th\right)             & 0 & 0 & -i\sin\left(\th\right)e^{-i\beta}  \\
+                \cos\left(\rotationangle\right)             & 0 & 0 & -i\sin\left(\rotationangle\right)e^{-i\beta}  \\
                 0                     & 1 & 0 & 0  \\
                 0                     & 0 & 1 & 0  \\
-                -i\sin\left(\th\right)e^{i\beta} & 0 & 0 & \cos\left(\th\right)
+                -i\sin\left(\rotationangle\right)e^{i\beta} & 0 & 0 & \cos\left(\rotationangle\right)
             \end{pmatrix}
 
     .. note::
@@ -79,15 +79,15 @@ class XXMinusYYGate(Gate):
 
         .. math::
 
-            \newcommand{\th}{\frac{\theta}{2}}
+            \newcommand{\rotationangle}{\frac{\theta}{2}}
 
             R_{XX-YY}(\theta, \beta) q_1, q_0 =
             RZ_0(\beta) \cdot \exp\left(-i \frac{\theta}{2} \frac{XX-YY}{2}\right) \cdot RZ_0(-\beta) =
                 \begin{pmatrix}
-                    \cos\left(\th\right)             & 0 & 0 & -i\sin\left(\th\right)e^{i\beta}  \\
+                    \cos\left(\rotationangle\right)             & 0 & 0 & -i\sin\left(\rotationangle\right)e^{i\beta}  \\
                     0                     & 1 & 0 & 0  \\
                     0                     & 0 & 1 & 0  \\
-                    -i\sin\left(\th\right)e^{-i\beta} & 0 & 0 & \cos\left(\th\right)
+                    -i\sin\left(\rotationangle\right)e^{-i\beta} & 0 & 0 & \cos\left(\rotationangle\right)
                 \end{pmatrix}
     """
 

--- a/qiskit/circuit/library/standard_gates/xx_plus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_plus_yy.py
@@ -40,14 +40,14 @@ class XXPlusYYGate(Gate):
 
     .. math::
 
-        \newcommand{\th}{\frac{\theta}{2}}
+        \newcommand{\rotationangle}{\frac{\theta}{2}}
 
         R_{XX+YY}(\theta, \beta)\ q_0, q_1 =
           RZ_0(-\beta) \cdot \exp\left(-i \frac{\theta}{2} \frac{XX+YY}{2}\right) \cdot RZ_0(\beta) =
             \begin{pmatrix}
                 1 & 0                     & 0                    & 0  \\
-                0 & \cos\left(\th\right)             & -i\sin\left(\th\right)e^{-i\beta} & 0  \\
-                0 & -i\sin\left(\th\right)e^{i\beta} & \cos\left(\th\right)            & 0  \\
+                0 & \cos\left(\rotationangle\right)             & -i\sin\left(\rotationangle\right)e^{-i\beta} & 0  \\
+                0 & -i\sin\left(\rotationangle\right)e^{i\beta} & \cos\left(\rotationangle\right)            & 0  \\
                 0 & 0                     & 0                    & 1
             \end{pmatrix}
 
@@ -70,14 +70,14 @@ class XXPlusYYGate(Gate):
 
     .. math::
 
-        \newcommand{\th}{\frac{\theta}{2}}
+        \newcommand{\rotationangle}{\frac{\theta}{2}}
 
         R_{XX+YY}(\theta, \beta)\ q_0, q_1 =
           RZ_1(-\beta) \cdot \exp\left(-i \frac{\theta}{2} \frac{XX+YY}{2}\right) \cdot RZ_1(\beta) =
             \begin{pmatrix}
                 1 & 0                     & 0                    & 0  \\
-                0 & \cos\left(\th\right)             & -i\sin\left(\th\right)e^{i\beta} & 0  \\
-                0 & -i\sin\left(\th\right)e^{-i\beta} & \cos\left(\th\right)            & 0  \\
+                0 & \cos\left(\rotationangle\right)             & -i\sin\left(\rotationangle\right)e^{i\beta} & 0  \\
+                0 & -i\sin\left(\rotationangle\right)e^{-i\beta} & \cos\left(\rotationangle\right)            & 0  \\
                 0 & 0                     & 0                    & 1
             \end{pmatrix}
     """

--- a/qiskit/circuit/library/standard_gates/xx_plus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_plus_yy.py
@@ -45,10 +45,10 @@ class XXPlusYYGate(Gate):
         R_{XX+YY}(\theta, \beta)\ q_0, q_1 =
           RZ_0(-\beta) \cdot \exp\left(-i \frac{\theta}{2} \frac{XX+YY}{2}\right) \cdot RZ_0(\beta) =
             \begin{pmatrix}
-                1 & 0                     & 0                    & 0  \\
-                0 & \cos\left(\rotationangle\right)             & -i\sin\left(\rotationangle\right)e^{-i\beta} & 0  \\
-                0 & -i\sin\left(\rotationangle\right)e^{i\beta} & \cos\left(\rotationangle\right)            & 0  \\
-                0 & 0                     & 0                    & 1
+                1 & 0 & 0 & 0  \\
+                0 & \cos\left(\rotationangle\right) & -i\sin\left(\rotationangle\right)e^{-i\beta} & 0 \\
+                0 & -i\sin\left(\rotationangle\right)e^{i\beta} & \cos\left(\rotationangle\right) & 0 \\
+                0 & 0 & 0 & 1
             \end{pmatrix}
 
     .. note::
@@ -75,10 +75,10 @@ class XXPlusYYGate(Gate):
         R_{XX+YY}(\theta, \beta)\ q_0, q_1 =
           RZ_1(-\beta) \cdot \exp\left(-i \frac{\theta}{2} \frac{XX+YY}{2}\right) \cdot RZ_1(\beta) =
             \begin{pmatrix}
-                1 & 0                     & 0                    & 0  \\
-                0 & \cos\left(\rotationangle\right)             & -i\sin\left(\rotationangle\right)e^{i\beta} & 0  \\
-                0 & -i\sin\left(\rotationangle\right)e^{-i\beta} & \cos\left(\rotationangle\right)            & 0  \\
-                0 & 0                     & 0                    & 1
+                1 & 0 & 0 & 0  \\
+                0 & \cos\left(\rotationangle\right) & -i\sin\left(\rotationangle\right)e^{i\beta} & 0 \\
+                0 & -i\sin\left(\rotationangle\right)e^{-i\beta} & \cos\left(\rotationangle\right) & 0 \\
+                0 & 0 & 0 & 1
             \end{pmatrix}
     """
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -40,3 +40,4 @@ ddt>=1.2.0,!=1.4.0,!=1.4.3
 Sphinx>=6.0,<7.2
 # TODO: switch to stable release when 4.1 is released
 reno @ git+https://github.com/openstack/reno.git@81587f616f17904336cdc431e25c42b46cd75b8f
+sphinxcontrib-katex==0.9.9


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
`\th` is already a latex command, so `\newcommand{\th}` raises an error in our public docs, which uses KaTeX. It seems that it renders in the Sphinx docs because it uses MathJax, which is lenient. See https://github.com/Qiskit/documentation/issues/59#issuecomment-1847804047.


### Details and comments


