### PR TITLE
Fix quadratic construction time of `QuantumCircuit`

### DIFF
--- a/crates/accelerate/src/quantum_circuit/circuit_data.rs
+++ b/crates/accelerate/src/quantum_circuit/circuit_data.rs
@@ -215,9 +215,9 @@ impl CircuitData {
 
     /// Returns the current sequence of registered :class:`.Qubit` instances as a list.
     ///
-    /// .. note::
+    /// .. warning::
     ///
-    ///     Modifying this list from Python space will invalidate the :class:`CircuitData` data
+    ///     Do not modify this list yourself.  It will invalidate the :class:`CircuitData` data
     ///     structures.
     ///
     /// Returns:
@@ -230,9 +230,9 @@ impl CircuitData {
     /// Returns the current sequence of registered :class:`.Clbit`
     /// instances as a list.
     ///
-    /// .. note::
+    /// .. warning::
     ///
-    ///     Modifying this list from Python space will invalidate the :class:`CircuitData` data
+    ///     Do not modify this list yourself.  It will invalidate the :class:`CircuitData` data
     ///     structures.
     ///
     /// Returns:

--- a/crates/accelerate/src/quantum_circuit/circuit_data.rs
+++ b/crates/accelerate/src/quantum_circuit/circuit_data.rs
@@ -184,12 +184,12 @@ impl CircuitData {
         };
         if let Some(qubits) = qubits {
             for bit in qubits.iter()? {
-                self_.add_qubit(bit?, true)?;
+                self_.add_qubit(py, bit?, true)?;
             }
         }
         if let Some(clbits) = clbits {
             for bit in clbits.iter()? {
-                self_.add_clbit(bit?, true)?;
+                self_.add_clbit(py, bit?, true)?;
             }
         }
         if let Some(data) = data {
@@ -252,7 +252,7 @@ impl CircuitData {
     ///     ValueError: The specified ``bit`` is already present and flag ``strict``
     ///         was provided.
     #[pyo3(signature = (bit, *, strict=true))]
-    pub fn add_qubit(&mut self, bit: &PyAny, strict: bool) -> PyResult<()> {
+    pub fn add_qubit(&mut self, py: Python, bit: &PyAny, strict: bool) -> PyResult<()> {
         if self.qubits_native.len() != self.qubits.as_ref(bit.py()).len() {
             return Err(PyRuntimeError::new_err(concat!(
                 "This circuit's 'qubits' list has become out of sync with the circuit data.",
@@ -269,7 +269,6 @@ impl CircuitData {
             .try_insert(BitAsKey::new(bit)?, idx)
             .is_ok()
         {
-            let py = bit.py();
             self.qubits_native.push(bit.into_py(py));
             self.qubits.as_ref(py).append(bit)?;
         } else if strict {
@@ -291,7 +290,7 @@ impl CircuitData {
     ///     ValueError: The specified ``bit`` is already present and flag ``strict``
     ///         was provided.
     #[pyo3(signature = (bit, *, strict=true))]
-    pub fn add_clbit(&mut self, bit: &PyAny, strict: bool) -> PyResult<()> {
+    pub fn add_clbit(&mut self, py: Python, bit: &PyAny, strict: bool) -> PyResult<()> {
         if self.clbits_native.len() != self.clbits.as_ref(bit.py()).len() {
             return Err(PyRuntimeError::new_err(concat!(
                 "This circuit's 'clbits' list has become out of sync with the circuit data.",
@@ -308,7 +307,6 @@ impl CircuitData {
             .try_insert(BitAsKey::new(bit)?, idx)
             .is_ok()
         {
-            let py = bit.py();
             self.clbits_native.push(bit.into_py(py));
             self.clbits.as_ref(py).append(bit)?;
         } else if strict {

--- a/crates/accelerate/src/quantum_circuit/circuit_data.rs
+++ b/crates/accelerate/src/quantum_circuit/circuit_data.rs
@@ -184,12 +184,12 @@ impl CircuitData {
         };
         if let Some(qubits) = qubits {
             for bit in qubits.iter()? {
-                self_.add_qubit(py, bit?, true)?;
+                self_.add_qubit(bit?, true)?;
             }
         }
         if let Some(clbits) = clbits {
             for bit in clbits.iter()? {
-                self_.add_clbit(py, bit?, true)?;
+                self_.add_clbit(bit?, true)?;
             }
         }
         if let Some(data) = data {
@@ -213,18 +213,18 @@ impl CircuitData {
         Ok((ty, args, None::<()>, self_.iter()?).into_py(py))
     }
 
-    /// Returns the current sequence of registered :class:`.Qubit`
-    /// instances as a list.
+    /// Returns the current sequence of registered :class:`.Qubit` instances as a list.
     ///
     /// .. note::
     ///
-    ///     This list is not kept in sync with the container.
+    ///     Modifying this list from Python space will invalidate the :class:`CircuitData` data
+    ///     structures.
     ///
     /// Returns:
     ///     list(:class:`.Qubit`): The current sequence of registered qubits.
     #[getter]
-    pub fn qubits(&self, py: Python<'_>) -> PyObject {
-        PyList::new(py, self.qubits.as_ref(py)).into_py(py)
+    pub fn qubits(&self, py: Python<'_>) -> Py<PyList> {
+        self.qubits.clone_ref(py)
     }
 
     /// Returns the current sequence of registered :class:`.Clbit`
@@ -232,13 +232,14 @@ impl CircuitData {
     ///
     /// .. note::
     ///
-    ///     This list is not kept in sync with the container.
+    ///     Modifying this list from Python space will invalidate the :class:`CircuitData` data
+    ///     structures.
     ///
     /// Returns:
     ///     list(:class:`.Clbit`): The current sequence of registered clbits.
     #[getter]
-    pub fn clbits(&self, py: Python<'_>) -> PyObject {
-        PyList::new(py, self.clbits.as_ref(py)).into_py(py)
+    pub fn clbits(&self, py: Python<'_>) -> Py<PyList> {
+        self.clbits.clone_ref(py)
     }
 
     /// Registers a :class:`.Qubit` instance.
@@ -251,7 +252,13 @@ impl CircuitData {
     ///     ValueError: The specified ``bit`` is already present and flag ``strict``
     ///         was provided.
     #[pyo3(signature = (bit, *, strict=true))]
-    pub fn add_qubit(&mut self, py: Python<'_>, bit: &PyAny, strict: bool) -> PyResult<()> {
+    pub fn add_qubit(&mut self, bit: &PyAny, strict: bool) -> PyResult<()> {
+        if self.qubits_native.len() != self.qubits.as_ref(bit.py()).len() {
+            return Err(PyRuntimeError::new_err(concat!(
+                "This circuit's 'qubits' list has become out of sync with the circuit data.",
+                " Did something modify it?"
+            )));
+        }
         let idx: BitType = self.qubits_native.len().try_into().map_err(|_| {
             PyRuntimeError::new_err(
                 "The number of qubits in the circuit has exceeded the maximum capacity",
@@ -262,8 +269,9 @@ impl CircuitData {
             .try_insert(BitAsKey::new(bit)?, idx)
             .is_ok()
         {
+            let py = bit.py();
             self.qubits_native.push(bit.into_py(py));
-            self.qubits = PyList::new(py, &self.qubits_native).into_py(py);
+            self.qubits.as_ref(py).append(bit)?;
         } else if strict {
             return Err(PyValueError::new_err(format!(
                 "Existing bit {:?} cannot be re-added in strict mode.",
@@ -283,7 +291,13 @@ impl CircuitData {
     ///     ValueError: The specified ``bit`` is already present and flag ``strict``
     ///         was provided.
     #[pyo3(signature = (bit, *, strict=true))]
-    pub fn add_clbit(&mut self, py: Python<'_>, bit: &PyAny, strict: bool) -> PyResult<()> {
+    pub fn add_clbit(&mut self, bit: &PyAny, strict: bool) -> PyResult<()> {
+        if self.clbits_native.len() != self.clbits.as_ref(bit.py()).len() {
+            return Err(PyRuntimeError::new_err(concat!(
+                "This circuit's 'clbits' list has become out of sync with the circuit data.",
+                " Did something modify it?"
+            )));
+        }
         let idx: BitType = self.clbits_native.len().try_into().map_err(|_| {
             PyRuntimeError::new_err(
                 "The number of clbits in the circuit has exceeded the maximum capacity",
@@ -294,8 +308,9 @@ impl CircuitData {
             .try_insert(BitAsKey::new(bit)?, idx)
             .is_ok()
         {
+            let py = bit.py();
             self.clbits_native.push(bit.into_py(py));
-            self.clbits = PyList::new(py, &self.clbits_native).into_py(py);
+            self.clbits.as_ref(py).append(bit)?;
         } else if strict {
             return Err(PyValueError::new_err(format!(
                 "Existing bit {:?} cannot be re-added in strict mode.",


### PR DESCRIPTION
### Summary

The current implementation of `CircuitData.add_qubit` (ditto `clbit`) has linear time complexity because it reconstructs the list on each addition, while the `CircuitData.qubits` getter silently clones the list on return.  This was intended to avoid inadvertant Python-space modifications from getting the Rust components out of sync, but in practice, this cost being hidden in a standard attribute access makes it very easy to introduce accidental quadratic dependencies.

In this case, `QuantumCircuit(num_qubits)` and subsequent `qc.append(..., qc.qubits)` calls were accidentally quadratic in `num_qubits` due to repeated accesses of `QuantumCircuit.qubits`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

No changelog because this hasn't been released.

This was motivated by trying to understand why `PauliBench.time_to_instruction` was so affected by the Rust `CircuitData`.  It seems like that might be one of the few places where we're really timing construction of few-hundred-qubit circuits without something else dominating the runtime; we probably should look to include larger-scale circuit-construction and `QuantumCircuit.append` benchmarks so quadratic complexities of simple components are caught more completely in the future.

To compare the following code-block:
```python
from qiskit import QuantumCircuit
for n in (1_000, 10_000, 100_000):
    %timeit QuantumCircuit(n).qubits
```
before this PR gives
```
10.8 ms ± 106 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
873 ms ± 3.81 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
2min 19s ± 26.9 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
where the quadratic scaling is fairly obvious, and afterwards gives:
```
2.72 ms ± 33.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
27.5 ms ± 843 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
277 ms ± 8.35 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
which tbh is still not as fast as I'd like, but I think the Python-space code is the culprit there, not the Rust code.

The Pauli benchmark looks something like:
```python
from qiskit.quantum_info import Pauli

p = Pauli("X"*500)
%timeit p.to_instruction()

p = Pauli("-" + "X"*500)
%timeit p.to_instruction()
```
Adding a non-zero phase to the Pauli term invokes a different return value, and before this PR this gave:
```
123 µs ± 278 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
13.6 ms ± 87.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
now it's:
```
123 µs ± 804 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
3.65 ms ± 74.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

That's not quite as fast as pre-#10827, but it's much more in line with the performance penalty we were expecting, and doesn't scale quadratically any more.