### PR TITLE
Expose `PauliList.noncommutation_graph` in public API

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -1168,7 +1168,8 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
 
         Returns:
             rustworkx.PyGraph: the non-commutation graph with nodes for each Pauli and edges
-                indicating a non-commutation relation.
+                indicating a non-commutation relation. Each node will hold the index of the Pauli
+                term it corresponds to in its data. The edges of the graph hold no data.
         """
         edges = self._noncommutation_graph(qubit_wise)
         graph = rx.PyGraph()

--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -1155,17 +1155,21 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         # results from one triangle to avoid symmetric duplications.
         return list(zip(*np.where(np.triu(adjacency_mat, k=1))))
 
-    def _create_graph(self, qubit_wise):
-        """Transform measurement operator grouping problem into graph coloring problem
+    def noncommutation_graph(self, qubit_wise: bool) -> rx.PyGraph:
+        """Create the non-commutation graph of this PauliList.
+
+        This transforms the measurement operator grouping problem into graph coloring problem. The
+        constructed graph contains one node for each Pauli. The nodes will be connecting for any two
+        Pauli terms that do _not_ commute.
 
         Args:
             qubit_wise (bool): whether the commutation rule is applied to the whole operator,
                 or on a per-qubit basis.
 
         Returns:
-            rustworkx.PyGraph: A class of undirected graphs
+            rustworkx.PyGraph: the non-commutation graph with nodes for each Pauli and edges
+                indicating a non-commutation relation.
         """
-
         edges = self._noncommutation_graph(qubit_wise)
         graph = rx.PyGraph()
         graph.add_nodes_from(range(self.size))
@@ -1186,7 +1190,7 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         Returns:
             dict[int, list[int]]: Dictionary of color indices mapping to a list of Pauli indices.
         """
-        graph = self._create_graph(qubit_wise)
+        graph = self.noncommutation_graph(qubit_wise)
         # Keys in coloring_dict are nodes, values are colors
         coloring_dict = rx.graph_greedy_color(graph)
         groups = defaultdict(list)

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -1000,6 +1000,23 @@ class SparsePauliOp(LinearOp):
 
         return MatrixIterator(self)
 
+    def noncommutation_graph(self, qubit_wise: bool) -> rx.PyGraph:
+        """Create the non-commutation graph of this SparsePauliOp.
+
+        This transforms the measurement operator grouping problem into graph coloring problem. The
+        constructed graph contains one node for each Pauli. The nodes will be connecting for any two
+        Pauli terms that do _not_ commute.
+
+        Args:
+            qubit_wise (bool): whether the commutation rule is applied to the whole operator,
+                or on a per-qubit basis.
+
+        Returns:
+            rustworkx.PyGraph: the non-commutation graph with nodes for each Pauli and edges
+                indicating a non-commutation relation.
+        """
+        return self.paulis.noncommutation_graph(qubit_wise)
+
     def group_commuting(self, qubit_wise: bool = False) -> list[SparsePauliOp]:
         """Partition a SparsePauliOp into sets of commuting Pauli strings.
 

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -1022,13 +1022,7 @@ class SparsePauliOp(LinearOp):
             list[SparsePauliOp]: List of SparsePauliOp where each SparsePauliOp contains
                 commuting Pauli operators.
         """
-
-        graph = self.paulis._create_graph(qubit_wise)
-        # Keys in coloring_dict are nodes, values are colors
-        coloring_dict = rx.graph_greedy_color(graph)
-        groups = defaultdict(list)
-        for idx, color in coloring_dict.items():
-            groups[color].append(idx)
+        groups = self.paulis._commuting_groups(qubit_wise)
         return [self[group] for group in groups.values()]
 
     @property

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -1000,23 +1000,6 @@ class SparsePauliOp(LinearOp):
 
         return MatrixIterator(self)
 
-    def _create_graph(self, qubit_wise):
-        """Transform measurement operator grouping problem into graph coloring problem
-
-        Args:
-            qubit_wise (bool): whether the commutation rule is applied to the whole operator,
-                or on a per-qubit basis.
-
-        Returns:
-            rustworkx.PyGraph: A class of undirected graphs
-        """
-
-        edges = self.paulis._noncommutation_graph(qubit_wise)
-        graph = rx.PyGraph()
-        graph.add_nodes_from(range(self.size))
-        graph.add_edges_from_no_data(edges)
-        return graph
-
     def group_commuting(self, qubit_wise: bool = False) -> list[SparsePauliOp]:
         """Partition a SparsePauliOp into sets of commuting Pauli strings.
 
@@ -1040,7 +1023,7 @@ class SparsePauliOp(LinearOp):
                 commuting Pauli operators.
         """
 
-        graph = self._create_graph(qubit_wise)
+        graph = self.paulis._create_graph(qubit_wise)
         # Keys in coloring_dict are nodes, values are colors
         coloring_dict = rx.graph_greedy_color(graph)
         groups = defaultdict(list)

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -16,7 +16,6 @@ N-Qubit Sparse Pauli Operator class.
 from __future__ import annotations
 from typing import TYPE_CHECKING, List
 
-from collections import defaultdict
 from collections.abc import Mapping, Sequence, Iterable
 from numbers import Number
 from copy import deepcopy

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -1012,7 +1012,8 @@ class SparsePauliOp(LinearOp):
 
         Returns:
             rustworkx.PyGraph: the non-commutation graph with nodes for each Pauli and edges
-                indicating a non-commutation relation.
+                indicating a non-commutation relation. Each node will hold the index of the Pauli
+                term it corresponds to in its data. The edges of the graph hold no data.
         """
         return self.paulis.noncommutation_graph(qubit_wise)
 

