### PR TITLE
Add `primitives.containers.BindingsArray.as_array()` method

### DIFF
--- a/qiskit/primitives/containers/bindings_array.py
+++ b/qiskit/primitives/containers/bindings_array.py
@@ -220,15 +220,16 @@ class BindingsArray(ShapedMixin):
                 pos += size
         elif self.kwvals:
             # use the order of the provided parameters
-            parameters = {_param_name(parameter): idx for idx, parameter in enumerate(parameters)}
+            parameters = list(parameters)
             if len(parameters) != (num_kwval := sum(arr.shape[-1] for arr in self.kwvals.values())):
                 raise ValueError(f"Expected {num_kwval} parameters but {len(parameters)} received.")
 
+            idx_lookup = {_param_name(parameter): idx for idx, parameter in enumerate(parameters)}
             for arr_params, arr in self.kwvals.items():
                 try:
-                    idxs = [parameters[_param_name(param)] + pos for param in arr_params]
+                    idxs = [idx_lookup[_param_name(param)] + pos for param in arr_params]
                 except KeyError as ex:
-                    missing = next(p for p in map(_param_name, arr_params) if p not in parameters)
+                    missing = next(p for p in map(_param_name, arr_params) if p not in idx_lookup)
                     raise ValueError(f"Could not find placement for parameter '{missing}'.") from ex
                 ret[..., idxs] = arr
 

--- a/qiskit/primitives/containers/bindings_array.py
+++ b/qiskit/primitives/containers/bindings_array.py
@@ -420,7 +420,7 @@ def _format_key(key: tuple[Parameter | str, ...]):
     return tuple(map(_param_name, key))
 
 
-def _param_name(param: Parameter | str):
+def _param_name(param: Parameter | str) -> str:
     return param.name if isinstance(param, Parameter) else param
 
 

--- a/qiskit/primitives/containers/bindings_array.py
+++ b/qiskit/primitives/containers/bindings_array.py
@@ -16,7 +16,7 @@ Bindings array class
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
-from itertools import chain
+from itertools import chain, islice
 from typing import Union
 
 import numpy as np
@@ -144,6 +144,15 @@ class BindingsArray(ShapedMixin):
         except StopIteration:
             shape = ()
         return BindingsArray(vals, kwvals, shape)
+
+    def __repr__(self):
+        descriptions = [f"shape={self.shape}", f"num_parameters={self.num_parameters}"]
+        if num_kwval_params := sum(val.shape[-1] for val in self._kwvals.values()):
+            names = list(islice(map(repr, chain.from_iterable(map(_format_key, self._kwvals))), 5))
+            if len(names) < num_kwval_params:
+                names.append("...")
+            descriptions.append(f"parameters=[{', '.join(names)}]")
+        return f"{type(self).__name__}(<{', '.join(descriptions)}>)"
 
     @property
     def kwvals(self) -> dict[tuple[str, ...], np.ndarray]:

--- a/test/python/primitives/containers/test_bindings_array.py
+++ b/test/python/primitives/containers/test_bindings_array.py
@@ -12,7 +12,7 @@
 
 """Test BindingsArray"""
 
-
+import ddt
 import numpy as np
 
 from qiskit.circuit import Parameter, ParameterVector, QuantumCircuit
@@ -20,6 +20,7 @@ from qiskit.primitives import BindingsArray
 from qiskit.test import QiskitTestCase
 
 
+@ddt.ddt
 class BindingsArrayTestCase(QiskitTestCase):
     """Test the BindingsArray class"""
 
@@ -75,6 +76,73 @@ class BindingsArrayTestCase(QiskitTestCase):
                 BindingsArray([1], {"p": 2, "q": 5, ("a", "b", "c", "d"): [1, 22, 4, 5]})
             ).startswith("BindingsArray")
         )
