### PR TITLE
Add `BindingsArray` as allowed input type to `BindingsArray.coerce()`

### DIFF
--- a/qiskit/primitives/containers/bindings_array.py
+++ b/qiskit/primitives/containers/bindings_array.py
@@ -270,6 +270,8 @@ class BindingsArray(ShapedMixin):
             bindings_array = cls(bindings_array)
         elif isinstance(bindings_array, Mapping):
             bindings_array = cls(kwvals=bindings_array)
+        elif isinstance(bindings_array, BindingsArray):
+            return bindings_array
         else:
             raise TypeError(f"Unsupported type {type(bindings_array)} is given.")
         return bindings_array

--- a/test/python/primitives/containers/test_bindings_array.py
+++ b/test/python/primitives/containers/test_bindings_array.py
@@ -431,3 +431,20 @@ class BindingsArrayTestCase(QiskitTestCase):
             self.assertEqual(ba.shape, (1,))
             self.assertEqual(len(ba.vals), 1)
             np.testing.assert_allclose(ba.vals[0], [[1, 2, 3]])
+
+    def test_coerce(self):
+        """Test the coerce() method."""
+        # BindingsArray passthrough
+        arg = BindingsArray({"a": np.linspace(0, 1, 5)})
+        ba = BindingsArray.coerce(arg)
+        self.assertEqual(ba, arg)
+
+        # dict-valued input
+        arg = {"a": np.linspace(0, 1, 5)}
+        ba = BindingsArray.coerce(arg)
+        self.assertEqual(ba.num_parameters, 1)
+
+        # None-valued input
+        arg = None
+        ba = BindingsArray.coerce(None)
+        self.assertEqual(ba.num_parameters, 0)


### PR DESCRIPTION
### Summary

This PR allows the `BindingsArray.coerce()` method to pass-through an input of type `BindingsArray`.

### Details and comments

This PR does not check sequence-like inputs in the tests because that conflicts with #11642. At the very least, we need to see if that PR gets approved.

