### PR TITLE
Construct subclasses of `InstructionDurations` from backend

### DIFF
--- a/qiskit/transpiler/instruction_durations.py
+++ b/qiskit/transpiler/instruction_durations.py
@@ -94,7 +94,7 @@ class InstructionDurations:
         except AttributeError:
             dt = None
 
-        return InstructionDurations(instruction_durations, dt=dt)
+        return cls(instruction_durations, dt=dt)
 
     def update(self, inst_durations: "InstructionDurationsType" | None, dt: float = None):
         """Update self with inst_durations (inst_durations overwrite self).

--- a/releasenotes/notes/instructiondurations-subclass-from-backend-1240cb924f386816.yaml
+++ b/releasenotes/notes/instructiondurations-subclass-from-backend-1240cb924f386816.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    InstructionDurations.from_backend now returns an instance of any subclass 
-    of InstructionDurations instead of the base class. 
+    :meth:`.InstructionDurations.from_backend` now returns an instance of any subclass 
+    of :class:`.InstructionDurations` instead of the base class. 

--- a/releasenotes/notes/instructiondurations-subclass-from-backend-1240cb924f386816.yaml
+++ b/releasenotes/notes/instructiondurations-subclass-from-backend-1240cb924f386816.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    InstructionDurations.from_backend now returns an instance of any subclass 
+    of InstructionDurations instead of the base class. 


### PR DESCRIPTION
### Summary

Modify construction of `InstructionDurations.from_backend` to return an instance of any subclass, as in the use model for dynamic circuits on [qiskit-ibm-provider](https://github.com/Qiskit/qiskit-ibm-provider/blob/e5f9af5cc85863b46ffc6e597a709f27c74bebee/qiskit_ibm_provider/transpiler/passes/scheduling/__init__.py#L55)

### Details and comments

In the current behavior `DynamicInstructionDurations.from_backend()` (a [subclass](https://github.com/Qiskit/qiskit-ibm-provider/blob/main/qiskit_ibm_provider/transpiler/passes/scheduling/utils.py#L131) of `InstructionDurations`) returns an instance of `InstructionDurations` (and corresponding durations) instead.




