### PR TITLE
Fix doc links to ``qiskit.extensions``

### DIFF
--- a/qiskit/circuit/library/data_preparation/state_preparation.py
+++ b/qiskit/circuit/library/data_preparation/state_preparation.py
@@ -419,7 +419,7 @@ def prepare_state(self, state, qubits=None, label=None, normalize=False):
     r"""Prepare qubits in a specific state.
 
     This class implements a state preparing unitary. Unlike
-    :class:`qiskit.extensions.Initialize` it does not reset the qubits first.
+    :class:`~qiskit.circuit.library.Initialize` it does not reset the qubits first.
 
     Args:
         state (str or list or int or Statevector):

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -4116,7 +4116,7 @@ class QuantumCircuit:
         r"""Initialize qubits in a specific state.
 
         Qubit initialization is done by first resetting the qubits to :math:`|0\rangle`
-        followed by calling :class:`qiskit.circuit.library.StatePreparation`
+        followed by calling :class:`~qiskit.circuit.library.StatePreparation`
         class to prepare the qubits in a specified state.
         Both these steps are included in the
         :class:`qiskit.circuit.library.Initialize` instruction.

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -4119,7 +4119,7 @@ class QuantumCircuit:
         followed by calling :class:`~qiskit.circuit.library.StatePreparation`
         class to prepare the qubits in a specified state.
         Both these steps are included in the
-        :class:`qiskit.circuit.library.Initialize` instruction.
+        :class:`~qiskit.circuit.library.Initialize` instruction.
 
         Args:
             params: The state to initialize to, can be either of the following.

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -4116,10 +4116,10 @@ class QuantumCircuit:
         r"""Initialize qubits in a specific state.
 
         Qubit initialization is done by first resetting the qubits to :math:`|0\rangle`
-        followed by calling :class:`qiskit.extensions.StatePreparation`
+        followed by calling :class:`qiskit.circuit.library.StatePreparation`
         class to prepare the qubits in a specified state.
         Both these steps are included in the
-        :class:`qiskit.extensions.Initialize` instruction.
+        :class:`qiskit.circuit.library.Initialize` instruction.
 
         Args:
             params: The state to initialize to, can be either of the following.


### PR DESCRIPTION
### Summary
QuantumCircuit initialize - the links are referring to extensions changed it to "circut.library" 

Closes #11611

(Added the above line to autoclose the issue once this is merged. The issue noted two aspects of the problem, the issue against main was already taken care of by #11631)


