### PR TITLE
QPy Deserialization

### DIFF
--- a/qiskit/circuit/library/generalized_gates/gms.py
+++ b/qiskit/circuit/library/generalized_gates/gms.py
@@ -84,6 +84,10 @@ class GMS(QuantumCircuit):
                 triangle is considered.
         """
         super().__init__(num_qubits, name="gms")
+        theta_shape = np.array(theta).shape
+        if theta_shape != (num_qubits, num_qubits):
+            theta = np.array(theta) * np.ones(shape=(num_qubits, num_qubits))
+            theta = theta.tolist()
         if not isinstance(theta, list):
             theta = [theta] * int((num_qubits**2 - 1) / 2)
         gms = QuantumCircuit(num_qubits, name="gms")

--- a/qiskit/qpy/binary_io/circuits.py
+++ b/qiskit/qpy/binary_io/circuits.py
@@ -408,6 +408,11 @@ def _read_instruction(
                 else:
                     gate = gate_class(*params)
                     gate.label = label
+            # NOTE: MSGate is deprecated, so we will switch it to the GMS gate. See
+            #       https://github.com/Qiskit/qiskit/issues/11378.
+            if gate_name == "MSGate":
+                gate_class = getattr(library, "GMS")
+                gate = gate_class(num_qubits=len(qargs), theta=params)
             else:
                 gate = gate_class(*params)
         if condition:

--- a/qiskit/qpy/binary_io/circuits.py
+++ b/qiskit/qpy/binary_io/circuits.py
@@ -410,7 +410,7 @@ def _read_instruction(
                     gate.label = label
             # NOTE: MSGate is deprecated, so we will switch it to the GMS gate. See
             #       https://github.com/Qiskit/qiskit/issues/11378.
-            if gate_name == "MSGate":
+            elif gate_name == "MSGate":
                 gate_class = getattr(library, "GMS")
                 gate = gate_class(num_qubits=len(qargs), theta=params)
             else:

--- a/releasenotes/notes/qpy-serialization-f08c241209706da2.yaml
+++ b/releasenotes/notes/qpy-serialization-f08c241209706da2.yaml
@@ -1,0 +1,10 @@
+---
+features_qpy:
+  - |
+    qiskit.qpy now saves and loads circuits reliably using
+    `qiskit.qpy.dump` and `qiskit.qpy.load`. Previously, an
+    error was thrown requiring a positional argument `theta` that is
+    now computed generated in the gate method.
+upgrade_qpy:
+  - |
+    Works in 1.x and may need a backport for 0.4x.

--- a/test/python/qpy/test_io_from_qpy.py
+++ b/test/python/qpy/test_io_from_qpy.py
@@ -19,6 +19,8 @@ from qiskit.qpy import dump, load
 
 
 def test_io():
+    """Test QPy serialization and de-serialization."""
+
     circuit = QuantumCircuit(2)
     circuit.ms(1.23, [0, 1])
 
@@ -27,5 +29,5 @@ def test_io():
 
     try:
         _ = load(io.BytesIO(buf.getvalue()))
-    except Exception as e:
-        raise IOError("Loading to and from qpy failed.") from e
+    except Exception as exception:
+        raise IOError("Loading to and from qpy failed.") from exception

--- a/test/python/qpy/test_io_from_qpy.py
+++ b/test/python/qpy/test_io_from_qpy.py
@@ -1,0 +1,31 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022, 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test cases for qpy loading and saving."""
+
+import io
+
+from qiskit import QuantumCircuit
+from qiskit.qpy import dump, load
+
+
+def test_io():
+    circuit = QuantumCircuit(2)
+    circuit.ms(1.23, [0, 1])
+
+    buf = io.BytesIO()
+    dump(circuit, buf)
+
+    try:
+        _ = load(io.BytesIO(buf.getvalue()))
+    except Exception as e:
+        raise IOError("Loading to and from qpy failed.") from e


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This commit modifies the following modules.

- `gms.py`: The `MSGate` in this module states in its docstring that it has been deprecated in favor of the `GMS` class. The `GMS` docstring states that the parameter `theta` is a `num_qubits x num_qubits` matrix, and then has some logic to ensure the given theta is the correct shape. This logic has been refactored to fix the failing example given in Issue #11378.
- `circuits.py`: The example in Issue #11378 needed extra logic to handle an `MS` gate during [de]serialization. The refactor adds this logic, and switches the deprecated `MSGate` for the `GSM` one.

### Details and comments

The MRE for the error is in the issue, and replicated below.

```python
import io
from qiskit import qiskit, qpy

circuit = qiskit.QuantumCircuit(2)
circuit.ms(1.23, [0, 1])
buf = io.BytesIO()
qpy.dump(circuit, buf)
_ = qpy.load(io.BytesIO(buf.getvalue()))
```

The changes fixes the following error

```python
TypeError: MSGate.__init__() missing 1 required positional argument: 'theta'
```

Resolves #11378 
