### PR TITLE
Add fast-path construction to `NLocal`

### DIFF
--- a/qiskit/circuit/library/n_local/n_local.py
+++ b/qiskit/circuit/library/n_local/n_local.py
@@ -13,16 +13,24 @@
 """The n-local circuit class."""
 
 from __future__ import annotations
+
+import collections
+import itertools
 import typing
 from collections.abc import Callable, Mapping, Sequence
-
-from itertools import combinations
 
 import numpy
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit.quantumregister import QuantumRegister
-from qiskit.circuit import Instruction, Parameter, ParameterVector, ParameterExpression
+from qiskit.circuit import (
+    Instruction,
+    Parameter,
+    ParameterVector,
+    ParameterExpression,
+    CircuitInstruction,
+)
 from qiskit.exceptions import QiskitError
+from qiskit.circuit.library.standard_gates import get_standard_gate_name_mapping
 
 from ..blueprintcircuit import BlueprintCircuit
 
@@ -153,6 +161,17 @@ class NLocal(BlueprintCircuit):
         self._initial_state_circuit: QuantumCircuit | None = None
         self._bounds: list[tuple[float | None, float | None]] | None = None
         self._flatten = flatten
+
+        # During the build, if a subclass hasn't overridden our parametrisation methods, we can use
+        # a newer fast-path method to parametrise the rotation and entanglement blocks if internally
+        # those are just simple stdlib gates that have been promoted to circuits.  We don't
+        # precalculate the fast-path layers themselves because there's far too much that can be
+        # overridden between object construction and build, and far too many subclasses of `NLocal`
+        # that override bits and bobs of the internal private methods, so it'd be too hard to keep
+        # everything in sync.
+        self._allow_fast_path_parametrization = (
+            getattr(self._parameter_generator, "__func__", None) is NLocal._parameter_generator
+        )
 
         if int(reps) != reps:
             raise TypeError("The value of reps should be int")
@@ -779,13 +798,10 @@ class NLocal(BlueprintCircuit):
             else:
                 entangler_map = entanglement
 
-            layer = QuantumCircuit(self.num_qubits)
             for i in entangler_map:
                 params = self.ordered_parameters[-len(get_parameters(block)) :]
                 parameterized_block = self._parameterize_block(block, params=params)
-                layer.compose(parameterized_block, i, inplace=True)
-
-            self.compose(layer, inplace=True)
+                self.compose(parameterized_block, i, inplace=True, copy=False)
         else:
             # cannot prepend a block currently, just rebuild
             self._invalidate()
@@ -843,52 +859,65 @@ class NLocal(BlueprintCircuit):
         """Build a rotation layer."""
         # if the unentangled qubits are skipped, compute the set of qubits that are not entangled
         if self._skip_unentangled_qubits:
-            unentangled_qubits = self.get_unentangled_qubits()
+            skipped_qubits = self.get_unentangled_qubits()
+        else:
+            skipped_qubits = set()
+
+        target_qubits = circuit.qubits
 
         # iterate over all rotation blocks
         for j, block in enumerate(self.rotation_blocks):
