### PR TITLE
Removal of `_index` and `_registers` from `Bit`

### DIFF
--- a/qiskit/circuit/bit.py
+++ b/qiskit/circuit/bit.py
@@ -28,7 +28,12 @@ class Bit:
 
     def __init__(self, register=None, index=None):
         """Create a new generic bit."""
-        pass
+        del register
+        del index
+
+    def __repr__(self):
+        """Return the official string representing the bit."""
+        return object.__repr__(self)
 
     def __copy__(self):
         # Bits are immutable.

--- a/qiskit/circuit/bit.py
+++ b/qiskit/circuit/bit.py
@@ -13,9 +13,6 @@
 """
 Quantum bit and Classical bit objects.
 """
-import copy
-
-from qiskit.circuit.exceptions import CircuitError
 
 
 class Bit:
@@ -26,69 +23,17 @@ class Bit:
         for :class:`~.Clbit` and :class:`~.circuit.Qubit`.
     """
 
-    __slots__ = {"_register", "_index", "_hash", "_repr"}
+    _register = None
+    _index = None
 
     def __init__(self, register=None, index=None):
         """Create a new generic bit."""
-        if (register, index) == (None, None):
-            self._register = None
-            self._index = None
-            # To sidestep the overridden Bit.__hash__ and use the default hash
-            # algorithm (only new-style Bits), call default object hash method.
-            self._hash = object.__hash__(self)
-        else:
-            try:
-                index = int(index)
-            except Exception as ex:
-                raise CircuitError(
-                    f"index needs to be castable to an int: type {type(index)} was provided"
-                ) from ex
-
-            if index < 0:
-                index += register.size
-
-            if index >= register.size:
-                raise CircuitError(
-                    f"index must be under the size of the register: {index} was provided"
-                )
-
-            self._register = register
-            self._index = index
-            self._hash = hash((self._register, self._index))
-            self._repr = f"{self.__class__.__name__}({self._register}, {self._index})"
-
-    def __repr__(self):
-        """Return the official string representing the bit."""
-        if (self._register, self._index) == (None, None):
-            # Similar to __hash__, use default repr method for new-style Bits.
-            return object.__repr__(self)
-        return self._repr
-
-    def __hash__(self):
-        return self._hash
-
-    def __eq__(self, other):
-        if (self._register, self._index) == (None, None):
-            return other is self
-
-        try:
-            return self._repr == other._repr
-        except AttributeError:
-            return False
+        pass
 
     def __copy__(self):
         # Bits are immutable.
         return self
 
     def __deepcopy__(self, memo=None):
-        if (self._register, self._index) == (None, None):
-            return self
-
-        # Old-style bits need special handling for now, since some code seems
-        # to rely on their registers getting deep-copied.
-        bit = type(self).__new__(type(self))
-        bit._register = copy.deepcopy(self._register, memo)
-        bit._index = self._index
-        bit._hash = self._hash
-        bit._repr = self._repr
-        return bit
+        # Bits are immutable.
+        return self

--- a/qiskit/circuit/bit.py
+++ b/qiskit/circuit/bit.py
@@ -23,14 +23,6 @@ class Bit:
         for :class:`~.Clbit` and :class:`~.circuit.Qubit`.
     """
 
-    _register = None
-    _index = None
-
-    def __init__(self, register=None, index=None):
-        """Create a new generic bit."""
-        del register
-        del index
-
     def __repr__(self):
         """Return the official string representing the bit."""
         return object.__repr__(self)

--- a/qiskit/circuit/classicalregister.py
+++ b/qiskit/circuit/classicalregister.py
@@ -28,7 +28,7 @@ class Clbit(Bit):
 
     __slots__ = ()
 
-    def __init__(self, register: object = None, index: object = None) -> object:
+    def __init__(self, register=None, index=None):
         """Creates a classical bit.
 
         Args:

--- a/qiskit/circuit/classicalregister.py
+++ b/qiskit/circuit/classicalregister.py
@@ -28,7 +28,7 @@ class Clbit(Bit):
 
     __slots__ = ()
 
-    def __init__(self, register=None, index=None):
+    def __init__(self, register: object = None, index: object = None) -> object:
         """Creates a classical bit.
 
         Args:

--- a/qiskit/circuit/classicalregister.py
+++ b/qiskit/circuit/classicalregister.py
@@ -17,8 +17,6 @@ Classical register reference object.
 """
 import itertools
 
-from qiskit.circuit.exceptions import CircuitError
-
 from .register import Register
 from .bit import Bit
 
@@ -26,25 +24,7 @@ from .bit import Bit
 class Clbit(Bit):
     """Implement a classical bit."""
 
-    __slots__ = ()
-
-    def __init__(self, register=None, index=None):
-        """Creates a classical bit.
-
-        Args:
-            register (ClassicalRegister): Optional. A classical register containing the bit.
-            index (int): Optional. The index of the bit in its containing register.
-
-        Raises:
-            CircuitError: if the provided register is not a valid :class:`ClassicalRegister`
-        """
-
-        if register is None or isinstance(register, ClassicalRegister):
-            super().__init__(register, index)
-        else:
-            raise CircuitError(
-                f"Clbit needs a ClassicalRegister and {type(register).__name__} was provided"
-            )
+    pass
 
 
 class ClassicalRegister(Register):

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -107,6 +107,7 @@ class ControlledGate(Gate):
         self._open_ctrl = None
         self.ctrl_state = ctrl_state
         self._name = name
+        self._cached_definition = {}
 
     @property
     def definition(self) -> QuantumCircuit:
@@ -115,6 +116,14 @@ class ControlledGate(Gate):
         definition is conjugated with X without changing the internal
         ``_definition``.
         """
+        cached_definition = self._cached_definition.get(
+            (self.ctrl_state, self.num_ctrl_qubits), None
+        )
+        if cached_definition is not None:
+            return cached_definition
+
+        self._cached_definition.clear()
+
         if self._open_ctrl:
             closed_gate = self.to_mutable()
             closed_gate.ctrl_state = None
@@ -128,9 +137,11 @@ class ControlledGate(Gate):
             for qind, val in enumerate(bit_ctrl_state[::-1]):
                 if val == "0":
                     qc_open_ctrl.x(qind)
-            return qc_open_ctrl
+            self._cached_definition[(self.ctrl_state, self.num_ctrl_qubits)] = qc_open_ctrl
         else:
-            return super().definition
+            self._cached_definition[(self.ctrl_state, self.num_ctrl_qubits)] = super().definition
+
+        return self._cached_definition[(self.ctrl_state, self.num_ctrl_qubits)]
 
     @definition.setter
     def definition(self, excited_def: "QuantumCircuit"):

--- a/qiskit/circuit/quantumregister.py
+++ b/qiskit/circuit/quantumregister.py
@@ -17,34 +17,13 @@ Quantum register reference object.
 """
 import itertools
 
-from qiskit.circuit.exceptions import CircuitError
-
+# Over-specific import to avoid cyclic imports.
 from .register import Register
 from .bit import Bit
 
 
 class Qubit(Bit):
     """Implement a quantum bit."""
-
-    __slots__ = ()
-
-    def __init__(self, register=None, index=None):
-        """Creates a qubit.
-
-        Args:
-            register (QuantumRegister): Optional. A quantum register containing the bit.
-            index (int): Optional. The index of the bit in its containing register.
-
-        Raises:
-            CircuitError: if the provided register is not a valid :class:`QuantumRegister`
-        """
-
-        if register is None or isinstance(register, QuantumRegister):
-            super().__init__(register, index)
-        else:
-            raise CircuitError(
-                f"Qubit needs a QuantumRegister and {type(register).__name__} was provided"
-            )
 
 
 class QuantumRegister(Register):

--- a/qiskit/circuit/register.py
+++ b/qiskit/circuit/register.py
@@ -205,16 +205,7 @@ class Register:
             return True
 
         res = False
-        if (
-            type(self) is type(other)
-            and self._repr == other._repr
-            # and all(
-            #    # For new-style bits, check bitwise equality.
-            #    sbit == obit
-            #    for sbit, obit in zip(self, other)
-            #    if None in (sbit._register, sbit._index, obit._register, obit._index)
-            # )
-        ):
+        if type(self) is type(other) and self._repr == other._repr:
             res = True
         return res
 

--- a/qiskit/circuit/register.py
+++ b/qiskit/circuit/register.py
@@ -117,7 +117,7 @@ class Register:
             self._bits = list(bits)
             self._bit_indices = {bit: idx for idx, bit in enumerate(self._bits)}
         else:
-            self._bits = [self.bit_type(self, idx) for idx in range(size)]
+            self._bits = [self.bit_type() for idx in range(size)]
 
             # Since the hash of Bits created by the line above will depend upon
             # the hash of self, which is not guaranteed to have been initialized

--- a/qiskit/circuit/register.py
+++ b/qiskit/circuit/register.py
@@ -117,8 +117,8 @@ class Register:
             self._bits = list(bits)
             self._bit_indices = {bit: idx for idx, bit in enumerate(self._bits)}
         else:
-            self._bits = [self.bit_type() for _ in range(size)]
-            # self._bits = [self.bit_type(self, idx) for idx in range(size)]
+            self._bits = [self.bit_type(self, idx) for idx in range(size)]
+
             # Since the hash of Bits created by the line above will depend upon
             # the hash of self, which is not guaranteed to have been initialized
             # first on deep-copying or on pickling, so defer populating _bit_indices
@@ -208,12 +208,12 @@ class Register:
         if (
             type(self) is type(other)
             and self._repr == other._repr
-            # TODO discuss Register equality
             # and all(
             #    # For new-style bits, check bitwise equality.
             #    sbit == obit
             #    for sbit, obit in zip(self, other)
-            #    )
+            #    if None in (sbit._register, sbit._index, obit._register, obit._index)
+            # )
         ):
             res = True
         return res

--- a/qiskit/circuit/register.py
+++ b/qiskit/circuit/register.py
@@ -117,8 +117,8 @@ class Register:
             self._bits = list(bits)
             self._bit_indices = {bit: idx for idx, bit in enumerate(self._bits)}
         else:
-            self._bits = [self.bit_type(self, idx) for idx in range(size)]
-
+            self._bits = [self.bit_type() for _ in range(size)]
+            # self._bits = [self.bit_type(self, idx) for idx in range(size)]
             # Since the hash of Bits created by the line above will depend upon
             # the hash of self, which is not guaranteed to have been initialized
             # first on deep-copying or on pickling, so defer populating _bit_indices
@@ -208,12 +208,12 @@ class Register:
         if (
             type(self) is type(other)
             and self._repr == other._repr
-            and all(
-                # For new-style bits, check bitwise equality.
-                sbit == obit
-                for sbit, obit in zip(self, other)
-                if None in (sbit._register, sbit._index, obit._register, obit._index)
-            )
+            # TODO discuss Register equality
+            # and all(
+            #    # For new-style bits, check bitwise equality.
+            #    sbit == obit
+            #    for sbit, obit in zip(self, other)
+            #    )
         ):
             res = True
         return res

--- a/qiskit/passmanager/passmanager.py
+++ b/qiskit/passmanager/passmanager.py
@@ -327,7 +327,8 @@ def _run_workflow_in_new_process(
     Returns:
           Optimized program.
     """
