### PR TITLE
Fix bad indentation on quantumcircuit.py

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2526,17 +2526,17 @@ class QuantumCircuit:
 
             .. code-block:: python
 
-            >>> from qiskit.circuit import QuantumCircuit, Parameter, ParameterVector
-            >>> x = ParameterVector("x", 12)
-            >>> circuit = QuantumCircuit(1)
-            >>> for x_i in x:
-            ...     circuit.rx(x_i, 0)
-            >>> circuit.parameters
-            ParameterView([
-                ParameterVectorElement(x[0]), ParameterVectorElement(x[1]),
-                ParameterVectorElement(x[2]), ParameterVectorElement(x[3]),
-                ..., ParameterVectorElement(x[11])
-            ])
+                >>> from qiskit.circuit import QuantumCircuit, Parameter, ParameterVector
+                >>> x = ParameterVector("x", 12)
+                >>> circuit = QuantumCircuit(1)
+                >>> for x_i in x:
+                ...     circuit.rx(x_i, 0)
+                >>> circuit.parameters
+                ParameterView([
+                    ParameterVectorElement(x[0]), ParameterVectorElement(x[1]),
+                    ParameterVectorElement(x[2]), ParameterVectorElement(x[3]),
+                    ..., ParameterVectorElement(x[11])
+                ])
 
 
         Returns:
@@ -3991,12 +3991,12 @@ class QuantumCircuit:
 
             .. code-block::
 
-            import numpy as np
-            from qiskit import QuantumCircuit
+                import numpy as np
+                from qiskit import QuantumCircuit
 
-            circuit = QuantumCircuit(1)
-            circuit.prepare_state([1/np.sqrt(2), -1/np.sqrt(2)], 0)
-            circuit.draw()
+                circuit = QuantumCircuit(1)
+                circuit.prepare_state([1/np.sqrt(2), -1/np.sqrt(2)], 0)
+                circuit.draw()
 
             output:
 


### PR DESCRIPTION
# Summary
This PR fixes a bad indentation of two code blocks that was causing the page to not render correctly those snippets.

## Screenshots before this PR

**First code block:**

![Captura desde 2024-02-07 21-54-51](https://github.com/Qiskit/qiskit/assets/47946624/bdc9c29f-17d6-4f8f-ab9f-1af1124c1ea7)

**Second code block:**
![Captura desde 2024-02-07 21-55-08](https://github.com/Qiskit/qiskit/assets/47946624/0836e64e-0e1e-4520-82f1-196a9bd3768e)

## Screenshots applying the change
**First code block:**
![Captura desde 2024-02-07 21-55-30](https://github.com/Qiskit/qiskit/assets/47946624/09b0e70f-d975-415e-b57d-9199e5e6f679)

**Second code block:**
![Captura desde 2024-02-07 21-55-18](https://github.com/Qiskit/qiskit/assets/47946624/2b12cc76-6052-4eb1-8824-2256a5d3741e)