### PR TITLE
Fix clippy issue on Rust 1.75

### DIFF
--- a/crates/accelerate/src/results/marginalization.rs
+++ b/crates/accelerate/src/results/marginalization.rs
@@ -132,7 +132,7 @@ pub fn marginal_memory(
     parallel_threshold: usize,
 ) -> PyResult<PyObject> {
     let run_in_parallel = getenv_use_multiple_threads();
-    let first_elem = memory.get(0);
+    let first_elem = memory.first();
     if first_elem.is_none() {
         let res: Vec<String> = Vec::new();
         return Ok(res.to_object(py));


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

With the recent release of Rust 1.75 there were some new clippy rules enabled. There was one minor usage issue highlighted in the new release. While we pin the rust version in CI when building and running clippy locally with the latest version this would trigger a failure. This commit fixes the one issue highlighted by clippy on Rust 1.75 which replaces `Vec<T>.get(0)` with `Vec<T>.first()`.

### Details and comments