### PR TITLE
Remove qiskit-terra link in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ release series is currently supported.
 To report vulnerabilities, you can privately report a potential security issue
 via the Github security vulnerabilities feature. This can be done here:
 
-https://github.com/Qiskit/qiskit-terra/security/advisories
+https://github.com/Qiskit/qiskit/security/advisories
 
 Please do **not** open a public issue about a potential security vulnerability.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Qiskit (and `qiskit-terra`) supports one minor version release at a time, both for bug and
+Qiskit supports one minor version release at a time, both for bug and
 security fixes. For example, if the most recent release is 0.12.1, then the 0.12.x
 release series is currently supported.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Link in SECURITY.md still used `qiskit-terra`, this PR updates to use the current repo name

### Details and comments


