### PR TITLE
Remove pulse scoped_parameters and search_parameters

### DIFF
--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -879,83 +879,53 @@ class ScheduleBlock:
     Appended reference directives are resolved when the main program is executed.
     Subroutines must be assigned through :meth:`assign_references` before execution.
 
-    .. rubric:: Program Scoping
-
-    When you call a subroutine from another subroutine, or append a schedule block
-    to another schedule block, the management of references and parameters
-    can be a hard task. Schedule block offers a convenient feature to help with this
-    by automatically scoping the parameters and subroutines.
+    One way to reference a subroutine in a schedule is to use the pulse
+    builder's :func:`~qiskit.pulse.builder.reference`  function to declare an
+    unassigned reference.  In this example, the program is called with the
+    reference key "grand_child".  You can call a subroutine without specifying
+    a substantial program.
 
     .. code-block::
 
         from qiskit import pulse
         from qiskit.circuit.parameter import Parameter
 
-        amp1 = Parameter("amp")
+        amp1 = Parameter("amp1")
+        amp2 = Parameter("amp2")
 
-        with pulse.build() as sched1:
+        with pulse.build() as sched_inner:
             pulse.play(pulse.Constant(100, amp1), pulse.DriveChannel(0))
 
-        print(sched1.scoped_parameters())
-
-    .. parsed-literal::
-
-       (Parameter(root::amp),)
-
-    The :meth:`~ScheduleBlock.scoped_parameters` method returns all :class:`~.Parameter`
-    objects defined in the schedule block. The parameter name is updated to reflect
-    its scope information, i.e. where it is defined.
-    The outer scope is called "root". Since the "amp" parameter is directly used
-    in the current builder context, it is prefixed with "root".
-    Note that the :class:`Parameter` object returned by :meth:`~ScheduleBlock.scoped_parameters`
-    preserves the hidden `UUID`_ key, and thus the scoped name doesn't break references
-    to the original :class:`Parameter`.
-
-    You may want to call this program from another program.
-    In this example, the program is called with the reference key "grand_child".
-    You can call a subroutine without specifying a substantial program
-    (like ``sched1`` above which we will assign later).
-
-    .. code-block::
-
-        amp2 = Parameter("amp")
-
-        with pulse.build() as sched2:
+        with pulse.build() as sched_outer:
             with pulse.align_right():
                 pulse.reference("grand_child")
                 pulse.play(pulse.Constant(200, amp2), pulse.DriveChannel(0))
 
-        print(sched2.scoped_parameters())
-
-    .. parsed-literal::
-
-       (Parameter(root::amp),)
-
-    This only returns "root::amp" because the "grand_child" reference is unknown.
-    Now you assign the actual pulse program to this reference.
+    Now you assign the inner pulse program to this reference.
 
     .. code-block::
 
-        sched2.assign_references({("grand_child", ): sched1})
-        print(sched2.scoped_parameters())
+        sched_outer.assign_references({("grand_child", ): sched_inner})
+        print(sched_outer.parameters)
 
     .. parsed-literal::
 
-       (Parameter(root::amp), Parameter(root::grand_child::amp))
+       {Parameter(amp1), Parameter(amp2)}
 
-    Now you get two parameters "root::amp" and "root::grand_child::amp".
-    The second parameter name indicates it is defined within the referred program "grand_child".
+    The outer program now has the parameter ``amp2`` from the inner program,
+    indicating that the inner program's data has been made available to the
+    outer program.
     The program calling the "grand_child" has a reference program description
     which is accessed through :attr:`ScheduleBlock.references`.
 
     .. code-block::
 
-        print(sched2.references)
+        print(sched_outer.references)
 
     .. parsed-literal::
 
        ReferenceManager:
