### PR TITLE
Fix an unchecked condition in InverseCancellation

### DIFF
--- a/qiskit/transpiler/passes/optimization/inverse_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/inverse_cancellation.py
@@ -119,8 +119,10 @@ class InverseCancellation(TransformationPass):
                             partitions.append(chunk)
                             chunk = []
                         continue
-                    if i == len(gate_cancel_run) - 1 or \
-                        gate_cancel_run[i].qargs != gate_cancel_run[i + 1].qargs:
+                    if (
+                        i == len(gate_cancel_run) - 1
+                        or gate_cancel_run[i].qargs != gate_cancel_run[i + 1].qargs
+                    ):
                         partitions.append(chunk)
                         chunk = []
                 # Remove an even number of gates from each chunk

--- a/qiskit/transpiler/passes/optimization/inverse_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/inverse_cancellation.py
@@ -119,12 +119,11 @@ class InverseCancellation(TransformationPass):
                             partitions.append(chunk)
                             chunk = []
                         continue
-                    if (
-                        i == len(gate_cancel_run) - 1
-                        or gate_cancel_run[i].qargs != gate_cancel_run[i + 1].qargs
-                    ):
+                    if gate_cancel_run[i].qargs != gate_cancel_run[i + 1].qargs:
                         partitions.append(chunk)
                         chunk = []
+                if chunks:
+                    partitions.append(chunk)
                 # Remove an even number of gates from each chunk
                 for chunk in partitions:
                     if len(chunk) % 2 == 0:

--- a/qiskit/transpiler/passes/optimization/inverse_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/inverse_cancellation.py
@@ -111,7 +111,7 @@ class InverseCancellation(TransformationPass):
             for gate_cancel_run in gate_runs:
                 partitions = []
                 chunk = []
-                for i in range(len(gate_cancel_run) - 1):
+                for i in range(len(gate_cancel_run)):
                     if gate_cancel_run[i].op == gate:
                         chunk.append(gate_cancel_run[i])
                     else:
@@ -119,11 +119,10 @@ class InverseCancellation(TransformationPass):
                             partitions.append(chunk)
                             chunk = []
                         continue
-                    if gate_cancel_run[i].qargs != gate_cancel_run[i + 1].qargs:
+                    if i == len(gate_cancel_run) - 1 or \
+                        gate_cancel_run[i].qargs != gate_cancel_run[i + 1].qargs:
                         partitions.append(chunk)
                         chunk = []
-                chunk.append(gate_cancel_run[-1])
-                partitions.append(chunk)
                 # Remove an even number of gates from each chunk
                 for chunk in partitions:
                     if len(chunk) % 2 == 0:

--- a/qiskit/transpiler/passes/optimization/inverse_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/inverse_cancellation.py
@@ -111,6 +111,7 @@ class InverseCancellation(TransformationPass):
             for gate_cancel_run in gate_runs:
                 partitions = []
                 chunk = []
+                max_index = len(gate_cancel_run) - 1
                 for i in range(len(gate_cancel_run)):
                     if gate_cancel_run[i].op == gate:
                         chunk.append(gate_cancel_run[i])
@@ -119,11 +120,9 @@ class InverseCancellation(TransformationPass):
                             partitions.append(chunk)
                             chunk = []
                         continue
-                    if gate_cancel_run[i].qargs != gate_cancel_run[i + 1].qargs:
+                    if i == max_index or gate_cancel_run[i].qargs != gate_cancel_run[i + 1].qargs:
                         partitions.append(chunk)
                         chunk = []
-                if chunks:
-                    partitions.append(chunk)
                 # Remove an even number of gates from each chunk
                 for chunk in partitions:
                     if len(chunk) % 2 == 0:

--- a/releasenotes/notes/fix-inverse-cancellation-self-inverse-e09a5553331e1b0b.yaml
+++ b/releasenotes/notes/fix-inverse-cancellation-self-inverse-e09a5553331e1b0b.yaml
@@ -1,0 +1,6 @@
+---
+
+fixes:
+  - |
+    :class: `InverseCancellation` transpilation pass will now correctly handle self-inverse
+    parameterized gates. Fixed `#11815 <https://github.com/Qiskit/qiskit/issues/11815>`__.

--- a/releasenotes/notes/fix-inverse-cancellation-self-inverse-e09a5553331e1b0b.yaml
+++ b/releasenotes/notes/fix-inverse-cancellation-self-inverse-e09a5553331e1b0b.yaml
@@ -2,5 +2,7 @@
 
 fixes:
   - |
