### PR TITLE
Add __call__ functions to synthesis docs

### DIFF
--- a/qiskit/synthesis/one_qubit/one_qubit_decompose.py
+++ b/qiskit/synthesis/one_qubit/one_qubit_decompose.py
@@ -128,6 +128,8 @@ class OneQubitEulerDecomposer:
           - :math:`Z(\phi) Y(\theta) Z(\lambda)`
           - :math:`e^{i\gamma} R\left(-\pi,\frac{\phi-\lambda+\pi}{2}\right).`
             :math:`R\left(\theta+\pi,\frac{\pi}{2}-\lambda\right)`
+
+    .. automethod:: __call__
     """
 
     def __init__(self, basis: str = "U3", use_dag: bool = False):
@@ -192,6 +194,7 @@ class OneQubitEulerDecomposer:
             simplify: reduce gate count in decomposition [Default: True].
             atol: absolute tolerance for checking angles when simplifying
                          returned circuit [Default: 1e-12].
+
         Returns:
             QuantumCircuit: the decomposed single-qubit gate circuit
 

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -903,6 +903,8 @@ class TwoQubitBasisDecomposer:
             optimal decomposition is not implemented. Currently, only [{CX, SX, RZ}] is known.
             If ``False``, don't attempt optimization. If ``None``, attempt optimization but don't raise
             if unknown.
+
+    .. automethod:: __call__
     """
 
     def __init__(
@@ -1159,11 +1161,13 @@ class TwoQubitBasisDecomposer:
         Args:
             unitary (Operator or ndarray): 4x4 unitary to synthesize.
             basis_fidelity (float or None): Fidelity to be assumed for applications of KAK Gate.
-                If given, overrides basis_fidelity given at init.
+                If given, overrides ``basis_fidelity`` given at init.
             approximate (bool): Approximates if basis fidelities are less than 1.0.
             _num_basis_uses (int): force a particular approximation by passing a number in [0, 3].
+
         Returns:
             QuantumCircuit: Synthesized circuit.
+
         Raises:
             QiskitError: if pulse_optimize is True but we don't know how to do it.
         """

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -1155,21 +1155,21 @@ class TwoQubitBasisDecomposer:
         *,
         _num_basis_uses: int | None = None,
     ) -> QuantumCircuit:
-        """Decompose a two-qubit ``unitary`` over fixed basis + SU(2) using the best approximation given
-        that each basis application has a finite ``basis_fidelity``.
+        r"""Decompose a two-qubit ``unitary`` over fixed basis and :math:`SU(2)` using the best
+        approximation given that each basis application has a finite ``basis_fidelity``.
 
         Args:
-            unitary (Operator or ndarray): 4x4 unitary to synthesize.
+            unitary (Operator or ndarray): :math:`4 \times 4` unitary to synthesize.
             basis_fidelity (float or None): Fidelity to be assumed for applications of KAK Gate.
                 If given, overrides ``basis_fidelity`` given at init.
             approximate (bool): Approximates if basis fidelities are less than 1.0.
             _num_basis_uses (int): force a particular approximation by passing a number in [0, 3].
 
         Returns:
-            QuantumCircuit: Synthesized circuit.
+            QuantumCircuit: Synthesized quantum circuit.
 
         Raises:
-            QiskitError: if pulse_optimize is True but we don't know how to do it.
+            QiskitError: if ``pulse_optimize`` is True but we don't know how to do it.
         """
         basis_fidelity = basis_fidelity or self.basis_fidelity
         if approximate is False:

--- a/qiskit/synthesis/two_qubit/xx_decompose/decomposer.py
+++ b/qiskit/synthesis/two_qubit/xx_decompose/decomposer.py
@@ -232,8 +232,8 @@ class XXDecomposer:
         approximate: bool = True,
     ) -> QuantumCircuit:
         r"""
-        Fashions a circuit which (perhaps `approximate`ly) models the special unitary operation
-        `unitary`, using the circuit templates supplied at initialization as `embodiments`.  The
+        Fashions a circuit which (perhaps ``approximate``ly) models the special unitary operation
+        ``unitary``, using the circuit templates supplied at initialization as ``embodiments``.  The
         routine uses ``basis_fidelity`` to select the optimal circuit template, including when
         performing exact synthesis; the contents of ``basis_fidelity`` is a dictionary mapping
         interaction strengths (scaled so that :math:`CX = RZX(\pi/2)` corresponds to :math:`\pi/2`)

--- a/qiskit/synthesis/two_qubit/xx_decompose/decomposer.py
+++ b/qiskit/synthesis/two_qubit/xx_decompose/decomposer.py
@@ -232,7 +232,7 @@ class XXDecomposer:
         approximate: bool = True,
     ) -> QuantumCircuit:
         r"""
