### PR TITLE
Make V2 primitive input container classes private

### DIFF
--- a/qiskit/primitives/__init__.py
+++ b/qiskit/primitives/__init__.py
@@ -31,7 +31,6 @@ Estimator
    BaseEstimator
    Estimator
    BackendEstimator
-   EstimatorPub
 
 EstimatorV2
 ===========
@@ -52,7 +51,6 @@ Sampler
    BackendSampler
    BaseSamplerV2
    StatevectorSampler
-   SamplerPub
 
 Results
 =======
@@ -72,12 +70,13 @@ from .base import BaseEstimator, BaseSampler, BaseSamplerV2
 from .base.estimator_result import EstimatorResult
 from .base.sampler_result import SamplerResult
 from .containers import (
-    BindingsArray,
-    EstimatorPub,
-    ObservablesArray,
     PrimitiveResult,
     PubResult,
-    SamplerPub,
+    EstimatorPubLike,
+    SamplerPubLike,
+    BindingsArrayLike,
+    ObservableLike,
+    ObservablesArrayLike,
 )
 from .estimator import Estimator
 from .sampler import Sampler

--- a/qiskit/primitives/base/base_estimator.py
+++ b/qiskit/primitives/base/base_estimator.py
@@ -169,11 +169,11 @@ from qiskit.utils.deprecation import deprecate_func
 from ..containers import (
     make_data_bin,
     DataBin,
-    EstimatorPub,
     EstimatorPubLike,
     PrimitiveResult,
     PubResult,
 )
+from ..containers.estimator_pub import EstimatorPub
 from . import validation
 from .base_primitive import BasePrimitive
 from .base_primitive_job import BasePrimitiveJob
@@ -367,12 +367,11 @@ class BaseEstimatorV2(ABC):
         """Estimate expectation values for each provided pub (Primitive Unified Bloc).
 
         Args:
-            pubs: An iterable of pub-like objects, such as tuples ``(circuit, observables)`` or
-                  ``(circuit, observables, parameter_values)``.
+            pubs: An iterable of pub-like objects, such as tuples ``(circuit, observables)``
+                  or ``(circuit, observables, parameter_values)``.
             precision: The target precision for expectation value estimates of each
-                       run :class:`.EstimatorPub` that does not specify its own
-                       precision. If None the estimator's default precision value
-                       will be used.
+                       run Estimator Pub that does not specify its own precision. If None
+                       the estimator's default precision value will be used.
 
         Returns:
             A job object that contains results.

--- a/qiskit/primitives/base/base_sampler.py
+++ b/qiskit/primitives/base/base_sampler.py
@@ -285,9 +285,9 @@ class BaseSamplerV2(ABC):
         Args:
             pubs: An iterable of pub-like objects. For example, a list of circuits
                   or tuples ``(circuit, parameter_values)``.
-            shots: The total number of shots to sample for each :class:`.SamplerPub`.
-                   that does not specify its own shots. If ``None``, the primitive's
-                   default shots value will be used, which can vary by implementation.
+            shots: The total number of shots to sample for each sampler pub that does
+                   not specify its own shots. If ``None``, the primitive's default
+                   shots value will be used, which can vary by implementation.
 
         Returns:
             The job object of Sampler's result.

--- a/qiskit/primitives/containers/__init__.py
+++ b/qiskit/primitives/containers/__init__.py
@@ -14,11 +14,12 @@
 Data containers for primitives.
 """
 
-from .bindings_array import BindingsArray
+
 from .bit_array import BitArray
 from .data_bin import make_data_bin, DataBin
-from .estimator_pub import EstimatorPub, EstimatorPubLike
-from .observables_array import ObservablesArray
 from .primitive_result import PrimitiveResult
 from .pub_result import PubResult
-from .sampler_pub import SamplerPub, SamplerPubLike
+from .estimator_pub import EstimatorPubLike
+from .sampler_pub import SamplerPubLike
+from .bindings_array import BindingsArrayLike
+from .observables_array import ObservableLike, ObservablesArrayLike

--- a/qiskit/primitives/containers/bindings_array.py
+++ b/qiskit/primitives/containers/bindings_array.py
@@ -27,6 +27,24 @@ from qiskit.circuit import Parameter, QuantumCircuit
 from .shape import ShapedMixin, ShapeInput, shape_tuple
 
 ParameterLike = Union[Parameter, str]
