### PR TITLE
Backend converter bugfix (edge case)

### DIFF
--- a/qiskit/providers/backend_compat.py
+++ b/qiskit/providers/backend_compat.py
@@ -240,6 +240,7 @@ def convert_to_target(
                 if (
                     name not in all_instructions
                     or name not in prop_name_map
+                    or prop_name_map[name] is None
                     or qubits not in prop_name_map[name]
                 ):
                     logger.info(

--- a/qiskit/providers/fake_provider/fake_openpulse_2q.py
+++ b/qiskit/providers/fake_provider/fake_openpulse_2q.py
@@ -123,6 +123,7 @@ class FakeOpenPulse2Q(FakeBackend):
                 "revision": "1.0",
                 "segment": "A",
             },
+            description="A fake test backend with pulse defaults",
         )
 
         self._defaults = PulseDefaults.from_dict(
@@ -294,6 +295,22 @@ class FakeOpenPulse2Q(FakeBackend):
             ],
             gates=[
                 Gate(
+                    gate="id",
+                    qubits=[0],
+                    parameters=[
+                        Nduv(date=mock_time, name="gate_error", unit="", value=0),
+                        Nduv(date=mock_time, name="gate_length", unit="ns", value=2 * dt),
+                    ],
+                ),
+                Gate(
+                    gate="id",
+                    qubits=[1],
+                    parameters=[
+                        Nduv(date=mock_time, name="gate_error", unit="", value=0),
+                        Nduv(date=mock_time, name="gate_length", unit="ns", value=2 * dt),
+                    ],
+                ),
+                Gate(
                     gate="u1",
                     qubits=[0],
                     parameters=[
@@ -302,11 +319,35 @@ class FakeOpenPulse2Q(FakeBackend):
                     ],
                 ),
                 Gate(
-                    gate="u3",
+                    gate="u1",
+                    qubits=[1],
+                    parameters=[
+                        Nduv(date=mock_time, name="gate_error", unit="", value=0.06),
+                        Nduv(date=mock_time, name="gate_length", unit="ns", value=0.0),
+                    ],
+                ),
+                Gate(
+                    gate="u2",
                     qubits=[0],
                     parameters=[
                         Nduv(date=mock_time, name="gate_error", unit="", value=0.06),
                         Nduv(date=mock_time, name="gate_length", unit="ns", value=2 * dt),
+                    ],
+                ),
+                Gate(
+                    gate="u2",
+                    qubits=[1],
+                    parameters=[
+                        Nduv(date=mock_time, name="gate_error", unit="", value=0.06),
+                        Nduv(date=mock_time, name="gate_length", unit="ns", value=2 * dt),
+                    ],
+                ),
+                Gate(
+                    gate="u3",
+                    qubits=[0],
+                    parameters=[
+                        Nduv(date=mock_time, name="gate_error", unit="", value=0.06),
+                        Nduv(date=mock_time, name="gate_length", unit="ns", value=4 * dt),
                     ],
                 ),
                 Gate(

--- a/releasenotes/notes/fix-v2-conversion-with-defective-backend-6d9cebe55b06b797.yaml
+++ b/releasenotes/notes/fix-v2-conversion-with-defective-backend-6d9cebe55b06b797.yaml
@@ -6,3 +6,7 @@ fixes:
     for a gate that doesn't have definition in the backend properties.
     Such gate should be broadcasted to all qubits as an ideal error-free instruction
     even though actual calibrations for finite set of qubits are reported.
+upgrade:
+  - |
+    Update properties and defaults information of :class:`.FakeOpenPulse2Q` backend.
+    Information for some missing instructions are added.

--- a/releasenotes/notes/fix-v2-conversion-with-defective-backend-6d9cebe55b06b797.yaml
+++ b/releasenotes/notes/fix-v2-conversion-with-defective-backend-6d9cebe55b06b797.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    A bug that :func:`.convert_to_target` or :class:`.BackendV2Converter` raises unexpected
+    error was solved. The bug occurs when the backend to convert includes calibration
+    for a gate that doesn't have definition in the backend properties.
+    Such gate should be broadcasted to all qubits as an ideal error-free instruction
+    even though actual calibrations for finite set of qubits are reported.


### PR DESCRIPTION
### Summary

Backend V2 converter raises unexpected error. This is an example code to reproduce the bug.

```python
backend = SomeBackendV1()  # Some backend includes calibration for sx
del backend._properties._gate["sx"]

backend_v2 = BackendV2Converter(backend)
backend_v2.target  # This causes error
```

```
TypeError: argument of type 'NoneType' is not iterable
```


### Details and comments

Qiskit Experiments relies on `FakeOpenPulse2Q` to [build own test backend](
https://github.com/Qiskit-Extensions/qiskit-experiments/blob/0ee488989b67d0239597741bf2bb3e51b5d68965/qiskit_experiments/test/mock_iq_backend.py#L45-L50). This backend is defective as it contains calibration for u1, u2, u3, and cx but properties are defined only for u1, u3, cx. This configuration unintentionally reproduces the same situation as written above. The target converter is upgraded to handle this edge case. Missing information in `FakeOpenPulse2Q` is also added.