### PR TITLE
Fix asv installation command

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -4,7 +4,7 @@
     "project_url": "https://qiskit.org",
     "repo": ".",
     "install_command": [
-        "in-dir={env_dir} python -m pip install {wheel_file}[all] python-constraint"
+        "in-dir={env_dir} python -m pip install {wheel_file}[csp-layout-pass]"
       ],
     "uninstall_command": [
         "return-code=any python -m pip uninstall -y qiskit qiskit-terra"


### PR DESCRIPTION
### Summary


The nightly benchmarking runs haven't been running recently due to failures to import Qiskit.  This happened immediately after the import poisoning.  The problem appears to be because the `all` extra in the metadata references the `qiskit` package by name, since this is how we avoid repeating ourselves in the definition of the extra.  However, as we note in `pyproject.toml`, when called on a local wheel file, this causes the resoution to install `qiskit` from PyPI, which means overwriting the package with a different version.  We don't actually need everything installed for the benchmarks, so we can just set the rule to install only what is needed.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->



### Details and comments

This seems to work locally for me, but I didn't actually try and reproduce the failures first.
