### PR TITLE
Fix `make_data_bin()` to allow no fields

### DIFF
--- a/qiskit/primitives/containers/data_bin.py
+++ b/qiskit/primitives/containers/data_bin.py
@@ -47,6 +47,9 @@ class DataBin(metaclass=DataBinMeta):
     _FIELD_TYPES: tuple[type, ...] = ()
     """The types of each field."""
 
+    def __len__(self):
+        return len(self._FIELDS)
+
     def __repr__(self):
         vals = (f"{name}={getattr(self, name)}" for name in self._FIELDS if hasattr(self, name))
         return f"{type(self)}({', '.join(vals)})"
@@ -71,7 +74,7 @@ def make_data_bin(
     Returns:
         A new class.
     """
-    field_names, field_types = zip(*fields)
+    field_names, field_types = zip(*fields) if fields else ([], [])
     for name in field_names:
         if name in DataBin._RESTRICTED_NAMES:
             raise ValueError(f"'{name}' is a restricted name for a DataBin.")

--- a/qiskit/primitives/statevector_sampler.py
+++ b/qiskit/primitives/statevector_sampler.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Iterable
+import warnings
 
 import numpy as np
 from numpy.typing import NDArray
@@ -79,6 +80,12 @@ class StatevectorSampler(BaseSamplerV2):
         if shots is None:
             shots = self._default_shots
         coerced_pubs = [SamplerPub.coerce(pub, shots) for pub in pubs]
+        if any(len(pub.circuit.cregs) == 0 for pub in coerced_pubs):
+            warnings.warn(
+                "One of your circuits has no output classical registers and so the result "
+                "will be empty. Did you mean to add measurement instructions?",
+                UserWarning,
+            )
 
         job = PrimitiveJob(self._run, coerced_pubs)
         job._submit()

--- a/test/python/primitives/containers/test_data_bin.py
+++ b/test/python/primitives/containers/test_data_bin.py
@@ -39,6 +39,7 @@ class DataBinTestCase(QiskitTestCase):
         alpha = np.empty((10, 20), dtype=np.uint16)
         beta = np.empty((10, 20), dtype=int)
         my_bin = data_bin_cls(alpha, beta)
+        self.assertEqual(len(my_bin), 2)
         self.assertTrue(np.all(my_bin.alpha == alpha))
         self.assertTrue(np.all(my_bin.beta == beta))
         self.assertTrue("alpha=" in str(my_bin))
@@ -62,3 +63,9 @@ class DataBinTestCase(QiskitTestCase):
         self.assertEqual(my_bin.beta, 5)
         self.assertTrue("alpha=" in str(my_bin))
         self.assertTrue(">" not in str(my_bin))
+
+    def test_make_databin_no_fields(self):
+        """Test the make_data_bin() function when no fields are given."""
+        data_bin_cls = make_data_bin([])
+        data_bin = data_bin_cls()
+        self.assertEqual(len(data_bin), 0)

--- a/test/python/primitives/test_statevector_sampler.py
+++ b/test/python/primitives/test_statevector_sampler.py
@@ -620,7 +620,8 @@ class TestStatevectorSampler(QiskitTestCase):
         """Test the sampler works when there are no measurements."""
         qc = QuantumCircuit(2)
         sampler = StatevectorSampler()
-        result = sampler.run([qc]).result()
+        with self.assertWarns(UserWarning):
+            result = sampler.run([qc]).result()
 
         self.assertEqual(len(result), 1)
         self.assertEqual(len(result[0].data), 0)

--- a/test/python/primitives/test_statevector_sampler.py
+++ b/test/python/primitives/test_statevector_sampler.py
@@ -615,8 +615,8 @@ class TestStatevectorSampler(QiskitTestCase):
             self.assertTrue(hasattr(data, creg_name))
             self._assert_allclose(getattr(data, creg_name), np.array(target[creg_name]))
 
-    def test_no_measurements(self):
-        """Test the sampler works when there are no measurements."""
+    def test_no_cregs(self):
+        """Test that the sampler works when there are no classical register in the circuit."""
         qc = QuantumCircuit(2)
         sampler = StatevectorSampler()
         with self.assertWarns(UserWarning):

--- a/test/python/primitives/test_statevector_sampler.py
+++ b/test/python/primitives/test_statevector_sampler.py
@@ -288,10 +288,9 @@ class TestStatevectorSampler(QiskitTestCase):
         qc1.measure_all()
         qc2 = RealAmplitudes(num_qubits=1, reps=1)
         qc2.measure_all()
-        qc3 = QuantumCircuit(1)
-        qc4 = QuantumCircuit(1, 1)
-        with qc4.for_loop(range(5)):
-            qc4.h(0)
+        qc3 = QuantumCircuit(1, 1)
+        with qc3.for_loop(range(5)):
+            qc3.h(0)
 
         sampler = StatevectorSampler()
         with self.subTest("set parameter values to a non-parameterized circuit"):
@@ -312,7 +311,7 @@ class TestStatevectorSampler(QiskitTestCase):
                 _ = sampler.run([(qc2, [1e2] * 100)]).result()
         with self.subTest("with control flow"):
             with self.assertRaises(QiskitError):
-                _ = sampler.run([qc4]).result()
+                _ = sampler.run([qc3]).result()
         with self.subTest("negative shots, run arg"):
             with self.assertRaises(ValueError):
                 _ = sampler.run([qc1], shots=-1).result()

--- a/test/python/primitives/test_statevector_sampler.py
+++ b/test/python/primitives/test_statevector_sampler.py
@@ -310,9 +310,6 @@ class TestStatevectorSampler(QiskitTestCase):
         with self.subTest("too many parameter values for a parameterized circuit"):
             with self.assertRaises(ValueError):
                 _ = sampler.run([(qc2, [1e2] * 100)]).result()
-        with self.subTest("no classical bits"):
-            with self.assertRaises(ValueError):
-                _ = sampler.run([qc3]).result()
         with self.subTest("with control flow"):
             with self.assertRaises(QiskitError):
                 _ = sampler.run([qc4]).result()

--- a/test/python/primitives/test_statevector_sampler.py
+++ b/test/python/primitives/test_statevector_sampler.py
@@ -619,6 +619,15 @@ class TestStatevectorSampler(QiskitTestCase):
             self.assertTrue(hasattr(data, creg_name))
             self._assert_allclose(getattr(data, creg_name), np.array(target[creg_name]))
 
+    def test_no_measurements(self):
+        """Test the sampler works when there are no measurements."""
+        qc = QuantumCircuit(2)
+        sampler = StatevectorSampler()
+        result = sampler.run([qc]).result()
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result[0].data), 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary

This PR fixes the edge case where `qiskit.primitives.container.make_data_bin()` errors when it receives no fields. Although unusual to have no fields, it shouldn't be an invalid state for the bin: if something using the bin wants to disallow it being empty, it is welcome to implement that restriction itself.

As a consequence of this PR, the `StatevectorSampler` no longer raises an error when there are no classical registers in the circuit. Edit: It does, however, now raise a warning in this case.

### Details and comments

Even if raising were the right thing for `make_data_bin` to do, it was raising it in the context of tuple unpacking, which would be confusing to users, especially when done through a sampler. 


