### PR TITLE
Fix custom pulse instruction conversion to Qobj.

### DIFF
--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -62,10 +62,10 @@ class ParametricPulseShapes(Enum):
         Raises:
             QiskitError: When pulse instance is not recognizable type.
         """
-        try:
+        if isinstance(instance, library.SymbolicPulse):
             return cls(instance.pulse_type)
-        except ValueError as ex:
-            raise QiskitError(f"'{instance}' is not valid pulse type.") from ex
+
+        raise QiskitError(f"'{instance}' is not valid pulse type.")
 
     @classmethod
     def to_type(cls, name: str) -> library.SymbolicPulse:

--- a/releasenotes/notes/fix-custom-pulse-qobj-conversion-5d6041b36356cfd1.yaml
+++ b/releasenotes/notes/fix-custom-pulse-qobj-conversion-5d6041b36356cfd1.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a bug in the conversion of custom pulse instructions to ``Qobj``. The bug was introduced in Qiskit 1.0.0
+    and caused conversion of custom pulse instructions to raise an error. After the fix, the conversion is
+    carried out correctly, and the custom pulse is converted to ``Waveform`` as it should.
+    Fixed `#11828 <https://github.com/Qiskit/qiskit/issues/11828>`__.

--- a/releasenotes/notes/fix-custom-pulse-qobj-conversion-5d6041b36356cfd1.yaml
+++ b/releasenotes/notes/fix-custom-pulse-qobj-conversion-5d6041b36356cfd1.yaml
@@ -3,5 +3,5 @@ fixes:
   - |
     Fixed a bug in the conversion of custom pulse instructions to the legacy :mod:`qiskit.qobj` format. The bug was introduced in Qiskit 1.0.0
     and caused conversion of instructions with custom pulse shapes to raise an error. After the fix, the conversion is
-    carried out correctly, and the custom pulse is converted to :class:`.Waveform` as it should.
+    carried out correctly, and the custom pulse is converted to :class:`.pulse.Waveform` as it should.
     Fixed `#11828 <https://github.com/Qiskit/qiskit/issues/11828>`__.

--- a/releasenotes/notes/fix-custom-pulse-qobj-conversion-5d6041b36356cfd1.yaml
+++ b/releasenotes/notes/fix-custom-pulse-qobj-conversion-5d6041b36356cfd1.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    Fixed a bug in the conversion of custom pulse instructions to ``Qobj``. The bug was introduced in Qiskit 1.0.0
-    and caused conversion of custom pulse instructions to raise an error. After the fix, the conversion is
-    carried out correctly, and the custom pulse is converted to ``Waveform`` as it should.
+    Fixed a bug in the conversion of custom pulse instructions to the legacy :mod:`qiskit.qobj` format. The bug was introduced in Qiskit 1.0.0
+    and caused conversion of instructions with custom pulse shapes to raise an error. After the fix, the conversion is
+    carried out correctly, and the custom pulse is converted to :class:`.Waveform` as it should.
     Fixed `#11828 <https://github.com/Qiskit/qiskit/issues/11828>`__.


### PR DESCRIPTION
### Summary
This is a possible fix to #11828.

### Details and comments
The behavior of [ParametricPulseShapes](https://github.com/Qiskit/qiskit/blob/12f24a76b6fbba4ebd9d7cf09c42f2c6c6e3c8f7/qiskit/qobj/converters/pulse_instruction.py#L68) is restored to raise `ValueError` when the pulse shape is not supported, and `QiskitError` when the pulse object is not recognized. The need for the second scenario is not clear to me, but as a quick fix I reverted to the code before #11410.

If we think that the two error types are not needed, we can alternatively change the error type used by the [assemble logic](https://github.com/Qiskit/qiskit/blob/12f24a76b6fbba4ebd9d7cf09c42f2c6c6e3c8f7/qiskit/assembler/assemble_schedules.py#L233).

fixes #11828
