### PR TITLE
Oxidize TwoQubitWeylDecomposition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-complex",
+ "num-traits",
+]
+
+[[package]]
 name = "ariadne"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +803,7 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
 dependencies = [
+ "approx",
  "matrixmultiply",
  "num-complex",
  "num-integer",
@@ -1149,6 +1160,7 @@ name = "qiskit_accelerate"
 version = "1.1.0"
 dependencies = [
  "ahash",
+ "approx",
  "faer",
  "faer-core",
  "hashbrown 0.14.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,6 +1089,7 @@ dependencies = [
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
+ "smallvec 1.13.1",
  "unindent",
 ]
 

--- a/crates/accelerate/Cargo.toml
+++ b/crates/accelerate/Cargo.toml
@@ -37,7 +37,11 @@ features = ["hashbrown", "indexmap", "num-complex", "num-bigint"]
 
 [dependencies.ndarray]
 version = "^0.15.6"
-features = ["rayon"]
+features = ["rayon", "approx-0_5"]
+
+[dependencies.approx]
+version = "0.5"
+features = ["num-complex"]
 
 [dependencies.hashbrown]
 workspace = true

--- a/crates/accelerate/Cargo.toml
+++ b/crates/accelerate/Cargo.toml
@@ -33,7 +33,7 @@ features = ["union"]
 
 [dependencies.pyo3]
 workspace = true
-features = ["hashbrown", "indexmap", "num-complex", "num-bigint"]
+features = ["hashbrown", "indexmap", "num-complex", "num-bigint", "smallvec"]
 
 [dependencies.ndarray]
 version = "^0.15.6"

--- a/crates/accelerate/src/euler_one_qubit_decomposer.rs
+++ b/crates/accelerate/src/euler_one_qubit_decomposer.rs
@@ -615,7 +615,6 @@ fn compute_error(
     }
 }
 
