### PR TITLE
Add import for classes in qiskit/quantum_info/synthesis

### DIFF
--- a/qiskit/quantum_info/synthesis/local_invariance.py
+++ b/qiskit/quantum_info/synthesis/local_invariance.py
@@ -9,27 +9,19 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+# pylint: disable=invalid-name
 
-# pylint: disable=unused-import
-
+"""Routines that use local invariants to compute properties
+of two-qubit unitary operators.
 """
-Expand 2-qubit Unitary operators into an equivalent
-decomposition over SU(2)+fixed 2q basis gate, using the KAK method.
 
-May be exact or approximate expansion. In either case uses the minimal
-number of basis applications.
-
-Method is described in Appendix B of Cross, A. W., Bishop, L. S., Sheldon, S., Nation, P. D. &
-Gambetta, J. M. Validating quantum computers using randomized model circuits.
-arXiv:1811.12926 [quant-ph] (2018).
-"""
 
 from __future__ import annotations
 import warnings
 
 # pylint: disable=wildcard-import,unused-wildcard-import
 
-from qiskit.synthesis.two_qubit.two_qubit_decompose import *
+from qiskit.synthesis.two_qubit.local_invariance import *
 
 warnings.warn(
     "The qiskit.quantum_info.synthesis module is deprecated since Qiskit 0.46.0."

--- a/qiskit/quantum_info/synthesis/qsd.py
+++ b/qiskit/quantum_info/synthesis/qsd.py
@@ -1,0 +1,28 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Quantum Shannon Decomposition.
+"""
+
+from __future__ import annotations
+import warnings
+
+# pylint: disable=wildcard-import,unused-wildcard-import
+
+from qiskit.synthesis.unitary.qsd import *
+
+warnings.warn(
+    "The qiskit.quantum_info.synthesis module is deprecated since Qiskit 0.46.0."
+    "It will be removed in the Qiskit 1.0 release.",
+    stacklevel=2,
+    category=DeprecationWarning,
+)

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -10,6 +10,20 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+# pylint: disable=unused-import
+
+"""
+Expand 2-qubit Unitary operators into an equivalent
+decomposition over SU(2)+fixed 2q basis gate, using the KAK method.
+
+May be exact or approximate expansion. In either case uses the minimal
+number of basis applications.
+
+Method is described in Appendix B of Cross, A. W., Bishop, L. S., Sheldon, S., Nation, P. D. &
+Gambetta, J. M. Validating quantum computers using randomized model circuits.
+arXiv:1811.12926 [quant-ph] (2018).
+"""
+
 from __future__ import annotations
 import warnings
 

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -1,0 +1,23 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+from __future__ import annotations
+import warnings
+
+from qiskit.synthesis.two_qubit.two_qubit_decompose import TwoQubitWeylDecomposition
+
+warnings.warn(
+    "The qiskit.quantum_info.synthesis module is deprecated since Qiskit 0.46.0."
+    "It will be removed in the Qiskit 1.0 release.",
+    stacklevel=2,
+    category=DeprecationWarning,
+)

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -27,7 +27,21 @@ arXiv:1811.12926 [quant-ph] (2018).
 from __future__ import annotations
 import warnings
 
