### PR TITLE
Deprecate legacy ``qcstyle`` module

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1727,7 +1727,7 @@ class QuantumCircuit:
                 The search path for style json files can be specified in the user
                 config, for example,
                 ``circuit_mpl_style_path = /home/user/styles:/home/user``.
-                See: :class:`~qiskit.visualization.qcstyle.DefaultStyle` for more
+                See: :class:`~qiskit.visualization.circuit.qcstyle.DefaultStyle` for more
                 information on the contents.
             interactive (bool): when set to true, show the circuit in a new window
                 (for `mpl` this depends on the matplotlib backend being used

--- a/qiskit/visualization/__init__.py
+++ b/qiskit/visualization/__init__.py
@@ -204,7 +204,7 @@ Circuit Visualizations
    :toctree: ../stubs/
 
    circuit_drawer
-   ~qiskit.visualization.qcstyle.DefaultStyle
+   ~qiskit.visualization.circuit.qcstyle.DefaultStyle
 
 DAG Visualizations
 ==================

--- a/qiskit/visualization/circuit/circuit_visualization.py
+++ b/qiskit/visualization/circuit/circuit_visualization.py
@@ -105,7 +105,7 @@ def circuit_drawer(
             The search path for style json files can be specified in the user
             config, for example,
             ``circuit_mpl_style_path = /home/user/styles:/home/user``.
-            See: :class:`~qiskit.visualization.qcstyle.DefaultStyle` for more
+            See: :class:`~qiskit.visualization.circuit.qcstyle.DefaultStyle` for more
             information on the contents.
         output (str): select the output method to use for drawing the circuit.
             Valid choices are ``text``, ``mpl``, ``latex``, ``latex_source``.

--- a/qiskit/visualization/qcstyle.py
+++ b/qiskit/visualization/qcstyle.py
@@ -14,4 +14,12 @@
 
 # Temporary import from 0.22.0 to be deprecated in future
 # pylint: disable=unused-wildcard-import,wildcard-import
+import warnings
 from .circuit.qcstyle import *
+
+warnings.warn(
+    "The qiskit.visualization.qcstyle module is deprecated as of Qiskit 0.46.0 and will be removed "
+    "for Qiskit 1.0. Use the qiskit.visualization.circuit.qcstyle as direct replacement.",
+    stacklevel=2,
+    category=DeprecationWarning,
+)

--- a/releasenotes/notes/deprecate-legacy-qcstyle-location-ba9173b0b1acf41e.yaml
+++ b/releasenotes/notes/deprecate-legacy-qcstyle-location-ba9173b0b1acf41e.yaml
@@ -1,0 +1,5 @@
+---
+deprecations:
+  - |
+    Deprecate the :mod:`qiskit.visualization.qcstyle` module. Use
+    :mod:`qiskit.visualization.circuit.qcstyle` as direct replacement.

--- a/test/visual/mpl/circuit/test_circuit_matplotlib_drawer.py
+++ b/test/visual/mpl/circuit/test_circuit_matplotlib_drawer.py
@@ -2234,6 +2234,12 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         )
         self.assertGreaterEqual(ratio, 0.9999)
 
+    def test_qcstyle_legacy_import(self):
+        """Test importing from the legacy import location raises a deprecation warning."""
+        with self.assertRaises(DeprecationWarning):
+            # pylint: disable=unused-import
+            from qiskit.visualization.qcstyle import DefaultStyle
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=1)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Deprecate the legacy module `qiskit.visualization.qcstyle`, which has been set for deprecation since Terra 0.22. The new location is `qiskit.visualization.circuit.qcstyle`.


