### PR TITLE
deterministic `test_transpile_target_with_qubits_without_delays_with_scheduling_8`

### DIFF
--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -3380,6 +3380,7 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
             target=target,
             optimization_level=optimization_level,
             scheduling_method=scheduling_method,
+            seed_transpiler=42,
         )
         invalid_qubits = {
             4,


### PR DESCRIPTION
### Summary

It seems like `test.python.compiler.test_transpiler.TestTranspileMultiChipTarget.test_transpile_target_with_qubits_without_delays_with_scheduling_8` is failing some times. Finding the issue is a task for another day :/

This PR just fix the test


For example: https://dev.azure.com/qiskit-ci/qiskit/_build/results?buildId=54567&view=logs&jobId=9fdc5efe-36bf-5711-5d37-3eac58d1aa55&j=9fdc5efe-36bf-5711-5d37-3eac58d1aa55&t=6f57c701-f471-5194-ae31-9cb1188fbecc
```

2024-02-13T13:38:04.4129421Z ==============================
2024-02-13T13:38:04.4129911Z Failed 1 tests - output below:
2024-02-13T13:38:04.4130127Z ==============================
2024-02-13T13:38:04.4130242Z 
2024-02-13T13:38:04.4130501Z test.python.compiler.test_transpiler.TestTranspileMultiChipTarget.test_transpile_target_with_qubits_without_delays_with_scheduling_8
2024-02-13T13:38:04.4131034Z ------------------------------------------------------------------------------------------------------------------------------------
2024-02-13T13:38:04.4131227Z 
2024-02-13T13:38:04.4131386Z Captured traceback:
2024-02-13T13:38:04.4131569Z ~~~~~~~~~~~~~~~~~~~
2024-02-13T13:38:04.4131973Z     Traceback (most recent call last):
2024-02-13T13:38:04.4132092Z 
2024-02-13T13:38:04.4132297Z       File "D:\a\1\s\qiskit\transpiler\passmanager.py", line 580, in wrapper
2024-02-13T13:38:04.4132509Z     return meth(*meth_args, **meth_kwargs)
2024-02-13T13:38:04.4132737Z 
2024-02-13T13:38:04.4132941Z       File "D:\a\1\s\qiskit\transpiler\passmanager.py", line 308, in run
2024-02-13T13:38:04.4133136Z     return super().run(
2024-02-13T13:38:04.4133263Z 
2024-02-13T13:38:04.4133450Z       File "D:\a\1\s\qiskit\passmanager\passmanager.py", line 222, in run
2024-02-13T13:38:04.4133662Z     out_program = _run_workflow(
2024-02-13T13:38:04.4133777Z 
2024-02-13T13:38:04.4133967Z       File "D:\a\1\s\qiskit\passmanager\passmanager.py", line 284, in _run_workflow
2024-02-13T13:38:04.4134199Z     passmanager_ir, _ = flow_controller.execute(
2024-02-13T13:38:04.4134321Z 
2024-02-13T13:38:04.4134516Z       File "D:\a\1\s\qiskit\passmanager\base_tasks.py", line 218, in execute
2024-02-13T13:38:04.4134733Z     passmanager_ir, state = next_task.execute(
2024-02-13T13:38:04.4134852Z 
2024-02-13T13:38:04.4135051Z       File "D:\a\1\s\qiskit\passmanager\base_tasks.py", line 218, in execute
2024-02-13T13:38:04.4135263Z     passmanager_ir, state = next_task.execute(
2024-02-13T13:38:04.4135397Z 
2024-02-13T13:38:04.4135581Z       File "D:\a\1\s\qiskit\passmanager\base_tasks.py", line 218, in execute
2024-02-13T13:38:04.4135797Z     passmanager_ir, state = next_task.execute(
2024-02-13T13:38:04.4135918Z 
2024-02-13T13:38:04.4136084Z       [Previous line repeated 1 more time]
2024-02-13T13:38:04.4136209Z 
2024-02-13T13:38:04.4136391Z       File "D:\a\1\s\qiskit\transpiler\basepasses.py", line 195, in execute
2024-02-13T13:38:04.4136608Z     new_dag, state = super().execute(
2024-02-13T13:38:04.4136723Z 
2024-02-13T13:38:04.4136907Z       File "D:\a\1\s\qiskit\passmanager\base_tasks.py", line 98, in execute
2024-02-13T13:38:04.4137120Z     ret = self.run(passmanager_ir)
2024-02-13T13:38:04.4137238Z 
2024-02-13T13:38:04.4137442Z       File "D:\a\1\s\qiskit\transpiler\passes\basis\basis_translator.py", line 198, in run
2024-02-13T13:38:04.4137648Z     raise TranspilerError(
2024-02-13T13:38:04.4137757Z 
2024-02-13T13:38:04.4138634Z     qiskit.transpiler.exceptions.TranspilerError: "Unable to translate the operations in the circuit: ['h', 'u'] to the backend's (or manually specified) target basis: ['x', 'snapshot', 'barrier', 'h', 'cx', 'delay']. This likely means the target basis is not universal or there are additional equivalence rules needed in the EquivalenceLibrary being used. For more details on this error see: https://docs.quantum-computing.ibm.com/api/qiskit/qiskit.transpiler.passes.BasisTranslator#translation-errors"
2024-02-13T13:38:04.4139067Z 
2024-02-13T13:38:04.4139208Z     
2024-02-13T13:38:04.4139397Z The above exception was the direct cause of the following exception:
2024-02-13T13:38:04.4139544Z 
2024-02-13T13:38:04.4139636Z 
2024-02-13T13:38:04.4139797Z     Traceback (most recent call last):
2024-02-13T13:38:04.4139927Z 
2024-02-13T13:38:04.4140273Z       File "D:\a\1\s\test-job\lib\site-packages\ddt.py", line 221, in wrapper
2024-02-13T13:38:04.4140492Z     return func(self, *args, **kwargs)
2024-02-13T13:38:04.4140612Z 
2024-02-13T13:38:04.4140853Z       File "D:\a\1\s\test\python\compiler\test_transpiler.py", line 3380, in test_transpile_target_with_qubits_without_delays_with_scheduling
2024-02-13T13:38:04.4141098Z     tqc = transpile(
2024-02-13T13:38:04.4141205Z 
2024-02-13T13:38:04.4141398Z       File "D:\a\1\s\qiskit\compiler\transpiler.py", line 428, in transpile
2024-02-13T13:38:04.4141612Z     out_circuits = pm.run(circuits, callback=callback)
2024-02-13T13:38:04.4141750Z 
2024-02-13T13:38:04.4141933Z       File "D:\a\1\s\qiskit\transpiler\passmanager.py", line 561, in run
2024-02-13T13:38:04.4142155Z     return super().run(circuits, output_name, callback)
2024-02-13T13:38:04.4142282Z 
2024-02-13T13:38:04.4142465Z       File "D:\a\1\s\qiskit\transpiler\passmanager.py", line 582, in wrapper
2024-02-13T13:38:04.4142750Z     raise TranspilerError(ex.message) from ex
2024-02-13T13:38:04.4142872Z 
2024-02-13T13:38:04.4143609Z     qiskit.transpiler.exceptions.TranspilerError: "Unable to translate the operations in the circuit: ['h', 'u'] to the backend's (or manually specified) target basis: ['x', 'snapshot', 'barrier', 'h', 'cx', 'delay']. This likely means the target basis is not universal or there are additional equivalence rules needed in the EquivalenceLibrary being used. For more details on this error see: https://docs.quantum-computing.ibm.com/api/qiskit/qiskit.transpiler.passes.BasisTranslator#translation-errors"
```