### PR TITLE
remove toqm from reserved names list

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/plugin.py
+++ b/qiskit/transpiler/preset_passmanagers/plugin.py
@@ -63,7 +63,7 @@ load external plugins via corresponding entry points.
        :func:`~.generate_embed_passmanager`.
    * - ``routing``
      - ``qiskit.transpiler.routing``
-     - ``basic``, ``stochastic``, ``lookahead``, ``sabre``, ``toqm``
+     - ``basic``, ``stochastic``, ``lookahead``, ``sabre``
      - The output from this stage is expected to have the circuit match the
        connectivity constraints of the target backend. This does not necessarily
        need to match the directionality of the edges in the target as a later


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
`toqm` is not a reserved name for a transpiler stage plugin.


### Details and comments


