### PR TITLE
Use math and cmath instead of numpy on scalars

### DIFF
--- a/qiskit/circuit/_utils.py
+++ b/qiskit/circuit/_utils.py
@@ -13,6 +13,7 @@
 This module contains utility functions for circuits.
 """
 
+import math
 import numpy
 from qiskit.exceptions import QiskitError
 from qiskit.circuit.exceptions import CircuitError
@@ -56,7 +57,7 @@ def _compute_control_matrix(base_mat, num_ctrl_qubits, ctrl_state=None):
     Raises:
         QiskitError: unrecognized mode or invalid ctrl_state
     """
-    num_target = int(numpy.log2(base_mat.shape[0]))
+    num_target = int(math.log2(base_mat.shape[0]))
     ctrl_dim = 2**num_ctrl_qubits
     ctrl_grnd = numpy.repeat([[1], [0]], [1, ctrl_dim - 1])
     if ctrl_state is None:

--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -42,6 +42,7 @@ class Gate(Instruction):
             params: A list of parameters.
             label: An optional label for the gate.
         """
+        self.definition = None
         super().__init__(name, num_qubits, 0, params, label=label, duration=duration, unit=unit)
 
     # Set higher priority than Numpy array and matrix classes

--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -42,7 +42,6 @@ class Gate(Instruction):
             params: A list of parameters.
             label: An optional label for the gate.
         """
-        self.definition = None
         super().__init__(name, num_qubits, 0, params, label=label, duration=duration, unit=unit)
 
     # Set higher priority than Numpy array and matrix classes

--- a/qiskit/circuit/library/arithmetic/integer_comparator.py
+++ b/qiskit/circuit/library/arithmetic/integer_comparator.py
@@ -14,7 +14,7 @@
 """Integer Comparator."""
 
 from __future__ import annotations
-import numpy as np
+import math
 
 from qiskit.circuit import QuantumCircuit, QuantumRegister, AncillaRegister
 from qiskit.circuit.exceptions import CircuitError
@@ -140,7 +140,7 @@ class IntegerComparator(BlueprintCircuit):
         Returns:
              The 2's complement of ``self.value``.
         """
-        twos_complement = pow(2, self.num_state_qubits) - int(np.ceil(self.value))
+        twos_complement = pow(2, self.num_state_qubits) - math.ceil(self.value)
         twos_complement = f"{twos_complement:b}".rjust(self.num_state_qubits, "0")
         twos_complement = [
             1 if twos_complement[i] == "1" else 0 for i in reversed(range(len(twos_complement)))

--- a/qiskit/circuit/library/arithmetic/quadratic_form.py
+++ b/qiskit/circuit/library/arithmetic/quadratic_form.py
@@ -13,6 +13,7 @@
 """A circuit implementing a quadratic form on binary variables."""
 
 from typing import Union, Optional, List
+import math
 
 import numpy as np
 
@@ -190,8 +191,8 @@ class QuadraticForm(QuantumCircuit):
 
         # the minimum number of qubits is the number of qubits needed to represent
         # the minimum/maximum value plus one sign qubit
-        num_qubits_for_min = int(np.ceil(np.log2(max(-bounds[0], 1))))
-        num_qubits_for_max = int(np.ceil(np.log2(bounds[1] + 1)))
+        num_qubits_for_min = math.ceil(math.log2(max(-bounds[0], 1)))
+        num_qubits_for_max = math.ceil(math.log2(bounds[1] + 1))
         num_result_qubits = 1 + max(num_qubits_for_min, num_qubits_for_max)
 
         return num_result_qubits

--- a/qiskit/circuit/library/data_preparation/state_preparation.py
+++ b/qiskit/circuit/library/data_preparation/state_preparation.py
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 """Prepare a quantum state from the state where all qubits are 0."""
 
+import cmath
 from typing import Union, Optional
 
 import math
@@ -339,20 +340,20 @@ class StatePreparation(Gate):
         a_complex = complex(a_complex)
         b_complex = complex(b_complex)
         mag_a = abs(a_complex)
-        final_r = np.sqrt(mag_a**2 + np.absolute(b_complex) ** 2)
+        final_r = math.sqrt(mag_a**2 + abs(b_complex) ** 2)
         if final_r < _EPS:
             theta = 0
             phi = 0
             final_r = 0
             final_t = 0
         else:
-            theta = 2 * np.arccos(mag_a / final_r)
-            a_arg = np.angle(a_complex)
-            b_arg = np.angle(b_complex)
+            theta = 2 * math.acos(mag_a / final_r)
+            a_arg = cmath.phase(a_complex)
+            b_arg = cmath.phase(b_complex)
             final_t = a_arg + b_arg
             phi = b_arg - a_arg
 
-        return final_r * np.exp(1.0j * final_t / 2), theta, phi
+        return final_r * cmath.exp(1.0j * final_t / 2), theta, phi
 
     def _multiplex(self, target_gate, list_of_angles, last_cnot=True):
         """

--- a/qiskit/circuit/library/generalized_gates/diagonal.py
+++ b/qiskit/circuit/library/generalized_gates/diagonal.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 import cmath
+import math
 import numpy as np
 
 from qiskit.circuit.gate import Gate
@@ -87,7 +88,7 @@ class Diagonal(QuantumCircuit):
                 number of qubits.
         """
         self._check_input(diag)
-        num_qubits = int(np.log2(len(diag)))
+        num_qubits = int(math.log2(len(diag)))
 
         circuit = QuantumCircuit(num_qubits, name="Diagonal")
 
@@ -100,7 +101,7 @@ class Diagonal(QuantumCircuit):
             for i in range(0, n, 2):
                 diag_phases[i // 2], rz_angle = _extract_rz(diag_phases[i], diag_phases[i + 1])
                 angles_rz.append(rz_angle)
-            num_act_qubits = int(np.log2(n))
+            num_act_qubits = int(math.log2(n))
             ctrl_qubits = list(range(num_qubits - num_act_qubits + 1, num_qubits))
             target_qubit = num_qubits - num_act_qubits
 
@@ -118,7 +119,7 @@ class Diagonal(QuantumCircuit):
         """Check if ``diag`` is in valid format."""
         if not isinstance(diag, (list, np.ndarray)):
             raise CircuitError("Diagonal entries must be in a list or numpy array.")
-        num_qubits = np.log2(len(diag))
+        num_qubits = math.log2(len(diag))
         if num_qubits < 1 or not num_qubits.is_integer():
             raise CircuitError("The number of diagonal entries is not a positive power of 2.")
         if not np.allclose(np.abs(diag), 1, atol=_EPS):
@@ -134,7 +135,7 @@ class DiagonalGate(Gate):
             diag: list of the :math:`2^k` diagonal entries (for a diagonal gate on :math:`k` qubits).
         """
         Diagonal._check_input(diag)
