### PR TITLE
DAG based Pulse IR - Demo

### DIFF
--- a/qiskit/pulse/compiler/__init__.py
+++ b/qiskit/pulse/compiler/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,11 +11,6 @@
 # that they have been altered from the originals.
 
 """
-.. _pulse-ir:
-
-=======================================
-Pulse IR (:mod:`qiskit.pulse.ir`)
-=======================================
-
+Temporary Compiler folder
 """
-from .ir import IrBlock
+from .temp_passes import analyze_target_frame_pass, sequence_pass, schedule_pass

--- a/qiskit/pulse/compiler/temp_passes.py
+++ b/qiskit/pulse/compiler/temp_passes.py
@@ -126,6 +126,7 @@ def _sequence_sequential(alignment, sequence: PyDAG, property_set):
 def schedule_pass(ir_block: IrBlock, property_set: dict) -> IrBlock:
     """Recursively schedule the block by setting initial time for every element"""
     # mutate graph
+    # TODO : Check if graph has edges. Override existing edges? Raise Error?
     _schedule_elements(ir_block.alignment, ir_block._time_table, ir_block._sequence, property_set)
     return ir_block
 

--- a/qiskit/pulse/compiler/temp_passes.py
+++ b/qiskit/pulse/compiler/temp_passes.py
@@ -1,0 +1,146 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Temporary Compiler passes
+"""
+
+from collections import defaultdict
+from functools import singledispatch
+from rustworkx import PyDAG
+
+from qiskit.pulse.model import MixedFrame
+from qiskit.pulse.ir import IrBlock
+from qiskit.pulse.ir.alignments import Alignment, AlignLeft
+
+
+def analyze_target_frame_pass(ir_block: IrBlock, property_set) -> None:
+    """Map the dependency of ``MixedFrame``s on ``PulseTarget`` and ``Frame``.
+
+    Recursively traverses through the ``ir_block`` to find all ``MixedFrame``s,
+    and maps their dependencies on ``PulseTarget`` and ``Frame``. The results
+    are added as a dictionary to ``property_set`` under the key ``target_frame_map``.
+    The added dictionary is keyed on every ``PulseTarget`` and ``Frame`` in ``ir_block``
+    with the value being a set of all ``MixedFrame``s associated with the key.
+    """
+    target_frame_map = defaultdict(set)
+    _analyze_target_frame_in_block(ir_block, target_frame_map)
+    property_set["target_frame_map"] = dict(target_frame_map)
+
+
+def _analyze_target_frame_in_block(ir_block: IrBlock, target_frame_map: dict) -> None:
+    """A helper function to recurse through the block while mapping mixed frame dependency"""
+    for elm in ir_block.elements():
+        # Sub Block
+        if isinstance(elm, IrBlock):
+            _analyze_target_frame_in_block(elm, target_frame_map)
+        # Pulse Instruction
+        else:
+            if isinstance(elm.inst_target, MixedFrame):
+                target_frame_map[elm.inst_target.frame].add(elm.inst_target)
+                target_frame_map[elm.inst_target.pulse_target].add(elm.inst_target)
+
+
+def sequence_pass(ir_block: IrBlock, property_set: dict) -> IrBlock:
+    """Finalize the sequence of the IrBlock by adding edges to the DAG"""
+    _sequence_instructions(ir_block.alignment, ir_block._sequence, property_set)
+    return ir_block
+
+
+@singledispatch
+def _sequence_instructions(alignment: Alignment, sequence: PyDAG, property_set: dict):
+    """Finalize the sequence of the IrBlock by adding edges to the DAG"""
+    raise NotImplementedError
+
+
+@_sequence_instructions.register(AlignLeft)
+def _sequence_left_justfied(alignment, sequence, property_set):
+    """Finalize the sequence of the IrBlock by recursively adding edges to the DAG,
+    aligning elements to the left."""
+    idle_after = {}
+    for ni in sequence.node_indices():
+        if ni in (0, 1):
+            # In, Out node
+            continue
+        node = sequence.get_node_data(ni)
+        node_mixed_frames = set()
+
+        if isinstance(node, IrBlock):
+            # Recurse over sub block
+            sequence_pass(node, property_set)
+            inst_targets = node.inst_targets
+        else:
+            inst_targets = [node.inst_target]
+
+        for inst_target in inst_targets:
+            if isinstance(inst_target, MixedFrame):
+                node_mixed_frames.add(inst_target)
+            else:
+                node_mixed_frames |= property_set["target_frame_map"][inst_target]
+
+        pred_nodes = [
+            idle_after[mixed_frame]
+            for mixed_frame in node_mixed_frames
+            if mixed_frame in idle_after
+        ]
+        if len(pred_nodes) == 0:
+            pred_nodes = [0]
+        for pred_node in pred_nodes:
+            sequence.add_edge(pred_node, ni, None)
+        for mixed_frame in node_mixed_frames:
+            idle_after[mixed_frame] = ni
+    sequence.add_edges_from_no_data([(ni, 1) for ni in idle_after.values()])
+
+
+def schedule_pass(ir_block: IrBlock, property_set: dict) -> IrBlock:
+    """Recursively schedule the block by setting initial time for every element"""
+    # mutate graph
+    _schedule_elements(ir_block.alignment, ir_block._time_table, ir_block._sequence, property_set)
+    return ir_block
+
+
+@singledispatch
+def _schedule_elements(alignment, table, sequence, property_set):
+    """Recursively schedule the block by setting initial time for every element"""
+    raise NotImplementedError
+
+
+@_schedule_elements.register(AlignLeft)
+def _schedule_left_justfied(alignment, table, sequence: PyDAG, property_set):
+    """Recursively schedule the block by setting initial time for every element,
+    aligning elements to the left."""
+
+    first_nodes = sequence.successor_indices(0)
+    nodes = []
+    # Node 0 has no duration so is treated separately
+    for node_index in first_nodes:
+        table[node_index] = 0
+        node = sequence.get_node_data(node_index)
+        if isinstance(node, IrBlock):
+            # Recruse over sub blocks
+            schedule_pass(node, property_set)
+        nodes.extend(sequence.successor_indices(node_index))
+
+    while nodes:
+        node_index = nodes.pop(0)
+        if node_index == 1 or node_index in table:
+            # reached end or already scheduled
+            continue
+        node = sequence.get_node_data(node_index)
+        if isinstance(node, IrBlock):
+            # Recruse over sub blocks
+            schedule_pass(node, property_set)
+        # Because we go in order, all predecessors are already scheduled
+        preds = sequence.predecessor_indices(node_index)
+        t0 = max([table.get(pred) + sequence.get_node_data(pred).duration for pred in preds])
+        table[node_index] = t0
+        nodes.extend(sequence.successor_indices(node_index))

--- a/qiskit/pulse/instructions/__init__.py
+++ b/qiskit/pulse/instructions/__init__.py
@@ -59,7 +59,7 @@ These are all instances of the same base class:
 from .acquire import Acquire
 from .delay import Delay
 from .directives import Directive, RelativeBarrier, TimeBlockade
-from .instruction import Instruction
+from .instruction import Instruction, FrameUpdate
 from .frequency import SetFrequency, ShiftFrequency
 from .phase import ShiftPhase, SetPhase
 from .play import Play

--- a/qiskit/pulse/ir/__init__.py
+++ b/qiskit/pulse/ir/__init__.py
@@ -18,4 +18,4 @@ Pulse IR (:mod:`qiskit.pulse.ir`)
 =======================================
 
 """
-from .ir import IrBlock
+from .ir import SequenceIR

--- a/qiskit/pulse/ir/alignments.py
+++ b/qiskit/pulse/ir/alignments.py
@@ -9,29 +9,44 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+"""
+=========
+Pulse IR Alignments
+=========
+"""
 
 
 class Alignment:
-    @property
-    def conditions(self) -> dict:
-        return {}
+    """Base abstract class for IR alignments"""
+
+    pass
 
 
 class ParallelAlignment(Alignment):
+    """Base abstract class for IR alignments which align instructions in parallel"""
+
     pass
 
 
 class SequentialAlignment(Alignment):
+    """Base abstract class for IR alignments which align instructions sequentially"""
+
     pass
 
 
 class AlignLeft(ParallelAlignment):
+    """Left Alignment"""
+
     pass
 
 
 class AlignRight(ParallelAlignment):
+    """Right Alignment"""
+
     pass
 
 
 class AlignSequential(SequentialAlignment):
+    """Sequential Alignment"""
+
     pass

--- a/qiskit/pulse/ir/alignments.py
+++ b/qiskit/pulse/ir/alignments.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -10,12 +10,24 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""
-.. _pulse-ir:
 
-=======================================
-Pulse IR (:mod:`qiskit.pulse.ir`)
-=======================================
+class Alignment:
+    @property
+    def conditions(self) -> dict:
+        return {}
 
-"""
-from .ir import IrBlock
+
+class ParallelAlignment(Alignment):
+    pass
+
+
+class SequentialAlignment(Alignment):
+    pass
+
+
+class AlignLeft(ParallelAlignment):
+    pass
+
+
+class AlignSequential(SequentialAlignment):
+    pass

--- a/qiskit/pulse/ir/alignments.py
+++ b/qiskit/pulse/ir/alignments.py
@@ -29,5 +29,9 @@ class AlignLeft(ParallelAlignment):
     pass
 
 
+class AlignRight(ParallelAlignment):
+    pass
+
+
 class AlignSequential(SequentialAlignment):
     pass

--- a/qiskit/pulse/ir/ir.py
+++ b/qiskit/pulse/ir/ir.py
@@ -20,143 +20,18 @@ Pulse IR
 """
 
 from __future__ import annotations
-from typing import List
-from abc import ABC, abstractmethod
 
-import numpy as np
+import rustworkx as rx
+from rustworkx import PyDAG
 
-from qiskit.pulse.exceptions import PulseError
+from qiskit.pulse.ir.alignments import Alignment
+from qiskit.pulse import Instruction
 
-from qiskit.pulse.transforms import AlignmentKind
-from qiskit.pulse.instructions import Instruction
-
-
-class IrElement(ABC):
-    """Base class for Pulse IR elements"""
-
-    @property
-    @abstractmethod
-    def initial_time(self) -> int | None:
-        """Return the initial time of the element"""
-        pass
-
-    @property
-    @abstractmethod
-    def duration(self) -> int | None:
-        """Return the duration of the element"""
-        pass
-
-    @abstractmethod
-    def shift_initial_time(self, value: int):
-        """Shift ``initial_time``
-
-        Shifts ``initial_time`` to ``initial_time+value``.
-
-        Args:
-            value: The integer value by which ``initial_time`` is to be shifted.
-        """
-        pass
-
-    @property
-    def final_time(self) -> int | None:
-        """Return the final time of the element"""
-        try:
-            return self.initial_time + self.duration
-        except TypeError:
-            return None
+InNode = object()
+OutNode = object()
 
 
-class IrInstruction(IrElement):
-    """Pulse IR Instruction
-
-    A Pulse IR instruction represents a ``ScheduleBlock`` instruction, with the addition of
-    an ``initial_time`` property.
-    """
-
-    def __init__(self, instruction: Instruction, initial_time: int | None = None):
-        """Pulse IR instructions
-
-        Args:
-            instruction: the Pulse `Instruction` represented by this IR instruction.
-            initial_time (Optional): Starting time of the instruction. Defaults to ``None``
-        """
-        self._instruction = instruction
-        if initial_time is None:
-            self._initial_time = None
-        else:
-            self.initial_time = initial_time
-
-    @property
-    def instruction(self) -> Instruction:
-        """Return the instruction associated with the IrInstruction"""
-        return self._instruction
-
-    @property
-    def initial_time(self) -> int | None:
-        """A clock time (in terms of system ``dt``) when this instruction is issued.
-
-        .. note::
-            initial_time value defaults to ``None`` and can only be set to non-negative integer.
-        """
-        return self._initial_time
-
-    @property
-    def duration(self) -> int:
-        """The duration of the instruction (in terms of system ``dt``)."""
-        return self._instruction.duration
-
-    @initial_time.setter
-    def initial_time(self, value: int):
-        """Set ``initial_time``
-
-        Args:
-            value: The integer value of ``initial_time``.
-
-        Raises:
-            PulseError: if ``value`` is not ``None`` and not non-negative integer.
-        """
-        if not isinstance(value, (int, np.integer)) or value < 0:
-            raise PulseError("initial_time must be a non-negative integer")
-        self._initial_time = value
-
-    def shift_initial_time(self, value: int) -> None:
-        """Shift ``initial_time``
-
-        Shifts ``initial_time`` to ``initial_time+value``.
-
-        Args:
-            value: The integer value by which ``initial_time`` is to be shifted.
-
-        Raises:
-            PulseError: If the instruction is not scheduled.
-        """
-        if self.initial_time is None:
-            raise PulseError("Can not shift initial_time of an untimed element")
-
-        # validation of new initial_time is done in initial_time setter.
-        self.initial_time = self.initial_time + value
-
-    def __eq__(self, other: "IrInstruction") -> bool:
-        """Return True iff self and other are equal
-
-        Args:
-            other: The IR instruction to compare to this one.
-
-        Returns:
-            True iff equal.
-        """
-        return (
-            type(self) is type(other)
-            and self._instruction == other.instruction
-            and self._initial_time == other.initial_time
-        )
-
-    def __repr__(self) -> str:
-        """IrInstruction representation"""
-        return f"IrInstruction({self.instruction}, t0={self.initial_time})"
-
-
-class IrBlock(IrElement):
+class IrBlock:
     """IR representation of instruction sequences
 
     ``IrBlock`` is the backbone of the intermediate representation used in the Qiskit Pulse compiler.
@@ -164,135 +39,88 @@ class IrBlock(IrElement):
     which include ``IrInstruction`` objects and other nested ``IrBlock`` objects.
     """
 
