### PR TITLE
Remove Qiskit Terra 0.25 from release_notes.rst

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,8 +4,11 @@
 Release Notes
 =============
 
-This page contains the release notes for Qiskit, starting from the point at which the legacy
-"elements" structure was completely removed.
+This page contains the release notes for Qiskit, starting from Qiskit 0.45, the first time that Qiskit and Qiskit Terra had the same versions.
+
+These release notes get converted into Markdown files via the infrastructure at https://github.com/Qiskit/documentation, which then gets deployed to https://docs.quantum.ibm.com/api/qiskit/release-notes. Changes to these release notes will update those release notes the next time the API docs are generated.
+
+To change release notes prior to Qiskit 0.45, update the Qiskit/documentation repository directly.
 
 .. release-notes::
    :earliest-version: 0.45.0rc1
@@ -18,7 +21,3 @@ This page contains the release notes for Qiskit, starting from the point at whic
 .. release-notes::
    :earliest-version: 0.45.0
    :branch: stable/0.45
-
-.. release-notes::
-   :earliest-version: 0.25.0
-   :branch: stable/0.25

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -6,9 +6,10 @@ Release Notes
 
 This page contains the release notes for Qiskit, starting from Qiskit 0.45, the first time that Qiskit and Qiskit Terra had the same versions.
 
-These release notes get converted into Markdown files via the infrastructure at https://github.com/Qiskit/documentation, which then gets deployed to https://docs.quantum.ibm.com/api/qiskit/release-notes. Changes to these release notes will update those release notes the next time the API docs are generated.
+..
+    These release notes get converted into Markdown files via the infrastructure at https://github.com/Qiskit/documentation, which then gets deployed to https://docs.quantum.ibm.com/api/qiskit/release-notes. Changes to these release notes will update those release notes the next time the API docs are generated.
 
-To change release notes prior to Qiskit 0.45, update the Qiskit/documentation repository directly.
+    To change release notes prior to Qiskit 0.45, update the Qiskit/documentation repository directly.
 
 .. release-notes::
    :earliest-version: 0.45.0rc1


### PR DESCRIPTION
@arnaucasau is improving the infrastructure in Qiskit/documentation in https://github.com/Qiskit/documentation/pull/537 so that changing release notes for prior release versions will properly update those release note files. Right now, the repository only updates with the current version.

However, we're running into issues due to Qiskit Terra 0.25 being included in `release_notes.html`. Really, Terra 0.25 refers to Qiskit 0.44. It messes up our script, which splits out the single file `release_notes.html` into distinct pages like `0.44.md`, `0.45.md`, etc. Our script naively thinks that Qiskit Terra 0.25 should be Qiskit 0.25, i.e. the file `0.25.md`.

We could add special-casing to the infrastructure in Qiskit/documentation to handle this edge case. But instead of adding that complexity, @ElePT, @arnaucasau and I were discussing that it seems unlikely we'll be changing release notes for Terra 0.25 at this point. If we do need to change them, we can always directly modify the notes in Qiskit/documentation.

This PR will make the infrastructure in Qiskit/documentation much simpler by avoiding adding special-case code.
