### PR TITLE
Fix handling of control flow instructions in convert_to_target()

### DIFF
--- a/qiskit/providers/backend_compat.py
+++ b/qiskit/providers/backend_compat.py
@@ -23,8 +23,13 @@ from qiskit.providers.backend import QubitProperties
 from qiskit.utils.units import apply_prefix
 from qiskit.circuit.library.standard_gates import get_standard_gate_name_mapping
 from qiskit.circuit.measure import Measure
-from qiskit.circuit.controlflow import CONTROL_FLOW_OP_NAMES
-from qiskit.circuit import IfElseOp, WhileLoopOp, ForLoopOp, SwitchCaseOp
+from qiskit.circuit.controlflow import (
+    CONTROL_FLOW_OP_NAMES,
+    IfElseOp,
+    WhileLoopOp,
+    ForLoopOp,
+    SwitchCaseOp,
+)
 from qiskit.providers.models.backendconfiguration import BackendConfiguration
 from qiskit.providers.models.backendproperties import BackendProperties
 from qiskit.providers.models.pulsedefaults import PulseDefaults

--- a/qiskit/providers/backend_compat.py
+++ b/qiskit/providers/backend_compat.py
@@ -23,6 +23,8 @@ from qiskit.providers.backend import QubitProperties
 from qiskit.utils.units import apply_prefix
 from qiskit.circuit.library.standard_gates import get_standard_gate_name_mapping
 from qiskit.circuit.measure import Measure
+from qiskit.circuit.controlflow import CONTROL_FLOW_OP_NAMES
+from qiskit.circuit import IfElseOp, WhileLoopOp, ForLoopOp, SwitchCaseOp
 from qiskit.providers.models.backendconfiguration import BackendConfiguration
 from qiskit.providers.models.backendproperties import BackendProperties
 from qiskit.providers.models.pulsedefaults import PulseDefaults