-    def __init__(self, alignment: AlignmentKind):
-        """Create ``IrBlock`` object
-
-        Args:
-            alignment: The ``AlignmentKind`` to be used for scheduling.
-        """
-        self._elements = []
+    def __init__(self, alignment: Alignment):
         self._alignment = alignment
 
-    @property
-    def initial_time(self) -> int | None:
-        """Return the initial time ``initial_time`` of the object"""
-        elements_initial_times = [element.initial_time for element in self._elements]
-        if None in elements_initial_times:
-            return None
-        else:
-            return min(elements_initial_times, default=None)
+        self.time_offset = 0
+        self._time_table = {}
+        self._children = []
+        self._sequence = rx.PyDAG(multigraph=False)
+        self._sequence.add_nodes_from([InNode, OutNode])
 
     @property
-    def final_time(self) -> int | None:
-        """Return the final time of the ``IrBlock``object"""
-        elements_final_times = [element.final_time for element in self._elements]
-        if None in elements_final_times:
+    def alignment(self) -> Alignment:
+        """Return the alignment of the IrBlock"""
+        return self._alignment
+
+    @property
+    def inst_targets(self) -> set:
+        """Recursively return a set of all Instruction.inst_target in the IrBlock"""
+        inst_targets = set()
+        for elm in self.elements():
+            if isinstance(elm, IrBlock):
+                inst_targets |= elm.inst_targets
+            else:
+                inst_targets.add(elm.inst_target)
+        return inst_targets
+
+    @property
+    def sequence(self) -> PyDAG:
+        """Return the DAG sequence of the IrBlock"""
+        return self._sequence
+
+    def append(self, element: IrBlock | Instruction) -> None:
+        """Append element to the IrBlock"""
+        new_node_id = self._sequence.add_node(element)
+        if isinstance(element, IrBlock):
+            self._children.append(new_node_id)
+
+    def elements(self) -> list[IrBlock | Instruction]:
+        """Return a list of all elements in the IrBlock"""
+        return self._sequence.nodes()[2:]
+
+    def scheduled_elements(self) -> list[list[int | None, IrBlock | Instruction]]:
+        """Return a list of scheduled elements.
+
+        Each element in the list is [initial_time, element].
+        """
+        return [
+            [self._time_table.get(ni, None), self._sequence.get_node_data(ni)]
+            for ni in self._sequence.node_indices()
+            if ni not in (0, 1)
+        ]
+
+    def initial_time(self) -> int | None:
+        """Return initial time"""
+        first_nodes = self._sequence.successor_indices(0)
+        if not first_nodes:
             return None
-        else:
-            return max(elements_final_times, default=None)
+        return min([self._time_table.get(node, None) for node in first_nodes], default=None)
+
+    def final_time(self) -> int | None:
+        """Return final time"""
+        last_nodes = self._sequence.predecessor_indices(1)
+        if not last_nodes:
+            return None
+        tf = None
+        for ni in last_nodes:
+            if (t0 := self._time_table.get(ni, None)) is not None:
+                duration = self._sequence.get_node_data(ni).duration
+                if tf is None:
+                    tf = t0 + duration
+                else:
+                    tf = max(tf, t0 + duration)
+        return tf
 
     @property
     def duration(self) -> int | None:
-        """Return the duration of the ir block"""
+        """Return the duration of the IrBlock"""
         try:
-            return self.final_time - self.initial_time
+            return self.final_time() - self.initial_time()
         except TypeError:
             return None
 
-    @property
-    def elements(self) -> List[IrElement]:
-        """Return the elements of the ``IrBlock`` object"""
-        return self._elements
-
-    @property
-    def alignment(self) -> AlignmentKind:
-        """Return the alignment of the ``IrBlock`` object"""
-        return self._alignment
-
-    def has_child_ir(self) -> bool:
-        """Check if IrBlock has child IrBlock object
-
-        Returns:
-            ``True`` if object has ``IrBlock`` object in its elements, and ``False`` otherwise.
-
-        """
-        for element in self._elements:
-            if isinstance(element, IrBlock):
-                return True
-        return False
-
-    def add_element(
-        self,
-        element: IrElement | List[IrElement],
-    ):
-        """Adds IR element or list thereof to the ``IrBlock`` object.
-
-        Args:
-            element: `IrElement` object, or list thereof to add.
-        """
-        if not isinstance(element, list):
-            element = [element]
-
-        self._elements.extend(element)
-
-    def shift_initial_time(self, value: int):
-        """Shifts ``initial_time`` of the ``IrBlock`` elements
-
-        The ``initial_time`` of all elements in the ``IrBlock`` are shifted by ``value``,
-        including recursively if any element is ``IrBlock``.
-
-        Args:
-            value: The integer value by which ``initial_time`` is to be shifted.
-
-        Raises:
-            PulseError: if the object is not scheduled (initial_time is None)
-        """
-        if self.initial_time is None:
-            raise PulseError("Can not shift initial_time of IrBlock with unscheduled elements")
-
-        for element in self.elements:
-            element.shift_initial_time(value)
-
-    def __eq__(self, other: "IrBlock") -> bool:
-        """Return True iff self and other are equal
-        Specifically, iff all of their properties are identical.
-
-        Args:
-            other: The IrBlock to compare to this one.
-
-        Returns:
-            True iff equal.
-        """
-        if (
-            type(self) is not type(self)
-            or self._alignment != other._alignment
-            or len(self._elements) != len(other._elements)
-        ):
+    def __eq__(self, other):
+        if self.alignment != other.alignment:
             return False
-        for element_self, element_other in zip(self._elements, other._elements):
-            if element_other != element_self:
-                return False
-
-        return True
-
-    def __len__(self) -> int:
-        """Return the length of the IR, defined as the number of elements in it"""
-        return len(self._elements)
-
-    def __repr__(self) -> str:
-        """IrBlock representation"""
-        inst_count = len(
-            [element for element in self.elements if isinstance(element, IrInstruction)]
-        )
-        block_count = len(self) - inst_count
-        reprstr = f"IrBlock({self.alignment}"
-        if inst_count > 0:
-            reprstr += f", {inst_count} IrInstructions"
-        if block_count > 0:
-            reprstr += f", {block_count} IrBlocks"
-        if self.initial_time is not None:
-            reprstr += f", initial_time={self.initial_time}"
-        if self.duration is not None:
-            reprstr += f", duration={self.duration}"
-        reprstr += ")"
-        return reprstr
+        return rx.is_isomorphic_node_match(self._sequence, other._sequence, lambda x, y: x == y)