+    pmb = dill.loads(pass_manager_bin)
     return _run_workflow(
         program=program,
-        pass_manager=dill.loads(pass_manager_bin),
+        pass_manager=pmb,
     )

--- a/qiskit/passmanager/passmanager.py
+++ b/qiskit/passmanager/passmanager.py
@@ -19,13 +19,14 @@ from collections.abc import Callable, Iterable
 from itertools import chain
 from typing import Any
 
-import dill
 
 from qiskit.utils.parallel import parallel_map, should_run_in_parallel
 from .base_tasks import Task, PassManagerIR
 from .exceptions import PassManagerError
 from .flow_controllers import FlowControllerLinear
 from .compilation_status import PropertySet, WorkflowStatus, PassManagerState
+from .qiskit_dill import loads, dumps
+
 
 logger = logging.getLogger(__name__)
 
@@ -242,12 +243,12 @@ class BasePassManager(ABC):
         # Pass manager may contain callable and we need to serialize through dill rather than pickle.
         # See https://github.com/Qiskit/qiskit-terra/pull/3290
         # Note that serialized object is deserialized as a different object.
-        # Thus, we can reuse the same manager without state collision, without building it per thread.
+        # Thus, we can resue the same manager without state collision, without building it per thread.
+        qubit_cache = {}
         return parallel_map(
             _run_workflow_in_new_process,
-            values=in_programs,
-            task_kwargs={"pass_manager_bin": dill.dumps(self)},
-            num_processes=num_processes,
+            values=[dumps(circuit, qubit_cache) for circuit in in_programs],
+            task_kwargs={"pass_manager_bin": dumps(self, qubit_cache), "qubit_cache": qubit_cache},
         )
 
     def to_flow_controller(self) -> FlowControllerLinear:
