### PR TITLE
Support standalone `Var` throughout transpiler

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -621,9 +621,7 @@ class QuantumCircuit:
                 q_1: ┤ RX(1.57) ├─────
                      └──────────┘
         """
-        reverse_circ = QuantumCircuit(
-            self.qubits, self.clbits, *self.qregs, *self.cregs, name=self.name + "_reverse"
-        )
+        reverse_circ = self.copy_empty_like(self.name + "_reverse")
 
         for instruction in reversed(self.data):
             reverse_circ._append(instruction.replace(operation=instruction.operation.reverse_ops()))

--- a/qiskit/circuit/store.py
+++ b/qiskit/circuit/store.py
@@ -59,6 +59,9 @@ class Store(Instruction):
     :class:`~.circuit.Measure` is a primitive for quantum measurement), and is not safe for
     subclassing."""
 
+    # This is a compiler/backend intrinsic operation, separate to any quantum processing.
+    _directive = True
+
     def __init__(self, lvalue: expr.Expr, rvalue: expr.Expr):
         """
         Args:

--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -148,12 +148,12 @@ class BasisTranslator(TransformationPass):
 
         # Names of instructions assumed to supported by any backend.
         if self._target is None:
-            basic_instrs = ["measure", "reset", "barrier", "snapshot", "delay"]
+            basic_instrs = ["measure", "reset", "barrier", "snapshot", "delay", "store"]
             target_basis = set(self._target_basis)
             source_basis = set(self._extract_basis(dag))
             qargs_local_source_basis = {}
         else:
-            basic_instrs = ["barrier", "snapshot"]
+            basic_instrs = ["barrier", "snapshot", "store"]
             target_basis = self._target.keys() - set(self._non_global_operations)
             source_basis, qargs_local_source_basis = self._extract_basis_target(dag, qarg_indices)
 

--- a/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
+++ b/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
@@ -61,7 +61,7 @@ class UnrollCustomDefinitions(TransformationPass):
             return dag
 
         if self._target is None:
-            basic_insts = {"measure", "reset", "barrier", "snapshot", "delay"}
+            basic_insts = {"measure", "reset", "barrier", "snapshot", "delay", "store"}
             device_insts = basic_insts | set(self._basis_gates)
 
         for node in dag.op_nodes():

--- a/qiskit/transpiler/passes/layout/apply_layout.py
+++ b/qiskit/transpiler/passes/layout/apply_layout.py
@@ -61,6 +61,12 @@ class ApplyLayout(TransformationPass):
 
         new_dag = DAGCircuit()
         new_dag.add_qreg(q)
+        for var in dag.iter_input_vars():
+            new_dag.add_input_var(var)
+        for var in dag.iter_captured_vars():
+            new_dag.add_captured_var(var)
+        for var in dag.iter_declared_vars():
+            new_dag.add_declared_var(var)
         new_dag.metadata = dag.metadata
         new_dag.add_clbits(dag.clbits)
         for creg in dag.cregs.values():

--- a/qiskit/transpiler/passes/layout/sabre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_layout.py
@@ -308,6 +308,12 @@ class SabreLayout(TransformationPass):
         mapped_dag.add_clbits(dag.clbits)
         for creg in dag.cregs.values():
             mapped_dag.add_creg(creg)
+        for var in dag.iter_input_vars():
+            mapped_dag.add_input_var(var)
+        for var in dag.iter_captured_vars():
+            mapped_dag.add_captured_var(var)
+        for var in dag.iter_declared_vars():
+            mapped_dag.add_declared_var(var)
         mapped_dag._global_phase = dag._global_phase
         self.property_set["original_qubit_indices"] = {
             bit: index for index, bit in enumerate(dag.qubits)

--- a/qiskit/transpiler/passes/optimization/optimize_annotated.py
+++ b/qiskit/transpiler/passes/optimization/optimize_annotated.py
@@ -77,7 +77,7 @@ class OptimizeAnnotated(TransformationPass):
         self._top_level_only = not recurse or (self._basis_gates is None and self._target is None)
 
         if not self._top_level_only and self._target is None:
-            basic_insts = {"measure", "reset", "barrier", "snapshot", "delay"}
+            basic_insts = {"measure", "reset", "barrier", "snapshot", "delay", "store"}
             self._device_insts = basic_insts | set(self._basis_gates)
 
     def run(self, dag: DAGCircuit):

--- a/qiskit/transpiler/passes/routing/stochastic_swap.py
+++ b/qiskit/transpiler/passes/routing/stochastic_swap.py
@@ -33,7 +33,6 @@ from qiskit.circuit import (
     ForLoopOp,
     SwitchCaseOp,
     ControlFlowOp,
-    Instruction,
     CASE_DEFAULT,
 )
 from qiskit._accelerate import stochastic_swap as stochastic_swap_rs
@@ -266,11 +265,15 @@ class StochasticSwap(TransformationPass):
         # Output any swaps
         if best_depth > 0:
             logger.debug("layer_update: there are swaps in this layer, depth %d", best_depth)
-            dag.compose(best_circuit, qubits={bit: bit for bit in best_circuit.qubits})
+            dag.compose(
+                best_circuit, qubits={bit: bit for bit in best_circuit.qubits}, inline_captures=True
+            )
         else:
             logger.debug("layer_update: there are no swaps in this layer")
         # Output this layer
-        dag.compose(layer["graph"], qubits=best_layout.reorder_bits(dag.qubits))
+        dag.compose(
+            layer["graph"], qubits=best_layout.reorder_bits(dag.qubits), inline_captures=True
+        )
 
     def _mapper(self, circuit_graph, coupling_graph, trials=20):
         """Map a DAGCircuit onto a CouplingMap using swap gates.
