### PR TITLE
Warn on import failures within optional dependencies

### DIFF
--- a/qiskit/exceptions.py
+++ b/qiskit/exceptions.py
@@ -15,7 +15,10 @@
 Top-level exceptions (:mod:`qiskit.exceptions`)
 ===============================================
 
-All Qiskit-related errors raised by Qiskit are subclasses of the base:
+Exceptions
+==========
+
+All Qiskit-related exceptions raised by Qiskit are subclasses of the base:
 
 .. autoexception:: QiskitError
 
@@ -42,6 +45,22 @@ filename that cannot be used:
 
 .. autoexception:: QiskitUserConfigError
 .. autoexception:: InvalidFileError
+
+
+Warnings
+========
+
+Some particular features of Qiskit may raise custom warnings.  In general, Qiskit will use built-in
+Python warnings (such as :exc:`DeprecationWarning`) when appropriate, but warnings related to
+Qiskit-specific functionality will be subtypes of :exc:`QiskitWarning`.
+
+.. autoexception:: QiskitWarning
+
+Related to :exc:`MissingOptionalLibraryError`, in some cases an optional dependency might be found,
+but fail to import for some other reason.  In this case, Qiskit will continue as if the dependency
+is not present, but will raise :exc:`OptionalDependencyImportWarning` to let you know about it.
+
+.. autoexception:: OptionalDependencyImportWarning
 """
 
 from typing import Optional
@@ -95,3 +114,13 @@ class MissingOptionalLibraryError(QiskitError, ImportError):
 
 class InvalidFileError(QiskitError):
     """Raised when the file provided is not valid for the specific task."""
+
+
+class QiskitWarning(UserWarning):
+    """Common subclass of warnings for Qiskit-specific warnings being raised."""
+
+
+class OptionalDependencyImportWarning(QiskitWarning):
+    """Raised when an optional library raises errors during its import."""
+
+    # Not a subclass of `ImportWarning` because those are hidden by default.

--- a/qiskit/qpy/exceptions.py
+++ b/qiskit/qpy/exceptions.py
@@ -12,7 +12,7 @@
 
 """Exception for errors raised by the QPY module."""
 
-from qiskit.exceptions import QiskitError
+from qiskit.exceptions import QiskitError, QiskitWarning
 
 
 class QpyError(QiskitError):
@@ -28,6 +28,6 @@ class QpyError(QiskitError):
         return repr(self.message)
 
 
-class QPYLoadingDeprecatedFeatureWarning(UserWarning):
+class QPYLoadingDeprecatedFeatureWarning(QiskitWarning):
     """Visible deprecation warning for QPY loading functions without
     a stable point in the call stack."""

--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -28,6 +28,7 @@ import warnings
 import unittest
 from unittest.util import safe_repr
 
+from qiskit.exceptions import QiskitWarning
 from qiskit.tools.parallel import get_platform_parallel_default
 from qiskit.utils import optionals as _optionals
 from qiskit.circuit import QuantumCircuit
@@ -201,6 +202,8 @@ class QiskitTestCase(BaseQiskitTestCase):
             setup_test_logging(cls.log, os.getenv("LOG_LEVEL"), filename)
 
         warnings.filterwarnings("error", category=DeprecationWarning)
+        warnings.filterwarnings("error", category=QiskitWarning)
+
         allow_DeprecationWarning_modules = [
             "test.python.pulse.test_builder",
             "test.python.pulse.test_block",

--- a/qiskit/utils/lazy_tester.py
+++ b/qiskit/utils/lazy_tester.py
@@ -292,9 +292,11 @@ class LazyImportTester(LazyDependencyManager):
             try:
                 imported = importlib.import_module(module)
             except ModuleNotFoundError as exc:
-                if exc.name == module:
-                    # If the module that wasn't found is the one we were explicitly searching for,
-                    # then it's just not installed.
+                failed_parts = exc.name.split(".")
+                target_parts = module.split(".")
+                if failed_parts == target_parts[: len(failed_parts)]:
+                    # If the module that wasn't found is the one we were explicitly searching for
+                    # (or one of its parents), then it's just not installed.
                     return False
                 # Otherwise, we _did_ find the module, it just didn't import, which is a problem.
                 failed_modules[module] = exc

--- a/qiskit/utils/lazy_tester.py
+++ b/qiskit/utils/lazy_tester.py
@@ -13,14 +13,16 @@
 """Lazy testers for optional features."""
 
 import abc
+import collections
 import contextlib
 import functools
 import importlib
 import subprocess
 import typing
+import warnings
 from typing import Union, Iterable, Dict, Optional, Callable, Type
 
-from qiskit.exceptions import MissingOptionalLibraryError
+from qiskit.exceptions import MissingOptionalLibraryError, OptionalDependencyImportWarning
 from .classtools import wrap_method
 
 
@@ -284,12 +286,41 @@ class LazyImportTester(LazyDependencyManager):
         super().__init__(name=name, callback=callback, install=install, msg=msg)
 
     def _is_available(self):
-        try:
-            for module, names in self._modules.items():
+        failed_modules = {}
+        failed_names = collections.defaultdict(list)
+        for module, names in self._modules.items():
+            try:
                 imported = importlib.import_module(module)
-                for name in names:
-                    getattr(imported, name)
-        except (ImportError, AttributeError):
+            except ModuleNotFoundError as exc:
+                if exc.name == module:
+                    # If the module that wasn't found is the one we were explicitly searching for,
+                    # then it's just not installed.
+                    return False
+                # Otherwise, we _did_ find the module, it just didn't import, which is a problem.
+                failed_modules[module] = exc
+                continue
+            except ImportError as exc:
+                failed_modules[module] = exc
+                continue
+            for name in names:
+                try:
+                    _ = getattr(imported, name)
+                except AttributeError:
+                    failed_names[module].append(name)
+        if failed_modules or failed_names:
+            package_description = f"'{self._name}'" if self._name else "optional packages"
+            message = (
+                f"While trying to import {package_description},"
+                " some components were located but raised other errors during import."
+                " You might have an incompatible version installed."
+                " Qiskit will continue as if the optional is not available."
+            )
+            for module, exc in failed_modules.items():
+                message += "".join(f"\n - module '{module}' failed to import with: {exc!r}")
+            for module, names in failed_names.items():
+                attributes = f"attribute '{names[0]}'" if len(names) == 1 else f"attributes {names}"
+                message += "".join(f"\n - '{module}' imported, but {attributes} couldn't be found")
+            warnings.warn(message, category=OptionalDependencyImportWarning)
             return False
         return True
 

--- a/releasenotes/notes/lazy-testers-warn-on-import-errors-95a9bdaacc9c3d2b.yaml
+++ b/releasenotes/notes/lazy-testers-warn-on-import-errors-95a9bdaacc9c3d2b.yaml
@@ -1,0 +1,14 @@
+---
+features:
+  - |
+    A new warning base class, :exc:`.QiskitWarning`, was added.  While Qiskit will continue to use
+    built-in Python warnings (such as :exc:`DeprecationWarning`) when those are most appropriate,
+    for cases that are more specific to Qiskit, the warnings will be subclasses of :exc:`.QiskitWarning`.
+  - |
+    :exc:`.QPYLoadingDeprecatedFeatureWarning` is now a subclass of :exc:`.QiskitWarning`.
+  - |
+    The optional-functionality testers (:mod:`qiskit.utils.optionals`) will now distinguish an
+    optional dependency that was completely not found (a normal situation) with one that was found,
+    but triggered errors during its import.  In the latter case, they will now issue an
+    :exc:`.OptionalDependencyImportWarning` telling you what happened, since it might indicate a
+    failed installation or an incompatible version.

--- a/test/python/utils/test_lazy_loaders.py
+++ b/test/python/utils/test_lazy_loaders.py
@@ -355,7 +355,7 @@ class TestLazyDependencyTester(QiskitTestCase):
         """Check that the module raising an `ImportError` other than being not found is warned
         against."""
 
-        # pylint: disable=missing-class-docstring,missing-function-docstring
+        # pylint: disable=missing-class-docstring,missing-function-docstring,abstract-method
 
         class RaisesImportErrorOnLoad(importlib.abc.Loader):
             def __init__(self, name):
@@ -381,7 +381,7 @@ class TestLazyDependencyTester(QiskitTestCase):
         (such as a module trying to import parts of Terra that don't exist any more) is caught and
         warned against, rather than silently caught as an expected `ModuleNotFoundError`."""
 
