### PR TITLE
Build release wheels for tier 1 platforms with PGO

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,8 +20,40 @@ jobs:
         with:
           python-version: '3.10'
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
+        env:
+          CIBW_BEFORE_BUILD: 'bash ./tools/build_pgo.sh'
+          CIBW_BEFORE_BUILD_WINDOWS: 'bash ./tools/build_pgo.sh && cp /tmp/pgo-data/merged.profdata ~/.'
+          CIBW_ENVIRONMENT: 'RUSTUP_TOOLCHAIN="stable" RUSTFLAGS="-Cprofile-use=/tmp/pgo-data/merged.profdata -Cllvm-args=-pgo-warn-missing-function"'
+          CIBW_ENVIRONMENT_LINUX: 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true" RUSTUP_TOOLCHAIN="stable" RUSTFLAGS="-Cprofile-use=/tmp/pgo-data/merged.profdata -Cllvm-args=-pgo-warn-missing-function"'
+          CIBW_ENVIRONMENT_WINDOWS: 'RUSTUP_TOOLCHAIN="stable" RUSTFLAGS="-Cprofile-use=c:\\Users\\runneradmin\\merged.profdata -Cllvm-args=-pgo-warn-missing-function"'
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+          name: shared-wheel-builds
+  build_wheels_32bit:
+    name: Build wheels 32bit
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: '3.10'
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.16.2
+        env:
+          CIBW_SKIP: 'pp* cp36-* cp37-* *musllinux* *amd64 *x86_64'
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
@@ -59,7 +91,7 @@ jobs:
     environment: release
     permissions:
       id-token: write
-    needs: ["build_wheels", "build_wheels_macos_arm"]
+    needs: ["build_wheels", "build_wheels_macos_arm", "build_wheels_32bit"]
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
         env:
-          CIBW_BEFORE_BUILD: 'bash ./tools/build_pgo.sh'
-          CIBW_BEFORE_BUILD_WINDOWS: 'bash ./tools/build_pgo.sh && cp /tmp/pgo-data/merged.profdata ~/.'
+          CIBW_BEFORE_BUILD: 'bash ./tools/build_pgo.sh /tmp/pgo-data/merged.profdata'
+          CIBW_BEFORE_BUILD_WINDOWS: 'bash ./tools/build_pgo.sh /tmp/pgo-data/merged.profdata && cp /tmp/pgo-data/merged.profdata ~/.'
           CIBW_ENVIRONMENT: 'RUSTUP_TOOLCHAIN="stable" RUSTFLAGS="-Cprofile-use=/tmp/pgo-data/merged.profdata -Cllvm-args=-pgo-warn-missing-function"'
           CIBW_ENVIRONMENT_LINUX: 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true" RUSTUP_TOOLCHAIN="stable" RUSTFLAGS="-Cprofile-use=/tmp/pgo-data/merged.profdata -Cllvm-args=-pgo-warn-missing-function"'
           CIBW_ENVIRONMENT_WINDOWS: 'RUSTUP_TOOLCHAIN="stable" RUSTFLAGS="-Cprofile-use=c:\\Users\\runneradmin\\merged.profdata -Cllvm-args=-pgo-warn-missing-function"'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ target-version = ['py38', 'py39', 'py310', 'py311']
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
-skip = "pp* cp36-* cp37-* *musllinux*"
+skip = "pp* cp36-* cp37-* *musllinux* *win32 *i686"
 test-skip = "*win32 *linux_i686"
 test-command = "python {project}/examples/python/stochastic_swap.py"
 # We need to use pre-built versions of Numpy and Scipy in the tests; they have a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,9 @@ test-command = "python {project}/examples/python/stochastic_swap.py"
 # Numpy 1.22 there are no i686 wheels, so we force pip to use older ones without
 # restricting any dependencies that Numpy and Scipy might have.
 before-test = "pip install --only-binary=numpy,scipy numpy scipy"
+# Some jobs locally override the before-build and environment configuration if a
+# specific job override is needed. For example tier 1 platforms locally override
+# see: .github/workflows/wheels.yml for the jobs where this is done
 environment = 'RUSTUP_TOOLCHAIN="stable"'
 
 [tool.cibuildwheel.linux]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ test-command = "python {project}/examples/python/stochastic_swap.py"
 before-test = "pip install --only-binary=numpy,scipy numpy scipy"
 # Some jobs locally override the before-build and environment configuration if a
 # specific job override is needed. For example tier 1 platforms locally override