--- a/test/python/pulse/test_pulse_compiler_passes.py
+++ b/test/python/pulse/test_pulse_compiler_passes.py
@@ -1,0 +1,514 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test compiler passes"""
+
+from test import QiskitTestCase
+from qiskit.pulse import (
+    Constant,
+    Play,
+    Delay,
+    ShiftPhase,
+)
+
+from qiskit.pulse.ir import (
+    IrBlock,
+)
+
+from qiskit.pulse.ir.alignments import AlignLeft
+from qiskit.pulse.model import QubitFrame, Qubit, MixedFrame
+from qiskit.pulse.compiler import analyze_target_frame_pass, sequence_pass, schedule_pass
+
+
+class TestAnalyzeTargetFramePass(QiskitTestCase):
+    """Test analyze_target_frame_pass"""
+
+    def test_basic_ir(self):
+        """test with basic IR"""
+        ir_example = IrBlock(AlignLeft())
+        mf = MixedFrame(Qubit(0), QubitFrame(1))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=mf))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        self.assertEqual(len(property_set.keys()), 1)
+        mapping = property_set["target_frame_map"]
+        self.assertEqual(len(mapping), 2)
+        self.assertEqual(mapping[mf.pulse_target], {mf})
+        self.assertEqual(mapping[mf.frame], {mf})
+
+        mf2 = MixedFrame(Qubit(0), QubitFrame(2))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=mf2))
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        mapping = property_set["target_frame_map"]
+        self.assertEqual(len(mapping), 3)
+        self.assertEqual(mapping[mf.pulse_target], {mf, mf2})
+        self.assertEqual(mapping[mf.frame], {mf})
+
+    def test_with_several_inst_target_types(self):
+        """test with different inst_target types"""
+        ir_example = IrBlock(AlignLeft())
+        mf = MixedFrame(Qubit(0), QubitFrame(1))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=mf))
+        ir_example.append(Delay(100, target=Qubit(2)))
+        ir_example.append(ShiftPhase(100, frame=QubitFrame(2)))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        mapping = property_set["target_frame_map"]
+        self.assertEqual(len(mapping), 2)
+        self.assertEqual(mapping[Qubit(0)], {mf})
+        self.assertEqual(mapping[QubitFrame(1)], {mf})
+
+    def test_with_sub_blocks(self):
+        """test with sub blocks"""
+        mf1 = MixedFrame(Qubit(0), QubitFrame(0))
+        mf2 = MixedFrame(Qubit(0), QubitFrame(1))
+        mf3 = MixedFrame(Qubit(0), QubitFrame(2))
+
+        sub_block_2 = IrBlock(AlignLeft())
+        sub_block_2.append(Play(Constant(100, 0.1), mixed_frame=mf1))
+
+        sub_block_1 = IrBlock(AlignLeft())
+        sub_block_1.append(Play(Constant(100, 0.1), mixed_frame=mf2))
+        sub_block_1.append(sub_block_2)
+
+        property_set = {}
+        analyze_target_frame_pass(sub_block_1, property_set)
+        mapping = property_set["target_frame_map"]
+        self.assertEqual(len(mapping), 3)
+        self.assertEqual(mapping[Qubit(0)], {mf1, mf2})
+        self.assertEqual(mapping[QubitFrame(0)], {mf1})
+        self.assertEqual(mapping[QubitFrame(1)], {mf2})
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=mf3))
+        ir_example.append(sub_block_1)
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        mapping = property_set["target_frame_map"]
+        self.assertEqual(len(mapping), 4)
+        self.assertEqual(mapping[Qubit(0)], {mf1, mf2, mf3})
+        self.assertEqual(mapping[QubitFrame(0)], {mf1})
+        self.assertEqual(mapping[QubitFrame(1)], {mf2})
+        self.assertEqual(mapping[QubitFrame(2)], {mf3})
+
+
+class TestSequencePassAlignLeft(QiskitTestCase):
+    """Test sequence_pass with align left"""
+
+    def test_single_instruction(self):
+        """test with a single instruction"""
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        edge_list = ir_example.sequence.edge_list()
+        self.assertEqual(len(edge_list), 2)
+        self.assertTrue((0, 2) in edge_list)
+        self.assertTrue((2, 1) in edge_list)
+
+    # TODO: Take care of this weird edge case
+    # def test_instruction_not_in_mapping(self):
+    #     """test with an instruction which is not in the mapping"""
+    #
+    #     ir_example = IrBlock(AlignLeft())
+    #     ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+    #     ir_example.append(Delay(100, target=Qubit(5)))
+    #
+    #     property_set = {}
+    #     analyze_target_frame_pass(ir_example, property_set)
+    #     ir_example = sequence_pass(ir_example, property_set)
+    #     edge_list = ir_example.sequence.edge_list()
+    #     self.assertEqual(len(edge_list), 4)
+    #     self.assertTrue((0, 2) in edge_list)
+    #     self.assertTrue((0, 3) in edge_list)
+    #     self.assertTrue((2, 1) in edge_list)
+    #     self.assertTrue((3, 1) in edge_list)
+
+    def test_parallel_instructions(self):
+        """test with two parallel instructions"""
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        edge_list = ir_example.sequence.edge_list()
+        self.assertEqual(len(edge_list), 4)
+        self.assertTrue((0, 2) in edge_list)
+        self.assertTrue((2, 1) in edge_list)
+        self.assertTrue((0, 3) in edge_list)
+        self.assertTrue((3, 1) in edge_list)
+
+    def test_sequential_instructions(self):
+        """test with two sequential instructions"""
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        edge_list = ir_example.sequence.edge_list()
+        self.assertEqual(len(edge_list), 3)
+        self.assertTrue((0, 2) in edge_list)
+        self.assertTrue((2, 3) in edge_list)
+        self.assertTrue((3, 1) in edge_list)
+
+    def test_pulse_target_instruction_broadcasting_to_children(self):
+        """test with an instruction which is defined on a PulseTarget and is
+        broadcasted to several children"""
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Delay(100, target=Qubit(0)))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(2))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        edge_list = ir_example.sequence.edge_list()
+        self.assertEqual(len(edge_list), 5)
+        self.assertTrue((0, 2) in edge_list)
+        self.assertTrue((2, 3) in edge_list)
+        self.assertTrue((2, 4) in edge_list)
+        self.assertTrue((3, 1) in edge_list)
+        self.assertTrue((4, 1) in edge_list)
+
+    def test_frame_instruction_broadcasting_to_children(self):
+        """test with an instruction which is defined on a Frame and is broadcasted to several children"""
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(ShiftPhase(100, frame=QubitFrame(0)))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(0))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        edge_list = ir_example.sequence.edge_list()
+        self.assertEqual(len(edge_list), 5)
+        self.assertTrue((0, 2) in edge_list)
+        self.assertTrue((2, 3) in edge_list)
+        self.assertTrue((2, 4) in edge_list)
+        self.assertTrue((3, 1) in edge_list)
+        self.assertTrue((4, 1) in edge_list)
+
+    def test_pulse_target_instruction_dependency(self):
+        """test with an instruction which is defined on a PulseTarget and depends on
+        several mixed frames"""
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(2))))
+        ir_example.append(Delay(100, target=Qubit(0)))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        edge_list = ir_example.sequence.edge_list()
+        self.assertEqual(len(edge_list), 5)
+        self.assertTrue((0, 2) in edge_list)
+        self.assertTrue((0, 3) in edge_list)
+        self.assertTrue((2, 4) in edge_list)
+        self.assertTrue((3, 4) in edge_list)
+        self.assertTrue((4, 1) in edge_list)
+
+    def test_frame_instruction_dependency(self):
+        """test with an instruction which is defined on a Frame and depends on several mixed frames"""
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(0))))
+        ir_example.append(ShiftPhase(100, frame=QubitFrame(0)))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        edge_list = ir_example.sequence.edge_list()
+        self.assertEqual(len(edge_list), 5)
+        self.assertTrue((0, 2) in edge_list)
+        self.assertTrue((0, 3) in edge_list)
+        self.assertTrue((2, 4) in edge_list)
+        self.assertTrue((3, 4) in edge_list)
+        self.assertTrue((4, 1) in edge_list)
+
+    def test_recursion_to_sub_blocks(self):
+        """test that sequencing is recursively applied to sub blocks"""
+
+        sub_block = IrBlock(AlignLeft())
+        sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+        ir_example.append(sub_block)
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+
+        edge_list_sub_block = ir_example.elements()[1].sequence.edge_list()
+        self.assertEqual(len(edge_list_sub_block), 2)
+        self.assertTrue((0, 2) in edge_list_sub_block)
+        self.assertTrue((2, 1) in edge_list_sub_block)
+
+    def test_with_parallel_sub_block(self):
+        """test with a sub block which doesn't depend on previous instructions"""
+
+        sub_block = IrBlock(AlignLeft())
+        sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+        ir_example.append(sub_block)
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        edge_list = ir_example.sequence.edge_list()
+        self.assertEqual(len(edge_list), 4)
+        self.assertTrue((0, 2) in edge_list)
+        self.assertTrue((0, 3) in edge_list)
+        self.assertTrue((2, 1) in edge_list)
+        self.assertTrue((3, 1) in edge_list)
+
+    def test_with_simple_sequential_sub_block(self):
+        """test with a sub block which depends on a single previous instruction"""
+
+        sub_block = IrBlock(AlignLeft())
+        sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(sub_block)
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        edge_list = ir_example.sequence.edge_list()
+        self.assertEqual(len(edge_list), 5)
+        self.assertTrue((0, 2) in edge_list)
+        self.assertTrue((0, 3) in edge_list)
+        self.assertTrue((3, 4) in edge_list)
+        self.assertTrue((2, 1) in edge_list)
+        self.assertTrue((4, 1) in edge_list)
+
+    def test_with_sequential_sub_block_with_more_dependencies(self):
+        """test with a sub block which depends on a single previous instruction"""
+
+        sub_block = IrBlock(AlignLeft())
+        sub_block.append(Delay(100, target=Qubit(0)))
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
+        ir_example.append(sub_block)
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        edge_list = ir_example.sequence.edge_list()
+        self.assertEqual(len(edge_list), 8)
+        self.assertTrue((0, 2) in edge_list)
+        self.assertTrue((0, 3) in edge_list)
+        self.assertTrue((0, 4) in edge_list)
+        self.assertTrue((2, 5) in edge_list)
+        self.assertTrue((3, 5) in edge_list)
+        self.assertTrue((4, 6) in edge_list)
+        self.assertTrue((5, 1) in edge_list)
+        self.assertTrue((6, 1) in edge_list)
+
+
+class TestSchedulePassAlignLeft(QiskitTestCase):
+    """Test schedule_pass with align left"""
+
+    def test_single_instruction(self):
+        """test with a single instruction"""
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+        self.assertEqual(ir_example.initial_time(), 0)
+        self.assertEqual(ir_example.final_time(), 100)
+
+    def test_parallel_instructions(self):
+        """test with two parallel instructions"""
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(Play(Constant(200, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+        self.assertEqual(ir_example.initial_time(), 0)
+        self.assertEqual(ir_example.final_time(), 200)
+        self.assertEqual(ir_example.scheduled_elements()[0][0], 0)
+        self.assertEqual(ir_example.scheduled_elements()[1][0], 0)
+
+    def test_sequential_instructions(self):
+        """test with two sequential instructions"""
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+        self.assertEqual(ir_example.initial_time(), 0)
+        self.assertEqual(ir_example.final_time(), 200)
+        self.assertEqual(ir_example.scheduled_elements()[0][0], 0)
+        self.assertEqual(ir_example.scheduled_elements()[1][0], 100)
+
+    def test_multiple_children(self):
+        """test for a graph where one node has several children"""
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Delay(100, target=Qubit(0)))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(2))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+        self.assertEqual(ir_example.initial_time(), 0)
+        self.assertEqual(ir_example.final_time(), 200)
+        self.assertEqual(ir_example.scheduled_elements()[0][0], 0)
+        self.assertEqual(ir_example.scheduled_elements()[1][0], 100)
+        self.assertEqual(ir_example.scheduled_elements()[2][0], 100)
+
+    def test_multiple_parents(self):
+        """test for a graph where one node has several parents"""
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(Play(Constant(200, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(2))))
+        ir_example.append(Delay(100, target=Qubit(0)))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+        self.assertEqual(ir_example.initial_time(), 0)
+        self.assertEqual(ir_example.final_time(), 300)
+        self.assertEqual(ir_example.scheduled_elements()[0][0], 0)
+        self.assertEqual(ir_example.scheduled_elements()[1][0], 0)
+        self.assertEqual(ir_example.scheduled_elements()[2][0], 200)
+
+    def test_recursion_to_leading_sub_blocks(self):
+        """test that scheduling is recursively applied to sub blocks which are first in the order"""
+
+        sub_block = IrBlock(AlignLeft())
+        sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+        ir_example.append(sub_block)
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+
+        sub_block = ir_example.elements()[1]
+        # Note that sub blocks are oblivious to their relative timing
+        self.assertEqual(sub_block.initial_time(), 0)
+        self.assertEqual(sub_block.final_time(), 100)
+        self.assertEqual(sub_block.scheduled_elements()[0][0], 0)
+
+    def test_recursion_to_non_leading_sub_blocks(self):
+        """test that scheduling is recursively applied to sub blocks when they are not first in order"""
+
+        sub_block = IrBlock(AlignLeft())
+        sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(sub_block)
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+
+        sub_block = ir_example.elements()[2]
+        # Note that sub blocks are oblivious to their relative timing
+        self.assertEqual(sub_block.initial_time(), 0)
+        self.assertEqual(sub_block.final_time(), 100)
+        self.assertEqual(sub_block.scheduled_elements()[0][0], 0)
+        self.assertEqual(ir_example.initial_time(), 0)
+        self.assertEqual(ir_example.final_time(), 200)
+
+    def test_with_parallel_sub_block(self):
+        """test with a sub block which doesn't depend on previous instructions"""
+
+        sub_block = IrBlock(AlignLeft())
+        sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+        ir_example.append(sub_block)
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+
+        self.assertEqual(ir_example.initial_time(), 0)
+        self.assertEqual(ir_example.final_time(), 100)
+
+    def test_with_sequential_sub_block_with_more_dependencies(self):
+        """test with a sub block which depends on a single previous instruction"""
+
+        sub_block = IrBlock(AlignLeft())
+        sub_block.append(Delay(100, target=Qubit(0)))
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+        ir_example.append(Play(Constant(200, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
+        ir_example.append(sub_block)
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+
+        self.assertEqual(ir_example.initial_time(), 0)
+        self.assertEqual(ir_example.final_time(), 300)
+        self.assertEqual(ir_example.scheduled_elements()[0][0], 0)
+        self.assertEqual(ir_example.scheduled_elements()[1][0], 0)
+        self.assertEqual(ir_example.scheduled_elements()[2][0], 0)
+        self.assertEqual(ir_example.scheduled_elements()[3][0], 200)
+        self.assertEqual(ir_example.scheduled_elements()[4][0], 100)

--- a/test/python/pulse/test_pulse_compiler_passes.py
+++ b/test/python/pulse/test_pulse_compiler_passes.py
@@ -11,8 +11,11 @@
 # that they have been altered from the originals.
 
 """Test compiler passes"""
-
+import copy
 from test import QiskitTestCase
+
+from ddt import ddt, named_data, unpack
+
 from qiskit.pulse import (
     Constant,
     Play,
@@ -24,7 +27,13 @@ from qiskit.pulse.ir import (
     IrBlock,
 )
 
-from qiskit.pulse.ir.alignments import AlignLeft
+from qiskit.pulse.ir.alignments import (
+    AlignLeft,
+    AlignRight,
+    ParallelAlignment,
+    SequentialAlignment,
+    AlignSequential,
+)
 from qiskit.pulse.model import QubitFrame, Qubit, MixedFrame
 from qiskit.pulse.compiler import analyze_target_frame_pass, sequence_pass, schedule_pass
 
@@ -105,13 +114,14 @@ class TestAnalyzeTargetFramePass(QiskitTestCase):
         self.assertEqual(mapping[QubitFrame(2)], {mf3})
 
 
-class TestSequencePassAlignLeft(QiskitTestCase):
-    """Test sequence_pass with align left"""
+@ddt
+class TestSequenceParallelAlignment(QiskitTestCase):
+    """Test sequence_pass with Parallel Alignment"""
 
     def test_single_instruction(self):
         """test with a single instruction"""
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = IrBlock(ParallelAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
         property_set = {}
@@ -143,7 +153,7 @@ class TestSequencePassAlignLeft(QiskitTestCase):
     def test_parallel_instructions(self):
         """test with two parallel instructions"""
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = IrBlock(ParallelAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
 
@@ -160,7 +170,7 @@ class TestSequencePassAlignLeft(QiskitTestCase):
     def test_sequential_instructions(self):
         """test with two sequential instructions"""
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = IrBlock(ParallelAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
@@ -177,7 +187,7 @@ class TestSequencePassAlignLeft(QiskitTestCase):
         """test with an instruction which is defined on a PulseTarget and is
         broadcasted to several children"""
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = IrBlock(ParallelAlignment())
         ir_example.append(Delay(100, target=Qubit(0)))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(2))))
@@ -196,7 +206,7 @@ class TestSequencePassAlignLeft(QiskitTestCase):
     def test_frame_instruction_broadcasting_to_children(self):
         """test with an instruction which is defined on a Frame and is broadcasted to several children"""
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = IrBlock(ParallelAlignment())
         ir_example.append(ShiftPhase(100, frame=QubitFrame(0)))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(0))))
@@ -216,7 +226,7 @@ class TestSequencePassAlignLeft(QiskitTestCase):
         """test with an instruction which is defined on a PulseTarget and depends on
         several mixed frames"""
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = IrBlock(ParallelAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(2))))
         ir_example.append(Delay(100, target=Qubit(0)))
