### PR TITLE
Added the ctrl_state parameter to mcx() function

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -4203,7 +4203,7 @@ class QuantumCircuit:
         target_qubit: QubitSpecifier,
         ancilla_qubits: QubitSpecifier | Sequence[QubitSpecifier] | None = None,
         mode: str = "noancilla",
-        ctrl_state: str | int | None = None
+        ctrl_state: str | int | None = None,
     ) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.MCXGate`.
 
@@ -4245,7 +4245,9 @@ class QuantumCircuit:
             # outdated, previous names
             "advanced": MCXRecursive(num_ctrl_qubits, ctrl_state=ctrl_state),
             "basic": MCXVChain(num_ctrl_qubits, dirty_ancillas=False, ctrl_state=ctrl_state),
-            "basic-dirty-ancilla": MCXVChain(num_ctrl_qubits, dirty_ancillas=True, ctrl_state=ctrl_state),
+            "basic-dirty-ancilla": MCXVChain(
+                num_ctrl_qubits, dirty_ancillas=True, ctrl_state=ctrl_state
+            ),
         }
 
         # check ancilla input

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -4203,6 +4203,7 @@ class QuantumCircuit:
         target_qubit: QubitSpecifier,
         ancilla_qubits: QubitSpecifier | Sequence[QubitSpecifier] | None = None,
         mode: str = "noancilla",
+        ctrl_state: str | int | None = None
     ) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.MCXGate`.
 
@@ -4221,6 +4222,7 @@ class QuantumCircuit:
             target_qubit: The qubit(s) targeted by the gate.
             ancilla_qubits: The qubits used as the ancillae, if the mode requires them.
             mode: The choice of mode, explained further above.
+            ctrl_state: The control state in decimal, or as a bitstring (e.g. '1').  Defaults to controlling on the '1' state.
 
         Returns:
             A handle to the instructions created.
@@ -4234,14 +4236,14 @@ class QuantumCircuit:
         num_ctrl_qubits = len(control_qubits)
 
         available_implementations = {
-            "noancilla": MCXGrayCode(num_ctrl_qubits),
-            "recursion": MCXRecursive(num_ctrl_qubits),
-            "v-chain": MCXVChain(num_ctrl_qubits, False),
-            "v-chain-dirty": MCXVChain(num_ctrl_qubits, dirty_ancillas=True),
+            "noancilla": MCXGrayCode(num_ctrl_qubits,ctrl_state=ctrl_state),
+            "recursion": MCXRecursive(num_ctrl_qubits,ctrl_state=ctrl_state),
+            "v-chain": MCXVChain(num_ctrl_qubits, False,ctrl_state=ctrl_state),
+            "v-chain-dirty": MCXVChain(num_ctrl_qubits, dirty_ancillas=True,ctrl_state=ctrl_state),
             # outdated, previous names
-            "advanced": MCXRecursive(num_ctrl_qubits),
-            "basic": MCXVChain(num_ctrl_qubits, dirty_ancillas=False),
-            "basic-dirty-ancilla": MCXVChain(num_ctrl_qubits, dirty_ancillas=True),
+            "advanced": MCXRecursive(num_ctrl_qubits,ctrl_state=ctrl_state),
+            "basic": MCXVChain(num_ctrl_qubits, dirty_ancillas=False,ctrl_state=ctrl_state),
+            "basic-dirty-ancilla": MCXVChain(num_ctrl_qubits, dirty_ancillas=True,ctrl_state=ctrl_state),
         }
 
         # check ancilla input

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -4238,14 +4238,14 @@ class QuantumCircuit:
         num_ctrl_qubits = len(control_qubits)
 
         available_implementations = {
-            "noancilla": MCXGrayCode(num_ctrl_qubits,ctrl_state=ctrl_state),
-            "recursion": MCXRecursive(num_ctrl_qubits,ctrl_state=ctrl_state),
-            "v-chain": MCXVChain(num_ctrl_qubits, False,ctrl_state=ctrl_state),
-            "v-chain-dirty": MCXVChain(num_ctrl_qubits, dirty_ancillas=True,ctrl_state=ctrl_state),
+            "noancilla": MCXGrayCode(num_ctrl_qubits, ctrl_state=ctrl_state),
+            "recursion": MCXRecursive(num_ctrl_qubits, ctrl_state=ctrl_state),
+            "v-chain": MCXVChain(num_ctrl_qubits, False, ctrl_state=ctrl_state),
+            "v-chain-dirty": MCXVChain(num_ctrl_qubits, dirty_ancillas=True, ctrl_state=ctrl_state),
             # outdated, previous names
-            "advanced": MCXRecursive(num_ctrl_qubits,ctrl_state=ctrl_state),
-            "basic": MCXVChain(num_ctrl_qubits, dirty_ancillas=False,ctrl_state=ctrl_state),
-            "basic-dirty-ancilla": MCXVChain(num_ctrl_qubits, dirty_ancillas=True,ctrl_state=ctrl_state),
+            "advanced": MCXRecursive(num_ctrl_qubits, ctrl_state=ctrl_state),
+            "basic": MCXVChain(num_ctrl_qubits, dirty_ancillas=False, ctrl_state=ctrl_state),
+            "basic-dirty-ancilla": MCXVChain(num_ctrl_qubits, dirty_ancillas=True, ctrl_state=ctrl_state),
         }
 
         # check ancilla input

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -4222,7 +4222,9 @@ class QuantumCircuit:
             target_qubit: The qubit(s) targeted by the gate.
             ancilla_qubits: The qubits used as the ancillae, if the mode requires them.
             mode: The choice of mode, explained further above.