+"""A parameter or parameter name."""
+
+BindingsArrayLike = Mapping[Union[ParameterLike, tuple[ParameterLike, ...]], ArrayLike]
+"""A mapping of numeric bindings for circuit parameters.
+
+This allows array values for single or multi-dimensional sweeps over parameter values.
+
+The mapping keys can be single or tuple of Parameter or parameter name strings.
+The values can be a float for a single parameter an N-dimensional array like where
+the array's last dimension indexes the circuit parameters, with its leading dimensions
+representing the array shape of its parameter bindings.
+
+Examples:
+- 0-d array (single binding): ``{"a": 4, ("b", "c"): [5, 6]}``
+- Single array (last index for parameters): ``{ParameterVector("a", 100): np.ones((10, 10, 100)))``
+- Multiple arrays (last index for parameters, flexible dimensions):
+  ``{("c", "a"): np.ones((10, 10, 2)), "b": np.zeros((10, 10))}``
+"""
 
 
 class BindingsArray(ShapedMixin):
@@ -63,7 +81,7 @@ class BindingsArray(ShapedMixin):
 
     def __init__(
         self,
-        data: Mapping[ParameterLike, ArrayLike | float] | None = None,
+        data: BindingsArrayLike | None = None,
         shape: ShapeInput | None = None,
     ):
         r"""
@@ -365,10 +383,3 @@ def _format_key(key: tuple[Parameter | str, ...]):
 
 def _param_name(param: Parameter | str) -> str:
     return param.name if isinstance(param, Parameter) else param
-
-
-BindingsArrayLike = Union[
-    BindingsArray,
-    "Mapping[Union[Parameter, str, Iterable[Union[Parameter, str]]], ArrayLike]",
-    None,
-]

--- a/qiskit/primitives/containers/bindings_array.py
+++ b/qiskit/primitives/containers/bindings_array.py
@@ -15,9 +15,9 @@ Bindings array class
 """
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from typing import Mapping, Union, Tuple
+from collections.abc import Iterable, Mapping as _Mapping
 from itertools import chain, islice
-from typing import Union
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -29,7 +29,7 @@ from .shape import ShapedMixin, ShapeInput, shape_tuple
 ParameterLike = Union[Parameter, str]
 """A parameter or parameter name."""
 
-BindingsArrayLike = Mapping[Union[ParameterLike, tuple[ParameterLike, ...]], ArrayLike]
+BindingsArrayLike = Mapping[Union[ParameterLike, Tuple[ParameterLike, ...]], ArrayLike]
 """A mapping of numeric bindings for circuit parameters.
 
 This allows array values for single or multi-dimensional sweeps over parameter values.
@@ -292,7 +292,7 @@ class BindingsArray(ShapedMixin):
         """
         if bindings_array is None:
             bindings_array = cls()
-        elif isinstance(bindings_array, Mapping):
+        elif isinstance(bindings_array, _Mapping):
             bindings_array = cls(data=bindings_array)
         elif isinstance(bindings_array, BindingsArray):
             return bindings_array

--- a/qiskit/primitives/containers/bindings_array.py
+++ b/qiskit/primitives/containers/bindings_array.py
@@ -26,6 +26,10 @@ from qiskit.circuit import Parameter, QuantumCircuit
 
 from .shape import ShapedMixin, ShapeInput, shape_tuple
 
+# Public API classes
+__all__ = ["ParameterLike", "BindingsArrayLike"]
+
+
 ParameterLike = Union[Parameter, str]
 """A parameter or parameter name."""
 

--- a/qiskit/primitives/containers/estimator_pub.py
+++ b/qiskit/primitives/containers/estimator_pub.py
@@ -193,3 +193,20 @@ EstimatorPubLike = Union[
     Tuple[QuantumCircuit, ObservablesArrayLike, BindingsArrayLike],
     Tuple[QuantumCircuit, ObservablesArrayLike, BindingsArrayLike, Real],
 ]
+"""A Pub (Primitive Unified Bloc) for an Estimator primitive.
+
+A fully specified estimator pub is a tuple ``(circuit, observables, parameter_values, precision)``.
+
+If precision is provided this should be used for the target precision of an
+estimator, if ``precision=None`` the estimator will determine the target precision.
+
+.. note::
+
+    An Estimator Pub can also be initialized in the following formats which
+    will be converted to the full Pub tuple:
+
+    * ``circuit
+    * ``(circuit,)``
+    * ``(circuit, observables)``
+    * ``(circuit, observalbes, parameter_values)``
+"""

--- a/qiskit/primitives/containers/estimator_pub.py
+++ b/qiskit/primitives/containers/estimator_pub.py
@@ -29,6 +29,9 @@ from .bindings_array import BindingsArray, BindingsArrayLike
 from .observables_array import ObservablesArray, ObservablesArrayLike
 from .shape import ShapedMixin
 
