### PR TITLE
Add `inst_targets` property to Pulse Instructions

### DIFF
--- a/qiskit/pulse/compiler/passes/set_sequence.py
+++ b/qiskit/pulse/compiler/passes/set_sequence.py
@@ -95,11 +95,8 @@ class SetSequence(TransformationPass):
 
             if isinstance(node, SequenceIR):
                 self._sequence_instructions(node.alignment, node.sequence)
-                inst_targets = node.inst_targets
-            else:
-                inst_targets = [node.inst_target]
 
-            for inst_target in inst_targets:
+            for inst_target in node.inst_targets:
                 if isinstance(inst_target, MixedFrame):
                     node_mixed_frames.add(inst_target)
                 else:

--- a/qiskit/pulse/instructions/acquire.py
+++ b/qiskit/pulse/instructions/acquire.py
@@ -113,6 +113,11 @@ class Acquire(Instruction):
         return self.operands[1]
 
     @property
+    def inst_targets(self) -> tuple[AcquireChannel | model.Qubit | MemorySlot | RegisterSlot, ...]:
+        """Returns the objects targeted by the instruction."""
+        return tuple(self.operands[ind] for ind in (1, 2, 3) if self.operands[ind] is not None)
+
+    @property
     def channels(self) -> tuple[AcquireChannel | MemorySlot | RegisterSlot, ...]:
         """Returns the channels that this schedule uses."""
         return tuple(self.operands[ind] for ind in (1, 2, 3) if self.operands[ind] is not None)

--- a/qiskit/pulse/instructions/delay.py
+++ b/qiskit/pulse/instructions/delay.py
@@ -93,6 +93,11 @@ class Delay(Instruction):
         return self.operands[1]
 
     @property
