### PR TITLE
Cache open_ctrl field in controlled gates

### DIFF
--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -104,6 +104,7 @@ class ControlledGate(Gate):
         self.num_ctrl_qubits = num_ctrl_qubits
         self.definition = copy.deepcopy(definition)
         self._ctrl_state = None
+        self.open_ctrl = None
         self.ctrl_state = ctrl_state
         self._name = name
 
@@ -209,6 +210,7 @@ class ControlledGate(Gate):
             CircuitError: ctrl_state is invalid.
         """
         self._ctrl_state = _ctrl_state_to_int(ctrl_state, self.num_ctrl_qubits)
+        self._open_ctrl = self.ctrl_state < 2 ** self.num_ctrl_qubits - 1
 
     @property
     def params(self):
@@ -253,7 +255,11 @@ class ControlledGate(Gate):
     @property
     def _open_ctrl(self) -> bool:
         """Return whether gate has any open controls"""
-        return self.ctrl_state < 2**self.num_ctrl_qubits - 1
+        return self.open_ctrl
+
+    @_open_ctrl.setter
+    def _open_ctrl(self, open_ctrl):
+        self.open_ctrl = open_ctrl
 
     def __eq__(self, other) -> bool:
         return (

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -210,7 +210,7 @@ class ControlledGate(Gate):
             CircuitError: ctrl_state is invalid.
         """
         self._ctrl_state = _ctrl_state_to_int(ctrl_state, self.num_ctrl_qubits)
-        self._open_ctrl = self.ctrl_state < 2 ** self.num_ctrl_qubits - 1
+        self._open_ctrl = self.ctrl_state < 2**self.num_ctrl_qubits - 1
 
     @property
     def params(self):

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -104,7 +104,7 @@ class ControlledGate(Gate):
         self.num_ctrl_qubits = num_ctrl_qubits
         self.definition = copy.deepcopy(definition)
         self._ctrl_state = None
-        self.open_ctrl = None
+        self._open_ctrl = None
         self.ctrl_state = ctrl_state
         self._name = name
 
@@ -251,15 +251,6 @@ class ControlledGate(Gate):
         if self._definition:
             cpy._definition = copy.deepcopy(self._definition, memo)
         return cpy
-
-    @property
-    def _open_ctrl(self) -> bool:
-        """Return whether gate has any open controls"""
-        return self.open_ctrl
-
-    @_open_ctrl.setter
-    def _open_ctrl(self, open_ctrl):
-        self.open_ctrl = open_ctrl
 
     def __eq__(self, other) -> bool:
         return (

--- a/test/python/transpiler/test_csp_layout.py
+++ b/test/python/transpiler/test_csp_layout.py
@@ -276,7 +276,7 @@ class TestCSPLayout(QiskitTestCase):
         pass_.run(dag)
         runtime = process_time() - start
 
-        self.assertLess(runtime, 3)
+        self.assertLess(runtime, 5)
         self.assertEqual(pass_.property_set["CSPLayout_stop_reason"], "time limit reached")
 
     def test_call_limit(self):

--- a/test/python/transpiler/test_csp_layout.py
+++ b/test/python/transpiler/test_csp_layout.py
@@ -276,7 +276,7 @@ class TestCSPLayout(QiskitTestCase):
         pass_.run(dag)
         runtime = process_time() - start
 
-        self.assertLess(runtime, 5)
+        self.assertLess(runtime, 3)
         self.assertEqual(pass_.property_set["CSPLayout_stop_reason"], "time limit reached")
 
     def test_call_limit(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Currently, every time the name of a controlled quantum gate is accessed, the field open_ctrl field  ist recomputed. It is not a terrible overhead but it adds up and it was observable while working on the runtime of the commutation analysis. I added a new field for open_ctrl and a setter for its corresponding property that is called whenever ctrl_state is set. 