-        Fashions a circuit which (perhaps ``approximate``ly) models the special unitary operation
+        Fashions a circuit which (perhaps approximately) models the special unitary operation
         ``unitary``, using the circuit templates supplied at initialization as ``embodiments``.  The
         routine uses ``basis_fidelity`` to select the optimal circuit template, including when
         performing exact synthesis; the contents of ``basis_fidelity`` is a dictionary mapping

--- a/qiskit/synthesis/two_qubit/xx_decompose/decomposer.py
+++ b/qiskit/synthesis/two_qubit/xx_decompose/decomposer.py
@@ -64,7 +64,7 @@ class XXDecomposer:
         euler_basis: Basis string provided to :class:`.OneQubitEulerDecomposer` for 1Q synthesis.
             Defaults to ``"U"``.
         embodiments: A dictionary mapping interaction strengths alpha to native circuits which
-            embody the gate :math:`CAN(\alpha, 0, 0)`. Strengths are taken so that :math:`pi/2`
+            embody the gate :math:`CAN(\alpha, 0, 0)`. Strengths are taken so that :math:`\pi/2`
             represents the class of a full :class:`.CXGate`.
         backup_optimizer: If supplied, defers synthesis to this callable when :class:`.XXDecomposer`
             has no efficient decomposition of its own. Useful for special cases involving 2 or 3
@@ -74,6 +74,8 @@ class XXDecomposer:
     .. note::
         If ``embodiments`` is not passed, or if an entry is missing, it will be populated as needed
         using the method ``_default_embodiment``.
+
+    .. automethod:: __call__
     """
 
     def __init__(
@@ -229,21 +231,22 @@ class XXDecomposer:
         basis_fidelity: dict | float | None = None,
         approximate: bool = True,
     ) -> QuantumCircuit:
-        """
+        r"""
         Fashions a circuit which (perhaps `approximate`ly) models the special unitary operation
         `unitary`, using the circuit templates supplied at initialization as `embodiments`.  The
-        routine uses `basis_fidelity` to select the optimal circuit template, including when
-        performing exact synthesis; the contents of `basis_fidelity` is a dictionary mapping
-        interaction strengths (scaled so that CX = RZX(pi/2) corresponds to pi/2) to circuit
-        fidelities.
+        routine uses ``basis_fidelity`` to select the optimal circuit template, including when
+        performing exact synthesis; the contents of ``basis_fidelity`` is a dictionary mapping
+        interaction strengths (scaled so that :math:`CX = RZX(\pi/2)` corresponds to :math:`\pi/2`)
+        to circuit fidelities.
 
         Args:
-            unitary (Operator or ndarray): 4x4 unitary to synthesize.
+            unitary (Operator or ndarray): :math:`4 \times 4` unitary to synthesize.
             basis_fidelity (dict or float): Fidelity of basis gates. Can be either (1) a dictionary
-                mapping XX angle values to fidelity at that angle; or (2) a single float f,
-                interpreted as {pi: f, pi/2: f/2, pi/3: f/3}.
+                mapping ``XX`` angle values to fidelity at that angle; or (2) a single float ``f``,
+                interpreted as ``{pi: f, pi/2: f/2, pi/3: f/3}``.
                 If given, overrides the basis_fidelity given at init.
             approximate (bool): Approximates if basis fidelities are less than 1.0 .
+
         Returns:
             QuantumCircuit: Synthesized circuit.
         """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Add `__call__` functions to synthesis docs, in the following classes:

- [x] TwoQubitBasisDecomposer
- [x] OneQubitEulerDecomposer
- [x] XXDecomposer


### Details and comments


