### PR TITLE
Fix cibuildwheel config for building 32bit Python 3.12 wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ target-version = ['py38', 'py39', 'py310', 'py311']
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
 skip = "pp* cp36-* cp37-* *musllinux*"
-test-skip = "cp310-win32 cp310-manylinux_i686 cp311-win32 cp311-manylinux_i686"
+test-skip = "cp310-win32 cp310-manylinux_i686 cp311-win32 cp311-manylinux_i686 cp312-win32 cp312-manylinux_i686"
 test-command = "python {project}/examples/python/stochastic_swap.py"
 # We need to use pre-built versions of Numpy and Scipy in the tests; they have a
 # tendency to crash if they're installed from source by `pip install`, and since


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue that was triggered during the 0.45.1 and 0.45.2 releases (the first two release with Python 3.12 support). Just as with Python 3.10 and 3.11 there were no precompiled binaries available as wheels for numpy and scipy which prevents us from testing the wheels in CI. However, when we added Python 3.12 support we neglected to also skip tests on the 32bit platforms with 3.12 too. This causes the CI wheel publish jobs to fail because they try unsuccessfully to install scipy and numpy. This commit fixes this oversight by also excluding Python 3.12 tests on these platforms. This isn't needed on `main` because for future releases we've downgraded 32 bit platform support to Tier 3 which doesn't run tests after wheel builds. This should be forward ported to stable/0.46 as we'll need it there too.

### Details and comments