### PR TITLE
Add `Observable` container type for Estimator

### DIFF
--- a/qiskit/primitives/__init__.py
+++ b/qiskit/primitives/__init__.py
@@ -65,6 +65,7 @@ from .base.estimator_result import EstimatorResult
 from .base.sampler_result import SamplerResult
 from .containers import (
     BindingsArray,
+    Observable,
     ObservablesArray,
     PrimitiveResult,
     PubResult,

--- a/qiskit/primitives/containers/__init__.py
+++ b/qiskit/primitives/containers/__init__.py
@@ -18,6 +18,7 @@ from .bindings_array import BindingsArray
 from .bit_array import BitArray
 from .data_bin import make_data_bin, DataBin
 from .estimator_pub import EstimatorPub, EstimatorPubLike
+from .observable import Observable
 from .observables_array import ObservablesArray
 from .primitive_result import PrimitiveResult
 from .pub_result import PubResult

--- a/qiskit/primitives/containers/observable.py
+++ b/qiskit/primitives/containers/observable.py
@@ -1,0 +1,188 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+
+"""
+Container class for an Estimator observable.
+"""
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Iterable
+from collections import defaultdict
+from functools import lru_cache
+from typing import Union
+from numbers import Complex
+
+from qiskit.quantum_info import Pauli, SparsePauliOp
+
+ObservableLike = Union[
+    str,
+    Pauli,
+    SparsePauliOp,
+    Mapping[Union[str, Pauli], complex],
+    Iterable[Union[str, Pauli, SparsePauliOp]],
+]
+"""Types that can be natively used to construct a :const:`BasisObservable`."""
+
+
+class Observable(Mapping):
+    """A sparse container for a Hermitian observable for an :class:`.Estimator` primitive."""
+
+    ALLOWED_BASIS: str = "IXYZ01+-lr"
+    """The allowed characters in :class:`.Observable` strings."""
+
+    def __init__(
+        self,
+        data: Mapping[str, complex],
+        validate: bool = True,
+    ):
+        """Initialize an observables array.
+
+        Args:
+            data: The observable data.
+            validate: If ``True``, the input data is validated during initialization.
+
+        Raises:
+            ValueError: If ``validate=True`` and the input observable-like is not valid.
+        """
+        self._data = data
+        self._num_qubits = len(next(iter(data)))
+        if validate:
+            self.validate()
+
+    def __repr__(self):
+        return f"{type(self).__name__}({self._data})"
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self):
+        return len(self._data)
+
+    @property
+    def num_qubits(self) -> int:
+        """The number of qubits in the observable"""
+        return self._num_qubits
+
+    def validate(self):
+        """Validate the consistency in observables array."""
+        if not isinstance(self._data, Mapping):
+            raise TypeError(f"Observable data type {type(self._data)} is not a Mapping.")
+        for key, value in self._data.items():
+            try:
+                self._validate_basis(key)
+                self._validate_coeff(value)
+            except TypeError as ex:
+                raise TypeError(f"Invalid type for item ({key}, {value})") from ex
+            except Exception as ex:  # pylint: disable = broad-except
+                raise ValueError(f"Invalid value for item ({key}, {value})") from ex
+
+    @classmethod
+    def coerce(cls, observable: ObservableLike) -> Observable:
+        """Coerce an observable-like object into an :class:`.Observable`.
+
+        Args:
+            observable: The observable-like input.
+
+        Returns:
+            A coerced observables array.
+
+        Raises:
+            TypeError: If the input cannot be formatted because its type is not valid.
+            ValueError: If the input observable is invalid.
+        """
+
+        # Pauli-type conversions
+        if isinstance(observable, SparsePauliOp):
+            # Call simplify to combine duplicate keys before converting to a mapping
+            data = dict(observable.simplify(atol=0).to_list())
+            return cls.coerce(data)
+
+        if isinstance(observable, Pauli):
+            label, phase = observable[:].to_label(), observable.phase
+            cls._validate_basis(label)
+            data = {label: 1} if phase == 0 else {label: (-1j) ** phase}
+            return Observable(data)
+
+        # String conversion
+        if isinstance(observable, str):
+            cls._validate_basis(observable)
+            return cls.coerce({observable: 1})
+
+        # Mapping conversion (with possible Pauli keys)
+        if isinstance(observable, Mapping):
+            # NOTE: This assumes length of keys is number of qubits
+            #       this might not be very robust
+            num_qubits = len(next(iter(observable)))
+            unique = defaultdict(complex)
+            for basis, coeff in observable.items():
+                if isinstance(basis, Pauli):
+                    basis, phase = basis[:].to_label(), basis.phase
+                    if phase != 0:
+                        coeff = coeff * (-1j) ** phase
+                # Validate basis
+                cls._validate_basis(basis)
+                if len(basis) != num_qubits:
+                    raise ValueError(
+                        "Number of qubits must be the same for all observable basis elements."
+                    )
+                unique[basis] += coeff
+            return Observable(dict(unique))
+
+        raise TypeError(f"Invalid observable type: {type(observable)}")
+
+    @classmethod
+    def _validate_basis(cls, basis: any) -> None:
+        """Validate a basis string.
+
+        Args:
+            basis: a basis object to validate.
+
+        Raises:
+            TypeError: If the input basis is not a string
+            ValueError: If basis string contains invalid characters
+        """
+        if not isinstance(basis, str):
+            raise TypeError(f"basis {basis} is not a string")
+
+        # NOTE: the allowed basis characters can be overridden by modifying the class
+        # attribute ALLOWED_BASIS
+        allowed_pattern = _regex_match(cls.ALLOWED_BASIS)
+        if not allowed_pattern.match(basis):
+            invalid_pattern = _regex_invalid(cls.ALLOWED_BASIS)
+            invalid_chars = list(set(invalid_pattern.findall(basis)))
+            raise ValueError(
+                f"Observable basis string '{basis}' contains invalid characters {invalid_chars},"
+                f" allowed characters are {list(cls.ALLOWED_BASIS)}.",
+            )
+
+    @classmethod
+    def _validate_coeff(cls, coeff: any):
+        """Validate the consistency in observables array."""
+        if not isinstance(coeff, Complex):
+            raise TypeError(f"Value {coeff} is not a complex number")
+
+
+@lru_cache(1)
+def _regex_match(allowed_chars: str) -> re.Pattern:
+    """Return pattern for matching if a string contains only the allowed characters."""
+    return re.compile(f"^[{re.escape(allowed_chars)}]*$")
+
+
+@lru_cache(1)
+def _regex_invalid(allowed_chars: str) -> re.Pattern:
+    """Return pattern for selecting invalid strings"""
+    return re.compile(f"[^{re.escape(allowed_chars)}]")

