### PR TITLE
[wip] Remove Qiskit 0.45 docs from release notes

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,13 +1,11 @@
 .. _release-notes:
 
-%%%%%%%%%%%%%
-Release Notes
-%%%%%%%%%%%%%
-
-This page contains the release notes for Qiskit, starting from Qiskit 0.45, the first time that Qiskit and Qiskit Terra had the same versions.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+Qiskit |version| release notes
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 ..
-    These release notes get converted into Markdown files via the infrastructure at https://github.com/Qiskit/documentation, which then gets deployed to https://docs.quantum.ibm.com/api/qiskit/release-notes. Changes to these release notes will update those release notes the next time the API docs are generated.
+    These release notes get converted into Markdown files via the infrastructure at https://github.com/Qiskit/documentation, which then gets deployed to https://docs.quantum.ibm.com/api/qiskit/release-notes. Changes to these release notes will update those release notes the next time the API docs are generated for this version.
 
 .. release-notes::
    :earliest-version: 0.46.0

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -9,7 +9,5 @@ This page contains the release notes for Qiskit, starting from Qiskit 0.45, the 
 ..
     These release notes get converted into Markdown files via the infrastructure at https://github.com/Qiskit/documentation, which then gets deployed to https://docs.quantum.ibm.com/api/qiskit/release-notes. Changes to these release notes will update those release notes the next time the API docs are generated.
 
-    To change release notes prior to Qiskit 0.45, update the Qiskit/documentation repository directly.
-
 .. release-notes::
-   :earliest-version: 0.45.0
+   :earliest-version: 0.46.0

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -8,4 +8,4 @@ Qiskit |version| release notes
     These release notes get converted into Markdown files via the infrastructure at https://github.com/Qiskit/documentation, which then gets deployed to https://docs.quantum.ibm.com/api/qiskit/release-notes. Changes to these release notes will update those release notes the next time the API docs are generated for this version.
 
 .. release-notes::
-   :earliest-version: 0.46.0
+   :earliest-version: 0.46.0rc1


### PR DESCRIPTION
See https://github.com/Qiskit/qiskit/pull/11840 for the context.