### PR TITLE
use faster aqc objective function evaluation by default

### DIFF
--- a/qiskit/transpiler/synthesis/aqc/aqc_plugin.py
+++ b/qiskit/transpiler/synthesis/aqc/aqc_plugin.py
@@ -109,7 +109,9 @@ class AQCSynthesisPlugin(UnitarySynthesisPlugin):
         from qiskit.transpiler.synthesis.aqc.aqc import AQC
         from qiskit.transpiler.synthesis.aqc.cnot_structures import make_cnot_network
         from qiskit.transpiler.synthesis.aqc.cnot_unit_circuit import CNOTUnitCircuit
-        from qiskit.transpiler.synthesis.aqc.fast_gradient.fast_gradient import FastCNOTUnitObjective
+        from qiskit.transpiler.synthesis.aqc.fast_gradient.fast_gradient import (
+            FastCNOTUnitObjective,
+        )
 
         num_qubits = int(round(np.log2(unitary.shape[0])))
 

--- a/qiskit/transpiler/synthesis/aqc/aqc_plugin.py
+++ b/qiskit/transpiler/synthesis/aqc/aqc_plugin.py
@@ -109,7 +109,7 @@ class AQCSynthesisPlugin(UnitarySynthesisPlugin):
         from qiskit.transpiler.synthesis.aqc.aqc import AQC
         from qiskit.transpiler.synthesis.aqc.cnot_structures import make_cnot_network
         from qiskit.transpiler.synthesis.aqc.cnot_unit_circuit import CNOTUnitCircuit
-        from qiskit.transpiler.synthesis.aqc.cnot_unit_objective import DefaultCNOTUnitObjective
+        from qiskit.transpiler.synthesis.aqc.fast_gradient.fast_gradient import FastCNOTUnitObjective
 
         num_qubits = int(round(np.log2(unitary.shape[0])))
 
@@ -132,7 +132,7 @@ class AQCSynthesisPlugin(UnitarySynthesisPlugin):
         aqc = AQC(optimizer, seed)
 
         approximate_circuit = CNOTUnitCircuit(num_qubits=num_qubits, cnots=cnots)
-        approximating_objective = DefaultCNOTUnitObjective(num_qubits=num_qubits, cnots=cnots)
+        approximating_objective = FastCNOTUnitObjective(num_qubits=num_qubits, cnots=cnots)
 
         initial_point = config.get("initial_point")
         aqc.compile_unitary(

--- a/releasenotes/notes/aqc-faster-default-8d47c88fefd1b6f6.yaml
+++ b/releasenotes/notes/aqc-faster-default-8d47c88fefd1b6f6.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    The AQC unitary synthesis plugin method now uses a faster objective function
+    evaluation by default, which results in substantial improvement in synthesis time.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x ] I have added the tests to cover my changes.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the CONTRIBUTING document.
-->

### Summary

In https://github.com/Qiskit/qiskit/pull/7697 a faster objective function evaluation for AQC was introduced which is a drop-in replacement and makes convergence several times faster. However the old default was still in place. Here I switch to the faster alternative. 
See the original issue about why it's worth to keep the old one around for now just in case.



