### PR TITLE
Update deprecation warning filter in ``QiskitTestCase``

### DIFF
--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -229,20 +229,6 @@ class QiskitTestCase(BaseQiskitTestCase):
         for msg in allow_DeprecationWarning_message:
             warnings.filterwarnings("default", category=DeprecationWarning, message=msg)
 
-        allow_aer_DeprecationWarning_message = [
-            # This warning should be fixed once Qiskit/qiskit-aer#1761 is in a release version of Aer.
-            "Setting metadata to None.*",
-            # and this one once Qiskit/qiskit-aer#1945 is merged and released.
-            r"The method ``qiskit\.circuit\.quantumcircuit\.QuantumCircuit\.i\(\)`` is "
-            r"deprecated as of qiskit 0\.45\.0\. It will be removed no earlier than 3 "
-            r"months after the release date\. Use QuantumCircuit\.id as direct replacement\.",
-        ]
-
-        for msg in allow_aer_DeprecationWarning_message:
-            warnings.filterwarnings(
-                "default", category=DeprecationWarning, module="qiskit_aer.*", message=msg
-            )
-
 
 class FullQiskitTestCase(QiskitTestCase):
     """Terra-specific further additions for test cases, if ``testtools`` is available.


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

No longer filter Aer warnings that have been fixed in Aer's 0.13. release.

