### PR TITLE
Remove dead `Instruction._qasmif` method

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -520,18 +520,6 @@ class Instruction(Operation):
             cpy._definition = copy.deepcopy(self._definition, memo)
         return cpy
 
-    def _qasmif(self, string):
-        """Print an if statement if needed."""
-        from qiskit.qasm2 import QASM2ExportError  # pylint: disable=cyclic-import
-
-        if self.condition is None:
-            return string
-        if not isinstance(self.condition[0], ClassicalRegister):
-            raise QASM2ExportError(
-                "OpenQASM 2 can only condition on registers, but got '{self.condition[0]}'"
-            )
-        return "if(%s==%d) " % (self.condition[0].name, self.condition[1]) + string
-
     def broadcast_arguments(self, qargs, cargs):
         """
         Validation of the arguments.


### PR DESCRIPTION
### Summary

This is not called, not referenced and not public, it just got missed in the removal of the greater `Instruction.qasm` machinery in 1.0.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments


