### PR TITLE
Fix broadcasting of `QuantumCircuit.delay`

### DIFF
--- a/qiskit/circuit/delay.py
+++ b/qiskit/circuit/delay.py
@@ -16,6 +16,7 @@ Delay instruction (for circuit module).
 import numpy as np
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.instruction import Instruction
+from qiskit.circuit.gate import Gate
 from qiskit.circuit.parameterexpression import ParameterExpression
 
 
@@ -29,12 +30,11 @@ class Delay(Instruction):
 
         super().__init__("delay", 1, 0, params=[duration], unit=unit)
 
+    broadcast_arguments = Gate.broadcast_arguments
+
     def inverse(self):
         """Special case. Return self."""
         return self
-
-    def broadcast_arguments(self, qargs, cargs):
-        yield [qarg for sublist in qargs for qarg in sublist], []
 
     def c_if(self, classical, val):
         raise CircuitError("Conditional Delay is not yet implemented.")

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3206,32 +3206,9 @@ class QuantumCircuit:
         Raises:
             CircuitError: if arguments have bad format.
         """
-        qubits: list[QubitSpecifier] = []
-        if qarg is None:  # -> apply delays to all qubits
-            for q in self.qubits:
-                qubits.append(q)
-        else:
-            if isinstance(qarg, QuantumRegister):
-                qubits.extend([qarg[j] for j in range(qarg.size)])
-            elif isinstance(qarg, list):
-                qubits.extend(qarg)
-            elif isinstance(qarg, (range, tuple)):
-                qubits.extend(list(qarg))
-            elif isinstance(qarg, slice):
-                qubits.extend(self.qubits[qarg])
-            else:
-                qubits.append(qarg)
-
-        instructions = InstructionSet(
-            resource_requester=self._current_scope().resolve_classical_resource
-        )
-        for q in qubits:
-            inst: tuple[
-                Instruction, Sequence[QubitSpecifier] | None, Sequence[ClbitSpecifier] | None
-            ] = (Delay(duration, unit), [q], [])
-            self.append(*inst)
-            instructions.add(*inst)
-        return instructions
+        if qarg is None:
+            qarg = self.qubits
+        return self.append(Delay(duration, unit=unit), [qarg], [])
 
     def h(self, qubit: QubitSpecifier) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.HGate`.

--- a/releasenotes/notes/fix-delay-broadcast-e8762b01dfd7e94f.yaml
+++ b/releasenotes/notes/fix-delay-broadcast-e8762b01dfd7e94f.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The qubit-argument broadcasting of :meth:`.QuantumCircuit.delay` now correctly produces
+    individual :class:`~.circuit.Delay` instructions for each qubit, as intended.  Previously, when
+    given certain iterables (such as :class:`set`\ s), it would instead silently produce an invalid
+    circuit that might fail in unusual locations.

--- a/test/python/circuit/test_delay.py
+++ b/test/python/circuit/test_delay.py
@@ -82,6 +82,17 @@ class TestDelayClass(QiskitTestCase):
         expected.delay(300, 2)
         self.assertEqual(qc, expected)
 
+    def test_delay_set(self):
+        """Test that a set argument to `delay` works."""
+        qc = QuantumCircuit(5)
+        qc.delay(8, {0, 1, 3, 4})
+        expected = QuantumCircuit(5)
+        expected.delay(8, 0)
+        expected.delay(8, 1)
+        expected.delay(8, 3)
+        expected.delay(8, 4)
+        self.assertEqual(qc, expected)
+
     def test_to_matrix_return_identity_matrix(self):
         actual = np.array(Delay(100))
         expected = np.array([[1, 0], [0, 1]], dtype=complex)


### PR DESCRIPTION
### Summary

The object is supposed to "broadcast" like a gate; one instruction per qubit.  This silently did the wrong thing when given a `set` as its argument, previously.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #11446.
