### PR TITLE
Fix custom constraints in `transpile` with `BackendV2`

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -81,7 +81,10 @@ def transpile(  # pylint: disable=too-many-return-statements
     ``dt`` or ``timing_constraints``). If a ``backend`` is provided together with any loose constraint
     from the list above, the loose constraint will take priority over the corresponding backend
     constraint. This behavior is independent of whether the ``backend`` instance is of type
-    :class:`.BackendV1` or :class:`.BackendV2`, as summarized in the table below:
+    :class:`.BackendV1` or :class:`.BackendV2`, as summarized in the table below. The first column
+    in the table summarizes the potential user-provided constraints, and each cell shows whether
+    the priority is assigned to that specific constraint input or another input
+    (`target`/`backend(V1)`/`backend(V2)`).
 
     ============================ ========= ======================== =======================
     User Provided                target    backend(V1)              backend(V2)

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -328,7 +328,7 @@ def transpile(  # pylint: disable=too-many-return-statements
     # it is invalidated by a custom basis gate list, custom coupling map,
     # custom dt or custom instruction_durations
     elif (
-        basis_gates is not None
+        basis_gates is not None  # pylint: disable=too-many-boolean-expressions
         or coupling_map is not None
         or dt is not None
         or instruction_durations is not None

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -325,8 +325,14 @@ def transpile(  # pylint: disable=too-many-return-statements
             backend_properties = target_to_backend_properties(target)
     # If target is not specified and any hardware constraint object is
     # manually specified then do not use the target from the backend as
-    # it is invalidated by a custom basis gate list or a custom coupling map
-    elif basis_gates is not None or coupling_map is not None:
+    # it is invalidated by a custom basis gate list, custom coupling map,
+    # custom dt or custom instruction_durations
+    elif (
+        basis_gates is not None
+        or coupling_map is not None
+        or dt is not None
+        or instruction_durations is not None
+    ):
         _skip_target = True
     else:
         target = getattr(backend, "target", None)

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -333,6 +333,7 @@ def transpile(  # pylint: disable=too-many-return-statements
         or dt is not None
         or instruction_durations is not None
         or backend_properties is not None
+        or timing_constraints is not None
     ):
         _skip_target = True
     else:

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017, 2019.
+# (C) Copyright IBM 2017, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -72,8 +72,28 @@ def transpile(  # pylint: disable=too-many-return-statements
     """Transpile one or more circuits, according to some desired transpilation targets.
 
     Transpilation is potentially done in parallel using multiprocessing when ``circuits``
-    is a list with > 1 :class:`~.QuantumCircuit` object depending on the local environment
+    is a list with > 1 :class:`~.QuantumCircuit` object, depending on the local environment
     and configuration.
+
+    The prioritization of transpilation target constraints works as follows: if a ``target``
+    input is provided, it will take priority over any ``backend`` input or loose constraints
+    (``basis_gates``, ``inst_map``, ``coupling_map``, ``backend_properties``, ``instruction_durations``,
+    ``dt`` or ``timing_constraints``). If a ``backend`` is provided together with any loose constraint
+    from the list above, the loose constraint will take priority over the corresponding backend
+    constraint. This behavior is independent of whether the ``backend`` instance is of type
+    :class:`.BackendV1` or :class:`.BackendV2`, as summarized in the table below:
+
+    ============================ ========= ======================== =======================
+    priority?                    target    backend(V1)              backend(V2)
+    ============================ ========= ======================== =======================
+    **basis_gates**              target    basis_gates              basis_gates
+    **coupling_map**             target    coupling_map             coupling_map
+    **instruction_durations**    target    instruction_durations    instruction_durations
+    **inst_map**                 target    inst_map                 inst_map
+    **dt**                       target    dt                       dt
+    **timing_constraints**       target    timing_constraints       timing_constraints
+    **backend_properties**       target    backend_properties       backend_properties
+    ============================ ========= ======================== =======================
 
     Args:
         circuits: Circuit(s) to transpile

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -84,7 +84,7 @@ def transpile(  # pylint: disable=too-many-return-statements
     :class:`.BackendV1` or :class:`.BackendV2`, as summarized in the table below:
 
     ============================ ========= ======================== =======================
-    priority?                    target    backend(V1)              backend(V2)
+    User Provided                target    backend(V1)              backend(V2)
     ============================ ========= ======================== =======================
     **basis_gates**              target    basis_gates              basis_gates
     **coupling_map**             target    coupling_map             coupling_map

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -332,6 +332,7 @@ def transpile(  # pylint: disable=too-many-return-statements
         or coupling_map is not None
         or dt is not None
         or instruction_durations is not None
+        or backend_properties is not None
     ):
         _skip_target = True
     else:

--- a/qiskit/transpiler/passes/scheduling/alignments/check_durations.py
+++ b/qiskit/transpiler/passes/scheduling/alignments/check_durations.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,6 +14,7 @@
 from qiskit.circuit.delay import Delay
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import AnalysisPass
+from qiskit.transpiler import Target
 
 
 class InstructionDurationCheck(AnalysisPass):
@@ -28,11 +29,7 @@ class InstructionDurationCheck(AnalysisPass):
     of the hardware alignment constraints, which is true in general.
     """
 
-    def __init__(
-        self,
-        acquire_alignment: int = 1,
-        pulse_alignment: int = 1,
-    ):
+    def __init__(self, acquire_alignment: int = 1, pulse_alignment: int = 1, target: Target = None):
         """Create new duration validation pass.
 
         The alignment values depend on the control electronics of your quantum processor.
@@ -42,10 +39,16 @@ class InstructionDurationCheck(AnalysisPass):
                 trigger acquisition instruction in units of ``dt``.
             pulse_alignment: Integer number representing the minimum time resolution to
                 trigger gate instruction in units of ``dt``.
+            target: The :class:`~.Target` representing the target backend, if
+                ``target`` is specified then this argument will take
+                precedence and ``acquire_alignment`` and ``pulse_alignment`` will be ignored.
         """
         super().__init__()
         self.acquire_align = acquire_alignment
         self.pulse_align = pulse_alignment
+        if target is not None:
+            self.acquire_align = target.acquire_alignment
+            self.pulse_align = target.pulse_alignment
 
     def run(self, dag: DAGCircuit):
         """Run duration validation passes.

--- a/qiskit/transpiler/passes/scheduling/alignments/pulse_gate_validation.py
+++ b/qiskit/transpiler/passes/scheduling/alignments/pulse_gate_validation.py
@@ -16,6 +16,7 @@ from qiskit.dagcircuit import DAGCircuit
 from qiskit.pulse import Play
 from qiskit.transpiler.basepasses import AnalysisPass
 from qiskit.transpiler.exceptions import TranspilerError
+from qiskit.transpiler import Target
 
 
 class ValidatePulseGates(AnalysisPass):
@@ -43,6 +44,7 @@ class ValidatePulseGates(AnalysisPass):
         self,
         granularity: int = 1,
         min_length: int = 1,
+        target: Target = None,
     ):
         """Create new pass.
 
@@ -53,10 +55,16 @@ class ValidatePulseGates(AnalysisPass):
             min_length: Integer number representing the minimum data point length to
                 define the pulse gate in units of ``dt``. This value depends on
                 the control electronics of your quantum processor.
+            target: The :class:`~.Target` representing the target backend, if
+                ``target`` is specified then this argument will take
+                precedence and ``granularity`` and ``min_length`` will be ignored.
         """
         super().__init__()
         self.granularity = granularity
         self.min_length = min_length
+        if target is not None:
+            self.granularity = target.granularity
+            self.min_length = target.min_length
 
     def run(self, dag: DAGCircuit):
         """Run the pulse gate validation attached to ``dag``.

--- a/qiskit/transpiler/passes/scheduling/alignments/reschedule.py
+++ b/qiskit/transpiler/passes/scheduling/alignments/reschedule.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -20,6 +20,7 @@ from qiskit.circuit.measure import Measure
 from qiskit.dagcircuit import DAGCircuit, DAGOpNode, DAGOutNode
 from qiskit.transpiler.basepasses import AnalysisPass
 from qiskit.transpiler.exceptions import TranspilerError
+from qiskit.transpiler import Target
 
 
 class ConstrainedReschedule(AnalysisPass):
@@ -63,6 +64,7 @@ class ConstrainedReschedule(AnalysisPass):
         self,
         acquire_alignment: int = 1,
         pulse_alignment: int = 1,
+        target: Target = None,
     ):
         """Create new rescheduler pass.
 
@@ -73,10 +75,16 @@ class ConstrainedReschedule(AnalysisPass):
                 trigger acquisition instruction in units of ``dt``.
             pulse_alignment: Integer number representing the minimum time resolution to
                 trigger gate instruction in units of ``dt``.
+            target: The :class:`~.Target` representing the target backend, if
+                ``target`` is specified then this argument will take
+                precedence and ``acquire_alignment`` and ``pulse_alignment`` will be ignored.
         """
         super().__init__()
         self.acquire_align = acquire_alignment
         self.pulse_align = pulse_alignment
+        if target is not None:
+            self.acquire_align = target.acquire_alignment
+            self.pulse_align = target.pulse_alignment
 
     @classmethod
     def _get_next_gate(cls, dag: DAGCircuit, node: DAGOpNode) -> Generator[DAGOpNode, None, None]:

--- a/qiskit/transpiler/preset_passmanagers/common.py
+++ b/qiskit/transpiler/preset_passmanagers/common.py
@@ -584,6 +584,7 @@ def generate_scheduling(
             InstructionDurationCheck(
                 acquire_alignment=timing_constraints.acquire_alignment,
                 pulse_alignment=timing_constraints.pulse_alignment,
+                target=target,
             )
         )
         scheduling.append(
@@ -591,6 +592,7 @@ def generate_scheduling(
                 ConstrainedReschedule(
                     acquire_alignment=timing_constraints.acquire_alignment,
                     pulse_alignment=timing_constraints.pulse_alignment,
+                    target=target,
                 ),
                 condition=_require_alignment,
             )
@@ -599,6 +601,7 @@ def generate_scheduling(
             ValidatePulseGates(
                 granularity=timing_constraints.granularity,
                 min_length=timing_constraints.min_length,
+                target=target,
             )
         )
     if scheduling_method:

--- a/releasenotes/notes/fix-custom-transpile-constraints-5defa36d540d1608.yaml
+++ b/releasenotes/notes/fix-custom-transpile-constraints-5defa36d540d1608.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    A bug in :func:`.transpile` has been fixed where custom `instruction_durations` and `dt` constraints
+    would be ignored when provided at the same time as a backend of type :class:`.BackendV2`. The behavior
+    after the fix is now independent of whether the provided backend is of type :class:`.BackendV1` or
+    type :class:`.BackendV2`.

--- a/releasenotes/notes/fix-custom-transpile-constraints-5defa36d540d1608.yaml
+++ b/releasenotes/notes/fix-custom-transpile-constraints-5defa36d540d1608.yaml
@@ -1,7 +1,21 @@
 ---
 fixes:
   - |
-    A bug in :func:`.transpile` has been fixed where custom `instruction_durations` and `dt` constraints
-    would be ignored when provided at the same time as a backend of type :class:`.BackendV2`. The behavior
+    A bug in :func:`.transpile` has been fixed where custom ``instruction_durations``, ``dt`` and ``backend_properties``
+    constraints would be ignored when provided at the same time as a backend of type :class:`.BackendV2`. The behavior
     after the fix is now independent of whether the provided backend is of type :class:`.BackendV1` or
-    type :class:`.BackendV2`.
+    type :class:`.BackendV2`. Similarly, custom ``timing_constraints`` are now overridden by ``target`` inputs
+    but take precedence over :class:`.BackendV1` and :class:`.BackendV2` inputs.
+
+features_transpiler:
+  - |
+    The following analysis passes now accept constraints encoded in a :class:`.Target` thanks to a new ``target`` 
+    input argument:
+    
+      * :class:`.InstructionDurationCheck`
+      * :class:`.ConstrainedReschedule`
+      * :class:`.ValidatePulseGates`
+    
+    The target constraints will have priority over user-provided constraints, for coherence with the rest of 
+    the transpiler pipeline.
+    

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -75,7 +75,7 @@ from qiskit.dagcircuit import DAGOpNode, DAGOutNode
 from qiskit.exceptions import QiskitError
 from qiskit.providers.backend import BackendV2
 from qiskit.providers.backend_compat import BackendV2Converter
-from qiskit.providers.fake_provider import Fake5QV1, Fake20QV1, Fake27QPulseV1, GenericBackendV2
+from qiskit.providers.fake_provider import Fake20QV1, Fake27QPulseV1, GenericBackendV2
 from qiskit.providers.basic_provider import BasicSimulator
 from qiskit.providers.options import Options
 from qiskit.pulse import InstructionScheduleMap, Schedule, Play, Gaussian, DriveChannel
@@ -96,7 +96,7 @@ from qiskit.transpiler.target import (
 
 from test import QiskitTestCase, combine, slow_test  # pylint: disable=wrong-import-order
 
-from ..legacy_cmaps import MELBOURNE_CMAP, RUESCHLIKON_CMAP, TOKYO_CMAP
+from ..legacy_cmaps import MELBOURNE_CMAP, RUESCHLIKON_CMAP
 
 
 class CustomCX(Gate):

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -75,7 +75,7 @@ from qiskit.dagcircuit import DAGOpNode, DAGOutNode
 from qiskit.exceptions import QiskitError
 from qiskit.providers.backend import BackendV2
 from qiskit.providers.backend_compat import BackendV2Converter
-from qiskit.providers.fake_provider import Fake20QV1, Fake27QPulseV1, GenericBackendV2
+from qiskit.providers.fake_provider import Fake5QV1, Fake20QV1, Fake27QPulseV1, GenericBackendV2
 from qiskit.providers.basic_provider import BasicSimulator
 from qiskit.providers.options import Options
 from qiskit.pulse import InstructionScheduleMap, Schedule, Play, Gaussian, DriveChannel
@@ -91,11 +91,12 @@ from qiskit.transpiler.target import (
     Target,
     TimingConstraints,
     InstructionDurations,
+    target_to_backend_properties,
 )
 
 from test import QiskitTestCase, combine, slow_test  # pylint: disable=wrong-import-order
 
-from ..legacy_cmaps import MELBOURNE_CMAP, RUESCHLIKON_CMAP
+from ..legacy_cmaps import MELBOURNE_CMAP, RUESCHLIKON_CMAP, TOKYO_CMAP
 
 
 class CustomCX(Gate):
@@ -1542,7 +1543,7 @@ class TestTranspile(QiskitTestCase):
 
     def test_scheduling_instruction_constraints(self):
         """Test that scheduling-related loose transpile constraints
-        work with BackendV1."""
+        work with both BackendV1 and BackendV2."""
 
         backend_v1 = Fake27QPulseV1()
         backend_v2 = BackendV2Converter(backend_v1)
@@ -1567,7 +1568,7 @@ class TestTranspile(QiskitTestCase):
 
     def test_scheduling_dt_constraints(self):
         """Test that scheduling-related loose transpile constraints
-        work with BackendV1."""
+        work with both BackendV1 and BackendV2."""
 
         backend_v1 = Fake27QPulseV1()
         backend_v2 = BackendV2Converter(backend_v1)
@@ -1584,6 +1585,62 @@ class TestTranspile(QiskitTestCase):
                     qc, backend=backend, scheduling_method="asap", dt=original_dt / 2
                 )
                 self.assertEqual(scheduled.duration, original_duration * 2)
+
+    def test_backend_props_constraints(self):
+        """Test that loose transpile constraints
+        work with both BackendV1 and BackendV2."""
+
+        backend_v1 = Fake20QV1()
+        backend_v2 = BackendV2Converter(backend_v1)
+        qr1 = QuantumRegister(3, "qr1")
+        qr2 = QuantumRegister(2, "qr2")
+        qc = QuantumCircuit(qr1, qr2)
+        qc.cx(qr1[0], qr1[1])
+        qc.cx(qr1[1], qr1[2])
+        qc.cx(qr1[2], qr2[0])
+        qc.cx(qr2[0], qr2[1])
+
+        # generate a fake backend with same number of qubits
+        # but different backend properties
+        fake_backend = GenericBackendV2(num_qubits=20, seed=42)
+        custom_backend_properties = target_to_backend_properties(fake_backend.target)
+
+        # expected layout for custom_backend_properties
+        # (different from expected layout for Fake20QV1)
+        vf2_layout = {
+            18: Qubit(QuantumRegister(3, "qr1"), 1),
+            13: Qubit(QuantumRegister(3, "qr1"), 2),
+            19: Qubit(QuantumRegister(3, "qr1"), 0),
+            14: Qubit(QuantumRegister(2, "qr2"), 0),
+            9: Qubit(QuantumRegister(2, "qr2"), 1),
+            0: Qubit(QuantumRegister(15, "ancilla"), 0),
+            1: Qubit(QuantumRegister(15, "ancilla"), 1),
+            2: Qubit(QuantumRegister(15, "ancilla"), 2),
+            3: Qubit(QuantumRegister(15, "ancilla"), 3),
+            4: Qubit(QuantumRegister(15, "ancilla"), 4),
+            5: Qubit(QuantumRegister(15, "ancilla"), 5),
+            6: Qubit(QuantumRegister(15, "ancilla"), 6),
+            7: Qubit(QuantumRegister(15, "ancilla"), 7),
+            8: Qubit(QuantumRegister(15, "ancilla"), 8),
+            10: Qubit(QuantumRegister(15, "ancilla"), 9),
+            11: Qubit(QuantumRegister(15, "ancilla"), 10),
+            12: Qubit(QuantumRegister(15, "ancilla"), 11),
+            15: Qubit(QuantumRegister(15, "ancilla"), 12),
+            16: Qubit(QuantumRegister(15, "ancilla"), 13),
+            17: Qubit(QuantumRegister(15, "ancilla"), 14),
+        }
+
+        for backend in [backend_v1, backend_v2]:
+            with self.subTest(backend=backend):
+                result = transpile(
+                    qc,
+                    backend=backend,
+                    backend_properties=custom_backend_properties,
+                    optimization_level=2,
+                    seed_transpiler=42,
+                )
+
+                self.assertEqual(result._layout.initial_layout._p2v, vf2_layout)
 
     @data(1, 2, 3)
     def test_no_infinite_loop(self, optimization_level):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR proposes a fix for the issue raised in https://github.com/Qiskit/qiskit/issues/11994, where custom scheduling constraints would be ignored when a `BackendV2` backend was provided to `transpile`. This happened because the underlying passes prioritize the information encoded in the target over user-provided information, which would set a clear order of priorities  with `BackendV1`: `custom target constraints>custom input constraints>backend constraints`, but a not so clear one with `BackendV2`, where `custom target constraints` and `backend target constraints` would be treated both as "target constraints", leading to the backend constraints always overriding the custom input ones.

The proposed solution is to extend the approach already used for custom `coupling_map`s and `basis_gates`: setting the `_skip_target` flag to `True` in these cases. This way, the priority order already established for `BackendV1` inputs will be maintained for target-based backends:

```custom target > custom individual constraints > backend.target ```

### Details and comments
- The unit tests that ensure that the outputs of `transpile` are the same for v1 and v2 backends are in `test_transpiler.py`, which I believe makes sense, because this PR is at the intersection of the scheduling passes and the `transpiler` interface.
- I have labelled this PR as a bugfix because I believe this discrepancy betweeen backend v1 and v2 was mostly an oversight, and users shouldn't expect the output /behavior of `transpile` to change when transitioning to v2, but let me know if you disagree.
- This PR sets the stage for #11996