### PR TITLE
Removing nested-min-max from lint exclusions and updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,7 +222,6 @@ disable = [
     "consider-using-enumerate",
     "consider-using-f-string",
     "modified-iterating-list",
-    "nested-min-max",
     "no-member",
     "no-value-for-parameter",
     "not-context-manager",

--- a/qiskit/transpiler/passes/layout/vf2_utils.py
+++ b/qiskit/transpiler/passes/layout/vf2_utils.py
@@ -129,7 +129,7 @@ def score_layout(
 ):
     """Score a layout given an average error map."""
     if layout_mapping:
-        size = max(max(layout_mapping), max(layout_mapping.values()))
+        size = max(layout_mapping, layout_mapping.values())
     else:
         size = 0
     nlayout = NLayout(layout_mapping, size + 1, size + 1)

--- a/test/python/primitives/test_backend_sampler_v2.py
+++ b/test/python/primitives/test_backend_sampler_v2.py
@@ -81,7 +81,7 @@ class TestBackendSamplerV2(QiskitTestCase):
             target_counts = (
                 target.get_int_counts(idx) if isinstance(target, BitArray) else target[idx]
             )
-            max_key = max(max(int_counts.keys()), max(target_counts.keys()))
+            max_key = max(int_counts.keys(), target_counts.keys())
             ary = np.array([int_counts.get(i, 0) for i in range(max_key + 1)])
             tgt = np.array([target_counts.get(i, 0) for i in range(max_key + 1)])
             np.testing.assert_allclose(ary, tgt, rtol=rtol, atol=atol, err_msg=f"index: {idx}")

--- a/test/python/primitives/test_statevector_sampler.py
+++ b/test/python/primitives/test_statevector_sampler.py
@@ -72,7 +72,7 @@ class TestStatevectorSampler(QiskitTestCase):
             target_counts = (
                 target.get_int_counts(idx) if isinstance(target, BitArray) else target[idx]
             )
-            max_key = max(max(int_counts.keys()), max(target_counts.keys()))
+            max_key = max(int_counts.keys(), target_counts.keys())
             ary = np.array([int_counts.get(i, 0) for i in range(max_key + 1)])
             tgt = np.array([target_counts.get(i, 0) for i in range(max_key + 1)])
             np.testing.assert_allclose(ary, tgt, rtol=rtol, err_msg=f"index: {idx}")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

#9614 test for removing `nested-min-max`

### Details and comments

Flattening nested `max`'s