-        # pylint: disable=missing-class-docstring,missing-function-docstring
+        # pylint: disable=missing-class-docstring,missing-function-docstring,abstract-method
 
         class ImportsBadModule(importlib.abc.Loader):
             def create_module(self, spec):


### PR DESCRIPTION
### Summary

This distinguishes the case of "failed to find an optional dependency" from "found the optional dependency, but it failed to import" within the lazy testers.  Now, a warning containing the import failures will be shown to users, rather than silently treating the dependency as missing.

This occurred recently when a PR caused an import failure in Aer, which the CI suite failed to detect because the optional-dependency checkers allowed the test suite to pass regardless.  Note that this commit alone won't reliably cause the test suite to fail on a failed import because:

1. this only emits a warning, not an exception (by design).
2. the `unittest` decorators are evaluated during test discovery, which happens before we activate our increased warning filters.

This commit also unifies the now two Qiskit-specific warnings (the other being `QPYLoadingDeprecatedFeatureWarning`) with a common `QiskitWarning` subclass, much as we do for `QiskitError`.  This gives us a convenient way to globally deny these errors during CI runs, without turning _all_ `UserWarning`s into errors, which we're not ready to do yet.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

I think, in a follow-up PR, we ought to move the major warning filters (`error::DeprecationWarning` and `error::qiskit.exceptions.QiskitWarning`) into `test.python.__init__` with:
```python
import sys
import warnings

if not sys.warnoptions:
    warnings.filterwarnings("error", category=DeprecationWarning)

    import qiskit.exceptions
    warnings.filterwarnings("error", category=qiskit.exceptions.QiskitWarning)
```

