### PR TITLE
Deprecate ``ConfigurableFakeBackend``

### DIFF
--- a/qiskit/providers/fake_provider/utils/configurable_backend.py
+++ b/qiskit/providers/fake_provider/utils/configurable_backend.py
@@ -35,7 +35,11 @@ from ..fake_backend import FakeBackend
 class ConfigurableFakeBackend(FakeBackend):
     """Configurable backend."""
 
-    @deprecate_func(since="0.46.0", additional_msg="Use ?? instead.")
+    @deprecate_func(
+        since="0.46.0",
+        additional_msg="Use a suitable FakeBackend instead.",
+        removal_timeline="Qiskit 1.0",
+    )
     def __init__(
         self,
         name: str,

--- a/qiskit/providers/fake_provider/utils/configurable_backend.py
+++ b/qiskit/providers/fake_provider/utils/configurable_backend.py
@@ -27,6 +27,7 @@ from qiskit.providers.models import (
 )
 from qiskit.providers.models.backendproperties import Nduv, Gate
 from qiskit.qobj import PulseQobjInstruction
+from qiskit.utils.deprecation import deprecate_func
 
 from ..fake_backend import FakeBackend
 
@@ -34,6 +35,7 @@ from ..fake_backend import FakeBackend
 class ConfigurableFakeBackend(FakeBackend):
     """Configurable backend."""
 
+    @deprecate_func(since="0.46.0", additional_msg="Use ?? instead.")
     def __init__(
         self,
         name: str,
@@ -155,7 +157,7 @@ class ConfigurableFakeBackend(FakeBackend):
         qubits = []
         gates = []
 
-        for (qubit_t1, qubit_t2, freq, read_err) in zip(
+        for qubit_t1, qubit_t2, freq, read_err in zip(
             self.qubit_t1, self.qubit_t2, self.qubit_frequency, self.qubit_readout_error
         ):
             qubits.append(
@@ -184,7 +186,7 @@ class ConfigurableFakeBackend(FakeBackend):
                         )
                     )
             elif gate == "cx":
-                for (qubit1, qubit2) in list(itertools.combinations(range(self.n_qubits), 2)):
+                for qubit1, qubit2 in list(itertools.combinations(range(self.n_qubits), 2)):
                     gates.append(
                         Gate(
                             gate=gate,
@@ -212,7 +214,7 @@ class ConfigurableFakeBackend(FakeBackend):
             ",".join([f"_SUM[i,0,{self.n_qubits}", "omegad{i}*X{i}||D{i}]"]),
         ]
         variables = []
-        for (qubit1, qubit2) in self.coupling_map:
+        for qubit1, qubit2 in self.coupling_map:
             h_str += [
                 "jq{q1}q{q2}*Sp{q1}*Sm{q2}".format(q1=qubit1, q2=qubit2),
                 "jq{q1}q{q2}*Sm{q1}*Sp{q2}".format(q1=qubit1, q2=qubit2),

--- a/releasenotes/notes/deprecate-configurable-fake-backend-82e8f9a7808a7b57.yaml
+++ b/releasenotes/notes/deprecate-configurable-fake-backend-82e8f9a7808a7b57.yaml
@@ -1,0 +1,5 @@
+---
+deprecations:
+  - |
+    Deprecated :class:`.ConfigurableFakeBackend`, which has mainly been used
+    for internal testing. Instead, a suitable :class:`.FakeBackend` can be used.

--- a/test/python/providers/fake_provider/test_configurable_backend.py
+++ b/test/python/providers/fake_provider/test_configurable_backend.py
@@ -20,7 +20,8 @@ class TestConfigurableFakeBackend(QiskitTestCase):
 
     def test_default_parameters(self):
         """Test default parameters."""
-        fake_backend = ConfigurableFakeBackend("Tashkent", n_qubits=10)
+        with self.assertWarns(DeprecationWarning):
+            fake_backend = ConfigurableFakeBackend("Tashkent", n_qubits=10)
 
         properties = fake_backend.properties()
         self.assertEqual(len(properties.qubits), 10)
@@ -39,17 +40,18 @@ class TestConfigurableFakeBackend(QiskitTestCase):
         """Test parameters setting."""
         for n_qubits in range(10, 100, 30):
             with self.subTest(n_qubits=n_qubits):
-                fake_backend = ConfigurableFakeBackend(
-                    "Tashkent",
-                    n_qubits=n_qubits,
-                    version="0.0.1",
-                    basis_gates=["u1"],
-                    qubit_t1=99.0,
-                    qubit_t2=146.0,
-                    qubit_frequency=5.0,
-                    qubit_readout_error=0.01,
-                    single_qubit_gates=["u1"],
-                )
+                with self.assertWarns(DeprecationWarning):
+                    fake_backend = ConfigurableFakeBackend(
+                        "Tashkent",
+                        n_qubits=n_qubits,
+                        version="0.0.1",
+                        basis_gates=["u1"],
+                        qubit_t1=99.0,
+                        qubit_t2=146.0,
+                        qubit_frequency=5.0,
+                        qubit_readout_error=0.01,
+                        single_qubit_gates=["u1"],
+                    )
 
                 properties = fake_backend.properties()
                 self.assertEqual(properties.backend_version, "0.0.1")
@@ -67,14 +69,17 @@ class TestConfigurableFakeBackend(QiskitTestCase):
 
     def test_gates(self):
         """Test generated gates."""
-        fake_backend = ConfigurableFakeBackend("Tashkent", n_qubits=4)
+        with self.assertWarns(DeprecationWarning):
+            fake_backend = ConfigurableFakeBackend("Tashkent", n_qubits=4)
+
         properties = fake_backend.properties()
 
         self.assertEqual(len(properties.gates), 22)
 
-        fake_backend = ConfigurableFakeBackend(
-            "Tashkent", n_qubits=4, basis_gates=["u1", "u2", "cx"]
-        )
+        with self.assertWarns(DeprecationWarning):
+            fake_backend = ConfigurableFakeBackend(
+                "Tashkent", n_qubits=4, basis_gates=["u1", "u2", "cx"]
+            )
         properties = fake_backend.properties()
 
         self.assertEqual(len(properties.gates), 14)
@@ -82,7 +87,8 @@ class TestConfigurableFakeBackend(QiskitTestCase):
 
     def test_coupling_map_generation(self):
         """Test generation of default coupling map."""
-        fake_backend = ConfigurableFakeBackend("Tashkent", n_qubits=10)
+        with self.assertWarns(DeprecationWarning):
+            fake_backend = ConfigurableFakeBackend("Tashkent", n_qubits=10)
         cmap = fake_backend.configuration().coupling_map
         target = [
             [0, 1],
@@ -107,7 +113,8 @@ class TestConfigurableFakeBackend(QiskitTestCase):
 
     def test_configuration(self):
         """Test backend configuration."""
-        fake_backend = ConfigurableFakeBackend("Tashkent", n_qubits=10)
+        with self.assertWarns(DeprecationWarning):
+            fake_backend = ConfigurableFakeBackend("Tashkent", n_qubits=10)
         configuration = fake_backend.configuration()
 
         self.assertEqual(configuration.n_qubits, 10)
@@ -120,7 +127,8 @@ class TestConfigurableFakeBackend(QiskitTestCase):
 
     def test_defaults(self):
         """Test backend defaults."""
-        fake_backend = ConfigurableFakeBackend("Tashkent", n_qubits=10)
+        with self.assertWarns(DeprecationWarning):
+            fake_backend = ConfigurableFakeBackend("Tashkent", n_qubits=10)
         defaults = fake_backend.defaults()
 
         self.assertEqual(len(defaults.cmd_def), 54)
@@ -130,9 +138,10 @@ class TestConfigurableFakeBackend(QiskitTestCase):
     def test_with_coupling_map(self):
         """Test backend generation with coupling map."""
         target_coupling_map = [[0, 1], [1, 2], [2, 3]]
-        fake_backend = ConfigurableFakeBackend(
-            "Tashkent", n_qubits=4, coupling_map=target_coupling_map
-        )
+        with self.assertWarns(DeprecationWarning):
+            fake_backend = ConfigurableFakeBackend(
+                "Tashkent", n_qubits=4, coupling_map=target_coupling_map
+            )
         cmd_def = fake_backend.defaults().cmd_def
         configured_cmap = fake_backend.configuration().coupling_map
         controlled_not_qubits = [cmd.qubits for cmd in cmd_def if cmd.name == "cx"]
@@ -142,6 +151,7 @@ class TestConfigurableFakeBackend(QiskitTestCase):
 
     def test_get_name_with_method(self):
         """Get backend name."""
-        fake_backend = ConfigurableFakeBackend("Tashkent", n_qubits=4)
+        with self.assertWarns(DeprecationWarning):
+            fake_backend = ConfigurableFakeBackend("Tashkent", n_qubits=4)
 
         self.assertEqual(fake_backend.name(), "Tashkent")

--- a/test/python/pulse/test_builder.py
+++ b/test/python/pulse/test_builder.py
@@ -21,10 +21,7 @@ from qiskit.pulse import builder, exceptions, macros
 from qiskit.pulse.instructions import directives
 from qiskit.pulse.transforms import target_qobj_transform
 from qiskit.test import QiskitTestCase
-from qiskit.providers.fake_provider import FakeOpenPulse2Q
-from qiskit.providers.fake_provider.utils.configurable_backend import (
-    ConfigurableFakeBackend as ConfigurableBackend,
-)
+from qiskit.providers.fake_provider import FakeOpenPulse2Q, FakeWashington
 from qiskit.pulse import library, instructions
 
 
@@ -729,12 +726,13 @@ class TestMacros(TestBuilder):
 
         self.assertScheduleEqual(schedule, reference)
 
-        backend_100q = ConfigurableBackend("100q", 100)
-        with pulse.build(backend_100q) as schedule:
+        backend = FakeWashington()
+        num_qubits = backend.configuration().num_qubits
+        with pulse.build(backend) as schedule:
             regs = pulse.measure_all()
 
-        reference = backend_100q.defaults().instruction_schedule_map.get(
-            "measure", list(range(100))
+        reference = backend.defaults().instruction_schedule_map.get(
+            "measure", list(range(num_qubits))
         )
 
         self.assertScheduleEqual(schedule, reference)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Deprecate ``ConfigurableFakeBackend``, which is only used in a single test in the pulse builder and can instead use a simple `FakeBackend`.

### Details and comments

Removal coming for 1.0.
