### PR TITLE
Pulse Compiler - fix sequencing of objects with no corresponding mixed frames

### DIFF
--- a/qiskit/pulse/compiler/passes/map_mixed_frames.py
+++ b/qiskit/pulse/compiler/passes/map_mixed_frames.py
@@ -47,10 +47,20 @@ class MapMixedFrame(AnalysisPass):
         """Run ``MapMixedFrame`` pass"""
         mixed_frames_mapping = defaultdict(set)
 
-        for inst_target in passmanager_ir.inst_targets:
+        inst_targets = passmanager_ir.inst_targets
+
+        for inst_target in inst_targets:
             if isinstance(inst_target, MixedFrame):
                 mixed_frames_mapping[inst_target.frame].add(inst_target)
                 mixed_frames_mapping[inst_target.pulse_target].add(inst_target)
+
+        # Accounting for inst_targets which have no corresponding mixed frames.
+        for inst_target in inst_targets:
+            if not isinstance(inst_target, MixedFrame) and not (
+                mapping := mixed_frames_mapping[inst_target]
+            ):
+                mapping.add(inst_target)
+
         self.property_set["mixed_frames_mapping"] = mixed_frames_mapping
 
     def __hash__(self):

--- a/test/python/pulse/compiler_passes/test_map_mixed_frames.py
+++ b/test/python/pulse/compiler_passes/test_map_mixed_frames.py
@@ -66,9 +66,11 @@ class TestMapMixedFrames(QiskitTestCase):
         mapping_pass = MapMixedFrame()
         mapping_pass.run(ir_example)
         mapping = mapping_pass.property_set["mixed_frames_mapping"]
-        self.assertEqual(len(mapping), 2)
+        self.assertEqual(len(mapping), 4)
         self.assertEqual(mapping[Qubit(0)], {mf})
         self.assertEqual(mapping[QubitFrame(1)], {mf})
+        self.assertEqual(mapping[QubitFrame(2)], {QubitFrame(2)})
+        self.assertEqual(mapping[Qubit(2)], {Qubit(2)})
 
     def test_with_sub_blocks(self):
         """test with sub blocks"""

--- a/test/python/pulse/compiler_passes/test_set_sequence.py
+++ b/test/python/pulse/compiler_passes/test_set_sequence.py
@@ -11,7 +11,6 @@
 # that they have been altered from the originals.
 
 """Test SetSequence"""
-import unittest
 from test import QiskitTestCase
 from ddt import ddt, named_data, unpack
 
@@ -71,24 +70,24 @@ class TestSetSequenceParallelAlignment(QiskitTestCase):
         with self.assertRaises(PulseCompilerError):
             pm.run(ir_example)
 
-    # TODO: Take care of this weird edge case
-    @unittest.expectedFailure
     @named_data(*ddt_named_data)
     @unpack
-    def test_instruction_not_in_mapping(self, alignment):
-        """test with an instruction which is not in the mapping"""
+    def test_instruction_no_corresponding_mixed_frame(self, alignment):
+        """test with an instruction which has no corresponding mixed frame"""
 
         ir_example = SequenceIR(alignment)
         ir_example.append(Play(Constant(100, 0.1), mixed_frame=MixedFrame(Qubit(0), QubitFrame(1))))
         ir_example.append(Delay(100, target=Qubit(5)))
+        ir_example.append(Delay(100, target=Qubit(5)))
 
         ir_example = self._pm.run(ir_example)
         edge_list = ir_example.sequence.edge_list()
-        self.assertEqual(len(edge_list), 4)
+        self.assertEqual(len(edge_list), 5)
         self.assertTrue((0, 2) in edge_list)
         self.assertTrue((0, 3) in edge_list)
+        self.assertTrue((3, 4) in edge_list)
         self.assertTrue((2, 1) in edge_list)
-        self.assertTrue((3, 1) in edge_list)
+        self.assertTrue((4, 1) in edge_list)
 
     @named_data(*ddt_named_data)
     @unpack


### PR DESCRIPTION
### Summary
PR #11980 had a known issue with instructions targeting objects with no corresponding mixed frames. This PR fixes that problem.


### Details and comments
The fix involves a change to `MapMixedFrames` where objects with no corresponding mixed frames are mapped to themselves.

While the original issue was a bizarre edge case which might not have any real implications, the fix actually allows to sequence pulse programs written in terms of the legacy channel model (where each channel blocks only itself for sequencing). It remains to be seen if we choose to divert legacy inputs into the new compiler, but it is still interesting to examine the performance - Converting from `ScheduleBlock` with legacy channels into scheduled `SequenceIR` takes about the same time as converting to `Schedule` (using `pulse.transforms.canonicalization.block_to_schedule`) for very small and simple programs. As we increase the complexity and number of instructions, the new compiler is 2-5X faster (I assume because of the rust based sequencing?).