so that the top-level defaults are set up in the recommended Python way _before_ test discovery.  This would let us fail the test suite if an optional has been installed but fails to import, without making the test suite dependent on what order the test cases happen to run or discover.

(It's possible that turning on deprecation warnings as errors during `qiskit` import might cause us some problems or require us to rewrite small parts of the test suite for old modules to delay the imports, but I think that might be a good thing.)

For example, if this PR is applied on top of #11488 using Aer 0.13.1, which will fail to import, the behaviour of trying to use the failed optional import now looks like this:
```python
from qiskit import QuantumCircuit
from qiskit.providers.fake_provider import FakeAthens

FakeAthens().run(QuantumCircuit(2, 2))
```
```
/Users/jake/code/qiskit/terra/qiskit/utils/lazy_tester.py:323: OptionalDependencyImportWarning: While trying to import 'Qiskit Aer', some components were located but raised other errors during import. You might have an incompatible version installed. Qiskit will continue as if the optional is not available.
 - module 'qiskit.providers.aer' failed to import with: ImportError("cannot import name 'UnitaryGate' from 'qiskit.extensions' (unknown location)")
  warnings.warn(message, category=OptionalDependencyImportWarning)
/Users/jake/code/qiskit/terra/qiskit/providers/fake_provider/fake_backend.py:568: RuntimeWarning: Aer not found using BasicAer and no noise
  warnings.warn("Aer not found using BasicAer and no noise", RuntimeWarning)
```

Previously, it would just silently behave as if Aer wasn't installed at all.