### PR TITLE
quantum-computing.ibm.com is going to disappear, eventually

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -43,11 +43,11 @@ The way documentation is structured in Qiskit is to push as much of the actual
 documentation into the docstrings as possible. This makes it easier for
 additions and corrections to be made during development, because the majority
 of the documentation lives near the code being changed. These docstrings are then pulled into
-the API Reference section of https://docs.quantum-computing.ibm.com.
+the API Reference section of https://docs.quantum.ibm.com.
 
 Refer to https://qiskit.github.io/qiskit_sphinx_theme/apidocs/index.html for how to create and
 write effective API documentation, such as setting up the RST files and docstrings.
 
-If changes you are making affect non-API reference content in https://docs.quantum-computing.ibm.com
+If changes you are making affect non-API reference content in https://docs.quantum.ibm.com
 you can open an issue (or better yet a PR) to update the relevant page in https://github.com/Qiskit/documentation.
 You can also use this repo to suggest or contribute brand new content beyond updates to the API reference.

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1025,7 +1025,7 @@ class QuantumCircuit:
 
         Remember that in the little-endian convention the leftmost operation will be at the bottom
         of the circuit. See also
-        `the docs <https://docs.quantum-computing.ibm.com/build/circuit-construction>`__
+        `the docs <https://docs.quantum.ibm.com/build/circuit-construction>`__
         for more information.
 
         .. parsed-literal::
@@ -1154,10 +1154,12 @@ class QuantumCircuit:
         return len(self._data)
 
     @typing.overload
-    def __getitem__(self, item: int) -> CircuitInstruction: ...
+    def __getitem__(self, item: int) -> CircuitInstruction:
+        ...
 
     @typing.overload
-    def __getitem__(self, item: slice) -> list[CircuitInstruction]: ...
+    def __getitem__(self, item: slice) -> list[CircuitInstruction]:
+        ...
 
     def __getitem__(self, item):
         """Return indexed operation."""
@@ -1288,7 +1290,8 @@ class QuantumCircuit:
     @typing.overload
     def _append(
         self, instruction: CircuitInstruction, _qargs: None = None, _cargs: None = None
-    ) -> CircuitInstruction: ...
+    ) -> CircuitInstruction:
+        ...
 
     # To-be-deprecated old style.
     @typing.overload
@@ -1297,7 +1300,8 @@ class QuantumCircuit:
         operation: Operation,
         qargs: Sequence[Qubit],
         cargs: Sequence[Clbit],
