### PR TITLE
Add better error messages for typical SamplerV2 and EstimatorV2 error cases

### DIFF
--- a/qiskit/primitives/containers/estimator_pub.py
+++ b/qiskit/primitives/containers/estimator_pub.py
@@ -136,7 +136,7 @@ class EstimatorPub(ShapedMixin):
         if isinstance(pub, QuantumCircuit):
             raise ValueError(
                 f"An invalid Estimator pub-like was given ({type(pub)}). "
-                "If you want to run a single pub-like, you need to wrap it with `[]` like "
+                "If you want to run a single pub, you need to wrap it with `[]` like "
                 "`estimator.run([(circuit, observables, param_values)])` "
                 "instead of `estimator.run((circuit, observables, param_values))`."
             )

--- a/qiskit/primitives/containers/estimator_pub.py
+++ b/qiskit/primitives/containers/estimator_pub.py
@@ -132,6 +132,15 @@ class EstimatorPub(ShapedMixin):
                     validate=False,  # Assume Pub is already validated
                 )
             return pub
+
+        if isinstance(pub, QuantumCircuit):
+            raise ValueError(
+                f"An invalid Estimator pub-like was given ({type(pub)}). "
+                "If you want to run a single pub-like, you need to wrap it with `[]` like "
+                "`estimator.run([(circuit, observables, param_values)])` "
+                "instead of `estimator.run((circuit, observables, param_values))`."
+            )
+
         if len(pub) not in [2, 3, 4]:
             raise ValueError(
                 f"The length of pub must be 2, 3 or 4, but length {len(pub)} is given."

--- a/qiskit/primitives/containers/estimator_pub.py
+++ b/qiskit/primitives/containers/estimator_pub.py
@@ -217,8 +217,6 @@ estimator, if ``precision=None`` the estimator will determine the target precisi
     An Estimator Pub can also be initialized in the following formats which
     will be converted to the full Pub tuple:
 
-    * ``circuit
-    * ``(circuit,)``
     * ``(circuit, observables)``
-    * ``(circuit, observalbes, parameter_values)``
+    * ``(circuit, observables, parameter_values)``
 """

--- a/qiskit/primitives/containers/sampler_pub.py
+++ b/qiskit/primitives/containers/sampler_pub.py
@@ -18,10 +18,11 @@ Sampler Pub class
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Tuple, Union
 from numbers import Integral
+from typing import Tuple, Union
 
 from qiskit import QuantumCircuit
+from qiskit.circuit import CircuitInstruction
 
 from .bindings_array import BindingsArray, BindingsArrayLike
 from .shape import ShapedMixin
@@ -112,6 +113,13 @@ class SamplerPub(ShapedMixin):
 
         if isinstance(pub, QuantumCircuit):
             return cls(circuit=pub, shots=shots, validate=True)
+
+        if isinstance(pub, CircuitInstruction):
+            raise ValueError(
+                f"An invalid Sampler pub-like was given ({pub}). If you want to run a circuit, "
+                "you need to wrap a circuit with `[]` like `sampler.run([circuit])` "
+                "instead of `sampler.run(circuit)`."
+            )
 
         if len(pub) not in [1, 2, 3]:
             raise ValueError(

--- a/qiskit/primitives/containers/sampler_pub.py
+++ b/qiskit/primitives/containers/sampler_pub.py
@@ -116,8 +116,8 @@ class SamplerPub(ShapedMixin):
 
         if isinstance(pub, CircuitInstruction):
             raise ValueError(
-                f"An invalid Sampler pub-like was given ({pub}). If you want to run a circuit, "
-                "you need to wrap a circuit with `[]` like `sampler.run([circuit])` "
+                f"An invalid Sampler pub-like was given ({pub}). If you want to run a single circuit, "
+                "you need to wrap the circuit with `[]` like `sampler.run([circuit])` "
                 "instead of `sampler.run(circuit)`."
             )
 

--- a/qiskit/primitives/containers/sampler_pub.py
+++ b/qiskit/primitives/containers/sampler_pub.py
@@ -116,8 +116,9 @@ class SamplerPub(ShapedMixin):
 
         if isinstance(pub, CircuitInstruction):
             raise ValueError(
-                f"An invalid Sampler pub-like was given ({pub}). If you want to run a single circuit, "
-                "you need to wrap the circuit with `[]` like `sampler.run([circuit])` "
+                f"An invalid Sampler pub-like was given ({type(pub)}). "
+                "If you want to run a single circuit, "
+                "you need to wrap it with `[]` like `sampler.run([circuit])` "
                 "instead of `sampler.run(circuit)`."
             )
 

--- a/qiskit/primitives/containers/sampler_pub.py
+++ b/qiskit/primitives/containers/sampler_pub.py
@@ -156,10 +156,17 @@ class SamplerPub(ShapedMixin):
         # Cross validate circuits and parameter values
         num_parameters = self.parameter_values.num_parameters
         if num_parameters != self.circuit.num_parameters:
-            raise ValueError(
+            message = (
                 f"The number of values ({num_parameters}) does not match "
                 f"the number of parameters ({self.circuit.num_parameters}) for the circuit."
             )
+            if num_parameters == 0:
+                message += (
+                    " Note that if you want to run a single pub, you need to wrap it with `[]` like "
+                    "`sampler.run([(circuit, param_values)])` instead of "
+                    "`sampler.run((circuit, param_values))`."
+                )
+            raise ValueError(message)
 
 
 SamplerPubLike = Union[
@@ -180,7 +187,7 @@ if ``shots=None`` the number of run shots is determined by the sampler.
     A Sampler Pub can also be initialized in the following formats which
     will be converted to the full Pub tuple:
 
-    * ``circuit
+    * ``circuit``
     * ``(circuit,)``
     * ``(circuit, parameter_values)``
 """

--- a/test/python/primitives/test_backend_estimator.py
+++ b/test/python/primitives/test_backend_estimator.py
@@ -56,6 +56,7 @@ class TestBackendEstimator(QiskitTestCase):
 
     def setUp(self):
         super().setUp()
+        self._rng = np.random.default_rng(12)
         self.ansatz = RealAmplitudes(num_qubits=2, reps=2)
         self.observable = SparsePauliOp.from_list(
             [
@@ -222,7 +223,7 @@ class TestBackendEstimator(QiskitTestCase):
         qc = RealAmplitudes(num_qubits=2, reps=2)
         op = SparsePauliOp.from_list([("IZ", 1), ("XI", 2), ("ZY", -1)])
         k = 5
-        params_array = np.random.rand(k, qc.num_parameters)
+        params_array = self._rng.random((k, qc.num_parameters))
         params_list = params_array.tolist()
         params_list_array = list(params_array)
         estimator = BackendEstimator(backend=backend)
@@ -288,7 +289,7 @@ class TestBackendEstimator(QiskitTestCase):
         qc = RealAmplitudes(num_qubits=2, reps=2)
         op = SparsePauliOp.from_list([("IZ", 1), ("XI", 2), ("ZY", -1)])
         k = 5
-        params_array = np.random.rand(k, qc.num_parameters)
+        params_array = self._rng.random((k, qc.num_parameters))
         params_list = params_array.tolist()
         estimator = BackendEstimator(backend=backend)
         with patch.object(backend, "run") as run_mock:
@@ -304,7 +305,7 @@ class TestBackendEstimator(QiskitTestCase):
         qc = RealAmplitudes(num_qubits=2, reps=2)
         op = SparsePauliOp.from_list([("IZ", 1), ("XI", 2), ("ZY", -1)])
         k = 5
-        params_array = np.random.rand(k, qc.num_parameters)
+        params_array = self._rng.random((k, qc.num_parameters))
         params_list = params_array.tolist()
         estimator = BackendEstimator(backend=backend)
         estimator.set_options(seed_simulator=123)
@@ -321,7 +322,7 @@ class TestBackendEstimator(QiskitTestCase):
         qc = RealAmplitudes(num_qubits=2, reps=2)
         op = SparsePauliOp.from_list([("IZ", 1), ("XI", 2), ("ZY", -1)])
         k = 5
-        params_array = np.random.rand(k, qc.num_parameters)
+        params_array = self._rng.random((k, qc.num_parameters))
         params_list = params_array.tolist()
         params_list_array = list(params_array)
         estimator = BackendEstimator(backend=backend)

--- a/test/python/primitives/test_backend_sampler.py
+++ b/test/python/primitives/test_backend_sampler.py
@@ -259,7 +259,8 @@ class TestBackendSampler(QiskitTestCase):
         qc = RealAmplitudes(num_qubits=2, reps=2)
         qc.measure_all()
         k = 5
-        params_array = np.random.rand(k, qc.num_parameters)
+        rng = np.random.default_rng(12)
+        params_array = rng.random((k, qc.num_parameters))
         params_list = params_array.tolist()
         params_list_array = list(params_array)
         sampler = BackendSampler(backend=backend)

--- a/test/python/primitives/test_backend_sampler_v2.py
+++ b/test/python/primitives/test_backend_sampler_v2.py
@@ -351,6 +351,9 @@ class TestBackendSamplerV2(QiskitTestCase):
         with self.subTest("zero shots, pub"):
             with self.assertRaises(ValueError):
                 _ = sampler.run([SamplerPub(qc1, shots=0)]).result()
+        with self.subTest("missing []"):
+            with self.assertRaisesRegex(ValueError, "An invalid Sampler pub-like was given"):
+                _ = sampler.run(qc1).result()
 
     @combine(backend=BACKENDS)
     def test_run_empty_parameter(self, backend):

--- a/test/python/primitives/test_backend_sampler_v2.py
+++ b/test/python/primitives/test_backend_sampler_v2.py
@@ -354,6 +354,9 @@ class TestBackendSamplerV2(QiskitTestCase):
         with self.subTest("missing []"):
             with self.assertRaisesRegex(ValueError, "An invalid Sampler pub-like was given"):
                 _ = sampler.run(qc1).result()
+        with self.subTest("missing [] for pqc"):
+            with self.assertRaisesRegex(ValueError, "Note that if you want to run a single pub,"):
+                _ = sampler.run((qc2, [0, 1])).result()
 
     @combine(backend=BACKENDS)
     def test_run_empty_parameter(self, backend):

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -237,7 +237,8 @@ class TestEstimator(QiskitTestCase):
         qc = RealAmplitudes(num_qubits=2, reps=2)
         op = SparsePauliOp.from_list([("IZ", 1), ("XI", 2), ("ZY", -1)])
         k = 5
-        params_array = np.random.rand(k, qc.num_parameters)
+        rng = np.random.default_rng(12)
+        params_array = rng.random((k, qc.num_parameters))
         params_list = params_array.tolist()
         params_list_array = list(params_array)
         estimator = Estimator()

--- a/test/python/primitives/test_sampler.py
+++ b/test/python/primitives/test_sampler.py
@@ -324,7 +324,8 @@ class TestSampler(QiskitTestCase):
         qc = RealAmplitudes(num_qubits=2, reps=2)
         qc.measure_all()
         k = 5
-        params_array = np.random.rand(k, qc.num_parameters)
+        rng = np.random.default_rng(12)
+        params_array = rng.random((k, qc.num_parameters))
         params_list = params_array.tolist()
         params_list_array = list(params_array)
         sampler = Sampler()

--- a/test/python/primitives/test_statevector_estimator.py
+++ b/test/python/primitives/test_statevector_estimator.py
@@ -236,13 +236,17 @@ class TestStatevectorEstimator(QiskitTestCase):
             est.run([(qc, op)], precision=-1).result()
         with self.assertRaises(ValueError):
             est.run([(qc, 1j * op)], precision=0.1).result()
+        with self.subTest("missing []"):
+            with self.assertRaisesRegex(ValueError, "An invalid Estimator pub-like was given"):
+                _ = est.run((qc, op)).result()
 
     def test_run_numpy_params(self):
         """Test for numpy array as parameter values"""
         qc = RealAmplitudes(num_qubits=2, reps=2)
         op = SparsePauliOp.from_list([("IZ", 1), ("XI", 2), ("ZY", -1)])
         k = 5
-        params_array = np.random.rand(k, qc.num_parameters)
+        rng = np.random.default_rng(12)
+        params_array = rng.random((k, qc.num_parameters))
         params_list = params_array.tolist()
         params_list_array = list(params_array)
         estimator = StatevectorEstimator()

--- a/test/python/primitives/test_statevector_sampler.py
+++ b/test/python/primitives/test_statevector_sampler.py
@@ -323,6 +323,9 @@ class TestStatevectorSampler(QiskitTestCase):
         with self.subTest("missing []"):
             with self.assertRaisesRegex(ValueError, "An invalid Sampler pub-like was given"):
                 _ = sampler.run(qc1).result()
+        with self.subTest("missing [] for pqc"):
+            with self.assertRaisesRegex(ValueError, "Note that if you want to run a single pub,"):
+                _ = sampler.run((qc2, [0, 1])).result()
 
     def test_run_empty_parameter(self):
         """Test for empty parameter"""

--- a/test/python/primitives/test_statevector_sampler.py
+++ b/test/python/primitives/test_statevector_sampler.py
@@ -320,6 +320,9 @@ class TestStatevectorSampler(QiskitTestCase):
         with self.subTest("zero shots, pub"):
             with self.assertRaises(ValueError):
                 _ = sampler.run([SamplerPub(qc1, shots=0)]).result()
+        with self.subTest("missing []"):
+            with self.assertRaisesRegex(ValueError, "An invalid Sampler pub-like was given"):
+                _ = sampler.run(qc1).result()
 
     def test_run_empty_parameter(self):
         """Test for empty parameter"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

If users want to run a circuit with SamplerV2, they need to call `SamplerV2.run([circuit])` according to the spec.
https://github.com/Qiskit/qiskit/blob/00b0952c47c5b63edff2674b7e5de4b8f5256927/qiskit/primitives/base/base_sampler.py#L166-L167

But, they may miss `[]` but the corresponding error message was not comprehensive as follows. This PR detects such a case and shows more comprehensive message.

```python
from qiskit import QuantumCircuit
from qiskit.circuit.library import RealAmplitudes
from qiskit.primitives import StatevectorSampler

qc = QuantumCircuit(1, 1)
qc.h(0)
qc.measure(0, 0)

sampler = StatevectorSampler()
result = sampler.run([qc]).result()
# OK

result = sampler.run(qc).result()
# NG
```

output
main branch:
> AttributeError: '_SingletonHGate' object has no attribute 'parameters'

this PR:
> ValueError: An invalid Sampler pub-like was given (<class 'qiskit._accelerate.quantum_circuit.CircuitInstruction'>). If you want to run a single circuit, you need to wrap it with `[]` like `sampler.run([circuit])` instead of `sampler.run(circuit)`.

----------------

I also added a similar error message for Estimator V2 as suggested by @ElePT.
```python
from qiskit import QuantumCircuit
from qiskit.circuit.library import RealAmplitudes
from qiskit.primitives import StatevectorEstimator

qc = QuantumCircuit(1, 1)
qc.h(0)
qc.h(0)
qc.h(0)

estimator = StatevectorEstimator()
result = estimator.run([(qc, "Z")]).result()
# OK

result = estimator.run((qc, "Z")).result()
# NG
```

output

main branch
> TypeError: Invalid observable type: <class 'qiskit._accelerate.quantum_circuit.CircuitInstruction'>

this PR
> ValueError: An invalid Estimator pub-like was given (<class 'qiskit.circuit.quantumcircuit.QuantumCircuit'>). If you want to run a single pub-like, you need to wrap it with `[]` like `estimator.run([(circuit, observables, param_values)])` instead of `estimator.run((circuit, observables, param_values))`.

### Details and comments

In addition to the error messages, I fixed random seed for primitives tests (replaced `np.random.rand` with `np.random.default_rng`).

