### PR TITLE
Change Block to Bloc for consistency

### DIFF
--- a/qiskit/primitives/__init__.py
+++ b/qiskit/primitives/__init__.py
@@ -110,7 +110,7 @@ Overview of SamplerV2
 :class:`~BaseSamplerV2` is a primitive that samples outputs of quantum circuits.
 
 Following construction, a sampler is used by calling its :meth:`~.BaseSamplerV2.run` method
-with a list of pubs (Primitive Unified Blocks). Each pub contains values that, together,
+with a list of pubs (Primitive Unified Blocs). Each pub contains values that, together,
 define a computational unit of work for the sampler to complete:
 
 * A single :class:`~qiskit.circuit.QuantumCircuit`, possibly parameterized.


### PR DESCRIPTION
As pointed out by @kevinsung in the qiskit/documentation repo issue [here](https://github.com/Qiskit/documentation/issues/1066), the spelling is Bloc rather than Block. Closes #12130 
