### PR TITLE
Removing lint rules that are unused

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,18 +227,14 @@ disable = [
     "no-value-for-parameter",
     "not-context-manager",
     "superfluous-parens",
-    "unknown-option-value",
     "unexpected-keyword-arg",
     "unnecessary-dict-index-lookup",
-    "unnecessary-direct-lambda-call",
     "unnecessary-dunder-call",
-    "unnecessary-ellipsis",
     "unnecessary-lambda-assignment",
     "unnecessary-list-index-lookup",
     "unspecified-encoding",
     "unsupported-assignment-operation",
     "use-dict-literal",
-    "use-list-literal",
     "use-implicit-booleaness-not-comparison",
 ]
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

#9614 removing some of the rules that currently do not result in an error

### Details and comments

Removing
`unknown-option-value`
`unnecessary-direct-lambda-call`
`unnecessary-ellipsis`
`use-list-literal`
because they do not appear to currently trigger. Figure they can be looked at again if they ever do cause an issue. Otherwise, I can close this and push them above for long term removal. 

It does appear that `use-list-literal` vs `use-dict-literal` is inconsistent:
https://github.com/Qiskit/qiskit/blob/ff7ba3f1a61b6e474c00055abb62fd99dd393a99/test/python/result/test_result.py#L59-L61

Line 59 defines a dictionary with `dict(...)` and line 61 defines a list with `[...]`