### PR TITLE
Fix bad release-notes section

### DIFF
--- a/releasenotes/notes/1.0/add-annotated-arg-to-control-d9a188fe66f037ad.yaml
+++ b/releasenotes/notes/1.0/add-annotated-arg-to-control-d9a188fe66f037ad.yaml
@@ -1,5 +1,5 @@
 ---
-features_circuit:
+features_circuits:
   - |
     Added a new argument, ``annotated``, to the methods :meth:`.QuantumCircuit.control`, :meth:`.Gate.control`
     and ``.control()`` methods of :class:`.Gate` subclasses (such as :class:`.UnitaryGate` or :class:`.SwapGate`)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This causes failures in the docs build since #11855 merged (which just exposes them - it wasn't the cause), though I'm slightly confused as to why it doesn't _always_ seem to cause failures, nor why it didn't fail the docs build for 1.0.

### Details and comments


