### PR TITLE
Expose BaseSamplerV1 and BaseEstimatorV1

### DIFF
--- a/qiskit/primitives/__init__.py
+++ b/qiskit/primitives/__init__.py
@@ -28,6 +28,7 @@ Estimator
 .. autosummary::
    :toctree: ../stubs/
 
+   BaseEstimatorV1
    BaseEstimator
    Estimator
    BackendEstimator
@@ -47,6 +48,7 @@ Sampler
 .. autosummary::
    :toctree: ../stubs/
 
+   BaseSamplerV1
    BaseSampler
    Sampler
    BackendSampler
@@ -74,7 +76,14 @@ Results
 
 from .backend_estimator import BackendEstimator
 from .backend_sampler import BackendSampler
-from .base import BaseEstimator, BaseEstimatorV2, BaseSampler, BaseSamplerV2
+from .base import (
+    BaseEstimator,
+    BaseEstimatorV1,
+    BaseEstimatorV2,
+    BaseSampler,
+    BaseSamplerV1,
+    BaseSamplerV2,
+)
 from .base.estimator_result import EstimatorResult
 from .base.sampler_result import SamplerResult
 from .containers import (

--- a/qiskit/primitives/base/__init__.py
+++ b/qiskit/primitives/base/__init__.py
@@ -14,7 +14,7 @@
 Abstract base classes for primitives module.
 """
 
-from .base_sampler import BaseSampler, BaseSamplerV2
-from .base_estimator import BaseEstimator, BaseEstimatorV2
+from .base_sampler import BaseSampler, BaseSamplerV1, BaseSamplerV2
+from .base_estimator import BaseEstimator, BaseEstimatorV1, BaseEstimatorV2
 from .estimator_result import EstimatorResult
 from .sampler_result import SamplerResult


### PR DESCRIPTION
Part of https://github.com/Qiskit/documentation/issues/814. As explained there, the Qiskit 1.0 API docs currently do not include documentation for `BaseSampler` and `BaseEstimator`. Part of that is an oversight from the API generation script. But even with the API generation script fixed, the docs would only be this:

![image](https://github.com/Qiskit/qiskit/assets/14852634/eb17a07f-bab9-4a20-bdd7-b04cdd9c7d11)

The link to `BaseSamplerV1` wouldn't work, so it's not very helpful to users. But if we properly expose `BaseSamplerV1` and `BaseEstimatorV1`, then the link will work correctly and take you to the class page.

Beyond documentation, it seems useful to let users be extra-explicit in specifying `V1` vs `V2` in their import paths.