### PR TITLE
Add clifford circuit name in test_qpy

### DIFF
--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -650,7 +650,7 @@ def generate_clifford_circuits():
             "destabilizer": ["+ZIZ", "+ZXZ", "-XIX"],
         }
     )
-    qc = QuantumCircuit(3)
+    qc = QuantumCircuit(3, name="Clifford Circuits")
     qc.append(cliff, [0, 1, 2])
     return [qc]
 


### PR DESCRIPTION
### Summary

Fix Clifford Circuit test case for QPY backwards compatibility.

### Details and comments

Added `name` argument to `QuantumCircuit`.
