### PR TITLE
Fix text drawer AnnotatedOperations

### DIFF
--- a/qiskit/visualization/circuit/text.py
+++ b/qiskit/visualization/circuit/text.py
@@ -1189,7 +1189,22 @@ class TextDrawing:
             )
             gates, controlled_top, controlled_bot, controlled_edge, rest = controls_array
             if mod_control:
-                gates.append(BoxOnQuWire(gate_text, conditional=conditional))
+                if len(rest) == 1:
+                    gates.append(BoxOnQuWire(gate_text, conditional=conditional))
+                else:
+                    top_connect = "┴" if controlled_top else None
+                    bot_connect = "┬" if controlled_bot else None
+                    indexes = layer.set_qu_multibox(
+                        rest,
+                        gate_text,
+                        conditional=conditional,
+                        controlled_edge=controlled_edge,
+                        top_connect=top_connect,
+                        bot_connect=bot_connect,
+                    )
+                    for index in range(min(indexes), max(indexes) + 1):
+                        # Dummy element to connect the multibox with the bullets
+                        current_cons.append((index, DrawElement("")))
             elif base_gate.name == "z":
                 # cz
                 gates.append(Bullet(conditional=conditional))

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -45,6 +45,7 @@ from qiskit.circuit.library import (
     U3Gate,
     XGate,
     CZGate,
+    CXGate,
     ZGate,
     YGate,
     SGate,
@@ -6342,6 +6343,29 @@ class TestCircuitAnnotatedOperations(QiskitVisualizationTestCase):
         )
         circuit.append(op1, [0, 1, 2])
         circuit.append(SXGate(), [1])
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=False)),
+            expected,
+        )
+
+    def test_annotated_operation(self):
+        """Test AnnotatedOperation and other non-Instructions."""
+        expected = "\n".join(
+            [
+                "                  ",
+                "q_0: ──────o──────",
+                "     ┌─────┴─────┐",
+                "q_1: ┤0          ├",
+                "     │  Cx - Inv │",
+                "q_2: ┤1          ├",
+                "     └─────┬─────┘",
+                "q_3: ──────■──────",
+                "                  ",
+            ]
+        )
+        gate = AnnotatedOperation(CXGate(), [ControlModifier(2, 2), InverseModifier()])
+        circuit = QuantumCircuit(gate.num_qubits)
+        circuit.append(gate, [0, 3, 1, 2])
         self.assertEqual(
             str(circuit_drawer(circuit, output="text", initial_state=False)),
             expected,

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -6348,7 +6348,7 @@ class TestCircuitAnnotatedOperations(QiskitVisualizationTestCase):
             expected,
         )
 
-    def test_annotated_operation(self):
+    def test_annotated_multi_qubit(self):
         """Test AnnotatedOperation and other non-Instructions."""
         expected = "\n".join(
             [


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #11465

### Details and comments

This PR fixes an issue in the text drawer where multi-qubit AnnotatedOperations were not displaying all the qubits.

Now this,
```
from qiskit.circuit import QuantumCircuit
from qiskit.circuit.annotated_operation import AnnotatedOperation, InverseModifier, ControlModifier
from qiskit.circuit.library import CXGate

gate = AnnotatedOperation(CXGate(), ControlModifier(1))
circuit = QuantumCircuit(gate.num_qubits)
circuit.append(gate, range(gate.num_qubits))
print(circuit)
```
displays as
```
            
q_0: ───■───
     ┌──┴──┐
q_1: ┤0    ├
     │  Cx │
q_2: ┤1    ├
     └─────┘
```