### PR TITLE
Fix `Instruction.repeat` with conditionals

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -595,9 +595,11 @@ class Instruction(Operation):
             qc = QuantumCircuit(self.num_qubits, self.num_clbits)
             qargs = tuple(qc.qubits)
             cargs = tuple(qc.clbits)
-            base = self.to_mutable()
-            # Condition is handled on the outer instruction.
-            base.condition = None
+            base = self.copy()
+            if self.condition:
+                # Condition is handled on the outer instruction.
+                base = base.to_mutable()
+                base.condition = None
             for _ in [None] * n:
                 qc._append(CircuitInstruction(base, qargs, cargs))
 

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -571,7 +571,13 @@ class Instruction(Operation):
         )
 
     def repeat(self, n):
-        """Creates an instruction with `gate` repeated `n` amount of times.
+        """Creates an instruction with ``self`` repeated :math`n` times.
+
+        If this operation has a conditional, the output instruction will have the same conditional
+        and the inner repeated operations will be unconditional; instructions within a compound
+        definition cannot be conditioned on registers within Qiskit's data model.  This means that
+        it is not valid to apply a repeated instruction to a clbit that it both writes to and reads
+        from in its condition.
 
         Args:
             n (int): Number of times to repeat the instruction

--- a/releasenotes/notes/fix-instruction-repeat-conditional-dfe4d7ced54a7bb6.yaml
+++ b/releasenotes/notes/fix-instruction-repeat-conditional-dfe4d7ced54a7bb6.yaml
@@ -1,7 +1,8 @@
 ---
 fixes:
   - |
-    :meth:`.Instruction.repeat` will now correctly move a set :attr:`~.Instruction.condition` to the
+    The method :meth:`.Instruction.repeat` now moves a set :attr:`~.Instruction.condition` to the
     outer returned :class:`~.circuit.Instruction` and leave the inner gates of its definition
     unconditional.  Previously, the method would leave :class:`.ClassicalRegister` instances within
-    the inner definition, which broke the data model.  Fixed `#11935 <https://github.com/Qiskit/qiskit/issues/11935>`__.
+    the inner definition, which was an invalid state, and would manifest itself as seemingly unrelated
+    bugs later, such as during transpilation or export.  Fixed `#11935 <https://github.com/Qiskit/qiskit/issues/11935>`__.

--- a/releasenotes/notes/fix-instruction-repeat-conditional-dfe4d7ced54a7bb6.yaml
+++ b/releasenotes/notes/fix-instruction-repeat-conditional-dfe4d7ced54a7bb6.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    :meth:`.Instruction.repeat` will now correctly move a set :attr:`~.Instruction.condition` to the
+    outer returned :class:`~.circuit.Instruction` and leave the inner gates of its definition
+    unconditional.  Previously, the method would leave :class:`.ClassicalRegister` instances within
+    the inner definition, which broke the data model.  Fixed `#11935 <https://github.com/Qiskit/qiskit/issues/11935>`__.

--- a/test/python/circuit/test_instruction_repeat.py
+++ b/test/python/circuit/test_instruction_repeat.py
@@ -52,6 +52,18 @@ class TestRepeatInt1Q(QiskitTestCase):
         self.assertEqual(result.definition, expected.definition)
         self.assertIsInstance(result, Gate)
 
+    def test_conditional(self):
+        """Test that repetition works with a condition."""
+        cr = ClassicalRegister(3, "cr")
+        gate = SGate().c_if(cr, 7).repeat(5)
+        self.assertEqual(gate.condition, (cr, 7))
+
+        defn = QuantumCircuit(1)
+        for _ in range(5):
+            # No conditions on the inner bit.
+            defn.s(0)
+        self.assertEqual(gate.definition, defn)
+
 
 class TestRepeatInt2Q(QiskitTestCase):
     """Test gate_q2.repeat() with integer"""
@@ -82,6 +94,18 @@ class TestRepeatInt2Q(QiskitTestCase):
         self.assertEqual(result.name, "cx*1")
         self.assertEqual(result.definition, expected.definition)
         self.assertIsInstance(result, Gate)
+
+    def test_conditional(self):
+        """Test that repetition works with a condition."""
+        cr = ClassicalRegister(3, "cr")
+        gate = CXGate().c_if(cr, 7).repeat(5)
+        self.assertEqual(gate.condition, (cr, 7))
+
+        defn = QuantumCircuit(2)
+        for _ in range(5):
+            # No conditions on the inner bit.
+            defn.cx(0, 1)
+        self.assertEqual(gate.definition, defn)
 
 
 class TestRepeatIntMeasure(QiskitTestCase):
@@ -117,6 +141,18 @@ class TestRepeatIntMeasure(QiskitTestCase):
         self.assertEqual(result.definition, expected.definition)
         self.assertIsInstance(result, Instruction)
         self.assertNotIsInstance(result, Gate)
+
+    def test_measure_conditional(self):
+        """Test conditional measure moves condition to the outside."""
+        cr = ClassicalRegister(3, "cr")
+        measure = Measure().c_if(cr, 7).repeat(5)
+        self.assertEqual(measure.condition, (cr, 7))
+
+        defn = QuantumCircuit(1, 1)
+        for _ in range(5):
+            # No conditions on the inner bit.
+            defn.measure(0, 0)
+        self.assertEqual(measure.definition, defn)
 
 
 class TestRepeatErrors(QiskitTestCase):


### PR DESCRIPTION
### Summary

We can't put register conditionals within an `Instruction.definition` field; the data model of `QuantumCircuit` doesn't permit closing over registers from within definitions.  This commit moves a condition to the outer `Instruction` that's returned.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #11935 
Fix #11936 (though note that #11761 would then be triggered for OQ3).

> [!IMPORTANT]
> As implemented, this commit isn't necessarily a completely valid transformation, but I'm putting it up in this form for a bit of discussion.

The point is that an instruction can in theory affect its own condition; consider a `Measure().c_if(cr, value)`, where the measure instruction _within the circuit_ is applied to a clbit that's in `cr`.  To go further, consider the custom instruction whose definition is `h q[0]; measure q[0] -> c[0];` - this is clearly not idempotent under a `c`-based condition (one could argue that the bare `measure` was, in the context of a noiseless abstract circuit, since the first measure would collapse the state).

Given that `Instruction.repeat` is only applied _without_ a circuit context, and we're moving to remove `Instruction.condition` for these same sorts of reasons (in favour of `IfElseOp`), I think this is a transformation we can accept, though perhaps with additional documentation.