### PR TITLE
Fixing Operator.from_circuit for circuits with final layouts and a non-trivial initial layout

### DIFF
--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -81,6 +81,9 @@ class Operator(LinearOp):
             a Numpy array of shape (2**N, 2**N) qubit systems will be used. If
             the input operator is not an N-qubit operator, it will assign a
             single subsystem with dimension specified by the shape of the input.
+            Note that two operators initialized via this method are only considered equivalent if they
+            match up to their canonical qubit order (or: permutation). See :meth:`.Operator.from_circuit`
+            to specify a different qubit permutation.
         """
         op_shape = None
         if isinstance(data, (list, np.ndarray)):
@@ -420,14 +423,13 @@ class Operator(LinearOp):
         # Convert circuit to an instruction
         instruction = circuit.to_instruction()
         op._append_instruction(instruction, qargs=qargs)
-        # If final layout is set permute output indices based on layout
+        # If final layout is set permute output indices based on that layout combined with initial layout
         if final_layout is not None:
             perm_pattern = [
                 layout.input_qubit_mapping[layout.initial_layout._p2v[final_layout._v2p[v]]]
                 for v in circuit.qubits
             ]
             perm_pattern = [perm_pattern[i] for i in layout.initial_layout.get_physical_bits()]
-
             op = op.apply_permutation(perm_pattern, front=False)
         return op
 

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -425,11 +425,14 @@ class Operator(LinearOp):
         op._append_instruction(instruction, qargs=qargs)
         # If final layout is set permute output indices based on that layout combined with initial layout
         if final_layout is not None:
-            perm_pattern = [
-                layout.input_qubit_mapping[layout.initial_layout._p2v[final_layout._v2p[v]]]
-                for v in circuit.qubits
-            ]
-            perm_pattern = [perm_pattern[i] for i in layout.initial_layout.get_physical_bits()]
+            if layout is None:
+                perm_pattern = [final_layout._v2p[v] for v in circuit.qubits]
+            else:
+                perm_pattern = [
+                    layout.input_qubit_mapping[layout.initial_layout._p2v[final_layout._v2p[v]]]
+                    for v in circuit.qubits
+                ]
+                perm_pattern = [perm_pattern[i] for i in layout.initial_layout.get_physical_bits()]
             op = op.apply_permutation(perm_pattern, front=False)
         return op
 

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -422,7 +422,12 @@ class Operator(LinearOp):
         op._append_instruction(instruction, qargs=qargs)
         # If final layout is set permute output indices based on layout
         if final_layout is not None:
-            perm_pattern = [final_layout._v2p[v] for v in circuit.qubits]
+            perm_pattern = [
+                layout.input_qubit_mapping[layout.initial_layout._p2v[final_layout._v2p[v]]]
+                for v in circuit.qubits
+            ]
+            perm_pattern = [perm_pattern[i] for i in layout.initial_layout.get_physical_bits()]
+
             op = op.apply_permutation(perm_pattern, front=False)
         return op
 

--- a/qiskit/transpiler/layout.py
+++ b/qiskit/transpiler/layout.py
@@ -368,6 +368,76 @@ class Layout:
             out.add_register(qreg)
         return out
 
+    def compose(self, other: Layout, qubits: List[Qubit]) -> Layout:
+        """Compose this layout with another layout.
+
+        If this layout represents a mapping from the P-qubits to the positions of the Q-qubits,
+        and the other layout represents a mapping from the Q-qubits to the positions of
+        the R-qubits, then the composed layout represents a mapping from the P-qubits to the
+        positions of the R-qubits.
+
+        Args:
+            other: The existing :class:`.Layout` to compose this :class:`.Layout` with.
+            qubits: A list of :class:`.Qubit` objects over which ``other`` is defined,
+                used to establish the correspondence between the positions of the ``other``
+                qubits and the actual qubits.
+
+        Returns:
+            A new layout object the represents this layout composed with the ``other`` layout.
+        """
+        other_v2p = other.get_virtual_bits()
+        return Layout({virt: other_v2p[qubits[phys]] for virt, phys in self._v2p.items()})
+
+    def inverse(self, source_qubits: List[Qubit], target_qubits: List[Qubit]):
+        """Finds the inverse of this layout.
+
+        This is possible when the layout is a bijective mapping, however the input
+        and the output qubits may be different (in particular, this layout may be
+        the mapping from the extended-with-ancillas virtual qubits to physical qubits).
+        Thus, if this layout represents a mapping from the P-qubits to the positions
+        of the Q-qubits, the inverse layout represents a mapping from the Q-qubits
+        to the positions of the P-qubits.
+
+        Args:
+            source_qubits: A list of :class:`.Qubit` objects representing the domain
+                of the layout.
+            target_qubits: A list of :class:`.Qubit` objects representing the image
+                of the layout.
+
+        Returns:
+            A new layout object the represents the inverse of this layout.
+        """
+        source_qubit_to_position = {q: p for p, q in enumerate(source_qubits)}
+        return Layout(
+            {
+                target_qubits[pos_phys]: source_qubit_to_position[virt]
+                for virt, pos_phys in self._v2p.items()
+            }
+        )
+
+    def to_permutation(self, qubits: List[Qubit]):
+        """Creates a permutation corresponding to this layout.
+
+        This is possible when the layout is a bijective mapping with the same
+        source and target qubits (for instance, a "final_layout" corresponds
+        to a permutation of the physical circuit qubits). If this layout is
+        a mapping from qubits to their new positions, the resulting permutation
+        describes which qubits occupy the positions 0, 1, 2, etc. after
+        applying the permutation.
+
+        For example, suppose that the list of qubits is ``[qr_0, qr_1, qr_2]``,
+        and the layout maps ``qr_0`` to ``2``, ``qr_1`` to ``0``, and
+        ``qr_2`` to ``1``. In terms of positions in ``qubits``, this maps ``0``
+        to ``2``, ``1`` to ``0`` and ``2`` to ``1``, with the corresponding
+        permutation being ``[1, 2, 0]``.
+        """
+
+        perm = [None] * len(qubits)
+        for i, q in enumerate(qubits):
+            pos = self._v2p[q]
+            perm[pos] = i
+        return perm
+
 
 @dataclass
 class TranspileLayout:

--- a/releasenotes/notes/operator-from-circuit-bugfix-5dab5993526a2b0a.yaml
+++ b/releasenotes/notes/operator-from-circuit-bugfix-5dab5993526a2b0a.yaml
@@ -1,12 +1,7 @@
 ---
-features_quantum_info:
+fixes:
   - |
-    Added a new test case to check the initialization of :class:`.Operator` via :meth:`.Operator.from_circuit`
-    when both an initial layout and a final layout is specified in the `_layout` attribute of a :class:`.QuantumCircuit` object.
+    Fixed an issue with the :meth:`.Operator.from_circuit` constructor method where it would incorrectly
+    interpret the final layout permutation resulting in an invalid `Operator` being constructed.
     Previously, the final layout was processed without regards for the initial layout, i.e. the
-    initialization was incorrect for all quantum circuits that have a non-trivial initial layout. In
-    addition, this behavior was fixed in :meth:`.Operator.from_circuit`, i.e. an :class:`.Operator` can
-    now be correctly initialized from a quantum circuit with arbitrary initial and final layouts.
-    Lastly, the documentation of the constructor of :class:`.Operator` was adapted to hint to :meth:`.Operator.from_circuit`
-    when e.g. the equivalency of two operators should be determined with non-canonical qubit permutations
-    specified via initial and final layouts.
+    initialization was incorrect for all quantum circuits that have a non-trivial initial layout.

--- a/releasenotes/notes/operator-from-circuit-bugfix-5dab5993526a2b0a.yaml
+++ b/releasenotes/notes/operator-from-circuit-bugfix-5dab5993526a2b0a.yaml
@@ -1,0 +1,12 @@
+---
+features_quantum_info:
+  - |
+    Added a new test case to check the initialization of :class:`.Operator` via :meth:`.Operator.from_circuit`
+    when both an initial layout and a final layout is specified in the `_layout` attribute of a :class:`.QuantumCircuit` object.
+    Previously, the final layout was processed without regards for the initial layout, i.e. the
+    initialization was incorrect for all quantum circuits that have a non-trivial initial layout. In
+    addition, this behavior was fixed in :meth:`.Operator.from_circuit`, i.e. an :class:`.Operator` can
+    now be correctly initialized from a quantum circuit with arbitrary initial and final layouts.
+    Lastly, the documentation of the constructor of :class:`.Operator` was adapted to hint to :meth:`.Operator.from_circuit`
+    when e.g. the equivalency of two operators should be determined with non-canonical qubit permutations
+    specified via initial and final layouts.

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -747,6 +747,7 @@ class TestOperator(OperatorTestCase):
         qc.cx(1, 3)
         qc.cx(1, 4)
         qc.h(2)
+
         qc_transpiled = transpile(
             qc,
             coupling_map=CouplingMap.from_line(5),
@@ -754,6 +755,7 @@ class TestOperator(OperatorTestCase):
             optimization_level=1,
             seed_transpiler=17,
         )
+
         self.assertTrue(Operator.from_circuit(qc_transpiled).equiv(qc))
 
     def test_from_circuit_constructor_reverse_embedded_layout(self):

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -841,7 +841,7 @@ class TestOperator(OperatorTestCase):
         circuit._layout = TranspileLayout(
             Layout({circuit.qubits[2]: 0, circuit.qubits[1]: 1, circuit.qubits[0]: 2}),
             {qubit: index for index, qubit in enumerate(circuit.qubits)},
-            Layout({circuit.qubits[0]: 1, circuit.qubits[1]: 0, circuit.qubits[2]: 2}),
+            Layout({circuit.qubits[0]: 2, circuit.qubits[1]: 0, circuit.qubits[2]: 1}),
         )
         circuit.swap(0, 1)
         circuit.swap(1, 2)
@@ -863,7 +863,7 @@ class TestOperator(OperatorTestCase):
             Layout({circuit.qubits[2]: 0, circuit.qubits[1]: 1, circuit.qubits[0]: 2}),
             {qubit: index for index, qubit in enumerate(circuit.qubits)},
         )
-        final_layout = Layout({circuit.qubits[0]: 1, circuit.qubits[1]: 0, circuit.qubits[2]: 2})
+        final_layout = Layout({circuit.qubits[0]: 2, circuit.qubits[1]: 0, circuit.qubits[2]: 1})
         circuit.swap(0, 1)
         circuit.swap(1, 2)
         op = Operator.from_circuit(circuit, final_layout=final_layout)
@@ -990,7 +990,7 @@ class TestOperator(OperatorTestCase):
         circuit.h(0)
         circuit.cx(0, 1)
         layout = Layout()
-        with self.assertRaises(IndexError):
+        with self.assertRaises(KeyError):
             Operator.from_circuit(circuit, layout=layout)
 
     def test_compose_scalar(self):
@@ -1101,6 +1101,27 @@ class TestOperator(OperatorTestCase):
         tqc = transpile(circuit, initial_layout=init_layout)
         result = Operator.from_circuit(tqc)
         self.assertTrue(Operator(circuit).equiv(result))
+
+    def test_from_circuit_into_larger_map(self):
+        """Test from_circuit method when the number of physical
+        qubits is larger than the number of original virtual qubits."""
+
+        # original circuit on 3 qubits
+        qc = QuantumCircuit(3)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+
+        # transpile into 5-qubits
+        tqc = transpile(qc, coupling_map=CouplingMap.from_line(5), initial_layout=[0, 2, 4])
+
+        # qc expanded with ancilla qubits
+        expected = QuantumCircuit(5)
+        expected.h(0)
+        expected.cx(0, 1)
+        expected.cx(1, 2)
+
+        self.assertEqual(Operator.from_circuit(tqc), Operator(expected))
 
     def test_apply_permutation_back(self):
         """Test applying permutation to the operator,

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -738,7 +738,8 @@ class TestOperator(OperatorTestCase):
         self.assertTrue(global_phase_equivalent)
 
     def test_from_circuit_initial_layout_final_layout(self):
