### PR TITLE
Reduce number of compose calls in LieTrotter synthesis

### DIFF
--- a/qiskit/synthesis/evolution/lie_trotter.py
+++ b/qiskit/synthesis/evolution/lie_trotter.py
@@ -89,9 +89,8 @@ class LieTrotter(ProductFormula):
             evolution_circuit.compose(
                 self.atomic_evolution(op, coeff * time / self.reps), wrap=wrap, inplace=True
             )
-
-        if self.insert_barriers:
-            evolution_circuit.barrier()
+            if self.insert_barriers:
+                evolution_circuit.barrier()
 
         return evolution_circuit.repeat(self.reps).decompose()
 

--- a/qiskit/synthesis/evolution/lie_trotter.py
+++ b/qiskit/synthesis/evolution/lie_trotter.py
@@ -85,11 +85,11 @@ class LieTrotter(ProductFormula):
         # if we only evolve a single Pauli we don't need to additionally wrap it
         wrap = not (len(pauli_list) == 1 and self.reps == 1)
 
-        for op, coeff in pauli_list:
+        for i, (op, coeff) in enumerate(pauli_list):
             evolution_circuit.compose(
                 self.atomic_evolution(op, coeff * time / self.reps), wrap=wrap, inplace=True
             )
-            if self.insert_barriers:
+            if self.insert_barriers and i != len(pauli_list) - 1:
                 evolution_circuit.barrier()
 
         return evolution_circuit.repeat(self.reps).decompose()

--- a/qiskit/synthesis/evolution/lie_trotter.py
+++ b/qiskit/synthesis/evolution/lie_trotter.py
@@ -93,7 +93,7 @@ class LieTrotter(ProductFormula):
         if self.insert_barriers:
             evolution_circuit.barrier()
 
-        return evolution_circuit.repeat(self.reps)
+        return evolution_circuit.repeat(self.reps).decompose()
 
     @property
     def settings(self) -> Dict[str, Any]:

--- a/releasenotes/notes/faster-lie-trotter-ba8f6dd84fe4cae4.yaml
+++ b/releasenotes/notes/faster-lie-trotter-ba8f6dd84fe4cae4.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    :meth:`.LieTrotter.synthesize` now uses :meth:`.QuantumCircuit.repeat` to generate additional reps
+    after the first. This reduces the number of :meth:`.QuantumCircuit.compose` calls by a factor of
+    ``reps`` and significantly reduces the runtime for larger operators.

--- a/releasenotes/notes/faster-lie-trotter-ba8f6dd84fe4cae4.yaml
+++ b/releasenotes/notes/faster-lie-trotter-ba8f6dd84fe4cae4.yaml
@@ -1,5 +1,5 @@
 ---
-upgrade:
+features_synthesis:
   - |
     :meth:`.LieTrotter.synthesize` now uses :meth:`.QuantumCircuit.repeat` to generate additional reps
     after the first. This reduces the number of :meth:`.QuantumCircuit.compose` calls by a factor of


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have read the CONTRIBUTING document.
-->

### Summary
In the LieTrotter class, during creation of the evolution circuit, `QuantumCircuit.compose` is called `num_reps * num_pauli_terms` times. We can reduce the number of calls to compose to `num_pauli_terms` by creating one step of the circuit and using `QuantumCircuit.repeat` to add the remaining steps.


### Details and comments
- For a 115q operator with 741 terms for 2 reps, this yields a run time improvement of 33% (18s to 12s)
- For a 291q operator with 1893 terms for 2 reps, this yields a run time improvement of ~60% (181s to 73s)