### PR TITLE
Corrected probabilities method names in stabilizer state for issue #11688

### DIFF
--- a/qiskit/quantum_info/states/stabilizerstate.py
+++ b/qiskit/quantum_info/states/stabilizerstate.py
@@ -415,7 +415,7 @@ class StabilizerState(QuantumState):
         outcome_prob = 1.0
         probs = {}  # probabilities dictionary
 
-        self._get_probablities(qubits, outcome, outcome_prob, probs)
+        self._get_probabilities(qubits, outcome, outcome_prob, probs)
 
         if decimals is not None:
             for key, value in probs.items():
@@ -644,7 +644,7 @@ class StabilizerState(QuantumState):
     # -----------------------------------------------------------------------
     # Helper functions for calculating the probabilities
     # -----------------------------------------------------------------------
-    def _get_probablities(self, qubits, outcome, outcome_prob, probs):
+    def _get_probabilities(self, qubits, outcome, outcome_prob, probs):
         """Recursive helper function for calculating the probabilities"""
 
         qubit_for_branching = -1
@@ -679,4 +679,4 @@ class StabilizerState(QuantumState):
             stab_cpy._measure_and_update(
                 qubits[len(qubits) - qubit_for_branching - 1], single_qubit_outcome
             )
-            stab_cpy._get_probablities(qubits, new_outcome, 0.5 * outcome_prob, probs)
+            stab_cpy._get_probabilities(qubits, new_outcome, 0.5 * outcome_prob, probs)

--- a/test/python/quantum_info/states/test_stabilizerstate.py
+++ b/test/python/quantum_info/states/test_stabilizerstate.py
@@ -303,7 +303,7 @@ class TestStabilizerState(QiskitTestCase):
                     value = res.measure()[0]
                     self.assertIn(value, ["000", "001"])
 
-    def test_probablities_dict_single_qubit(self):
+    def test_probabilities_dict_single_qubit(self):
         """Test probabilities and probabilities_dict methods of a single qubit"""
 
         num_qubits = 1
@@ -342,7 +342,7 @@ class TestStabilizerState(QiskitTestCase):
                 target = np.array([0.5, 0.5])
                 self.assertTrue(np.allclose(probs, target))
 
-    def test_probablities_dict_two_qubits(self):
+    def test_probabilities_dict_two_qubits(self):
         """Test probabilities and probabilities_dict methods of two qubits"""
 
         num_qubits = 2
@@ -395,7 +395,7 @@ class TestStabilizerState(QiskitTestCase):
                 target = np.array([1, 0])
                 self.assertTrue(np.allclose(probs, target))
 
-    def test_probablities_dict_qubits(self):
+    def test_probabilities_dict_qubits(self):
         """Test probabilities and probabilities_dict methods of a subsystem of qubits"""
 
         num_qubits = 3
@@ -459,7 +459,7 @@ class TestStabilizerState(QiskitTestCase):
                 target = np.array([0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125])
                 self.assertTrue(np.allclose(probs, target))
 
-    def test_probablities_dict_ghz(self):
+    def test_probabilities_dict_ghz(self):
         """Test probabilities and probabilities_dict method of a subsystem of qubits"""
 
         num_qubits = 3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ x] I have added the tests to cover my changes.
    No new tests needed, previous tests will cover change
- [x] I have updated the documentation accordingly.
    No new classes or methods add, fixing typo
- [ x] I have read the CONTRIBUTING document.
-->

### Summary
stabilizerstate and test_stabilizerstate had a misspelling of probabilities for method names in /qiskit/quantum_info/states and test/python/quantum_info/states/stabilizerstate

### Details and comments
change of the method names throughout the project to the correct spelling

fixes #11688 

