### PR TITLE
Add mapping-like features to data_bin

### DIFF
--- a/qiskit/primitives/containers/data_bin.py
+++ b/qiskit/primitives/containers/data_bin.py
@@ -15,7 +15,7 @@ Dataclass tools for data namespaces (bins)
 """
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import make_dataclass
 from typing import Any
 
@@ -74,15 +74,15 @@ class DataBin(metaclass=DataBinMeta):
     def __iter__(self) -> Iterable[str]:
         return iter(self._FIELDS)
 
-    def keys(self) -> tuple[str, ...]:
+    def keys(self) -> Sequence[str]:
         """Return a list of field names."""
         return tuple(self._FIELDS)
 
-    def values(self) -> tuple:
+    def values(self) -> Sequence[Any]:
         """Return a list of values."""
         return tuple(getattr(self, key) for key in self._FIELDS)
 
-    def items(self) -> tuple[tuple[str, Any], ...]:
+    def items(self) -> Sequence[tuple[str, Any]]:
         """Return a list of field names and values"""
         return tuple((key, getattr(self, key)) for key in self._FIELDS)
 

--- a/qiskit/primitives/containers/data_bin.py
+++ b/qiskit/primitives/containers/data_bin.py
@@ -76,7 +76,7 @@ class DataBin(metaclass=DataBinMeta):
 
     def keys(self) -> list[str]:
         """Return a list of field names."""
-        return self._FIELDS
+        return list(self._FIELDS)
 
     def values(self) -> list[Any]:
         """Return a list of values."""

--- a/qiskit/primitives/containers/data_bin.py
+++ b/qiskit/primitives/containers/data_bin.py
@@ -57,7 +57,7 @@ class DataBin(metaclass=DataBinMeta):
 
     def __getitem__(self, key: str) -> Any:
         if not hasattr(self, key):
-            raise ValueError(f"Key ({key}) does not exist in this data bin.")
+            raise KeyError(f"Key ({key}) does not exist in this data bin.")
         return getattr(self, key)
 
     def __contains__(self, key: str) -> bool:

--- a/qiskit/primitives/containers/data_bin.py
+++ b/qiskit/primitives/containers/data_bin.py
@@ -64,27 +64,27 @@ class DataBin(metaclass=DataBinMeta):
         return f"{type(self)}({', '.join(vals)})"
 
     def __getitem__(self, key: str) -> Any:
-        if not hasattr(self, key):
+        if key not in self._FIELDS:
             raise KeyError(f"Key ({key}) does not exist in this data bin.")
         return getattr(self, key)
 
     def __contains__(self, key: str) -> bool:
-        return hasattr(self, key)
+        return key in self._FIELDS
 
     def __iter__(self) -> Iterable[str]:
         return iter(self._FIELDS)
 
-    def keys(self) -> list[str]:
+    def keys(self) -> tuple[str, ...]:
         """Return a list of field names."""
-        return list(self._FIELDS)
+        return tuple(self._FIELDS)
 
-    def values(self) -> list[Any]:
+    def values(self) -> tuple:
         """Return a list of values."""
-        return [getattr(self, key) for key in self._FIELDS]
+        return tuple(getattr(self, key) for key in self._FIELDS)
 
-    def items(self) -> list[tuple[str, Any]]:
+    def items(self) -> tuple[tuple[str, Any], ...]:
         """Return a list of field names and values"""
-        return [(key, getattr(self, key)) for key in self._FIELDS]
+        return tuple((key, getattr(self, key)) for key in self._FIELDS)
 
 
 def make_data_bin(
@@ -106,7 +106,7 @@ def make_data_bin(
     Returns:
         A new class.
     """
-    field_names, field_types = zip(*fields) if fields else ([], [])
+    field_names, field_types = zip(*fields) if fields else ((), ())
     for name in field_names:
         if name in DataBin._RESTRICTED_NAMES:
             raise ValueError(f"'{name}' is a restricted name for a DataBin.")

--- a/qiskit/primitives/containers/data_bin.py
+++ b/qiskit/primitives/containers/data_bin.py
@@ -41,7 +41,15 @@ class DataBin(metaclass=DataBinMeta):
     :class:`make_dataclass`.
     """
 
-    _RESTRICTED_NAMES = ("_RESTRICTED_NAMES", "_SHAPE", "_FIELDS", "_FIELD_TYPES")
+    _RESTRICTED_NAMES = (
+        "_RESTRICTED_NAMES",
+        "_SHAPE",
+        "_FIELDS",
+        "_FIELD_TYPES",
+        "keys",
+        "values",
+        "items",
+    )
     _SHAPE: tuple[int, ...] | None = None
     _FIELDS: tuple[str, ...] = ()
     """The fields allowed in this data bin."""
@@ -70,9 +78,14 @@ class DataBin(metaclass=DataBinMeta):
         """Return an iterable of field names."""
         return iter(self)
 
+    def values(self) -> Iterable[Any]:
+        """Return an iterable of values."""
+        for key in self._FIELDS:
+            yield getattr(self, key)
+
     def items(self) -> Iterable[tuple[str, Any]]:
         """Return an iterable of field names and values"""
-        for key in self:
+        for key in self._FIELDS:
             yield key, getattr(self, key)
 
 

--- a/qiskit/primitives/containers/data_bin.py
+++ b/qiskit/primitives/containers/data_bin.py
@@ -41,7 +41,7 @@ class DataBin(metaclass=DataBinMeta):
     :class:`make_dataclass`.
     """
 