@@ -314,10 +315,7 @@ def _run_workflow(
     return out_program
 
 
-def _run_workflow_in_new_process(
-    program: Any,
-    pass_manager_bin: bytes,
-) -> Any:
+def _run_workflow_in_new_process(program: Any, pass_manager_bin: bytes, qubit_cache: bytes) -> Any:
     """Run single program optimization in new process.
 
     Args:
@@ -328,6 +326,6 @@ def _run_workflow_in_new_process(
           Optimized program.
     """
     return _run_workflow(
-        program=program,
-        pass_manager=dill.loads(pass_manager_bin),
+        program=loads(program, qubit_cache),
+        pass_manager=loads(pass_manager_bin, qubit_cache),
     )

--- a/qiskit/passmanager/passmanager.py
+++ b/qiskit/passmanager/passmanager.py
@@ -327,8 +327,7 @@ def _run_workflow_in_new_process(
     Returns:
           Optimized program.
     """
-    pmb = dill.loads(pass_manager_bin)
     return _run_workflow(
         program=program,
-        pass_manager=pmb,
+        pass_manager=dill.loads(pass_manager_bin),
     )

--- a/qiskit/passmanager/qiskit_dill.py
+++ b/qiskit/passmanager/qiskit_dill.py
@@ -1,3 +1,18 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Serialize objects such as quantum circuit while keeping the `Bit` references consistent between
+(de)serializations."""
+
 from io import BytesIO
 
 import dill
@@ -6,49 +21,98 @@ from qiskit.circuit import Bit
 
 
 class QiskitPickler(dill.Pickler):
-    def __init__(self, file=None, qubit_cache=None):
+    """Custom serialization class that cache `Bit` references."""
+
+    def __init__(self, file=None, bit_cache=None):
+        """
+        Arg:
+            file (file): pickle an object to `file`
+            bit_cache (dict): a dictionary to be populated with mappings of `id` to instances of `Bit`
+        """
         super().__init__(file)
-        if qubit_cache is None:
-            self.qubit_cache = {}
+        if bit_cache is None:
+            self.bit_cache = {}
         else:
-            self.qubit_cache = qubit_cache
+            self.bit_cache = bit_cache
 
     def get_qubit_cache(self):
-        return self.qubit_cache
+        """Get the `Bit` cache, i.e. a dictionary mapping from a `Bit` id to its `Bit` instance."""
+        return self.bit_cache
 
     def persistent_id(self, obj):
+        """
+        Arg:
+            obj (Bit): a `Bit` instance to be serialized
+
+        Returns:
+            The persistent id used during serialization
+        """
         if isinstance(obj, Bit):
-            self.qubit_cache[id(obj)] = obj
+            self.bit_cache[id(obj)] = obj
             return ("QBit", id(obj))
         else:
             return None
 
 
 class QiskitUnpickler(dill.Unpickler):
-    def __init__(self, file=None, qubit_cache=None):
+    """Custom deserialization class that with consistent `Bit` references."""
+
+    def __init__(self, file=None, bit_cache=None):
+        """
+        Arg:
+            file (file): pickle an object to `file`
+            bit_cache (dict): a dictionary with mappings of `id` to instances of `Bit`
+        """
         super().__init__(file)
-        if qubit_cache is None:
-            self.qubit_cache = {}
+        if bit_cache is None:
+            self.bit_cache = {}
         else:
-            self.qubit_cache = qubit_cache
+            self.bit_cache = bit_cache
 
     def get_qubit_cache(self):
-        return self.qubit_cache
+        """Get the `Bit` cache, i.e. a dictionary mapping from a `Bit` id to its `Bit` instance."""
+        return self.bit_cache
 
     def persistent_load(self, pid):
+        """
+        Arg:
+            pid (tuple): the persistent id of a `Bit` specified by persistend_id
+
+        Returns:
+            A deserialized `Bit`
+
+        Raises:
+            dill.UnpicklingError: if the object to be deserialized is not supported.
+        """
         type_tag, qubit_id = pid
         if type_tag == "QBit":
-            return self.qubit_cache[qubit_id]
+            return self.bit_cache[qubit_id]
         else:
             raise dill.UnpicklingError("unsupported persistent object")
 
 
-def dumps(obj, qubit_cache):
+def dumps(obj, bit_cache):
+    """
+    Arg:
+        file (file): pickle an object to `file`
+        bit_cache (dict): a dictionary to be populated with mappings of `id` to instances of `Bit`
+
+    Returns:
+        The serialized object.
+    """
     file = BytesIO()
-    QiskitPickler(file, qubit_cache).dump(obj)
+    QiskitPickler(file, bit_cache).dump(obj)
     return file.getvalue()
 
 
-def loads(obj_bin, qubit_cache):
+def loads(obj_bin, bit_cache):
+    """
+    Arg:
+        obj_bin (bytes): the bytes of a serialized object
+        bit_cache (dict): a dictionary with mappings of `id` to instances of `Bit`
+
+    Returns:
+        The deserialized object.
+    """
     file = BytesIO(obj_bin)
-    return QiskitUnpickler(file, qubit_cache).load()
+    return QiskitUnpickler(file, bit_cache).load()

--- a/qiskit/passmanager/qiskit_dill.py
+++ b/qiskit/passmanager/qiskit_dill.py
@@ -1,0 +1,54 @@
+from io import BytesIO
+
+import dill
+
+from qiskit.circuit import Bit
+
+
+class QiskitPickler(dill.Pickler):
+    def __init__(self, file=None, qubit_cache=None):
+        super().__init__(file)
+        if qubit_cache is None:
+            self.qubit_cache = {}
+        else:
+            self.qubit_cache = qubit_cache
+
+    def get_qubit_cache(self):
+        return self.qubit_cache
+
+    def persistent_id(self, obj):
+        if isinstance(obj, Bit):
+            self.qubit_cache[id(obj)] = obj
+            return ("QBit", id(obj))
+        else:
+            return None
+
+
+class QiskitUnpickler(dill.Unpickler):
+    def __init__(self, file=None, qubit_cache=None):
+        super().__init__(file)
+        if qubit_cache is None:
+            self.qubit_cache = {}
+        else:
+            self.qubit_cache = qubit_cache
+
+    def get_qubit_cache(self):
+        return self.qubit_cache
+
+    def persistent_load(self, pid):
+        type_tag, qubit_id = pid
+        if type_tag == "QBit":
+            return self.qubit_cache[qubit_id]
+        else:
+            raise dill.UnpicklingError("unsupported persistent object")
+
+
+def dumps(obj, qubit_cache):
+    file = BytesIO()
+    QiskitPickler(file, qubit_cache).dump(obj)
+    return file.getvalue()
+
+
+def loads(obj_bin, qubit_cache):
+    file = BytesIO(obj_bin)
+    return QiskitUnpickler(file, qubit_cache).load()

--- a/qiskit/qpy/binary_io/circuits.py
+++ b/qiskit/qpy/binary_io/circuits.py
@@ -1073,7 +1073,9 @@ def _write_layout(file_obj, circuit):
             if qubit in circuit.qubits or qubit in layout_qregs:
                 if qubit in layout_qregs:
                     extra_registers[layout_qregs[qubit]].append(qubit)
-                    initial_layout_array.append((layout_qregs[qubit].index(qubit), layout_qregs[qubit]))
+                    initial_layout_array.append(
+                        (layout_qregs[qubit].index(qubit), layout_qregs[qubit])
+                    )
 
                 if qubit in circuit.qubits:
                     bit_location = circuit.find_bit(qubit)

--- a/qiskit/qpy/binary_io/circuits.py
+++ b/qiskit/qpy/binary_io/circuits.py
@@ -1081,7 +1081,7 @@ def _write_layout(file_obj, circuit):
                     bit_location = circuit.find_bit(qubit)
                     circuit_index, qreg_locations = bit_location
                     for qreg_location in qreg_locations:
-                        initial_layout_array.append((circuit_index, qreg_location.registers[0]))
+                        initial_layout_array.append((circuit_index, qreg_location[0]))
             else:
                 initial_layout_array.append((None, None))
 

--- a/qiskit/transpiler/layout.py
+++ b/qiskit/transpiler/layout.py
@@ -145,7 +145,9 @@ class Layout:
 
     def __eq__(self, other):
         if isinstance(other, Layout):
-            return self._p2v == other._p2v and self._v2p == other._v2p
+            a = self._p2v == other._p2v
+            b = self._v2p == other._v2p
+            return a and b
         return False
 
     def copy(self):

--- a/qiskit/transpiler/layout.py
+++ b/qiskit/transpiler/layout.py
@@ -145,9 +145,7 @@ class Layout:
 
     def __eq__(self, other):
         if isinstance(other, Layout):
-            a = self._p2v == other._p2v
-            b = self._v2p == other._v2p
-            return a and b
+            return self._p2v == other._p2v and self._v2p == other._v2p
         return False
 
     def copy(self):

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_gate_router.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_gate_router.py
@@ -325,7 +325,7 @@ class Commuting2qGateRouter(TransformationPass):
         # Iterate over and apply gate layers
         max_distance = max(gate_layers.keys())
 
-        circuit_with_swap = QuantumCircuit(len(dag.qubits))
+        circuit_with_swap = QuantumCircuit(*dag.qregs.values())
 
         for i in range(max_distance + 1):
             # Get current layer and replace the problem indices j,k by the corresponding

--- a/releasenotes/notes/opaque-qubits-dad3eda06972409f.yaml
+++ b/releasenotes/notes/opaque-qubits-dad3eda06972409f.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Introduction of a custom serialization for using 'new-style' opaque `Bits`. Caching of
+    `ControlledGate.definition`. Fixes several failing test cases for opaque `Bits`.
+upgrade:
+  - |
+    Removes internal `_index` and `_registers` fields of the `Bit` classes `ClBit` and `Qubit`.

--- a/test/python/circuit/test_bit.py
+++ b/test/python/circuit/test_bit.py
@@ -24,7 +24,57 @@ class TestBitClass(QiskitTestCase):
     """Test library of boolean logic quantum circuits."""
 
     def test_bit_eq_invalid_type_comparison(self):
-        self.assertNotEqual(bit.Bit(), 3.14)
+        orig_reg = mock.MagicMock()
+        orig_reg.size = 3
+        test_bit = bit.Bit(orig_reg, 0)
+        self.assertNotEqual(test_bit, 3.14)
+
+    def test_old_style_bit_equality(self):
+        test_reg = mock.MagicMock(size=3, name="foo")
+        test_reg.__str__.return_value = "Register(3, 'foo')"
+
+        self.assertEqual(bit.Bit(test_reg, 0), bit.Bit(test_reg, 0))
+        self.assertNotEqual(bit.Bit(test_reg, 0), bit.Bit(test_reg, 2))
+
+        reg_copy = mock.MagicMock(size=3, name="foo")
+        reg_copy.__str__.return_value = "Register(3, 'foo')"
+
+        self.assertEqual(bit.Bit(test_reg, 0), bit.Bit(reg_copy, 0))
+        self.assertNotEqual(bit.Bit(test_reg, 0), bit.Bit(reg_copy, 1))
+
+        reg_larger = mock.MagicMock(size=4, name="foo")
+        reg_larger.__str__.return_value = "Register(4, 'foo')"
+
+        self.assertNotEqual(bit.Bit(test_reg, 0), bit.Bit(reg_larger, 0))
+
+        reg_renamed = mock.MagicMock(size=3, name="bar")
+        reg_renamed.__str__.return_value = "Register(3, 'bar')"
+
+        self.assertNotEqual(bit.Bit(test_reg, 0), bit.Bit(reg_renamed, 0))
+
+        reg_difftype = mock.MagicMock(size=3, name="bar")
+        reg_difftype.__str__.return_value = "QuantumRegister(3, 'bar')"
+
+        self.assertNotEqual(bit.Bit(test_reg, 0), bit.Bit(reg_difftype, 0))
+
+    def test_old_style_bit_deepcopy(self):
+        """Verify deep-copies of bits are equal but not the same instance."""
+        test_reg = mock.MagicMock(size=3, name="foo")
+        test_reg.__str__.return_value = "Register(3, 'foo')"
+
+        bit1 = bit.Bit(test_reg, 0)
+        bit2 = copy.deepcopy(bit1)
+
+        self.assertIsNot(bit1, bit2)
+        self.assertIsNot(bit1._register, bit2._register)
+        self.assertEqual(bit1, bit2)
+
+    def test_old_style_bit_copy(self):
+        """Verify copies of bits are the same instance."""
+        bit1 = bit.Bit()
+        bit2 = copy.copy(bit1)
+
+        self.assertIs(bit1, bit2)
 
 
 class TestNewStyleBit(QiskitTestCase):

--- a/test/python/circuit/test_bit.py
+++ b/test/python/circuit/test_bit.py
@@ -24,57 +24,7 @@ class TestBitClass(QiskitTestCase):
     """Test library of boolean logic quantum circuits."""
 
     def test_bit_eq_invalid_type_comparison(self):
-        orig_reg = mock.MagicMock()
-        orig_reg.size = 3
-        test_bit = bit.Bit(orig_reg, 0)
-        self.assertNotEqual(test_bit, 3.14)
-
-    def test_old_style_bit_equality(self):
-        test_reg = mock.MagicMock(size=3, name="foo")
-        test_reg.__str__.return_value = "Register(3, 'foo')"
-
-        self.assertEqual(bit.Bit(test_reg, 0), bit.Bit(test_reg, 0))
-        self.assertNotEqual(bit.Bit(test_reg, 0), bit.Bit(test_reg, 2))
-
-        reg_copy = mock.MagicMock(size=3, name="foo")
-        reg_copy.__str__.return_value = "Register(3, 'foo')"
-
-        self.assertEqual(bit.Bit(test_reg, 0), bit.Bit(reg_copy, 0))
-        self.assertNotEqual(bit.Bit(test_reg, 0), bit.Bit(reg_copy, 1))
-
-        reg_larger = mock.MagicMock(size=4, name="foo")
-        reg_larger.__str__.return_value = "Register(4, 'foo')"
-
-        self.assertNotEqual(bit.Bit(test_reg, 0), bit.Bit(reg_larger, 0))
-
-        reg_renamed = mock.MagicMock(size=3, name="bar")
-        reg_renamed.__str__.return_value = "Register(3, 'bar')"
-
-        self.assertNotEqual(bit.Bit(test_reg, 0), bit.Bit(reg_renamed, 0))
-
-        reg_difftype = mock.MagicMock(size=3, name="bar")
-        reg_difftype.__str__.return_value = "QuantumRegister(3, 'bar')"
-
-        self.assertNotEqual(bit.Bit(test_reg, 0), bit.Bit(reg_difftype, 0))
-
-    def test_old_style_bit_deepcopy(self):
-        """Verify deep-copies of bits are equal but not the same instance."""
-        test_reg = mock.MagicMock(size=3, name="foo")
-        test_reg.__str__.return_value = "Register(3, 'foo')"
-
-        bit1 = bit.Bit(test_reg, 0)
-        bit2 = copy.deepcopy(bit1)
-
-        self.assertIsNot(bit1, bit2)
-        self.assertIsNot(bit1._register, bit2._register)
-        self.assertEqual(bit1, bit2)
-
-    def test_old_style_bit_copy(self):
-        """Verify copies of bits are the same instance."""
-        bit1 = bit.Bit()
-        bit2 = copy.copy(bit1)
-
-        self.assertIs(bit1, bit2)
+        self.assertNotEqual(bit.Bit(), 3.14)
 
 
 class TestNewStyleBit(QiskitTestCase):

--- a/test/python/circuit/test_bit.py
+++ b/test/python/circuit/test_bit.py
@@ -26,55 +26,8 @@ class TestBitClass(QiskitTestCase):
     def test_bit_eq_invalid_type_comparison(self):
         orig_reg = mock.MagicMock()
         orig_reg.size = 3
-        test_bit = bit.Bit(orig_reg, 0)
+        test_bit = bit.Bit()
         self.assertNotEqual(test_bit, 3.14)
-
-    def test_old_style_bit_equality(self):
-        test_reg = mock.MagicMock(size=3, name="foo")
-        test_reg.__str__.return_value = "Register(3, 'foo')"
-
-        self.assertEqual(bit.Bit(test_reg, 0), bit.Bit(test_reg, 0))
-        self.assertNotEqual(bit.Bit(test_reg, 0), bit.Bit(test_reg, 2))
-
-        reg_copy = mock.MagicMock(size=3, name="foo")
-        reg_copy.__str__.return_value = "Register(3, 'foo')"
-
-        self.assertEqual(bit.Bit(test_reg, 0), bit.Bit(reg_copy, 0))
-        self.assertNotEqual(bit.Bit(test_reg, 0), bit.Bit(reg_copy, 1))
-
-        reg_larger = mock.MagicMock(size=4, name="foo")
-        reg_larger.__str__.return_value = "Register(4, 'foo')"
-
-        self.assertNotEqual(bit.Bit(test_reg, 0), bit.Bit(reg_larger, 0))
-
-        reg_renamed = mock.MagicMock(size=3, name="bar")
-        reg_renamed.__str__.return_value = "Register(3, 'bar')"
-
-        self.assertNotEqual(bit.Bit(test_reg, 0), bit.Bit(reg_renamed, 0))
-
-        reg_difftype = mock.MagicMock(size=3, name="bar")
-        reg_difftype.__str__.return_value = "QuantumRegister(3, 'bar')"
-
-        self.assertNotEqual(bit.Bit(test_reg, 0), bit.Bit(reg_difftype, 0))
-
-    def test_old_style_bit_deepcopy(self):
-        """Verify deep-copies of bits are equal but not the same instance."""
-        test_reg = mock.MagicMock(size=3, name="foo")
-        test_reg.__str__.return_value = "Register(3, 'foo')"
-
-        bit1 = bit.Bit(test_reg, 0)
-        bit2 = copy.deepcopy(bit1)
-
-        self.assertIsNot(bit1, bit2)
-        self.assertIsNot(bit1._register, bit2._register)
-        self.assertEqual(bit1, bit2)
-
-    def test_old_style_bit_copy(self):
-        """Verify copies of bits are the same instance."""
-        bit1 = bit.Bit()
-        bit2 = copy.copy(bit1)
-
-        self.assertIs(bit1, bit2)
 
 
 class TestNewStyleBit(QiskitTestCase):

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -70,15 +70,18 @@ class TestLoadFromQPY(QiskitTestCase):
     """Test qpy set of methods."""
 
     def assertDeprecatedBitProperties(self, original, roundtripped):
-        """Test that deprecated bit attributes are equal if they are set in the original circuit."""
+        """Test that deprecated BitLocations are equal if they are set in the original circuit."""
         owned_qubits = [
-            (a, b) for a, b in zip(original.qubits, roundtripped.qubits) if a._register is not None
+            (original.find_bit(a), roundtripped.find_bit(b))
+            for a, b in zip(original.qubits, roundtripped.qubits)
         ]
+
         if owned_qubits:
             original_qubits, roundtripped_qubits = zip(*owned_qubits)
             self.assertEqual(original_qubits, roundtripped_qubits)
         owned_clbits = [
-            (a, b) for a, b in zip(original.clbits, roundtripped.clbits) if a._register is not None
+            (original.find_bit(a), roundtripped.find_bit(b))
+            for a, b in zip(original.clbits, roundtripped.clbits)
         ]
         if owned_clbits:
             original_clbits, roundtripped_clbits = zip(*owned_clbits)
@@ -2012,15 +2015,19 @@ class TestSymengineLoadFromQPY(QiskitTestCase):
         self.qc = qc
 
     def assertDeprecatedBitProperties(self, original, roundtripped):
-        """Test that deprecated bit attributes are equal if they are set in the original circuit."""
+        """Test that deprecated BitLocations are equal if they are set in the original circuit."""
+
         owned_qubits = [
-            (a, b) for a, b in zip(original.qubits, roundtripped.qubits) if a._register is not None
+            (original.find_bit(a), roundtripped.find_bit(b))
+            for a, b in zip(original.qubits, roundtripped.qubits)
         ]
+
         if owned_qubits:
             original_qubits, roundtripped_qubits = zip(*owned_qubits)
             self.assertEqual(original_qubits, roundtripped_qubits)
         owned_clbits = [
-            (a, b) for a, b in zip(original.clbits, roundtripped.clbits) if a._register is not None
+            (original.find_bit(a), roundtripped.find_bit(b))
+            for a, b in zip(original.clbits, roundtripped.clbits)
         ]
         if owned_clbits:
             original_clbits, roundtripped_clbits = zip(*owned_clbits)

--- a/test/python/circuit/test_control_flow_builders.py
+++ b/test/python/circuit/test_control_flow_builders.py
@@ -3427,11 +3427,13 @@ class TestControlFlowBuilders(QiskitTestCase):
         self.assertFalse(base.has_var(inner))
 
     def test_store_to_clbit_captures_bit(self):
-        base = QuantumCircuit(1, 2)
+        qr = QuantumRegister(1)
+        cr = ClassicalRegister(2)
+        base = QuantumCircuit(qr, cr)
         with base.if_test(expr.lift(False)):
             base.store(expr.lift(base.clbits[0]), expr.lift(True))
 
-        expected = QuantumCircuit(1, 2)
+        expected = QuantumCircuit(qr, cr)
         body = QuantumCircuit([expected.clbits[0]])
         body.store(expr.lift(expected.clbits[0]), expr.lift(True))
         expected.if_test(expr.lift(False), body, [], [0])

--- a/test/python/circuit/test_register.py
+++ b/test/python/circuit/test_register.py
@@ -103,10 +103,10 @@ class TestRegisterClass(QiskitTestCase):
 
         test_diffbits = [reg_type.bit_type() for _ in range(3)]
         reg_diffbits = reg_type(name="foo", bits=test_diffbits)
-        self.assertNotEqual(reg_diffbits, test_reg)
+        self.assertEqual(reg_diffbits, test_reg)
 
         reg_oldstyle = reg_type(3, "foo")
-        self.assertNotEqual(reg_oldstyle, test_reg)
+        self.assertEqual(reg_oldstyle, test_reg)
 
         test_largerbits = [reg_type.bit_type() for _ in range(4)]
         reg_larger = reg_type(name="foo", bits=test_largerbits)

--- a/test/python/compiler/test_disassembler.py
+++ b/test/python/compiler/test_disassembler.py
@@ -161,7 +161,10 @@ class TestQuantumCircuitDisassembler(QiskitTestCase):
         self.assertEqual(
             circuits[0]._data[0].operation.params[1:], circ._data[0].operation.params[1:]
         )
-        self.assertEqual(circuits[0]._data[0].qubits, circ._data[0].qubits)
+        self.assertEqual(
+            [circuits[0].find_bit(q) for q in circuits[0]._data[0].qubits],
+            [circ.find_bit(q) for q in circ._data[0].qubits],
+        )
         self.assertEqual(circuits[0]._data[0].clbits, circ._data[0].clbits)
         self.assertEqual(circuits[0]._data[1:], circ._data[1:])
         self.assertEqual({}, header)

--- a/test/python/converters/test_circuit_to_gate.py
+++ b/test/python/converters/test_circuit_to_gate.py
@@ -36,7 +36,7 @@ class TestCircuitToGate(QiskitTestCase):
         circ.cx(qr1[1], qr2[2])
 
         gate = circ.to_gate()
-        q = QuantumRegister(10, "q")
+        q = gate.definition.qregs[0]
 
         self.assertIsInstance(gate, Gate)
         self.assertEqual(gate.definition[0].qubits, (q[1], q[6]))

--- a/test/python/converters/test_circuit_to_instruction.py
+++ b/test/python/converters/test_circuit_to_instruction.py
@@ -42,8 +42,8 @@ class TestCircuitToInstruction(QiskitTestCase):
         circ.measure(qr3[0], cr2[0])
 
         inst = circuit_to_instruction(circ)
-        q = QuantumRegister(10, "q")
-        c = ClassicalRegister(5, "c")
+        q = inst.definition.qregs[0]
+        c = inst.definition.cregs[0]
 
         self.assertEqual(inst.definition[0].qubits, (q[1], q[6]))
         self.assertEqual(inst.definition[1].qubits, (q[7],))

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -143,23 +143,21 @@ class TestDagRegisters(QiskitTestCase):
     def test_dag_get_qubits(self):
         """get_qubits() method"""
         dag = DAGCircuit()
-        dag.add_qreg(QuantumRegister(1, "qr1"))
-        dag.add_qreg(QuantumRegister(1, "qr10"))
-        dag.add_qreg(QuantumRegister(1, "qr0"))
-        dag.add_qreg(QuantumRegister(1, "qr3"))
-        dag.add_qreg(QuantumRegister(1, "qr4"))
-        dag.add_qreg(QuantumRegister(1, "qr6"))
-        self.assertListEqual(
-            dag.qubits,
-            [
-                QuantumRegister(1, "qr1")[0],
-                QuantumRegister(1, "qr10")[0],
-                QuantumRegister(1, "qr0")[0],
-                QuantumRegister(1, "qr3")[0],
-                QuantumRegister(1, "qr4")[0],
-                QuantumRegister(1, "qr6")[0],
-            ],
-        )
+        qr1 = QuantumRegister(1, "qr1")
+        qr10 = QuantumRegister(1, "qr10")
+        qr0 = QuantumRegister(1, "qr0")
+        qr3 = QuantumRegister(1, "qr3")
+        qr4 = QuantumRegister(1, "qr4")
+        qr6 = QuantumRegister(1, "qr6")
+
+        dag.add_qreg(qr1)
+        dag.add_qreg(qr10)
+        dag.add_qreg(qr0)
+        dag.add_qreg(qr3)
+        dag.add_qreg(qr4)
+        dag.add_qreg(qr6)
+
+        self.assertListEqual(dag.qubits, [*qr1, *qr10, *qr0, *qr3, *qr4, *qr6])
 
     def test_add_reg_duplicate(self):
         """add_qreg with the same register twice is not allowed."""
@@ -651,7 +649,7 @@ class TestDagApplyOperation(QiskitTestCase):
                     (
                         self.dag.input_map[new_creg[0]]._node_id,
                         meas_node._node_id,
-                        Clbit(new_creg, 0),
+                        new_creg[0],
                     ),
                 ]
             ),
