### PR TITLE
Add EstimatorV2Converter and BackendEstimatorV2

### DIFF
--- a/qiskit/primitives/__init__.py
+++ b/qiskit/primitives/__init__.py
@@ -395,6 +395,7 @@ Estimator V2
 
    BaseEstimatorV2
    StatevectorEstimator
+   BackendEstimatorV2
    EstimatorV2Converter
 
 Sampler V2
@@ -446,7 +447,7 @@ Sampler V1
 
 """
 
-from .backend_estimator import BackendEstimator
+from .backend_estimator import BackendEstimator, BackendEstimatorV2
 from .backend_sampler import BackendSampler
 from .base import (
     BaseEstimator,
@@ -459,15 +460,15 @@ from .base import (
 from .base.estimator_result import EstimatorResult
 from .base.sampler_result import SamplerResult
 from .containers import (
+    BindingsArrayLike,
     BitArray,
     DataBin,
-    PrimitiveResult,
-    PubResult,
     EstimatorPubLike,
-    SamplerPubLike,
-    BindingsArrayLike,
     ObservableLike,
     ObservablesArrayLike,
+    PrimitiveResult,
+    PubResult,
+    SamplerPubLike,
 )
 from .estimator import Estimator
 from .estimatorv2converter import EstimatorV2Converter

--- a/qiskit/primitives/__init__.py
+++ b/qiskit/primitives/__init__.py
@@ -387,7 +387,7 @@ level, however, here are some notable differences keep in mind when migrating fr
 Primitives API
 ==============
 
-Primitives V2
+Estimator V2
 -------------
 
 .. autosummary::
@@ -395,6 +395,7 @@ Primitives V2
 
    BaseEstimatorV2
    StatevectorEstimator
+   EstimatorV2Converter
 
 Sampler V2
 ----------
@@ -469,6 +470,7 @@ from .containers import (
     ObservablesArrayLike,
 )
 from .estimator import Estimator
+from .estimatorv2converter import EstimatorV2Converter
 from .primitive_job import BasePrimitiveJob, PrimitiveJob
 from .sampler import Sampler
 from .statevector_estimator import StatevectorEstimator

--- a/qiskit/primitives/estimatorv2converter.py
+++ b/qiskit/primitives/estimatorv2converter.py
@@ -1,0 +1,87 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Estimator Converter class
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+import numpy as np
+
+from qiskit.quantum_info import SparsePauliOp
+
+from .base import BaseEstimatorV1, BaseEstimatorV2
+from .containers import EstimatorPubLike, PrimitiveResult, PubResult
+from .containers.estimator_pub import EstimatorPub
+from .primitive_job import PrimitiveJob
+
+
+class EstimatorV2Converter(BaseEstimatorV2):
+    """A converter class that takes a :class:`~.BaseEstimatorV1` instance and wraps it in a
+    :class:`~.BaseEstimatorV2` interface.
+    """
+
+    def __init__(
+        self,
+        estimator: BaseEstimatorV1,
+    ):
+        """Initialize a EstimatorV2Converter converter instance based on a BaseEstiamtorV1 instance.
+
+        Args:
+            estimator: The input :class:`~.BaseEstimatorV1` based backend to wrap in a
+                :class:`~.BaseEstimatorV2` interface.
+        """
+        self._estimatorv1 = estimator
+
+    def run(
+        self, pubs: Iterable[EstimatorPubLike], *, precision: float | None = None
+    ) -> BasePrimitiveJob[PrimitiveResult[PubResult]]:
+        coerced_pubs = [EstimatorPub.coerce(pub, precision) for pub in pubs]
+
+        job = PrimitiveJob(self._run, coerced_pubs)
+        job._submit()
+        return job
+
+    def _run(self, pubs: list[EstimatorPub]) -> PrimitiveResult[PubResult]:
+        return PrimitiveResult([self._run_pub(pub) for pub in pubs])
+
+    def _run_pub(self, pub: EstimatorPub) -> PubResult:
+        circuit = pub.circuit
+        observables = pub.observables
+        parameter_values = pub.parameter_values
+        precision = pub.precision
+
+        out_shape = np.broadcast_shapes(pub.observables.shape, pub.parameter_values.shape)
+        param_broad = np.broadcast_to(pub.parameter_values, out_shape)
+        param_object = np.zeros(pub.parameter_values.shape, dtype=object)
+        param_array = pub.parameter_values.as_array(circuit.parameters)
+        for idx in np.ndindex(pub.parameter_values.shape):
+            param_object[idx] = param_array[idx].tolist()
+
+        obs_list = []
+        param_list = []
+        for obs, param in np.broadcast(pub.observables, param_object):
+            spo = SparsePauliOp.from_list(list(obs.items()))
+            obs_list.append(spo)
+            param_list.append(param)
+
+        size = len(obs_list)
+        result = self._estimatorv1.run([circuit] * size, obs_list, param_list).result()
+        evs = result.values.reshape(out_shape)
+        stds_list = [
+            np.sqrt(dat.get("variance", 0) / dat.get("shots", 1)) for dat in result.metadata
+        ]
+        stds = np.array(stds_list).reshape(out_shape)
+        data_bin = self._make_data_bin(pub)(evs=evs, stds=stds)
+        return PubResult(data_bin, metadata={"precision": precision})

--- a/qiskit/primitives/estimatorv2converter.py
+++ b/qiskit/primitives/estimatorv2converter.py
@@ -43,7 +43,7 @@ class EstimatorV2Converter(BaseEstimatorV2):
             estimator: The input :class:`~.BaseEstimatorV1` based backend to wrap in a
                 :class:`~.BaseEstimatorV2` interface.
         """
