### PR TITLE
Add rust file support to verify_headers.py and check crates/

### DIFF
--- a/crates/accelerate/src/utils.rs
+++ b/crates/accelerate/src/utils.rs
@@ -1,3 +1,15 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2024
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
 use pyo3::prelude::*;
 
 use faer::prelude::*;

--- a/tools/verify_headers.py
+++ b/tools/verify_headers.py
@@ -11,6 +11,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+# pylint: disable=too-many-return-statements
+
 """Utility script to verify qiskit copyright file headers"""
 
 import argparse
@@ -21,6 +23,8 @@ import re
 
 # regex for character encoding from PEP 263
 pep263 = re.compile(r"^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)")
+line_start = re.compile(r"^(\/\/|#) This code is part of Qiskit.$")
+copyright_line = re.compile(r"^(\/\/|#) \(C\) Copyright IBM 20")
 
 
 def discover_files(code_paths):
@@ -37,6 +41,7 @@ def discover_files(code_paths):
                         subfile.endswith(".py")
                         or subfile.endswith(".pyx")
                         or subfile.endswith(".pxd")
+                        or subfile.endswith(".rs")
                     ):
                         out_paths.append(os.path.join(dir_path, subfile))
     return out_paths
@@ -56,6 +61,18 @@ def validate_header(file_path):
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """
+    header_rs = """// This code is part of Qiskit.
+//
+"""
+    apache_text_rs = """//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+"""
     count = 0
     with open(file_path, encoding="utf8") as fd:
         lines = fd.readlines()
@@ -66,15 +83,23 @@ def validate_header(file_path):
             return file_path, False, "Header not found in first 5 lines"
         if count <= 2 and pep263.match(line):
             return file_path, False, "Unnecessary encoding specification (PEP 263, 3120)"
-        if line == "# This code is part of Qiskit.\n":
+        if line_start.search(line):
             start = index
             break
-    if "".join(lines[start : start + 2]) != header:
-        return (file_path, False, "Header up to copyright line does not match: %s" % header)
-    if not lines[start + 2].startswith("# (C) Copyright IBM 20"):
-        return (file_path, False, "Header copyright line not found")
-    if "".join(lines[start + 3 : start + 11]) != apache_text:
-        return (file_path, False, "Header apache text string doesn't match:\n %s" % apache_text)
+    if file_path.endswith(".rs"):
+        if "".join(lines[start : start + 2]) != header_rs:
+            return (file_path, False, "Header up to copyright line does not match: %s" % header)
+        if not copyright_line.search(lines[start + 2]):
+            return (file_path, False, "Header copyright line not found")
+        if "".join(lines[start + 3 : start + 11]) != apache_text_rs:
+            return (file_path, False, "Header apache text string doesn't match:\n %s" % apache_text)
+    else:
+        if "".join(lines[start : start + 2]) != header:
+            return (file_path, False, "Header up to copyright line does not match: %s" % header)
+        if not copyright_line.search(lines[start + 2]):
+            return (file_path, False, "Header copyright line not found")
+        if "".join(lines[start + 3 : start + 11]) != apache_text:
+            return (file_path, False, "Header apache text string doesn't match:\n %s" % apache_text)
     return (file_path, True, None)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands =
   # This line is commented out until #6649 merges. We can't run this currently
   # via tox because tox doesn't support globbing
   # pylint -rn --disable='invalid-name,missing-module-docstring,redefined-outer-name' examples/python/*.py
-  python {toxinidir}/tools/verify_headers.py qiskit test tools examples
+  python {toxinidir}/tools/verify_headers.py qiskit test tools examples crates
   python {toxinidir}/tools/find_optional_imports.py
   python {toxinidir}/tools/find_stray_release_notes.py
   reno -q lint
@@ -53,7 +53,7 @@ commands =
   -git fetch -q https://github.com/Qiskit/qiskit.git :lint_incr_latest
   python {toxinidir}/tools/pylint_incr.py -rn -j4 -sn --paths :/qiskit/*.py :/test/*.py :/tools/*.py
   python {toxinidir}/tools/pylint_incr.py -rn -j4 -sn --disable='invalid-name,missing-module-docstring,redefined-outer-name' --paths :(glob,top)examples/python/*.py
-  python {toxinidir}/tools/verify_headers.py qiskit test tools examples
+  python {toxinidir}/tools/verify_headers.py qiskit test tools examples crates
   python {toxinidir}/tools/find_optional_imports.py
   python {toxinidir}/tools/find_stray_release_notes.py
   reno -q lint


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the verify_headers.py file to run the validation on the rust files in crates/ too. After noticing we were missing a file header in one of the rust source files this has become more necessary as it's easy to potentially overlook the standard required file header for Qiskit source files.

### Details and comments