### PR TITLE
Fix `GenericBackendV2` duration tests

### DIFF
--- a/qiskit/providers/fake_provider/generic_backend_v2.py
+++ b/qiskit/providers/fake_provider/generic_backend_v2.py
@@ -62,8 +62,8 @@ _NOISE_DEFAULTS = {
 
 # Fallback values for gates with unknown noise default ranges.
 _NOISE_DEFAULTS_FALLBACK = {
-    "1-q": (3e-8, 6e-8, 9e-5, 1e-4),
-    "multi-q": (8e-8, 9e-7, 1e-5, 5e-3),
+    "1-q": (2.997e-08, 5.994e-08, 9e-5, 1e-4),
+    "multi-q": (7.992e-08, 8.99988e-07, 5e-3),
 }
 
 # Ranges to sample qubit properties from.

--- a/test/python/providers/fake_provider/test_generic_backend_v2.py
+++ b/test/python/providers/fake_provider/test_generic_backend_v2.py
@@ -117,19 +117,21 @@ class TestGenericBackendV2(QiskitTestCase):
 
         basis_gates = ["cx", "id", "rz", "sx", "x", "sdg", "rxx"]
         expected_durations = {
-            "cx": (8e-8, 9e-7),
-            "id": (3e-8, 6e-8),
+            "cx": (7.992e-08, 8.99988e-07),
+            "id": (2.997e-08, 5.994e-08),
             "rz": (0.0, 0.0),
-            "sx": (3e-8, 6e-8),
-            "x": (3e-8, 6e-8),
-            "measure": (7e-7, 1.5e-6),
-            "sdg": (3e-8, 6e-8),
-            "rxx": (8e-8, 9e-7),
+            "sx": (2.997e-08, 5.994e-08),
+            "x": (2.997e-08, 5.994e-08),
+            "measure": (6.99966e-07, 1.500054e-06),
+            "sdg": (2.997e-08, 5.994e-08),
+            "sdg": (2.997e-08, 5.994e-08),
+            "rxx": (7.992e-08, 8.99988e-07),
         }
-        target = GenericBackendV2(num_qubits=2, basis_gates=basis_gates).target
-        for inst in target:
-            for qargs in target.qargs_for_operation_name(inst):
-                duration = target[inst][qargs].duration
-                if inst not in ["delay", "reset"]:
-                    self.assertGreaterEqual(duration, expected_durations[inst][0])
-                    self.assertLessEqual(duration, expected_durations[inst][1])
+        for _ in range(20):
+            target = GenericBackendV2(num_qubits=2, basis_gates=basis_gates).target
+            for inst in target:
+                for qargs in target.qargs_for_operation_name(inst):
+                    duration = target[inst][qargs].duration
+                    if inst not in ["delay", "reset"]:
+                        self.assertGreaterEqual(duration, expected_durations[inst][0])
+                        self.assertLessEqual(duration, expected_durations[inst][1])

--- a/test/python/providers/fake_provider/test_generic_backend_v2.py
+++ b/test/python/providers/fake_provider/test_generic_backend_v2.py
@@ -124,7 +124,6 @@ class TestGenericBackendV2(QiskitTestCase):
             "x": (2.997e-08, 5.994e-08),
             "measure": (6.99966e-07, 1.500054e-06),
             "sdg": (2.997e-08, 5.994e-08),
-            "sdg": (2.997e-08, 5.994e-08),
             "rxx": (7.992e-08, 8.99988e-07),
         }
         for _ in range(20):


### PR DESCRIPTION
### Summary
This PR fixes two oversights from #11780: applying the rounding to the fallback durations and adjusting the unit tests to the new ranges. I've also added a loop (I guess it could be longer) in the unit test to check more values, given that with random sampling it's not so likely to hit one of the edge values if we only execute it once. I'm not adding a changelog as the changes are contained in the release note of #11780.


### Details and comments
Fixes some flaky nightly tests such as: [fix-test-ranges](https://dev.azure.com/qiskit-ci/qiskit/_build/results?buildId=55833&view=logs&j=0ce5729b-6b73-5da7-85a9-9bdc84ba4b0f&t=71396f53-c82e-5b39-4444-0cdcd8d021a3&l=16896)

