### PR TITLE
Bump pylint version used to latest release

### DIFF
--- a/qiskit/passmanager/flow_controllers.py
+++ b/qiskit/passmanager/flow_controllers.py
@@ -45,8 +45,7 @@ class FlowControllerLinear(BaseController):
         return list(self.tasks)
 
     def iter_tasks(self, state: PassManagerState) -> Generator[Task, PassManagerState, None]:
-        for task in self.tasks:
-            state = yield task
+        yield from self.tasks
 
 
 class DoWhileController(BaseController):
@@ -78,8 +77,7 @@ class DoWhileController(BaseController):
     def iter_tasks(self, state: PassManagerState) -> Generator[Task, PassManagerState, None]:
         max_iteration = self._options.get("max_iteration", 1000)
         for _ in range(max_iteration):
-            for task in self.tasks:
-                state = yield task
+            yield from self.tasks
             if not self.do_while(state.property_set):
                 return
             # Remove stored tasks from the completed task collection for next loop
@@ -112,5 +110,4 @@ class ConditionalController(BaseController):
 
     def iter_tasks(self, state: PassManagerState) -> Generator[Task, PassManagerState, None]:
         if self.condition(state.property_set):
-            for task in self.tasks:
-                state = yield task
+            yield from self.tasks

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -31,6 +31,7 @@ from .basepasses import BasePass
 from .exceptions import TranspilerError
 from .layout import TranspileLayout
 
+# pylint: disable=invalid-name
 _CircuitsT = Union[List[QuantumCircuit], QuantumCircuit]
 
 

--- a/qiskit/visualization/circuit/_utils.py
+++ b/qiskit/visualization/circuit/_utils.py
@@ -472,10 +472,8 @@ def _get_gate_span(qubits, node):
     for qreg in node.qargs:
         index = qubits.index(qreg)
 
-        if index < min_index:
-            min_index = index
-        if index > max_index:
-            max_index = index
+        min_index = min(index, min_index)
+        max_index = max(index, max_index)
 
     # Because of wrapping boxes for mpl control flow ops, this
     # type of op must be the only op in the layer

--- a/qiskit/visualization/circuit/matplotlib.py
+++ b/qiskit/visualization/circuit/matplotlib.py
@@ -608,8 +608,7 @@ class MatplotlibDrawer:
                         gate_width += 0.21
 
                 box_width = max(gate_width, ctrl_width, param_width, WID)
-                if box_width > widest_box:
-                    widest_box = box_width
+                widest_box = max(box_width, widest_box)
                 if not isinstance(node.op, ControlFlowOp):
                     node_data[node].width = max(raw_gate_width, raw_param_width)
             for node in layer:
@@ -666,8 +665,7 @@ class MatplotlibDrawer:
                 )
                 * 1.15
             )
-            if text_width > longest_wire_label_width:
-                longest_wire_label_width = text_width
+            longest_wire_label_width = max(text_width, longest_wire_label_width)
 
             if isinstance(wire, Qubit):
                 pos = -ii

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,8 +17,8 @@ black[jupyter]~=24.1
 #
 # These versions are pinned precisely because pylint frequently includes new
 # on-by-default lint failures in new versions, which breaks our CI.
-astroid==2.14.2
-pylint==2.16.2
+astroid==3.1.0
+pylint==3.1.0
 ruff==0.0.267
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The pinned version of pylint we're running in CI right now doesn't support Python 3.12. This is an issue if you're developing with Python 3.12 because you couldn't run pylint. This commit bumps to the latest version as of this commit and fixes the additional checks flagged by the newer version.

### Details and comments