### PR TITLE
Document generate_preset_pass_manager supports list for initial_layout

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/__init__.py
+++ b/qiskit/transpiler/preset_passmanagers/__init__.py
@@ -136,7 +136,7 @@ def generate_preset_pass_manager(
         instruction_durations (InstructionDurations): Dictionary of duration
             (in dt) for each instruction.
         timing_constraints (TimingConstraints): Hardware time alignment restrictions.
-        initial_layout (Layout): Initial position of virtual qubits on
+        initial_layout (Layout | List[int]): Initial position of virtual qubits on
             physical qubits.
         layout_method (str): The :class:`~.Pass` to use for choosing initial qubit
             placement. Valid choices are ``'trivial'``, ``'dense'``,

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -1436,6 +1436,38 @@ class TestGeneratePresetPassManagers(QiskitTestCase):
         # Ensure the DAGs from both methods are identical
         self.assertEqual(transpiled_circuit_list, transpiled_circuit_object)
 
+    @data(0, 1, 2, 3)
+    def test_generate_preset_pass_manager_with_list_initial_layout(self, optimization_level):
+        """Test that generate_preset_pass_manager can handle list based initial layouts."""
+        coupling_map_list = [[0, 1]]
+
+        # Circuit that doesn't fit in the coupling map
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.cx(1, 0)
+        qc.measure_all()
+
+        pm_list = generate_preset_pass_manager(
+            optimization_level=optimization_level,
+            coupling_map=coupling_map_list,
+            basis_gates=["u", "cx"],
+            seed_transpiler=42,
+            initial_layout=[1, 0],
+        )
+        pm_object = generate_preset_pass_manager(
+            optimization_level=optimization_level,
+            coupling_map=coupling_map_list,
+            basis_gates=["u", "cx"],
+            seed_transpiler=42,
+            initial_layout=Layout.from_intlist([1, 0], *qc.qregs),
+        )
+        tqc_list = pm_list.run(qc)
+        tqc_obj = pm_list.run(qc)
+        self.assertIsInstance(pm_list, PassManager)
+        self.assertIsInstance(pm_object, PassManager)
+        self.assertEqual(tqc_list, tqc_obj)
+
 
 @ddt
 class TestIntegrationControlFlow(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the documentation for the
generate_preset_pass_manager() function to clearly indicate that the function will accept a integer list for the initial_layout field. This already was supported but it wasn't documented. As it's now a documented part of the API a unittest is added to ensure we don't regress this functionality in the future.

### Details and comments

Fixes #11690