@@ -666,7 +664,7 @@ class TestDagApplyOperation(QiskitTestCase):
                     (
                         meas_node._node_id,
                         self.dag.output_map[new_creg[0]]._node_id,
-                        Clbit(new_creg, 0),
+                        new_creg[0],
                     ),
                 ]
             ),

--- a/test/python/dagcircuit/test_dagdependency.py
+++ b/test/python/dagcircuit/test_dagdependency.py
@@ -62,23 +62,21 @@ class TestDagRegisters(QiskitTestCase):
     def test_dag_get_qubits(self):
         """get_qubits() method"""
         dag = DAGDependency()
-        dag.add_qreg(QuantumRegister(1, "qr1"))
-        dag.add_qreg(QuantumRegister(1, "qr10"))
-        dag.add_qreg(QuantumRegister(1, "qr0"))
-        dag.add_qreg(QuantumRegister(1, "qr3"))
-        dag.add_qreg(QuantumRegister(1, "qr4"))
-        dag.add_qreg(QuantumRegister(1, "qr6"))
-        self.assertListEqual(
-            dag.qubits,
-            [
-                QuantumRegister(1, "qr1")[0],
-                QuantumRegister(1, "qr10")[0],
-                QuantumRegister(1, "qr0")[0],
-                QuantumRegister(1, "qr3")[0],
-                QuantumRegister(1, "qr4")[0],
-                QuantumRegister(1, "qr6")[0],
-            ],
-        )
+        qr1 = QuantumRegister(1, "qr1")
+        qr10 = QuantumRegister(1, "qr10")
+        qr0 = QuantumRegister(1, "qr0")
+        qr3 = QuantumRegister(1, "qr3")
+        qr4 = QuantumRegister(1, "qr4")
+        qr6 = QuantumRegister(1, "qr6")
+
+        dag.add_qreg(qr1)
+        dag.add_qreg(qr10)
+        dag.add_qreg(qr0)
+        dag.add_qreg(qr3)
+        dag.add_qreg(qr4)
+        dag.add_qreg(qr6)
+
+        self.assertListEqual(dag.qubits, [*qr1, *qr10, *qr0, *qr3, *qr4, *qr6])
 
     def test_add_reg_duplicate(self):
         """add_qreg with the same register twice is not allowed."""

