### PR TITLE
Fixes "phsyical" Typos

### DIFF
--- a/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
+++ b/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
@@ -63,7 +63,7 @@ class Unroll3qOrMore(TransformationPass):
 
             if self.target is not None:
                 # Treat target instructions as global since this pass can be run
-                # prior to layout and routing we don't have phsyical qubits from
+                # prior to layout and routing we don't have physical qubits from
                 # the circuit yet
                 if node.name in self.target:
                     continue

--- a/qiskit/transpiler/passes/layout/apply_layout.py
+++ b/qiskit/transpiler/passes/layout/apply_layout.py
@@ -71,9 +71,9 @@ class ApplyLayout(TransformationPass):
             }
             for qreg in dag.qregs.values():
                 self.property_set["layout"].add_register(qreg)
-            virtual_phsyical_map = layout.get_virtual_bits()
+            virtual_physical_map = layout.get_virtual_bits()
             for node in dag.topological_op_nodes():
-                qargs = [q[virtual_phsyical_map[qarg]] for qarg in node.qargs]
+                qargs = [q[virtual_physical_map[qarg]] for qarg in node.qargs]
                 new_dag.apply_operation_back(node.op, qargs, node.cargs, check=False)
         else:
             # First build a new layout object going from:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
Fixes typos in variable names and docstrings.


### Details and comments
Fixes typos in variable names and in a docstring where "physical" was written "phsyical."

