### PR TITLE
Deprecate `PauliList` estimator observables

### DIFF
--- a/qiskit/primitives/base/base_estimator.py
+++ b/qiskit/primitives/base/base_estimator.py
@@ -154,6 +154,12 @@ class BaseEstimator(BasePrimitive, Generic[T]):
 
             values = parameter_values[i].
 
+        .. deprecated:: 0.46.0
+           Implicit conversion from a ``PauliList`` to a ``SparsePauliOp`` with ``coeffs=1`` in
+           the ``observables`` arguments is deprecated as of Qiskit 0.46 and will be removed
+           in Qiskit 1.0. You should explicitly convert to a ``SparsePauli`` using
+           ``SparsePauliOp(pauli_list)`` to avoid this warning.
+
         Args:
             circuits: one or more circuit objects.
             observables: one or more observable objects. Several formats are allowed;

--- a/qiskit/primitives/utils.py
+++ b/qiskit/primitives/utils.py
@@ -14,6 +14,7 @@ Utility functions for primitives
 """
 from __future__ import annotations
 
+import warnings
 import sys
 import typing
 from collections.abc import Iterable
@@ -23,7 +24,7 @@ import numpy as np
 from qiskit.circuit import Instruction, ParameterExpression, QuantumCircuit
 from qiskit.circuit.bit import Bit
 from qiskit.circuit.library.data_preparation import Initialize
-from qiskit.quantum_info import SparsePauliOp, Statevector
+from qiskit.quantum_info import SparsePauliOp, Statevector, PauliList
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.quantum_info.operators.symplectic.base_pauli import BasePauli
 
@@ -82,6 +83,15 @@ def init_observable(observable: BaseOperator | PauliSumOp | str) -> SparsePauliO
     elif isinstance(observable, BaseOperator) and not isinstance(observable, BasePauli):
         return SparsePauliOp.from_operator(observable)
     else:
+        if isinstance(observable, PauliList):
+            warnings.warn(
+                "Implicit conversion from a PauliList to a SparsePauliOp with coeffs=1 in"
+                " estimator observable arguments is deprecated as of Qiskit 0.46 and will be"
+                " in Qiskit 1.0. You should explicitly convert to a SparsePauli op using"
+                " SparsePauliOp(pauli_list) to avoid this warning.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return SparsePauliOp(observable)
 
 

--- a/qiskit/primitives/utils.py
+++ b/qiskit/primitives/utils.py
@@ -87,7 +87,7 @@ def init_observable(observable: BaseOperator | PauliSumOp | str) -> SparsePauliO
             warnings.warn(
                 "Implicit conversion from a PauliList to a SparsePauliOp with coeffs=1 in"
                 " estimator observable arguments is deprecated as of Qiskit 0.46 and will be"
-                " in Qiskit 1.0. You should explicitly convert to a SparsePauli op using"
+                " removed in Qiskit 1.0. You should explicitly convert to a SparsePauli op using"
                 " SparsePauliOp(pauli_list) to avoid this warning.",
                 DeprecationWarning,
                 stacklevel=2,

--- a/releasenotes/notes/dep-estimator-paulilist-ef2bb2865b66f012.yaml
+++ b/releasenotes/notes/dep-estimator-paulilist-ef2bb2865b66f012.yaml
@@ -1,0 +1,7 @@
+---
+deprecations:
+  - |
+    Deprecates using a :class:`~.PauliList` as an observable that is implicitly
+    converted to a :class:`~.SparsePauliOp` with coefficients 1 when calling
+    :meth:`.Estimator.run`. Users should instead explicitly convert the argument
+    using ``SparsePauliOp(pauli_list)`` first.

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -383,7 +383,7 @@ class TestObservableValidation(QiskitTestCase):
     def test_validate_observables_deprecated(self, obsevables, expected):
         """Test obsevables standardization."""
         with self.assertRaises(DeprecationWarning):
-            self.assertEqual(validation._validate_observables(obsevables), expected)
+            self.assertEqual(BaseEstimator._validate_observables(obsevables), expected)
 
     @data(None, "ERROR")
     def test_qiskit_error(self, observables):

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -348,7 +348,6 @@ class TestObservableValidation(QiskitTestCase):
     @data(
         ("IXYZ", (SparsePauliOp("IXYZ"),)),
         (Pauli("IXYZ"), (SparsePauliOp("IXYZ"),)),
-        (PauliList("IXYZ"), (SparsePauliOp("IXYZ"),)),
         (SparsePauliOp("IXYZ"), (SparsePauliOp("IXYZ"),)),
         (PauliSumOp(SparsePauliOp("IXYZ")), (SparsePauliOp("IXYZ"),)),
         (
@@ -357,10 +356,6 @@ class TestObservableValidation(QiskitTestCase):
         ),
         (
             [Pauli("IXYZ"), Pauli("ZYXI")],
-            (SparsePauliOp("IXYZ"), SparsePauliOp("ZYXI")),
-        ),
-        (
-            [PauliList("IXYZ"), PauliList("ZYXI")],
             (SparsePauliOp("IXYZ"), SparsePauliOp("ZYXI")),
         ),
         (
@@ -376,6 +371,19 @@ class TestObservableValidation(QiskitTestCase):
     def test_validate_observables(self, obsevables, expected):
         """Test obsevables standardization."""
         self.assertEqual(BaseEstimator._validate_observables(obsevables), expected)
+
+    @data(
+        (PauliList("IXYZ"), (SparsePauliOp("IXYZ"),)),
+        (
+            [PauliList("IXYZ"), PauliList("ZYXI")],
+            (SparsePauliOp("IXYZ"), SparsePauliOp("ZYXI")),
+        ),
+    )
+    @unpack
+    def test_validate_observables_deprecated(self, obsevables, expected):
+        """Test obsevables standardization."""
+        with self.assertRaises(DeprecationWarning):
+            self.assertEqual(validation._validate_observables(obsevables), expected)
 
     @data(None, "ERROR")
     def test_qiskit_error(self, observables):


### PR DESCRIPTION
Ports #11055 to stable/0.46, as it was not included in 0.45

Also, includes a docstring note for warning about it.