### PR TITLE
Make BaseEstimatorV2 importable from qiskit.primitives

### DIFF
--- a/qiskit/primitives/__init__.py
+++ b/qiskit/primitives/__init__.py
@@ -57,7 +57,7 @@ SamplerV2
 .. autosummary::
    :toctree: ../stubs/
 
-   BaserSamplerV2
+   BaseSamplerV2
    StatevectorSampler
 
 Results

--- a/qiskit/primitives/__init__.py
+++ b/qiskit/primitives/__init__.py
@@ -38,6 +38,7 @@ EstimatorV2
 .. autosummary::
    :toctree: ../stubs/
 
+   BaseEstimatorV2
    StatevectorEstimator
 
 Sampler
@@ -49,7 +50,14 @@ Sampler
    BaseSampler
    Sampler
    BackendSampler
-   BaseSamplerV2
+
+SamplerV2
+=========
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   BaserSamplerV2
    StatevectorSampler
 
 Results
@@ -66,7 +74,7 @@ Results
 
 from .backend_estimator import BackendEstimator
 from .backend_sampler import BackendSampler
-from .base import BaseEstimator, BaseSampler, BaseSamplerV2
+from .base import BaseEstimator, BaseEstimatorV2, BaseSampler, BaseSamplerV2
 from .base.estimator_result import EstimatorResult
 from .base.sampler_result import SamplerResult
 from .containers import (


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
`BaseSamplerV2` is importable from `qiskit.primitives`, but `BaseEstimatorV2` [is not](https://github.com/Qiskit/qiskit/blob/de4d0157ddb299f97504b1ed785d09bfd52c7ef6/qiskit/primitives/__init__.py#L69). I think these two classes should be importable from the same locations, so I'm adding `BaseEstimatorV2` as importable from `qiskit.primitives`.


