### PR TITLE
Exclude non-rc pre-releases from qpy backwards compat tests

### DIFF
--- a/test/qpy_compat/process_version.sh
+++ b/test/qpy_compat/process_version.sh
@@ -29,6 +29,11 @@ if [[ ${parts[0]} -eq 0 && ${parts[1]} -lt 18 ]] ; then
     exit 0
 fi
 
+# Exclude any non-rc pre-releases as they don't have stable API guarantees
+if [[ $version == *"b"* || $version == *"a"* ]] ; then
+    exit 0
+fi
+
 # If the source version is newer than the version under test exit fast because
 # there is no QPY compatibility for loading a qpy file generated from a newer
 # release with an older release of Qiskit.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The QPY backwards compatibility tests are setup to verify that we can load qpy files generated with historical releases using the current version of Qiskit under development. This ensures we're meeting our backwards compatibility guarantees with QPY. However, the tests were over eagerly running on pre-releases that don't have any stability guarantees, mainly alpha and beta releases indicated by "a" and "b" suffixes respectively in the version number. This commit excludes these pre-release versions from the tests as it's not valid to run with these. Release candidate pre-releases should still be run because they have stable APIs and they're not skipped by this PR.

### Details and comments