@@ -235,7 +245,7 @@ class TestSequencePassAlignLeft(QiskitTestCase):
     def test_frame_instruction_dependency(self):
         """test with an instruction which is defined on a Frame and depends on several mixed frames"""
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = IrBlock(ParallelAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(0))))
         ir_example.append(ShiftPhase(100, frame=QubitFrame(0)))
@@ -254,10 +264,10 @@ class TestSequencePassAlignLeft(QiskitTestCase):
     def test_recursion_to_sub_blocks(self):
         """test that sequencing is recursively applied to sub blocks"""
 
-        sub_block = IrBlock(AlignLeft())
+        sub_block = IrBlock(ParallelAlignment())
         sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = IrBlock(ParallelAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(sub_block)
 
@@ -273,10 +283,10 @@ class TestSequencePassAlignLeft(QiskitTestCase):
     def test_with_parallel_sub_block(self):
         """test with a sub block which doesn't depend on previous instructions"""
 
-        sub_block = IrBlock(AlignLeft())
+        sub_block = IrBlock(ParallelAlignment())
         sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = IrBlock(ParallelAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(sub_block)
 
@@ -293,10 +303,10 @@ class TestSequencePassAlignLeft(QiskitTestCase):
     def test_with_simple_sequential_sub_block(self):
         """test with a sub block which depends on a single previous instruction"""
 
-        sub_block = IrBlock(AlignLeft())
+        sub_block = IrBlock(ParallelAlignment())
         sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = IrBlock(ParallelAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(sub_block)
@@ -315,10 +325,10 @@ class TestSequencePassAlignLeft(QiskitTestCase):
     def test_with_sequential_sub_block_with_more_dependencies(self):
         """test with a sub block which depends on a single previous instruction"""
 
-        sub_block = IrBlock(AlignLeft())
+        sub_block = IrBlock(ParallelAlignment())
         sub_block.append(Delay(100, target=Qubit(0)))
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = IrBlock(ParallelAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
@@ -338,6 +348,136 @@ class TestSequencePassAlignLeft(QiskitTestCase):
         self.assertTrue((4, 6) in edge_list)
         self.assertTrue((5, 1) in edge_list)
         self.assertTrue((6, 1) in edge_list)
+
+    @named_data(["align_left", AlignLeft()], ["align_right", AlignRight()])
+    @unpack
+    def test_specific_alignments(self, alignment):
+        """Test that specific alignments are the same as parallel alignment"""
+
+        sub_block = IrBlock(ParallelAlignment())
+        sub_block.append(Delay(100, target=Qubit(0)))
+
+        ir_example = IrBlock(ParallelAlignment())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
+        ir_example.append(sub_block)
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
+
+        ir_example_specific = copy.deepcopy(ir_example)
+        ir_example_specific._alignment = alignment
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example_specific, property_set)
+        ir_example_specific = sequence_pass(ir_example_specific, property_set)
+
+        self.assertEqual(ir_example.sequence.edge_list(), ir_example_specific.sequence.edge_list())
+
+
+class TestSequenceSequentialAlignment(QiskitTestCase):
+    """Test sequence_pass with Sequential Alignment"""
+
+    def test_single_instruction(self):
+        """test with a single instruction"""
+
+        ir_example = IrBlock(SequentialAlignment())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        edge_list = ir_example.sequence.edge_list()
+        self.assertEqual(len(edge_list), 2)
+        self.assertTrue((0, 2) in edge_list)
+        self.assertTrue((2, 1) in edge_list)
+
+    def test_several_instructions(self):
+        """test with several instructions"""
+
+        ir_example = IrBlock(SequentialAlignment())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(2), QubitFrame(1))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        edge_list = ir_example.sequence.edge_list()
+        self.assertEqual(len(edge_list), 4)
+        self.assertTrue((0, 2) in edge_list)
+        self.assertTrue((2, 3) in edge_list)
+        self.assertTrue((3, 4) in edge_list)
+        self.assertTrue((4, 1) in edge_list)
+
+    def test_recursion_to_sub_blocks(self):
+        """test that sequencing is recursively applied to sub blocks"""
+
+        sub_block = IrBlock(SequentialAlignment())
+        sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        ir_example = IrBlock(SequentialAlignment())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+        ir_example.append(sub_block)
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+
+        edge_list_sub_block = ir_example.elements()[1].sequence.edge_list()
+        self.assertEqual(len(edge_list_sub_block), 2)
+        self.assertTrue((0, 2) in edge_list_sub_block)
+        self.assertTrue((2, 1) in edge_list_sub_block)
+
+    def test_sub_blocks_and_instructions(self):
+        """test sequencing with a mix of instructions and sub blocks"""
+
+        sub_block = IrBlock(SequentialAlignment())
+        sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        ir_example = IrBlock(SequentialAlignment())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+        ir_example.append(sub_block)
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(2))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+
+        edge_list = ir_example.sequence.edge_list()
+        self.assertEqual(len(edge_list), 4)
+        self.assertTrue((0, 2) in edge_list)
+        self.assertTrue((2, 3) in edge_list)
+        self.assertTrue((3, 4) in edge_list)
+        self.assertTrue((4, 1) in edge_list)
+
+    def test_align_sequential(self):
+        """test sequencing with AlignSequential"""
+
+        sub_block = IrBlock(SequentialAlignment())
+        sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        ir_example = IrBlock(SequentialAlignment())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+        ir_example.append(sub_block)
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(2))))
+
+        ir_example_specific = copy.deepcopy(ir_example)
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example_specific, property_set)
+        ir_example_specific = sequence_pass(ir_example_specific, property_set)
+
+        edge_list = ir_example.sequence.edge_list()
+        edge_list_specific = ir_example_specific.sequence.edge_list()
+        self.assertEqual(edge_list, edge_list_specific)
 
 
 class TestSchedulePassAlignLeft(QiskitTestCase):
@@ -488,7 +628,7 @@ class TestSchedulePassAlignLeft(QiskitTestCase):
         self.assertEqual(ir_example.final_time(), 100)
 
     def test_with_sequential_sub_block_with_more_dependencies(self):
-        """test with a sub block which depends on a single previous instruction"""
+        """test with a sub block which depends on a several previous instruction"""
 
         sub_block = IrBlock(AlignLeft())
         sub_block.append(Delay(100, target=Qubit(0)))
@@ -512,3 +652,234 @@ class TestSchedulePassAlignLeft(QiskitTestCase):
         self.assertEqual(ir_example.scheduled_elements()[2][0], 0)
         self.assertEqual(ir_example.scheduled_elements()[3][0], 200)
         self.assertEqual(ir_example.scheduled_elements()[4][0], 100)
