### PR TITLE
Expand docstrings for annotated flag on `control()` and `inverse()`

### DIFF
--- a/qiskit/circuit/library/generalized_gates/unitary.py
+++ b/qiskit/circuit/library/generalized_gates/unitary.py
@@ -74,7 +74,7 @@ class UnitaryGate(Gate):
 
         Args:
             data: Unitary operator.
-            label: Unitary name for backend [Default: None].
+            label: Unitary name for backend [Default: ``None``].
             check_input: If set to ``False`` this asserts the input
                 is known to be unitary and the checking to validate this will
                 be skipped. This should only ever be used if you know the

--- a/qiskit/circuit/library/hamiltonian_gate.py
+++ b/qiskit/circuit/library/hamiltonian_gate.py
@@ -52,7 +52,7 @@ class HamiltonianGate(Gate):
         Args:
             data: A hermitian operator.
             time: Time evolution parameter.
-            label: Unitary name for backend [Default: None].
+            label: Unitary name for backend [Default: ``None``].
 
         Raises:
             ValueError: if input data is not an N-qubit unitary operator.

--- a/qiskit/circuit/library/standard_gates/ecr.py
+++ b/qiskit/circuit/library/standard_gates/ecr.py
@@ -113,9 +113,10 @@ class ECRGate(SingletonGate):
         """Return inverse ECR gate (itself).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this gate is self inverse.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
 
         Returns:
             ECRGate: inverse gate (self-inverse).

--- a/qiskit/circuit/library/standard_gates/ecr.py
+++ b/qiskit/circuit/library/standard_gates/ecr.py
@@ -113,8 +113,9 @@ class ECRGate(SingletonGate):
         """Return inverse ECR gate (itself).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this gate is self inverse.
 
         Returns:
             ECRGate: inverse gate (self-inverse).