-        """Test initialization from a circuit with a non-trivial initial_layout and final_layout."""
+        """Test initialization from a circuit with a non-trivial initial_layout and final_layout as given
+        by a transpiled circuit."""
         qc = QuantumCircuit(5)
         qc.h(0)
         qc.cx(2, 1)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

`Operator.from_circuit` generates a wrong operator when a final layout is specified with a non-trivial initial layout via the `transpile` function. This behavior is fixed in this PR while adding new tests to check the correct operator initialization using `Operator.from_circuit`. This PR also modifies the documentation on the `Operator` constructor slightly, i.e. there is a hint for using `Operator.from_circuit` when a non-canonical qubit order/permutation should be assumed for the initialization of the operator.

### Details and comments
For example, `Operator.from_circuit(transpile(qc, cm, initial_layout=[2, 3, 4, 0, 1])).equiv(qc)` would incorrectly return false while `Operator.from_circuit(transpile(qc, cm, initial_layout=[0, 1, 2, 3, 4])).equiv(qc)` would correctly return true (with the only change being the initial layout).

This is error occurs because the specification of `final_layout` in `Operator.from_circuit` does not account for a permutation introduced by the `initial_layout` of a quantum circuit. However, this permutation is introduced by:
https://github.com/Qiskit/qiskit/blob/dd2570bc0e71a830d6078edb4854f95705fce932/qiskit/quantum_info/operators/operator.py#L422

In this PR, the permutation given by `final_layout` is first combined with the permutation given by the `initial_layout` before the permutation is applied to the operator.

