### PR TITLE
_mcsu2 should raise a QiskitError with a non-SU(2) input

### DIFF
--- a/qiskit/circuit/library/standard_gates/multi_control_rotation_gates.py
+++ b/qiskit/circuit/library/standard_gates/multi_control_rotation_gates.py
@@ -123,6 +123,9 @@ def _mcsu2_real_diagonal(
     if not is_unitary_matrix(unitary):
         raise QiskitError(f"The unitary in must be an unitary matrix, but is {unitary}.")
 
+    if not np.isclose(1.0, np.linalg.det(unitary)):
+        raise QiskitError("Invalid Value _mcsu2_real_diagonal requires det(unitary) equal to one.")
+
     is_main_diag_real = np.isclose(unitary[0, 0].imag, 0.0) and np.isclose(unitary[1, 1].imag, 0.0)
     is_secondary_diag_real = np.isclose(unitary[0, 1].imag, 0.0) and np.isclose(
         unitary[1, 0].imag, 0.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
As pointed by @ShellyGarion in #5872 _mcsu2 should throw an error when receiving a non-SU(2) unitary.