-            ctrl_state: The control state in decimal, or as a bitstring (e.g. '1').  Defaults to controlling on the '1' state.
+            ctrl_state:
+                The control state in decimal, or as a bitstring (e.g. '1').  Defaults to controlling
+                on the '1' state.
 
         Returns:
             A handle to the instructions created.

--- a/releasenotes/notes/added-parameter-ctrl_state-mcx-816dcd80e459a5ed.yaml
+++ b/releasenotes/notes/added-parameter-ctrl_state-mcx-816dcd80e459a5ed.yaml
@@ -1,0 +1,18 @@
+---
+features:
+  - |
+    Added ctrl_state parameter to mcx() function.
+
+    The mcx() function in the quantum circuit library has been enhanced to
+    include a ctrl_state parameter, allowing users to specify the control state
+    of the multi-controlled X gate. This parameter can accept either a decimal
+    value or a bitstring and defaults to controlling the '1' state if not
+    provided.
+
+
+    .. code-block:: python
+
+      from qiskit import QuantumCircuit
+      
+      qc = QuantumCircuit(3, 3)
+      qc.mcx([0, 1], 2, ctrl_state="00")

--- a/releasenotes/notes/added-parameter-ctrl_state-mcx-816dcd80e459a5ed.yaml
+++ b/releasenotes/notes/added-parameter-ctrl_state-mcx-816dcd80e459a5ed.yaml
@@ -1,14 +1,14 @@
 ---
 features:
   - |
-    Added ctrl_state parameter to mcx() function.
+    Added `ctrl_state` parameter to :func:`QuantumCircuit.mcx()`.
 
-    The mcx() function in the quantum circuit library has been enhanced to
-    include a ctrl_state parameter, allowing users to specify the control state
-    of the multi-controlled X gate. This parameter can accept either a decimal
-    value or a bitstring and defaults to controlling the '1' state if not
-    provided.
 
+    The :func:`QuantumCircuit.mcx()` function in the quantum circuit library has
+    been enhanced to include a `ctrl_state` parameter, allowing users to specify
+    the control state of the multi-controlled X gate. This parameter can accept
+    either a decimal value or a bitstring and defaults to controlling the '1'
+    state if not provided.
 
     .. code-block:: python
 

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -969,22 +969,24 @@ class TestControlledGate(QiskitTestCase):
         ccx = CCXGate(ctrl_state=0)
         ref_circuit.append(ccx, [qreg[0], qreg[1], qreg[2]])
         self.assertEqual(qc, ref_circuit)
-    
-    @data((4,[0, 1, 2], 3, "010"),(4,[2, 1, 3], 0, "010"))
+
+    @data((4, [0, 1, 2], 3, "010"), (4, [2, 1, 3], 0, "010"))
     @unpack
