### PR TITLE
Fix global-phase handling during OpenQASM 3 export

### DIFF
--- a/qiskit/qasm3/printer.py
+++ b/qiskit/qasm3/printer.py
@@ -381,8 +381,10 @@ class BasicPrinter:
         self.visit(node.quantumGateName)
         if node.parameters:
             self._visit_sequence(node.parameters, start="(", end=")", separator=", ")
-        self.stream.write(" ")
-        self._visit_sequence(node.indexIdentifierList, separator=", ")
+        if node.indexIdentifierList:
+            # `gphase` has no qubit arguments.
+            self.stream.write(" ")
+            self._visit_sequence(node.indexIdentifierList, separator=", ")
         self._end_statement()
 
     def _visit_QuantumBarrier(self, node: ast.QuantumBarrier) -> None:

--- a/releasenotes/notes/fix-qasm3-gphase-10fa67c4e669932b.yaml
+++ b/releasenotes/notes/fix-qasm3-gphase-10fa67c4e669932b.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The OpenQASM 3 exporter (:func:`.qasm3.dump` and :func:`.qasm3.dumps`) will now output a
+    `gphase` instruction for the global phase of the circuit and any contained control-flow blocks.
+    Previously it was silently omitted.

--- a/test/python/qasm3/test_import.py
+++ b/test/python/qasm3/test_import.py
@@ -80,6 +80,21 @@ class TestOldQASM3Import(QiskitTestCase):
         expected.measure(1, 1)
         self.assertEqual(parsed, expected)
 
+    def test_global_phase_import(self):
+        program = """
+            OPENQASM 3.0;
+            bit b;
+            gphase(1.0);
+            // Phases inside blocks should also be understood.
+            if (b) {
+              gphase(1.5);
+            }
+        """
+        expected = QuantumCircuit([Clbit()], global_phase=1.0)
+        with expected.if_test((expected.clbits[0], True)):
+            expected.global_phase = 1.5
+        self.assertEqual(qasm3.loads(program), expected)
+
 
 class TestQASM3Import(QiskitTestCase):
     @classmethod


### PR DESCRIPTION
### Summary

Unlike OpenQASM 2, OpenQASM 3 has a built-in way to represent global-phase advancement through its `gphase` statement, but we weren't outputting it.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Fix #12114.

I'm marking this temporarily "on hold" because I'm not convinced that the IBM backend stack can support `gphase` end-to-end - my rough preliminary testing with direct OQ3 submission threw up a parser error, ~but if I use the parser locally, it seems to work fine.  Not quite sure what's going on with it,~ *edit*: actually it throws the same error locally as well, so it seems like it's not supported.  I don't want to merge this PR before I'm confident it won't break dynamic-circuit submission.