### PR TITLE
Fix runtime scaling of StarPreRouting pass

### DIFF
--- a/qiskit/transpiler/passes/routing/star_prerouting.py
+++ b/qiskit/transpiler/passes/routing/star_prerouting.py
@@ -329,13 +329,13 @@ class StarPreRouting(TransformationPass):
             last_2q_gate = None
 
         int_digits = floor(log10(len(processing_order))) + 1
-        processing_order_s = set(processing_order)
+        processing_order_index_map = {
+            node: f"a{str(index).zfill(int(int_digits))}"
+            for index, node in enumerate(processing_order)
+        }
 
         def tie_breaker_key(node):
-            if node in processing_order_s:
-                return "a" + str(processing_order.index(node)).zfill(int(int_digits))
-            else:
-                return node.sort_key
+            return processing_order_index_map.get(node, node.sort_key)
 
         for node in dag.topological_op_nodes(key=tie_breaker_key):
             block_id = node_to_block_id.get(node, None)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes a runtime performance scaling issue with the new StarPreRouting pass. If there are any stars identified by the pass when the pass goes to pre-route those star connectivity blocks it specifies a custom lexicographical topological sort key to ensure the stars are kept together in the sort. However the mechanism by which this sort key was generated scaled quadratically with the number of DAG nodes in the identified stars. This ended up being a large runtime performance bottleneck. This commit fixes this issue by pre-computing the sort key for all nodes in the stars and putting that in a dictionary so that when we call rustworkx to perform the topological sort the sort key callback does not become the bottleneck for the entire pass.

### Details and comments