### PR TITLE
Fix handling of control flow instructions in convert_to_target()

### DIFF
--- a/qiskit/providers/backend_compat.py
+++ b/qiskit/providers/backend_compat.py
@@ -21,7 +21,7 @@ from qiskit.providers.backend import BackendV1, BackendV2
 from qiskit.providers.backend import QubitProperties
 from qiskit.providers.models.backendconfiguration import BackendConfiguration
 from qiskit.providers.models.backendproperties import BackendProperties
-
+from qiskit.circuit.controlflow import CONTROL_FLOW_OP_NAMES
 from qiskit.providers.models.pulsedefaults import PulseDefaults
 from qiskit.providers.options import Options
 from qiskit.providers.exceptions import BackendPropertyError
@@ -92,8 +92,12 @@ def convert_to_target(
 
     # Create instruction property placeholder from backend configuration
     basis_gates = set(getattr(configuration, "basis_gates", []))
+    supported_instructions = set(getattr(configuration, "supported_instructions", []))
     gate_configs = {gate.name: gate for gate in configuration.gates}
-    all_instructions = set.union(basis_gates, set(required))
+    all_instructions = set.union(
+        basis_gates, set(required), supported_instructions.intersection(CONTROL_FLOW_OP_NAMES)
+    )
+
     inst_name_map = {}  # type: Dict[str, Instruction]
 
     faulty_ops = set()

--- a/releasenotes/notes/fix-control-flow-convert-to-target-ae838418a7ad2a20.yaml
+++ b/releasenotes/notes/fix-control-flow-convert-to-target-ae838418a7ad2a20.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :func:`.convert_to_target` where the converter
+    would incorrectly ignore control flow instructions if they were specified
+    in the :attr:`.BackendConfiguration.supported_instructions` attribute which
+    is the typical location that control flow instructions are specified in a
+    :class:`.BackendConfiguration` object.
+    Fixed `#11872 <https://github.com/Qiskit/qiskit/issues/11872>`__.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue in the convert_to_target() function where it wasn't looking for control flow instructions in the proper location. Typically the control flow instructions are put in the supported_instructions field of the BackendConfiguration, but the convert_to_target() function was ignoring this field. This commit updates the function to check supported_instructions for the control flow instructions. It doesn't more broadly look at the supported_instructions field, because on other backends this field is used to list the supported pulse instructions which might have name conflicts with other instructions and cause issues building a target.

### Details and comments

Fixes #11872