+
+    @ddt.idata([(True, True), (True, False), (False, True), (False, False)])
+    @ddt.unpack
+    def test_as_array(self, kwvals_str, args_str):
+        """Test as_array() with all combinations of Parameter and str"""
+        kwval_param = lambda param: Parameter(param) if kwvals_str else param
+        args_param = lambda param: Parameter(param) if args_str else param
+        with self.subTest("error: dtype"):
+            ba = BindingsArray([np.empty((50, 5), dtype=float), np.empty((50, 2), dtype=int)])
+            with self.assertRaises(RuntimeError):
+                ba.as_array()
+
+        with self.subTest("error: missing param"):
+            ba = BindingsArray(kwvals={(kwval_param("a"), kwval_param("b")): np.empty((5, 2))})
+            with self.assertRaises(KeyError):
+                ba.as_array([args_param("b")])
+
+        with self.subTest("completely empty"):
+            ba = BindingsArray(shape=())
+            np.testing.assert_allclose(ba.as_array(), np.array([[]]))
+
+        with self.subTest("single array"):
+            arr = np.linspace(0, 20, 250).reshape((25, 5, 2))
+            ba = BindingsArray(arr)
+            np.testing.assert_allclose(ba.as_array(), arr)
+
+        with self.subTest("multiple arrays"):
+            arr_a = np.linspace(0, 20, 250).reshape((25, 5, 2))
+            arr_b = np.linspace(0, 5, 1000).reshape((25, 5, 8))
+            ba = BindingsArray([arr_a, arr_b])
+            np.testing.assert_allclose(ba.as_array(), np.concatenate([arr_a, arr_b], axis=2))
+
+        with self.subTest("kwvals"):
+            arr_a = np.linspace(0, 20, 250).reshape((25, 5, 2))
+            arr_b = np.linspace(0, 5, 375).reshape((25, 5, 3))
+            ba = BindingsArray(
+                kwvals={
+                    (kwval_param("a"), kwval_param("b")): arr_a,
+                    (kwval_param("c"), kwval_param("d"), kwval_param("e")): arr_b,
+                }
+            )
+            np.testing.assert_allclose(ba.as_array(), np.concatenate([arr_a, arr_b], axis=2))
+
+            params = map(args_param, "dabec")
+            expected = [arr_b[..., 1], arr_a[..., 0], arr_a[..., 1], arr_b[..., 2], arr_b[..., 0]]
+            expected = np.concatenate([arr[..., None] for arr in expected], axis=2)
+            np.testing.assert_allclose(ba.as_array(params), expected)
+
+        with self.subTest("mixed"):
+            arr_a = np.linspace(0, 20, 375).reshape((25, 5, 3))
+            arr_b = np.linspace(0, 5, 250).reshape((25, 5, 2))
+            arr_c = np.linspace(0, 5, 375).reshape((25, 5, 3))
+            ba = BindingsArray(
+                arr_a,
+                kwvals={
+                    (kwval_param("a"), kwval_param("b")): arr_b,
+                    (kwval_param("c"), kwval_param("d"), kwval_param("e")): arr_c,
+                },
+            )
+
+            expected = np.concatenate([arr_a, arr_b, arr_c], axis=2)
+            np.testing.assert_allclose(ba.as_array(), expected)
+
+            params = map(args_param, "xxxdabec")
+            expected = [arr_c[..., 1], arr_b[..., 0], arr_b[..., 1], arr_c[..., 2], arr_c[..., 0]]
+            expected = np.concatenate([arr_a] + [arr[..., None] for arr in expected], axis=2)
+            np.testing.assert_allclose(ba.as_array(params), expected)
 
     def test_bind_at_idx(self):
         """Test binding at a specified index"""

--- a/test/python/primitives/containers/test_bindings_array.py
+++ b/test/python/primitives/containers/test_bindings_array.py
@@ -85,14 +85,17 @@ class BindingsArrayTestCase(QiskitTestCase):
 
     @ddt.idata([(True, True), (True, False), (False, True), (False, False)])
     @ddt.unpack
-    def test_as_array_missing_param_raises(self, kwvals_str, args_str):
+    def test_as_array_bad_param_raises(self, kwvals_str, args_str):
         """Test as_array() raises when a parameter key is missing."""
         kwval_param = lambda param: Parameter(param) if kwvals_str else param
         args_param = lambda param: Parameter(param) if args_str else param
 
         ba = BindingsArray(kwvals={(kwval_param("a"), kwval_param("b")): np.empty((5, 2))})
-        with self.assertRaises(KeyError):
+        with self.assertRaisesRegex(ValueError, "Expected 2 parameters but 1 received"):
             ba.as_array([args_param("b")])
+
+        with self.assertRaisesRegex(ValueError, "Could not find placement for parameter 'a'"):
+            ba.as_array([args_param("b"), args_param("c")])
 
     def test_as_array_vals_only(self):
         """Test as_array() works when only vals are present."""
@@ -154,7 +157,7 @@ class BindingsArrayTestCase(QiskitTestCase):
         expected = np.concatenate([arr_a, arr_b, arr_c], axis=2)
         np.testing.assert_allclose(ba.as_array(), expected)
 
-        params = map(args_param, "xxxdabec")
+        params = map(args_param, "dabec")
         expected = [arr_c[..., 1], arr_b[..., 0], arr_b[..., 1], arr_c[..., 2], arr_c[..., 0]]
         expected = np.concatenate([arr_a] + [arr[..., None] for arr in expected], axis=2)
         np.testing.assert_allclose(ba.as_array(params), expected)

--- a/test/python/primitives/containers/test_bindings_array.py
+++ b/test/python/primitives/containers/test_bindings_array.py
@@ -94,6 +94,10 @@ class BindingsArrayTestCase(QiskitTestCase):
         with self.assertRaisesRegex(ValueError, "Expected 2 parameters but 1 received"):
             ba.as_array([args_param("b")])
 
+        ba = BindingsArray(kwvals={(kwval_param("a"), kwval_param("b")): np.empty((5, 2))})
+        with self.assertRaisesRegex(ValueError, "Expected 2 parameters but 3 received"):
+            ba.as_array([args_param("b"), args_param("a"), args_param("b")])
+
         with self.assertRaisesRegex(ValueError, "Could not find placement for parameter 'a'"):
             ba.as_array([args_param("b"), args_param("c")])
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This method converts a `BindingsArray` instance to a single NumPy array, when possible. See the tests and docstrings for more info.


### Details and comments


