### PR TITLE
Deprecate implicit Estimator conversion to SparsePauliOp 

### DIFF
--- a/qiskit/primitives/utils.py
+++ b/qiskit/primitives/utils.py
@@ -14,6 +14,7 @@ Utility functions for primitives
 """
 from __future__ import annotations
 
+import warnings
 import sys
 import typing
 from collections.abc import Iterable
@@ -52,6 +53,12 @@ def init_circuit(state: QuantumCircuit | Statevector) -> QuantumCircuit:
 def init_observable(observable: BaseOperator | PauliSumOp | str) -> SparsePauliOp:
     """Initialize observable by converting the input to a :class:`~qiskit.quantum_info.SparsePauliOp`.
 
+    .. deprecated:: 0.46.0
+        Implicit conversion from a ``BaseOperator`` to a ``SparsePauliOp`` in estimator
+        observable arguments is deprecated as of Qiskit 0.46 and will be removed
+        in Qiskit 1.0. You should explicitly convert to a SparsePauli op using
+        ``SparsePauliOp.from_operator(op)`` instead.
+
     Args:
         observable: The observable.
 
@@ -80,6 +87,14 @@ def init_observable(observable: BaseOperator | PauliSumOp | str) -> SparsePauliO
             )
         return observable.coeff * observable.primitive
     elif isinstance(observable, BaseOperator) and not isinstance(observable, BasePauli):
+        warnings.warn(
+            "Implicit conversion from a dense BaseOperator to a SparsePauliOp in estimator"
+            " observable arguments is deprecated as of Qiskit 0.46 and will be removed"
+            " in Qiskit 1.0. You should explicitly convert to a SparsePauli op using"
+            " `SparsePauliOp.from_operator(op)` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return SparsePauliOp.from_operator(observable)
     else:
         return SparsePauliOp(observable)

--- a/releasenotes/notes/deprecate-estimator-baseop-61f6bbcb9a63fe2d.yaml
+++ b/releasenotes/notes/deprecate-estimator-baseop-61f6bbcb9a63fe2d.yaml
@@ -1,0 +1,7 @@
+---
+deprecations:
+  - |
+    Implicit conversion from a dense ``BaseOperator`` to a :class:`~.SparsePauliOp`
+    in ``Estimator`` observable arguments is deprecated as of Qiskit 0.46 and will
+    be removed in Qiskit 1.0. You should explicitly convert to a SparsePauli op
+    using ``SparsePauliOp.from_operator(op)`` instead.

--- a/test/python/algorithms/eigensolvers/test_vqd.py
+++ b/test/python/algorithms/eigensolvers/test_vqd.py
@@ -103,11 +103,19 @@ class TestVQD(QiskitAlgorithmsTestCase):
             self.assertIsNotNone(result.optimizer_times)
 
         with self.subTest(msg="assert return ansatz is set"):
-            job = self.estimator.run(
-                result.optimal_circuits,
-                [op] * len(result.optimal_points),
-                result.optimal_points,
-            )
+            if isinstance(op, Operator):
+                with self.assertWarns(DeprecationWarning):
+                    job = self.estimator.run(
+                        result.optimal_circuits,
+                        [op] * len(result.optimal_points),
+                        result.optimal_points,
+                    )
+            else:
+                job = self.estimator.run(
+                    result.optimal_circuits,
+                    [op] * len(result.optimal_points),
+                    result.optimal_points,
+                )
             np.testing.assert_array_almost_equal(job.result().values, result.eigenvalues, 6)
 
         with self.subTest(msg="assert returned values are eigenvalues"):

--- a/test/python/algorithms/eigensolvers/test_vqd.py
+++ b/test/python/algorithms/eigensolvers/test_vqd.py
@@ -82,7 +82,11 @@ class TestVQD(QiskitAlgorithmsTestCase):
             betas=self.betas,
         )
 
-        result = vqd.compute_eigenvalues(operator=op)
+        if isinstance(op, Operator):
+            with self.assertWarns(DeprecationWarning):
+                result = vqd.compute_eigenvalues(operator=op)
+        else:
+            result = vqd.compute_eigenvalues(operator=op)
 
         with self.subTest(msg="test eigenvalue"):
             np.testing.assert_array_almost_equal(
@@ -188,7 +192,11 @@ class TestVQD(QiskitAlgorithmsTestCase):
             betas=self.betas,
         )
 
-        vqd.compute_eigenvalues(operator=op)
+        if isinstance(op, Operator):
+            with self.assertWarns(DeprecationWarning):
+                vqd.compute_eigenvalues(operator=op)
+        else:
+            vqd.compute_eigenvalues(operator=op)
 
         self.assertTrue(all(isinstance(count, int) for count in history["eval_count"]))
         self.assertTrue(all(isinstance(mean, float) for mean in history["mean"]))

--- a/test/python/algorithms/eigensolvers/test_vqd.py
+++ b/test/python/algorithms/eigensolvers/test_vqd.py
@@ -41,7 +41,6 @@ H2_SPARSE_PAULI = SparsePauliOp.from_list(
         ("XX", 0.18093119978423156),
     ]
 )
