### PR TITLE
Use pulp for simd acceleration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,18 +240,18 @@ dependencies = [
 
 [[package]]
 name = "equator"
-version = "0.1.7"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b6bac4108dd2c0e180d556b1296be20815f5bd106787ae4f7b14155addc71f"
+checksum = "a3b0a88aa91d0ad2b9684e4479aed31a17d3f9051bdbbc634bd2c01bc5a5eee8"
 dependencies = [
  "equator-macro",
 ]
 
 [[package]]
 name = "equator-macro"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a576659e2372c3ac65a3b25dc68fe455d8fae1c67450f251776ec0ffb7bdab8"
+checksum = "60d08acb9849f7fb4401564f251be5a526829183a3645a90197dea8e786cf3ae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -276,10 +276,11 @@ dependencies = [
 
 [[package]]
 name = "faer"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70e56a6aaf3f56ab0b44ed10b9263dc6e1dcdb32a2a698e732327687fde7737"
+checksum = "cb5b7c1c105faf9be15068cc5674b46632ba31ea1022f96c6cecd35050f2afcc"
 dependencies = [
+ "bytemuck",
  "coe-rs",
  "dbgf",
  "dyn-stack",
@@ -299,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "faer-cholesky"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d1c7944403c66085e9b4187ca8a710c6cb1cdeb2511228fb745387b29215a9"
+checksum = "66fd0c4375aaab0de60a61cc3c70fa30d382475ff4994ff4394a0836c82451d2"
 dependencies = [
  "bytemuck",
  "dyn-stack",
@@ -316,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "faer-core"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c11e871d9a8e09c645ce2356ec980838930e884379894a084aa946ef349f26e"
+checksum = "32da0f6262445261106407bdfb548df4f8f1c89bcc3cff1bb6d08e7f525b575a"
 dependencies = [
  "bytemuck",
  "coe-rs",
@@ -334,13 +335,14 @@ dependencies = [
  "rayon",
  "reborrow",
  "seq-macro",
+ "serde",
 ]
 
 [[package]]
 name = "faer-entity"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab27f48f17fee3ea487eb5ee828892348bcc903ad7297c472953236e62229b84"
+checksum = "93fb12f36da3162b3fefc0c7343d905d5bd2c2bf444a7f63ceeaa2bc003311d3"
 dependencies = [
  "bytemuck",
  "coe-rs",
@@ -353,12 +355,13 @@ dependencies = [
 
 [[package]]
 name = "faer-evd"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa2267c1dfcf7e74e47114a4c37dc8a3ecc5e61dfdede1ce24a89e663e342c0"
+checksum = "81dabba6c1683c8db79eb58930a4af10c26eb49327294548c69e40ffd76fc61f"
 dependencies = [
  "bytemuck",
  "coe-rs",
+ "dbgf",
  "dyn-stack",
  "faer-core",
  "faer-entity",
@@ -372,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "faer-lu"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf3c7ef8bc8d55e101c0a9b71839543dece2e9c3a796ac6c3aa9784826d6c00"
+checksum = "1e228cc81aa617beb681363fa6adbdd6478dd3ff9c7eeb7a0a7dd231b9e6fbb1"
 dependencies = [
  "bytemuck",
  "coe-rs",
@@ -392,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "faer-qr"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816658a3b4abd8cf67a0431d7ee48e40108061dce5e466d4f0004f6f45cdd060"
+checksum = "26951fb0b7e37915342e0f03324d45560b2c5092787af16a01d7bb34e44b8563"
 dependencies = [
  "bytemuck",
  "coe-rs",
@@ -410,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "faer-sparse"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27799c41a4f14db0d37c03fb3dc784ebef0c916ab55ff7a5f61b7bbf9bb55dfc"
+checksum = "4029f857ba897958cae80a985b33b5f58698d6ab2da0224b4f393566dcbd1e1b"
 dependencies = [
  "bytemuck",
  "coe-rs",
@@ -430,12 +433,13 @@ dependencies = [
 
 [[package]]
 name = "faer-svd"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402ae5bd9451228c4fef5db431321b04fc40692664d025d5c8e6ea72afb6ed92"
+checksum = "43f99c35d92fe6e46b5a00dfeaa0bf8a728acb0ea643962137c2016adb990cc9"
 dependencies = [
  "bytemuck",
  "coe-rs",
+ "dbgf",
  "dyn-stack",
  "faer-core",
  "faer-entity",
@@ -460,9 +464,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "gemm"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97d506c68f4fb12325b52a638e7d54cc87e3593a4ded0de60218b6dfd65f645"
+checksum = "6ab24cc62135b40090e31a76a9b2766a501979f3070fa27f689c27ec04377d32"
 dependencies = [
  "dyn-stack",
  "gemm-c32",
@@ -480,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "gemm-c32"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd16f26e8f34661edc906d8c9522b59ec1655c865a98a58950d0246eeaca9da"
+checksum = "b9c030d0b983d1e34a546b86e08f600c11696fde16199f971cd46c12e67512c0"
 dependencies = [
  "dyn-stack",
  "gemm-common",
@@ -495,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "gemm-c64"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e34381bc060b47fbd25522a281799ef763cd27f43bbd1783d935774659242a"
+checksum = "fbb5f2e79fefb9693d18e1066a557b4546cd334b226beadc68b11a8f9431852a"
 dependencies = [
  "dyn-stack",
  "gemm-common",
@@ -510,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "gemm-common"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22518a76339b09276f77c3166c44262e55f633712fe8a44fd0573505887feeab"
+checksum = "a2e7ea062c987abcd8db95db917b4ffb4ecdfd0668471d8dc54734fdff2354e8"
 dependencies = [
  "bytemuck",
  "dyn-stack",
@@ -530,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "gemm-f16"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70409bbf3ef83b38cbe4a58cd4b797c1c27902505bdd926a588ea61b6c550a84"
+checksum = "7ca4c06b9b11952071d317604acb332e924e817bd891bec8dfb494168c7cedd4"
 dependencies = [
  "dyn-stack",
  "gemm-common",
@@ -548,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "gemm-f32"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3068edca27f100964157211782eba19e961aa4d0d2bdac3e1775a51aa7680"
+checksum = "e9a69f51aaefbd9cf12d18faf273d3e982d9d711f60775645ed5c8047b4ae113"
 dependencies = [
  "dyn-stack",
  "gemm-common",
@@ -563,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "gemm-f64"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd41e8f5a60dce8d8acd852a3f4b22f8e18be957e1937731be692c037652510"
+checksum = "aa397a48544fadf0b81ec8741e5c0fba0043008113f71f2034def1935645d2b0"
 dependencies = [
  "dyn-stack",
  "gemm-common",
@@ -1033,14 +1037,26 @@ dependencies = [
 
 [[package]]
 name = "pulp"
-version = "0.18.6"
+version = "0.18.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16785ee69419641c75affff7c9fdbdb7c0ab26dc9a5fb5218c2a2e9e4ef2087d"
+checksum = "091bad01115892393939669b38f88ff2b70838e969a7ac172a9d06d05345a732"
 dependencies = [
  "bytemuck",
  "libm",
  "num-complex",
+ "pulp-macro",
  "reborrow",
+]
+
+[[package]]
+name = "pulp-macro"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d315b3197b780e4873bc0e11251cb56a33f65a6032a3d39b8d1405c255513766"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1142,6 +1158,7 @@ dependencies = [
  "num-complex",
  "num-traits",
  "numpy",
+ "pulp",
  "pyo3",
  "rand 0.8.5",
  "rand_distr",

--- a/crates/accelerate/Cargo.toml
+++ b/crates/accelerate/Cargo.toml
@@ -25,6 +25,7 @@ num-traits = "0.2"
 num-complex = "0.4"
 num-bigint = "0.4"
 rustworkx-core = "0.14"
+faer-core = "0.17.0"
 
 [dependencies.smallvec]
 version = "1.13"
@@ -47,8 +48,9 @@ workspace = true
 features = ["rayon"]
 
 [dependencies.faer]
-version = "0.16.0"
+version = "0.17.0"
 features = ["ndarray"]
 
-[dependencies.faer-core]
-version = "0.16.0"
+[dependencies.pulp]
+version = "0.18.8"
+features = ["macro"]

--- a/crates/accelerate/src/pauli_exp_val.rs
+++ b/crates/accelerate/src/pauli_exp_val.rs
@@ -10,10 +10,9 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use std::convert::TryInto;
-
 use num_complex::Complex64;
 use numpy::PyReadonlyArray1;
+use pulp::Simd;
 use pyo3::exceptions::PyOverflowError;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
@@ -21,31 +20,16 @@ use rayon::prelude::*;
 
 use crate::getenv_use_multiple_threads;
 
-const LANES: usize = 8;
 const PARALLEL_THRESHOLD: usize = 19;
 
-// Based on the sum implementation in:
-// https://stackoverflow.com/a/67191480/14033130
-// and adjust for f64 usage
-#[inline]
-pub fn fast_sum(values: &[f64]) -> f64 {
-    let chunks = values.chunks_exact(LANES);
-    let remainder = chunks.remainder();
-
-    let sum = chunks.fold([0.; LANES], |mut acc, chunk| {
-        let chunk: [f64; LANES] = chunk.try_into().unwrap();
-        for i in 0..LANES {
-            acc[i] += chunk[i];
-        }
-        acc
-    });
-    let remainder: f64 = remainder.iter().copied().sum();
-
-    let mut reduced = 0.;
-    for val in sum {
-        reduced += val;
-    }
-    reduced + remainder
+#[pulp::with_simd(fast_sum = pulp::Arch::new())]
+#[inline(always)]
+pub fn fast_sum_with_simd<S: Simd>(simd: S, values: &[f64]) -> f64 {
+    let (head, tail) = S::f64s_as_simd(values);
+    let sum: f64 = head
+        .iter()
+        .fold(0., |acc, chunk| acc + simd.f64s_reduce_sum(*chunk));
+    sum + tail.iter().sum::<f64>()
 }
 
 /// Compute the pauli expectatation value of a statevector without x


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the fast_sum() function to improve the runtime for rust functions that are computing the sum of an array of f64s. This is done by leveraging runtime simd dispatch via the pulp library[1]. The pulp library is already a dependency as it's getting pulled in from faer/faer-core. This commit just makes it an direct dependency of qiskit and we use it directly to compute the sums inside fast sum. This commit also updates the faer version so that we're keeping pulp and faer on the latest versions explicitly.

### Details and comments