### PR TITLE
Fix 1.0 release note leaving off entries

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -8,4 +8,4 @@ Qiskit |version| release notes
     These release notes get converted into Markdown files via the infrastructure at https://github.com/Qiskit/documentation, which then gets deployed to https://docs.quantum.ibm.com/api/qiskit/release-notes. Changes to these release notes will update those release notes the next time the API docs are generated for this version.
 
 .. release-notes::
-   :earliest-version: 1.0.0
+   :earliest-version: 1.0.0rc1


### PR DESCRIPTION
https://github.com/Qiskit/qiskit/pull/11840 had a mistake in not setting the first release as the rc1. My bad!

This PR fixes `release_notes.html` so that it has everything we'd expect. 