### PR TITLE
Make scipy imports on default path lazy

### DIFF
--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -21,7 +21,6 @@ import re
 from numbers import Number
 from typing import TYPE_CHECKING
 
-import scipy.linalg
 import numpy as np
 
 from qiskit.circuit.instruction import Instruction
@@ -528,6 +527,8 @@ class Operator(LinearOp):
         if isinstance(n, int):
             ret._data = np.linalg.matrix_power(self.data, n)
         else:
+            import scipy.linalg
+
             # Experimentally, for fractional powers this seems to be 3x faster than
             # calling scipy.linalg.fractional_matrix_power(self.data, n)
             decomposition, unitary = scipy.linalg.schur(self.data, output="complex")

--- a/qiskit/synthesis/unitary/aqc/aqc.py
+++ b/qiskit/synthesis/unitary/aqc/aqc.py
@@ -12,17 +12,20 @@
 """A generic implementation of Approximate Quantum Compiler."""
 from __future__ import annotations
 
+import typing
 from functools import partial
 
 from collections.abc import Callable
 from typing import Protocol
 
 import numpy as np
-from scipy.optimize import OptimizeResult, minimize
 
 from qiskit.quantum_info import Operator
 
 from .approximate import ApproximateCircuit, ApproximatingObjective
+
+if typing.TYPE_CHECKING:
+    import scipy.optimize
 
 
 class Minimizer(Protocol):
@@ -52,7 +55,7 @@ class Minimizer(Protocol):
         x0: np.ndarray,  # pylint: disable=invalid-name
         jac: Callable[[np.ndarray], np.ndarray] | None = None,
         bounds: list[tuple[float, float]] | None = None,
-    ) -> OptimizeResult:
+    ) -> scipy.optimize.OptimizeResult:
         """Minimize the objective function.
 
         This interface is based on `SciPy's optimize module <https://docs.scipy.org/doc
@@ -112,9 +115,11 @@ class AQC:
                 ``L-BFGS-B`` method is used with max iterations set to 1000.
             seed: a seed value to be used by a random number generator.
         """
+        import scipy.optimize
+
         super().__init__()
         self._optimizer = optimizer or partial(
-            minimize, args=(), method="L-BFGS-B", options={"maxiter": 1000}
+            scipy.optimize.minimize, args=(), method="L-BFGS-B", options={"maxiter": 1000}
         )
 
         self._seed = seed

--- a/tools/find_optional_imports.py
+++ b/tools/find_optional_imports.py
@@ -27,6 +27,8 @@ def _main():
         "pydot",
         "pygments",
         "ipywidgets",
+        "scipy.linalg",
+        "scipy.optimize",
         "scipy.stats",
         "matplotlib",
         "qiskit_aer",


### PR DESCRIPTION
### Summary


The scipy subpackages are typically fairly heavy, and we want to delay importing them until they're actually used.  This makes two such imports lazy, which are either newly on the import path, or a new import introdcued at around the same time.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->



### Details and comments

Fix #11713
