### PR TITLE
Disable cron runs on old stable branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,20 +16,6 @@ pr:
     include:
       - '*'
 
-# A schedule only runs on branches that match include rules from _both_ `main`
-# and the branch itself.  On `main`, we blanket include all branches that might
-# want to be enabled, then particular branches can override it to exclude
-# themselves by removing themselves from the trigger list.  For example, old
-# stable branches can remove `stable/*` from their copy of this file once they
-# reach their end-of-life.
-schedules:
-  - cron: "20 6 * * *"
-    displayName: "Complete matrix test"
-    branches:
-      include: [ "main", "stable/*" ]
-    always: false  # Only run if the code changed since the last cron sync.
-
-
 # Configuration.  In theory a manual trigger on the Azure website or embedding
 # this pipeline as a template can override these, but we're not interested in
 # that.  We just want to give names to things to make it easier to read.


### PR DESCRIPTION
### Summary

We no longer need to be running nightly CI on the 0.45.x series, since it is no longer supported.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


