### PR TITLE
Fix improper handling of `BindingsArray` in `EstimatorPub.coerce()`

### DIFF
--- a/qiskit/primitives/containers/estimator_pub.py
+++ b/qiskit/primitives/containers/estimator_pub.py
@@ -141,7 +141,7 @@ class EstimatorPub(ShapedMixin):
 
         if len(pub) > 2 and pub[2] is not None:
             values = pub[2]
-            if not isinstance(values, Mapping):
+            if not isinstance(values, (BindingsArray, Mapping)):
                 values = {tuple(circuit.parameters): values}
             parameter_values = BindingsArray.coerce(values)
         else:

--- a/releasenotes/notes/fix-estimator-pub-coerce-5d13700e15126421.yaml
+++ b/releasenotes/notes/fix-estimator-pub-coerce-5d13700e15126421.yaml
@@ -1,0 +1,7 @@
+---
+
+fixes:
+  - |
+    Fixed a bug where `qiskit.primitives.containers.estimator_pub.EstimatorPub.coerce()`
+    improperly handles the case where the third value is a `BindingsArray` instance, giving
+    rise to a ``ValueError`` whenever it is attempted.

--- a/test/python/primitives/containers/test_estimator_pub.py
+++ b/test/python/primitives/containers/test_estimator_pub.py
@@ -182,6 +182,19 @@ class EstimatorPubTestCase(QiskitTestCase):
         pub2 = EstimatorPub.coerce(pub1, precision=precision)
         self.assertEqual(pub1, pub2)
 
+    def test_coerce_pub_with_exact_types(self):
+        """Test coercing an EstimatorPub"""
+        params = (Parameter("a"), Parameter("b"))
+        circuit = QuantumCircuit(2)
+        circuit.rx(params[0], 0)
+        circuit.ry(params[1], 1)
+        obs = ObservablesArray({"XY": 1})
+        params = BindingsArray(data={params: np.ones((10, 2))})
+        pub = EstimatorPub.coerce((circuit, obs, params))
+        self.assertIs(pub.circuit, circuit)
+        self.assertIs(pub.observables, obs)
+        self.assertIs(pub.parameter_values, params)
+
     @ddt.data(0.01, 0.02)
     def test_coerce_pub_without_shots(self, precision):
         """Test coercing an EstimatorPub"""


### PR DESCRIPTION
### Summary

There is a bug in `EstimatorPub.coerce()` where if an actual `BindingsArray` is passed in the third slot, then it attempts to send `{params: bindings_array}` to `BindingsArray.coerce` rather than `bindings_array`, which raises a ValueError. This PR fixes this behaviour by passing the bindings array through.

### Details and comments

Since Neither `BindingsArray` not `EstimatorPub` are (currently) part of the public interface, this is a low impact bug for non-developers.


