### PR TITLE
Add `SequenceIR.copy`

### DIFF
--- a/qiskit/pulse/ir/ir.py
+++ b/qiskit/pulse/ir/ir.py
@@ -242,7 +242,6 @@ class SequenceIR:
         else:
             block = self.copy()
 
-
         def edge_map(_x, _y, _node):
             if _y == _node:
                 return 0
@@ -313,5 +312,17 @@ class SequenceIR:
         #  to be different, But then it's not straightforward to compare the time_table.
         #  It is reasonable to assume that blocks with the same alignment and the same sequence
         #  will result in the same time_table, but this decision should be made consciously.
+
+    def __deepcopy__(self, memo=None):
+        if memo is None:
+            memo = {}
+        copied = self.__class__(copy.deepcopy(self.alignment, memo=memo))
+        memo[id(self)] = copied
+        copied._time_table = copy.copy(self._time_table)  # Only int keys and values.
+        copied._sequence = copy.deepcopy(self._sequence, memo=memo)
+        # To ensure that copied object will be equal to the original.
+        copied._sequence[0] = self._InNode
+        copied._sequence[1] = self._OutNode
+        return copied
 
     # TODO : __repr__

--- a/qiskit/pulse/ir/ir.py
+++ b/qiskit/pulse/ir/ir.py
@@ -257,20 +257,24 @@ class SequenceIR:
         return block
 
     def copy(self) -> SequenceIR:
-        """Semi-deep copy of ``SequenceIR``.
+        """Create a copy of ``SequenceIR``.
 
         The returned copy can be safely mutated without affecting the original object, while immutable
         objects are still passed as reference for memory efficiency.
 
+        .. warning::
+            If node data (not a nester IR object) is mutated via ``.sequence`` or ``.elements`` it will
+            affect the original IR object.
+
         ``SequenceIR`` is poorly suited for both shallow and deep copy. A shallow copy
         will contain references to mutable properties like ``sequence`` and ``time_table``.
         A deep copy on the other hand will needlessly copy immutable objects like
-        :class:`.qiskit.pulse.Instruction`. This function returns a semi-deep copy -
+        :class:`.qiskit.pulse.Instruction`. This function returns a "semi-deep" copy -
         A new object containing new objects for ``sequence`` and ``time_table``. However,
         node data of type :class:`.qiskit.pulse.Instruction` will be passed as a reference.
         Nested ``SequenceIR`` objects are copied using the same logic.
 
-        Returns: A semi-deep copy of the object.
+        Returns: A copy of the object.
         """
         copied = self.__class__(self.alignment)
         copied._time_table = copy.copy(self._time_table)

--- a/qiskit/pulse/ir/ir.py
+++ b/qiskit/pulse/ir/ir.py
@@ -281,9 +281,10 @@ class SequenceIR:
         objects are still passed as reference for memory efficiency.
 
         .. warning::
-            If an :class:`.qiskit.pulse.Instruction` instance attached to the node of the internal graph is modified
-            via :meth:`.sequence` or :meth:`.elements`, it will also modify the data in the original object.
-            Although this is not an expected usage of ``SequenceIR``, 
+            If an :class:`.qiskit.pulse.Instruction` instance attached to the node of the
+            internal graph is modified via :meth:`.sequence` or :meth:`.elements`, it will
+            also modify the data in the original object.
+            Although this is not an expected usage of ``SequenceIR``,
             deepcopy is also available at the price of performance
             to protect these node data from any modification.
 
@@ -297,7 +298,8 @@ class SequenceIR:
 
         Returns: A copy of the object.
         """
-        copied = self.__class__(self.alignment)
+        copied = object.__new__(self.__class__)
+        copied._alignment = self.alignment
         copied._time_table = copy.copy(self._time_table)
         copied._sequence = copy.copy(self._sequence)
         for node_index in copied.sequence.node_indices():

