### PR TITLE
Fix bad header in 0.46 release note

### DIFF
--- a/releasenotes/notes/remove-fake-provider-and-backends-2fcf5256c772935f.yaml
+++ b/releasenotes/notes/remove-fake-provider-and-backends-2fcf5256c772935f.yaml
@@ -10,8 +10,7 @@ deprecations:
       * ``qiskit.providers.fake_provider.FakeProviderForBackendV2``
       * ``qiskit.providers.fake_provider.FakeProviderFactory``
       * ``qiskit.providers.fake_provider.fake_backends.FakeBackendV2``
-      * any fake backend contained in ``qiskit.providers.fake_provider.backends``
-        (accessible through the provider)
+      * any fake backend contained in ``qiskit.providers.fake_provider.backends`` (accessible through the provider)
       * ``qiskit.providers.fake_provider.FakeQasmSimulator``
       * ``qiskit.providers.fake_provider.FakeJob``
       * ``qiskit.providers.fake_provider.FakeQobj``


### PR DESCRIPTION
Closes https://github.com/Qiskit/qiskit/issues/11836. As explained there, the problem is from Sphinx rather than our API generation script. It's using a `<dl>` in HTML where it should not be.

After, the list works properly:

<img width="685" alt="Screenshot 2024-02-14 at 6 08 47 PM" src="https://github.com/Qiskit/qiskit/assets/14852634/6fbea272-33d6-4ec4-93ff-1ecc7ce8e7de">
