### PR TITLE
remove deprecated aquire alignment

### DIFF
--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -44,7 +44,6 @@ from qiskit.transpiler.instruction_durations import InstructionDurations
 from qiskit.transpiler.timing_constraints import TimingConstraints
 from qiskit.providers.exceptions import BackendPropertyError
 from qiskit.pulse.exceptions import PulseError, UnassignedDurationError
-from qiskit.utils.deprecation import deprecate_arg, deprecate_func
 from qiskit.exceptions import QiskitError
 
 # import QubitProperties here to provide convenience alias for building a

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -242,12 +242,6 @@ class Target(Mapping):
         "concurrent_measurements",
     )
 
-    @deprecate_arg(
-        "aquire_alignment",
-        new_alias="acquire_alignment",
-        since="0.23.0",
-        package_name="qiskit-terra",
-    )
     def __init__(
         self,
         description=None,
@@ -1142,28 +1136,6 @@ class Target(Mapping):
         else:
             self._non_global_basis = incomplete_basis_gates
         return incomplete_basis_gates
-
-    @property
-    @deprecate_func(
-        additional_msg="Use the property ``acquire_alignment`` instead.",
-        since="0.24.0",
-        is_property=True,
-        package_name="qiskit-terra",
-    )
-    def aquire_alignment(self):
-        """Alias of deprecated name. This will be removed."""
-        return self.acquire_alignment
-
-    @aquire_alignment.setter
-    @deprecate_func(
-        additional_msg="Use the property ``acquire_alignment`` instead.",
-        since="0.24.0",
-        is_property=True,
-        package_name="qiskit-terra",
-    )
-    def aquire_alignment(self, new_value: int):
-        """Alias of deprecated name. This will be removed."""
-        self.acquire_alignment = new_value
 
     def __iter__(self):
         return iter(self._gate_map)

--- a/releasenotes/notes/deprecate_aquire_alignment-28f64480ed838328.yaml
+++ b/releasenotes/notes/deprecate_aquire_alignment-28f64480ed838328.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    The method ``qiskit.transpiler.target.Target.aquire_alignment``, deprecated in 0.24, has been removed. The method ``qiskit.transpiler.target.Target.acquire_alignment`` should be used instead.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
This removes deprecated method "aquire_alignment".

### Details and comments


