### PR TITLE
Fix improper handling of BindingsArray in SamplerPub.coerce() 

### DIFF
--- a/qiskit/primitives/containers/sampler_pub.py
+++ b/qiskit/primitives/containers/sampler_pub.py
@@ -121,7 +121,7 @@ class SamplerPub(ShapedMixin):
 
         if len(pub) > 1 and pub[1] is not None:
             values = pub[1]
-            if not isinstance(values, Mapping):
+            if not isinstance(values, (BindingsArray, Mapping)):
                 values = {tuple(circuit.parameters): values}
             parameter_values = BindingsArray.coerce(values)
         else:

--- a/releasenotes/notes/fix-estimator-pub-coerce-5d13700e15126421.yaml
+++ b/releasenotes/notes/fix-estimator-pub-coerce-5d13700e15126421.yaml
@@ -1,7 +1,0 @@
----
-
-fixes:
-  - |
-    Fixed a bug where `qiskit.primitives.containers.estimator_pub.EstimatorPub.coerce()`
-    improperly handles the case where the third value is a `BindingsArray` instance, giving
-    rise to a ``ValueError`` whenever it is attempted.

--- a/releasenotes/notes/fix-pub-coerce-5d13700e15126421.yaml
+++ b/releasenotes/notes/fix-pub-coerce-5d13700e15126421.yaml
@@ -2,7 +2,7 @@
 
 fixes:
   - |
-    Fixed a bug where `qiskit.primitives.containers.estimator_pub.EstimatorPub.coerce()` and
-    `qiskit.primitives.containers.sampler_pub.SamplerPub.coerce()`
-    improperly handle the case where the parameter values are a `BindingsArray` instance, giving
+    Fixed a bug where ``qiskit.primitives.containers.estimator_pub.EstimatorPub.coerce()`` and
+    ``qiskit.primitives.containers.sampler_pub.SamplerPub.coerce()``
+    improperly handle the case where the parameter values are a ``BindingsArray`` instance, giving
     rise to a ``ValueError`` whenever it is attempted.

--- a/releasenotes/notes/fix-pub-coerce-5d13700e15126421.yaml
+++ b/releasenotes/notes/fix-pub-coerce-5d13700e15126421.yaml
@@ -1,0 +1,8 @@
+---
+
+fixes:
+  - |
+    Fixed a bug where `qiskit.primitives.containers.estimator_pub.EstimatorPub.coerce()` and
+    `qiskit.primitives.containers.sampler_pub.SamplerPub.coerce()`
+    improperly handle the case where the parameter values are a `BindingsArray` instance, giving
+    rise to a ``ValueError`` whenever it is attempted.

--- a/test/python/primitives/containers/test_sampler_pub.py
+++ b/test/python/primitives/containers/test_sampler_pub.py
@@ -333,3 +333,15 @@ class SamplerPubTestCase(QiskitTestCase):
             0,
             msg="incorrect num parameters for `parameter_values` property",
         )
+
+    def test_coerce_pub_with_exact_types(self):
+        """Test coercing a SamplerPub with exact types."""
+        params = (Parameter("a"), Parameter("b"))
+        circuit = QuantumCircuit(2)
+        circuit.rx(params[0], 0)
+        circuit.ry(params[1], 1)
+
+        params = BindingsArray(data={params: np.ones((10, 2))})
+        pub = SamplerPub.coerce((circuit, params))
+        self.assertIs(pub.circuit, circuit)
+        self.assertIs(pub.parameter_values, params)


### PR DESCRIPTION
### Summary

The exact same mistake as in #11871 in the SamplerPub. This PR fixes the issue in the same way and unifies the release note.

### Details and comments


