### PR TITLE
Fix installed packages in randomised tests

### DIFF
--- a/.github/workflows/randomized_tests.yml
+++ b/.github/workflows/randomized_tests.yml
@@ -17,13 +17,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip setuptools wheel
-          python -m pip install -U -r requirements.txt -c constraints.txt
-          python -m pip install -U -r requirements-dev.txt coveralls -c constraints.txt
-          python -m pip install -c constraints.txt -e .
-          python -m pip install "qiskit-ibmq-provider" -c constraints.txt
-          python -m pip install "qiskit-aer"
-        env:
-          SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
+          python -m pip install -U \
+            -c constraints.txt \
+            -r requirements.txt \
+            -r requirements-dev.txt \
+            coveralls \
+            qiskit-aer \
+            -e .
       - name: Run randomized tests
         run: make test_randomized
         env:


### PR DESCRIPTION
### Summary

The randomised test suite does not to install the long-deprecated `qiskit_ibmq_provider`, and doing so causes an old, incompatible version of `qiskit-terra` to be installed, breaking the editable install.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


