### PR TITLE
Fix typo in ``QuantumCircuit.initialize``

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -4560,7 +4560,7 @@ class QuantumCircuit:
         r"""Initialize qubits in a specific state.
 
         Qubit initialization is done by first resetting the qubits to :math:`|0\rangle`
-        followed by calling :class:`~qiskit.circuit.librar.StatePreparation`
+        followed by calling :class:`~qiskit.circuit.library.StatePreparation`
         class to prepare the qubits in a specified state.
         Both these steps are included in the
         :class:`~qiskit.circuit.library.Initialize` instruction.


### PR DESCRIPTION
### Summary
Typo in the main branch is fixed. 


### Details and comments