-        num_qubits = int(np.log2(len(diag)))
+        num_qubits = int(math.log2(len(diag)))
 
         super().__init__("diagonal", num_qubits, diag)
 

--- a/qiskit/circuit/library/generalized_gates/isometry.py
+++ b/qiskit/circuit/library/generalized_gates/isometry.py
@@ -22,6 +22,7 @@ Generic isometries from m to n qubits.
 from __future__ import annotations
 
 import itertools
+import math
 import numpy as np
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.instruction import Instruction
@@ -93,8 +94,8 @@ class Isometry(Instruction):
         self._epsilon = epsilon
 
         # Check if the isometry has the right dimension and if the columns are orthonormal
-        n = np.log2(isometry.shape[0])
-        m = np.log2(isometry.shape[1])
+        n = math.log2(isometry.shape[0])
+        m = math.log2(isometry.shape[1])
         if not n.is_integer() or n < 0:
             raise QiskitError(
                 "The number of rows of the isometry is not a non negative power of 2."
@@ -150,7 +151,7 @@ class Isometry(Instruction):
         # to keep a copyof the input isometry)
         remaining_isometry = self.iso_data.astype(complex)  # note: "astype" does copy the isometry
         diag = []
-        m = int(np.log2((self.iso_data).shape[1]))
+        m = int(math.log2(self.iso_data.shape[1]))
         # Decompose the column with index column_index and attache the gate to the circuit object.
         # Return the isometry that is left to decompose, where the columns up to index column_index
         # correspond to the firstfew columns of the identity matrix up to diag, and hence we only
@@ -170,7 +171,7 @@ class Isometry(Instruction):
         """
         Decomposes the column with index column_index.
         """
-        n = int(np.log2(self.iso_data.shape[0]))
+        n = int(math.log2(self.iso_data.shape[0]))
         for s in range(n):
             self._disentangle(circuit, q, diag, remaining_isometry, column_index, s)
 
@@ -185,7 +186,7 @@ class Isometry(Instruction):
         # (note that we remove columns of the isometry during the procedure for efficiency)
         k_prime = 0
         v = remaining_isometry
-        n = int(np.log2(self.iso_data.shape[0]))
+        n = int(math.log2(self.iso_data.shape[0]))
 
         # MCG to set one entry to zero (preparation for disentangling with UCGate):
         index1 = 2 * _a(k, s + 1) * 2**s + _b(k, s + 1)
@@ -237,7 +238,7 @@ class Isometry(Instruction):
     # The qubit with label n-s-1 is disentangled into the basis state k_s(k,s).
     def _find_squs_for_disentangling(self, v, k, s):
         k_prime = 0
-        n = int(np.log2(self.iso_data.shape[0]))
+        n = int(math.log2(self.iso_data.shape[0]))
         if _b(k, s + 1) == 0:
             i_start = _a(k, s + 1)
         else:
@@ -264,7 +265,7 @@ class Isometry(Instruction):
             q_ancillas_zero,
             q_ancillas_dirty,
         ) = self._define_qubit_role(q)
-        n = int(np.log2(self.iso_data.shape[0]))
+        n = int(math.log2(self.iso_data.shape[0]))
         qubits = q_input + q_ancillas_for_output
         # Note that we have to reverse the control labels, since controls are provided by
         # increasing qubit number toa UCGate by convention
@@ -286,7 +287,7 @@ class Isometry(Instruction):
             q_ancillas_zero,
             q_ancillas_dirty,
         ) = self._define_qubit_role(q)
-        n = int(np.log2(self.iso_data.shape[0]))
+        n = int(math.log2(self.iso_data.shape[0]))
         qubits = q_input + q_ancillas_for_output
         control_qubits = _reverse_qubit_oder(_get_qubits_by_label(control_labels, qubits, n))
         target_qubit = _get_qubits_by_label([target_label], qubits, n)[0]
@@ -307,8 +308,8 @@ class Isometry(Instruction):
 
     def _define_qubit_role(self, q):
 
-        n = int(np.log2(self.iso_data.shape[0]))
-        m = int(np.log2(self.iso_data.shape[1]))
+        n = int(math.log2(self.iso_data.shape[0]))
+        m = int(math.log2(self.iso_data.shape[1]))
 
         # Define the role of the qubits
         q_input = q[:m]
@@ -372,7 +373,7 @@ def _reverse_qubit_state(state, basis_state, epsilon):
 def _apply_ucg(m, k, single_qubit_gates):
     # ToDo: Improve efficiency by parallelizing the gate application. A generalized version of
     # ToDo: this method should be implemented by the state vector simulator in Qiskit AER.
-    num_qubits = int(np.log2(m.shape[0]))
+    num_qubits = int(math.log2(m.shape[0]))
     num_col = m.shape[1]
     spacing = 2 ** (num_qubits - k - 1)
     for j in range(2 ** (num_qubits - 1)):
@@ -395,7 +396,7 @@ def _apply_ucg(m, k, single_qubit_gates):
 def _apply_diagonal_gate(m, action_qubit_labels, diag):
     # ToDo: Improve efficiency by parallelizing the gate application. A generalized version of
     # ToDo: this method should be implemented by the state vector simulator in Qiskit AER.
-    num_qubits = int(np.log2(m.shape[0]))
+    num_qubits = int(math.log2(m.shape[0]))
     num_cols = m.shape[1]
     basis_states = list(itertools.product([0, 1], repeat=num_qubits))
     for state in basis_states:
