### PR TITLE
Ignore Pandas import warning in Seaborn

### DIFF
--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -206,9 +206,11 @@ class QiskitTestCase(BaseQiskitTestCase):
         # We only use pandas transitively through seaborn, so it's their responsibility to mark if
         # their use of pandas would be a problem.
         warnings.filterwarnings(
-            "ignore",
+            "default",
             category=DeprecationWarning,
-            message="Pyarrow will become.*in the next major release of pandas",
+            # The `(?s)` magic is to force use of the `re.DOTALL` flag, because the Pandas message
+            # includes hard-break newlines all over the place.
+            message="(?s).*Pyarrow.*required dependency.*next major release of pandas",
             module=r"seaborn(\..*)?",
         )
 

--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -203,6 +203,15 @@ class QiskitTestCase(BaseQiskitTestCase):
         warnings.filterwarnings("error", category=DeprecationWarning)
         warnings.filterwarnings("error", category=QiskitWarning)
 
+        # We only use pandas transitively through seaborn, so it's their responsibility to mark if
+        # their use of pandas would be a problem.
+        warnings.filterwarnings(
+            "ignore",
+            category=DeprecationWarning,
+            message="Pyarrow will become.*in the next major release of pandas",
+            module=r"seaborn(\..*)?",
+        )
+
         allow_DeprecationWarning_modules = [
             "test.python.pulse.test_builder",
             "test.python.pulse.test_block",


### PR DESCRIPTION
### Summary

As of Pandas 2.2.0, a `DeprecationWarning` is raised during `import pandas` if Pyarrow is not installed.  We only use Pandas transitively through seaborn, so it's not our responsibility to verify the compatibility; we assume Seaborn will handle things correctly if any changes are needed around the time of Pandas 3.0.

This warning does not fail the CI test suite because `seaborn` (and thus `pandas`) gets imported during test collection, _before_ our warning filters kick in to turn deprecation warnings into errors.  The suite does fail during the image tests of the `main` branch, though, because there `seaborn` doesn't get checked until the tests actually run (that suite assumes that the image-test requirements are present). We don't see the same CI failure in PR because we use Python 3.8 there, which Pandas 2.2 doesn't support, but we use Python 3.9 on `main` deliberately to increase our coverage for things like this.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

This should fix all commits to `main` getting marked with a CI push failure.
