### PR TITLE
Fix `qiskit.circuit` method header and broken cross-reference

### DIFF
--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -832,10 +832,10 @@ Subclasses of :class:`Gate` will also likely wish to override `the Numpy array-p
 method <https://numpy.org/devdocs/user/basics.interoperability.html#the-array-method>`__,
 ``__array__``.  This is used by :meth:`Gate.to_matrix`, and has the signature:
 
-.. currentmodule:: None
+.. currentmodule:: builtins
 .. py:method:: __array__(dtype=None, copy=None)
 
-    Return a Numpy array representing the gate.  This can use the gate's :attr:`~Instruction.params`
+    Return a Numpy array representing the gate.  This can use the gate's :attr:`~qiskit.circuit.Instruction.params`
     field, and may assume that these are numeric values (assuming the subclass expects that) and not
     :ref:`compile-time parameters <circuit-compile-time-parameters>`.
 

--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -832,8 +832,8 @@ Subclasses of :class:`Gate` will also likely wish to override `the Numpy array-p
 method <https://numpy.org/devdocs/user/basics.interoperability.html#the-array-method>`__,
 ``__array__``.  This is used by :meth:`Gate.to_matrix`, and has the signature:
 
-.. currentmodule:: object
-.. py:method:: __array__(dtype=None, copy=None)
+.. currentmodule:: None
+.. py:method:: object.__array__(dtype=None, copy=None)
 
     Return a Numpy array representing the gate. This can use the gate's
     :attr:`~qiskit.circuit.Instruction.params` field, and may assume that these are numeric

--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -835,8 +835,9 @@ method <https://numpy.org/devdocs/user/basics.interoperability.html#the-array-me
 .. currentmodule:: object
 .. py:method:: __array__(dtype=None, copy=None)
 
-    Return a Numpy array representing the gate.  This can use the gate's :attr:`~qiskit.circuit.Instruction.params`
-    field, and may assume that these are numeric values (assuming the subclass expects that) and not
+    Return a Numpy array representing the gate. This can use the gate's
+    :attr:`~qiskit.circuit.Instruction.params` field, and may assume that these are numeric
+    values (assuming the subclass expects that) and not
     :ref:`compile-time parameters <circuit-compile-time-parameters>`.
 
     For greatest efficiency, the returned array should default to a dtype of :class:`complex`.

--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -832,7 +832,7 @@ Subclasses of :class:`Gate` will also likely wish to override `the Numpy array-p
 method <https://numpy.org/devdocs/user/basics.interoperability.html#the-array-method>`__,
 ``__array__``.  This is used by :meth:`Gate.to_matrix`, and has the signature:
 
-.. currentmodule:: builtins
+.. currentmodule:: object
 .. py:method:: __array__(dtype=None, copy=None)
 
     Return a Numpy array representing the gate.  This can use the gate's :attr:`~qiskit.circuit.Instruction.params`


### PR DESCRIPTION
Part of https://github.com/Qiskit/documentation/issues/1275

The `__array__` method has a wrong header in the API docs (as we can see in the following screenshot) because Sphinx is not able to set the correct id in the generated HTML for methods starting with double underscore. Instead, Sphinx truncates the name to `array__`.

![Captura desde 2024-05-13 14-31-08](https://github.com/Qiskit/qiskit/assets/47946624/ce47b713-b8a2-4bff-a346-39e32b7f3a3c)

This PR changes the method to be instead `builtins.__array__`, and it also fixes a broken reference for `Instruction.params`. The cross-reference was broken due to the` .. currentmodule:: None` directive.

This is the result of Sphinx after this PR:

![Captura desde 2024-05-13 14-27-06](https://github.com/Qiskit/qiskit/assets/47946624/7788c300-2c12-485f-810d-1b797a4541a5)

The API docs will have the correct header because we only use the part after the last dot in the id.

The PR will need backport to `stable/1.1`