### PR TITLE
Switch back to reno from release

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -38,9 +38,8 @@ threadpoolctl
 # Be careful when adding new requirements. We want to keep the docs build simple because
 # we only build docs in this repo to generate API references that get consumed by
 # https://github.com/Qiskit/documentation. For example, coordinate adding dependencies
-# like `sphinx-design` to make sure that `Qiskit/documentation` will be able to 
+# like `sphinx-design` to make sure that `Qiskit/documentation` will be able to
 # consume it properly.
 Sphinx>=6.0,<7.2
-# TODO: switch to stable release when 4.1 is released
-reno @ git+https://github.com/openstack/reno.git@85b9a9bb52c8f9ce4a5e66fa8d9eba7fde90bf6d
+reno >= 4.1.0
 sphinxcontrib-katex==0.9.9


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

We had previously been using reno from a git to get early access to the subsections feature and also a bugfix with excessive debug logging (thanks to @Eric-Arellano for implementing both of these). However, with the recent release of reno 4.1.0 these have been included in a release and we no longer need to rely on a pre-release of reno. This commit updates reno version listed in requirements-dev.txt to be >=4.1.0.

### Details and comments