@@ -438,7 +441,7 @@ class StochasticSwap(TransformationPass):
                 root_dag, self.coupling_map, layout, final_layout, seed=self._new_seed()
             )
             if swap_dag.size(recurse=False):
-                updated_dag_block.compose(swap_dag, qubits=swap_qubits)
+                updated_dag_block.compose(swap_dag, qubits=swap_qubits, inline_captures=True)
             idle_qubits &= set(updated_dag_block.idle_wires())
 
         # Now for each block, expand it to be full width over all active wires (all blocks of a
@@ -504,10 +507,18 @@ def _dag_from_block(block, node, root_dag):
         out.add_qreg(qreg)
     # For clbits, we need to take more care.  Nested control-flow might need registers to exist for
     # conditions on inner blocks.  `DAGCircuit.substitute_node_with_dag` handles this register
-    # mapping when required, so we use that with a dummy block.
+    # mapping when required, so we use that with a dummy block that pretends to act on all variables
+    # in the DAG.
     out.add_clbits(node.cargs)
+    for var in block.iter_input_vars():
+        out.add_input_var(var)
+    for var in block.iter_captured_vars():
+        out.add_captured_var(var)
+    for var in block.iter_declared_vars():
+        out.add_declared_var(var)
+
     dummy = out.apply_operation_back(
-        Instruction("dummy", len(node.qargs), len(node.cargs), []),
+        IfElseOp(expr.lift(True), block.copy_empty_like(vars_mode="captures")),
         node.qargs,
         node.cargs,
         check=False,

--- a/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
@@ -363,7 +363,7 @@ class HighLevelSynthesis(TransformationPass):
 
         # include path for when target exists but target.num_qubits is None (BasicSimulator)
         if not self._top_level_only and (self._target is None or self._target.num_qubits is None):
-            basic_insts = {"measure", "reset", "barrier", "snapshot", "delay"}
+            basic_insts = {"measure", "reset", "barrier", "snapshot", "delay", "store"}
             self._device_insts = basic_insts | set(self._basis_gates)
 
     def run(self, dag: DAGCircuit) -> DAGCircuit:

--- a/qiskit/transpiler/passes/utils/gates_basis.py
+++ b/qiskit/transpiler/passes/utils/gates_basis.py
@@ -32,7 +32,7 @@ class GatesInBasis(AnalysisPass):
         self._basis_gates = None
         if basis_gates is not None:
             self._basis_gates = set(basis_gates).union(
-                {"measure", "reset", "barrier", "snapshot", "delay"}
+                {"measure", "reset", "barrier", "snapshot", "delay", "store"}
             )
         self._target = target
 
@@ -46,8 +46,8 @@ class GatesInBasis(AnalysisPass):
 
             def _visit_target(dag, wire_map):
                 for gate in dag.op_nodes():
-                    # Barrier is universal and supported by all backends
-                    if gate.name == "barrier":
+                    # Barrier and store are assumed universal and supported by all backends
+                    if gate.name in ("barrier", "store"):
                         continue
                     if not self._target.instruction_supported(
                         gate.name, tuple(wire_map[bit] for bit in gate.qargs)

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -1013,9 +1013,9 @@ class TestCircuitOperations(QiskitTestCase):
         qc.h(0)
         qc.cx(0, 1)
         with qc.if_test(a):
-            # We don't really comment on what should happen to control-flow operations in this
-            # method, and Sabre doesn't care (nor use this method, in the fast paths), so this is
-            # deliberately using a body of length 1 (a single `Store`).
+            # We don't really comment on what should happen within control-flow operations in this
+            # method - it's not really defined in a non-linear CFG.  This deliberately uses a body
+            # of length 1 (a single `Store`), so there's only one possibility.
             qc.add_var(c, 12)
 
         expected = qc.copy_empty_like()

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -1002,6 +1002,31 @@ class TestCircuitOperations(QiskitTestCase):
 
         self.assertEqual(qc.reverse_ops(), expected)
 
+    def test_reverse_with_standlone_vars(self):
+        """Test that instruction-reversing works in the presence of stand-alone variables."""
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Uint(8))
+        c = expr.Var.new("c", types.Uint(8))
+
+        qc = QuantumCircuit(2, inputs=[a])
+        qc.add_var(b, 12)
+        qc.h(0)
+        qc.cx(0, 1)
+        with qc.if_test(a):
+            # We don't really comment on what should happen to control-flow operations in this
+            # method, and Sabre doesn't care (nor use this method, in the fast paths), so this is
+            # deliberately using a body of length 1 (a single `Store`).
+            qc.add_var(c, 12)
+
+        expected = qc.copy_empty_like()
+        with expected.if_test(a):
+            expected.add_var(c, 12)
+        expected.cx(0, 1)
+        expected.h(0)
+        expected.store(b, 12)
+
+        self.assertEqual(qc.reverse_ops(), expected)
+
     def test_repeat(self):
         """Test repeating the circuit works."""
         qr = QuantumRegister(2)

--- a/test/python/transpiler/test_apply_layout.py
+++ b/test/python/transpiler/test_apply_layout.py
@@ -15,6 +15,7 @@
 import unittest
 
 from qiskit.circuit import QuantumRegister, QuantumCircuit, ClassicalRegister
+from qiskit.circuit.classical import expr, types
 from qiskit.converters import circuit_to_dag
 from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.passes import ApplyLayout, SetLayout
@@ -166,6 +167,31 @@ class TestApplyLayout(QiskitTestCase):
                 }
             ),
         )
