### PR TITLE
Fix node not being properly handled after control removal in HoareOptimizer

### DIFF
--- a/qiskit/transpiler/passes/optimization/hoare_opt.py
+++ b/qiskit/transpiler/passes/optimization/hoare_opt.py
@@ -212,7 +212,7 @@ class HoareOptimizer(TransformationPass):
             remove_ctrl, new_dag, qb_idx = self._remove_control(gate, ctrlvar, trgtvar)
 
             if remove_ctrl:
-                dag.substitute_node_with_dag(node, new_dag)
+                replacement_nodes = dag.substitute_node_with_dag(node, new_dag)
                 gate = gate.base_gate
                 node.op = gate.to_mutable()
                 node.name = gate.name
@@ -220,6 +220,7 @@ class HoareOptimizer(TransformationPass):
                 _, ctrlvar, trgtqb, trgtvar = self._seperate_ctrl_trgt(node)
 
                 ctrl_ones = z3.And(*ctrlvar)
+                node = list(replacement_nodes.values())[0]
 
             trivial = self._test_gate(gate, ctrl_ones, trgtvar)
             if trivial:

--- a/releasenotes/notes/fix-hoare-opt-wrong-removal-848d35cd8a2de06d.yaml
+++ b/releasenotes/notes/fix-hoare-opt-wrong-removal-848d35cd8a2de06d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a bug in which node wasn't removed during Hoare optimization.

--- a/test/python/transpiler/test_hoare_opt.py
+++ b/test/python/transpiler/test_hoare_opt.py
@@ -660,6 +660,25 @@ class TestHoareOptimizer(QiskitTestCase):
 
         self.assertEqual(result2, circuit_to_dag(expected))
 
+    def test_controlled_removal_pass(self):
+        """Verify that after control removal the node is
+        handled properly
+        """
+
+        circuit1 = QuantumCircuit(2)
+        circuit1.y(0)
+        circuit1.cy(0, 1)
+        circuit1.y(1)
+
+        expected1 = QuantumCircuit(2)
+        expected1.y(0)
+
+        pass_ = HoareOptimizer()
+
+        result1 = pass_.run(circuit_to_dag(circuit1))
+
+        self.assertEqual(result1, circuit_to_dag(expected1))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Hoare optimizer didn't update cache properly if the control was removed from gate.
Closes https://github.com/Qiskit/qiskit/issues/11201


