### PR TITLE
Fix lurking `qiskit.tools` usage

### DIFF
--- a/qiskit/passmanager/__init__.py
+++ b/qiskit/passmanager/__init__.py
@@ -75,7 +75,7 @@ for different input and output types.
 A single flow controller always takes a single IR object, and returns a single
 IR object. Parallelism for multiple input objects is supported by the
 :class:`BasePassManager` by broadcasting the flow controller via
-the :func:`qiskit.tools.parallel_map` function.
+the :func:`.parallel_map` function.
 
 
 Examples

--- a/qiskit/utils/parallel.py
+++ b/qiskit/utils/parallel.py
@@ -139,7 +139,7 @@ def parallel_map(  # pylint: disable=dangerous-default-value
         .. code-block:: python
 
             import time
-            from qiskit.tools.parallel import parallel_map
+            from qiskit.utils import parallel_map
             def func(_):
                     time.sleep(0.1)
                     return 0

--- a/qiskit/visualization/gate_map.py
+++ b/qiskit/visualization/gate_map.py
@@ -1141,13 +1141,9 @@ def plot_circuit_layout(circuit, backend, view="virtual", qubit_coordinates=None
         .. plot::
            :include-source:
 
-            import numpy as np
             from qiskit import QuantumCircuit, transpile
             from qiskit.providers.fake_provider import FakeVigoV2
             from qiskit.visualization import plot_circuit_layout
-            from qiskit.tools.monitor import job_monitor
-            from qiskit.providers.fake_provider import FakeVigoV2
-            import matplotlib.pyplot as plt
 
             ghz = QuantumCircuit(3, 3)
             ghz.h(0)

--- a/test/benchmarks/qft.py
+++ b/test/benchmarks/qft.py
@@ -16,15 +16,10 @@
 import itertools
 import math
 
-from qiskit import QuantumRegister, QuantumCircuit
+from qiskit import QuantumRegister, QuantumCircuit, transpile
 from qiskit.converters import circuit_to_dag
 from qiskit.transpiler import CouplingMap
 from qiskit.transpiler.passes import SabreSwap
-
-try:
-    from qiskit.compiler import transpile
-except ImportError:
-    from qiskit.transpiler import transpile
 
 
 def build_model_circuit(qreg, circuit=None):

--- a/test/benchmarks/random_circuit_hex.py
+++ b/test/benchmarks/random_circuit_hex.py
@@ -15,25 +15,9 @@
 
 import copy
 
+from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister, transpile
+from qiskit.quantum_info.random import random_unitary
 from qiskit.quantum_info.synthesis import OneQubitEulerDecomposer
-from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister
-
-try:
-    from qiskit.compiler import transpile
-
-    TRANSPILER_SEED_KEYWORD = "seed_transpiler"
-except ImportError:
-    from qiskit.transpiler import transpile
-
-    TRANSPILER_SEED_KEYWORD = "seed_mapper"
-try:
-    from qiskit.quantum_info.random import random_unitary
-
-    HAS_RANDOM_UNITARY = True
-except ImportError:
-    from qiskit.tools.qi.qi import random_unitary_matrix
-
-    HAS_RANDOM_UNITARY = False
 
 
 # Make a random circuit on a ring
@@ -55,11 +39,7 @@ def make_circuit_ring(nq, depth, seed):
             k = i * 2 + offset + j % 2  # j%2 makes alternating rounds overlap
             qc.cx(q[k % nq], q[(k + 1) % nq])
         for i in range(nq):  # round of single-qubit unitaries
-            if HAS_RANDOM_UNITARY:
-                u = random_unitary(2, seed).data
-            else:
-                u = random_unitary_matrix(2)  # pylint: disable=used-before-assignment  # noqa
-
+            u = random_unitary(2, seed).data
             angles = decomposer.angles(u)
             qc.u3(angles[0], angles[1], angles[2], q[i])
 
@@ -106,7 +86,7 @@ class BenchRandomCircuitHex:
             self.circuit,
             basis_gates=["u1", "u2", "u3", "cx", "id"],
             coupling_map=coupling_map,
-            **{TRANSPILER_SEED_KEYWORD: self.seed},
+            seed_transpiler=self.seed,
         )
 
     def track_depth_ibmq_backend_transpile(self, _):
@@ -135,5 +115,5 @@ class BenchRandomCircuitHex:
             self.circuit,
             basis_gates=["u1", "u2", "u3", "cx", "id"],
             coupling_map=coupling_map,
-            **{TRANSPILER_SEED_KEYWORD: self.seed},
+            seed_transpiler=self.seed,
         ).depth()

--- a/test/benchmarks/randomized_benchmarking.py
+++ b/test/benchmarks/randomized_benchmarking.py
@@ -17,15 +17,7 @@
 import os
 import numpy as np
 from qiskit_experiments.library import StandardRB
-
-try:
-    from qiskit.compiler import transpile
-
-    TRANSPILER_SEED_KEYWORD = "seed_transpiler"
-except ImportError:
-    from qiskit.transpiler import transpile
-
-    TRANSPILER_SEED_KEYWORD = "seed_mapper"
+from qiskit import transpile
 
 
 def build_rb_circuit(qubits, length_vector, num_samples=1, seed=None):
@@ -102,7 +94,7 @@ class RandomizedBenchmarkingBenchmark:
             basis_gates=["u1", "u2", "u3", "cx", "id"],
             coupling_map=coupling_map,
             optimization_level=0,
-            **{TRANSPILER_SEED_KEYWORD: self.seed},
+            seed_transpiler=self.seed,
         )
 
     def time_ibmq_backend_transpile_single_thread(self, __):
@@ -135,5 +127,5 @@ class RandomizedBenchmarkingBenchmark:
             basis_gates=["u1", "u2", "u3", "cx", "id"],
             coupling_map=coupling_map,
             optimization_level=0,
-            **{TRANSPILER_SEED_KEYWORD: self.seed},
+            seed_transpiler=self.seed,
         )


### PR DESCRIPTION
### Summary

A few places in docstrings where we'd left in references to `qiskit.tools`.  At least one of these was executed as part of the documentation build, so was causing failures that weren't being caught because `tox` is currently building an invalid environment for the docs for Qiskit 1.0.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

These are true Qiskit-1.0 bugs that fixing the tox environment in #11621 found.
