### PR TITLE
Fix quadratic dependency in `QuantumCircuit.add_bits`

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1955,7 +1955,9 @@ class QuantumCircuit:
 
     def add_bits(self, bits: Iterable[Bit]) -> None:
         """Add Bits to the circuit."""
-        duplicate_bits = set(self._qubit_indices).union(self._clbit_indices).intersection(bits)
+        duplicate_bits = {
+            bit for bit in bits if bit in self._qubit_indices or bit in self._clbit_indices
+        }
         if duplicate_bits:
             raise CircuitError(f"Attempted to add bits found already in circuit: {duplicate_bits}")
 


### PR DESCRIPTION
### Summary

This is in the Python space component only.  When `add_bits` is called many times, it constructs as temporary set of the union of all qubits and clbits present in the circuit in order to calculate an intersection with the input.  This causes the method to be linear in the number of bits already present in the circuit, whereas it should be amortised linear in the _to be added_.

This commit fixes the intersection to be a manual calculation that does not construct three temporary set objects, removing the quadratic cost.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

This has been around for ages, but I noticed it when seeing excessive runtimes for parsing OQ2 and OQ3 programs constructed as
```qasm
qubit q0;
qubit q1;
qubit q2;
// ...
qubit q999999;
```

Adding jillions of registers is still quadratic in the number of registers because there's no constant-time lookup for them in `QuantumCircuit` (still), but that's a known problem.
