### PR TITLE
Use const arrays for non-normalized basis in unitary synthesis

### DIFF
--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -37,17 +37,40 @@ const PI32: f64 = 3.0 * PI2;
 // FIXME: zero and one exist but I cant find the right incantation
 const C0: c64 = c64 { re: 0.0, im: 0.0 };
 const C1: c64 = c64 { re: 1.0, im: 0.0 };
+const C1_NEG: c64 = c64 { re: -1.0, im: 0.0 };
 const C1IM: c64 = c64 { re: 0.0, im: 1.0 };
+const C1_NEG_IM: c64 = c64 { re: 0.0, im: -1.0 };
+const C0_5: c64 = c64 { re: 0.5, im: 0.0 };
+const C0_5_NEG: c64 = c64 { re: -0.5, im: 0.0 };
+const C0_5_IM: c64 = c64 { re: 0.0, im: 0.5 };
+const C0_5_IM_NEG: c64 = c64 { re: 0.0, im: -0.5 };
 
-// FIXME: Find a way to compute these matrices at compile time.
+const B_NON_NORMALIZED: [c64; 16] = [
+    C1, C1IM, C0, C0, C0, C0, C1IM, C1, C0, C0, C1IM, C1_NEG, C1, C1_NEG_IM, C0, C0,
+];
+
+const B_NON_NORMALIZED_DAGGER: [c64; 16] = [
+    C0_5,
+    C0,
+    C0,
+    C0_5,
+    C0_5_IM_NEG,
+    C0,
+    C0,
+    C0_5_IM,
+    C0,
+    C0_5_IM_NEG,
+    C0_5_IM_NEG,
+    C0,
+    C0,
+    C0_5,
+    C0_5_NEG,
+    C0,
+];
+
 fn transform_from_magic_basis(unitary: Mat<c64>) -> Mat<c64> {
-    let _b_nonnormalized: Mat<c64> = mat![
-        [C1, C1IM, C0, C0],
-        [C0, C0, C1IM, C1],
-        [C0, C0, C1IM, -C1],
-        [C1, -C1IM, C0, C0]
-    ];
-    let _b_nonnormalized_dagger = scale(c64 { re: 0.5, im: 0.0 }) * _b_nonnormalized.adjoint();
+    let _b_nonnormalized = mat::from_row_major_slice::<c64>(&B_NON_NORMALIZED, 4, 4);
+    let _b_nonnormalized_dagger = mat::from_row_major_slice::<c64>(&B_NON_NORMALIZED_DAGGER, 4, 4);
     _b_nonnormalized_dagger * unitary * _b_nonnormalized
 }
 

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -34,7 +34,6 @@ use crate::utils;
 const PI2: f64 = PI / 2.0;
 const PI4: f64 = PI / 4.0;
 const PI32: f64 = 3.0 * PI2;
-// FIXME: zero and one exist but I cant find the right incantation
 const C0: c64 = c64 { re: 0.0, im: 0.0 };
 const C1: c64 = c64 { re: 1.0, im: 0.0 };
 const C1_NEG: c64 = c64 { re: -1.0, im: 0.0 };


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the the two_qubit_decompose rust module to use const arrays for the underlying data in the transform_from_magic_basis function used as part of computing the weyl coordinates of a unitary. There was previously a `FIXME` comment to move these to compile time variables. This commit implements this and removes the comment.

Another `FIXME` comment is removed about using the built-ins for zero and one. There is no pattern to support that as the methods to return zero and one are not const fns, so we can't use them in the context of this PR. Previously with the dynamically allocated matrix objects we could have used the `c64.zero()` and `c64.one()` methods from `num_traits::Zero` and `num_traits::One` respectively (with faer 0.17.0 which added the trait impls) or `c64.faer_zero()` and `c64.faer_one()`, but now that we've moved these arrays to const objects this no longer applies.

### Details and comments