### PR TITLE
Fix a type hint of an private method `BackendSamplerV2._run` (follow-up #12291)

### DIFF
--- a/qiskit/primitives/backend_sampler_v2.py
+++ b/qiskit/primitives/backend_sampler_v2.py
@@ -142,7 +142,7 @@ class BackendSamplerV2(BaseSamplerV2):
                     UserWarning,
                 )
 
-    def _run(self, pubs: Iterable[SamplerPub]) -> PrimitiveResult[PubResult]:
+    def _run(self, pubs: list[SamplerPub]) -> PrimitiveResult[PubResult]:
         pub_dict = defaultdict(list)
         # consolidate pubs with the same number of shots
         for i, pub in enumerate(pubs):

--- a/test/python/primitives/test_backend_estimator_v2.py
+++ b/test/python/primitives/test_backend_estimator_v2.py
@@ -461,6 +461,18 @@ class TestBackendEstimatorV2(QiskitTestCase):
             estimator.run([(qc, op, param_list)] * k).result()
         self.assertEqual(run_mock.call_count, 10)
 
+    def test_iter_pub(self):
+        """test for an iterable of pubs"""
+        backend = BasicSimulator()
+        circuit = self.ansatz.assign_parameters([0, 1, 1, 2, 3, 5])
+        pm = generate_preset_pass_manager(optimization_level=0, backend=backend)
+        circuit = pm.run(circuit)
+        estimator = BackendEstimatorV2(backend=backend, options=self._options)
+        observable = self.observable.apply_layout(circuit.layout)
+        result = estimator.run(iter([(circuit, observable), (circuit, observable)])).result()
+        np.testing.assert_allclose(result[0].data.evs, [-1.284366511861733], rtol=self._rtol)
+        np.testing.assert_allclose(result[1].data.evs, [-1.284366511861733], rtol=self._rtol)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/primitives/test_backend_sampler_v2.py
+++ b/test/python/primitives/test_backend_sampler_v2.py
@@ -733,6 +733,23 @@ class TestBackendSamplerV2(QiskitTestCase):
         self._assert_allclose(result[0].data.meas, np.array({0: self._shots}))
         self._assert_allclose(result[1].data.meas, np.array({1: self._shots}))
 
+    def test_iter_pub(self):
+        """Test of an iterable of pubs"""
+        backend = BasicSimulator()
+        qc = QuantumCircuit(1)
+        qc.measure_all()
+        qc2 = QuantumCircuit(1)
+        qc2.x(0)
+        qc2.measure_all()
+        sampler = BackendSamplerV2(backend=backend)
+        result = sampler.run(iter([qc, qc2]), shots=self._shots).result()
+        self.assertIsInstance(result, PrimitiveResult)
+        self.assertEqual(len(result), 2)
+        self.assertIsInstance(result[0], PubResult)
+        self.assertIsInstance(result[1], PubResult)
+        self._assert_allclose(result[0].data.meas, np.array({0: self._shots}))
+        self._assert_allclose(result[1].data.meas, np.array({1: self._shots}))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/primitives/test_statevector_estimator.py
+++ b/test/python/primitives/test_statevector_estimator.py
@@ -281,6 +281,15 @@ class TestStatevectorEstimator(QiskitTestCase):
         result = job.result()
         np.testing.assert_allclose(result[0].data.evs, [1.5555572817900956])
 
+    def test_iter_pub(self):
+        """test for an iterable of pubs"""
+        estimator = StatevectorEstimator()
+        circuit = self.ansatz.assign_parameters([0, 1, 1, 2, 3, 5])
+        observable = self.observable.apply_layout(circuit.layout)
+        result = estimator.run(iter([(circuit, observable), (circuit, observable)])).result()
+        np.testing.assert_allclose(result[0].data.evs, [-1.284366511861733])
+        np.testing.assert_allclose(result[1].data.evs, [-1.284366511861733])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/primitives/test_statevector_sampler.py
+++ b/test/python/primitives/test_statevector_sampler.py
@@ -621,6 +621,22 @@ class TestStatevectorSampler(QiskitTestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(len(result[0].data), 0)
 
+    def test_iter_pub(self):
+        """Test of an iterable of pubs"""
+        qc = QuantumCircuit(1)
+        qc.measure_all()
+        qc2 = QuantumCircuit(1)
+        qc2.x(0)
+        qc2.measure_all()
+        sampler = StatevectorSampler()
+        result = sampler.run(iter([qc, qc2]), shots=self._shots).result()
+        self.assertIsInstance(result, PrimitiveResult)
+        self.assertEqual(len(result), 2)
+        self.assertIsInstance(result[0], PubResult)
+        self.assertIsInstance(result[1], PubResult)
+        self._assert_allclose(result[0].data.meas, np.array({0: self._shots}))
+        self._assert_allclose(result[1].data.meas, np.array({1: self._shots}))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

I noticed that `BackendSamplerV2` modified by #12291 has an incorrect type hint. This PR fixed it.
This PR does not change any behavior of the existing codes.
Because #12291 has not been released yet, I don't think it requires reno.

This change is related to the input type of `_run` method, which is guaranteed to be a list thanks to the preprocessing in `run` method.

I also noticed that there are no tests whether Primitives V2 work fine given an iterable  of pub-likes instead of a sequence of pub-like.

Follow-up #12291

### Details and comments


