### PR TITLE
Bugfix for missing qubit property

### DIFF
--- a/qiskit/providers/backend_compat.py
+++ b/qiskit/providers/backend_compat.py
@@ -158,15 +158,22 @@ def convert_to_target(
         faulty_qubits = {
             q for q in range(configuration.num_qubits) if not properties.is_qubit_operational(q)
         }
-        qubit_properties = [
-            QubitProperties(
-                t1=properties.qubit_property(qubit_idx)["T1"][0],
-                t2=properties.qubit_property(qubit_idx)["T2"][0],
-                frequency=properties.qubit_property(qubit_idx)["frequency"][0],
-            )
-            for qubit_idx in range(0, configuration.num_qubits)
-        ]
 
+        qubit_properties = []
+        for qi in range(0, configuration.num_qubits):
+            # TODO faulty qubit handling might be needed since
+            #  faulty qubit reporting qubit properties doesn't make sense.
+            try:
+                prop_dict = properties.qubit_property(qubit=qi)
+            except KeyError:
+                continue
+            qubit_properties.append(
+                QubitProperties(
+                    t1=prop_dict.get("T1", (None, None))[0],
+                    t2=prop_dict.get("T2", (None, None))[0],
+                    frequency=prop_dict.get("frequency", (None, None))[0],
+                )
+            )
         in_data["qubit_properties"] = qubit_properties
 
         for name in all_instructions:

--- a/releasenotes/notes/fix-missing-qubit-properties-35137aa5250d9368.yaml
+++ b/releasenotes/notes/fix-missing-qubit-properties-35137aa5250d9368.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    A bug that crashes the :func:`.convert_to_target` function when qubit properties
+    (either T1, T2 or frequency) are missing was fixed.
+    The missing property values in :class:`.QubitProperties` are filled with ``None``.

--- a/test/python/providers/faulty_backends.py
+++ b/test/python/providers/faulty_backends.py
@@ -34,6 +34,18 @@ class Fake7QV1FaultyQ1(Fake7QPulseV1):
         return BackendProperties.from_dict(props)
 
 
+class Fake7QV1MissingQ1Property(Fake7QPulseV1):
+    """A fake 7 qubit backend, with a missing T1 property in q1."""
+
+    def properties(self):
+        """Returns a snapshot of device properties as recorded on 8/30/19.
+        Remove property from qubit 1.
+        """
+        props = super().properties().to_dict()
+        props["qubits"][1] = filter(lambda q: q["name"] != "T1", props["qubits"][1])
+        return BackendProperties.from_dict(props)
+
+
 class Fake7QV1FaultyCX01CX10(Fake7QPulseV1):
     """A fake 5 qubit backend, with faulty CX(Q1, Q0) and CX(Q0, Q1)
     0 (↔) 1 ↔ 3 ↔ 4


### PR DESCRIPTION
### Summary

With #11095 handling for the missing qubit property was gone. This PR readds the handling for partly missing qubit property with a unit test.

### Details and comments

When some qubit doesn't report qubit properties (i.e. T1, T2, frequency), the `convert_to_target` function crashes during the conversion of BackendV1 into V2 model.
