### PR TITLE
Remove defunct directories from `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,9 +23,6 @@
 * @Qiskit/terra-core
 
 # Qiskit folders (also their corresponding tests)
-algorithms/           @Qiskit/terra-core @woodsp-ibm @ElePT
-opflow/               @Qiskit/terra-core @woodsp-ibm @ikkoham
-qiskit/utils/         @Qiskit/terra-core @woodsp-ibm
 providers/            @Qiskit/terra-core @jyu00
 quantum_info/         @Qiskit/terra-core @ikkoham
 qpy/                  @Qiskit/terra-core


### PR DESCRIPTION
### Summary

These directories in `CODEOWNERS` were initially migrated from Aqua, but have since been removed from the repository (or repurposed, in the case of `utils`).  This removes the now-obsolete specific overrides from the owners file, since they were no longer having a meaningful effect.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


