### PR TITLE
Fix handling of `Var` nodes in full-rebuild control-flow blocks

### DIFF
--- a/qiskit/circuit/controlflow/_builder_utils.py
+++ b/qiskit/circuit/controlflow/_builder_utils.py
@@ -174,8 +174,16 @@ def _unify_circuit_resources_rebuild(  # pylint: disable=invalid-name  # (it's t
     out_circuits = []
     for circuit in circuits:
         out = QuantumCircuit(
-            qubits, clbits, *circuit.qregs, *circuit.cregs, global_phase=circuit.global_phase
+            qubits,
+            clbits,
+            *circuit.qregs,
+            *circuit.cregs,
+            global_phase=circuit.global_phase,
+            inputs=circuit.iter_input_vars(),
+            captures=circuit.iter_captured_vars(),
         )
+        for var in circuit.iter_declared_vars():
+            out.add_uninitialized_var(var)
         for instruction in circuit.data:
             out._append(instruction)
         out_circuits.append(out)


### PR DESCRIPTION
### Summary

In the control-flow builders, there are typically two ways the individual blocks can be reconstructed to be unified over the qubit and clbit resources.  We generally attempt to avoid completely rebuilding the cirucits unless we have to.  In cases where the resources are visited in an incompatible order, however, we have to construct new circuit objects, and in these cases, we were failing to transfer the `Var` use over completely.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

This is a bug fix for the `expr.Var` support, which is going to be deferred from 1.0, so I've marked it as on hold pending the release of that.