### PR TITLE
Supporting floating-point exponents in ``Operator.power``

### DIFF
--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -77,23 +77,7 @@ class Gate(Instruction):
         from qiskit.quantum_info.operators import Operator
         from qiskit.circuit.library.generalized_gates.unitary import UnitaryGate
 
-        from scipy.linalg import schur
-
-        # Should be diagonalized because it's a unitary.
-        decomposition, unitary = schur(Operator(self).data, output="complex")
-        # Raise the diagonal entries to the specified power
-        decomposition_power = []
-
-        decomposition_diagonal = decomposition.diagonal()
-        # assert off-diagonal are 0
-        if not np.allclose(np.diag(decomposition_diagonal), decomposition):
-            raise CircuitError("The matrix is not diagonal")
-
-        for element in decomposition_diagonal:
-            decomposition_power.append(pow(element, exponent))
-        # Then reconstruct the resulting gate.
-        unitary_power = unitary @ np.diag(decomposition_power) @ unitary.conj().T
-        return UnitaryGate(unitary_power, label=f"{self.name}^{exponent}")
+        return UnitaryGate(Operator(self).power(exponent), label=f"{self.name}^{exponent}")
 
     def __pow__(self, exponent: float) -> "Gate":
         return self.power(exponent)

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -525,7 +525,16 @@ class Operator(LinearOp):
         if self.input_dims() != self.output_dims():
             raise QiskitError("Can only power with input_dims = output_dims.")
         ret = copy.copy(self)
-        ret._data = scipy.linalg.fractional_matrix_power(self.data, n)
+        if isinstance(n, int):
+            ret._data = np.linalg.matrix_power(self.data, n)
+        else:
+            # Experimentally, for fractional powers this seems to be 3x faster than
+            # calling scipy.linalg.fractional_matrix_power(self.data, n)
+            decomposition, unitary = scipy.linalg.schur(self.data, output="complex")
+            decomposition_diagonal = decomposition.diagonal()
+            decomposition_power = [pow(element, n) for element in decomposition_diagonal]
+            unitary_power = unitary @ np.diag(decomposition_power) @ unitary.conj().T
+            ret._data = unitary_power
         return ret
 
     def tensor(self, other: Operator) -> Operator:

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -21,6 +21,7 @@ import re
 from numbers import Number
 from typing import TYPE_CHECKING
 
+import scipy.linalg
 import numpy as np
 
 from qiskit.circuit.instruction import Instruction
@@ -524,7 +525,7 @@ class Operator(LinearOp):
         if self.input_dims() != self.output_dims():
             raise QiskitError("Can only power with input_dims = output_dims.")
         ret = copy.copy(self)
-        ret._data = np.linalg.matrix_power(self.data, n)
+        ret._data = scipy.linalg.fractional_matrix_power(self.data, n)
         return ret
 
     def tensor(self, other: Operator) -> Operator:

--- a/releasenotes/notes/fix-operator-power-bd9a00b4e6700d2e.yaml
+++ b/releasenotes/notes/fix-operator-power-bd9a00b4e6700d2e.yaml
@@ -1,9 +1,4 @@
 ---
-upgrade:
-  - |
-    Improved performance for :meth:`.Gate.power` method for floating-point
-    exponents.
-
 fixes:
   - |
     The :meth:`.Operator.power` method now works with floating-point exponents,

--- a/releasenotes/notes/fix-operator-power-bd9a00b4e6700d2e.yaml
+++ b/releasenotes/notes/fix-operator-power-bd9a00b4e6700d2e.yaml
@@ -1,0 +1,11 @@
+---
+upgrade:
+  - |
+    Improved performance for :meth:`.Gate.power` method for floating-point
+    exponents.
+
+fixes:
+  - |
+    The :meth:`.Operator.power` method now works with floating-point exponents,
+    matching the documented description.
+

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -498,6 +498,18 @@ class TestOperator(OperatorTestCase):
         self.assertEqual(op.power(4), Operator(-1 * np.eye(2)))
         self.assertEqual(op.power(8), Operator(np.eye(2)))
 
+    def test_floating_point_power(self):
+        """Test handling floating-point powers."""
+        circuit = QuantumCircuit(2)
+        circuit.crz(np.pi, 0, 1)
+        op = Operator(circuit)
+
+        expected_circuit = QuantumCircuit(2)
+        expected_circuit.crz(np.pi / 4, 0, 1)
+        expected_op = Operator(expected_circuit)
+
+        self.assertEqual(op.power(0.25), expected_op)
+
     def test_expand(self):
         """Test expand method."""
         mat1 = self.UX


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #11454.

### Details and comments

In `operator.py` we simply switch from `np.linalg.matrix_power` to `scipy.linalg.fractional_matrix_power`. Thanks to @sadbro for this one-liner. This automatically supports floating-point powers. 

In `gate.py` we switch to using `Operator.power` method. 

### Benchmarking

Initially I was sure that the new method (`scipy.linalg.fractional_matrix_power`, see https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.fractional_matrix_power.html) is faster than the previously implemented method in `Gate` (based on `scipy.linalg.schur`), but after running a few more tests (on my windows laptop), I am no longer convinced of this, and this seems to depend on the exponents. I may need to remove the sentence in release notes about the increased performance. 

@jakelishman, I know that you have done quite a bit of performance tuning, and so you can probably explain the results I am seeing.

Here is the code that I am running:

```
def method1(M, t):
    # NEW METHOD
    return scipy.linalg.fractional_matrix_power(M, t)


def method2(M, t):
    # OLD METHOD (adapted from gate.py)
    decomposition, unitary = schur(M, output="complex")
    decomposition_diagonal = decomposition.diagonal()
    decomposition_power = [pow(element, t) for element in decomposition_diagonal]
    unitary_power = unitary @ np.diag(decomposition_power) @ unitary.conj().T
    return unitary_power

time1 = 0
time2 = 0

for seed in range(1000):
	for n in [8, 16, 32, 64]:
		for p in [3, 13, 23, 33, 43]:
			U = random_unitary(n, seed=seed)

			A = U.copy()
			B = U.copy()

			time_start = time.time()
			ret1 = method1(A, p)
			time_end = time.time()
			time1 += time_end - time_start

			time_start = time.time()
			ret2 = method2(B, p)
			time_end = time.time()
			time2 += time_end - time_start

print(f"Method1: time elapsed: {time1:.2f}")
print(f"Method2: time elapsed: {time2:.2f}")
```

When I run this, I get the time for method1 is `8.36` seconds, while the time for method2 is `25.05` seconds, so we have ~3x performance improvement. However, when I replace the exponents to be floating-point, and explicitly by 
```
[3.1415, 13.5767, 23.4545, 33.4544, 43.122]:
```
then I get that method 1 takes `119.71` seconds and method 2 `26.63` seconds, we we get ~4.5 slowdown.

I still think that whichever method is faster should be implemented in `operator.py` and `gate.py` should call that method, but I don't understand which method is better. 




