### PR TITLE
Use pickle `__reduce__` for `TwoQubitWeylDecomposition`

### DIFF
--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -248,7 +248,7 @@ class TwoQubitWeylDecomposition:
         bytes_in: bytes,
         *,
         requested_fidelity: float,
-        _specialization: two_qubit_decompose.Specialization | None,
+        _specialization: two_qubit_decompose.Specialization | None = None,
         **kwargs,
     ) -> "TwoQubitWeylDecomposition":
         """Decode bytes into :class:`.TwoQubitWeylDecomposition`."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Since this class does complicated calculation within its `__new__` method (as many extension classes do), we want to use an alternative extension-module constructor for the object on unpickle, to avoid leaking the "pickle" / "no pickle" state through the default constructor.

This implements a private Python-space method that directly constructs the object from components, which is then used as the `__reduce__` target, along with the pickle state.



### Details and comments

Built on top of #11946, since that might be on the verge of landing.  See https://github.com/Qiskit/qiskit/pull/11946#discussion_r1519881910 for context.

It's plausible we might want to expose `_from_state` as a public constructor, or otherwise provide a convenient debugging method that produces a copy/paste codeblock in terms of it, since unlike `from_bytes`, it _completely_ skips all the recalculation of the decomposition and simply builds the state in place; there's zero risk of floating-point errors from the re-decomposition, because it simply doesn't happen.