### PR TITLE
use pulse_alignment from Target in PadDynamicalDecoupling

### DIFF
--- a/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
@@ -171,6 +171,7 @@ class PadDynamicalDecoupling(BasePadding):
         self._sequence_phase = 0
         if target is not None:
             self._durations = target.durations()
+            self._alignment = target.pulse_alignment
             for gate in dd_sequence:
                 if gate.name not in target.operation_names:
                     raise TranspilerError(

--- a/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
@@ -145,9 +145,10 @@ class PadDynamicalDecoupling(BasePadding):
                     - "middle": Put the extra slack to the interval at the middle of the sequence.
                     - "edges": Divide the extra slack as evenly as possible into
                       intervals at beginning and end of the sequence.
-            target: The :class:`~.Target` representing the target backend, if both
-                  ``durations`` and this are specified then this argument will take
-                  precedence and ``durations`` will be ignored.
+            target: The :class:`~.Target` representing the target backend.
+                Target takes precedence over other arguments when they can be inferred from target.
+                Therefore specifying target as well as other arguments like ``durations`` or
+                ``pulse_alignment`` will cause those other arguments to be ignored.
 
         Raises:
             TranspilerError: When invalid DD sequence is specified.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x ] I have added the tests to cover my changes.
- [ x] I have updated the documentation accordingly.
- [x ] I have read the CONTRIBUTING document.
-->

### Summary

The intent for the Target argument in transpiler passes is that they will supply the necessary information for passes to use. There was an oversight when adding this for the PadDynamicalDecoupling pass, where users still had to separately pass `pulse_alignment` even though this information is contained in the Target. This commit is a simple fix of that oversight.

### Details and comments


