### PR TITLE
Add a method to `BitArray` to return bitstrings

### DIFF
--- a/test/python/primitives/containers/test_bit_array.py
+++ b/test/python/primitives/containers/test_bit_array.py
@@ -108,6 +108,29 @@ class BitArrayTestCase(QiskitTestCase):
         # test that providing no location takes the union over all shots
         self.assertEqual(bit_array.get_int_counts(), {val1: 2, val2: 1, val3: 1, val4: 2})
 
+    def test_get_bitstrings(self):
+        """Test conversion to bitstrings."""
+        # note that [234, 100] requires 16 bits, not 15; we are testing that get_counts ignores the
+        # junk columns
+        bit_array = BitArray(u_8([[3, 5], [3, 5], [234, 100]]), num_bits=15)
+        bs1 = "0000011" + "00000101"  # 3, 5
+        bs2 = "1101010" + "01100100"  # 234, 100
+        self.assertEqual(bit_array.get_bitstrings(), [bs1, bs1, bs2])
+
+        bit_array = BitArray(
+            u_8([[[3, 5], [3, 5], [234, 100]], [[0, 1], [1, 0], [1, 0]]]),
+            num_bits=15,
+        )
+        bs1 = "0000011" + "00000101"  # 3, 5
+        bs2 = "1101010" + "01100100"  # 234, 100
+        self.assertEqual(bit_array.get_bitstrings(0), [bs1, bs1, bs2])
+        bs3 = "0000000" + "00000001"  # 0, 1
+        bs4 = "0000001" + "00000000"  # 1, 0
+        self.assertEqual(bit_array.get_bitstrings(1), [bs3, bs4, bs4])
+
+        # test that providing no location takes the union over all shots
+        self.assertEqual(bit_array.get_bitstrings(), [bs1, bs1, bs2, bs3, bs4, bs4])
+
     def test_equality(self):
         """Test the equality operator"""
         ba1 = BitArray.from_bool_array([[1, 0, 0], [1, 1, 0]])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

`BitArray` has methods `get_counts` and `get_int_counts` to return counts dictionary, and `array` property to return array of bitstrings as uint8.
The array does not look intuitive because the data is packed, and the number of qubits is not visible.
This PR adds `get_bitstrings` method to return bitstrings as str.

I think it's useful, but I don't have a strong opinion.

Example:
```python
from qiskit.circuit import QuantumCircuit, Parameter
from qiskit.primitives import StatevectorSampler

qc = QuantumCircuit(2, 2)
a = Parameter('a')
qc.ry(a, 0)
qc.measure([0, 1], [0, 1])

sampler = StatevectorSampler()
result = sampler.run([(qc, [0, 1, 2], 10)]).result()
print(result[0].data.c.array[1])
# [[0]
#  [1]
#  [0]
#  [0]
#  [1]
#  [0]
#  [0]
#  [0]
#  [0]
#  [0]]

print(result[0].data.c.get_bitstrings(1))
# ['00', '01', '00', '00', '01', '00', '00', '00', '00', '00']
```

TODO
- [x] unit test


### Details and comments