-from qiskit.synthesis.two_qubit.two_qubit_decompose import TwoQubitWeylDecomposition
+from qiskit.synthesis.two_qubit.two_qubit_decompose import (
+    TwoQubitWeylDecomposition,
+    TwoQubitControlledUDecomposer,
+    TwoQubitDecomposeUpToDiagonal,
+    TwoQubitWeylIdEquiv,
+    TwoQubitWeylSWAPEquiv,
+    TwoQubitWeylPartialSWAPEquiv,
+    TwoQubitWeylPartialSWAPFlipEquiv,
+    TwoQubitWeylControlledEquiv,
+    TwoQubitWeylMirrorControlledEquiv,
+    TwoQubitWeylfSimaabEquiv,
+    TwoQubitWeylfSimabbEquiv,
+    TwoQubitWeylfSimabmbEquiv,
+    TwoQubitWeylGeneral,
+)
 
 warnings.warn(
     "The qiskit.quantum_info.synthesis module is deprecated since Qiskit 0.46.0."

--- a/qiskit/quantum_info/synthesis/weyl.py
+++ b/qiskit/quantum_info/synthesis/weyl.py
@@ -9,19 +9,9 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+# pylint: disable=invalid-name
 
-# pylint: disable=unused-import
-
-"""
-Expand 2-qubit Unitary operators into an equivalent
-decomposition over SU(2)+fixed 2q basis gate, using the KAK method.
-
-May be exact or approximate expansion. In either case uses the minimal
-number of basis applications.
-
-Method is described in Appendix B of Cross, A. W., Bishop, L. S., Sheldon, S., Nation, P. D. &
-Gambetta, J. M. Validating quantum computers using randomized model circuits.
-arXiv:1811.12926 [quant-ph] (2018).
+"""Routines that compute  and use the Weyl chamber coordinates.
 """
 
 from __future__ import annotations
@@ -29,7 +19,7 @@ import warnings
 
 # pylint: disable=wildcard-import,unused-wildcard-import
 
-from qiskit.synthesis.two_qubit.two_qubit_decompose import *
+from qiskit.synthesis.two_qubit.weyl import *
 
 warnings.warn(
     "The qiskit.quantum_info.synthesis module is deprecated since Qiskit 0.46.0."

--- a/test/python/synthesis/test_synthesis.py
+++ b/test/python/synthesis/test_synthesis.py
@@ -1274,6 +1274,8 @@ class TestTwoQubitDecompose(CheckDecompositions):
         with self.assertWarns(DeprecationWarning):
             import qiskit.quantum_info.synthesis.weyl
 
+        with self.assertWarns(DeprecationWarning):
+            import qiskit.quantum_info.synthesis.qsd
 
 @ddt
 class TestPulseOptimalDecompose(CheckDecompositions):

--- a/test/python/synthesis/test_synthesis.py
+++ b/test/python/synthesis/test_synthesis.py
@@ -1268,6 +1268,12 @@ class TestTwoQubitDecompose(CheckDecompositions):
         with self.assertWarns(DeprecationWarning):
             import qiskit.quantum_info.synthesis.two_qubit_decompose
 
+        with self.assertWarns(DeprecationWarning):
+            import qiskit.quantum_info.synthesis.local_invariance
+
+        with self.assertWarns(DeprecationWarning):
+            import qiskit.quantum_info.synthesis.weyl
+
 
 @ddt
 class TestPulseOptimalDecompose(CheckDecompositions):

--- a/test/python/synthesis/test_synthesis.py
+++ b/test/python/synthesis/test_synthesis.py
@@ -1266,9 +1266,7 @@ class TestTwoQubitDecompose(CheckDecompositions):
 
         # pylint: disable = unused-import
         with self.assertWarns(DeprecationWarning):
-            from qiskit.quantum_info.synthesis.two_qubit_decompose import (
-                TwoQubitWeylDecomposition as old_TwoQubitWeylDecomposition,
-            )
+            import qiskit.quantum_info.synthesis.two_qubit_decompose
 
 
 @ddt

--- a/test/python/synthesis/test_synthesis.py
+++ b/test/python/synthesis/test_synthesis.py
@@ -1277,6 +1277,7 @@ class TestTwoQubitDecompose(CheckDecompositions):
         with self.assertWarns(DeprecationWarning):
             import qiskit.quantum_info.synthesis.qsd
 
+
 @ddt
 class TestPulseOptimalDecompose(CheckDecompositions):
     """Check pulse optimal decomposition."""

--- a/test/python/synthesis/test_synthesis.py
+++ b/test/python/synthesis/test_synthesis.py
@@ -1264,6 +1264,12 @@ class TestTwoQubitDecompose(CheckDecompositions):
 
             _ = old_two_qubit_cnot_decompose(unitary)
 
+        # pylint: disable = unused-import
+        with self.assertWarns(DeprecationWarning):
+            from qiskit.quantum_info.synthesis.two_qubit_decompose import (
+                TwoQubitWeylDecomposition as old_TwoQubitWeylDecomposition,
+            )
+
 
 @ddt
 class TestPulseOptimalDecompose(CheckDecompositions):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix a problem that was mentioned here:
https://github.com/Qiskit/qiskit/pull/11635#issuecomment-1915526756

This line:
`from qiskit.quantum_info.synthesis.two_qubit_decompose import TwoQubitWeylDecomposition`
will work in Qiskit 0.46 and raise a deprecation warning.

### Details and comments