-    ) -> Operation: ...
+    ) -> Operation:
+        ...
 
     def _append(
         self,
@@ -1370,11 +1374,13 @@ class QuantumCircuit:
                     self._parameters = None
 
     @typing.overload
-    def get_parameter(self, name: str, default: T) -> Union[Parameter, T]: ...
+    def get_parameter(self, name: str, default: T) -> Union[Parameter, T]:
+        ...
 
     # The builtin `types` module has `EllipsisType`, but only from 3.10+!
     @typing.overload
-    def get_parameter(self, name: str, default: type(...) = ...) -> Parameter: ...
+    def get_parameter(self, name: str, default: type(...) = ...) -> Parameter:
+        ...
 
     # We use a _literal_ `Ellipsis` as the marker value to leave `None` available as a default.
     def get_parameter(self, name: str, default: typing.Any = ...) -> Parameter:
@@ -2574,7 +2580,8 @@ class QuantumCircuit:
         *,
         flat_input: bool = ...,
         strict: bool = ...,
-    ) -> "QuantumCircuit": ...
+    ) -> "QuantumCircuit":
+        ...
 
     @overload
     def assign_parameters(
@@ -2584,7 +2591,8 @@ class QuantumCircuit:
         *,
         flat_input: bool = ...,
         strict: bool = ...,
-    ) -> None: ...
+    ) -> None:
+        ...
 
     def assign_parameters(  # pylint: disable=missing-raises-doc
         self,
@@ -4326,7 +4334,8 @@ class QuantumCircuit:
         clbits: None,
         *,
         label: str | None,
-    ) -> WhileLoopContext: ...
+    ) -> WhileLoopContext:
+        ...
 
     @typing.overload
     def while_loop(
@@ -4337,7 +4346,8 @@ class QuantumCircuit:
         clbits: Sequence[ClbitSpecifier],
         *,
         label: str | None,
-    ) -> InstructionSet: ...
+    ) -> InstructionSet:
+        ...
 
     def while_loop(self, condition, body=None, qubits=None, clbits=None, *, label=None):
         """Create a ``while`` loop on this circuit.
@@ -4412,7 +4422,8 @@ class QuantumCircuit:
         clbits: None,
         *,
         label: str | None,
-    ) -> ForLoopContext: ...
+    ) -> ForLoopContext:
+        ...
 
     @typing.overload
     def for_loop(
@@ -4424,7 +4435,8 @@ class QuantumCircuit:
         clbits: Sequence[ClbitSpecifier],
         *,
         label: str | None,
-    ) -> InstructionSet: ...
+    ) -> InstructionSet:
+        ...
 
     def for_loop(
         self, indexset, loop_parameter=None, body=None, qubits=None, clbits=None, *, label=None
@@ -4500,7 +4512,8 @@ class QuantumCircuit:
         clbits: None,
         *,
         label: str | None,
-    ) -> IfContext: ...
+    ) -> IfContext:
+        ...
 
     @typing.overload
     def if_test(
@@ -4511,7 +4524,8 @@ class QuantumCircuit:
         clbits: Sequence[ClbitSpecifier],
         *,
         label: str | None = None,
-    ) -> InstructionSet: ...
+    ) -> InstructionSet:
+        ...
 
     def if_test(
         self,
@@ -4665,7 +4679,8 @@ class QuantumCircuit:
         clbits: None,
         *,
         label: Optional[str],
-    ) -> SwitchContext: ...
+    ) -> SwitchContext:
+        ...
 
     @typing.overload
     def switch(
@@ -4676,7 +4691,8 @@ class QuantumCircuit:
         clbits: Sequence[ClbitSpecifier],
         *,
         label: Optional[str],
-    ) -> InstructionSet: ...
+    ) -> InstructionSet:
+        ...
 
     def switch(self, target, cases=None, qubits=None, clbits=None, *, label=None):
         """Create a ``switch``/``case`` structure on this circuit.

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1154,12 +1154,10 @@ class QuantumCircuit:
         return len(self._data)
 
     @typing.overload
-    def __getitem__(self, item: int) -> CircuitInstruction:
-        ...
+    def __getitem__(self, item: int) -> CircuitInstruction: ...
 
     @typing.overload
-    def __getitem__(self, item: slice) -> list[CircuitInstruction]:
-        ...
+    def __getitem__(self, item: slice) -> list[CircuitInstruction]: ...
 
     def __getitem__(self, item):
         """Return indexed operation."""
@@ -1290,8 +1288,7 @@ class QuantumCircuit:
     @typing.overload
     def _append(
         self, instruction: CircuitInstruction, _qargs: None = None, _cargs: None = None
-    ) -> CircuitInstruction:
-        ...
+    ) -> CircuitInstruction: ...
 
     # To-be-deprecated old style.
     @typing.overload
@@ -1300,8 +1297,7 @@ class QuantumCircuit:
         operation: Operation,
         qargs: Sequence[Qubit],
         cargs: Sequence[Clbit],