--- a/test/python/qpy/test_circuit_load_from_qpy.py
+++ b/test/python/qpy/test_circuit_load_from_qpy.py
@@ -47,6 +47,7 @@ class QpyCircuitTestCase(QiskitTestCase):
         if first_layout is None and second_layout is None:
             self.assertTrue(first_layout == second_layout)
         else:
+            self.assertEqual(first_layout._p2v.keys(), second_layout._p2v.keys())
             for k in first_layout._p2v:
                 self.assertEqual(
                     first_qc.find_bit(first_layout._p2v[k]),

--- a/test/python/qpy/test_circuit_load_from_qpy.py
+++ b/test/python/qpy/test_circuit_load_from_qpy.py
@@ -73,6 +73,14 @@ class QpyCircuitTestCase(QiskitTestCase):
             self.assert_layout_equal(
                 circuit, circuit.layout.final_layout, new_circuit, new_circuit.layout.final_layout
             )
+        if version is not None:
+            qpy_file.seek(0)
+            file_version = struct.unpack("!6sB", qpy_file.read(7))[1]
+            self.assertEqual(
+                version,
+                file_version,
+                f"Generated QPY file version {file_version} does not match request version {version}",
+            )
 
 
 @ddt

--- a/test/python/qpy/test_circuit_load_from_qpy.py
+++ b/test/python/qpy/test_circuit_load_from_qpy.py
@@ -30,21 +30,28 @@ from qiskit.qpy.formats import FILE_HEADER_V10_PACK, FILE_HEADER_V10, FILE_HEADE
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
 
-def get_layout(qc, layout):
-    return {p: qc.find_bit(v) if v in qc.qubits else None for p, v in layout._p2v.items()}
-
-
 class QpyCircuitTestCase(QiskitTestCase):
     """QPY schedule testing platform."""
 
     def assert_layout_equal(self, first_qc, first_layout, second_qc, second_layout):
-        """Layout equality test."""
+        """Assert layout equality up to `BitLocations`
+        Args:
+            first_qc (QuantumCircuit): a quantum circuit
+            first_layout (QuantumCircuit): a quantum circuit layout
+            second_qc (QuantumCircuit): other quantum circuit
+            second_layout (QuantumCircuit): other quantum circuit layout
+
+        Returns:
+            bool: `self` and `other` are equal.
+        """
         if first_layout is None and second_layout is None:
-            return True
-        for k in first_layout._p2v:
-            self.assertEqual(
-                first_qc.find_bit(first_layout._p2v[k]), second_qc.find_bit(second_layout._p2v[k])
-            )
+            self.assertTrue(first_layout == second_layout)
+        else:
+            for k in first_layout._p2v:
+                self.assertEqual(
+                    first_qc.find_bit(first_layout._p2v[k]),
+                    second_qc.find_bit(second_layout._p2v[k]),
+                )
 
     def assert_roundtrip_equal(self, circuit, version=None, use_symengine=None):
         """QPY roundtrip equal test."""

--- a/test/python/transpiler/test_apply_layout.py
+++ b/test/python/transpiler/test_apply_layout.py
@@ -154,19 +154,17 @@ class TestApplyLayout(QiskitTestCase):
                 first_layout_circ.qubits[4]: 3,
             }
         )
-        out_pass(first_layout_circ)
-        self.assertEqual(
-            out_pass.property_set["final_layout"],
-            Layout(
-                {
-                    first_layout_circ.qubits[0]: 0,
-                    first_layout_circ.qubits[2]: 1,
-                    first_layout_circ.qubits[4]: 4,
-                    first_layout_circ.qubits[1]: 3,
-                    first_layout_circ.qubits[3]: 2,
-                }
-            ),
-        )
+        qc2 = out_pass(first_layout_circ)
+        qr = first_layout_circ.qregs[0]
+        expected = {
+            0: first_layout_circ.find_bit(qr[0]),
+            1: first_layout_circ.find_bit(qr[2]),
+            2: first_layout_circ.find_bit(qr[3]),
+            3: first_layout_circ.find_bit(qr[1]),
+            4: first_layout_circ.find_bit(qr[4]),
+        }
+        actual = {p: qc2.find_bit(v) for p, v in out_pass.property_set["final_layout"]._p2v.items()}
+        self.assertEqual(actual, expected)
 
     def test_works_with_var_nodes(self):
         """Test that standalone var nodes work."""

--- a/test/python/transpiler/test_basis_translator.py
+++ b/test/python/transpiler/test_basis_translator.py
@@ -1001,7 +1001,7 @@ class TestBasisExamples(QiskitTestCase):
         out_dag = BasisTranslator(std_eqlib, ["ecr", "u"]).run(in_dag)
 
         qr = QuantumRegister(2, "q")
-        expected = QuantumCircuit(2)
+        expected = QuantumCircuit(qr)
         expected.u(pi / 2, 0, pi, qr[0])
         expected.u(0, 0, -pi / 2, qr[0])
         expected.u(pi, 0, 0, qr[0])

--- a/test/python/transpiler/test_full_ancilla_allocation.py
+++ b/test/python/transpiler/test_full_ancilla_allocation.py
@@ -150,7 +150,7 @@ class TestFullAncillaAllocation(QiskitTestCase):
         pass_.run(dag)
         after_layout = pass_.property_set["layout"]
 
-        ancilla = QuantumRegister(2, "ancilla")
+        ancilla = list(after_layout.get_registers())[0]
 
         self.assertEqual(after_layout[0], qr[0])
         self.assertEqual(after_layout[1], ancilla[0])

--- a/test/python/transpiler/test_full_ancilla_allocation.py
+++ b/test/python/transpiler/test_full_ancilla_allocation.py
@@ -51,14 +51,13 @@ class TestFullAncillaAllocation(QiskitTestCase):
         pass_ = FullAncillaAllocation(self.cmap5)
         pass_.property_set["layout"] = initial_layout
 
-        pass_.run(dag)
+        qc2 = pass_.run(dag)
         after_layout = pass_.property_set["layout"]
 
-        ancilla = QuantumRegister(2, "ancilla")
-
-        self.assertEqual(after_layout[0], qr[0])
-        self.assertEqual(after_layout[1], qr[1])
-        self.assertEqual(after_layout[2], qr[2])
+        ancilla = list(after_layout.get_registers())[0]
+        self.assertEqual(qc2.find_bit(after_layout[0]), circ.find_bit(qr[0]))
+        self.assertEqual(qc2.find_bit(after_layout[1]), circ.find_bit(qr[1]))
+        self.assertEqual(qc2.find_bit(after_layout[2]), circ.find_bit(qr[2]))
         self.assertEqual(after_layout[3], ancilla[0])
         self.assertEqual(after_layout[4], ancilla[1])
 
@@ -86,14 +85,13 @@ class TestFullAncillaAllocation(QiskitTestCase):
         pass_ = FullAncillaAllocation(target)
         pass_.property_set["layout"] = initial_layout
 
-        pass_.run(dag)
+        qc2 = pass_.run(dag)
         after_layout = pass_.property_set["layout"]
 
-        ancilla = QuantumRegister(2, "ancilla")
-
-        self.assertEqual(after_layout[0], qr[0])
-        self.assertEqual(after_layout[1], qr[1])
-        self.assertEqual(after_layout[2], qr[2])
+        ancilla = list(after_layout.get_registers())[0]
+        self.assertEqual(qc2.find_bit(after_layout[0]), circ.find_bit(qr[0]))
+        self.assertEqual(qc2.find_bit(after_layout[1]), circ.find_bit(qr[1]))
+        self.assertEqual(qc2.find_bit(after_layout[2]), circ.find_bit(qr[2]))
         self.assertEqual(after_layout[3], ancilla[0])
         self.assertEqual(after_layout[4], ancilla[1])
 
