### PR TITLE
Updates for removing use-maxsplit-arg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,7 +241,6 @@ disable = [
     "use-dict-literal",
     "use-list-literal",
     "use-implicit-booleaness-not-comparison",
-    "use-maxsplit-arg",
 ]
 
 enable = [

--- a/test/python/visualization/test_circuit_drawer.py
+++ b/test/python/visualization/test_circuit_drawer.py
@@ -136,7 +136,7 @@ class TestCircuitDrawer(QiskitTestCase):
                 if filename.endswith("jpg"):
                     self.assertIn(im.format.lower(), "jpeg")
                 else:
-                    self.assertIn(im.format.lower(), filename.split(".")[-1])
+                    self.assertIn(im.format.lower(), filename.rsplit(".", maxsplit=1)[-1])
             os.remove(filename)
 
     def test_wire_order(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Part of the effort in #9614 to incrementally remove lints

### Details and comments

Only used in one place. It makes sense if the line only cares about the extension. On the other hand, is also very much a nit in this case since most image files don't have multiple `.` in them and makes the line a bit longer.