-    ) -> Operation:
-        ...
+    ) -> Operation: ...
 
     def _append(
         self,
@@ -1374,13 +1370,11 @@ class QuantumCircuit:
                     self._parameters = None
 
     @typing.overload
-    def get_parameter(self, name: str, default: T) -> Union[Parameter, T]:
-        ...
+    def get_parameter(self, name: str, default: T) -> Union[Parameter, T]: ...
 
     # The builtin `types` module has `EllipsisType`, but only from 3.10+!
     @typing.overload
-    def get_parameter(self, name: str, default: type(...) = ...) -> Parameter:
-        ...
+    def get_parameter(self, name: str, default: type(...) = ...) -> Parameter: ...
 
     # We use a _literal_ `Ellipsis` as the marker value to leave `None` available as a default.
     def get_parameter(self, name: str, default: typing.Any = ...) -> Parameter:
@@ -2580,8 +2574,7 @@ class QuantumCircuit:
         *,
         flat_input: bool = ...,
         strict: bool = ...,
-    ) -> "QuantumCircuit":
-        ...
+    ) -> "QuantumCircuit": ...
 
     @overload
     def assign_parameters(
@@ -2591,8 +2584,7 @@ class QuantumCircuit:
         *,
         flat_input: bool = ...,
         strict: bool = ...,
-    ) -> None:
-        ...
+    ) -> None: ...
 
     def assign_parameters(  # pylint: disable=missing-raises-doc
         self,
@@ -4334,8 +4326,7 @@ class QuantumCircuit:
         clbits: None,
         *,
         label: str | None,
-    ) -> WhileLoopContext:
-        ...
+    ) -> WhileLoopContext: ...
 
     @typing.overload
     def while_loop(
@@ -4346,8 +4337,7 @@ class QuantumCircuit:
         clbits: Sequence[ClbitSpecifier],
         *,
         label: str | None,
-    ) -> InstructionSet:
-        ...
+    ) -> InstructionSet: ...
 
     def while_loop(self, condition, body=None, qubits=None, clbits=None, *, label=None):
         """Create a ``while`` loop on this circuit.
@@ -4422,8 +4412,7 @@ class QuantumCircuit:
         clbits: None,
         *,
         label: str | None,
-    ) -> ForLoopContext:
-        ...
+    ) -> ForLoopContext: ...
 
     @typing.overload
     def for_loop(
@@ -4435,8 +4424,7 @@ class QuantumCircuit:
         clbits: Sequence[ClbitSpecifier],
         *,
         label: str | None,
-    ) -> InstructionSet:
-        ...
+    ) -> InstructionSet: ...
 
     def for_loop(
         self, indexset, loop_parameter=None, body=None, qubits=None, clbits=None, *, label=None
@@ -4512,8 +4500,7 @@ class QuantumCircuit:
         clbits: None,
         *,
         label: str | None,
-    ) -> IfContext:
-        ...
+    ) -> IfContext: ...
 
     @typing.overload
     def if_test(
@@ -4524,8 +4511,7 @@ class QuantumCircuit:
         clbits: Sequence[ClbitSpecifier],
         *,
         label: str | None = None,
-    ) -> InstructionSet:
-        ...
+    ) -> InstructionSet: ...
 
     def if_test(
         self,
@@ -4679,8 +4665,7 @@ class QuantumCircuit:
         clbits: None,
         *,
         label: Optional[str],
-    ) -> SwitchContext:
-        ...
+    ) -> SwitchContext: ...
 
     @typing.overload
     def switch(
@@ -4691,8 +4676,7 @@ class QuantumCircuit:
         clbits: Sequence[ClbitSpecifier],
         *,
         label: Optional[str],
-    ) -> InstructionSet:
-        ...
+    ) -> InstructionSet: ...
 
     def switch(self, target, cases=None, qubits=None, clbits=None, *, label=None):
         """Create a ``switch``/``case`` structure on this circuit.

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -540,7 +540,7 @@ In addition, new payload MAP_ITEM is defined to implement the :ref:`qpy_mapping`
 
 With the support of :class:`.~ScheduleBlock`, now :class:`~.QuantumCircuit` can be
 serialized together with :attr:`~.QuantumCircuit.calibrations`, or
