### PR TITLE
Fix typo in document qiskit.transpiler.preset_passmanagers.generate_preset_pass_manager.

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/__init__.py
+++ b/qiskit/transpiler/preset_passmanagers/__init__.py
@@ -140,7 +140,7 @@ def generate_preset_pass_manager(
             physical qubits.
         layout_method (str): The :class:`~.Pass` to use for choosing initial qubit
             placement. Valid choices are ``'trivial'``, ``'dense'``,
-            and ``'sabre'``, representing :class:`~.TrivialLayout`, :class:`~DenseLayout` and
+            and ``'sabre'``, representing :class:`~.TrivialLayout`, :class:`~.DenseLayout` and
             :class:`~.SabreLayout` respectively. This can also
             be the external plugin name to use for the ``layout`` stage of the output
             :class:`~.StagedPassManager`. You can see a list of installed plugins by using


### PR DESCRIPTION
- [ ] I have added the tests to cover my changes.
  - no need
- [ ] I have updated the documentation accordingly.
 - no need
- [x] I have read the CONTRIBUTING document.

### Summary
Fix a minor typo in the document for the [qiskit.transpiler.preset_passmanagers.generate_preset_pass_manager](https://docs.quantum.ibm.com/api/qiskit/0.38/qiskit.transpiler.preset_passmanagers.generate_preset_pass_manager).

### Details and comments

The link in the document of [qiskit.transpiler.preset_passmanagers.generate_preset_pass_manager](https://docs.quantum.ibm.com/api/qiskit/0.38/qiskit.transpiler.preset_passmanagers.generate_preset_pass_manager) is partially broken.
For the descriptions of layout_method in the parameters, the method `DenseLayout` has no link, as other methods have links.

This PR fixes the link.
