### PR TITLE
Fix image tests on 0.46 stable branch

### DIFF
--- a/.azure/test-linux.yml
+++ b/.azure/test-linux.yml
@@ -174,7 +174,8 @@ jobs:
               -r requirements.txt \
               -r requirements-dev.txt \
               -r requirements-optional.txt \
-              -e .
+              -e . \
+              -e ./qiskit_pkg
             sudo apt-get update
             sudo apt-get install -y graphviz pandoc
             image_tests/bin/pip check


### PR DESCRIPTION
### Summary

The image test venv setup currently only does `pip install -e .`, which causes `qiskit-terra` to be installed without pinning a particular version of `qiskit`.  The other dependencies then insert a dependency on `qiskit`, which `pip` fulfills (validly, from the information it has available to it) with Qiskit 1.0, breaking the environment.

The import poisoning correctly triggered to detect this case.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments


