### PR TITLE
fix edge coloring bug in plot_coupling_map

### DIFF
--- a/qiskit/visualization/gate_map.py
+++ b/qiskit/visualization/gate_map.py
@@ -1039,7 +1039,9 @@ def plot_coupling_map(
         graph = CouplingMap(coupling_map).graph
 
     if not plot_directed:
+        line_color_map = dict(zip(graph.edge_list(), line_color))
         graph = graph.to_undirected(multigraph=False)
+        line_color = [line_color_map[edge] for edge in graph.edge_list()]
 
     for node in graph.node_indices():
         graph[node] = node

--- a/releasenotes/notes/plot-circuit-layout-5935646107893c12.yaml
+++ b/releasenotes/notes/plot-circuit-layout-5935646107893c12.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a bug in :func:`plot_coupling_map` that caused the edges of the coupling map to be colored incorrectly.
+    See https://github.com/Qiskit/qiskit/pull/12369 for details.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #12354 .

### Details and comments

The conversion to an undirected graph changes the edge ordering, causing it not to match the color ordering. This change uses a dictionary to recover the correct ordering.
