### PR TITLE
Fix transpilation of control flow to no hardware

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/common.py
+++ b/qiskit/transpiler/preset_passmanagers/common.py
@@ -86,9 +86,12 @@ class _InvalidControlFlowForBackend:
     def __init__(self, basis_gates=(), target=None):
         if target is not None:
             self.unsupported = [op for op in CONTROL_FLOW_OP_NAMES if op not in target]
-        else:
-            basis_gates = set(basis_gates) if basis_gates is not None else set()
+        elif basis_gates is not None:
+            basis_gates = set(basis_gates)
             self.unsupported = [op for op in CONTROL_FLOW_OP_NAMES if op not in basis_gates]
+        else:
+            # Pass manager without basis gates or target; assume everything's valid.
+            self.unsupported = []
 
     def message(self, property_set):
         """Create an error message for the given property set."""

--- a/releasenotes/notes/fix-transpile-control-flow-no-hardware-7c00ad733a569bb9.yaml
+++ b/releasenotes/notes/fix-transpile-control-flow-no-hardware-7c00ad733a569bb9.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The preset pass managers of :func:`.transpile` will no longer fail on circuits
+    with control flow, if no hardware target or basis-gate set is specified.  They
+    will now treat such abstract targets as permitting all control-flow operations.
+    Fixed `#11906 <https://github.com/Qiskit/qiskit/issues/11906>`__.

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -1646,6 +1646,27 @@ class TestTranspile(QiskitTestCase):
         self.assertEqual(Operator.from_circuit(result), Operator.from_circuit(qc))
 
     @data(0, 1, 2, 3)
+    def test_transpile_control_flow_no_backend(self, opt_level):
+        """Test `transpile` with control flow and no specified hardware constraints."""
+        qc = QuantumCircuit(QuantumRegister(1, "q"), ClassicalRegister(1, "c"))
+        qc.h(0)
+        qc.measure(0, 0)
+        with qc.if_test((qc.clbits[0], False)):
+            qc.x(0)
+        with qc.while_loop((qc.clbits[0], True)):
+            qc.x(0)
+        with qc.for_loop(range(2)):
+            qc.x(0)
+        with qc.switch(qc.cregs[0]) as case:
+            with case(case.DEFAULT):
+                qc.x(0)
+        qc.measure(0, 0)
+
+        transpiled = transpile(qc, optimization_level=opt_level)
+        # There's nothing that can be optimized here.
+        self.assertEqual(qc, transpiled)
+
+    @data(0, 1, 2, 3)
     def test_transpile_with_custom_control_flow_target(self, opt_level):
         """Test transpile() with a target and constrol flow ops."""
         target = GenericBackendV2(num_qubits=8, control_flow=True).target


### PR DESCRIPTION
### Summary

Previously we treated `basis_gates=None` the same as `basis_gates=()` in the hardware check; that is, we treated it as meaning "nothing is allowed", when the intention (and how it's treated elsewhere) is more that "everything is allowed."

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Marked as stable for 1.0.2, but I could definitely be convinced otherwise.

Fix #11906.