### PR TITLE
Make GenericPass target aware

### DIFF
--- a/qiskit/passmanager/compilation_status.py
+++ b/qiskit/passmanager/compilation_status.py
@@ -11,10 +11,14 @@
 # that they have been altered from the originals.
 
 """A property set dictionary that shared among optimization passes."""
-
+from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Any
+
+# Type alias
+AnyTarget = Any
 
 
 class PropertySet(dict):
@@ -58,13 +62,22 @@ class PassManagerState:
 
     This object can contain every information about the running pass manager workflow,
     except for the IR object being optimized.
-    The data structure consists of two elements; one for the status of the
-    workflow itself, and another one for the additional information about the IR
-    analyzed through pass executions. This container aims at just providing
-    a robust interface for the :meth:`.Task.execute`, and no logic that modifies
-    the container elements must be implemented.
+    This container aims at providing a robust interface for the the :meth:`.Task.execute`
+    method, and no logic that modifies the container elements must be implemented.
+    The data structure consists of three elements.
 
-    This object is mutable, and might be mutated by pass executions.
+    * :attr:`.workflow_status`: Status of current workflow, which is consumed by
+      the given pass manager callback and system logger.
+      Execution of passes may be condition on the status.
+    * :attr:`.property_set`: Information of the IR gained through pass executions.
+      Typically, analysis-type pass mutates and updates the property set, and
+      transform-type pass consumes the data for optimization task.
+    * :attr:`.target`: Read-only information about a computing system that
+      IR is optimized for. Any type of pass can consume this information
+      to perform hardware-aware task. Altough this object may not be protected from
+      falsification, modified target infomation may result in the failure in execution.
+
+    This object is mutable, and might be mutated by pass executions except for :attr:`.target`.
     """
 
     workflow_status: WorkflowStatus
@@ -72,3 +85,6 @@ class PassManagerState:
 
     property_set: PropertySet
     """Information about IR being optimized."""
+
+    target: AnyTarget | None = None
+    """Information about target system that IR is optimized for."""

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -30,6 +30,7 @@ from qiskit.passmanager.exceptions import PassManagerError
 from .basepasses import BasePass
 from .exceptions import TranspilerError
 from .layout import TranspileLayout
+from .target import Target
 
 _CircuitsT = Union[List[QuantumCircuit], QuantumCircuit]
 
@@ -130,6 +131,7 @@ class PassManager(BasePassManager):
         output_name: str | None = None,
         callback: Callable = None,
         num_processes: int = None,
+        target: Target | None = None,
     ) -> _CircuitsT:
         """Run all the passes on the specified ``circuits``.
 
@@ -172,6 +174,7 @@ class PassManager(BasePassManager):
                 execution is enabled. This argument overrides ``num_processes`` in the user
                 configuration file, and the ``QISKIT_NUM_PROCS`` environment variable. If set
                 to ``None`` the system default or local user configuration will be used.
+            target: Information of target quantum backend that input quantum circuits are optimized for.
 
         Returns:
             The transformed circuit(s).
@@ -179,8 +182,11 @@ class PassManager(BasePassManager):
         if callback is not None:
             callback = _legacy_style_callback(callback)
 
+        # TODO turn target into required after
+        #  we remove target from the constructor of existing passes.
         return super().run(
             in_programs=circuits,
+            target=target,
             callback=callback,
             output_name=output_name,
             num_processes=num_processes,
@@ -392,9 +398,16 @@ class StagedPassManager(PassManager):
         output_name: str | None = None,
         callback: Callable | None = None,
         num_processes: int = None,
+        target: Target | None = None,
     ) -> _CircuitsT:
         self._update_passmanager()
-        return super().run(circuits, output_name, callback, num_processes=num_processes)
+        return super().run(
+            circuits,
+            output_name,
+            callback,
+            num_processes=num_processes,
+            target=target,
+        )
 
     def to_flow_controller(self) -> FlowControllerLinear:
         self._update_passmanager()

--- a/releasenotes/notes/add-target-to-passmanager-run-846d5959a400340f.yaml
+++ b/releasenotes/notes/add-target-to-passmanager-run-846d5959a400340f.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    Added new argument ``target`` to :meth:`qiskit.passmanager.BasePassManager.run`.
+    Given target is shared among scheduled passes, so that we don't need to set
+    target object to individual passes. 
+
+    .. code-block:: python
+
+      pm = PassManager(...)
+      pm.run(circuits, target=backend.target)
+
+    In future we may drop target argument from the constructor of builtin passses.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR adds new attribute `GenericPass.target` and new argument `target` to `PassManager.run`. 

### Details and comments

Currently hardware-provided constraints and user specified compile options are mixed together in the constructor of individual passes. For example, in the [PadDynamicalDecoupling](https://github.com/Qiskit/qiskit/blob/35a8e5312147a537fc3ad635901621506a6ca007/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py#L106-L116) pass, dd_sequence, qubits, spacing, skip_reset_qubits, and extra_slack_distribution are the user provided compile options, while the rest of arguments must be provided by the target hardware. This pattern induces several drawbacks, 

1) Unnecessary coupling to a particular hardware constraints
In quantum computing, flow controller (pass pipeline) is largely architecture dependent, while hardware constraints are device dependent due to fluctuation/distribution of qubit physical parameters. Current pattern of instantiation of passes induces unnecessary tight coupling of pass pipeline, i.e. pass manager instance, to the constraints of a particular device/snapshot. For example, when transpile is called repeatedly (e.g. VQA solver), one may need to instantiate pass manager each time, because the target data may change due to hardware parameter drift.

2) Difficulty of manually instantiating passes
If a user want to define a tailor-made pass manager (i.e. non-builtin/plugin), one needs to understand source of constructor arguments. Randomly chosen hardware constraints may results in faulty optimization and failure in the hardware execution. 

[edit] This was not right. Dill/pickle must keep reference structure.
3) ~~Memory inefficiency~~
Current pattern may cause unnecessary memory overhead when a user transpiles multiple quantum circuits. In this situation, Qiskit copies the pass manager instance through dill and distribute them to each process. Currently each hardware-aware pass instance contains `Target` object, which is copied individually even if they are just a reference to the same target object. 

With new pattern enabled with this PR

```python
PassManager([pass1, pass2, ...]).run(circuits, target=backend.target)
```

above difficulties and inefficiencies can be addressed.