### PR TITLE
Fix composition of multiple virtual permutation layouts

### DIFF
--- a/qiskit/transpiler/passes/optimization/elide_permutations.py
+++ b/qiskit/transpiler/passes/optimization/elide_permutations.py
@@ -105,8 +105,10 @@ class ElidePermutations(TransformationPass):
             self.property_set["original_qubit_indices"] = input_qubit_mapping
 
         new_layout = Layout({dag.qubits[out]: idx for idx, out in enumerate(qubit_mapping)})
-        if current_layout := self.property_set["virtual_permutation_layout"] is not None:
-            self.property_set["virtual_permutation_layout"] = current_layout.compose(new_layout)
+        if current_layout := self.property_set["virtual_permutation_layout"]:
+            self.property_set["virtual_permutation_layout"] = new_layout.compose(
+                current_layout.inverse(dag.qubits, dag.qubits), dag.qubits
+            )
         else:
             self.property_set["virtual_permutation_layout"] = new_layout
         return new_dag

--- a/qiskit/transpiler/passes/routing/star_prerouting.py
+++ b/qiskit/transpiler/passes/routing/star_prerouting.py
@@ -267,8 +267,10 @@ class StarPreRouting(TransformationPass):
             self.property_set["original_qubit_indices"] = input_qubit_mapping
 
         new_layout = Layout({dag.qubits[out]: idx for idx, out in enumerate(qubit_mapping)})
-        if current_layout := self.property_set["virtual_permutation_layout"] is not None:
-            self.property_set["virtual_permutation_layout"] = current_layout.compose(new_layout)
+        if current_layout := self.property_set["virtual_permutation_layout"]:
+            self.property_set["virtual_permutation_layout"] = new_layout.compose(
+                current_layout.inverse(dag.qubits, dag.qubits), dag.qubits
+            )
         else:
             self.property_set["virtual_permutation_layout"] = new_layout
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes the composition of multiple virtual permutation layouts in StarPreRouting and ElidePermutations. Both of these passes set a virtual permutation layout and if both running a pipeline the layouts need to be composed together to track the permutation. Previously the logic for doing this was incorrect (and also had a syntax error). This commit fixes this so that you can run the two passes together (along with any other future passes that do a similar thing). This was spun out from #12196 as a standalone bugfix.

### Details and comments