### PR TITLE
PulseTarget protocol and reference implementation

### DIFF
--- a/qiskit/pulse/compiler/target.py
+++ b/qiskit/pulse/compiler/target.py
@@ -15,6 +15,8 @@
 from __future__ import annotations
 
 from typing import Protocol
+import dataclasses
+
 from qiskit.pulse import model
 from qiskit.pulse.exceptions import NotExistingComponent
 
@@ -46,19 +48,19 @@ class PulseTarget(Protocol):
 
     Here we make native assumptions. A provider of this taregt must design
     its data structure to meet following rules otherwise the compiled program may cause
-    faulty behavior. The hardware devices, or pulse controller, 
-    must distinghish every hardware ports and frames with unique string identifiers, and 
-    frames are tied to ports. In other words, frames don't exist standalone and 
+    faulty behavior. The hardware devices, or pulse controller,
+    must distinghish every hardware ports and frames with unique string identifiers, and
+    frames are tied to ports. In other words, frames don't exist standalone and
     always can form a mixed frame with a port in pair.
-    
-    In addition, Qiskit provides special preset frame types, 
-    :class:`.QubitFrame` and :class:`.MeasurementFrame`, and the backend must provide 
-    special string identifiers for these frame objects. 
-    If there is any architecture specific frames, a vendor can also define custom 
+
+    In addition, Qiskit provides special preset frame types,
+    :class:`.QubitFrame` and :class:`.MeasurementFrame`, and the backend must provide
+    special string identifiers for these frame objects.
+    If there is any architecture specific frames, a vendor can also define custom
     frame subclasses to extend the target model to align with their hardware devices.
-    If the backend defines any calibration for its basis gates, 
+    If the backend defines any calibration for its basis gates,
     we assume the same string identifier is used within the calibration so that
-    a user provided inline calibration (pulse gates) can work seamlessly 
+    a user provided inline calibration (pulse gates) can work seamlessly
     with the backend calibrated gate sets.
 
     See :class:`.QiskitPulseTarget` for the reference implementation.
@@ -82,74 +84,108 @@ class PulseTarget(Protocol):
         raise NotExistingComponent(
             f"This hardware doesn't proivde any resource implementing {frame}."
         )
