### PR TITLE
deterministic `test_fake_backend_v2_noise_model_always_present`

### DIFF
--- a/test/python/providers/fake_provider/test_fake_backends.py
+++ b/test/python/providers/fake_provider/test_fake_backends.py
@@ -50,9 +50,10 @@ class FakeBackendsTest(QiskitTestCase):
         self.assertEqual(sum(raw_counts.values()), 1000)
 
     @unittest.skipUnless(optionals.HAS_AER, "qiskit-aer is required to run this test")
+    @unittest.skip("non-determinitic. See #11768")
     def test_fake_backend_v2_noise_model_always_present(self):
         """Test that FakeBackendV2 instances always run with noise."""
-        backend = GenericBackendV2(num_qubits=5)
+        backend = GenericBackendV2(num_qubits=5, seed=42)
         qc = QuantumCircuit(1)
         qc.x(0)
         qc.measure_all()

--- a/test/python/providers/fake_provider/test_fake_backends.py
+++ b/test/python/providers/fake_provider/test_fake_backends.py
@@ -50,10 +50,10 @@ class FakeBackendsTest(QiskitTestCase):
         self.assertEqual(sum(raw_counts.values()), 1000)
 
     @unittest.skipUnless(optionals.HAS_AER, "qiskit-aer is required to run this test")
-    @unittest.skip("non-determinitic. See #11768")
     def test_fake_backend_v2_noise_model_always_present(self):
         """Test that FakeBackendV2 instances always run with noise."""
         backend = GenericBackendV2(num_qubits=5, seed=42)
+        backend.set_options(seed_simulator=42)
         qc = QuantumCircuit(1)
         qc.x(0)
         qc.measure_all()


### PR DESCRIPTION
The test `test.python.providers.fake_provider.test_fake_backends.FakeBackendsTest.test_fake_backend_v2_noise_model_always_present`sometimes is failing in CI. When trying to `seed` it, the problem seems deeper (see #11768). So, skipping it for now.