### PR TITLE
Reduce noise from `reno lint`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -39,5 +39,5 @@ ddt>=1.2.0,!=1.4.0,!=1.4.3
 # consume it properly.
 Sphinx>=6.0,<7.2
 # TODO: switch to stable release when 4.1 is released
-reno @ git+https://github.com/openstack/reno.git@81587f616f17904336cdc431e25c42b46cd75b8f
+reno @ git+https://github.com/openstack/reno.git@85b9a9bb52c8f9ce4a5e66fa8d9eba7fde90bf6d
 sphinxcontrib-katex==0.9.9

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands =
   python {toxinidir}/tools/verify_headers.py qiskit test tools examples
   python {toxinidir}/tools/find_optional_imports.py
   python {toxinidir}/tools/find_stray_release_notes.py
-  reno lint
+  reno -q lint
 
 [testenv:lint-incr]
 basepython = python3
@@ -56,7 +56,7 @@ commands =
   python {toxinidir}/tools/verify_headers.py qiskit test tools examples
   python {toxinidir}/tools/find_optional_imports.py
   python {toxinidir}/tools/find_stray_release_notes.py
-  reno lint
+  reno -q lint
 
 [testenv:black]
 skip_install = true


### PR DESCRIPTION
### Summary

This applies the "quiet" option to `reno` during lint runs, so it only prints out failures from the lint, not the general messages about what it's up to.  The dev version of reno is bumped to include the commit that removes the hard-printed "unable to find ..." non-error note, since we're still waiting for a reno 4.1 release.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

This makes the `lint` tox job rather easier to run - in a full, all-branches checkout of the repository (like we need for the full docs/lint jobs), the regular output of `reno lint` is about 4500 lines, even on zero errors.  This makes it harder to scroll through the logs to find useful information, so this commit reduces that to zero.