### PR TITLE
Fix bug in `BindingsArray.__getitem__()`

### DIFF
--- a/qiskit/primitives/containers/bindings_array.py
+++ b/qiskit/primitives/containers/bindings_array.py
@@ -137,7 +137,7 @@ class BindingsArray(ShapedMixin):
         # would not be a particularly friendly way to chop parameters
         data = {params: val[args] for params, val in self._data.items()}
         try:
-            shape = next(data.values()).shape[:-1]
+            shape = next(iter(data.values())).shape[:-1]
         except StopIteration:
             shape = ()
         return BindingsArray(data, shape)

--- a/test/python/primitives/containers/test_bindings_array.py
+++ b/test/python/primitives/containers/test_bindings_array.py
@@ -413,3 +413,23 @@ class BindingsArrayTestCase(QiskitTestCase):
         ba = BindingsArray({"a": np.ones((0, 1))}, shape=(0,))
         arr = ba.as_array()
         self.assertEqual(arr.shape, (0, 1))
+
+    def test_get_item(self):
+        """Test the __getitem__() method."""
+        ba = BindingsArray()
+        self.assertEqual(ba[:].shape, ())
+        self.assertEqual(ba[:].num_parameters, 0)
+
+        data = np.linspace(0, 1, 300).reshape((5, 6, 10))
+        params = tuple(f"a{idx:03d}" for idx in range(10))
+        ba = BindingsArray({params: data})
+        np.testing.assert_allclose(ba[...].as_array(params), data)
+        np.testing.assert_allclose(ba[0].as_array(params), data[0])
+        np.testing.assert_allclose(ba[6:2:-1, -1].as_array(params), data[6:2:-1, -1])
+
+        data = np.linspace(0, 1, 300).reshape((5, 6, 10))
+        params = tuple(f"a{idx:03d}" for idx in range(10))
+        ba = BindingsArray({params[:3]: data[..., :3], params[3:]: data[..., 3:]})
+        np.testing.assert_allclose(ba[...].as_array(params), data)
+        np.testing.assert_allclose(ba[0].as_array(params), data[0])
+        np.testing.assert_allclose(ba[6:2:-1, -1].as_array(params), data[6:2:-1, -1])


### PR DESCRIPTION
### Summary

This PR fixes a critical bug in `BindingsArray.__getitem__()` that causes this method not to work at all, and adds tests for it.

### Details and comments

The tests that used to test the behaviour of this function were somehow removed in the process of porting this class into Qiskit from a prototype library. This bug was introduced by #11642.


