### PR TITLE
Annotate and clarify that metadata keys should be strings

### DIFF
--- a/qiskit/primitives/containers/primitive_result.py
+++ b/qiskit/primitives/containers/primitive_result.py
@@ -29,7 +29,8 @@ class PrimitiveResult(Generic[T]):
         """
         Args:
             pub_results: Pub results.
-            metadata: Any metadata that doesn't make sense to put inside of pub results.
+            metadata: Metadata that is common to all pub results; metadata specific to particular
+                pubs should be placed in their metadata fields. Keys are expected to be strings.
         """
         self._pub_results = list(pub_results)
         self._metadata = metadata or {}

--- a/qiskit/primitives/containers/pub_result.py
+++ b/qiskit/primitives/containers/pub_result.py
@@ -16,6 +16,8 @@ Base Pub class
 
 from __future__ import annotations
 
+from typing import Any
+
 from .data_bin import DataBin
 
 
@@ -24,12 +26,12 @@ class PubResult:
 
     __slots__ = ("_data", "_metadata")
 
-    def __init__(self, data: DataBin, metadata: dict | None = None):
+    def __init__(self, data: DataBin, metadata: dict[str, Any] | None = None):
         """Initialize a pub result.
 
         Args:
-            data: result data bin.
-            metadata: metadata dictionary.
+            data: Result data.
+            metadata: Metadata specific to this pub. Keys are expected to be strings.
         """
         self._data = data
         self._metadata = metadata or {}

--- a/test/python/primitives/containers/test_primitive_result.py
+++ b/test/python/primitives/containers/test_primitive_result.py
@@ -36,9 +36,10 @@ class PrimitiveResultCase(QiskitTestCase):
             PubResult(data_bin_cls(alpha, beta)),
             PubResult(data_bin_cls(alpha, beta)),
         ]
-        result = PrimitiveResult(pub_results, {1: 2})
+        result = PrimitiveResult(pub_results, {"x": 2})
 
         self.assertTrue(result[0] is pub_results[0])
         self.assertTrue(result[1] is pub_results[1])
         self.assertTrue(list(result)[0] is pub_results[0])
         self.assertEqual(len(result), 2)
+        self.assertEqual(result.metadata, {"x": 2})


### PR DESCRIPTION
### Summary

This PR further annotates the metadata type of `PubResult`, and reinforces that key values should be strings in the docs. It also changes a (benign) test that uses a non-string as a key. This is done to clarify the nature of serialization in the runtime.

### Details and comments