-    
-    def get_generic_port_identifier(
+
+    def get_port_identifier(
         self,
-        signal_entry: model.SignalEntry,        
+        pulse_endpoint: model.PulseEndpoint,
+        op_type: str,
     ) -> str:
-        """Return the unique port identifier of the Qiskit pulse signal entry
-        for generic operations.
+        """Return the unique port identifier of the Qiskit Pulse pulse endpoint.
 
         Args:
-            signal_entry: Qiskit pulse mixed frame to inquire.
+            pulse_endpoint: Qiskit pulse PulseEndpoint object to inquire.
+            op_type: Context of operation.
 
         Returns:
             A unique port identifier.
 
         Raises:
-            NotExistingComponent: When the frame identifier is not found.
+            NotExistingComponent: When the port identifier is not found.
         """
         raise NotExistingComponent(
-            f"This hardware doesn't proivde any resource implementing {signal_entry}."
-        )
-
-    def get_measure_port_identifier(
-        self,
-        signal_entry: model.SignalEntry,        
-    ) -> str:
-        """Return the unique port identifier of the Qiskit pulse signal entry
-        for measurement operations.
-
-        Args:
-            signal_entry: Qiskit pulse mixed frame to inquire.
-
-        Returns:
-            A unique port identifier.
-
-        Raises:
-            NotExistingComponent: When the frame identifier is not found.
-        """  
-        raise NotExistingComponent(
-            f"This hardware doesn't proivde any resource implementing {signal_entry}."
+            f"This hardware doesn't provide any resource implementing {pulse_endpoint}."
         )
 
     def reserved_mixed_frames(
         self,
         *,
         frame: model.Frame | None = None,
-        signal_entry: model.SignalEntry | None = None,        
+        pulse_endpoint: model.PulseEndpoint | None = None,
     ) -> list[model.MixedFrame]:
         """Return a list of mixed frames reserved for the backend gate calibrations.
-        
+
         Args:
             frame: Qiskit pulse Frame object to include.
-            signal_entry: Qiskit pulse SignalEntry object to include.
+            pulse_endpoint: Qiskit pulse PulseEndpoint object to include.
 
         Returns:
-            A list of Qiskit pulse mixed frame objects that 
+            A list of Qiskit pulse mixed frame objects that
             include given frame and logical element.
         """
         return []
 
 
+@dataclasses.dataclass(frozen=True)
+class TXPort:
+    """Software abstraction of transmission port.
+
+    Transmission ports send control singals down to qubit
+    or any quantum elements.
+    """
+
+    identifier: str
+    """Unique identifier of this port."""
+
+    qubits: tuple[int]
+    """Tuple of qubit indicies that are affected through this port."""
+
+    num_frames: int
+    """Number of hadware supported frames tied to this port."""
+
+    reserved_frames: list[str]
+    """List of frame identifiers already used for circuit gate operations."""
+
+
+@dataclasses.dataclass(frozen=True)
+class RXPort:
+    """Software abstraction of receiver port.
+
+    Reciever ports record signals emitted from qubits
+    to readout their state.
+    """
+
+    identifier: str
+    """Unique identifier of this port."""
+
+    qubits: tuple[int]
+    """Tuple of qubit indices that this port get signals from."""
+
+
+class ControlPort(TXPort):
+    """A type of port controlling qubit state."""
+
+    pass
+
+
+class MeasurePort(TXPort):
+    """A type of port stimulating qubits for state readout."""
+
+    pass
+
+
 class QiskitPulseTarget(PulseTarget):
     """Qiskit reference implementation of :class:`.PulseTarget`."""
+
+    __type_alias = {
+        ControlPort: "control",
+        MeasurePort: "measure",
+    }
 
     def __init__(
         self,
         qubit_frames: dict[int, str] | None = None,
         meas_frames: dict[int, str] | None = None,
-        tx_ports: dict[str, dict] | None = None,
+        tx_ports: list[TXPort] | None = None,
         rx_ports: dict[str, dict] | None = None,
     ) -> None:
         """Create new Qiskit pulse target.
@@ -163,21 +199,74 @@ class QiskitPulseTarget(PulseTarget):
                 the Qiskit :class:`.MeasurementFrame` object index.
                 This frame must track the rotating frame
                 of the measurement stimulus signal.
-            tx_ports: A list of dictionary representing a spec of transmission ports. 
-                The spec dictionary must contain "qubits", "op_type", "num_frames",
-                "reserved_frames" keyes.
+            tx_ports: A list of :class:`.TXPort` dataclasses representing
+                available hardware resources on the controller.
+                TX port sends control singals down to qubit or any quantum elements.
+                Port is not a user-configurable element.
             rx_ports: A list of dictionary representing a spec of receiver ports.
-                The spec dictionary must contain ...
+
+        TODO: implement RX port configuration, i.e. acquire port. Spec is not yet designed well.
         """
-        self._qubit_frames = qubit_frames
-        self._qubit_frames_inv = dict(zip(qubit_frames.values(), qubit_frames.keys()))
+        self._qubit_frames: dict[int, str] = qubit_frames
+        self._meas_frames: dict[int, str] = meas_frames
+        self._calibrated_mixed_frames: list[model.MixedFrame] = []
 
-        self._meas_frames = meas_frames
-        self._meas_frames_inv = dict(zip(meas_frames.values(), meas_frames.keys()))
+        self._tx_ports: dict[str, dict[tuple[int, ...], TXPort]] = {
+            t: {} for t in self.__type_alias.values()
+        }
 
-        # Use table-like data format, if we can add to dependency.
-        # In realistic provider implementation use of schema is recommended.
-        self._tx_ports = tx_ports
+        # TODO what is the data?
+        self._rx_ports = rx_ports
+
+        # Cache all port names for efficient resource check.
+        self._port_names = [p.identifier for p in tx_ports]
+
+        self._sort_tx_ports(tx_ports=tx_ports)
+        self._build_mixed_frames(tx_ports=tx_ports)
+
+    def _sort_tx_ports(self, tx_ports: list[TXPort]):
+        # Helper method to sort tx port list by port type and qubit indices.
+        for port in tx_ports:
+            try:
+                port_type_str = self.__type_alias[type(port)]
+            except KeyError as ex:
+                raise TypeError(
+                    f"Transmission port {port} is not defined type in {self.__class__.__name__}. "
+                    "Please create new implementation of PulseTarget protocol for your contoller."
+                ) from ex
+            if (indices := tuple(port.qubits)) in self._tx_ports[port_type_str]:
+                raise TypeError(
+                    f"Transmission port '{port_type_str}' for qubits {indices} is already defined. "
+                    "Qiskit reference implmentation of PulseTarget doesn't allow multiple ports "
+                    "for the same set of qubits under under same port type."
+                )
+            self._tx_ports[port_type_str][indices] = port
+
+    def _build_mixed_frames(self, tx_ports: list[TXPort]):
+        # Helper method to build Qiskit MixedFrame models from the port configuraion data.
+        qubit_frames_inv = dict(zip(self._qubit_frames.values(), self._qubit_frames.keys()))
+        meas_frames_inv = dict(zip(self._meas_frames.values(), self._meas_frames.keys()))
+        for port in tx_ports:
+            for fuid in port.reserved_frames:
+                if (fidx := qubit_frames_inv.get(fuid, None)) is not None:
+                    # Qiskit special type: Qubit mixed frame
+                    mixed_frame = model.MixedFrame(
+                        pulse_target=model.Qubit(port.qubits[0]),
+                        frame=model.QubitFrame(fidx),
+                    )
+                elif (fidx := meas_frames_inv.get(fuid, None)) is not None:
+                    # Qiskit special type: Measurement mixed frame
+                    mixed_frame = model.MixedFrame(
+                        pulse_target=model.Qubit(port.qubits[0]),
+                        frame=model.MeasurementFrame(fidx),
+                    )
+                else:
+                    # Generic
+                    mixed_frame = model.MixedFrame(
+                        pulse_target=model.Port(port.identifier),
+                        frame=model.GenericFrame(fuid),
+                    )
+                self._calibrated_mixed_frames.append(mixed_frame)
 
     def get_frame_identifier(
         self,
@@ -207,50 +296,50 @@ class QiskitPulseTarget(PulseTarget):
             "you must also define PulseTarget class supporting this type."
         )
 
-    def get_generic_port_identifier(
+    def get_port_identifier(
         self,
-        signal_entry: model.SignalEntry,        
-    ) -> str:
-        return self._get_port_common(signal_entry, "generic")
-
-    def get_measure_port_identifier(
-        self,
-        signal_entry: model.SignalEntry,        
-    ) -> str:
-        return self._get_port_common(signal_entry, "measure")
-
-    def _get_port_common(
-        self,
-        signal_entry: model.SignalEntry,
+        pulse_endpoint: model.PulseTarget,
         op_type: str,
     ) -> str:
-        if isinstance(signal_entry, model.Port):
-            if signal_entry.name not in self._tx_ports:
+        if isinstance(pulse_endpoint, model.Port):
+            if pulse_endpoint.name not in self._port_names:
                 raise NotExistingComponent(
-                    f"Port identifier {signal_entry.name} is not defined in this system. "
+                    f"Port identifier {pulse_endpoint.name} is not defined in this system. "
                     "Hardware may not implement this port."
                 )
-            return signal_entry.name        
-        if isinstance(signal_entry, model.LogicalElement):
-            qubit_index = list(signal_entry.index)
-            for port_uid, data in self._tx_ports.items():
-                if data["qubits"] == qubit_index and data["op_type"] == op_type:
-                    return port_uid
-            else:
-                raise NotExistingComponent(
-                    "This control system doesn't provide any port for "
-                    f"implementing LogicalElement {signal_entry}."
-                )
-        raise TypeError(
-            f"{self.__class__.__name__} doesn't recognize the signal entry object of type "
-            f"{signal_entry.__class__.__name__}. If you are using a custom subclass, "
-            "you must also define PulseTarget class supporting this type."
-        )        
+            return pulse_endpoint.name
+
+        # Resolve logical elements.
+        if op_type not in self._tx_ports:
+            raise ValueError(
+                f"Given operation type '{op_type}' is not defined on this system. "
+                f"PulseTarget of the controller supports {list(self.__type_alias.keys())} types. "
+                f"Request of port identifier for {pulse_endpoint} "
+                f"in the '{op_type}' context is not resolved."
+            )
+        qubit_index = tuple(pulse_endpoint.index)
+        try:
+            return self._tx_ports[op_type][qubit_index].identifier
+        except KeyError as ex:
+            raise NotExistingComponent(
+                "This control system doesn't provide any hardware port for "
+                f"implementing LogicalElement {pulse_endpoint} in the '{op_type}' context."
+            ) from ex
 
     def reserved_mixed_frames(
         self,
         *,
         frame: model.Frame | None = None,
-        signal_entry: model.SignalEntry | None = None,        
+        pulse_endpoint: model.PulseEndpoint | None = None,
     ) -> list[model.MixedFrame]:
-        # TODO implement this
+        if frame is None and pulse_endpoint is None:
+            raise ValueError("Either frame or pulse_endpoint must be specified.")
+
+        out = []
+        for mixed_frame in self._calibrated_mixed_frames:
+            if frame is not None and frame != mixed_frame.frame:
+                continue
+            if pulse_endpoint is not None and pulse_endpoint != mixed_frame.pulse_target:
+                continue
+            out.append(mixed_frame)
+        return out

--- a/qiskit/pulse/compiler/target.py
+++ b/qiskit/pulse/compiler/target.py
@@ -1,0 +1,306 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Compiler target information."""
+
+from __future__ import annotations
+
+from typing import Protocol
+from qiskit.pulse import model
+from qiskit.pulse.exceptions import NotExistingComponent
+
+
+class PulseTarget(Protocol):
+    """Protocol of feeding hardware configuration to the Qiskit pulse compiler.
+
+    This class defines interfaces for the Qiskit pulse compiler to receive
+    necessary information to lower the input pulse programs.
+
+    Because the system configuration is usually vendor dependent, we don't enforce
+    the use of any Qiskit abstract class to give such vendors
+    more flexibility to choose the most convenient data structure to
+    represent their own device.
+
+    The collection of interfaces is designed to provide all necessary information
+    to convert the Qiskit pulse model into a vendor specific target bianry.
+
+    Qiskit pulse uses an abstract model to represent hardware components, such as
+    :class:`.QubitFrame` and :class:`qiskit.pulse.model.Qubit`.
+    These components might be, not limited to, a software abstraction of
+    a numerically controlled oscillator tracking the rotating frame of qubit,
+    and a microwave or laser port connected with a particular qubit.
+
+    This abstraction allows quantum physics experimentalists to use
+    similar semantics with the ciruict quantum electrodynamics theory,
+    while the compiler needs to lower those components down to the actual hardware resouces.
+
+    We make a native assumption that such hardware devices provide unique string identifier
+    for each component that it equips, and there are limited number of
+    such physical resources. We also assume a frame is tie to ports on the hardware,
+    namely, frames don't exist standalone and always form a mixed frame with a port in pair.
+
+    See :class:`.QiskitPulseTarget` for the reference implementation.
+    """
+
+    def get_frame_identifier(
+        self,
+        frame: model.Frame,
+    ) -> str:
+        """Return the unique string identifier of the frame.
+
+        Args:
+            frame: Qiskit pulse Frame object to inquire.
+
+        Returns:
+            A unique identifier of given frame.
+        """
+        raise NotExistingComponent(
+            f"This hardware doesn't proivde any resource implementing {frame}."
+        )
+
+    def get_port_identifier(
+        self,
+        port: model.LogicalElement,
+    ) -> str:
+        """Return the unique string identifier of the hardware port.
+
+        Args:
+            port: Qiskit pulse LogicalElement object to inquire.
+
+        Returns:
+            A unique identifier of given port.
+        """
+        raise NotExistingComponent(
+            f"This hardware doesn't proivde any resource implementing {port}."
+        )
+
+    def is_mixed_frame_available(
+        self,
+        mixed_frame: model.MixedFrame,
+    ) -> bool:
+        """Check if given mixed frame is implementable on the hardware.
+
+        Args:
+            mixed_frame: Qiskit pulse MixedFrame object to test.
+
+        Returns:
+            True if given mixed frame is implementable.
+        """
+        return False
+
+    def filter_mixed_frames(
+        self,
+        *,
+        frame: model.Frame | None = None,
+        port: model.LogicalElement | None = None,
+    ) -> list[model.MixedFrame]:
+        """Filter available mixed frames on the hardware.
+
+        Args:
+            frame: Qiskit pulse Frame object to include.
+            port: Qiskit pulse LogicalElement object to include.
+
+        Returns:
+            A list of Qiskit pulse MixedFrame objects that include given frame and port.
+        """
+        return []
+
+    def extra_frames(
+        self,
+        port: model.LogicalElement,
+    ) -> list[model.GenericFrame]:
+        """Get a list of string identifier of unused frames tied to the given port.
+
+        Args:
+            port: Qiskit pulse LogicalElement object to inquire.
+
+        Returns:
+            A list of unique identifier of unsed frames.
+        """
+        return []
+
+
+class QiskitPulseTarget(PulseTarget):
+    """Qiskit reference implementation of :class:`.PulseTarget`."""
+
+    def __init__(
+        self,
+        qubit_frames: dict[int, str] | None = None,
+        meas_frames: dict[int, str] | None = None,
+        qubit_ports: dict[int, str] | None = None,
+        coupler_ports: dict[tuple[int, ...], str] | None = None,
+        mixed_frames: dict[str, list[str]] | None = None,
+    ) -> None:
+        """Create new Qiskit pulse target.
+
+        Args:
+            qubit_frames: A dictionary of qubit frame identifier keyed on
+                the Qiskit :class:`.QubitFrame` object index.
+                This frame must track the rotating frame
+                of the qubit control signal.
+            meas_frames: A dictionary of measurement frame identifier keyed on
+                the Qiskit :class:`.MeasurementFrame` object index.
+                This frame must track the rotating frame
+                of the measurement stimulus signal.
+            qubit_ports: A dictioanry of hardware port identifier keyed on
+                the Qiskit :class:`~qiskit.pulse.model.Qubit` object index.
+                This port must be used to drive qubit regardless of frames.
+            coupler_ports: A dictionary of hardware port identifier keyed on
+                the Qiskit :class:`.Port` object index.
+                This port must be used to drive multi-qubit interactions.
+            mixed_frams: A dictionary of avilable mixed frame resources keyed on
+                the unique identifier of the port. Values are list of frame identifiers
+                available for this port to form a mixed frame.
+
+        """
+        self._qubit_frames = qubit_frames
+        self._qubit_frames_inv = dict(zip(qubit_frames.values(), qubit_frames.keys()))
+
+        self._meas_frames = meas_frames
+        self._meas_frames_inv = dict(zip(meas_frames.values(), meas_frames.keys()))
+
+        self._qubit_ports = qubit_ports
+        self._qubit_ports_inv = dict(zip(qubit_ports.values(), qubit_ports.keys()))
+
+        self._coupler_ports = coupler_ports
+        self._coupler_ports_inv = dict(zip(coupler_ports.values(), coupler_ports.keys()))
+
+        self._mixed_frames = mixed_frames
+
+    def is_mixed_frame_available(
+        self,
+        mixed_frame: model.MixedFrame,
+    ) -> bool:
+        if not isinstance(mixed_frame, model.MixedFrame):
+            raise TypeError(f"{mixed_frame} is not a MixedFrame object.")
+        try:
+            p_uid = self.get_port_identifier(mixed_frame.pulse_target)
+            f_uid = self.get_frame_identifier(mixed_frame.frame)
+        except NotExistingComponent:
+            return False
+        try:
+            return f_uid in self._mixed_frames[p_uid]
+        except KeyError:
+            return False
+
+    def get_frame_identifier(
+        self,
+        frame: model.Frame,
+    ) -> str:
+        if isinstance(frame, model.QubitFrame):
+            try:
+                return self._qubit_frames[frame.index]
+            except KeyError as ex:
+                raise NotExistingComponent(
+                    "This hardware doesn't provide any frame for "
+                    f"QubitFrame of index {frame.index}."
+                ) from ex
+        if isinstance(frame, model.MeasurementFrame):
+            try:
+                return self._meas_frames[frame.index]
+            except KeyError as ex:
+                raise NotExistingComponent(
+                    "This hardware doesn't provide any frame for "
+                    f"MeasurementFrame of index {frame.index}."
+                ) from ex
+        raise TypeError(
+            f"Input frame type {frame.__class__.__name__} cannot "
+            "be directly mapped to hardware elements."
+        )
+
+    def get_port_identifier(
+        self,
+        port: model.LogicalElement,
+    ) -> str:
+        if isinstance(port, model.Qubit):
+            try:
+                return self._qubit_ports[port.qubit_index]
+            except KeyError as ex:
+                raise NotExistingComponent(
+                    "This hardware doesn't provide any port for "
+                    f"Qubit of index {port.qubit_index}."
+                ) from ex
+        if isinstance(port, model.Coupler):
+            try:
+                return self._coupler_ports[port.index]
+            except KeyError as ex:
+                raise NotExistingComponent(
+                    "This hardware doesn't provide any port for " f"Coupler of index {port.index}."
+                ) from ex
+        raise TypeError(
+            f"Input port type {port.__class__.__name__} cannot "
+            "be directly mapped to hardware elements."
+        )
+
+    def filter_mixed_frames(
+        self,
+        *,
+        frame: model.Frame | None = None,
+        port: model.LogicalElement | None = None,
+    ) -> list[model.MixedFrame]:
+        try:
+            if port is not None:
+                p_uid = self.get_port_identifier(port)
+            else:
+                p_uid = None
+            if frame is not None:
+                f_uid = self.get_frame_identifier(frame)
+            else:
+                f_uid = None
+        except NotExistingComponent:
+            return []
+
+        matched = []
+        for port_name, frame_names in self._mixed_frames.items():
+            if p_uid is not None and p_uid != port_name:
+                continue
+            for frame_name in frame_names:
+                if f_uid is not None and f_uid != frame_name:
+                    continue
+                matched.append(
+                    model.MixedFrame(
+                        pulse_target=self._port_uid_to_obj(port_name),
+                        frame=self._frame_uid_to_obj(frame_name),
+                    )
+                )
+        return matched
+
+    def extra_frames(
+        self,
+        port: model.LogicalElement,
+    ) -> list[model.GenericFrame]:
+        p_uid = self.get_port_identifier(port)
+        try:
+            frames = self._mixed_frames[p_uid]
+        except KeyError as ex:
+            raise NotExistingComponent(
+                f"This hardware doesn't provide any mixed frame for the port {port}."
+            ) from ex
+        out = []
+        for frame in frames:
+            if frame not in self._qubit_frames_inv and frame not in self._meas_frames_inv:
+                out.append(model.GenericFrame(frame))
+        return out
+
+    def _port_uid_to_obj(self, port_uid: str) -> model.LogicalElement:
+        if (index := self._qubit_ports_inv.get(port_uid, None)) is not None:
+            return model.Qubit(index)
+        if (index := self._coupler_ports.get(port_uid, None)) is not None:
+            return model.Coupler(index)
+        return model.Port(port_uid)
+
+    def _frame_uid_to_obj(self, frame_uid: str) -> model.Frame:
+        if (index := self._qubit_frames_inv.get(frame_uid, None)) is not None:
+            return model.QubitFrame(index)
+        if (index := self._meas_frames_inv.get(frame_uid, None)) is not None:
+            return model.MeasurementFrame(index)
+        return model.GenericFrame(frame_uid)

--- a/qiskit/pulse/exceptions.py
+++ b/qiskit/pulse/exceptions.py
@@ -45,3 +45,7 @@ class UnassignedDurationError(PulseError):
 
 class UnassignedReferenceError(PulseError):
     """Raised if subroutine is unassigned."""
+
+
+class NotExistingComponent(PulseError):
+    """Raised if specified pulse component is not available on hardware."""

--- a/qiskit/pulse/model/__init__.py
+++ b/qiskit/pulse/model/__init__.py
@@ -102,4 +102,4 @@ from .mixed_frames import (
 )
 
 # TODO Alias to minimize logical change. Name will be updated in the followup PR.
-SignalEntry = PulseTarget
+PulseEndpoint = PulseTarget

--- a/qiskit/pulse/model/__init__.py
+++ b/qiskit/pulse/model/__init__.py
@@ -100,3 +100,6 @@ from .frames import (
 from .mixed_frames import (
     MixedFrame,
 )
+
+# TODO Alias to minimize logical change. Name will be updated in the followup PR.
+SignalEntry = PulseTarget

--- a/test/python/pulse/_dummy_targets.py
+++ b/test/python/pulse/_dummy_targets.py
@@ -12,7 +12,7 @@
 
 """Pulse target for unit tests."""
 
-from qiskit.pulse.compiler.target import QiskitPulseTarget
+from qiskit.pulse.compiler.target import QiskitPulseTarget, ControlPort, MeasurePort
 
 
 TWOQ_CROSSRES_TARGET = QiskitPulseTarget(
@@ -24,31 +24,35 @@ TWOQ_CROSSRES_TARGET = QiskitPulseTarget(
         0: "M0",
         1: "M1",
     },
-    tx_ports={
-        "Q_channel-0": {
-            "qubits": [0],
-            "op_type": "generic",
-            "num_frames": 3, 
-            "reserved_frames": ["Q0", "Q1"],
-        },
-        "Q_channel-1": {
-            "qubits": [1],
-            "op_type": "generic",
-            "num_frames": 3, 
-            "reserved_frames": ["Q1"],
-        },
-        "R_channel-0": {
-            "qubits": [0],
-            "op_type": "measure",
-            "num_frames": 1, 
-            "reserved_frames": ["M0"],
-        },
-        "R_channel-1": {
-            "qubits": [1],
-            "op_type": "measure",
-            "num_frames": 1, 
-            "reserved_frames": ["M1"],
-        },
-    },
+    tx_ports=[
+        # Self-drive port + CR drive port for qubit 1
+        ControlPort(
+            identifier="Q_channel-0",
+            qubits=(0,),
+            num_frames=3,
+            reserved_frames=["Q0", "Q1"],
+        ),
+        # Only self-drive port
+        ControlPort(
+            identifier="Q_channel-1",
+            qubits=(1,),
+            num_frames=3,
+            reserved_frames=["Q1"],
+        ),
+        # Dispersive measurement for self qubit
+        MeasurePort(
+            identifier="R_Channel-0",
+            qubits=(0,),
+            num_frames=1,
+            reserved_frames=["M0"],
+        ),
+        # Dispersive measurement for self qubit
+        MeasurePort(
+            identifier="R_Channel-1",
+            qubits=(1,),
+            num_frames=1,
+            reserved_frames=["M1"],
+        ),
+    ],
 )
 """Pedagogical target for two qubit device control with cross resonance."""

--- a/test/python/pulse/_dummy_targets.py
+++ b/test/python/pulse/_dummy_targets.py
@@ -24,13 +24,31 @@ TWOQ_CROSSRES_TARGET = QiskitPulseTarget(
         0: "M0",
         1: "M1",
     },
-    qubit_ports={
-        0: "Port0",
-        1: "Port1",
-    },
-    mixed_frames={
-        "Port0": ["Q0", "Q1", "M0"],
-        "Port1": ["Q1", "Q0", "M1"],
+    tx_ports={
+        "Q_channel-0": {
+            "qubits": [0],
+            "op_type": "generic",
+            "num_frames": 3, 
+            "reserved_frames": ["Q0", "Q1"],
+        },
+        "Q_channel-1": {
+            "qubits": [1],
+            "op_type": "generic",
+            "num_frames": 3, 
+            "reserved_frames": ["Q1"],
+        },
+        "R_channel-0": {
+            "qubits": [0],
+            "op_type": "measure",
+            "num_frames": 1, 
+            "reserved_frames": ["M0"],
+        },
+        "R_channel-1": {
+            "qubits": [1],
+            "op_type": "measure",
+            "num_frames": 1, 
+            "reserved_frames": ["M1"],
+        },
     },
 )
 """Pedagogical target for two qubit device control with cross resonance."""

--- a/test/python/pulse/_dummy_targets.py
+++ b/test/python/pulse/_dummy_targets.py
@@ -1,0 +1,36 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Pulse target for unit tests."""
+
+from qiskit.pulse.compiler.target import QiskitPulseTarget
+
+
+TWOQ_CROSSRES_TARGET = QiskitPulseTarget(
+    qubit_frames={
+        0: "Q0",
+        1: "Q1",
+    },
+    meas_frames={
+        0: "M0",
+        1: "M1",
+    },
+    qubit_ports={
+        0: "Port0",
+        1: "Port1",
+    },
+    mixed_frames={
+        "Port0": ["Q0", "Q1", "M0"],
+        "Port1": ["Q1", "Q0", "M1"],
+    },
+)
+"""Pedagogical target for two qubit device control with cross resonance."""

--- a/test/python/pulse/test_target.py
+++ b/test/python/pulse/test_target.py
@@ -19,6 +19,8 @@ from qiskit.pulse.compiler.target import QiskitPulseTarget
 from qiskit.pulse.exceptions import NotExistingComponent
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
+# TODO update test
+
 
 @ddt
 class TestPulseTarget(QiskitTestCase):

--- a/test/python/pulse/test_target.py
+++ b/test/python/pulse/test_target.py
@@ -1,0 +1,168 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test for pulse target for pulse compiler."""
+
+from ddt import ddt, named_data, unpack
+
+from qiskit.pulse import model
+from qiskit.pulse.compiler.target import QiskitPulseTarget
+from qiskit.pulse.exceptions import NotExistingComponent
+from test import QiskitTestCase  # pylint: disable=wrong-import-order
+
+
+@ddt
+class TestPulseTarget(QiskitTestCase):
+    """Test cases of hardware information acquitision from QiskitPulseTarget with mock data."""
+
+    def setUp(self):
+        super().setUp()
+        self.target = QiskitPulseTarget(
+            qubit_frames={
+                0: "Q0",
+                1: "Q1",
+            },
+            meas_frames={
+                0: "M0",
+                1: "M1",
+            },
+            qubit_ports={
+                0: "Port0",
+                1: "Port1",
+                2: "OnlyPort",
+            },
+            coupler_ports={
+                (0, 1): "PortA",
+            },
+            mixed_frames={
+                "Port0": ["Q0", "Q1", "M0", "EX0"],
+                "Port1": ["Q1", "M1", "EX1", "EX2"],
+            },
+        )
+
+    @named_data(
+        ["qubit0", model.Qubit(0), "Port0"],
+        ["qubit1", model.Qubit(1), "Port1"],
+        ["coupler", model.Coupler(0, 1), "PortA"],
+    )
+    @unpack
+    def test_get_port_uid(self, port, uid):
+        """Test get Qiskit port UID from pulse target."""
+        self.assertEqual(self.target.get_port_identifier(port), uid)
+
+    def test_get_generic_port_fail(self):
+        """Test get cannot get port UID with generic Port object."""
+        with self.assertRaises(TypeError):
+            self.target.get_port_identifier(model.Port("GenericPort"))
+
+    def test_port_not_found(self):
+        """Test port is not available in pulse target."""
+        with self.assertRaises(NotExistingComponent):
+            self.target.get_port_identifier(model.Qubit(100))
+
+    @named_data(
+        ["frame_q0", model.QubitFrame(0), "Q0"],
+        ["frame_q1", model.QubitFrame(1), "Q1"],
+        ["frame_m0", model.MeasurementFrame(0), "M0"],
+        ["frame_m1", model.MeasurementFrame(1), "M1"],
+    )
+    def test_get_frame_uid(self, frame, uid):
+        """Test get Qiskit frame UID from pulse target."""
+        self.assertEqual(self.target.get_frame_identifier(frame), uid)
+
+    def test_get_generic_frame_fail(self):
+        """Test get cannot get frame UID with GenericFrame object."""
+        with self.assertRaises(TypeError):
+            self.target.get_frame_identifier(model.GenericFrame("GenericFrame"))
+
+    def test_frame_not_found(self):
+        """Test frame is not available in pulse target."""
+        with self.assertRaises(NotExistingComponent):
+            self.target.get_frame_identifier(model.QubitFrame(100))
+
+    @named_data(
+        [
+            "qubit0",
+            model.Qubit(0),
+            [model.GenericFrame("EX0")],
+        ],
+        [
+            "qubit1",
+            model.Qubit(1),
+            [model.GenericFrame("EX1"), model.GenericFrame("EX2")],
+        ],
+    )
+    @unpack
+    def test_get_extra_frames(self, port, frames):
+        """Test get extra frames tied to a particular Qiskit port."""
+        self.assertListEqual(self.target.extra_frames(port), frames)
+
+    def test_get_extra_frames_not_available_for_port(self):
+        """Test port exists but no mixed frame is defined."""
+        with self.assertRaises(NotExistingComponent):
+            self.target.extra_frames(model.Qubit(2))
+
+    @named_data(
+        ["q0_port0", model.MixedFrame(model.Qubit(0), model.QubitFrame(0))],
+        ["q1_port0", model.MixedFrame(model.Qubit(0), model.QubitFrame(1))],
+        ["m0_port0", model.MixedFrame(model.Qubit(0), model.MeasurementFrame(0))],
+    )
+    def test_check_mixed_frame_available(self, mixed_frame):
+        """Test available mixed frames on this target."""
+        self.assertTrue(self.target.is_mixed_frame_available(mixed_frame))
+
+    @named_data(
+        ["q0_port1", model.MixedFrame(model.Qubit(1), model.QubitFrame(0))],
+        ["q0_port100", model.MixedFrame(model.Qubit(100), model.QubitFrame(0))],
+        ["m1_port0", model.MixedFrame(model.Qubit(0), model.MeasurementFrame(1))],
+    )
+    def test_check_mixed_frame_not_available(self, mixed_frame):
+        """Test unavailable mixed frames on this target."""
+        self.assertFalse(self.target.is_mixed_frame_available(mixed_frame))
+
+    def test_filter_mixed_frame_only_port(self):
+        """Test get mixed frame list filtered by port."""
+        self.assertListEqual(
+            self.target.filter_mixed_frames(port=model.Qubit(0)),
+            [
+                model.MixedFrame(model.Qubit(0), model.QubitFrame(0)),
+                model.MixedFrame(model.Qubit(0), model.QubitFrame(1)),
+                model.MixedFrame(model.Qubit(0), model.MeasurementFrame(0)),
+                model.MixedFrame(model.Qubit(0), model.GenericFrame("EX0")),
+            ],
+        )
+
+    def test_filter_mixed_frame_only_frame(self):
+        """Test get mixed frame list filtered by frame."""
+        self.assertListEqual(
+            self.target.filter_mixed_frames(frame=model.QubitFrame(1)),
+            [
+                model.MixedFrame(model.Qubit(0), model.QubitFrame(1)),
+                model.MixedFrame(model.Qubit(1), model.QubitFrame(1)),
+            ],
+        )
+
+    def test_filter_mixed_frame_both_port_frame(self):
+        """Test get mixed frame list filtered by both port and frame."""
+        self.assertListEqual(
+            self.target.filter_mixed_frames(frame=model.QubitFrame(1), port=model.Qubit(0)),
+            [
+                model.MixedFrame(model.Qubit(0), model.QubitFrame(1)),
+            ],
+        )
+
+    def test_filter_mixed_frame_non_existing(self):
+        """Test no mixed frame mached with the condition."""
+        self.assertListEqual(
+            self.target.filter_mixed_frames(port=model.Qubit(100)),
+            [],
+        )


### PR DESCRIPTION
### Summary

This PR adds Qiskit Target model for pulse domain, `PulseTarget`, and its reference implementation `QiskitPulseTarget`.

### Details and comments

Currently PulseTarget only defines APIs that map Qiskit pulse model to hardware resources. This could be extended to include more information, such as generic parametric pulse schema, available frequency range of frames, and supported instruction types. But these are as-needed basis. Vendor can also define own Target class based on the protocol, that provides necessary information for vendor specific compiler passes. Qiskit implementation is bare minimum to support builtin pulse compiler passes in Qiskit.