-        self._estimatorv1 = estimator
+        self.estimatorv1 = estimator
 
     def run(
         self, pubs: Iterable[EstimatorPubLike], *, precision: float | None = None
@@ -79,7 +79,7 @@ class EstimatorV2Converter(BaseEstimatorV2):
             param_list.append(param)
 
         size = len(obs_list)
-        result = self._estimatorv1.run([circuit] * size, obs_list, param_list).result()
+        result = self.estimatorv1.run([circuit] * size, obs_list, param_list).result()
         evs = result.values.reshape(out_shape)
         stds_list = [
             np.sqrt(dat.get("variance", np.nan) / dat.get("shots", 1)) for dat in result.metadata

--- a/releasenotes/notes/estimatorv2converter-7a87ea0ae1775952.yaml
+++ b/releasenotes/notes/estimatorv2converter-7a87ea0ae1775952.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    New classes :class:`.EstimatorV2Converter` and :class:`.BackendEstimatorV2` have been added to
+    the :mod:`qiskit.primitives` module. :class:`.EstimatorV2Converter` converts an instance of
+    :class:`.BaseEstimatorV1` into an instance of :class:`.BaseEstimatorV2`.
+    :class:`.BackendEstimatorV2` is simple conversion of :class:`.BackendEstimator` that inherits
+    :class:`.BaseEstimatorV1`.

--- a/test/python/primitives/test_backend_estimator.py
+++ b/test/python/primitives/test_backend_estimator.py
@@ -13,23 +13,26 @@
 """Tests for BackendEstimator."""
 
 import unittest
-from unittest.mock import patch
 from multiprocessing import Manager
+from test import QiskitTestCase  # pylint: disable=wrong-import-order
+from test import combine  # pylint: disable=wrong-import-order
+from test.python.transpiler._dummy_passes import DummyAP  # pylint: disable=wrong-import-order
+from unittest.mock import patch
+
 import numpy as np
 from ddt import ddt
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library import RealAmplitudes
-from qiskit.primitives import BackendEstimator, EstimatorResult
-from qiskit.providers.fake_provider import Fake7QPulseV1, GenericBackendV2
+from qiskit.primitives import BackendEstimator, BackendEstimatorV2, EstimatorResult
+from qiskit.primitives.containers.bindings_array import BindingsArray
+from qiskit.primitives.containers.estimator_pub import EstimatorPub
+from qiskit.primitives.containers.observables_array import ObservablesArray
 from qiskit.providers.backend_compat import BackendV2Converter
+from qiskit.providers.fake_provider import Fake7QPulseV1, GenericBackendV2
 from qiskit.quantum_info import SparsePauliOp
 from qiskit.transpiler import PassManager
 from qiskit.utils import optionals
-from test import QiskitTestCase  # pylint: disable=wrong-import-order
-from test import combine  # pylint: disable=wrong-import-order
-from test.python.transpiler._dummy_passes import DummyAP  # pylint: disable=wrong-import-order
-
 
 BACKENDS = [
     Fake7QPulseV1(),
@@ -453,6 +456,409 @@ class TestBackendEstimator(QiskitTestCase):
         result = estimator.run(qc, observable).result()
         self.assertAlmostEqual(result.values[0], 0, places=1)
 
+
+@ddt
+class TestBackendEstimatorV2(QiskitTestCase):
+    """Test Estimator"""
+
+    def setUp(self):
+        super().setUp()
+        self.ansatz = RealAmplitudes(num_qubits=2, reps=2)
+        self.observable = SparsePauliOp.from_list(
+            [
+                ("II", -1.052373245772859),
+                ("IZ", 0.39793742484318045),
+                ("ZI", -0.39793742484318045),
+                ("ZZ", -0.01128010425623538),
+                ("XX", 0.18093119978423156),
+            ]
+        )
+        self.expvals = -1.0284380963435145, -1.284366511861733
+
+        self.psi = (RealAmplitudes(num_qubits=2, reps=2), RealAmplitudes(num_qubits=2, reps=3))
+        self.params = tuple(psi.parameters for psi in self.psi)
+        self.hamiltonian = (
+            SparsePauliOp.from_list([("II", 1), ("IZ", 2), ("XI", 3)]),
+            SparsePauliOp.from_list([("IZ", 1)]),
+            SparsePauliOp.from_list([("ZI", 1), ("ZZ", 1)]),
+        )
+        self.theta = (
+            [0, 1, 1, 2, 3, 5],
+            [0, 1, 1, 2, 3, 5, 8, 13],
+            [1, 2, 3, 4, 5, 6],
+        )
+
+    @combine(backend=BACKENDS)
+    def test_estimator_run(self, backend):
+        """Test Estimator.run()"""
+        psi1, psi2 = self.psi
+        hamiltonian1, hamiltonian2, hamiltonian3 = self.hamiltonian
+        theta1, theta2, theta3 = self.theta
+        estimator = BackendEstimatorV2(backend=backend)
+        estimator.set_options(seed_simulator=123)
+
+        # Specify the circuit and observable by indices.
+        # calculate [ <psi1(theta1)|H1|psi1(theta1)> ]
+        job = estimator.run([(psi1, hamiltonian1, theta1)])
+        result = job.result()
+        np.testing.assert_allclose(result[0].data.evs, [1.5555572817900956], rtol=0.5, atol=0.2)
+
+        # Objects can be passed instead of indices.
+        # Note that passing objects has an overhead
+        # since the corresponding indices need to be searched.
+        # User can append a circuit and observable.
+        # calculate [ <psi2(theta2)|H2|psi2(theta2)> ]
+        result2 = estimator.run([(psi2, hamiltonian1, theta2)]).result()
+        np.testing.assert_allclose(result2[0].data.evs, [2.97797666], rtol=0.5, atol=0.2)
+
+        # calculate [ <psi1(theta1)|H2|psi1(theta1)>, <psi1(theta1)|H3|psi1(theta1)> ]
+        result3 = estimator.run([(psi1, [hamiltonian2, hamiltonian3], theta1)]).result()
+        np.testing.assert_allclose(result3[0].data.evs, [-0.551653, 0.07535239], rtol=0.5, atol=0.2)
+
+        # calculate [ <psi1(theta1)|H1|psi1(theta1)>,
+        #             <psi2(theta2)|H2|psi2(theta2)>,
+        #             <psi1(theta3)|H3|psi1(theta3)> ]
+        result4 = estimator.run(
+            [(psi1, [hamiltonian1, hamiltonian3], [theta1, theta3]), (psi2, hamiltonian2, theta2)]
+        ).result()
+        np.testing.assert_allclose(
+            result4[0].data.evs, [1.55555728, -1.08766318], rtol=0.5, atol=0.2
+        )
+        np.testing.assert_allclose(result4[1].data.evs, [0.17849238], rtol=0.5, atol=0.2)
+
+    @combine(backend=BACKENDS)
+    def test_estimator_with_pub(self, backend):
+        """Test estimator with explicit EstimatorPubs."""
+        psi1, psi2 = self.psi
+        hamiltonian1, hamiltonian2, hamiltonian3 = self.hamiltonian
+        theta1, theta2, theta3 = self.theta
+
+        obs1 = ObservablesArray.coerce([hamiltonian1, hamiltonian3])
+        bind1 = BindingsArray.coerce({tuple(psi1.parameters): [theta1, theta3]})
+        pub1 = EstimatorPub(psi1, obs1, bind1)
+        obs2 = ObservablesArray.coerce(hamiltonian2)
+        bind2 = BindingsArray.coerce({tuple(psi2.parameters): theta2})
+        pub2 = EstimatorPub(psi2, obs2, bind2)
+
+        estimator = BackendEstimatorV2(backend=backend)
+        estimator.set_options(seed_simulator=123)
+        result4 = estimator.run([pub1, pub2]).result()
+        np.testing.assert_allclose(
+            result4[0].data.evs, [1.55555728, -1.08766318], rtol=0.5, atol=0.2
+        )
+        np.testing.assert_allclose(result4[1].data.evs, [0.17849238], rtol=0.5, atol=0.2)
+
+    @combine(backend=BACKENDS)
+    def test_estimator_run_no_params(self, backend):
+        """test for estimator without parameters"""
+        circuit = self.ansatz.assign_parameters([0, 1, 1, 2, 3, 5])
+        est = BackendEstimatorV2(backend=backend)
+        est.set_options(seed_simulator=123)
+        result = est.run([(circuit, self.observable)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [-1.284366511861733], rtol=0.05)
+
+    @combine(backend=BACKENDS, creg=[True, False])
+    def test_run_1qubit(self, backend, creg):
+        """Test for 1-qubit cases"""
+        qc = QuantumCircuit(1, 1) if creg else QuantumCircuit(1)
+        qc2 = QuantumCircuit(1, 1) if creg else QuantumCircuit(1)
+        qc2.x(0)
+
+        op = SparsePauliOp.from_list([("I", 1)])
+        op2 = SparsePauliOp.from_list([("Z", 1)])
+
+        est = BackendEstimatorV2(backend=backend)
+        est.set_options(seed_simulator=123)
+        result = est.run([(qc, op)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [1], rtol=0.1)
+
+        result = est.run([(qc, op2)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [1], rtol=0.1)
+
+        result = est.run([(qc2, op)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [1], rtol=0.1)
+
+        result = est.run([(qc2, op2)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [-1], rtol=0.1)
+
+    @combine(backend=BACKENDS, creg=[True, False])
+    def test_run_2qubits(self, backend, creg):
+        """Test for 2-qubit cases (to check endian)"""
+        backend.set_options(seed_simulator=123)
+        qc = QuantumCircuit(2, 1) if creg else QuantumCircuit(2)
+        qc2 = QuantumCircuit(2, 1) if creg else QuantumCircuit(2, 1)
+        qc2.x(0)
+
+        op = SparsePauliOp.from_list([("II", 1)])
+        op2 = SparsePauliOp.from_list([("ZI", 1)])
+        op3 = SparsePauliOp.from_list([("IZ", 1)])
+
+        est = BackendEstimatorV2(backend=backend)
+        result = est.run([(qc, op)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [1], rtol=0.1)
+
+        result = est.run([(qc2, op)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [1], rtol=0.1)
+
+        result = est.run([(qc, op2)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [1], rtol=0.1)
+
+        result = est.run([(qc2, op2)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [1], rtol=0.1)
+
+        result = est.run([(qc, op3)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [1], rtol=0.1)
+
+        result = est.run([(qc2, op3)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [-1], rtol=0.1)
+
+    @combine(backend=BACKENDS)
+    def test_run_errors(self, backend):
+        """Test for errors"""
+        qc = QuantumCircuit(1)
+        qc2 = QuantumCircuit(2)
+
+        op = SparsePauliOp.from_list([("I", 1)])
+        op2 = SparsePauliOp.from_list([("II", 1)])
+
+        est = BackendEstimatorV2(backend=backend)
+        est.set_options(seed_simulator=123)
+        with self.assertRaises(ValueError):
+            est.run([(qc, op2)]).result()
+        with self.assertRaises(ValueError):
+            est.run([(qc, op, [[1e4]])]).result()
+        with self.assertRaises(ValueError):
+            est.run([(qc2, op2, [[1, 2]])]).result()
+        with self.assertRaises(ValueError):
+            est.run([(qc, [op, op2], [[1]])]).result()
+        with self.assertRaises(ValueError):
+            est.run([(qc, op)], precision=-1).result()
+        with self.assertRaises(ValueError):
+            est.run([(qc, 1j * op)], precision=0.1).result()
+
+    @combine(backend=BACKENDS)
+    def test_run_numpy_params(self, backend):
+        """Test for numpy array as parameter values"""
+        qc = RealAmplitudes(num_qubits=2, reps=2)
+        op = SparsePauliOp.from_list([("IZ", 1), ("XI", 2), ("ZY", -1)])
+        k = 5
+        params_array = np.random.rand(k, qc.num_parameters)
+        params_list = params_array.tolist()
+        params_list_array = list(params_array)
+        estimator = BackendEstimatorV2(backend=backend)
+        estimator.set_options(seed_simulator=123)
+
+        target = estimator.run([(qc, op, params_list)]).result()
+
+        with self.subTest("ndarrary"):
+            result = estimator.run([(qc, op, params_array)]).result()
+            self.assertEqual(len(result[0].data.evs), k)
+            np.testing.assert_allclose(result[0].data.evs, target[0].data.evs, rtol=0.2, atol=0.2)
+
+        with self.subTest("list of ndarray"):
+            result = estimator.run([(qc, op, params_list_array)]).result()
+            self.assertEqual(len(result[0].data.evs), k)
+            np.testing.assert_allclose(result[0].data.evs, target[0].data.evs, rtol=0.2, atol=0.2)
+
+    @combine(backend=BACKENDS)
+    def test_options(self, backend):
+        """Test for options"""
+        with self.subTest("init"):
+            estimator = BackendEstimatorV2(backend=backend, options={"shots": 3000})
+            self.assertEqual(estimator.options.get("shots"), 3000)
+        with self.subTest("set_options"):
+            estimator.set_options(shots=1024, seed_simulator=15)
+            self.assertEqual(estimator.options.get("shots"), 1024)
+            self.assertEqual(estimator.options.get("seed_simulator"), 15)
+        with self.subTest("run"):
+            result = estimator.run([(self.ansatz, self.observable, [[0, 1, 1, 2, 3, 5]])]).result()
+            np.testing.assert_allclose(result[0].data.evs, [-1.307397243478641], rtol=0.1)
+
+    def test_job_size_limit_v2(self):
+        """Test BackendEstimator respects job size limit"""
+
+        class FakeBackendLimitedCircuits(GenericBackendV2):
+            """Generic backend V2 with job size limit."""
+
+            @property
+            def max_circuits(self):
+                return 1
+
+        backend = FakeBackendLimitedCircuits(num_qubits=5)
+        backend.set_options(seed_simulator=123)
+        qc = RealAmplitudes(num_qubits=2, reps=2)
+        op = SparsePauliOp.from_list([("IZ", 1), ("XI", 2), ("ZY", -1)])
+        k = 5
+        params_array = np.random.rand(k, qc.num_parameters)
+        params_list = params_array.tolist()
+        estimator = BackendEstimatorV2(backend=backend)
+        with patch.object(backend, "run") as run_mock:
+            estimator.run([(qc, op, params_list)]).result()
+        self.assertEqual(run_mock.call_count, 10)
+
+    def test_job_size_limit_v1(self):
+        """Test BackendEstimator respects job size limit"""
+        backend = Fake7QPulseV1()
+        config = backend.configuration()
+        config.max_experiments = 1
+        backend._configuration = config
+        qc = RealAmplitudes(num_qubits=2, reps=2)
+        op = SparsePauliOp.from_list([("IZ", 1), ("XI", 2), ("ZY", -1)])
+        k = 5
+        params_array = np.random.rand(k, qc.num_parameters)
+        params_list = params_array.tolist()
+        estimator = BackendEstimatorV2(backend=backend)
+        estimator.set_options(seed_simulator=123)
+        with patch.object(backend, "run") as run_mock:
+            estimator.run([(qc, op, params_list)]).result()
+        self.assertEqual(run_mock.call_count, 10)
+
+    def test_no_max_circuits(self):
+        """Test BackendEstimator works with BackendV1 and no max_experiments set."""
+        backend = Fake7QPulseV1()
+        config = backend.configuration()
+        del config.max_experiments
+        backend._configuration = config
+        qc = RealAmplitudes(num_qubits=2, reps=2)
+        op = SparsePauliOp.from_list([("IZ", 1), ("XI", 2), ("ZY", -1)])
+        k = 5
+        params_array = np.random.rand(k, qc.num_parameters)
+        params_list = params_array.tolist()
+        params_list_array = list(params_array)
+        estimator = BackendEstimatorV2(backend=backend)
+        estimator.set_options(seed_simulator=123)
+        target = estimator.run([(qc, op, params_list)]).result()
+        with self.subTest("ndarrary"):
+            result = estimator.run([(qc, op, params_array)]).result()
+            self.assertEqual(len(result[0].metadata), k)
+            np.testing.assert_allclose(result[0].data.evs, target[0].data.evs, rtol=0.2, atol=0.2)
+
+        with self.subTest("list of ndarray"):
+            result = estimator.run([(qc, op, params_list_array)]).result()
+            self.assertEqual(len(result[0].metadata), k)
+            np.testing.assert_allclose(result[0].data.evs, target[0].data.evs, rtol=0.2, atol=0.2)
+
+    def test_bound_pass_manager(self):
+        """Test bound pass manager."""
+
+        qc = QuantumCircuit(2)
+        op = SparsePauliOp.from_list([("II", 1)])
+
+        with self.subTest("Test single circuit"):
+            messages = []
+
+            def callback(msg):
+                messages.append(msg)
+
+            bound_counter = CallbackPass("bound_pass_manager", callback)
+            bound_pass = PassManager(bound_counter)
+            estimator = BackendEstimatorV2(backend=Fake7QPulseV1(), bound_pass_manager=bound_pass)
+            _ = estimator.run([(qc, op)]).result()
+            expected = [
+                "bound_pass_manager",
+            ]
+            self.assertEqual(messages, expected)
+
+        with self.subTest("Test circuit batch"):
+            with Manager() as manager:
+                # The multiprocessing manager is used to share data
+                # between different processes. Pass Managers parallelize
+                # execution for batches of circuits, so this is necessary
+                # to keep track of the callback calls for num_circuits > 1
+                messages = manager.list()
+
+                def callback(msg):  # pylint: disable=function-redefined
+                    messages.append(msg)
+
+                bound_counter = CallbackPass("bound_pass_manager", callback)
+                bound_pass = PassManager(bound_counter)
+                estimator = BackendEstimatorV2(
+                    backend=Fake7QPulseV1(), bound_pass_manager=bound_pass
+                )
+                _ = estimator.run([(qc, [op] * 2)]).result()
+                expected = [
+                    "bound_pass_manager",
+                    "bound_pass_manager",
+                ]
+                self.assertEqual(list(messages), expected)
+
+    @combine(backend=BACKENDS)
+    def test_layout(self, backend):
+        """Test layout for split transpilation."""
+        with self.subTest("initial layout test"):
+            qc = QuantumCircuit(3)
+            qc.x(0)
+            qc.cx(0, 1)
+            qc.cx(0, 2)
+            op = SparsePauliOp("IZI")
+            backend.set_options(seed_simulator=15, shots=10000)
+            estimator = BackendEstimatorV2(backend)
+            estimator.set_transpile_options(seed_transpiler=15)
+            value = estimator.run([(qc, op)]).result()[0].data.evs
+            if optionals.HAS_AER:
+                ref_value = -0.9954 if isinstance(backend, GenericBackendV2) else -0.916
+            else:
+                ref_value = -1
+            self.assertEqual(value, ref_value)
+
+        with self.subTest("final layout test"):
+            qc = QuantumCircuit(3)
+            qc.x(0)
+            qc.cx(0, 1)
+            qc.cx(0, 2)
+            op = SparsePauliOp("IZI")
+            estimator = BackendEstimatorV2(backend)
+            estimator.set_transpile_options(initial_layout=[0, 1, 2], seed_transpiler=15)
+            estimator.set_options(seed_simulator=15, shots=10000)
+            value = estimator.run([(qc, op)]).result()[0].data.evs
+            if optionals.HAS_AER:
+                ref_value = -0.9954 if isinstance(backend, GenericBackendV2) else -0.8902
+            else:
+                ref_value = -1
+            self.assertEqual(value, ref_value)
+
+    @unittest.skipUnless(optionals.HAS_AER, "qiskit-aer is required to run this test")
+    def test_circuit_with_measurement(self):
+        """Test estimator with a dynamic circuit"""
+        from qiskit_aer import AerSimulator
+
+        bell = QuantumCircuit(2)
+        bell.h(0)
+        bell.cx(0, 1)
+        bell.measure_all()
+        observable = SparsePauliOp("ZZ")
+
+        backend = AerSimulator()
+        backend.set_options(seed_simulator=15)
+        estimator = BackendEstimator(backend, skip_transpilation=True)
+        estimator.set_transpile_options(seed_transpiler=15)
+        result = estimator.run(bell, observable).result()
+        self.assertAlmostEqual(result.values[0], 1, places=1)
+
+    @unittest.skipUnless(optionals.HAS_AER, "qiskit-aer is required to run this test")
+    def test_dynamic_circuit(self):
+        """Test estimator with a dynamic circuit"""
+        from qiskit_aer import AerSimulator
+
+        qc = QuantumCircuit(2, 1)
+        with qc.for_loop(range(5)):
+            qc.h(0)
+            qc.cx(0, 1)
+            qc.measure(1, 0)
+            qc.break_loop().c_if(0, True)
+
+        observable = SparsePauliOp("IZ")
+
+        backend = AerSimulator()
+        backend.set_options(seed_simulator=15)
+        estimator = BackendEstimator(backend, skip_transpilation=True)
+        estimator.set_transpile_options(seed_transpiler=15)
+        result = estimator.run(qc, observable).result()
+        self.assertAlmostEqual(result.values[0], 0, places=1)
+
+
+if __name__ == "__main__":
+    unittest.main()
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/primitives/test_estimatorv2converter.py
+++ b/test/python/primitives/test_estimatorv2converter.py
@@ -1,0 +1,291 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for EstimatorV2Converter."""
+
+import unittest
+from test import QiskitTestCase
+
+import numpy as np
+
+from qiskit.circuit import Parameter, QuantumCircuit
+from qiskit.circuit.library import RealAmplitudes
+from qiskit.primitives import Estimator, EstimatorV2Converter, StatevectorEstimator
+from qiskit.primitives.containers.bindings_array import BindingsArray
+from qiskit.primitives.containers.estimator_pub import EstimatorPub
+from qiskit.primitives.containers.observables_array import ObservablesArray
+from qiskit.quantum_info import SparsePauliOp
+
+
+class TestEstimatorV2Converter(QiskitTestCase):
+    """Test EstimatorV2Converter"""
+
+    def setUp(self):
+        super().setUp()
+        self.ansatz = RealAmplitudes(num_qubits=2, reps=2)
+        self.observable = SparsePauliOp.from_list(
+            [
+                ("II", -1.052373245772859),
+                ("IZ", 0.39793742484318045),
+                ("ZI", -0.39793742484318045),
+                ("ZZ", -0.01128010425623538),
+                ("XX", 0.18093119978423156),
+            ]
+        )
+        self.expvals = -1.0284380963435145, -1.284366511861733
+
+        self.psi = (RealAmplitudes(num_qubits=2, reps=2), RealAmplitudes(num_qubits=2, reps=3))
+        self.params = tuple(psi.parameters for psi in self.psi)
+        self.hamiltonian = (
+            SparsePauliOp.from_list([("II", 1), ("IZ", 2), ("XI", 3)]),
+            SparsePauliOp.from_list([("IZ", 1)]),
+            SparsePauliOp.from_list([("ZI", 1), ("ZZ", 1)]),
+        )
+        self.theta = (
+            [0, 1, 1, 2, 3, 5],
+            [0, 1, 1, 2, 3, 5, 8, 13],
+            [1, 2, 3, 4, 5, 6],
+        )
+
+    def test_estimator_run(self):
+        """Test Estimator.run()"""
+        psi1, psi2 = self.psi
+        hamiltonian1, hamiltonian2, hamiltonian3 = self.hamiltonian
+        theta1, theta2, theta3 = self.theta
+        estimator_v1 = Estimator()
+        estimator = EstimatorV2Converter(estimator_v1)
+
+        # Specify the circuit and observable by indices.
+        # calculate [ <psi1(theta1)|H1|psi1(theta1)> ]
+        job = estimator.run([(psi1, hamiltonian1, [theta1])])
+        result = job.result()
+        np.testing.assert_allclose(result[0].data.evs, [1.5555572817900956])
+
+        # Objects can be passed instead of indices.
+        # Note that passing objects has an overhead
+        # since the corresponding indices need to be searched.
+        # User can append a circuit and observable.
+        # calculate [ <psi2(theta2)|H2|psi2(theta2)> ]
+        result2 = estimator.run([(psi2, hamiltonian1, theta2)]).result()
+        np.testing.assert_allclose(result2[0].data.evs, [2.97797666])
+
+        # calculate [ <psi1(theta1)|H2|psi1(theta1)>, <psi1(theta1)|H3|psi1(theta1)> ]
+        result3 = estimator.run([(psi1, [hamiltonian2, hamiltonian3], theta1)]).result()
+        np.testing.assert_allclose(result3[0].data.evs, [-0.551653, 0.07535239])
+
+        # calculate [ [<psi1(theta1)|H1|psi1(theta1)>,
+        #              <psi1(theta3)|H3|psi1(theta3)>],
+        #             [<psi2(theta2)|H2|psi2(theta2)>] ]
+        result4 = estimator.run(
+            [(psi1, [hamiltonian1, hamiltonian3], [theta1, theta3]), (psi2, hamiltonian2, theta2)]
+        ).result()
+        np.testing.assert_allclose(result4[0].data.evs, [1.55555728, -1.08766318])
+        np.testing.assert_allclose(result4[1].data.evs, [0.17849238])
+
+    def test_estimator_with_pub(self):
+        """Test estimator with explicit EstimatorPubs."""
+        psi1, psi2 = self.psi
+        hamiltonian1, hamiltonian2, hamiltonian3 = self.hamiltonian
+        theta1, theta2, theta3 = self.theta
+
+        obs1 = ObservablesArray.coerce([hamiltonian1, hamiltonian3])
+        bind1 = BindingsArray.coerce({tuple(psi1.parameters): [theta1, theta3]})
+        pub1 = EstimatorPub(psi1, obs1, bind1)
+        obs2 = ObservablesArray.coerce(hamiltonian2)
+        bind2 = BindingsArray.coerce({tuple(psi2.parameters): theta2})
+        pub2 = EstimatorPub(psi2, obs2, bind2)
+
+        estimator_v1 = Estimator()
+        estimator = EstimatorV2Converter(estimator_v1)
+        result4 = estimator.run([pub1, pub2]).result()
+        np.testing.assert_allclose(result4[0].data.evs, [1.55555728, -1.08766318])
+        np.testing.assert_allclose(result4[1].data.evs, [0.17849238])
+
+    def test_estimator_run_no_params(self):
+        """test for estimator without parameters"""
+        circuit = self.ansatz.assign_parameters([0, 1, 1, 2, 3, 5])
+        estimator_v1 = Estimator()
+        est = EstimatorV2Converter(estimator_v1)
+        result = est.run([(circuit, self.observable)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [-1.284366511861733])
+
+    def test_run_single_circuit_observable(self):
+        """Test for single circuit and single observable case."""
+        estimator_v1 = Estimator()
+        est = EstimatorV2Converter(estimator_v1)
+
+        with self.subTest("No parameter"):
+            qc = QuantumCircuit(1)
+            qc.x(0)
+            op = SparsePauliOp("Z")
+            param_vals = [None, [], [[]], np.array([]), np.array([[]]), [np.array([])]]
+            target = [-1]
+            for val in param_vals:
+                self.subTest(f"{val}")
+                result = est.run([(qc, op, val)]).result()
+                np.testing.assert_allclose(result[0].data.evs, target)
+                self.assertEqual(result[0].metadata["precision"], 0)
+
+        with self.subTest("One parameter"):
+            param = Parameter("x")
+            qc = QuantumCircuit(1)
+            qc.ry(param, 0)
+            op = SparsePauliOp("Z")
+            param_vals = [
+                [np.pi],
+                np.array([np.pi]),
+            ]
+            target = [-1]
+            for val in param_vals:
+                self.subTest(f"{val}")
+                result = est.run([(qc, op, val)]).result()
+                np.testing.assert_allclose(result[0].data.evs, target)
+
+        with self.subTest("More than one parameter"):
+            qc = self.psi[0]
+            op = self.hamiltonian[0]
+            param_vals = [
+                self.theta[0],
+                [self.theta[0]],
+                np.array(self.theta[0]),
+                np.array([self.theta[0]]),
+                [np.array(self.theta[0])],
+            ]
+            target = [1.5555572817900956]
+            for val in param_vals:
+                self.subTest(f"{val}")
+                result = est.run([(qc, op, val)]).result()
+                np.testing.assert_allclose(result[0].data.evs, target)
+
+    def test_run_1qubit(self):
+        """Test for 1-qubit cases"""
+        qc = QuantumCircuit(1)
+        qc2 = QuantumCircuit(1)
+        qc2.x(0)
+
+        op = SparsePauliOp.from_list([("I", 1)])
+        op2 = SparsePauliOp.from_list([("Z", 1)])
+
+        estimator_v1 = Estimator()
+        est = EstimatorV2Converter(estimator_v1)
+        result = est.run([(qc, op)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [1])
+
+        result = est.run([(qc, op2)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [1])
+
+        result = est.run([(qc2, op)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [1])
+
+        result = est.run([(qc2, op2)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [-1])
+
+    def test_run_2qubits(self):
+        """Test for 2-qubit cases (to check endian)"""
+        qc = QuantumCircuit(2)
+        qc2 = QuantumCircuit(2)
+        qc2.x(0)
+
+        op = SparsePauliOp.from_list([("II", 1)])
+        op2 = SparsePauliOp.from_list([("ZI", 1)])
+        op3 = SparsePauliOp.from_list([("IZ", 1)])
+
+        estimator_v1 = Estimator()
+        est = EstimatorV2Converter(estimator_v1)
+        result = est.run([(qc, op)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [1])
+
+        result = est.run([(qc2, op)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [1])
+
+        result = est.run([(qc, op2)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [1])
+
+        result = est.run([(qc2, op2)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [1])
+
+        result = est.run([(qc, op3)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [1])
+
+        result = est.run([(qc2, op3)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [-1])
+
+    def test_run_errors(self):
+        """Test for errors"""
+        qc = QuantumCircuit(1)
+        qc2 = QuantumCircuit(2)
+
+        op = SparsePauliOp.from_list([("I", 1)])
+        op2 = SparsePauliOp.from_list([("II", 1)])
+
+        estimator_v1 = Estimator()
+        est = EstimatorV2Converter(estimator_v1)
+        with self.assertRaises(ValueError):
+            est.run([(qc, op2)]).result()
+        with self.assertRaises(ValueError):
+            est.run([(qc, op, [[1e4]])]).result()
+        with self.assertRaises(ValueError):
+            est.run([(qc2, op2, [[1, 2]])]).result()
+        with self.assertRaises(ValueError):
+            est.run([(qc, [op, op2], [[1]])]).result()
+        with self.assertRaises(ValueError):
+            est.run([(qc, op)], precision=-1).result()
+        with self.assertRaises(ValueError):
+            est.run([(qc, 1j * op)], precision=0.1).result()
+
+    def test_run_numpy_params(self):
+        """Test for numpy array as parameter values"""
+        qc = RealAmplitudes(num_qubits=2, reps=2)
+        op = SparsePauliOp.from_list([("IZ", 1), ("XI", 2), ("ZY", -1)])
+        k = 5
+        params_array = np.random.rand(k, qc.num_parameters)
+        params_list = params_array.tolist()
+        params_list_array = list(params_array)
+        estimator_v1 = Estimator()
+        estimator = EstimatorV2Converter(estimator_v1)
+        target = estimator.run([(qc, op, params_list)]).result()
+
+        with self.subTest("ndarrary"):
+            result = estimator.run([(qc, op, params_array)]).result()
+            self.assertEqual(len(result[0].data.evs), k)
+            np.testing.assert_allclose(result[0].data.evs, target[0].data.evs)
+
+        with self.subTest("list of ndarray"):
+            result = estimator.run([(qc, op, params_list_array)]).result()
+            self.assertEqual(len(result[0].data.evs), k)
+            np.testing.assert_allclose(result[0].data.evs, target[0].data.evs)
+
+    def test_precision_seed(self):
+        """Test for precision and seed"""
+        precision = 0.1
+        shots = int(1 / precision)  # TODO: define the relation between precision and shots
+        estimator_v1 = Estimator({"seed": 1, "shots": shots})
+        estimator = EstimatorV2Converter(estimator_v1)
+        psi1 = self.psi[0]
+        hamiltonian1 = self.hamiltonian[0]
+        theta1 = self.theta[0]
+        job = estimator.run([(psi1, hamiltonian1, [theta1])])
+        result = job.result()
+        np.testing.assert_allclose(result[0].data.evs, [1.901141473854881])
+        # The result of the second run is the same
+        job = estimator.run([(psi1, hamiltonian1, [theta1]), (psi1, hamiltonian1, [theta1])])
+        result = job.result()
+        np.testing.assert_allclose(result[0].data.evs, [1.901141473854881])
+        np.testing.assert_allclose(result[1].data.evs, [1.901141473854881])
+        # precision=0 impliese the exact expectation value
+        job = estimator.run([(psi1, hamiltonian1, [theta1])], precision=0)
+        result = job.result()
+        np.testing.assert_allclose(result[0].data.evs, [1.5555572817900956])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Add `EstimatorV2Converter` and `BackendEstimatorV2` to `qiskit.primitives`.
EstimatorV2Converter converts an instance of BaseEstimatorV1 into an instance
of BaseEstimatorV2. BackendEstimatorV2 is simple conversion of BackendEstimator
that inherits BaseEstimatorV1.

