### PR TITLE
Small fixes docs

### DIFF
--- a/qiskit/circuit/library/data_preparation/zz_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/zz_feature_map.py
@@ -18,7 +18,7 @@ from .pauli_feature_map import PauliFeatureMap
 
 
 class ZZFeatureMap(PauliFeatureMap):
-    """Second-order Pauli-Z evolution circuit.
+    r"""Second-order Pauli-Z evolution circuit.
 
     For 3 qubits and 1 repetition and linear entanglement the circuit is represented by:
 
@@ -33,7 +33,7 @@ class ZZFeatureMap(PauliFeatureMap):
         └───┘└─────────────────┘                                  └───┘└──────────────────────┘└───┘
 
     where ``φ`` is a classical non-linear function, which defaults to ``φ(x) = x`` if and
-    ``φ(x,y) = (pi - x)(pi - y)``.
+    ``φ(x,y) = (\pi - x)(\pi - y)``.
 
     Examples:
 

--- a/qiskit/circuit/library/data_preparation/zz_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/zz_feature_map.py
@@ -32,8 +32,8 @@ class ZZFeatureMap(PauliFeatureMap):
         ┤ H ├┤ U1(2.0*φ(x[2])) ├──────────────────────────────────┤ X ├┤ U1(2.0*φ(x[1],x[2])) ├┤ X ├
         └───┘└─────────────────┘                                  └───┘└──────────────────────┘└───┘
 
-    where ``φ`` is a classical non-linear function, which defaults to ``φ(x) = x`` if and
-    ``φ(x,y) = (\pi - x)(\pi - y)``.
+    where :math:`\varphi` is a classical non-linear function, which defaults to :math:`\varphi(x) = x`
+    if and :math:`\varphi(x,y) = (\pi - x)(\pi - y)`.
 
     Examples:
 

--- a/qiskit/circuit/library/generalized_gates/linear_function.py
+++ b/qiskit/circuit/library/generalized_gates/linear_function.py
@@ -19,6 +19,9 @@ from qiskit.circuit.exceptions import CircuitError
 from qiskit.synthesis.linear import check_invertible_binary_matrix
 from qiskit.circuit.library.generalized_gates.permutation import PermutationGate
 
+# pylint: disable=cyclic-import
+from qiskit.quantum_info import Clifford
+
 
 class LinearFunction(Gate):
     r"""A linear reversible circuit on n qubits.
@@ -62,16 +65,23 @@ class LinearFunction(Gate):
     `Online at umich.edu. <https://web.eecs.umich.edu/~imarkov/pubs/jour/qic08-cnot.pdf>`_
     """
 
-    def __init__(self, linear, validate_input=False):
+    def __init__(
+        self,
+        linear: list[list]
+        | np.ndarray[bool]
+        | QuantumCircuit
+        | LinearFunction
+        | PermutationGate
+        | Clifford,
+        validate_input: bool = False,
+    ) -> None:
         """Create a new linear function.
 
         Args:
-            linear (list[list] or ndarray[bool] or QuantumCircuit or LinearFunction
-                or PermutationGate or Clifford): data from which a linear function
-                can be constructed. It can be either a nxn matrix (describing the
-                linear transformation), a permutation (which is a special case of
-                a linear function), another linear function, a clifford (when it
-                corresponds to a linear function), or a quantum circuit composed of
+            linear: data from which a linear function can be constructed. It can be either a
+                nxn matrix (describing the linear transformation), a permutation (which is a
+                special case of a linear function), another linear function, a clifford (when
+                it corresponds to a linear function), or a quantum circuit composed of
                 linear gates (CX and SWAP) and other objects described above, including
                 nested subcircuits.
 
@@ -85,9 +95,6 @@ class LinearFunction(Gate):
                 (for example, a Hadamard gate, or a Clifford that does
                 not correspond to a linear function).
         """
-
-        # pylint: disable=cyclic-import
-        from qiskit.quantum_info import Clifford
 
         original_circuit = None
 

--- a/qiskit/circuit/library/n_local/excitation_preserving.py
+++ b/qiskit/circuit/library/n_local/excitation_preserving.py
@@ -119,9 +119,6 @@ class ExcitationPreserving(TwoLocal):
             skip_unentangled_qubits: If True, the single qubit gates are only applied to qubits
                 that are entangled with another qubit. If False, the single qubit gates are applied
                 to each qubit in the Ansatz. Defaults to False.