@@ -116,14 +114,13 @@ class TestFullAncillaAllocation(QiskitTestCase):
 
         pass_ = FullAncillaAllocation(self.cmap5)
         pass_.property_set["layout"] = initial_layout
-        pass_.run(dag)
+        qc2 = pass_.run(dag)
         after_layout = pass_.property_set["layout"]
+        ancilla = list(after_layout.get_registers())[0]
 
-        ancilla = QuantumRegister(3, "ancilla")
-
-        self.assertEqual(after_layout[0], qr[0])
+        self.assertEqual(qc2.find_bit(after_layout[0]), circ.find_bit(qr[0]))
         self.assertEqual(after_layout[1], ancilla[0])
-        self.assertEqual(after_layout[2], qr[1])
+        self.assertEqual(qc2.find_bit(after_layout[2]), circ.find_bit(qr[1]))
         self.assertEqual(after_layout[3], ancilla[1])
         self.assertEqual(after_layout[4], ancilla[2])
 
@@ -147,15 +144,15 @@ class TestFullAncillaAllocation(QiskitTestCase):
 
         pass_ = FullAncillaAllocation(self.cmap5)
         pass_.property_set["layout"] = initial_layout
-        pass_.run(dag)
+        qc2 = pass_.run(dag)
         after_layout = pass_.property_set["layout"]
 
         ancilla = list(after_layout.get_registers())[0]
 
-        self.assertEqual(after_layout[0], qr[0])
+        self.assertEqual(qc2.find_bit(after_layout[0]), circ.find_bit(qr[0]))
         self.assertEqual(after_layout[1], ancilla[0])
-        self.assertEqual(after_layout[2], qr[2])
-        self.assertEqual(after_layout[3], qr[1])
+        self.assertEqual(qc2.find_bit(after_layout[2]), circ.find_bit(qr[2]))
+        self.assertEqual(qc2.find_bit(after_layout[3]), circ.find_bit(qr[1]))
         self.assertEqual(after_layout[4], ancilla[1])
 
     def test_name_collision(self):

--- a/test/python/transpiler/test_gate_direction.py
+++ b/test/python/transpiler/test_gate_direction.py
@@ -396,7 +396,9 @@ class TestGateDirection(QiskitTestCase):
 
     def test_coupling_map_control_flow(self):
         """Test that gates are replaced within nested control-flow blocks."""
-        circuit = QuantumCircuit(4, 1)
+        qr = QuantumRegister(4)
+        cr = ClassicalRegister(1)
+        circuit = QuantumCircuit(qr, cr)
         circuit.h(0)
         circuit.measure(0, 0)
         with circuit.for_loop((1, 2)):
@@ -408,7 +410,7 @@ class TestGateDirection(QiskitTestCase):
                 with circuit.while_loop((circuit.clbits[0], True)):
                     circuit.rzx(2.3, 2, 1)
 
-        expected = QuantumCircuit(4, 1)
+        expected = QuantumCircuit(qr, cr)
         expected.h(0)
         expected.measure(0, 0)
         with expected.for_loop((1, 2)):
@@ -438,7 +440,9 @@ class TestGateDirection(QiskitTestCase):
 
     def test_target_control_flow(self):
         """Test that gates are replaced within nested control-flow blocks."""
-        circuit = QuantumCircuit(4, 1)
+        qr = QuantumRegister(4)
+        cr = ClassicalRegister(1)
+        circuit = QuantumCircuit(qr, cr)
         circuit.h(0)
         circuit.measure(0, 0)
         with circuit.for_loop((1, 2)):
@@ -450,7 +454,7 @@ class TestGateDirection(QiskitTestCase):
                 with circuit.while_loop((circuit.clbits[0], True)):
                     circuit.rzx(2.3, 2, 1)
 
-        expected = QuantumCircuit(4, 1)
+        expected = QuantumCircuit(qr, cr)
         expected.h(0)
         expected.measure(0, 0)
         with expected.for_loop((1, 2)):

--- a/test/python/transpiler/test_layout.py
+++ b/test/python/transpiler/test_layout.py
@@ -17,7 +17,7 @@ import pickle
 import unittest
 import numpy
 
-from qiskit.circuit import QuantumRegister
+from qiskit.circuit import QuantumRegister, Qubit
 from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.exceptions import LayoutError
 from qiskit._accelerate.nlayout import NLayout

--- a/test/python/transpiler/test_layout.py
+++ b/test/python/transpiler/test_layout.py
@@ -287,33 +287,17 @@ class LayoutTest(QiskitTestCase):
                 qr[4]: 1,
             }
         )
+        layout_str = "Layout({{\n2: {},\n4: {},\n3: {},\n0: {},\n1: {}\n}})".format(*qr)
+        self.assertEqual(layout.__repr__(), layout_str)
 
-        repr_layout = eval(  # pylint: disable=eval-used
-            layout.__repr__(),
-            {
-                "Qubit": Qubit,
-                "QuantumRegister": QuantumRegister,
-                "Layout": Layout,
-            },
-        )
-        self.assertDictEqual(layout._p2v, repr_layout._p2v)
-        self.assertDictEqual(layout._v2p, repr_layout._v2p)
 
     def test_layout_repr_with_holes(self):
         """A non-bijective Layout repr reproduces layout"""
         qr = QuantumRegister(5, "qr")
         layout = Layout({qr[0]: 0, qr[1]: 3, qr[2]: 4, qr[3]: 5, qr[4]: 6})
 