--- a/qiskit/pulse/ir/ir.py
+++ b/qiskit/pulse/ir/ir.py
@@ -259,6 +259,9 @@ class SequenceIR:
     def copy(self) -> SequenceIR:
         """Semi-deep copy of ``SequenceIR``.
 
+        The returned copy can be safely mutated without affecting the original object, while immutable
+        objects are still passed as reference for memory efficiency.
+
         ``SequenceIR`` is poorly suited for both shallow and deep copy. A shallow copy
         will contain references to mutable properties like ``sequence`` and ``time_table``.
         A deep copy on the other hand will needlessly copy immutable objects like

--- a/qiskit/pulse/ir/ir.py
+++ b/qiskit/pulse/ir/ir.py
@@ -281,8 +281,11 @@ class SequenceIR:
         objects are still passed as reference for memory efficiency.
 
         .. warning::
-            If node data (not a nester IR object) is mutated via ``.sequence`` or ``.elements`` it will
-            affect the original IR object.
+            If an :class:`.qiskit.pulse.Instruction` instance attached to the node of the internal graph is modified
+            via :meth:`.sequence` or :meth:`.elements`, it will also modify the data in the original object.
+            Although this is not an expected usage of ``SequenceIR``, 
+            deepcopy is also available at the price of performance
+            to protect these node data from any modification.
 
         ``SequenceIR`` is poorly suited for both shallow and deep copy. A shallow copy
         will contain references to mutable properties like ``sequence`` and ``time_table``.

--- a/qiskit/pulse/ir/ir.py
+++ b/qiskit/pulse/ir/ir.py
@@ -272,7 +272,7 @@ class SequenceIR:
 
         Returns: A semi-deep copy of the object.
         """
-        copied = SequenceIR(self.alignment)
+        copied = self.__class__(self.alignment)
         copied._time_table = copy.copy(self._time_table)
         copied._sequence = copy.copy(self._sequence)
         for node_index in copied.sequence.node_indices():

--- a/test/python/pulse/test_pulse_ir.py
+++ b/test/python/pulse/test_pulse_ir.py
@@ -490,21 +490,19 @@ class TestSequenceIR(QiskitTestCase):
         copied = ir1.copy()
         # Top level properties and nested IRs are new objects
         self.assertEqual(copied, ir1)
-        self.assertFalse(copied is ir1)
+        self.assertIsNot(copied, ir1)
         self.assertEqual(copied.alignment, ir1.alignment)
         self.assertEqual(copied._time_table, ir1._time_table)
-        self.assertFalse(copied._time_table is ir1._time_table)
+        self.assertIsNot(copied._time_table, ir1._time_table)
         # PyDAG has no built-in equality check
         self.assertTrue(
             is_isomorphic_node_match(copied._sequence, ir1._sequence, lambda x, y: x == y)
         )
-        self.assertFalse(copied._sequence is ir1._sequence)
+        self.assertIsNot(copied._sequence, ir1._sequence)
         self.assertEqual(copied.elements()[0], ir1.elements()[0])
-        self.assertFalse(copied.elements()[0] is ir1.elements()[0])
+        self.assertIsNot(copied.elements()[0], ir1.elements()[0])
         # Instructions are passed by reference
-        self.assertEqual(copied.elements()[1], inst2)
-        self.assertTrue(copied.elements()[1] is inst2)
-        self.assertEqual(copied.elements()[0].elements()[0], inst1)
-        self.assertTrue(copied.elements()[0].elements()[0] is inst1)
+        self.assertIs(copied.elements()[1], inst2)
+        self.assertIs(copied.elements()[0].elements()[0], inst1)
 
     # TODO : Test SequenceIR.draw()


### PR DESCRIPTION
### Summary
A semi-deep copy method is added to `SequenceIR`. The returned copy can be safely mutated without affecting the original object, while immutable objects (pulse instructions) are still passed as reference for memory efficiency.

Also added `__deepcopy__` to guarantee that deep copy of IR objects will be equal to the original.