+
+
+class TestSchedulePassAlignRight(QiskitTestCase):
+    """Test schedule_pass with align right"""
+
+    def test_single_instruction(self):
+        """test with a single instruction"""
+
+        ir_example = IrBlock(AlignRight())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+        self.assertEqual(ir_example.initial_time(), 0)
+        self.assertEqual(ir_example.final_time(), 100)
+
+    def test_parallel_instructions(self):
+        """test with two parallel instructions"""
+
+        ir_example = IrBlock(AlignRight())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(Play(Constant(200, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+        self.assertEqual(ir_example.initial_time(), 0)
+        self.assertEqual(ir_example.final_time(), 200)
+        self.assertEqual(ir_example.scheduled_elements()[0][0], 100)
+        self.assertEqual(ir_example.scheduled_elements()[1][0], 0)
+
+    def test_sequential_instructions(self):
+        """test with two sequential instructions"""
+
+        ir_example = IrBlock(AlignRight())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+        self.assertEqual(ir_example.initial_time(), 0)
+        self.assertEqual(ir_example.final_time(), 200)
+        self.assertEqual(ir_example.scheduled_elements()[0][0], 0)
+        self.assertEqual(ir_example.scheduled_elements()[1][0], 100)
+
+    def test_multiple_children(self):
+        """test for a graph where one node has several children"""
+
+        ir_example = IrBlock(AlignRight())
+        ir_example.append(Delay(100, target=Qubit(0)))
+        ir_example.append(Play(Constant(200, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(2))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+        self.assertEqual(ir_example.initial_time(), 0)
+        self.assertEqual(ir_example.final_time(), 300)
+        self.assertEqual(ir_example.scheduled_elements()[0][0], 0)
+        self.assertEqual(ir_example.scheduled_elements()[1][0], 100)
+        self.assertEqual(ir_example.scheduled_elements()[2][0], 200)
+
+    def test_multiple_parents(self):
+        """test for a graph where one node has several parents"""
+
+        ir_example = IrBlock(AlignRight())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(Play(Constant(200, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(2))))
+        ir_example.append(Delay(100, target=Qubit(0)))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+        self.assertEqual(ir_example.initial_time(), 0)
+        self.assertEqual(ir_example.final_time(), 300)
+        self.assertEqual(ir_example.scheduled_elements()[0][0], 100)
+        self.assertEqual(ir_example.scheduled_elements()[1][0], 0)
+        self.assertEqual(ir_example.scheduled_elements()[2][0], 200)
+
+    def test_recursion_to_sub_blocks(self):
+        """test that scheduling is recursively applied to sub blocks which are first in the order"""
+
+        sub_block = IrBlock(AlignRight())
+        sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        ir_example = IrBlock(AlignRight())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+        ir_example.append(sub_block)
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+
+        sub_block = ir_example.elements()[1]
+        # Note that sub blocks are oblivious to their relative timing
+        self.assertEqual(sub_block.initial_time(), 0)
+        self.assertEqual(sub_block.final_time(), 100)
+        self.assertEqual(sub_block.scheduled_elements()[0][0], 0)
+
+    def test_with_parallel_sub_block(self):
+        """test with a sub block which doesn't depend on previous instructions"""
+
+        sub_block = IrBlock(AlignRight())
+        sub_block.append(Play(Constant(200, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        ir_example = IrBlock(AlignRight())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+        ir_example.append(sub_block)
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+
+        self.assertEqual(ir_example.initial_time(), 0)
+        self.assertEqual(ir_example.final_time(), 200)
+        self.assertEqual(ir_example._time_table[2], 100)
+        self.assertEqual(ir_example._time_table[3], 0)
+
+    def test_with_sequential_sub_block_with_more_dependencies(self):
+        """test with a sub block which depends on a several previous instruction"""
+
+        sub_block = IrBlock(AlignRight())
+        sub_block.append(Delay(100, target=Qubit(0)))
+
+        ir_example = IrBlock(AlignRight())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+        ir_example.append(Play(Constant(200, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
+        ir_example.append(sub_block)
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+
+        self.assertEqual(ir_example.initial_time(), 0)
+        self.assertEqual(ir_example.final_time(), 300)
+        self.assertEqual(ir_example.scheduled_elements()[0][0], 100)
+        self.assertEqual(ir_example.scheduled_elements()[1][0], 0)
+        self.assertEqual(ir_example.scheduled_elements()[2][0], 100)
+        self.assertEqual(ir_example.scheduled_elements()[3][0], 200)
+        self.assertEqual(ir_example.scheduled_elements()[4][0], 200)
+
+
+class TestSchedulePassAlignSequential(QiskitTestCase):
+    """Test schedule_pass with align sequential"""
+
+    def test_single_instruction(self):
+        """test with a single instruction"""
+
+        ir_example = IrBlock(AlignSequential())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+        self.assertEqual(ir_example.initial_time(), 0)
+        self.assertEqual(ir_example.final_time(), 100)
+
+    def test_several_instructions(self):
+        """test with several instructions"""
+
+        ir_example = IrBlock(AlignSequential())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        ir_example.append(Play(Constant(200, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+        self.assertEqual(ir_example.initial_time(), 0)
+        self.assertEqual(ir_example.final_time(), 400)
+        self.assertEqual(ir_example.scheduled_elements()[0][0], 0)
+        self.assertEqual(ir_example.scheduled_elements()[1][0], 100)
+        self.assertEqual(ir_example.scheduled_elements()[2][0], 300)
+
+    def test_recursion_to_sub_blocks(self):
+        """test that scheduling is recursively applied to sub blocks"""
+
+        sub_block = IrBlock(AlignSequential())
+        sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+
+        ir_example = IrBlock(AlignSequential())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+        ir_example.append(sub_block)
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+
+        sub_block = ir_example.elements()[1]
+        # Note that sub blocks are oblivious to their relative timing
+        self.assertEqual(sub_block.initial_time(), 0)
+        self.assertEqual(sub_block.final_time(), 100)
+        self.assertEqual(sub_block.scheduled_elements()[0][0], 0)
+
+    def test_with_instructions_and_sub_blocks(self):
+        """test that scheduling is recursively applied to sub blocks"""
+
+        sub_block = IrBlock(AlignSequential())
+        sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
+        sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+
+        ir_example = IrBlock(AlignSequential())
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+        ir_example.append(sub_block)
+        ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+
+        self.assertEqual(ir_example.initial_time(), 0)
+        self.assertEqual(ir_example.final_time(), 400)
+        self.assertEqual(ir_example.scheduled_elements()[0][0], 0)
+        self.assertEqual(ir_example.scheduled_elements()[1][0], 100)
+        self.assertEqual(ir_example.scheduled_elements()[2][0], 300)

--- a/test/python/pulse/test_pulse_compiler_passes.py
+++ b/test/python/pulse/test_pulse_compiler_passes.py
@@ -24,7 +24,7 @@ from qiskit.pulse import (
 )
 
 from qiskit.pulse.ir import (
-    IrBlock,
+    SequenceIR,
 )
 
 from qiskit.pulse.ir.alignments import (
@@ -43,7 +43,7 @@ class TestAnalyzeTargetFramePass(QiskitTestCase):
 
     def test_basic_ir(self):
         """test with basic IR"""
-        ir_example = IrBlock(AlignLeft())
+        ir_example = SequenceIR(AlignLeft())
         mf = MixedFrame(Qubit(0), QubitFrame(1))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=mf))
 
@@ -66,7 +66,7 @@ class TestAnalyzeTargetFramePass(QiskitTestCase):
 
     def test_with_several_inst_target_types(self):
         """test with different inst_target types"""
-        ir_example = IrBlock(AlignLeft())
+        ir_example = SequenceIR(AlignLeft())
         mf = MixedFrame(Qubit(0), QubitFrame(1))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=mf))
         ir_example.append(Delay(100, target=Qubit(2)))
@@ -85,10 +85,10 @@ class TestAnalyzeTargetFramePass(QiskitTestCase):
         mf2 = MixedFrame(Qubit(0), QubitFrame(1))
         mf3 = MixedFrame(Qubit(0), QubitFrame(2))
 
-        sub_block_2 = IrBlock(AlignLeft())
+        sub_block_2 = SequenceIR(AlignLeft())
         sub_block_2.append(Play(Constant(100, 0.1), mixed_frame=mf1))
 
-        sub_block_1 = IrBlock(AlignLeft())
+        sub_block_1 = SequenceIR(AlignLeft())
         sub_block_1.append(Play(Constant(100, 0.1), mixed_frame=mf2))
         sub_block_1.append(sub_block_2)
 
@@ -100,7 +100,7 @@ class TestAnalyzeTargetFramePass(QiskitTestCase):
         self.assertEqual(mapping[QubitFrame(0)], {mf1})
         self.assertEqual(mapping[QubitFrame(1)], {mf2})
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = SequenceIR(AlignLeft())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=mf3))
         ir_example.append(sub_block_1)
 
@@ -121,7 +121,7 @@ class TestSequenceParallelAlignment(QiskitTestCase):
     def test_single_instruction(self):
         """test with a single instruction"""
 
-        ir_example = IrBlock(ParallelAlignment())
+        ir_example = SequenceIR(ParallelAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
         property_set = {}
@@ -136,7 +136,7 @@ class TestSequenceParallelAlignment(QiskitTestCase):
     # def test_instruction_not_in_mapping(self):
     #     """test with an instruction which is not in the mapping"""
     #
-    #     ir_example = IrBlock(AlignLeft())
+    #     ir_example = SequenceIR(AlignLeft())
     #     ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
     #     ir_example.append(Delay(100, target=Qubit(5)))
     #
@@ -153,7 +153,7 @@ class TestSequenceParallelAlignment(QiskitTestCase):
     def test_parallel_instructions(self):
         """test with two parallel instructions"""
 
-        ir_example = IrBlock(ParallelAlignment())
+        ir_example = SequenceIR(ParallelAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
 
@@ -170,7 +170,7 @@ class TestSequenceParallelAlignment(QiskitTestCase):
     def test_sequential_instructions(self):
         """test with two sequential instructions"""
 
-        ir_example = IrBlock(ParallelAlignment())
+        ir_example = SequenceIR(ParallelAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
@@ -187,7 +187,7 @@ class TestSequenceParallelAlignment(QiskitTestCase):
         """test with an instruction which is defined on a PulseTarget and is
         broadcasted to several children"""
 
-        ir_example = IrBlock(ParallelAlignment())
+        ir_example = SequenceIR(ParallelAlignment())
         ir_example.append(Delay(100, target=Qubit(0)))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(2))))
@@ -206,7 +206,7 @@ class TestSequenceParallelAlignment(QiskitTestCase):
     def test_frame_instruction_broadcasting_to_children(self):
         """test with an instruction which is defined on a Frame and is broadcasted to several children"""
 
-        ir_example = IrBlock(ParallelAlignment())
+        ir_example = SequenceIR(ParallelAlignment())
         ir_example.append(ShiftPhase(100, frame=QubitFrame(0)))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(0))))
@@ -226,7 +226,7 @@ class TestSequenceParallelAlignment(QiskitTestCase):
         """test with an instruction which is defined on a PulseTarget and depends on
         several mixed frames"""
 
-        ir_example = IrBlock(ParallelAlignment())
+        ir_example = SequenceIR(ParallelAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(2))))
         ir_example.append(Delay(100, target=Qubit(0)))
@@ -245,7 +245,7 @@ class TestSequenceParallelAlignment(QiskitTestCase):
     def test_frame_instruction_dependency(self):
         """test with an instruction which is defined on a Frame and depends on several mixed frames"""
 
-        ir_example = IrBlock(ParallelAlignment())
+        ir_example = SequenceIR(ParallelAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(0))))
         ir_example.append(ShiftPhase(100, frame=QubitFrame(0)))
@@ -264,10 +264,10 @@ class TestSequenceParallelAlignment(QiskitTestCase):
     def test_recursion_to_sub_blocks(self):
         """test that sequencing is recursively applied to sub blocks"""
 
-        sub_block = IrBlock(ParallelAlignment())
+        sub_block = SequenceIR(ParallelAlignment())
         sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
-        ir_example = IrBlock(ParallelAlignment())
+        ir_example = SequenceIR(ParallelAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(sub_block)
 
@@ -283,10 +283,10 @@ class TestSequenceParallelAlignment(QiskitTestCase):
     def test_with_parallel_sub_block(self):
         """test with a sub block which doesn't depend on previous instructions"""
 
-        sub_block = IrBlock(ParallelAlignment())
+        sub_block = SequenceIR(ParallelAlignment())
         sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
-        ir_example = IrBlock(ParallelAlignment())
+        ir_example = SequenceIR(ParallelAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(sub_block)
 
@@ -303,10 +303,10 @@ class TestSequenceParallelAlignment(QiskitTestCase):
     def test_with_simple_sequential_sub_block(self):
         """test with a sub block which depends on a single previous instruction"""
 
-        sub_block = IrBlock(ParallelAlignment())
+        sub_block = SequenceIR(ParallelAlignment())
         sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
-        ir_example = IrBlock(ParallelAlignment())
+        ir_example = SequenceIR(ParallelAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(sub_block)
@@ -325,10 +325,10 @@ class TestSequenceParallelAlignment(QiskitTestCase):
     def test_with_sequential_sub_block_with_more_dependencies(self):
         """test with a sub block which depends on a single previous instruction"""
 
-        sub_block = IrBlock(ParallelAlignment())
+        sub_block = SequenceIR(ParallelAlignment())
         sub_block.append(Delay(100, target=Qubit(0)))
 
-        ir_example = IrBlock(ParallelAlignment())
+        ir_example = SequenceIR(ParallelAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
@@ -354,10 +354,10 @@ class TestSequenceParallelAlignment(QiskitTestCase):
     def test_specific_alignments(self, alignment):
         """Test that specific alignments are the same as parallel alignment"""
 
-        sub_block = IrBlock(ParallelAlignment())
+        sub_block = SequenceIR(ParallelAlignment())
         sub_block.append(Delay(100, target=Qubit(0)))
 
-        ir_example = IrBlock(ParallelAlignment())
+        ir_example = SequenceIR(ParallelAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
@@ -384,7 +384,7 @@ class TestSequenceSequentialAlignment(QiskitTestCase):
     def test_single_instruction(self):
         """test with a single instruction"""
 
-        ir_example = IrBlock(SequentialAlignment())
+        ir_example = SequenceIR(SequentialAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
         property_set = {}
@@ -398,7 +398,7 @@ class TestSequenceSequentialAlignment(QiskitTestCase):
     def test_several_instructions(self):
         """test with several instructions"""
 
-        ir_example = IrBlock(SequentialAlignment())
+        ir_example = SequenceIR(SequentialAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(2), QubitFrame(1))))
@@ -416,10 +416,10 @@ class TestSequenceSequentialAlignment(QiskitTestCase):
     def test_recursion_to_sub_blocks(self):
         """test that sequencing is recursively applied to sub blocks"""
 
-        sub_block = IrBlock(SequentialAlignment())
+        sub_block = SequenceIR(SequentialAlignment())
         sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
-        ir_example = IrBlock(SequentialAlignment())
+        ir_example = SequenceIR(SequentialAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(sub_block)
 
@@ -435,10 +435,10 @@ class TestSequenceSequentialAlignment(QiskitTestCase):
     def test_sub_blocks_and_instructions(self):
         """test sequencing with a mix of instructions and sub blocks"""
 
-        sub_block = IrBlock(SequentialAlignment())
+        sub_block = SequenceIR(SequentialAlignment())
         sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
-        ir_example = IrBlock(SequentialAlignment())
+        ir_example = SequenceIR(SequentialAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(sub_block)
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(2))))
@@ -457,10 +457,10 @@ class TestSequenceSequentialAlignment(QiskitTestCase):
     def test_align_sequential(self):
         """test sequencing with AlignSequential"""
 
-        sub_block = IrBlock(SequentialAlignment())
+        sub_block = SequenceIR(SequentialAlignment())
         sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
-        ir_example = IrBlock(SequentialAlignment())
+        ir_example = SequenceIR(SequentialAlignment())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(sub_block)
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(2))))
@@ -486,7 +486,7 @@ class TestSchedulePassAlignLeft(QiskitTestCase):
     def test_single_instruction(self):
         """test with a single instruction"""
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = SequenceIR(AlignLeft())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
         property_set = {}
@@ -499,7 +499,7 @@ class TestSchedulePassAlignLeft(QiskitTestCase):
     def test_parallel_instructions(self):
         """test with two parallel instructions"""
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = SequenceIR(AlignLeft())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(200, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
 
@@ -515,7 +515,7 @@ class TestSchedulePassAlignLeft(QiskitTestCase):
     def test_sequential_instructions(self):
         """test with two sequential instructions"""
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = SequenceIR(AlignLeft())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
@@ -531,7 +531,7 @@ class TestSchedulePassAlignLeft(QiskitTestCase):
     def test_multiple_children(self):
         """test for a graph where one node has several children"""
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = SequenceIR(AlignLeft())
         ir_example.append(Delay(100, target=Qubit(0)))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(2))))