+    def inst_targets(self) -> tuple[Channel | MixedFrame | PulseTarget]:
+        """Returns the object targeted by the instruction."""
+        return (self.inst_target,)
+
+    @property
     def channel(self) -> Channel | None:
         """Return the :py:class:`~qiskit.pulse.channels.Channel` that this instruction is
         scheduled on.

--- a/qiskit/pulse/instructions/directives.py
+++ b/qiskit/pulse/instructions/directives.py
@@ -62,6 +62,11 @@ class RelativeBarrier(Directive):
         """Returns the channels that this schedule uses."""
         return self.operands
 
+    @property
+    def inst_targets(self):
+        """Returns the objects targeted by the instruction."""
+        raise NotImplementedError
+
     def __eq__(self, other: object) -> bool:
         """Verify two barriers are equivalent."""
         return isinstance(other, type(self)) and set(self.channels) == set(other.channels)
@@ -147,6 +152,11 @@ class TimeBlockade(Directive):
     def channels(self) -> tuple[chans.Channel]:
         """Returns the channels that this schedule uses."""
         return (self.channel,)
+
+    @property
+    def inst_targets(self):
+        """Returns the objects targeted by the instruction."""
+        raise NotImplementedError
 
     @property
     def duration(self) -> int:

--- a/qiskit/pulse/instructions/instruction.py
+++ b/qiskit/pulse/instructions/instruction.py
@@ -75,6 +75,12 @@ class Instruction(ABC):
         raise NotImplementedError
 
     @property
+    @abstractmethod
+    def inst_targets(self) -> tuple[Channel | MixedFrame | Frame | PulseTarget, ...]:
+        """Returns the objects targeted by the instruction."""
+        raise NotImplementedError
+
+    @property
     def start_time(self) -> int:
         """Relative begin time of this instruction."""
         return 0
@@ -319,6 +325,11 @@ class FrameUpdate(Instruction, ABC):
     def inst_target(self) -> MixedFrame | Frame | PulseChannel:
         """Return the frame or mixed frame targeted by this instruction."""
         return self.operands[1]
+
+    @property
+    def inst_targets(self) -> tuple[PulseChannel | MixedFrame | Frame]:
+        """Returns the frame or mixed frame targeted by the instruction."""
+        return (self.inst_target,)
 
     @property
     def channels(self) -> Tuple[Channel]:

--- a/qiskit/pulse/instructions/play.py
+++ b/qiskit/pulse/instructions/play.py
@@ -107,6 +107,11 @@ class Play(Instruction):
         return self.operands[1]
 
     @property
+    def inst_targets(self) -> tuple[PulseChannel | MixedFrame]:
+        """Returns the mixed frame targeted by the instruction."""
+        return (self.inst_target,)
+
+    @property
     def channels(self) -> Tuple[PulseChannel | None]:
         """Returns the channels that this schedule uses."""
         return (self.channel,)

--- a/qiskit/pulse/instructions/reference.py
+++ b/qiskit/pulse/instructions/reference.py
@@ -87,6 +87,11 @@ class Reference(instruction.Instruction):
         raise UnassignedReferenceError(f"Subroutine is not assigned to {self.ref_keys}.")
 
     @property
+    def inst_targets(self):
+        """Returns the objects targeted by the instruction."""
+        raise NotImplementedError
+
+    @property
     def parameters(self) -> set:
         """Parameters which determine the instruction behavior."""
         return set()

--- a/qiskit/pulse/instructions/snapshot.py
+++ b/qiskit/pulse/instructions/snapshot.py
@@ -69,6 +69,11 @@ class Snapshot(Instruction):
         return (self.channel,)
 
     @property
+    def inst_targets(self):
+        """Returns the objects targeted by the instruction."""
+        raise NotImplementedError
+
+    @property
     def duration(self) -> int:
         """Duration of this instruction."""
         return 0

--- a/qiskit/pulse/ir/ir.py
+++ b/qiskit/pulse/ir/ir.py
@@ -66,10 +66,7 @@ class SequenceIR:
         """Recursively return a set of all Instruction.inst_target in the SequenceIR"""
         inst_targets = set()
         for elm in self.elements():
-            if isinstance(elm, SequenceIR):
-                inst_targets |= elm.inst_targets
-            else:
-                inst_targets.add(elm.inst_target)
+            inst_targets = inst_targets.union(elm.inst_targets)
         return inst_targets
 
     @property

--- a/test/python/pulse/test_instructions.py
+++ b/test/python/pulse/test_instructions.py
@@ -94,6 +94,7 @@ class TestAcquire(QiskitTestCase):
         self.assertEqual(acq.duration, 10)
         self.assertEqual(acq.channel, None)
         self.assertEqual(acq.qubit, Qubit(1))
+        self.assertEqual(acq.inst_targets, (Qubit(1), channels.MemorySlot(0)))
         self.assertEqual(acq.discriminator.name, "linear_discriminator")
         self.assertEqual(acq.discriminator.params, discriminator_opts)
         self.assertEqual(acq.kernel.name, "boxcar")
@@ -173,6 +174,7 @@ class TestDelay(QiskitTestCase):
             ref = target or mixed_frame
 
         self.assertEqual(delay.inst_target, ref)
+        self.assertEqual(delay.inst_targets, (ref,))
         self.assertEqual(delay.operands, (10, ref))
 
     @named_data(
@@ -269,6 +271,7 @@ class TestSetFrequency(QiskitTestCase):
         self.assertEqual(set_freq.frequency, 4.5e9)
         self.assertEqual(set_freq.channel, channels.DriveChannel(1))
         self.assertEqual(set_freq.inst_target, channels.DriveChannel(1))
+        self.assertEqual(set_freq.inst_targets, (channels.DriveChannel(1),))
         self.assertEqual(set_freq.operands, (4.5e9, channels.DriveChannel(1)))
         self.assertEqual(
             set_freq,
@@ -297,6 +300,7 @@ class TestSetFrequency(QiskitTestCase):
         else:
             ref = frame or mixed_frame
         self.assertEqual(set_freq.inst_target, ref)
+        self.assertEqual(set_freq.inst_targets, (ref,))
         self.assertEqual(set_freq.operands, (4.5e9, ref))
 
     @named_data(*_invalid_frame_input_combinations)
@@ -361,6 +365,7 @@ class TestShiftFrequency(QiskitTestCase):
         self.assertEqual(shift_freq.frequency, 4.5e9)
         self.assertEqual(shift_freq.channel, channels.DriveChannel(1))
         self.assertEqual(shift_freq.inst_target, channels.DriveChannel(1))
+        self.assertEqual(shift_freq.inst_targets, (channels.DriveChannel(1),))
         self.assertEqual(shift_freq.operands, (4.5e9, channels.DriveChannel(1)))
         self.assertEqual(
             shift_freq,
@@ -391,6 +396,7 @@ class TestShiftFrequency(QiskitTestCase):
         else:
             ref = frame or mixed_frame
         self.assertEqual(set_freq.inst_target, ref)
+        self.assertEqual(set_freq.inst_targets, (ref,))
         self.assertEqual(set_freq.operands, (4.5e9, ref))
 
     @named_data(*_invalid_frame_input_combinations)
@@ -454,6 +460,7 @@ class TestSetPhase(QiskitTestCase):
         self.assertEqual(set_phase.phase, 1.57)
         self.assertEqual(set_phase.channel, channels.DriveChannel(0))
         self.assertEqual(set_phase.inst_target, channels.DriveChannel(0))
+        self.assertEqual(set_phase.inst_targets, (channels.DriveChannel(0),))
         self.assertEqual(set_phase.operands, (1.57, channels.DriveChannel(0)))
         self.assertEqual(
             set_phase, instructions.SetPhase(1.57, channel=channels.DriveChannel(0), name="test")
@@ -480,6 +487,7 @@ class TestSetPhase(QiskitTestCase):
         else:
             ref = frame or mixed_frame
         self.assertEqual(set_freq.inst_target, ref)
+        self.assertEqual(set_freq.inst_targets, (ref,))
         self.assertEqual(set_freq.operands, (1.5, ref))
 
     @named_data(*_invalid_frame_input_combinations)
@@ -543,6 +551,7 @@ class TestShiftPhase(QiskitTestCase):
         self.assertEqual(shift_phase.phase, 1.57)
         self.assertEqual(shift_phase.channel, channels.DriveChannel(0))
         self.assertEqual(shift_phase.inst_target, channels.DriveChannel(0))
+        self.assertEqual(shift_phase.inst_targets, (channels.DriveChannel(0),))
         self.assertEqual(shift_phase.operands, (1.57, channels.DriveChannel(0)))
         self.assertEqual(
             shift_phase,
@@ -571,6 +580,7 @@ class TestShiftPhase(QiskitTestCase):
         else:
             ref = frame or mixed_frame
         self.assertEqual(set_freq.inst_target, ref)
+        self.assertEqual(set_freq.inst_targets, (ref,))
         self.assertEqual(set_freq.operands, (1.5, ref))
 
     @named_data(*_invalid_frame_input_combinations)
@@ -654,6 +664,7 @@ class TestPlay(QiskitTestCase):
         self.assertEqual(play.duration, self.duration)
         self.assertEqual(play.channel, channels.DriveChannel(1))
         self.assertEqual(play.inst_target, channels.DriveChannel(1))
+        self.assertEqual(play.inst_targets, (channels.DriveChannel(1),))
         self.assertEqual(
             repr(play),
             "Play(Waveform(array([1.+0.j, 1.+0.j, 1.+0.j, 1.+0.j]), name='test'),"
@@ -674,6 +685,7 @@ class TestPlay(QiskitTestCase):
         self.assertEqual(play.duration, self.duration)
         self.assertEqual(play.pulse, self.pulse_op)
         self.assertEqual(play.inst_target, MixedFrame(Qubit(0), QubitFrame(1)))
+        self.assertEqual(play.inst_targets, (MixedFrame(Qubit(0), QubitFrame(1)),))
         self.assertEqual(play.channel, None)
 
     def test_play_non_pulse_ch_raises(self):

--- a/test/python/pulse/test_transforms.py
+++ b/test/python/pulse/test_transforms.py
@@ -956,6 +956,10 @@ class _TestDirective(directives.Directive):
     def channels(self):
         return self.operands
 
+    @property
+    def inst_targets(self):
+        return self.operands
+
 
 class TestRemoveDirectives(QiskitTestCase):
     """Test removing of directives."""


### PR DESCRIPTION
### Summary
This PR adds `inst_targets` property to Pulse Instructions.


### Details and comments
PR #11726 updated the Pulse Instructions interface to the new pulse model. As a counterpart to the legacy `channel` property, an `inst_target` property was introduced. This PR adds a second property `inst_targets`, the same way the legacy model had `channels`. The added property creates a unified property structure for both Pulse Instructions and `SequenceIR`, it will also make it easier to deal with instructions which target more than one object (like barriers).

Some instructions haven't been modified to the new model, and raise a not implemented error at the moment.

