### PR TITLE
Rework handling of instruction durations in preset pass managers

### DIFF
--- a/qiskit/transpiler/passes/scheduling/dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/dynamical_decoupling.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -20,6 +20,7 @@ from qiskit.circuit.library.standard_gates import IGate, UGate, U3Gate
 from qiskit.dagcircuit import DAGOpNode, DAGInNode
 from qiskit.quantum_info.operators.predicates import matrix_equal
 from qiskit.synthesis.one_qubit import OneQubitEulerDecomposer
+from qiskit.transpiler import InstructionDurations
 from qiskit.transpiler.passes.optimization import Optimize1qGates
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
@@ -168,6 +169,8 @@ class DynamicalDecoupling(TransformationPass):
         if dag.duration is None:
             raise TranspilerError("DD runs after circuit is scheduled.")
 
+        durations = self._update_inst_durations(dag)
+
         num_pulses = len(self._dd_sequence)
         sequence_gphase = 0
         if num_pulses != 1:
@@ -208,7 +211,7 @@ class DynamicalDecoupling(TransformationPass):
             for index, gate in enumerate(self._dd_sequence):
                 gate = gate.to_mutable()
                 self._dd_sequence[index] = gate
-                gate.duration = self._durations.get(gate, physical_qubit)
+                gate.duration = durations.get(gate, physical_qubit)
 
                 dd_sequence_duration += gate.duration
             index_sequence_duration_map[physical_qubit] = dd_sequence_duration
@@ -276,6 +279,26 @@ class DynamicalDecoupling(TransformationPass):
             new_dag.global_phase = new_dag.global_phase + sequence_gphase
 
         return new_dag
+
+    def _update_inst_durations(self, dag):
+        """Update instruction durations with circuit information. If the dag contains gate
+        calibrations and no instruction durations were provided through the target or as a
+        standalone input, the circuit calibration durations will be used.
+        The priority order for instruction durations is: target > standalone > circuit.
+        """
+        circ_durations = InstructionDurations()
+
+        if dag.calibrations:
+            cal_durations = []
+            for gate, gate_cals in dag.calibrations.items():
+                for (qubits, parameters), schedule in gate_cals.items():
+                    cal_durations.append((gate, qubits, parameters, schedule.duration))
+            circ_durations.update(cal_durations, circ_durations.dt)
+
+        if self._durations is not None:
+            circ_durations.update(self._durations, getattr(self._durations, "dt", None))
+
+        return circ_durations
 
     def __gate_supported(self, gate: Gate, qarg: int) -> bool:
         """A gate is supported on the qubit (qarg) or not."""

--- a/qiskit/transpiler/passes/scheduling/time_unit_conversion.py
+++ b/qiskit/transpiler/passes/scheduling/time_unit_conversion.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -51,6 +51,7 @@ class TimeUnitConversion(TransformationPass):
         self.inst_durations = inst_durations or InstructionDurations()
         if target is not None:
             self.inst_durations = target.durations()
+        self._durations_provided = inst_durations is not None or target is not None
 
     def run(self, dag: DAGCircuit):
         """Run the TimeUnitAnalysis pass on `dag`.
@@ -64,8 +65,11 @@ class TimeUnitConversion(TransformationPass):
         Raises:
             TranspilerError: if the units are not unifiable
         """
+
+        inst_durations = self._update_inst_durations(dag)
+
         # Choose unit
-        if self.inst_durations.dt is not None:
+        if inst_durations.dt is not None:
             time_unit = "dt"
         else:
             # Check what units are used in delays and other instructions: dt or SI or mixed
@@ -75,7 +79,7 @@ class TimeUnitConversion(TransformationPass):
                     "Fail to unify time units in delays. SI units "
                     "and dt unit must not be mixed when dt is not supplied."
                 )
-            units_other = self.inst_durations.units_used()
+            units_other = inst_durations.units_used()
             if self._unified(units_other) == "mixed":
                 raise TranspilerError(
                     "Fail to unify time units in instruction_durations. SI units "
@@ -96,7 +100,7 @@ class TimeUnitConversion(TransformationPass):
         # Make units consistent
         for node in dag.op_nodes():
             try:
-                duration = self.inst_durations.get(
+                duration = inst_durations.get(
                     node.op, [dag.find_bit(qarg).index for qarg in node.qargs], unit=time_unit
                 )
             except TranspilerError:
@@ -107,6 +111,26 @@ class TimeUnitConversion(TransformationPass):
 
         self.property_set["time_unit"] = time_unit
         return dag
+
+    def _update_inst_durations(self, dag):
+        """Update instruction durations with circuit information. If the dag contains gate
+        calibrations and no instruction durations were provided through the target or as a
+        standalone input, the circuit calibration durations will be used.
+        The priority order for instruction durations is: target > standalone > circuit.
+        """
+        circ_durations = InstructionDurations()
+
+        if dag.calibrations:
+            cal_durations = []
+            for gate, gate_cals in dag.calibrations.items():
+                for (qubits, parameters), schedule in gate_cals.items():
+                    cal_durations.append((gate, qubits, parameters, schedule.duration))
+            circ_durations.update(cal_durations, circ_durations.dt)
+
+        if self._durations_provided:
+            circ_durations.update(self.inst_durations, getattr(self.inst_durations, "dt", None))
+
+        return circ_durations
 
     @staticmethod
     def _units_used_in_delays(dag: DAGCircuit) -> Set[str]:

--- a/releasenotes/notes/rework-inst-durations-passes-28c78401682e22c0.yaml
+++ b/releasenotes/notes/rework-inst-durations-passes-28c78401682e22c0.yaml
@@ -1,5 +1,5 @@
 ---
-features_transpiler:
+fixes:
   - |
     The internal handling of custom circuit calibrations and :class:`.InstructionDurations`
     has been offloaded from the :func:`.transpile` function to the individual transpiler passes: 
@@ -9,3 +9,7 @@ features_transpiler:
     they were manually incorporated into `instruction_durations` input argument, but the passes
     that need it now analyze the circuit and pick the most relevant duration value according 
     to the following priority order: target > custom input > circuit calibrations.
+
+  - |
+    Fixed a bug in :func:`.transpile` where the ``num_processes`` argument would only be used
+    if ``dt`` or ``instruction_durations`` were provided. 

--- a/releasenotes/notes/rework-inst-durations-passes-28c78401682e22c0.yaml
+++ b/releasenotes/notes/rework-inst-durations-passes-28c78401682e22c0.yaml
@@ -1,0 +1,11 @@
+---
+features_transpiler:
+  - |
+    The internal handling of custom circuit calibrations and :class:`.InstructionDurations`
+    has been offloaded from the :func:`.transpile` function to the individual transpiler passes: 
+    :class:`qiskit.transpiler.passes.scheduling.DynamicalDecoupling`,
+    :class:`qiskit.transpiler.passes.scheduling.padding.DynamicalDecoupling`. Before, 
+    instruction durations from circuit calibrations would not be taken into account unless 
+    they were manually incorporated into `instruction_durations` input argument, but the passes
+    that need it now analyze the circuit and pick the most relevant duration value according 
+    to the following priority order: target > custom input > circuit calibrations.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes #10449 by removing the "hack" in `transpile` that handled the priority order of different sources of `InstructionDurations` in scheduling passes. The passes now analyze the dag calibrations and set the relevant value themselves, which allows for a much easier use of the standalone passes.

I believe that the change in line 412 (where `num_processes` wasn't used) was a bug that also got fixed in this PR, unless I am missing something. 

### Details and comments
Connected to #9256.