@@ -549,7 +549,7 @@ class TestSchedulePassAlignLeft(QiskitTestCase):
     def test_multiple_parents(self):
         """test for a graph where one node has several parents"""
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = SequenceIR(AlignLeft())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(200, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(2))))
         ir_example.append(Delay(100, target=Qubit(0)))
@@ -567,10 +567,10 @@ class TestSchedulePassAlignLeft(QiskitTestCase):
     def test_recursion_to_leading_sub_blocks(self):
         """test that scheduling is recursively applied to sub blocks which are first in the order"""
 
-        sub_block = IrBlock(AlignLeft())
+        sub_block = SequenceIR(AlignLeft())
         sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = SequenceIR(AlignLeft())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(sub_block)
 
@@ -588,10 +588,10 @@ class TestSchedulePassAlignLeft(QiskitTestCase):
     def test_recursion_to_non_leading_sub_blocks(self):
         """test that scheduling is recursively applied to sub blocks when they are not first in order"""
 
-        sub_block = IrBlock(AlignLeft())
+        sub_block = SequenceIR(AlignLeft())
         sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = SequenceIR(AlignLeft())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(sub_block)
@@ -612,10 +612,10 @@ class TestSchedulePassAlignLeft(QiskitTestCase):
     def test_with_parallel_sub_block(self):
         """test with a sub block which doesn't depend on previous instructions"""
 
-        sub_block = IrBlock(AlignLeft())
+        sub_block = SequenceIR(AlignLeft())
         sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = SequenceIR(AlignLeft())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(sub_block)
 
@@ -630,10 +630,10 @@ class TestSchedulePassAlignLeft(QiskitTestCase):
     def test_with_sequential_sub_block_with_more_dependencies(self):
         """test with a sub block which depends on a several previous instruction"""
 
-        sub_block = IrBlock(AlignLeft())
+        sub_block = SequenceIR(AlignLeft())
         sub_block.append(Delay(100, target=Qubit(0)))
 
-        ir_example = IrBlock(AlignLeft())
+        ir_example = SequenceIR(AlignLeft())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(Play(Constant(200, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
@@ -660,7 +660,7 @@ class TestSchedulePassAlignRight(QiskitTestCase):
     def test_single_instruction(self):
         """test with a single instruction"""
 
-        ir_example = IrBlock(AlignRight())
+        ir_example = SequenceIR(AlignRight())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
         property_set = {}
@@ -673,7 +673,7 @@ class TestSchedulePassAlignRight(QiskitTestCase):
     def test_parallel_instructions(self):
         """test with two parallel instructions"""
 
-        ir_example = IrBlock(AlignRight())
+        ir_example = SequenceIR(AlignRight())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(200, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
 
@@ -689,7 +689,7 @@ class TestSchedulePassAlignRight(QiskitTestCase):
     def test_sequential_instructions(self):
         """test with two sequential instructions"""
 
-        ir_example = IrBlock(AlignRight())
+        ir_example = SequenceIR(AlignRight())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
@@ -705,7 +705,7 @@ class TestSchedulePassAlignRight(QiskitTestCase):
     def test_multiple_children(self):
         """test for a graph where one node has several children"""
 
-        ir_example = IrBlock(AlignRight())
+        ir_example = SequenceIR(AlignRight())
         ir_example.append(Delay(100, target=Qubit(0)))
         ir_example.append(Play(Constant(200, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(2))))
@@ -723,7 +723,7 @@ class TestSchedulePassAlignRight(QiskitTestCase):
     def test_multiple_parents(self):
         """test for a graph where one node has several parents"""
 
-        ir_example = IrBlock(AlignRight())
+        ir_example = SequenceIR(AlignRight())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(200, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(2))))
         ir_example.append(Delay(100, target=Qubit(0)))
@@ -741,10 +741,10 @@ class TestSchedulePassAlignRight(QiskitTestCase):
     def test_recursion_to_sub_blocks(self):
         """test that scheduling is recursively applied to sub blocks which are first in the order"""
 
-        sub_block = IrBlock(AlignRight())
+        sub_block = SequenceIR(AlignRight())
         sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
-        ir_example = IrBlock(AlignRight())
+        ir_example = SequenceIR(AlignRight())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(sub_block)
 
@@ -762,10 +762,10 @@ class TestSchedulePassAlignRight(QiskitTestCase):
     def test_with_parallel_sub_block(self):
         """test with a sub block which doesn't depend on previous instructions"""
 
-        sub_block = IrBlock(AlignRight())
+        sub_block = SequenceIR(AlignRight())
         sub_block.append(Play(Constant(200, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
-        ir_example = IrBlock(AlignRight())
+        ir_example = SequenceIR(AlignRight())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(sub_block)
 
@@ -782,10 +782,10 @@ class TestSchedulePassAlignRight(QiskitTestCase):
     def test_with_sequential_sub_block_with_more_dependencies(self):
         """test with a sub block which depends on a several previous instruction"""
 
-        sub_block = IrBlock(AlignRight())
+        sub_block = SequenceIR(AlignRight())
         sub_block.append(Delay(100, target=Qubit(0)))
 
-        ir_example = IrBlock(AlignRight())
+        ir_example = SequenceIR(AlignRight())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(Play(Constant(200, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
@@ -812,7 +812,7 @@ class TestSchedulePassAlignSequential(QiskitTestCase):
     def test_single_instruction(self):
         """test with a single instruction"""
 
-        ir_example = IrBlock(AlignSequential())
+        ir_example = SequenceIR(AlignSequential())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
         property_set = {}
@@ -825,7 +825,7 @@ class TestSchedulePassAlignSequential(QiskitTestCase):
     def test_several_instructions(self):
         """test with several instructions"""
 
-        ir_example = IrBlock(AlignSequential())
+        ir_example = SequenceIR(AlignSequential())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Play(Constant(200, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(1), QubitFrame(1))))
@@ -843,10 +843,10 @@ class TestSchedulePassAlignSequential(QiskitTestCase):
     def test_recursion_to_sub_blocks(self):
         """test that scheduling is recursively applied to sub blocks"""
 
-        sub_block = IrBlock(AlignSequential())
+        sub_block = SequenceIR(AlignSequential())
         sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
 
-        ir_example = IrBlock(AlignSequential())
+        ir_example = SequenceIR(AlignSequential())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(sub_block)
 
@@ -864,11 +864,11 @@ class TestSchedulePassAlignSequential(QiskitTestCase):
     def test_with_instructions_and_sub_blocks(self):
         """test that scheduling is recursively applied to sub blocks"""
 
-        sub_block = IrBlock(AlignSequential())
+        sub_block = SequenceIR(AlignSequential())
         sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         sub_block.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
 
-        ir_example = IrBlock(AlignSequential())
+        ir_example = SequenceIR(AlignSequential())
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))
         ir_example.append(sub_block)
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(0))))

--- a/test/python/pulse/test_pulse_ir.py
+++ b/test/python/pulse/test_pulse_ir.py
@@ -30,6 +30,11 @@ from qiskit.pulse.ir import (
 
 from qiskit.pulse.ir.alignments import AlignLeft
 from qiskit.pulse.model import QubitFrame, Qubit
+from qiskit.pulse.compiler.temp_passes import (
+    sequence_pass,
+    schedule_pass,
+    analyze_target_frame_pass,
+)
 
 
 class TestIrBlock(QiskitTestCase):
@@ -135,3 +140,147 @@ class TestIrBlock(QiskitTestCase):
         self.assertEqual(ir_example.initial_time(), 100)
         self.assertEqual(ir_example.final_time(), 400)
         self.assertEqual(ir_example.duration, 300)
+
+    def test_flatten_ir_no_sub_blocks(self):
+        """Test that flattening ir with no sub blocks doesn't do anything"""
+        ir_example = IrBlock(AlignLeft())
+        inst = Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(1))
+        inst2 = Play(Constant(100, 0.5), frame=QubitFrame(2), target=Qubit(2))
+        ir_example.append(inst)
+        ir_example.append(inst2)
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+
+        self.assertEqual(ir_example.flatten(), ir_example)
+
+    def test_flatten_inplace_flag(self):
+        """Test that inplace flag in flattening works"""
+        ir_example = IrBlock(AlignLeft())
+        inst = Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(1))
+        inst2 = Play(Constant(100, 0.5), frame=QubitFrame(2), target=Qubit(2))
+        ir_example.append(inst)
+        ir_example.append(inst2)
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+
+        self.assertTrue(ir_example.flatten(inplace=True) is ir_example)
+        self.assertFalse(ir_example.flatten() is ir_example)
+
+    def test_flatten_one_sub_block(self):
+        """Test that flattening works with one block"""
+        ir_example = IrBlock(AlignLeft())
+        inst = Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(1))
+        inst2 = Play(Constant(100, 0.5), frame=QubitFrame(2), target=Qubit(2))
+        block = IrBlock(AlignLeft())
+        block.append(inst)
+        block.append(inst2)
+        ir_example.append(block)
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+
+        flat = ir_example.flatten()
+        edge_list = flat.sequence.edge_list()
+        print(edge_list)
+        self.assertEqual(len(edge_list), 4)
+        self.assertTrue((0, 5) in edge_list)
+        self.assertTrue((0, 6) in edge_list)
+        self.assertTrue((5, 1) in edge_list)
+        self.assertTrue((6, 1) in edge_list)
+
+    def test_flatten_one_sub_block_and_parallel_instruction(self):
+        """Test that flattening works with one block and parallel instruction"""
+        ir_example = IrBlock(AlignLeft())
+        inst = Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(1))
+        inst2 = Play(Constant(100, 0.5), frame=QubitFrame(2), target=Qubit(2))
+        block = IrBlock(AlignLeft())
+        block.append(inst)
+        block.append(inst2)
+        ir_example.append(block)
+        ir_example.append(Play(Constant(100, 0.5), frame=QubitFrame(3), target=Qubit(3)))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+
+        flat = ir_example.flatten()
+        edge_list = flat.sequence.edge_list()
+        self.assertEqual(len(edge_list), 6)
+        self.assertTrue((0, 3) in edge_list)
+        self.assertTrue((3, 1) in edge_list)
+        self.assertTrue((0, 6) in edge_list)
+        self.assertTrue((0, 7) in edge_list)
+        self.assertTrue((6, 1) in edge_list)
+        self.assertTrue((7, 1) in edge_list)
+
+    def test_flatten_one_sub_block_and_sequential_instructions(self):
+        """Test that flattening works with one block and sequential instructions"""
+        ir_example = IrBlock(AlignLeft())
+        inst = Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(1))
+        inst2 = Play(Constant(100, 0.5), frame=QubitFrame(2), target=Qubit(2))
+        block = IrBlock(AlignLeft())
+        block.append(inst)
+        block.append(inst2)
+        ir_example.append(Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(1)))
+        ir_example.append(block)
+        ir_example.append(Play(Constant(100, 0.5), frame=QubitFrame(2), target=Qubit(2)))
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+
+        flat = ir_example.flatten()
+        edge_list = flat.sequence.edge_list()
+        self.assertEqual(len(edge_list), 8)
+        self.assertTrue((0, 2) in edge_list)
+        self.assertTrue((4, 1) in edge_list)
+        self.assertTrue((2, 7) in edge_list)
+        self.assertTrue((2, 8) in edge_list)
+        self.assertTrue((7, 1) in edge_list)
+        self.assertTrue((8, 1) in edge_list)
+        self.assertTrue((7, 4) in edge_list)
+        self.assertTrue((8, 4) in edge_list)
+
+    def test_flatten_two_levels(self):
+        """Test that flattening works with one block and sequential instructions"""
+        inst = Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(1))
+
+        block1 = IrBlock(AlignLeft())
+        block1.append(inst)
+        block = IrBlock(AlignLeft())
+        block.append(inst)
+        block.append(block1)
+
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(inst)
+        ir_example.append(block)
+
+        property_set = {}
+        analyze_target_frame_pass(ir_example, property_set)
+        ir_example = sequence_pass(ir_example, property_set)
+        ir_example = schedule_pass(ir_example, property_set)
+
+        flat = ir_example.flatten()
+        edge_list = flat.sequence.edge_list()
+        self.assertEqual(len(edge_list), 4)
+        self.assertTrue((0, 2) in edge_list)
+        self.assertTrue((2, 6) in edge_list)
+        self.assertTrue((6, 7) in edge_list)
+        self.assertTrue((7, 1) in edge_list)
+        self.assertEqual(flat.scheduled_elements()[0], [0, inst])
+        self.assertEqual(flat.scheduled_elements()[1], [100, inst])
+        self.assertEqual(flat.scheduled_elements()[2], [200, inst])
+
+    # TODO : Test IrBlock equating. Problem with Alignment, and possibly InNode,OutNode.
+
+    # TODO : Test IrBlock.draw()