-         - ('grand_child',): ScheduleBlock(Play(Constant(duration=100, amp=amp,...
+         - ('grand_child',): ScheduleBlock(Play(Constant(duration=100, amp=amp1,...
 
     Finally, you may want to call this program from another program.
     Here we try a different approach to define subroutine. Namely, we call
@@ -963,37 +933,20 @@ class ScheduleBlock:
 
     .. code-block::
 
-        amp3 = Parameter("amp")
+        amp3 = Parameter("amp3")
 
         with pulse.build() as main:
             pulse.play(pulse.Constant(300, amp3), pulse.DriveChannel(0))
-            pulse.call(sched2, name="child")
+            pulse.call(sched_outer, name="child")
 
-        print(main.scoped_parameters())
+        print(main.parameters)
 
     .. parsed-literal::
 
-       (Parameter(root::amp), Parameter(root::child::amp), Parameter(root::child::grand_child::amp))
+       {Parameter(amp1), Parameter(amp2), Parameter(amp3}
 
     This implicitly creates a reference named "child" within
-    the root program and assigns ``sched2`` to it.
-    You get three parameters "root::amp", "root::child::amp", and "root::child::grand_child::amp".
-    As you can see, each parameter name reflects the layer of calls from the root program.
-    If you know the scope of a parameter, you can directly get the parameter object
-    using :meth:`ScheduleBlock.search_parameters` as follows.
-
-    .. code-block::
-
-        main.search_parameters("root::child::grand_child::amp")
-
-    You can use a regular expression to specify the scope.
-    The following returns the parameters defined within the scope of "ground_child"
-    regardless of its parent scope. This is sometimes convenient if you
-    want to extract parameters from a deeply nested program.
-
-    .. code-block::
-
-        main.search_parameters("\\S::grand_child::amp")
+    the root program and assigns ``sched_outer`` to it.
 
     Note that the root program is only aware of its direct references.
 
@@ -1015,10 +968,8 @@ class ScheduleBlock:
 
         main.references[("child", )].references[("grand_child", )]
 
-    Note that :attr:`ScheduleBlock.parameters` and :meth:`ScheduleBlock.scoped_parameters()`
-    still collect all parameters also from the subroutine once it's assigned.
-
-    .. _UUID: https://docs.python.org/3/library/uuid.html#module-uuid
+    Note that :attr:`ScheduleBlock.parameters` still collects all parameters
+    also from the subroutine once it's assigned.
     """
 
     __slots__ = (
@@ -1225,25 +1176,6 @@ class ScheduleBlock:
             out_params |= subroutine.parameters
 
         return out_params
-
-    def scoped_parameters(self) -> tuple[Parameter, ...]:
-        """Return unassigned parameters with scoped names.
-
-        .. note::
-
-            If a parameter is defined within a nested scope,
-            it is prefixed with all parent-scope names with the delimiter string,
-            which is "::". If a reference key of the scope consists of
-            multiple key strings, it will be represented by a single string joined with ",".
-            For example, "root::xgate,q0::amp" for the parameter "amp" defined in the
-            reference specified by the key strings ("xgate", "q0").
-        """
-        return tuple(
-            sorted(
-                _collect_scoped_parameters(self, current_scope="root").values(),
-                key=lambda p: p.name,
-            )
-        )
 
     @property
     def references(self) -> ReferenceManager:
@@ -1624,43 +1556,6 @@ class ScheduleBlock:
         matched = [p for p in self.parameters if p.name == parameter_name]
         return matched
 
-    def search_parameters(self, parameter_regex: str) -> list[Parameter]:
-        """Search parameter with regular expression.
-
-        This method looks for the scope-aware parameters.
-        For example,
-
-        .. code-block:: python
-
-            from qiskit import pulse, circuit
-
-            amp1 = circuit.Parameter("amp")
-            amp2 = circuit.Parameter("amp")
-
-            with pulse.build() as sub_prog:
-                pulse.play(pulse.Constant(100, amp1), pulse.DriveChannel(0))
-
-            with pulse.build() as main_prog:
-                pulse.call(sub_prog, name="sub")
-                pulse.play(pulse.Constant(100, amp2), pulse.DriveChannel(0))
-
-            main_prog.search_parameters("root::sub::amp")
-
-        This finds ``amp1`` with scoped name "root::sub::amp".
-
-        Args:
-            parameter_regex: Regular expression for scoped parameter name.
-
-        Returns:
-            Parameter objects that have corresponding name.
-        """
-        pattern = re.compile(parameter_regex)
-
-        return sorted(
-            _collect_scoped_parameters(self, current_scope="root", filter_regex=pattern).values(),
-            key=lambda p: p.name,
-        )
-
     def __len__(self) -> int:
         """Return number of instructions in the schedule."""
         return len(self.blocks)
@@ -1936,56 +1831,6 @@ def _get_references(block_elms: list["BlockComponent"]) -> set[Reference]:
         elif isinstance(elm, Reference):
             references.add(elm)
     return references
-
-
-def _collect_scoped_parameters(
-    schedule: ScheduleBlock,
-    current_scope: str,
-    filter_regex: re.Pattern | None = None,
-) -> dict[tuple[str, int], Parameter]:
-    """A helper function to collect parameters from all references in scope-aware fashion.
-
-    Parameter object is renamed with attached scope information but its UUID is remained.
-    This means object is treated identically on the assignment logic.
-    This function returns a dictionary of all parameters existing in the target program
-    including its reference, which is keyed on the unique identifier consisting of
-    scoped parameter name and parameter object UUID.
-
-    This logic prevents parameter clash in the different scope.
-    For example, when two parameter objects with the same UUID exist in different references,
-    both of them appear in the output dictionary, even though they are technically the same object.
-    This feature is particularly convenient to search parameter object with associated scope.
-
-    Args:
-        schedule: Schedule to get parameters.
-        current_scope: Name of scope where schedule exist.
-        filter_regex: Optional. Compiled regex to sort parameter by name.
-
-    Returns:
-        A dictionary of scoped parameter objects.
-    """
-    parameters_out = {}
-    for param in schedule._parameter_manager.parameters:
-        new_name = f"{current_scope}{Reference.scope_delimiter}{param.name}"
-
-        if filter_regex and not re.search(filter_regex, new_name):
-            continue
-        scoped_param = Parameter(new_name, uuid=getattr(param, "_uuid"))
-
-        unique_key = new_name, hash(param)
-        parameters_out[unique_key] = scoped_param
-
-    for sub_namespace, subroutine in schedule.references.items():
-        if subroutine is None:
-            continue
-        composite_key = Reference.key_delimiter.join(sub_namespace)
-        full_path = f"{current_scope}{Reference.scope_delimiter}{composite_key}"
-        sub_parameters = _collect_scoped_parameters(
-            subroutine, current_scope=full_path, filter_regex=filter_regex
-        )
-        parameters_out.update(sub_parameters)
-
-    return parameters_out
 
 
 # These type aliases are defined at the bottom of the file, because as of 2022-01-18 they are

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -36,7 +36,6 @@ import copy
 import functools
 import itertools
 import multiprocessing as mp
-import re
 import sys
 import warnings
 from collections.abc import Callable, Iterable

--- a/releasenotes/notes/remove-pulse-scoped-parameters-fa897399900f2ef2.yaml
+++ b/releasenotes/notes/remove-pulse-scoped-parameters-fa897399900f2ef2.yaml
@@ -1,0 +1,12 @@
+---
+upgrade:
+  - |
+    The ``scoped_parameters`` and ``search_parameters`` methods have been
+    removed from the `.ScheduleBlock` class. These methods returned
+    `.Parameter` objects that partially linked to the parameters in the
+    `.ScheduleBlock` instance but assigning values using these objects did not
+    work correctly. Users should use `.ScheduleBlock.parameters` instead and
+    iterate through `.ScheduleBlock.references` and compare to the
+    `.Schedule.parameters` attributes of the subreferences when needing to
+    distinguish which subroutine a parameter is used in. See `#11654
+    https://github.com/Qiskit/qiskit/issues/11654`__ for more information.

--- a/releasenotes/notes/remove-pulse-scoped-parameters-fa897399900f2ef2.yaml
+++ b/releasenotes/notes/remove-pulse-scoped-parameters-fa897399900f2ef2.yaml
@@ -2,11 +2,11 @@
 upgrade:
   - |
     The ``scoped_parameters`` and ``search_parameters`` methods have been
-    removed from the `.ScheduleBlock` class. These methods returned
-    `.Parameter` objects that partially linked to the parameters in the
-    `.ScheduleBlock` instance but assigning values using these objects did not
-    work correctly. Users should use `.ScheduleBlock.parameters` instead and
-    iterate through `.ScheduleBlock.references` and compare to the
-    `.Schedule.parameters` attributes of the subreferences when needing to
+    removed from the :class:`.ScheduleBlock` class. These methods returned
+    :class:`.Parameter` objects that partially linked to the parameters in the
+    :class:`.ScheduleBlock` instance but assigning values using these objects did not
+    work correctly. Users should use :attr:`.ScheduleBlock.parameters` instead and
+    iterate through :attr:`.ScheduleBlock.references` and compare to the
+    :attr:`.Schedule.parameters` attributes of the subreferences when needing to
     distinguish which subroutine a parameter is used in. See `#11654
-    https://github.com/Qiskit/qiskit/issues/11654`__ for more information.
+    https://github.com/Qiskit/qiskit/issues/11654>`__ for more information.

--- a/test/python/pulse/test_reference.py
+++ b/test/python/pulse/test_reference.py
@@ -15,7 +15,7 @@
 import numpy as np
 
 from qiskit import circuit, pulse
-from qiskit.pulse import builder
+from qiskit.pulse import ScheduleBlock, builder
 from qiskit.pulse.transforms import inline_subroutines
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
@@ -39,31 +39,6 @@ class TestReference(QiskitTestCase):
             builder.append_schedule(sched_y1)
 
         self.assertEqual(len(sched_z1.references), 0)
-
-    def test_append_schedule_parameter_scope(self):
-        """Test appending schedule without calling.
-
-        Parameter in the appended schedule has the scope of outer schedule.
-        """
-        param = circuit.Parameter("name")
-
-        with pulse.build() as sched_x1:
-            pulse.play(pulse.Constant(100, param, name="x1"), pulse.DriveChannel(0))
-
-        with pulse.build() as sched_y1:
-            builder.append_schedule(sched_x1)
-
-        with pulse.build() as sched_z1:
-            builder.append_schedule(sched_y1)
-
-        sched_param = next(iter(sched_z1.scoped_parameters()))
-        self.assertEqual(sched_param.name, "root::name")
-
-        # object equality
-        self.assertEqual(
-            sched_z1.search_parameters("root::name")[0],
-            param,
-        )
 
     def test_refer_schedule(self):
         """Test refer to schedule by name.
@@ -108,20 +83,47 @@ class TestReference(QiskitTestCase):
         sched_y1.assign_references({("x1", "d0"): sched_x1})
         sched_z1.assign_references({("y1", "d0"): sched_y1})
 
-        sched_param = next(iter(sched_z1.scoped_parameters()))
-        self.assertEqual(sched_param.name, "root::y1,d0::x1,d0::name")
+        self.assertEqual(sched_z1.parameters, sched_x1.parameters)
+        self.assertEqual(sched_z1.parameters, sched_y1.parameters)
 
-        # object equality
-        self.assertEqual(
-            sched_z1.search_parameters("root::y1,d0::x1,d0::name")[0],
-            param,
-        )
+    def test_refer_schedule_parameter_assignment(self):
+        """Test assigning to parametr in referenced schedule"""
+        param = circuit.Parameter("name")
 
-        # regex
-        self.assertEqual(
-            sched_z1.search_parameters(r"\S::x1,d0::name")[0],
-            param,
-        )
+        with pulse.build() as sched_x1:
+            pulse.play(pulse.Constant(100, param, name="x1"), pulse.DriveChannel(0))
+
+        with pulse.build() as sched_y1:
+            builder.reference("x1", "d0")
+
+        with pulse.build() as sched_z1:
+            builder.reference("y1", "d0")
+
+        sched_y1.assign_references({("x1", "d0"): sched_x1})
+        sched_z1.assign_references({("y1", "d0"): sched_y1})
+
+        assigned_z1 = sched_z1.assign_parameters({param: 0.5}, inplace=False)
+
+        assigned_x1 = sched_x1.assign_parameters({param: 0.5}, inplace=False)
+        ref_assigned_y1 = ScheduleBlock()
+        ref_assigned_y1.append(assigned_x1)
+        ref_assigned_z1 = ScheduleBlock()
+        ref_assigned_z1.append(ref_assigned_y1)
+
+        # Test that assignment was successful and resolved references
+        self.assertEqual(assigned_z1, ref_assigned_z1)
+
+        # Test that inplace=False for sched_z1 also did not modify sched_z1 or  subroutine sched_x1
+        self.assertEqual(sched_z1.parameters, {param})
+        self.assertEqual(sched_x1.parameters, {param})
+        self.assertEqual(assigned_z1.parameters, set())
+
+        # Now test inplace=True
+        sched_z1.assign_parameters({param: 0.5}, inplace=True)
+        self.assertEqual(sched_z1, assigned_z1)
+        # assign_references copies the subroutine, so the original subschedule
+        # is still not modified here:
+        self.assertNotEqual(sched_x1, assigned_x1)
 
     def test_call_schedule(self):
         """Test call schedule.
@@ -160,20 +162,8 @@ class TestReference(QiskitTestCase):
         with pulse.build() as sched_z1:
             builder.call(sched_y1, name="y1")
 
-        sched_param = next(iter(sched_z1.scoped_parameters()))
-        self.assertEqual(sched_param.name, "root::y1::x1::name")
-
-        # object equality
-        self.assertEqual(
-            sched_z1.search_parameters("root::y1::x1::name")[0],
-            param,
-        )
-
-        # regex
-        self.assertEqual(
-            sched_z1.search_parameters(r"\S::x1::name")[0],
-            param,
-        )
+        self.assertEqual(sched_z1.parameters, sched_x1.parameters)
+        self.assertEqual(sched_z1.parameters, sched_y1.parameters)
 
     def test_append_and_call_schedule(self):
         """Test call and append schedule.
@@ -353,32 +343,8 @@ class TestReference(QiskitTestCase):
         self.assertEqual(sched_z2.references[("r1",)], sched_r1)
         self.assertEqual(sched_z2.references[("y1",)], sched_y1)
 
-    def test_special_parameter_name(self):
-        """Testcase to guarantee usage of some special symbols in parameter name.
-
-        These symbols might be often used in user code.
-        No conflict should occur with the default scope delimiter.
-        """
-        param = circuit.Parameter("my.parameter_object")
-
-        with pulse.build() as sched_x1:
-            pulse.play(pulse.Constant(100, param, name="x1"), pulse.DriveChannel(0))
-
-        with pulse.build() as sched_y1:
-            pulse.reference("sub", "q0")
-        sched_y1.assign_references({("sub", "q0"): sched_x1})
-
-        ret_param = sched_y1.search_parameters(r"\Ssub,q0::my.parameter_object")[0]
-
-        self.assertEqual(param, ret_param)
-
     def test_parameter_in_multiple_scope(self):
-        """Testcase for scope-aware parameter getter.
-
-        When a single parameter object is used in multiple scopes,
-        the scoped_parameters method must return parameter objects associated to each scope,
-        while parameters property returns a single parameter object.
-        """
+        """Test that using parameter in multiple scopes causes no error"""
         param = circuit.Parameter("name")
 
         with pulse.build() as sched_x1:
@@ -392,10 +358,7 @@ class TestReference(QiskitTestCase):
             pulse.call(sched_y1, name="y1")
 
         self.assertEqual(len(sched_z1.parameters), 1)
-        self.assertEqual(len(sched_z1.scoped_parameters()), 2)
-
-        self.assertEqual(sched_z1.search_parameters("root::x1::name")[0], param)
-        self.assertEqual(sched_z1.search_parameters("root::y1::name")[0], param)
+        self.assertEqual(sched_z1.parameters, {param})
 
     def test_parallel_alignment_equality(self):
         """Testcase for potential edge case.
@@ -557,10 +520,6 @@ class TestSubroutineWithCXGate(QiskitTestCase):
         params = {p.name for p in sched.parameters}
         self.assertSetEqual(params, {"cr"})
 
-        # Parameter names are scoepd
-        scoped_params = {p.name for p in sched.scoped_parameters()}
-        self.assertSetEqual(scoped_params, {"root::cr"})
-
         # Assign CR and XP schedule to the empty reference
         sched.assign_references({("cr", "q0", "q1"): self.cr_sched})
         sched.assign_references({("xp", "q0"): self.xp_sched})
@@ -571,31 +530,12 @@ class TestSubroutineWithCXGate(QiskitTestCase):
         self.assertEqual(assigned_refs[("xp", "q0")], self.xp_sched)
 
         # Parameter added from subroutines
-        scoped_params = {p.name for p in sched.scoped_parameters()}
-        ref_params = {
-            # This is the cr parameter that belongs to phase_offset instruction in the root scope
-            "root::cr",
-            # This is the same cr parameter that belongs to the play instruction in a child scope
-            "root::cr,q0,q1::cr",
-            "root::cr,q0,q1::amp",
-            "root::cr,q0,q1::dur",
-            "root::cr,q0,q1::risefall",
-            "root::cr,q0,q1::sigma",
-            "root::xp,q0::ctrl",
-            "root::xp,q0::amp",
-            "root::xp,q0::beta",
-            "root::xp,q0::dur",
-            "root::xp,q0::sigma",
-        }
-        self.assertSetEqual(scoped_params, ref_params)
+        ref_params = {self.cr_ch} | self.cr_sched.parameters | self.xp_sched.parameters
+        self.assertSetEqual(sched.parameters, ref_params)
 
         # Get parameter without scope, cr amp and xp amp are hit.
         params = sched.get_parameters(parameter_name="amp")
         self.assertEqual(len(params), 2)
-
-        # Get parameter with scope, only xp amp
-        params = sched.search_parameters(parameter_regex="root::xp,q0::amp")
-        self.assertEqual(len(params), 1)
 
     def test_cnot(self):
         """Integration test with CNOT schedule construction."""
@@ -612,14 +552,6 @@ class TestSubroutineWithCXGate(QiskitTestCase):
             pulse.shift_phase(np.pi / 2, pulse.DriveChannel(self.control_ch))
             pulse.call(self.sx_sched, name="sx")
             pulse.call(ecr_sched, name="ecr")
-
-        # get parameter with scope, full scope is not needed
-        xp_amp = cx_sched.search_parameters(r"\S:xp::amp")[0]
-        self.assertEqual(self.xp_amp, xp_amp)
-
-        # get parameter with scope, of course full scope can be specified
-        xp_amp_full_scoped = cx_sched.search_parameters("root::ecr::xp::amp")[0]
-        self.assertEqual(xp_amp_full_scoped, xp_amp)
 
         # assign parameters
         assigned_cx = cx_sched.assign_parameters(


### PR DESCRIPTION
The `scoped_parameters` and `search_parameters` methods have been removed from the `ScheduleBlock` class. These methods returned `Parameter` objects that partially linked to the parameters in the `ScheduleBlock` instance but assigning values using these objects did not work correctly. Users should use `ScheduleBlock.parameters` instead and iterate through `ScheduleBlock.references` and compare to the `Schedule.parameters` attributes of the subreferences when needing to distinguish which subroutine a parameter is used in. See https://github.com/Qiskit/qiskit/issues/11654 for more information.

The code removal itself was straightforward here because the relevant methods were not used anywhere else except the tests. For the tests, it was a little tricky because I didn't want to remove logic that was testing schedule references. Where I could, I changed the scoped parameter checks to regular parameter checks. I might have kept more tests than needed. I added one test for assignment to a parameter in a subroutine since not having such a test was why #11654 was not found earlier.

The documentation was also tricky because the scoped parameters were used to document some of the features of schedule references. I tried to pull out the discussion of scoped parameters while leaving the examples of assigning references. I substituted in some use of regular parameters (changed to have distinguishable names) just as a way to show that data from the subroutine was available in the caller after the assignment.

Related deprecation in #11691.