### PR TITLE
Fix RNG-compatibility of Sabre for large sizes

### DIFF
--- a/crates/accelerate/src/sabre/route.rs
+++ b/crates/accelerate/src/sabre/route.rs
@@ -541,10 +541,10 @@ pub fn swap_map_trial(
             let best_swap = state.choose_best_swap();
             state.apply_swap(best_swap);
             current_swaps.push(best_swap);
-            if let Some(node) = state.routable_node_on_qubit(best_swap[0]) {
+            if let Some(node) = state.routable_node_on_qubit(best_swap[1]) {
                 routable_nodes.push(node);
             }
-            if let Some(node) = state.routable_node_on_qubit(best_swap[1]) {
+            if let Some(node) = state.routable_node_on_qubit(best_swap[0]) {
                 routable_nodes.push(node);
             }
             num_search_steps += 1;


### PR DESCRIPTION
### Summary

The recent Sabre refactor (gh-11977, 3af3cf588) inadvertently switched the order that physical qubits were considered when modifying the front layer after a swap insertion. This could occasionally have an impact in the swap-chooser and extended-set population, if a swap enabled two separate gates at once.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

The reason that this changed is that before #11977 we looked at the two physical qubits of the swap in this order, but _before_ we swapped them.  After #11977 we look at them afterwards, so to maintain RNG compatibility, we should look at them in the reverse order.

ASV flagged modifications in the depths and sizes (and mostly corresponding changes in the timings) following #11977 that were unexpected.  Timing the large-scale passes on my laptop is a little volatile because of other stuff it's doing and thermal throttling, but I can easily verify that this PR fixes the RNG variance.

Commit 4ff0fa2f624d5b834c4afaf871c9b5b3b7e22367 is `main` _before_ #11977.  Commit 3af3cf58809700aea1db5f1392939fd1ebda54f8 is #11977. Commit 902557f265 is this PR.  I ran the `LargeQuantumVolume` benches and the QUEKO benches (which are in the changed set), and first up we can reproduce the changes caused by #11977:
```text
       before           after         ratio
     [4ff0fa2f]       [3af3cf58]
     <var/qpy~3>       <var/qpy~2>
-             547              495     0.90  quantum_volume.LargeQuantumVolumeMappingTrackBench.track_depth_sabre_swap(115, 10, 'lookahead')
-        456±30ms          346±5ms     0.76  queko.QUEKOTranspilerBench.time_transpile_bss(2, 'sabre')
-             672              499     0.74  queko.QUEKOTranspilerBench.track_depth_bntf_optimal_depth_25(0, 'sabre')
-             394              348     0.88  queko.QUEKOTranspilerBench.track_depth_bntf_optimal_depth_25(1, 'sabre')
-             836              684     0.82  queko.QUEKOTranspilerBench.track_depth_bss_optimal_depth_100(0, 'sabre')
-             370              314     0.85  queko.QUEKOTranspilerBench.track_depth_bss_optimal_depth_100(1, 'sabre')
       before           after         ratio
     [4ff0fa2f]       [3af3cf58]
     <var/qpy~3>       <var/qpy~2>
+      2.31±0.01s        3.10±0.1s     1.34  quantum_volume.LargeQuantumVolumeMappingTimeBench.time_sabre_swap(1081, 10, 'lookahead')
+         364±4ms         512±20ms     1.40  quantum_volume.LargeQuantumVolumeMappingTimeBench.time_sabre_swap(409, 10, 'decay')
+            2955             3527     1.19  quantum_volume.LargeQuantumVolumeMappingTrackBench.track_depth_sabre_swap(409, 10, 'decay')
+          217448           251736     1.16  quantum_volume.LargeQuantumVolumeMappingTrackBench.track_size_sabre_swap(1081, 10, 'decay')
+           42115            46814     1.11  quantum_volume.LargeQuantumVolumeMappingTrackBench.track_size_sabre_swap(409, 10, 'decay')
+        554±30ms         696±30ms     1.26  queko.QUEKOTranspilerBench.time_transpile_bntf(3, 'sabre')
+             299              384     1.28  queko.QUEKOTranspilerBench.track_depth_bntf_optimal_depth_25(2, 'sabre')
+             200              224     1.12  queko.QUEKOTranspilerBench.track_depth_bntf_optimal_depth_25(3, 'sabre')
+             261              290     1.11  queko.QUEKOTranspilerBench.track_depth_bss_optimal_depth_100(3, 'sabre')
```

Then we can see that the diff from #11977 to this PR inverts that:
```
       before           after         ratio
     [3af3cf58]       [902557f265]
     <var/qpy~2>
-       3.10±0.1s       2.42±0.01s     0.78  quantum_volume.LargeQuantumVolumeMappingTimeBench.time_sabre_swap(1081, 10, 'lookahead')
-        512±20ms          380±8ms     0.74  quantum_volume.LargeQuantumVolumeMappingTimeBench.time_sabre_swap(409, 10, 'decay')
-            3527             2955     0.84  quantum_volume.LargeQuantumVolumeMappingTrackBench.track_depth_sabre_swap(409, 10, 'decay')
-          251736           217448     0.86  quantum_volume.LargeQuantumVolumeMappingTrackBench.track_size_sabre_swap(1081, 10, 'decay')
-           46814            42115     0.90  quantum_volume.LargeQuantumVolumeMappingTrackBench.track_size_sabre_swap(409, 10, 'decay')
-        374±30ms          328±3ms     0.88  queko.QUEKOTranspilerBench.time_transpile_bntf(2, 'sabre')
-        696±30ms         513±10ms     0.74  queko.QUEKOTranspilerBench.time_transpile_bntf(3, 'sabre')
-         743±7ms          655±6ms     0.88  queko.QUEKOTranspilerBench.time_transpile_bss(3, 'sabre')
-             384              299     0.78  queko.QUEKOTranspilerBench.track_depth_bntf_optimal_depth_25(2, 'sabre')
-             224              200     0.89  queko.QUEKOTranspilerBench.track_depth_bntf_optimal_depth_25(3, 'sabre')
-             290              261     0.90  queko.QUEKOTranspilerBench.track_depth_bss_optimal_depth_100(3, 'sabre')
       before           after         ratio
     [3af3cf58]       [90ef7f28]
     <var/qpy~2>
+             495              547     1.11  quantum_volume.LargeQuantumVolumeMappingTrackBench.track_depth_sabre_swap(115, 10, 'lookahead')
+         346±5ms          406±6ms     1.17  queko.QUEKOTranspilerBench.time_transpile_bss(2, 'sabre')
+             499              672     1.35  queko.QUEKOTranspilerBench.track_depth_bntf_optimal_depth_25(0, 'sabre')
+             348              394     1.13  queko.QUEKOTranspilerBench.track_depth_bntf_optimal_depth_25(1, 'sabre')
+             684              836     1.22  queko.QUEKOTranspilerBench.track_depth_bss_optimal_depth_100(0, 'sabre')
+             314              370     1.18  queko.QUEKOTranspilerBench.track_depth_bss_optimal_depth_100(1, 'sabre')
```

and then finally the diff between 4ff0fa2f624d5b834c4afaf871c9b5b3b7e22367 and this PR shows no change.