### PR TITLE
Fix `PropertySet` re-use in `BasePassManager.run`

### DIFF
--- a/releasenotes/notes/fix-passmanager-reuse-151877e1905d49df.yaml
+++ b/releasenotes/notes/fix-passmanager-reuse-151877e1905d49df.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    :meth:`.BasePassManager.run` will no longer leak the previous :class:`.PropertySet` into new
+    workflows when called more than once.  Previously, the same :class:`.PropertySet` as before
+    would be used to initialize follow-on runs, which could mean that invalid property information
+    was being given to tasks.  The behavior now matches that of Qiskit 0.44.  Fixed `#11784 <https://github.com/Qiskit/qiskit/issues/11784>`__.

--- a/test/python/passmanager/test_passmanager.py
+++ b/test/python/passmanager/test_passmanager.py
@@ -124,3 +124,24 @@ class TestPassManager(PassManagerTestCase):
         with self.assertLogContains(expected):
             out = pm.run(data)
         self.assertEqual(out, data)
+
+    def test_reruns_have_clean_property_set(self):
+        """Test that re-using a pass manager produces a clean property set for the state."""
+
+        sentinel = object()
+
+        class CheckPropertySetClean(GenericPass):
+            def __init__(self, test_case):
+                super().__init__()
+                self.test_case = test_case
+
+            def run(self, _):
+                self.test_case.assertIs(self.property_set["check_property"], None)
+                self.property_set["check_property"] = sentinel
+                self.test_case.assertIs(self.property_set["check_property"], sentinel)
+
+        pm = ToyPassManager([CheckPropertySetClean(self)])
+        pm.run(0)
+        self.assertIs(pm.property_set["check_property"], sentinel)
+        pm.run(1)
+        self.assertIs(pm.property_set["check_property"], sentinel)


### PR DESCRIPTION
### Summary

Since the genericised `PassManager`, the `PropertySet` used in the `WorkflowState` of a pass-manager pipeline was taken directly from the internal state of the `BasePassManager`.  This is set to a clean `PropertySet` during the pass-manager initialisation (similar to how it was in the previous version), but is not reset on subsequent runs.  This didn't cause problems in the old form because the "iterator" over tasks in the old form was a new `RunningPassManager` instance.

Failing to generate a clean property set could lead to passes getting fed old analysis data when the pass manager was used more than once, leading to miscompilations.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Fix #11784.  This was a bug introduced in Qiskit 0.45.0, so I don't think it's critical to merge ahead of 1.0.0final, but can go into 1.0.1 and is suitable for backport to 0.46.1 as well.
