### PR TITLE
Reduce number of decomposers used during UnitarySynthesis default plugin

### DIFF
--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -772,7 +772,7 @@ class DefaultUnitarySynthesis(plugin.UnitarySynthesisPlugin):
             decomposers.append(decomposer)
 
         # If our 2q basis gates are a subset of cx, ecr, or cz then we know TwoQubitBasisDecomposer
-        # is an ideal deocmposition and there is no need to bother calculating the XX embodiments
+        # is an ideal decomposition and there is no need to bother calculating the XX embodiments
         # or try the XX decomposer
         if {"cx", "cz", "ecr"}.issuperset(available_2q_basis):
             self._decomposer_cache[qubits_tuple] = decomposers

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -35,6 +35,7 @@ from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.dagcircuit.dagcircuit import DAGCircuit
 from qiskit.synthesis.one_qubit import one_qubit_decompose
+from qiskit.transpiler.passes.optimization.optimize_1q_decomposition import _possible_decomposers
 from qiskit.synthesis.two_qubit.xx_decompose import XXDecomposer, XXEmbodiments
 from qiskit.synthesis.two_qubit.two_qubit_decompose import (
     TwoQubitBasisDecomposer,
@@ -84,23 +85,16 @@ def _choose_kak_gate(basis_gates):
 def _choose_euler_basis(basis_gates):
     """Choose the first available 1q basis to use in the Euler decomposition."""
     basis_set = set(basis_gates or [])
-
-    for basis, gates in one_qubit_decompose.ONE_QUBIT_EULER_BASIS_GATES.items():
-
-        if set(gates).issubset(basis_set):
-            return basis
-
+    decomposers = _possible_decomposers(basis_set)
+    if decomposers:
+        return decomposers[0]
     return "U"
 
 
 def _find_matching_euler_bases(target, qubit):
     """Find matching available 1q basis to use in the Euler decomposition."""
-    euler_basis_gates = []
     basis_set = target.operation_names_for_qargs((qubit,))
-    for basis, gates in one_qubit_decompose.ONE_QUBIT_EULER_BASIS_GATES.items():
-        if set(gates).issubset(basis_set):
-            euler_basis_gates.append(basis)
-    return euler_basis_gates
+    return _possible_decomposers(basis_set)
 
 
 def _choose_bases(basis_gates, basis_dict=None):
@@ -776,6 +770,13 @@ class DefaultUnitarySynthesis(plugin.UnitarySynthesisPlugin):
                 basis_fidelity=basis_2q_fidelity,
             )
             decomposers.append(decomposer)
+
+        # If our 2q basis gates are a subset of cx, ecr, or cz then we know TwoQubitBasisDecomposer
+        # is an ideal deocmposition and there is no need to bother calculating the XX embodiments
+        # or try the XX decomposer
+        if {"cx", "cz", "ecr"}.issuperset(available_2q_basis):
+            self._decomposer_cache[qubits_tuple] = decomposers
+            return decomposers
 
         # possible controlled decomposers (i.e. XXDecomposer)
         controlled_basis = {k: v for k, v in available_2q_basis.items() if is_controlled(v)}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit reduces the number of decomposers we run in the default synthesis plugin when we're in known targets. Previously the unitary synthesis plugin was trying to product of all 1q basis and 2q basis for every 2q pair that is being synthesized. This would result in duplicated work for several 1q bases where there were potential subsets available as two different target euler bases, mainly U321 and U3 or ZSX and ZSXX if the basis gates for a qubit where U3, U2, U1 or Rz, SX, and X respectively. This reuses the logic from Optimize1qGatesDecomposition to make the euler basis selection which does the deduplication. Similarly, in the presence of known 2q gates we can skip the XXDecomposer checks (or potentially running the XXDecomposer) which should speed up both the selection of decomposers and also reduce the number of decomposers we run.

### Details and comments