+
+    def test_works_with_var_nodes(self):
+        """Test that standalone var nodes work."""
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Uint(8))
+
+        qc = QuantumCircuit(2, 2, inputs=[a])
+        qc.add_var(b, 12)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.measure([0, 1], [0, 1])
+        qc.store(a, expr.bit_and(a, expr.bit_xor(qc.clbits[0], qc.clbits[1])))
+
+        expected = QuantumCircuit(QuantumRegister(2, "q"), *qc.cregs, inputs=[a])
+        expected.add_var(b, 12)
+        expected.h(1)
+        expected.cx(1, 0)
+        expected.measure([1, 0], [0, 1])
+        expected.store(a, expr.bit_and(a, expr.bit_xor(qc.clbits[0], qc.clbits[1])))
+
+        pass_ = ApplyLayout()
+        pass_.property_set["layout"] = Layout(dict(enumerate(reversed(qc.qubits))))
+        after = pass_(qc)
+
+        self.assertEqual(after, expected)
 
 
 if __name__ == "__main__":

--- a/test/python/transpiler/test_basis_translator.py
+++ b/test/python/transpiler/test_basis_translator.py
@@ -19,8 +19,10 @@ from numpy import pi
 
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit import transpile
-from qiskit.circuit import Gate, Parameter, EquivalenceLibrary, Qubit, Clbit
+from qiskit.circuit import Gate, Parameter, EquivalenceLibrary, Qubit, Clbit, Measure
+from qiskit.circuit.classical import expr, types
 from qiskit.circuit.library import (
+    HGate,
     U1Gate,
     U2Gate,
     U3Gate,
@@ -889,6 +891,50 @@ class TestUnrollerCompatability(QiskitTestCase):
 
         self.assertEqual(circuit_to_dag(expected), out_dag)
 
+    def test_treats_store_as_builtin(self):
+        """Test that the `store` instruction is allowed as a builtin in all cases with no target."""
+
+        class MyHGate(Gate):
+            """Hadamard, but it's _mine_."""
+
+            def __init__(self):
+                super().__init__("my_h", 1, [])
+
+        class MyCXGate(Gate):
+            """CX, but it's _mine_."""
+
+            def __init__(self):
+                super().__init__("my_cx", 2, [])
+
+        h_to_my = QuantumCircuit(1)
+        h_to_my.append(MyHGate(), [0], [])
+        cx_to_my = QuantumCircuit(2)
+        cx_to_my.append(MyCXGate(), [0, 1], [])
+        eq_lib = EquivalenceLibrary()
+        eq_lib.add_equivalence(HGate(), h_to_my)
+        eq_lib.add_equivalence(CXGate(), cx_to_my)
+
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Uint(8))
+
+        qc = QuantumCircuit(2, 2, inputs=[a])
+        qc.add_var(b, 12)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.measure([0, 1], [0, 1])
+        qc.store(a, expr.bit_xor(qc.clbits[0], qc.clbits[1]))
+
+        expected = qc.copy_empty_like()
+        expected.store(b, 12)
+        expected.append(MyHGate(), [0], [])
+        expected.append(MyCXGate(), [0, 1], [])
+        expected.measure([0, 1], [0, 1])
+        expected.store(a, expr.bit_xor(expected.clbits[0], expected.clbits[1]))
+
+        # Note: store is present in the circuit but not in the basis set.
+        out = BasisTranslator(eq_lib, ["my_h", "my_cx"])(qc)
+        self.assertEqual(out, expected)
+
 
 class TestBasisExamples(QiskitTestCase):
     """Test example circuits targeting example bases over the StandardEquivalenceLibrary."""
