### PR TITLE
Deduplicate SliceOrInt

### DIFF
--- a/crates/accelerate/src/euler_one_qubit_decomposer.rs
+++ b/crates/accelerate/src/euler_one_qubit_decomposer.rs
@@ -25,10 +25,9 @@ use pyo3::Python;
 use ndarray::prelude::*;
 use numpy::PyReadonlyArray2;
 
-use crate::quantum_circuit::circuit_data::SliceOrInt;
+use crate::utils::SliceOrInt;
 
 const DEFAULT_ATOL: f64 = 1e-12;
-
 
 #[pyclass(module = "qiskit._accelerate.euler_one_qubit_decomposer")]
 pub struct OneQubitGateErrorMap {

--- a/crates/accelerate/src/euler_one_qubit_decomposer.rs
+++ b/crates/accelerate/src/euler_one_qubit_decomposer.rs
@@ -19,20 +19,16 @@ use std::f64::consts::PI;
 
 use pyo3::exceptions::{PyIndexError, PyTypeError};
 use pyo3::prelude::*;
-use pyo3::types::PySlice;
 use pyo3::wrap_pyfunction;
 use pyo3::Python;
 
 use ndarray::prelude::*;
 use numpy::PyReadonlyArray2;
 
+use crate::quantum_circuit::circuit_data::SliceOrInt;
+
 const DEFAULT_ATOL: f64 = 1e-12;
 
-#[derive(FromPyObject)]
-enum SliceOrInt<'a> {
-    Slice(&'a PySlice),
-    Int(isize),
-}
 
 #[pyclass(module = "qiskit._accelerate.euler_one_qubit_decomposer")]
 pub struct OneQubitGateErrorMap {

--- a/crates/accelerate/src/quantum_circuit/circuit_data.rs
+++ b/crates/accelerate/src/quantum_circuit/circuit_data.rs
@@ -13,6 +13,7 @@
 use crate::quantum_circuit::circuit_instruction::CircuitInstruction;
 use crate::quantum_circuit::intern_context::{BitType, IndexType, InternContext};
 use crate::quantum_circuit::py_ext;
+use crate::utils::SliceOrInt;
 use hashbrown::HashMap;
 use pyo3::exceptions::{PyIndexError, PyKeyError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -151,16 +152,6 @@ pub struct CircuitData {
     qubits: Py<PyList>,
     /// The clbits registered, cached as a ``list[Clbit]``.
     clbits: Py<PyList>,
-}
-
-/// A private enumeration type used to extract arguments to pymethods
-/// that may be either an index or a slice.
-#[derive(FromPyObject)]
-pub enum SliceOrInt<'a> {
-    // The order here defines the order the variants are tried in the `FromPyObject` derivation.
-    // `Int` is _much_ more common, so that should be first.
-    Int(isize),
-    Slice(&'a PySlice),
 }
 
 #[pymethods]

--- a/crates/accelerate/src/utils.rs
+++ b/crates/accelerate/src/utils.rs
@@ -1,9 +1,20 @@
 use pyo3::prelude::*;
+use pyo3::types::PySlice;
 
 use faer::prelude::*;
 use faer::IntoFaerComplex;
 use num_complex::Complex;
 use numpy::{IntoPyArray, PyReadonlyArray2};
+
+/// A private enumeration type used to extract arguments to pymethod
+/// that may be either an index or a slice
+#[derive(FromPyObject)]
+pub enum SliceOrInt<'a> {
+    // The order here defines the order the variants are tried in the FromPyObject` derivation.
+    // `Int` is _much_ more common, so that should be first.
+    Int(isize),
+    Slice(&'a PySlice),
+}
 
 /// Return indices that sort partially ordered data.
 /// If `data` contains two elements that are incomparable,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

After doing some post-merge analysis on the impact of #11842 it turns out the enum being modified in that PR was duplicated in the rust code unnecessarily. The same enum was already defined in the euler_one_qubit_decomposer module for it's custom 1 qubit gate sequence return type. This commit updates the code so it just use the one defined in the circuit data module that has the fix from #11842 applied already.

### Details and comments