### PR TITLE
Add short-circuit to exit BasisTranslator early when possible

### DIFF
--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -158,6 +158,11 @@ class BasisTranslator(TransformationPass):
             source_basis, qargs_local_source_basis = self._extract_basis_target(dag, qarg_indices)
 
         target_basis = set(target_basis).union(basic_instrs)
+        # If the source basis is a subset of the target basis and we have no circuit
+        # instructions on qargs that have non-global operations there is nothing to
+        # translate and we can exit early.
+        if source_basis.issubset(target_basis) and not qargs_local_source_basis:
+            return dag
 
         logger.info(
             "Begin BasisTranslator from source basis %s to target basis %s.",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a small performance optimization to the basis translator for when there is nothing to translate. One of the early steps the BasisTranslator pass does is to enumerate the source instructions in the circuit and the target instructions available. This is necessary to perform the basis search, however the pass was only using this information as an input to it's operations and it was still unconditionally iterating through the circuit to perform the basis translation. This commit updates the logic to look at the source instruction set and target instruction set and determine upfront if there is any translation necessary. In the cases when there isn't the pass just returns the dag unmodified because there is no work needed and the pass would be spending a great deal of time to do.

### Details and comments