@@ -1127,3 +1173,52 @@ class TestBasisTranslatorWithTarget(QiskitTestCase):
         expected.sx(1)
         expected.rz(3 * pi, 1)
         self.assertEqual(output, expected)
+
+    def test_treats_store_as_builtin(self):
+        """Test that the `store` instruction is allowed as a builtin in all cases with a target."""
+
+        class MyHGate(Gate):
+            """Hadamard, but it's _mine_."""
+
+            def __init__(self):
+                super().__init__("my_h", 1, [])
+
+        class MyCXGate(Gate):
+            """CX, but it's _mine_."""
+
+            def __init__(self):
+                super().__init__("my_cx", 2, [])
+
+        h_to_my = QuantumCircuit(1)
+        h_to_my.append(MyHGate(), [0], [])
+        cx_to_my = QuantumCircuit(2)
+        cx_to_my.append(MyCXGate(), [0, 1], [])
+        eq_lib = EquivalenceLibrary()
+        eq_lib.add_equivalence(HGate(), h_to_my)
+        eq_lib.add_equivalence(CXGate(), cx_to_my)
+
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Uint(8))
+
+        qc = QuantumCircuit(2, 2, inputs=[a])
+        qc.add_var(b, 12)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.measure([0, 1], [0, 1])
+        qc.store(a, expr.bit_xor(qc.clbits[0], qc.clbits[1]))
+
+        expected = qc.copy_empty_like()
+        expected.store(b, 12)
+        expected.append(MyHGate(), [0], [])
+        expected.append(MyCXGate(), [0, 1], [])
+        expected.measure([0, 1], [0, 1])
+        expected.store(a, expr.bit_xor(expected.clbits[0], expected.clbits[1]))
+
+        # Note: store is present in the circuit but not in the target.
+        target = Target()
+        target.add_instruction(MyHGate(), {(i,): None for i in range(qc.num_qubits)})
+        target.add_instruction(Measure(), {(i,): None for i in range(qc.num_qubits)})
+        target.add_instruction(MyCXGate(), {(0, 1): None, (1, 0): None})
+
+        out = BasisTranslator(eq_lib, {"my_h", "my_cx"}, target)(qc)
+        self.assertEqual(out, expected)

