### PR TITLE
fix UnitaryOverlap docstring tex

### DIFF
--- a/qiskit/circuit/library/overlap.py
+++ b/qiskit/circuit/library/overlap.py
@@ -26,11 +26,11 @@ class UnitaryOverlap(QuantumCircuit):
     names `"p1"` (for circuit ``unitary1``) and `"p2"` (for circuit ``unitary_2``) in the output
     circuit.
 
-    This circuit is usually employed in computing the fidelity::
+    This circuit is usually employed in computing the fidelity:
 
-        .. math::
+    .. math::
 
-            \left|\langle 0| U_2^{\dag} U_1|0\rangle\right|^{2}
+        \left|\langle 0| U_2^{\dag} U_1|0\rangle\right|^{2}
 
     by computing the probability of being in the all-zeros bit-string, or equivalently,
     the expectation value of projector :math:`|0\rangle\langle 0|`.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Currently renders incorrectly at
https://docs.quantum.ibm.com/api/qiskit/qiskit.circuit.library.UnitaryOverlap#unitaryoverlap

![image](https://github.com/Qiskit/qiskit/assets/4296166/c69f4dc8-6af4-4bdb-b636-a980960d3471)


### Details and comments


