### PR TITLE
Fix qpy.dump()'s use_symengine when passed a truthy object

### DIFF
--- a/qiskit/qpy/type_keys.py
+++ b/qiskit/qpy/type_keys.py
@@ -541,7 +541,7 @@ class SymExprEncoding(TypeKeyBase):
 
     @classmethod
     def assign(cls, obj):
-        if obj is True:
+        if obj:
             return cls.SYMENGINE
         else:
             return cls.SYMPY

--- a/releasenotes/notes/fix-qpy-use-symengine-bool-like-d17550057a58abf2.yaml
+++ b/releasenotes/notes/fix-qpy-use-symengine-bool-like-d17550057a58abf2.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :func:`.qpy.dump` function, when the
+    ``use_symengine`` flag was set to a truthy object that evaluated to
+    ``True`` but was not actually the boolean ``True`` the generated QPY
+    payload would be corrupt. For example, if you set ``use_symengine`` to
+    :obj:`.HAS_SYMENGINE` which evaluates to ``True`` when cast as a bool,
+    but isn't actually ``True``.


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue in the qpy dump() function's use_symengine kwarg. When a user provided a truthy value that wasn't the literal `Truth` boolean object the generated qpy payload would be corrupted. That's because the check that assigns the encoding key in the file header was unecessarily checking for the literal ``True`` object instead of a object that evaluated to true. This was causing the header to say it was using a sympy encoding, but then all the checks that were encoding the data were evaluating true and setting symengine data. This would cause a failure on reading the qpy payload when the parameter expressions were parsed as it would try to load the binary symengine encoding with the sympy parser.

### Details and comments