-H2_OP = Operator(H2_SPARSE_PAULI.to_matrix())
 
 H2_PAULI = PauliSumOp(H2_SPARSE_PAULI)
 
@@ -70,7 +69,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
         self.fidelity = ComputeUncompute(Sampler())
         self.betas = [50, 50]
 
-    @data(H2_PAULI, H2_OP, H2_SPARSE_PAULI)
+    @data(H2_PAULI, H2_SPARSE_PAULI)
     def test_basic_operator(self, op):
         """Test the VQD without aux_operators."""
         wavefunction = self.ryrz_wavefunction
@@ -133,7 +132,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
         beta = float(logs.output[0].split()[-1])
         self.assertAlmostEqual(beta, 20.40459399499687, 4)
 
-    @data(H2_PAULI, H2_OP, H2_SPARSE_PAULI)
+    @data(H2_PAULI, H2_SPARSE_PAULI)
     def test_mismatching_num_qubits(self, op):
         """Ensuring circuit and operator mismatch is caught"""
         wavefunction = QuantumCircuit(1)
@@ -149,7 +148,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
         with self.assertRaises(AlgorithmError):
             _ = vqd.compute_eigenvalues(operator=op)
 
-    @data(H2_PAULI, H2_OP, H2_SPARSE_PAULI)
+    @data(H2_PAULI, H2_SPARSE_PAULI)
     def test_missing_varform_params(self, op):
         """Test specifying a variational form with no parameters raises an error."""
         circuit = QuantumCircuit(op.num_qubits)
@@ -164,7 +163,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
         with self.assertRaises(AlgorithmError):
             vqd.compute_eigenvalues(operator=op)
 
-    @data(H2_PAULI, H2_OP, H2_SPARSE_PAULI)
+    @data(H2_PAULI, H2_SPARSE_PAULI)
     def test_callback(self, op):
         """Test the callback on VQD."""
         history = {"eval_count": [], "parameters": [], "mean": [], "metadata": [], "step": []}
@@ -208,7 +207,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
         np.testing.assert_array_almost_equal(history["mean"], ref_mean, decimal=2)
         np.testing.assert_array_almost_equal(history["step"], ref_step, decimal=0)
 
-    @data(H2_PAULI, H2_OP, H2_SPARSE_PAULI)
+    @data(H2_PAULI, H2_SPARSE_PAULI)
     def test_vqd_optimizer(self, op):
         """Test running same VQD twice to re-use optimizer, then switch optimizer"""
 
@@ -247,7 +246,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
             result = vqd.compute_eigenvalues(operator=op)
             self.assertIsInstance(result, VQDResult)
 
-    @data(H2_PAULI, H2_OP, H2_SPARSE_PAULI)
+    @data(H2_PAULI, H2_SPARSE_PAULI)
     def test_optimizer_list(self, op):
         """Test sending an optimizer list"""
 
@@ -287,7 +286,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
             result.eigenvalues.real, self.h2_energy_excited[:2], decimal=3
         )
 
-    @data(H2_PAULI, H2_OP, H2_SPARSE_PAULI)
+    @data(H2_PAULI, H2_SPARSE_PAULI)
     def test_aux_operators_list(self, op):
         """Test list-based aux_operators."""
         wavefunction = self.ry_wavefunction
@@ -340,7 +339,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
         self.assertIsInstance(result.aux_operators_evaluated[0][1][1], dict)
         self.assertIsInstance(result.aux_operators_evaluated[0][3][1], dict)
 
-    @data(H2_PAULI, H2_OP, H2_SPARSE_PAULI)
+    @data(H2_PAULI, H2_SPARSE_PAULI)
     def test_aux_operators_dict(self, op):
         """Test dictionary compatibility of aux_operators"""
         wavefunction = self.ry_wavefunction
@@ -394,7 +393,7 @@ class TestVQD(QiskitAlgorithmsTestCase):
         self.assertIsInstance(result.aux_operators_evaluated[0]["aux_op2"][1], dict)
         self.assertIsInstance(result.aux_operators_evaluated[0]["zero_operator"][1], dict)
 
-    @data(H2_PAULI, H2_OP, H2_SPARSE_PAULI)
+    @data(H2_PAULI, H2_SPARSE_PAULI)
     def test_aux_operator_std_dev(self, op):
         """Test non-zero standard deviations of aux operators."""
         wavefunction = self.ry_wavefunction

--- a/test/python/algorithms/eigensolvers/test_vqd.py
+++ b/test/python/algorithms/eigensolvers/test_vqd.py
@@ -28,7 +28,6 @@ from qiskit.circuit.library import TwoLocal, RealAmplitudes
 from qiskit.opflow import PauliSumOp
 from qiskit.primitives import Sampler, Estimator
 from qiskit.quantum_info import SparsePauliOp
-from qiskit.quantum_info.operators import Operator
 from qiskit.utils import algorithm_globals
 
 

