### PR TITLE
Improve `primitives.containers.PubResult __repr__`

### DIFF
--- a/qiskit/primitives/containers/pub_result.py
+++ b/qiskit/primitives/containers/pub_result.py
@@ -36,7 +36,7 @@ class PubResult:
 
     def __repr__(self):
         metadata = f", metadata={self.metadata}" if self.metadata else ""
-        return f"{type(self).__name__}({self._data}{metadata})"
+        return f"{type(self).__name__}(data={self._data}{metadata})"
 
     @property
     def data(self) -> DataBin:


### PR DESCRIPTION
### Summary

This cosmetic change to the `PubResult` repr emphasizes to users how they can access their data.

### Details and comments

I'm hoping that a cosmetic change like this one can make it into 1.0.0 and so have tagged it as such. Just lemme know if this is not true.
