### PR TITLE
Add indexing and bitshift expressions

### DIFF
--- a/qiskit/circuit/classical/expr/__init__.py
+++ b/qiskit/circuit/classical/expr/__init__.py
@@ -45,7 +45,7 @@ real-time variable, or a wrapper around a :class:`.Clbit` or :class:`.ClassicalR
 .. autoclass:: Var
     :members: var, name
 
-Similarly, literals used in comparison (such as integers) should be lifted to :class:`Value` nodes
+Similarly, literals used in expressions (such as integers) should be lifted to :class:`Value` nodes
 with associated types.
 
 .. autoclass:: Value
@@ -61,6 +61,12 @@ and :class:`Binary.Op` respectively.
 .. autoclass:: Binary
     :members: Op
     :member-order: bysource
+
+Bit-like types (unsigned integers) can be indexed by integer types, represented by :class:`Index`.
+The result is a single bit.  The resulting expression has an associated memory location (and so can
+be used as an lvalue for :class:`.Store`, etc) if the target is also an lvalue.
+
+.. autoclass:: Index
 
 When constructing expressions, one must ensure that the types are valid for the operation.
 Attempts to construct expressions with invalid types will raise a regular Python ``TypeError``.
@@ -122,6 +128,13 @@ Similarly, the binary operations and relations have helper functions defined.
 .. autofunction:: less_equal
 .. autofunction:: greater
 .. autofunction:: greater_equal
+.. autofunction:: shift_left
+.. autofunction:: shift_right
+
+You can index into unsigned integers and bit-likes using another unsigned integer of any width.
+This includes in storing operations, if the target of the index is writeable.
+
+.. autofunction:: index
 
 Qiskit's legacy method for specifying equality conditions for use in conditionals is to use a
 two-tuple of a :class:`.Clbit` or :class:`.ClassicalRegister` and an integer.  This represents an
@@ -174,6 +187,7 @@ __all__ = [
     "Cast",
     "Unary",
     "Binary",
+    "Index",
     "ExprVisitor",
     "iter_vars",
     "structurally_equivalent",
@@ -185,6 +199,8 @@ __all__ = [
     "bit_and",
     "bit_or",
     "bit_xor",
+    "shift_left",
+    "shift_right",
     "logic_and",
     "logic_or",
     "equal",
@@ -193,10 +209,11 @@ __all__ = [
     "less_equal",
     "greater",
     "greater_equal",
+    "index",
     "lift_legacy_condition",
 ]
 
-from .expr import Expr, Var, Value, Cast, Unary, Binary
+from .expr import Expr, Var, Value, Cast, Unary, Binary, Index
 from .visitors import ExprVisitor, iter_vars, structurally_equivalent, is_lvalue
 from .constructors import (
     lift,
@@ -214,5 +231,8 @@ from .constructors import (
     less_equal,
     greater,
     greater_equal,
+    shift_left,
+    shift_right,
+    index,
     lift_legacy_condition,
 )

--- a/qiskit/circuit/classical/expr/expr.py
+++ b/qiskit/circuit/classical/expr/expr.py
@@ -300,6 +300,11 @@ class Binary(Expr):
         The binary mathematical relations :data:`EQUAL`, :data:`NOT_EQUAL`, :data:`LESS`,
         :data:`LESS_EQUAL`, :data:`GREATER` and :data:`GREATER_EQUAL` take unsigned integers
         (with an implicit cast to make them the same width), and return a Boolean.
+
+        The bitshift operations :data:`SHIFT_LEFT` and :data:`SHIFT_RIGHT` can take bit-like
+        container types (e.g. unsigned integers) as the left operand, and any integer type as the
+        right-hand operand.  In all cases, the output bit width is the same as the input, and zeros
+        fill in the "exposed" spaces.
         """
 
         # If adding opcodes, remember to add helper constructor functions in `constructors.py`
@@ -327,6 +332,10 @@ class Binary(Expr):
         """Numeric greater than. ``lhs > rhs``."""
         GREATER_EQUAL = 11
         """Numeric greater than or equal to. ``lhs >= rhs``."""
+        SHIFT_LEFT = 12
+        """Zero-padding bitshift to the left.  ``lhs << rhs``."""
+        SHIFT_RIGHT = 13
+        """Zero-padding bitshift to the right.  ``lhs >> rhs``."""
 
         def __str__(self):
             return f"Binary.{super().__str__()}"
@@ -354,3 +363,35 @@ class Binary(Expr):
 
     def __repr__(self):
         return f"Binary({self.op}, {self.left}, {self.right}, {self.type})"
+
+
+@typing.final
+class Index(Expr):
+    """An indexing expression.
+
+    Args:
+        target: The object being indexed.
+        index: The expression doing the indexing.
+        type: The resolved type of the result.
+    """
+
+    __slots__ = ("target", "index")
+
+    def __init__(self, target: Expr, index: Expr, type: types.Type):
+        self.target = target
+        self.index = index
+        self.type = type
+
+    def accept(self, visitor, /):
+        return visitor.visit_index(self)
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, Index)
+            and self.type == other.type
+            and self.target == other.target
+            and self.index == other.index
+        )
+
+    def __repr__(self):
+        return f"Index({self.target}, {self.index}, {self.type})"

--- a/qiskit/circuit/classical/expr/visitors.py
+++ b/qiskit/circuit/classical/expr/visitors.py
@@ -55,6 +55,9 @@ class ExprVisitor(typing.Generic[_T_co]):
     def visit_cast(self, node: expr.Cast, /) -> _T_co:  # pragma: no cover
         return self.visit_generic(node)
 
+    def visit_index(self, node: expr.Index, /) -> _T_co:  # pragma: no cover
+        return self.visit_generic(node)
+
 
 class _VarWalkerImpl(ExprVisitor[typing.Iterable[expr.Var]]):
     __slots__ = ()
@@ -74,6 +77,10 @@ class _VarWalkerImpl(ExprVisitor[typing.Iterable[expr.Var]]):
 
     def visit_cast(self, node, /):
         yield from node.operand.accept(self)
+
+    def visit_index(self, node, /):
+        yield from node.target.accept(self)
+        yield from node.index.accept(self)
 
 
 _VAR_WALKER = _VarWalkerImpl()
@@ -164,6 +171,16 @@ class _StructuralEquivalenceImpl(ExprVisitor[bool]):
         self.other = self.other.operand
         return node.operand.accept(self)
 
+    def visit_index(self, node, /):
+        if self.other.__class__ is not node.__class__ or self.other.type != node.type:
+            return False
+        other = self.other
+        self.other = other.target
+        if not node.target.accept(self):
+            return False
+        self.other = other.index
+        return node.index.accept(self)
+
 
 def structurally_equivalent(
     left: expr.Expr,
@@ -234,6 +251,9 @@ class _IsLValueImpl(ExprVisitor[bool]):
 
     def visit_cast(self, node, /):
         return False
+
+    def visit_index(self, node, /):
+        return node.target.accept(self)
 
 
 _IS_LVALUE = _IsLValueImpl()

--- a/qiskit/qasm3/ast.py
+++ b/qiskit/qasm3/ast.py
@@ -252,6 +252,8 @@ class Binary(Expression):
         GREATER_EQUAL = ">="
         EQUAL = "=="
         NOT_EQUAL = "!="
+        SHIFT_LEFT = "<<"
+        SHIFT_RIGHT = ">>"
 
     def __init__(self, op: Op, left: Expression, right: Expression):
         self.op = op
@@ -263,6 +265,12 @@ class Cast(Expression):
     def __init__(self, type: ClassicalType, operand: Expression):
         self.type = type
         self.operand = operand
+
+
+class Index(Expression):
+    def __init__(self, target: Expression, index: Expression):
+        self.target = target
+        self.index = index
 
 
 class IndexSet(ASTNode):

--- a/qiskit/qasm3/exporter.py
+++ b/qiskit/qasm3/exporter.py
@@ -1165,3 +1165,6 @@ class _ExprBuilder(expr.ExprVisitor[ast.Expression]):
         return ast.Binary(
             ast.Binary.Op[node.op.name], node.left.accept(self), node.right.accept(self)
         )
+
+    def visit_index(self, node, /):
+        return ast.Index(node.target.accept(self), node.index.accept(self))

--- a/qiskit/qasm3/printer.py
+++ b/qiskit/qasm3/printer.py
@@ -34,13 +34,16 @@ from .experimental import ExperimentalFeatures
 # indexing and casting are all higher priority than these, so we just ignore them.
 _BindingPower = collections.namedtuple("_BindingPower", ("left", "right"), defaults=(255, 255))
 _BINDING_POWER = {
-    # Power: (21, 22)
+    # Power: (24, 23)
     #
-    ast.Unary.Op.LOGIC_NOT: _BindingPower(right=20),
-    ast.Unary.Op.BIT_NOT: _BindingPower(right=20),
+    ast.Unary.Op.LOGIC_NOT: _BindingPower(right=22),
+    ast.Unary.Op.BIT_NOT: _BindingPower(right=22),
     #
-    # Multiplication/division/modulo: (17, 18)
-    # Addition/subtraction: (15, 16)
+    # Multiplication/division/modulo: (19, 20)
+    # Addition/subtraction: (17, 18)
+    #
+    ast.Binary.Op.SHIFT_LEFT: _BindingPower(15, 16),
+    ast.Binary.Op.SHIFT_RIGHT: _BindingPower(15, 16),
     #
     ast.Binary.Op.LESS: _BindingPower(13, 14),
     ast.Binary.Op.LESS_EQUAL: _BindingPower(13, 14),
@@ -331,6 +334,17 @@ class BasicPrinter:
         self.stream.write("(")
         self.visit(node.operand)
         self.stream.write(")")
+
+    def _visit_Index(self, node: ast.Index):
+        if isinstance(node.target, (ast.Unary, ast.Binary)):
+            self.stream.write("(")
+            self.visit(node.target)
+            self.stream.write(")")
+        else:
+            self.visit(node.target)
+        self.stream.write("[")
+        self.visit(node.index)
+        self.stream.write("]")
 
     def _visit_ClassicalDeclaration(self, node: ast.ClassicalDeclaration) -> None:
         self._start_line()

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -382,6 +382,21 @@ Python class                 Type code  Payload
 Notably, this new type-code indexes into pre-defined variables from the circuit header, rather than
 redefining the variable again in each location it is used.
 
+
+Changes to EXPRESSION
+---------------------
+
+The EXPRESSION type code has a new possible entry, ``i``, corresponding to :class:`.expr.Index`
+nodes.
+
+======================  =========  =======================================================  ========
+Qiskit class            Type code  Payload                                                  Children
+======================  =========  =======================================================  ========
+:class:`~.expr.Index`   ``i``      No additional payload. The children are the target       2
+                                   and the index, in that order.
+======================  =========  =======================================================  ========
+
+
 .. _qpy_version_11:
 
 Version 11

--- a/qiskit/qpy/binary_io/schedules.py
+++ b/qiskit/qpy/binary_io/schedules.py
@@ -328,7 +328,7 @@ def _read_element(file_obj, version, metadata_deserializer, use_symengine):
     return instance
 
 
-def _loads_reference_item(type_key, data_bytes, version, metadata_deserializer):
+def _loads_reference_item(type_key, data_bytes, metadata_deserializer, version):
     if type_key == type_keys.Value.NULL:
         return None
     if type_key == type_keys.Program.SCHEDULE_BLOCK:
@@ -346,13 +346,13 @@ def _loads_reference_item(type_key, data_bytes, version, metadata_deserializer):
     )
 
 
-def _write_channel(file_obj, data):
+def _write_channel(file_obj, data, version):
     type_key = type_keys.ScheduleChannel.assign(data)
     common.write_type_key(file_obj, type_key)
-    value.write_value(file_obj, data.index)
+    value.write_value(file_obj, data.index, version=version)
 
 
-def _write_waveform(file_obj, data):
+def _write_waveform(file_obj, data, version):
     samples_bytes = common.data_to_binary(data.samples, np.save)
 
     header = struct.pack(
@@ -363,39 +363,43 @@ def _write_waveform(file_obj, data):
     )
     file_obj.write(header)
     file_obj.write(samples_bytes)
-    value.write_value(file_obj, data.name)
+    value.write_value(file_obj, data.name, version=version)
 
 
-def _dumps_obj(obj):
+def _dumps_obj(obj, version):
     """Wraps `value.dumps_value` to serialize dictionary and list objects
     which are not supported by `value.dumps_value`.
     """
     if isinstance(obj, dict):
         with BytesIO() as container:
-            common.write_mapping(file_obj=container, mapping=obj, serializer=_dumps_obj)
+            common.write_mapping(
+                file_obj=container, mapping=obj, serializer=_dumps_obj, version=version
+            )
             binary_data = container.getvalue()
         return b"D", binary_data
     elif isinstance(obj, list):
         with BytesIO() as container:
-            common.write_sequence(file_obj=container, sequence=obj, serializer=_dumps_obj)
+            common.write_sequence(
+                file_obj=container, sequence=obj, serializer=_dumps_obj, version=version
+            )
             binary_data = container.getvalue()
         return b"l", binary_data
     else:
-        return value.dumps_value(obj)
+        return value.dumps_value(obj, version=version)
 
 
-def _write_kernel(file_obj, data):
+def _write_kernel(file_obj, data, version):
     name = data.name
     params = data.params
-    common.write_mapping(file_obj=file_obj, mapping=params, serializer=_dumps_obj)
-    value.write_value(file_obj, name)
+    common.write_mapping(file_obj=file_obj, mapping=params, serializer=_dumps_obj, version=version)
+    value.write_value(file_obj, name, version=version)
 
 
-def _write_discriminator(file_obj, data):
+def _write_discriminator(file_obj, data, version):
     name = data.name
     params = data.params
-    common.write_mapping(file_obj=file_obj, mapping=params, serializer=_dumps_obj)
-    value.write_value(file_obj, name)
+    common.write_mapping(file_obj=file_obj, mapping=params, serializer=_dumps_obj, version=version)
+    value.write_value(file_obj, name, version=version)
 
 
 def _dumps_symbolic_expr(expr, use_symengine):
@@ -410,7 +414,7 @@ def _dumps_symbolic_expr(expr, use_symengine):
     return zlib.compress(expr_bytes)
 
 
-def _write_symbolic_pulse(file_obj, data, use_symengine):
+def _write_symbolic_pulse(file_obj, data, use_symengine, version):
     class_name_bytes = data.__class__.__name__.encode(common.ENCODE)
     pulse_type_bytes = data.pulse_type.encode(common.ENCODE)
     envelope_bytes = _dumps_symbolic_expr(data.envelope, use_symengine)
@@ -436,52 +440,51 @@ def _write_symbolic_pulse(file_obj, data, use_symengine):
         file_obj,
         mapping=data._params,
         serializer=value.dumps_value,
+        version=version,
     )
-    value.write_value(file_obj, data.duration)
-    value.write_value(file_obj, data.name)
+    value.write_value(file_obj, data.duration, version=version)
+    value.write_value(file_obj, data.name, version=version)
 
 
-def _write_alignment_context(file_obj, context):
+def _write_alignment_context(file_obj, context, version):
     type_key = type_keys.ScheduleAlignment.assign(context)
     common.write_type_key(file_obj, type_key)
     common.write_sequence(
-        file_obj,
-        sequence=context._context_params,
-        serializer=value.dumps_value,
+        file_obj, sequence=context._context_params, serializer=value.dumps_value, version=version
     )
 
 
-def _dumps_operand(operand, use_symengine):
+def _dumps_operand(operand, use_symengine, version):
     if isinstance(operand, library.Waveform):
         type_key = type_keys.ScheduleOperand.WAVEFORM
-        data_bytes = common.data_to_binary(operand, _write_waveform)
+        data_bytes = common.data_to_binary(operand, _write_waveform, version=version)
     elif isinstance(operand, library.SymbolicPulse):
         type_key = type_keys.ScheduleOperand.SYMBOLIC_PULSE
         data_bytes = common.data_to_binary(
-            operand, _write_symbolic_pulse, use_symengine=use_symengine
+            operand, _write_symbolic_pulse, use_symengine=use_symengine, version=version
         )
     elif isinstance(operand, channels.Channel):
         type_key = type_keys.ScheduleOperand.CHANNEL
-        data_bytes = common.data_to_binary(operand, _write_channel)
+        data_bytes = common.data_to_binary(operand, _write_channel, version=version)
     elif isinstance(operand, str):
         type_key = type_keys.ScheduleOperand.OPERAND_STR
         data_bytes = operand.encode(common.ENCODE)
     elif isinstance(operand, Kernel):
         type_key = type_keys.ScheduleOperand.KERNEL
-        data_bytes = common.data_to_binary(operand, _write_kernel)
+        data_bytes = common.data_to_binary(operand, _write_kernel, version=version)
     elif isinstance(operand, Discriminator):
         type_key = type_keys.ScheduleOperand.DISCRIMINATOR
-        data_bytes = common.data_to_binary(operand, _write_discriminator)
+        data_bytes = common.data_to_binary(operand, _write_discriminator, version=version)
     else:
-        type_key, data_bytes = value.dumps_value(operand)
+        type_key, data_bytes = value.dumps_value(operand, version=version)
 
     return type_key, data_bytes
 
 
-def _write_element(file_obj, element, metadata_serializer, use_symengine):
+def _write_element(file_obj, element, metadata_serializer, use_symengine, version):
     if isinstance(element, ScheduleBlock):
         common.write_type_key(file_obj, type_keys.Program.SCHEDULE_BLOCK)
-        write_schedule_block(file_obj, element, metadata_serializer, use_symengine)
+        write_schedule_block(file_obj, element, metadata_serializer, use_symengine, version=version)
     else:
         type_key = type_keys.ScheduleInstruction.assign(element)
         common.write_type_key(file_obj, type_key)
@@ -490,11 +493,12 @@ def _write_element(file_obj, element, metadata_serializer, use_symengine):
             sequence=element.operands,
             serializer=_dumps_operand,
             use_symengine=use_symengine,
+            version=version,
         )
-        value.write_value(file_obj, element.name)
+        value.write_value(file_obj, element.name, version=version)
 
 
-def _dumps_reference_item(schedule, metadata_serializer):
+def _dumps_reference_item(schedule, metadata_serializer, version):
     if schedule is None:
         type_key = type_keys.Value.NULL
         data_bytes = b""
@@ -504,6 +508,7 @@ def _dumps_reference_item(schedule, metadata_serializer):
             obj=schedule,
             serializer=write_schedule_block,
             metadata_serializer=metadata_serializer,
+            version=version,
         )
     return type_key, data_bytes
 
@@ -576,7 +581,7 @@ def read_schedule_block(file_obj, version, metadata_deserializer=None, use_symen
 
 def write_schedule_block(
     file_obj, block, metadata_serializer=None, use_symengine=False, version=common.QPY_VERSION
-):  # pylint: disable=unused-argument
+):
     """Write a single ScheduleBlock object in the file like object.
 
     Args:
@@ -610,11 +615,11 @@ def write_schedule_block(
     file_obj.write(block_name)
     file_obj.write(metadata)
 
-    _write_alignment_context(file_obj, block.alignment_context)
+    _write_alignment_context(file_obj, block.alignment_context, version=version)
     for block_elm in block._blocks:
         # Do not call block.blocks. This implicitly assigns references to instruction.
         # This breaks original reference structure.
-        _write_element(file_obj, block_elm, metadata_serializer, use_symengine)
+        _write_element(file_obj, block_elm, metadata_serializer, use_symengine, version=version)
 
     # Write references
     flat_key_refdict = {}
@@ -627,4 +632,5 @@ def write_schedule_block(
         mapping=flat_key_refdict,
         serializer=_dumps_reference_item,
         metadata_serializer=metadata_serializer,
+        version=version,
     )

--- a/qiskit/qpy/type_keys.py
+++ b/qiskit/qpy/type_keys.py
@@ -457,6 +457,7 @@ class Expression(TypeKeyBase):
     CAST = b"c"
     UNARY = b"u"
     BINARY = b"b"
+    INDEX = b"i"
 
     @classmethod
     def assign(cls, obj):

--- a/releasenotes/notes/expr-bitshift-index-e9cfc6ea8729ef5e.yaml
+++ b/releasenotes/notes/expr-bitshift-index-e9cfc6ea8729ef5e.yaml
@@ -1,0 +1,20 @@
+---
+features_circuits:
+  - |
+    The classical realtime-expressions module :mod:`qiskit.circuit.classical` can now represent
+    indexing and bitshifting of unsigned integers and bitlikes (e.g. :class:`.ClassicalRegister`).
+    For example, it is now possible to compare one register with the bitshift of another::
+
+      from qiskit.circuit import QuantumCircuit, ClassicalRegister
+      from qiskit.circuit.classical import expr
+
+      cr1 = ClassicalRegister(4, "cr1")
+      cr2 = ClassicalRegister(4, "cr2")
+      qc = QuantumCircuit(cr1, cr2)
+      with qc.if_test(expr.equal(cr1, expr.shift_left(cr2, 2))):
+          pass
+
+    Qiskit can also represent a condition that dynamically indexes into a register::
+    
+      with qc.if_test(expr.index(cr1, cr2)):
+          pass

--- a/test/python/circuit/classical/test_expr_constructors.py
+++ b/test/python/circuit/classical/test_expr_constructors.py
@@ -387,3 +387,57 @@ class TestExprConstructors(QiskitTestCase):
             function(ClassicalRegister(3, "c"), False)
         with self.assertRaisesRegex(TypeError, "invalid types"):
             function(Clbit(), Clbit())
+
+    def test_index_explicit(self):
+        cr = ClassicalRegister(4, "c")
+        a = expr.Var.new("a", types.Uint(8))
+
+        self.assertEqual(
+            expr.index(cr, 3),
+            expr.Index(expr.Var(cr, types.Uint(4)), expr.Value(3, types.Uint(2)), types.Bool()),
+        )
+        self.assertEqual(
+            expr.index(a, cr),
+            expr.Index(a, expr.Var(cr, types.Uint(4)), types.Bool()),
+        )
+
+    def test_index_forbidden(self):
+        with self.assertRaisesRegex(TypeError, "invalid types"):
+            expr.index(Clbit(), 3)
+        with self.assertRaisesRegex(TypeError, "invalid types"):
+            expr.index(ClassicalRegister(3, "a"), False)
+
+    @ddt.data(
+        (expr.shift_left, expr.Binary.Op.SHIFT_LEFT),
+        (expr.shift_right, expr.Binary.Op.SHIFT_RIGHT),
+    )
+    @ddt.unpack
+    def test_shift_explicit(self, function, opcode):
+        cr = ClassicalRegister(8, "c")
+        a = expr.Var.new("a", types.Uint(4))
+
+        self.assertEqual(
+            function(cr, 5),
+            expr.Binary(
+                opcode, expr.Var(cr, types.Uint(8)), expr.Value(5, types.Uint(3)), types.Uint(8)
+            ),
+        )
+        self.assertEqual(
+            function(a, cr),
+            expr.Binary(opcode, a, expr.Var(cr, types.Uint(8)), types.Uint(4)),
+        )
+        self.assertEqual(
+            function(3, 5, types.Uint(8)),
+            expr.Binary(
+                opcode, expr.Value(3, types.Uint(8)), expr.Value(5, types.Uint(3)), types.Uint(8)
+            ),
+        )
+
+    @ddt.data(expr.shift_left, expr.shift_right)
+    def test_shift_forbidden(self, function):
+        with self.assertRaisesRegex(TypeError, "invalid types"):
+            function(Clbit(), ClassicalRegister(3, "c"))
+        with self.assertRaisesRegex(TypeError, "invalid types"):
+            function(ClassicalRegister(3, "c"), False)
+        with self.assertRaisesRegex(TypeError, "invalid types"):
+            function(Clbit(), Clbit())

--- a/test/python/circuit/classical/test_expr_helpers.py
+++ b/test/python/circuit/classical/test_expr_helpers.py
@@ -30,6 +30,8 @@ class TestStructurallyEquivalent(QiskitTestCase):
         expr.logic_not(Clbit()),
         expr.bit_and(5, ClassicalRegister(3, "a")),
         expr.logic_and(expr.less(2, ClassicalRegister(3, "a")), expr.lift(Clbit())),
+        expr.shift_left(expr.shift_right(255, 3), 3),
+        expr.index(expr.Var.new("a", types.Uint(8)), 0),
     )
     def test_equivalent_to_self(self, node):
         self.assertTrue(expr.structurally_equivalent(node, node))
@@ -124,6 +126,7 @@ class TestIsLValue(QiskitTestCase):
         expr.Var.new("b", types.Uint(8)),
         expr.Var(Clbit(), types.Bool()),
         expr.Var(ClassicalRegister(8, "cr"), types.Uint(8)),
+        expr.index(expr.Var.new("a", types.Uint(8)), 0),
     )
     def test_happy_cases(self, lvalue):
         self.assertTrue(expr.is_lvalue(lvalue))
@@ -139,6 +142,7 @@ class TestIsLValue(QiskitTestCase):
             expr.Var.new("b", types.Bool()),
             types.Bool(),
         ),
+        expr.index(expr.bit_not(expr.Var.new("a", types.Uint(8))), 0),
     )
     def test_bad_cases(self, not_an_lvalue):
         self.assertFalse(expr.is_lvalue(not_an_lvalue))

--- a/test/python/circuit/classical/test_expr_properties.py
+++ b/test/python/circuit/classical/test_expr_properties.py
@@ -51,6 +51,21 @@ class TestExprProperties(QiskitTestCase):
             expr.Value(True, types.Bool()),
             types.Bool(),
         ),
+        expr.Index(
+            expr.Var.new("a", types.Uint(3)),
+            expr.Binary(
+                expr.Binary.Op.SHIFT_LEFT,
+                expr.Binary(
+                    expr.Binary.Op.SHIFT_RIGHT,
+                    expr.Var.new("b", types.Uint(3)),
+                    expr.Value(1, types.Uint(1)),
+                    types.Uint(3),
+                ),
+                expr.Value(1, types.Uint(1)),
+                types.Uint(3),
+            ),
+            types.Bool(),
+        ),
     )
     def test_expr_can_be_cloned(self, obj):
         """Test that various ways of cloning an `Expr` object are valid and produce equal output."""

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -802,6 +802,24 @@ def generate_standalone_var():
     return [qc]
 
 
+def generate_v12_expr():
+    """Circuits that contain the `Index` and bitshift operators new in QPY v12."""
+    import uuid
+    from qiskit.circuit.classical import expr, types
+
+    a = expr.Var(uuid.UUID(bytes=b"hello, qpy world", version=4), types.Uint(8), name="a")
+    cr = ClassicalRegister(4, "cr")
+
+    index = QuantumCircuit(cr, inputs=[a], name="index_expr")
+    index.store(expr.index(cr, 0), expr.index(a, a))
+
+    shift = QuantumCircuit(cr, inputs=[a], name="shift_expr")
+    with shift.if_test(expr.equal(expr.shift_right(expr.shift_left(a, 1), 1), a)):
+        pass
+
+    return [index, shift]
+
+
 def generate_circuits(version_parts):
     """Generate reference circuits."""
     output_circuits = {
@@ -852,6 +870,7 @@ def generate_circuits(version_parts):
         output_circuits["annotated.qpy"] = generate_annotated_circuits()
     if version_parts >= (1, 1, 0):
         output_circuits["standalone_vars.qpy"] = generate_standalone_var()
+        output_circuits["v12_expr.qpy"] = generate_v12_expr()
     return output_circuits
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This adds the concepts of `Index` and the binary operations `SHIFT_LEFT` and `SHIFT_RIGHT` to the `Expr` system, and threads them through all the `ExprVisitor` nodes defined in Qiskit, including OQ3 and QPY serialisation/deserialisation.  (The not-new OQ3 parser is managed separately and doesn't have support for _any_ `Expr` nodes at the
moment).

Along with `Store`, this should close the gap between what Qiskit was able to represent with dynamic circuits, and what was supported by hardware with direct OpenQASM 3 submission, although since this remains Qiskit's fairly low-level representation, it still was potentially more ergonomic to use OpenQASM 3 strings.  This remains a general point for
improvement in the Qiskit API, however.



### Details and comments

Unfortunately, I can't really test this through the IBM stack until we've got a release candidate, and it may need a couple of tweaks to our Python-space backend bits to permit through the dynamic circuits paths, which I can help with.

On hold because it depends on #12308 merging.