+# Public API classes
+__all__ = ["EstimatorPubLike"]
+
 
 class EstimatorPub(ShapedMixin):
     """Primitive Unified Bloc for any Estimator primitive.

--- a/qiskit/primitives/containers/observables_array.py
+++ b/qiskit/primitives/containers/observables_array.py
@@ -18,9 +18,9 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict
-from collections.abc import Mapping as MappingType
+from collections.abc import Iterable, Mapping as _Mapping
 from functools import lru_cache
-from typing import Iterable, Mapping, Union, overload
+from typing import Union, Mapping, overload
 from numbers import Complex
 
 import numpy as np
@@ -36,7 +36,7 @@ ObservableLike = Union[
     str,
     Pauli,
     SparsePauliOp,
-    Mapping[Union[str, Pauli], float],  # TODO: Clean up abc vs typing
+    Mapping[Union[str, Pauli], float],
 ]
 """Types that can be natively used to construct a Hermitian Estimator observable."""
 
@@ -188,7 +188,7 @@ class ObservablesArray(ShapedMixin):
             return {observable: 1}
 
         # Mapping conversion (with possible Pauli keys)
-        if isinstance(observable, MappingType):
+        if isinstance(observable, _Mapping):
             num_qubits = len(next(iter(observable)))
             unique = defaultdict(float)
             for basis, coeff in observable.items():
@@ -232,7 +232,7 @@ class ObservablesArray(ShapedMixin):
         """
         if isinstance(observables, ObservablesArray):
             return observables
-        if isinstance(observables, (str, SparsePauliOp, Pauli, Mapping)):
+        if isinstance(observables, (str, SparsePauliOp, Pauli, _Mapping)):
             observables = [observables]
         return cls(observables)
 

--- a/qiskit/primitives/containers/observables_array.py
+++ b/qiskit/primitives/containers/observables_array.py
@@ -21,6 +21,7 @@ from collections import defaultdict
 from collections.abc import Mapping as MappingType
 from functools import lru_cache
 from typing import Iterable, Mapping, Union, overload
+from numbers import Complex
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -79,7 +80,7 @@ class ObservablesArray(ShapedMixin):
         if validate:
             num_qubits = None
             for ndi, obs in np.ndenumerate(self._array):
-                basis_obs = self.format_observable(obs)
+                basis_obs = self.coerce_observable(obs)
                 basis_num_qubits = len(next(iter(basis_obs)))
                 if num_qubits is None:
                     num_qubits = basis_num_qubits
@@ -146,7 +147,7 @@ class ObservablesArray(ShapedMixin):
         return self.reshape(self.size)
 
     @classmethod
-    def format_observable(cls, observable: ObservableLike) -> Mapping[str, float]:
+    def coerce_observable(cls, observable: ObservableLike) -> Mapping[str, float]:
         """Format an observable-like object into a :const:`BasisObservable`.
 
         Args:
@@ -159,15 +160,27 @@ class ObservablesArray(ShapedMixin):
             TypeError: If the input cannot be formatted because its type is not valid.
             ValueError: If the input observable is invalid.
         """
-        # TODO: ERROR ON NON HERMITIAN PAULI/SPARSE PAULI
         # Pauli-type conversions
         if isinstance(observable, SparsePauliOp):
+            observable = observable.simplify(atol=0)
+            # Check that the operator is Hermitian and has real coeffs
+            coeffs = np.real_if_close(observable.coeffs)
+            if np.iscomplexobj(coeffs):
+                raise ValueError(
+                    "Non-Hermitian input observable: the input SparsePauliOp has non-zero"
+                    " imaginary part in its coefficients."
+                )
+            paulis = observable.paulis.to_labels()
             # Call simplify to combine duplicate keys before converting to a mapping
-            return cls.format_observable(dict(observable.simplify(atol=0).to_list()))
+            return dict(zip(paulis, coeffs))
 
         if isinstance(observable, Pauli):
             label, phase = observable[:].to_label(), observable.phase
-            return {label: 1} if phase == 0 else {label: (-1j) ** phase}
+            if phase % 2:
+                raise ValueError(
+                    "Non-Hermitian input observable: the input Pauli has an imaginary phase."
+                )
+            return {label: 1} if phase == 0 else {label: -1}
 
         # String conversion
         if isinstance(observable, str):
@@ -177,12 +190,25 @@ class ObservablesArray(ShapedMixin):
         # Mapping conversion (with possible Pauli keys)
         if isinstance(observable, MappingType):
             num_qubits = len(next(iter(observable)))
