### PR TITLE
Use explicit `IndexMap::swap_remove` in Sabre

### DIFF
--- a/crates/accelerate/src/sabre_swap/layer.rs
+++ b/crates/accelerate/src/sabre_swap/layer.rs
@@ -58,7 +58,9 @@ impl FrontLayer {
 
     /// Remove a node from the front layer.
     pub fn remove(&mut self, index: &NodeIndex) {
-        let [a, b] = self.nodes.remove(index).unwrap();
+        // The actual order in the indexmap doesn't matter as long as it's reproducible.
+        // Swap-remove is more efficient than a full shift-remove.
+        let [a, b] = self.nodes.swap_remove(index).unwrap();
         self.qubits[a.index()] = None;
         self.qubits[b.index()] = None;
     }


### PR DESCRIPTION
### Summary

`indexmap` are moving to deprecate the `remove` function to push people to be explicit about whether they want `swap_remove` or `shift_remove` in IndexMap 2.2.0.  Sabre doesn't care about the order provided it's deterministic and reproducible, so we just use the more efficient swap.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Needed for #11663.
