### PR TITLE
sampled_expval_complex now returns Complex64 instead of float64

### DIFF
--- a/crates/accelerate/src/sampled_exp_val.rs
+++ b/crates/accelerate/src/sampled_exp_val.rs
@@ -83,8 +83,6 @@ pub fn sampled_expval_complex(
         .enumerate()
         .map(|(idx, string)| coeff_arr[idx] * Complex64::new(bitstring_expval(&dist, string), 0.))
         .sum();
-    //println!("zebwasere");
-    //dbg!("heelo");
     Ok(out)
 }
 

--- a/crates/accelerate/src/sampled_exp_val.rs
+++ b/crates/accelerate/src/sampled_exp_val.rs
@@ -76,14 +76,16 @@ pub fn sampled_expval_complex(
     oper_strs: Vec<String>,
     coeff: PyReadonlyArray1<Complex64>,
     dist: HashMap<String, f64>,
-) -> PyResult<f64> {
+) -> PyResult<Complex64> {
     let coeff_arr = coeff.as_slice()?;
     let out: Complex64 = oper_strs
         .into_iter()
         .enumerate()
         .map(|(idx, string)| coeff_arr[idx] * Complex64::new(bitstring_expval(&dist, string), 0.))
         .sum();
-    Ok(out.re)
+    //println!("zebwasere");
+    //dbg!("heelo");
+    Ok(out)
 }
 
 #[pymodule]

--- a/qiskit/result/sampled_expval.py
+++ b/qiskit/result/sampled_expval.py
@@ -34,7 +34,7 @@ def sampled_expectation_value(dist, oper):
                                                                        the observable
 
     Returns:
-        float: The expectation value
+        float or complex: The expectation value
     Raises:
         QiskitError: if the input distribution or operator is an invalid type
     """

--- a/test/python/result/test_sampled_expval.py
+++ b/test/python/result/test_sampled_expval.py
@@ -101,6 +101,12 @@ class TestSampledExpval(QiskitTestCase):
         result2 = sampled_expectation_value(dist, "00ZI")
         self.assertAlmostEqual(result2, 0.4376)
 
+    def test_complex(self):
+        """test that complex values can be returned"""
+        sp = SparsePauliOp.from_list([["ZZZZZ", -1j]])
+        dist = {"11111": 1}
+        self.assertAlmostEqual(sampled_expectation_value(dist, sp), 1j)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the CONTRIBUTING document.
-->

A small change to allow `samled_expval_complex` to return `Complex64` instead of `f64` see the following issue. fixes #11393 
I'm marking as draft as this is my first PR on this project and would like some feedback on the style of it. 


