### PR TITLE
Improve performance of `CircuitData::__getitem__`

### DIFF
--- a/crates/accelerate/src/quantum_circuit/circuit_data.rs
+++ b/crates/accelerate/src/quantum_circuit/circuit_data.rs
@@ -157,8 +157,10 @@ pub struct CircuitData {
 /// that may be either an index or a slice.
 #[derive(FromPyObject)]
 pub enum SliceOrInt<'a> {
-    Slice(&'a PySlice),
+    // The order here defines the order the variants are tried in the `FromPyObject` derivation.
+    // `Int` is _much_ more common, so that should be first.
     Int(isize),
+    Slice(&'a PySlice),
 }
 
 #[pymethods]


### PR DESCRIPTION
### Summary

The order of the variants in `SliceOrInt` determines which is tried first by the `FromPyObject` derivation.  `Int` is more common in like 99.9+% of cases, so wants to be first.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

For the microbenchmark:
```python
import qiskit
qc = qiskit.QuantumCircuit(1)
for _ in [None]*10_000:
    qc.x(0)
d = qc.data
%timeit d[-1]
```

I saw the timings go from ~350ns on my machine to ~280ns with the PR, which is a 20% improvement.  That's not as impressive as Qiskit/rustworkx#1096 because we're doing more object-generation work here within the method, but still nothing to sneeze at for a one-line change.

*edit*: having looked closer - I made this in a big rush at the end of the day, having just spotted the problem on Rustworkx - there's no reason `__getitem__` should have shown a speedup here; it manually avoids using `SliceOrInt` (quite possibly for the exact reason of this PR).  Running the numbers again just now (post merge) showed the same behaviour for both this PR and its parent, so it might just be I was tricked by thermal throttling the first time around.  Still, this PR should improve `__setitem__` and `__delitem__`.