### PR TITLE
Remove `Unroller` entry-point registration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,6 @@ default = "qiskit.transpiler.preset_passmanagers.builtin_plugins:DefaultInitPass
 [project.entry-points."qiskit.transpiler.translation"]
 synthesis = "qiskit.transpiler.preset_passmanagers.builtin_plugins:UnitarySynthesisPassManager"
 translator = "qiskit.transpiler.preset_passmanagers.builtin_plugins:BasisTranslatorPassManager"
-unroller = "qiskit.transpiler.preset_passmanagers.builtin_plugins:UnrollerPassManager"
 
 [project.entry-points."qiskit.transpiler.routing"]
 basic = "qiskit.transpiler.preset_passmanagers.builtin_plugins:BasicSwapPassManager"


### PR DESCRIPTION
### Summary

The `Unroller` pass and its associated plugin was removed in gh-11581, but this registration was overlooked (not surprisingly - it's very easy to miss!).  This is causing the test suite to log warnings at the moment during plugin evaluation.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


