### PR TITLE
Add validation kwarg to `SamplerPub.coerce` and `EstimatorPub.coerce`

### DIFF
--- a/qiskit/primitives/containers/estimator_pub.py
+++ b/qiskit/primitives/containers/estimator_pub.py
@@ -110,7 +110,7 @@ class EstimatorPub(ShapedMixin):
             pub: A compatible object for coercion.
             precision: an optional default precision to use if not
                        already specified by the pub-like object.
-            validate: Whether to validate the returned pub.
+            validate: Whether to validate the pub before returning.
 
         Returns:
             An estimator pub.

--- a/qiskit/primitives/containers/sampler_pub.py
+++ b/qiskit/primitives/containers/sampler_pub.py
@@ -87,7 +87,7 @@ class SamplerPub(ShapedMixin):
             pub: An object to coerce.
             shots: An optional default number of shots to use if not
                    already specified by the pub-like object.
-            validate: Whether to validate the returned pub.
+            validate: Whether to validate the pub before returning.
 
         Returns:
             A sampler pub.

--- a/qiskit/primitives/containers/sampler_pub.py
+++ b/qiskit/primitives/containers/sampler_pub.py
@@ -78,16 +78,23 @@ class SamplerPub(ShapedMixin):
         return self._shots
 
     @classmethod
-    def coerce(cls, pub: SamplerPubLike, shots: int | None = None) -> SamplerPub:
+    def coerce(
+        cls, pub: SamplerPubLike, shots: int | None = None, validate: bool = True
+    ) -> SamplerPub:
         """Coerce a :class:`~.SamplerPubLike` object into a :class:`~.SamplerPub` instance.
 
         Args:
             pub: An object to coerce.
             shots: An optional default number of shots to use if not
                    already specified by the pub-like object.
+            validate: Whether to validate the returned pub.
 
         Returns:
-            A coerced sampler pub.
+            A sampler pub.
+
+        Raises:
+            ValueError: If validation fails from a bad value.
+            TypeError: If validation fails from an unexpected type.
         """
         # Validate shots kwarg if provided
         if shots is not None:
@@ -102,8 +109,10 @@ class SamplerPub(ShapedMixin):
                     circuit=pub.circuit,
                     parameter_values=pub.parameter_values,
                     shots=shots,
-                    validate=False,  # Assume Pub is already validated
+                    validate=validate,
                 )
+            if validate:
+                pub.validate()
             return pub
 
         if isinstance(pub, QuantumCircuit):
@@ -117,7 +126,9 @@ class SamplerPub(ShapedMixin):
         parameter_values = BindingsArray.coerce(pub[1]) if len(pub) > 1 else None
         if len(pub) > 2 and pub[2] is not None:
             shots = pub[2]
-        return cls(circuit=circuit, parameter_values=parameter_values, shots=shots, validate=True)
+        return cls(
+            circuit=circuit, parameter_values=parameter_values, shots=shots, validate=validate
+        )
 
     def validate(self):
         """Validate the pub."""

--- a/test/python/primitives/containers/test_estimator_pub.py
+++ b/test/python/primitives/containers/test_estimator_pub.py
@@ -359,6 +359,30 @@ class EstimatorPubTestCase(QiskitTestCase):
             msg="incorrect num parameters for `parameter_values` property",
         )
 
+    def test_coerce_validation_with_pub(self):
+        """Test the coerce method when there is no validation with pub input."""
+        pub = EstimatorPub("the circuit", ObservablesArray("XX"), precision=0.07, validate=False)
+
+        EstimatorPub.coerce(pub, validate=False)
+        with self.assertRaises(TypeError):
+            EstimatorPub.coerce(pub, validate=True)
+
+    def test_coerce_validation_with_pub_no_precision(self):
+        """Test the coerce method when there is no validation with pub input but no precision."""
+        pub = EstimatorPub("the circuit", ObservablesArray("XX"), validate=False)
+
+        EstimatorPub.coerce(pub, validate=False)
+        with self.assertRaises(TypeError):
+            EstimatorPub.coerce(pub, validate=True)
+
+    def test_coerce_validation_from_tuple(self):
+        """Test the coerce method when there is no validation."""
+        obs = ObservablesArray("XX")
+        EstimatorPub.coerce(("the circuit", obs), validate=False)
+
+        with self.assertRaises(TypeError):
+            EstimatorPub.coerce(("the circuit", obs), validate=True)
+
     @ddt.data(
         [(), (), ()],
         [(5,), (5,), (5,)],

--- a/test/python/primitives/containers/test_sampler_pub.py
+++ b/test/python/primitives/containers/test_sampler_pub.py
@@ -327,3 +327,26 @@ class SamplerPubTestCase(QiskitTestCase):
             0,
             msg="incorrect num parameters for `parameter_values` property",
         )
+
+    def test_coerce_validation_with_pub(self):
+        """Test the coerce method when there is no validation with pub input."""
+        pub = SamplerPub(["the circuit"], shots=52, validate=False)
+
+        SamplerPub.coerce(pub, validate=False)
+        with self.assertRaises(TypeError):
+            SamplerPub.coerce(pub, validate=True)
+
+    def test_coerce_validation_with_pub_no_precision(self):
+        """Test the coerce method when there is no validation with pub input but no precision."""
+        pub = SamplerPub(["the circuit"], validate=False)
+
+        SamplerPub.coerce(pub, validate=False)
+        with self.assertRaises(TypeError):
+            SamplerPub.coerce(pub, validate=True)
+
+    def test_coerce_validation_from_tuple(self):
+        """Test the coerce method when there is no validation."""
+        SamplerPub.coerce(["the circuit"], validate=False)
+
+        with self.assertRaises(TypeError):
+            SamplerPub.coerce(["the circuit"], validate=True)


### PR DESCRIPTION
### Summary

This PR adds a boolean kwarg `validate` to both `SamplerPub` and `EstimatorPub` that defaults to true. This flag controls whether the validate method should be called in the course of coersion.

### Details and comments


