### PR TITLE
Update circuit construction benchmarks

### DIFF
--- a/test/benchmarks/circuit_construction.py
+++ b/test/benchmarks/circuit_construction.py
@@ -45,7 +45,7 @@ class CircuitConstructionBench:
         build_circuit(width, gates)
 
     def time_circuit_extend(self, _, __):
-        self.empty_circuit.extend(self.sample_circuit)
+        self.empty_circuit.compose(self.sample_circuit, inplace=True)
 
     def time_circuit_copy(self, _, __):
         self.sample_circuit.copy()
@@ -61,7 +61,7 @@ def build_parameterized_circuit(width, gates, param_count):
     while len(qc) < gates:
         for k in range(width):
             param = next(param_iter)
-            qc.u2(0, param, qr[k])
+            qc.r(0, param, qr[k])
         for k in range(width - 1):
             param = next(param_iter)
             qc.crx(param, qr[k], qr[k + 1])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The circuit construction benchmarks had all bit rotted a fair amount and were using syntax and functionality that no longer exists. This commit updates the benchmarks to work with current qiskit. Longer term we should add a CI job to ensure all the benchmarks work.

### Details and comments