### PR TITLE
Avoid lossing precision when scaling frequencies

### DIFF
--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -234,7 +234,7 @@ class InstructionToQobjConverter:
             "name": "setf",
             "t0": time_offset + instruction.start_time,
             "ch": instruction.channel.name,
-            "frequency": instruction.frequency / 1e9,
+            "frequency": instruction.frequency / 10**9,
         }
         return self._qobj_model(**command_dict)
 
@@ -257,7 +257,7 @@ class InstructionToQobjConverter:
             "name": "shiftf",
             "t0": time_offset + instruction.start_time,
             "ch": instruction.channel.name,
-            "frequency": instruction.frequency / 1e9,
+            "frequency": instruction.frequency / 10**9,
         }
         return self._qobj_model(**command_dict)
 
@@ -746,7 +746,7 @@ class QobjToInstructionConverter:
         .. note::
 
             We assume frequency value is expressed in string with "GHz".
-            Operand value is thus scaled by a factor of 1e9.
+            Operand value is thus scaled by a factor of 10^9.
 
         Args:
             instruction: SetFrequency qobj instruction
@@ -755,7 +755,7 @@ class QobjToInstructionConverter:
             Qiskit Pulse set frequency instructions
         """
         channel = self.get_channel(instruction.ch)
-        frequency = self.disassemble_value(instruction.frequency) * 1e9
+        frequency = self.disassemble_value(instruction.frequency) * 10**9
 
         yield instructions.SetFrequency(frequency, channel)
 
@@ -768,7 +768,7 @@ class QobjToInstructionConverter:
         .. note::
 
             We assume frequency value is expressed in string with "GHz".
-            Operand value is thus scaled by a factor of 1e9.
+            Operand value is thus scaled by a factor of 10^9.
 
         Args:
             instruction: ShiftFrequency qobj instruction
@@ -777,7 +777,7 @@ class QobjToInstructionConverter:
             Qiskit Pulse shift frequency schedule instructions
         """
         channel = self.get_channel(instruction.ch)
-        frequency = self.disassemble_value(instruction.frequency) * 1e9
+        frequency = self.disassemble_value(instruction.frequency) * 10**9
 
         yield instructions.ShiftFrequency(frequency, channel)
 

--- a/releasenotes/notes/fix-symbolic-unit-scaling-c3eb4d9be674dfd6.yaml
+++ b/releasenotes/notes/fix-symbolic-unit-scaling-c3eb4d9be674dfd6.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a floating-point imprecision when scaling certain pulse units
+    between seconds and nanoseconds.  If the pulse was symbolically defined,
+    an unnecessary floating-point error could be introduced by the scaling
+    for certain builds of ``symengine``, which could manifest in unexpected
+    results once the symbols were fully bound.  See `#12392 <https://github.com/Qiskit/qiskit/pull/12392>`__.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Classes in `pulse_instruction.py` scale frequency values to GHz by multipliying `ParameterExpression` with float `1e9`. This can lead to numerical errors on some systems due to `symengine` "rounding" errors. Instead, this scaling can be done multiplying by integer `10**9`.

### Details and comments

In this unit test
https://github.com/Qiskit/qiskit/blob/235e581b1f76f29add0399989ed47f47a4e98bb8/test/python/qobj/test_pulse_converter.py#L343

The `frequency` string `"f / 1000"` gets converted to `ParameterExpression(1000000.0*f)` after `ParameterExpression(f/1000)` is multiplied by `1e9`. For some unknown reason, when the symbol `f` is later substituted with the value `3.14`, and the `RealDouble` is converted to `float`, an error is introduced that can't be fixed by
https://github.com/Qiskit/qiskit/blob/235e581b1f76f29add0399989ed47f47a4e98bb8/qiskit/pulse/utils.py#L71-L74

This fixes: https://github.com/Qiskit/qiskit/issues/12359#issuecomment-2104426621

Upstream issue: https://github.com/symengine/symengine.py/issues/476