### PR TITLE
Remove Hamamura-san from maintainer lists

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,7 @@
 
 # Qiskit folders (also their corresponding tests)
 providers/            @Qiskit/terra-core @jyu00
-quantum_info/         @Qiskit/terra-core @ikkoham
+quantum_info/         @Qiskit/terra-core
 qpy/                  @Qiskit/terra-core
 pulse/                @Qiskit/terra-core @eggerdj @wshanks
 synthesis/            @Qiskit/terra-core @alexanderivrii @ShellyGarion

--- a/qiskit_bot.yaml
+++ b/qiskit_bot.yaml
@@ -18,13 +18,10 @@ notifications:
         - "`@nkanazawa1989`"
     "two_qubit_decompose":
         - "`@levbishop`"
-    "quantum_info":
-        - "`@ikkoham`"
     "circuit/library":
         - "`@Cryoris`"
         - "`@ajavadia`"
     "primitives":
-        - "`@ikkoham`"
         - "`@t-imamichi`"
         - "`@ajavadia`"
         - "`@levbishop`"


### PR DESCRIPTION
### Summary

With Hamamura-san having moved on from IBM now, this commit removes him from being tagged/mentioned as a primary contact/reviewer for the modules he'd previously been working in.  We're of course happy to keep working together, just there's no expectation anymore!

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


