### PR TITLE
transpiler/Decompose: make string patterns matches always case-sensitive

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2052,10 +2052,12 @@ class QuantumCircuit:
 
         Args:
             gates_to_decompose (type or str or list(type, str)): Optional subset of gates
-                to decompose. Can be a gate type, such as ``HGate``, or a gate name, such
-                as 'h', or a gate label, such as 'My H Gate', or a list of any combination
-                of these. If a gate name is entered, it will decompose all gates with that
-                name, whether the gates have labels or not. Defaults to all gates in circuit.
+                to decompose. Can be a gate type, such as ``HGate``, or a gate name pattern,
+                such as 'h', or a gate label pattern, such as 'My H Gate', or a list of any
+                combination of these. If a gate name pattern is entered, it will decompose
+                all gates matching that pattern, whether the gates have labels or not.
+                See :mod:`fnmatch` for the supported patterns. Pattern-matching is
+                case-sensitive. Defaults to all gates in circuit.
             reps (int): Optional number of times the circuit should be decomposed.
                 For instance, ``reps=2`` equals calling ``circuit.decompose().decompose()``.
                 can decompose specific gates specific time

--- a/qiskit/transpiler/passes/basis/decompose.py
+++ b/qiskit/transpiler/passes/basis/decompose.py
@@ -12,7 +12,7 @@
 
 """Expand a gate in a circuit using its decomposition rules."""
 from typing import Type, Union, List, Optional
-from fnmatch import fnmatch
+from fnmatch import fnmatchcase
 
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.dagcircuit.dagcircuit import DAGCircuit
@@ -84,12 +84,12 @@ class Decompose(TransformationPass):
             getattr(node.op, "label", None) is not None
             and node.op.label != ""
             and (  # check if label or label wildcard is given
-                node.op.label in gates or any(fnmatch(node.op.label, p) for p in strings_list)
+                node.op.label in gates or any(fnmatchcase(node.op.label, p) for p in strings_list)
             )
         ):
             return True
         elif node.name in gates or any(  # check if name or name wildcard is given
-            fnmatch(node.name, p) for p in strings_list
+            fnmatchcase(node.name, p) for p in strings_list
         ):
             return True
         elif any(isinstance(node.op, op) for op in gate_type_list):  # check if Gate type given

--- a/releasenotes/notes/decompose-match-always-case-sensitive-265d36d6fe86dc6e.yaml
+++ b/releasenotes/notes/decompose-match-always-case-sensitive-265d36d6fe86dc6e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix varying behavior between platforms in :meth:`QiskitCircuit.decompose` and the associated transpilation pass :class:`Decompose <qiskit.transpiler.passes.basis.decompose.Decompose>`.
+    Matching gate labels or names patterns to decompose is now always case-sensitive, instead of dependent on the platform standard for handling filesystem paths (e.g. case-sensitive on Unix but case-insensitive on Windows).

--- a/test/python/transpiler/test_decompose.py
+++ b/test/python/transpiler/test_decompose.py
@@ -234,6 +234,37 @@ class TestDecompose(QiskitTestCase):
         self.assertEqual(dag.op_nodes()[11].name, "h")
         self.assertRegex(dag.op_nodes()[12].name, "circuit-")
 
+    def test_decompose_only_given_name_case_sensitive(self):
+        """Test decomposition parameters so that only given name is decompose.
+
+        The given names are case-sensitive.
+        """
+        decom_circ = self.complex_circuit.decompose(
+            [
+                "mcx",  # present
+                "GATE1",  # absent (label 'gate1' exists)
+                "CIRCUIT-*",  # absent (names matching 'circuit-*' exist)
+            ]
+        )
+        dag = circuit_to_dag(decom_circ)
+
+        # GATE1 and CIRCUIT-* do not match in the source circuit
+        # so the result is the same as for test_decompose_only_given_name above.
+        self.assertEqual(len(dag.op_nodes()), 13)
+        self.assertEqual(dag.op_nodes()[0].op.label, "gate1")
+        self.assertEqual(dag.op_nodes()[1].op.label, "gate2")
+        self.assertEqual(dag.op_nodes()[2].name, "h")
+        self.assertEqual(dag.op_nodes()[3].name, "cu1")
+        self.assertEqual(dag.op_nodes()[4].name, "rcccx")
+        self.assertEqual(dag.op_nodes()[5].name, "h")
+        self.assertEqual(dag.op_nodes()[6].name, "h")
+        self.assertEqual(dag.op_nodes()[7].name, "cu1")
+        self.assertEqual(dag.op_nodes()[8].name, "rcccx_dg")
+        self.assertEqual(dag.op_nodes()[9].name, "h")
+        self.assertEqual(dag.op_nodes()[10].name, "c3sx")
+        self.assertEqual(dag.op_nodes()[11].name, "h")
+        self.assertRegex(dag.op_nodes()[12].name, "circuit-")
+
     def test_decompose_mixture_of_names_and_labels(self):
         """Test decomposition parameters so that mixture of names and labels is decomposed"""
         decom_circ = self.complex_circuit.decompose(["mcx", "gate2"])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix varying behavior between platforms when passing string patterns to `QuantumCircuit.decompose` (or the associated transpilation pass `Decompose`).

Because [`fnmatch`](https://docs.python.org/3/library/fnmatch.html#fnmatch.fnmatch) is used, matches are case-sensitive on Unix but case-insensitive on Windows (because paths are case-insensitive on this platform).

This patch uses [`fnmatchcase`](https://docs.python.org/3/library/fnmatch.html#fnmatch.fnmatchcase) instead, making the matches always case-sensitive.

This may break some code tested only on Windows, where the behavior changes.
