### PR TITLE
Add build requirements to `requirements-dev.txt`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,10 @@
 # never become actual package requirements, but still try to be as relaxed as
 # possible so it's easy to develop multiple packages from the same venv.
 
+# Build Rust directly
+setuptools
+setuptools-rust
+
 # Style
 black[jupyter]~=24.1
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,6 @@ passenv =
   QISKIT_IN_PARALLEL
   QISKIT_DOCS_GITHUB_BRANCH_NAME
 deps =
-    setuptools_rust  # This is work around for the bug of tox 3 (see #8606 for more details.)
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements-dev.txt
 commands =


### PR DESCRIPTION
### Summary

We previously have not added the build-only requirements `setuptools` and `setuptools-rust` to `requirements-dev.txt` because the majority of contributors would not to build the Rust components outside of the regular build isolation provided by `pip` or other PEP-517 compatible builders.

Since we are accelerating our use of Rust, and it's more likely that more users will need to touch the Rust components, this adds the build requirements to the developer environment, so it's easier for people to do our recommended

        python setup.py build_rust --inplace --release

for the cases that they want to test against optimised versions of the Rust extensions while still maintaining a Python editable installation.


### Details and comments

We talk about re-building Rust outside the build-system isolation in the contributing guide, and in practice, those of us who do a bunch of Rust development for Qiskit already do this tonnes.  This just makes it a bit easier for contributors to make sure they've got an environment where they can do the same stuff as us.