### PR TITLE
Fix pip uninstall command in qiskit-neko

### DIFF
--- a/.github/workflows/neko.yml
+++ b/.github/workflows/neko.yml
@@ -18,4 +18,4 @@ jobs:
           test_selection: terra
           # We have to forcibly uninstall any old version of qiskit or qiskit-terra during the
           # changeover, because it's not possible to safely upgrade an existing installation to 1.0.
-          repo_install_command: "pip uninstall qiskit qiskit-terra && pip install -c constraints.txt ."
+          repo_install_command: "pip uninstall -y qiskit qiskit-terra && pip install -c constraints.txt ."


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The pip uninstall command used in the qiskit neko job was missing the -y flag used to force pip to run the uninstall. Instead it was failing on the prompt to confirm the uninstall and then not uninstalling an existing install because of the failure. This has been causing us to not actually test the propsed PR because it was mixing the state of qiskit < 1.0 from pypi and >=1.0. Now that 1.0 has been released we're hitting failures in CI because all the breaking API changes we introduced in 1.0 are finally being run and the test suite is and downstream packages we were integration testing with are now broken. This commit fixes the uninstall command (although arguably it probably could be removed). The neko job will still fail with this applied as we'll need to fix it upstream but this is currently blocked on a qiskit-nature release.

### Details and comments