--- a/test/python/transpiler/test_sabre_layout.py
+++ b/test/python/transpiler/test_sabre_layout.py
@@ -17,9 +17,10 @@ import unittest
 import math
 
 from qiskit import QuantumRegister, QuantumCircuit
+from qiskit.circuit.classical import expr, types
 from qiskit.circuit.library import EfficientSU2
 from qiskit.transpiler import CouplingMap, AnalysisPass, PassManager
-from qiskit.transpiler.passes import SabreLayout, DenseLayout
+from qiskit.transpiler.passes import SabreLayout, DenseLayout, StochasticSwap
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.converters import circuit_to_dag
 from qiskit.compiler.transpiler import transpile
@@ -256,6 +257,46 @@ barrier q18585[5],q18585[2],q18585[8],q18585[3],q18585[6];
         self.assertEqual(
             [layout[q] for q in qc.qubits], [22, 7, 2, 12, 1, 5, 14, 4, 11, 0, 16, 15, 3, 10]
         )
+
+    def test_support_var_with_rust_fastpath(self):
+        """Test that the joint layout/embed/routing logic for the Rust-space fast-path works in the
+        presence of standalone `Var` nodes."""
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Uint(8))
+
+        qc = QuantumCircuit(5, inputs=[a])
+        qc.add_var(b, 12)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+        qc.cx(2, 3)
+        qc.cx(3, 4)
+        qc.cx(4, 0)
+
+        out = SabreLayout(CouplingMap.from_line(8), seed=0, swap_trials=2, layout_trials=2)(qc)
+
+        self.assertIsInstance(out, QuantumCircuit)
+        self.assertEqual(out.layout.initial_index_layout(), [4, 5, 6, 3, 2, 0, 1, 7])
+
+    def test_support_var_with_explicit_routing_pass(self):
+        """Test that the logic works if an explicit routing pass is given."""
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Uint(8))
+
+        qc = QuantumCircuit(5, inputs=[a])
+        qc.add_var(b, 12)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+        qc.cx(2, 3)
+        qc.cx(3, 4)
+        qc.cx(4, 0)
+
+        cm = CouplingMap.from_line(8)
+        pass_ = SabreLayout(
+            cm, seed=0, routing_pass=StochasticSwap(cm, trials=1, seed=0, fake_run=True)
+        )
+        _ = pass_(qc)
+        layout = pass_.property_set["layout"]
+        self.assertEqual([layout[q] for q in qc.qubits], [2, 3, 4, 1, 5])
 
 
 class DensePartialSabreTrial(AnalysisPass):