-#[inline]
 #[pyfunction]
 pub fn compute_error_one_qubit_sequence(
     circuit: &OneQubitGateSequence,
@@ -625,7 +624,6 @@ pub fn compute_error_one_qubit_sequence(
     compute_error(&circuit.gates, error_map, qubit)
 }
 
-#[inline]
 #[pyfunction]
 pub fn compute_error_list(
     circuit: Vec<(String, SmallVec<[f64; 3]>)>,
@@ -723,7 +721,6 @@ fn params_zxz_inner(mat: ArrayView2<Complex64>) -> [f64; 4] {
     [theta, phi + PI / 2., lam - PI / 2., phase]
 }
 
-#[inline]
 #[pyfunction]
 pub fn params_zyz(unitary: PyReadonlyArray2<Complex64>) -> [f64; 4] {
     let mat = unitary.as_array();
@@ -739,7 +736,6 @@ fn params_u3_inner(mat: ArrayView2<Complex64>) -> [f64; 4] {
     [theta, phi, lam, phase - 0.5 * (phi + lam)]
 }
 
-#[inline]
 #[pyfunction]
 pub fn params_u3(unitary: PyReadonlyArray2<Complex64>) -> [f64; 4] {
     let mat = unitary.as_array();
@@ -754,7 +750,6 @@ fn params_u1x_inner(mat: ArrayView2<Complex64>) -> [f64; 4] {
     [theta, phi, lam, phase - 0.5 * (theta + phi + lam)]
 }
 
-#[inline]
 #[pyfunction]
 pub fn params_u1x(unitary: PyReadonlyArray2<Complex64>) -> [f64; 4] {
     let mat = unitary.as_array();

--- a/crates/accelerate/src/euler_one_qubit_decomposer.rs
+++ b/crates/accelerate/src/euler_one_qubit_decomposer.rs
@@ -28,7 +28,7 @@ use numpy::PyReadonlyArray2;
 
 use crate::utils::SliceOrInt;
 
-pub const DEFAULT_ATOL: f64 = 1e-12;
+pub const ANGLE_ZERO_EPSILON: f64 = 1e-12;
 
 #[pyclass(module = "qiskit._accelerate.euler_one_qubit_decomposer")]
 pub struct OneQubitGateErrorMap {
@@ -151,7 +151,7 @@ fn circuit_kak(
     let mut circuit: Vec<(String, SmallVec<[f64; 3]>)> = Vec::with_capacity(3);
     let mut atol = match atol {
         Some(atol) => atol,
-        None => DEFAULT_ATOL,
+        None => ANGLE_ZERO_EPSILON,
     };
     if !simplify {
         atol = -1.0;
@@ -210,7 +210,7 @@ fn circuit_u3(
     let mut circuit = Vec::new();
     let atol = match atol {
         Some(atol) => atol,
-        None => DEFAULT_ATOL,
+        None => ANGLE_ZERO_EPSILON,
     };
     let phi = mod_2pi(phi, atol);
     let lam = mod_2pi(lam, atol);
@@ -234,7 +234,7 @@ fn circuit_u321(
     let mut circuit = Vec::new();
     let mut atol = match atol {
         Some(atol) => atol,
-        None => DEFAULT_ATOL,
+        None => ANGLE_ZERO_EPSILON,
     };
     if !simplify {
         atol = -1.0;
@@ -272,7 +272,7 @@ fn circuit_u(
     let mut circuit = Vec::new();
     let mut atol = match atol {
         Some(atol) => atol,
-        None => DEFAULT_ATOL,
+        None => ANGLE_ZERO_EPSILON,
     };
     if !simplify {
         atol = -1.0;
@@ -313,7 +313,7 @@ where
     };
     let mut atol = match atol {
         Some(atol) => atol,
-        None => DEFAULT_ATOL,
+        None => ANGLE_ZERO_EPSILON,
     };
     if !simplify {
         atol = -1.0;
@@ -373,7 +373,7 @@ fn circuit_rr(
     let mut circuit = Vec::new();
     let mut atol = match atol {
         Some(atol) => atol,
-        None => DEFAULT_ATOL,
+        None => ANGLE_ZERO_EPSILON,
     };
     if !simplify {
         atol = -1.0;
@@ -428,7 +428,7 @@ pub fn generate_circuit(
         "PSX" => {
             let mut inner_atol = match atol {
                 Some(atol) => atol,
-                None => DEFAULT_ATOL,
+                None => ANGLE_ZERO_EPSILON,
             };
             if !simplify {
                 inner_atol = -1.0;
@@ -458,7 +458,7 @@ pub fn generate_circuit(
         "ZSX" => {
             let mut inner_atol = match atol {
                 Some(atol) => atol,
-                None => DEFAULT_ATOL,
+                None => ANGLE_ZERO_EPSILON,
             };
             if !simplify {
                 inner_atol = -1.0;
@@ -488,7 +488,7 @@ pub fn generate_circuit(
         "U1X" => {
             let mut inner_atol = match atol {
                 Some(atol) => atol,
-                None => DEFAULT_ATOL,
+                None => ANGLE_ZERO_EPSILON,
             };
             if !simplify {
                 inner_atol = -1.0;
@@ -518,7 +518,7 @@ pub fn generate_circuit(
         "ZSXX" => {
             let mut inner_atol = match atol {
                 Some(atol) => atol,
-                None => DEFAULT_ATOL,
+                None => ANGLE_ZERO_EPSILON,
             };
             if !simplify {
                 inner_atol = -1.0;

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -57,14 +57,8 @@ const TWO_PI: f64 = 2.0 * PI;
 const C1: c64 = c64 { re: 1.0, im: 0.0 };
 
 const ONE_QUBIT_IDENTITY: [[Complex64; 2]; 2] = [
-    [
-        Complex64::new(1., 0.),
-        Complex64::new(0., 0.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(1., 0.),
-    ],
+    [Complex64::new(1., 0.), Complex64::new(0., 0.)],
+    [Complex64::new(0., 0.), Complex64::new(1., 0.)],
 ];
 
 const B_NON_NORMALIZED: [[Complex64; 4]; 4] = [
@@ -381,7 +375,7 @@ pub struct TwoQubitWeylDecomposition {
 
 impl TwoQubitWeylDecomposition {
     fn weyl_gate(
-        &mut self,
+        &self,
         simplify: bool,
         sequence: &mut TwoQubitSequenceVec,
         atol: f64,
@@ -1001,13 +995,12 @@ impl TwoQubitWeylDecomposition {
 
     #[pyo3(signature = (euler_basis=None, simplify=false, atol=None))]
     fn circuit(
-        &mut self,
+        &self,
         euler_basis: Option<&str>,
         simplify: bool,
         atol: Option<f64>,
     ) -> TwoQubitGateSequence {
-        let binding = self.default_euler_basis.clone();
-        let euler_basis: &str = euler_basis.unwrap_or(&binding);
+        let euler_basis: &str = euler_basis.unwrap_or(&self.default_euler_basis);
         let target_1q_basis_list: Vec<&str> = vec![euler_basis];
 
         let mut gate_sequence = Vec::new();

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -41,7 +41,7 @@ use numpy::PyReadonlyArray2;
 use numpy::ToPyArray;
 
 use crate::euler_one_qubit_decomposer::{
-    angles_from_unitary, det_one_qubit, unitary_to_gate_sequence_inner, DEFAULT_ATOL,
+    angles_from_unitary, det_one_qubit, unitary_to_gate_sequence_inner, ANGLE_ZERO_EPSILON,
 };
 use crate::utils;
 
@@ -1034,7 +1034,7 @@ impl TwoQubitWeylDecomposition {
         self.weyl_gate(
             simplify,
             &mut gate_sequence,
-            atol.unwrap_or(DEFAULT_ATOL),
+            atol.unwrap_or(ANGLE_ZERO_EPSILON),
             &mut global_phase,
         );
         let c1r = unitary_to_gate_sequence_inner(

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -18,59 +18,118 @@
 // of real components and one of imaginary components.
 // In order to avoid copying we want to use `MatRef<c64>` or `MatMut<c64>`.
 
-use num_complex::Complex;
+use approx::abs_diff_eq;
+use num_complex::{Complex, Complex64, ComplexFloat};
+use pyo3::exceptions::{PyIndexError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use pyo3::Python;
 use std::f64::consts::PI;
 
 use faer::IntoFaerComplex;
-use faer::{mat, prelude::*, scale, Mat, MatRef};
+use faer::IntoNdarray;
+use faer::IntoNdarrayComplex;
+use faer::Side::Lower;
+use faer::{prelude::*, scale, Mat, MatRef};
 use faer_core::{c64, ComplexField};
+use ndarray::linalg::kron;
+use ndarray::prelude::*;
+use ndarray::Zip;
 use numpy::PyReadonlyArray2;
+use numpy::ToPyArray;
 
+use crate::euler_one_qubit_decomposer::{
+    angles_from_unitary, det_one_qubit, unitary_to_gate_sequence_inner, DEFAULT_ATOL,
+};
 use crate::utils;
+
+use rand::prelude::*;
+use rand_distr::StandardNormal;
+use rand_pcg::Pcg64Mcg;
 
 const PI2: f64 = PI / 2.0;
 const PI4: f64 = PI / 4.0;
 const PI32: f64 = 3.0 * PI2;
-const C0: c64 = c64 { re: 0.0, im: 0.0 };
+const TWO_PI: f64 = 2.0 * PI;
+
 const C1: c64 = c64 { re: 1.0, im: 0.0 };
-const C1_NEG: c64 = c64 { re: -1.0, im: 0.0 };
-const C1IM: c64 = c64 { re: 0.0, im: 1.0 };
-const C1_NEG_IM: c64 = c64 { re: 0.0, im: -1.0 };
-const C0_5: c64 = c64 { re: 0.5, im: 0.0 };
-const C0_5_NEG: c64 = c64 { re: -0.5, im: 0.0 };
-const C0_5_IM: c64 = c64 { re: 0.0, im: 0.5 };
-const C0_5_IM_NEG: c64 = c64 { re: 0.0, im: -0.5 };
 
-const B_NON_NORMALIZED: [c64; 16] = [
-    C1, C1IM, C0, C0, C0, C0, C1IM, C1, C0, C0, C1IM, C1_NEG, C1, C1_NEG_IM, C0, C0,
+const B_NON_NORMALIZED: [[Complex64; 4]; 4] = [
+    [
+        Complex64::new(1.0, 0.),
+        Complex64::new(0., 1.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 1.),
+        Complex64::new(1.0, 0.0),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 1.),
+        Complex64::new(-1., 0.),
+    ],
+    [
+        Complex64::new(1., 0.),
+        Complex64::new(-0., -1.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+    ],
 ];
 
-const B_NON_NORMALIZED_DAGGER: [c64; 16] = [
-    C0_5,
-    C0,
-    C0,
-    C0_5,
-    C0_5_IM_NEG,
-    C0,
-    C0,
-    C0_5_IM,
-    C0,
-    C0_5_IM_NEG,
-    C0_5_IM_NEG,
-    C0,
-    C0,
-    C0_5,
-    C0_5_NEG,
-    C0,
+const B_NON_NORMALIZED_DAGGER: [[Complex64; 4]; 4] = [
+    [
+        Complex64::new(0.5, 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0.5, 0.0),
+    ],
+    [
+        Complex64::new(0., -0.5),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(-0., 0.5),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0., -0.5),
+        Complex64::new(0., -0.5),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0.5, 0.),
+        Complex64::new(-0.5, -0.),
+        Complex64::new(0., 0.),
+    ],
 ];
 
-fn transform_from_magic_basis(unitary: Mat<c64>) -> Mat<c64> {
-    let _b_nonnormalized = mat::from_row_major_slice::<c64>(&B_NON_NORMALIZED, 4, 4);
-    let _b_nonnormalized_dagger = mat::from_row_major_slice::<c64>(&B_NON_NORMALIZED_DAGGER, 4, 4);
-    _b_nonnormalized_dagger * unitary * _b_nonnormalized
+fn transform_from_magic_basis(unitary: ArrayView2<Complex64>, reverse: bool) -> Array2<Complex64> {
+    let _b_nonnormalized = aview2(&B_NON_NORMALIZED);
+    let _b_nonnormalized_dagger = aview2(&B_NON_NORMALIZED_DAGGER);
+    if reverse {
+        _b_nonnormalized_dagger.dot(&unitary).dot(&_b_nonnormalized)
+    } else {
+        _b_nonnormalized.dot(&unitary).dot(&_b_nonnormalized_dagger)
+    }
+}
+
+fn transform_from_magic_basis_faer(u: Mat<c64>, reverse: bool) -> Mat<c64> {
+    let unitary: ArrayView2<Complex64> = u.as_ref().into_ndarray_complex();
+    let _b_nonnormalized = aview2(&B_NON_NORMALIZED);
+    let _b_nonnormalized_dagger = aview2(&B_NON_NORMALIZED_DAGGER);
+    if reverse {
+        _b_nonnormalized_dagger.dot(&unitary).dot(&_b_nonnormalized)
+    } else {
+        _b_nonnormalized.dot(&unitary).dot(&_b_nonnormalized_dagger)
+    }
+    .view()
+    .into_faer_complex()
+    .to_owned()
 }
 
 // faer::c64 and num_complex::Complex<f64> are both structs
@@ -98,9 +157,33 @@ impl Arg for c64 {
     }
 }
 
+fn decompose_two_qubit_product_gate(
+    unitary: ArrayView2<Complex64>,
+) -> (Array2<Complex64>, Array2<Complex64>, f64) {
+    let mut r: Array2<Complex64> = unitary.slice(s![..2, ..2]).to_owned();
+    let mut det_r = det_one_qubit(r.view());
+    if det_r.abs() < 0.1 {
+        r = unitary.slice(s![2.., ..2]).to_owned();
+        det_r = det_one_qubit(r.view());
+    }
+    r.mapv_inplace(|x| x / det_r.sqrt());
+    let r_t_conj: Array2<Complex64> = r.t().mapv(|x| x.conj()).to_owned();
+    let eye = array![
+        [Complex64::new(1., 0.), Complex64::new(0., 0.)],
+        [Complex64::new(0., 0.), Complex64::new(1., 0.)],
+    ];
+    let mut temp = kron(&eye, &r_t_conj);
+    temp = unitary.dot(&temp);
+    let mut l = temp.slice_mut(s![..;2, ..;2]).to_owned();
+    let det_l = det_one_qubit(l.view());
+    l.mapv_inplace(|x| x / det_l.sqrt());
+    let phase = det_l.arg() / 2.;
+    (l, r, phase)
+}
+
 fn __weyl_coordinates(unitary: MatRef<c64>) -> [f64; 3] {
     let uscaled = scale(C1 / unitary.determinant().powf(0.25)) * unitary;
-    let uup = transform_from_magic_basis(uscaled);
+    let uup = transform_from_magic_basis_faer(uscaled, true);
     let mut darg: Vec<_> = (uup.transpose() * &uup)
         .complex_eigenvalues()
         .into_iter()
@@ -180,7 +263,12 @@ fn __num_basis_gates(basis_b: f64, basis_fidelity: f64, unitary: MatRef<c64>) ->
     traces
         .into_iter()
         .enumerate()
-        .map(|(idx, trace)| (idx, trace_to_fid(&trace) * basis_fidelity.powi(idx as i32)))
+        .map(|(idx, trace)| {
+            (
+                idx,
+                trace_to_fid_c64(&trace) * basis_fidelity.powi(idx as i32),
+            )
+        })
         .min_by(|(_idx1, fid1), (_idx2, fid2)| fid2.partial_cmp(fid1).unwrap())
         .unwrap()
         .0
@@ -188,12 +276,779 @@ fn __num_basis_gates(basis_b: f64, basis_fidelity: f64, unitary: MatRef<c64>) ->
 
 /// Average gate fidelity is :math:`Fbar = (d + |Tr (Utarget \\cdot U^dag)|^2) / d(d+1)`
 /// M. Horodecki, P. Horodecki and R. Horodecki, PRA 60, 1888 (1999)
-fn trace_to_fid(trace: &c64) -> f64 {
+fn trace_to_fid_c64(trace: &c64) -> f64 {
     (4.0 + trace.faer_abs2()) / 20.0
+}
+
+fn trace_to_fid(trace: Complex64) -> f64 {
+    (4.0 + trace.abs().powi(2)) / 20.0
+}
+
+/// A good approximation to the best value x to get the minimum
+/// trace distance for :math:`U_d(x, x, x)` from :math:`U_d(a, b, c)`.
+fn closest_partial_swap(a: f64, b: f64, c: f64) -> f64 {
+    let m = (a + b + c) / 3.;
+    let [am, bm, cm] = [a - m, b - m, c - m];
+    let [ab, bc, ca] = [a - b, b - c, c - a];
+    m + am * bm * cm * (6. + ab * ab + bc * bc * ca * ca) / 18.
+}
+
+fn rx_matrix(theta: f64) -> Array2<Complex64> {
+    let half_theta = theta / 2.;
+    let cos = Complex64::new(half_theta.cos(), 0.);
+    let isin = Complex64::new(0., -half_theta.sin());
+    array![[cos, isin], [isin, cos]]
+}
+
+fn ry_matrix(theta: f64) -> Array2<Complex64> {
+    let half_theta = theta / 2.;
+    let cos = Complex64::new(half_theta.cos(), 0.);
+    let isin = Complex64::new(0., half_theta.sin());
+    array![[cos, -isin], [isin, cos]]
+}
+
+fn rz_matrix(theta: f64) -> Array2<Complex64> {
+    let ilam2 = Complex64::new(0., 0.5 * theta);
+    array![
+        [-ilam2.exp(), Complex64::new(0., 0.)],
+        [Complex64::new(0., 0.), ilam2.exp()]
+    ]
+}
+
+const DEFAULT_FIDELITY: f64 = 1.0 - 1.0e-9;
+const C1_IM: Complex64 = Complex64::new(0.0, 1.0);
+
+#[derive(Clone)]
+#[pyclass(module = "qiskit._accelerate.two_qubit_decompose")]
+enum Specializations {
+    General,
+    IdEquiv,
+    SWAPEquiv,
+    PartialSWAPEquiv,
+    PartialSWAPFlipEquiv,
+    ControlledEquiv,
+    MirrorControlledEquiv,
+    // These next 3 gates use the definition of fSim from eq (1) in:
+    // https://arxiv.org/pdf/2001.08343.pdf
+    SimaabEquiv,
+    SimabbEquiv,
+    SimabmbEquiv,
+}
+
+#[derive(Clone)]
+#[allow(non_snake_case)]
+#[pyclass(module = "qiskit._accelerate.two_qubit_decompose", subclass)]
+pub struct TwoQubitWeylDecomposition {
+    #[pyo3(get)]
+    a: f64,
+    #[pyo3(get)]
+    b: f64,
+    #[pyo3(get)]
+    c: f64,
+    #[pyo3(get)]
+    global_phase: f64,
+    K1l: Array2<Complex64>,
+    K2l: Array2<Complex64>,
+    K1r: Array2<Complex64>,
+    K2r: Array2<Complex64>,
+    specialization: Specializations,
+    default_euler_basis: String,
+    #[pyo3(get)]
+    requested_fidelity: Option<f64>,
+    #[pyo3(get)]
+    calculated_fidelity: f64,
+    unitary_matrix: Array2<Complex64>,
+}
+
+impl TwoQubitWeylDecomposition {
+    fn weyl_gate(
+        &mut self,
+        simplify: bool,
+        sequence: &mut Vec<(String, Vec<f64>, [u8; 2])>,
+        atol: f64,
+    ) {
+        match self.specialization {
+            Specializations::MirrorControlledEquiv => {
+                sequence.push(("swap".to_string(), Vec::new(), [0, 1]));
+                sequence.push(("rzz".to_string(), vec![PI4 - self.c], [0, 1]));
+                self.global_phase += PI4;
+            }
+            Specializations::SWAPEquiv => {
+                sequence.push(("swap".to_string(), Vec::new(), [0, 1]));
+                self.global_phase -= 3. * PI / 4.;
+            }
+            _ => {
+                if !simplify || self.a.abs() > atol {
+                    sequence.push(("rxx".to_string(), vec![-self.a * 2.], [0, 1]));
+                }
+                if !simplify || self.b.abs() > atol {
+                    sequence.push(("ryy".to_string(), vec![-self.b * 2.], [0, 1]));
+                }
+                if !simplify || self.c.abs() > atol {
+                    sequence.push(("rzz".to_string(), vec![-self.c * 2.], [0, 1]));
+                }
+            }
+        }
+    }
+}
+
+const IPZ: [[Complex64; 2]; 2] = [
+    [C1_IM, Complex64::new(0., 0.)],
+    [Complex64::new(0., 0.), Complex64::new(0., -1.)],
+];
+const IPY: [[Complex64; 2]; 2] = [
+    [Complex64::new(0., 0.), Complex64::new(1., 0.)],
+    [Complex64::new(-1., 0.), Complex64::new(0., 0.)],
+];
+const IPX: [[Complex64; 2]; 2] = [
+    [Complex64::new(0., 0.), C1_IM],
+    [C1_IM, Complex64::new(0., 0.)],
+];
+
+#[pymethods]
+impl TwoQubitWeylDecomposition {
+    #[new]
+    #[pyo3(signature=(unitary_matrix, fidelity=DEFAULT_FIDELITY, specialization=None))]
+    fn new(
+        unitary_matrix: PyReadonlyArray2<Complex64>,
+        fidelity: Option<f64>,
+        specialization: Option<Specializations>,
+    ) -> PyResult<Self> {
+        let ipz: ArrayView2<Complex64> = aview2(&IPZ);
+        let ipy: ArrayView2<Complex64> = aview2(&IPY);
+        let ipx: ArrayView2<Complex64> = aview2(&IPX);
+        let mut u = unitary_matrix.as_array().to_owned();
+        let unitary_matrix = unitary_matrix.as_array().to_owned();
+        let det_u = u.view().into_faer_complex().determinant().to_num_complex();
+        u.mapv_inplace(|x| x * det_u.powf(-0.25));
+        let mut global_phase = det_u.arg() / 4.;
+        let u_p = transform_from_magic_basis(u.view(), true);
+        // Use ndarray here because matmul precision in faer is lower, it seems
+        // to more aggressively round to zero which causes different behaviour
+        // during the eigen decomposition below.
+        let m2 = u_p.t().dot(&u_p);
+        let default_euler_basis = "ZYZ";
+
+        // M2 is a symmetric complex matrix. We need to decompose it as M2 = P D P^T where
+        // P ∈ SO(4), D is diagonal with unit-magnitude elements.
+        //
+        // We can't use raw `eig` directly because it isn't guaranteed to give us real or othogonal
+        // eigenvectors. Instead, since `M2` is complex-symmetric,
+        //   M2 = A + iB
+        // for real-symmetric `A` and `B`, and as
+        //   M2^+ @ M2 = A^2 + B^2 + i [A, B] = 1
+        // we must have `A` and `B` commute, and consequently they are simultaneously diagonalizable.
+        // Mixing them together _should_ account for any degeneracy problems, but it's not
+        // guaranteed, so we repeat it a little bit.  The fixed seed is to make failures
+        // deterministic; the value is not important.
+        let mut state = Pcg64Mcg::seed_from_u64(2023);
+        let mut found = false;
+        let mut d: Array1<Complex64> = Array1::zeros(0);
+        let mut p: Array2<Complex64> = Array2::zeros((0, 0));
+        for _ in 0..100 {
+            let rand_a: f64 = state.sample(StandardNormal);
+            let rand_b: f64 = state.sample(StandardNormal);
+            let m2_real = m2.mapv(|val| rand_a * val.re + rand_b * val.im).to_owned();
+            let p_inner = m2_real
+                .view()
+                .into_faer()
+                .selfadjoint_eigendecomposition(Lower)
+                .u()
+                .into_ndarray()
+                .mapv(Complex64::from)
+                .to_owned();
+            // Uncomment this to use numpy for eigh instead of faer (useful if needed to compare)
+
+            //            let m2_real = m2.as_ref().into_ndarray().map(|val| rand_a * val.re + rand_b * val.im).to_owned();
+            //            let numpy_linalg = PyModule::import(py, "numpy.linalg")?;
+            //            let eigh = numpy_linalg.getattr("eigh")?;
+            //            let m2_real_arr = m2_real.to_pyarray(py);
+            //            let result = eigh.call1((m2_real_arr,))?.downcast::<PyTuple>()?;
+            //            let p_raw = result.get_item(1)?;
+            //            let p_arr = p_raw.extract::<PyReadonlyArray2<f64>>()?.as_array().to_owned();
+            //            let p_inner = p_arr.mapv(Complex64::from).to_owned();
+
+            //            let m2_arr: ArrayView2<Complex64> = m2.as_ref().into_ndarray_complex();
+            let d_inner = p_inner.t().dot(&m2).dot(&p_inner).diag().to_owned();
+            let mut diag_d: Array2<Complex64> = Array2::zeros((4, 4));
+            diag_d
+                .diag_mut()
+                .iter_mut()
+                .enumerate()
+                .for_each(|(index, x)| *x = d_inner[index]);
+            let compare = p_inner.dot(&diag_d).dot(&p_inner.t()).to_owned();
+            found = abs_diff_eq!(compare.view(), m2, epsilon = 1.0e-13);
+            if found {
+                p = p_inner;
+                d = d_inner;
+                break;
+            }
+        }
+        if !found {
+            return Err(PyTypeError::new_err(format!(
+                "TwoQubitWeylDecomposition: failed to diagonalize M2. Please report this at https://github.com/Qiskit/qiskit-terra/issues/4159. Input: {:?}", unitary_matrix
+            )));
+        }
+        let mut d = -d.map(|x| x.arg() / 2.);
+        d[3] = -d[0] - d[1] - d[2];
+        let mut cs: Array1<f64> = (0..3)
+            .map(|i| ((d[i] + d[3]) / 2.0).rem_euclid(TWO_PI))
+            .collect();
+        let cstemp: Vec<f64> = cs
+            .iter()
+            .map(|x| x.rem_euclid(PI2))
+            .map(|x| x.min(PI2 - x))
+            .collect();
+        let mut order = utils::arg_sort(&cstemp);
+        (order[0], order[1], order[2]) = (order[1], order[2], order[0]);
+        (cs[0], cs[1], cs[2]) = (cs[order[0]], cs[order[1]], cs[order[2]]);
+        (d[0], d[1], d[2]) = (d[order[0]], d[order[1]], d[order[2]]);
+        let mut p_orig = p.clone();
+        for (i, item) in order.iter().enumerate().take(3) {
+            let slice_a = p.slice_mut(s![.., i]);
+            let slice_b = p_orig.slice_mut(s![.., *item]);
+            Zip::from(slice_a).and(slice_b).for_each(::std::mem::swap);
+        }
+        if p.view().into_faer_complex().determinant().re < 0. {
+            p.slice_mut(s![.., -1]).mapv_inplace(|x| -x);
+        }
+        let mut temp: Array2<Complex64> = Array2::zeros((4, 4));
+        temp.diag_mut()
+            .iter_mut()
+            .enumerate()
+            .for_each(|(index, x)| *x = (C1_IM * d[index]).exp());
+        let k1 = transform_from_magic_basis(u_p.dot(&p).dot(&temp).view(), false);
+        let k2 = transform_from_magic_basis(p.t(), false);
+
+        #[allow(non_snake_case)]
+        let (mut K1l, mut K1r, phase_l) = decompose_two_qubit_product_gate(k1.view());
+        #[allow(non_snake_case)]
+        let (K2l, mut K2r, phase_r) = decompose_two_qubit_product_gate(k2.view());
+        global_phase += phase_l + phase_r;
+
+        // Flip into Weyl chamber
+        if cs[0] > PI2 {
+            cs[0] -= PI32;
+            K1l = K1l.dot(&ipy);
+            K1r = K1r.dot(&ipy);
+            global_phase += PI2;
+        }
+        if cs[1] > PI2 {
+            cs[1] -= PI32;
+            K1l = K1l.dot(&ipx);
+            K1r = K1r.dot(&ipx);
+            global_phase += PI2;
+        }
+        let mut conjs = 0;
+        if cs[0] > PI4 {
+            cs[0] = PI2 - cs[0];
+            K1l = K1l.dot(&ipy);
+            K2r = ipy.dot(&K2r);
+            conjs += 1;
+            global_phase -= PI2;
+        }
+        if cs[1] > PI4 {
+            cs[1] = PI2 - cs[1];
+            conjs += 1;
+            K1l = K1l.dot(&ipx);
+            K2r = ipx.dot(&K2r);
+            conjs += 1;
+            global_phase += PI2;
+            if conjs == 1 {
+                global_phase -= PI;
+            }
+        }
+        if cs[2] > PI2 {
+            cs[2] -= PI32;
+            K1l = K1l.dot(&ipz);
+            K1r = K1r.dot(&ipz);
+            global_phase += PI2;
+            if conjs == 1 {
+                global_phase -= PI;
+            }
+        }
+        if conjs == 1 {
+            cs[2] = PI2 - cs[2];
+            K1l = K1l.dot(&ipz);
+            K2r = ipz.dot(&K2r);
+            global_phase += PI2;
+        }
+        if cs[2] > PI4 {
+            cs[2] -= PI2;
+            K1l = K1l.dot(&ipz);
+            K1r = K1r.dot(&ipz);
+            global_phase -= PI2;
+        }
+        let [a, b, c] = [cs[1], cs[0], cs[2]];
+
+        let is_close = |ap: f64, bp: f64, cp: f64| -> bool {
+            let [da, db, dc] = [a - ap, b - bp, c - cp];
+            let tr = 4.
+                * Complex64::new(
+                    da.cos() * db.cos() * dc.cos(),
+                    da.sin() * db.sin() * dc.sin(),
+                );
+            match fidelity {
+                Some(fid) => trace_to_fid(tr) >= fid,
+                // Set to false here to default to general specialization in the absence of a
+                // fidelity and provided specialization.
+                None => false,
+            }
+        };
+
+        let closest_abc = closest_partial_swap(a, b, c);
+        let closest_ab_minus_c = closest_partial_swap(a, b, -c);
+        let mut flipped_from_original = false;
+        let specialization = match specialization {
+            Some(specialization) => specialization,
+            None => {
+                if is_close(0., 0., 0.) {
+                    Specializations::IdEquiv
+                } else if is_close(PI4, PI4, PI4) || is_close(PI4, PI4, -PI4) {
+                    Specializations::SWAPEquiv
+                } else if is_close(closest_abc, closest_abc, closest_abc) {
+                    Specializations::PartialSWAPEquiv
+                } else if is_close(closest_ab_minus_c, closest_ab_minus_c, -closest_ab_minus_c) {
+                    Specializations::PartialSWAPFlipEquiv
+                } else if is_close(a, 0., 0.) {
+                    Specializations::ControlledEquiv
+                } else if is_close(PI4, PI4, c) {
+                    Specializations::MirrorControlledEquiv
+                } else if is_close((a + b) / 2., (a + b) / 2., c) {
+                    Specializations::SimaabEquiv
+                } else if is_close(a, (b + c) / 2., (b + c) / 2.) {
+                    Specializations::SimabbEquiv
+                } else if is_close(a, (b - c) / 2., (c - b) / 2.) {
+                    Specializations::SimabmbEquiv
+                } else {
+                    Specializations::General
+                }
+            }
+        };
+
+        let mut specialized: TwoQubitWeylDecomposition = match specialization {
+            Specializations::IdEquiv => TwoQubitWeylDecomposition {
+                a: 0.,
+                b: 0.,
+                c: 0.,
+                global_phase,
+                K1l: K1l.dot(&K2l),
+                K1r: K1r.dot(&K2r),
+                K2l: Array2::eye(2),
+                K2r: Array2::eye(2),
+                specialization: Specializations::IdEquiv,
+                default_euler_basis: default_euler_basis.to_string(),
+                requested_fidelity: fidelity,
+                calculated_fidelity: 1.0,
+                unitary_matrix,
+            },
+            Specializations::SWAPEquiv => {
+                if c > 0. {
+                    TwoQubitWeylDecomposition {
+                        a: PI4,
+                        b: PI4,
+                        c: PI4,
+                        global_phase,
+                        K1l: K1l.dot(&K2r),
+                        K1r: K1r.dot(&K2l),
+                        K2l: Array2::eye(2),
+                        K2r: Array2::eye(2),
+                        specialization: Specializations::SWAPEquiv,
+                        default_euler_basis: default_euler_basis.to_string(),
+                        requested_fidelity: fidelity,
+                        calculated_fidelity: 1.0,
+                        unitary_matrix,
+                    }
+                } else {
+                    flipped_from_original = true;
+                    TwoQubitWeylDecomposition {
+                        a: PI4,
+                        b: PI4,
+                        c: PI4,
+                        global_phase: global_phase + PI2,
+                        K1l: K1l.dot(&ipz).dot(&K2r),
+                        K1r: K1r.dot(&ipz).dot(&K2l),
+                        K2l: Array2::eye(2),
+                        K2r: Array2::eye(2),
+                        specialization: Specializations::SWAPEquiv,
+                        default_euler_basis: default_euler_basis.to_string(),
+                        requested_fidelity: fidelity,
+                        calculated_fidelity: 1.0,
+                        unitary_matrix,
+                    }
+                }
+            }
+            Specializations::PartialSWAPEquiv => {
+                let closest = closest_partial_swap(a, b, c);
+                let mut k2r_temp = K2l.t().to_owned();
+                k2r_temp.view_mut().mapv_inplace(|x| x.conj());
+                TwoQubitWeylDecomposition {
+                    a: closest,
+                    b: closest,
+                    c: closest,
+                    global_phase,
+                    K1l: K1l.dot(&K2l),
+                    K1r: K1r.dot(&K2l),
+                    K2r: k2r_temp.dot(&K2r),
+                    K2l: Array2::eye(2),
+                    specialization: Specializations::PartialSWAPEquiv,
+                    default_euler_basis: default_euler_basis.to_string(),
+                    requested_fidelity: fidelity,
+                    calculated_fidelity: 1.0,
+                    unitary_matrix,
+                }
+            }
+            Specializations::PartialSWAPFlipEquiv => {
+                let closest = closest_partial_swap(a, b, -c);
+                let mut k2_temp = K2l.t().to_owned();
+                k2_temp.mapv_inplace(|x| x.conj());
+                TwoQubitWeylDecomposition {
+                    a: closest,
+                    b: closest,
+                    c: -a,
+                    global_phase,
+                    K1l: K1l.dot(&K2l),
+                    K1r: K1r.dot(&ipz).dot(&K2l).dot(&ipz),
+                    K2r: ipz.dot(&k2_temp).dot(&ipz).dot(&K2r),
+                    K2l: Array2::eye(2),
+                    specialization: Specializations::PartialSWAPFlipEquiv,
+                    default_euler_basis: default_euler_basis.to_string(),
+                    requested_fidelity: fidelity,
+                    calculated_fidelity: 1.0,
+                    unitary_matrix,
+                }
+            }
+            Specializations::ControlledEquiv => {
+                let default_euler_basis = "XYX";
+                let [k2ltheta, k2lphi, k2llambda, k2lphase] =
+                    angles_from_unitary(K2l.view(), "XYX");
+                let [k2rtheta, k2rphi, k2rlambda, k2rphase] =
+                    angles_from_unitary(K2r.view(), "XYX");
+                TwoQubitWeylDecomposition {
+                    a,
+                    b: 0.,
+                    c: 0.,
+                    global_phase: global_phase + k2lphase + k2rphase,
+                    K1l: K1l.dot(&rx_matrix(k2lphi)),
+                    K1r: K1r.dot(&rx_matrix(k2rphi)),
+                    K2l: ry_matrix(k2ltheta).dot(&rx_matrix(k2llambda)),
+                    K2r: ry_matrix(k2rtheta).dot(&rx_matrix(k2rlambda)),
+                    specialization: Specializations::ControlledEquiv,
+                    default_euler_basis: default_euler_basis.to_string(),
+                    requested_fidelity: fidelity,
+                    calculated_fidelity: 1.0,
+                    unitary_matrix,
+                }
+            }
+            Specializations::MirrorControlledEquiv => {
+                let [k2ltheta, k2lphi, k2llambda, k2lphase] =
+                    angles_from_unitary(K2l.view(), "ZYZ");
+                let [k2rtheta, k2rphi, k2rlambda, k2rphase] =
+                    angles_from_unitary(K2r.view(), "ZYZ");
+                TwoQubitWeylDecomposition {
+                    a: PI4,
+                    b: PI4,
+                    c,
+                    global_phase: global_phase + k2lphase + k2rphase,
+                    K1l: K1l.dot(&rz_matrix(k2lphi)),
+                    K1r: K1r.dot(&rz_matrix(k2rphi)),
+                    K2l: ry_matrix(k2ltheta).dot(&rz_matrix(k2llambda)),
+                    K2r: ry_matrix(k2rtheta).dot(&rz_matrix(k2rlambda)),
+                    specialization: Specializations::MirrorControlledEquiv,
+                    default_euler_basis: default_euler_basis.to_string(),
+                    requested_fidelity: fidelity,
+                    calculated_fidelity: 1.0,
+                    unitary_matrix,
+                }
+            }
+            Specializations::SimaabEquiv => {
+                let [k2ltheta, k2lphi, k2llambda, k2lphase] =
+                    angles_from_unitary(K2l.view(), "ZYZ");
+                TwoQubitWeylDecomposition {
+                    a: (a + b) / 2.,
+                    b: (a + b) / 2.,
+                    c,
+                    global_phase: global_phase + k2lphase,
+                    K1r: K1r.dot(&rz_matrix(k2lphi)),
+                    K1l: K1l.dot(&rz_matrix(k2lphi)),
+                    K2l: ry_matrix(k2ltheta).dot(&rz_matrix(k2llambda)),
+                    K2r: rz_matrix(-k2lphi).dot(&K2r),
+                    specialization: Specializations::SimaabEquiv,
+                    default_euler_basis: default_euler_basis.to_string(),
+                    requested_fidelity: fidelity,
+                    calculated_fidelity: 1.0,
+                    unitary_matrix,
+                }
+            }
+            Specializations::SimabbEquiv => {
+                let default_euler_basis = "XYX";
+                let [k2ltheta, k2lphi, k2llambda, k2lphase] =
+                    angles_from_unitary(K2l.view(), "XYX");
+                TwoQubitWeylDecomposition {
+                    a,
+                    b: (b + c) / 2.,
+                    c: (b + c) / 2.,
+                    global_phase: global_phase + k2lphase,
+                    K1r: K1r.dot(&rx_matrix(k2lphi)),
+                    K1l: K1l.dot(&rx_matrix(k2lphi)),
+                    K2l: ry_matrix(k2ltheta).dot(&rz_matrix(k2llambda)),
+                    K2r: ry_matrix(-k2lphi).dot(&K2r),
+                    specialization: Specializations::SimabbEquiv,
+                    default_euler_basis: default_euler_basis.to_string(),
+                    requested_fidelity: fidelity,
+                    calculated_fidelity: 1.0,
+                    unitary_matrix,
+                }
+            }
+            Specializations::SimabmbEquiv => {
+                // TwoQubitWeylfSimabmbEquiv
+                let default_euler_basis = "XYX";
+                let [k2ltheta, k2lphi, k2llambda, k2lphase] =
+                    angles_from_unitary(K2l.view(), "XYX");
+                TwoQubitWeylDecomposition {
+                    a,
+                    b: (b - c) / 2.,
+                    c: (b - c) / 2.,
+                    global_phase: global_phase + k2lphase,
+                    K1l: K1l.dot(&rz_matrix(k2lphi)),
+                    K1r: K1r.dot(&ipz).dot(&rx_matrix(k2lphi)).dot(&ipz),
+                    K2l: ry_matrix(k2ltheta).dot(&rx_matrix(k2llambda)),
+                    K2r: ipz.dot(&rx_matrix(-k2lphi)).dot(&ipz).dot(&K2r),
+                    specialization: Specializations::SimabmbEquiv,
+                    default_euler_basis: default_euler_basis.to_string(),
+                    requested_fidelity: fidelity,
+                    calculated_fidelity: 1.0,
+                    unitary_matrix,
+                }
+            }
+            Specializations::General => TwoQubitWeylDecomposition {
+                a,
+                b,
+                c,
+                global_phase,
+                K1l,
+                K2l,
+                K1r,
+                K2r,
+                specialization: Specializations::General,
+                default_euler_basis: default_euler_basis.to_string(),
+                requested_fidelity: fidelity,
+                calculated_fidelity: 1.0,
+                unitary_matrix,
+            },
+        };
+
+        let tr = if flipped_from_original {
+            let [da, db, dc] = [
+                PI2 - a - specialized.a,
+                b - specialized.b,
+                -c - specialized.c,
+            ];
+            4. * Complex64::new(
+                da.cos() * db.cos() * dc.cos(),
+                da.sin() * db.sin() * dc.sin(),
+            )
+        } else {
+            let [da, db, dc] = [a - specialized.a, b - specialized.b, c - specialized.c];
+            4. * Complex64::new(
+                da.cos() * db.cos() * dc.cos(),
+                da.sin() * db.sin() * dc.sin(),
+            )
+        };
+
+        specialized.calculated_fidelity = trace_to_fid(tr);
+        if let Some(fid) = specialized.requested_fidelity {
+            if specialized.calculated_fidelity + 1.0e-13 < fid {
+                return Err(PyValueError::new_err("Uh oh"));
+            }
+        }
+        specialized.global_phase += tr.arg();
+        Ok(specialized)
+    }
+
+    #[allow(non_snake_case)]
+    #[getter]
+    fn K1l(&self, py: Python) -> PyObject {
+        self.K1l.to_pyarray(py).into()
+    }
+
+    #[allow(non_snake_case)]
+    #[getter]
+    fn K1r(&self, py: Python) -> PyObject {
+        self.K1r.to_pyarray(py).into()
+    }
+
+    #[allow(non_snake_case)]
+    #[getter]
+    fn K2l(&self, py: Python) -> PyObject {
+        self.K2l.to_pyarray(py).into()
+    }
+
+    #[allow(non_snake_case)]
+    #[getter]
+    fn K2r(&self, py: Python) -> PyObject {
+        self.K2r.to_pyarray(py).into()
+    }
+
+    #[getter]
+    fn unitary_matrix(&self, py: Python) -> PyObject {
+        self.unitary_matrix.to_pyarray(py).into()
+    }
+
+    #[pyo3(signature = (euler_basis=None, simplify=false, atol=None))]
+    fn circuit(
+        &mut self,
+        euler_basis: Option<&str>,
+        simplify: bool,
+        atol: Option<f64>,
+    ) -> TwoQubitGateSequence {
+        let binding = self.default_euler_basis.clone();
+        let euler_basis: &str = euler_basis.unwrap_or(&binding);
+        let target_1q_basis_list: Vec<&str> = vec![euler_basis];
+
+        let mut gate_sequence = Vec::new();
+        let mut global_phase: f64 = self.global_phase;
+
+        let c2r = unitary_to_gate_sequence_inner(
+            self.K2r.view(),
+            &target_1q_basis_list,
+            0,
+            None,
+            simplify,
+            atol,
+        )
+        .unwrap();
+        for gate in c2r.gates {
+            gate_sequence.push((gate.0, gate.1, [0, 0]))
+        }
+        global_phase += c2r.global_phase;
+        let c2l = unitary_to_gate_sequence_inner(
+            self.K2l.view(),
+            &target_1q_basis_list,
+            1,
+            None,
+            simplify,
+            atol,
+        )
+        .unwrap();
+        for gate in c2l.gates {
+            gate_sequence.push((gate.0, gate.1, [1, 1]))
+        }
+        global_phase += c2l.global_phase;
+        self.weyl_gate(simplify, &mut gate_sequence, atol.unwrap_or(DEFAULT_ATOL));
+        let c1r = unitary_to_gate_sequence_inner(
+            self.K1r.view(),
+            &target_1q_basis_list,
+            0,
+            None,
+            simplify,
+            atol,
+        )
+        .unwrap();
+        for gate in c1r.gates {
+            gate_sequence.push((gate.0, gate.1, [0, 0]))
+        }
+        global_phase += c2r.global_phase;
+        let c1l = unitary_to_gate_sequence_inner(
+            self.K1l.view(),
+            &target_1q_basis_list,
+            1,
+            None,
+            simplify,
+            atol,
+        )
+        .unwrap();
+        for gate in c1l.gates {
+            gate_sequence.push((gate.0, gate.1, [1, 1]))
+        }
+        TwoQubitGateSequence {
+            gates: gate_sequence,
+            global_phase,
+        }
+    }
+}
+
+type TwoQubitSequenceVec = Vec<(String, Vec<f64>, [u8; 2])>;
+
+#[pyclass(sequence)]
+pub struct TwoQubitGateSequence {
+    gates: TwoQubitSequenceVec,
+    #[pyo3(get)]
+    global_phase: f64,
+}
+
+#[pymethods]
+impl TwoQubitGateSequence {
+    #[new]
+    fn new() -> Self {
+        TwoQubitGateSequence {
+            gates: Vec::new(),
+            global_phase: 0.,
+        }
+    }
+
+    fn __getstate__(&self) -> (TwoQubitSequenceVec, f64) {
+        (self.gates.clone(), self.global_phase)
+    }
+
+    fn __setstate__(&mut self, state: (TwoQubitSequenceVec, f64)) {
+        self.gates = state.0;
+        self.global_phase = state.1;
+    }
+
+    fn __len__(&self) -> PyResult<usize> {
+        Ok(self.gates.len())
+    }
+
+    fn __getitem__(&self, py: Python, idx: utils::SliceOrInt) -> PyResult<PyObject> {
+        match idx {
+            utils::SliceOrInt::Slice(slc) => {
+                let len = self.gates.len().try_into().unwrap();
+                let indices = slc.indices(len)?;
+                let mut out_vec: Vec<(String, Vec<f64>, [u8; 2])> = Vec::new();
+                // Start and stop will always be positive the slice api converts
+                // negatives to the index for example:
+                // list(range(5))[-1:-3:-1]
+                // will return start=4, stop=2, and step=-
+                let mut pos: isize = indices.start;
+                let mut cond = if indices.step < 0 {
+                    pos > indices.stop
+                } else {
+                    pos < indices.stop
+                };
+                while cond {
+                    if pos < len as isize {
+                        out_vec.push(self.gates[pos as usize].clone());
+                    }
+                    pos += indices.step;
+                    if indices.step < 0 {
+                        cond = pos > indices.stop;
+                    } else {
+                        cond = pos < indices.stop;
+                    }
+                }
+                Ok(out_vec.into_py(py))
+            }
+            utils::SliceOrInt::Int(idx) => {
+                let len = self.gates.len() as isize;
+                if idx >= len || idx < -len {
+                    Err(PyIndexError::new_err(format!("Invalid index, {idx}")))
+                } else if idx < 0 {
+                    let len = self.gates.len();
+                    Ok(self.gates[len - idx.unsigned_abs()].to_object(py))
+                } else {
+                    Ok(self.gates[idx as usize].to_object(py))
+                }
+            }
+        }
+    }
 }
 
 #[pymodule]
 pub fn two_qubit_decompose(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(_num_basis_gates))?;
+    m.add_class::<TwoQubitGateSequence>()?;
+    m.add_class::<TwoQubitWeylDecomposition>()?;
+    m.add_class::<Specializations>()?;
     Ok(())
 }

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -56,6 +56,17 @@ const TWO_PI: f64 = 2.0 * PI;
 
 const C1: c64 = c64 { re: 1.0, im: 0.0 };
 
+const ONE_QUBIT_IDENTITY: [[Complex64; 2]; 2] = [
+    [
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(1., 0.),
+    ],
+];
+
 const B_NON_NORMALIZED: [[Complex64; 4]; 4] = [
     [
         Complex64::new(1.0, 0.),
@@ -174,10 +185,7 @@ fn decompose_two_qubit_product_gate(
     );
     r.mapv_inplace(|x| x / det_r.sqrt());
     let r_t_conj: Array2<Complex64> = r.t().mapv(|x| x.conj());
-    let eye = array![
-        [Complex64::new(1., 0.), Complex64::new(0., 0.)],
-        [Complex64::new(0., 0.), Complex64::new(1., 0.)],
-    ];
+    let eye = aview2(&ONE_QUBIT_IDENTITY);
     let mut temp = kron(&eye, &r_t_conj);
     temp = unitary.dot(&temp);
     let mut l = temp.slice_mut(s![..;2, ..;2]).to_owned();

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -459,9 +459,21 @@ impl TwoQubitWeylDecomposition {
         let mut found = false;
         let mut d: Array1<Complex64> = Array1::zeros(0);
         let mut p: Array2<Complex64> = Array2::zeros((0, 0));
-        for _ in 0..100 {
-            let rand_a: f64 = state.sample(StandardNormal);
-            let rand_b: f64 = state.sample(StandardNormal);
+        for i in 0..100 {
+            let rand_a: f64;
+            let rand_b: f64;
+            // For debugging the algorithm use the same RNG values from the
+            // previous Python implementation for the first random trial.
+            // In most cases this loop only executes a single iteration and
+            // using the same rng values rules out possible RNG differences
+            // as the root cause of a test failure
+            if i == 0 {
+                rand_a = 1.2602066112249388;
+                rand_b = 0.22317849046722027;
+            } else {
+                rand_a = state.sample(StandardNormal);
+                rand_b = state.sample(StandardNormal);
+            }
             let m2_real = m2.mapv(|val| rand_a * val.re + rand_b * val.im).to_owned();
             let p_inner = m2_real
                 .view()

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -182,7 +182,7 @@ fn decompose_two_qubit_product_gate(
     let eye = aview2(&ONE_QUBIT_IDENTITY);
     let mut temp = kron(&eye, &r_t_conj);
     temp = unitary.dot(&temp);
-    let mut l = temp.slice_mut(s![..;2, ..;2]).to_owned();
+    let mut l = temp.slice(s![..;2, ..;2]).to_owned();
     let det_l = det_one_qubit(l.view());
     assert!(
         det_l.abs() >= 0.9,
@@ -585,15 +585,14 @@ impl TwoQubitWeylDecomposition {
                 rand_a = state.sample(StandardNormal);
                 rand_b = state.sample(StandardNormal);
             }
-            let m2_real = m2.mapv(|val| rand_a * val.re + rand_b * val.im).to_owned();
+            let m2_real = m2.mapv(|val| rand_a * val.re + rand_b * val.im);
             let p_inner = m2_real
                 .view()
                 .into_faer()
                 .selfadjoint_eigendecomposition(Lower)
                 .u()
                 .into_ndarray()
-                .mapv(Complex64::from)
-                .to_owned();
+                .mapv(Complex64::from);
             let d_inner = p_inner.t().dot(&m2).dot(&p_inner).diag().to_owned();
             let mut diag_d: Array2<Complex64> = Array2::zeros((4, 4));
             diag_d
@@ -602,7 +601,7 @@ impl TwoQubitWeylDecomposition {
                 .enumerate()
                 .for_each(|(index, x)| *x = d_inner[index]);
 
-            let compare = p_inner.dot(&diag_d).dot(&p_inner.t()).to_owned();
+            let compare = p_inner.dot(&diag_d).dot(&p_inner.t());
             found = abs_diff_eq!(compare.view(), m2, epsilon = 1.0e-13);
             if found {
                 p = p_inner;
@@ -618,7 +617,7 @@ impl TwoQubitWeylDecomposition {
         }
         let mut d = -d.map(|x| x.arg() / 2.);
         d[3] = -d[0] - d[1] - d[2];
-        let mut cs: Array1<f64> = (0..3)
+        let mut cs: SmallVec<[f64; 3]> = (0..3)
             .map(|i| ((d[i] + d[3]) / 2.0).rem_euclid(TWO_PI))
             .collect();
         let cstemp: SmallVec<[f64; 3]> = cs

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -499,11 +499,11 @@ impl TwoQubitWeylDecomposition {
     }
 
     #[new]
-    #[pyo3(signature=(unitary_matrix, fidelity=DEFAULT_FIDELITY, specialization=None, _pickle_context=false))]
+    #[pyo3(signature=(unitary_matrix, fidelity=DEFAULT_FIDELITY, _specialization=None, _pickle_context=false))]
     fn new(
         unitary_matrix: PyReadonlyArray2<Complex64>,
         fidelity: Option<f64>,
-        specialization: Option<Specializations>,
+        _specialization: Option<Specializations>,
         _pickle_context: bool,
     ) -> PyResult<Self> {
         // If we're in a pickle context just make the closest to an empty
@@ -727,7 +727,7 @@ impl TwoQubitWeylDecomposition {
         let closest_abc = closest_partial_swap(a, b, c);
         let closest_ab_minus_c = closest_partial_swap(a, b, -c);
         let mut flipped_from_original = false;
-        let specialization = match specialization {
+        let specialization = match _specialization {
             Some(specialization) => specialization,
             None => {
                 if is_close(0., 0., 0.) {

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -423,7 +423,8 @@ impl TwoQubitWeylDecomposition {
         // Faer sometimes returns negative 0s which will throw off the signs
         // after the powf we do below, normalize to 0. instead by adding a
         // zero complex.
-        let det_u = u.view().into_faer_complex().determinant().to_num_complex() + Complex64::new(0., 0.);
+        let det_u =
+            u.view().into_faer_complex().determinant().to_num_complex() + Complex64::new(0., 0.);
         let det_pow = det_u.powf(-0.25);
         u.mapv_inplace(|x| x * det_pow);
         let mut global_phase = det_u.arg() / 4.;

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -347,6 +347,39 @@ enum Specialization {
     SimabmbEquiv,
 }
 
+impl Specialization {
+    fn to_u8(self) -> u8 {
+        match self {
+            Specialization::General => 0,
+            Specialization::IdEquiv => 1,
+            Specialization::SWAPEquiv => 2,
+            Specialization::PartialSWAPEquiv => 3,
+            Specialization::PartialSWAPFlipEquiv => 4,
+            Specialization::ControlledEquiv => 5,
+            Specialization::MirrorControlledEquiv => 6,
+            Specialization::SimaabEquiv => 7,
+            Specialization::SimabbEquiv => 8,
+            Specialization::SimabmbEquiv => 9,
+        }
+    }
+
+    fn from_u8(val: u8) -> Self {
+        match val {
+            0 => Specialization::General,
+            1 => Specialization::IdEquiv,
+            2 => Specialization::SWAPEquiv,
+            3 => Specialization::PartialSWAPEquiv,
+            4 => Specialization::PartialSWAPFlipEquiv,
+            5 => Specialization::ControlledEquiv,
+            6 => Specialization::MirrorControlledEquiv,
+            7 => Specialization::SimaabEquiv,
+            8 => Specialization::SimabbEquiv,
+            9 => Specialization::SimabmbEquiv,
+            _ => unreachable!("Invalid specialization value"),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 #[allow(non_snake_case)]
 #[pyclass(module = "qiskit._accelerate.two_qubit_decompose", subclass)]
@@ -426,18 +459,7 @@ const IPX: [[Complex64; 2]; 2] = [
 #[pymethods]
 impl TwoQubitWeylDecomposition {
     fn __getstate__(&self, py: Python) -> ([f64; 5], [PyObject; 5], u8, String, Option<f64>) {
-        let specialization = match self.specialization {
-            Specialization::General => 0,
-            Specialization::IdEquiv => 1,
-            Specialization::SWAPEquiv => 2,
-            Specialization::PartialSWAPEquiv => 3,
-            Specialization::PartialSWAPFlipEquiv => 4,
-            Specialization::ControlledEquiv => 5,
-            Specialization::MirrorControlledEquiv => 6,
-            Specialization::SimaabEquiv => 7,
-            Specialization::SimabbEquiv => 8,
-            Specialization::SimabmbEquiv => 9,
-        };
+        let specialization = self.specialization.to_u8();
         (
             [
                 self.a,
@@ -481,19 +503,7 @@ impl TwoQubitWeylDecomposition {
         self.unitary_matrix = state.1[4].as_array().to_owned();
         self.default_euler_basis = state.3;
         self.requested_fidelity = state.4;
-        self.specialization = match state.2 {
-            0 => Specialization::General,
-            1 => Specialization::IdEquiv,
-            2 => Specialization::SWAPEquiv,
-            3 => Specialization::PartialSWAPEquiv,
-            4 => Specialization::PartialSWAPFlipEquiv,
-            5 => Specialization::ControlledEquiv,
-            6 => Specialization::MirrorControlledEquiv,
-            7 => Specialization::SimaabEquiv,
-            8 => Specialization::SimabbEquiv,
-            9 => Specialization::SimabmbEquiv,
-            _ => unreachable!("Invalid specialization value"),
-        };
+        self.specialization = Specialization::from_u8(state.2);
     }
 
     fn __getnewargs__(&self, py: Python) -> (PyObject, Option<f64>, Option<Specialization>, bool) {
@@ -539,8 +549,7 @@ impl TwoQubitWeylDecomposition {
 
         let mut u = unitary_matrix.as_array().to_owned();
         let unitary_matrix = unitary_matrix.as_array().to_owned();
-        let det_u =
-            u.view().into_faer_complex().determinant().to_num_complex();
+        let det_u = u.view().into_faer_complex().determinant().to_num_complex();
         let det_pow = det_u.powf(-0.25);
         u.mapv_inplace(|x| x * det_pow);
         let mut global_phase = det_u.arg() / 4.;

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -290,7 +290,7 @@ fn closest_partial_swap(a: f64, b: f64, c: f64) -> f64 {
     let m = (a + b + c) / 3.;
     let [am, bm, cm] = [a - m, b - m, c - m];
     let [ab, bc, ca] = [a - b, b - c, c - a];
-    m + am * bm * cm * (6. + ab * ab + bc * bc * ca * ca) / 18.
+    m + am * bm * cm * (6. + ab * ab + bc * bc + ca * ca) / 18.
 }
 
 fn rx_matrix(theta: f64) -> Array2<Complex64> {

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -20,7 +20,8 @@
 
 use approx::abs_diff_eq;
 use num_complex::{Complex, Complex64, ComplexFloat};
-use pyo3::exceptions::{PyIndexError, PyTypeError, PyValueError};
+use pyo3::exceptions::PyIndexError;
+use pyo3::import_exception;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use pyo3::Python;
@@ -613,7 +614,8 @@ impl TwoQubitWeylDecomposition {
             }
         }
         if !found {
-            return Err(PyTypeError::new_err(format!(
+            import_exception!(qiskit, QiskitError);
+            return Err(QiskitError::new_err(format!(
                 "TwoQubitWeylDecomposition: failed to diagonalize M2. Please report this at https://github.com/Qiskit/qiskit-terra/issues/4159. Input: {:?}", unitary_matrix
             )));
         }
@@ -982,7 +984,8 @@ impl TwoQubitWeylDecomposition {
         specialized.calculated_fidelity = trace_to_fid(tr);
         if let Some(fid) = specialized.requested_fidelity {
             if specialized.calculated_fidelity + 1.0e-13 < fid {
-                return Err(PyValueError::new_err(format!(
+                import_exception!(qiskit, QiskitError);
+                return Err(QiskitError::new_err(format!(
                     "Specialization: {:?} calculated fidelity: {} is worse than requested fidelity: {}",
                     specialized.specialization,
                     specialized.calculated_fidelity,

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -332,7 +332,7 @@ const C1_IM: Complex64 = Complex64::new(0.0, 1.0);
 
 #[derive(Clone, Debug, Copy)]
 #[pyclass(module = "qiskit._accelerate.two_qubit_decompose")]
-enum Specializations {
+enum Specialization {
     General,
     IdEquiv,
     SWAPEquiv,
@@ -364,7 +364,7 @@ pub struct TwoQubitWeylDecomposition {
     K1r: Array2<Complex64>,
     K2r: Array2<Complex64>,
     #[pyo3(get)]
-    specialization: Specializations,
+    specialization: Specialization,
     default_euler_basis: String,
     #[pyo3(get)]
     requested_fidelity: Option<f64>,
@@ -382,7 +382,7 @@ impl TwoQubitWeylDecomposition {
         global_phase: &mut f64,
     ) {
         match self.specialization {
-            Specializations::MirrorControlledEquiv => {
+            Specialization::MirrorControlledEquiv => {
                 sequence.push(("swap".to_string(), SmallVec::new(), smallvec![0, 1]));
                 sequence.push((
                     "rzz".to_string(),
@@ -391,7 +391,7 @@ impl TwoQubitWeylDecomposition {
                 ));
                 *global_phase += PI4
             }
-            Specializations::SWAPEquiv => {
+            Specialization::SWAPEquiv => {
                 sequence.push(("swap".to_string(), SmallVec::new(), smallvec![0, 1]));
                 *global_phase -= 3. * PI / 4.
             }
@@ -427,16 +427,16 @@ const IPX: [[Complex64; 2]; 2] = [
 impl TwoQubitWeylDecomposition {
     fn __getstate__(&self, py: Python) -> ([f64; 5], [PyObject; 5], u8, String, Option<f64>) {
         let specialization = match self.specialization {
-            Specializations::General => 0,
-            Specializations::IdEquiv => 1,
-            Specializations::SWAPEquiv => 2,
-            Specializations::PartialSWAPEquiv => 3,
-            Specializations::PartialSWAPFlipEquiv => 4,
-            Specializations::ControlledEquiv => 5,
-            Specializations::MirrorControlledEquiv => 6,
-            Specializations::SimaabEquiv => 7,
-            Specializations::SimabbEquiv => 8,
-            Specializations::SimabmbEquiv => 9,
+            Specialization::General => 0,
+            Specialization::IdEquiv => 1,
+            Specialization::SWAPEquiv => 2,
+            Specialization::PartialSWAPEquiv => 3,
+            Specialization::PartialSWAPFlipEquiv => 4,
+            Specialization::ControlledEquiv => 5,
+            Specialization::MirrorControlledEquiv => 6,
+            Specialization::SimaabEquiv => 7,
+            Specialization::SimabbEquiv => 8,
+            Specialization::SimabmbEquiv => 9,
         };
         (
             [
@@ -482,21 +482,21 @@ impl TwoQubitWeylDecomposition {
         self.default_euler_basis = state.3;
         self.requested_fidelity = state.4;
         self.specialization = match state.2 {
-            0 => Specializations::General,
-            1 => Specializations::IdEquiv,
-            2 => Specializations::SWAPEquiv,
-            3 => Specializations::PartialSWAPEquiv,
-            4 => Specializations::PartialSWAPFlipEquiv,
-            5 => Specializations::ControlledEquiv,
-            6 => Specializations::MirrorControlledEquiv,
-            7 => Specializations::SimaabEquiv,
-            8 => Specializations::SimabbEquiv,
-            9 => Specializations::SimabmbEquiv,
+            0 => Specialization::General,
+            1 => Specialization::IdEquiv,
+            2 => Specialization::SWAPEquiv,
+            3 => Specialization::PartialSWAPEquiv,
+            4 => Specialization::PartialSWAPFlipEquiv,
+            5 => Specialization::ControlledEquiv,
+            6 => Specialization::MirrorControlledEquiv,
+            7 => Specialization::SimaabEquiv,
+            8 => Specialization::SimabbEquiv,
+            9 => Specialization::SimabmbEquiv,
             _ => unreachable!("Invalid specialization value"),
         };
     }
 
-    fn __getnewargs__(&self, py: Python) -> (PyObject, Option<f64>, Option<Specializations>, bool) {
+    fn __getnewargs__(&self, py: Python) -> (PyObject, Option<f64>, Option<Specialization>, bool) {
         (
             self.unitary_matrix.to_pyarray(py).into(),
             self.requested_fidelity,
@@ -510,7 +510,7 @@ impl TwoQubitWeylDecomposition {
     fn new(
         unitary_matrix: PyReadonlyArray2<Complex64>,
         fidelity: Option<f64>,
-        _specialization: Option<Specializations>,
+        _specialization: Option<Specialization>,
         _pickle_context: bool,
     ) -> PyResult<Self> {
         // If we're in a pickle context just make the closest to an empty
@@ -526,7 +526,7 @@ impl TwoQubitWeylDecomposition {
                 K2l: Array2::zeros((0, 0)),
                 K1r: Array2::zeros((0, 0)),
                 K2r: Array2::zeros((0, 0)),
-                specialization: Specializations::General,
+                specialization: Specialization::General,
                 default_euler_basis: "ZYZ".to_string(),
                 requested_fidelity: fidelity,
                 calculated_fidelity: 0.,
@@ -728,25 +728,25 @@ impl TwoQubitWeylDecomposition {
             Some(specialization) => specialization,
             None => {
                 if is_close(0., 0., 0.) {
-                    Specializations::IdEquiv
+                    Specialization::IdEquiv
                 } else if is_close(PI4, PI4, PI4) || is_close(PI4, PI4, -PI4) {
-                    Specializations::SWAPEquiv
+                    Specialization::SWAPEquiv
                 } else if is_close(closest_abc, closest_abc, closest_abc) {
-                    Specializations::PartialSWAPEquiv
+                    Specialization::PartialSWAPEquiv
                 } else if is_close(closest_ab_minus_c, closest_ab_minus_c, -closest_ab_minus_c) {
-                    Specializations::PartialSWAPFlipEquiv
+                    Specialization::PartialSWAPFlipEquiv
                 } else if is_close(a, 0., 0.) {
-                    Specializations::ControlledEquiv
+                    Specialization::ControlledEquiv
                 } else if is_close(PI4, PI4, c) {
-                    Specializations::MirrorControlledEquiv
+                    Specialization::MirrorControlledEquiv
                 } else if is_close((a + b) / 2., (a + b) / 2., c) {
-                    Specializations::SimaabEquiv
+                    Specialization::SimaabEquiv
                 } else if is_close(a, (b + c) / 2., (b + c) / 2.) {
-                    Specializations::SimabbEquiv
+                    Specialization::SimabbEquiv
                 } else if is_close(a, (b - c) / 2., (c - b) / 2.) {
-                    Specializations::SimabmbEquiv
+                    Specialization::SimabmbEquiv
                 } else {
-                    Specializations::General
+                    Specialization::General
                 }
             }
         };
@@ -759,14 +759,14 @@ impl TwoQubitWeylDecomposition {
             K1r,
             K2l,
             K2r,
-            specialization: Specializations::General,
+            specialization: Specialization::General,
             default_euler_basis: default_euler_basis.to_owned(),
             requested_fidelity: fidelity,
             calculated_fidelity: -1.0,
             unitary_matrix,
         };
         let mut specialized: TwoQubitWeylDecomposition = match specialization {
-            Specializations::IdEquiv => TwoQubitWeylDecomposition {
+            Specialization::IdEquiv => TwoQubitWeylDecomposition {
                 specialization,
                 a: 0.,
                 b: 0.,
@@ -777,7 +777,7 @@ impl TwoQubitWeylDecomposition {
                 K2r: Array2::eye(2),
                 ..general
             },
-            Specializations::SWAPEquiv => {
+            Specialization::SWAPEquiv => {
                 if c > 0. {
                     TwoQubitWeylDecomposition {
                         specialization,
@@ -806,7 +806,7 @@ impl TwoQubitWeylDecomposition {
                     }
                 }
             }
-            Specializations::PartialSWAPEquiv => {
+            Specialization::PartialSWAPEquiv => {
                 let closest = closest_partial_swap(a, b, c);
                 let mut k2l_dag = general.K2l.t().to_owned();
                 k2l_dag.view_mut().mapv_inplace(|x| x.conj());
@@ -822,7 +822,7 @@ impl TwoQubitWeylDecomposition {
                     ..general
                 }
             }
-            Specializations::PartialSWAPFlipEquiv => {
+            Specialization::PartialSWAPFlipEquiv => {
                 let closest = closest_partial_swap(a, b, -c);
                 let mut k2l_dag = general.K2l.t().to_owned();
                 k2l_dag.mapv_inplace(|x| x.conj());
@@ -838,7 +838,7 @@ impl TwoQubitWeylDecomposition {
                     ..general
                 }
             }
-            Specializations::ControlledEquiv => {
+            Specialization::ControlledEquiv => {
                 let euler_basis = "XYX".to_owned();
                 let [k2ltheta, k2lphi, k2llambda, k2lphase] =
                     angles_from_unitary(general.K2l.view(), &euler_basis);
@@ -858,7 +858,7 @@ impl TwoQubitWeylDecomposition {
                     ..general
                 }
             }
-            Specializations::MirrorControlledEquiv => {
+            Specialization::MirrorControlledEquiv => {
                 let [k2ltheta, k2lphi, k2llambda, k2lphase] =
                     angles_from_unitary(general.K2l.view(), "ZYZ");
                 let [k2rtheta, k2rphi, k2rlambda, k2rphase] =
@@ -876,7 +876,7 @@ impl TwoQubitWeylDecomposition {
                     ..general
                 }
             }
-            Specializations::SimaabEquiv => {
+            Specialization::SimaabEquiv => {
                 let [k2ltheta, k2lphi, k2llambda, k2lphase] =
                     angles_from_unitary(general.K2l.view(), "ZYZ");
                 TwoQubitWeylDecomposition {
@@ -892,7 +892,7 @@ impl TwoQubitWeylDecomposition {
                     ..general
                 }
             }
-            Specializations::SimabbEquiv => {
+            Specialization::SimabbEquiv => {
                 let euler_basis = "XYX".to_owned();
                 let [k2ltheta, k2lphi, k2llambda, k2lphase] =
                     angles_from_unitary(general.K2l.view(), &euler_basis);
@@ -910,7 +910,7 @@ impl TwoQubitWeylDecomposition {
                     ..general
                 }
             }
-            Specializations::SimabmbEquiv => {
+            Specialization::SimabmbEquiv => {
                 let euler_basis = "XYX".to_owned();
                 let [k2ltheta, k2lphi, k2llambda, k2lphase] =
                     angles_from_unitary(general.K2l.view(), &euler_basis);
@@ -928,7 +928,7 @@ impl TwoQubitWeylDecomposition {
                     ..general
                 }
             }
-            Specializations::General => general,
+            Specialization::General => general,
         };
 
         let tr = if flipped_from_original {
@@ -1151,6 +1151,6 @@ pub fn two_qubit_decompose(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(_num_basis_gates))?;
     m.add_class::<TwoQubitGateSequence>()?;
     m.add_class::<TwoQubitWeylDecomposition>()?;
-    m.add_class::<Specializations>()?;
+    m.add_class::<Specialization>()?;
     Ok(())
 }

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -924,14 +924,13 @@ impl TwoQubitWeylDecomposition {
                 }
             }
             Specializations::SimabmbEquiv => {
-                // TwoQubitWeylfSimabmbEquiv
                 let default_euler_basis = "XYX";
                 let [k2ltheta, k2lphi, k2llambda, k2lphase] =
-                    angles_from_unitary(K2l.view(), "XYX");
+                    angles_from_unitary(K2l.view(), default_euler_basis);
                 TwoQubitWeylDecomposition {
                     a,
                     b: (b - c) / 2.,
-                    c: (b - c) / 2.,
+                    c: -((b - c) / 2.),
                     global_phase: global_phase + k2lphase,
                     K1l: K1l.dot(&rz_matrix(k2lphi)),
                     K1r: K1r.dot(&ipz).dot(&rx_matrix(k2lphi)).dot(&ipz),
@@ -982,7 +981,12 @@ impl TwoQubitWeylDecomposition {
         specialized.calculated_fidelity = trace_to_fid(tr);
         if let Some(fid) = specialized.requested_fidelity {
             if specialized.calculated_fidelity + 1.0e-13 < fid {
-                return Err(PyValueError::new_err("Uh oh"));
+                return Err(PyValueError::new_err(format!(
+                    "Specialization: {:?} calculated fidelity: {} is worse than requested fidelity: {}",
+                    specialized.specialization,
+                    specialized.calculated_fidelity,
+                    fid
+                )));
             }
         }
         specialized.global_phase += tr.arg();

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -777,6 +777,10 @@ impl TwoQubitWeylDecomposition {
             unitary_matrix,
         };
         let mut specialized: TwoQubitWeylDecomposition = match specialization {
+            // :math:`U \sim U_d(0,0,0) \sim Id`
+            //
+            // This gate binds 0 parameters, we make it canonical by setting
+            // :math:`K2_l = Id` , :math:`K2_r = Id`.
             Specialization::IdEquiv => TwoQubitWeylDecomposition {
                 specialization,
                 a: 0.,
@@ -788,6 +792,10 @@ impl TwoQubitWeylDecomposition {
                 K2r: Array2::eye(2),
                 ..general
             },
+            // :math:`U \sim U_d(\pi/4, \pi/4, \pi/4) \sim U(\pi/4, \pi/4, -\pi/4) \sim \text{SWAP}`
+            //
+            // This gate binds 0 parameters, we make it canonical by setting
+            // :math:`K2_l = Id` , :math:`K2_r = Id`.
             Specialization::SWAPEquiv => {
                 if c > 0. {
                     TwoQubitWeylDecomposition {
@@ -817,6 +825,11 @@ impl TwoQubitWeylDecomposition {
                     }
                 }
             }
+            // :math:`U \sim U_d(\alpha\pi/4, \alpha\pi/4, \alpha\pi/4) \sim \text{SWAP}^\alpha`
+            //
+            // This gate binds 3 parameters, we make it canonical by setting:
+            //
+            // :math:`K2_l = Id`.
             Specialization::PartialSWAPEquiv => {
                 let closest = closest_partial_swap(a, b, c);
                 let mut k2l_dag = general.K2l.t().to_owned();
@@ -833,6 +846,14 @@ impl TwoQubitWeylDecomposition {
                     ..general
                 }
             }
+            // :math:`U \sim U_d(\alpha\pi/4, \alpha\pi/4, -\alpha\pi/4) \sim \text{SWAP}^\alpha`
+            //
+            // (a non-equivalent root of SWAP from the TwoQubitWeylPartialSWAPEquiv
+            // similar to how :math:`x = (\pm \sqrt(x))^2`)
+            //
+            // This gate binds 3 parameters, we make it canonical by setting:
+            //
+            // :math:`K2_l = Id`
             Specialization::PartialSWAPFlipEquiv => {
                 let closest = closest_partial_swap(a, b, -c);
                 let mut k2l_dag = general.K2l.t().to_owned();
@@ -849,6 +870,12 @@ impl TwoQubitWeylDecomposition {
                     ..general
                 }
             }
+            // :math:`U \sim U_d(\alpha, 0, 0) \sim \text{Ctrl-U}`
+            //
+            // This gate binds 4 parameters, we make it canonical by setting:
+            //
+            //      :math:`K2_l = Ry(\theta_l) Rx(\lambda_l)` ,
+            //      :math:`K2_r = Ry(\theta_r) Rx(\lambda_r)` .
             Specialization::ControlledEquiv => {
                 let euler_basis = EulerBasis::XYX;
                 let [k2ltheta, k2lphi, k2llambda, k2lphase] =
@@ -869,6 +896,11 @@ impl TwoQubitWeylDecomposition {
                     ..general
                 }
             }
+            // :math:`U \sim U_d(\pi/4, \pi/4, \alpha) \sim \text{SWAP} \cdot \text{Ctrl-U}`
+            //
+            // This gate binds 4 parameters, we make it canonical by setting:
+            //
+            // :math:`K2_l = Ry(\theta_l)\cdot Rz(\lambda_l)` , :math:`K2_r = Ry(\theta_r)\cdot Rz(\lambda_r)`
             Specialization::MirrorControlledEquiv => {
                 let [k2ltheta, k2lphi, k2llambda, k2lphase] =
                     angles_from_unitary(general.K2l.view(), EulerBasis::ZYZ);
@@ -887,6 +919,11 @@ impl TwoQubitWeylDecomposition {
                     ..general
                 }
             }
+            // :math:`U \sim U_d(\alpha, \alpha, \beta), \alpha \geq |\beta|`
+            //
+            // This gate binds 5 parameters, we make it canonical by setting:
+            //
+            // :math:`K2_l = Ry(\theta_l)\cdot Rz(\lambda_l)`.
             Specialization::SimaabEquiv => {
                 let [k2ltheta, k2lphi, k2llambda, k2lphase] =
                     angles_from_unitary(general.K2l.view(), EulerBasis::ZYZ);
@@ -903,6 +940,11 @@ impl TwoQubitWeylDecomposition {
                     ..general
                 }
             }
+            // :math:`U \sim U_d(\alpha, \beta, -\beta), \alpha \geq \beta \geq 0`
+            //
+            // This gate binds 5 parameters, we make it canonical by setting:
+            //
+            // :math:`K2_l = Ry(\theta_l)Rx(\lambda_l)`
             Specialization::SimabbEquiv => {
                 let euler_basis = EulerBasis::XYX;
                 let [k2ltheta, k2lphi, k2llambda, k2lphase] =
@@ -921,6 +963,11 @@ impl TwoQubitWeylDecomposition {
                     ..general
                 }
             }
+            // :math:`U \sim U_d(\alpha, \beta, -\beta), \alpha \geq \beta \geq 0`
+            //
+            // This gate binds 5 parameters, we make it canonical by setting:
+            //
+            // :math:`K2_l = Ry(\theta_l)Rx(\lambda_l)`
             Specialization::SimabmbEquiv => {
                 let euler_basis = EulerBasis::XYX;
                 let [k2ltheta, k2lphi, k2llambda, k2lphase] =
@@ -939,6 +986,10 @@ impl TwoQubitWeylDecomposition {
                     ..general
                 }
             }
+            // U has no special symmetry.
+            //
+            // This gate binds all 6 possible parameters, so there is no need to make the single-qubit
+            // pre-/post-gates canonical.
             Specialization::General => general,
         };
 

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -378,7 +378,7 @@ impl TwoQubitWeylDecomposition {
         match self.specialization {
             Specializations::MirrorControlledEquiv => {
                 sequence.push(("swap".to_string(), Vec::new(), [0, 1]));
-                sequence.push(("rzz".to_string(), vec![PI4 - self.c], [0, 1]));
+                sequence.push(("rzz".to_string(), vec![(PI4 - self.c) * 2.], [0, 1]));
                 self.global_phase += PI4;
             }
             Specializations::SWAPEquiv => {

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -464,17 +464,15 @@ impl TwoQubitWeylDecomposition {
                 .mapv(Complex64::from)
                 .to_owned();
             // Uncomment this to use numpy for eigh instead of faer (useful if needed to compare)
-
-            //            let m2_real = m2.as_ref().into_ndarray().map(|val| rand_a * val.re + rand_b * val.im).to_owned();
-            //            let numpy_linalg = PyModule::import(py, "numpy.linalg")?;
-            //            let eigh = numpy_linalg.getattr("eigh")?;
-            //            let m2_real_arr = m2_real.to_pyarray(py);
-            //            let result = eigh.call1((m2_real_arr,))?.downcast::<PyTuple>()?;
-            //            let p_raw = result.get_item(1)?;
-            //            let p_arr = p_raw.extract::<PyReadonlyArray2<f64>>()?.as_array().to_owned();
-            //            let p_inner = p_arr.mapv(Complex64::from).to_owned();
-
-            //            let m2_arr: ArrayView2<Complex64> = m2.as_ref().into_ndarray_complex();
+            // let numpy_linalg = PyModule::import(py, "numpy.linalg")?;
+            // let eigh = numpy_linalg.getattr("eigh")?;
+            // let m2_real_arr = m2_real.to_pyarray(py);
+            // let result = eigh.call1((m2_real_arr,))?.downcast::<PyTuple>()?;
+            // let p_raw = result.get_item(1)?;
+            // let p_inner = p_raw
+            //     .extract::<PyReadonlyArray2<f64>>()?
+            //     .as_array()
+            //     .mapv(Complex64::from);
             let d_inner = p_inner.t().dot(&m2).dot(&p_inner).diag().to_owned();
             let mut diag_d: Array2<Complex64> = Array2::zeros((4, 4));
             diag_d

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -351,9 +351,12 @@ enum Specialization {
     MirrorControlledEquiv,
     // These next 3 gates use the definition of fSim from eq (1) in:
     // https://arxiv.org/pdf/2001.08343.pdf
-    SimaabEquiv,
-    SimabbEquiv,
-    SimabmbEquiv,
+    #[allow(non_camel_case_types)]
+    fSimaabEquiv,
+    #[allow(non_camel_case_types)]
+    fSimabbEquiv,
+    #[allow(non_camel_case_types)]
+    fSimabmbEquiv,
 }
 
 impl Specialization {
@@ -366,9 +369,9 @@ impl Specialization {
             Specialization::PartialSWAPFlipEquiv => 4,
             Specialization::ControlledEquiv => 5,
             Specialization::MirrorControlledEquiv => 6,
-            Specialization::SimaabEquiv => 7,
-            Specialization::SimabbEquiv => 8,
-            Specialization::SimabmbEquiv => 9,
+            Specialization::fSimaabEquiv => 7,
+            Specialization::fSimabbEquiv => 8,
+            Specialization::fSimabmbEquiv => 9,
         }
     }
 
@@ -381,9 +384,9 @@ impl Specialization {
             4 => Specialization::PartialSWAPFlipEquiv,
             5 => Specialization::ControlledEquiv,
             6 => Specialization::MirrorControlledEquiv,
-            7 => Specialization::SimaabEquiv,
-            8 => Specialization::SimabbEquiv,
-            9 => Specialization::SimabmbEquiv,
+            7 => Specialization::fSimaabEquiv,
+            8 => Specialization::fSimabbEquiv,
+            9 => Specialization::fSimabmbEquiv,
             _ => unreachable!("Invalid specialization value"),
         }
     }
@@ -751,11 +754,11 @@ impl TwoQubitWeylDecomposition {
                 } else if is_close(PI4, PI4, c) {
                     Specialization::MirrorControlledEquiv
                 } else if is_close((a + b) / 2., (a + b) / 2., c) {
-                    Specialization::SimaabEquiv
+                    Specialization::fSimaabEquiv
                 } else if is_close(a, (b + c) / 2., (b + c) / 2.) {
-                    Specialization::SimabbEquiv
+                    Specialization::fSimabbEquiv
                 } else if is_close(a, (b - c) / 2., (c - b) / 2.) {
-                    Specialization::SimabmbEquiv
+                    Specialization::fSimabmbEquiv
                 } else {
                     Specialization::General
                 }
@@ -924,7 +927,7 @@ impl TwoQubitWeylDecomposition {
             // This gate binds 5 parameters, we make it canonical by setting:
             //
             // :math:`K2_l = Ry(\theta_l)\cdot Rz(\lambda_l)`.
-            Specialization::SimaabEquiv => {
+            Specialization::fSimaabEquiv => {
                 let [k2ltheta, k2lphi, k2llambda, k2lphase] =
                     angles_from_unitary(general.K2l.view(), EulerBasis::ZYZ);
                 TwoQubitWeylDecomposition {
@@ -945,7 +948,7 @@ impl TwoQubitWeylDecomposition {
             // This gate binds 5 parameters, we make it canonical by setting:
             //
             // :math:`K2_l = Ry(\theta_l)Rx(\lambda_l)`
-            Specialization::SimabbEquiv => {
+            Specialization::fSimabbEquiv => {
                 let euler_basis = EulerBasis::XYX;
                 let [k2ltheta, k2lphi, k2llambda, k2lphase] =
                     angles_from_unitary(general.K2l.view(), euler_basis);
@@ -968,7 +971,7 @@ impl TwoQubitWeylDecomposition {
             // This gate binds 5 parameters, we make it canonical by setting:
             //
             // :math:`K2_l = Ry(\theta_l)Rx(\lambda_l)`
-            Specialization::SimabmbEquiv => {
+            Specialization::fSimabmbEquiv => {
                 let euler_basis = EulerBasis::XYX;
                 let [k2ltheta, k2lphi, k2llambda, k2lphase] =
                     angles_from_unitary(general.K2l.view(), euler_basis);

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -166,6 +166,10 @@ fn decompose_two_qubit_product_gate(
         r = unitary.slice(s![2.., ..2]).to_owned();
         det_r = det_one_qubit(r.view());
     }
+    assert!(
+        det_r.abs() < 0.1,
+        "decompose_two_qubit_product_gate: unable to decompose: detR < 0 .1"
+    );
     r.mapv_inplace(|x| x / det_r.sqrt());
     let r_t_conj: Array2<Complex64> = r.t().mapv(|x| x.conj()).to_owned();
     let eye = array![
@@ -176,6 +180,10 @@ fn decompose_two_qubit_product_gate(
     temp = unitary.dot(&temp);
     let mut l = temp.slice_mut(s![..;2, ..;2]).to_owned();
     let det_l = det_one_qubit(l.view());
+    assert!(
+        det_l.abs() < 0.9,
+        "decompose_two_qubit_product_gate: unable to decompose: detL < 0.9"
+    );
     l.mapv_inplace(|x| x / det_l.sqrt());
     let phase = det_l.arg() / 2.;
     (l, r, phase)

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -82,7 +82,7 @@ const B_NON_NORMALIZED: [[Complex64; 4]; 4] = [
     ],
     [
         Complex64::new(1., 0.),
-        Complex64::new(-0., -1.),
+        Complex64::new(0., -1.),
         Complex64::new(0., 0.),
         Complex64::new(0., 0.),
     ],
@@ -99,7 +99,7 @@ const B_NON_NORMALIZED_DAGGER: [[Complex64; 4]; 4] = [
         Complex64::new(0., -0.5),
         Complex64::new(0., 0.),
         Complex64::new(0., 0.),
-        Complex64::new(-0., 0.5),
+        Complex64::new(0., 0.5),
     ],
     [
         Complex64::new(0., 0.),
@@ -110,7 +110,7 @@ const B_NON_NORMALIZED_DAGGER: [[Complex64; 4]; 4] = [
     [
         Complex64::new(0., 0.),
         Complex64::new(0.5, 0.),
-        Complex64::new(-0.5, -0.),
+        Complex64::new(-0.5, 0.),
         Complex64::new(0., 0.),
     ],
 ];
@@ -539,18 +539,12 @@ impl TwoQubitWeylDecomposition {
 
         let mut u = unitary_matrix.as_array().to_owned();
         let unitary_matrix = unitary_matrix.as_array().to_owned();
-        // Faer sometimes returns negative 0s which will throw off the signs
-        // after the powf we do below, normalize to 0. instead by adding a
-        // zero complex.
         let det_u =
-            u.view().into_faer_complex().determinant().to_num_complex() + Complex64::new(0., 0.);
+            u.view().into_faer_complex().determinant().to_num_complex();
         let det_pow = det_u.powf(-0.25);
         u.mapv_inplace(|x| x * det_pow);
         let mut global_phase = det_u.arg() / 4.;
         let u_p = transform_from_magic_basis(u.view(), true);
-        // Use ndarray here because matmul precision in faer is lower, it seems
-        // to more aggressively round to zero which causes different behaviour
-        // during the eigen decomposition below.
         let m2 = u_p.t().dot(&u_p);
         let default_euler_basis = "ZYZ";
 

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -172,7 +172,7 @@ fn decompose_two_qubit_product_gate(
         "decompose_two_qubit_product_gate: unable to decompose: detR < 0.1"
     );
     r.mapv_inplace(|x| x / det_r.sqrt());
-    let r_t_conj: Array2<Complex64> = r.t().mapv(|x| x.conj()).to_owned();
+    let r_t_conj: Array2<Complex64> = r.t().mapv(|x| x.conj());
     let eye = array![
         [Complex64::new(1., 0.), Complex64::new(0., 0.)],
         [Complex64::new(0., 0.), Complex64::new(1., 0.)],
@@ -587,16 +587,6 @@ impl TwoQubitWeylDecomposition {
                 .into_ndarray()
                 .mapv(Complex64::from)
                 .to_owned();
-            // Uncomment this to use numpy for eigh instead of faer (useful if needed to compare)
-            // let numpy_linalg = PyModule::import(py, "numpy.linalg")?;
-            // let eigh = numpy_linalg.getattr("eigh")?;
-            // let m2_real_arr = m2_real.to_pyarray(py);
-            // let result = eigh.call1((m2_real_arr,))?.downcast::<PyTuple>()?;
-            // let p_raw = result.get_item(1)?;
-            // let p_inner = p_raw
-            //     .extract::<PyReadonlyArray2<f64>>()?
-            //     .as_array()
-            //     .mapv(Complex64::from);
             let d_inner = p_inner.t().dot(&m2).dot(&p_inner).diag().to_owned();
             let mut diag_d: Array2<Complex64> = Array2::zeros((4, 4));
             diag_d

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -167,7 +167,7 @@ fn decompose_two_qubit_product_gate(
         det_r = det_one_qubit(r.view());
     }
     assert!(
-        det_r.abs() < 0.1,
+        det_r.abs() >= 0.1,
         "decompose_two_qubit_product_gate: unable to decompose: detR < 0.1"
     );
     r.mapv_inplace(|x| x / det_r.sqrt());
@@ -181,7 +181,7 @@ fn decompose_two_qubit_product_gate(
     let mut l = temp.slice_mut(s![..;2, ..;2]).to_owned();
     let det_l = det_one_qubit(l.view());
     assert!(
-        det_l.abs() < 0.9,
+        det_l.abs() >= 0.9,
         "decompose_two_qubit_product_gate: unable to decompose: detL < 0.9"
     );
     l.mapv_inplace(|x| x / det_l.sqrt());

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -675,7 +675,6 @@ impl TwoQubitWeylDecomposition {
         }
         if cs[1] > PI4 {
             cs[1] = PI2 - cs[1];
-            conjs += 1;
             K1l = K1l.dot(&ipx);
             K2r = ipx.dot(&K2r);
             conjs += 1;

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -41,7 +41,8 @@ use numpy::PyReadonlyArray2;
 use numpy::ToPyArray;
 
 use crate::euler_one_qubit_decomposer::{
-    angles_from_unitary, det_one_qubit, unitary_to_gate_sequence_inner, ANGLE_ZERO_EPSILON,
+    angles_from_unitary, det_one_qubit, unitary_to_gate_sequence_inner, EulerBasis,
+    ANGLE_ZERO_EPSILON,
 };
 use crate::utils;
 
@@ -405,7 +406,7 @@ pub struct TwoQubitWeylDecomposition {
     K2r: Array2<Complex64>,
     #[pyo3(get)]
     specialization: Specialization,
-    default_euler_basis: String,
+    default_euler_basis: EulerBasis,
     #[pyo3(get)]
     requested_fidelity: Option<f64>,
     #[pyo3(get)]
@@ -483,7 +484,7 @@ impl TwoQubitWeylDecomposition {
                 self.unitary_matrix.to_pyarray(py).into(),
             ],
             specialization,
-            self.default_euler_basis.clone(),
+            self.default_euler_basis.to_str(),
             self.requested_fidelity,
         )
     }
@@ -508,7 +509,7 @@ impl TwoQubitWeylDecomposition {
         self.K2l = state.1[2].as_array().to_owned();
         self.K2r = state.1[3].as_array().to_owned();
         self.unitary_matrix = state.1[4].as_array().to_owned();
-        self.default_euler_basis = state.3;
+        self.default_euler_basis = EulerBasis::from_string(&state.3).unwrap();
         self.requested_fidelity = state.4;
         self.specialization = Specialization::from_u8(state.2);
     }
@@ -544,7 +545,7 @@ impl TwoQubitWeylDecomposition {
                 K1r: Array2::zeros((0, 0)),
                 K2r: Array2::zeros((0, 0)),
                 specialization: Specialization::General,
-                default_euler_basis: "ZYZ".to_string(),
+                default_euler_basis: EulerBasis::ZYZ,
                 requested_fidelity: fidelity,
                 calculated_fidelity: 0.,
                 unitary_matrix: Array2::zeros((0, 0)),
@@ -562,7 +563,7 @@ impl TwoQubitWeylDecomposition {
         let mut global_phase = det_u.arg() / 4.;
         let u_p = transform_from_magic_basis(u.view(), true);
         let m2 = u_p.t().dot(&u_p);
-        let default_euler_basis = "ZYZ";
+        let default_euler_basis = EulerBasis::ZYZ;
 
         // M2 is a symmetric complex matrix. We need to decompose it as M2 = P D P^T where
         // P ∈ SO(4), D is diagonal with unit-magnitude elements.
@@ -769,7 +770,7 @@ impl TwoQubitWeylDecomposition {
             K2l,
             K2r,
             specialization: Specialization::General,
-            default_euler_basis: default_euler_basis.to_owned(),
+            default_euler_basis,
             requested_fidelity: fidelity,
             calculated_fidelity: -1.0,
             unitary_matrix,
@@ -848,11 +849,11 @@ impl TwoQubitWeylDecomposition {
                 }
             }
             Specialization::ControlledEquiv => {
-                let euler_basis = "XYX".to_owned();
+                let euler_basis = EulerBasis::XYX;
                 let [k2ltheta, k2lphi, k2llambda, k2lphase] =
-                    angles_from_unitary(general.K2l.view(), &euler_basis);
+                    angles_from_unitary(general.K2l.view(), euler_basis);
                 let [k2rtheta, k2rphi, k2rlambda, k2rphase] =
-                    angles_from_unitary(general.K2r.view(), &euler_basis);
+                    angles_from_unitary(general.K2r.view(), euler_basis);
                 TwoQubitWeylDecomposition {
                     specialization,
                     a,
@@ -869,9 +870,9 @@ impl TwoQubitWeylDecomposition {
             }
             Specialization::MirrorControlledEquiv => {
                 let [k2ltheta, k2lphi, k2llambda, k2lphase] =
-                    angles_from_unitary(general.K2l.view(), "ZYZ");
+                    angles_from_unitary(general.K2l.view(), EulerBasis::ZYZ);
                 let [k2rtheta, k2rphi, k2rlambda, k2rphase] =
-                    angles_from_unitary(general.K2r.view(), "ZYZ");
+                    angles_from_unitary(general.K2r.view(), EulerBasis::ZYZ);
                 TwoQubitWeylDecomposition {
                     specialization,
                     a: PI4,
@@ -887,7 +888,7 @@ impl TwoQubitWeylDecomposition {
             }
             Specialization::SimaabEquiv => {
                 let [k2ltheta, k2lphi, k2llambda, k2lphase] =
-                    angles_from_unitary(general.K2l.view(), "ZYZ");
+                    angles_from_unitary(general.K2l.view(), EulerBasis::ZYZ);
                 TwoQubitWeylDecomposition {
                     specialization,
                     a: (a + b) / 2.,
@@ -902,9 +903,9 @@ impl TwoQubitWeylDecomposition {
                 }
             }
             Specialization::SimabbEquiv => {
-                let euler_basis = "XYX".to_owned();
+                let euler_basis = EulerBasis::XYX;
                 let [k2ltheta, k2lphi, k2llambda, k2lphase] =
-                    angles_from_unitary(general.K2l.view(), &euler_basis);
+                    angles_from_unitary(general.K2l.view(), euler_basis);
                 TwoQubitWeylDecomposition {
                     specialization,
                     a,
@@ -920,9 +921,9 @@ impl TwoQubitWeylDecomposition {
                 }
             }
             Specialization::SimabmbEquiv => {
-                let euler_basis = "XYX".to_owned();
+                let euler_basis = EulerBasis::XYX;
                 let [k2ltheta, k2lphi, k2llambda, k2lphase] =
-                    angles_from_unitary(general.K2l.view(), &euler_basis);
+                    angles_from_unitary(general.K2l.view(), euler_basis);
                 TwoQubitWeylDecomposition {
                     specialization,
                     a,
@@ -1008,9 +1009,12 @@ impl TwoQubitWeylDecomposition {
         euler_basis: Option<&str>,
         simplify: bool,
         atol: Option<f64>,
-    ) -> TwoQubitGateSequence {
-        let euler_basis: &str = euler_basis.unwrap_or(&self.default_euler_basis);
-        let target_1q_basis_list: Vec<&str> = vec![euler_basis];
+    ) -> PyResult<TwoQubitGateSequence> {
+        let euler_basis: EulerBasis = match euler_basis {
+            Some(basis) => EulerBasis::from_string(basis)?,
+            None => self.default_euler_basis,
+        };
+        let target_1q_basis_list: Vec<EulerBasis> = vec![euler_basis];
 
         let mut gate_sequence = Vec::new();
         let mut global_phase: f64 = self.global_phase;
@@ -1072,10 +1076,10 @@ impl TwoQubitWeylDecomposition {
         for gate in c1l.gates {
             gate_sequence.push((gate.0, gate.1, smallvec![1]))
         }
-        TwoQubitGateSequence {
+        Ok(TwoQubitGateSequence {
             gates: gate_sequence,
             global_phase,
-        }
+        })
     }
 }
 

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -168,7 +168,7 @@ fn decompose_two_qubit_product_gate(
     }
     assert!(
         det_r.abs() < 0.1,
-        "decompose_two_qubit_product_gate: unable to decompose: detR < 0 .1"
+        "decompose_two_qubit_product_gate: unable to decompose: detR < 0.1"
     );
     r.mapv_inplace(|x| x / det_r.sqrt());
     let r_t_conj: Array2<Complex64> = r.t().mapv(|x| x.conj()).to_owned();

--- a/crates/accelerate/src/utils.rs
+++ b/crates/accelerate/src/utils.rs
@@ -15,9 +15,7 @@ use pyo3::types::PySlice;
 
 use faer::prelude::*;
 use faer::IntoFaerComplex;
-use faer::IntoNdarray;
-use faer::Side::Lower;
-use num_complex::{Complex, Complex64};
+use num_complex::Complex;
 use numpy::{IntoPyArray, PyReadonlyArray2};
 
 /// A private enumeration type used to extract arguments to pymethod
@@ -55,25 +53,8 @@ pub fn eigenvalues(py: Python, unitary: PyReadonlyArray2<Complex<f64>>) -> PyObj
         .into()
 }
 
-/// Return the eigenvalues of `unitary` as a one-dimensional `numpy.ndarray`
-/// with `dtype(complex128)`.
-#[pyfunction]
-#[pyo3(text_signature = "(unitary, /")]
-pub fn eigh(py: Python, unitary: PyReadonlyArray2<f64>) -> PyObject {
-    unitary
-        .as_array()
-        .into_faer()
-        .selfadjoint_eigendecomposition(Lower)
-        .u()
-        .into_ndarray()
-        .mapv(Complex64::from)
-        .into_pyarray(py)
-        .into()
-}
-
 #[pymodule]
 pub fn utils(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(eigenvalues))?;
-    m.add_wrapped(wrap_pyfunction!(eigh))?;
     Ok(())
 }

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -70,6 +70,7 @@ sys.modules["qiskit._accelerate.euler_one_qubit_decomposer"] = (
 sys.modules["qiskit._accelerate.convert_2q_block_matrix"] = (
     qiskit._accelerate.convert_2q_block_matrix
 )
+sys.modules["qiskit._accelerate.two_qubit_decompose"] = qiskit._accelerate.two_qubit_decompose
 
 # qiskit errors operator
 from qiskit.exceptions import QiskitError, MissingOptionalLibraryError

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -186,7 +186,7 @@ class TwoQubitWeylDecomposition(two_qubit_decompose.TwoQubitWeylDecomposition):
             + b64ascii
             + [
                 f"requested_fidelity={self.requested_fidelity},",
-                f"specialization={self.specialization},"
+                f"_specialization={self.specialization},"
                 f"calculated_fidelity={self.calculated_fidelity},",
                 f"actual_fidelity={self.actual_fidelity()},",
                 f"abc={(self.a, self.b, self.c)})",
@@ -200,7 +200,7 @@ class TwoQubitWeylDecomposition(two_qubit_decompose.TwoQubitWeylDecomposition):
         bytes_in: bytes,
         *,
         requested_fidelity: float,
-        specialization: two_qubit_decompose.Specializations | None,
+        _specialization: two_qubit_decompose.Specializations | None,
         **kwargs,
     ) -> "TwoQubitWeylDecomposition":
         """Decode bytes into :class:`.TwoQubitWeylDecomposition`."""
@@ -209,7 +209,7 @@ class TwoQubitWeylDecomposition(two_qubit_decompose.TwoQubitWeylDecomposition):
         b64 = base64.decodebytes(bytes_in)
         with io.BytesIO(b64) as f:
             arr = np.load(f, allow_pickle=False)
-        return cls(arr, fidelity=requested_fidelity, specialization=specialization)
+        return cls(arr, fidelity=requested_fidelity, _specialization=_specialization)
 
     def __str__(self):
         pre = f"{self.__class__.__name__}(\n\t"
@@ -248,7 +248,7 @@ class TwoQubitControlledUDecomposer:
             decomposer_rxx = TwoQubitWeylDecomposition(
                 Operator(circ).data,
                 fidelity=None,
-                specialization=two_qubit_decompose.Specializations.ControlledEquiv,
+                _specialization=two_qubit_decompose.Specializations.ControlledEquiv,
             )
 
             circ = QuantumCircuit(2)
@@ -256,7 +256,7 @@ class TwoQubitControlledUDecomposer:
             decomposer_equiv = TwoQubitWeylDecomposition(
                 Operator(circ).data,
                 fidelity=None,
-                specialization=two_qubit_decompose.Specializations.ControlledEquiv,
+                _specialization=two_qubit_decompose.Specializations.ControlledEquiv,
             )
 
             scale = decomposer_rxx.a / decomposer_equiv.a

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -256,7 +256,8 @@ class TwoQubitWeylDecomposition:
         return cls(arr, fidelity=requested_fidelity, _specialization=_specialization)
 
     def __str__(self):
-        pre = f"{self.__class__.__name__}(\n\t"
+        specialization = str(self._inner_decomposition.specialization).split(".")[1]
+        pre = f"{self.__class__.__name__} [specialization={specialization}] (\n\t"
         circ_indent = "\n\t".join(self.circuit(simplify=True).draw("text").lines(-1))
         return f"{pre}{circ_indent}\n)"
 

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -29,17 +29,16 @@ import math
 import io
 import base64
 import warnings
-from typing import ClassVar, Optional, Type
+from typing import Optional, Type
 
 import logging
 
 import numpy as np
 
 from qiskit.circuit import QuantumRegister, QuantumCircuit, Gate
-from qiskit.circuit.library.standard_gates import CXGate, RXGate, RYGate, RZGate
+from qiskit.circuit.library.standard_gates import CXGate, RXGate
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.operators import Operator
-from qiskit.synthesis.two_qubit.weyl import transform_to_magic_basis
 from qiskit.synthesis.one_qubit.one_qubit_decompose import (
     OneQubitEulerDecomposer,
     DEFAULT_ATOL,
@@ -155,7 +154,7 @@ class TwoQubitWeylDecomposition(two_qubit_decompose.TwoQubitWeylDecomposition):
         self, *, euler_basis: str | None = None, simplify: bool = False, atol: float = DEFAULT_ATOL
     ) -> QuantumCircuit:
         """Returns Weyl decomposition in circuit form."""
-        circuit_sequence = super().circuit()
+        circuit_sequence = super().circuit(euler_basis=euler_basis, simplify=simplify, atol=atol)
         circ = QuantumCircuit(2, global_phase=circuit_sequence.global_phase)
         for name, params, qubits in circuit_sequence:
             if qubits[0] == qubits[1]:
@@ -240,11 +239,19 @@ class TwoQubitControlledUDecomposer:
 
             circ = QuantumCircuit(2)
             circ.rxx(test_angle, 0, 1)
-            decomposer_rxx = TwoQubitWeylDecomposition(Operator(circ).data, fidelity=None, specialization=two_qubit_decompose.Specializations.ControlledEquiv)
+            decomposer_rxx = TwoQubitWeylDecomposition(
+                Operator(circ).data,
+                fidelity=None,
+                specialization=two_qubit_decompose.Specializations.ControlledEquiv,
+            )
 
             circ = QuantumCircuit(2)
             circ.append(rxx_equivalent_gate(test_angle), qargs=[0, 1])
-            decomposer_equiv = TwoQubitWeylDecomposition(Operator(circ).data, fidelity=None, specialization=two_qubit_decompose.Specializations.ControlledEquiv)
+            decomposer_equiv = TwoQubitWeylDecomposition(
+                Operator(circ).data,
+                fidelity=None,
+                specialization=two_qubit_decompose.Specializations.ControlledEquiv,
+            )
 
             scale = decomposer_rxx.a / decomposer_equiv.a
 

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -186,6 +186,7 @@ class TwoQubitWeylDecomposition(two_qubit_decompose.TwoQubitWeylDecomposition):
             + b64ascii
             + [
                 f"requested_fidelity={self.requested_fidelity},",
+                f"specialization={self.specialization},"
                 f"calculated_fidelity={self.calculated_fidelity},",
                 f"actual_fidelity={self.actual_fidelity()},",
                 f"abc={(self.a, self.b, self.c)})",
@@ -195,7 +196,12 @@ class TwoQubitWeylDecomposition(two_qubit_decompose.TwoQubitWeylDecomposition):
 
     @classmethod
     def from_bytes(
-        cls, bytes_in: bytes, *, requested_fidelity: float, **kwargs
+        cls,
+        bytes_in: bytes,
+        *,
+        requested_fidelity: float,
+        specialization: two_qubit_decompose.Specializations | None,
+        **kwargs,
     ) -> "TwoQubitWeylDecomposition":
         """Decode bytes into :class:`.TwoQubitWeylDecomposition`."""
         # Used by __repr__
@@ -203,7 +209,7 @@ class TwoQubitWeylDecomposition(two_qubit_decompose.TwoQubitWeylDecomposition):
         b64 = base64.decodebytes(bytes_in)
         with io.BytesIO(b64) as f:
             arr = np.load(f, allow_pickle=False)
-        return cls(arr, fidelity=requested_fidelity)
+        return cls(arr, fidelity=requested_fidelity, specialization=specialization)
 
     def __str__(self):
         pre = f"{self.__class__.__name__}(\n\t"

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -272,7 +272,7 @@ class TwoQubitControlledUDecomposer:
                 rxx_equivalent_gate(test_angle, label="foo")
             except TypeError as _:
                 raise QiskitError("Equivalent gate needs to take exactly 1 angle parameter.") from _
-            decomp = TwoQubitWeylDecomposition(rxx_equivalent_gate(test_angle).to_matrix())
+            decomp = TwoQubitWeylDecomposition(rxx_equivalent_gate(test_angle))
 
             circ = QuantumCircuit(2)
             circ.rxx(test_angle, 0, 1)
@@ -317,7 +317,7 @@ class TwoQubitControlledUDecomposer:
         """
 
         # pylint: disable=attribute-defined-outside-init
-        self.decomposer = TwoQubitWeylDecomposition(np.asarray(unitary, dtype=complex))
+        self.decomposer = TwoQubitWeylDecomposition(unitary)
 
         oneq_decompose = OneQubitEulerDecomposer("ZYZ")
         c1l, c1r, c2l, c2r = (

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -173,6 +173,19 @@ class TwoQubitWeylDecomposition:
         self.unitary_matrix = unitary_matrix
         self.requested_fidelity = fidelity
         self.calculated_fidelity = self._inner_decomposition.calculated_fidelity
+        if logger.isEnabledFor(logging.DEBUG):
+            actual_fidelity = self.actual_fidelity()
+            logger.debug(
+                "Requested fidelity: %s calculated fidelity: %s actual fidelity %s",
+                self.requested_fidelity,
+                self.calculated_fidelity,
+                actual_fidelity,
+            )
+            if abs(self.calculated_fidelity - actual_fidelity) > 1.0e-12:
+                logger.warning(
+                    "Requested fidelity different from actual by %s",
+                    self.calculated_fidelity - actual_fidelity,
+                )
 
     @deprecate_func(since="1.1.0", removal_timeline="in the 2.0.0 release")
     def specialize(self):

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -157,11 +157,7 @@ class TwoQubitWeylDecomposition(two_qubit_decompose.TwoQubitWeylDecomposition):
         circuit_sequence = super().circuit(euler_basis=euler_basis, simplify=simplify, atol=atol)
         circ = QuantumCircuit(2, global_phase=circuit_sequence.global_phase)
         for name, params, qubits in circuit_sequence:
-            if qubits[0] == qubits[1]:
-                qargs = (qubits[0],)
-            else:
-                qargs = tuple(qubits)
-            getattr(circ, name)(*params, *qargs)
+            getattr(circ, name)(*params, *qubits)
         return circ
 
     def actual_fidelity(self, **kwargs) -> float:

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -151,6 +151,8 @@ class TwoQubitWeylDecomposition:
     requested_fidelity: Optional[float]  # None means no automatic specialization
     calculated_fidelity: float  # Fidelity after specialization
 
+    _specializations = two_qubit_decompose.Specialization
+
     def __init__(
         self,
         unitary_matrix: np.ndarray,
@@ -224,13 +226,15 @@ class TwoQubitWeylDecomposition:
         b64ascii[-1] += ","
         pretty = [f"# {x.rstrip()}" for x in str(self).splitlines()]
         indent = "\n" + " " * 4
+        specialization_variant = str(self._inner_decomposition.specialization).split(".")[1]
+        specialization_repr = f"{type(self).__qualname__}._specializations.{specialization_variant}"
         lines = (
             [prefix]
             + pretty
             + b64ascii
             + [
                 f"requested_fidelity={self.requested_fidelity},",
-                f"_specialization={self._inner_decomposition.specialization},",
+                f"_specialization={specialization_repr},",
                 f"calculated_fidelity={self.calculated_fidelity},",
                 f"actual_fidelity={self.actual_fidelity()},",
                 f"abc={(self.a, self.b, self.c)})",

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -196,7 +196,7 @@ class TwoQubitWeylDecomposition(two_qubit_decompose.TwoQubitWeylDecomposition):
         bytes_in: bytes,
         *,
         requested_fidelity: float,
-        _specialization: two_qubit_decompose.Specializations | None,
+        _specialization: two_qubit_decompose.Specialization | None,
         **kwargs,
     ) -> "TwoQubitWeylDecomposition":
         """Decode bytes into :class:`.TwoQubitWeylDecomposition`."""
@@ -244,7 +244,7 @@ class TwoQubitControlledUDecomposer:
             decomposer_rxx = TwoQubitWeylDecomposition(
                 Operator(circ).data,
                 fidelity=None,
-                _specialization=two_qubit_decompose.Specializations.ControlledEquiv,
+                _specialization=two_qubit_decompose.Specialization.ControlledEquiv,
             )
 
             circ = QuantumCircuit(2)
@@ -252,7 +252,7 @@ class TwoQubitControlledUDecomposer:
             decomposer_equiv = TwoQubitWeylDecomposition(
                 Operator(circ).data,
                 fidelity=None,
-                _specialization=two_qubit_decompose.Specializations.ControlledEquiv,
+                _specialization=two_qubit_decompose.Specialization.ControlledEquiv,
             )
 
             scale = decomposer_rxx.a / decomposer_equiv.a

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -43,6 +43,7 @@ from qiskit.synthesis.one_qubit.one_qubit_decompose import (
     OneQubitEulerDecomposer,
     DEFAULT_ATOL,
 )
+from qiskit.utils.deprecation import deprecate_func
 from qiskit._accelerate import two_qubit_decompose
 
 logger = logging.getLogger(__name__)
@@ -149,6 +150,15 @@ class TwoQubitWeylDecomposition(two_qubit_decompose.TwoQubitWeylDecomposition):
     unitary_matrix: np.ndarray  # The unitary that was input
     requested_fidelity: Optional[float]  # None means no automatic specialization
     calculated_fidelity: float  # Fidelity after specialization
+
+    @deprecate_func(since="1.1.0", removal_timeline="in the 2.0.0 release")
+    def specialize(self):
+        """Make changes to the decomposition to comply with any specializations.
+
+        This method will always raise a ``NotImplementedError`` because
+        there are no specializations to comply with in the current implementation.
+        """
+        raise NotImplementedError
 
     def circuit(
         self, *, euler_basis: str | None = None, simplify: bool = False, atol: float = DEFAULT_ATOL

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -96,7 +96,7 @@ _ipz = np.array([[1j, 0], [0, -1j]], dtype=complex)
 _id = np.array([[1, 0], [0, 1]], dtype=complex)
 
 
-class TwoQubitWeylDecomposition:
+class TwoQubitWeylDecomposition(two_qubit_decompose.TwoQubitWeylDecomposition):
     r"""Two-qubit Weyl decomposition.
 
     Decompose two-qubit unitary
@@ -151,305 +151,25 @@ class TwoQubitWeylDecomposition:
     requested_fidelity: Optional[float]  # None means no automatic specialization
     calculated_fidelity: float  # Fidelity after specialization
 
-    _original_decomposition: "TwoQubitWeylDecomposition"
-    _is_flipped_from_original: bool  # The approx is closest to a Weyl reflection of the original?
-
-    _default_1q_basis: ClassVar[str] = "ZYZ"  # Default one qubit basis (explicit parameterization)
-
-    def __init_subclass__(cls, **kwargs):
-        """Subclasses should be concrete, not factories.
-
-        Make explicitly-instantiated subclass __new__  call base __new__ with fidelity=None"""
-        super().__init_subclass__(**kwargs)
-        cls.__new__ = lambda cls, *a, fidelity=None, **k: TwoQubitWeylDecomposition.__new__(
-            cls, *a, fidelity=None, **k
-        )
-
-    @staticmethod
-    def __new__(cls, unitary_matrix, *, fidelity=(1.0 - 1.0e-9), _unpickling=False):
-        """Perform the Weyl chamber decomposition, and optionally choose a specialized subclass."""
-
-        # The flip into the Weyl Chamber is described in B. Kraus and J. I. Cirac, Phys. Rev. A 63,
-        # 062309 (2001).
-        #
-        # FIXME: There's a cleaner-seeming method based on choosing branch cuts carefully, in Andrew
-        # M. Childs, Henry L. Haselgrove, and Michael A. Nielsen, Phys. Rev. A 68, 052311, but I
-        # wasn't able to get that to work.
-        #
-        # The overall decomposition scheme is taken from Drury and Love, arXiv:0806.4015 [quant-ph].
-
-        if _unpickling:
-            return super().__new__(cls)
-
-        pi = np.pi
-        pi2 = np.pi / 2
-        pi4 = np.pi / 4
-
-        # Make U be in SU(4)
-        U = np.array(unitary_matrix, dtype=complex, copy=True)
-        detU = np.linalg.det(U)
-        U *= detU ** (-0.25)
-        global_phase = cmath.phase(detU) / 4
-
-        Up = transform_to_magic_basis(U, reverse=True)
-        M2 = Up.T.dot(Up)
-
-        # M2 is a symmetric complex matrix. We need to decompose it as M2 = P D P^T where
-        # P ∈ SO(4), D is diagonal with unit-magnitude elements.
-        #
-        # We can't use raw `eig` directly because it isn't guaranteed to give us real or othogonal
-        # eigenvectors.  Instead, since `M2` is complex-symmetric,
-        #   M2 = A + iB
-        # for real-symmetric `A` and `B`, and as
-        #   M2^+ @ M2 = A^2 + B^2 + i [A, B] = 1
-        # we must have `A` and `B` commute, and consequently they are simultaneously diagonalizable.
-        # Mixing them together _should_ account for any degeneracy problems, but it's not
-        # guaranteed, so we repeat it a little bit.  The fixed seed is to make failures
-        # deterministic; the value is not important.
-        state = np.random.default_rng(2020)
-        for _ in range(100):  # FIXME: this randomized algorithm is horrendous
-            M2real = state.normal() * M2.real + state.normal() * M2.imag
-            _, P = np.linalg.eigh(M2real)
-            D = P.T.dot(M2).dot(P).diagonal()
-            if np.allclose(P.dot(np.diag(D)).dot(P.T), M2, rtol=0, atol=1.0e-13):
-                break
-        else:
-            raise QiskitError(
-                "TwoQubitWeylDecomposition: failed to diagonalize M2."
-                " Please report this at https://github.com/Qiskit/qiskit-terra/issues/4159."
-                f" Input: {U.tolist()}"
-            )
-
-        d = -np.angle(D) / 2
-        d[3] = -d[0] - d[1] - d[2]
-        cs = np.mod((d[:3] + d[3]) / 2, 2 * np.pi)
-
-        # Reorder the eigenvalues to get in the Weyl chamber
-        cstemp = np.mod(cs, pi2)
-        np.minimum(cstemp, pi2 - cstemp, cstemp)
-        order = np.argsort(cstemp)[[1, 2, 0]]
-        cs = cs[order]
-        d[:3] = d[order]
-        P[:, :3] = P[:, order]
-
-        # Fix the sign of P to be in SO(4)
-        if np.real(np.linalg.det(P)) < 0:
-            P[:, -1] = -P[:, -1]
-
-        # Find K1, K2 so that U = K1.A.K2, with K being product of single-qubit unitaries
-        K1 = transform_to_magic_basis(Up @ P @ np.diag(np.exp(1j * d)))
-        K2 = transform_to_magic_basis(P.T)
-
-        K1l, K1r, phase_l = decompose_two_qubit_product_gate(K1)
-        K2l, K2r, phase_r = decompose_two_qubit_product_gate(K2)
-        global_phase += phase_l + phase_r
-
-        K1l = K1l.copy()
-
-        # Flip into Weyl chamber
-        if cs[0] > pi2:
-            cs[0] -= 3 * pi2
-            K1l = K1l.dot(_ipy)
-            K1r = K1r.dot(_ipy)
-            global_phase += pi2
-        if cs[1] > pi2:
-            cs[1] -= 3 * pi2
-            K1l = K1l.dot(_ipx)
-            K1r = K1r.dot(_ipx)
-            global_phase += pi2
-        conjs = 0
-        if cs[0] > pi4:
-            cs[0] = pi2 - cs[0]
-            K1l = K1l.dot(_ipy)
-            K2r = _ipy.dot(K2r)
-            conjs += 1
-            global_phase -= pi2
-        if cs[1] > pi4:
-            cs[1] = pi2 - cs[1]
-            K1l = K1l.dot(_ipx)
-            K2r = _ipx.dot(K2r)
-            conjs += 1
-            global_phase += pi2
-            if conjs == 1:
-                global_phase -= pi
-        if cs[2] > pi2:
-            cs[2] -= 3 * pi2
-            K1l = K1l.dot(_ipz)
-            K1r = K1r.dot(_ipz)
-            global_phase += pi2
-            if conjs == 1:
-                global_phase -= pi
-        if conjs == 1:
-            cs[2] = pi2 - cs[2]
-            K1l = K1l.dot(_ipz)
-            K2r = _ipz.dot(K2r)
-            global_phase += pi2
-        if cs[2] > pi4:
-            cs[2] -= pi2
-            K1l = K1l.dot(_ipz)
-            K1r = K1r.dot(_ipz)
-            global_phase -= pi2
-
-        a, b, c = cs[1], cs[0], cs[2]
-
-        # Save the non-specialized decomposition for later comparison
-        od = super().__new__(TwoQubitWeylDecomposition)
-        od.a = a
-        od.b = b
-        od.c = c
-        od.K1l = K1l
-        od.K1r = K1r
-        od.K2l = K2l
-        od.K2r = K2r
-        od.global_phase = global_phase
-        od.requested_fidelity = fidelity
-        od.calculated_fidelity = 1.0
-        od.unitary_matrix = np.array(unitary_matrix, dtype=complex, copy=True)
-        od.unitary_matrix.setflags(write=False)
-        od._original_decomposition = None
-        od._is_flipped_from_original = False
-
-        def is_close(ap, bp, cp):
-            da, db, dc = a - ap, b - bp, c - cp
-            tr = 4 * complex(
-                math.cos(da) * math.cos(db) * math.cos(dc),
-                math.sin(da) * math.sin(db) * math.sin(dc),
-            )
-            fid = trace_to_fid(tr)
-            return fid >= fidelity
-
-        if fidelity is None:  # Don't specialize if None
-            instance = super().__new__(
-                TwoQubitWeylGeneral if cls is TwoQubitWeylDecomposition else cls
-            )
-        elif is_close(0, 0, 0):
-            instance = super().__new__(TwoQubitWeylIdEquiv)
-        elif is_close(pi4, pi4, pi4) or is_close(pi4, pi4, -pi4):
-            instance = super().__new__(TwoQubitWeylSWAPEquiv)
-        elif (lambda x: is_close(x, x, x))(_closest_partial_swap(a, b, c)):
-            instance = super().__new__(TwoQubitWeylPartialSWAPEquiv)
-        elif (lambda x: is_close(x, x, -x))(_closest_partial_swap(a, b, -c)):
-            instance = super().__new__(TwoQubitWeylPartialSWAPFlipEquiv)
-        elif is_close(a, 0, 0):
-            instance = super().__new__(TwoQubitWeylControlledEquiv)
-        elif is_close(pi4, pi4, c):
-            instance = super().__new__(TwoQubitWeylMirrorControlledEquiv)
-        elif is_close((a + b) / 2, (a + b) / 2, c):
-            instance = super().__new__(TwoQubitWeylfSimaabEquiv)
-        elif is_close(a, (b + c) / 2, (b + c) / 2):
-            instance = super().__new__(TwoQubitWeylfSimabbEquiv)
-        elif is_close(a, (b - c) / 2, (c - b) / 2):
-            instance = super().__new__(TwoQubitWeylfSimabmbEquiv)
-        else:
-            instance = super().__new__(TwoQubitWeylGeneral)
-
-        instance._original_decomposition = od
-        return instance
-
-    def __init__(
-        self,
-        unitary_matrix: list[list[complex]] | np.ndarray[complex],
-        fidelity: float | None = None,
-    ):
-        """
-        Args:
-            unitary_matrix: The unitary to decompose.
-            fidelity: The target fidelity of the decomposed operation.
-        """
-        del unitary_matrix  # unused in __init__ (used in new)
-        od = self._original_decomposition
-        self.a, self.b, self.c = od.a, od.b, od.c
-        self.K1l, self.K1r = od.K1l, od.K1r
-        self.K2l, self.K2r = od.K2l, od.K2r
-        self.global_phase = od.global_phase
-        self.unitary_matrix = od.unitary_matrix
-        self.requested_fidelity = fidelity
-        self._is_flipped_from_original = False
-        self.specialize()
-
-        # Update the phase after specialization:
-        if self._is_flipped_from_original:
-            da, db, dc = (np.pi / 2 - od.a) - self.a, od.b - self.b, -od.c - self.c
-            tr = 4 * complex(
-                math.cos(da) * math.cos(db) * math.cos(dc),
-                math.sin(da) * math.sin(db) * math.sin(dc),
-            )
-        else:
-            da, db, dc = od.a - self.a, od.b - self.b, od.c - self.c
-            tr = 4 * complex(
-                math.cos(da) * math.cos(db) * math.cos(dc),
-                math.sin(da) * math.sin(db) * math.sin(dc),
-            )
-        self.global_phase += cmath.phase(tr)
-        self.calculated_fidelity = trace_to_fid(tr)
-        if logger.isEnabledFor(logging.DEBUG):
-            actual_fidelity = self.actual_fidelity()
-            logger.debug(
-                "Requested fidelity: %s calculated fidelity: %s actual fidelity %s",
-                self.requested_fidelity,
-                self.calculated_fidelity,
-                actual_fidelity,
-            )
-            if abs(self.calculated_fidelity - actual_fidelity) > 1.0e-12:
-                logger.warning(
-                    "Requested fidelity different from actual by %s",
-                    self.calculated_fidelity - actual_fidelity,
-                )
-        if self.requested_fidelity and self.calculated_fidelity + 1.0e-13 < self.requested_fidelity:
-            raise QiskitError(
-                f"{self.__class__.__name__}: "
-                f"calculated fidelity: {self.calculated_fidelity} "
-                f"is worse than requested fidelity: {self.requested_fidelity}."
-            )
-
-    def specialize(self):
-        """Make changes to the decomposition to comply with any specialization."""
-
-        # Do update a, b, c, k1l, k1r, k2l, k2r, _is_flipped_from_original to round to the
-        # specialization. Do not update the global phase, since this gets done in generic
-        # __init__()
-        raise NotImplementedError
-
     def circuit(
         self, *, euler_basis: str | None = None, simplify: bool = False, atol: float = DEFAULT_ATOL
     ) -> QuantumCircuit:
         """Returns Weyl decomposition in circuit form."""
-
-        # simplify, atol arguments are passed to OneQubitEulerDecomposer
-        if euler_basis is None:
-            euler_basis = self._default_1q_basis
-        oneq_decompose = OneQubitEulerDecomposer(euler_basis)
-        c1l, c1r, c2l, c2r = (
-            oneq_decompose(k, simplify=simplify, atol=atol)
-            for k in (self.K1l, self.K1r, self.K2l, self.K2r)
-        )
-        circ = QuantumCircuit(2, global_phase=self.global_phase)
-        circ.compose(c2r, [0], inplace=True)
-        circ.compose(c2l, [1], inplace=True)
-        self._weyl_gate(simplify, circ, atol)
-        circ.compose(c1r, [0], inplace=True)
-        circ.compose(c1l, [1], inplace=True)
+        circuit_sequence = super().circuit()
+        circ = QuantumCircuit(2, global_phase=circuit_sequence.global_phase)
+        for name, params, qubits in circuit_sequence:
+            if qubits[0] == qubits[1]:
+                qargs = (qubits[0],)
+            else:
+                qargs = tuple(qubits)
+            getattr(circ, name)(*params, *qargs)
         return circ
-
-    def _weyl_gate(self, simplify, circ: QuantumCircuit, atol):
-        """Appends U_d(a, b, c) to the circuit.
-
-        Can be overridden in subclasses for special cases"""
-        if not simplify or abs(self.a) > atol:
-            circ.rxx(-self.a * 2, 0, 1)
-        if not simplify or abs(self.b) > atol:
-            circ.ryy(-self.b * 2, 0, 1)
-        if not simplify or abs(self.c) > atol:
-            circ.rzz(-self.c * 2, 0, 1)
 
     def actual_fidelity(self, **kwargs) -> float:
         """Calculates the actual fidelity of the decomposed circuit to the input unitary."""
         circ = self.circuit(**kwargs)
         trace = np.trace(Operator(circ).data.T.conj() @ self.unitary_matrix)
         return trace_to_fid(trace)
-
-    def __getnewargs_ex__(self):
-        return (self.unitary_matrix,), {"_unpickling": True}
 
     def __repr__(self):
         """Represent with enough precision to allow copy-paste debugging of all corner cases"""
@@ -492,113 +212,6 @@ class TwoQubitWeylDecomposition:
         return f"{pre}{circ_indent}\n)"
 
 
-class TwoQubitWeylIdEquiv(TwoQubitWeylDecomposition):
-    r""":math:`U \sim U_d(0,0,0) \sim Id`
-
-    This gate binds 0 parameters, we make it canonical by setting
-    :math:`K2_l = Id` , :math:`K2_r = Id`.
-    """
-
-    def specialize(self):
-        self.a = self.b = self.c = 0.0
-        self.K1l = self.K1l @ self.K2l
-        self.K1r = self.K1r @ self.K2r
-        self.K2l = _id.copy()
-        self.K2r = _id.copy()
-
-
-class TwoQubitWeylSWAPEquiv(TwoQubitWeylDecomposition):
-    r""":math:`U \sim U_d(\pi/4, \pi/4, \pi/4) \sim U(\pi/4, \pi/4, -\pi/4) \sim \text{SWAP}`
-
-    This gate binds 0 parameters, we make it canonical by setting
-    :math:`K2_l = Id` , :math:`K2_r = Id`.
-    """
-
-    def specialize(self):
-        if self.c > 0:
-            self.K1l = self.K1l @ self.K2r
-            self.K1r = self.K1r @ self.K2l
-        else:
-            self._is_flipped_from_original = True
-            self.K1l = self.K1l @ _ipz @ self.K2r
-            self.K1r = self.K1r @ _ipz @ self.K2l
-            self.global_phase = self.global_phase + np.pi / 2
-        self.a = self.b = self.c = np.pi / 4
-        self.K2l = _id.copy()
-        self.K2r = _id.copy()
-
-    def _weyl_gate(self, simplify, circ: QuantumCircuit, atol):
-        del self, simplify, atol  # unused
-        circ.swap(0, 1)
-        circ.global_phase -= 3 * np.pi / 4
-
-
-def _closest_partial_swap(a, b, c) -> float:
-    r"""A good approximation to the best value x to get the minimum
-    trace distance for :math:`U_d(x, x, x)` from :math:`U_d(a, b, c)`.
-    """
-    m = (a + b + c) / 3
-    am, bm, cm = a - m, b - m, c - m
-    ab, bc, ca = a - b, b - c, c - a
-
-    return m + am * bm * cm * (6 + ab * ab + bc * bc + ca * ca) / 18
-
-
-class TwoQubitWeylPartialSWAPEquiv(TwoQubitWeylDecomposition):
-    r""":math:`U \sim U_d(\alpha\pi/4, \alpha\pi/4, \alpha\pi/4) \sim \text{SWAP}^\alpha`
-    This gate binds 3 parameters, we make it canonical by setting:
-    :math:`K2_l = Id`.
-    """
-
-    def specialize(self):
-        self.a = self.b = self.c = _closest_partial_swap(self.a, self.b, self.c)
-        self.K1l = self.K1l @ self.K2l
-        self.K1r = self.K1r @ self.K2l
-        self.K2r = self.K2l.T.conj() @ self.K2r
-        self.K2l = _id.copy()
-
-
-class TwoQubitWeylPartialSWAPFlipEquiv(TwoQubitWeylDecomposition):
-    r""":math:`U \sim U_d(\alpha\pi/4, \alpha\pi/4, -\alpha\pi/4) \sim \text{SWAP}^\alpha`
-    (a non-equivalent root of SWAP from the TwoQubitWeylPartialSWAPEquiv
-    similar to how :math:`x = (\pm \sqrt(x))^2`)
-    This gate binds 3 parameters, we make it canonical by setting:
-    :math:`K2_l = Id`.
-    """
-
-    def specialize(self):
-        self.a = self.b = _closest_partial_swap(self.a, self.b, -self.c)
-        self.c = -self.a
-        self.K1l = self.K1l @ self.K2l
-        self.K1r = self.K1r @ _ipz @ self.K2l @ _ipz
-        self.K2r = _ipz @ self.K2l.T.conj() @ _ipz @ self.K2r
-        self.K2l = _id.copy()
-
-
-_oneq_xyx = OneQubitEulerDecomposer("XYX")
-_oneq_zyz = OneQubitEulerDecomposer("ZYZ")
-
-
-class TwoQubitWeylControlledEquiv(TwoQubitWeylDecomposition):
-    r""":math:`U \sim U_d(\alpha, 0, 0) \sim \text{Ctrl-U}`
-    This gate binds 4 parameters, we make it canonical by setting:
-        :math:`K2_l = Ry(\theta_l) Rx(\lambda_l)` ,
-        :math:`K2_r = Ry(\theta_r) Rx(\lambda_r)` .
-    """
-
-    _default_1q_basis = "XYX"
-
-    def specialize(self):
-        self.b = self.c = 0
-        k2ltheta, k2lphi, k2llambda, k2lphase = _oneq_xyx.angles_and_phase(self.K2l)
-        k2rtheta, k2rphi, k2rlambda, k2rphase = _oneq_xyx.angles_and_phase(self.K2r)
-        self.global_phase += k2lphase + k2rphase
-        self.K1l = self.K1l @ np.asarray(RXGate(k2lphi))
-        self.K1r = self.K1r @ np.asarray(RXGate(k2rphi))
-        self.K2l = np.asarray(RYGate(k2ltheta)) @ np.asarray(RXGate(k2llambda))
-        self.K2r = np.asarray(RYGate(k2rtheta)) @ np.asarray(RXGate(k2rlambda))
-
-
 class TwoQubitControlledUDecomposer:
     r"""Decompose two-qubit unitary in terms of a desired
     :math:`U \sim U_d(\alpha, 0, 0) \sim \text{Ctrl-U}`
@@ -623,22 +236,19 @@ class TwoQubitControlledUDecomposer:
                 rxx_equivalent_gate(test_angle, label="foo")
             except TypeError as _:
                 raise QiskitError("Equivalent gate needs to take exactly 1 angle parameter.") from _
-            decomp = TwoQubitWeylDecomposition(rxx_equivalent_gate(test_angle))
+            decomp = TwoQubitWeylDecomposition(rxx_equivalent_gate(test_angle).to_matrix())
 
             circ = QuantumCircuit(2)
             circ.rxx(test_angle, 0, 1)
-            decomposer_rxx = TwoQubitWeylControlledEquiv(Operator(circ).data)
+            decomposer_rxx = TwoQubitWeylDecomposition(Operator(circ).data, fidelity=None, specialization=two_qubit_decompose.Specializations.ControlledEquiv)
 
             circ = QuantumCircuit(2)
             circ.append(rxx_equivalent_gate(test_angle), qargs=[0, 1])
-            decomposer_equiv = TwoQubitWeylControlledEquiv(Operator(circ).data)
+            decomposer_equiv = TwoQubitWeylDecomposition(Operator(circ).data, fidelity=None, specialization=two_qubit_decompose.Specializations.ControlledEquiv)
 
             scale = decomposer_rxx.a / decomposer_equiv.a
 
-            if (
-                not isinstance(decomp, TwoQubitWeylControlledEquiv)
-                or abs(decomp.a * 2 - test_angle / scale) > atol
-            ):
+            if abs(decomp.a * 2 - test_angle / scale) > atol:
                 raise QiskitError(
                     f"{rxx_equivalent_gate.__name__} is not equivalent to an RXXGate."
                 )
@@ -663,7 +273,7 @@ class TwoQubitControlledUDecomposer:
         """
 
         # pylint: disable=attribute-defined-outside-init
-        self.decomposer = TwoQubitWeylDecomposition(unitary)
+        self.decomposer = TwoQubitWeylDecomposition(np.asarray(unitary, dtype=complex))
 
         oneq_decompose = OneQubitEulerDecomposer("ZYZ")
         c1l, c1r, c2l, c2r = (
@@ -706,7 +316,7 @@ class TwoQubitControlledUDecomposer:
 
         circ = QuantumCircuit(2)
         circ.append(self.rxx_equivalent_gate(self.scale * angle), qargs=[0, 1])
-        decomposer_inv = TwoQubitWeylControlledEquiv(Operator(circ).data)
+        decomposer_inv = TwoQubitWeylDecomposition(Operator(circ).data)
 
         oneq_decompose = OneQubitEulerDecomposer("ZYZ")
 
@@ -761,97 +371,6 @@ class TwoQubitControlledUDecomposer:
                 circ.compose(circ_rzz, inplace=True)
 
         return circ
-
-
-class TwoQubitWeylMirrorControlledEquiv(TwoQubitWeylDecomposition):
-    r""":math:`U \sim U_d(\pi/4, \pi/4, \alpha) \sim \text{SWAP} \cdot \text{Ctrl-U}`
-
-    This gate binds 4 parameters, we make it canonical by setting:
-    :math:`K2_l = Ry(\theta_l)\cdot Rz(\lambda_l)` , :math:`K2_r = Ry(\theta_r)\cdot Rz(\lambda_r)`.
-    """
-
-    def specialize(self):
-        self.a = self.b = np.pi / 4
-        k2ltheta, k2lphi, k2llambda, k2lphase = _oneq_zyz.angles_and_phase(self.K2l)
-        k2rtheta, k2rphi, k2rlambda, k2rphase = _oneq_zyz.angles_and_phase(self.K2r)
-        self.global_phase += k2lphase + k2rphase
-        self.K1r = self.K1r @ np.asarray(RZGate(k2lphi))
-        self.K1l = self.K1l @ np.asarray(RZGate(k2rphi))
-        self.K2l = np.asarray(RYGate(k2ltheta)) @ np.asarray(RZGate(k2llambda))
-        self.K2r = np.asarray(RYGate(k2rtheta)) @ np.asarray(RZGate(k2rlambda))
-
-    def _weyl_gate(self, simplify, circ: QuantumCircuit, atol):
-        circ.swap(0, 1)
-        circ.rzz((np.pi / 4 - self.c) * 2, 0, 1)
-        circ.global_phase += np.pi / 4
-
-
-# These next 3 gates use the definition of fSim from https://arxiv.org/pdf/2001.08343.pdf eq (1)
-class TwoQubitWeylfSimaabEquiv(TwoQubitWeylDecomposition):
-    r""":math:`U \sim U_d(\alpha, \alpha, \beta), \alpha \geq |\beta|`
-
-    This gate binds 5 parameters, we make it canonical by setting:
-    :math:`K2_l = Ry(\theta_l)\cdot Rz(\lambda_l)`.
-    """
-
-    def specialize(self):
-        self.a = self.b = (self.a + self.b) / 2
-        k2ltheta, k2lphi, k2llambda, k2lphase = _oneq_zyz.angles_and_phase(self.K2l)
-        self.global_phase += k2lphase
-        self.K1r = self.K1r @ np.asarray(RZGate(k2lphi))
-        self.K1l = self.K1l @ np.asarray(RZGate(k2lphi))
-        self.K2l = np.asarray(RYGate(k2ltheta)) @ np.asarray(RZGate(k2llambda))
-        self.K2r = np.asarray(RZGate(-k2lphi)) @ self.K2r
-
-
-class TwoQubitWeylfSimabbEquiv(TwoQubitWeylDecomposition):
-    r""":math:`U \sim U_d(\alpha, \beta, -\beta), \alpha \geq \beta \geq 0`
-
-    This gate binds 5 parameters, we make it canonical by setting:
-    :math:`K2_l = Ry(\theta_l)Rx(\lambda_l)`.
-    """
-
-    _default_1q_basis = "XYX"
-
-    def specialize(self):
-        self.b = self.c = (self.b + self.c) / 2
-        k2ltheta, k2lphi, k2llambda, k2lphase = _oneq_xyx.angles_and_phase(self.K2l)
-        self.global_phase += k2lphase
-        self.K1r = self.K1r @ np.asarray(RXGate(k2lphi))
-        self.K1l = self.K1l @ np.asarray(RXGate(k2lphi))
-        self.K2l = np.asarray(RYGate(k2ltheta)) @ np.asarray(RXGate(k2llambda))
-        self.K2r = np.asarray(RXGate(-k2lphi)) @ self.K2r
-
-
-class TwoQubitWeylfSimabmbEquiv(TwoQubitWeylDecomposition):
-    r""":math:`U \sim U_d(\alpha, \beta, -\beta), \alpha \geq \beta \geq 0`
-
-    This gate binds 5 parameters, we make it canonical by setting:
-    :math:`K2_l = Ry(\theta_l)Rx(\lambda_l)`.
-    """
-
-    _default_1q_basis = "XYX"
-
-    def specialize(self):
-        self.b = (self.b - self.c) / 2
-        self.c = -self.b
-        k2ltheta, k2lphi, k2llambda, k2lphase = _oneq_xyx.angles_and_phase(self.K2l)
-        self.global_phase += k2lphase
-        self.K1r = self.K1r @ _ipz @ np.asarray(RXGate(k2lphi)) @ _ipz
-        self.K1l = self.K1l @ np.asarray(RXGate(k2lphi))
-        self.K2l = np.asarray(RYGate(k2ltheta)) @ np.asarray(RXGate(k2llambda))
-        self.K2r = _ipz @ np.asarray(RXGate(-k2lphi)) @ _ipz @ self.K2r
-
-
-class TwoQubitWeylGeneral(TwoQubitWeylDecomposition):
-    """U has no special symmetry.
-
-    This gate binds all 6 possible parameters, so there is no need to make the single-qubit
-    pre-/post-gates canonical.
-    """
-
-    def specialize(self):
-        pass  # Nothing to do
 
 
 def Ud(a, b, c):

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -230,7 +230,7 @@ class TwoQubitWeylDecomposition:
             + b64ascii
             + [
                 f"requested_fidelity={self.requested_fidelity},",
-                f"_specialization={self._inner_decomposition.specialization},"
+                f"_specialization={self._inner_decomposition.specialization},",
                 f"calculated_fidelity={self.calculated_fidelity},",
                 f"actual_fidelity={self.actual_fidelity()},",
                 f"abc={(self.a, self.b, self.c)})",

--- a/releasenotes/notes/rust-two-qubit-weyl-ec551f3f9c812124.yaml
+++ b/releasenotes/notes/rust-two-qubit-weyl-ec551f3f9c812124.yaml
@@ -23,5 +23,5 @@ deprecations_synthesis:
     :class:`.TwoQubitWeylDecomposition` object. Despite this it was still a
     documented part of the public API for the class and is now being
     deprecated without any potential replacement. This release it always will
-    raise a ``NotImplementedError` when called because the specialization
+    raise a ``NotImplementedError`` when called because the specialization
     subclassing has been removed as part of the Rust rewrite of the class.

--- a/releasenotes/notes/rust-two-qubit-weyl-ec551f3f9c812124.yaml
+++ b/releasenotes/notes/rust-two-qubit-weyl-ec551f3f9c812124.yaml
@@ -1,0 +1,14 @@
+---
+features_synthesis:
+  - |
+    The :class:`.TwoQubitWeylDecomposition` synthesis class has been rewritten
+    in Rust for better performance.
+upgrade_synthesis:
+  - |
+    The :class:`.TwoQubitWeylDecomposition` no longer will self specialize into
+    a subclass on creation. This was an internal detail of the :class:`.TwoQubitWeylDecomposition`
+    previously, and was not a documented public behavior as all the subclasses behaved
+    the same and were only used for internal dispatch. However, as it was discoverable
+    behavior this release note is to document that this will no longer occur and all
+    instances of :class:`.TwoQubitWeylDecomposition` will be of the same type. There is no
+    change in behavior for public methods of the class.

--- a/releasenotes/notes/rust-two-qubit-weyl-ec551f3f9c812124.yaml
+++ b/releasenotes/notes/rust-two-qubit-weyl-ec551f3f9c812124.yaml
@@ -5,10 +5,23 @@ features_synthesis:
     in Rust for better performance.
 upgrade_synthesis:
   - |
-    The :class:`.TwoQubitWeylDecomposition` no longer will self specialize into
+    The :class:`.TwoQubitWeylDecomposition` no longer will self-specialize into
     a subclass on creation. This was an internal detail of the :class:`.TwoQubitWeylDecomposition`
     previously, and was not a documented public behavior as all the subclasses behaved
     the same and were only used for internal dispatch. However, as it was discoverable
     behavior this release note is to document that this will no longer occur and all
     instances of :class:`.TwoQubitWeylDecomposition` will be of the same type. There is no
     change in behavior for public methods of the class.
+
+deprecations_synthesis:
+  - |
+    The :meth:`.TwoQubitWeylDecomposition.specialize` method is now deprecated
+    and will be removed in the Qiskit 2.0.0 release. This method never had
+    a public purpose and was unsafe for an end user to call as it would
+    mutate the calculated decomposition in the object and produce invalid
+    fields in the object. It was only used internally to construct a new
+    :class:`.TwoQubitWeylDecomposition` object. Despite this it was still a
+    documented part of the public API for the class and is now being
+    deprecated without any potential replacement. This release it always will
+    raise a ``NotImplementedError` when called because the specialization
+    subclassing has been removed as part of the Rust rewrite of the class.

--- a/test/python/synthesis/test_synthesis.py
+++ b/test/python/synthesis/test_synthesis.py
@@ -620,13 +620,13 @@ class TestTwoQubitWeylDecomposition(CheckDecompositions):
     def test_TwoQubitWeylDecomposition_repr(self, seed=42):
         """Check that eval(__repr__) is exact round trip"""
         target = random_unitary(4, seed=seed)
-        weyl1 = TwoQubitWeylDecomposition(target.data, fidelity=0.99)
+        weyl1 = TwoQubitWeylDecomposition(target, fidelity=0.99)
         self.assertRoundTrip(weyl1)
 
     def test_TwoQubitWeylDecomposition_pickle(self, seed=42):
         """Check that loads(dumps()) is exact round trip"""
         target = random_unitary(4, seed=seed)
-        weyl1 = TwoQubitWeylDecomposition(target.data, fidelity=0.99)
+        weyl1 = TwoQubitWeylDecomposition(target, fidelity=0.99)
         self.assertRoundTripPickle(weyl1)
 
     def test_two_qubit_weyl_decomposition_cnot(self):

--- a/test/python/synthesis/test_synthesis.py
+++ b/test/python/synthesis/test_synthesis.py
@@ -219,7 +219,9 @@ class CheckDecompositions(QiskitTestCase):
                 "Incorrect saved unitary in the decomposition.",
             )
             self.assertEqual(
-                decomp.specialization, expected_specialization, "Incorrect Weyl specialization."
+                decomp._inner_decomposition.specialization,
+                expected_specialization,
+                "Incorrect Weyl specialization.",
             )
             circ = decomp.circuit(simplify=True)
             self.assertDictEqual(

--- a/test/python/synthesis/test_synthesis.py
+++ b/test/python/synthesis/test_synthesis.py
@@ -14,8 +14,6 @@
 
 import pickle
 import unittest
-import contextlib
-import logging
 import math
 import numpy as np
 import scipy
@@ -228,10 +226,9 @@ class CheckDecompositions(QiskitTestCase):
         decomp2 = expected_specialization(target_unitary, fidelity=None)  # Shouldn't raise
         self.assertRoundTrip(decomp2)
         self.assertRoundTripPickle(decomp2)
-        if expected_specialization is not TwoQubitWeylGeneral:
-            with self.assertRaises(QiskitError) as exc:
-                _ = expected_specialization(target_unitary, fidelity=1.0)
-            self.assertIn("worse than requested", exc.exception.message)
+        with self.assertRaises(QiskitError) as exc:
+            _ = expected_specialization(target_unitary, fidelity=1.0)
+        self.assertIn("worse than requested", exc.exception.message)
 
     def check_exact_decomposition(
         self, target_unitary, decomposer, tolerance=1.0e-12, num_basis_uses=None

--- a/test/python/synthesis/test_synthesis.py
+++ b/test/python/synthesis/test_synthesis.py
@@ -61,7 +61,7 @@ from qiskit.synthesis.two_qubit.two_qubit_decompose import (
     decompose_two_qubit_product_gate,
     TwoQubitDecomposeUpToDiagonal,
 )
-from qiskit._accelerate.two_qubit_decompose import Specializations
+from qiskit._accelerate.two_qubit_decompose import Specialization
 from qiskit.synthesis.unitary import qsd
 from test import combine  # pylint: disable=wrong-import-order
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
@@ -236,7 +236,7 @@ class CheckDecompositions(QiskitTestCase):
         )  # Shouldn't raise
         self.assertRoundTrip(decomp2)
         self.assertRoundTripPickle(decomp2)
-        if expected_specialization != Specializations.General:
+        if expected_specialization != Specialization.General:
             with self.assertRaises(QiskitError) as exc:
                 _ = TwoQubitWeylDecomposition(
                     target_unitary, fidelity=1.0, _specialization=expected_specialization
@@ -811,7 +811,7 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                 self.check_two_qubit_weyl_specialization(
                     k1 @ Ud(a + da, b + db, c + dc) @ k2,
                     0.999,
-                    Specializations.IdEquiv,
+                    Specialization.IdEquiv,
                     {"rz": 4, "ry": 2},
                 )
 
@@ -825,7 +825,7 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                 self.check_two_qubit_weyl_specialization(
                     k1 @ Ud(a + da, b + db, c + dc) @ k2,
                     0.999,
-                    Specializations.SWAPEquiv,
+                    Specialization.SWAPEquiv,
                     {"rz": 4, "ry": 2, "swap": 1},
                 )
 
@@ -839,7 +839,7 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                 self.check_two_qubit_weyl_specialization(
                     k1 @ Ud(a + da, b + db, c + dc) @ k2,
                     0.999,
-                    Specializations.SWAPEquiv,
+                    Specialization.SWAPEquiv,
                     {"rz": 4, "ry": 2, "swap": 1},
                 )
 
@@ -853,7 +853,7 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                 self.check_two_qubit_weyl_specialization(
                     k1 @ Ud(a + da, b + db, c + dc) @ k2,
                     0.999,
-                    Specializations.PartialSWAPEquiv,
+                    Specialization.PartialSWAPEquiv,
                     {"rz": 6, "ry": 3, "rxx": 1, "ryy": 1, "rzz": 1},
                 )
 
@@ -867,7 +867,7 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                 self.check_two_qubit_weyl_specialization(
                     k1 @ Ud(a + da, b + db, c + dc) @ k2,
                     0.999,
-                    Specializations.PartialSWAPFlipEquiv,
+                    Specialization.PartialSWAPFlipEquiv,
                     {"rz": 6, "ry": 3, "rxx": 1, "ryy": 1, "rzz": 1},
                 )
 
@@ -881,7 +881,7 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                 self.check_two_qubit_weyl_specialization(
                     k1 @ Ud(a + da, b + db, c + dc) @ k2,
                     0.999,
-                    Specializations.SimaabEquiv,
+                    Specialization.SimaabEquiv,
                     {"rz": 7, "ry": 4, "rxx": 1, "ryy": 1, "rzz": 1},
                 )
 
@@ -895,7 +895,7 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                 self.check_two_qubit_weyl_specialization(
                     k1 @ Ud(a + da, b + db, c + dc) @ k2,
                     0.999,
-                    Specializations.SimabbEquiv,
+                    Specialization.SimabbEquiv,
                     {"rx": 7, "ry": 4, "rxx": 1, "ryy": 1, "rzz": 1},
                 )
 
@@ -909,7 +909,7 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                 self.check_two_qubit_weyl_specialization(
                     k1 @ Ud(a + da, b + db, c + dc) @ k2,
                     0.999,
-                    Specializations.SimabmbEquiv,
+                    Specialization.SimabmbEquiv,
                     {"rx": 7, "ry": 4, "rxx": 1, "ryy": 1, "rzz": 1},
                 )
 
@@ -923,7 +923,7 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                 self.check_two_qubit_weyl_specialization(
                     k1 @ Ud(a + da, b + db, c + dc) @ k2,
                     0.999,
-                    Specializations.ControlledEquiv,
+                    Specialization.ControlledEquiv,
                     {"rx": 6, "ry": 4, "rxx": 1},
                 )
 
@@ -937,7 +937,7 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                 self.check_two_qubit_weyl_specialization(
                     k1 @ Ud(a + da, b + db, c + dc) @ k2,
                     0.999,
-                    Specializations.MirrorControlledEquiv,
+                    Specialization.MirrorControlledEquiv,
                     {"rz": 6, "ry": 4, "rzz": 1, "swap": 1},
                 )
 
@@ -951,7 +951,7 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                 self.check_two_qubit_weyl_specialization(
                     k1 @ Ud(a + da, b + db, c + dc) @ k2,
                     0.999,
-                    Specializations.General,
+                    Specialization.General,
                     {"rz": 8, "ry": 4, "rxx": 1, "ryy": 1, "rzz": 1},
                 )
 

--- a/test/python/synthesis/test_synthesis.py
+++ b/test/python/synthesis/test_synthesis.py
@@ -903,7 +903,7 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                 self.check_two_qubit_weyl_specialization(
                     k1 @ Ud(a + da, b + db, c + dc) @ k2,
                     0.999,
-                    Specialization.SimaabEquiv,
+                    Specialization.fSimaabEquiv,
                     {"rz": 7, "ry": 4, "rxx": 1, "ryy": 1, "rzz": 1},
                 )
 
@@ -917,7 +917,7 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                 self.check_two_qubit_weyl_specialization(
                     k1 @ Ud(a + da, b + db, c + dc) @ k2,
                     0.999,
-                    Specialization.SimabbEquiv,
+                    Specialization.fSimabbEquiv,
                     {"rx": 7, "ry": 4, "rxx": 1, "ryy": 1, "rzz": 1},
                 )
 
@@ -931,7 +931,7 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                 self.check_two_qubit_weyl_specialization(
                     k1 @ Ud(a + da, b + db, c + dc) @ k2,
                     0.999,
-                    Specialization.SimabmbEquiv,
+                    Specialization.fSimabmbEquiv,
                     {"rx": 7, "ry": 4, "rxx": 1, "ryy": 1, "rzz": 1},
                 )
 

--- a/test/python/synthesis/test_synthesis.py
+++ b/test/python/synthesis/test_synthesis.py
@@ -208,7 +208,7 @@ class CheckDecompositions(QiskitTestCase):
                 decomp_name = decomp.specialization
             else:
                 decomp = TwoQubitWeylDecomposition(
-                    target_unitary, fidelity=None, specialization=expected_specialization
+                    target_unitary, fidelity=None, _specialization=expected_specialization
                 )
                 decomp_name = expected_specialization
             self.assertRoundTrip(decomp)
@@ -232,14 +232,14 @@ class CheckDecompositions(QiskitTestCase):
             trace = np.trace(actual_unitary.T.conj() @ target_unitary)
             self.assertAlmostEqual(trace.imag, 0, places=13, msg=f"Real trace for {decomp_name}")
         decomp2 = TwoQubitWeylDecomposition(
-            target_unitary, fidelity=None, specialization=expected_specialization
+            target_unitary, fidelity=None, _specialization=expected_specialization
         )  # Shouldn't raise
         self.assertRoundTrip(decomp2)
         self.assertRoundTripPickle(decomp2)
         if expected_specialization != Specializations.General:
             with self.assertRaises(QiskitError) as exc:
                 _ = TwoQubitWeylDecomposition(
-                    target_unitary, fidelity=1.0, specialization=expected_specialization
+                    target_unitary, fidelity=1.0, _specialization=expected_specialization
                 )
             self.assertIn("worse than requested", str(exc.exception))
 

--- a/test/python/synthesis/test_synthesis.py
+++ b/test/python/synthesis/test_synthesis.py
@@ -237,11 +237,10 @@ class CheckDecompositions(QiskitTestCase):
         self.assertRoundTrip(decomp2)
         self.assertRoundTripPickle(decomp2)
         if expected_specialization != Specializations.General:
-            # TODO: When rust code emits QiskitError change assertion to match
-            with self.assertRaises(ValueError) as exc:
+            with self.assertRaises(QiskitError) as exc:
                 _ = TwoQubitWeylDecomposition(
                     target_unitary, fidelity=1.0, specialization=expected_specialization
-            )
+                )
             self.assertIn("worse than requested", str(exc.exception))
 
     def check_exact_decomposition(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit is part 1 of migrating the default 2q unitary synthesis to leverage parallel rust described in #8774, the eventual goal is to be able to run unitary synthesis in parallel for all the unitary matrices in a circuit in a single call from the `UnitarySynthesis` pass. This commit lays the initial groundwork for doing this by starting with the largest piece of the default 2q unitary synthesis code, the TwoQubitWeylDecomposition class. It migrates the entire class to be a pyclass in rust. There is still a Python subclass for it that handles the actual QuantumCircuit generation and also the string representations which are dependent on circuit generation. The goal of this is to keep the same basic algorithm in place but re-implement as-is in Rust as a common starting point for eventual improvements to the underlying algorithm as well as parallelizing the synthesis of multiple 2q unitary matrices.

### Details and comments

TODO:

- [x] Fix test failures (this should be a drop in replacement)
  - [x]  Restore specialization tests using rust specialization enum instead of `isinstance` check. These were initially removed because the specialized subclassing mechanism has been removed, but we shouldn't lose the coverage.
- [x] Figure out path to raise `QiskitError` from rust code.
- [x] Benchmark, profile, and optimize after tests are all passing
- [x] Add release note