### PR TITLE
Treat Reset like Measure in ConstrainedReschedule

### DIFF
--- a/qiskit/transpiler/passes/scheduling/alignments/reschedule.py
+++ b/qiskit/transpiler/passes/scheduling/alignments/reschedule.py
@@ -17,6 +17,7 @@ from collections.abc import Generator
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.delay import Delay
 from qiskit.circuit.measure import Measure
+from qiskit.circuit.reset import Reset
 from qiskit.dagcircuit import DAGCircuit, DAGOpNode, DAGOutNode
 from qiskit.transpiler.basepasses import AnalysisPass
 from qiskit.transpiler.exceptions import TranspilerError
@@ -113,7 +114,7 @@ class ConstrainedReschedule(AnalysisPass):
 
         if isinstance(node.op, Gate):
             alignment = self.pulse_align
-        elif isinstance(node.op, Measure):
+        elif isinstance(node.op, (Measure, Reset)):
             alignment = self.acquire_align
         elif isinstance(node.op, Delay) or getattr(node.op, "_directive", False):
             # Directive or delay. These can start at arbitrary time.
@@ -135,7 +136,7 @@ class ConstrainedReschedule(AnalysisPass):
         # Compute shifted t1 of this node separately for qreg and creg
         new_t1q = this_t0 + node.op.duration
         this_qubits = set(node.qargs)
-        if isinstance(node.op, Measure):
+        if isinstance(node.op, (Measure, Reset)):
             # creg access ends at the end of instruction
             new_t1c = new_t1q
             this_clbits = set(node.cargs)
@@ -153,7 +154,7 @@ class ConstrainedReschedule(AnalysisPass):
             # Compute next node start time separately for qreg and creg
             next_t0q = node_start_time[next_node]
             next_qubits = set(next_node.qargs)
-            if isinstance(next_node.op, Measure):
+            if isinstance(next_node.op, (Measure, Reset)):
                 # creg access starts after write latency
                 next_t0c = next_t0q + clbit_write_latency
                 next_clbits = set(next_node.cargs)

--- a/qiskit/transpiler/passes/scheduling/base_scheduler.py
+++ b/qiskit/transpiler/passes/scheduling/base_scheduler.py
@@ -11,6 +11,8 @@
 # that they have been altered from the originals.
 
 """Base circuit scheduling pass."""
+import warnings
+
 from qiskit.transpiler import InstructionDurations
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.passes.scheduling.time_unit_conversion import TimeUnitConversion
@@ -19,8 +21,6 @@ from qiskit.circuit import Delay, Gate, Measure, Reset
 from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.target import Target
-
-import warnings
 
 
 class BaseSchedulerTransform(TransformationPass):

--- a/qiskit/transpiler/passes/scheduling/base_scheduler.py
+++ b/qiskit/transpiler/passes/scheduling/base_scheduler.py
@@ -20,6 +20,8 @@ from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.target import Target
 
