### PR TITLE
Improve mesage on failed Graphviz optional

### DIFF
--- a/qiskit/utils/optionals.py
+++ b/qiskit/utils/optionals.py
@@ -307,8 +307,12 @@ HAS_Z3 = _LazyImportTester("z3", install="pip install z3-solver")
 
 HAS_GRAPHVIZ = _LazySubprocessTester(
     ("dot", "-V"),
-    name="graphviz",
-    install="'brew install graphviz' if on Mac, or by downloding it from their website",
+    name="Graphviz",
+    msg=(
+        "To install, follow the instructions at https://graphviz.org/download/."
+        " Qiskit needs the Graphviz binaries. The 'graphviz' package on pip does not install these."
+        " You must install the actual Graphviz software."
+    ),
 )
 HAS_PDFLATEX = _LazySubprocessTester(
     ("pdflatex", "-version"),

--- a/qiskit/utils/optionals.py
+++ b/qiskit/utils/optionals.py
@@ -310,8 +310,8 @@ HAS_GRAPHVIZ = _LazySubprocessTester(
     name="Graphviz",
     msg=(
         "To install, follow the instructions at https://graphviz.org/download/."
-        " Qiskit needs the Graphviz binaries. The 'graphviz' package on pip does not install these."
-        " You must install the actual Graphviz software."
+        " Qiskit needs the Graphviz binaries, which the 'graphviz' package on pip does not install."
+        " You must install the actual Graphviz software"
     ),
 )
 HAS_PDFLATEX = _LazySubprocessTester(


### PR DESCRIPTION
### Summary

I have recently seen several users struggle to install a complete version of Graphviz upon seeing the `MissingOptionalLibraryError` message.  This updates the message to make it clearer that the PyPI distribution `graphviz` *is not* the actual Graphviz software, and it must be installed separately.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Fix #11865, also a couple more messages I've seen on [the public Qiskit slack](https://qisk.it/join-slack).
