### PR TITLE
Fix `approximation_degree` default in `generate_preset_pass_maanger`

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/__init__.py
+++ b/qiskit/transpiler/preset_passmanagers/__init__.py
@@ -84,7 +84,7 @@ def generate_preset_pass_manager(
     routing_method=None,
     translation_method=None,
     scheduling_method=None,
-    approximation_degree=None,
+    approximation_degree=1.0,
     seed_transpiler=None,
     unitary_synthesis_method="default",
     unitary_synthesis_plugin_config=None,

--- a/releasenotes/notes/preset-pass-manager-approximation-degree-503198b1974adf79.yaml
+++ b/releasenotes/notes/preset-pass-manager-approximation-degree-503198b1974adf79.yaml
@@ -2,7 +2,7 @@
 upgrade:
   - |
     The implicit use of ``approximation_degree!=1.0`` by default in the
-    :func:`~.generate_preset_pass_manager` function at ``optimization_level=3`` has been
+    :func:`~.generate_preset_pass_manager` function has been
     disabled.  The previous default could cause undue and unexpected approximations, especially in
     workloads involving Trotterization or similar runs of operations that are close, but decidedly
     not equal, to the identity.

--- a/releasenotes/notes/preset-pass-manager-approximation-degree-503198b1974adf79.yaml
+++ b/releasenotes/notes/preset-pass-manager-approximation-degree-503198b1974adf79.yaml
@@ -1,0 +1,12 @@
+---
+upgrade:
+  - |
+    The implicit use of ``approximation_degree!=1.0`` by default in the
+    :func:`~.generate_preset_pass_manager` function at ``optimization_level=3`` has been
+    disabled.  The previous default could cause undue and unexpected approximations, especially in
+    workloads involving Trotterization or similar runs of operations that are close, but decidedly
+    not equal, to the identity.
+
+    This change brings the inner pass-manager generation defaults in line with :func:`.transpile`,
+    which was always the intention.  See `#8595 <https://github.com/Qiskit/qiskit/pull/8595>`__ for
+    more detail.


### PR DESCRIPTION
### Summary

This brings it inline with `transpile`, as was done in gh-8595.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

I'm proposing this as a candidate for 1.0 despite missing the deadline (needs another maintainer's sign-off) because this is really surprising behaviour, and we decided way back in #8595 that the default of "approximate away literally all of my Trotterisation" was a sufficiently poor default we ought to make the change as a sort-of bugfix.  It's even more surprising for `generate_preset_pass_manager` to do this if `transpile` isn't.

Fix #11693.