### PR TITLE
Add uuid property to Parameter

### DIFF
--- a/qiskit/circuit/parameter.py
+++ b/qiskit/circuit/parameter.py
@@ -114,6 +114,16 @@ class Parameter(ParameterExpression):
         """Returns the name of the :class:`Parameter`."""
         return self._name
 
+    @property
+    def uuid(self) -> UUID:
+        """Returns the UUID of the :class:`Parameter`.
+
+        In advanced use cases, this property can be passed to the
+        :class:`Parameter` constructor to produce an instance that compares
+        equal to another instance.
+        """
+        return self._uuid
+
     def __str__(self):
         return self.name
 

--- a/qiskit/circuit/parameter.py
+++ b/qiskit/circuit/parameter.py
@@ -116,7 +116,7 @@ class Parameter(ParameterExpression):
 
     @property
     def uuid(self) -> UUID:
-        """Returns the UUID of the :class:`Parameter`.
+        """Returns the :class:`~uuid.UUID` of the :class:`Parameter`.
 
         In advanced use cases, this property can be passed to the
         :class:`Parameter` constructor to produce an instance that compares

--- a/qiskit/qpy/binary_io/value.py
+++ b/qiskit/qpy/binary_io/value.py
@@ -34,8 +34,8 @@ from qiskit.qpy import common, formats, exceptions, type_keys
 
 
 def _write_parameter(file_obj, obj):
-    name_bytes = obj._name.encode(common.ENCODE)
-    file_obj.write(struct.pack(formats.PARAMETER_PACK, len(name_bytes), obj._uuid.bytes))
+    name_bytes = obj.name.encode(common.ENCODE)
+    file_obj.write(struct.pack(formats.PARAMETER_PACK, len(name_bytes), obj.uuid.bytes))
     file_obj.write(name_bytes)
 
 
@@ -46,7 +46,7 @@ def _write_parameter_vec(file_obj, obj):
             formats.PARAMETER_VECTOR_ELEMENT_PACK,
             len(name_bytes),
             obj._vector._size,
-            obj._uuid.bytes,
+            obj.uuid.bytes,
             obj._index,
         )
     )
@@ -215,7 +215,7 @@ def _read_parameter_vec(file_obj, vectors):
     if name not in vectors:
         vectors[name] = (ParameterVector(name, data.vector_size), set())
     vector = vectors[name][0]
-    if vector[data.index]._uuid != param_uuid:
+    if vector[data.index].uuid != param_uuid:
         vectors[name][1].add(data.index)
         vector._params[data.index] = ParameterVectorElement(vector, data.index, uuid=param_uuid)
     return vector[data.index]

--- a/releasenotes/notes/parameter-uuid-60dd46a739afabce.yaml
+++ b/releasenotes/notes/parameter-uuid-60dd46a739afabce.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    A :attr:`~qiskit.circuit.Parameter.uuid` property was added to the
+    :class:`qiskit.circuit.Parameter` class. In advanced use cases,
+    this property can be used for creating
+    :class:`qiskit.circuit.Parameter` instances that compare equal to
+    each other.

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -107,6 +107,16 @@ def raise_if_parameter_table_invalid(circuit):
 class TestParameters(QiskitTestCase):
     """Test Parameters."""
 
+    def test_equality(self):
+        """Test Parameter equality"""
+        param = Parameter("a")
+        param_copy = Parameter(param.name, uuid=param.uuid)
+        param_different = Parameter("a")
+
+        self.assertEqual(param, param, "Parameter does not equal itself")
+        self.assertEqual(param, param_copy, "Parameters with same data are not equal")
+        self.assertNotEqual(param, param_different, "Different Parameters are treated as equal")
+
     def test_gate(self):
         """Test instantiating gate with variable parameters"""
         theta = Parameter("θ")


### PR DESCRIPTION
This change adds a public, read-only uuid property to Parameter which can be used in advanced use cases for getting the uuid value to pass to the Parameter constructor.