### PR TITLE
Remove Qiskit 0.45 and 0.46 release notes from 1.0

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,11 +1,11 @@
 .. _release-notes:
 
-=============
-Release Notes
-=============
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+Qiskit |version| release notes
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 ..
-    These release notes get converted into Markdown files via the infrastructure at https://github.com/Qiskit/documentation, which then gets deployed to https://docs.quantum.ibm.com/api/qiskit/release-notes. Changes to these release notes will update those release notes the next time the API docs are generated.
+    These release notes get converted into Markdown files via the infrastructure at https://github.com/Qiskit/documentation, which then gets deployed to https://docs.quantum.ibm.com/api/qiskit/release-notes. Changes to these release notes will update those release notes the next time the API docs are generated for this version.
 
 .. release-notes::
    :earliest-version: 1.0.0

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -7,15 +7,5 @@ Release Notes
 ..
     These release notes get converted into Markdown files via the infrastructure at https://github.com/Qiskit/documentation, which then gets deployed to https://docs.quantum.ibm.com/api/qiskit/release-notes. Changes to these release notes will update those release notes the next time the API docs are generated.
 
-    To change release notes prior to Qiskit 0.45, update the Qiskit/documentation repository directly.
-
 .. release-notes::
-   :earliest-version: 1.0.0rc1
-
-.. release-notes::
-   :earliest-version: 0.46.0
-   :branch: stable/0.46
-
-.. release-notes::
-   :earliest-version: 0.45.0
-   :branch: stable/0.45
+   :earliest-version: 1.0.0


### PR DESCRIPTION
Closes https://github.com/Qiskit/qiskit/issues/11835. We decided in the dev meeting that the simplest fix is to have each stable branch solely have release notes for its own minor version.