--- a/test/python/transpiler/test_unroll_custom_definitions.py
+++ b/test/python/transpiler/test_unroll_custom_definitions.py
@@ -16,10 +16,11 @@ from qiskit.transpiler.passes.basis import UnrollCustomDefinitions
 
 from qiskit.circuit import EquivalenceLibrary, Gate, Qubit, Clbit, Parameter
 from qiskit.circuit import QuantumCircuit, QuantumRegister
+from qiskit.circuit.classical import expr, types
 from qiskit.converters import circuit_to_dag
 from qiskit.exceptions import QiskitError
 from qiskit.transpiler import Target
-from qiskit.circuit.library import CXGate, U3Gate
+from qiskit.circuit.library import CXGate, U3Gate, UGate
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
 
@@ -316,4 +317,57 @@ class TestUnrollCustomDefinitions(QiskitTestCase):
         qc.append(QuantumCircuit(2, global_phase=0.5).to_gate(), [0, 1], [])
         pass_ = UnrollCustomDefinitions(EquivalenceLibrary(), ["u"])
         expected = QuantumCircuit(2, global_phase=0.5)
+        self.assertEqual(pass_(qc), expected)
+
+    def test_leave_store_alone(self):
+        """Don't attempt to unroll `Store` instructions."""
+
+        pass_ = UnrollCustomDefinitions(EquivalenceLibrary(), ["u", "cx"])
+
+        bell = QuantumCircuit(2)
+        bell.h(0)
+        bell.cx(0, 1)
+
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+        qc = QuantumCircuit(2, inputs=[a])
+        qc.add_var(b, a)
+        qc.compose(bell, [0, 1], inplace=True)
+        qc.store(b, a)
+
+        expected = qc.copy_empty_like()
+        expected.store(b, a)
+        expected.compose(pass_(bell), [0, 1], inplace=True)
+        expected.store(b, a)
+
+        self.assertEqual(pass_(qc), expected)
+
+    def test_leave_store_alone_with_target(self):
+        """Don't attempt to unroll `Store` instructions with a `Target`."""
+
+        # Note no store.
+        target = Target()
+        target.add_instruction(
+            UGate(Parameter("a"), Parameter("b"), Parameter("c")), {(0,): None, (1,): None}
+        )
+        target.add_instruction(CXGate(), {(0, 1): None, (1, 0): None})
+
+        pass_ = UnrollCustomDefinitions(EquivalenceLibrary(), target=target)
+
+        bell = QuantumCircuit(2)
+        bell.h(0)
+        bell.cx(0, 1)
+
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+        qc = QuantumCircuit(2, inputs=[a])
+        qc.add_var(b, a)
+        qc.compose(bell, [0, 1], inplace=True)
+        qc.store(b, a)
+
+        expected = qc.copy_empty_like()
+        expected.store(b, a)
+        expected.compose(pass_(bell), [0, 1], inplace=True)
+        expected.store(b, a)
+
         self.assertEqual(pass_(qc), expected)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This adds the missing pieces to fully support standalone `Var` nodes through every part of the transpiler (that I could detect).  It's quite possible there's some problem in a more esoteric non-preset pass somewhere, but I couldn't spot them.

For the most part there were very few changes needed to the actual passes, and only one place in `QuantumCircuit` that had previously been missed.  Most of the commit is updating passes to correctly pass `inline_captures=True` when appropriate for dealing with `DAGCircuit.compose`, and making sure that any place that needed to build a raw `DAGCircuit` for a rebuild _without_ using `DAGCircuit.copy_empty_like` made sure to correctly add in the variables.

This commit adds specific tests for every pass that I touched, plus the general integration tests that we have for the transpiler to make sure that OQ3 and QPY serialisation work afterwards.



### Details and comments

Close #10931.

This is the top of the stack and depends on #12215 and #12308 (the latter of which depends on #12307, though those could be merged together).

I'll write the full release note as a full PR after the tagging of rc1.