### PR TITLE
Fix bad indentation and missing hyphen on `vqd.py`

### DIFF
--- a/qiskit/algorithms/eigensolvers/vqd.py
+++ b/qiskit/algorithms/eigensolvers/vqd.py
@@ -94,7 +94,7 @@ class VQD(VariationalAlgorithm, Eigensolver):
                 overlap estimation as indicated in the VQD paper.
             ansatz (QuantumCircuit): A parameterized circuit used as ansatz for the wave function.
             optimizer(Optimizer | Sequence[Optimizer]): A classical optimizer or a list of optimizers,
-            one for every k-th eigenvalue. Can either be a Qiskit optimizer or a callable
+                one for every k-th eigenvalue. Can either be a Qiskit optimizer or a callable
                 that takes an array as input and returns a Qiskit or SciPy optimization result.
             k (int): the number of eigenvalues to return. Returns the lowest k eigenvalues.
             betas (list[float]): Beta parameters in the VQD paper.
@@ -102,7 +102,7 @@ class VQD(VariationalAlgorithm, Eigensolver):
                 These hyper-parameters balance the contribution of each overlap term to the cost
                 function and have a default value computed as the mean square sum of the
                 coefficients of the observable.
-            initial point (Sequence[float] | Sequence[Sequence[float]] | None): An optional initial
+            initial_point (Sequence[float] | Sequence[Sequence[float]] | None): An optional initial
                 point (i.e. initial parameter values) or a list of initial points
                 (one for every k-th eigenvalue) for the optimizer.
                 If ``None`` then VQD will look to the ansatz for a

--- a/qiskit/algorithms/eigensolvers/vqd.py
+++ b/qiskit/algorithms/eigensolvers/vqd.py
@@ -102,11 +102,6 @@ class VQD(VariationalAlgorithm, Eigensolver):
                 These hyper-parameters balance the contribution of each overlap term to the cost
                 function and have a default value computed as the mean square sum of the
                 coefficients of the observable.
-            initial_point (Sequence[float] | Sequence[Sequence[float]] | None): An optional initial
-                point (i.e. initial parameter values) or a list of initial points
-                (one for every k-th eigenvalue) for the optimizer.
-                If ``None`` then VQD will look to the ansatz for a
-                preferred point and if not will simply compute a random one.
             callback (Callable[[int, np.ndarray, float, dict[str, Any]], None] | None):
                 A callback that can access the intermediate data
                 during the optimization. Four parameter values are passed to the callback as


### PR DESCRIPTION
This little PR fixes the docs of two attributes of `qiskit/algorithms/eigensolvers/vqd.py`

The attribute `optimizer` had bad indentation and was split between two bullet points in the list of attributes.

![Captura desde 2024-04-08 18-56-13](https://github.com/Qiskit/qiskit/assets/47946624/87797344-b62e-41a3-bed2-fe65885a0439)

The attribute `initial_point` was missing a hyphen.

![Screenshot 2024-04-09 at 14 40 10](https://github.com/Qiskit/qiskit/assets/47946624/ce4f5fbe-24e4-4fff-b603-507d901b2c3b)


This issue is tracked by **https://github.com/Qiskit/documentation/issues/1120**