### PR TITLE
Fix a corner case of `SparsePauliOp.apply_layout`

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -1165,6 +1165,8 @@ class SparsePauliOp(LinearOp):
                 raise QiskitError("Provided layout contains indices outside the number of qubits.")
             if len(set(layout)) != len(layout):
                 raise QiskitError("Provided layout contains duplicate indices.")
+        if self.num_qubits == 0:
+            return type(self)(["I" * n_qubits] * self.size, self.coeffs)
         new_op = type(self)("I" * n_qubits)
         return new_op.compose(self, qargs=layout)
 

--- a/releasenotes/notes/fix-sparse-pauli-op-apply-layout-zero-43b9e70f0d1536a6.yaml
+++ b/releasenotes/notes/fix-sparse-pauli-op-apply-layout-zero-43b9e70f0d1536a6.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    Fixed :meth:`~.SparsePauliOp.apply_layout` to work correctly with zero-qubit operators.
+    Fixed :meth:`.SparsePauliOp.apply_layout` to work correctly with zero-qubit operators.

--- a/releasenotes/notes/fix-sparse-pauli-op-apply-layout-zero-43b9e70f0d1536a6.yaml
+++ b/releasenotes/notes/fix-sparse-pauli-op-apply-layout-zero-43b9e70f0d1536a6.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fixed :meth:`~.SparsePauliOp.apply_layout` to work correctly with zero-qubit operators.

--- a/releasenotes/notes/fix-sparse-pauli-op-apply-layout-zero-43b9e70f0d1536a6.yaml
+++ b/releasenotes/notes/fix-sparse-pauli-op-apply-layout-zero-43b9e70f0d1536a6.yaml
@@ -1,3 +1,10 @@
 fixes:
   - |
     Fixed :meth:`.SparsePauliOp.apply_layout` to work correctly with zero-qubit operators.
+    For example, if you previously created a 0 qubit and applied a layout like::
+    
+        op = SparsePauliOp("")
+        op.apply_layout(None, 3)
+
+    this would have previously raised an error. Now this will correctly return an operator of the form:
+    ``SparsePauliOp(['III'], coeffs=[1.+0.j])``

--- a/test/python/quantum_info/operators/symplectic/test_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli.py
@@ -618,6 +618,29 @@ class TestPauli(QiskitTestCase):
         with self.assertRaises(QiskitError):
             op.apply_layout(layout=[0, 0], num_qubits=3)
 
+    def test_apply_layout_zero_qubit(self):
+        """Test apply_layout with a zero-qubit operator"""
+        with self.subTest("default"):
+            op = Pauli("")
+            res = op.apply_layout(layout=None, num_qubits=5)
+            self.assertEqual(Pauli("IIIII"), res)
+        with self.subTest("phase -1j"):
+            op = Pauli("-i")
+            res = op.apply_layout(layout=None, num_qubits=5)
+            self.assertEqual(Pauli("-iIIIII"), res)
+        with self.subTest("phase -1"):
+            op = Pauli("-")
+            res = op.apply_layout(layout=None, num_qubits=5)
+            self.assertEqual(Pauli("-IIIII"), res)
+        with self.subTest("phase 1j"):
+            op = Pauli("i")
+            res = op.apply_layout(layout=None, num_qubits=5)
+            self.assertEqual(Pauli("iIIIII"), res)
+        with self.subTest("layout"):
+            op = Pauli("")
+            res = op.apply_layout(layout=[], num_qubits=5)
+            self.assertEqual(Pauli("IIIII"), res)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -1191,6 +1191,25 @@ class TestSparsePauliOpMethods(QiskitTestCase):
         with self.assertRaises(QiskitError):
             op.apply_layout(layout=[0, 0], num_qubits=3)
 
+    def test_apply_layout_zero_qubit(self):
+        """Test apply_layout with a zero-qubit operator"""
+        with self.subTest("default"):
+            op = SparsePauliOp("")
+            res = op.apply_layout(layout=None, num_qubits=5)
+            self.assertEqual(SparsePauliOp("IIIII"), res)
+        with self.subTest("coeff"):
+            op = SparsePauliOp("", 2)
+            res = op.apply_layout(layout=None, num_qubits=5)
+            self.assertEqual(SparsePauliOp("IIIII", 2), res)
+        with self.subTest("layout"):
+            op = SparsePauliOp("")
+            res = op.apply_layout(layout=[], num_qubits=5)
+            self.assertEqual(SparsePauliOp("IIIII"), res)
+        with self.subTest("multiple ops"):
+            op = SparsePauliOp.from_list([("", 1), ("", 2)])
+            res = op.apply_layout(layout=None, num_qubits=5)
+            self.assertEqual(SparsePauliOp.from_list([("IIIII", 1), ("IIIII", 2)]), res)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -14,23 +14,22 @@
 
 import itertools as it
 import unittest