-    def test_multi_control_x_ctrl_state_parameter(self, num_qubits, ctrl_qubits, target_qubit, ctrl_state):
+    def test_multi_control_x_ctrl_state_parameter(
+        self, num_qubits, ctrl_qubits, target_qubit, ctrl_state
+    ):
         """To check the consistency of parameters ctrl_state in MCX
         See issue: https://github.com/Qiskit/qiskit-terra/issues/12050
         """
         qc = QuantumCircuit(num_qubits)
         qc.mcx(ctrl_qubits, target_qubit, ctrl_state=ctrl_state)
         operator_qc = Operator(qc)
-        
+
         qc1 = QuantumCircuit(num_qubits)
         gate = MCXGate(num_ctrl_qubits=len(ctrl_qubits), ctrl_state=ctrl_state)
-        qc1.append(gate, ctrl_qubits+[target_qubit])
+        qc1.append(gate, ctrl_qubits + [target_qubit])
         operator_qc1 = Operator(qc1)
-        
+
         self.assertEqual(operator_qc, operator_qc1)
 
     def test_open_control_composite_unrolling(self):

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -970,14 +970,12 @@ class TestControlledGate(QiskitTestCase):
         ref_circuit.append(ccx, [qreg[0], qreg[1], qreg[2]])
         self.assertEqual(qc, ref_circuit)
 
-    @data((4, [0, 1, 2], 3, "010"), (4, [2, 1, 3], 0, "010"))
+    @data((4, [0, 1, 2], 3, "010"), (4, [2, 1, 3], 0, 2))
     @unpack
     def test_multi_control_x_ctrl_state_parameter(
         self, num_qubits, ctrl_qubits, target_qubit, ctrl_state
     ):
-        """To check the consistency of parameters ctrl_state in MCX
-        See issue: https://github.com/Qiskit/qiskit-terra/issues/12050
-        """
+        """To check the consistency of parameters ctrl_state in MCX"""
         qc = QuantumCircuit(num_qubits)
         qc.mcx(ctrl_qubits, target_qubit, ctrl_state=ctrl_state)
         operator_qc = Operator(qc)

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -969,6 +969,23 @@ class TestControlledGate(QiskitTestCase):
         ccx = CCXGate(ctrl_state=0)
         ref_circuit.append(ccx, [qreg[0], qreg[1], qreg[2]])
         self.assertEqual(qc, ref_circuit)
+    
+    @data((4,[0, 1, 2], 3, "010"),(4,[2, 1, 3], 0, "010"))
+    @unpack
+    def test_multi_control_x_ctrl_state_parameter(self, num_qubits, ctrl_qubits, target_qubit, ctrl_state):
+        """To check the consistency of parameters ctrl_state in MCX
+        See issue: https://github.com/Qiskit/qiskit-terra/issues/12050
+        """
+        qc = QuantumCircuit(num_qubits)
+        qc.mcx(ctrl_qubits, target_qubit, ctrl_state=ctrl_state)
+        operator_qc = Operator(qc)
+        
+        qc1 = QuantumCircuit(num_qubits)
+        gate = MCXGate(num_ctrl_qubits=len(ctrl_qubits), ctrl_state=ctrl_state)
+        qc1.append(gate, ctrl_qubits+[target_qubit])
+        operator_qc1 = Operator(qc1)
+        
+        self.assertEqual(operator_qc, operator_qc1)
 
     def test_open_control_composite_unrolling(self):
         """test unrolling of open control gates when gate is in basis"""


### PR DESCRIPTION
### Description:

This PR addresses a feature request (#12044) to enhance the functionality of the mcx function in the quantum circuit library. Currently, the mcx function lacks a ctrl_state parameter, limiting its flexibility in certain quantum operations. 

The proposed change modifies the mcx function to include a ctrl_state parameter, allowing users to specify the control state of the multi-controlled X gate. This parameter can accept either a decimal value or a bitstring and defaults to controlling the '1' state if not provided.

### Expected Behavior:
Upon calling the mcx function, users can now pass the ctrl_state parameter to specify the control state for the multi-controlled X gate. This enhancement significantly enhances the functionality and flexibility of the function, enabling users to perform more complex quantum operations efficiently.

### Implementation Details:
- Modified the mcx function to accept the ctrl_state parameter.

@ShellyGarion: Please review the changes and provide feedback. Thank you :D