-`Pulse Gates <https://docs.quantum-computing.ibm.com/build/pulse>`_.
+`Pulse Gates <https://docs.quantum.ibm.com/build/pulse>`_.
 In QPY version 5 and above, :ref:`qpy_circuit_calibrations` payload is
 packed after the :ref:`qpy_instructions` block.
 

--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -109,7 +109,7 @@ class BasisTranslator(TransformationPass):
             equivalence_library (EquivalenceLibrary): The equivalence library
                 which will be used by the BasisTranslator pass. (Instructions in
                 this library will not be unrolled by this pass.)
-            target_basis (list[str]): Target basis names to unroll to, e.g. `['u3', 'cx']`.
+            target_basis (list[str]): Target basis names to unroll to, e.g. ``['u3', 'cx']``.
             target (Target): The backend compilation target
             min_qubits (int): The minimum number of qubits for operations in the input
                 dag to translate.
@@ -207,7 +207,7 @@ class BasisTranslator(TransformationPass):
                     "target basis is not universal or there are additional equivalence rules "
                     "needed in the EquivalenceLibrary being used. For more details on this "
                     "error see: "
-                    "https://docs.quantum-computing.ibm.com/api/qiskit/qiskit.transpiler.passes."
+                    "https://docs.quantum.ibm.com/api/qiskit/qiskit.transpiler.passes."
                     "BasisTranslator#translation-errors"
                 )
 
@@ -225,7 +225,7 @@ class BasisTranslator(TransformationPass):
                 f"basis: {list(target_basis)}. This likely means the target basis is not universal "
                 "or there are additional equivalence rules needed in the EquivalenceLibrary being "
                 "used. For more details on this error see: "
-                "https://docs.quantum-computing.ibm.com/api/qiskit/qiskit.transpiler.passes."
+                "https://docs.quantum.ibm.com/api/qiskit/qiskit.transpiler.passes."
                 "BasisTranslator#translation-errors"
             )
 

--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -207,7 +207,7 @@ class BasisTranslator(TransformationPass):
                     "target basis is not universal or there are additional equivalence rules "
                     "needed in the EquivalenceLibrary being used. For more details on this "
                     "error see: "
-                    "https://docs.quantum.ibm.com/api/qiskit/qiskit.transpiler.passes."
+                    "https://docs.quantum.ibm.com/api/qiskit/transpiler_passes."
                     "BasisTranslator#translation-errors"
                 )
 
@@ -225,7 +225,7 @@ class BasisTranslator(TransformationPass):
                 f"basis: {list(target_basis)}. This likely means the target basis is not universal "
                 "or there are additional equivalence rules needed in the EquivalenceLibrary being "
                 "used. For more details on this error see: "
-                "https://docs.quantum.ibm.com/api/qiskit/qiskit.transpiler.passes."
+                "https://docs.quantum.ibm.com/api/qiskit/transpiler_passes."
                 "BasisTranslator#translation-errors"
             )
 

--- a/qiskit/transpiler/passes/scheduling/alignments/pulse_gate_validation.py
+++ b/qiskit/transpiler/passes/scheduling/alignments/pulse_gate_validation.py
@@ -30,7 +30,7 @@ class ValidatePulseGates(AnalysisPass):
 
     In Qiskit SDK, we can define the pulse-level implementation of custom quantum gate
     instructions, as a `pulse gate
-    <https://docs.quantum-computing.ibm.com/build/pulse>`__,
+    <https://docs.quantum.ibm.com/build/pulse>`__,
     thus user gates should satisfy all waveform memory constraints imposed by the backend.
 
     This pass validates all attached calibration entries and raises ``TranspilerError`` to


### PR DESCRIPTION
`quantum.ibm.com` and `quantum-computing.ibm.com` are aliases. However, the latter might be sunset at some point. Probably not urgent, but better to move all to `quantum.ibm.com` sooner rather than later.