### PR TITLE
Change `BaseEstimator/SamplerV2` to be abstract

### DIFF
--- a/qiskit/primitives/base/base_estimator.py
+++ b/qiskit/primitives/base/base_estimator.py
@@ -151,7 +151,7 @@ Here is an example of how the estimator is used.
 from __future__ import annotations
 
 import warnings
-from abc import abstractmethod
+from abc import abstractmethod, ABC
 from collections.abc import Iterable, Sequence
 from copy import copy
 from typing import Generic, TypeVar
@@ -341,7 +341,7 @@ class BaseEstimatorV1(BasePrimitive, Generic[T]):
 BaseEstimator = BaseEstimatorV1
 
 
-class BaseEstimatorV2:
+class BaseEstimatorV2(ABC):
     """Estimator base class version 2.
 
     An estimator estimates expectation values for provided quantum circuit and
@@ -377,4 +377,3 @@ class BaseEstimatorV2:
         Returns:
             A job object that contains results.
         """
-        pass

--- a/qiskit/primitives/base/base_sampler.py
+++ b/qiskit/primitives/base/base_sampler.py
@@ -134,7 +134,7 @@ Here is an example of how sampler is used.
 from __future__ import annotations
 
 import warnings
-from abc import abstractmethod
+from abc import abstractmethod, ABC
 from collections.abc import Iterable, Sequence
 from copy import copy
 from typing import Generic, TypeVar
@@ -267,7 +267,7 @@ class BaseSamplerV1(BasePrimitive, Generic[T]):
 BaseSampler = BaseSamplerV1
 
 
-class BaseSamplerV2:
+class BaseSamplerV2(ABC):
     """Sampler base class version 2.
 
     A Sampler returns samples of quantum circuit outputs.
@@ -292,4 +292,3 @@ class BaseSamplerV2:
         Returns:
             The job object of Sampler's result.
         """
-        pass


### PR DESCRIPTION
### Summary

In an oversight, the original introduction of these classes did not include inheritance from `ABC`. This PR adds this inheritance.

### Details and comments