+# the before-build and environment configuration to enable PGO,
 # see: .github/workflows/wheels.yml for the jobs where this is done
 environment = 'RUSTUP_TOOLCHAIN="stable"'
 

--- a/tools/build_pgo.sh
+++ b/tools/build_pgo.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -x
+
+python -c 'import sys;assert sys.platform == "win32"'
+is_win=$?
+
+set -e
+# Create venv for instrumented build and test
+python -m venv build_pgo
+
+if [[ $is_win -eq 0 ]]; then
+    source build_pgo/Scripts/activate
+else
+    source build_pgo/bin/activate
+fi
+
+# Build with instrumentation
+pip install --prefer-binary -c constraints.txt -r requirements.txt setuptools-rust wheel
+RUSTFLAGS="-Cprofile-generate=/tmp/pgo-data" pip install --prefer-binary -c constraints.txt -e .
+RUSTFLAGS="-Cprofile-generate=/tmp/pgo-data" python setup.py build_rust --release --inplace
+pip install -c constraints.txt --prefer-binary -r requirements-dev.txt
+# Run profile data generation
+
+QISKIT_PARALLEL=FALSE stestr run --abbreviate
+
+deactivate
+
+${HOME}/.rustup/toolchains/*x86_64*/lib/rustlib/x86_64*/bin/llvm-profdata merge -o /tmp/pgo-data/merged.profdata /tmp/pgo-data

--- a/tools/build_pgo.sh
+++ b/tools/build_pgo.sh
@@ -18,10 +18,9 @@ else
 fi
 
 # Build with instrumentation
-pip install --prefer-binary -c constraints.txt -r requirements.txt setuptools-rust wheel
-RUSTFLAGS="-Cprofile-generate=/tmp/pgo-data" pip install --prefer-binary -c constraints.txt -e .
+pip install -U -c constraints.txt setuptools-rust wheel setuptools
+RUSTFLAGS="-Cprofile-generate=/tmp/pgo-data" pip install --prefer-binary -c constraints.txt -r requirements-dev.txt -e .
 RUSTFLAGS="-Cprofile-generate=/tmp/pgo-data" python setup.py build_rust --release --inplace
-pip install -c constraints.txt --prefer-binary -r requirements-dev.txt
 # Run profile data generation
 
 QISKIT_PARALLEL=FALSE stestr run --abbreviate

--- a/tools/build_pgo.sh
+++ b/tools/build_pgo.sh
@@ -2,6 +2,8 @@
 
 set -x
 
+merged_path=$1
+
 python -c 'import sys;assert sys.platform == "win32"'
 is_win=$?
 
@@ -26,4 +28,4 @@ QISKIT_PARALLEL=FALSE stestr run --abbreviate
 
 deactivate
 
-${HOME}/.rustup/toolchains/*x86_64*/lib/rustlib/x86_64*/bin/llvm-profdata merge -o /tmp/pgo-data/merged.profdata /tmp/pgo-data
+${HOME}/.rustup/toolchains/*x86_64*/lib/rustlib/x86_64*/bin/llvm-profdata merge -o $merged_path /tmp/pgo-data

--- a/tools/install_rust.sh
+++ b/tools/install_rust.sh
@@ -2,5 +2,5 @@
 if [ ! -d rust-installer ]; then
     mkdir rust-installer
     wget https://sh.rustup.rs -O rust-installer/rustup.sh
-    sh rust-installer/rustup.sh -y
+    sh rust-installer/rustup.sh -y -c llvm-tools-preview
 fi


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds the infrastructure to build the wheels we publish to PyPI at release time with PGO. Profile guided optimization (PGO) is a compiler technique that uses collected data about a typical execution to inform optimizations the compiler can make about building the output binary. For more details on PGO you can refer to the Rust [1] and Clang [2] documentation on the topic.

To start the only data collected is from running the qiskit unittests. This should give us some broad coverage as we'll exercise everything as we do in the unittests. This also means as we grow our Rust usage in Qiskit we'll continue to cover that code in the unittests and ensure we have coverage in PGO too. However, longer term we'll potentially want to look at dedicated PGO scripts that exercise Qiskit at larger scale than what we can do in the unittests.

### Details and comments

[1] https://doc.rust-lang.org/rustc/profile-guided-optimization.html
[2] https://clang.llvm.org/docs/UsersManual.html#profile-guided-optimization