### PR TITLE
Reactive the viewcode extension for docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,8 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.doctest",
+    # This is used by qiskit/documentation to generate links to github.com.
+    "sphinx.ext.viewcode",
     "matplotlib.sphinxext.plot_directive",
     "reno.sphinxext",
     "sphinxcontrib.katex",


### PR DESCRIPTION
We got source links working in API docs on docs.quantum.ibm.com! See https://github.com/Qiskit/documentation/pull/620. To do this, we need to active `sphinx.ext.viewcode`.

Note that we still plan to improve this implementation in the future to have more precise links by using `sphinx.ext.linkcode`, tracked by https://github.com/Qiskit/documentation/issues/517. This PR is to unblock the first iteration of this source links mechanism.