+from test import QiskitTestCase, combine
+
 import numpy as np
-import scipy.sparse
 import rustworkx as rx
+import scipy.sparse
 from ddt import ddt
 
-
 from qiskit import QiskitError
-from qiskit.circuit import ParameterExpression, Parameter, ParameterVector
-from qiskit.circuit.parametertable import ParameterView
-from qiskit.quantum_info.operators import Operator, Pauli, PauliList, SparsePauliOp
+from qiskit.circuit import Parameter, ParameterExpression, ParameterVector
 from qiskit.circuit.library import EfficientSU2
+from qiskit.circuit.parametertable import ParameterView
+from qiskit.compiler.transpiler import transpile
 from qiskit.primitives import BackendEstimator
 from qiskit.providers.fake_provider import GenericBackendV2
-from qiskit.compiler.transpiler import transpile
+from qiskit.quantum_info.operators import Operator, Pauli, PauliList, SparsePauliOp
 from qiskit.utils import optionals
-from test import QiskitTestCase  # pylint: disable=wrong-import-order
-from test import combine  # pylint: disable=wrong-import-order
 
 
 def pauli_mat(label):
@@ -1191,23 +1190,20 @@ class TestSparsePauliOpMethods(QiskitTestCase):
         with self.assertRaises(QiskitError):
             op.apply_layout(layout=[0, 0], num_qubits=3)
 
-    def test_apply_layout_zero_qubit(self):
+    @combine(layout=[None, []])
+    def test_apply_layout_zero_qubit(self, layout):
         """Test apply_layout with a zero-qubit operator"""
         with self.subTest("default"):
             op = SparsePauliOp("")
-            res = op.apply_layout(layout=None, num_qubits=5)
+            res = op.apply_layout(layout=layout, num_qubits=5)
             self.assertEqual(SparsePauliOp("IIIII"), res)
         with self.subTest("coeff"):
             op = SparsePauliOp("", 2)
-            res = op.apply_layout(layout=None, num_qubits=5)
+            res = op.apply_layout(layout=layout, num_qubits=5)
             self.assertEqual(SparsePauliOp("IIIII", 2), res)
-        with self.subTest("layout"):
-            op = SparsePauliOp("")
-            res = op.apply_layout(layout=[], num_qubits=5)
-            self.assertEqual(SparsePauliOp("IIIII"), res)
         with self.subTest("multiple ops"):
             op = SparsePauliOp.from_list([("", 1), ("", 2)])
-            res = op.apply_layout(layout=None, num_qubits=5)
+            res = op.apply_layout(layout=layout, num_qubits=5)
             self.assertEqual(SparsePauliOp.from_list([("IIIII", 1), ("IIIII", 2)]), res)
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

`SparsePauliOp.apply_layout` raises an error if a zero-qubit operator is given.
This PR fixes the case.

```python
from qiskit.quantum_info import SparsePauliOp

op = SparsePauliOp("")
print(op.apply_layout(None, 3))
```

main branch
```
SparsePauliOp([''],
              coeffs=[1.+0.j])
Traceback (most recent call last):
  File "/Users/ima/tasks/4_2024/qiskit/terra/tmp/layout.py", line 5, in <module>
    print(op.apply_layout(None, 3))
  File "/Users/ima/tasks/4_2024/qiskit/terra/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py", line 1167, in apply_layout
    return new_op.compose(self, qargs=layout)
  File "/Users/ima/tasks/4_2024/qiskit/terra/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py", line 349, in compose
    q = np.logical_and(z1[:, np.newaxis], x2).reshape((-1, num_qubits))
ValueError: cannot reshape array of size 0 into shape (0)
```

this PR
```
SparsePauliOp(['III'],
              coeffs=[1.+0.j])
```

Although `Pauli.apply_layout` works correctly, I added the zero-qubit test cases to ensure it.

### Details and comments


