### PR TITLE
Fix a misprint in a formula in two_qubit_decompose

### DIFF
--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -541,7 +541,7 @@ def _closest_partial_swap(a, b, c) -> float:
     am, bm, cm = a - m, b - m, c - m
     ab, bc, ca = a - b, b - c, c - a
 
-    return m + am * bm * cm * (6 + ab * ab + bc * bc * ca * ca) / 18
+    return m + am * bm * cm * (6 + ab * ab + bc * bc + ca * ca) / 18
 
 
 class TwoQubitWeylPartialSWAPEquiv(TwoQubitWeylDecomposition):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fix a misprint in a formula in the function `_closest_partial_swap` in `two_qubit_decompose`,
according to @levbishop .

### Details and comments
The formula is based on equations (B3)-(B5) in https://arxiv.org/abs/1811.12926

![image](https://github.com/Qiskit/qiskit/assets/46566946/16144cd3-cfa9-435b-9b47-a368cbc3ff6c)
![image](https://github.com/Qiskit/qiskit/assets/46566946/56619bb8-3c7a-44fa-adc1-c6dbffd85a99)

Set `m = (a+b+c)/3` and write everything as deviations from that mean
`a -> eps da + m, b-> eps db + m, c -> eps dc + m`
`x -> eps dx + m `
and then solve for `d/dx = 0` up to nth order in `eps` gives:

![image](https://github.com/Qiskit/qiskit/assets/46566946/a1c2f259-a02f-41a6-9f70-f2c27c61323f)

Since this change is of order `eps^6` it does not affect the tests, and is almost undetectable.