### PR TITLE
Fix {Pauli,SparsePauliOp}.apply_layout to raise an error with negative or duplicate indices

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -736,8 +736,11 @@ class Pauli(BasePauli):
             n_qubits = num_qubits
         if layout is None:
             layout = list(range(self.num_qubits))
-        elif any(x >= n_qubits for x in layout):
-            raise QiskitError("Provided layout contains indices outside the number of qubits.")
+        else:
+            if any(x < 0 or x >= n_qubits for x in layout):
+                raise QiskitError("Provided layout contains indices outside the number of qubits.")
+            if len(set(layout)) != len(layout):
+                raise QiskitError("Provided layout contains duplicate indices.")
         new_op = type(self)("I" * n_qubits)
         return new_op.compose(self, qargs=layout)
 

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -1139,7 +1139,6 @@ class SparsePauliOp(LinearOp):
                 specified will be applied without any expansion. If layout is
                 None, the operator will be expanded to the given number of qubits.
 
-
         Returns:
             A new :class:`.SparsePauliOp` with the provided layout applied
         """
@@ -1159,10 +1158,13 @@ class SparsePauliOp(LinearOp):
                     f"applied to a {n_qubits} qubit operator"
                 )
             n_qubits = num_qubits
-        if layout is not None and any(x >= n_qubits for x in layout):
-            raise QiskitError("Provided layout contains indices outside the number of qubits.")
         if layout is None:
             layout = list(range(self.num_qubits))
+        else:
+            if any(x < 0 or x >= n_qubits for x in layout):
+                raise QiskitError("Provided layout contains indices outside the number of qubits.")
+            if len(set(layout)) != len(layout):
+                raise QiskitError("Provided layout contains duplicate indices.")
         new_op = type(self)("I" * n_qubits)
         return new_op.compose(self, qargs=layout)
 

--- a/releasenotes/notes/fix-apply-layout-duplicate-negative-indices-cf5517921fe52706.yaml
+++ b/releasenotes/notes/fix-apply-layout-duplicate-negative-indices-cf5517921fe52706.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     Fixed :meth:`.SparsePauliOp.apply_layout` and :meth:`.Pauli.apply_layout`
-    to raise :exc:`QiskitError` if duplicate indices or negative indices are provided
+    to raise :exc:`.QiskitError` if duplicate indices or negative indices are provided
     as part of a layout.

--- a/releasenotes/notes/fix-apply-layout-duplicate-negative-indices-cf5517921fe52706.yaml
+++ b/releasenotes/notes/fix-apply-layout-duplicate-negative-indices-cf5517921fe52706.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    Fixed :meth:`~.SparsePauliOp.apply_layout` and :meth:`~.Pauli.apply_layout`
-    to raise ``QiskitError`` if duplicate indices or negative indices are provided
+    Fixed :meth:`.SparsePauliOp.apply_layout` and :meth:`.Pauli.apply_layout`
+    to raise :exc:`QiskitError` if duplicate indices or negative indices are provided
     as part of a layout.

--- a/releasenotes/notes/fix-apply-layout-duplicate-negative-indices-cf5517921fe52706.yaml
+++ b/releasenotes/notes/fix-apply-layout-duplicate-negative-indices-cf5517921fe52706.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed :meth:`~.SparsePauliOp.apply_layout` and :meth:`~.Pauli.apply_layout`
+    to raise ``QiskitError`` if duplicate indices or negative indices are provided
+    as part of a layout.

--- a/test/python/quantum_info/operators/symplectic/test_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli.py
@@ -606,6 +606,18 @@ class TestPauli(QiskitTestCase):
         with self.assertRaises(QiskitError):
             op.apply_layout(layout=None, num_qubits=1)
 
+    def test_apply_layout_negative_indices(self):
+        """Test apply_layout with negative indices"""
+        op = Pauli("IZ")
+        with self.assertRaises(QiskitError):
+            op.apply_layout(layout=[-1, 0], num_qubits=3)
+
+    def test_apply_layout_duplicate_indices(self):
+        """Test apply_layout with duplicate indices"""
+        op = Pauli("IZ")
+        with self.assertRaises(QiskitError):
+            op.apply_layout(layout=[0, 0], num_qubits=3)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -1179,6 +1179,18 @@ class TestSparsePauliOpMethods(QiskitTestCase):
         with self.assertRaises(QiskitError):
             op.apply_layout(layout=None, num_qubits=1)
 
+    def test_apply_layout_negative_indices(self):
+        """Test apply_layout with negative indices"""
+        op = SparsePauliOp.from_list([("II", 1), ("IZ", 2), ("XI", 3)])
+        with self.assertRaises(QiskitError):
+            op.apply_layout(layout=[-1, 0], num_qubits=3)
+
+    def test_apply_layout_duplicate_indices(self):
+        """Test apply_layout with duplicate indices"""
+        op = SparsePauliOp.from_list([("II", 1), ("IZ", 2), ("XI", 3)])
+        with self.assertRaises(QiskitError):
+            op.apply_layout(layout=[0, 0], num_qubits=3)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

{Pauli,SparsePauliOp}.apply_layout currently allow negative or duplicate indices.
The behavior is not always comprehensive.

1. If we give duplicate indices, some coefficients or phases may change. 
2. If we give negative indices that are out of bounds, it raises IndexError while positive indices raises QiskitError.

This PR raises QiskitError with duplicate indices or negative indices (even within bounds for simplicity).
I think duplicate indices are not valid as a layout. But, if we need to support the pattern, we might need to update the code not to change the coefficients.

I noticed this situation when I review https://github.com/Qiskit/qiskit/pull/12221#issuecomment-2101839871

```python
from qiskit.quantum_info import Pauli, SparsePauliOp

op = Pauli("XY")
op2 = SparsePauliOp("XY")

print("duplicate indices")
try:
    print(op.apply_layout([0, 0]))
except Exception as ex:
    print(ex)
try:
    print(op2.apply_layout([0, 0]))
except Exception as ex:
    print(ex)

print("\nnegative indices not out of bounds")
try:
    print(op.apply_layout([-1, 0]))
except Exception as ex:
    print(ex)
try:
    print(op2.apply_layout([-1, 0]))
except Exception as ex:
    print(ex)

print("\nnegative indices out of bounds")
try:
    print(op.apply_layout([-3, 0]))
except Exception as ex:
    print(ex)
try:
    print(op2.apply_layout([-3, 0]))
except Exception as ex:
    print(ex)

print("\npositive indices out of bounds")
try:
    print(op.apply_layout([3, 0]))
except Exception as ex:
    print(ex)
try:
    print(op2.apply_layout([3, 0]))
except Exception as ex:
    print(ex)
```

main
```
duplicate indices
-iIX
SparsePauliOp(['IX'],
              coeffs=[0.-1.j])

negative indices not out of bounds
YX
SparsePauliOp(['YX'],
              coeffs=[1.+0.j])

negative indices out of bounds
index -3 is out of bounds for axis 1 with size 2
index -3 is out of bounds for axis 1 with size 2

positive indices out of bounds
'Provided layout contains indices outside the number of qubits.'
'Provided layout contains indices outside the number of qubits.'
```

this PR
```
duplicate indices
'Provided layout contains duplicate indices.'
'Provided layout contains duplicate indices.'

negative indices not out of bounds
'Provided layout contains indices outside the number of qubits.'
'Provided layout contains indices outside the number of qubits.'

negative indices out of bounds
'Provided layout contains indices outside the number of qubits.'
'Provided layout contains indices outside the number of qubits.'

positive indices out of bounds
'Provided layout contains indices outside the number of qubits.'
'Provided layout contains indices outside the number of qubits.'
```

### Details and comments


