### PR TITLE
Remove not-context-manager lint rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,7 +221,6 @@ disable = [
     "consider-using-f-string",
     "no-member",
     "no-value-for-parameter",
-    "not-context-manager",
     "unexpected-keyword-arg",
     "unnecessary-dunder-call",
     "unnecessary-lambda-assignment",

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -5029,29 +5029,15 @@ class QuantumCircuit:
             else:
                 self._parameter_table[atomic_parameter] = new_entries
 
-    @typing.overload
     def while_loop(
         self,
         condition: tuple[ClassicalRegister | Clbit, int] | expr.Expr,
-        body: None,
-        qubits: None,
-        clbits: None,
+        body: Union["QuantumCircuit", None] = None,
+        qubits: Sequence[QubitSpecifier] | None = None,
+        clbits: Sequence[ClbitSpecifier] | None = None,
         *,
-        label: str | None,
-    ) -> WhileLoopContext: ...
-
-    @typing.overload
-    def while_loop(
-        self,
-        condition: tuple[ClassicalRegister | Clbit, int] | expr.Expr,
-        body: "QuantumCircuit",
-        qubits: Sequence[QubitSpecifier],
-        clbits: Sequence[ClbitSpecifier],
-        *,
-        label: str | None,
-    ) -> InstructionSet: ...
-
-    def while_loop(self, condition, body=None, qubits=None, clbits=None, *, label=None):
+        label: str | None = None,
+    ) -> Union[InstructionSet, WhileLoopContext]:
         """Create a ``while`` loop on this circuit.
 
         There are two forms for calling this function.  If called with all its arguments (with the
@@ -5114,33 +5100,16 @@ class QuantumCircuit:
 
         return self.append(WhileLoopOp(condition, body, label), qubits, clbits, copy=False)
 
-    @typing.overload
     def for_loop(
         self,
         indexset: Iterable[int],
-        loop_parameter: Parameter | None,
-        body: None,
-        qubits: None,
-        clbits: None,
+        loop_parameter: Union[Parameter, None] = None,
+        body: Union["QuantumCircuit", None] = None,
+        qubits: Sequence[QubitSpecifier] | None = None,
+        clbits: Sequence[ClbitSpecifier] | None = None,
         *,
-        label: str | None,
-    ) -> ForLoopContext: ...
-
-    @typing.overload
-    def for_loop(
-        self,
-        indexset: Iterable[int],
-        loop_parameter: Union[Parameter, None],
-        body: "QuantumCircuit",
-        qubits: Sequence[QubitSpecifier],
-        clbits: Sequence[ClbitSpecifier],
-        *,
-        label: str | None,
-    ) -> InstructionSet: ...
-
-    def for_loop(
-        self, indexset, loop_parameter=None, body=None, qubits=None, clbits=None, *, label=None
-    ):
+        label: str | None = None,
+    ) -> Union[InstructionSet, ForLoopContext]:
         """Create a ``for`` loop on this circuit.
 
         There are two forms for calling this function.  If called with all its arguments (with the
@@ -5205,37 +5174,15 @@ class QuantumCircuit:
             ForLoopOp(indexset, loop_parameter, body, label), qubits, clbits, copy=False
         )
 
-    @typing.overload
     def if_test(
         self,
         condition: tuple[ClassicalRegister | Clbit, int],
-        true_body: None,
-        qubits: None,
-        clbits: None,
-        *,
-        label: str | None,
-    ) -> IfContext: ...
-
-    @typing.overload
-    def if_test(
-        self,
-        condition: tuple[ClassicalRegister | Clbit, int],
-        true_body: "QuantumCircuit",
-        qubits: Sequence[QubitSpecifier],
-        clbits: Sequence[ClbitSpecifier],
+        true_body: Union["QuantumCircuit", None] = None,
+        qubits: Sequence[QubitSpecifier] | None = None,
+        clbits: Sequence[ClbitSpecifier] | None = None,
         *,
         label: str | None = None,
-    ) -> InstructionSet: ...
-
-    def if_test(
-        self,
-        condition,
-        true_body=None,
-        qubits=None,
-        clbits=None,
-        *,
-        label=None,
-    ):
+    ) -> Union[InstructionSet, IfContext]:
         """Create an ``if`` statement on this circuit.
 
         There are two forms for calling this function.  If called with all its arguments (with the
@@ -5372,29 +5319,15 @@ class QuantumCircuit:
             IfElseOp(condition, true_body, false_body, label), qubits, clbits, copy=False
         )
 
-    @typing.overload
     def switch(
         self,
         target: Union[ClbitSpecifier, ClassicalRegister],
-        cases: None,
-        qubits: None,
-        clbits: None,
+        cases: Iterable[Tuple[typing.Any, QuantumCircuit]] | None = None,
+        qubits: Sequence[QubitSpecifier] | None = None,
+        clbits: Sequence[ClbitSpecifier] | None = None,
         *,
-        label: Optional[str],
-    ) -> SwitchContext: ...
-
-    @typing.overload
-    def switch(
-        self,
-        target: Union[ClbitSpecifier, ClassicalRegister],
-        cases: Iterable[Tuple[typing.Any, QuantumCircuit]],
-        qubits: Sequence[QubitSpecifier],
-        clbits: Sequence[ClbitSpecifier],
-        *,
-        label: Optional[str],
-    ) -> InstructionSet: ...
-
-    def switch(self, target, cases=None, qubits=None, clbits=None, *, label=None):
+        label: Optional[str] | None = None,
+    ) -> InstructionSet | SwitchContext:
         """Create a ``switch``/``case`` structure on this circuit.
 
         There are two forms for calling this function.  If called with all its arguments (with the


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

#9614 removing `not-context-manager`

### Details and comments

This is the only way i could find to get the typing to not be an issue other than removing it completely
