### PR TITLE
Fix to #11949: plot_histogram fails to operate correctly when numerous starting and ending values are zero

### DIFF
--- a/qiskit/visualization/counts_visualization.py
+++ b/qiskit/visualization/counts_visualization.py
@@ -142,9 +142,7 @@ def plot_histogram(
 
     kind = "counts"
     for dat in data:
-        if isinstance(dat, (QuasiDistribution, ProbDistribution)) or isinstance(
-            next(iter(dat.values())), float
-        ):
+        if isinstance(dat, (QuasiDistribution, ProbDistribution)) or any(isinstance(value, float) for value in dat.values()):
             kind = "distribution"
     return _plotting_core(
         data,

--- a/qiskit/visualization/counts_visualization.py
+++ b/qiskit/visualization/counts_visualization.py
@@ -142,7 +142,9 @@ def plot_histogram(
 
     kind = "counts"
     for dat in data:
-        if isinstance(dat, (QuasiDistribution, ProbDistribution)) or any(isinstance(value, float) for value in dat.values()):
+        if isinstance(dat, (QuasiDistribution, ProbDistribution)) or any(
+            isinstance(value, float) for value in dat.values()
+        ):
             kind = "distribution"
     return _plotting_core(
         data,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
The original 'plot_histogram' code determines the mode by checking the type of the first value in the dictionary. If this value is a float, it classifies the data as "distribution"; otherwise, it assumes "counts" mode. This failed to produce the correct plot when a dictionary contained integers and floats (for a distribution).

This modification involves iterating over ALL the values in each dataset of the input data. It now checks if any of these values is a float. If any float values are found, the function classifies the input as "distribution" mode.

### Details and comments
This fix has been tested and fixes the issue faced in #11949.
fixes #11949

