### PR TITLE
Fix performance issue in parsing bit indices in QPY

### DIFF
--- a/qiskit/qpy/binary_io/circuits.py
+++ b/qiskit/qpy/binary_io/circuits.py
@@ -226,8 +226,8 @@ def _read_instruction(
             use_symengine=use_symengine,
         )
     if circuit is not None:
-        qubit_indices = dict(enumerate(circuit.qubits))
-        clbit_indices = dict(enumerate(circuit.clbits))
+        qubit_indices = circuit.qubits
+        clbit_indices = circuit.clbits
     else:
         qubit_indices = {}
         clbit_indices = {}

--- a/qiskit/qpy/binary_io/circuits.py
+++ b/qiskit/qpy/binary_io/circuits.py
@@ -225,13 +225,6 @@ def _read_instruction(
             cregs=registers["c"],
             use_symengine=use_symengine,
         )
-    if circuit is not None:
-        qubit_indices = circuit.qubits
-        clbit_indices = circuit.clbits
-    else:
-        qubit_indices = {}
-        clbit_indices = {}
-
     # Load Arguments
     if circuit is not None:
         for _qarg in range(instruction.num_qargs):
@@ -243,7 +236,7 @@ def _read_instruction(
             )
             if qarg.type.decode(common.ENCODE) == "c":
                 raise TypeError("Invalid input carg prior to all qargs")
-            qargs.append(qubit_indices[qarg.size])
+            qargs.append(circuit.qubits[qarg.size])
         for _carg in range(instruction.num_cargs):
             carg = formats.CIRCUIT_INSTRUCTION_ARG._make(
                 struct.unpack(
@@ -253,7 +246,7 @@ def _read_instruction(
             )
             if carg.type.decode(common.ENCODE) == "q":
                 raise TypeError("Invalid input qarg after all qargs")
-            cargs.append(clbit_indices[carg.size])
+            cargs.append(circuit.clbits[carg.size])
 
     # Load Parameters
     for _param in range(instruction.num_parameters):

--- a/releasenotes/notes/fix-performance-scaling-num-bits-qpy-37b5109a40cccc54.yaml
+++ b/releasenotes/notes/fix-performance-scaling-num-bits-qpy-37b5109a40cccc54.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a performance issue in the :func:`.qpy.load` function when
+    deserializing QPY payloads with large numbers of qubits or clbits in
+    a circuit.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes a performance issue in the deserialization of QPY payloads. Previously when parsing every instruction the deserialization would build up a dictionary of indices to bits so that when we load the bit index in the qargs and cargs for each instruction. This mean the worst case scaling of this section was O(n * m) for n instructions and m bits, which for very large circuits could end up dominating the time spent in deserialization. However, this was unnecessary work because it is rebuilding a mapping from index to bit as a dictionary, but that mapping already existed in the bit lists the circuit is carrying around. This commit fixes the performance issue by removing the dictionary generation and just using the bit lists directly.

### Details and comments