### PR TITLE
Fix mistaken QPY custom-instructions documentation

### DIFF
--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -1101,7 +1101,6 @@ The contents of HEADER are defined as a C struct are:
         uint64_t metadata_size;
         uint32_t num_registers;
         uint64_t num_instructions;
-        uint64_t num_custom_gates;
     }
 
 This is immediately followed by ``name_size`` bytes of utf8 data for the name
@@ -1134,7 +1133,6 @@ The contents of HEADER as defined as a C struct are:
         uint64_t metadata_size;
         uint32_t num_registers;
         uint64_t num_instructions;
-        uint64_t num_custom_gates;
     }
 
 This is immediately followed by ``name_size`` bytes of utf8 data for the name


### PR DESCRIPTION
### Summary

`num_custom_gates` is not actually part of the `CIRCUIT_HEADER` structs in any version of QPY.  The number of custom-instruction objects is instead stored as a `uint64_t` inline in the `CUSTOM_DEFINITIONS` part of the file, so separately to the rest of the header.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

It's always been this way, ever since #5578, and in fact even in the commit within that PR introduced custom gates: https://github.com/Qiskit/qiskit/pull/5578/commits/733d32bf6fa21a9e3ef0fa06d90bd9615f503be8.
