### PR TITLE
Reject vars in `QuantumCircuit.to_instruction` and `to_gate`

### DIFF
--- a/qiskit/converters/circuit_to_gate.py
+++ b/qiskit/converters/circuit_to_gate.py
@@ -58,6 +58,8 @@ def circuit_to_gate(circuit, parameter_map=None, equivalence_library=None, label
 
     if circuit.clbits:
         raise QiskitError("Circuit with classical bits cannot be converted to gate.")
+    if circuit.num_vars:
+        raise QiskitError("circuits with realtime classical variables cannot be converted to gates")
 
     for instruction in circuit.data:
         if not _check_is_gate(instruction.operation):

--- a/qiskit/converters/circuit_to_instruction.py
+++ b/qiskit/converters/circuit_to_instruction.py
@@ -148,8 +148,6 @@ def circuit_to_instruction(circuit, parameter_map=None, equivalence_library=None
     data.map_ops(fix_condition)
 
     qc = QuantumCircuit(*regs, name=out_instruction.name)
-    for var in circuit.iter_declared_vars():
-        qc.add_uninitialized_var(var)
     qc._data = data
     qc._parameter_table = ParameterTable(
         {

--- a/qiskit/converters/circuit_to_instruction.py
+++ b/qiskit/converters/circuit_to_instruction.py
@@ -61,6 +61,28 @@ def circuit_to_instruction(circuit, parameter_map=None, equivalence_library=None
     # pylint: disable=cyclic-import
     from qiskit.circuit.quantumcircuit import QuantumCircuit
 
+    if circuit.num_input_vars:
+        # This could be supported by moving the `input` variables to be parameters of the
+        # instruction, but we don't really have a good reprssentation of that yet, so safer to
+        # forbid it.
+        raise QiskitError("Circuits with 'input' variables cannot yet be converted to instructions")
+    if circuit.num_captured_vars:
+        raise QiskitError("Circuits that capture variables cannot be converted to instructions")
+    if circuit.num_declared_vars:
+        # This could very easily be supported in representations, since the variables are allocated
+        # and freed within the instruction itself.  The reason to initially forbid it is to avoid
+        # needing to support unrolling such instructions within the transpiler; we would potentially
+        # need to remap variables to unique names in the larger context, and we don't yet have a way
+        # to return that information from the transpiler.  We have to catch that in the transpiler
+        # as well since a user could manually make an instruction with such a definition, but
+        # forbidding it here means users get a more meaningful error at the point that the
+        # instruction actually gets created (since users often aren't aware that
+        # `QuantumCircuit.append(QuantumCircuit)` implicitly converts to an instruction).
+        raise QiskitError(
+            "Circuits with internal variables cannot yet be converted to instructions."
+            " You may be able to use `QuantumCircuit.compose` to inline this circuit into another."
+        )
+
     if parameter_map is None:
         parameter_dict = {p: p for p in circuit.parameters}
     else:
@@ -126,6 +148,8 @@ def circuit_to_instruction(circuit, parameter_map=None, equivalence_library=None
     data.map_ops(fix_condition)
 
     qc = QuantumCircuit(*regs, name=out_instruction.name)
+    for var in circuit.iter_declared_vars():
+        qc.add_uninitialized_var(var)
     qc._data = data
     qc._parameter_table = ParameterTable(
         {

--- a/test/python/converters/test_circuit_to_gate.py
+++ b/test/python/converters/test_circuit_to_gate.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.circuit import Gate, Qubit
+from qiskit.circuit.classical import expr, types
 from qiskit.quantum_info import Operator
 from qiskit.exceptions import QiskitError
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
@@ -122,3 +123,16 @@ class TestCircuitToGate(QiskitTestCase):
         compound = QuantumCircuit(1)
         compound.append(gate, [], [])
         np.testing.assert_allclose(-np.eye(2), Operator(compound), atol=1e-16)
+
+    def test_realtime_vars_rejected(self):
+        """Gates can't have realtime variables."""
+        qc = QuantumCircuit(1, inputs=[expr.Var.new("a", types.Bool())])
+        with self.assertRaisesRegex(QiskitError, "circuits with realtime classical variables"):
+            qc.to_gate()
+        qc = QuantumCircuit(1, captures=[expr.Var.new("a", types.Bool())])
+        with self.assertRaisesRegex(QiskitError, "circuits with realtime classical variables"):
+            qc.to_gate()
+        qc = QuantumCircuit(1)
+        qc.add_var("a", False)
+        with self.assertRaisesRegex(QiskitError, "circuits with realtime classical variables"):
+            qc.to_gate()

--- a/test/python/converters/test_circuit_to_instruction.py
+++ b/test/python/converters/test_circuit_to_instruction.py
@@ -21,6 +21,7 @@ from qiskit.converters import circuit_to_instruction
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.circuit import Qubit, Clbit, Instruction
 from qiskit.circuit import Parameter
+from qiskit.circuit.classical import expr, types
 from qiskit.quantum_info import Operator
 from qiskit.exceptions import QiskitError
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
@@ -217,6 +218,38 @@ class TestCircuitToInstruction(QiskitTestCase):
         compound = QuantumCircuit(1)
         compound.append(instruction, [], [])
         np.testing.assert_allclose(-np.eye(2), Operator(compound), atol=1e-16)
+
+    def test_forbids_captured_vars(self):
+        """Instructions (here an analogue of functions) cannot close over outer scopes."""
+        qc = QuantumCircuit(captures=[expr.Var.new("a", types.Bool())])
+        with self.assertRaisesRegex(QiskitError, "Circuits that capture variables cannot"):
+            qc.to_instruction()
+
+    def test_forbids_input_vars(self):
+        """This test can be relaxed when we have proper support for the behaviour.
+
+        This actually has a natural meaning; the input variables could become typed parameters.
+        We don't have a formal structure for managing that yet, though, so it's forbidden until the
+        library is ready for that."""
+        qc = QuantumCircuit(inputs=[expr.Var.new("a", types.Bool())])
+        with self.assertRaisesRegex(QiskitError, "Circuits with 'input' variables cannot"):
+            qc.to_instruction()
+
+    def test_forbids_declared_vars(self):
+        """This test can be relaxed when we have proper support for the behaviour.
+
+        This has a very natural representation, which needs basically zero special handling, since
+        the variables are necessarily entirely internal to the subroutine.  The reason it is
+        starting off as forbidden is because we don't have a good way to support variable renaming
+        during unrolling in transpilation, and we want the error to indicate an alternative at the
+        point the conversion happens."""
+        qc = QuantumCircuit()
+        qc.add_var("a", False)
+        with self.assertRaisesRegex(
+            QiskitError,
+            "Circuits with internal variables.*You may be able to use `QuantumCircuit.compose`",
+        ):
+            qc.to_instruction()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

`QuantumCircuit.to_gate` may be able to support `input` variables that are angle-typed at some point in the future, but that's very limited and not immediately on the roadmap.

`QuantumCircuit.to_instruction` does have a natural way to support both `input` vars (they become function arguments) and declared vars (since they're completely internal to the function body), but those are currently rejected because we don't have a way of specifying function signatures / calling functions yet and we don't have a neat complete story around unrolling variables into circuits yet (where there may be naming clashes), especially through transpilation.  This opts to raise the errors immediately, with alternatives where possible, rather than letting things _kind of_ work.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

I will add support for `QuantumCircuit.compose`, `DAGCircuit.compose` and the other `DAGCircuit` replacement passes in a follow-up, with some minimum support for inlining classical variables (though probably not yet with renaming, except maybe in `QuantumCircuit.compose`).