### PR TITLE
Fix `BackendSamplerV2` when used with an empty classical register

### DIFF
--- a/qiskit/primitives/backend_sampler_v2.py
+++ b/qiskit/primitives/backend_sampler_v2.py
@@ -186,7 +186,10 @@ def _analyze_circuit(circuit: QuantumCircuit) -> tuple[list[_MeasureInfo], int]:
     for creg in circuit.cregs:
         name = creg.name
         num_bits = creg.size
-        start = circuit.find_bit(creg[0]).index
+        if num_bits != 0:
+            start = circuit.find_bit(creg[0]).index
+        else:
+            start = 0
         meas_info.append(
             _MeasureInfo(
                 creg_name=name,

--- a/test/python/primitives/test_backend_sampler_v2.py
+++ b/test/python/primitives/test_backend_sampler_v2.py
@@ -656,6 +656,21 @@ class TestBackendSamplerV2(QiskitTestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(len(result[0].data), 0)
 
+    @combine(backend=BACKENDS)
+    def test_empty_creg(self, backend):
+        """Test that the sampler works if provided a classical register with no bits."""
+        # Test case for issue #12043
+        q = QuantumRegister(1, "q")
+        c1 = ClassicalRegister(0, "c1")
+        c2 = ClassicalRegister(1, "c2")
+        qc = QuantumCircuit(q, c1, c2)
+        qc.h(0)
+        qc.measure(0, 0)
+
+        sampler = BackendSamplerV2(backend=backend, options=self._options)
+        result = sampler.run([qc], shots=self._shots).result()
+        self.assertEqual(result[0].data.c1.array.shape, (self._shots, 0))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #12043


### Details and comments

Remaining action items:
- [x] ~~fix `get_counts` (currently throws an error in `reshape` because an array dimension is zero)~~ This is a problem with `BitArray`, not `BackendSamplerV2`, so I opened an issue instead: #12062