### PR TITLE
Add reprs to `containers.BindingsArray` and `containers.PubResult`

### DIFF
--- a/qiskit/primitives/containers/bindings_array.py
+++ b/qiskit/primitives/containers/bindings_array.py
@@ -16,7 +16,7 @@ Bindings array class
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
-from itertools import chain
+from itertools import chain, islice
 from typing import Union
 
 import numpy as np
@@ -144,6 +144,15 @@ class BindingsArray(ShapedMixin):
         except StopIteration:
             shape = ()
         return BindingsArray(vals, kwvals, shape)
+
+    def __repr__(self):
+        descriptions = [f"shape={self.shape}", f"num_parameters={self.num_parameters}"]
+        if num_kwparams := sum(val.shape[-1] for val in self._kwvals.values()):
+            names = list(islice(map(repr, chain.from_iterable(map(_format_key, self._kwvals))), 5))
+            if len(names) < num_kwparams:
+                names.append("...")
+            descriptions.append(f"parameters=[{', '.join(names)}]")
+        return f"{type(self).__name__}(<{', '.join(descriptions)}>)"
 
     @property
     def kwvals(self) -> dict[tuple[str, ...], np.ndarray]:

--- a/qiskit/primitives/containers/bindings_array.py
+++ b/qiskit/primitives/containers/bindings_array.py
@@ -147,9 +147,9 @@ class BindingsArray(ShapedMixin):
 
     def __repr__(self):
         descriptions = [f"shape={self.shape}", f"num_parameters={self.num_parameters}"]
-        if num_kwparams := sum(val.shape[-1] for val in self._kwvals.values()):
+        if num_kwval_params := sum(val.shape[-1] for val in self._kwvals.values()):
             names = list(islice(map(repr, chain.from_iterable(map(_format_key, self._kwvals))), 5))
-            if len(names) < num_kwparams:
+            if len(names) < num_kwval_params:
                 names.append("...")
             descriptions.append(f"parameters=[{', '.join(names)}]")
         return f"{type(self).__name__}(<{', '.join(descriptions)}>)"

--- a/qiskit/primitives/containers/pub_result.py
+++ b/qiskit/primitives/containers/pub_result.py
@@ -34,6 +34,10 @@ class PubResult:
         self._data = data
         self._metadata = metadata or {}
 
+    def __repr__(self):
+        metadata = f", metadata={self.metadata}" if self.metadata else ""
+        return f"{type(self).__name__}({self._data}{metadata})"
+
     @property
     def data(self) -> DataBin:
         """Result data for the pub."""

--- a/test/python/primitives/containers/test_bindings_array.py
+++ b/test/python/primitives/containers/test_bindings_array.py
@@ -63,6 +63,19 @@ class BindingsArrayTestCase(QiskitTestCase):
                 kwvals={(Parameter("a"), Parameter("b")): np.empty((5, 10, 3))},
             )
 
+    def test_repr(self):
+        """Test that the repr doesn't fail"""
+        # we are primarily interested in making sure some future change doesn't cause the repr to
+        # raise an error. it is more sensible for humans to detect a deficiency in the formatting
+        # itself, should one be uncovered
+        self.assertTrue(repr(BindingsArray()).startswith("BindingsArray"))
+        self.assertTrue(repr(BindingsArray(np.empty((1, 2, 3)))).startswith("BindingsArray"))
+        self.assertTrue(
+            repr(
+                BindingsArray([1], {"p": 2, "q": 5, ("a", "b", "c", "d"): [1, 22, 4, 5]})
+            ).startswith("BindingsArray")
+        )
+
     def test_bind_at_idx(self):
         """Test binding at a specified index"""
         vals = np.linspace(0, 1, 1000).reshape((5, 4, 50))

--- a/test/python/primitives/containers/test_pub_result.py
+++ b/test/python/primitives/containers/test_pub_result.py
@@ -1,0 +1,43 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+
+"""Unit tests for PubResult."""
+
+from qiskit.primitives.containers import PubResult, make_data_bin
+from qiskit.test import QiskitTestCase
+
+
+class PubResultCase(QiskitTestCase):
+    """Test the PubResult class."""
+
+    def test_construction(self):
+        """Test that the constructor works."""
+        data_bin = make_data_bin((("a", float), ("b", int)))
+        pub_result = PubResult(data_bin(a=1.0, b=2))
+        self.assertEqual(pub_result.data.a, 1.0)
+        self.assertEqual(pub_result.data.b, 2)
+        self.assertEqual(pub_result.metadata, {})
+
+        pub_result = PubResult(data_bin(a=1.0, b=2), {"x": 1})
+        self.assertEqual(pub_result.data.a, 1.0)
+        self.assertEqual(pub_result.data.b, 2)
+        self.assertEqual(pub_result.metadata, {"x": 1})
+
+    def test_repr(self):
+        """Test that the repr doesn't fail"""
+        # we are primarily interested in making sure some future change doesn't cause the repr to
+        # raise an error. it is more sensible for humans to detect a deficiency in the formatting
+        # itself, should one be uncovered
+        data_bin = make_data_bin((("a", float), ("b", int)))
+        self.assertTrue(repr(PubResult(data_bin(a=1.0, b=2))).startswith("PubResult"))
+        self.assertTrue(repr(PubResult(data_bin(a=1.0, b=2), {"x": 1})).startswith("PubResult"))


### PR DESCRIPTION
### Summary

This PR adds reprs to `primitives.containers.BindingsArray` and `primitives.containers.PubResult`.

Edit: This also adds a test file for `PubResult`, since it apparently slid under the radar.

### Details and comments

Examples:

```python
BindingsArray()
> BindingsArray(<shape=(), num_parameters=0>)

BindingsArray(np.empty((1,2,3)))
> BindingsArray(<shape=(1, 2), num_parameters=3>)

BindingsArray([1], {"p": 2, "q": 5, ("a", "b", "c", "d"): [1,22,4,5]})
> BindingsArray(<shape=(), num_parameters=7, parameters=['p', 'q', 'a', 'b', 'c', ...]>)


PubResult(qpc.make_data_bin((("a", int),), (5,))(a=[5,6,6,6]), {5:2})
> PubResult(DataBin<5>(a=[5, 6, 6, 6]), metadata={5: 2})
```



