### PR TITLE
Fix incorrect TeX

### DIFF
--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -194,6 +194,8 @@ class CU3Gate(ControlledGate):
 
         .. math::
 
+            \newcommand{\rotationangle}{\frac{\theta}{2}}
+
             CU3(\theta, \phi, \lambda)\ q_1, q_0 =
                 |0\rangle\langle 0| \otimes I +
                 |1\rangle\langle 1| \otimes U3(\theta,\phi,\lambda) =

--- a/qiskit/pulse/library/symbolic_pulses.py
+++ b/qiskit/pulse/library/symbolic_pulses.py
@@ -554,7 +554,6 @@ class SymbolicPulse(Pulse):
         return params
 
     def __eq__(self, other: object) -> bool:
-
         if not isinstance(other, SymbolicPulse):
             return NotImplemented
 
@@ -723,8 +722,10 @@ class Gaussian(metaclass=_PulseType):
 
     .. math::
 
+        \begin{align*}
         f'(x) &= \exp\Bigl( -\frac12 \frac{{(x - \text{duration}/2)}^2}{\text{sigma}^2} \Bigr)\\
         f(x) &= \text{A} \times  \frac{f'(x) - f'(-1)}{1-f'(-1)}, \quad 0 \le x < \text{duration}
+        \end{align*}
 
     where :math:`f'(x)` is the gaussian waveform without lifting or amplitude scaling, and
     :math:`\text{A} = \text{amp} \times \exp\left(i\times\text{angle}\right)`.
@@ -793,8 +794,10 @@ class GaussianSquare(metaclass=_PulseType):
 
     .. math::
 
-        \\text{risefall} &= \\text{risefall_sigma_ratio} \\times \\text{sigma}\\\\
+        \\begin{align*}
+        \\text{risefall} &= \\text{risefall\\_sigma\\_ratio} \\times \\text{sigma}\\\\
         \\text{width} &= \\text{duration} - 2 \\times \\text{risefall}
+        \\end{align*}
 
     If ``width`` is not None and ``risefall_sigma_ratio`` is None:
 
@@ -804,6 +807,7 @@ class GaussianSquare(metaclass=_PulseType):
 
     .. math::
 
+        \\begin{align*}
         f'(x) &= \\begin{cases}\
             \\exp\\biggl(-\\frac12 \\frac{(x - \\text{risefall})^2}{\\text{sigma}^2}\\biggr)\
                 & x < \\text{risefall}\\\\
@@ -817,6 +821,7 @@ class GaussianSquare(metaclass=_PulseType):
         \\end{cases}\\\\
         f(x) &= \\text{A} \\times \\frac{f'(x) - f'(-1)}{1-f'(-1)},\
             \\quad 0 \\le x < \\text{duration}
+        \\end{align*}
 
     where :math:`f'(x)` is the gaussian square waveform without lifting or amplitude scaling, and
     :math:`\\text{A} = \\text{amp} \\times \\exp\\left(i\\times\\text{angle}\\right)`.
@@ -935,8 +940,10 @@ def GaussianSquareDrag(
 
     .. math::
 
-        \\text{risefall} &= \\text{risefall_sigma_ratio} \\times \\text{sigma}\\\\
+        \\begin{align*}
+        \\text{risefall} &= \\text{risefall\\_sigma\\_ratio} \\times \\text{sigma}\\\\
         \\text{width} &= \\text{duration} - 2 \\times \\text{risefall}
+        \\end{align*}
 
     If ``width`` is not None and ``risefall_sigma_ratio`` is None:
 
@@ -947,8 +954,10 @@ def GaussianSquareDrag(
 
     .. math::
 
+        \\begin{align*}
         g(x, c, σ) &= \\exp\\Bigl(-\\frac12 \\frac{(x - c)^2}{σ^2}\\Bigr)\\\\
         g'(x, c, σ) &= \\frac{g(x, c, σ)-g(-1, c, σ)}{1-g(-1, c, σ)}
+        \\end{align*}
 
     From these, the lifted DRAG curve :math:`d'(x, c, σ, β)` can be written as
 
@@ -961,6 +970,7 @@ def GaussianSquareDrag(
 
     .. math::
 
+        \\begin{align*}
         f'(x) &= \\begin{cases}\
             \\text{A} \\times d'(x, \\text{risefall}, \\text{sigma}, \\text{beta})\
                 & x < \\text{risefall}\\\\
@@ -974,6 +984,7 @@ def GaussianSquareDrag(
                 )\
                 & \\text{risefall} + \\text{width} \\le x\
         \\end{cases}\\\\
+        \\end{align*}
 
     where :math:`\\text{A} = \\text{amp} \\times
     \\exp\\left(i\\times\\text{angle}\\right)`.
@@ -1077,12 +1088,14 @@ def gaussian_square_echo(
 
     .. math::
 
+        \\begin{align*}
         g_e(x) &= \\begin{cases}\
             f_{\\text{active}} + f_{\\text{echo}}(x)\
                 & x < \\frac{\\text{duration}}{2}\\\\
             f_{\\text{active}} - f_{\\text{echo}}(x)\
                 & \\frac{\\text{duration}}{2} < x\
         \\end{cases}\\\\
+        \\end{align*}
 
     One case where this pulse can be used is when implementing a direct CNOT gate with
     a cross-resonance superconducting qubit architecture. When applying this pulse to
@@ -1095,8 +1108,10 @@ def gaussian_square_echo(
 
     .. math::
 
-        \\text{risefall} &= \\text{risefall_sigma_ratio} \\times \\text{sigma}\\\\
+        \\begin{align*}
+        \\text{risefall} &= \\text{risefall\\_sigma\\_ratio} \\times \\text{sigma}\\\\
         \\text{width} &= \\text{duration} - 2 \\times \\text{risefall}
+        \\end{align*}
 
     If ``width`` is not None and ``risefall_sigma_ratio`` is None:
 
@@ -1326,11 +1341,13 @@ class Drag(metaclass=_PulseType):
 
     .. math::
 
+        \\begin{align*}
         g(x) &= \\exp\\Bigl(-\\frac12 \\frac{(x - \\text{duration}/2)^2}{\\text{sigma}^2}\\Bigr)\\\\
         g'(x) &= \\text{A}\\times\\frac{g(x)-g(-1)}{1-g(-1)}\\\\
         f(x) &=  g'(x) \\times \\Bigl(1 + 1j \\times \\text{beta} \\times\
             \\Bigl(-\\frac{x - \\text{duration}/2}{\\text{sigma}^2}\\Bigr)  \\Bigr),
             \\quad 0 \\le x < \\text{duration}
+        \\end{align*}
 
     where :math:`g(x)` is a standard unlifted Gaussian waveform, :math:`g'(x)` is the lifted
     :class:`~qiskit.pulse.library.Gaussian` waveform, and

--- a/qiskit/pulse/library/symbolic_pulses.py
+++ b/qiskit/pulse/library/symbolic_pulses.py
@@ -722,10 +722,10 @@ class Gaussian(metaclass=_PulseType):
 
     .. math::
 
-        \begin{align*}
+        \begin{aligned}
         f'(x) &= \exp\Bigl( -\frac12 \frac{{(x - \text{duration}/2)}^2}{\text{sigma}^2} \Bigr)\\
         f(x) &= \text{A} \times  \frac{f'(x) - f'(-1)}{1-f'(-1)}, \quad 0 \le x < \text{duration}
-        \end{align*}
+        \end{aligned}
 
     where :math:`f'(x)` is the gaussian waveform without lifting or amplitude scaling, and
     :math:`\text{A} = \text{amp} \times \exp\left(i\times\text{angle}\right)`.
@@ -794,10 +794,10 @@ class GaussianSquare(metaclass=_PulseType):
 
     .. math::
 
-        \\begin{align*}
+        \\begin{aligned}
         \\text{risefall} &= \\text{risefall\\_sigma\\_ratio} \\times \\text{sigma}\\\\
         \\text{width} &= \\text{duration} - 2 \\times \\text{risefall}
-        \\end{align*}
+        \\end{aligned}
 
     If ``width`` is not None and ``risefall_sigma_ratio`` is None:
 
@@ -807,7 +807,7 @@ class GaussianSquare(metaclass=_PulseType):
 
     .. math::
 
-        \\begin{align*}
+        \\begin{aligned}
         f'(x) &= \\begin{cases}\
             \\exp\\biggl(-\\frac12 \\frac{(x - \\text{risefall})^2}{\\text{sigma}^2}\\biggr)\
                 & x < \\text{risefall}\\\\
@@ -821,7 +821,7 @@ class GaussianSquare(metaclass=_PulseType):
         \\end{cases}\\\\
         f(x) &= \\text{A} \\times \\frac{f'(x) - f'(-1)}{1-f'(-1)},\
             \\quad 0 \\le x < \\text{duration}
-        \\end{align*}
+        \\end{aligned}
 
     where :math:`f'(x)` is the gaussian square waveform without lifting or amplitude scaling, and
     :math:`\\text{A} = \\text{amp} \\times \\exp\\left(i\\times\\text{angle}\\right)`.
@@ -940,10 +940,10 @@ def GaussianSquareDrag(
 
     .. math::
 
-        \\begin{align*}
+        \\begin{aligned}
         \\text{risefall} &= \\text{risefall\\_sigma\\_ratio} \\times \\text{sigma}\\\\
         \\text{width} &= \\text{duration} - 2 \\times \\text{risefall}
-        \\end{align*}
+        \\end{aligned}
 
     If ``width`` is not None and ``risefall_sigma_ratio`` is None:
 
@@ -954,10 +954,10 @@ def GaussianSquareDrag(
 
     .. math::
 
-        \\begin{align*}
+        \\begin{aligned}
         g(x, c, σ) &= \\exp\\Bigl(-\\frac12 \\frac{(x - c)^2}{σ^2}\\Bigr)\\\\
         g'(x, c, σ) &= \\frac{g(x, c, σ)-g(-1, c, σ)}{1-g(-1, c, σ)}
-        \\end{align*}
+        \\end{aligned}
 
     From these, the lifted DRAG curve :math:`d'(x, c, σ, β)` can be written as
 
@@ -970,7 +970,7 @@ def GaussianSquareDrag(
 
     .. math::
 
-        \\begin{align*}
+        \\begin{aligned}
         f'(x) &= \\begin{cases}\
             \\text{A} \\times d'(x, \\text{risefall}, \\text{sigma}, \\text{beta})\
                 & x < \\text{risefall}\\\\
@@ -984,7 +984,7 @@ def GaussianSquareDrag(
                 )\
                 & \\text{risefall} + \\text{width} \\le x\
         \\end{cases}\\\\
-        \\end{align*}
+        \\end{aligned}
 
     where :math:`\\text{A} = \\text{amp} \\times
     \\exp\\left(i\\times\\text{angle}\\right)`.
@@ -1088,14 +1088,14 @@ def gaussian_square_echo(
 
     .. math::
 
-        \\begin{align*}
+        \\begin{aligned}
         g_e(x) &= \\begin{cases}\
             f_{\\text{active}} + f_{\\text{echo}}(x)\
                 & x < \\frac{\\text{duration}}{2}\\\\
             f_{\\text{active}} - f_{\\text{echo}}(x)\
                 & \\frac{\\text{duration}}{2} < x\
         \\end{cases}\\\\
-        \\end{align*}
+        \\end{aligned}
 
     One case where this pulse can be used is when implementing a direct CNOT gate with
     a cross-resonance superconducting qubit architecture. When applying this pulse to
@@ -1108,10 +1108,10 @@ def gaussian_square_echo(
 
     .. math::
 
-        \\begin{align*}
+        \\begin{aligned}
         \\text{risefall} &= \\text{risefall\\_sigma\\_ratio} \\times \\text{sigma}\\\\
         \\text{width} &= \\text{duration} - 2 \\times \\text{risefall}
-        \\end{align*}
+        \\end{aligned}
 
     If ``width`` is not None and ``risefall_sigma_ratio`` is None:
 
@@ -1341,13 +1341,13 @@ class Drag(metaclass=_PulseType):
 
     .. math::
 
-        \\begin{align*}
+        \\begin{aligned}
         g(x) &= \\exp\\Bigl(-\\frac12 \\frac{(x - \\text{duration}/2)^2}{\\text{sigma}^2}\\Bigr)\\\\
         g'(x) &= \\text{A}\\times\\frac{g(x)-g(-1)}{1-g(-1)}\\\\
         f(x) &=  g'(x) \\times \\Bigl(1 + 1j \\times \\text{beta} \\times\
             \\Bigl(-\\frac{x - \\text{duration}/2}{\\text{sigma}^2}\\Bigr)  \\Bigr),
             \\quad 0 \\le x < \\text{duration}
-        \\end{align*}
+        \\end{aligned}
 
     where :math:`g(x)` is a standard unlifted Gaussian waveform, :math:`g'(x)` is the lifted
     :class:`~qiskit.pulse.library.Gaussian` waveform, and

--- a/qiskit/quantum_info/operators/measures.py
+++ b/qiskit/quantum_info/operators/measures.py
@@ -154,12 +154,12 @@ def average_gate_fidelity(
     The average gate fidelity :math:`F_{\text{ave}}` is given by
 
     .. math::
-        \begin{align*}
+        \begin{aligned}
         F_{\text{ave}}(\mathcal{E}, U)
             &= \int d\psi \langle\psi|U^\dagger
                 \mathcal{E}(|\psi\rangle\!\langle\psi|)U|\psi\rangle \\
             &= \frac{d F_{\text{pro}}(\mathcal{E}, U) + 1}{d + 1}
-        \end{align*}
+        \end{aligned}
 
     where :math:`F_{\text{pro}}(\mathcal{E}, U)` is the
     :meth:`~qiskit.quantum_info.process_fidelity` of the input quantum

--- a/qiskit/quantum_info/operators/measures.py
+++ b/qiskit/quantum_info/operators/measures.py
@@ -76,7 +76,7 @@ def process_fidelity(
         require_tp (bool): check if input and target channels are
                            trace-preserving and if non-TP log warning
                            containing negative eigenvalues of partial
-                           Choi-matrix :math:`Tr_{\mbox{out}}[\mathcal{E}] - I`
+                           Choi-matrix :math:`Tr_{\text{out}}[\mathcal{E}] - I`
                            [Default: True].
 
     Returns:
@@ -154,10 +154,12 @@ def average_gate_fidelity(
     The average gate fidelity :math:`F_{\text{ave}}` is given by
 
     .. math::
+        \begin{align*}
         F_{\text{ave}}(\mathcal{E}, U)
             &= \int d\psi \langle\psi|U^\dagger
                 \mathcal{E}(|\psi\rangle\!\langle\psi|)U|\psi\rangle \\
             &= \frac{d F_{\text{pro}}(\mathcal{E}, U) + 1}{d + 1}
+        \end{align*}
 
     where :math:`F_{\text{pro}}(\mathcal{E}, U)` is the
     :meth:`~qiskit.quantum_info.process_fidelity` of the input quantum
@@ -175,7 +177,7 @@ def average_gate_fidelity(
         require_tp (bool): check if input and target channels are
                            trace-preserving and if non-TP log warning
                            containing negative eigenvalues of partial
-                           Choi-matrix :math:`Tr_{\mbox{out}}[\mathcal{E}] - I`
+                           Choi-matrix :math:`Tr_{\text{out}}[\mathcal{E}] - I`
                            [Default: True].
 
     Returns:
@@ -232,7 +234,7 @@ def gate_error(
         require_tp (bool): check if input and target channels are
                            trace-preserving and if non-TP log warning
                            containing negative eigenvalues of partial
-                           Choi-matrix :math:`Tr_{\mbox{out}}[\mathcal{E}] - I`
+                           Choi-matrix :math:`Tr_{\text{out}}[\mathcal{E}] - I`
                            [Default: True].
 
     Returns:

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -115,8 +115,10 @@ class Pauli(BasePauli):
 
     .. math::
 
+        \begin{align*}
         P &= P_{n-1} \otimes ... \otimes P_{0} \\
         P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}
+        \end{align*}
 
     where ``z[k] = P.z[k]``, ``x[k] = P.x[k]`` respectively.
 

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -115,10 +115,10 @@ class Pauli(BasePauli):
 
     .. math::
 
-        \begin{align*}
+        \begin{aligned}
         P &= P_{n-1} \otimes ... \otimes P_{0} \\
         P_k &= (-i)^{z[k] * x[k]} Z^{z[k]}\cdot X^{x[k]}
-        \end{align*}
+        \end{aligned}
 
     where ``z[k] = P.z[k]``, ``x[k] = P.x[k]`` respectively.
 

--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -63,7 +63,7 @@ class ConsolidateBlocks(TransformationPass):
             kak_basis_gate (Gate): Basis gate for KAK decomposition.
             force_consolidate (bool): Force block consolidation.
             basis_gates (List(str)): Basis gates from which to choose a KAK gate.
-            approximation_degree (float): a float between $[0.0, 1.0]$. Lower approximates more.
+            approximation_degree (float): a float between :math:`[0.0, 1.0]`. Lower approximates more.
             target (Target): The target object for the compilation target backend.
         """
         super().__init__()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
These bugs broke the internal docs build; see https://github.com/Qiskit/documentation/pull/635.


### Details and comments
- Incorrect omission of `align` environments.
- Underscores not escaped
- `mbox` not defined
- A few other issues