--- a/qiskit/primitives/containers/observable.py
+++ b/qiskit/primitives/containers/observable.py
@@ -16,19 +16,20 @@ Container class for an Estimator observable.
 """
 from __future__ import annotations
 
-from typing import Union, Iterable, Mapping as MappingType
+from typing import Union, Mapping as MappingType
 from collections.abc import Mapping
 from collections import defaultdict
 from numbers import Complex
 
 from qiskit.quantum_info import Pauli, SparsePauliOp
 
+
+ObservableKey = "tuple[tuple[int, ...], str]"  # pylint: disable = invalid-name
+ObservableKeyLike = Union[Pauli, str, ObservableKey]
 ObservableLike = Union[
-    str,
-    Pauli,
     SparsePauliOp,
-    MappingType[Union[str, Pauli], complex],
-    Iterable[Union[str, Pauli, SparsePauliOp]],
+    ObservableKeyLike,
+    MappingType[ObservableKeyLike, complex],
 ]
 """Types that can be natively used to construct a :const:`BasisObservable`."""
 
@@ -36,32 +37,33 @@ ObservableLike = Union[
 class Observable(Mapping):
     """A sparse container for a Hermitian observable for an :class:`.Estimator` primitive."""
 
-    __slots__ = ("_data", "_num_qubits", "_terms")
+    __slots__ = ("_data", "_num_qubits")
 
     def __init__(
         self,
-        data: Mapping[str, complex],
+        data: Mapping[ObservableKey, complex],
+        num_qubits: int = None,
         validate: bool = True,
     ):
         """Initialize an observables array.
 
         Args:
             data: The observable data.
