### PR TITLE
Update built-in pass managers (followup of #11448)

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -69,63 +69,20 @@ class DefaultInitPassManager(PassManagerStagePlugin):
     """Plugin class for default init stage."""
 
     def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
-        if optimization_level == 0:
-            init = None
-            if (
-                pass_manager_config.initial_layout
-                or pass_manager_config.coupling_map
-                or (
-                    pass_manager_config.target is not None
-                    and pass_manager_config.target.build_coupling_map() is not None
-                )
-            ):
-                init = common.generate_unroll_3q(
-                    pass_manager_config.target,
-                    pass_manager_config.basis_gates,
-                    pass_manager_config.approximation_degree,
-                    pass_manager_config.unitary_synthesis_method,
-                    pass_manager_config.unitary_synthesis_plugin_config,
-                    pass_manager_config.hls_config,
-                )
-        elif optimization_level in {1, 2}:
-            init = PassManager()
-            if (
-                pass_manager_config.initial_layout
-                or pass_manager_config.coupling_map
-                or (
-                    pass_manager_config.target is not None
-                    and pass_manager_config.target.build_coupling_map() is not None
-                )
-            ):
-                init += common.generate_unroll_3q(
-                    pass_manager_config.target,
-                    pass_manager_config.basis_gates,
-                    pass_manager_config.approximation_degree,
-                    pass_manager_config.unitary_synthesis_method,
-                    pass_manager_config.unitary_synthesis_plugin_config,
-                    pass_manager_config.hls_config,
-                )
-            init.append(
-                InverseCancellation(
-                    [
-                        CXGate(),
-                        ECRGate(),
-                        CZGate(),
-                        CYGate(),
-                        XGate(),
-                        YGate(),
-                        ZGate(),
-                        HGate(),
-                        SwapGate(),
-                        (TGate(), TdgGate()),
-                        (SGate(), SdgGate()),
-                        (SXGate(), SXdgGate()),
-                    ]
-                )
-            )
 
-        elif optimization_level == 3:
-            init = common.generate_unroll_3q(
+        any_layout_or_coupling_map = (
+            pass_manager_config.initial_layout
+            or pass_manager_config.coupling_map
+            or (
+                pass_manager_config.target is not None
+                and pass_manager_config.target.build_coupling_map() is not None
+            )
+        )
+
+        if optimization_level == 0:
+            if not any_layout_or_coupling_map:
+                return None
+            return common.generate_unroll_3q(
                 pass_manager_config.target,
                 pass_manager_config.basis_gates,
                 pass_manager_config.approximation_degree,
@@ -133,30 +90,59 @@ class DefaultInitPassManager(PassManagerStagePlugin):
                 pass_manager_config.unitary_synthesis_plugin_config,
                 pass_manager_config.hls_config,
             )
-            init.append(OptimizeSwapBeforeMeasure())
-            init.append(RemoveDiagonalGatesBeforeMeasure())
-            init.append(
-                InverseCancellation(
+
+        _inv_cancellation = InverseCancellation(
+            [
+                CXGate(),
+                ECRGate(),
+                CZGate(),
+                CYGate(),
+                XGate(),
+                YGate(),
+                ZGate(),
+                HGate(),
+                SwapGate(),
+                (TGate(), TdgGate()),
+                (SGate(), SdgGate()),
+                (SXGate(), SXdgGate()),
+            ]
+        )
+
+        if optimization_level in {1, 2}:
+            if any_layout_or_coupling_map:
+                return PassManager(
                     [
-                        CXGate(),
-                        ECRGate(),
-                        CZGate(),
-                        CYGate(),
-                        XGate(),
-                        YGate(),
-                        ZGate(),
-                        HGate(),
-                        SwapGate(),
-                        (TGate(), TdgGate()),
-                        (SGate(), SdgGate()),
-                        (SXGate(), SXdgGate()),
+                        common.generate_unroll_3q(
+                            pass_manager_config.target,
+                            pass_manager_config.basis_gates,
+                            pass_manager_config.approximation_degree,
+                            pass_manager_config.unitary_synthesis_method,
+                            pass_manager_config.unitary_synthesis_plugin_config,
+                            pass_manager_config.hls_config,
+                        ).to_flow_controller(),
+                        _inv_cancellation,
                     ]
                 )
+            return PassManager(_inv_cancellation)
+
+        if optimization_level == 3:
+            return PassManager(
+                [
+                    common.generate_unroll_3q(
+                        pass_manager_config.target,
+                        pass_manager_config.basis_gates,
+                        pass_manager_config.approximation_degree,
+                        pass_manager_config.unitary_synthesis_method,
+                        pass_manager_config.unitary_synthesis_plugin_config,
+                        pass_manager_config.hls_config,
+                    ).to_flow_controller(),
+                    OptimizeSwapBeforeMeasure(),
+                    RemoveDiagonalGatesBeforeMeasure(),
+                    _inv_cancellation,
+                ]
             )
 
-        else:
-            return TranspilerError(f"Invalid optimization level {optimization_level}")
-        return init
+        raise TranspilerError(f"Invalid optimization level {optimization_level}")
 
 
 class BasisTranslatorPassManager(PassManagerStagePlugin):
@@ -509,119 +495,175 @@ class OptimizationPassManager(PassManagerStagePlugin):
 
     def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
         """Build pass manager for optimization stage."""
+        if optimization_level == 0:
+            return None
+
         # Obtain the translation method required for this pass to work
-        translation_method = pass_manager_config.translation_method or "translator"
-        optimization = PassManager()
-        if optimization_level != 0:
-            plugin_manager = PassManagerStagePluginManager()
-            _depth_check = [Depth(recurse=True), FixedPoint("depth")]
-            _size_check = [Size(recurse=True), FixedPoint("size")]
-            # Minimum point check for optimization level 3.
+        plugin_manager = PassManagerStagePluginManager()
+        translation = plugin_manager.get_passmanager_stage(
+            "translation",
+            pass_manager_config.translation_method or "translator",
+            pass_manager_config,
+            optimization_level=optimization_level,
+        )
+        _unroll = translation.to_flow_controller()
+
+        def _unroll_condition(property_set):
+            return not property_set["all_gates_in_basis"]
+
+        if optimization_level == 1:
+
+            def _opt_control(property_set):
+                return not (property_set["depth_fixed_point"] and property_set["size_fixed_point"])
+
+            _depth_size_check = [
+                Depth(recurse=True),
+                FixedPoint("depth"),
+                Size(recurse=True),
+                FixedPoint("size"),
+            ]
+            return PassManager(
+                [
+                    *_depth_size_check,
+                    DoWhileController(
+                        [
+                            # Optimization
+                            Optimize1qGatesDecomposition(
+                                basis=pass_manager_config.basis_gates,
+                                target=pass_manager_config.target,
+                            ),
+                            InverseCancellation(
+                                [
+                                    CXGate(),
+                                    ECRGate(),
+                                    CZGate(),
+                                    CYGate(),
+                                    XGate(),
+                                    YGate(),
+                                    ZGate(),
+                                    HGate(),
+                                    SwapGate(),
+                                    (TGate(), TdgGate()),
+                                    (SGate(), SdgGate()),
+                                    (SXGate(), SXdgGate()),
+                                ]
+                            ),
+                            # Check if any gate is not in the basis, and if so, run unroll passes
+                            GatesInBasis(
+                                basis_gates=pass_manager_config.basis_gates,
+                                target=pass_manager_config.target,
+                            ),
+                            ConditionalController(
+                                _unroll,
+                                condition=_unroll_condition,
+                            ),
+                            # Check depth and size to update condition
+                            *_depth_size_check,
+                        ],
+                        do_while=_opt_control,
+                    ),
+                ]
+            )
+
+        if optimization_level == 2:
+
+            def _opt_control(property_set):
+                return not (property_set["depth_fixed_point"] and property_set["size_fixed_point"])
+
+            _depth_size_check = [
+                Depth(recurse=True),
+                FixedPoint("depth"),
+                Size(recurse=True),
+                FixedPoint("size"),
+            ]
+            return PassManager(
+                [
+                    *_depth_size_check,
+                    DoWhileController(
+                        [
+                            # Optimization
+                            Optimize1qGatesDecomposition(
+                                basis=pass_manager_config.basis_gates,
+                                target=pass_manager_config.target,
+                            ),
+                            CommutativeCancellation(
+                                basis_gates=pass_manager_config.basis_gates,
+                                target=pass_manager_config.target,
+                            ),
+                            # Check if any gate is not in the basis, and if so, run unroll passes
+                            GatesInBasis(
+                                basis_gates=pass_manager_config.basis_gates,
+                                target=pass_manager_config.target,
+                            ),
+                            ConditionalController(
+                                _unroll,
+                                condition=_unroll_condition,
+                            ),
+                            # Check depth and size to update condition
+                            *_depth_size_check,
+                        ],
+                        do_while=_opt_control,
+                    ),
+                ]
+            )
+
+        if optimization_level == 3:
+
+            def _opt_control(property_set):
+                return not property_set["optimization_loop_minimum_point"]
+
             _minimum_point_check = [
                 Depth(recurse=True),
                 Size(recurse=True),
                 MinimumPoint(["depth", "size"], "optimization_loop"),
             ]
-
-            def _opt_control(property_set):
-                return (not property_set["depth_fixed_point"]) or (
-                    not property_set["size_fixed_point"]
-                )
-
-            translation = plugin_manager.get_passmanager_stage(
-                "translation",
-                translation_method,
-                pass_manager_config,
-                optimization_level=optimization_level,
-            )
-            if optimization_level == 1:
-                # Steps for optimization level 1
-                _opt = [
-                    Optimize1qGatesDecomposition(
-                        basis=pass_manager_config.basis_gates, target=pass_manager_config.target
-                    ),
-                    InverseCancellation(
+            return PassManager(
+                [
+                    *_minimum_point_check,
+                    DoWhileController(
                         [
-                            CXGate(),
-                            ECRGate(),
-                            CZGate(),
-                            CYGate(),
-                            XGate(),
-                            YGate(),
-                            ZGate(),
-                            HGate(),
-                            SwapGate(),
-                            (TGate(), TdgGate()),
-                            (SGate(), SdgGate()),
-                            (SXGate(), SXdgGate()),
-                        ]
+                            # Optimization
+                            Collect2qBlocks(),
+                            ConsolidateBlocks(
+                                basis_gates=pass_manager_config.basis_gates,
+                                target=pass_manager_config.target,
+                                approximation_degree=pass_manager_config.approximation_degree,
+                            ),
+                            UnitarySynthesis(
+                                pass_manager_config.basis_gates,
+                                approximation_degree=pass_manager_config.approximation_degree,
+                                coupling_map=pass_manager_config.coupling_map,
+                                backend_props=pass_manager_config.backend_properties,
+                                method=pass_manager_config.unitary_synthesis_method,
+                                plugin_config=pass_manager_config.unitary_synthesis_plugin_config,
+                                target=pass_manager_config.target,
+                            ),
+                            Optimize1qGatesDecomposition(
+                                basis=pass_manager_config.basis_gates,
+                                target=pass_manager_config.target,
+                            ),
+                            CommutativeCancellation(
+                                basis_gates=pass_manager_config.basis_gates,
+                                target=pass_manager_config.target,
+                            ),
+                            # Check if any gate is not in the basis, and if so, run unroll passes
+                            GatesInBasis(
+                                basis_gates=pass_manager_config.basis_gates,
+                                target=pass_manager_config.target,
+                            ),
+                            ConditionalController(
+                                _unroll,
+                                condition=_unroll_condition,
+                            ),
+                            # Check depth and size to update condition
+                            *_minimum_point_check,
+                        ],
+                        do_while=_opt_control,
                     ),
                 ]
-            elif optimization_level == 2:
-                # Steps for optimization level 2
-                _opt = [
-                    Optimize1qGatesDecomposition(
-                        basis=pass_manager_config.basis_gates, target=pass_manager_config.target
-                    ),
-                    CommutativeCancellation(
-                        basis_gates=pass_manager_config.basis_gates,
-                        target=pass_manager_config.target,
-                    ),
-                ]
-            elif optimization_level == 3:
-                # Steps for optimization level 3
-                _opt = [
-                    Collect2qBlocks(),
-                    ConsolidateBlocks(
-                        basis_gates=pass_manager_config.basis_gates,
-                        target=pass_manager_config.target,
-                        approximation_degree=pass_manager_config.approximation_degree,
-                    ),
-                    UnitarySynthesis(
-                        pass_manager_config.basis_gates,
-                        approximation_degree=pass_manager_config.approximation_degree,
-                        coupling_map=pass_manager_config.coupling_map,
-                        backend_props=pass_manager_config.backend_properties,
-                        method=pass_manager_config.unitary_synthesis_method,
-                        plugin_config=pass_manager_config.unitary_synthesis_plugin_config,
-                        target=pass_manager_config.target,
-                    ),
-                    Optimize1qGatesDecomposition(
-                        basis=pass_manager_config.basis_gates, target=pass_manager_config.target
-                    ),
-                    CommutativeCancellation(target=pass_manager_config.target),
-                ]
-
-                def _opt_control(property_set):
-                    return not property_set["optimization_loop_minimum_point"]
-
-            else:
-                raise TranspilerError(f"Invalid optimization_level: {optimization_level}")
-
-            unroll = translation.to_flow_controller()
-            # Build nested Flow controllers
-            def _unroll_condition(property_set):
-                return not property_set["all_gates_in_basis"]
-
-            # Check if any gate is not in the basis, and if so, run unroll passes
-            _unroll_if_out_of_basis = [
-                GatesInBasis(pass_manager_config.basis_gates, target=pass_manager_config.target),
-                ConditionalController(unroll, condition=_unroll_condition),
-            ]
-
-            if optimization_level == 3:
-                optimization.append(_minimum_point_check)
-            else:
-                optimization.append(_depth_check + _size_check)
-            opt_loop = (
-                _opt + _unroll_if_out_of_basis + _minimum_point_check
-                if optimization_level == 3
-                else _opt + _unroll_if_out_of_basis + _depth_check + _size_check
             )
-            optimization.append(DoWhileController(opt_loop, do_while=_opt_control))
-            return optimization
-        else:
-            return None
+
+        raise TranspilerError(f"Invalid optimization_level: {optimization_level}")
 
 
 class AlapSchedulingPassManager(PassManagerStagePlugin):
@@ -679,10 +721,25 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
     """Plugin class for default layout stage."""
 
     def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
-        _given_layout = SetLayout(pass_manager_config.initial_layout)
-
         def _choose_layout_condition(property_set):
             return not property_set["layout"]
+
+        if pass_manager_config.target is None:
+            coupling_map = pass_manager_config.coupling_map
+        else:
+            coupling_map = pass_manager_config.target
+
+        if optimization_level == 0:
+            return PassManager(
+                [
+                    SetLayout(pass_manager_config.initial_layout),
+                    ConditionalController(
+                        TrivialLayout(coupling_map),
+                        condition=_choose_layout_condition,
+                    ),
+                    common.generate_embed_passmanager(coupling_map).to_flow_controller(),
+                ]
+            )
 
         def _layout_not_perfect(property_set):
             """Return ``True`` if the first attempt at layout has been checked and found to be
@@ -704,28 +761,7 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
         def _swap_mapped(property_set):
             return property_set["final_layout"] is None
 
-        if pass_manager_config.target is None:
-            coupling_map = pass_manager_config.coupling_map
-        else:
-            coupling_map = pass_manager_config.target
-
-        layout = PassManager()
-        layout.append(_given_layout)
-        if optimization_level == 0:
-            layout.append(
-                ConditionalController(
-                    TrivialLayout(coupling_map), condition=_choose_layout_condition
-                )
-            )
-            layout += common.generate_embed_passmanager(coupling_map)
-            return layout
-        elif optimization_level == 1:
-            layout.append(
-                ConditionalController(
-                    [TrivialLayout(coupling_map), CheckMap(coupling_map)],
-                    condition=_choose_layout_condition,
-                )
-            )
+        if optimization_level == 1:
             choose_layout_1 = VF2Layout(
                 coupling_map=pass_manager_config.coupling_map,
                 seed=pass_manager_config.seed_transpiler,
@@ -734,7 +770,6 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
                 target=pass_manager_config.target,
                 max_trials=2500,  # Limits layout scoring to < 600ms on ~400 qubit devices
             )
-            layout.append(ConditionalController(choose_layout_1, condition=_layout_not_perfect))
             choose_layout_2 = SabreLayout(
                 coupling_map,
                 max_iterations=2,
@@ -744,18 +779,34 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
                 skip_routing=pass_manager_config.routing_method is not None
                 and pass_manager_config.routing_method != "sabre",
             )
-            layout.append(
-                ConditionalController(
-                    [
-                        BarrierBeforeFinalMeasurements(
-                            "qiskit.transpiler.internal.routing.protection.barrier"
-                        ),
-                        choose_layout_2,
-                    ],
-                    condition=_vf2_match_not_found,
-                )
+            return PassManager(
+                [
+                    SetLayout(pass_manager_config.initial_layout),
+                    ConditionalController(
+                        [TrivialLayout(coupling_map), CheckMap(coupling_map)],
+                        condition=_choose_layout_condition,
+                    ),
+                    ConditionalController(
+                        choose_layout_1,
+                        condition=_layout_not_perfect,
+                    ),
+                    ConditionalController(
+                        [
+                            BarrierBeforeFinalMeasurements(
+                                "qiskit.transpiler.internal.routing.protection.barrier"
+                            ),
+                            choose_layout_2,
+                        ],
+                        condition=_vf2_match_not_found,
+                    ),
+                    ConditionalController(
+                        common.generate_embed_passmanager(coupling_map).to_flow_controller(),
+                        condition=_swap_mapped,
+                    ),
+                ]
             )
-        elif optimization_level == 2:
+
+        if optimization_level == 2:
             choose_layout_0 = VF2Layout(
                 coupling_map=pass_manager_config.coupling_map,
                 seed=pass_manager_config.seed_transpiler,
@@ -763,9 +814,6 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
                 properties=pass_manager_config.backend_properties,
                 target=pass_manager_config.target,
                 max_trials=25000,  # Limits layout scoring to < 10s on ~400 qubit devices
-            )
-            layout.append(
-                ConditionalController(choose_layout_0, condition=_choose_layout_condition)
             )
             choose_layout_1 = SabreLayout(
                 coupling_map,
@@ -776,18 +824,30 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
                 skip_routing=pass_manager_config.routing_method is not None
                 and pass_manager_config.routing_method != "sabre",
             )
-            layout.append(
-                ConditionalController(
-                    [
-                        BarrierBeforeFinalMeasurements(
-                            "qiskit.transpiler.internal.routing.protection.barrier"
-                        ),
-                        choose_layout_1,
-                    ],
-                    condition=_vf2_match_not_found,
-                )
+            return PassManager(
+                [
+                    SetLayout(pass_manager_config.initial_layout),
+                    ConditionalController(
+                        choose_layout_0,
+                        condition=_choose_layout_condition,
+                    ),
+                    ConditionalController(
+                        [
+                            BarrierBeforeFinalMeasurements(
+                                "qiskit.transpiler.internal.routing.protection.barrier"
+                            ),
+                            choose_layout_1,
+                        ],
+                        condition=_vf2_match_not_found,
+                    ),
+                    ConditionalController(
+                        common.generate_embed_passmanager(coupling_map).to_flow_controller(),
+                        condition=_swap_mapped,
+                    ),
+                ]
             )
-        elif optimization_level == 3:
+
+        if optimization_level == 3:
             choose_layout_0 = VF2Layout(
                 coupling_map=pass_manager_config.coupling_map,
                 seed=pass_manager_config.seed_transpiler,
@@ -795,9 +855,6 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
                 properties=pass_manager_config.backend_properties,
                 target=pass_manager_config.target,
                 max_trials=250000,  # Limits layout scoring to < 60s on ~400 qubit devices
-            )
-            layout.append(
-                ConditionalController(choose_layout_0, condition=_choose_layout_condition)
             )
             choose_layout_1 = SabreLayout(
                 coupling_map,
@@ -808,31 +865,36 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
                 skip_routing=pass_manager_config.routing_method is not None
                 and pass_manager_config.routing_method != "sabre",
             )
-            layout.append(
-                ConditionalController(
-                    [
-                        BarrierBeforeFinalMeasurements(
-                            "qiskit.transpiler.internal.routing.protection.barrier"
-                        ),
-                        choose_layout_1,
-                    ],
-                    condition=_vf2_match_not_found,
-                )
+            return PassManager(
+                [
+                    SetLayout(pass_manager_config.initial_layout),
+                    ConditionalController(
+                        choose_layout_0,
+                        condition=_choose_layout_condition,
+                    ),
+                    ConditionalController(
+                        [
+                            BarrierBeforeFinalMeasurements(
+                                "qiskit.transpiler.internal.routing.protection.barrier"
+                            ),
+                            choose_layout_1,
+                        ],
+                        condition=_vf2_match_not_found,
+                    ),
+                    ConditionalController(
+                        common.generate_embed_passmanager(coupling_map).to_flow_controller(),
+                        condition=_swap_mapped,
+                    ),
+                ]
             )
-        else:
-            raise TranspilerError(f"Invalid optimization level: {optimization_level}")
 
-        embed = common.generate_embed_passmanager(coupling_map)
-        layout.append(ConditionalController(embed.to_flow_controller(), condition=_swap_mapped))
-        return layout
+        raise TranspilerError(f"Invalid optimization level: {optimization_level}")
 
 
 class TrivialLayoutPassManager(PassManagerStagePlugin):
     """Plugin class for trivial layout stage."""
 
     def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
-        _given_layout = SetLayout(pass_manager_config.initial_layout)
-
         def _choose_layout_condition(property_set):
             return not property_set["layout"]
 
@@ -841,12 +903,16 @@ class TrivialLayoutPassManager(PassManagerStagePlugin):
         else:
             coupling_map = pass_manager_config.target
 
-        layout = PassManager()
-        layout.append(_given_layout)
-        layout.append(
-            ConditionalController(TrivialLayout(coupling_map), condition=_choose_layout_condition)
+        layout = PassManager(
+            [
+                SetLayout(pass_manager_config.initial_layout),
+                ConditionalController(
+                    TrivialLayout(coupling_map),
+                    condition=_choose_layout_condition,
+                ),
+                common.generate_embed_passmanager(coupling_map).to_flow_controller(),
+            ]
         )
-        layout += common.generate_embed_passmanager(coupling_map)
         return layout
 
 
@@ -854,8 +920,6 @@ class DenseLayoutPassManager(PassManagerStagePlugin):
     """Plugin class for dense layout stage."""
 
     def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
-        _given_layout = SetLayout(pass_manager_config.initial_layout)
-
         def _choose_layout_condition(property_set):
             return not property_set["layout"]
 
@@ -864,28 +928,26 @@ class DenseLayoutPassManager(PassManagerStagePlugin):
         else:
             coupling_map = pass_manager_config.target
 
-        layout = PassManager()
-        layout.append(_given_layout)
-        layout.append(
-            ConditionalController(
-                DenseLayout(
-                    coupling_map=pass_manager_config.coupling_map,
-                    backend_prop=pass_manager_config.backend_properties,
-                    target=pass_manager_config.target,
+        return PassManager(
+            [
+                SetLayout(pass_manager_config.initial_layout),
+                ConditionalController(
+                    DenseLayout(
+                        coupling_map=pass_manager_config.coupling_map,
+                        backend_prop=pass_manager_config.backend_properties,
+                        target=pass_manager_config.target,
+                    ),
+                    condition=_choose_layout_condition,
                 ),
-                condition=_choose_layout_condition,
-            )
+                common.generate_embed_passmanager(coupling_map).to_flow_controller(),
+            ]
         )
-        layout += common.generate_embed_passmanager(coupling_map)
-        return layout
 
 
 class SabreLayoutPassManager(PassManagerStagePlugin):
     """Plugin class for sabre layout stage."""
 
     def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
-        _given_layout = SetLayout(pass_manager_config.initial_layout)
-
         def _choose_layout_condition(property_set):
             return not property_set["layout"]
 
@@ -897,61 +959,50 @@ class SabreLayoutPassManager(PassManagerStagePlugin):
         else:
             coupling_map = pass_manager_config.target
 
-        layout = PassManager()
-        layout.append(_given_layout)
-        if optimization_level == 0:
-            layout_pass = SabreLayout(
-                coupling_map,
-                max_iterations=1,
-                seed=pass_manager_config.seed_transpiler,
-                swap_trials=5,
-                layout_trials=5,
-                skip_routing=pass_manager_config.routing_method is not None
-                and pass_manager_config.routing_method != "sabre",
-            )
-        elif optimization_level == 1:
-            layout_pass = SabreLayout(
-                coupling_map,
-                max_iterations=2,
-                seed=pass_manager_config.seed_transpiler,
-                swap_trials=5,
-                layout_trials=5,
-                skip_routing=pass_manager_config.routing_method is not None
-                and pass_manager_config.routing_method != "sabre",
-            )
-        elif optimization_level == 2:
-            layout_pass = SabreLayout(
-                coupling_map,
-                max_iterations=2,
-                seed=pass_manager_config.seed_transpiler,
-                swap_trials=10,
-                layout_trials=10,
-                skip_routing=pass_manager_config.routing_method is not None
-                and pass_manager_config.routing_method != "sabre",
-            )
-        elif optimization_level == 3:
-            layout_pass = SabreLayout(
-                coupling_map,
-                max_iterations=4,
-                seed=pass_manager_config.seed_transpiler,
-                swap_trials=20,
-                layout_trials=20,
-                skip_routing=pass_manager_config.routing_method is not None
-                and pass_manager_config.routing_method != "sabre",
-            )
-        else:
-            raise TranspilerError(f"Invalid optimization level: {optimization_level}")
-        layout.append(
-            ConditionalController(
-                [
-                    BarrierBeforeFinalMeasurements(
-                        "qiskit.transpiler.internal.routing.protection.barrier"
-                    ),
-                    layout_pass,
-                ],
-                condition=_choose_layout_condition,
-            )
+        sabre_configs = {
+            0: {
+                "max_iterations": 1,
+                "swap_trials": 5,
+                "layout_trials": 5,
+            },
+            1: {
+                "max_iterations": 2,
+                "swap_trials": 5,
+                "layout_trials": 5,
+            },
+            2: {
+                "max_iterations": 2,
+                "swap_trials": 10,
+                "layout_trials": 10,
+            },
+            3: {
+                "max_iterations": 4,
+                "swap_trials": 20,
+                "layout_trials": 20,
+            },
+        }
+
+        return PassManager(
+            [
+                SetLayout(pass_manager_config.initial_layout),
+                ConditionalController(
+                    [
+                        BarrierBeforeFinalMeasurements(
+                            "qiskit.transpiler.internal.routing.protection.barrier"
+                        ),
+                        SabreLayout(
+                            coupling_map,
+                            **sabre_configs[optimization_level],
+                            seed=pass_manager_config.seed_transpiler,
+                            skip_routing=pass_manager_config.routing_method is not None
+                            and pass_manager_config.routing_method != "sabre",
+                        ),
+                    ],
+                    condition=_choose_layout_condition,
+                ),
+                ConditionalController(
+                    common.generate_embed_passmanager(coupling_map).to_flow_controller(),
+                    condition=_swap_mapped,
+                ),
+            ]
         )
-        embed = common.generate_embed_passmanager(coupling_map)
-        layout.append(ConditionalController(embed.to_flow_controller(), condition=_swap_mapped))
-        return layout

--- a/qiskit/transpiler/preset_passmanagers/common.py
+++ b/qiskit/transpiler/preset_passmanagers/common.py
@@ -144,24 +144,38 @@ def generate_control_flow_options_check(
                     f" Got {option}='{given}', but the entire {stage} stage is not supported."
                 )
             bad_options.append(option)
-    out = PassManager()
-    out.append(ContainsInstruction(CONTROL_FLOW_OP_NAMES, recurse=False))
-    if bad_options:
-        out.append(ConditionalController(Error(message), condition=_has_control_flow))
+
     backend_control = _InvalidControlFlowForBackend(basis_gates, target)
-    out.append(
-        ConditionalController(Error(backend_control.message), condition=backend_control.condition)
+
+    pm = PassManager(ContainsInstruction(CONTROL_FLOW_OP_NAMES, recurse=False))
+    if bad_options:
+        pm.append(
+            ConditionalController(
+                Error(message),
+                condition=_has_control_flow,
+            )
+        )
+    pm.append(
+        ConditionalController(
+            Error(backend_control.message),
+            condition=backend_control.condition,
+        )
     )
-    return out
+    return pm
 
 
 def generate_error_on_control_flow(message):
     """Get a pass manager that always raises an error if control flow is present in a given
     circuit."""
-    out = PassManager()
-    out.append(ContainsInstruction(CONTROL_FLOW_OP_NAMES, recurse=False))
-    out.append(ConditionalController(Error(message), condition=_has_control_flow))
-    return out
+    return PassManager(
+        [
+            ContainsInstruction(CONTROL_FLOW_OP_NAMES, recurse=False),
+            ConditionalController(
+                Error(message),
+                condition=_has_control_flow,
+            ),
+        ]
+    )
 
 
 def if_has_control_flow_else(if_present, if_absent):
@@ -171,11 +185,13 @@ def if_has_control_flow_else(if_present, if_absent):
         if_present = if_present.to_flow_controller()
     if isinstance(if_absent, PassManager):
         if_absent = if_absent.to_flow_controller()
-    out = PassManager()
-    out.append(ContainsInstruction(CONTROL_FLOW_OP_NAMES, recurse=False))
-    out.append(ConditionalController(if_present, condition=_has_control_flow))
-    out.append(ConditionalController(if_absent, condition=_without_control_flow))
-    return out
+    return PassManager(
+        [
+            ContainsInstruction(CONTROL_FLOW_OP_NAMES, recurse=False),
+            ConditionalController(if_present, condition=_has_control_flow),
+            ConditionalController(if_absent, condition=_without_control_flow),
+        ]
+    )
 
 
 def generate_unroll_3q(
@@ -206,35 +222,43 @@ def generate_unroll_3q(
     Returns:
         PassManager: The unroll 3q or more pass manager
     """
-    unroll_3q = PassManager()
-    unroll_3q.append(
-        UnitarySynthesis(
-            basis_gates,
-            approximation_degree=approximation_degree,
-            method=unitary_synthesis_method,
-            min_qubits=3,
-            plugin_config=unitary_synthesis_plugin_config,
-            target=target,
-        )
-    )
-    unroll_3q.append(
-        HighLevelSynthesis(
-            hls_config=hls_config,
-            coupling_map=None,
-            target=target,
-            use_qubit_indices=False,
-            equivalence_library=sel,
-            basis_gates=basis_gates,
-            min_qubits=3,
-        )
-    )
-    # If there are no target instructions revert to using unroll3qormore so
-    # routing works.
     if basis_gates is None and target is None:
-        unroll_3q.append(Unroll3qOrMore(target, basis_gates))
+        # If there are no target instructions revert to using unroll3qormore so
+        # routing works.
+        _unroll = Unroll3qOrMore(
+            target=target,
+            basis_gates=basis_gates,
+        )
     else:
-        unroll_3q.append(BasisTranslator(sel, basis_gates, target=target, min_qubits=3))
-    return unroll_3q
+        _unroll = BasisTranslator(
+            equivalence_library=sel,
+            target_basis=basis_gates,
+            target=target,
+            min_qubits=3,
+        )
+
+    return PassManager(
+        [
+            UnitarySynthesis(
+                basis_gates,
+                approximation_degree=approximation_degree,
+                method=unitary_synthesis_method,
+                min_qubits=3,
+                plugin_config=unitary_synthesis_plugin_config,
+                target=target,
+            ),
+            HighLevelSynthesis(
+                hls_config=hls_config,
+                coupling_map=None,
+                target=target,
+                use_qubit_indices=False,
+                equivalence_library=sel,
+                basis_gates=basis_gates,
+                min_qubits=3,
+            ),
+            _unroll,
+        ]
+    )
 
 
 def generate_embed_passmanager(coupling_map):
@@ -319,33 +343,25 @@ def generate_routing_passmanager(
                 return True
         return False
 
-    routing = PassManager()
-    if target is not None:
-        routing.append(CheckMap(target, property_set_field="routing_not_needed"))
-    else:
-        routing.append(CheckMap(coupling_map, property_set_field="routing_not_needed"))
-
     def _swap_condition(property_set):
         return not property_set["routing_not_needed"]
 
-    if use_barrier_before_measurement:
-        routing.append(
-            ConditionalController(
-                [
-                    BarrierBeforeFinalMeasurements(
-                        label="qiskit.transpiler.internal.routing.protection.barrier"
-                    ),
-                    routing_pass,
-                ],
-                condition=_swap_condition,
-            )
+    def filter_fn(node):
+        return (
+            getattr(node.op, "label", None)
+            != "qiskit.transpiler.internal.routing.protection.barrier"
         )
-    else:
-        routing.append(ConditionalController(routing_pass, condition=_swap_condition))
 
-    is_vf2_fully_bounded = vf2_call_limit and vf2_max_trials
-    if (target is not None or backend_properties is not None) and is_vf2_fully_bounded:
-        routing.append(
+    if use_barrier_before_measurement:
+        routing_pass = [
+            BarrierBeforeFinalMeasurements(
+                label="qiskit.transpiler.internal.routing.protection.barrier"
+            ),
+            routing_pass,
+        ]
+
+    if (target is not None or backend_properties is not None) and vf2_call_limit and vf2_max_trials:
+        post_layout = [
             ConditionalController(
                 VF2PostLayout(
                     target,
@@ -357,19 +373,29 @@ def generate_routing_passmanager(
                     strict_direction=False,
                 ),
                 condition=_run_post_layout_condition,
-            )
-        )
-        routing.append(ConditionalController(ApplyLayout(), condition=_apply_post_layout_condition))
+            ),
+            ConditionalController(
+                ApplyLayout(),
+                condition=_apply_post_layout_condition,
+            ),
+        ]
+    else:
+        post_layout = []
 
-    def filter_fn(node):
-        return (
-            getattr(node.op, "label", None)
-            != "qiskit.transpiler.internal.routing.protection.barrier"
-        )
-
-    routing.append([FilterOpNodes(filter_fn)])
-
-    return routing
+    return PassManager(
+        [
+            CheckMap(
+                target or coupling_map,
+                property_set_field="routing_not_needed",
+            ),
+            ConditionalController(
+                routing_pass,
+                condition=_swap_condition,
+            ),
+            *post_layout,
+            FilterOpNodes(filter_fn),
+        ]
+    )
 
 
 def generate_pre_op_passmanager(target=None, coupling_map=None, remove_reset_in_zero=False):
@@ -387,22 +413,25 @@ def generate_pre_op_passmanager(target=None, coupling_map=None, remove_reset_in_
         PassManager: The pass manager
 
     """
-    pre_opt = PassManager()
+    pm = PassManager()
+
     if coupling_map:
-        pre_opt.append(CheckGateDirection(coupling_map, target=target))
 
         def _direction_condition(property_set):
             return not property_set["is_direction_mapped"]
 
-        pre_opt.append(
-            ConditionalController(
-                [GateDirection(coupling_map, target=target)],
-                condition=_direction_condition,
-            )
+        pm.append(
+            [
+                CheckGateDirection(coupling_map, target=target),
+                ConditionalController(
+                    GateDirection(coupling_map, target=target),
+                    condition=_direction_condition,
+                ),
+            ]
         )
     if remove_reset_in_zero:
-        pre_opt.append(RemoveResetInZeroState())
-    return pre_opt
+        pm.append(RemoveResetInZeroState())
+    return pm
 
 
 def generate_translation_passmanager(
@@ -448,78 +477,86 @@ def generate_translation_passmanager(
         TranspilerError: If the ``method`` kwarg is not a valid value
     """
     if method == "unroller":
-        unroll = [Unroller(basis=basis_gates, target=target)]
-    elif method == "translator":
-        unroll = [
-            # Use unitary synthesis for basis aware decomposition of
-            # UnitaryGates before custom unrolling
-            UnitarySynthesis(
-                basis_gates,
-                approximation_degree=approximation_degree,
-                coupling_map=coupling_map,
-                backend_props=backend_props,
-                plugin_config=unitary_synthesis_plugin_config,
-                method=unitary_synthesis_method,
-                target=target,
-            ),
-            HighLevelSynthesis(
-                hls_config=hls_config,
-                coupling_map=coupling_map,
-                target=target,
-                use_qubit_indices=True,
-                equivalence_library=sel,
-                basis_gates=basis_gates,
-            ),
-            BasisTranslator(sel, basis_gates, target),
-        ]
-    elif method == "synthesis":
-        unroll = [
-            # # Use unitary synthesis for basis aware decomposition of
-            # UnitaryGates > 2q before collection
-            UnitarySynthesis(
-                basis_gates,
-                approximation_degree=approximation_degree,
-                coupling_map=coupling_map,
-                backend_props=backend_props,
-                plugin_config=unitary_synthesis_plugin_config,
-                method=unitary_synthesis_method,
-                min_qubits=3,
-                target=target,
-            ),
-            HighLevelSynthesis(
-                hls_config=hls_config,
-                coupling_map=coupling_map,
-                target=target,
-                use_qubit_indices=True,
-                basis_gates=basis_gates,
-                min_qubits=3,
-            ),
-            Unroll3qOrMore(target=target, basis_gates=basis_gates),
-            Collect2qBlocks(),
-            Collect1qRuns(),
-            ConsolidateBlocks(
-                basis_gates=basis_gates, target=target, approximation_degree=approximation_degree
-            ),
-            UnitarySynthesis(
-                basis_gates=basis_gates,
-                approximation_degree=approximation_degree,
-                coupling_map=coupling_map,
-                backend_props=backend_props,
-                plugin_config=unitary_synthesis_plugin_config,
-                method=unitary_synthesis_method,
-                target=target,
-            ),
-            HighLevelSynthesis(
-                hls_config=hls_config,
-                coupling_map=coupling_map,
-                target=target,
-                use_qubit_indices=True,
-                basis_gates=basis_gates,
-            ),
-        ]
-    else:
-        raise TranspilerError("Invalid translation method %s." % method)
-    return PassManager(unroll)
+        return PassManager(
+            [
+                Unroller(basis=basis_gates, target=target),
+            ]
+        )
+    if method == "translator":
+        return PassManager(
+            [
+                # Use unitary synthesis for basis aware decomposition of
+                # UnitaryGates before custom unrolling
+                UnitarySynthesis(
+                    basis_gates,
+                    approximation_degree=approximation_degree,
+                    coupling_map=coupling_map,
+                    backend_props=backend_props,
+                    plugin_config=unitary_synthesis_plugin_config,
+                    method=unitary_synthesis_method,
+                    target=target,
+                ),
+                HighLevelSynthesis(
+                    hls_config=hls_config,
+                    coupling_map=coupling_map,
+                    target=target,
+                    use_qubit_indices=True,
+                    equivalence_library=sel,
+                    basis_gates=basis_gates,
+                ),
+                BasisTranslator(sel, basis_gates, target),
+            ]
+        )
+    if method == "synthesis":
+        return PassManager(
+            [
+                # # Use unitary synthesis for basis aware decomposition of
+                # UnitaryGates > 2q before collection
+                UnitarySynthesis(
+                    basis_gates,
+                    approximation_degree=approximation_degree,
+                    coupling_map=coupling_map,
+                    backend_props=backend_props,
+                    plugin_config=unitary_synthesis_plugin_config,
+                    method=unitary_synthesis_method,
+                    min_qubits=3,
+                    target=target,
+                ),
+                HighLevelSynthesis(
+                    hls_config=hls_config,
+                    coupling_map=coupling_map,
+                    target=target,
+                    use_qubit_indices=True,
+                    basis_gates=basis_gates,
+                    min_qubits=3,
+                ),
+                Unroll3qOrMore(target=target, basis_gates=basis_gates),
+                Collect2qBlocks(),
+                Collect1qRuns(),
+                ConsolidateBlocks(
+                    basis_gates=basis_gates,
+                    target=target,
+                    approximation_degree=approximation_degree,
+                ),
+                UnitarySynthesis(
+                    basis_gates=basis_gates,
+                    approximation_degree=approximation_degree,
+                    coupling_map=coupling_map,
+                    backend_props=backend_props,
+                    plugin_config=unitary_synthesis_plugin_config,
+                    method=unitary_synthesis_method,
+                    target=target,
+                ),
+                HighLevelSynthesis(
+                    hls_config=hls_config,
+                    coupling_map=coupling_map,
+                    target=target,
+                    use_qubit_indices=True,
+                    basis_gates=basis_gates,
+                ),
+            ]
+        )
+    raise TranspilerError("Invalid translation method %s." % method)
 
 
 def generate_scheduling(
@@ -542,70 +579,77 @@ def generate_scheduling(
     Raises:
         TranspilerError: If the ``scheduling_method`` kwarg is not a valid value
     """
-    scheduling = PassManager()
-    if inst_map and inst_map.has_custom_gate():
-        scheduling.append(PulseGates(inst_map=inst_map, target=target))
     if scheduling_method:
-        # Do scheduling after unit conversion.
-        scheduler = {
+        # Do scheduling
+        schedule_opts = {
             "alap": ALAPScheduleAnalysis,
             "as_late_as_possible": ALAPScheduleAnalysis,
             "asap": ASAPScheduleAnalysis,
             "as_soon_as_possible": ASAPScheduleAnalysis,
         }
-        scheduling.append(TimeUnitConversion(instruction_durations, target=target))
         try:
-            scheduling.append(scheduler[scheduling_method](instruction_durations, target=target))
+            _scheduling_passes = [
+                TimeUnitConversion(instruction_durations, target=target),
+                schedule_opts[scheduling_method](instruction_durations, target=target),
+            ]
         except KeyError as ex:
             raise TranspilerError("Invalid scheduling method %s." % scheduling_method) from ex
     elif instruction_durations:
         # No scheduling. But do unit conversion for delays.
+
         def _contains_delay(property_set):
             return property_set["contains_delay"]
 
-        scheduling.append(ContainsInstruction("delay"))
-        scheduling.append(
+        _scheduling_passes = [
+            ContainsInstruction("delay"),
             ConditionalController(
-                TimeUnitConversion(instruction_durations, target=target), condition=_contains_delay
-            )
-        )
+                TimeUnitConversion(instruction_durations, target=target),
+                condition=_contains_delay,
+            ),
+        ]
+    else:
+        _scheduling_passes = []
+
     if (
         timing_constraints.granularity != 1
         or timing_constraints.min_length != 1
         or timing_constraints.acquire_alignment != 1
         or timing_constraints.pulse_alignment != 1
     ):
-        # Run alignment analysis regardless of scheduling.
 
         def _require_alignment(property_set):
             return property_set["reschedule_required"]
 
-        scheduling.append(
+        _alignment_passes = [
             InstructionDurationCheck(
                 acquire_alignment=timing_constraints.acquire_alignment,
                 pulse_alignment=timing_constraints.pulse_alignment,
-            )
-        )
-        scheduling.append(
+            ),
             ConditionalController(
                 ConstrainedReschedule(
                     acquire_alignment=timing_constraints.acquire_alignment,
                     pulse_alignment=timing_constraints.pulse_alignment,
                 ),
                 condition=_require_alignment,
-            )
-        )
-        scheduling.append(
+            ),
             ValidatePulseGates(
                 granularity=timing_constraints.granularity,
                 min_length=timing_constraints.min_length,
-            )
-        )
+            ),
+        ]
+    else:
+        _alignment_passes = []
+
+    pm = PassManager()
+
+    if inst_map and inst_map.has_custom_gate():
+        # Call pulse gate pass to apply custom calibration
+        pm.append(PulseGates(inst_map=inst_map, target=target))
+    pm.append(_scheduling_passes + _alignment_passes)
     if scheduling_method:
         # Call padding pass if circuit is scheduled
-        scheduling.append(PadDelay(target=target))
-
-    return scheduling
+        pm.append(PadDelay(target=target))
+    return pm
 
 
 VF2Limits = collections.namedtuple("VF2Limits", ("call_limit", "max_trials"))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR is a followup of #11448 to keep logical change minimum. This PR overhauls built-in pass managers. `PassManager.append` pattern is almost removed from them since this is no longer necessary. 

### Details and comments

PassManager can be instantiated with predefined pass sequence even though they include conditional or do-while controllers as follows

```python
pm = PassManager(
    ConditionalController(
        DoWhileController(
            [my_pass1, my_pass2, my_pass3], 
            do_while=callable2
        ), 
        condition=callable1
    )
)
```

The append pattern may be necessary when the pipeline changes with some condition (conditional branching):

```python
if some_condition:
  pm.append(some_passes)
else:
  pm.append(some_other_passes)
```

In principle this can be also updated by introducing something like `IfElseController`. Then `PassManager.append` can be also dropped like flow controllers. However this is not the scope of this PR.

In addition, some inefficiency is removed with this PR. In the current code, following pattern is often used

```python
pm_stage += some_other_pm
```

this implicitly builds new instance instead of mutating the original instance, thus it always comes with extra memory overhead (the original instance is discarded by GC though).