-            # create a new layer
-            layer = QuantumCircuit(*self.qregs)
-
-            # we apply the rotation gates stacked on top of each other, i.e.
-            # if we have 4 qubits and a rotation block of width 2, we apply two instances
-            block_indices = [
-                list(range(k * block.num_qubits, (k + 1) * block.num_qubits))
-                for k in range(self.num_qubits // block.num_qubits)
-            ]
-
-            # if unentangled qubits should not be acted on, remove all operations that
-            # touch an unentangled qubit
-            if self._skip_unentangled_qubits:
+            skipped_blocks = {qubit // block.num_qubits for qubit in skipped_qubits}
+            if (
+                self._allow_fast_path_parametrization
+                and (simple_block := _stdlib_gate_from_simple_block(block)) is not None
+            ):
+                all_qubits = (
+                    tuple(target_qubits[k * block.num_qubits : (k + 1) * block.num_qubits])
+                    for k in range(self.num_qubits // block.num_qubits)
+                    if k not in skipped_blocks
+                )
+                for qubits in all_qubits:
+                    instr = CircuitInstruction(
+                        simple_block.gate(*itertools.islice(param_iter, simple_block.num_params)),
+                        qubits,
+                    )
+                    circuit._append(instr)
+            else:
                 block_indices = [
-                    indices
-                    for indices in block_indices
-                    if set(indices).isdisjoint(unentangled_qubits)
+                    list(range(k * block.num_qubits, (k + 1) * block.num_qubits))
+                    for k in range(self.num_qubits // block.num_qubits)
+                    if k not in skipped_blocks
                 ]
-
-            # apply the operations in the layer
-            for indices in block_indices:
-                parameterized_block = self._parameterize_block(block, param_iter, i, j, indices)
-                layer.compose(parameterized_block, indices, inplace=True)
-
-            # add the layer to the circuit
-            circuit.compose(layer, inplace=True)
+                # apply the operations in the layer
+                for indices in block_indices:
+                    parameterized_block = self._parameterize_block(block, param_iter, i, j, indices)
+                    circuit.compose(parameterized_block, indices, inplace=True, copy=False)
 
     def _build_entanglement_layer(self, circuit, param_iter, i):
         """Build an entanglement layer."""
         # iterate over all entanglement blocks
+        target_qubits = circuit.qubits
         for j, block in enumerate(self.entanglement_blocks):
-            # create a new layer and get the entangler map for this block
-            layer = QuantumCircuit(*self.qregs)
             entangler_map = self.get_entangler_map(i, j, block.num_qubits)
-
-            # apply the operations in the layer
-            for indices in entangler_map:
-                parameterized_block = self._parameterize_block(block, param_iter, i, j, indices)
-                layer.compose(parameterized_block, indices, inplace=True)
-
-            # add the layer to the circuit
-            circuit.compose(layer, inplace=True)
+            if (
+                self._allow_fast_path_parametrization
+                and (simple_block := _stdlib_gate_from_simple_block(block)) is not None
+            ):
+                for indices in entangler_map:
+                    # It's actually nontrivially faster to use a listcomp and pass that to `tuple`
+                    # than to pass a generator expression directly.
+                    # pylint: disable=consider-using-generator
+                    instr = CircuitInstruction(
+                        simple_block.gate(*itertools.islice(param_iter, simple_block.num_params)),
+                        tuple([target_qubits[i] for i in indices]),
+                    )
+                    circuit._append(instr)
+            else:
+                # apply the operations in the layer
+                for indices in entangler_map:
+                    parameterized_block = self._parameterize_block(block, param_iter, i, j, indices)
+                    circuit.compose(parameterized_block, indices, inplace=True, copy=False)
 
     def _build_additional_layers(self, circuit, which):
         if which == "appended":
@@ -901,13 +930,10 @@ class NLocal(BlueprintCircuit):
             raise ValueError("`which` must be either `appended` or `prepended`.")
 
         for block, ent in zip(blocks, entanglements):
-            layer = QuantumCircuit(*self.qregs)
             if isinstance(ent, str):
                 ent = get_entangler_map(block.num_qubits, self.num_qubits, ent)
             for indices in ent:
-                layer.compose(block, indices, inplace=True)
-
-            circuit.compose(layer, inplace=True)
+                circuit.compose(block, indices, inplace=True, copy=False)
 
     def _build(self) -> None:
         """If not already built, build the circuit."""
@@ -926,7 +952,7 @@ class NLocal(BlueprintCircuit):
 
         # use the initial state as starting circuit, if it is set
         if self.initial_state:
-            circuit.compose(self.initial_state.copy(), inplace=True)
+            circuit.compose(self.initial_state.copy(), inplace=True, copy=False)
 
         param_iter = iter(self.ordered_parameters)
 
@@ -972,7 +998,7 @@ class NLocal(BlueprintCircuit):
             except QiskitError:
                 block = circuit.to_instruction()
 
-            self.append(block, self.qubits)
+            self.append(block, self.qubits, copy=False)
 
     # pylint: disable=unused-argument
     def _parameter_generator(self, rep: int, block: int, indices: list[int]) -> Parameter | None:
@@ -1023,7 +1049,7 @@ def get_entangler_map(
         raise ValueError("Pairwise entanglement is not defined for blocks with more than 2 qubits.")
 
     if entanglement == "full":
-        return list(combinations(list(range(n)), m))
+        return list(itertools.combinations(list(range(n)), m))
     elif entanglement == "reverse_linear":
         # reverse linear connectivity. In the case of m=2 and the entanglement_block='cx'
         # then it's equivalent to 'full' entanglement
@@ -1057,3 +1083,28 @@ def get_entangler_map(
 
     else:
         raise ValueError(f"Unsupported entanglement type: {entanglement}")
+
+
+_StdlibGateResult = collections.namedtuple("_StdlibGateResult", ("gate", "num_params"))
+_STANDARD_GATE_MAPPING = get_standard_gate_name_mapping()
+
+
+def _stdlib_gate_from_simple_block(block: QuantumCircuit) -> _StdlibGateResult | None:
+    if block.global_phase != 0.0 or len(block) != 1:
+        return None
+    instruction = block.data[0]
+    # If the single instruction isn't a standard-library gate that spans the full width of the block
+    # in the correct order, we're not simple.  If the gate isn't fully parametrised with pure,
+    # unique `Parameter` instances (expressions are too complex) that are in order, we're not
+    # simple.
+    if (
+        instruction.clbits
+        or tuple(instruction.qubits) != tuple(block.qubits)
+        or (
+            getattr(_STANDARD_GATE_MAPPING.get(instruction.operation.name), "base_class", None)
+            is not instruction.operation.base_class
+        )
+        or tuple(instruction.operation.params) != tuple(block.parameters)
+    ):
+        return None
+    return _StdlibGateResult(instruction.operation.base_class, len(instruction.operation.params))

--- a/releasenotes/notes/nlocal-perf-3b8ebd9be1b2f4b3.yaml
+++ b/releasenotes/notes/nlocal-perf-3b8ebd9be1b2f4b3.yaml
@@ -1,0 +1,9 @@
+---
+features_circuits:
+  - |
+    The construction performance of :class:`.NLocal` and its derived circuit-library subclasses
+    (e.g. :class:`.EfficientSU2` and :class:`.RealAmplitudes`) has significantly improved, when the
+    rotation and/or entanglement subblocks are simple applications of a single Qiskit
+    standard-library gate.  Since these circuits are constructed lazily, you might not see the
+    improvement immediately on instantiation of the class, but instead on first access to its
+    internal structure.  Performance improvements are on the order of ten times faster.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This class is hard to make the most efficient, due to how abstract the base class is, with many different options and many private methods that subclasses override.  Still, in cases where, _at the point of build_, we can detect that rotation or entanglement layers are simple applications of a single standard-library gate, we can skip the entire `copy` + `assign` + `compose` pipeline and simply construct the gates in-place with the correct parameters.  This skips huge tracts of overhead that using the high-level, abstract interfaces (which are somewhat necessarily more optimised to work with large operands) in tight inner loops adds, culminating in about a 10x improvement in build time.

`NLocal` is so abstract that it's hard to hit similar performance to an idiomatic direct construction of the relevant structure, but to be fair, the concept of a circuit library is not necessarily to make the absolute fastest constructors for tight loops, but to make it much simpler to just get a circuit that works as intended.


### Details and comments

Just to be clear: I don't love this PR, and generally think it's an unpleasant fragile hack, but these are some of our most used circuits in practice, and my feeling is that we need to make some amount of sacrifice to make them faster to construct than the bottlenecks they currently can be.

Built on top of #12098.
