### PR TITLE
Fix Observables.coerce() for 0-d inputs

### DIFF
--- a/qiskit/primitives/containers/observables_array.py
+++ b/qiskit/primitives/containers/observables_array.py
@@ -230,8 +230,6 @@ class ObservablesArray(ShapedMixin):
         """
         if isinstance(observables, ObservablesArray):
             return observables
-        if isinstance(observables, (str, SparsePauliOp, Pauli, _Mapping)):
-            observables = [observables]
         return cls(observables)
 
     def validate(self):

--- a/releasenotes/notes/obs-array-coerce-0d-28b192fb3d004d4a.yaml
+++ b/releasenotes/notes/obs-array-coerce-0d-28b192fb3d004d4a.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed `qiskit.primitives.containers.observables_array.ObservablesArray.coerce()`
+    so that it returns a 0-d array when the input is a single, unnested observable. 
+    Previously, it erroneously upgraded to a single dimension, with shape `(1,)`.

--- a/test/python/primitives/containers/test_observables_array.py
+++ b/test/python/primitives/containers/test_observables_array.py
@@ -34,7 +34,7 @@ class ObservablesArrayTestCase(QiskitTestCase):
             self.assertEqual(obs, {label: 1})
 
     def test_coerce_observable_custom_basis(self):
-        """Test coerce_observable for custom allowed basis"""
+        """Test coerce_observable for custom al flowed basis"""
 
         class PauliArray(ObservablesArray):
             """Custom array allowing only Paulis, not projectors"""
@@ -126,6 +126,20 @@ class ObservablesArrayTestCase(QiskitTestCase):
         obs = ObservablesArray.coerce_observable(mapping)
         target = {key.to_label(): val for key, val in mapping.items()}
         self.assertEqual(obs, target)
+
+    def test_coerce_0d(self):
+        """Test the coerce() method with 0-d input."""
+        obs = ObservablesArray.coerce("X")
+        self.assertEqual(obs.shape, ())
+        self.assertDictAlmostEqual(obs[()], {"X": 1})
+
+        obs = ObservablesArray.coerce({"I": 2})
+        self.assertEqual(obs.shape, ())
+        self.assertDictAlmostEqual(obs[()], {"I": 2})
+
+        obs = ObservablesArray.coerce(qi.SparsePauliOp(["X", "Y"], [1, 3]))
+        self.assertEqual(obs.shape, ())
+        self.assertDictAlmostEqual(obs[()], {"X": 1, "Y": 3})
 
     def test_format_invalid_mapping_qubits(self):
         """Test an error is raised when different qubits in mapping keys"""


### PR DESCRIPTION
### Summary

This PR fixes `qiskit.primitives.containers.observables_array.ObservablesArray.coerce()`
so that it returns a 0-d array when the input is a single, unnested observable. 
Previously, it erroneously upgraded the input to a single dimension, with shape `(1,)`.

### Details and comments

For example, currently `ObservablesArray.coerce("I").shape` has `(1,)`, but after this PR, it would be `()`.
