### PR TITLE
Fix `pulse.build()` default alignment argument

### DIFF
--- a/qiskit/pulse/builder.py
+++ b/qiskit/pulse/builder.py
@@ -531,7 +531,10 @@ class _PulseBuilder:
             self._context_stack.append(root_block)
 
         # Set default alignment context
-        alignment = _PulseBuilder.__alignment_kinds__.get(default_alignment, default_alignment)
+        if isinstance(default_alignment, AlignmentKind):  # AlignmentKind instance
+            alignment = default_alignment
+        else:  # str identifier
+            alignment = _PulseBuilder.__alignment_kinds__.get(default_alignment, default_alignment)
         if not isinstance(alignment, AlignmentKind):
             raise exceptions.PulseError(
                 f"Given `default_alignment` {repr(default_alignment)} is "

--- a/releasenotes/notes/fix-pulse-builder-default-alingment-52f81224d90c21e2.yaml
+++ b/releasenotes/notes/fix-pulse-builder-default-alingment-52f81224d90c21e2.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug in the handling of ``default_alignment`` argument of :func:`~qiskit.pulse.build`.
+    Inputs of type :class:`~qiskit.pulse.transforms.AlignmentKind` are now correctly processed as
+    default alignments.

--- a/test/python/pulse/test_builder.py
+++ b/test/python/pulse/test_builder.py
@@ -21,6 +21,7 @@ from qiskit.pulse.instructions import directives
 from qiskit.pulse.transforms import target_qobj_transform
 from qiskit.providers.fake_provider import FakeOpenPulse2Q, Fake127QPulseV1
 from qiskit.pulse import library, instructions
+from qiskit.pulse.exceptions import PulseError
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
 
@@ -105,6 +106,29 @@ class TestBuilderBase(TestBuilder):
                 pulse.delay(20, d1)
 
         self.assertScheduleEqual(schedule, reference)
+
+    def test_default_alignment_alignmentkind_instance(self):
+        """Test default AlignmentKind instance"""
+        d0 = pulse.DriveChannel(0)
+        d1 = pulse.DriveChannel(0)
+
+        with pulse.build(default_alignment=pulse.transforms.AlignEquispaced(100)) as schedule:
+            pulse.delay(10, d0)
+            pulse.delay(20, d1)
+
+        with pulse.build() as reference:
+            with pulse.align_equispaced(100):
+                pulse.delay(10, d0)
+                pulse.delay(20, d1)
+
+        self.assertScheduleEqual(schedule, reference)
+
+    def test_unknown_string_identifier(self):
+        """Test that unknown string identifier raises an error"""
+
+        with self.assertRaises(PulseError):
+            with pulse.build(default_alignment="unknown") as _:
+                pass
 
 
 class TestContexts(TestBuilder):


### PR DESCRIPTION
### Summary
Fix #12028 such that `pulse.build()` will accept `AlignmentKind` instances as valid input for argument `default_alignment`.



