### PR TITLE
Update Commutation Checker to Support UTF-8 Encoded Gate Names

### DIFF
--- a/qiskit/circuit/commutation_checker.py
+++ b/qiskit/circuit/commutation_checker.py
@@ -313,7 +313,7 @@ def _persistent_id(op_name: str) -> int:
     Return:
         The integer id of the input string.
     """
-    return int.from_bytes(bytes(op_name, encoding="ascii"), byteorder="big", signed=True)
+    return int.from_bytes(bytes(op_name, encoding="utf-8"), byteorder="big", signed=True)
 
 
 def _order_operations(

--- a/releasenotes/notes/commutation-checker-utf8-47b13b78a40af196.yaml
+++ b/releasenotes/notes/commutation-checker-utf8-47b13b78a40af196.yaml
@@ -1,5 +1,8 @@
 ---
-features_transpiler:
+fixes:
   - |
-    Added support for utf-8 quantum gate names in :class:`.CommutationChecker`.
+    Fixed an issue with the :class:`.CommutationChecker` class where it would error if a gate's
+    :attr:`~.Gate.name` attribute was UTF8 encoded. Previously only gate names with ascii
+    encoding would work.
+    Fixed `#12501 <https://github.com/Qiskit/qiskit/issues/12051>`__
     

--- a/releasenotes/notes/commutation-checker-utf8-47b13b78a40af196.yaml
+++ b/releasenotes/notes/commutation-checker-utf8-47b13b78a40af196.yaml
@@ -1,0 +1,5 @@
+---
+features_transpiler:
+  - |
+    Added support for utf-8 quantum gate names in :class:`.CommutationChecker`.
+    

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -39,6 +39,7 @@ from qiskit.circuit.library import (
     Reset,
     LinearFunction,
     SGate,
+    RXXGate,
 )
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
@@ -408,6 +409,15 @@ class TestCommutationChecker(QiskitTestCase):
         self.assertTrue(scc.commute(op1, [0, 1], [], op2, [1], []))
         self.assertTrue(scc.commute(op1, [0, 1], [], op3, [1], []))
         self.assertTrue(scc.commute(op2, [1], [], op3, [1], []))
+
+    def test_utf8_gate_names(self):
+        g0 = RXXGate(1.234).to_mutable()
+        g0.name = "すみません"
+
+        g1 = RXXGate(2.234).to_mutable()
+        g1.name = "ok_0"
+
+        self.assertTrue(scc.commute(g0, [0, 1], [], g1, [1, 0], []))
 
     def test_annotated_operations_no_commute(self):
         """Check non-commutativity involving annotated operations."""

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -411,6 +411,7 @@ class TestCommutationChecker(QiskitTestCase):
         self.assertTrue(scc.commute(op2, [1], [], op3, [1], []))
 
     def test_utf8_gate_names(self):
+        """Check compatibility of non-ascii quantum gate names."""
         g0 = RXXGate(1.234).to_mutable()
         g0.name = "すみません"
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

fixes #12051

### Details and comments

Previously, the `CommutationChecker` assumed that quantum gates names are ascii-encoded. This PR extends the support of the commutation checker by utf-8-encoded quantum gates. The difference in  performance and memory consumption between utf-8- and ascii-encoded strings appears to be negligible.
