### PR TITLE
Fixing bug in `qcstyle` that modified custom style dict

### DIFF
--- a/qiskit/visualization/circuit/qcstyle.py
+++ b/qiskit/visualization/circuit/qcstyle.py
@@ -96,9 +96,9 @@ class StyleDict(dict):
         nested_attrs = {"displaycolor", "displaytext"}
         for attr in nested_attrs.intersection(other.keys()):
             if attr in self.keys():
-                self[attr].update(other.pop(attr))
+                self[attr].update(other[attr])
             else:
-                self[attr] = other.pop(attr)
+                self[attr] = other[attr]
 
         super().update(other)
 

--- a/qiskit/visualization/circuit/qcstyle.py
+++ b/qiskit/visualization/circuit/qcstyle.py
@@ -100,7 +100,7 @@ class StyleDict(dict):
             else:
                 self[attr] = other[attr]
 
-        super().update(other)
+        super().update((key, value) for key, value in other.items() if key not in nested_attrs)
 
 
 class DefaultStyle:

--- a/releasenotes/notes/qcstyle-bug-custom-style-dicts-22deab6c602ccd6a.yaml
+++ b/releasenotes/notes/qcstyle-bug-custom-style-dicts-22deab6c602ccd6a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed bug in `qcstyle` that was causing custom style dictionaries passed by the used to be modified upon calling the `circuit_drawer`.

--- a/releasenotes/notes/qcstyle-bug-custom-style-dicts-22deab6c602ccd6a.yaml
+++ b/releasenotes/notes/qcstyle-bug-custom-style-dicts-22deab6c602ccd6a.yaml
@@ -1,4 +1,5 @@
 ---
 fixes:
   - |
-    Fixed bug in `qcstyle` that was causing custom style dictionaries passed by the used to be modified upon calling the `circuit_drawer`.
+    Fixed bug in :meth:`.QuantumCircuit.draw` that was causing custom style dictionaries 
+    for the Matplotlib drawer to be modified upon execution.

--- a/test/visual/mpl/circuit/test_circuit_matplotlib_drawer.py
+++ b/test/visual/mpl/circuit/test_circuit_matplotlib_drawer.py
@@ -1010,15 +1010,16 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.barrier(5, 6)
         circuit.reset(5)
 
+        style = {
+            "name": "user_style",
+            "displaytext": {"H2": "H_2"},
+            "displaycolor": {"H2": ("#EEDD00", "#FF0000")},
+        }
         fname = "user_style.png"
         self.circuit_drawer(
             circuit,
             output="mpl",
-            style={
-                "name": "user_style",
-                "displaytext": {"H2": "H_2"},
-                "displaycolor": {"H2": ("#EEDD00", "#FF0000")},
-            },
+            style=style,
             filename=fname,
         )
 
@@ -1029,7 +1030,18 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             FAILURE_DIFF_DIR,
             FAILURE_PREFIX,
         )
-        self.assertGreaterEqual(ratio, self.threshold)
+
+        with self.subTest(msg="check image"):
+            self.assertGreaterEqual(ratio, self.threshold)
+
+        with self.subTest(msg="check style dict unchanged"):
+            self.assertEqual(
+                style, {
+                    "name": "user_style",
+                    "displaytext": {"H2": "H_2"},
+                    "displaycolor": {"H2": ("#EEDD00", "#FF0000")},
+                }
+            )
 
     def test_subfont_change(self):
         """Tests changing the subfont size"""

--- a/test/visual/mpl/circuit/test_circuit_matplotlib_drawer.py
+++ b/test/visual/mpl/circuit/test_circuit_matplotlib_drawer.py
@@ -1036,11 +1036,12 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
 
         with self.subTest(msg="check style dict unchanged"):
             self.assertEqual(
-                style, {
+                style,
+                {
                     "name": "user_style",
                     "displaytext": {"H2": "H_2"},
                     "displaycolor": {"H2": ("#EEDD00", "#FF0000")},
-                }
+                },
             )
 
     def test_subfont_change(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
`visualization.circuit.qcstyle` popped elements from the style dictionary instead of extracting them, resulting in modyfied style dicts.
As discussed with @Cryoris, this PR solves this issue, leaving style dicts untouchted.


### Details and comments
Solved the issue described above, added test.

