### PR TITLE
Bump `actions/{upload,download}-artifact` to v4

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -33,7 +33,7 @@ jobs:
         run: tox run -e docs
 
       - name: Store built documentation artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: qiskit-docs
           path: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,10 +30,10 @@ jobs:
           CIBW_ENVIRONMENT: 'RUSTUP_TOOLCHAIN="stable" RUSTFLAGS="-Cprofile-use=/tmp/pgo-data/merged.profdata -Cllvm-args=-pgo-warn-missing-function"'
           CIBW_ENVIRONMENT_LINUX: 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true" RUSTUP_TOOLCHAIN="stable" RUSTFLAGS="-Cprofile-use=/tmp/pgo-data/merged.profdata -Cllvm-args=-pgo-warn-missing-function"'
           CIBW_ENVIRONMENT_WINDOWS: 'RUSTUP_TOOLCHAIN="stable" RUSTFLAGS="-Cprofile-use=c:\\Users\\runneradmin\\merged.profdata -Cllvm-args=-pgo-warn-missing-function"'
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: shared-wheel-builds
+          name: wheels-${{ matrix.os }}
   build_wheels_32bit:
     name: Build wheels 32bit
     runs-on: ${{ matrix.os }}
@@ -54,10 +54,10 @@ jobs:
         uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_SKIP: 'pp* cp36-* cp37-* *musllinux* *amd64 *x86_64'
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: shared-wheel-builds
+          name: wheels-${{ matrix.os }}-32
   build_wheels_macos_arm:
     name: Build wheels on macOS arm
     runs-on: ${{ matrix.os }}
@@ -81,10 +81,10 @@ jobs:
           CIBW_ENVIRONMENT: >-
             CARGO_BUILD_TARGET="aarch64-apple-darwin"
             PYO3_CROSS_LIB_DIR="/Library/Frameworks/Python.framework/Versions/$(python -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))')/lib/python$(python -c 'import sys; print(str(sys.version_info[0])+"."+str(sys.version_info[1]))')"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: shared-wheel-builds
+          name: wheels-${{ matrix.os }}-arm
   upload_shared_wheels:
     name: Upload shared build wheels
     runs-on: ubuntu-latest
@@ -93,9 +93,10 @@ jobs:
       id-token: write
     needs: ["build_wheels", "build_wheels_macos_arm", "build_wheels_32bit"]
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: shared-wheel-builds
+          pattern: 'wheels-*'
+          merge-multiple: true
           path: deploy
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -127,8 +128,9 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: s390x
           CIBW_TEST_SKIP: "cp*"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: wheels-${{ matrix.os }}-s390x
           path: ./wheelhouse/*.whl
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -160,8 +162,9 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: ppc64le
           CIBW_TEST_SKIP: "cp*"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: wheels-${{ matrix.os }}-ppc64le
           path: ./wheelhouse/*.whl
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -192,8 +195,9 @@ jobs:
         uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_ARCHS_LINUX: aarch64
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: wheels-${{ matrix.os }}-aarch64
           path: ./wheelhouse/*.whl
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
### Summary

This bumps `upload-artifact` and `download-artifact` to version 4.  The jump from version 3 to version 4 is a major incompatible change, especially around uploading to an existing artefact, which we do during our wheel builds.  The new recommended pattern is to use different file names for each call to `upload-artifact`, and match the download with a glob match in `download-artifact`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

This does the `upload-artifact`/`download-artifact` of #11741 separately, because Dependabot would not be able to safely update our actions through this breaking interface change.

I ran a test run of the wheel build job that you can see here: https://github.com/jakelishman/qiskit-terra/actions/runs/7871625586.  The "upload shared wheels" step of that job is modified to just list out the generated wheels, which has found the expected set.

This is a change to the deployment pipelines, with 1.0.0 final due on Thursday, so I'm happy if we'd prefer to leave merging this til after - it could do with backporting to `stable/0.46` and `stable/1.0`.  That said, the 1.0.0 release _should_ be smooth from a CI-load perspective, so maybe it's not terrible if we have this in it.