### PR TITLE
Fix global-phase of copied `BlueprintCircuit`s

### DIFF
--- a/qiskit/circuit/library/blueprintcircuit.py
+++ b/qiskit/circuit/library/blueprintcircuit.py
@@ -178,6 +178,16 @@ class BlueprintCircuit(QuantumCircuit, ABC):
             self._build()
         return super().num_connected_components(unitary_only=unitary_only)
 
+    def copy_empty_like(self, name=None):
+        if not self._is_built:
+            self._build()
+        cpy = super().copy_empty_like(name=name)
+        # The base `copy_empty_like` will typically trigger code that `BlueprintCircuit` treats as
+        # an "invalidation", so we have to manually restore properties deleted by that that
+        # `copy_empty_like` is supposed to propagate.
+        cpy.global_phase = self.global_phase
+        return cpy
+
     def copy(self, name=None):
         if not self._is_built:
             self._build()

--- a/releasenotes/notes/fix-blueprintcircuit-phase-7102043cf2e47e33.yaml
+++ b/releasenotes/notes/fix-blueprintcircuit-phase-7102043cf2e47e33.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Calling :meth:`~.QuantumCircuit.copy` or :meth:`~.QuantumCircuit.copy_empty_like` on a
+    :class:¬.BlueprintCircuit` will now correctly propagate the
+    :attr:`~.QuantumCircuit.global_phase` to the copy.  Previously, the global phase would always be zero after the copy.


### PR DESCRIPTION
### Summary

Using `BlueprintCircuit.copy()` or `.copy_empty_like()` would previously erase the global phase as part of the rebuild operation.  This overrides `BlueprintCircuit.copy_empty_like()` to ensure that it is always propagated through.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