+            num_qubits: The number of qubits in the data.
             validate: If ``True``, the input data is validated during initialization.
 
         Raises:
             ValueError: If ``validate=True`` and the input observable-like is not valid.
         """
         self._data = data
-        self._num_qubits: int = len(next(iter(data)))
-        self._terms: str = ""
+        self._num_qubits = num_qubits
         if validate:
             self.validate()
 
     def __repr__(self):
         return f"{type(self).__name__}({self._data})"
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: ObservableKey) -> complex:
         return self._data[key]
 
     def __iter__(self):
@@ -71,28 +73,38 @@ class Observable(Mapping):
         return len(self._data)
 
     @property
-    def terms(self) -> str:
-        """Return a string containing all unique basis terms used in the observable"""
-        if not self._terms:
-            # QUESTION: Should terms be `tuple[str, ...]` instead
-            # to allow for basis identification using more than 1 character?
-            self._terms = "".join(set().union(*self._data))
-        return self._terms
-
-    @property
     def num_qubits(self) -> int:
         """The number of qubits in the observable"""
+        if self._num_qubits is None:
+            num_qubits = 0
+            for term in self._data:
+                num_qubits = max(num_qubits, 1 + max(term.qubits))
+            self._num_qubits = num_qubits
         return self._num_qubits
 
     def validate(self):
         """Validate the consistency in observables array."""
         if not isinstance(self._data, Mapping):
             raise TypeError(f"Observable data type {type(self._data)} is not a Mapping.")
+
+        # If not already set, we set terms and num_qubits while iterating over data
+        # to avoid having to do another iteration later
+        term_nq = 0
         for key, value in self._data.items():
-            if not isinstance(key, str):
-                raise TypeError(f"Item {key} is not a str")
+            if not isinstance(key, tuple):
+                raise TypeError("Invalid Observable key type")
+            if len(key) != 2:
+                raise ValueError(f"Invalid Observable key value {key}")
+            # Check tuple pos types after checking length
+            if not isinstance(key[0], tuple) or not isinstance(key[1], str):
+                raise TypeError("Invalid Observable key type")
+            term_nq = max(term_nq, 1 + max(key[0]))
             if not isinstance(value, Complex):
                 raise TypeError(f"Value {value} is not a complex number")
+        if self._num_qubits is None:
+            self._num_qubits = term_nq
+        elif self.num_qubits < term_nq:
+            raise ValueError("Num qubits is less than the maximum qubit in ObservableTerms")
 
     @classmethod
     def coerce(cls, observable: ObservableLike) -> Observable:
@@ -108,45 +120,43 @@ class Observable(Mapping):
             TypeError: If the input cannot be formatted because its type is not valid.
             ValueError: If the input observable is invalid.
         """
+        return cls._coerce(observable, num_qubits=None)
 
+    @classmethod
+    def _coerce(cls, observable, num_qubits=None):
         # Pauli-type conversions
         if isinstance(observable, SparsePauliOp):
-            # Call simplify to combine duplicate keys before converting to a mapping
+            # TODO: Make sparse by removing identity in terms
             data = dict(observable.simplify(atol=0).to_list())
-            return cls.coerce(data)
+            return cls._coerce(data, num_qubits=observable.num_qubits)
 
-        if isinstance(observable, Pauli):
-            label, phase = observable[:].to_label(), observable.phase
-            data = {label: 1} if phase == 0 else {label: (-1j) ** phase}
-            return cls.coerce(data)
-
-        # String conversion
-        if isinstance(observable, str):
-            return cls.coerce({observable: 1})
+        if isinstance(observable, (Pauli, str, tuple)):
+            return cls._coerce({observable: 1}, num_qubits=num_qubits)
 
         # Mapping conversion (with possible Pauli keys)
         if isinstance(observable, Mapping):
-            # NOTE: This assumes length of keys is number of qubits
-            #       this might not be very robust
-            # We also compute terms while iterating to save doing it again later
-            terms = set()
-            num_qubits = len(next(iter(observable)))
+            term_qubits = set()
             unique = defaultdict(complex)
-            for basis, coeff in observable.items():
-                if isinstance(basis, Pauli):
-                    basis, phase = basis[:].to_label(), basis.phase
+            for term, coeff in observable.items():
+                if isinstance(term, Pauli):
+                    # TODO: Make sparse by removing identity terms
+                    label, phase = term[:].to_label(), term.phase
                     if phase != 0:
                         coeff = coeff * (-1j) ** phase