--- a/releasenotes/notes/public-noncommutation-graph-dd31c931b7045a4f.yaml
+++ b/releasenotes/notes/public-noncommutation-graph-dd31c931b7045a4f.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Adds the :meth:`.PauliList.noncommutation_graph` and
+    :meth:`.SparsePauliOp.noncommutation_graph` methods, exposing the
+    construction of non-commutation graphs, recasting the measurement operator
+    grouping problem into a graph coloring problem. This permits users to work
+    with these graphs directly, for example to explore coloring algorithms other
+    than the one used by :meth:`.SparsePauliOp.group_commuting`.

--- a/test/python/quantum_info/operators/symplectic/test_pauli_list.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli_list.py
@@ -2088,7 +2088,7 @@ class TestPauliListMethods(QiskitTestCase):
                 qubit_wise_comparison = (vec_l * vec_r) * (vec_l - vec_r)
                 return np.all(qubit_wise_comparison == 0)
 
-        input_labels = ["IY", "ZX", "XZ", "YI", "YX", "YY", "YZ", "ZI", "ZX", "ZY", "iZZ", "II"]
+        input_labels = ["IY", "ZX", "XZ", "-YI", "YX", "YY", "-iYZ", "ZI", "ZX", "ZY", "iZZ", "II"]
         np.random.shuffle(input_labels)
         pauli_list = PauliList(input_labels)
         graph = pauli_list.noncommutation_graph(qubit_wise=qubit_wise)

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -953,7 +953,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
                 qubit_wise_comparison = (vec_l * vec_r) * (vec_l - vec_r)
                 return np.all(qubit_wise_comparison == 0)
 
-        input_labels = ["IX", "IY", "IZ", "XX", "YY", "ZZ", "XY", "YX", "ZX", "ZY", "XZ", "YZ"]
+        input_labels = ["IX", "IY", "IZ", "XX", "YY", "ZZ", "XY", "iYX", "ZX", "-iZY", "XZ", "YZ"]
         np.random.shuffle(input_labels)
         if parameterized:
             coeffs = np.array(ParameterVector("a", len(input_labels)))

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -15,6 +15,7 @@
 import itertools as it
 import unittest
 import numpy as np
+import rustworkx as rx
 from ddt import ddt
 
 from qiskit import QiskitError
@@ -935,6 +936,42 @@ class TestSparsePauliOpMethods(QiskitTestCase):
             spp_op2 = SparsePauliOp.from_list([("X", 1), ("Y", 1), ("Z", 0)])
             self.assertNotEqual(spp_op1, spp_op2)
             self.assertTrue(spp_op1.equiv(spp_op2))
+
+    @combine(parameterized=[True, False], qubit_wise=[True, False])
+    def test_noncommutation_graph(self, parameterized, qubit_wise):
+        """Test noncommutation graph"""
+
+        def commutes(left: Pauli, right: Pauli, qubit_wise: bool) -> bool:
+            if len(left) != len(right):
+                return False
+            if not qubit_wise:
+                return left.commutes(right)
+            else:
+                # qubit-wise commuting check
+                vec_l = left.z + 2 * left.x
+                vec_r = right.z + 2 * right.x
+                qubit_wise_comparison = (vec_l * vec_r) * (vec_l - vec_r)
+                return np.all(qubit_wise_comparison == 0)
+
+        input_labels = ["IX", "IY", "IZ", "XX", "YY", "ZZ", "XY", "YX", "ZX", "ZY", "XZ", "YZ"]
+        np.random.shuffle(input_labels)
+        if parameterized:
+            coeffs = np.array(ParameterVector("a", len(input_labels)))
+        else:
+            coeffs = np.random.random(len(input_labels)) + np.random.random(len(input_labels)) * 1j
+        sparse_pauli_list = SparsePauliOp(input_labels, coeffs)
+        graph = sparse_pauli_list.noncommutation_graph(qubit_wise)
+
+        expected = rx.PyGraph()
+        expected.add_nodes_from(range(len(input_labels)))
+        edges = [
+            (ia, ib)
+            for (ia, a), (ib, b) in it.combinations(enumerate(input_labels), 2)
+            if not commutes(Pauli(a), Pauli(b), qubit_wise)
+        ]
+        expected.add_edges_from_no_data(edges)
+
+        self.assertTrue(rx.is_isomorphic(graph, expected))
 
     @combine(parameterized=[True, False], qubit_wise=[True, False])
     def test_group_commuting(self, parameterized, qubit_wise):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This exposes the previously internal method `PauliList._create_graph` as part of the public API in the form of `PauliList.noncommutation_graph`. The same method is also exposed via the `SparsePauliOp`.

### Details and comments

In doing the above, I also slightly updated the code of the `SparsePauliOp` to de-duplicate some of the logic from the `PauliList`.

See #11779 for more information on the motivation for this change.

### Remaining tasks
- [x] add some unittests for the new publicly visible method

