### PR TITLE
fix typo in soft_compare

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -240,8 +240,8 @@ class Instruction(Operation):
         """
         if (
             self.name != other.name
-            or other.num_qubits != other.num_qubits
-            or other.num_clbits != other.num_clbits
+            or self.num_qubits != other.num_qubits
+            or self.num_clbits != other.num_clbits
             or len(self.params) != len(other.params)
         ):
             return False

--- a/releasenotes/notes/fix_soft_compare-3f4148aab3a4606b.yaml
+++ b/releasenotes/notes/fix_soft_compare-3f4148aab3a4606b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+  The method :meth:`qiskit.instruction.Instruction.soft_compare` is meant to compare whether two gates match in their name, number of qubits, number of clbits, and the number of parameters. However, there was a typo where it would not check the number of qubits and number of clbits for a match. This resolves the apparent typo.

--- a/releasenotes/notes/fix_soft_compare-3f4148aab3a4606b.yaml
+++ b/releasenotes/notes/fix_soft_compare-3f4148aab3a4606b.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-  The method :meth:`qiskit.instruction.Instruction.soft_compare` is meant to compare whether two gates match in their name, number of qubits, number of clbits, and the number of parameters. However, there was a typo where it would not check the number of qubits and number of clbits for a match. This resolves the apparent typo.
+    The method :meth:`qiskit.instruction.Instruction.soft_compare` is meant to compare whether two gates match in their name, number of qubits, number of clbits, and the number of parameters. However, there was a typo where it would not check the number of qubits and number of clbits for a match. This resolves the apparent typo.

--- a/test/python/circuit/test_instructions.py
+++ b/test/python/circuit/test_instructions.py
@@ -119,14 +119,10 @@ class TestInstructions(QiskitTestCase):
         )
 
         # Test that when names are the same but number of qubits differ we get False
-        self.assertFalse(
-            Instruction("u", 1, 0, []).soft_compare(Instruction("u", 2, 0, []))
-        )
+        self.assertFalse(Instruction("u", 1, 0, []).soft_compare(Instruction("u", 2, 0, [])))
 
         # Test that when names are the same but number of clbits differ we get False
-        self.assertFalse(
-            Instruction("u", 1, 0, []).soft_compare(Instruction("u", 1, 1, []))
-        )
+        self.assertFalse(Instruction("u", 1, 0, []).soft_compare(Instruction("u", 1, 1, [])))
 
         # Test cutoff precision.
         self.assertFalse(
@@ -138,7 +134,6 @@ class TestInstructions(QiskitTestCase):
             Instruction("v", 1, 0, [0.4 + 1.0e-20, phi]).soft_compare(
                 Instruction("v", 1, 0, [0.4, phi])
             )
-
         )
 
     def test_instructions_equal_with_parameter_expressions(self):

--- a/test/python/circuit/test_instructions.py
+++ b/test/python/circuit/test_instructions.py
@@ -118,6 +118,16 @@ class TestInstructions(QiskitTestCase):
             Instruction("u", 1, 0, [0.4, phi]).soft_compare(Instruction("v", 1, 0, [theta, phi]))
         )
 
+        # Test that when names are the same but number of qubits differ we get False
+        self.assertFalse(
+            Instruction("u", 1, 0, []).soft_compare(Instruction("u", 2, 0, []))
+        )
+
+        # Test that when names are the same but number of clbits differ we get False
+        self.assertFalse(
+            Instruction("u", 1, 0, []).soft_compare(Instruction("u", 1, 1, []))
+        )
+
         # Test cutoff precision.
         self.assertFalse(
             Instruction("v", 1, 0, [0.401, phi]).soft_compare(Instruction("v", 1, 0, [0.4, phi]))
@@ -128,6 +138,7 @@ class TestInstructions(QiskitTestCase):
             Instruction("v", 1, 0, [0.4 + 1.0e-20, phi]).soft_compare(
                 Instruction("v", 1, 0, [0.4, phi])
             )
+
         )
 
     def test_instructions_equal_with_parameter_expressions(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
This fixes what appears to be a typo in `Instruction.soft_compare`. 

### Summary
This is supposed to return False if the name, number of qubits, number of clbits, or number of parameters are not equal but was ignoring differences in number of qubits and clbits.


### Details and comments