--- a/test/python/algorithms/gradients/test_estimator_gradient.py
+++ b/test/python/algorithms/gradients/test_estimator_gradient.py
@@ -70,9 +70,14 @@ class TestEstimatorGradient(QiskitTestCase):
         value = gradient.run([qc], [op], [param]).result().gradients[0]
         self.assertAlmostEqual(value[0], correct_result, 3)
         op = Operator.from_label("Z")
-        with self.assertWarns(DeprecationWarning):
+        if isinstance(gradient, ReverseEstimatorGradient):
+            # NOTE: ReverseEstimatorGradient doesn't actually use an Estimator
+            # so won't raise a deprecation warning
             value = gradient.run([qc], [op], [param]).result().gradients[0]
-            self.assertAlmostEqual(value[0], correct_result, 3)
+        else:
+            with self.assertWarns(DeprecationWarning):
+                value = gradient.run([qc], [op], [param]).result().gradients[0]
+        self.assertAlmostEqual(value[0], correct_result, 3)
 
     @data(*gradient_factories)
     def test_single_circuit_observable(self, grad):

--- a/test/python/algorithms/gradients/test_estimator_gradient.py
+++ b/test/python/algorithms/gradients/test_estimator_gradient.py
@@ -70,8 +70,9 @@ class TestEstimatorGradient(QiskitTestCase):
         value = gradient.run([qc], [op], [param]).result().gradients[0]
         self.assertAlmostEqual(value[0], correct_result, 3)
         op = Operator.from_label("Z")
-        value = gradient.run([qc], [op], [param]).result().gradients[0]
-        self.assertAlmostEqual(value[0], correct_result, 3)
+        with self.assertWarns(DeprecationWarning):
+            value = gradient.run([qc], [op], [param]).result().gradients[0]
+            self.assertAlmostEqual(value[0], correct_result, 3)
 
     @data(*gradient_factories)
     def test_single_circuit_observable(self, grad):

--- a/test/python/algorithms/minimum_eigensolvers/test_sampling_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_sampling_vqe.py
@@ -19,7 +19,6 @@ from functools import partial
 from test.python.algorithms import QiskitAlgorithmsTestCase
 
 import numpy as np
-from ddt import data, ddt
 from scipy.optimize import minimize as scipy_minimize
 
 from qiskit.algorithms import AlgorithmError
@@ -30,7 +29,7 @@ from qiskit.circuit import ParameterVector, QuantumCircuit
 from qiskit.circuit.library import RealAmplitudes, TwoLocal
 from qiskit.opflow import PauliSumOp
 from qiskit.primitives import Sampler
-from qiskit.quantum_info import Operator, Pauli, SparsePauliOp
+from qiskit.quantum_info import Pauli, SparsePauliOp
 from qiskit.utils import algorithm_globals
 
 
@@ -53,7 +52,6 @@ def _mock_optimizer(fun, x0, jac=None, bounds=None, inputs=None):
 PAULI_OP = PauliSumOp(SparsePauliOp(["ZZ", "IZ", "II"], coeffs=[1, -0.5, 0.12]))
 
 
-@ddt
 class TestSamplerVQE(QiskitAlgorithmsTestCase):
     """Test VQE"""
 

--- a/test/python/algorithms/minimum_eigensolvers/test_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_vqe.py
@@ -280,7 +280,8 @@ class TestVQE(QiskitAlgorithmsTestCase):
         operator = Operator(np.array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 2, 0], [0, 0, 0, 3]]))
 
         with self.subTest(msg="assert vqe works on re-use."):
-            result = vqe.compute_minimum_eigenvalue(operator=operator)
+            with self.assertWarns(DeprecationWarning):
+                result = vqe.compute_minimum_eigenvalue(operator=operator)
             self.assertAlmostEqual(result.eigenvalue.real, -1.0, places=5)
 
     def test_vqe_optimizer_reuse(self):

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -266,10 +266,28 @@ class TestEstimator(QiskitTestCase):
                 [0.1809312, 0.0, 0.0, -1.06365335],
             ]
         )
+        obs = SparsePauliOp.from_operator(matrix)
         est = Estimator()
-        result = est.run([circuit], [matrix]).result()
+        result = est.run([circuit], [obs]).result()
         self.assertIsInstance(result, EstimatorResult)
         np.testing.assert_allclose(result.values, [-1.284366511861733])
+
+    def test_run_with_operator_deprecated(self):
+        """test for run with Operator as an observable"""
+        circuit = self.ansatz.assign_parameters([0, 1, 1, 2, 3, 5])
+        matrix = Operator(
+            [
+                [-1.06365335, 0.0, 0.0, 0.1809312],
+                [0.0, -1.83696799, 0.1809312, 0.0],
+                [0.0, 0.1809312, -0.24521829, 0.0],
+                [0.1809312, 0.0, 0.0, -1.06365335],
+            ]
+        )
+        est = Estimator()
+        with self.assertRaises(DeprecationWarning):
+            result = est.run([circuit], [matrix]).result()
+            self.assertIsInstance(result, EstimatorResult)
+            np.testing.assert_allclose(result.values, [-1.284366511861733])
 
     def test_run_with_shots_option(self):
         """test with shots option."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Port of #11056 to stable/0.46 branch

### Details and comments


