### PR TITLE
Relax CI constraint on `jsonschema`

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,7 +1,3 @@
-# jsonschema pinning needed due nbformat==5.1.3 using deprecated behaviour in
-# 4.0+. The pin can be removed after nbformat is updated.
-jsonschema==3.2.0
-
 # Scipy 1.11 seems to have caused an instability in the Weyl coordinates
 # eigensystem code for one of the test cases.  See
 # https://github.com/Qiskit/qiskit-terra/issues/10345 for current details.


### PR DESCRIPTION
### Summary

This was originally added because of `nbformat` using deprecated functionality.  The constraint is causing installation problems for some of our optionals now, particularly on Python 3.12, and should be fixed by now anyway.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

If this doesn't already pass CI in all configurations, we can think about potential alternatives - the constraint is causing problems, so hopefully `nbformat` have updated by now.  My recollection is that they were being a shade dismissive of the warning at the time, but that was a year or more ago.