### PR TITLE
Pulse pass manager bugfix

### DIFF
--- a/qiskit/pulse/compiler/basepasses.py
+++ b/qiskit/pulse/compiler/basepasses.py
@@ -46,6 +46,16 @@ class TransformationPass(GenericPass, ABC):
     ) -> IrBlock:
         pass
 
+    def __hash__(self) -> int:
+        warnings.warn(
+            f"{self.__class__} does not explicitly define a protocol to calculate hash. "
+            "This pass created the hash only by considering the class name. "
+            "Qiskit flow controller assumes passes with the identical hash are idempotent, "
+            "and it may skip execution of the other passes in the pipeline.",
+            RuntimeWarning,
+        )
+        return hash((self.__class__.__name__,))
+
     def __eq__(self, other):
         warnings.warn(
             f"{self.__class__} does not explicitly define a protocol to evaluate equality. "
@@ -82,6 +92,16 @@ class AnalysisPass(GenericPass, ABC):
         passmanager_ir: IrBlock,
     ) -> None:
         pass
+
+    def __hash__(self) -> int:
+        warnings.warn(
+            f"{self.__class__} does not explicitly define a protocol to calculate hash. "
+            "This pass created the hash only by considering the class name. "
+            "Qiskit flow controller assumes passes with the identical hash are idempotent, "
+            "and it may skip execution of the other passes in the pipeline.",
+            RuntimeWarning,
+        )
+        return hash((self.__class__.__name__,))
 
     def __eq__(self, other):
         warnings.warn(

--- a/qiskit/pulse/compiler/passmanager.py
+++ b/qiskit/pulse/compiler/passmanager.py
@@ -55,11 +55,12 @@ class BasePulsePassManager(BasePassManager, ABC):
     ) -> IrBlock:
 
         def _wrap_recursive(_prog):
-            _ret = IrBlock(alignment=input_program.alignment_context)
+            _ret = IrBlock(alignment=_prog.alignment_context)
             for _elm in _prog.blocks:
                 if isinstance(_elm, ScheduleBlock):
-                    return _wrap_recursive(_elm)
-                _ret.add_element(IrInstruction(instruction=_elm))
+                    _ret.add_element(_wrap_recursive(_elm))
+                else:
+                    _ret.add_element(IrInstruction(instruction=_elm))
             return _ret
 
         return _wrap_recursive(input_program)
@@ -148,11 +149,12 @@ class BlockTranspiler(BasePulsePassManager):
     ) -> ScheduleBlock:
 
         def _unwrap_recursive(_prog):
-            _ret = ScheduleBlock(alignment_context=passmanager_ir.alignment)
+            _ret = ScheduleBlock(alignment_context=_prog.alignment)
             for _elm in _prog.elements:
                 if isinstance(_elm, IrBlock):
-                    return _unwrap_recursive(_elm)
-                _ret.append(_elm.instruction, inplace=True)
+                    _ret.append(_unwrap_recursive(_elm), inplace=True)
+                else:
+                    _ret.append(_elm.instruction, inplace=True)
             return _ret
 
         out_block = _unwrap_recursive(passmanager_ir)

--- a/test/python/pulse/test_compile.py
+++ b/test/python/pulse/test_compile.py
@@ -13,9 +13,25 @@
 """A test cases for pulse compilation."""
 
 from qiskit.pulse.compiler import BlockTranspiler
+from qiskit.pulse.compiler.basepasses import TransformationPass
+from qiskit.pulse.ir.ir import IrBlock
+from qiskit.providers.fake_provider import GenericBackendV2
 
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 from . import _dummy_programs as schedule_lib
+
+
+class _DummyPass(TransformationPass):
+    """A test pass that doesn't perform any transformation."""
+
+    def run(self, passmanager_ir: IrBlock) -> IrBlock:
+        return passmanager_ir
+
+    def __hash__(self) -> int:
+        return hash((self.__class__.__name__,))
+
+    def __eq__(self, other):
+        return self.__class__.__name == other.__class__.name__
 
 
 class TestCompiler(QiskitTestCase):
@@ -24,7 +40,8 @@ class TestCompiler(QiskitTestCase):
     def test_roundtrip_simple(self):
         """Test just returns the input program."""
         # Just convert an input to PulseIR and convert it back to ScheduleBlock.
-        pm = BlockTranspiler()
+        backend = GenericBackendV2(2)
+        pm = BlockTranspiler([_DummyPass(backend.target)])
 
         in_prog = schedule_lib.play_gaussian()
         out_prog = pm.run(pulse_programs=in_prog)
@@ -33,7 +50,8 @@ class TestCompiler(QiskitTestCase):
     def test_roundtrip_nested(self):
         """Test just returns the input program."""
         # Just convert an input to PulseIR and convert it back to ScheduleBlock.
-        pm = BlockTranspiler()
+        backend = GenericBackendV2(2)
+        pm = BlockTranspiler([_DummyPass(backend.target)])
 
         in_prog = schedule_lib.play_and_inner_block_sequential()
         out_prog = pm.run(pulse_programs=in_prog)


### PR DESCRIPTION
### Summary

Pulse pass manager skeleton was added by #11743. This PR fixes bugs.

### Details and comments

#### 1: Pass must be hashable.

Due to the original implementation of Qiskit PassManager, passes with the identical hash are considered as idempotent and execution of the duplicated (same hash) passes are omitted by design. There was long discussion in #10127 but we decided to remain this behavior.
https://github.com/Qiskit/qiskit/blob/6ebb7aa577e3ab487108ba0e9d9e6ae2f7cf6d4c/qiskit/passmanager/base_tasks.py#L97-L101

The base passes introduced in #11743 didn't implement hash, and crashes the pass manager since a pass instance cannot be added to the completed pass set.

#### 2: Bug fix of schedule block -> IR conversion.

A small test added in #11743 was unintentionally passed due to
https://github.com/Qiskit/qiskit/blob/6ebb7aa577e3ab487108ba0e9d9e6ae2f7cf6d4c/qiskit/passmanager/passmanager.py#L220-L221

Although the pass and conversion logic had bugs, round trip test unintentionally succeeded because nothing was really executed (pass manager run just returned input object as-is, since no pass was added to the flow controller).
