### PR TITLE
Fix documentation build

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -13,7 +13,6 @@ This page contains the release notes for Qiskit, starting from Qiskit 0.45, the 
 
 .. release-notes::
    :earliest-version: 0.45.0rc1
-   :branch: main
 
 .. release-notes::
    :earliest-version: 0.45.0

--- a/releasenotes/notes/remove-pulse-scoped-parameters-fa897399900f2ef2.yaml
+++ b/releasenotes/notes/remove-pulse-scoped-parameters-fa897399900f2ef2.yaml
@@ -9,4 +9,4 @@ upgrade:
     iterate through :attr:`.ScheduleBlock.references` and compare to the
     :attr:`.Schedule.parameters` attributes of the subreferences when needing to
     distinguish which subroutine a parameter is used in. See `#11654
-    https://github.com/Qiskit/qiskit/issues/11654>`__ for more information.
+    <https://github.com/Qiskit/qiskit/issues/11654>`__ for more information.


### PR DESCRIPTION
### Summary


A recent commit merged with a release note with invalid rST in a release note.  Our docs build currently sets the `branch` of the release notes for the newest notes to be `main`, which causes new release notes in PRs to be skipped during the PR CI, allowing potentially bad notes through.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