-            unique = defaultdict(complex)
+            unique = defaultdict(float)
             for basis, coeff in observable.items():
                 if isinstance(basis, Pauli):
                     basis, phase = basis[:].to_label(), basis.phase
-                    if phase != 0:
-                        coeff = coeff * (-1j) ** phase
+                    if phase % 2:
+                        raise ValueError(
+                            "Non-Hermitian input observable: the input Pauli has an imaginary phase."
+                        )
+                    if phase == 2:
+                        coeff = -coeff
+                # Truncate complex numbers to real
+                if isinstance(coeff, Complex):
+                    if abs(coeff.imag) > 1e-7:
+                        raise TypeError(
+                            f"Non-Hermitian input observable: {basis} term has a complex value"
+                            " coefficient."
+                        )
+                    coeff = coeff.real
+
                 # Validate basis
                 cls._validate_basis(basis)
                 if len(basis) != num_qubits:

--- a/qiskit/primitives/containers/observables_array.py
+++ b/qiskit/primitives/containers/observables_array.py
@@ -31,6 +31,8 @@ from qiskit.quantum_info import Pauli, PauliList, SparsePauliOp
 from .object_array import object_array
 from .shape import ShapedMixin, shape_tuple
 
+# Public API classes
+__all__ = ["ObservableLike", "ObservablesArrayLike"]
 
 ObservableLike = Union[
     str,

--- a/qiskit/primitives/containers/sampler_pub.py
+++ b/qiskit/primitives/containers/sampler_pub.py
@@ -28,7 +28,7 @@ from .shape import ShapedMixin
 
 
 class SamplerPub(ShapedMixin):
-    """Pub (Primitive Unified Bloc) for Sampler.
+    """Pub (Primitive Unified Bloc) for a Sampler.
 
     Pub is composed of tuple (circuit, parameter_values, shots).
 
@@ -151,9 +151,24 @@ class SamplerPub(ShapedMixin):
 
 
 SamplerPubLike = Union[
-    SamplerPub,
     QuantumCircuit,
     Tuple[QuantumCircuit],
     Tuple[QuantumCircuit, BindingsArrayLike],
     Tuple[QuantumCircuit, BindingsArrayLike, Union[Integral, None]],
 ]
+"""A Pub (Primitive Unified Bloc) for a Sampler.
+
+A fully specified sample Pub is a tuple ``(circuit, parameter_values, shots)``.
+
+If shots are provided this number of shots will be run with the sampler,
+if ``shots=None`` the number of run shots is determined by the sampler.
+
+.. note::
+
+    A Sampler Pub can also be initialized in the following formats which
+    will be converted to the full Pub tuple:
+
+    * ``circuit
+    * ``(circuit,)``
+    * ``(circuit, parameter_values)``
+"""

--- a/qiskit/primitives/containers/sampler_pub.py
+++ b/qiskit/primitives/containers/sampler_pub.py
@@ -26,6 +26,9 @@ from qiskit import QuantumCircuit
 from .bindings_array import BindingsArray, BindingsArrayLike
 from .shape import ShapedMixin
 
+# Public API classes
+__all__ = ["SamplerPubLike"]
+
 
 class SamplerPub(ShapedMixin):
     """Pub (Primitive Unified Bloc) for a Sampler.

--- a/qiskit/primitives/statevector_estimator.py
+++ b/qiskit/primitives/statevector_estimator.py
@@ -22,7 +22,8 @@ import numpy as np
 from qiskit.quantum_info import SparsePauliOp, Statevector
 
 from .base import BaseEstimatorV2
-from .containers import EstimatorPub, EstimatorPubLike, PrimitiveResult, PubResult
+from .containers import EstimatorPubLike, PrimitiveResult, PubResult
+from .containers.estimator_pub import EstimatorPub
 from .primitive_job import PrimitiveJob
 from .utils import bound_circuit_to_instruction
 

--- a/qiskit/primitives/statevector_sampler.py
+++ b/qiskit/primitives/statevector_sampler.py
@@ -32,10 +32,10 @@ from .containers import (
     BitArray,
     PrimitiveResult,
     PubResult,
-    SamplerPub,
     SamplerPubLike,
     make_data_bin,
 )
+from .containers.sampler_pub import SamplerPub
 from .containers.bit_array import _min_num_bytes
 from .primitive_job import PrimitiveJob
 from .utils import bound_circuit_to_instruction

--- a/test/python/primitives/containers/test_bindings_array.py
+++ b/test/python/primitives/containers/test_bindings_array.py
@@ -16,8 +16,8 @@ import ddt
 import numpy as np
 
 from qiskit.circuit import Parameter, ParameterVector, QuantumCircuit
-from qiskit.primitives import BindingsArray
-from test import QiskitTestCase  # pylint: disable=wrong-import-order
+from qiskit.primitives.containers.bindings_array import BindingsArray
+from qiskit import QiskitTestCase  # pylint: disable=wrong-import-order
 
 
 @ddt.ddt

--- a/test/python/primitives/containers/test_bindings_array.py
+++ b/test/python/primitives/containers/test_bindings_array.py
@@ -17,7 +17,7 @@ import numpy as np
 
 from qiskit.circuit import Parameter, ParameterVector, QuantumCircuit
 from qiskit.primitives.containers.bindings_array import BindingsArray
-from qiskit import QiskitTestCase  # pylint: disable=wrong-import-order
+from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
 
 @ddt.ddt

--- a/test/python/primitives/containers/test_estimator_pub.py
+++ b/test/python/primitives/containers/test_estimator_pub.py
@@ -16,7 +16,9 @@ import ddt
 import numpy as np
 
 from qiskit.circuit import QuantumCircuit, Parameter
-from qiskit.primitives.containers import BindingsArray, EstimatorPub, ObservablesArray
+from qiskit.primitives.containers.estimator_pub import EstimatorPub
+from qiskit.primitives.containers.observables_array import ObservablesArray
+from qiskit.primitives.containers.bindings_array import BindingsArray
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
 

--- a/test/python/primitives/containers/test_observables_array.py
+++ b/test/python/primitives/containers/test_observables_array.py
@@ -17,7 +17,7 @@ import ddt
 import numpy as np
 
 import qiskit.quantum_info as qi
-from qiskit.primitives import ObservablesArray
+from qiskit.primitives.containers.observables_array import ObservablesArray
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
 

--- a/test/python/primitives/containers/test_sampler_pub.py
+++ b/test/python/primitives/containers/test_sampler_pub.py
@@ -16,7 +16,8 @@ import ddt
 import numpy as np
 
 from qiskit.circuit import QuantumCircuit, Parameter
-from qiskit.primitives.containers import SamplerPub, BindingsArray
+from qiskit.primitives.containers.sampler_pub import SamplerPub
+from qiskit.primitives.containers.bindings_array import BindingsArray
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
 

--- a/test/python/primitives/test_statevector_estimator.py
+++ b/test/python/primitives/test_statevector_estimator.py
@@ -18,7 +18,10 @@ import numpy as np
 
 from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.circuit.library import RealAmplitudes
-from qiskit.primitives import BindingsArray, EstimatorPub, ObservablesArray, StatevectorEstimator
+from qiskit.primitives import StatevectorEstimator
+from qiskit.primitives.containers.estimator_pub import EstimatorPub
+from qiskit.primitives.containers.observables_array import ObservablesArray
+from qiskit.primitives.containers.bindings_array import BindingsArray
 from qiskit.quantum_info import SparsePauliOp
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 

--- a/test/python/primitives/test_statevector_sampler.py
+++ b/test/python/primitives/test_statevector_sampler.py
@@ -23,9 +23,10 @@ from numpy.typing import NDArray
 from qiskit import ClassicalRegister, QiskitError, QuantumCircuit, QuantumRegister
 from qiskit.circuit import Parameter
 from qiskit.circuit.library import RealAmplitudes, UnitaryGate
-from qiskit.primitives import PrimitiveResult, PubResult, SamplerPub
+from qiskit.primitives import PrimitiveResult, PubResult
 from qiskit.primitives.containers import BitArray
 from qiskit.primitives.containers.data_bin import DataBin
+from qiskit.primitives.containers.sampler_pub import SamplerPub
 from qiskit.primitives.statevector_sampler import StatevectorSampler
 from qiskit.providers import JobStatus
 from test import QiskitTestCase  # pylint: disable=wrong-import-order


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Make the V2 primitives input container and pubs classes private and removes them from public API Docs

### Details and comments

This removes the EstimatorPub, SamplerPub, BindingsArray, ObservablesArray classes from API docs to make them internal and not subject to qiskits deprecation policies for public classes. This is because we have not had sufficient time to fully finalize these classes before the 1.0 release and anticipate making possibly breaking changes to them in future qiskit releases.

Note that we still intend for the `<class>Like` type hints to be in the API docs, though im not entirely sure how to get these to build and render in sphinx with propert doc strings and without unrolling all the composite type hints.