@@ -153,6 +155,17 @@ def convert_to_target(
         target.min_length = configuration.timing_constraints.get("min_length")
         target.pulse_alignment = configuration.timing_constraints.get("pulse_alignment")
         target.acquire_alignment = configuration.timing_constraints.get("acquire_alignment")
+    # Handle control flow ops in supported instructions of configuratios
+    supported_instructions = set(getattr(configuration, "supported_instructions", []))
+    control_flow_ops = CONTROL_FLOW_OP_NAMES.intersection(supported_instructions)
+    control_flow_name_map = {
+        "if_else": IfElseOp,
+        "while_loop": WhileLoopOp,
+        "for_loop": ForLoopOp,
+        "switch_case": SwitchCaseOp,
+    }
+    for op in control_flow_ops:
+        target.add_instruction(control_flow_name_map[op], name=op)
     # If a pulse defaults exists use that as the source of truth
     if defaults is not None:
         inst_map = defaults.instruction_schedule_map

--- a/releasenotes/notes/fix-control-flow-convert-to-target-ae838418a7ad2a20.yaml
+++ b/releasenotes/notes/fix-control-flow-convert-to-target-ae838418a7ad2a20.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :func:`.convert_to_target` where the converter
+    would incorrectly ignore control flow instructions if they were specified
+    in the :attr:`.BackendConfiguration.supported_instructions` attribute which
+    is the typical location that control flow instructions are specified in a
+    :class:`.BackendConfiguration` object.
+    Fixed `#11872 <https://github.com/Qiskit/qiskit/issues/11872>`__.

--- a/test/python/providers/test_fake_backends.py
+++ b/test/python/providers/test_fake_backends.py
@@ -635,3 +635,59 @@ class TestFakeBackends(QiskitTestCase):
         tqc = transpile(qc, v2_backend, seed_transpiler=433, optimization_level=opt_level)
         connections = [tuple(sorted(tqc.find_bit(q).index for q in x.qubits)) for x in tqc.data]
         self.assertNotIn((0, 1), connections)
+
+    def test_convert_to_target_control_flow(self):
+        backend = FakeMumbaiV2()
+        properties = backend.properties()
+        configuration = backend.configuration()
+        configuration.supported_instructions = [
+            "cx",
+            "id",
+            "delay",
+            "measure",
+            "reset",
+            "rz",
+            "sx",
+            "x",
+            "if_else",
+            "for_loop",
+            "switch_case",
+        ]
+        defaults = backend.defaults()
+        target = convert_to_target(configuration, properties, defaults)
+        self.assertTrue(target.instruction_supported("if_else", ()))
+        self.assertFalse(target.instruction_supported("while_loop", ()))
+        self.assertTrue(target.instruction_supported("for_loop", ()))
+        self.assertTrue(target.instruction_supported("switch_case", ()))
+
+    def test_convert_unrelated_supported_instructions(self):
+        backend = FakeMumbaiV2()
+        properties = backend.properties()
+        configuration = backend.configuration()
+        configuration.supported_instructions = [
+            "cx",
+            "id",
+            "delay",
+            "measure",
+            "reset",
+            "rz",
+            "sx",
+            "x",
+            "play",
+            "u2",
+            "u3",
+            "u1",
+            "shiftf",
+            "acquire",
+            "setf",
+            "if_else",
+            "for_loop",
+            "switch_case",
+        ]
+        defaults = backend.defaults()
+        target = convert_to_target(configuration, properties, defaults)
+        self.assertTrue(target.instruction_supported("if_else", ()))
+        self.assertFalse(target.instruction_supported("while_loop", ()))
+        self.assertTrue(target.instruction_supported("for_loop", ()))
+        self.assertTrue(target.instruction_supported("switch_case", ()))
+        self.assertFalse(target.instruction_supported("u3", (0,)))

--- a/test/python/providers/test_fake_backends.py
+++ b/test/python/providers/test_fake_backends.py
@@ -37,7 +37,7 @@ from qiskit.providers.fake_provider import (
     FakeSherbrooke,
     FakePrague,
 )
-from qiskit.providers.backend_compat import BackendV2Converter
+from qiskit.providers.backend_compat import BackendV2Converter, convert_to_target
 from qiskit.providers.models.backendproperties import BackendProperties
 from qiskit.providers.backend import BackendV2
 from qiskit.utils import optionals
@@ -637,7 +637,7 @@ class TestFakeBackends(QiskitTestCase):
         self.assertNotIn((0, 1), connections)
 
     def test_convert_to_target_control_flow(self):
-        backend = FakeMumbaiV2()
+        backend = FakeMumbai()
         properties = backend.properties()
         configuration = backend.configuration()
         configuration.supported_instructions = [
@@ -661,7 +661,7 @@ class TestFakeBackends(QiskitTestCase):
         self.assertTrue(target.instruction_supported("switch_case", ()))
 
     def test_convert_unrelated_supported_instructions(self):
-        backend = FakeMumbaiV2()
+        backend = FakeMumbai()
         properties = backend.properties()
         configuration = backend.configuration()
         configuration.supported_instructions = [


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue in the convert_to_target() function where it wasn't looking for control flow instructions in the proper location. Typically the control flow instructions are put in the supported_instructions field of the BackendConfiguration, but the convert_to_target() function was ignoring this field. This commit updates the function to check supported_instructions for the control flow instructions. It doesn't more broadly look at the supported_instructions field, because on other backends this field is used to list the supported pulse instructions which might have name conflicts with other instructions and cause issues building a target.

This is the spiritual backport of #11877, but because the state of the convert_to_target() function on stable/0.46 is very different very little code is carried over from the version on main and stable/1.0, basically only the tests. This is actually closer in implementation to the equivalent PR on qiskit-ibm-runtime: Qiskit/qiskit-ibm-runtime#1443 as the internal conversion function in that repository is very similar to the function on the stable/0.46 branch.

### Details and comments