### PR TITLE
Make `typing_extensions` required on all Python versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ sympy>=1.3
 dill>=0.3
 python-dateutil>=2.8.0
 stevedore>=3.0.0
-typing-extensions; python_version<'3.11'
+typing-extensions
 symengine>=0.9,!=0.10.0


### PR DESCRIPTION
### Summary

The extent of our use of `typing_extensions` has fluctuated over time, but we've often had a dependency on it.  This is typically not an onerous dependency, being pure Python, and is not uncommon for other packages.

We've often had an upper limit on the Python version for it, just for the principle of least requirements, but this has led to a subtle bug recently where we began using a Python 3.12 feature from it (`Unpack`) with the requirement left at `python_version<'3.11'` from before.  This was caught by our nightly full test suite, but for unrelated reasons, that's not commenting correctly on issues at the moment.  This error is quite likely to repeat; we only use the backport package for Python versions that _aren't_ the newest, but our PR CI tests only oldest and newest.

This commit simply lifts the upper limit on the package; the impact should be minimal since most environments will already be installing it.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

`main` currently cannot be imported on Python 3.11 without a fix.

The problem was introduced in #8268, but it could have been any PR updating the typing, and this is the kind of infrequent bug our full-matrix nightly CI is supposed to catch - it would be overkill to revert to the full matrix in PR CI and destroy our throughput.