--- a/test/python/pulse/test_pulse_ir.py
+++ b/test/python/pulse/test_pulse_ir.py
@@ -11,13 +11,11 @@
 # that they have been altered from the originals.
 
 """Test pulse IR"""
-import copy
 
 from test import QiskitTestCase
 from qiskit.pulse import (
     Constant,
     MemorySlot,
-    PulseError,
     Play,
     Delay,
     Acquire,
@@ -27,334 +25,113 @@ from qiskit.pulse import (
 )
 
 from qiskit.pulse.ir import (
-    IrInstruction,
     IrBlock,
 )
 
-from qiskit.pulse.transforms import AlignSequential, AlignLeft
-
-
-class TestIrInstruction(QiskitTestCase):
-    """Test IR Instruction"""
-
-    _play_inst = Play(Constant(100, 0.5), channel=DriveChannel(1))
-
-    def test_instruction_creation(self):
-        """Test ir instruction creation"""
-        ir_inst = IrInstruction(self._play_inst)
-        self.assertEqual(ir_inst.initial_time, None)
-        self.assertEqual(ir_inst.duration, 100)
-        self.assertEqual(ir_inst.duration, self._play_inst.duration)
-        self.assertEqual(ir_inst.instruction, self._play_inst)
-
-        ir_inst = IrInstruction(self._play_inst, initial_time=100)
-        self.assertEqual(ir_inst.initial_time, 100)
-        self.assertEqual(ir_inst.final_time, 200)
-
-    def test_instruction_creation_invalid_initial_time(self):
-        """Test that instructions can't be constructed with invalid initial_time"""
-        with self.assertRaises(PulseError):
-            IrInstruction(self._play_inst, initial_time=0.5)
-
-        with self.assertRaises(PulseError):
-            IrInstruction(self._play_inst, initial_time=-1)
-
-    def test_initial_time_update(self):
-        """Test that initial_time update is done and validated correctly"""
-        ir_inst = IrInstruction(self._play_inst)
-
-        ir_inst.initial_time = 50
-        self.assertEqual(ir_inst.initial_time, 50)
-
-        with self.assertRaises(PulseError):
-            ir_inst.initial_time = -10
-        with self.assertRaises(PulseError):
-            ir_inst.initial_time = 0.5
-
-    def test_instruction_shift_initial_time(self):
-        """Test that shifting initial_time is done correctly"""
-        initial_time = 10
-        shift = 15
-
-        ir_inst = IrInstruction(self._play_inst)
-
-        with self.assertRaises(PulseError):
-            ir_inst.shift_initial_time(shift)
-
-        ir_inst = IrInstruction(self._play_inst, initial_time=initial_time)
-        ir_inst.shift_initial_time(shift)
-
-        self.assertEqual(ir_inst.initial_time, initial_time + shift)
-
-        with self.assertRaises(PulseError):
-            ir_inst.shift_initial_time(0.5)
-
-    def test_final_time_unscheduled(self):
-        """Test that final time is returned as None if unscheduled"""
-        ir_inst = IrInstruction(self._play_inst)
-        self.assertEqual(ir_inst.final_time, None)
-
-    def test_repr(self):
-        """Test repr"""
-        ir_inst = IrInstruction(self._play_inst)
-        self.assertEqual(
-            str(ir_inst),
-            "IrInstruction(Play(Constant(duration=100, amp=0.5, angle=0.0), DriveChannel(1)), t0=None)",
-        )
-
-        ir_inst = IrInstruction(self._play_inst, 100)
-        self.assertEqual(
-            str(ir_inst),
-            "IrInstruction(Play(Constant(duration=100, amp=0.5, angle=0.0), DriveChannel(1)), t0=100)",
-        )
+from qiskit.pulse.ir.alignments import AlignLeft
+from qiskit.pulse.model import QubitFrame, Qubit
 
 
 class TestIrBlock(QiskitTestCase):
     """Test IrBlock objects"""
 
     _delay_inst = Delay(50, channel=DriveChannel(0))
-    _play_inst = Play(Constant(100, 0.5), channel=DriveChannel(1))
+    _play_inst = Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(1))
     _shift_phase_inst = ShiftPhase(0.1, channel=DriveChannel(3))
     _acquire_inst = Acquire(200, channel=AcquireChannel(2), mem_slot=MemorySlot(4))
 
-    def ir_creation(self):
+    def test_ir_creation(self):
         """Test ir creation"""
-        ir_example = IrBlock(AlignSequential())
-        self.assertEqual(ir_example.alignment, AlignSequential())
-        self.assertEqual(len(ir_example), 0)
+        ir_example = IrBlock(AlignLeft())
+        self.assertEqual(ir_example.sequence.num_nodes(), 2)
+        self.assertEqual(ir_example.initial_time(), None)
+        self.assertEqual(ir_example.final_time(), None)
+        self.assertEqual(ir_example.duration, None)
 
-    def test_add_instruction(self):
-        """Test adding single instruction"""
+    def test_add_elements(self):
+        """Test addition of elements"""
+        ir_example = IrBlock(AlignLeft())
+        inst = Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(1))
+        ir_example.append(inst)
 
-        pulse_ir = IrBlock(AlignLeft())
-        ir_inst = IrInstruction(self._play_inst)
-        pulse_ir.add_element(ir_inst)
-        self.assertEqual(pulse_ir.elements[0], ir_inst)
-        ir_inst = IrInstruction(self._delay_inst)
-        pulse_ir.add_element(ir_inst)
-        self.assertEqual(pulse_ir.elements[1], ir_inst)
-        self.assertEqual(len(pulse_ir), 2)
+        self.assertEqual(ir_example.sequence.num_nodes(), 3)
+        self.assertEqual(ir_example.elements()[0], inst)
 
-    def test_add_instruction_list(self):
-        """Test adding instruction list"""
+        inst = Play(Constant(100, 0.5), frame=QubitFrame(2), target=Qubit(2))
+        ir_example.append(inst)
+        self.assertEqual(ir_example.sequence.num_nodes(), 4)
+        self.assertEqual(len(ir_example.elements()), 2)
+        self.assertEqual(ir_example.elements()[1], inst)
 
-        pulse_ir = IrBlock(AlignLeft())
-        inst_list = [
-            IrInstruction(self._play_inst),
-            IrInstruction(self._delay_inst),
-            IrInstruction(self._acquire_inst),
-        ]
+    def test_initial_time(self):
+        """Test initial time"""
+        ir_example = IrBlock(AlignLeft())
+        inst = Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(1))
+        ir_example.append(inst)
+        ir_example.append(inst)
+        ir_example.append(inst)
+        ir_example._time_table[2] = 100
+        ir_example._time_table[3] = 200
+        # Just for the sake of the test. The minimal initial time has to have an edge with 0.
+        ir_example._time_table[4] = 50
+        ir_example._sequence.add_edge(0, 2, None)
+        ir_example._sequence.add_edge(0, 3, None)
+        self.assertEqual(ir_example.initial_time(), 100)
 
-        pulse_ir.add_element(inst_list)
+        ir_example._time_table[3] = 0
+        self.assertEqual(ir_example.initial_time(), 0)
 
-        self.assertEqual(pulse_ir.elements, inst_list)
-        self.assertEqual(len(pulse_ir), 3)
+    def test_final_time(self):
+        """Test final time"""
+        ir_example = IrBlock(AlignLeft())
+        inst = Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(1))
+        ir_example.append(inst)
+        ir_example.append(inst)
+        ir_example.append(inst)
+        # Just for the sake of the test. The maximal final time has to have an edge with 1.
+        ir_example._time_table[2] = 1000
+        ir_example._time_table[3] = 100
+        ir_example._time_table[4] = 200
+        ir_example._sequence.add_edge(3, 1, None)
+        ir_example._sequence.add_edge(4, 1, None)
+        self.assertEqual(ir_example.final_time(), 300)
 
-    def test_add_sub_block(self):
-        """Test adding sub block"""
+    def test_duration(self):
+        """Test duration"""
+        ir_example = IrBlock(AlignLeft())
+        inst = Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(1))
+        ir_example.append(inst)
+        ir_example.append(inst)
+        ir_example._time_table[2] = 100
+        ir_example._time_table[3] = 300
+        ir_example._sequence.add_edge(0, 2, None)
+        ir_example._sequence.add_edge(3, 1, None)
 
-        pulse_ir = IrBlock(AlignLeft())
-        pulse_ir.add_element(IrInstruction(self._play_inst))
+        self.assertEqual(ir_example.initial_time(), 100)
+        self.assertEqual(ir_example.final_time(), 400)
+        self.assertEqual(ir_example.duration, 300)
 
-        block = IrBlock(AlignLeft())
-        block.add_element(IrInstruction(self._delay_inst))
-        pulse_ir.add_element(block)
+    def test_duration_with_sub_block(self):
+        """Test duration with sub block"""
+        inst = Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(1))
+        sub_block = IrBlock(AlignLeft())
+        sub_block.append(inst)
+        sub_block._time_table[2] = 0
+        sub_block._sequence.add_edge(0, 2, None)
+        sub_block._sequence.add_edge(2, 1, None)
 
-        self.assertEqual(pulse_ir.elements[1], block)
-        self.assertEqual(len(pulse_ir), 2)
+        self.assertEqual(sub_block.initial_time(), 0)
+        self.assertEqual(sub_block.final_time(), 100)
+        self.assertEqual(sub_block.duration, 100)
 
-    def test_get_initial_time(self):
-        """Test initial_time is returned correctly"""
+        ir_example = IrBlock(AlignLeft())
+        ir_example.append(inst)
+        ir_example.append(sub_block)
+        ir_example._time_table[2] = 100
+        ir_example._time_table[3] = 300
+        ir_example._sequence.add_edge(0, 2, None)
+        ir_example._sequence.add_edge(3, 1, None)
 