-            skip_unentangled_qubits: If True, the single qubit gates are only applied to qubits
-                that are entangled with another qubit. If False, the single qubit gates are applied
-                to each qubit in the Ansatz. Defaults to False.
             skip_final_rotation_layer: If True, a rotation layer is added at the end of the
                 ansatz. If False, no rotation layer is added. Defaults to True.
             parameter_prefix: The parameterized gates require a parameter to be defined, for which

--- a/qiskit/circuit/library/n_local/real_amplitudes.py
+++ b/qiskit/circuit/library/n_local/real_amplitudes.py
@@ -147,9 +147,6 @@ class RealAmplitudes(TwoLocal):
             skip_unentangled_qubits: If True, the single qubit gates are only applied to qubits
                 that are entangled with another qubit. If False, the single qubit gates are applied
                 to each qubit in the Ansatz. Defaults to False.
-            skip_unentangled_qubits: If True, the single qubit gates are only applied to qubits
-                that are entangled with another qubit. If False, the single qubit gates are applied
-                to each qubit in the Ansatz. Defaults to False.
             skip_final_rotation_layer: If False, a rotation layer is added at the end of the
                 ansatz. If True, no rotation layer is added.
             parameter_prefix: The parameterized gates require a parameter to be defined, for which

--- a/qiskit/circuit/library/phase_estimation.py
+++ b/qiskit/circuit/library/phase_estimation.py
@@ -24,7 +24,7 @@ class PhaseEstimation(QuantumCircuit):
 
     In the Quantum Phase Estimation (QPE) algorithm [1, 2, 3], the Phase Estimation circuit is used
     to estimate the phase :math:`\phi` of an eigenvalue :math:`e^{2\pi i\phi}` of a unitary operator
-    :math:`U`, provided with the corresponding eigenstate :math:`|psi\rangle`.
+    :math:`U`, provided with the corresponding eigenstate :math:`|\psi\rangle`.
     That is
 
     .. math::

--- a/qiskit/circuit/library/standard_gates/sx.py
+++ b/qiskit/circuit/library/standard_gates/sx.py
@@ -139,7 +139,7 @@ class SXdgGate(SingletonGate):
                         1 & i \\
                         i & 1
                       \end{pmatrix}
-                    = e^{-i pi/4} \sqrt{X}^{\dagger}
+                    = e^{-i \pi/4} \sqrt{X}^{\dagger}
 
     """
 

--- a/qiskit/circuit/library/standard_gates/xx_minus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_minus_yy.py
@@ -65,8 +65,8 @@ class XXMinusYYGate(Gate):
         In Qiskit's convention, higher qubit indices are more significant
         (little endian convention). In the above example we apply the gate
         on (q_0, q_1) which results in adding the (optional) phase defined
-        by :math:`beta` on q_1. Instead, if we apply it on (q_1, q_0), the
-        phase is added on q_0. If :math:`beta` is set to its default value
+        by :math:`\beta` on q_1. Instead, if we apply it on (q_1, q_0), the
+        phase is added on q_0. If :math:`\beta` is set to its default value
         of :math:`0`, the gate is equivalent in big and little endian.
 
         .. parsed-literal::

--- a/qiskit/circuit/library/standard_gates/xx_plus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_plus_yy.py
@@ -56,8 +56,8 @@ class XXPlusYYGate(Gate):
         In Qiskit's convention, higher qubit indices are more significant
         (little endian convention). In the above example we apply the gate
         on (q_0, q_1) which results in adding the (optional) phase defined
-        by :math:`beta` on q_0. Instead, if we apply it on (q_1, q_0), the
-        phase is added on q_1. If :math:`beta` is set to its default value
+        by :math:`\beta` on q_0. Instead, if we apply it on (q_1, q_0), the
+        phase is added on q_1. If :math:`\beta` is set to its default value
         of :math:`0`, the gate is equivalent in big and little endian.
 
         .. parsed-literal::


### PR DESCRIPTION
- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.


### Summary
Noticed a couple of typo's and an issue with the docstring for `LinearFunction`.


### Details and comments
- Removed duplicate `skip_unentangled_bits` parameter from `ExcitationPreserving` and `RealAmplitudes docstrings`.
- Added missing backslashes to a couple of Greek letters in docstrings  (`PhaseEstimation`, `SXdgGate`, `XXPlusYYGate`, `XXMinusYYGate`, `ZZFeatureMap`)
- Added type hints to `LinearFunction` and removed the hardcoded argument types from the docstring. This fixes the documentation showing `LinearFunction` instead of `linear` as parameter and the stray ) in the list of allowed argument types. 


