### PR TITLE
Update package metadata license field to use text

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "qiskit"
 description = "An open-source SDK for working with quantum computers at the level of extended quantum circuits, operators, and primitives."
 requires-python = ">=3.8"
-license = { file = "LICENSE.txt" }
+license = {text = "Apache 2.0"}
 authors = [
     { name = "Qiskit Development Team", email = "qiskit@us.ibm.com" },
 ]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

For Qiskit 1.0.0rc1 we started to use the file include feature in the pyproject.toml to include a copy of our license text (which is just the apache 2.0 license) in the package metadata. However, when doing this PyPI attempts to render the entire license text in the package metadata on the website, see: https://pypi.org/project/qiskit/1.0.0rc1/ for an example. In order to avoid this in future releases this commit switches back to just using the "Apache 2.0" text for our license field in the package metadata. As Qiskit is Apache 2.0 licensed and we include the full license text in the sdist and the wheels we also don't need to include the full text in the package metadata too. Just labeling the project as Apache 2.0 licensed in the metadata is sufficient and will render correctly.

### Details and comments