+import warnings
+
 
 class BaseSchedulerTransform(TransformationPass):
     """Base scheduler pass.
@@ -270,7 +272,7 @@ class BaseSchedulerTransform(TransformationPass):
             duration = node.op.duration
 
         if isinstance(node.op, Reset):
-            raise RuntimeWarning(
+            warnings.warn(
                 "Qiskit scheduler assumes Reset works similarly to Measure instruction. "
                 "Actual behavior depends on the control system of your quantum backend. "
                 "Your backend may provide a plugin scheduler pass."
@@ -280,7 +282,7 @@ class BaseSchedulerTransform(TransformationPass):
                 isinstance(x, DAGOutNode) for x in dag.quantum_successors(node)
             )
             if is_mid_circuit:
-                raise RuntimeWarning(
+                warnings.warn(
                     "Qiskit scheduler assumes mid-circuit measurement works as a standard instruction. "
                     "Actual backend may apply custom scheduling. "
                     "Your backend may provide a plugin scheduler pass."

--- a/qiskit/transpiler/passes/scheduling/base_scheduler.py
+++ b/qiskit/transpiler/passes/scheduling/base_scheduler.py
@@ -277,7 +277,9 @@ class BaseSchedulerTransform(TransformationPass):
                 )
                 if is_mid_circuit:
                     raise RuntimeWarning(
-                        "Mid-circuit measurement durations reported from IBM backends are currently untrustworthy. Do not rely on on scheduling output."
+                        "Qiskit scheduler assumes mid-circuit measurement works as a standard instruction. "
+                        "Actual backend may apply custom scheduling. "
+                    "Your backend may provide a plugin scheduler pass."                                      
                     )
             duration = dag.calibrations[node.op.name][cal_key].duration
         else:

--- a/qiskit/transpiler/passes/scheduling/base_scheduler.py
+++ b/qiskit/transpiler/passes/scheduling/base_scheduler.py
@@ -265,25 +265,26 @@ class BaseSchedulerTransform(TransformationPass):
         if dag.has_calibration_for(node):
             # If node has calibration, this value should be the highest priority
             cal_key = tuple(indices), tuple(float(p) for p in node.op.params)
-            if isinstance(node.op, Reset):
-                raise RuntimeWarning(
-                    "Qiskit scheduler assumes Reset works similarly to Measure instruction. "
-                    "Actual behavior depends on the control system of your quantum backend. "
-                    "Your backend may provide a plugin scheduler pass."
-                )
-            elif isinstance(node.op, Measure):
-                is_mid_circuit = not any(
-                    isinstance(x, DAGOutNode) for x in dag.quantum_successors(node)
-                )
-                if is_mid_circuit:
-                    raise RuntimeWarning(
-                        "Qiskit scheduler assumes mid-circuit measurement works as a standard instruction. "
-                        "Actual backend may apply custom scheduling. "
-                    "Your backend may provide a plugin scheduler pass."                                      
-                    )
             duration = dag.calibrations[node.op.name][cal_key].duration
         else:
             duration = node.op.duration
+
+        if isinstance(node.op, Reset):
+            raise RuntimeWarning(
+                "Qiskit scheduler assumes Reset works similarly to Measure instruction. "
+                "Actual behavior depends on the control system of your quantum backend. "
+                "Your backend may provide a plugin scheduler pass."
+            )
+        elif isinstance(node.op, Measure):
+            is_mid_circuit = not any(
+                isinstance(x, DAGOutNode) for x in dag.quantum_successors(node)
+            )
+            if is_mid_circuit:
+                raise RuntimeWarning(
+                    "Qiskit scheduler assumes mid-circuit measurement works as a standard instruction. "
+                    "Actual backend may apply custom scheduling. "
+                    "Your backend may provide a plugin scheduler pass."
+                )
 
         if isinstance(duration, ParameterExpression):
             raise TranspilerError(

--- a/qiskit/transpiler/passes/scheduling/base_scheduler.py
+++ b/qiskit/transpiler/passes/scheduling/base_scheduler.py
@@ -267,7 +267,9 @@ class BaseSchedulerTransform(TransformationPass):
             cal_key = tuple(indices), tuple(float(p) for p in node.op.params)
             if isinstance(node.op, Reset):
                 raise RuntimeWarning(
-                    "Reset durations reported from IBM backends are currently untrustworthy. Do not rely on on scheduling output."
+                    "Qiskit scheduler assumes Reset works similarly to Measure instruction. "
+                    "Actual behavior depends on the control system of your quantum backend. "
+                    "Your backend may provide a plugin scheduler pass."
                 )
             elif isinstance(node.op, Measure):
                 is_mid_circuit = not any(

--- a/qiskit/transpiler/passes/scheduling/base_scheduler.py
+++ b/qiskit/transpiler/passes/scheduling/base_scheduler.py
@@ -14,8 +14,8 @@
 from qiskit.transpiler import InstructionDurations
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.passes.scheduling.time_unit_conversion import TimeUnitConversion
-from qiskit.dagcircuit import DAGOpNode, DAGCircuit
-from qiskit.circuit import Delay, Gate
+from qiskit.dagcircuit import DAGOpNode, DAGCircuit, DAGOutNode
+from qiskit.circuit import Delay, Gate, Measure, Reset
 from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.target import Target
@@ -265,6 +265,18 @@ class BaseSchedulerTransform(TransformationPass):
         if dag.has_calibration_for(node):
             # If node has calibration, this value should be the highest priority
             cal_key = tuple(indices), tuple(float(p) for p in node.op.params)
+            if isinstance(node.op, Reset):
+                raise RuntimeWarning(
+                    "Reset durations reported from IBM backends are currently untrustworthy. Do not rely on on scheduling output."
+                )
+            elif isinstance(node.op, Measure):
+                is_mid_circuit = not any(
+                    isinstance(x, DAGOutNode) for x in dag.quantum_successors(node)
+                )
+                if is_mid_circuit:
+                    raise RuntimeWarning(
+                        "Mid-circuit measurement durations reported from IBM backends are currently untrustworthy. Do not rely on on scheduling output."
+                    )
             duration = dag.calibrations[node.op.name][cal_key].duration
         else:
             duration = node.op.duration

--- a/releasenotes/notes/add-scheduler-warnings-da6968a39fd8e6e7.yaml
+++ b/releasenotes/notes/add-scheduler-warnings-da6968a39fd8e6e7.yaml
@@ -1,0 +1,9 @@
+fixes:
+  - |
+    Fixed an issue where the :class:`.ConstrainedReschedule` transpiler pass would previously error
+    if the circuit contained a :class:`~.circuit.Reset` instruction. This has been corrected so that the
+    pass no longer errors, however as the durations reported by IBM backends are not always
+    trustworthy for mid-circuit measurements and resets a ``RuntimeWarning`` is now raised if
+    the :class:`.ConstrainedReschedule` is run on a circuit containing either.
+    Fixed `#10354 <https://github.com/Qiskit/qiskit/issues/10354>`__
+

--- a/releasenotes/notes/add-scheduler-warnings-da6968a39fd8e6e7.yaml
+++ b/releasenotes/notes/add-scheduler-warnings-da6968a39fd8e6e7.yaml
@@ -2,8 +2,10 @@ fixes:
   - |
     Fixed an issue where the :class:`.ConstrainedReschedule` transpiler pass would previously error
     if the circuit contained a :class:`~.circuit.Reset` instruction. This has been corrected so that the
-    pass no longer errors, however as the durations reported by IBM backends are not always
-    trustworthy for mid-circuit measurements and resets a ``RuntimeWarning`` is now raised if
-    the :class:`.ConstrainedReschedule` is run on a circuit containing either.
+    pass no longer errors, however an actual hardware may behave differently from 
+    what Qiskit scheduler assumes especially for 
+    mid-circuit measurements and resets.
+    Qiskit scheduler raises ``RuntimeWarning`` if
+    it encounters circuit containing either.
     Fixed `#10354 <https://github.com/Qiskit/qiskit/issues/10354>`__
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

fixes #10354 ConstrainedReschedule raises an error with reset

### Details and comments

Reset and Measure (mid-circuit) both provide duration data from the backend, but this is untrustworthy. To reflect this, I added RuntimeWarnings in `qiskit/transpiler/passes/scheduling/base_scheduler.py`.

That Reset reports duration data is not recognized in `ConstrainedReschedule`, leading to the error in Issue #10354. Thus, I added the same handling for Reset in `ConstrainedReschedule `as is used for Measure.

