### PR TITLE
Add representation of `expr.Var` to `DAGCircuit`

### DIFF
--- a/qiskit/circuit/controlflow/control_flow.py
+++ b/qiskit/circuit/controlflow/control_flow.py
@@ -22,6 +22,7 @@ from qiskit.circuit.exceptions import CircuitError
 
 if typing.TYPE_CHECKING:
     from qiskit.circuit import QuantumCircuit
+    from qiskit.circuit.classical import expr
 
 
 class ControlFlowOp(Instruction, ABC):
@@ -72,3 +73,12 @@ class ControlFlowOp(Instruction, ABC):
         Returns:
             New :class:`ControlFlowOp` with replaced blocks.
         """
+
+    def iter_captured_vars(self) -> typing.Iterable[expr.Var]:
+        """Get an iterator over the unique captured variables in all blocks of this construct."""
+        seen = set()
+        for block in self.blocks:
+            for var in block.iter_captured_vars():
+                if var not in seen:
+                    seen.add(var)
+                    yield var

--- a/qiskit/converters/circuit_to_dag.py
+++ b/qiskit/converters/circuit_to_dag.py
@@ -79,6 +79,13 @@ def circuit_to_dag(circuit, copy_operations=True, *, qubit_order=None, clbit_ord
     dagcircuit.add_qubits(qubits)
     dagcircuit.add_clbits(clbits)
 
+    for var in circuit.iter_input_vars():
+        dagcircuit.add_input_var(var)
+    for var in circuit.iter_captured_vars():
+        dagcircuit.add_captured_var(var)
+    for var in circuit.iter_declared_vars():
+        dagcircuit.add_declared_var(var)
+
     for register in circuit.qregs:
         dagcircuit.add_qreg(register)
 

--- a/qiskit/converters/dag_to_circuit.py
+++ b/qiskit/converters/dag_to_circuit.py
@@ -62,7 +62,11 @@ def dag_to_circuit(dag, copy_operations=True):
         *dag.cregs.values(),
         name=name,
         global_phase=dag.global_phase,
+        inputs=dag.iter_input_vars(),
+        captures=dag.iter_captured_vars(),
     )
+    for var in dag.iter_declared_vars():
+        circuit.add_uninitialized_var(var)
     circuit.metadata = dag.metadata
     circuit.calibrations = dag.calibrations
 

--- a/test/python/converters/test_circuit_to_dag.py
+++ b/test/python/converters/test_circuit_to_dag.py
@@ -15,9 +15,9 @@
 import unittest
 
 from qiskit.dagcircuit import DAGCircuit
-from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit, Clbit
+from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit, Clbit, SwitchCaseOp
 from qiskit.circuit.library import HGate, Measure
-from qiskit.circuit.classical import expr
+from qiskit.circuit.classical import expr, types
 from qiskit.converters import dag_to_circuit, circuit_to_dag
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
@@ -105,6 +105,38 @@ class TestCircuitToDag(QiskitTestCase):
         roundtripped = dag_to_circuit(dag)
         for original, test in zip(outer, roundtripped):
             self.assertEqual(original.operation.target, test.operation.target)
+
+    def test_runtime_vars_in_roundtrip(self):
+        """`expr.Var` nodes should be fully roundtripped."""
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+        c = expr.Var.new("c", types.Uint(8))
+        d = expr.Var.new("d", types.Uint(8))
+        qc = QuantumCircuit(inputs=[a, c])
+        qc.add_var(b, False)
+        qc.add_var(d, 255)
+        qc.store(a, expr.logic_or(a, b))
+        with qc.if_test(expr.logic_and(a, expr.equal(c, d))):
+            pass
+        with qc.while_loop(a):
+            qc.store(a, expr.logic_or(a, b))
+        with qc.switch(d) as case:
+            with case(0):
+                qc.store(c, d)
+            with case(case.DEFAULT):
+                qc.store(a, False)
+
+        roundtrip = dag_to_circuit(circuit_to_dag(qc))
+        self.assertEqual(qc, roundtrip)
+
+        self.assertIsInstance(qc.data[-1].operation, SwitchCaseOp)
+        # This is guaranteed to be topologically last, even after the DAG roundtrip.
+        self.assertIsInstance(roundtrip.data[-1].operation, SwitchCaseOp)
+        self.assertEqual(qc.data[-1].operation.blocks, roundtrip.data[-1].operation.blocks)
+
+        blocks = roundtrip.data[-1].operation.blocks
+        self.assertEqual(set(blocks[0].iter_captured_vars()), {c, d})
+        self.assertEqual(set(blocks[1].iter_captured_vars()), {a})
 
     def test_wire_order(self):
         """Test that the `qubit_order` and `clbit_order` parameters are respected."""

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -38,8 +38,10 @@ from qiskit.circuit import (
     SwitchCaseOp,
     IfElseOp,
     WhileLoopOp,
+    CASE_DEFAULT,
+    Store,
 )
-from qiskit.circuit.classical import expr
+from qiskit.circuit.classical import expr, types
 from qiskit.circuit.library import IGate, HGate, CXGate, CZGate, XGate, YGate, U1Gate, RXGate
 from qiskit.converters import circuit_to_dag
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
@@ -420,6 +422,22 @@ class TestDagWireRemoval(QiskitTestCase):
         self.assertEqual(self.dag.qregs, result_dag.qregs)
         self.assertEqual(self.dag.duration, result_dag.duration)
         self.assertEqual(self.dag.unit, result_dag.unit)
+
+    def test_copy_empty_like_vars(self):
+        """Variables should be part of the empty copy."""
+        dag = DAGCircuit()
+        dag.add_input_var(expr.Var.new("a", types.Bool()))
+        dag.add_input_var(expr.Var.new("b", types.Uint(8)))
+        dag.add_declared_var(expr.Var.new("c", types.Bool()))
+        dag.add_declared_var(expr.Var.new("d", types.Uint(8)))
+        self.assertEqual(dag, dag.copy_empty_like())
+
+        dag = DAGCircuit()
+        dag.add_captured_var(expr.Var.new("a", types.Bool()))
+        dag.add_captured_var(expr.Var.new("b", types.Uint(8)))
+        dag.add_declared_var(expr.Var.new("c", types.Bool()))
+        dag.add_declared_var(expr.Var.new("d", types.Uint(8)))
+        self.assertEqual(dag, dag.copy_empty_like())
 
     def test_remove_busy_clbit(self):
         """Classical bit removal of busy classical bits raises."""
@@ -1821,6 +1839,187 @@ class TestDagEquivalence(QiskitTestCase):
         qc2 = QuantumCircuit([Qubit(), clbit2], cr)
         qc2.switch(expr.bit_and(cr, 5), [(1, body)], [0], [])
         self.assertNotEqual(circuit_to_dag(qc1), circuit_to_dag(qc2))
+
+    def test_present_vars(self):
+        """The vars should be compared whether or not they're used."""
+        a_bool = expr.Var.new("a", types.Bool())
+        a_u8 = expr.Var.new("a", types.Uint(8))
+        a_u8_other = expr.Var.new("a", types.Uint(8))
+        b_bool = expr.Var.new("b", types.Bool())
+
+        left = DAGCircuit()
+        left.add_input_var(a_bool)
+        left.add_input_var(b_bool)
+        self.assertEqual(left.num_input_vars, 2)
+        self.assertEqual(left.num_captured_vars, 0)
+        self.assertEqual(left.num_declared_vars, 0)
+
+        right = DAGCircuit()
+        right.add_input_var(a_bool)
+        right.add_input_var(b_bool)
+        self.assertEqual(right.num_input_vars, 2)
+        self.assertEqual(right.num_captured_vars, 0)
+        self.assertEqual(right.num_declared_vars, 0)
+        self.assertEqual(left, right)
+
+        right = DAGCircuit()
+        right.add_input_var(a_u8)
+        right.add_input_var(b_bool)
+        self.assertEqual(right.num_input_vars, 2)
+        self.assertEqual(right.num_captured_vars, 0)
+        self.assertEqual(right.num_declared_vars, 0)
+        self.assertNotEqual(left, right)
+
+        right = DAGCircuit()
+        self.assertEqual(right.num_input_vars, 0)
+        self.assertEqual(right.num_captured_vars, 0)
+        self.assertEqual(right.num_declared_vars, 0)
+        self.assertNotEqual(left, right)
+
+        right = DAGCircuit()
+        right.add_captured_var(a_bool)
+        right.add_captured_var(b_bool)
+        self.assertEqual(right.num_input_vars, 0)
+        self.assertEqual(right.num_captured_vars, 2)
+        self.assertEqual(right.num_declared_vars, 0)
+        self.assertNotEqual(left, right)
+
+        right = DAGCircuit()
+        right.add_declared_var(a_bool)
+        right.add_declared_var(b_bool)
+        self.assertEqual(right.num_input_vars, 0)
+        self.assertEqual(right.num_captured_vars, 0)
+        self.assertEqual(right.num_declared_vars, 2)
+        self.assertNotEqual(left, right)
+
+        left = DAGCircuit()
+        left.add_captured_var(a_u8)
+
+        right = DAGCircuit()
+        right.add_captured_var(a_u8)
+        self.assertEqual(left, right)
+
+        right = DAGCircuit()
+        right.add_captured_var(a_u8_other)
+        self.assertNotEqual(left, right)
+
+    def test_wires_added_for_simple_classical_vars(self):
+        """Var uses should be represented in the wire structure."""
+        a = expr.Var.new("a", types.Bool())
+        dag = DAGCircuit()
+        dag.add_input_var(a)
+        self.assertEqual(list(dag.iter_vars()), [a])
+        self.assertEqual(list(dag.iter_input_vars()), [a])
+        self.assertEqual(list(dag.iter_captured_vars()), [])
+        self.assertEqual(list(dag.iter_declared_vars()), [])
+
+        expected_nodes = [dag.input_map[a], dag.output_map[a]]
+        self.assertEqual(list(dag.topological_nodes()), expected_nodes)
+        self.assertTrue(dag.is_successor(dag.input_map[a], dag.output_map[a]))
+
+        op_mid = dag.apply_operation_back(Store(a, expr.lift(True)), (), ())
+        self.assertTrue(dag.is_successor(dag.input_map[a], op_mid))
+        self.assertTrue(dag.is_successor(op_mid, dag.output_map[a]))
+        self.assertFalse(dag.is_successor(dag.input_map[a], dag.output_map[a]))
+
+        op_front = dag.apply_operation_front(Store(a, expr.logic_not(a)), (), ())
+        self.assertTrue(dag.is_successor(dag.input_map[a], op_front))
+        self.assertTrue(dag.is_successor(op_front, op_mid))
+        self.assertFalse(dag.is_successor(dag.input_map[a], op_mid))
+
+        op_back = dag.apply_operation_back(Store(a, expr.logic_not(a)), (), ())
+        self.assertTrue(dag.is_successor(op_mid, op_back))
+        self.assertTrue(dag.is_successor(op_back, dag.output_map[a]))
+        self.assertFalse(dag.is_successor(op_mid, dag.output_map[a]))
+
+    def test_wires_added_for_var_control_flow_condition(self):
+        """Vars used in if/else or while conditionals should be added to the wire structure."""
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+        dag = DAGCircuit()
+        dag.add_declared_var(a)
+        dag.add_input_var(b)
+
+        op_store = dag.apply_operation_back(Store(a, expr.lift(False)), (), ())
+        op_if = dag.apply_operation_back(IfElseOp(a, QuantumCircuit()), (), ())
+        op_while = dag.apply_operation_back(
+            WhileLoopOp(expr.logic_or(a, b), QuantumCircuit()), (), ()
+        )
+
+        expected_edges = {
+            (dag.input_map[a], op_store, a),
+            (op_store, op_if, a),
+            (op_if, op_while, a),
+            (op_while, dag.output_map[a], a),
+            (dag.input_map[b], op_while, b),
+            (op_while, dag.output_map[b], b),
+        }
+        self.assertEqual(set(dag.edges()), expected_edges)
+
+    def test_wires_added_for_var_control_flow_target(self):
+        """Vars used in switch targets should be added to the wire structure."""
+        a = expr.Var.new("a", types.Uint(8))
+        b = expr.Var.new("b", types.Uint(8))
+        dag = DAGCircuit()
+        dag.add_declared_var(a)
+        dag.add_input_var(b)
+
+        op_store = dag.apply_operation_back(Store(a, expr.lift(3, a.type)), (), ())
+        op_switch = dag.apply_operation_back(
+            SwitchCaseOp(expr.bit_xor(a, b), [(CASE_DEFAULT, QuantumCircuit())]), (), ()
+        )
+
+        expected_edges = {
+            (dag.input_map[a], op_store, a),
+            (op_store, op_switch, a),
+            (op_switch, dag.output_map[a], a),
+            (dag.input_map[b], op_switch, b),
+            (op_switch, dag.output_map[b], b),
+        }
+        self.assertEqual(set(dag.edges()), expected_edges)
+
+    def test_wires_added_for_control_flow_captures(self):
+        """Vars captured in control-flow blocks should be in the wire structure."""
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+        c = expr.Var.new("c", types.Bool())
+        d = expr.Var.new("d", types.Uint(8))
+        dag = DAGCircuit()
+        dag.add_input_var(a)
+        dag.add_input_var(b)
+        dag.add_declared_var(c)
+        dag.add_input_var(d)
+        op_store = dag.apply_operation_back(Store(c, expr.lift(False)), (), ())
+        op_if = dag.apply_operation_back(IfElseOp(a, QuantumCircuit(captures=[b])), (), ())
+        op_switch = dag.apply_operation_back(
+            SwitchCaseOp(
+                d,
+                [
+                    (0, QuantumCircuit(captures=[b])),
+                    (CASE_DEFAULT, QuantumCircuit(captures=[c])),
+                ],
+            ),
+            (),
+            (),
+        )
+
+        expected_edges = {
+            # a
+            (dag.input_map[a], op_if, a),
+            (op_if, dag.output_map[a], a),
+            # b
+            (dag.input_map[b], op_if, b),
+            (op_if, op_switch, b),
+            (op_switch, dag.output_map[b], b),
+            # c
+            (dag.input_map[c], op_store, c),
+            (op_store, op_switch, c),
+            (op_switch, dag.output_map[c], c),
+            # d
+            (dag.input_map[d], op_switch, d),
+            (op_switch, dag.output_map[d], d),
+        }
+        self.assertEqual(set(dag.edges()), expected_edges)
 
 
 class TestDagSubstitute(QiskitTestCase):

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -1870,14 +1870,14 @@ class TestDagEquivalence(QiskitTestCase):
         self.assertEqual(right.num_input_vars, 2)
         self.assertEqual(right.num_captured_vars, 0)
         self.assertEqual(right.num_declared_vars, 0)