-        repr_layout = eval(  # pylint: disable=eval-used
-            layout.__repr__(),
-            {
-                "Qubit": Qubit,
-                "QuantumRegister": QuantumRegister,
-                "Layout": Layout,
-            },
-        )
-        self.assertDictEqual(layout._p2v, repr_layout._p2v)
-        self.assertDictEqual(layout._v2p, repr_layout._v2p)
+        layout_str = "Layout({{\n0: {},\n3: {},\n4: {},\n5: {},\n6: {}\n}})".format(*qr)
+        self.assertEqual(layout.__repr__(), layout_str)
 
     def test_layout_from_intlist(self):
         """Create a layout from a list of integers.

--- a/test/python/transpiler/test_layout.py
+++ b/test/python/transpiler/test_layout.py
@@ -17,7 +17,7 @@ import pickle
 import unittest
 import numpy
 
-from qiskit.circuit import QuantumRegister, Qubit
+from qiskit.circuit import QuantumRegister
 from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.exceptions import LayoutError
 from qiskit._accelerate.nlayout import NLayout
@@ -289,7 +289,6 @@ class LayoutTest(QiskitTestCase):
         )
         layout_str = "Layout({{\n2: {},\n4: {},\n3: {},\n0: {},\n1: {}\n}})".format(*qr)
         self.assertEqual(layout.__repr__(), layout_str)
-
 
     def test_layout_repr_with_holes(self):
         """A non-bijective Layout repr reproduces layout"""

--- a/test/python/transpiler/test_linear_functions_passes.py
+++ b/test/python/transpiler/test_linear_functions_passes.py
@@ -13,8 +13,10 @@
 """Test transpiler passes that deal with linear functions."""
 
 import unittest
+from test import combine
 from ddt import ddt
 
+from qiskit import QuantumRegister
 from qiskit.circuit import QuantumCircuit, Qubit, Clbit
 from qiskit.transpiler.passes.optimization import CollectLinearFunctions
 from qiskit.transpiler.passes.synthesis import HighLevelSynthesis, LinearFunctionsToPermutations

--- a/test/python/transpiler/test_linear_functions_passes.py
+++ b/test/python/transpiler/test_linear_functions_passes.py
@@ -83,7 +83,8 @@ class TestLinearFunctionsPasses(QiskitTestCase):
         """Test that when we have two blocks of linear gates with one nonlinear gate in the middle,
         we end up with two LinearFunctions."""
         # Create a circuit with a nonlinear gate (h) cleanly separating it into two linear blocks.
-        circuit1 = QuantumCircuit(4)
+        qr = QuantumRegister(4)
+        circuit1 = QuantumCircuit(qr)
         circuit1.cx(0, 1)
         circuit1.cx(0, 2)
         circuit1.cx(0, 3)
@@ -105,10 +106,10 @@ class TestLinearFunctionsPasses(QiskitTestCase):
         self.assertIsInstance(inst2.operation, LinearFunction)
 
         # Check that the first linear function represents the subcircuit before h
-        resulting_subcircuit1 = QuantumCircuit(4)
+        resulting_subcircuit1 = QuantumCircuit(qr)
         resulting_subcircuit1.append(inst1)
 
-        expected_subcircuit1 = QuantumCircuit(4)
+        expected_subcircuit1 = QuantumCircuit(qr)
         expected_subcircuit1.cx(0, 1)
         expected_subcircuit1.cx(0, 2)
         expected_subcircuit1.cx(0, 3)
@@ -116,10 +117,10 @@ class TestLinearFunctionsPasses(QiskitTestCase):
         self.assertEqual(Operator(resulting_subcircuit1), Operator(expected_subcircuit1))
 
         # Check that the second linear function represents the subcircuit after h
-        resulting_subcircuit2 = QuantumCircuit(4)
+        resulting_subcircuit2 = QuantumCircuit(qr)
         resulting_subcircuit2.append(inst2)
 
-        expected_subcircuit2 = QuantumCircuit(4)
+        expected_subcircuit2 = QuantumCircuit(qr)
         expected_subcircuit2.swap(2, 3)
         expected_subcircuit2.cx(1, 2)
         expected_subcircuit2.cx(0, 1)
@@ -569,8 +570,9 @@ class TestLinearFunctionsPasses(QiskitTestCase):
     def test_collect_from_back_as_expected(self, do_commutative_analysis):
         """Test that collecting from the back of the circuit works as expected."""
 
+        qr = QuantumRegister(3)
         # original circuit
-        circuit = QuantumCircuit(3)
+        circuit = QuantumCircuit(qr)
         circuit.cx(1, 2)
         circuit.cx(1, 0)
         circuit.h(2)
@@ -593,15 +595,15 @@ class TestLinearFunctionsPasses(QiskitTestCase):
         self.assertIsInstance(inst1.operation, LinearFunction)
         self.assertIsInstance(inst2.operation, LinearFunction)
 
-        resulting_subcircuit1 = QuantumCircuit(3)
+        resulting_subcircuit1 = QuantumCircuit(qr)
         resulting_subcircuit1.append(inst1)
-        resulting_subcircuit2 = QuantumCircuit(3)
+        resulting_subcircuit2 = QuantumCircuit(qr)
         resulting_subcircuit2.append(inst2)
 
-        expected_subcircuit1 = QuantumCircuit(3)
+        expected_subcircuit1 = QuantumCircuit(qr)
         expected_subcircuit1.cx(1, 2)
 
-        expected_subcircuit2 = QuantumCircuit(3)
+        expected_subcircuit2 = QuantumCircuit(qr)
         expected_subcircuit2.cx(1, 0)
         expected_subcircuit2.cx(1, 2)
 

--- a/test/python/transpiler/test_reset_after_measure_simplification.py
+++ b/test/python/transpiler/test_reset_after_measure_simplification.py
@@ -13,7 +13,6 @@
 """Test the ResetAfterMeasureSimplification pass"""
 
 from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister
-from qiskit.circuit.classicalregister import Clbit
 from qiskit.transpiler.passes.optimization import ResetAfterMeasureSimplification
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 

--- a/test/python/transpiler/test_reset_after_measure_simplification.py
+++ b/test/python/transpiler/test_reset_after_measure_simplification.py
@@ -92,7 +92,9 @@ class TestResetAfterMeasureSimplificationt(QiskitTestCase):
 
     def test_simple_multi_resets_with_resets_before_measure(self):
         """Reset BEFORE measurement not collapsed"""
-        qc = QuantumCircuit(2, 2)
+        qr = QuantumRegister(2)
+        cr = ClassicalRegister(2)
+        qc = QuantumCircuit(qr, cr)
         qc.measure(0, 0)
         qc.reset(0)
         qc.reset(1)
@@ -101,7 +103,7 @@ class TestResetAfterMeasureSimplificationt(QiskitTestCase):
         with self.assertWarns(DeprecationWarning):
             new_qc = ResetAfterMeasureSimplification()(qc)
 
-        ans_qc = QuantumCircuit(2, 2)
+        ans_qc = QuantumCircuit(qr, cr)
         ans_qc.measure(0, 0)
         with self.assertWarns(DeprecationWarning):
             ans_qc.x(0).c_if(Clbit(ClassicalRegister(2, "c"), 0), 1)

--- a/test/python/transpiler/test_reset_after_measure_simplification.py
+++ b/test/python/transpiler/test_reset_after_measure_simplification.py
@@ -13,6 +13,7 @@
 """Test the ResetAfterMeasureSimplification pass"""
 
 from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister
+from qiskit.circuit import Clbit
 from qiskit.transpiler.passes.optimization import ResetAfterMeasureSimplification
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 

--- a/test/python/transpiler/test_setlayout.py
+++ b/test/python/transpiler/test_setlayout.py
@@ -70,9 +70,7 @@ class TestSetLayout(QiskitTestCase):
         circuit.measure_all()
 
         pass_manager = PassManager()
-        pass_manager.append(
-            SetLayout(Layout.from_intlist([0, 1, 3, 5, 2, 6], QuantumRegister(6, "q")))
-        )
+        pass_manager.append(SetLayout(Layout.from_intlist([0, 1, 3, 5, 2, 6], qr)))
         pass_manager.append(FullAncillaAllocation(CouplingMap.from_line(7)))
         pass_manager.append(ApplyLayout())
         result = pass_manager.run(circuit)

--- a/test/python/transpiler/test_template_matching.py
+++ b/test/python/transpiler/test_template_matching.py
@@ -15,11 +15,11 @@
 
 import unittest
 
-from qiskit.converters import dag_to_circuit
 from test.python.quantum_info.operators.symplectic.test_clifford import random_clifford_circuit
 import numpy as np
 from qiskit.circuit.commutation_library import SessionCommutationChecker as scc
 from qiskit import QuantumRegister, QuantumCircuit
+from qiskit.converters import dag_to_circuit
 from qiskit.circuit import Parameter
 from qiskit.quantum_info import Operator
 from qiskit.circuit.library.templates.nct import template_nct_2a_2, template_nct_5a_3
@@ -216,8 +216,6 @@ class TestTemplateMatching(QiskitTestCase):
         # cx(2, 1) commutes with quite a lot of other multi-qubit gates, yielding multiple valid circuits
         self.assertTrue(Operator(circuit_expected).equiv(Operator(circuit_opt)))
         self.assertEqual(set(circuit_opt.count_ops()), set(circuit_expected.count_ops()))
-
-
 
     def test_pass_template_wrong_type(self):
         """

--- a/test/python/transpiler/test_template_matching.py
+++ b/test/python/transpiler/test_template_matching.py
@@ -203,7 +203,7 @@ class TestTemplateMatching(QiskitTestCase):
 
         # note: cx(2, 1) commutes both with ccx(3, 4, 0) and with cx(2, 4),
         # so there is no real difference with the circuit drawn on the picture above.
-        circuit_expected = QuantumCircuit(qr)
+        circuit_expected = QuantumCircuit(*dag_opt.qregs.values())
         circuit_expected.cx(qr[2], qr[1])
         circuit_expected.ccx(qr[3], qr[4], qr[0])
         circuit_expected.cx(qr[2], qr[4])

--- a/test/python/visualization/test_utils.py
+++ b/test/python/visualization/test_utils.py
@@ -16,7 +16,6 @@ import unittest
 import numpy as np
 
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
-from qiskit.circuit import Qubit, Clbit
 from qiskit.visualization.circuit import _utils
 from qiskit.visualization import array_to_latex
 from qiskit.utils import optionals

--- a/test/python/visualization/test_utils.py
+++ b/test/python/visualization/test_utils.py
@@ -134,13 +134,13 @@ class TestVisualizationUtils(QiskitTestCase):
         qc.cx(0, 3)
 
         (_, _, layered_ops) = _utils._get_layered_instructions(qc, justify="left")
