### PR TITLE
Creating a challenging backend to show the transpiler stochasticity 

### DIFF
--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -799,7 +799,7 @@ circuit repeatedly will in general result in a distribution of circuit depths an
 at the output.
 
 In order to highlight this, we run a GHZ circuit 100 times, using a "bad" (disconnected)
-`initial_layout`:
+``initial_layout`` in a heavy hex coupling map:
 
 .. plot::
 
@@ -816,18 +816,22 @@ In order to highlight this, we run a GHZ circuit 100 times, using a "bad" (disco
    import matplotlib.pyplot as plt
    from qiskit import QuantumCircuit, transpile
    from qiskit.providers.fake_provider import GenericBackendV2
-   backend = GenericBackendV2(16)
+   from qiskit.transpiler import CouplingMap
+
+   coupling_map = CouplingMap.from_heavy_hex(3)
+   backend = GenericBackendV2(coupling_map.size(), coupling_map=coupling_map)
 
    ghz = QuantumCircuit(15)
    ghz.h(0)
    ghz.cx(0, range(1, 15))
 
    depths = []
-   for _ in range(100):
+   for i in range(100):
        depths.append(
            transpile(
                ghz,
                backend,
+               seed_transpiler=i,
                layout_method='trivial'  # Fixed layout mapped in circuit order
            ).depth()
        )


### PR DESCRIPTION
The documentation about the transpiler shows that the process is stochastic in https://docs.quantum.ibm.com/api/qiskit/transpiler#routing-stage:

> In order to highlight this, we run a GHZ circuit 100 times, using a “bad” (disconnected) initial_layout:
![image](https://docs.quantum.ibm.com/_next/image?url=%2Fimages%2Fapi%2Fqiskit%2Ftranspiler-11.png&w=1200&q=75)
![image](https://github.com/Qiskit/qiskit/assets/766693/643960a1-5d4a-4e65-8f80-404d4f24a1cf)
> This distribution is quite wide, signaling the difficulty the swap mapper is having in computing the best mapping. 

Which is not very wide. That's because `GenericFakeBackend` replaced a `FakeBackend` in #11376. The `GenericFakeBackend` has an all-to-all connectivity by default.

This PR produces the following image:
![image](https://github.com/Qiskit/qiskit/assets/766693/66c49e23-0f50-42ce-b6d8-38e9e03f2253)

