### PR TITLE
`empty` is deprecated in PyO3 0.21 in favor of `empty_bound`

### DIFF
--- a/crates/accelerate/src/quantum_circuit/circuit_data.rs
+++ b/crates/accelerate/src/quantum_circuit/circuit_data.rs
@@ -343,8 +343,8 @@ impl CircuitData {
     /// Returns:
     ///     tuple[set[:class:`.Qubit`], set[:class:`.Clbit`]]: The active qubits and clbits.
     pub fn active_bits(&self, py: Python<'_>) -> PyResult<Py<PyTuple>> {
-        let qubits = PySet::empty(py)?;
-        let clbits = PySet::empty(py)?;
+        let qubits = PySet::empty_bound(py)?;
+        let clbits = PySet::empty_bound(py)?;
         for inst in self.data.iter() {
             for b in self.intern_context.lookup(inst.qubits_id).iter() {
                 qubits.add(self.qubits_native[*b as usize].clone_ref(py))?;


### PR DESCRIPTION
follow up to https://github.com/Qiskit/qiskit/pull/12121/

```
error: use of deprecated associated function `pyo3::types::PySet::empty`: `PySet::empty` will be replaced by `PySet::empty_bound` in a future PyO3 version
   --> crates/accelerate/src/quantum_circuit/circuit_data.rs:346:29
    |
346 |         let qubits = PySet::empty(py)?;
    |                             ^^^^^
    |
    = note: `-D deprecated` implied by `-D warnings`

error: use of deprecated associated function `pyo3::types::PySet::empty`: `PySet::empty` will be replaced by `PySet::empty_bound` in a future PyO3 version
   --> crates/accelerate/src/quantum_circuit/circuit_data.rs:347:29
    |
347 |         let clbits = PySet::empty(py)?;
    |                             ^^^^^
```