@@ -436,7 +437,7 @@ def _apply_diagonal_gate_to_diag(m_diagonal, action_qubit_labels, diag, num_qubi
 
 def _apply_multi_controlled_gate(m, control_labels, target_label, gate):
     # ToDo: This method should be integrated into the state vector simulator in Qiskit AER.
-    num_qubits = int(np.log2(m.shape[0]))
+    num_qubits = int(math.log2(m.shape[0]))
     num_cols = m.shape[1]
     control_labels.sort()
     free_qubits = num_qubits - len(control_labels) - 1

--- a/qiskit/circuit/library/generalized_gates/rv.py
+++ b/qiskit/circuit/library/generalized_gates/rv.py
@@ -12,6 +12,7 @@
 
 """Rotation around an arbitrary axis on the Bloch sphere."""
 
+import math
 import numpy
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.exceptions import CircuitError
@@ -82,12 +83,12 @@ class RVGate(Gate):
     def to_matrix(self):
         """Return a numpy.array for the R(v) gate."""
         v = numpy.asarray(self.params, dtype=float)
-        angle = numpy.sqrt(v.dot(v))
+        angle = math.sqrt(v.dot(v))
         if angle == 0:
             return numpy.array([[1, 0], [0, 1]])
         nx, ny, nz = v / angle
-        sin = numpy.sin(angle / 2)
-        cos = numpy.cos(angle / 2)
+        sin = math.sin(angle / 2)
+        cos = math.cos(angle / 2)
         return numpy.array(
             [
                 [cos - 1j * nz * sin, (-ny - 1j * nx) * sin],

--- a/qiskit/circuit/library/generalized_gates/unitary.py
+++ b/qiskit/circuit/library/generalized_gates/unitary.py
@@ -13,6 +13,7 @@
 """Arbitrary unitary circuit instruction."""
 
 from __future__ import annotations
+import math
 
 import typing
 import numpy
@@ -96,7 +97,7 @@ class UnitaryGate(Gate):
         # Convert to numpy array in case not already an array
         data = numpy.asarray(data, dtype=complex)
         input_dim, output_dim = data.shape
-        num_qubits = int(numpy.log2(input_dim))
+        num_qubits = int(math.log2(input_dim))
         if check_input:
             # Check input is unitary
             if not is_unitary_matrix(data):

--- a/qiskit/circuit/library/hamiltonian_gate.py
+++ b/qiskit/circuit/library/hamiltonian_gate.py
@@ -15,6 +15,7 @@ Gate described by the time evolution of a Hermitian Hamiltonian operator.
 """
 
 from __future__ import annotations
+import math
 import typing
 
 from numbers import Number
@@ -67,7 +68,7 @@ class HamiltonianGate(Gate):
             # numpy matrix from `Operator.data`.
             data = data.to_operator().data
         # Convert to np array in case not already an array
-        data = np.array(data, dtype=complex)
+        data = np.asarray(data, dtype=complex)
         # Check input is unitary
         if not is_hermitian_matrix(data):
             raise ValueError("Input matrix is not Hermitian.")
@@ -75,7 +76,7 @@ class HamiltonianGate(Gate):
             raise ValueError("Evolution time is not real.")
         # Check input is N-qubit matrix
         input_dim, output_dim = data.shape
-        num_qubits = int(np.log2(input_dim))
+        num_qubits = int(math.log2(input_dim))
         if input_dim != output_dim or 2**num_qubits != input_dim:
             raise ValueError("Input matrix is not an N-qubit operator.")
 

--- a/qiskit/circuit/library/standard_gates/multi_control_rotation_gates.py
+++ b/qiskit/circuit/library/standard_gates/multi_control_rotation_gates.py
@@ -14,6 +14,7 @@ Multiple-Controlled U3 gate. Not using ancillary qubits.
 """
 
 from math import pi
+import math
 from typing import Optional, Union, Tuple, List
 import numpy as np
 
@@ -144,18 +145,20 @@ def _mcsu2_real_diagonal(
     if np.isclose(z, -1):
         s_op = [[1.0, 0.0], [0.0, 1.0j]]
     else:
-        alpha_r = np.sqrt((np.sqrt((z.real + 1.0) / 2.0) + 1.0) / 2.0)
-        alpha_i = z.imag / (2.0 * np.sqrt((z.real + 1.0) * (np.sqrt((z.real + 1.0) / 2.0) + 1.0)))
+        alpha_r = math.sqrt((math.sqrt((z.real + 1.0) / 2.0) + 1.0) / 2.0)
+        alpha_i = z.imag / (
+            2.0 * math.sqrt((z.real + 1.0) * (math.sqrt((z.real + 1.0) / 2.0) + 1.0))
+        )
         alpha = alpha_r + 1.0j * alpha_i
-        beta = x / (2.0 * np.sqrt((z.real + 1.0) * (np.sqrt((z.real + 1.0) / 2.0) + 1.0)))
+        beta = x / (2.0 * math.sqrt((z.real + 1.0) * (math.sqrt((z.real + 1.0) / 2.0) + 1.0)))
 
         # S gate definition
         s_op = np.array([[alpha, -np.conj(beta)], [beta, np.conj(alpha)]])
 
     s_gate = UnitaryGate(s_op)
 
-    k_1 = int(np.ceil(num_controls / 2.0))
-    k_2 = int(np.floor(num_controls / 2.0))
+    k_1 = math.ceil(num_controls / 2.0)
+    k_2 = math.floor(num_controls / 2.0)
 
     ctrl_state_k_1 = None
     ctrl_state_k_2 = None

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Two-pulse single-qubit gate."""
+import cmath
 import copy
 import math
 from cmath import exp
@@ -339,12 +340,12 @@ class CUGate(ControlledGate):
     def __array__(self, dtype=None):
         """Return a numpy.array for the CU gate."""
         theta, phi, lam, gamma = (float(param) for param in self.params)
-        cos = numpy.cos(theta / 2)
-        sin = numpy.sin(theta / 2)
-        a = numpy.exp(1j * gamma) * cos
-        b = -numpy.exp(1j * (gamma + lam)) * sin
-        c = numpy.exp(1j * (gamma + phi)) * sin
-        d = numpy.exp(1j * (gamma + phi + lam)) * cos
+        cos = math.cos(theta / 2)
+        sin = math.sin(theta / 2)
+        a = cmath.exp(1j * gamma) * cos
+        b = -cmath.exp(1j * (gamma + lam)) * sin
+        c = cmath.exp(1j * (gamma + phi)) * sin
+        d = cmath.exp(1j * (gamma + phi + lam)) * cos
         if self.ctrl_state:
             return numpy.array(
                 [[1, 0, 0, 0], [0, a, 0, b], [0, 0, 1, 0], [0, c, 0, d]], dtype=dtype

--- a/qiskit/primitives/backend_estimator_v2.py
+++ b/qiskit/primitives/backend_estimator_v2.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
+import math
 
 import numpy as np
 
@@ -146,7 +147,7 @@ class BackendEstimatorV2(BaseEstimatorV2):
         return PrimitiveResult([self._run_pub(pub) for pub in pubs])
 
     def _run_pub(self, pub: EstimatorPub) -> PubResult:
-        shots = int(np.ceil(1.0 / pub.precision**2))
+        shots = math.ceil(1.0 / pub.precision**2)
         circuit = pub.circuit
         observables = pub.observables
         parameter_values = pub.parameter_values

--- a/qiskit/providers/basic_provider/basic_simulator.py
+++ b/qiskit/providers/basic_provider/basic_simulator.py
@@ -29,6 +29,7 @@ field, which is a result of measurements for each shot.
 
 from __future__ import annotations
 
+import math
 import uuid
 import time
 import logging
@@ -331,9 +332,9 @@ class BasicSimulator(BackendV2):
 
         # update quantum state
         if outcome == "0":
-            update_diag = [[1 / np.sqrt(probability), 0], [0, 0]]
+            update_diag = [[1 / math.sqrt(probability), 0], [0, 0]]
         else:
-            update_diag = [[0, 0], [0, 1 / np.sqrt(probability)]]
+            update_diag = [[0, 0], [0, 1 / math.sqrt(probability)]]
         # update classical state
         self._add_unitary(update_diag, [qubit])
 
@@ -351,10 +352,10 @@ class BasicSimulator(BackendV2):
         outcome, probability = self._get_measure_outcome(qubit)
         # update quantum state
         if outcome == "0":
-            update = [[1 / np.sqrt(probability), 0], [0, 0]]
+            update = [[1 / math.sqrt(probability), 0], [0, 0]]
             self._add_unitary(update, [qubit])
         else:
-            update = [[0, 1 / np.sqrt(probability)], [0, 0]]
+            update = [[0, 1 / math.sqrt(probability)], [0, 0]]
             self._add_unitary(update, [qubit])
 
     def _validate_initial_statevector(self) -> None:
@@ -478,7 +479,7 @@ class BasicSimulator(BackendV2):
             Example::
 
                 backend_options = {
-                    "initial_statevector": np.array([1, 0, 0, 1j]) / np.sqrt(2),
+                    "initial_statevector": np.array([1, 0, 0, 1j]) / math.sqrt(2),
                 }
         """
         # TODO: replace assemble with new run flow

--- a/qiskit/quantum_info/analysis/distance.py
+++ b/qiskit/quantum_info/analysis/distance.py
@@ -12,7 +12,7 @@
 
 """A collection of discrete probability metrics."""
 from __future__ import annotations
-import numpy as np
+import math
 
 
 def hellinger_distance(dist_p: dict, dist_q: dict) -> float:
@@ -43,13 +43,13 @@ def hellinger_distance(dist_p: dict, dist_q: dict) -> float:
     total = 0
     for key, val in p_normed.items():
         if key in q_normed:
-            total += (np.sqrt(val) - np.sqrt(q_normed[key])) ** 2
+            total += (math.sqrt(val) - math.sqrt(q_normed[key])) ** 2
             del q_normed[key]
         else:
             total += val
     total += sum(q_normed.values())
 
-    dist = np.sqrt(total) / np.sqrt(2)
+    dist = math.sqrt(total) / math.sqrt(2)
 
     return dist
 

--- a/qiskit/quantum_info/analysis/make_observable.py
+++ b/qiskit/quantum_info/analysis/make_observable.py
@@ -13,6 +13,7 @@
 """Helper functions for building dictionaries from matrices and lists."""
 
 from __future__ import annotations
+import math
 import numpy as np
 
 
@@ -33,7 +34,7 @@ def make_dict_observable(matrix_observable: list | np.ndarray) -> dict:
     dict_observable = {}
     observable = np.array(matrix_observable)
     observable_size = len(observable)
-    observable_bits = int(np.ceil(np.log2(observable_size)))
+    observable_bits = math.ceil(math.log2(observable_size))
     binary_formatter = f"0{observable_bits}b"
     if observable.ndim == 2:
         observable = observable.diagonal()

--- a/qiskit/quantum_info/analysis/z2_symmetries.py
+++ b/qiskit/quantum_info/analysis/z2_symmetries.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import itertools
 from collections.abc import Iterable
 from copy import deepcopy
+import math
 from typing import Union, cast
 
 import numpy as np
@@ -121,7 +122,7 @@ class Z2Symmetries:
             A list of unitaries used to diagonalize the Hamiltonian.
         """
         cliffords = [
-            (SparsePauliOp(pauli_symm) + SparsePauliOp(sq_pauli)) / np.sqrt(2)
+            (SparsePauliOp(pauli_symm) + SparsePauliOp(sq_pauli)) / math.sqrt(2)
             for pauli_symm, sq_pauli in zip(self._symmetries, self._sq_paulis)
         ]
         return cliffords

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -17,6 +17,7 @@ Chi-matrix representation of a Quantum Channel.
 
 from __future__ import annotations
 import copy
+import math
 import numpy as np
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -96,7 +97,7 @@ class Chi(QuantumChannel):
             if output_dims:
                 output_dim = np.prod(input_dims)
             if output_dims is None and input_dims is None:
-                output_dim = int(np.sqrt(dim_l))
+                output_dim = int(math.sqrt(dim_l))
                 input_dim = dim_l // output_dim
             elif input_dims is None:
                 input_dim = dim_l // output_dim
@@ -125,7 +126,7 @@ class Chi(QuantumChannel):
             if output_dims is None:
                 output_dims = data.output_dims()
         # Check input is N-qubit channel
-        num_qubits = int(np.log2(input_dim))
+        num_qubits = int(math.log2(input_dim))
         if 2**num_qubits != input_dim or input_dim != output_dim:
             raise QiskitError("Input is not an n-qubit Chi matrix.")
         super().__init__(chi_mat, num_qubits=num_qubits)

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -17,6 +17,7 @@ Choi-matrix representation of a Quantum Channel.
 
 from __future__ import annotations
 import copy
+import math
 import numpy as np
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -103,7 +104,7 @@ class Choi(QuantumChannel):
             if output_dims:
                 output_dim = np.prod(output_dims)
             if output_dims is None and input_dims is None:
-                output_dim = int(np.sqrt(dim_l))
+                output_dim = int(math.sqrt(dim_l))
                 input_dim = dim_l // output_dim
             elif input_dims is None:
                 input_dim = dim_l // output_dim

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -16,6 +16,7 @@ Kraus representation of a Quantum Channel.
 
 from __future__ import annotations
 import copy
+import math
 from numbers import Number
 import numpy as np
 
@@ -315,7 +316,7 @@ class Kraus(QuantumChannel):
             return ret
         # If the number is real we can update the Kraus operators
         # directly
-        val = np.sqrt(other)
+        val = math.sqrt(other)
         kraus_r = None
         kraus_l = [val * k for k in self._data[0]]
         if self._data[1] is not None:

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -17,6 +17,7 @@ Pauli Transfer Matrix (PTM) representation of a Quantum Channel.
 
 from __future__ import annotations
 import copy
+import math
 import numpy as np
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -100,11 +101,11 @@ class PTM(QuantumChannel):
             if input_dims:
                 input_dim = np.prod(input_dims)
             else:
-                input_dim = int(np.sqrt(din))
+                input_dim = int(math.sqrt(din))
             if output_dims:
                 output_dim = np.prod(input_dims)
             else:
-                output_dim = int(np.sqrt(dout))
+                output_dim = int(math.sqrt(dout))
             if output_dim**2 != dout or input_dim**2 != din or input_dim != output_dim:
                 raise QiskitError("Invalid shape for PTM matrix.")
         else:
@@ -127,7 +128,7 @@ class PTM(QuantumChannel):
             if output_dims is None:
                 output_dims = data.output_dims()
         # Check input is N-qubit channel
-        num_qubits = int(np.log2(input_dim))
+        num_qubits = int(math.log2(input_dim))
         if 2**num_qubits != input_dim or input_dim != output_dim:
             raise QiskitError("Input is not an n-qubit Pauli transfer matrix.")
         super().__init__(ptm, num_qubits=num_qubits)

--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -16,6 +16,7 @@ Abstract base class for Quantum Channels.
 
 from __future__ import annotations
 import copy
+import math
 import sys
 from abc import abstractmethod
 from numbers import Number, Integral
@@ -249,7 +250,7 @@ class QuantumChannel(LinearOp):
         """
 
         # Check if input is an N-qubit CPTP channel.
-        num_qubits = int(np.log2(self._input_dim))
+        num_qubits = int(math.log2(self._input_dim))
         if self._input_dim != self._output_dim or 2**num_qubits != self._input_dim:
             raise QiskitError(
                 "Cannot convert QuantumChannel to Instruction: channel is not an N-qubit channel."

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -15,6 +15,7 @@ Stinespring representation of a Quantum Channel.
 
 from __future__ import annotations
 import copy
+import math
 from numbers import Number
 import numpy as np
 
@@ -281,7 +282,7 @@ class Stinespring(QuantumChannel):
             return ret
         # If the number is real we can update the Kraus operators
         # directly
-        num = np.sqrt(other)
+        num = math.sqrt(other)
         stine_l, stine_r = self._data
         stine_l = num * self._data[0]
         stine_r = None

--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -16,6 +16,7 @@ Superoperator representation of a Quantum Channel."""
 from __future__ import annotations
 
 import copy
+import math
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -94,8 +95,8 @@ class SuperOp(QuantumChannel):
             super_mat = np.asarray(data, dtype=complex)
             # Determine total input and output dimensions
             dout, din = super_mat.shape
-            input_dim = int(np.sqrt(din))
-            output_dim = int(np.sqrt(dout))
+            input_dim = int(math.sqrt(din))
+            output_dim = int(math.sqrt(dout))
             if output_dim**2 != dout or input_dim**2 != din:
                 raise QiskitError("Invalid shape for SuperOp matrix.")
             op_shape = OpShape.auto(

--- a/qiskit/quantum_info/operators/channel/transformations.py
+++ b/qiskit/quantum_info/operators/channel/transformations.py
@@ -18,6 +18,7 @@ Transformations between QuantumChannel representations.
 """
 
 from __future__ import annotations
+import math
 import numpy as np
 
 from qiskit.exceptions import QiskitError
@@ -328,25 +329,25 @@ def _kraus_to_superop(data):
 
 def _chi_to_choi(data, input_dim):
     """Transform Chi representation to a Choi representation."""
-    num_qubits = int(np.log2(input_dim))
+    num_qubits = int(math.log2(input_dim))
     return _transform_from_pauli(data, num_qubits)
 
 
 def _choi_to_chi(data, input_dim):
     """Transform Choi representation to the Chi representation."""
-    num_qubits = int(np.log2(input_dim))
+    num_qubits = int(math.log2(input_dim))
     return _transform_to_pauli(data, num_qubits)
 
 
 def _ptm_to_superop(data, input_dim):
     """Transform PTM representation to SuperOp representation."""
-    num_qubits = int(np.log2(input_dim))
+    num_qubits = int(math.log2(input_dim))
     return _transform_from_pauli(data, num_qubits)
 
 
 def _superop_to_ptm(data, input_dim):
     """Transform SuperOp representation to PTM representation."""
-    num_qubits = int(np.log2(input_dim))
+    num_qubits = int(math.log2(input_dim))
     return _transform_to_pauli(data, num_qubits)
 
 
@@ -375,12 +376,12 @@ def _bipartite_tensor(mat1, mat2, shape1=None, shape2=None):
     dim_a0, dim_a1 = mat1.shape
     dim_b0, dim_b1 = mat2.shape
     if shape1 is None:
-        sdim_a0 = int(np.sqrt(dim_a0))
-        sdim_a1 = int(np.sqrt(dim_a1))
+        sdim_a0 = int(math.sqrt(dim_a0))
+        sdim_a1 = int(math.sqrt(dim_a1))
         shape1 = (sdim_a0, sdim_a0, sdim_a1, sdim_a1)
     if shape2 is None:
-        sdim_b0 = int(np.sqrt(dim_b0))
-        sdim_b1 = int(np.sqrt(dim_b1))
+        sdim_b0 = int(math.sqrt(dim_b0))
+        sdim_b1 = int(math.sqrt(dim_b1))
         shape2 = (sdim_b0, sdim_b0, sdim_b1, sdim_b1)
     # Check dimensions
     if len(shape1) != 4 or shape1[0] * shape1[1] != dim_a0 or shape1[2] * shape1[3] != dim_a1:
@@ -416,7 +417,7 @@ def _transform_to_pauli(data, num_qubits):
     # to avoid rounding errors from square-roots of 2.
     cob = basis_mat
     for _ in range(num_qubits - 1):
-        dim = int(np.sqrt(len(cob)))
+        dim = int(math.sqrt(len(cob)))
         cob = np.reshape(
             np.transpose(
                 np.reshape(np.kron(basis_mat, cob), (4, dim * dim, 2, 2, dim, dim)),
@@ -437,7 +438,7 @@ def _transform_from_pauli(data, num_qubits):
     # to avoid rounding errors from square-roots of 2.
     cob = basis_mat
     for _ in range(num_qubits - 1):
-        dim = int(np.sqrt(len(cob)))
+        dim = int(math.sqrt(len(cob)))
         cob = np.reshape(
             np.transpose(
                 np.reshape(np.kron(basis_mat, cob), (2, 2, dim, dim, 4, dim * dim)),
@@ -462,6 +463,6 @@ def _check_nqubit_dim(input_dim, output_dim):
         raise QiskitError(
             f"Not an n-qubit channel: input_dim ({input_dim}) != output_dim ({output_dim})"
         )
-    num_qubits = int(np.log2(input_dim))
+    num_qubits = int(math.log2(input_dim))
     if 2**num_qubits != input_dim:
         raise QiskitError("Not an n-qubit channel: input_dim != 2 ** n")

--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import functools
 import itertools
+import math
 import re
 from typing import Literal
 
@@ -973,7 +974,7 @@ class Clifford(BaseOperator, AdjointMixin, Operation):
     @staticmethod
     def _unitary_matrix_to_tableau(matrix):
         # pylint: disable=invalid-name
-        num_qubits = int(np.log2(len(matrix)))
+        num_qubits = int(math.log2(len(matrix)))
 
         stab = np.empty((num_qubits, 2 * num_qubits + 1), dtype=bool)
         for i in range(num_qubits):

--- a/qiskit/quantum_info/operators/symplectic/random.py
+++ b/qiskit/quantum_info/operators/symplectic/random.py
@@ -14,6 +14,7 @@ Random symplectic operator functions
 """
 
 from __future__ import annotations
+import math
 
 import numpy as np
 from numpy.random import default_rng
@@ -173,7 +174,7 @@ def _sample_qmallows(n, rng=None):
         m = n - i
         eps = 4 ** (-m)
         r = rng.uniform(0, 1)
-        index = -int(np.ceil(np.log2(r + (1 - r) * eps)))
+        index = -math.ceil(math.log2(r + (1 - r) * eps))
         had[i] = index < m
         if index < m:
             k = index

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -15,6 +15,7 @@ Statevector quantum state class.
 """
 from __future__ import annotations
 import copy
+import math
 import re
 from numbers import Number
 
@@ -702,7 +703,7 @@ class Statevector(QuantumState, TolerancesMixin):
         state = Statevector(data)
         if xy_states:
             # Apply hadamards to all qubits in X eigenstates
-            x_mat = np.array([[1, 1], [1, -1]], dtype=complex) / np.sqrt(2)
+            x_mat = np.array([[1, 1], [1, -1]], dtype=complex) / math.sqrt(2)
             # Apply S.H to qubits in Y eigenstates
             y_mat = np.dot(np.diag([1, 1j]), x_mat)
             for qubit, char in enumerate(reversed(label)):

--- a/qiskit/quantum_info/states/utils.py
+++ b/qiskit/quantum_info/states/utils.py
@@ -15,6 +15,7 @@ Quantum information utility functions for states.
 """
 
 from __future__ import annotations
+import math
 
 import numpy as np
 
@@ -102,17 +103,18 @@ def shannon_entropy(pvec: list | np.ndarray, base: int = 2) -> float:
     if base == 2:
 
         def logfn(x):
-            return -x * np.log2(x)
+            return -x * math.log2(x)
 
     elif base == np.e:
 
         def logfn(x):
-            return -x * np.log(x)
+            return -x * math.log(x)
 
     else:
+        log_base = math.log(base)
 
         def logfn(x):
-            return -x * np.log(x) / np.log(base)
+            return -x * math.log(x) / log_base
 
     h_val = 0.0
     for x in pvec:

--- a/qiskit/result/mitigation/correlated_readout_mitigator.py
+++ b/qiskit/result/mitigation/correlated_readout_mitigator.py
@@ -13,6 +13,7 @@
 Readout mitigator class based on the A-matrix inversion method
 """
 
+import math
 from typing import Optional, List, Tuple, Iterable, Callable, Union, Dict
 import numpy as np
 
@@ -46,7 +47,7 @@ class CorrelatedReadoutMitigator(BaseReadoutMitigator):
         if np.any(assignment_matrix < 0) or not np.allclose(np.sum(assignment_matrix, axis=0), 1):
             raise QiskitError("Assignment matrix columns must be valid probability distributions")
         assignment_matrix = np.asarray(assignment_matrix, dtype=float)
-        matrix_qubits_num = int(np.log2(assignment_matrix.shape[0]))
+        matrix_qubits_num = int(math.log2(assignment_matrix.shape[0]))
         if qubits is None:
             self._num_qubits = matrix_qubits_num
             self._qubits = range(self._num_qubits)
@@ -260,7 +261,7 @@ class CorrelatedReadoutMitigator(BaseReadoutMitigator):
             float: the standard deviation upper bound.
         """
         gamma = self._compute_gamma()
-        return gamma / np.sqrt(shots)
+        return gamma / math.sqrt(shots)
 
     @property
     def qubits(self) -> Tuple[int]:

--- a/qiskit/result/mitigation/local_readout_mitigator.py
+++ b/qiskit/result/mitigation/local_readout_mitigator.py
@@ -14,6 +14,7 @@ Readout mitigator class based on the 1-qubit local tensored mitigation method
 """
 
 
+import math
 from typing import Optional, List, Tuple, Iterable, Callable, Union, Dict
 import numpy as np
 
@@ -288,7 +289,7 @@ class LocalReadoutMitigator(BaseReadoutMitigator):
             float: the standard deviation upper bound.
         """
         gamma = self._compute_gamma(qubits=qubits)
-        return gamma / np.sqrt(shots)
+        return gamma / math.sqrt(shots)
 
     def _from_backend(self, backend, qubits):
         """Calculates amats from backend properties readout_error"""

--- a/qiskit/result/mitigation/utils.py
+++ b/qiskit/result/mitigation/utils.py
@@ -14,6 +14,7 @@ Readout mitigation data handling utils
 """
 
 import logging
+import math
 from typing import Optional, List, Tuple, Dict
 import numpy as np
 
@@ -55,7 +56,7 @@ def expval_with_stddev(coeffs: np.ndarray, probs: np.ndarray, shots: int) -> Tup
             "(%f). Setting standard deviation of result to 0.",
             variance,
         )
-    calc_stddev = np.sqrt(variance) if variance > 0 else 0.0
+    calc_stddev = math.sqrt(variance) if variance > 0 else 0.0
     return [expval, calc_stddev]
 
 
@@ -63,7 +64,7 @@ def stddev(probs, shots):
     """Calculate stddev dict"""
     ret = {}
     for key, prob in probs.items():
-        std_err = np.sqrt(prob * (1 - prob) / shots)
+        std_err = math.sqrt(prob * (1 - prob) / shots)
         ret[key] = std_err
     return ret
 

--- a/qiskit/synthesis/discrete_basis/commutator_decompose.py
+++ b/qiskit/synthesis/discrete_basis/commutator_decompose.py
@@ -92,7 +92,7 @@ def _solve_decomposition_angle(matrix: np.ndarray) -> float:
     lhs = math.sin(angle / 2)
 
     def objective(phi):
-        sin_sq = math.sin(phi[0] / 2) ** 2
+        sin_sq = math.sin(phi.item() / 2) ** 2
         return 2 * sin_sq * math.sqrt(1 - sin_sq**2) - lhs
 
     decomposition_angle = fsolve(objective, angle)[0]

--- a/qiskit/synthesis/discrete_basis/commutator_decompose.py
+++ b/qiskit/synthesis/discrete_basis/commutator_decompose.py
@@ -92,8 +92,8 @@ def _solve_decomposition_angle(matrix: np.ndarray) -> float:
     lhs = math.sin(angle / 2)
 
     def objective(phi):
-        sin_sq = np.sin(phi / 2) ** 2
-        return 2 * sin_sq * np.sqrt(1 - sin_sq**2) - lhs
+        sin_sq = math.sin(phi[0] / 2) ** 2
+        return 2 * sin_sq * math.sqrt(1 - sin_sq**2) - lhs
 
     decomposition_angle = fsolve(objective, angle)[0]
     return decomposition_angle

--- a/qiskit/synthesis/evolution/qdrift.py
+++ b/qiskit/synthesis/evolution/qdrift.py
@@ -12,6 +12,7 @@
 
 """QDrift Class"""
 
+import math
 from typing import Union, Optional, Callable
 import numpy as np
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -73,7 +74,7 @@ class QDrift(ProductFormula):
         weights = np.abs(coeffs)
         lambd = np.sum(weights)
 
-        num_gates = int(np.ceil(2 * (lambd**2) * (time**2) * self.reps))
+        num_gates = math.ceil(2 * (lambd**2) * (time**2) * self.reps)
         # The protocol calls for the removal of the individual coefficients,
         # and multiplication by a constant evolution time.
         evolution_time = lambd * time / num_gates

--- a/qiskit/synthesis/two_qubit/xx_decompose/circuits.py
+++ b/qiskit/synthesis/two_qubit/xx_decompose/circuits.py
@@ -23,6 +23,7 @@ Output:
 """
 
 from __future__ import annotations
+import cmath
 from functools import reduce
 import math
 from operator import itemgetter
@@ -55,8 +56,8 @@ def decompose_xxyy_into_xxyy_xx(a_target, b_target, a_source, b_source, interact
     Returns the 6-tuple (r, s, u, v, x, y).
     """
 
-    cplus, cminus = np.cos(a_source + b_source), np.cos(a_source - b_source)
-    splus, sminus = np.sin(a_source + b_source), np.sin(a_source - b_source)
+    cplus, cminus = math.cos(a_source + b_source), math.cos(a_source - b_source)
+    splus, sminus = math.sin(a_source + b_source), math.sin(a_source - b_source)
     ca, sa = np.cos(interaction), np.sin(interaction)
 
     uplusv = (
@@ -117,10 +118,10 @@ def decompose_xxyy_into_xxyy_xx(a_target, b_target, a_source, b_source, interact
         ]
     )
     inner_phases = [
-        np.angle(middle_matrix[0, 0]),
-        np.angle(middle_matrix[1, 1]),
-        np.angle(middle_matrix[1, 2]) + np.pi / 2,
-        np.angle(middle_matrix[0, 3]) + np.pi / 2,
+        cmath.phase(middle_matrix[0, 0]),
+        cmath.phase(middle_matrix[1, 1]),
+        cmath.phase(middle_matrix[1, 2]) + np.pi / 2,
+        cmath.phase(middle_matrix[0, 3]) + np.pi / 2,
     ]
     r, s, x, y = np.dot(phase_solver, inner_phases)
 
@@ -133,8 +134,8 @@ def decompose_xxyy_into_xxyy_xx(a_target, b_target, a_source, b_source, interact
             np.kron(RZGate(2 * x).to_matrix(), RZGate(2 * y).to_matrix()),
         ],
     )
-    if (abs(np.angle(generated_matrix[3, 0]) - np.pi / 2) < 0.01 and a_target > b_target) or (
-        abs(np.angle(generated_matrix[3, 0]) + np.pi / 2) < 0.01 and a_target < b_target
+    if (abs(cmath.phase(generated_matrix[3, 0]) - np.pi / 2) < 0.01 and a_target > b_target) or (
+        abs(cmath.phase(generated_matrix[3, 0]) + np.pi / 2) < 0.01 and a_target < b_target
     ):
         x += np.pi / 4
         y += np.pi / 4
@@ -231,8 +232,8 @@ def xx_circuit_step(source, strength, target, embodiment):
     # finally conjugated by p_s_f_o.
     prefix_circuit.compose(permute_source_for_overlap, inplace=True)
     prefix_circuit.compose(source_reflection, inplace=True)
-    prefix_circuit.global_phase += -np.log(reflection_phase_shift).imag
-    prefix_circuit.global_phase += -np.log(shift_phase_shift).imag
+    prefix_circuit.global_phase -= cmath.phase(reflection_phase_shift)
+    prefix_circuit.global_phase -= cmath.phase(shift_phase_shift)
 
     # the affix circuit is constructed in reverse.
     # first (i.e., innermost), we install the other half of the source transformations and p_s_f_o.
@@ -291,8 +292,8 @@ def canonical_xx_circuit(target, strength_sequence, basis_embodiments):
         circuit.compose(basis_embodiments[strength_sequence[0]], inplace=True)
         circuit.compose(source_reflection.inverse(), inplace=True)
         circuit.compose(source_shift, inplace=True)
-        circuit.global_phase += -np.log(shift_phase_shift).imag
-        circuit.global_phase += -np.log(reflection_phase_shift).imag
+        circuit.global_phase -= cmath.phase(shift_phase_shift)
+        circuit.global_phase -= cmath.phase(reflection_phase_shift)
 
     circuit.compose(affix_circuit, inplace=True)
 

--- a/qiskit/synthesis/unitary/aqc/__init__.py
+++ b/qiskit/synthesis/unitary/aqc/__init__.py
@@ -108,7 +108,7 @@ A basic usage of the AQC algorithm should consist of the following steps::
     unitary = ...
 
     # Define a number of qubits for the algorithm, at least 3 qubits
-    num_qubits = int(round(np.log2(unitary.shape[0])))
+    num_qubits = int(round(math.log2(unitary.shape[0])))
 
     # Choose a layout of the CNOT structure for the approximate circuit, e.g. ``spin`` for
     # a linear layout.

--- a/qiskit/synthesis/unitary/aqc/__init__.py
+++ b/qiskit/synthesis/unitary/aqc/__init__.py
@@ -108,7 +108,7 @@ A basic usage of the AQC algorithm should consist of the following steps::
     unitary = ...
 
     # Define a number of qubits for the algorithm, at least 3 qubits
-    num_qubits = int(round(math.log2(unitary.shape[0])))
+    num_qubits = round(math.log2(unitary.shape[0]))
 
     # Choose a layout of the CNOT structure for the approximate circuit, e.g. ``spin`` for
     # a linear layout.

--- a/qiskit/synthesis/unitary/aqc/cnot_structures.py
+++ b/qiskit/synthesis/unitary/aqc/cnot_structures.py
@@ -13,6 +13,7 @@
 These are the CNOT structure methods: anything that you need for creating CNOT structures.
 """
 import logging
+import math
 
 import numpy as np
 
@@ -34,7 +35,7 @@ def _lower_limit(num_qubits: int) -> int:
     Returns:
         lower limit on the number of CNOT units.
     """
-    num_cnots = round(np.ceil((4**num_qubits - 3 * num_qubits - 1) / 4.0))
+    num_cnots = math.ceil((4**num_qubits - 3 * num_qubits - 1) / 4.0)
     return num_cnots
 
 

--- a/qiskit/synthesis/unitary/aqc/fast_gradient/fast_gradient.py
+++ b/qiskit/synthesis/unitary/aqc/fast_gradient/fast_gradient.py
@@ -14,6 +14,7 @@
 Implementation of the fast objective function class.
 """
 
+import math
 import warnings
 import numpy as np
 
@@ -110,7 +111,7 @@ class FastCNOTUnitObjective(CNOTUnitObjective):
         # If thetas are the same as used for objective value calculation
         # before calling this function, then we re-use the computations,
         # otherwise we have to re-compute the objective.
-        tol = float(np.sqrt(np.finfo(float).eps))
+        tol = math.sqrt(np.finfo(float).eps)
         if not np.allclose(param_values, self._circ_thetas, atol=tol, rtol=tol):
             self.objective(param_values)
             warnings.warn("gradient is computed before the objective")

--- a/qiskit/synthesis/unitary/qsd.py
+++ b/qiskit/synthesis/unitary/qsd.py
@@ -15,6 +15,7 @@ Quantum Shannon Decomposition.
 Method is described in arXiv:quant-ph/0406176.
 """
 from __future__ import annotations
+import math
 from typing import Callable
 import scipy
 import numpy as np
@@ -93,7 +94,7 @@ def qs_decomposition(
     """
     #  _depth (int): Internal use parameter to track recursion depth.
     dim = mat.shape[0]
-    nqubits = int(np.log2(dim))
+    nqubits = int(math.log2(dim))
     if np.allclose(np.identity(dim), mat):
         return QuantumCircuit(nqubits)
     if dim == 2:
@@ -185,7 +186,7 @@ def _demultiplex(um0, um1, opt_a1=False, opt_a2=False, *, _depth=0):
         QuantumCircuit: decomposed circuit
     """
     dim = um0.shape[0] + um1.shape[0]  # these should be same dimension
-    nqubits = int(np.log2(dim))
+    nqubits = int(math.log2(dim))
     um0um1 = um0 @ um1.T.conjugate()
     if is_hermitian_matrix(um0um1):
         eigvals, vmat = scipy.linalg.eigh(um0um1)

--- a/qiskit/transpiler/passes/calibration/rzx_builder.py
+++ b/qiskit/transpiler/passes/calibration/rzx_builder.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import enum
+import math
 import warnings
 from collections.abc import Sequence
 from math import pi, erf
@@ -135,7 +136,7 @@ class RZXCalibrationBuilder(CalibrationBuilder):
         # The error function is used because the Gaussian may have chopped tails.
         # Area is normalized by amplitude.
         # This makes widths robust to the rounding error.
-        risefall_area = params["sigma"] * np.sqrt(2 * pi) * erf(risefall_sigma_ratio)
+        risefall_area = params["sigma"] * math.sqrt(2 * pi) * erf(risefall_sigma_ratio)
         full_area = params["width"] + risefall_area
 
         # Get estimate of target area. Assume this is pi/2 controlled rotation.

--- a/qiskit/transpiler/passes/synthesis/aqc_plugin.py
+++ b/qiskit/transpiler/passes/synthesis/aqc_plugin.py
@@ -118,7 +118,7 @@ class AQCSynthesisPlugin(UnitarySynthesisPlugin):
         from qiskit.synthesis.unitary.aqc.cnot_unit_circuit import CNOTUnitCircuit
         from qiskit.synthesis.unitary.aqc.fast_gradient.fast_gradient import FastCNOTUnitObjective
 
-        num_qubits = int(round(math.log2(unitary.shape[0])))
+        num_qubits = round(math.log2(unitary.shape[0]))
 
         config = options.get("config") or {}
 

--- a/qiskit/transpiler/passes/synthesis/aqc_plugin.py
+++ b/qiskit/transpiler/passes/synthesis/aqc_plugin.py
@@ -20,7 +20,7 @@ AQC Synthesis Plugin (in :mod:`qiskit.transpiler.passes.synthesis.aqc_plugin`)
    AQCSynthesisPlugin
 """
 from functools import partial
-import numpy as np
+import math
 
 from qiskit.converters import circuit_to_dag
 from qiskit.transpiler.passes.synthesis.plugin import UnitarySynthesisPlugin
@@ -118,7 +118,7 @@ class AQCSynthesisPlugin(UnitarySynthesisPlugin):
         from qiskit.synthesis.unitary.aqc.cnot_unit_circuit import CNOTUnitCircuit
         from qiskit.synthesis.unitary.aqc.fast_gradient.fast_gradient import FastCNOTUnitObjective
 
-        num_qubits = int(round(np.log2(unitary.shape[0])))
+        num_qubits = int(round(math.log2(unitary.shape[0])))
 
         config = options.get("config") or {}
 

--- a/qiskit/visualization/bloch.py
+++ b/qiskit/visualization/bloch.py
@@ -48,6 +48,7 @@
 
 __all__ = ["Bloch"]
 
+import math
 import os
 import numpy as np
 import matplotlib
@@ -648,9 +649,7 @@ class Bloch:
                 )
 
             elif self.point_style[k] == "m":
-                pnt_colors = np.array(
-                    self.point_color * int(np.ceil(num / float(len(self.point_color))))
-                )
+                pnt_colors = np.array(self.point_color * math.ceil(num / len(self.point_color)))
 
                 pnt_colors = pnt_colors[0:num]
                 pnt_colors = list(pnt_colors[indperm])

--- a/qiskit/visualization/state_visualization.py
+++ b/qiskit/visualization/state_visualization.py
@@ -17,6 +17,7 @@
 Visualization functions for quantum states.
 """
 
+import math
 from typing import List, Union
 from functools import reduce
 import colorsys
@@ -97,7 +98,7 @@ def plot_state_hinton(state, title="", figsize=None, ax_real=None, ax_imag=None,
     num = rho.num_qubits
     if num is None:
         raise VisualizationError("Input is not a multi-qubit quantum state.")
-    max_weight = 2 ** np.ceil(np.log(np.abs(rho.data).max()) / np.log(2))
+    max_weight = 2 ** math.ceil(math.log2(np.abs(rho.data).max()))
     datareal = np.real(rho.data)
     dataimag = np.imag(rho.data)
 
@@ -1314,7 +1315,7 @@ def _state_to_latex_ket(
     Returns:
         String with LaTeX representation of the state vector
     """
-    num = int(np.log2(len(data)))
+    num = int(math.log2(len(data)))
 
     def ket_name(i):
         return bin(i)[2:].zfill(num)


### PR DESCRIPTION
There's no reason to use numpy functions instead of math/cmath for scalars and the latter are around 10x faster due to avoiding the numpy dispatch overhead. This PR replaces a bunch of instances. I don't expect any sizeable performance impact as most are not in any core loop but there may be some minor benefit and I'd rather have more examples of best-practice in the codebase. One slight difference between math and numpy is that floor/ceil do already return integer so no need to wrap int(np.floor(x))