### PR TITLE
Unskipping the test: `test.python.transpiler.test_layout_transformation.TestLayoutTransformation.test_full_connected_coupling_map`

### DIFF
--- a/test/python/transpiler/test_layout_transformation.py
+++ b/test/python/transpiler/test_layout_transformation.py
@@ -85,13 +85,8 @@ class TestLayoutTransformation(QiskitTestCase):
 
         self.assertEqual(circuit_to_dag(expected), output_dag)
 
-    @unittest.skip("rustworkx token_swapper produces correct, but sometimes random output")
     def test_full_connected_coupling_map(self):
         """Test if the permutation {0->3,1->0,2->1,3->2} in a fully connected map."""
-
-        # TODO: Remove skip when https://github.com/Qiskit/rustworkx/pull/897 is
-        # merged and released. Should be rustworkx 0.13.1.
-
         v = QuantumRegister(4, "v")  # virtual qubits
         from_layout = Layout({v[0]: 0, v[1]: 1, v[2]: 2, v[3]: 3})
         to_layout = Layout({v[0]: 3, v[1]: 0, v[2]: 1, v[3]: 2})


### PR DESCRIPTION
#10001 marked `test.python.transpiler.test_layout_transformation.TestLayoutTransformation.test_full_connected_coupling_map` as skip because https://github.com/Qiskit/rustworkx/pull/897 . Now rustworkx released the PR, the test can return