-    _RESTRICTED_NAMES = (
+    _RESTRICTED_NAMES = {
         "_RESTRICTED_NAMES",
         "_SHAPE",
         "_FIELDS",
@@ -49,7 +49,7 @@ class DataBin(metaclass=DataBinMeta):
         "keys",
         "values",
         "items",
-    )
+    }
     _SHAPE: tuple[int, ...] | None = None
     _FIELDS: tuple[str, ...] = ()
     """The fields allowed in this data bin."""
@@ -74,19 +74,17 @@ class DataBin(metaclass=DataBinMeta):
     def __iter__(self) -> Iterable[str]:
         return iter(self._FIELDS)
 
-    def keys(self) -> Iterable[str]:
-        """Return an iterable of field names."""
-        return iter(self)
+    def keys(self) -> list[str]:
+        """Return a list of field names."""
+        return self._FIELDS
 
-    def values(self) -> Iterable[Any]:
-        """Return an iterable of values."""
-        for key in self._FIELDS:
-            yield getattr(self, key)
+    def values(self) -> list[Any]:
+        """Return a list of values."""
+        return [getattr(self, key) for key in self._FIELDS]
 
-    def items(self) -> Iterable[tuple[str, Any]]:
-        """Return an iterable of field names and values"""
-        for key in self._FIELDS:
-            yield key, getattr(self, key)
+    def items(self) -> list[tuple[str, Any]]:
+        """Return a list of field names and values"""
+        return [(key, getattr(self, key)) for key in self._FIELDS]
 
 
 def make_data_bin(

--- a/qiskit/primitives/containers/data_bin.py
+++ b/qiskit/primitives/containers/data_bin.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import make_dataclass
+from typing import Any
 
 
 class DataBinMeta(type):
@@ -54,10 +55,30 @@ class DataBin(metaclass=DataBinMeta):
         vals = (f"{name}={getattr(self, name)}" for name in self._FIELDS if hasattr(self, name))
         return f"{type(self)}({', '.join(vals)})"
 
+    def __getitem__(self, key: str) -> Any:
+        if not hasattr(self, key):
+            raise ValueError(f"Key ({key}) does not exist in this data bin.")
+        return getattr(self, key)
+
+    def __contains__(self, key: str) -> bool:
+        return hasattr(self, key)
+
+    def __iter__(self) -> Iterable[str]:
+        return iter(self._FIELDS)
+
+    def keys(self) -> Iterable[str]:
+        """Return an iterable of field names."""
+        return iter(self)
+
+    def items(self) -> Iterable[tuple[str, Any]]:
+        """Return an iterable of field names and values"""
+        for key in self:
+            yield key, getattr(self, key)
+
 
 def make_data_bin(
     fields: Iterable[tuple[str, type]], shape: tuple[int, ...] | None = None
-) -> DataBinMeta:
+) -> type[DataBin]:
     """Return a new subclass of :class:`~DataBin` with the provided fields and shape.
 
     .. code-block:: python

--- a/releasenotes/notes/databin-mapping-45d24d71f9bb4eda.yaml
+++ b/releasenotes/notes/databin-mapping-45d24d71f9bb4eda.yaml
@@ -1,0 +1,24 @@
+---
+features_primitives:
+  - |
+    Added mapping-like features to :class:`~.DataBin`, i.e.,
+    ``__getitem__``, ``__contains__``, ``__iter__``,
+    :meth:`~.DataBin.keys`, :meth:`~.DataBin.values`, and
+    :meth:`~.DataBin.items`.
+
+    .. code-block:: python
+    
+      from qiskit import QuantumCircuit
+      from qiskit.primitives import StatevectorSampler
+
+      circuit = QuantumCircuit(1)
+      circuit.h(0)
+      circuit.measure_all()
+
+      sampler = StatevectorSampler()
+      result = sampler.run([circuit]).result()
+      databin = result[0].data
+      for creg, arr in databin.items():
+          print(creg, arr)
+      for creg in databin:
+          print(creg, databin[creg])

--- a/test/python/primitives/containers/test_data_bin.py
+++ b/test/python/primitives/containers/test_data_bin.py
@@ -90,6 +90,15 @@ class DataBinTestCase(QiskitTestCase):
             key = next(iterator)
             self.assertEqual(key, "beta")
 
+        with self.subTest("values"):
+            iterator = data_bin.values()
+            val = next(iterator)
+            self.assertIsInstance(val, int)
+            self.assertEqual(val, 10)
+            val = next(iterator)
+            self.assertIsInstance(val, dict)
+            self.assertEqual(val, {1: 2})
+
         with self.subTest("items"):
             iterator = data_bin.items()
             key, val = next(iterator)
@@ -115,5 +124,5 @@ class DataBinTestCase(QiskitTestCase):
             self.assertEqual(val, {1: 2})
 
         with self.subTest("error"):
-            with self.assertRaises(ValueError):
+            with self.assertRaises(KeyError):
                 _ = data_bin["gamma"]

--- a/test/python/primitives/containers/test_data_bin.py
+++ b/test/python/primitives/containers/test_data_bin.py
@@ -82,30 +82,32 @@ class DataBinTestCase(QiskitTestCase):
             self.assertEqual(key, "alpha")
             key = next(iterator)
             self.assertEqual(key, "beta")
+            with self.assertRaises(StopIteration):
+                _ = next(iterator)
 
         with self.subTest("keys"):
-            iterator = data_bin.keys()
-            key = next(iterator)
+            lst = data_bin.keys()
+            key = lst[0]
             self.assertEqual(key, "alpha")
-            key = next(iterator)
+            key = lst[1]
             self.assertEqual(key, "beta")
 
         with self.subTest("values"):
-            iterator = data_bin.values()
-            val = next(iterator)
+            lst = data_bin.values()
+            val = lst[0]
             self.assertIsInstance(val, int)
             self.assertEqual(val, 10)
-            val = next(iterator)
+            val = lst[1]
             self.assertIsInstance(val, dict)
             self.assertEqual(val, {1: 2})
 
         with self.subTest("items"):
-            iterator = data_bin.items()
-            key, val = next(iterator)
+            lst = data_bin.items()
+            key, val = lst[0]
             self.assertEqual(key, "alpha")
             self.assertIsInstance(val, int)
             self.assertEqual(val, 10)
-            key, val = next(iterator)
+            key, val = lst[1]
             self.assertEqual(key, "beta")
             self.assertIsInstance(val, dict)
             self.assertEqual(val, {1: 2})

--- a/test/python/primitives/containers/test_data_bin.py
+++ b/test/python/primitives/containers/test_data_bin.py
@@ -69,3 +69,51 @@ class DataBinTestCase(QiskitTestCase):
         data_bin_cls = make_data_bin([])
         data_bin = data_bin_cls()
         self.assertEqual(len(data_bin), 0)
+
+    def test_make_databin_mapping(self):
+        """Test the make_data_bin() function with mapping features."""
+        data_bin_cls = make_data_bin([("alpha", int), ("beta", dict)])
+        data_bin = data_bin_cls(10, {1: 2})
+        self.assertEqual(len(data_bin), 2)
+
+        with self.subTest("iterator"):
+            iterator = iter(data_bin)
+            key = next(iterator)
+            self.assertEqual(key, "alpha")
+            key = next(iterator)
+            self.assertEqual(key, "beta")
+
+        with self.subTest("keys"):
+            iterator = data_bin.keys()
+            key = next(iterator)
+            self.assertEqual(key, "alpha")
+            key = next(iterator)
+            self.assertEqual(key, "beta")
+
+        with self.subTest("items"):
+            iterator = data_bin.items()
+            key, val = next(iterator)
+            self.assertEqual(key, "alpha")
+            self.assertIsInstance(val, int)
+            self.assertEqual(val, 10)
+            key, val = next(iterator)
+            self.assertEqual(key, "beta")
+            self.assertIsInstance(val, dict)
+            self.assertEqual(val, {1: 2})
+
+        with self.subTest("contains"):
+            self.assertIn("alpha", data_bin)
+            self.assertIn("beta", data_bin)
+            self.assertNotIn("gamma", data_bin)
+
+        with self.subTest("getitem"):
+            val = data_bin["alpha"]
+            self.assertIsInstance(val, int)
+            self.assertEqual(val, 10)
+            val = data_bin["beta"]
+            self.assertIsInstance(val, dict)
+            self.assertEqual(val, {1: 2})
+
+        with self.subTest("error"):
+            with self.assertRaises(ValueError):
+                _ = data_bin["gamma"]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Adds mapping-like features to `DataBin` (`__iter__`, `__getitem__`, `__contains__`, `keys`, `values`, `items`).
It also revises the return type of `make_data_bin` so that IDE can recognize the new methods.

### Details and comments


