### PR TITLE
Document release note subsections and categorize 1.1 notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -332,7 +332,14 @@ deprecations:
     :func:`~qiskit.bar.foobar` calls to :func:`~qiskit.foo`.
 ```
 
-You can also look at other release notes for other examples. 
+You can also look at other release notes for other examples.
+
+For the ``features``, ``deprecations``, and ``upgrade`` sections there are a
+list of subsections available which are used to provide more structure to the
+release notes organization. If you're adding a feature, making an API change,
+or deprecating an API you should pick the subsection that matches that note.
+For example if you're adding a new feature to the transpiler, you should put
+it under the ``upgrade_transpiler`` section.
 
 Note that you can use sphinx [restructured text syntax](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html).
 In fact, you can use any restructured text feature in them (code sections, tables,

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -49,3 +49,174 @@ sections:
   - [security, Security Issues]
   - [fixes, Bug Fixes]
   - [other, Other Notes]
+template: |
+  ---
+  prelude: >
+      Replace this text with content to appear at the top of the section for this
+      release. All of the prelude content is merged together and then rendered
+      separately from the items listed in other parts of the file, so the text
+      needs to be worded so that both the prelude and the other items make sense
+      when read independently. This may mean repeating some details. Not every
+      release note requires a prelude. Usually only notes describing major
+      features or adding release theme details should have a prelude.
+  features:
+    - |
+      List new features here, or remove this section.  All of the list items in
+      this section are combined when the release notes are rendered, so the text
+      needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details. If the feature note is contained within one of the modules
+      listed below you should use the appropriate subsection instead.
+  features_circuits:
+    - |
+      New features related to the qiskit.circuit module.
+  features_primitives:
+    - |
+      New features related to the qiskit.primitives module.
+  features_providers:
+    - |
+      New features related to the qiskit.providers module.
+  features_pulse:
+    - |
+      New features related to the qiskit.pulse module.
+  features_qasm:
+    - |
+      New features related to the qiskit.qasm2 or qiskit.qasm3 modules.
+  features_qpy:
+    - |
+      New features related to the qiskit.qpy module.
+  features_quantum_info:
+    - |
+      New features releated to the qiskit.quantum_info module.
+  features_synthesis:
+    - |
+      New features related to the qiskit.synthesis module.
+  features_transpiler:
+    - |
+      New features related to the qiskit.transpiler and qiskit.dagcircuit
+      modules.
+  features_visualization:
+    - |
+      New features related to the qiskit.visualization module.
+  features_misc:
+    - |
+      New miscellaneous features.
+  issues:
+    - |
+      List known issues here, or remove this section.  All of the list items in
+      this section are combined when the release notes are rendered, so the text
+      needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.
+  upgrade:
+    - |
+      List upgrade notes here, or remove this section.  All of the list items in
+      this section are combined when the release notes are rendered, so the text
+      needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details. If the upgrade note is contained within one of the modules
+      listed below you should use the appropriate subsection instead.
+  upgrade_circuits:
+    - |
+      Notes with upgrade impact related to the qiskit.circuit module.
+  upgrade_primitives:
+    - |
+      Notes with upgrade impact related to the qiskit.primitives module.
+  upgrade_providers:
+    - |
+      Notes with upgrade impact related to the qiskit.providers module.
+  upgrade_pulse:
+    - |
+      Notes with upgrade impact related to the qiskit.pulse module.
+  upgrade_qasm:
+    - |
+      Notes with upgrade impact related to the qiskit.qasm2 or qiskit.qasm3
+      modules.
+  upgrade_qpy:
+    - |
+      Notes with upgrade impact related to the qiskit.qpy module.
+  upgrade_quantum_info:
+    - |
+      Notes with upgrade impact related to the qiskit.quantum_info module.
+  upgrade_synthesis:
+    - |
+      Notes with upgrade impact related to the qiskit.synthesis module.
+  upgrade_transpiler:
+    - |
+      Notes with upgrade impact related to the qiskit.transpiler and
+      qiskit.dagcircuit modules.
+  upgrade_visualization:
+    - |
+      Notes with upgrade impact related to the qiskit.visualization module.
+  upgrade_misc:
+    - |
+      Miscellaneous notes about potential upgrade impact.
+  deprecations:
+    - |
+      List deprecations notes here, or remove this section.  All of the list
+      items in this section are combined when the release notes are rendered, so
+      the text needs to be worded so that it does not depend on any information
+      only available in another section, such as the prelude. This may mean
+      repeating some details.
+  deprecations_circuits:
+    - |
+      Deprecations related to the qiskit.circuit module.
+  deprecations_primitives:
+    - |
+      Deprecations related to the qiskit.primitives module.
+  deprecations_providers:
+    - |
+      Deprecations related to the qiskit.providers module.
+  deprecations_pulse:
+    - |
+      Deprecations related to the qiskit.pulse module.
+  deprecations_qasm:
+    - |
+      Deprecations related to the qiskit.qasm2 or qiskit.qasm3 modules.
+  deprecations_qpy:
+    - |
+      Deprecations related to the qiskit.qpy module.
+  deprecations_quantum_info:
+    - |
+      Deprecations releated to the qiskit.quantum_info module.
+  deprecations_synthesis:
+    - |
+      Deprecations related to the qiskit.synthesis module.
+  deprecations_transpiler:
+    - |
+      Deprecations related to the qiskit.transpiler and qiskit.dagcircuit
+      modules.
+  deprecations_visualization:
+    - |
+      Deprecations related to the qiskit.visualization module.
+  deprecations_misc:
+    - |
+      New miscellaneous features.
+  critical:
+    - |
+      Add critical notes here, or remove this section.  All of the list items in
+      this section are combined when the release notes are rendered, so the text
+      needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.
+  security:
+    - |
+      Add security notes here, or remove this section.  All of the list items in
+      this section are combined when the release notes are rendered, so the text
+      needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.
+  fixes:
+    - |
+      Add normal bug fixes here, or remove this section.  All of the list items
+      in this section are combined when the release notes are rendered, so the
+      text needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.
+  other:
+    - |
+      Add other notes here, or remove this section.  All of the list items in
+      this section are combined when the release notes are rendered, so the text
+      needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.

--- a/releasenotes/notes/classical-store-e64ee1286219a862.yaml
+++ b/releasenotes/notes/classical-store-e64ee1286219a862.yaml
@@ -1,5 +1,5 @@
 ---
-features_circuit:
+features_circuits:
   - |
     A :class:`.QuantumCircuit` can now contain typed classical variables::
 

--- a/releasenotes/notes/classical-store-e64ee1286219a862.yaml
+++ b/releasenotes/notes/classical-store-e64ee1286219a862.yaml
@@ -1,5 +1,5 @@
 ---
-features:
+features_circuit:
   - |
     A :class:`.QuantumCircuit` can now contain typed classical variables::
 

--- a/releasenotes/notes/public-noncommutation-graph-dd31c931b7045a4f.yaml
+++ b/releasenotes/notes/public-noncommutation-graph-dd31c931b7045a4f.yaml
@@ -1,5 +1,5 @@
 ---
-features:
+features_quantum_info:
   - |
     Adds the :meth:`.PauliList.noncommutation_graph` and
     :meth:`.SparsePauliOp.noncommutation_graph` methods, exposing the


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds contributor documentation about the release note subsections. Now that we're using subsections on main we should encourage contributors to use the appropriate subsection when adding new release notes to reduce the release time effort needed to correctly categorize the release notes. This also updates the new release note template to list out all the subsections.

This also updates the current notes pending for the 1.1.0 release to use subsections so that from this point forward we're using subsections for all feature, deprecation, and upgrade notes.


### Details and comments