-        self.assertEqual(left.num_vars, 2)
+        self.assertEqual(right.num_vars, 2)
         self.assertNotEqual(left, right)
 
         right = DAGCircuit()
         self.assertEqual(right.num_input_vars, 0)
         self.assertEqual(right.num_captured_vars, 0)
         self.assertEqual(right.num_declared_vars, 0)
-        self.assertEqual(left.num_vars, 0)
+        self.assertEqual(right.num_vars, 0)
         self.assertNotEqual(left, right)
 
         right = DAGCircuit()
@@ -1886,7 +1886,7 @@ class TestDagEquivalence(QiskitTestCase):
         self.assertEqual(right.num_input_vars, 0)
         self.assertEqual(right.num_captured_vars, 2)
         self.assertEqual(right.num_declared_vars, 0)
-        self.assertEqual(left.num_vars, 2)
+        self.assertEqual(right.num_vars, 2)
         self.assertNotEqual(left, right)
 
         right = DAGCircuit()
@@ -1895,7 +1895,7 @@ class TestDagEquivalence(QiskitTestCase):
         self.assertEqual(right.num_input_vars, 0)
         self.assertEqual(right.num_captured_vars, 0)
         self.assertEqual(right.num_declared_vars, 2)
-        self.assertEqual(left.num_vars, 2)
+        self.assertEqual(right.num_vars, 2)
         self.assertNotEqual(left, right)
 
         left = DAGCircuit()


### PR DESCRIPTION
### Summary

This adds basic support for `Var`s to `DAGCircuit`, enabling the base representation using the same wire structure used for clbits.  This is known to be an inefficient representation of the dataflow for clbits, which can be read multiple times without implying an order between those operations (unlike qubits for which reads and writes are more naturally linked).  We're using this simpler representation to make a better initial MVP; optimising the data-flow representation would come as part of a larger effort within the `DAGCircuit`.

This commit adds support in `DAGCircuit` for:

- representation of `Var` nodes
- appending all operations that might contain `Var` nodes to the DAG and updating the wire structure (including control-flow ops and stores)
- equality checking of DAGs with `Var`s (and so enables `QuantumCircuit.__eq__` as well)
- `DAGCircuit.copy_empty_like` with `Var`s
- the DAG/circuit converters

The other methods in `DAGCircuit` that might need to be aware of `Var` nodes will be handled separately.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Close #10927 
Close #10960