### PR TITLE
Fix unnecessary serialisation of `PassManager` in serial contexts

### DIFF
--- a/qiskit/utils/__init__.py
+++ b/qiskit/utils/__init__.py
@@ -43,8 +43,9 @@ Multiprocessing
 
 .. autofunction:: local_hardware_info
 .. autofunction:: is_main_process
+.. autofunction:: should_run_in_parallel
 
-A helper function for calling a custom function with python
+A helper function for calling a custom function with Python
 :class:`~concurrent.futures.ProcessPoolExecutor`. Tasks can be executed in parallel using this function.
 
 .. autofunction:: parallel_map
@@ -70,7 +71,7 @@ from .lazy_tester import LazyDependencyManager, LazyImportTester, LazySubprocess
 
 from . import optionals
 
-from .parallel import parallel_map
+from .parallel import parallel_map, should_run_in_parallel
 
 __all__ = [
     "LazyDependencyManager",
@@ -85,4 +86,5 @@ __all__ = [
     "is_main_process",
     "apply_prefix",
     "parallel_map",
+    "should_run_in_parallel",
 ]

--- a/qiskit/utils/__init__.py
+++ b/qiskit/utils/__init__.py
@@ -43,7 +43,6 @@ Multiprocessing
 
 .. autofunction:: local_hardware_info
 .. autofunction:: is_main_process
-.. autofunction:: should_run_in_parallel
 
 A helper function for calling a custom function with Python
 :class:`~concurrent.futures.ProcessPoolExecutor`. Tasks can be executed in parallel using this function.

--- a/qiskit/utils/parallel.py
+++ b/qiskit/utils/parallel.py
@@ -48,6 +48,8 @@ Routines for running Python functions in parallel using process pools
 from the multiprocessing library.
 """
 
+from __future__ import annotations
+
 import os
 from concurrent.futures import ProcessPoolExecutor
 import sys
@@ -101,6 +103,21 @@ def _task_wrapper(param):
     return task(value, *task_args, **task_kwargs)
 
 
+def should_run_in_parallel(num_processes: int | None = None) -> bool:
+    """Return whether the current parallelisation configuration suggests that we should run things
+    like :func:`parallel_map` in parallel (``True``) or degrade to serial (``False``).
+
+    Args:
+        num_processes: the number of processes requested for use (if given).
+    """
+    num_processes = CPU_COUNT if num_processes is None else num_processes
+    return (
+        num_processes > 1
+        and os.getenv("QISKIT_IN_PARALLEL", "FALSE") == "FALSE"
+        and CONFIG.get("parallel_enabled", PARALLEL_DEFAULT)
+    )
+
+
 def parallel_map(  # pylint: disable=dangerous-default-value
     task, values, task_args=(), task_kwargs={}, num_processes=CPU_COUNT
 ):
@@ -110,21 +127,20 @@ def parallel_map(  # pylint: disable=dangerous-default-value
 
         result = [task(value, *task_args, **task_kwargs) for value in values]
 
-    On Windows this function defaults to a serial implementation to avoid the
-    overhead from spawning processes in Windows.
+    This will parallelise the results if the number of ``values`` is greater than one and
+    :func:`should_run_in_parallel` returns ``True``.  If not, it will run in serial.
 
     Args:
         task (func): Function that is to be called for each value in ``values``.
-        values (array_like): List or array of values for which the ``task``
-                            function is to be evaluated.
+        values (array_like): List or array of values for which the ``task`` function is to be
+            evaluated.
         task_args (list): Optional additional arguments to the ``task`` function.
         task_kwargs (dict): Optional additional keyword argument to the ``task`` function.
         num_processes (int): Number of processes to spawn.
 
     Returns:
-        result: The result list contains the value of
-                ``task(value, *task_args, **task_kwargs)`` for
-                    each value in ``values``.
+        result: The result list contains the value of ``task(value, *task_args, **task_kwargs)`` for
+        each value in ``values``.
 
     Raises:
         QiskitError: If user interrupts via keyboard.
@@ -147,12 +163,7 @@ def parallel_map(  # pylint: disable=dangerous-default-value
     if len(values) == 1:
         return [task(values[0], *task_args, **task_kwargs)]
 
-    # Run in parallel if not Win and not in parallel already
-    if (
-        num_processes > 1
-        and os.getenv("QISKIT_IN_PARALLEL") == "FALSE"
-        and CONFIG.get("parallel_enabled", PARALLEL_DEFAULT)
-    ):
+    if should_run_in_parallel(num_processes):
         os.environ["QISKIT_IN_PARALLEL"] = "TRUE"
         try:
             results = []
@@ -173,8 +184,6 @@ def parallel_map(  # pylint: disable=dangerous-default-value
         os.environ["QISKIT_IN_PARALLEL"] = "FALSE"
         return results
 
-    # Cannot do parallel on Windows , if another parallel_map is running in parallel,
-    # or len(values) == 1.
     results = []
     for _, value in enumerate(values):
         result = task(value, *task_args, **task_kwargs)

--- a/qiskit/utils/parallel.py
+++ b/qiskit/utils/parallel.py
@@ -127,8 +127,8 @@ def parallel_map(  # pylint: disable=dangerous-default-value
 
         result = [task(value, *task_args, **task_kwargs) for value in values]
 
-    This will parallelise the results if the number of ``values`` is greater than one and
-    :func:`should_run_in_parallel` returns ``True``.  If not, it will run in serial.
+    This will parallelise the results if the number of ``values`` is greater than one, and the
+    current system configuration permits parallelization.
 
     Args:
         task (func): Function that is to be called for each value in ``values``.

--- a/releasenotes/notes/parallel-check-8186a8f074774a1f.yaml
+++ b/releasenotes/notes/parallel-check-8186a8f074774a1f.yaml
@@ -1,0 +1,11 @@
+---
+features_misc:
+  - |
+    A new function, :func:`qiskit.utils.should_run_in_parallel`, is available to determine whether
+    :func:`.parallel_map` will choose to run in parallel or degrade to running in serial.  This
+    decision is dependent on how many CPUs are available to Qiskit, what the :mod:`multiprocessing`
+    start method is, how many processes were requested.
+fixes:
+  - |
+    :meth:`.PassManager.run` will no longer waste time serializing itself when given multiple inputs
+    if it is only going to work in serial.

--- a/releasenotes/notes/parallel-check-8186a8f074774a1f.yaml
+++ b/releasenotes/notes/parallel-check-8186a8f074774a1f.yaml
@@ -1,10 +1,4 @@
 ---
-features_misc:
-  - |
-    A new function, :func:`qiskit.utils.should_run_in_parallel`, is available to determine whether
-    :func:`.parallel_map` will choose to run in parallel or degrade to running in serial.  This
-    decision is dependent on how many CPUs are available to Qiskit, what the :mod:`multiprocessing`
-    start method is, how many processes were requested.
 fixes:
   - |
     :meth:`.PassManager.run` will no longer waste time serializing itself when given multiple inputs


### PR DESCRIPTION
### Summary

This exposes the interal decision in `parallel_map` of whether to actually run in serial or not.  If not, there's no need for `PassManager` to side-car its `dill` serialisation onto the side of the IPC (we use `dill` because we need to pickle lambdas), which can be an unfortunately huge cost for certain IBM pulse-enabled backends.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

@sbrandhsn: as the release manager for 1.1.0, it's up to you whether you want to accept this PR in this form for 1.1.0, or defer to 1.1.1 (you can tag the milestone appropriately).  I could also suppress exporting `should_run_in_parallel` into the public namespace if you're not on board with a new public feature this late into the release cycle.