### PR TITLE
Fix scheduling units

### DIFF
--- a/qiskit/circuit/duration.py
+++ b/qiskit/circuit/duration.py
@@ -78,10 +78,16 @@ def convert_durations_to_dt(qc: QuantumCircuit, dt_in_sec: float, inplace=True):
         operation.duration = duration_in_dt(duration, dt_in_sec)
         operation.unit = "dt"
 
-    if circ.duration is not None:
-        if circ.unit != "dt":
-            circ.duration = duration_in_dt(circ.duration, dt_in_sec)
-            circ.unit = "dt"
+    if circ.duration is not None and circ.unit != "dt":
+        if not circ.unit.endswith("s"):
+            raise CircuitError(f"Invalid time unit: '{circ.unit}'")
+
+        duration = circ.duration
+        if circ.unit != "s":
+            duration = apply_prefix(duration, circ.unit)
+
+        circ.duration = duration_in_dt(duration, dt_in_sec)
+        circ.unit = "dt"
 
     if not inplace:
         return circ

--- a/qiskit/circuit/duration.py
+++ b/qiskit/circuit/duration.py
@@ -79,8 +79,9 @@ def convert_durations_to_dt(qc: QuantumCircuit, dt_in_sec: float, inplace=True):
         operation.unit = "dt"
 
     if circ.duration is not None:
-        circ.duration = duration_in_dt(circ.duration, dt_in_sec)
-        circ.unit = "dt"
+        if circ.unit != "dt":
+            circ.duration = duration_in_dt(circ.duration, dt_in_sec)
+            circ.unit = "dt"
 
     if not inplace:
         return circ

--- a/releasenotes/notes/fix-scheduling-units-59477912b47d3dc1.yaml
+++ b/releasenotes/notes/fix-scheduling-units-59477912b47d3dc1.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    A bug has been fixed in the scheduling transpiler pass where :func:`.convert_durations_to_dt`
+    would always "convert" circuit durations to ``dt`` without checking if the durations were originally
+    in ``s`` (seconds) or ``dt``. This could lead to wrong orders of magnitude in the reported circuit durations.

--- a/releasenotes/notes/fix-scheduling-units-59477912b47d3dc1.yaml
+++ b/releasenotes/notes/fix-scheduling-units-59477912b47d3dc1.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    A bug has been fixed in the scheduling transpiler pass where :func:`.convert_durations_to_dt`
-    would always "convert" circuit durations to ``dt`` without checking if the durations were originally
-    in ``s`` (seconds) or ``dt``. This could lead to wrong orders of magnitude in the reported circuit durations.
+    A bug has been fixed in :func:`.convert_durations_to_dt` where the function would blindly apply
+    a conversion from seconds to ``dt`` on circuit durations, independently of the original units of the attribute.
+    This could lead to wrong orders of magnitude in the reported circuit durations.

--- a/test/python/compiler/test_scheduler.py
+++ b/test/python/compiler/test_scheduler.py
@@ -11,14 +11,12 @@
 # that they have been altered from the originals.
 
 """Scheduler Test."""
-from qiskit import transpile
+
 from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit
-from qiskit.circuit.duration import convert_durations_to_dt
 from qiskit.exceptions import QiskitError
 from qiskit.pulse import InstructionScheduleMap, Schedule
-from qiskit.providers.fake_provider import FakeOpenPulse3Q, GenericBackendV2
+from qiskit.providers.fake_provider import FakeOpenPulse3Q
 from qiskit.compiler.scheduler import schedule
-from qiskit.scheduler import ScheduleConfig
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
 
@@ -94,29 +92,3 @@ class TestCircuitScheduler(QiskitTestCase):
             circuit_two_schedule,
             schedule(self.circ2, self.backend, method="asap"),
         )
