### PR TITLE
Remove redundant entries from qiskit_bot yaml

### DIFF
--- a/qiskit_bot.yaml
+++ b/qiskit_bot.yaml
@@ -20,16 +20,6 @@ notifications:
         - "`@levbishop`"
     "quantum_info":
         - "`@ikkoham`"
-    "utils/run_circuits":
-        - "`@woodsp-ibm`"
-    "utils/quantum_instance":
-        - "`@woodsp-ibm`"
-    "opflow":
-        - "`@woodsp-ibm`"
-        - "`@Cryoris`"
-    "algorithms":
-        - "`@ElePT`"
-        - "`@woodsp-ibm`"
     "circuit/library":
         - "`@Cryoris`"
         - "`@ajavadia`"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

#11441 removed defunct entries from codeowners but it seems I stuck around in the bot yaml. This removes the entries from there that correspond with the algorithms and opflow removal

### Details and comments


