### PR TITLE
[0.46] Update the deprecation decorator towards SemVer

### DIFF
--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -245,8 +245,8 @@ class QiskitTestCase(BaseQiskitTestCase):
             "Setting metadata to None.*",
             # and this one once Qiskit/qiskit-aer#1945 is merged and released.
             r"The method ``qiskit\.circuit\.quantumcircuit\.QuantumCircuit\.i\(\)`` is "
-            r"deprecated as of qiskit 0\.45\.0\. It will be removed no earlier than 3 "
-            r"months after the release date\. Use QuantumCircuit\.id as direct replacement\.",
+            r"deprecated as of qiskit 0\.45\.0\. It will be removed in the next major release 1\.0\. "
+            r"Use QuantumCircuit\.id as direct replacement\.",
             # This warning will be fixed once Qiskit/qiskit-aer#2023 is released.
             "The qiskit.extensions module is deprecated since Qiskit 0.46.0. It will be removed "
             "in the Qiskit 1.0 release.",

--- a/qiskit/utils/deprecation.py
+++ b/qiskit/utils/deprecation.py
@@ -27,7 +27,7 @@ def deprecate_func(
     additional_msg: str | None = None,
     pending: bool = False,
     package_name: str = "qiskit",
-    removal_timeline: str = "no earlier than 3 months after the release date",
+    removal_timeline: str | None = None,
     is_property: bool = False,
 ):
     """Decorator to indicate a function has been deprecated.
@@ -46,7 +46,8 @@ def deprecate_func(
         pending: Set to ``True`` if the deprecation is still pending.
         package_name: The PyPI package name, e.g. "qiskit-nature".
         removal_timeline: How soon can this deprecation be removed? Expects a value
-            like "no sooner than 6 months after the latest release" or "in release 9.99".
+            like "in two major releases" or "in release 9.99". Default:
+            "in the next major release {since_major + 1}".
         is_property: If the deprecated function is a `@property`, set this to True so that the
             generated message correctly describes it as such. (This isn't necessary for
             property setters, as their docstring is ignored by Python.)
@@ -111,7 +112,7 @@ def deprecate_arg(
     package_name: str = "qiskit",
     new_alias: str | None = None,
     predicate: Callable[[Any], bool] | None = None,
-    removal_timeline: str = "no earlier than 3 months after the release date",
+    removal_timeline: str | None = None,
 ):
     """Decorator to indicate an argument has been deprecated in some way.
 
@@ -138,7 +139,8 @@ def deprecate_arg(
             `lambda my_arg: isinstance(my_arg, dict)`. Regardless of if a predicate is set, the
             runtime warning will only log when the user specifies the argument.
         removal_timeline: How soon can this deprecation be removed? Expects a value
-            like "no sooner than 6 months after the latest release" or "in release 9.99".
+            like "in two major releases" or "in release 9.99". Default:
+            "in the next major release {since_major + 1}".
 
     Returns:
         Callable: The decorated callable.
@@ -353,8 +355,13 @@ def _write_deprecation_msg(
     since: str,
     pending: bool,
     additional_msg: str,
-    removal_timeline: str,
+    removal_timeline: str | None,
 ) -> tuple[str, Type[DeprecationWarning] | Type[PendingDeprecationWarning]]:
+    if not removal_timeline:
+        # TODO: remove the cast `str()` once https://github.com/Qiskit/qiskit-aer/pull/2006 is released
+        removal_major = int(str(since).split(".")[0]) + 1
+        removal_timeline = f"in the next major release {removal_major}.0"
+
     if pending:
         category: Type[DeprecationWarning] | Type[
             PendingDeprecationWarning

--- a/test/python/utils/test_deprecation.py
+++ b/test/python/utils/test_deprecation.py
@@ -84,8 +84,7 @@ class TestDeprecationDecorators(QiskitTestCase):
 
                 .. deprecated:: 9.99_pending
                   The class ``{__name__}._Foo`` is pending deprecation as of qiskit 9.99. It \
-will be marked deprecated in a future release, and then removed no earlier than 3 months after \
-the release date.
+will be marked deprecated in a future release, and then removed in the next major release 10.0.
                 """
             ),
         )
@@ -97,7 +96,7 @@ the release date.
 
                 .. deprecated:: 9.99
                   The method ``{__name__}._Foo.my_method()`` is deprecated as of qiskit \
-9.99. It will be removed no earlier than 3 months after the release date. Stop using this!
+9.99. It will be removed in the next major release 10.0. Stop using this!
                 """
             ),
         )
@@ -109,7 +108,7 @@ the release date.
 
                 .. deprecated:: 9.99
                   The property ``{__name__}._Foo.my_property`` is deprecated as of qiskit \
-9.99. It will be removed no earlier than 3 months after the release date.
+9.99. It will be removed in the next major release 10.0.
                 """
             ),
         )
@@ -143,18 +142,18 @@ the release date.
 
                 .. deprecated:: 9.99
                   ``{__name__}.{my_func.__qualname__}()``'s argument ``arg4`` is deprecated as of \
-qiskit 9.99. It will be removed no earlier than 3 months after the release date. Instead, \
+qiskit 9.99. It will be removed in the next major release 10.0. Instead, \
 use foo.
 
                 .. deprecated:: 9.99
                   Using the argument arg3 is deprecated as of qiskit 9.99. It will be \
-removed no earlier than 3 months after the release date. Instead, use the argument ``new_arg3``, \
+removed in the next major release 10.0. Instead, use the argument ``new_arg3``, \
 which behaves identically.
 
                 .. deprecated:: 9.99_pending
                   ``{__name__}.{my_func.__qualname__}()``'s argument ``arg2`` is pending \
 deprecation as of qiskit 9.99. It will be marked deprecated in a future release, and then \
-removed no earlier than 3 months after the release date.
+removed in the next major release 10.0.
 
                 .. deprecated:: 9.99
                   ``{__name__}.{my_func.__qualname__}()``'s argument ``arg1`` is deprecated as of \


### PR DESCRIPTION
This is the `stable/0.46` version of https://github.com/Qiskit/qiskit/pull/11296 ([as merigify didnt do what I was expecting](https://github.com/Qiskit/qiskit/pull/11296#issuecomment-1892059157)). 

----

The current `deprecate` decorators extend the docstring with the following:

![current](https://github.com/Qiskit/qiskit/assets/766693/7fd2def8-16ea-4687-a8db-c512c79b4b7f)

I suggest the following to be aligned with https://github.com/Qiskit/documentation/pull/366/

![suggestion](https://github.com/Qiskit/qiskit/assets/766693/ba1b2ee2-d782-4c61-b860-e6f465d3787a)