### PR TITLE
Adding note for nested-min-max for linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,7 @@ disable = [
     "no-else-return",  # relax "elif" after a clause with a return
     "docstring-first-line-empty", # relax docstring style
     "import-outside-toplevel", "import-error", # overzealous with our optionals/dynamic packages
-    "nested-min-max", # this gives false equivalencies if implemented
+    "nested-min-max", # this gives false equivalencies if implemented for the current lint version
 # TODO(#9614): these were added in modern Pylint. Decide if we want to enable them. If so,
 #  remove from here and fix the issues. Else, move it above this section and add a comment
 #  with the rationale

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,7 @@ disable = [
     "no-else-return",  # relax "elif" after a clause with a return
     "docstring-first-line-empty", # relax docstring style
     "import-outside-toplevel", "import-error", # overzealous with our optionals/dynamic packages
+    "nested-min-max", # this gives false equivalencies if implemented
 # TODO(#9614): these were added in modern Pylint. Decide if we want to enable them. If so,
 #  remove from here and fix the issues. Else, move it above this section and add a comment
 #  with the rationale
@@ -221,7 +222,6 @@ disable = [
     "consider-using-dict-items",
     "consider-using-enumerate",
     "consider-using-f-string",
-    "nested-min-max",
     "no-member",
     "no-value-for-parameter",
     "not-context-manager",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

#9614 adding `nested-min-max` to the more permanent section

### Details and comments

Discovered in #12295 that this lint rule is necessary for the current versions