-                # Validate basis
-                if len(basis) != num_qubits:
-                    raise ValueError(
-                        "Number of qubits must be the same for all observable basis elements."
-                    )
-                terms = terms.union(basis)
-                unique[basis] += coeff
-            obs = Observable(dict(unique))
-            # Manually set terms so a second iteration over data is not needed
-            obs._data = "".join(terms)
+                    qubits = tuple(range(term.num_qubits))
+                    term = (qubits, label)
+                elif isinstance(term, str):
+                    qubits = tuple(range(len(term)))
+                    term = (qubits, term)
+                if not isinstance(term, tuple):
+                    raise TypeError(f"Invalid term type {type(term)}")
+                if len(term) != 2:
+                    raise ValueError(f"Invalid term {term}")
+                term_qubits.update(term[0])
+                unique[term] += coeff
+            if num_qubits is None:
+                num_qubits = 1 + max(term_qubits)
+            obs = Observable(dict(unique), num_qubits=num_qubits)
             return obs
 
         raise TypeError(f"Invalid observable type: {type(observable)}")

--- a/qiskit/primitives/containers/observables_array.py
+++ b/qiskit/primitives/containers/observables_array.py
@@ -58,21 +58,47 @@ class ObservablesArray(ShapedMixin):
             observables = observables._array
         self._array = object_array(observables, copy=copy, list_types=(PauliList,))
         self._shape = self._array.shape
+        self._num_qubits = None
+        self._terms = None
         if validate:
             # Convert array items to Observable objects
-            # and validate they are on the same number of qubits
-            num_qubits = None
+            # and set terms and num_qubits, validating consistency
+            terms = set()
+            num_qubits = set()
             for ndi, obs in np.ndenumerate(self._array):
-                basis_obs = Observable.coerce(obs)
-                basis_num_qubits = len(next(iter(basis_obs)))
-                if num_qubits is None:
-                    num_qubits = basis_num_qubits
-                elif basis_num_qubits != num_qubits:
+                obs = Observable.coerce(obs)
+                terms.update(obs.terms)
+                num_qubits.add(obs.num_qubits)
+                if len(num_qubits) > 1:
                     raise ValueError(
                         "The number of qubits must be the same for all observables in the "
                         "observables array."
                     )
-                self._array[ndi] = basis_obs
+                self._array[ndi] = obs
+            self._num_qubits = num_qubits
+            self._terms = "".join(terms)
+
+    @property
+    def terms(self) -> str:
+        """Return a string containing all unique basis terms used in the observable"""
+        if not self._terms:
+            # QUESTION: Should terms be `tuple[str, ...]` instead
+            # to allow for basis identification using more than 1 character?
+            self._terms = "".join(set().union(*(elem.terms for elem in self._array.ravel())))
+        return self._terms
+
+    @property
+    def num_qubits(self) -> int:
+        """The number of qubits in the observable"""
+        if self._num_qubits is None:
+            qubits = {elem.num_qubits for elem in self._array.ravel()}
+            if len(qubits) > 1:
+                raise ValueError(
+                    "The number of qubits must be the same for all observables in the "
+                    "observables array."
+                )
+            self._num_qubits = next(iter(qubits))
+        return self._num_qubits
 
     def __repr__(self):
         prefix = f"{type(self).__name__}("
@@ -115,7 +141,10 @@ class ObservablesArray(ShapedMixin):
         Returns:
             A new array.
         """
-        return ObservablesArray(self._array.reshape(shape), copy=False, validate=False)
+        obs = ObservablesArray(self._array.reshape(shape), copy=False, validate=False)
+        obs._num_qubits = self._num_qubits
+        obs._terms = self._terms
+        return obs
 
     def ravel(self) -> ObservablesArray:
         """Return a new array with one dimension.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This aims to add a concrete container class type for the items in an `ObservableArray` which was an oversite when adding that container.

This is important so that we can use this to abstract away the internal storage format of an observable from how it is constructed for Estimator inputs, and consumed by Estimator primitive developers.

### Details and comments

Some open questions / ideas:
- Should the abc for this class be a `Mapping` or `Sequence` to define the developer API for how it is iterated over and accessed.
- What should the item types be?
  - We should make the internal format of the Observable sparse in terms of qubits rather than full strings
  - Do we need a BaseObservable that doesn't assume the allowed strings (ie "basis") supported by a vendor Estimator implementation, then we should have `ObservableArray[BaseObservable]` and `EstimatorPub[BaseObservable]` as templated types?
  - We should not use single-character representations for "basis" terms in strings, but a type of strings to allow custom label for basis observables supported by a vendor Estimator