### PR TITLE
Update intersphinx URLs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,7 +78,7 @@ modindex_common_prefix = ["qiskit."]
 
 intersphinx_mapping = {
     "rustworkx": ("https://www.rustworkx.org/", None),
-    "qiskit-ibm-runtime": ("https://docs.quantum.ibm.com/qiskit-ibm-runtime/", None),
+    "qiskit-ibm-runtime": ("https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/", None),
     "qiskit-aer": ("https://qiskit.org/ecosystem/aer/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,8 +77,8 @@ modindex_common_prefix = ["qiskit."]
 # ----------------------------------------------------------------------------------
 
 intersphinx_mapping = {
-    "rustworkx": ("https://qiskit.org/ecosystem/rustworkx/", None),
-    "qiskit-ibm-runtime": ("https://qiskit.org/ecosystem/ibm-runtime/", None),
+    "rustworkx": ("https://www.rustworkx.org/", None),
+    "qiskit-ibm-runtime": ("https://docs.quantum.ibm.com/qiskit-ibm-runtime/", None),
     "qiskit-aer": ("https://qiskit.org/ecosystem/aer/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),


### PR DESCRIPTION
* docs.quantum.ibm.com now provides objects.inv, so we can point directly at it for Qiskit Runtime.
* Rustworkx now has a new home