### PR TITLE
remove PauliList support as observable type for Estimator.run

### DIFF
--- a/qiskit/primitives/utils.py
+++ b/qiskit/primitives/utils.py
@@ -14,7 +14,6 @@ Utility functions for primitives
 """
 from __future__ import annotations
 
-import warnings
 from collections.abc import Iterable
 
 import numpy as np
@@ -22,9 +21,10 @@ import numpy as np
 from qiskit.circuit import Instruction, QuantumCircuit
 from qiskit.circuit.bit import Bit
 from qiskit.circuit.library.data_preparation import Initialize
-from qiskit.quantum_info import SparsePauliOp, Statevector, PauliList
+from qiskit.quantum_info import SparsePauliOp, Statevector
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.quantum_info.operators.symplectic.base_pauli import BasePauli
+from qiskit.exceptions import QiskitError
 
 
 def init_circuit(state: QuantumCircuit | Statevector) -> QuantumCircuit:
@@ -54,6 +54,8 @@ def init_observable(observable: BaseOperator | str) -> SparsePauliOp:
     Returns:
         The observable as :class:`~qiskit.quantum_info.SparsePauliOp`.
 
+    Raises:
+        QiskitError: when observable type cannot be converted to SparsePauliOp.
     """
 
     if isinstance(observable, SparsePauliOp):
@@ -61,16 +63,7 @@ def init_observable(observable: BaseOperator | str) -> SparsePauliOp:
     elif isinstance(observable, BaseOperator) and not isinstance(observable, BasePauli):
         return SparsePauliOp.from_operator(observable)
     else:
-        if isinstance(observable, PauliList):
-            warnings.warn(
-                "Implicit conversion from a PauliList to a SparsePauliOp with coeffs=1 in"
-                " estimator observable arguments is deprecated as of Qiskit 0.46 and will be"
-                " in Qiskit 1.0. You should explicitly convert to a SparsePauli op using"
-                " SparsePauliOp(pauli_list) to avoid this warning.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        return SparsePauliOp(observable)
+        raise QiskitError(f"observable type not supported: {type(observable)}")
 
 
 def final_measurement_mapping(circuit: QuantumCircuit) -> dict[int, int]:

--- a/qiskit/primitives/utils.py
+++ b/qiskit/primitives/utils.py
@@ -21,7 +21,7 @@ import numpy as np
 from qiskit.circuit import Instruction, QuantumCircuit
 from qiskit.circuit.bit import Bit
 from qiskit.circuit.library.data_preparation import Initialize
-from qiskit.quantum_info import SparsePauliOp, Statevector
+from qiskit.quantum_info import SparsePauliOp, Statevector, PauliList
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.quantum_info.operators.symplectic.base_pauli import BasePauli
 from qiskit.exceptions import QiskitError
@@ -63,7 +63,9 @@ def init_observable(observable: BaseOperator | str) -> SparsePauliOp:
     elif isinstance(observable, BaseOperator) and not isinstance(observable, BasePauli):
         return SparsePauliOp.from_operator(observable)
     else:
-        raise QiskitError(f"observable type not supported: {type(observable)}")
+        if isinstance(observable, PauliList):
+            raise QiskitError(f"observable type not supported: {type(observable)}")
+        return SparsePauliOp(observable)
 
 
 def final_measurement_mapping(circuit: QuantumCircuit) -> dict[int, int]:

--- a/releasenotes/notes/dep-estimator-paulilist-ef2bb2865b66f012.yaml
+++ b/releasenotes/notes/dep-estimator-paulilist-ef2bb2865b66f012.yaml
@@ -1,7 +1,7 @@
 ---
-deprecations:
+upgrade:
   - |
-    Deprecates using a :class:`~.PauliList` as an observable that is implicitly
-    converted to a :class:`~.SparsePauliOp` with coefficients 1 when calling
-    :meth:`.Estimator.run`. Users should instead explicitly convert the argument
-    using ``SparsePauliOp(pauli_list)`` first.
+    Using a :class:`~.PauliList` as an observable
+    when calling
+    :meth:`.Estimator.run` is not further supported. Users should instead explicitly convert the argument
+    using ``SparsePauliOp(pauli_list)`` first (see :class:`~.SparsePauliOp`).

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -377,7 +377,7 @@ class TestObservableValidation(QiskitTestCase):
     @unpack
     def test_validate_observables_deprecated(self, obsevables, expected):
         """Test obsevables standardization."""
-        with self.assertRaises(DeprecationWarning):
+        with self.assertRaises(QiskitError):
             self.assertEqual(validation._validate_observables(obsevables), expected)
 
     @data(None, "ERROR")


### PR DESCRIPTION
Removal of the deprecation introduced in https://github.com/Qiskit/qiskit/pull/11520 (port of https://github.com/Qiskit/qiskit/pull/11055)