-
-    def test_convert_duration_to_dt(self):
-        """Test that circuit duration unit conversion is applied only when necessary.
-        Tests fix for bug reported in PR #11782."""
-
-        backend = GenericBackendV2(num_qubits=3, calibrate_instructions=True, seed=10)
-        schedule_config = ScheduleConfig(
-            inst_map=backend.target.instruction_schedule_map(),
-            meas_map=backend.meas_map,
-            dt=backend.dt,
-        )
-
-        for circuit in [self.circ, self.circ2]:
-            with self.subTest(circuit=circuit):
-                transpiled_circ = transpile(circuit, backend, scheduling_method="asap")
-                converted_circ = convert_durations_to_dt(
-                    transpiled_circ, dt_in_sec=schedule_config.dt, inplace=False
-                )
-                self.assertEqual(
-                    converted_circ.duration,
-                    transpiled_circ.duration,
-                )
-                self.assertEqual(
-                    converted_circ.unit,
-                    transpiled_circ.unit,
-                )

--- a/test/python/compiler/test_scheduler.py
+++ b/test/python/compiler/test_scheduler.py
@@ -11,12 +11,14 @@
 # that they have been altered from the originals.
 
 """Scheduler Test."""
-
+from qiskit import transpile
 from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit.circuit.duration import convert_durations_to_dt
 from qiskit.exceptions import QiskitError
 from qiskit.pulse import InstructionScheduleMap, Schedule
-from qiskit.providers.fake_provider import FakeOpenPulse3Q
+from qiskit.providers.fake_provider import FakeOpenPulse3Q, GenericBackendV2
 from qiskit.compiler.scheduler import schedule
+from qiskit.scheduler import ScheduleConfig
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
 
@@ -92,3 +94,29 @@ class TestCircuitScheduler(QiskitTestCase):
             circuit_two_schedule,
             schedule(self.circ2, self.backend, method="asap"),
         )
+
+    def test_convert_duration_to_dt(self):
+        """Test that circuit duration unit conversion is applied only when necessary.
+        Tests fix for bug reported in PR #11782."""
+
+        backend = GenericBackendV2(num_qubits=3, calibrate_instructions=True, seed=10)
+        schedule_config = ScheduleConfig(
+            inst_map=backend.target.instruction_schedule_map(),
+            meas_map=backend.meas_map,
+            dt=backend.dt,
+        )
+
+        for circuit in [self.circ, self.circ2]:
+            with self.subTest(circuit=circuit):
+                transpiled_circ = transpile(circuit, backend, scheduling_method="asap")
+                converted_circ = convert_durations_to_dt(
+                    transpiled_circ, dt_in_sec=schedule_config.dt, inplace=False
+                )
+                self.assertEqual(
+                    converted_circ.duration,
+                    transpiled_circ.duration,
+                )
+                self.assertEqual(
+                    converted_circ.unit,
+                    transpiled_circ.unit,
+                )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
While trying to fix #11780, @Cryoris and I noticed that the rounding errors after scheduling were reporting durations of the order of `e14 dt`, instead of `e4 dt`. This was due to a conversion to `dt` of circuit units that were already in `dt`. This PR adds a fix that checks the existing units before converting.

### Details and comments
To reproduce the issue, run the following code without the fix in #11780

```
from qiskit.circuit import QuantumCircuit
from qiskit.providers.fake_provider import GenericBackendV2
from qiskit.compiler import transpile
from qiskit.compiler.scheduler import schedule

simple = QuantumCircuit(3)
simple.sx([0, 1, 2])
simple.cx(0, 1)
simple.cx(1, 2)
simple.cx(0, 1)
simple.sx(0)

backend = GenericBackendV2(num_qubits=3, calibrate_instructions=True, seed=10)
tqc = transpile(simple, backend, scheduling_method="asap")
sched = schedule(tqc, backend)
```

Where the following line shows the output:
```
>>> sched = schedule(tqc, backend)
/Users/ept/qiskit_workspace/qiskit/qiskit/circuit/duration.py:37: UserWarning: Duration is rounded to 72234234234234 [dt] = 1.603600e+04 [s] from 1.603600e+04 [s]
  warnings.warn(
```