-        pulse_ir = IrBlock(AlignLeft())
-        # Empty IR defaults to None
-        self.assertEqual(pulse_ir.initial_time, None)
-
-        pulse_ir.add_element(IrInstruction(self._play_inst, initial_time=100))
-        pulse_ir.add_element(IrInstruction(self._delay_inst, initial_time=50))
-        self.assertEqual(pulse_ir.initial_time, 50)
-
-        # Test recursion initial_time
-        block = IrBlock(AlignLeft())
-        block.add_element(IrInstruction(self._shift_phase_inst, initial_time=20))
-        pulse_ir.add_element(block)
-        self.assertEqual(pulse_ir.initial_time, 20)
-
-        # If any instruction is not scheduled, initial_time is none
-        pulse_ir.add_element(IrInstruction(self._acquire_inst))
-        self.assertEqual(pulse_ir.initial_time, None)
-
-    def test_shift_initial_time(self):
-        """Test shift initial_time"""
-        pulse_ir = IrBlock(AlignLeft())
-        pulse_ir.add_element(IrInstruction(self._play_inst))
-
-        # Can't shift initial_time of IR with unscheduled instructions.
-        with self.assertRaises(PulseError):
-            pulse_ir.shift_initial_time(100)
-
-        pulse_ir.elements[0].initial_time = 1000
-        pulse_ir.add_element(IrInstruction(self._delay_inst, initial_time=500))
-        pulse_ir.shift_initial_time(100)
-        self.assertEqual(pulse_ir.initial_time, 600)
-        self.assertEqual(pulse_ir.elements[0].initial_time, 1100)
-        self.assertEqual(pulse_ir.elements[1].initial_time, 600)
-
-        with self.assertRaises(PulseError):
-            pulse_ir.shift_initial_time(0.5)
-
-    def test_shift_initial_time_with_sub_blocks(self):
-        """Test shift initial_time with sub blocks"""
-        pulse_ir = IrBlock(AlignLeft())
-        pulse_ir.add_element(IrInstruction(self._play_inst, 100))
-        pulse_ir.add_element(IrInstruction(self._play_inst, 200))
-        block = copy.deepcopy(pulse_ir)
-        block.shift_initial_time(1000)
-        pulse_ir.add_element(block)
-        pulse_ir.shift_initial_time(100)
-        self.assertEqual(pulse_ir.elements[0].initial_time, 200)
-        self.assertEqual(pulse_ir.elements[1].initial_time, 300)
-        self.assertEqual(pulse_ir.elements[2].elements[0].initial_time, 1200)
-        self.assertEqual(pulse_ir.elements[2].elements[1].initial_time, 1300)
-
-    def test_get_final_time(self):
-        """Test final time is returned correctly"""
-
-        pulse_ir = IrBlock(AlignLeft())
-        # Empty IR defaults to None
-        self.assertEqual(pulse_ir.final_time, None)
-
-        pulse_ir.add_element(IrInstruction(self._delay_inst, initial_time=500))
-        pulse_ir.add_element(IrInstruction(self._play_inst, initial_time=1000))
-        self.assertEqual(pulse_ir.final_time, 1000 + self._play_inst.duration)
-
-        # Recursion final time
-        block = IrBlock(AlignLeft())
-        block.add_element(IrInstruction(self._shift_phase_inst, initial_time=2000))
-        pulse_ir.add_element(block)
-        self.assertEqual(pulse_ir.final_time, 2000)
-
-        # If any instruction is not scheduled, final time is none
-        pulse_ir.add_element(IrInstruction(self._shift_phase_inst))
-        self.assertEqual(pulse_ir.initial_time, None)
-
-    def test_get_duration(self):
-        """Test that duration is calculated and returned correctly"""
-        pulse_ir = IrBlock(AlignLeft())
-        pulse_ir.add_element(
-            [
-                IrInstruction(self._delay_inst, initial_time=10),
-                IrInstruction(self._play_inst, initial_time=100),
-            ]
-        )
-        self.assertEqual(pulse_ir.duration, 190)
-
-    def test_get_duration_with_sub_blocks(self):
-        """Test that duration is calculated and returned correctly with sub blocks"""
-        pulse_ir = IrBlock(AlignLeft())
-        pulse_ir.add_element(
-            [
-                IrInstruction(self._delay_inst, initial_time=10),
-                IrInstruction(self._play_inst, initial_time=100),
-            ]
-        )
-        block = IrBlock(AlignLeft())
-        block.add_element(IrInstruction(self._play_inst, 200))
-        pulse_ir.add_element(block)
-        self.assertEqual(pulse_ir.duration, 290)
-
-    def test_get_duration_unscheduled(self):
-        """Test that duration is returned as None if something is not scheduled"""
-        pulse_ir = IrBlock(AlignLeft())
-        pulse_ir.add_element(
-            [
-                IrInstruction(self._delay_inst, initial_time=10),
-                IrInstruction(self._play_inst),
-            ]
-        )
-        self.assertEqual(pulse_ir.duration, None)
-
-    def test_has_child(self):
-        """Test that has_child_IR method works correctly"""
-        pulse_ir = IrBlock(AlignLeft())
-        self.assertFalse(pulse_ir.has_child_ir())
-
-        pulse_ir.add_element(IrInstruction(self._shift_phase_inst, initial_time=2000))
-        self.assertFalse(pulse_ir.has_child_ir())
-
-        block = IrBlock(AlignLeft())
-        pulse_ir.add_element(block)
-        self.assertTrue(pulse_ir.has_child_ir())
-
-    def test_ir_comparison_no_sub_blocks(self):
-        """Test that ir is compared correctly with no sub blocks"""
-        pulse_ir = IrBlock(AlignLeft())
-        pulse_ir.add_element(
-            [
-                IrInstruction(self._delay_inst, initial_time=10),
-                IrInstruction(self._play_inst, initial_time=100),
-            ]
-        )
-        ref = copy.deepcopy(pulse_ir)
-        self.assertEqual(pulse_ir, ref)
-
-        # One element is different
-        ref.elements[0] = IrInstruction(self._shift_phase_inst, initial_time=50)
-        self.assertNotEqual(pulse_ir, ref)
-
-        # Extra element
-        ref = copy.deepcopy(pulse_ir)
-        ref.add_element(IrInstruction(self._shift_phase_inst, initial_time=50))
-        self.assertNotEqual(pulse_ir, ref)
-
-        # Different alignment
-        ref = copy.deepcopy(pulse_ir)
-        ref._alignment = AlignLeft
-        self.assertNotEqual(pulse_ir, ref)
-
-    def test_ir_comparison_with_sub_blocks(self):
-        """Test that ir is compared correctly with sub blocks"""
-        pulse_ir = IrBlock(AlignLeft())
-        pulse_ir.add_element(
-            [
-                IrInstruction(self._delay_inst, initial_time=10),
-                IrInstruction(self._play_inst, initial_time=100),
-            ]
-        )
-        block = IrBlock(AlignLeft())
-        pulse_ir.add_element(block)
-
-        # empty sub block
-        ref = copy.deepcopy(pulse_ir)
-        self.assertEqual(pulse_ir, ref)
-
-        # sub block has extra element
-        ref.elements[2].add_element(IrInstruction(self._shift_phase_inst, initial_time=500))
-        self.assertNotEqual(pulse_ir, ref)
-
-        # sub block is identical
-        pulse_ir.elements[2].add_element(IrInstruction(self._shift_phase_inst, initial_time=500))
-        self.assertEqual(pulse_ir, ref)
-
-    def test_repr(self):
-        """Test repr"""
-        pulse_ir = IrBlock(AlignLeft())
-        pulse_ir.add_element(
-            [
-                IrInstruction(self._play_inst),
-                IrInstruction(self._play_inst),
-                IrInstruction(self._play_inst),
-            ]
-        )
-        self.assertEqual(str(pulse_ir), "IrBlock(AlignLeft(), 3 IrInstructions)")
-        block = IrBlock(AlignLeft())
-        block.add_element(IrInstruction(self._delay_inst, 100))
-        pulse_ir.add_element(block)
-        self.assertEqual(str(pulse_ir), "IrBlock(AlignLeft(), 3 IrInstructions, 1 IrBlocks)")
-        pulse_ir.elements[0].initial_time = 10
-        pulse_ir.elements[1].initial_time = 20
-        pulse_ir.elements[2].initial_time = 30
-        self.assertEqual(
-            str(pulse_ir),
-            "IrBlock(AlignLeft(), 3 IrInstructions, 1 IrBlocks, initial_time=10, duration=140)",
-        )
+        self.assertEqual(ir_example.initial_time(), 100)
+        self.assertEqual(ir_example.final_time(), 400)
+        self.assertEqual(ir_example.duration, 300)


### PR DESCRIPTION
### Summary
This is an initial example for a DAG based PulseIR as an alternative to the option added in #11767.
This is based on a code example by @nkanazawa1989.

### Details and comments
In #11767 we used a composite pattern and a list based tracking of the elements in the IR.
Here, we use instead a DAG representation. When initialized, the IR is comprised of graph of only nodes, and the edges are later added as part of a sequencing pass. This makes scheduling simple, as demonstrated by the scheduling pass implemented here.

As #11743 is still pending, the passes implemented here are kept in temporary files until the compiler will be added, and they could be sorted into their final homes.

### Demo
A lot of the functionalities we need are already in place.
Quick set up:
```python
from qiskit.pulse import Play, Qubit, QubitFrame, Constant, ShiftPhase
from qiskit.pulse.ir import IrBlock
from qiskit.pulse.ir.alignments import AlignRight, AlignSequential, AlignLeft
from qiskit.pulse.compiler.temp_passes import analyze_target_frame_pass, sequence_pass, schedule_pass
from matplotlib import pyplot as plt
```
And we can dive into a simple example with 3 play pulses - two of them sharing a mixed frame.
```python
ir_example = IrBlock(AlignLeft())
ir_example.append(Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(1), name="q1qf1"))
ir_example.append(Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(1), name="q1qf1"))
ir_example.append(Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(2), name="q2qf1"))

ir_example.draw()
```
![image](https://github.com/Qiskit/qiskit/assets/113579969/986f7596-f0a0-46c9-b412-8e4946617bbe)

Initially, the IR is just a collection of nodes. To understand the dependencies, we first need to find all `MixedFrame`s associated with each `PulseTarget` and `Frame`. We can use an analysis pass for that: (currently implemented as function, later we'll hook it into the compiler as a pass).

```python
property_set = {}
analyze_target_frame_pass(ir_example, property_set)

print(property_set["target_frame_map"])
```
Examining `property_set["target_frame_map"]` we'll see that `QubitFrame(1)` is associated with two mixed frames, while all other objects are associated with just one of the two existing in the IR.

We can use this to sequence the instructions according to the alignment we choose.
```python
sequence_pass(ir_example, property_set)
ir_example.draw()
```
![image](https://github.com/Qiskit/qiskit/assets/113579969/a2692dc4-0e9b-4762-a47d-6260e9c46f08)
Note how the instructions acting on the same mixed frame "block" each other.

If we repeat this procedure with `AlignSequential()` we'll get instead
![image](https://github.com/Qiskit/qiskit/assets/113579969/f4b676ec-c30a-4029-8121-b361e2fc3307)

The previous example didn't require any mapping or broadcasting. Let's see one with broadcasting:
```python
ir_example = IrBlock(AlignLeft())
ir_example.append(ShiftPhase(0.1, frame=QubitFrame(1), name="qf1"))
ir_example.append(Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(1), name="q1qf1"))
ir_example.append(Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(1), name="q1qf1"))
ir_example.append(Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(2), name="q2qf1"))

property_set = {}
analyze_target_frame_pass(ir_example, property_set)
sequence_pass(ir_example, property_set)

ir_example.draw()
```
![image](https://github.com/Qiskit/qiskit/assets/113579969/83ab6dc8-1630-4bd0-b8f1-4a0b6a83eb3a)
Note how the shift phase instruction is broadcasted to all mixed frames, thus "blocking" all of them.

Now we can take this and schedule it.
```python
schedule_pass(ir_example, property_set)
print(ir_example.scheduled_elements())
```
```
[
[0, ShiftPhase(..., name='qf1')],
[0, Play(..., name='q1qf1')],
[100, Play(..., name='q1qf1')],
[0, Play(..., name='q2qf1')]
]
```
Note how `q1qf2` is pushed to the left because it's not "blocked" by the other instructions. If we swapped this for right alignment we'll have that instruction pushed to the right:
```
[
[0, ShiftPhase(..., name='qf1')],
[0, Play(..., name='q1qf1')],
[100, Play(..., name='q1qf1')],
[*100*, Play(..., name='q2qf1')]
]
```

And we can do the same thing with sub blocks.
```python
block = IrBlock(AlignLeft())
block.append(Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(1), name="q1qf1"))
block.append(Play(Constant(100, 0.5), frame=QubitFrame(2), target=Qubit(2), name="q2qf2"))

ir_example = IrBlock(AlignLeft())
ir_example.append(block)
ir_example.append(Play(Constant(100, 0.5), frame=QubitFrame(1), target=Qubit(1), name="q1qf1"))
ir_example.append(Play(Constant(100, 0.5), frame=QubitFrame(2), target=Qubit(2), name="q2qf2"))
ir_example.append(Play(Constant(100, 0.5), frame=QubitFrame(3), target=Qubit(3), name="q3qf3"))

property_set = {}
analyze_target_frame_pass(ir_example, property_set)
sequence_pass(ir_example, property_set)

ir_example.draw()
```
![image](https://github.com/Qiskit/qiskit/assets/113579969/999eadf9-129b-4ae0-80c6-1b37a28a1fd3)
Note, how the sub block "blocks" all instructions which correspond to any of the mixed frames in it (but not others).

If we flatten the representation we get:
```python
ir_example.draw(recursive=True)
```
![image](https://github.com/Qiskit/qiskit/assets/113579969/8266e623-3c07-44c2-af84-c21e726c1640)
Note how the instructions within the original sub-block now "block" the following instructions by themselves.

The PR is not in shape to be merged as is, and several issues still need addressing:

- Validation of inputs, graphs etc.
- Old model inputs - validation, conversion
- Edge cases (instructions on one of `Frame` or `PulseTarget` with no associated `MixedFrame` will cause an error currently)
- Alignment classes - how do they stack against the existing `AlignmentKind`?
- Documentation
- Should timing data be stored in the IR object (as done now) or in each node?

The PR does, however, provide a solid basis for discussion.