### PR TITLE
Fix type hint and doc of `StatevectorEstimator.default_precision`

### DIFF
--- a/qiskit/primitives/statevector_estimator.py
+++ b/qiskit/primitives/statevector_estimator.py
@@ -115,8 +115,8 @@ class StatevectorEstimator(BaseEstimatorV2):
         self._seed = seed
 
     @property
-    def default_precision(self) -> int:
-        """Return the default shots"""
+    def default_precision(self) -> float:
+        """Return the default precision"""
         return self._default_precision
 
     @property


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

`StatevectorEstimator.default_precision` looks a copy of `StatevectorSampler.default_shots`.
It should be float as defined in the constructor.

### Details and comments


