### PR TITLE
Remove more qiskit.org links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -646,7 +646,7 @@ is a need additional release candidates can be published from `stable/*` and whe
 release is ready a full release will be tagged and published from `stable/*`.
 
 ## Adding deprecation warnings
-The qiskit code is part of Qiskit and, therefore, the [Qiskit Deprecation Policy](https://qiskit.org/documentation/contributing_to_qiskit.html#deprecation-policy) fully applies here. Additionally, qiskit does not allow `DeprecationWarning`s in its testsuite. If you are deprecating code, you should add a test to use the new/non-deprecated method (most of the time based on the existing test of the deprecated method) and alter the existing test to check that the deprecated method still works as expected, [using `assertWarns`](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertWarns). The `assertWarns` context will silence the deprecation warning while checking that it raises.
+The qiskit code is part of Qiskit and, therefore, the [Qiskit Deprecation Policy](./DEPRECATION.md) fully applies here. Additionally, qiskit does not allow `DeprecationWarning`s in its testsuite. If you are deprecating code, you should add a test to use the new/non-deprecated method (most of the time based on the existing test of the deprecated method) and alter the existing test to check that the deprecated method still works as expected, [using `assertWarns`](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertWarns). The `assertWarns` context will silence the deprecation warning while checking that it raises.
 
 For example, if `Obj.method1` is being deprecated in favour of `Obj.method2`, the existing test (or tests) for `method1` might look like this:
 
@@ -699,7 +699,7 @@ You should also add a new "tester" to [`qiskit.utils.optionals`](qiskit/utils/op
 
 You cannot `import` an optional dependency at the top of a file, because if it is not installed, it will raise an error and qiskit will be unusable.
 We also largely want to avoid importing packages until they are actually used; if we import a lot of packages during `import qiskit`, it becomes sluggish for the user if they have a large environment.
-Instead, you should use [one of the "lazy testers" for optional dependencies](https://qiskit.org/documentation/apidoc/utils.html#module-qiskit.utils.optionals), and import your optional dependency inside the function or class that uses it, as in the examples within that link.
+Instead, you should use [one of the "lazy testers" for optional dependencies](https://docs.quantum.ibm.com/api/qiskit/utils#optional-dependency-checkers), and import your optional dependency inside the function or class that uses it, as in the examples within that link.
 Very lightweight _requirements_ can be imported at the tops of files, but even this should be limited; it's always ok to `import numpy`, but Scipy modules are relatively heavy, so only import them within functions that use them.
 
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install qiskit
 
 Pip will handle all dependencies automatically and you will always install the latest (and well-tested) version.
 
-To install from source, follow the instructions in the [documentation](https://qiskit.org/documentation/contributing_to_qiskit.html#install-install-from-source-label).
+To install from source, follow the instructions in the [documentation](https://docs.quantum.ibm.com/start/install-qiskit-source).
 
 ## Create your first quantum program in Qiskit
 
@@ -89,7 +89,7 @@ and see if you can achieve this outcome. (Spoiler alert: this is not possible!)
 Using the Qiskit-provided `qiskit.primitives.Sampler` and `qiskit.primitives.Estimator` will not take you very far. The power of quantum computing cannot be simulated 
 on classical computers and you need to use real quantum hardware to scale to larger quantum circuits. However, running a quantum 
 circuit on hardware requires rewriting them to the basis gates and connectivity of the quantum hardware.
-The tool that does this is the [transpiler](https://qiskit.org/documentation/apidoc/transpiler.html) 
+The tool that does this is the [transpiler](https://docs.quantum.ibm.com/api/qiskit/transpiler) 
 and Qiskit includes transpiler passes for synthesis, optimization, mapping, and scheduling. However, it also includes a
 default compiler which works very well in most examples. The following code will map the example circuit to the `basis_gates = ['cz', 'sx', 'rz']` and a linear chain of qubits $0 \rightarrow 1 \rightarrow 2$ with the `coupling_map =[[0, 1], [1, 2]]`.
 
@@ -97,10 +97,6 @@ default compiler which works very well in most examples. The following code will
 from qiskit import transpile
 qc_transpiled = transpile(qc_example, basis_gates = ['cz', 'sx', 'rz'], coupling_map =[[0, 1], [1, 2]] , optimization_level=3)
 ```
-
-For further examples of using Qiskit you can look at the tutorials in the documentation here:
-
-<https://qiskit.org/documentation/tutorials.html>
 
 ### Executing your code on real quantum hardware
 
@@ -146,22 +142,18 @@ to the project at different levels. If you use Qiskit, please cite as per the in
 
 The changelog for a particular release is dynamically generated and gets
 written to the release page on Github for each release. For example, you can
-find the page for the `0.9.0` release here:
+find the page for the `0.46.0` release here:
 
-<https://github.com/Qiskit/qiskit-terra/releases/tag/0.9.0>
+<https://github.com/Qiskit/qiskit/releases/tag/0.46.0>
 
 The changelog for the current release can be found in the releases tab:
-[![Releases](https://img.shields.io/github/release/Qiskit/qiskit-terra.svg?style=flat&label=)](https://github.com/Qiskit/qiskit-terra/releases)
+[![Releases](https://img.shields.io/github/release/Qiskit/qiskit-terra.svg?style=flat&label=)](https://github.com/Qiskit/qiskit/releases)
 The changelog provides a quick overview of notable changes for a given
 release.
 
-Additionally, as part of each release detailed release notes are written to
+Additionally, as part of each release, detailed release notes are written to
 document in detail what has changed as part of a release. This includes any
-documentation on potential breaking changes on upgrade and new features.
-For example, you can find the release notes for the `0.9.0` release in the
-Qiskit documentation here:
-
-https://qiskit.org/documentation/release_notes.html#terra-0-9
+documentation on potential breaking changes on upgrade and new features. See [all release notes here](https://docs.quantum.ibm.com/api/qiskit/release-notes).
 
 ## Acknowledgements
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,10 +30,6 @@ release = "1.1.0"
 
 language = "en"
 
-# This tells 'qiskit_sphinx_theme' that we're based at 'https://qiskit.org/<docs_url_prefix>'.
-# Should not include the subdirectory for the stable version.
-docs_url_prefix = "documentation"
-
 rst_prolog = f".. |version| replace:: {version}"
 
 extensions = [
@@ -79,7 +75,7 @@ modindex_common_prefix = ["qiskit."]
 intersphinx_mapping = {
     "rustworkx": ("https://www.rustworkx.org/", None),
     "qiskit-ibm-runtime": ("https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/", None),
-    "qiskit-aer": ("https://qiskit.org/ecosystem/aer/", None),
+    "qiskit-aer": ("https://qiskit.github.io/qiskit-aer/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "python": ("https://docs.python.org/3/", None),

--- a/qiskit/utils/optionals.py
+++ b/qiskit/utils/optionals.py
@@ -29,7 +29,7 @@ Qiskit Components
     :widths: 25 75
 
     * - .. py:data:: HAS_AER
-      - `Qiskit Aer <https://qiskit.org/ecosystem/aer/>` provides high-performance simulators for
+      - `Qiskit Aer <https://qiskit.github.io/qiskit-aer/>` provides high-performance simulators for
         the quantum circuits constructed within Qiskit.
 
     * - .. py:data:: HAS_IBMQ
@@ -103,7 +103,7 @@ External Python Libraries
         <https://github.com/Qiskit/rustworkx>`__ library as a core dependency, and during the
         change-over period, it was sometimes convenient to convert things into the Python-only
         `NetworkX <https://networkx.org/>`__ format.  Some tests of application modules, such as
-        `Qiskit Nature <https://qiskit.org/ecosystem/nature/>`__ still use NetworkX.
+        `Qiskit Nature <https://qiskit-community.github.io/qiskit-nature/>`__ still use NetworkX.
 
     * - .. py:data:: HAS_NLOPT
       - `NLopt <https://nlopt.readthedocs.io/en/latest/>`__ is a nonlinear optimization library,

--- a/test/python/transpiler/test_basis_translator.py
+++ b/test/python/transpiler/test_basis_translator.py
@@ -1112,7 +1112,7 @@ class TestBasisTranslatorWithTarget(QiskitTestCase):
         output = bt_pass(qc)
         # We need a second run of BasisTranslator to correct gates outside of
         # the target basis. This is a known isssue, see:
-        #  https://qiskit.org/documentation/release_notes.html#release-notes-0-19-0-known-issues
+        #  https://docs.quantum.ibm.com/api/qiskit/release-notes/0.33#known-issues
         output = bt_pass(output)
         expected = QuantumCircuit(2)
         expected.rz(pi, 1)


### PR DESCRIPTION
All qiskit.org links are now removed other than:

* Old release notes, since these aren't even built anymore.
* The PDFs for Qiskit CLA. Opened https://github.com/Qiskit/documentation/issues/796 to discuss what to do
* `asv.conf.json`. I'm not sure if that messes things up to change it.