-    :class:`InverseCancellation` transpilation pass will now correctly handle self-inverse
-    parameterized gates. `#11815 <https://github.com/Qiskit/qiskit/issues/11815>`__ is now fixed.
+    Fixed an issue in the :class:`.InverseCancellation` transpiler pass where in some cases it
+    would incorrectly cancel a self-inverse parameterized gate even if the parameter value
+    didn't match.
+    Fixed  `#11815 <https://github.com/Qiskit/qiskit/issues/11815>`__

--- a/releasenotes/notes/fix-inverse-cancellation-self-inverse-e09a5553331e1b0b.yaml
+++ b/releasenotes/notes/fix-inverse-cancellation-self-inverse-e09a5553331e1b0b.yaml
@@ -2,5 +2,5 @@
 
 fixes:
   - |
-    :class: `InverseCancellation` transpilation pass will now correctly handle self-inverse
-    parameterized gates. Fixed `#11815 <https://github.com/Qiskit/qiskit/issues/11815>`__.
+    :class:`InverseCancellation` transpilation pass will now correctly handle self-inverse
+    parameterized gates. `#11815 <https://github.com/Qiskit/qiskit/issues/11815>`__ is now fixed.

--- a/test/python/transpiler/test_inverse_cancellation.py
+++ b/test/python/transpiler/test_inverse_cancellation.py
@@ -358,8 +358,10 @@ class TestInverseCancellation(QiskitTestCase):
         new_circ = inverse_pass(qc)
         self.assertEqual(new_circ, QuantumCircuit(1))
 
-    def test_parameterized_self_inverse_not_equal_parameter(self):
-        """Test that a parameterized self inverse gate doesn't cancel incorrectly."""
+    def test_parameterized_self_inverse_not_equal_parameter_1(self):
+        """Test that a parameterized self inverse gate doesn't cancel incorrectly.
+        This test, checks three gates with the same name but the middle one has a
+        different parameter."""
         qc = QuantumCircuit(1)
         qc.rz(0, 0)
         qc.rz(3.14159, 0)
@@ -367,6 +369,15 @@ class TestInverseCancellation(QiskitTestCase):
         inverse_pass = InverseCancellation([RZGate(0)])
         new_circ = inverse_pass(qc)
         self.assertEqual(new_circ, qc)
+
+    def test_parameterized_self_inverse_not_equal_parameter_2(self):
+        """Test that a parameterized self inverse gate doesn't cancel incorrectly.
+        This test, checks two gates with the same name but different parameters."""
+        qc = QuantumCircuit(1)
+        qc.rz(0, 0)
+        qc.rz(3.14159, 0)
+        inverse_pass = InverseCancellation([RZGate(0)])
+        new_circ = inverse_pass(qc)
 
     def test_controlled_gate_open_control_does_not_cancel(self):
         """Test that a controlled gate with an open control doesn't cancel."""

--- a/test/python/transpiler/test_inverse_cancellation.py
+++ b/test/python/transpiler/test_inverse_cancellation.py
@@ -378,6 +378,7 @@ class TestInverseCancellation(QiskitTestCase):
         qc.rz(3.14159, 0)
         inverse_pass = InverseCancellation([RZGate(0)])
         new_circ = inverse_pass(qc)
+        self.assertEqual(qc, new_circ)
 
     def test_controlled_gate_open_control_does_not_cancel(self):
         """Test that a controlled gate with an open control doesn't cancel."""


### PR DESCRIPTION
### Summary

`InverseCancellation` treats self-inverse and pair of inverse gates differently. 

Recently it was reported that (#11815) using a self-inverse gate, `InverseCancellation` can cancel-out non-equal (but with the same name) gates in some cases.

It was due to the fact that some of the conditions are not checked for the last gates while traversing the circuit. By changing the loop boundaries and generalizing the condition to cover the last one it could be solved.

### Details and comments

It is noteworthy that there is already a test-case for parameterized gates:

https://github.com/Qiskit/qiskit/blob/5ae4790cf6f7ca918b2d1cb9a740bd4287171c30/test/python/transpiler/test_inverse_cancellation.py#L361-L369

This test-case could have raised this bug if it has not the third gate,

```python
        qc = QuantumCircuit(1)
        qc.rz(0, 0)
        qc.rz(3.14159, 0)
        inverse_pass = InverseCancellation([RZGate(0)])
        new_circ = inverse_pass(qc)
        self.assertEqual(new_circ, qc)
```

Yet, I do **not** think it is necessary to change this test-case or add another one.