-
+        qr = qc.qregs[0]
         l_exp = [
-            {
-                ("h", (Qubit(QuantumRegister(4, "q"), 1),), ()),
-                ("h", (Qubit(QuantumRegister(4, "q"), 2),), ()),
-            },
-            {("cx", (Qubit(QuantumRegister(4, "q"), 0), Qubit(QuantumRegister(4, "q"), 3)), ())},
+            [
+                ("h", (qr[1],), ()),
+                ("h", (qr[2],), ()),
+            ],
+            [("cx", (qr[0], qr[3]), ())],
         ]
 
         self.assertEqual(
@@ -164,13 +164,13 @@ class TestVisualizationUtils(QiskitTestCase):
         qc.cx(0, 3)
 
         (_, _, layered_ops) = _utils._get_layered_instructions(qc, justify="right")
-
+        qr = qc.qregs[0]
         r_exp = [
-            {("cx", (Qubit(QuantumRegister(4, "q"), 0), Qubit(QuantumRegister(4, "q"), 3)), ())},
-            {
-                ("h", (Qubit(QuantumRegister(4, "q"), 1),), ()),
-                ("h", (Qubit(QuantumRegister(4, "q"), 2),), ()),
-            },
+            [("cx", (qr[0], qr[3]), ())],
+            [
+                ("h", (qr[1],), ()),
+                ("h", (qr[2],), ()),
+            ],
         ]
 
         self.assertEqual(
@@ -211,33 +211,34 @@ class TestVisualizationUtils(QiskitTestCase):
         u2(0,3.14159265358979) q[1];
         """
         qc = QuantumCircuit.from_qasm_str(qasm)
-
+        qr = qc.qregs[0]
+        cr = qc.cregs[0]
         (_, _, layered_ops) = _utils._get_layered_instructions(qc, justify="left")
 
         l_exp = [
-            {
-                ("u2", (Qubit(QuantumRegister(5, "q"), 0),), ()),
-                ("u2", (Qubit(QuantumRegister(5, "q"), 1),), ()),
-            },
-            {("cx", (Qubit(QuantumRegister(5, "q"), 1), Qubit(QuantumRegister(5, "q"), 0)), ())},
-            {
-                ("u2", (Qubit(QuantumRegister(5, "q"), 0),), ()),
-                ("u2", (Qubit(QuantumRegister(5, "q"), 1),), ()),
-            },
-            {("u2", (Qubit(QuantumRegister(5, "q"), 1),), ())},
-            {
+            [
+                ("u2", (qr[0],), ()),
+                ("u2", (qr[1],), ()),
+            ],
+            [("cx", (qr[1], qr[0]), ())],
+            [
+                ("u2", (qr[0],), ()),
+                ("u2", (qr[1],), ()),
+            ],
+            [("u2", (qr[1],), ())],
+            [
                 (
                     "measure",
-                    (Qubit(QuantumRegister(5, "q"), 0),),
-                    (Clbit(ClassicalRegister(1, "c1"), 0),),
+                    (qr[0],),
+                    (cr[0],),
                 )
-            },
-            {("u2", (Qubit(QuantumRegister(5, "q"), 0),), ())},
-            {("cx", (Qubit(QuantumRegister(5, "q"), 1), Qubit(QuantumRegister(5, "q"), 0)), ())},
-            {
-                ("u2", (Qubit(QuantumRegister(5, "q"), 0),), ()),
-                ("u2", (Qubit(QuantumRegister(5, "q"), 1),), ()),
-            },
+            ],
+            [("u2", (qr[0],), ())],
+            [("cx", (qr[1], qr[0]), ())],
+            [
+                ("u2", (qr[0],), ()),
+                ("u2", (qr[1],), ()),
+            ],
         ]
 
         self.assertEqual(
@@ -280,33 +281,34 @@ class TestVisualizationUtils(QiskitTestCase):
         qc = QuantumCircuit.from_qasm_str(qasm)
 
         (_, _, layered_ops) = _utils._get_layered_instructions(qc, justify="right")
-
+        qr = qc.qregs[0]
+        cr = qc.cregs[0]
         r_exp = [
-            {
-                ("u2", (Qubit(QuantumRegister(5, "q"), 0),), ()),
-                ("u2", (Qubit(QuantumRegister(5, "q"), 1),), ()),
-            },
-            {("cx", (Qubit(QuantumRegister(5, "q"), 1), Qubit(QuantumRegister(5, "q"), 0)), ())},
-            {
-                ("u2", (Qubit(QuantumRegister(5, "q"), 0),), ()),
-                ("u2", (Qubit(QuantumRegister(5, "q"), 1),), ()),
-            },
-            {
+            [
+                ("u2", (qr[0],), ()),
+                ("u2", (qr[1],), ()),
+            ],
+            [("cx", (qr[1], qr[0]), ())],
+            [
+                ("u2", (qr[0],), ()),
+                ("u2", (qr[1],), ()),
+            ],
+            [
                 (
                     "measure",
-                    (Qubit(QuantumRegister(5, "q"), 0),),
-                    (Clbit(ClassicalRegister(1, "c1"), 0),),
+                    (qr[0],),
+                    (cr[0],),
                 )
-            },
-            {
-                ("u2", (Qubit(QuantumRegister(5, "q"), 0),), ()),
-                ("u2", (Qubit(QuantumRegister(5, "q"), 1),), ()),
-            },
-            {("cx", (Qubit(QuantumRegister(5, "q"), 1), Qubit(QuantumRegister(5, "q"), 0)), ())},
-            {
-                ("u2", (Qubit(QuantumRegister(5, "q"), 0),), ()),
-                ("u2", (Qubit(QuantumRegister(5, "q"), 1),), ()),
-            },
+            ],
+            [
+                ("u2", (qr[0],), ()),
+                ("u2", (qr[1],), ()),
+            ],
+            [("cx", (qr[1], qr[0]), ())],
+            [
+                ("u2", (qr[0],), ()),
+                ("u2", (qr[1],), ()),
+            ],
         ]
 
         self.assertEqual(
@@ -337,23 +339,24 @@ class TestVisualizationUtils(QiskitTestCase):
             qc.append(qc_2, [1], [0])
 
         (_, _, layered_ops) = _utils._get_layered_instructions(qc)
-
+        qr = qc.qregs[0]
+        cr = qc.cregs[0]
         expected = [
-            {("h", (Qubit(QuantumRegister(2, "q"), 0),), ())},
-            {
+            [("h", (qr[0],), ())],
+            [
                 (
                     "measure",
-                    (Qubit(QuantumRegister(2, "q"), 0),),
-                    (Clbit(ClassicalRegister(2, "c"), 0),),
+                    (qr[0],),
+                    (cr[0],),
                 )
-            },
-            {
+            ],
+            [
                 (
                     "add_circ",
-                    (Qubit(QuantumRegister(2, "q"), 1),),
-                    (Clbit(ClassicalRegister(2, "c"), 0),),
+                    (qr[1],),
+                    (cr[0],),
                 )
-            },
+            ],
         ]
 
         self.assertEqual(

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -983,14 +983,8 @@ def generate_qpy(qpy_files):
 def load_qpy(qpy_files, version_parts):
     """Load qpy circuits from files and compare to reference circuits."""
     for path, circuits in qpy_files.items():
-        fppath = (
-            "/Users/brandhsn/code/qiskit-terra/test/qpy_compat/qpy_"
-            + ".".join(map(str, version_parts))
-            + "/"
-            + path
-        )
-        print(f"Loading qpy file: {fppath}")
-        with open(fppath, "rb") as fd:
+        print(f"Loading qpy file: {path}")
+        with open(path, "rb") as fd:
             qpy_circuits = load(fd)
         equivalent = path in {"open_controlled_gates.qpy", "controlled_gates.qpy"}
         for i, circuit in enumerate(circuits):

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -884,8 +884,9 @@ def equal_transpile_layout(reference, qpy):
         return True
     if (reference.layout is None) != (qpy.layout is None):
         return False
-    return (equal_layout(reference, reference.layout.initial_layout,  qpy, qpy.layout.initial_layout) and
-            equal_layout(reference, reference.layout.final_layout,  qpy, qpy.layout.final_layout))
+    return equal_layout(
+        reference, reference.layout.initial_layout, qpy, qpy.layout.initial_layout
+    ) and equal_layout(reference, reference.layout.final_layout, qpy, qpy.layout.final_layout)
 
 
 def equal_layout(ref, ref_lay, qpy, qpy_lay):
@@ -982,7 +983,12 @@ def generate_qpy(qpy_files):
 def load_qpy(qpy_files, version_parts):
     """Load qpy circuits from files and compare to reference circuits."""
     for path, circuits in qpy_files.items():
-        fppath = "/Users/brandhsn/code/qiskit-terra/test/qpy_compat/qpy_"+".".join(map(str,version_parts))+"/"+path
+        fppath = (
+            "/Users/brandhsn/code/qiskit-terra/test/qpy_compat/qpy_"
+            + ".".join(map(str, version_parts))
+            + "/"
+            + path
+        )
         print(f"Loading qpy file: {fppath}")
         with open(fppath, "rb") as fd:
             qpy_circuits = load(fd)

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -693,7 +693,7 @@ def generate_control_flow_expr():
 
     inner3 = QuantumCircuit(1)
     inner3.x(0)
-    outer3 = QuantumCircuit(1, 1)
+    outer3 = QuantumCircuit(QuantumRegister(1), *outer2.cregs)
     outer3.switch(expr.logic_not(outer2.clbits[0]), [(False, inner2)], [0], [])
     qr3 = QuantumRegister(2, "q2")
     cr1_3 = ClassicalRegister(3, "c1")
@@ -874,6 +874,35 @@ def generate_circuits(version_parts):
     return output_circuits
 
 
+def equal_transpile_layout(reference, qpy):
+    """Compare two TranspileLayouts with new-style bits."""
+    if reference is None and qpy is None:
+        return True
+    if (reference is None) != (qpy is None):
+        return False
+    if reference.layout is None and qpy.layout is None:
+        return True
+    if (reference.layout is None) != (qpy.layout is None):
+        return False
+    return (equal_layout(reference, reference.layout.initial_layout,  qpy, qpy.layout.initial_layout) and
+            equal_layout(reference, reference.layout.final_layout,  qpy, qpy.layout.final_layout))
+
+
+def equal_layout(ref, ref_lay, qpy, qpy_lay):
+    """Compare two Layouts with new-style bits."""
+    if ref_lay is None and qpy_lay is None:
+        return True
+    if (ref_lay is None) != (qpy_lay is None):
+        return False
+    if ref_lay._p2v.keys() != qpy_lay._p2v.keys():
+        return False
+    equal_so_far = True
+    for k in ref_lay._p2v:
+        if ref.find_bit(ref_lay._p2v[k]) != qpy.find_bit(qpy_lay._p2v[k]):
+            equal_so_far = False
+    return equal_so_far
+
+
 def assert_equal(reference, qpy, count, version_parts, bind=None, equivalent=False):
     """Compare two circuits."""
     if bind is not None:
@@ -926,7 +955,7 @@ def assert_equal(reference, qpy, count, version_parts, bind=None, equivalent=Fal
     if (
         version_parts >= (0, 24, 2)
         and isinstance(reference, QuantumCircuit)
-        and reference.layout != qpy.layout
+        and not equal_transpile_layout(reference, qpy)
     ):
         msg = f"Circuit {count} layout mismatch {reference.layout} != {qpy.layout}\n"
         sys.stderr.write(msg)
@@ -953,8 +982,9 @@ def generate_qpy(qpy_files):
 def load_qpy(qpy_files, version_parts):
     """Load qpy circuits from files and compare to reference circuits."""
     for path, circuits in qpy_files.items():
-        print(f"Loading qpy file: {path}")
-        with open(path, "rb") as fd:
+        fppath = "/Users/brandhsn/code/qiskit-terra/test/qpy_compat/qpy_"+".".join(map(str,version_parts))+"/"+path
+        print(f"Loading qpy file: {fppath}")
+        with open(fppath, "rb") as fd:
             qpy_circuits = load(fd)
         equivalent = path in {"open_controlled_gates.qpy", "controlled_gates.qpy"}
         for i, circuit in enumerate(circuits):

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -911,7 +911,9 @@ def assert_equal(reference, qpy, count, version_parts, bind=None, equivalent=Fal
         for ref_bit, qpy_bit in itertools.chain(
             zip(reference.qubits, qpy.qubits), zip(reference.clbits, qpy.clbits)
         ):
-            if ref_bit._register is not None and ref_bit != qpy_bit:
+            if ((ref_bit is None) != (qpy_bit is None)) or (
+                reference.find_bit(ref_bit) != qpy.find_bit(qpy_bit)
+            ):
                 msg = (
                     f"Reference Circuit {count}:\n"
                     "deprecated bit-level register information mismatch\n"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Addresses and builds on top of #11407 

### Details and comments

With the removal of `_index` and `_registers` from `Bit`, `Bit`s become opaque and can only be distinguished by their `id`. This breaks several test cases, requires a new de/serialization and a caching of `ControlledGate.definition`. These issues are addressed in this PR, leaving a potential refactoring of `Layout` for the future (see #11604). 

