### PR TITLE
Poison import if `qiskit-terra` detected

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -15,6 +15,7 @@
 """Main Qiskit public functionality."""
 
 import importlib.metadata
+import importlib.util
 import os
 import sys
 import warnings
@@ -25,8 +26,13 @@ except importlib.metadata.PackageNotFoundError:
     # All good!
     pass
 else:
+    # 'qiskit.tools' is present in all 0.x series of Qiskit and not in Qiskit 1.0+.  If a dev has an
+    # editable install and switches from 0.x branches to 1.0+ branches, they might have an empty
+    # `qiskit/tools` folder in their path, which will appear as a "namespace package" with no valid
+    # location.  We catch that case as "not actually having Qiskit 0.x" as a convenience to devs.
+    _has_tools = getattr(importlib.util.find_spec("qiskit.tools"), "has_location", False)
     _suppress_error = os.environ.get("QISKIT_SUPPRESS_1_0_IMPORT_ERROR", False) == "1"
-    if not _suppress_error:
+    if not _suppress_error and _has_tools:
         raise ImportError(
             "Qiskit is installed in an invalid environment that has both Qiskit 1.0+"
             " and an earlier version."

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -34,10 +34,10 @@ else:
     _suppress_error = os.environ.get("QISKIT_SUPPRESS_1_0_IMPORT_ERROR", False) == "1"
     if not _suppress_error and _has_tools:
         raise ImportError(
-            "Qiskit is installed in an invalid environment that has both Qiskit 1.0+"
+            "Qiskit is installed in an invalid environment that has both Qiskit >=1.0"
             " and an earlier version."
             " You should create a new virtual environment, and ensure that you do not mix"
-            " dependencies between Qiskit pre-1.0 and post-1.0."
+            " dependencies between Qiskit <1.0 and >=1.0."
             " Any packages that depend on 'qiskit-terra' are not compatible with Qiskit 1.0 and"
             " will need to be updated."
             " Qiskit unfortunately cannot enforce this requirement during environment resolution."

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -14,8 +14,28 @@
 
 """Main Qiskit public functionality."""
 
+import importlib.metadata
+import os
 import sys
 import warnings
+
+try:
+    importlib.metadata.version("qiskit-terra")
+except importlib.metadata.PackageNotFoundError:
+    # All good!
+    pass
+else:
+    _suppress_error = os.environ.get("QISKIT_SUPPRESS_1_0_IMPORT_ERROR", False) == "1"
+    if not _suppress_error:
+        raise ImportError(
+            "Qiskit is installed in an invalid environment that has both Qiskit 1.0+"
+            " and an earlier version."
+            " You should create a new virtual environment, and ensure that you do not mix"
+            " dependencies between Qiskit pre-1.0 and post-1.0."
+            " Any packages that depend on 'qiskit-terra' are not compatible with Qiskit 1.0 and"
+            " will need to be updated."
+            " Qiskit unfortunately cannot enforce this requirement during environment resolution."
+        )
 
 import qiskit._accelerate
 

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -35,6 +35,7 @@ else:
             " Any packages that depend on 'qiskit-terra' are not compatible with Qiskit 1.0 and"
             " will need to be updated."
             " Qiskit unfortunately cannot enforce this requirement during environment resolution."
+            " See https://qisk.it/packaging-1-0 for more detail."
         )
 
 import qiskit._accelerate


### PR DESCRIPTION
### Summary

This uses `importlib.metadata` to search for installations of `qiskit-terra` at runtime, and poison the import if one is detected. The two packages are incompatible in a way that we cannot express to `pip` without having poisoned the `qiskit-terra` package as a whole, which is something we're less willing to do in order to keep it easier to install old versions of Qiskit-dependent software, and to keep the Qiskit 1.0 packaging story clean for the coming years.

`qiskit>=1.0` and `qiskit-terra<1.0` both attempt to install files in the same directories, so we can't do the detection by looking at the Qiskit version; we'll likely get whichever was installed second if they've both been installed to `site-packages`, or otherwise, whichever comes first on the search path.  This uses the distribution component of `importlib.metadata` to detect installed _distributions_ rather than imported files, allowing us to distinguish `qiskit` from `qiskit-terra`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

See #11617 for a similar PR made to the 0.45 series (which I propose we release as 0.45.3) and to be ported to the 0.46 branch.  The reason I think we also need the 0.45.x and 0.46.x series to have this error is in case they get accidentally installed _after_ Qiskit 1.0 (such as during a subsequent `pip install` command), and the import system resolves `qiskit.__file__` to the `qiskit-terra` `__init__.py` rather than the Qiskit 1.0 init.

A similar false-positive to the one I mentioned on #11617 applies here too, but is probably a fair amount more likely if a developer still has a `qiskit_terra.egg-info` directory in their path, such as in the repo root of Qiskit.  The remedy is to delete that directory; it's not part of the actual installation (and tbh, I'm not sure why pip/setuptools drops it there given that `pip uninstall` doesn't clear it up).