### PR TITLE
Unskipping the test: `test.python.compiler.test_transpiler.TestTranspileMultiChipTarget.test_transpile_does_not_affect_backend_coupling_4_3`

### DIFF
--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -17,7 +17,6 @@ import io
 import math
 import os
 import sys
-import unittest
 from logging import StreamHandler, getLogger
 from unittest.mock import patch
 import numpy as np
@@ -3336,8 +3335,6 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
     def test_transpile_does_not_affect_backend_coupling(self, opt_level):
         """Test that transpiliation of a circuit does not mutate the `CouplingMap` stored by a V2
         backend.  Regression test of gh-9997."""
-        if opt_level == 3:
-            raise unittest.SkipTest("unitary resynthesis fails due to gh-10004")
         qc = QuantumCircuit(127)
         for i in range(1, 127):
             qc.ecr(0, i)


### PR DESCRIPTION
#10004 was fixed. So, unskipping `test.python.compiler.test_transpiler.TestTranspileMultiChipTarget.test_transpile_does_not_affect_backend_coupling_4_3` which was marked in #9999 as such.