--- a/qiskit/circuit/library/standard_gates/ecr.py
+++ b/qiskit/circuit/library/standard_gates/ecr.py
@@ -115,6 +115,9 @@ class ECRGate(SingletonGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            ECRGate: inverse gate (self-inverse).
         """
         return ECRGate()  # self-inverse
 

--- a/qiskit/circuit/library/standard_gates/ecr.py
+++ b/qiskit/circuit/library/standard_gates/ecr.py
@@ -110,7 +110,12 @@ class ECRGate(SingletonGate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Return inverse ECR gate (itself)."""
+        """Return inverse ECR gate (itself).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return ECRGate()  # self-inverse
 
     def __eq__(self, other):

--- a/qiskit/circuit/library/standard_gates/global_phase.py
+++ b/qiskit/circuit/library/standard_gates/global_phase.py
@@ -58,9 +58,9 @@ class GlobalPhaseGate(Gate):
         :math:`\text{GlobalPhaseGate}(\lambda)^{\dagger} = \text{GlobalPhaseGate}(-\lambda)`
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as the inverse is always another :class:`.GlobalPhaseGate` with an inverted
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse is always another :class:`.GlobalPhaseGate` with an inverted
                 parameter value.
 
         Returns:

--- a/qiskit/circuit/library/standard_gates/global_phase.py
+++ b/qiskit/circuit/library/standard_gates/global_phase.py
@@ -60,7 +60,8 @@ class GlobalPhaseGate(Gate):
         Args:
             annotated: when set to ``True``, this is typically used to return an
                 :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
-                :class:`.Gate`. However, for this class this argument is ignored as the inverse is always another :class:`.GlobalPhaseGate` with an inverted
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                is always another :class:`.GlobalPhaseGate` with an inverted
                 parameter value.
 
         Returns:

--- a/qiskit/circuit/library/standard_gates/global_phase.py
+++ b/qiskit/circuit/library/standard_gates/global_phase.py
@@ -58,8 +58,10 @@ class GlobalPhaseGate(Gate):
         :math:`\text{GlobalPhaseGate}(\lambda)^{\dagger} = \text{GlobalPhaseGate}(-\lambda)`
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as the inverse is always another :class:`.GlobalPhaseGate` with an inverted
+                parameter value.
 
         Returns:
             GlobalPhaseGate: inverse gate.

--- a/qiskit/circuit/library/standard_gates/global_phase.py
+++ b/qiskit/circuit/library/standard_gates/global_phase.py
@@ -53,9 +53,13 @@ class GlobalPhaseGate(Gate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        r"""Return inverted GlobalPhaseGate gate.
+        r"""Return inverse GlobalPhaseGate gate.
 
         :math:`\text{GlobalPhaseGate}(\lambda)^{\dagger} = \text{GlobalPhaseGate}(-\lambda)`
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
         """
         return GlobalPhaseGate(-self.params[0])
 

--- a/qiskit/circuit/library/standard_gates/global_phase.py
+++ b/qiskit/circuit/library/standard_gates/global_phase.py
@@ -60,6 +60,9 @@ class GlobalPhaseGate(Gate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            GlobalPhaseGate: inverse gate.
         """
         return GlobalPhaseGate(-self.params[0])
 

--- a/qiskit/circuit/library/standard_gates/h.py
+++ b/qiskit/circuit/library/standard_gates/h.py
@@ -110,8 +110,9 @@ class HGate(SingletonGate):
         r"""Return inverted H gate (itself).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this gate is self inverse.
 
         Returns:
             HGate: inverse gate (self-inverse).

--- a/qiskit/circuit/library/standard_gates/h.py
+++ b/qiskit/circuit/library/standard_gates/h.py
@@ -112,6 +112,9 @@ class HGate(SingletonGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            HGate: inverse gate (self-inverse).
         """
         return HGate()  # self-inverse
 

--- a/qiskit/circuit/library/standard_gates/h.py
+++ b/qiskit/circuit/library/standard_gates/h.py
@@ -110,9 +110,10 @@ class HGate(SingletonGate):
         r"""Return inverted H gate (itself).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this gate is self inverse.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
 
         Returns:
             HGate: inverse gate (self-inverse).

--- a/qiskit/circuit/library/standard_gates/h.py
+++ b/qiskit/circuit/library/standard_gates/h.py
@@ -85,10 +85,10 @@ class HGate(SingletonGate):
         One control qubit returns a CH gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -107,7 +107,12 @@ class HGate(SingletonGate):
         return gate
 
     def inverse(self, annotated: bool = False):
-        r"""Return inverted H gate (itself)."""
+        r"""Return inverted H gate (itself).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return HGate()  # self-inverse
 
     def __eq__(self, other):

--- a/qiskit/circuit/library/standard_gates/i.py
+++ b/qiskit/circuit/library/standard_gates/i.py
@@ -55,9 +55,10 @@ class IGate(SingletonGate):
         """Returne the inverse gate (itself).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this gate is self inverse.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
 
         Returns:
             IGate: inverse gate (self-inverse).

--- a/qiskit/circuit/library/standard_gates/i.py
+++ b/qiskit/circuit/library/standard_gates/i.py
@@ -57,6 +57,9 @@ class IGate(SingletonGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            IGate: inverse gate (self-inverse).
         ."""
         return IGate()  # self-inverse
 

--- a/qiskit/circuit/library/standard_gates/i.py
+++ b/qiskit/circuit/library/standard_gates/i.py
@@ -52,7 +52,12 @@ class IGate(SingletonGate):
     _singleton_lookup_key = stdlib_singleton_key()
 
     def inverse(self, annotated: bool = False):
-        """Invert this gate."""
+        """Returne the inverse gate (itself).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        ."""
         return IGate()  # self-inverse
 
     def power(self, exponent: float):

--- a/qiskit/circuit/library/standard_gates/i.py
+++ b/qiskit/circuit/library/standard_gates/i.py
@@ -55,8 +55,9 @@ class IGate(SingletonGate):
         """Returne the inverse gate (itself).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this gate is self inverse.
 
         Returns:
             IGate: inverse gate (self-inverse).

--- a/qiskit/circuit/library/standard_gates/p.py
+++ b/qiskit/circuit/library/standard_gates/p.py
@@ -130,8 +130,10 @@ class PhaseGate(Gate):
         r"""Return inverted Phase gate (:math:`Phase(\lambda)^{\dagger} = Phase(-\lambda)`)
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as the inverse of this gate is always another :class:`.PGate` with an
+                inverse parameter value.
 
         Returns:
             PGate: inverse gate.

--- a/qiskit/circuit/library/standard_gates/p.py
+++ b/qiskit/circuit/library/standard_gates/p.py
@@ -130,10 +130,10 @@ class PhaseGate(Gate):
         r"""Return inverted Phase gate (:math:`Phase(\lambda)^{\dagger} = Phase(-\lambda)`)
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as the inverse of this gate is always another :class:`.PGate` with an
-                inverse parameter value.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always another :class:`.PGate` with an inverse parameter value.
 
         Returns:
             PGate: inverse gate.

--- a/qiskit/circuit/library/standard_gates/p.py
+++ b/qiskit/circuit/library/standard_gates/p.py
@@ -132,6 +132,9 @@ class PhaseGate(Gate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            PGate: inverse gate.
         """
         return PhaseGate(-self.params[0])
 

--- a/qiskit/circuit/library/standard_gates/p.py
+++ b/qiskit/circuit/library/standard_gates/p.py
@@ -101,10 +101,10 @@ class PhaseGate(Gate):
         """Return a (multi-)controlled-Phase gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g. ``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -127,7 +127,12 @@ class PhaseGate(Gate):
         return gate
 
     def inverse(self, annotated: bool = False):
-        r"""Return inverted Phase gate (:math:`Phase(\lambda)^{\dagger} = Phase(-\lambda)`)"""
+        r"""Return inverted Phase gate (:math:`Phase(\lambda)^{\dagger} = Phase(-\lambda)`)
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return PhaseGate(-self.params[0])
 
     def __array__(self, dtype=None):
@@ -244,10 +249,10 @@ class CPhaseGate(ControlledGate):
         """Controlled version of this gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -370,10 +375,10 @@ class MCPhaseGate(ControlledGate):
         """Controlled version of this gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 

--- a/qiskit/circuit/library/standard_gates/r.py
+++ b/qiskit/circuit/library/standard_gates/r.py
@@ -80,9 +80,11 @@ class RGate(Gate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Invert this gate.
+        """Invert this gate as: :math:`r(θ, φ)^dagger = r(-θ, φ)`
 
-        r(θ, φ)^dagger = r(-θ, φ)
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
         """
         return RGate(-self.params[0], self.params[1])
 

--- a/qiskit/circuit/library/standard_gates/r.py
+++ b/qiskit/circuit/library/standard_gates/r.py
@@ -83,8 +83,10 @@ class RGate(Gate):
         """Invert this gate as: :math:`r(θ, φ)^dagger = r(-θ, φ)`
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.RGate` with an inverted parameter value.
 
         Returns:
             RGate: inverse gate.

--- a/qiskit/circuit/library/standard_gates/r.py
+++ b/qiskit/circuit/library/standard_gates/r.py
@@ -85,6 +85,9 @@ class RGate(Gate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            RGate: inverse gate.
         """
         return RGate(-self.params[0], self.params[1])
 

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -112,6 +112,9 @@ class RXGate(Gate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            RXGate: inverse gate.
         """
         return RXGate(-self.params[0])
 
@@ -251,6 +254,9 @@ class CRXGate(ControlledGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            CRXGate: inverse gate.
         """
         return CRXGate(-self.params[0], ctrl_state=self.ctrl_state)
 

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -82,10 +82,10 @@ class RXGate(Gate):
         """Return a (multi-)controlled-RX gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -108,6 +108,10 @@ class RXGate(Gate):
         r"""Return inverted RX gate.
 
         :math:`RX(\lambda)^{\dagger} = RX(-\lambda)`
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
         """
         return RXGate(-self.params[0])
 
@@ -242,7 +246,12 @@ class CRXGate(ControlledGate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Return inverse CRX gate (i.e. with the negative rotation angle)."""
+        """Return inverse CRX gate (i.e. with the negative rotation angle).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return CRXGate(-self.params[0], ctrl_state=self.ctrl_state)
 
     def __array__(self, dtype=None):

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -110,8 +110,10 @@ class RXGate(Gate):
         :math:`RX(\lambda)^{\dagger} = RX(-\lambda)`
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.RXGate` with an inverted parameter value.
 
         Returns:
             RXGate: inverse gate.
@@ -252,8 +254,10 @@ class CRXGate(ControlledGate):
         """Return inverse CRX gate (i.e. with the negative rotation angle).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.CRXGate` with an inverted parameter value.
 
         Returns:
             CRXGate: inverse gate.

--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -112,8 +112,10 @@ class RXXGate(Gate):
         """Return inverse RXX gate (i.e. with the negative rotation angle).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.RXXGate` with an inverted parameter value.
 
         Returns:
             RXXGate: inverse gate.

--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -114,6 +114,9 @@ class RXXGate(Gate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            RXXGate: inverse gate.
         """
         return RXXGate(-self.params[0])
 

--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -109,7 +109,12 @@ class RXXGate(Gate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Return inverse RXX gate (i.e. with the negative rotation angle)."""
+        """Return inverse RXX gate (i.e. with the negative rotation angle).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return RXXGate(-self.params[0])
 
     def __array__(self, dtype=None):

--- a/qiskit/circuit/library/standard_gates/ry.py
+++ b/qiskit/circuit/library/standard_gates/ry.py
@@ -81,10 +81,10 @@ class RYGate(Gate):
         """Return a (multi-)controlled-RY gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -104,9 +104,13 @@ class RYGate(Gate):
         return gate
 
     def inverse(self, annotated: bool = False):
-        r"""Return inverted RY gate.
+        r"""Return inverse RY gate.
 
         :math:`RY(\lambda)^{\dagger} = RY(-\lambda)`
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
         """
         return RYGate(-self.params[0])
 
@@ -237,7 +241,12 @@ class CRYGate(ControlledGate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Return inverse CRY gate (i.e. with the negative rotation angle)."""
+        """Return inverse CRY gate (i.e. with the negative rotation angle)
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        ."""
         return CRYGate(-self.params[0], ctrl_state=self.ctrl_state)
 
     def __array__(self, dtype=None):

--- a/qiskit/circuit/library/standard_gates/ry.py
+++ b/qiskit/circuit/library/standard_gates/ry.py
@@ -111,6 +111,9 @@ class RYGate(Gate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            RYGate: inverse gate.
         """
         return RYGate(-self.params[0])
 
@@ -246,6 +249,9 @@ class CRYGate(ControlledGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            CRYGate: inverse gate.
         ."""
         return CRYGate(-self.params[0], ctrl_state=self.ctrl_state)
 

--- a/qiskit/circuit/library/standard_gates/ry.py
+++ b/qiskit/circuit/library/standard_gates/ry.py
@@ -109,8 +109,10 @@ class RYGate(Gate):
         :math:`RY(\lambda)^{\dagger} = RY(-\lambda)`
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.RYGate` with an inverted parameter value.
 
         Returns:
             RYGate: inverse gate.
@@ -247,8 +249,10 @@ class CRYGate(ControlledGate):
         """Return inverse CRY gate (i.e. with the negative rotation angle)
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.CRYGate` with an inverted parameter value.
 
         Returns:
             CRYGate: inverse gate.

--- a/qiskit/circuit/library/standard_gates/ryy.py
+++ b/qiskit/circuit/library/standard_gates/ryy.py
@@ -112,8 +112,10 @@ class RYYGate(Gate):
         """Return inverse RYY gate (i.e. with the negative rotation angle).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.RYYGate` with an inverted parameter value.
 
         Returns:
             RYYGate: inverse gate.

--- a/qiskit/circuit/library/standard_gates/ryy.py
+++ b/qiskit/circuit/library/standard_gates/ryy.py
@@ -114,6 +114,9 @@ class RYYGate(Gate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            RYYGate: inverse gate.
         """
         return RYYGate(-self.params[0])
 

--- a/qiskit/circuit/library/standard_gates/ryy.py
+++ b/qiskit/circuit/library/standard_gates/ryy.py
@@ -109,7 +109,12 @@ class RYYGate(Gate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Return inverse RYY gate (i.e. with the negative rotation angle)."""
+        """Return inverse RYY gate (i.e. with the negative rotation angle).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return RYYGate(-self.params[0])
 
     def __array__(self, dtype=None):

--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -120,8 +120,10 @@ class RZGate(Gate):
         :math:`RZ(\lambda)^{\dagger} = RZ(-\lambda)`
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.RZGate` with an inverted parameter value.
 
         Returns:
             RZGate: inverse gate.
@@ -265,8 +267,10 @@ class CRZGate(ControlledGate):
         """Return inverse CRZ gate (i.e. with the negative rotation angle).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.CRZGate` with an inverted parameter value.
 
          Returns:
             CRZGate: inverse gate.

--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -122,6 +122,9 @@ class RZGate(Gate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            RZGate: inverse gate.
         """
         return RZGate(-self.params[0])
 
@@ -264,6 +267,9 @@ class CRZGate(ControlledGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+         Returns:
+            CRZGate: inverse gate.
         """
         return CRZGate(-self.params[0], ctrl_state=self.ctrl_state)
 

--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -92,10 +92,10 @@ class RZGate(Gate):
         """Return a (multi-)controlled-RZ gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -118,6 +118,10 @@ class RZGate(Gate):
         r"""Return inverted RZ gate
 
         :math:`RZ(\lambda)^{\dagger} = RZ(-\lambda)`
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
         """
         return RZGate(-self.params[0])
 
@@ -255,7 +259,12 @@ class CRZGate(ControlledGate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Return inverse CRZ gate (i.e. with the negative rotation angle)."""
+        """Return inverse CRZ gate (i.e. with the negative rotation angle).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return CRZGate(-self.params[0], ctrl_state=self.ctrl_state)
 
     def __array__(self, dtype=None):

--- a/qiskit/circuit/library/standard_gates/rzx.py
+++ b/qiskit/circuit/library/standard_gates/rzx.py
@@ -158,6 +158,9 @@ class RZXGate(Gate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+         Returns:
+            RZXGate: inverse gate.
         """
         return RZXGate(-self.params[0])
 

--- a/qiskit/circuit/library/standard_gates/rzx.py
+++ b/qiskit/circuit/library/standard_gates/rzx.py
@@ -153,7 +153,12 @@ class RZXGate(Gate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Return inverse RZX gate (i.e. with the negative rotation angle)."""
+        """Return inverse RZX gate (i.e. with the negative rotation angle).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return RZXGate(-self.params[0])
 
     def __array__(self, dtype=None):

--- a/qiskit/circuit/library/standard_gates/rzx.py
+++ b/qiskit/circuit/library/standard_gates/rzx.py
@@ -156,8 +156,10 @@ class RZXGate(Gate):
         """Return inverse RZX gate (i.e. with the negative rotation angle).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.RZXGate` with an inverted parameter value.
 
          Returns:
             RZXGate: inverse gate.

--- a/qiskit/circuit/library/standard_gates/rzz.py
+++ b/qiskit/circuit/library/standard_gates/rzz.py
@@ -117,7 +117,12 @@ class RZZGate(Gate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Return inverse RZZ gate (i.e. with the negative rotation angle)."""
+        """Return inverse RZZ gate (i.e. with the negative rotation angle).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return RZZGate(-self.params[0])
 
     def __array__(self, dtype=None):

--- a/qiskit/circuit/library/standard_gates/rzz.py
+++ b/qiskit/circuit/library/standard_gates/rzz.py
@@ -122,6 +122,9 @@ class RZZGate(Gate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            RZZGate: inverse gate.
         """
         return RZZGate(-self.params[0])
 

--- a/qiskit/circuit/library/standard_gates/rzz.py
+++ b/qiskit/circuit/library/standard_gates/rzz.py
@@ -120,8 +120,10 @@ class RZZGate(Gate):
         """Return inverse RZZ gate (i.e. with the negative rotation angle).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.RZZGate` with an inverted parameter value.
 
         Returns:
             RZZGate: inverse gate.

--- a/qiskit/circuit/library/standard_gates/s.py
+++ b/qiskit/circuit/library/standard_gates/s.py
@@ -86,6 +86,9 @@ class SGate(SingletonGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            SdgGate: inverse of :class:`.SGate`
         """
         return SdgGate()
 
@@ -159,6 +162,9 @@ class SdgGate(SingletonGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            SGate: inverse of :class:`.SdgGate`
         """
         return SGate()
 
@@ -241,6 +247,9 @@ class CSGate(SingletonControlledGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            CSdgGate: inverse of :class:`.CSGate`
         """
         return CSdgGate(ctrl_state=self.ctrl_state)
 
@@ -322,6 +331,9 @@ class CSdgGate(SingletonControlledGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            CSGate: inverse of :class:`.CSdgGate`
         """
         return CSGate(ctrl_state=self.ctrl_state)
 

--- a/qiskit/circuit/library/standard_gates/s.py
+++ b/qiskit/circuit/library/standard_gates/s.py
@@ -86,7 +86,8 @@ class SGate(SingletonGate):
         Args:
             annotated: when set to ``True``, this is typically used to return an
                 :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
-                :class:`.Gate`. However, for this class this argument is ignored as the inverse of this gate is always a :class:`.SdgGate`.
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.SdgGate`.
 
         Returns:
             SdgGate: inverse of :class:`.SGate`
@@ -163,7 +164,8 @@ class SdgGate(SingletonGate):
         Args:
             annotated: when set to ``True``, this is typically used to return an
                 :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
-                :class:`.Gate`. However, for this class this argument is ignored as the inverse of this gate is always a :class:`.SGate`.
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.SGate`.
 
         Returns:
             SGate: inverse of :class:`.SdgGate`
@@ -249,7 +251,8 @@ class CSGate(SingletonControlledGate):
         Args:
             annotated: when set to ``True``, this is typically used to return an
                 :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
-                :class:`.Gate`. However, for this class this argument is ignored as the inverse of this gate is always a :class:`.CSdgGate`.
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.CSdgGate`.
 
         Returns:
             CSdgGate: inverse of :class:`.CSGate`

--- a/qiskit/circuit/library/standard_gates/s.py
+++ b/qiskit/circuit/library/standard_gates/s.py
@@ -81,7 +81,12 @@ class SGate(SingletonGate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Return inverse of S (SdgGate)."""
+        """Return inverse of S (SdgGate).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return SdgGate()
 
     def power(self, exponent: float):
@@ -149,7 +154,12 @@ class SdgGate(SingletonGate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Return inverse of Sdg (SGate)."""
+        """Return inverse of Sdg (SGate).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return SGate()
 
     def power(self, exponent: float):
@@ -226,7 +236,12 @@ class CSGate(SingletonControlledGate):
         self.definition = CPhaseGate(theta=pi / 2).definition
 
     def inverse(self, annotated: bool = False):
-        """Return inverse of CSGate (CSdgGate)."""
+        """Return inverse of CSGate (CSdgGate).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return CSdgGate(ctrl_state=self.ctrl_state)
 
     def power(self, exponent: float):
@@ -302,7 +317,12 @@ class CSdgGate(SingletonControlledGate):
         self.definition = CPhaseGate(theta=-pi / 2).definition
 
     def inverse(self, annotated: bool = False):
-        """Return inverse of CSdgGate (CSGate)."""
+        """Return inverse of CSdgGate (CSGate).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return CSGate(ctrl_state=self.ctrl_state)
 
     def power(self, exponent: float):

--- a/qiskit/circuit/library/standard_gates/s.py
+++ b/qiskit/circuit/library/standard_gates/s.py
@@ -84,8 +84,9 @@ class SGate(SingletonGate):
         """Return inverse of S (SdgGate).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this inverse of this gate is always a :class:`.SdgGate`.
 
         Returns:
             SdgGate: inverse of :class:`.SGate`
@@ -160,8 +161,9 @@ class SdgGate(SingletonGate):
         """Return inverse of Sdg (SGate).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this inverse of this gate is always a :class:`.SGate`.
 
         Returns:
             SGate: inverse of :class:`.SdgGate`
@@ -245,8 +247,9 @@ class CSGate(SingletonControlledGate):
         """Return inverse of CSGate (CSdgGate).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this inverse of this gate is always a :class:`.CSdgGate`.
 
         Returns:
             CSdgGate: inverse of :class:`.CSGate`
@@ -329,8 +332,9 @@ class CSdgGate(SingletonControlledGate):
         """Return inverse of CSdgGate (CSGate).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this inverse of this gate is always a :class:`.CSGate`.
 
         Returns:
             CSGate: inverse of :class:`.CSdgGate`

--- a/qiskit/circuit/library/standard_gates/s.py
+++ b/qiskit/circuit/library/standard_gates/s.py
@@ -84,9 +84,9 @@ class SGate(SingletonGate):
         """Return inverse of S (SdgGate).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this inverse of this gate is always a :class:`.SdgGate`.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse of this gate is always a :class:`.SdgGate`.
 
         Returns:
             SdgGate: inverse of :class:`.SGate`
@@ -161,9 +161,9 @@ class SdgGate(SingletonGate):
         """Return inverse of Sdg (SGate).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this inverse of this gate is always a :class:`.SGate`.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse of this gate is always a :class:`.SGate`.
 
         Returns:
             SGate: inverse of :class:`.SdgGate`
@@ -247,9 +247,9 @@ class CSGate(SingletonControlledGate):
         """Return inverse of CSGate (CSdgGate).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this inverse of this gate is always a :class:`.CSdgGate`.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse of this gate is always a :class:`.CSdgGate`.
 
         Returns:
             CSdgGate: inverse of :class:`.CSGate`
@@ -332,9 +332,10 @@ class CSdgGate(SingletonControlledGate):
         """Return inverse of CSdgGate (CSGate).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this inverse of this gate is always a :class:`.CSGate`.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.CSGate`.
 
         Returns:
             CSGate: inverse of :class:`.CSdgGate`

--- a/qiskit/circuit/library/standard_gates/swap.py
+++ b/qiskit/circuit/library/standard_gates/swap.py
@@ -121,8 +121,9 @@ class SwapGate(SingletonGate):
         """Return inverse Swap gate (itself).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this gate is self inverse.
 
         Returns:
             SwapGate: inverse gate (self-inverse).
@@ -265,8 +266,9 @@ class CSwapGate(SingletonControlledGate):
         """Return inverse CSwap gate (itself).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this gate is self inverse.
 
         Returns:
             CSwapGate: inverse gate (self-inverse).

--- a/qiskit/circuit/library/standard_gates/swap.py
+++ b/qiskit/circuit/library/standard_gates/swap.py
@@ -123,6 +123,9 @@ class SwapGate(SingletonGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            SwapGate: inverse gate (self-inverse).
         """
         return SwapGate()  # self-inverse
 
@@ -264,6 +267,9 @@ class CSwapGate(SingletonControlledGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            CSwapGate: inverse gate (self-inverse).
         """
         return CSwapGate(ctrl_state=self.ctrl_state)  # self-inverse
 

--- a/qiskit/circuit/library/standard_gates/swap.py
+++ b/qiskit/circuit/library/standard_gates/swap.py
@@ -96,10 +96,10 @@ class SwapGate(SingletonGate):
         One control returns a CSWAP (Fredkin) gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -118,7 +118,12 @@ class SwapGate(SingletonGate):
         return gate
 
     def inverse(self, annotated: bool = False):
-        """Return inverse Swap gate (itself)."""
+        """Return inverse Swap gate (itself).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return SwapGate()  # self-inverse
 
     def __eq__(self, other):
@@ -254,7 +259,12 @@ class CSwapGate(SingletonControlledGate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Return inverse CSwap gate (itself)."""
+        """Return inverse CSwap gate (itself).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return CSwapGate(ctrl_state=self.ctrl_state)  # self-inverse
 
     def __eq__(self, other):

--- a/qiskit/circuit/library/standard_gates/swap.py
+++ b/qiskit/circuit/library/standard_gates/swap.py
@@ -121,9 +121,10 @@ class SwapGate(SingletonGate):
         """Return inverse Swap gate (itself).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this gate is self inverse.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
 
         Returns:
             SwapGate: inverse gate (self-inverse).
@@ -266,9 +267,10 @@ class CSwapGate(SingletonControlledGate):
         """Return inverse CSwap gate (itself).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this gate is self inverse.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
 
         Returns:
             CSwapGate: inverse gate (self-inverse).

--- a/qiskit/circuit/library/standard_gates/sx.py
+++ b/qiskit/circuit/library/standard_gates/sx.py
@@ -88,8 +88,9 @@ class SXGate(SingletonGate):
         """Return inverse SX gate (i.e. SXdg).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this inverse of this gate is always a :class:`.SXdgGate`.
 
         Returns:
             SXdgGate: inverse of :class:`.SXGate`.
@@ -188,8 +189,9 @@ class SXdgGate(SingletonGate):
         """Return inverse SXdg gate (i.e. SX).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this inverse of this gate is always a :class:`.SXGate`.
 
         Returns:
             SXGate: inverse of :class:`.SXdgGate`

--- a/qiskit/circuit/library/standard_gates/sx.py
+++ b/qiskit/circuit/library/standard_gates/sx.py
@@ -85,7 +85,12 @@ class SXGate(SingletonGate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Return inverse SX gate (i.e. SXdg)."""
+        """Return inverse SX gate (i.e. SXdg).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return SXdgGate()
 
     def control(
@@ -100,10 +105,10 @@ class SXGate(SingletonGate):
         One control returns a CSX gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -153,6 +158,9 @@ class SXdgGate(SingletonGate):
                       \end{pmatrix}
                     = e^{-i \pi/4} \sqrt{X}^{\dagger}
 
+    Args:
+        annotated: indicates whether the inverse gate can be implemented
+            as an annotated gate.
     """
 
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
@@ -178,7 +186,12 @@ class SXdgGate(SingletonGate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Return inverse SXdg gate (i.e. SX)."""
+        """Return inverse SXdg gate (i.e. SX).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return SXGate()
 
     def __eq__(self, other):

--- a/qiskit/circuit/library/standard_gates/sx.py
+++ b/qiskit/circuit/library/standard_gates/sx.py
@@ -88,9 +88,10 @@ class SXGate(SingletonGate):
         """Return inverse SX gate (i.e. SXdg).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this inverse of this gate is always a :class:`.SXdgGate`.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.SXdgGate`.
 
         Returns:
             SXdgGate: inverse of :class:`.SXGate`.
@@ -189,9 +190,9 @@ class SXdgGate(SingletonGate):
         """Return inverse SXdg gate (i.e. SX).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this inverse of this gate is always a :class:`.SXGate`.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse of this gate is always a :class:`.SXGate`.
 
         Returns:
             SXGate: inverse of :class:`.SXdgGate`

--- a/qiskit/circuit/library/standard_gates/sx.py
+++ b/qiskit/circuit/library/standard_gates/sx.py
@@ -192,7 +192,8 @@ class SXdgGate(SingletonGate):
         Args:
             annotated: when set to ``True``, this is typically used to return an
                 :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
-                :class:`.Gate`. However, for this class this argument is ignored as the inverse of this gate is always a :class:`.SXGate`.
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.SXGate`.
 
         Returns:
             SXGate: inverse of :class:`.SXdgGate`

--- a/qiskit/circuit/library/standard_gates/sx.py
+++ b/qiskit/circuit/library/standard_gates/sx.py
@@ -90,6 +90,9 @@ class SXGate(SingletonGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            SXdgGate: inverse of :class:`.SXGate`.
         """
         return SXdgGate()
 
@@ -157,10 +160,6 @@ class SXdgGate(SingletonGate):
                         i & 1
                       \end{pmatrix}
                     = e^{-i \pi/4} \sqrt{X}^{\dagger}
-
-    Args:
-        annotated: indicates whether the inverse gate can be implemented
-            as an annotated gate.
     """
 
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
@@ -191,6 +190,9 @@ class SXdgGate(SingletonGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            SXGate: inverse of :class:`.SXdgGate`
         """
         return SXGate()
 

--- a/qiskit/circuit/library/standard_gates/t.py
+++ b/qiskit/circuit/library/standard_gates/t.py
@@ -82,8 +82,9 @@ class TGate(SingletonGate):
         """Return inverse T gate (i.e. Tdg).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this inverse of this gate is always a :class:`.TdgGate`.
 
         Returns:
             TdgGate: inverse of :class:`.TGate`
@@ -156,8 +157,9 @@ class TdgGate(SingletonGate):
         """Return inverse Tdg gate (i.e. T).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this inverse of this gate is always a :class:`.TGate`.
 
         Returns:
             TGate: inverse of :class:`.TdgGate`

--- a/qiskit/circuit/library/standard_gates/t.py
+++ b/qiskit/circuit/library/standard_gates/t.py
@@ -82,9 +82,10 @@ class TGate(SingletonGate):
         """Return inverse T gate (i.e. Tdg).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this inverse of this gate is always a :class:`.TdgGate`.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.TdgGate`.
 
         Returns:
             TdgGate: inverse of :class:`.TGate`
@@ -157,9 +158,9 @@ class TdgGate(SingletonGate):
         """Return inverse Tdg gate (i.e. T).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this inverse of this gate is always a :class:`.TGate`.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse of this gate is always a :class:`.TGate`.
 
         Returns:
             TGate: inverse of :class:`.TdgGate`

--- a/qiskit/circuit/library/standard_gates/t.py
+++ b/qiskit/circuit/library/standard_gates/t.py
@@ -160,7 +160,8 @@ class TdgGate(SingletonGate):
         Args:
             annotated: when set to ``True``, this is typically used to return an
                 :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
-                :class:`.Gate`. However, for this class this argument is ignored as the inverse of this gate is always a :class:`.TGate`.
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.TGate`.
 
         Returns:
             TGate: inverse of :class:`.TdgGate`

--- a/qiskit/circuit/library/standard_gates/t.py
+++ b/qiskit/circuit/library/standard_gates/t.py
@@ -84,6 +84,9 @@ class TGate(SingletonGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            TdgGate: inverse of :class:`.TGate`
         """
         return TdgGate()
 
@@ -155,6 +158,9 @@ class TdgGate(SingletonGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            TGate: inverse of :class:`.TdgGate`
         """
         return TGate()
 

--- a/qiskit/circuit/library/standard_gates/t.py
+++ b/qiskit/circuit/library/standard_gates/t.py
@@ -79,7 +79,12 @@ class TGate(SingletonGate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Return inverse T gate (i.e. Tdg)."""
+        """Return inverse T gate (i.e. Tdg).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return TdgGate()
 
     def power(self, exponent: float):
@@ -145,7 +150,12 @@ class TdgGate(SingletonGate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Return inverse Tdg gate (i.e. T)."""
+        """Return inverse Tdg gate (i.e. T).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return TGate()
 
     def power(self, exponent: float):

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -321,7 +321,8 @@ class CUGate(ControlledGate):
         Args:
             annotated: when set to ``True``, this is typically used to return an
                 :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
-                :class:`.Gate`. However, for this class this argument is ignored as the inverse of this gate is always a :class:`.CUGate` with inverse parameter
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.CUGate` with inverse parameter
                 values.
 
         Returns:

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -88,6 +88,9 @@ class UGate(Gate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            UGate: inverse gate.
         """
         return UGate(-self.params[0], -self.params[2], -self.params[1])
 
@@ -316,6 +319,9 @@ class CUGate(ControlledGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            CUGate: inverse gate.
         """
         return CUGate(
             -self.params[0],

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -86,10 +86,10 @@ class UGate(Gate):
         :math:`U(\theta,\phi,\lambda)^{\dagger} =U(-\theta,-\lambda,-\phi))`
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this inverse of this gate is always a :class:`.UGate` with inverse parameter
-                values.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the
+                inverse of this gate is always a :class:`.UGate` with inverse parameter values.
 
         Returns:
             UGate: inverse gate.
@@ -319,9 +319,9 @@ class CUGate(ControlledGate):
         :math:`CU(\theta,\phi,\lambda,\gamma)^{\dagger} = CU(-\theta,-\phi,-\lambda,-\gamma))`
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this inverse of this gate is always a :class:`.CUGate` with inverse parameter
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse of this gate is always a :class:`.CUGate` with inverse parameter
                 values.
 
         Returns:

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -83,7 +83,11 @@ class UGate(Gate):
     def inverse(self, annotated: bool = False):
         r"""Return inverted U gate.
 
-        :math:`U(\theta,\phi,\lambda)^{\dagger} =U(-\theta,-\lambda,-\phi)`)
+        :math:`U(\theta,\phi,\lambda)^{\dagger} =U(-\theta,-\lambda,-\phi))`
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
         """
         return UGate(-self.params[0], -self.params[2], -self.params[1])
 
@@ -97,10 +101,10 @@ class UGate(Gate):
         """Return a (multi-)controlled-U gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -307,7 +311,11 @@ class CUGate(ControlledGate):
     def inverse(self, annotated: bool = False):
         r"""Return inverted CU gate.
 
-        :math:`CU(\theta,\phi,\lambda,\gamma)^{\dagger} = CU(-\theta,-\phi,-\lambda,-\gamma)`)
+        :math:`CU(\theta,\phi,\lambda,\gamma)^{\dagger} = CU(-\theta,-\phi,-\lambda,-\gamma))`
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
         """
         return CUGate(
             -self.params[0],

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -86,8 +86,10 @@ class UGate(Gate):
         :math:`U(\theta,\phi,\lambda)^{\dagger} =U(-\theta,-\lambda,-\phi))`
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this inverse of this gate is always a :class:`.UGate` with inverse parameter
+                values.
 
         Returns:
             UGate: inverse gate.
@@ -317,8 +319,10 @@ class CUGate(ControlledGate):
         :math:`CU(\theta,\phi,\lambda,\gamma)^{\dagger} = CU(-\theta,-\phi,-\lambda,-\gamma))`
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this inverse of this gate is always a :class:`.CUGate` with inverse parameter
+                values.
 
         Returns:
             CUGate: inverse gate.

--- a/qiskit/circuit/library/standard_gates/u1.py
+++ b/qiskit/circuit/library/standard_gates/u1.py
@@ -150,10 +150,10 @@ class U1Gate(Gate):
         r"""Return inverted U1 gate (:math:`U1(\lambda)^{\dagger} = U1(-\lambda))`
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this inverse of this gate is always a :class:`.U1Gate` with inverse parameter
-                values.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.U1Gate` with inverse parameter values.
 
         Returns:
             U1Gate: inverse gate.
@@ -293,9 +293,9 @@ class CU1Gate(ControlledGate):
         r"""Return inverted CU1 gate (:math:`CU1(\lambda)^{\dagger} = CU1(-\lambda))`
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this inverse of this gate is always a :class:`.CU1Gate` with inverse parameter
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse of this gate is always a :class:`.CU1Gate` with inverse parameter
                 values.
 
         Returns:
@@ -429,9 +429,9 @@ class MCU1Gate(ControlledGate):
         r"""Return inverted MCU1 gate (:math:`MCU1(\lambda)^{\dagger} = MCU1(-\lambda))`
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this inverse of this gate is always a :class:`.MCU1Gate` with inverse
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse of this gate is always a :class:`.MCU1Gate` with inverse
                 parameter values.
 
         Returns:

--- a/qiskit/circuit/library/standard_gates/u1.py
+++ b/qiskit/circuit/library/standard_gates/u1.py
@@ -295,7 +295,8 @@ class CU1Gate(ControlledGate):
         Args:
             annotated: when set to ``True``, this is typically used to return an
                 :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
-                :class:`.Gate`. However, for this class this argument is ignored as the inverse of this gate is always a :class:`.CU1Gate` with inverse parameter
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.CU1Gate` with inverse parameter
                 values.
 
         Returns:
@@ -431,7 +432,8 @@ class MCU1Gate(ControlledGate):
         Args:
             annotated: when set to ``True``, this is typically used to return an
                 :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
-                :class:`.Gate`. However, for this class this argument is ignored as the inverse of this gate is always a :class:`.MCU1Gate` with inverse
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.MCU1Gate` with inverse
                 parameter values.
 
         Returns:

--- a/qiskit/circuit/library/standard_gates/u1.py
+++ b/qiskit/circuit/library/standard_gates/u1.py
@@ -152,6 +152,9 @@ class U1Gate(Gate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            U1Gate: inverse gate.
         """
         return U1Gate(-self.params[0])
 
@@ -290,6 +293,9 @@ class CU1Gate(ControlledGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            CU1Gate: inverse gate.
         """
         return CU1Gate(-self.params[0], ctrl_state=self.ctrl_state)
 
@@ -421,5 +427,8 @@ class MCU1Gate(ControlledGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            MCU1Gate: inverse gate.
         """
         return MCU1Gate(-self.params[0], self.num_ctrl_qubits)

--- a/qiskit/circuit/library/standard_gates/u1.py
+++ b/qiskit/circuit/library/standard_gates/u1.py
@@ -121,10 +121,10 @@ class U1Gate(Gate):
         """Return a (multi-)controlled-U1 gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -147,7 +147,12 @@ class U1Gate(Gate):
         return gate
 
     def inverse(self, annotated: bool = False):
-        r"""Return inverted U1 gate (:math:`U1(\lambda)^{\dagger} = U1(-\lambda)`)"""
+        r"""Return inverted U1 gate (:math:`U1(\lambda)^{\dagger} = U1(-\lambda))`
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return U1Gate(-self.params[0])
 
     def __array__(self, dtype=None):
@@ -257,10 +262,10 @@ class CU1Gate(ControlledGate):
         """Controlled version of this gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -280,7 +285,12 @@ class CU1Gate(ControlledGate):
         return gate
 
     def inverse(self, annotated: bool = False):
-        r"""Return inverted CU1 gate (:math:`CU1(\lambda)^{\dagger} = CU1(-\lambda)`)"""
+        r"""Return inverted CU1 gate (:math:`CU1(\lambda)^{\dagger} = CU1(-\lambda))`
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return CU1Gate(-self.params[0], ctrl_state=self.ctrl_state)
 
     def __array__(self, dtype=None):
@@ -376,10 +386,10 @@ class MCU1Gate(ControlledGate):
         """Controlled version of this gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -406,5 +416,10 @@ class MCU1Gate(ControlledGate):
         return gate
 
     def inverse(self, annotated: bool = False):
-        r"""Return inverted MCU1 gate (:math:`MCU1(\lambda)^{\dagger} = MCU1(-\lambda)`)"""
+        r"""Return inverted MCU1 gate (:math:`MCU1(\lambda)^{\dagger} = MCU1(-\lambda))`
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return MCU1Gate(-self.params[0], self.num_ctrl_qubits)

--- a/qiskit/circuit/library/standard_gates/u1.py
+++ b/qiskit/circuit/library/standard_gates/u1.py
@@ -150,8 +150,10 @@ class U1Gate(Gate):
         r"""Return inverted U1 gate (:math:`U1(\lambda)^{\dagger} = U1(-\lambda))`
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this inverse of this gate is always a :class:`.U1Gate` with inverse parameter
+                values.
 
         Returns:
             U1Gate: inverse gate.
@@ -291,8 +293,10 @@ class CU1Gate(ControlledGate):
         r"""Return inverted CU1 gate (:math:`CU1(\lambda)^{\dagger} = CU1(-\lambda))`
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this inverse of this gate is always a :class:`.CU1Gate` with inverse parameter
+                values.
 
         Returns:
             CU1Gate: inverse gate.
@@ -425,8 +429,10 @@ class MCU1Gate(ControlledGate):
         r"""Return inverted MCU1 gate (:math:`MCU1(\lambda)^{\dagger} = MCU1(-\lambda))`
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this inverse of this gate is always a :class:`.MCU1Gate` with inverse
+                parameter values.
 
         Returns:
             MCU1Gate: inverse gate.

--- a/qiskit/circuit/library/standard_gates/u2.py
+++ b/qiskit/circuit/library/standard_gates/u2.py
@@ -114,7 +114,11 @@ class U2Gate(Gate):
     def inverse(self, annotated: bool = False):
         r"""Return inverted U2 gate.
 
-        :math:`U2(\phi, \lambda)^{\dagger} =U2(-\lambda-\pi, -\phi+\pi)`)
+        :math:`U2(\phi, \lambda)^{\dagger} =U2(-\lambda-\pi, -\phi+\pi))`
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
         """
         return U2Gate(-self.params[1] - pi, -self.params[0] + pi)
 

--- a/qiskit/circuit/library/standard_gates/u2.py
+++ b/qiskit/circuit/library/standard_gates/u2.py
@@ -117,8 +117,10 @@ class U2Gate(Gate):
         :math:`U2(\phi, \lambda)^{\dagger} =U2(-\lambda-\pi, -\phi+\pi))`
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this inverse of this gate is always a :class:`.U2Gate` with inverse
+                parameter values.
 
         Returns:
             U2Gate: inverse gate.

--- a/qiskit/circuit/library/standard_gates/u2.py
+++ b/qiskit/circuit/library/standard_gates/u2.py
@@ -117,10 +117,10 @@ class U2Gate(Gate):
         :math:`U2(\phi, \lambda)^{\dagger} =U2(-\lambda-\pi, -\phi+\pi))`
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this inverse of this gate is always a :class:`.U2Gate` with inverse
-                parameter values.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.U2Gate` with inverse parameter values.
 
         Returns:
             U2Gate: inverse gate.

--- a/qiskit/circuit/library/standard_gates/u2.py
+++ b/qiskit/circuit/library/standard_gates/u2.py
@@ -119,6 +119,9 @@ class U2Gate(Gate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            U2Gate: inverse gate.
         """
         return U2Gate(-self.params[1] - pi, -self.params[0] + pi)
 

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -101,6 +101,9 @@ class U3Gate(Gate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            U3Gate: inverse gate.
         """
         return U3Gate(-self.params[0], -self.params[2], -self.params[1])
 
@@ -289,6 +292,9 @@ class CU3Gate(ControlledGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            CU3Gate: inverse gate.
         """
         return CU3Gate(
             -self.params[0], -self.params[2], -self.params[1], ctrl_state=self.ctrl_state

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -294,7 +294,8 @@ class CU3Gate(ControlledGate):
         Args:
             annotated: when set to ``True``, this is typically used to return an
                 :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
-                :class:`.Gate`. However, for this class this argument is ignored as the inverse of this gate is always a :class:`.CU3Gate` with inverse
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.CU3Gate` with inverse
                 parameter values.
 
         Returns:

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -96,7 +96,11 @@ class U3Gate(Gate):
     def inverse(self, annotated: bool = False):
         r"""Return inverted U3 gate.
 
-        :math:`U3(\theta,\phi,\lambda)^{\dagger} =U3(-\theta,-\lambda,-\phi)`)
+        :math:`U3(\theta,\phi,\lambda)^{\dagger} =U3(-\theta,-\lambda,-\phi))`
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
         """
         return U3Gate(-self.params[0], -self.params[2], -self.params[1])
 
@@ -110,10 +114,10 @@ class U3Gate(Gate):
         """Return a (multi-)controlled-U3 gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -280,7 +284,11 @@ class CU3Gate(ControlledGate):
     def inverse(self, annotated: bool = False):
         r"""Return inverted CU3 gate.
 
-        :math:`CU3(\theta,\phi,\lambda)^{\dagger} =CU3(-\theta,-\phi,-\lambda)`)
+        :math:`CU3(\theta,\phi,\lambda)^{\dagger} =CU3(-\theta,-\phi,-\lambda))`
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
         """
         return CU3Gate(
             -self.params[0], -self.params[2], -self.params[1], ctrl_state=self.ctrl_state

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -99,8 +99,10 @@ class U3Gate(Gate):
         :math:`U3(\theta,\phi,\lambda)^{\dagger} =U3(-\theta,-\lambda,-\phi))`
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this inverse of this gate is always a :class:`.U3Gate` with inverse
+                parameter values.
 
         Returns:
             U3Gate: inverse gate.
@@ -290,8 +292,10 @@ class CU3Gate(ControlledGate):
         :math:`CU3(\theta,\phi,\lambda)^{\dagger} =CU3(-\theta,-\phi,-\lambda))`
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this inverse of this gate is always a :class:`.CU3Gate` with inverse
+                parameter values.
 
         Returns:
             CU3Gate: inverse gate.

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -99,10 +99,10 @@ class U3Gate(Gate):
         :math:`U3(\theta,\phi,\lambda)^{\dagger} =U3(-\theta,-\lambda,-\phi))`
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this inverse of this gate is always a :class:`.U3Gate` with inverse
-                parameter values.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.U3Gate` with inverse parameter values.
 
         Returns:
             U3Gate: inverse gate.
@@ -292,9 +292,9 @@ class CU3Gate(ControlledGate):
         :math:`CU3(\theta,\phi,\lambda)^{\dagger} =CU3(-\theta,-\phi,-\lambda))`
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this inverse of this gate is always a :class:`.CU3Gate` with inverse
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse of this gate is always a :class:`.CU3Gate` with inverse
                 parameter values.
 
         Returns:

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -134,8 +134,9 @@ class XGate(SingletonGate):
         r"""Return inverted X gate (itself).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this gate is self inverse.
 
         Returns:
             XGate: inverse gate (self-inverse).
@@ -277,8 +278,9 @@ class CXGate(SingletonControlledGate):
         """Return inverted CX gate (itself).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this gate is self inverse.
 
         Returns:
             CXGate: inverse gate (self-inverse).
@@ -469,8 +471,9 @@ class CCXGate(SingletonControlledGate):
         """Return an inverted CCX gate (also a CCX).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this gate is self inverse.
 
         Returns:
             CCXGate: inverse gate (self-inverse).
@@ -808,8 +811,9 @@ class C3XGate(SingletonControlledGate):
         """Invert this gate. The C3X is its own inverse.
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this gate is self inverse.
 
         Returns:
             C3XGate: inverse gate (self-inverse).
@@ -1050,8 +1054,9 @@ class C4XGate(SingletonControlledGate):
         """Invert this gate. The C4X is its own inverse.
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this gate is self inverse.
 
         Returns:
             C4XGate: inverse gate (self-inverse).
@@ -1130,8 +1135,9 @@ class MCXGate(ControlledGate):
         """Invert this gate. The MCX is its own inverse.
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this gate is self inverse.
 
         Returns:
             MCXGate: inverse gate (self-inverse).
@@ -1252,8 +1258,9 @@ class MCXGrayCode(MCXGate):
         """Invert this gate. The MCX is its own inverse.
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this gate is self inverse.
 
         Returns:
             MCXGrayCode: inverse gate (self-inverse).
@@ -1312,8 +1319,9 @@ class MCXRecursive(MCXGate):
         """Invert this gate. The MCX is its own inverse.
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this gate is self inverse.
 
         Returns:
             MCXRecursive: inverse gate (self-inverse).
@@ -1416,8 +1424,9 @@ class MCXVChain(MCXGate):
         """Invert this gate. The MCX is its own inverse.
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this gate is self inverse.
 
         Returns:
             MCXVChain: inverse gate (self-inverse).

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -136,6 +136,9 @@ class XGate(SingletonGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            XGate: inverse gate (self-inverse).
         """
         return XGate()  # self-inverse
 
@@ -276,6 +279,9 @@ class CXGate(SingletonControlledGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            CXGate: inverse gate (self-inverse).
         """
         return CXGate(ctrl_state=self.ctrl_state)  # self-inverse
 
@@ -465,6 +471,9 @@ class CCXGate(SingletonControlledGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            CCXGate: inverse gate (self-inverse).
         """
         return CCXGate(ctrl_state=self.ctrl_state)  # self-inverse
 
@@ -796,11 +805,14 @@ class C3XGate(SingletonControlledGate):
         return gate
 
     def inverse(self, annotated: bool = False):
-        """Invert this gate. The C4X is its own inverse.
+        """Invert this gate. The C3X is its own inverse.
 
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            C3XGate: inverse gate (self-inverse).
         """
         return C3XGate(ctrl_state=self.ctrl_state)
 
@@ -1040,6 +1052,9 @@ class C4XGate(SingletonControlledGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            C4XGate: inverse gate (self-inverse).
         """
         return C4XGate(ctrl_state=self.ctrl_state)
 
@@ -1117,6 +1132,9 @@ class MCXGate(ControlledGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            MCXGate: inverse gate (self-inverse).
         """
         return MCXGate(num_ctrl_qubits=self.num_ctrl_qubits, ctrl_state=self.ctrl_state)
 
@@ -1236,6 +1254,9 @@ class MCXGrayCode(MCXGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            MCXGrayCode: inverse gate (self-inverse).
         """
         return MCXGrayCode(num_ctrl_qubits=self.num_ctrl_qubits, ctrl_state=self.ctrl_state)
 
@@ -1293,6 +1314,9 @@ class MCXRecursive(MCXGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            MCXRecursive: inverse gate (self-inverse).
         """
         return MCXRecursive(num_ctrl_qubits=self.num_ctrl_qubits, ctrl_state=self.ctrl_state)
 
@@ -1394,6 +1418,9 @@ class MCXVChain(MCXGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            MCXVChain: inverse gate (self-inverse).
         """
         return MCXVChain(
             num_ctrl_qubits=self.num_ctrl_qubits,

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -104,10 +104,10 @@ class XGate(SingletonGate):
         One control returns a CX gate. Two controls returns a CCX gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -131,7 +131,12 @@ class XGate(SingletonGate):
         return gate
 
     def inverse(self, annotated: bool = False):
-        r"""Return inverted X gate (itself)."""
+        r"""Return inverted X gate (itself).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return XGate()  # self-inverse
 
     def __eq__(self, other):
@@ -237,10 +242,10 @@ class CXGate(SingletonControlledGate):
         """Return a controlled-X gate with more control lines.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -266,7 +271,12 @@ class CXGate(SingletonControlledGate):
         return gate
 
     def inverse(self, annotated: bool = False):
-        """Return inverted CX gate (itself)."""
+        """Return inverted CX gate (itself).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return CXGate(ctrl_state=self.ctrl_state)  # self-inverse
 
     def __eq__(self, other):
@@ -421,10 +431,10 @@ class CCXGate(SingletonControlledGate):
         """Controlled version of this gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -450,7 +460,12 @@ class CCXGate(SingletonControlledGate):
         return gate
 
     def inverse(self, annotated: bool = False):
-        """Return an inverted CCX gate (also a CCX)."""
+        """Return an inverted CCX gate (also a CCX).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return CCXGate(ctrl_state=self.ctrl_state)  # self-inverse
 
     def __eq__(self, other):
@@ -553,9 +568,9 @@ class C3SXGate(SingletonControlledGate):
         """Create a new 3-qubit controlled sqrt-X gate.
 
         Args:
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
         """
         from .sx import SXGate
 
@@ -752,10 +767,10 @@ class C3XGate(SingletonControlledGate):
         """Controlled version of this gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -781,7 +796,12 @@ class C3XGate(SingletonControlledGate):
         return gate
 
     def inverse(self, annotated: bool = False):
-        """Invert this gate. The C4X is its own inverse."""
+        """Invert this gate. The C4X is its own inverse.
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return C3XGate(ctrl_state=self.ctrl_state)
 
     def __eq__(self, other):
@@ -986,10 +1006,10 @@ class C4XGate(SingletonControlledGate):
         """Controlled version of this gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -1015,7 +1035,12 @@ class C4XGate(SingletonControlledGate):
         return gate
 
     def inverse(self, annotated: bool = False):
-        """Invert this gate. The C4X is its own inverse."""
+        """Invert this gate. The C4X is its own inverse.
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return C4XGate(ctrl_state=self.ctrl_state)
 
     def __eq__(self, other):
@@ -1087,7 +1112,12 @@ class MCXGate(ControlledGate):
         )
 
     def inverse(self, annotated: bool = False):
-        """Invert this gate. The MCX is its own inverse."""
+        """Invert this gate. The MCX is its own inverse.
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return MCXGate(num_ctrl_qubits=self.num_ctrl_qubits, ctrl_state=self.ctrl_state)
 
     @staticmethod
@@ -1130,10 +1160,10 @@ class MCXGate(ControlledGate):
         """Return a multi-controlled-X gate with more control lines.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -1201,7 +1231,12 @@ class MCXGrayCode(MCXGate):
         super().__init__(num_ctrl_qubits, label=label, ctrl_state=ctrl_state, _name="mcx_gray")
 
     def inverse(self, annotated: bool = False):
-        """Invert this gate. The MCX is its own inverse."""
+        """Invert this gate. The MCX is its own inverse.
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return MCXGrayCode(num_ctrl_qubits=self.num_ctrl_qubits, ctrl_state=self.ctrl_state)
 
     def _define(self):
@@ -1253,7 +1288,12 @@ class MCXRecursive(MCXGate):
         return MCXGate.get_num_ancilla_qubits(num_ctrl_qubits, mode)
 
     def inverse(self, annotated: bool = False):
-        """Invert this gate. The MCX is its own inverse."""
+        """Invert this gate. The MCX is its own inverse.
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return MCXRecursive(num_ctrl_qubits=self.num_ctrl_qubits, ctrl_state=self.ctrl_state)
 
     def _define(self):
@@ -1349,7 +1389,12 @@ class MCXVChain(MCXGate):
         self._dirty_ancillas = dirty_ancillas
 
     def inverse(self, annotated: bool = False):
-        """Invert this gate. The MCX is its own inverse."""
+        """Invert this gate. The MCX is its own inverse.
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return MCXVChain(
             num_ctrl_qubits=self.num_ctrl_qubits,
             dirty_ancillas=self._dirty_ancillas,

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -134,9 +134,10 @@ class XGate(SingletonGate):
         r"""Return inverted X gate (itself).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this gate is self inverse.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
 
         Returns:
             XGate: inverse gate (self-inverse).
@@ -278,9 +279,10 @@ class CXGate(SingletonControlledGate):
         """Return inverted CX gate (itself).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this gate is self inverse.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
 
         Returns:
             CXGate: inverse gate (self-inverse).
@@ -471,9 +473,10 @@ class CCXGate(SingletonControlledGate):
         """Return an inverted CCX gate (also a CCX).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this gate is self inverse.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
 
         Returns:
             CCXGate: inverse gate (self-inverse).
@@ -811,9 +814,10 @@ class C3XGate(SingletonControlledGate):
         """Invert this gate. The C3X is its own inverse.
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this gate is self inverse.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
 
         Returns:
             C3XGate: inverse gate (self-inverse).
@@ -1054,9 +1058,10 @@ class C4XGate(SingletonControlledGate):
         """Invert this gate. The C4X is its own inverse.
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this gate is self inverse.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
 
         Returns:
             C4XGate: inverse gate (self-inverse).
@@ -1135,9 +1140,10 @@ class MCXGate(ControlledGate):
         """Invert this gate. The MCX is its own inverse.
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this gate is self inverse.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
 
         Returns:
             MCXGate: inverse gate (self-inverse).
@@ -1258,9 +1264,10 @@ class MCXGrayCode(MCXGate):
         """Invert this gate. The MCX is its own inverse.
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this gate is self inverse.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
 
         Returns:
             MCXGrayCode: inverse gate (self-inverse).
@@ -1319,9 +1326,10 @@ class MCXRecursive(MCXGate):
         """Invert this gate. The MCX is its own inverse.
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this gate is self inverse.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
 
         Returns:
             MCXRecursive: inverse gate (self-inverse).
@@ -1424,9 +1432,10 @@ class MCXVChain(MCXGate):
         """Invert this gate. The MCX is its own inverse.
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this gate is self inverse.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
 
         Returns:
             MCXVChain: inverse gate (self-inverse).

--- a/qiskit/circuit/library/standard_gates/xx_minus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_minus_yy.py
@@ -154,7 +154,12 @@ class XXMinusYYGate(Gate):
         self.definition = circuit
 
     def inverse(self, annotated: bool = False):
-        """Inverse gate."""
+        """Inverse gate.
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         theta, beta = self.params
         return XXMinusYYGate(-theta, beta)
 

--- a/qiskit/circuit/library/standard_gates/xx_minus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_minus_yy.py
@@ -157,9 +157,10 @@ class XXMinusYYGate(Gate):
         """Inverse gate.
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this inverse of this gate is always a :class:`.XXMinusYYGate` with inverse
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.XXMinusYYGate` with inverse
                 parameter values.
 
         Returns:

--- a/qiskit/circuit/library/standard_gates/xx_minus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_minus_yy.py
@@ -159,6 +159,9 @@ class XXMinusYYGate(Gate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            XXMinusYYGate: inverse gate.
         """
         theta, beta = self.params
         return XXMinusYYGate(-theta, beta)

--- a/qiskit/circuit/library/standard_gates/xx_minus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_minus_yy.py
@@ -157,8 +157,10 @@ class XXMinusYYGate(Gate):
         """Inverse gate.
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this inverse of this gate is always a :class:`.XXMinusYYGate` with inverse
+                parameter values.
 
         Returns:
             XXMinusYYGate: inverse gate.

--- a/qiskit/circuit/library/standard_gates/xx_plus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_plus_yy.py
@@ -156,9 +156,10 @@ class XXPlusYYGate(Gate):
         """Return inverse XX+YY gate (i.e. with the negative rotation angle and same phase angle).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this inverse of this gate is always a :class:`.XXPlusYYGate` with inverse
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as the inverse
+                of this gate is always a :class:`.XXPlusYYGate` with inverse
                 parameter values.
 
         Returns:

--- a/qiskit/circuit/library/standard_gates/xx_plus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_plus_yy.py
@@ -158,6 +158,9 @@ class XXPlusYYGate(Gate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            XXPlusYYGate: inverse gate.
         """
         return XXPlusYYGate(-self.params[0], self.params[1])
 

--- a/qiskit/circuit/library/standard_gates/xx_plus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_plus_yy.py
@@ -153,7 +153,12 @@ class XXPlusYYGate(Gate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Return inverse XX+YY gate (i.e. with the negative rotation angle and same phase angle)."""
+        """Return inverse XX+YY gate (i.e. with the negative rotation angle and same phase angle).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return XXPlusYYGate(-self.params[0], self.params[1])
 
     def __array__(self, dtype=complex):

--- a/qiskit/circuit/library/standard_gates/xx_plus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_plus_yy.py
@@ -156,8 +156,10 @@ class XXPlusYYGate(Gate):
         """Return inverse XX+YY gate (i.e. with the negative rotation angle and same phase angle).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this inverse of this gate is always a :class:`.XXPlusYYGate` with inverse
+                parameter values.
 
         Returns:
             XXPlusYYGate: inverse gate.

--- a/qiskit/circuit/library/standard_gates/y.py
+++ b/qiskit/circuit/library/standard_gates/y.py
@@ -101,10 +101,10 @@ class YGate(SingletonGate):
         One control returns a CY gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -123,7 +123,12 @@ class YGate(SingletonGate):
         return gate
 
     def inverse(self, annotated: bool = False):
-        r"""Return inverted Y gate (:math:`Y^{\dagger} = Y`)"""
+        r"""Return inverted Y gate (:math:`Y^{\dagger} = Y`)
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return YGate()  # self-inverse
 
     def __eq__(self, other):
@@ -229,7 +234,12 @@ class CYGate(SingletonControlledGate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Return inverted CY gate (itself)."""
+        """Return inverted CY gate (itself).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return CYGate(ctrl_state=self.ctrl_state)  # self-inverse
 
     def __eq__(self, other):

--- a/qiskit/circuit/library/standard_gates/y.py
+++ b/qiskit/circuit/library/standard_gates/y.py
@@ -128,6 +128,9 @@ class YGate(SingletonGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            YGate: inverse gate (self-inverse).
         """
         return YGate()  # self-inverse
 
@@ -239,6 +242,9 @@ class CYGate(SingletonControlledGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            CYGate: inverse gate (self-inverse).
         """
         return CYGate(ctrl_state=self.ctrl_state)  # self-inverse
 

--- a/qiskit/circuit/library/standard_gates/y.py
+++ b/qiskit/circuit/library/standard_gates/y.py
@@ -126,8 +126,9 @@ class YGate(SingletonGate):
         r"""Return inverted Y gate (:math:`Y^{\dagger} = Y`)
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this gate is self inverse.
 
         Returns:
             YGate: inverse gate (self-inverse).
@@ -240,8 +241,9 @@ class CYGate(SingletonControlledGate):
         """Return inverted CY gate (itself).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this gate is self inverse.
 
         Returns:
             CYGate: inverse gate (self-inverse).

--- a/qiskit/circuit/library/standard_gates/y.py
+++ b/qiskit/circuit/library/standard_gates/y.py
@@ -126,9 +126,10 @@ class YGate(SingletonGate):
         r"""Return inverted Y gate (:math:`Y^{\dagger} = Y`)
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this gate is self inverse.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
 
         Returns:
             YGate: inverse gate (self-inverse).
@@ -241,9 +242,10 @@ class CYGate(SingletonControlledGate):
         """Return inverted CY gate (itself).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this gate is self inverse.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
 
         Returns:
             CYGate: inverse gate (self-inverse).

--- a/qiskit/circuit/library/standard_gates/z.py
+++ b/qiskit/circuit/library/standard_gates/z.py
@@ -130,9 +130,10 @@ class ZGate(SingletonGate):
         """Return inverted Z gate (itself).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this gate is self inverse.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
 
         Returns:
             ZGate: inverse gate (self-inverse).
@@ -227,9 +228,10 @@ class CZGate(SingletonControlledGate):
         """Return inverted CZ gate (itself).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this gate is self inverse.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
 
         Returns:
             CZGate: inverse gate (self-inverse).
@@ -326,9 +328,10 @@ class CCZGate(SingletonControlledGate):
         """Return inverted CCZ gate (itself).
 
         Args:
-            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
-                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
-                argument is ignored as this gate is self inverse.
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
 
         Returns:
             CCZGate: inverse gate (self-inverse).

--- a/qiskit/circuit/library/standard_gates/z.py
+++ b/qiskit/circuit/library/standard_gates/z.py
@@ -105,10 +105,10 @@ class ZGate(SingletonGate):
         One control returns a CZ gate.
 
         Args:
-            num_ctrl_qubits (int): number of control qubits.
-            label (str or None): An optional label for the gate [Default: None]
-            ctrl_state (int or str or None): control state expressed as integer,
-                string (e.g. '110'), or None. If None, use all 1s.
+            num_ctrl_qubits: number of control qubits.
+            label: An optional label for the gate [Default: ``None``]
+            ctrl_state: control state expressed as integer,
+                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate can be implemented
                 as an annotated gate.
 
@@ -127,7 +127,12 @@ class ZGate(SingletonGate):
         return gate
 
     def inverse(self, annotated: bool = False):
-        """Return inverted Z gate (itself)."""
+        """Return inverted Z gate (itself).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return ZGate()  # self-inverse
 
     def power(self, exponent: float):
@@ -215,7 +220,12 @@ class CZGate(SingletonControlledGate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Return inverted CZ gate (itself)."""
+        """Return inverted CZ gate (itself).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return CZGate(ctrl_state=self.ctrl_state)  # self-inverse
 
     def __eq__(self, other):
@@ -305,7 +315,12 @@ class CCZGate(SingletonControlledGate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Return inverted CCZ gate (itself)."""
+        """Return inverted CCZ gate (itself).
+
+        Args:
+            annotated: indicates whether the inverse gate can be implemented
+                as an annotated gate.
+        """
         return CCZGate(ctrl_state=self.ctrl_state)  # self-inverse
 
     def __eq__(self, other):

--- a/qiskit/circuit/library/standard_gates/z.py
+++ b/qiskit/circuit/library/standard_gates/z.py
@@ -130,8 +130,9 @@ class ZGate(SingletonGate):
         """Return inverted Z gate (itself).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this gate is self inverse.
 
         Returns:
             ZGate: inverse gate (self-inverse).
@@ -226,8 +227,9 @@ class CZGate(SingletonControlledGate):
         """Return inverted CZ gate (itself).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this gate is self inverse.
 
         Returns:
             CZGate: inverse gate (self-inverse).
@@ -324,8 +326,9 @@ class CCZGate(SingletonControlledGate):
         """Return inverted CCZ gate (itself).
 
         Args:
-            annotated: indicates whether the inverse gate can be implemented
-                as an annotated gate.
+            annotated: Typically when set to ``True`` this is used to return an :class:`.AnnotatedOperation` 
+                with an inverse modifier set instead of a concrete :class:`.Gate`. However, for this class this
+                argument is ignored as this gate is self inverse.
 
         Returns:
             CCZGate: inverse gate (self-inverse).

--- a/qiskit/circuit/library/standard_gates/z.py
+++ b/qiskit/circuit/library/standard_gates/z.py
@@ -132,6 +132,9 @@ class ZGate(SingletonGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            ZGate: inverse gate (self-inverse).
         """
         return ZGate()  # self-inverse
 
@@ -225,6 +228,9 @@ class CZGate(SingletonControlledGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            CZGate: inverse gate (self-inverse).
         """
         return CZGate(ctrl_state=self.ctrl_state)  # self-inverse
 
@@ -320,6 +326,9 @@ class CCZGate(SingletonControlledGate):
         Args:
             annotated: indicates whether the inverse gate can be implemented
                 as an annotated gate.
+
+        Returns:
+            CCZGate: inverse gate (self-inverse).
         """
         return CCZGate(ctrl_state=self.ctrl_state)  # self-inverse
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Documents `annotated` argument for `inverse()` in all gates in the standard library that provider their own implementation. I found that `control()` was already documented, but I made sure the types were indicated in the signature instead of the args. definition to make @Cryoris happy (unfortunately there is still quite a lot of inconsistency documenting the types).


### Details and comments
Addresses #11707.

I only looked for gates in the standard library, if you know of any other affected gates, let me know and I can add them to the PR.

