### PR TITLE
Correct misplaced gates on qubits in BasisTranslator

### DIFF
--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -144,6 +144,16 @@ class BasisTranslator(TransformationPass):
         if self._target_basis is None and self._target is None:
             return dag
 
+        if dag is not None and self._target is not None:
+            # Sometimes target.num_qubits is set to None, to prevent transpiler to resize the cirucit.
+            if (target_num_qubits := self._target.num_qubits) is not None:
+                if dag.num_qubits() > target_num_qubits:
+                    raise TranspilerError(
+                        f"Number of qubits: {dag.num_qubits()} in the circuit "
+                        f"is more than the number of qubits: {self._target.num_qubits} "
+                        "in the target"
+                    )
+
         qarg_indices = {qubit: index for index, qubit in enumerate(dag.qubits)}
 
         # Names of instructions assumed to supported by any backend.

--- a/releasenotes/notes/correct-misplaced-gates-on-qubits-in-BasisTranslator-021c1959fabfcdce.yaml
+++ b/releasenotes/notes/correct-misplaced-gates-on-qubits-in-BasisTranslator-021c1959fabfcdce.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixes the issue with :class:`.BasisTranslator` where the output circuit had gates 
+    placed on those qubits which didn't have that particular gate available as
+    basis_gates.
+    Refer to `#11339 <https://github.com/Qiskit/qiskit/issues/11339>` for more details.
+

--- a/test/python/transpiler/test_basis_translator.py
+++ b/test/python/transpiler/test_basis_translator.py
@@ -1103,7 +1103,6 @@ class TestBasisTranslatorWithTarget(QiskitTestCase):
         }
         self.target.add_instruction(CXGate(), cx_props)
 
-
     def test_gate_inside_qubits_local_basis_gates(self):
         """
         Test gates placed on qubits which has that particular gate

--- a/test/python/transpiler/test_basis_translator.py
+++ b/test/python/transpiler/test_basis_translator.py
@@ -1123,3 +1123,14 @@ class TestBasisTranslatorWithTarget(QiskitTestCase):
             # Just check for 1Q gates.
             if node.op.num_qubits == 1:
                 self.assertTrue(node.op.name in target_qarg_gate_map[(node.qargs[0]._index,)])
+
+    def test_raises_num_qubits_in_ckt_more_than_in_target(self):
+        """
+        Test if TranspilerError is raised when number of qubits in
+        the circuit exceeds the number of qubits available in the target.
+        """
+        qc = QuantumCircuit(3)
+        qc.h(qc.qregs[0])
+        bt_pass = BasisTranslator(std_eqlib, target_basis=None, target=self.target)
+        with self.assertRaisesRegex(TranspilerError, "circuit is more than the number of qubits"):
+            bt_pass(qc)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
current `BasisTranslator` sometimes misplaces the gates on qubits which do not have the implementation of that particular gate.
This PR tries to fix this by placing the gates onto the correct qubits which have those gates available on them.
To follow more see: #11339

Example
```python
from qiskit.circuit import QuantumCircuit, Parameter
from qiskit.circuit.library import UGate, RZGate, XGate, SXGate, CXGate
from qiskit.circuit.equivalence_library import SessionEquivalenceLibrary as sel

from qiskit.transpiler import PassManager, Target, InstructionProperties
from qiskit.transpiler.passes import BasisTranslator

gmap = Target()

# U gate in qubit 0.
theta = Parameter('theta')
phi = Parameter('phi')
lam = Parameter('lambda')
u_props = {
    (0,): InstructionProperties(duration=5.23e-8, error=0.00038115),
}
gmap.add_instruction(UGate(theta, phi, lam), u_props)

# Rz gate in qubit 1.
phi = Parameter("phi")
rz_props = {
    (1,): InstructionProperties(duration=0.0, error=0),
}
gmap.add_instruction(RZGate(phi), rz_props)

# X gate in qubit 1.
x_props = {
    (1,): InstructionProperties(
        duration=3.5555555555555554e-08, error=0.00020056469709026198
    ),
}
gmap.add_instruction(XGate(), x_props)

# SX gate in qubit 1.
sx_props = {
    (1,): InstructionProperties(
        duration=3.5555555555555554e-08, error=0.00020056469709026198
    ),
}
gmap.add_instruction(SXGate(), sx_props)

cx_props = {
    (0, 1): InstructionProperties(duration=5.23e-7, error=0.00098115),
    (1, 0): InstructionProperties(duration=4.52e-7, error=0.00132115),
}
gmap.add_instruction(CXGate(), cx_props)

bt_pass = BasisTranslator(sel, target_basis=None, target=gmap)

qc = QuantumCircuit(2)
qc.iswap(0, 1)
output = bt_pass(qc)
```

Produces this as output:
![Screenshot_20240316_190029](https://github.com/Qiskit/qiskit/assets/54737489/a509c277-3639-45ce-8f2d-8a744d5608b5)



### Details and comments
fixes #11339 

