### PR TITLE
Update release support in security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,15 @@
 
 ## Supported Versions
 
-Qiskit supports one minor version release at a time, both for bug and
-security fixes. For example, if the most recent release is 0.12.1, then the 0.12.x
-release series is currently supported.
+Qiskit supports the most recent major release with new features, which will only appear in minor releases of that series.
+The most recent minor release in the current major release series is also supported with bug fixes.
+In addition, the last minor release of the *previous* major release series is supported with bug fixes for six months after a new major release.
+
+For example, if the most recent release is 1.0.1, then the current major release series is 1.x and the current minor release is 1.0.x.
+The 1.0.x series will be supported with bug fixes, until the release of 1.1.0, which will include new features.
+The last version of the previous major release, 0.46.x, is supported with bugfixes only until six months after the final release of 1.0.0.
+
+We provide more detail on [the release and support schedule of Qiskit in our documentation](https://docs.quantum.ibm.com/start/install#release-schedule).
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
### Summary

The release schedule and support windows in `SECURITY.md` were still referring to the pre-1.0 policy.  The new policy is not drastically different from a security perspective, but did need updating to mention the overlapping support window for the previous major version.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Close #11745
