### PR TITLE
Update gate dictionary in `two_local.py`

### DIFF
--- a/qiskit/circuit/library/n_local/two_local.py
+++ b/qiskit/circuit/library/n_local/two_local.py
@@ -17,35 +17,10 @@ import typing
 from collections.abc import Callable, Sequence
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
-from qiskit.circuit import Gate, Instruction, Parameter
+from qiskit.circuit import Gate, Instruction
 
 from .n_local import NLocal
-from ..standard_gates import (
-    IGate,
-    XGate,
-    YGate,
-    ZGate,
-    RXGate,
-    RYGate,
-    RZGate,
-    HGate,
-    SGate,
-    SdgGate,
-    TGate,
-    TdgGate,
-    RXXGate,
-    RYYGate,
-    RZXGate,
-    RZZGate,
-    SwapGate,
-    CXGate,
-    CYGate,
-    CZGate,
-    CRXGate,
-    CRYGate,
-    CRZGate,
-    CHGate,
-)
+from ..standard_gates import get_standard_gate_name_mapping
 
 if typing.TYPE_CHECKING:
     import qiskit  # pylint: disable=cyclic-import
@@ -269,38 +244,7 @@ class TwoLocal(NLocal):
         if isinstance(layer, QuantumCircuit):
             return layer
 
-        # check the list of valid layers
-        # this could be a lot easier if the standard layers would have ``name`` and ``num_params``
-        # as static types, which might be something they should have anyway
-        theta = Parameter("θ")
-        valid_layers = {
-            "ch": CHGate(),
-            "cx": CXGate(),
-            "cy": CYGate(),
-            "cz": CZGate(),
-            "crx": CRXGate(theta),
-            "cry": CRYGate(theta),
-            "crz": CRZGate(theta),
-            "h": HGate(),
-            "i": IGate(),
-            "id": IGate(),
-            "iden": IGate(),
-            "rx": RXGate(theta),
-            "rxx": RXXGate(theta),
-            "ry": RYGate(theta),
-            "ryy": RYYGate(theta),
-            "rz": RZGate(theta),
-            "rzx": RZXGate(theta),
-            "rzz": RZZGate(theta),
-            "s": SGate(),
-            "sdg": SdgGate(),
-            "swap": SwapGate(),
-            "x": XGate(),
-            "y": YGate(),
-            "z": ZGate(),
-            "t": TGate(),
-            "tdg": TdgGate(),
-        }
+        valid_layers = get_standard_gate_name_mapping()
 
         # try to exchange `layer` from a string to a gate instance
         if isinstance(layer, str):

--- a/releasenotes/notes/update-gate-dictionary-c0c017be67bb2f29.yaml
+++ b/releasenotes/notes/update-gate-dictionary-c0c017be67bb2f29.yaml
@@ -7,4 +7,4 @@ fixes:
 features_circuits:
   - |
     All of the gates in the ``standard_gates`` library are now supported
-    as valid sting gates for ``TwoLocal`` circuits.
+    as valid string gates for ``TwoLocal`` circuits.

--- a/releasenotes/notes/update-gate-dictionary-c0c017be67bb2f29.yaml
+++ b/releasenotes/notes/update-gate-dictionary-c0c017be67bb2f29.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixes adding all supported gates in ``TwoLocal`` circuits. Refer to
+    `#12002 <https://github.com/Qiskit/qiskit/issues/12002>` for more
+    details.
+features_circuits:
+  - |
+    All of the gates in the ``standard_gates`` library are now supported
+    as valid sting gates for ``TwoLocal`` circuits.

--- a/releasenotes/notes/update-gate-dictionary-c0c017be67bb2f29.yaml
+++ b/releasenotes/notes/update-gate-dictionary-c0c017be67bb2f29.yaml
@@ -1,10 +1,7 @@
 ---
-fixes:
-  - |
-    Fixes adding all supported gates in ``TwoLocal`` circuits. Refer to
-    `#12002 <https://github.com/Qiskit/qiskit/issues/12002>` for more
-    details.
 features_circuits:
   - |
-    All of the gates in the ``standard_gates`` library are now supported
-    as valid string gates for ``TwoLocal`` circuits.
+    All of the "standard gates" in the circuit library
+    (:mod:`qiskit.circuit.library`) can now be specified by string name for
+    the entangling operations in :class:`.TwoLocal` circuits, such as
+    :class:`.RealAmplitudes` and :class:`.EfficientSU2`.

--- a/test/python/circuit/library/test_nlocal.py
+++ b/test/python/circuit/library/test_nlocal.py
@@ -37,6 +37,7 @@ from qiskit.circuit.library import (
     RXXGate,
     RYYGate,
     CXGate,
+    SXGate,
 )
 from qiskit.circuit.random.utils import random_circuit
 from qiskit.converters.circuit_to_dag import circuit_to_dag
@@ -696,6 +697,16 @@ class TestTwoLocal(QiskitTestCase):
         with self.subTest(msg="test parameter bounds"):
             expected = [(-np.pi, np.pi)] * two.num_parameters
             np.testing.assert_almost_equal(two.parameter_bounds, expected)
+
+    def test_rzsx_blocks(self):
+        """Test that the EfficientSU2 circuit is instantiated correctly."""
+        two = EfficientSU2(3, ["rz", "sx", "rz", "sx", "rz"])
+        expected = [[RZGate], [SXGate], [RZGate], [SXGate], [RZGate]]
+        actual = [
+            [instruction.operation.base_class for instruction in block]
+            for block in two.rotation_blocks
+        ]
+        self.assertEqual(actual, expected)
 
     def test_ryrz_circuit(self):
         """Test an EfficientSU2 circuit."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.

### Summary

This commit removes the hard coded gate dictionary with the one generated by the method `get_standard_gate_name_mapping`.

### Details and comments

Resolves #12002 