### PR TITLE
Provide return annotations to all `providers.JobV1.result()` methods

### DIFF
--- a/qiskit/providers/job.py
+++ b/qiskit/providers/job.py
@@ -14,7 +14,7 @@
 
 import time
 from abc import ABC, abstractmethod
-from typing import Callable, Optional, Generic, TypeVar
+from typing import Callable, Generic, Optional, TypeVar
 
 from qiskit.exceptions import QiskitError
 from qiskit.providers.backend import Backend

--- a/qiskit/providers/job.py
+++ b/qiskit/providers/job.py
@@ -21,7 +21,7 @@ from qiskit.providers.backend import Backend
 from qiskit.providers.exceptions import JobTimeoutError
 from qiskit.providers.jobstatus import JOB_FINAL_STATES, JobStatus
 
-T = TypeVar("T")
+T_co = TypeVar("T_co", covariant=True)
 
 
 class Job:
@@ -36,7 +36,7 @@ class Job:
     version = 0
 
 
-class JobV1(Job, ABC, Generic[T]):
+class JobV1(Job, ABC, Generic[T_co]):
     """Class to handle jobs
 
     This first version of the Backend abstract class is written to be mostly
@@ -130,7 +130,7 @@ class JobV1(Job, ABC, Generic[T]):
         pass
 
     @abstractmethod
-    def result(self) -> T:
+    def result(self) -> T_co:
         """Return the results of the job."""
         pass
 

--- a/qiskit/providers/job.py
+++ b/qiskit/providers/job.py
@@ -14,14 +14,13 @@
 
 import time
 from abc import ABC, abstractmethod
-from typing import Callable, Generic, Optional, TypeVar
+from typing import Callable, Optional
 
 from qiskit.exceptions import QiskitError
 from qiskit.providers.backend import Backend
 from qiskit.providers.exceptions import JobTimeoutError
 from qiskit.providers.jobstatus import JOB_FINAL_STATES, JobStatus
-
-T_co = TypeVar("T_co", covariant=True)
+from qiskit.result import Result
 
 
 class Job:
@@ -36,7 +35,7 @@ class Job:
     version = 0
 
 
-class JobV1(Job, ABC, Generic[T_co]):
+class JobV1(Job, ABC):
     """Class to handle jobs
 
     This first version of the Backend abstract class is written to be mostly
@@ -130,7 +129,7 @@ class JobV1(Job, ABC, Generic[T_co]):
         pass
 
     @abstractmethod
-    def result(self) -> T_co:
+    def result(self) -> Result:
         """Return the results of the job."""
         pass
 

--- a/qiskit/providers/job.py
+++ b/qiskit/providers/job.py
@@ -12,8 +12,6 @@
 
 """Job abstract interface."""
 
-from __future__ import annotations
-
 import time
 from abc import ABC, abstractmethod
 from typing import Callable, Optional, Generic, TypeVar

--- a/qiskit/providers/job.py
+++ b/qiskit/providers/job.py
@@ -14,13 +14,15 @@
 
 import time
 from abc import ABC, abstractmethod
-from typing import Callable, Optional
+from typing import Callable, Optional, TYPE_CHECKING
 
 from qiskit.exceptions import QiskitError
 from qiskit.providers.backend import Backend
 from qiskit.providers.exceptions import JobTimeoutError
 from qiskit.providers.jobstatus import JOB_FINAL_STATES, JobStatus
-from qiskit.result import Result
+
+if TYPE_CHECKING:
+    from qiskit.result import Result
 
 
 class Job:

--- a/qiskit/providers/job.py
+++ b/qiskit/providers/job.py
@@ -12,6 +12,8 @@
 
 """Job abstract interface."""
 
+from __future__ import annotations
+
 import time
 from abc import ABC, abstractmethod
 from typing import Callable, Optional, TYPE_CHECKING

--- a/qiskit/providers/job.py
+++ b/qiskit/providers/job.py
@@ -12,14 +12,18 @@
 
 """Job abstract interface."""
 
+from __future__ import annotations
+
 import time
 from abc import ABC, abstractmethod
-from typing import Callable, Optional
+from typing import Callable, Optional, Generic, TypeVar
 
 from qiskit.exceptions import QiskitError
 from qiskit.providers.backend import Backend
 from qiskit.providers.exceptions import JobTimeoutError
 from qiskit.providers.jobstatus import JOB_FINAL_STATES, JobStatus
+
+T = TypeVar("T")
 
 
 class Job:
@@ -34,7 +38,7 @@ class Job:
     version = 0
 
 
-class JobV1(Job, ABC):
+class JobV1(Job, ABC, Generic[T]):
     """Class to handle jobs
 
     This first version of the Backend abstract class is written to be mostly
@@ -128,7 +132,7 @@ class JobV1(Job, ABC):
         pass
 
     @abstractmethod
-    def result(self):
+    def result(self) -> T:
         """Return the results of the job."""
         pass
 
@@ -137,6 +141,6 @@ class JobV1(Job, ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def status(self):
+    def status(self) -> JobStatus:
         """Return the status of the job, among the values of ``JobStatus``."""
         pass


### PR DESCRIPTION
### Summary

~This PR makes `providers.JobV1` a `Generic[T]` class where `T` is the return type of the `run()` method. The intended value is to allow tools such as the primitives to be more explicit about what the jobs they return will contain.~

Edit: In the discussion below it was clarified that `result()` is only every expected to return `Result`, and that the primitives have actually been misusing this class by returning something else. I have made this change, and changed the title of the PR to reflect this.

This PR also gives a return type to `JobStatus` since 1) it causes all methods to have return annotations, and 2) there already is an implicit assumption that this is always the return type in some other method implementations like `in_final_state()`.

### Details and comments

I have submitted this PR as a nice-to-have feature. If it turns out to be a can of worms for whatever reason, then I would not be overly disappointed to see it closed.
