### PR TITLE
remove deprecated clifford get/set item

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -30,7 +30,6 @@ from qiskit.quantum_info.operators.mixins import AdjointMixin, generate_apidocs
 from qiskit.quantum_info.operators.operator import Operator
 from qiskit.quantum_info.operators.scalar_op import ScalarOp
 from qiskit.quantum_info.operators.symplectic.base_pauli import _count_y
-from qiskit.utils.deprecation import deprecate_func
 from qiskit.synthesis.linear import calc_inverse_matrix
 
 from .base_pauli import BasePauli
@@ -227,24 +226,6 @@ class Clifford(BaseOperator, AdjointMixin, Operation):
     # ---------------------------------------------------------------------
 
     # pylint: disable=bad-docstring-quotes
-
-    @deprecate_func(
-        since="0.24.0",
-        package_name="qiskit-terra",
-        additional_msg="Instead, index or iterate through the Clifford.tableau attribute.",
-    )
-    def __getitem__(self, key):
-        """Return a stabilizer Pauli row"""
-        return self.table.__getitem__(key)
-
-    @deprecate_func(
-        since="0.24.0",
-        package_name="qiskit-terra",
-        additional_msg="Use Clifford.tableau property instead.",
-    )
-    def __setitem__(self, key, value):
-        """Set a stabilizer Pauli row"""
-        self.tableau.__setitem__(key, self._stack_table_phase(value.array, value.phase))
 
     @property
     def symplectic_matrix(self):

--- a/releasenotes/notes/deprecate_clifford_indexing-5e3500301a696bdc.yaml
+++ b/releasenotes/notes/deprecate_clifford_indexing-5e3500301a696bdc.yaml
@@ -1,5 +1,6 @@
 ---
 upgrade:
   - |
-    Remove deprecated getitem/setitem magic methods of 
+    Remove deprecated ``__getitem__``/``__setitem__`` magic methods of 
     :class:`~qiskit.quantum_info.operators.symplectic.Clifford`.
+    The methods were deprecated since Qiskit 0.44, released on July 2023. Instead, index or iterate through the :attr:`.Clifford.tableau` attribute.

--- a/releasenotes/notes/deprecate_clifford_indexing-5e3500301a696bdc.yaml
+++ b/releasenotes/notes/deprecate_clifford_indexing-5e3500301a696bdc.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Remove deprecated getitem/setitem methods of :class:`qiskit.quantum_info.operators.symplectic.Clifford`.

--- a/releasenotes/notes/deprecate_clifford_indexing-5e3500301a696bdc.yaml
+++ b/releasenotes/notes/deprecate_clifford_indexing-5e3500301a696bdc.yaml
@@ -1,4 +1,5 @@
 ---
 upgrade:
   - |
-    Remove deprecated getitem/setitem methods of :class:`qiskit.quantum_info.operators.symplectic.Clifford`.
+    Remove deprecated getitem/setitem magic methods of 
+    :class:`~qiskit.quantum_info.operators.symplectic.Clifford`.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Remove previously deprecated clifford get/set item in quantum_info.


### Details and comments


