### PR TITLE
Add convert data

### DIFF
--- a/qiskit/converters/__init__.py
+++ b/qiskit/converters/__init__.py
@@ -23,23 +23,25 @@ QuantumCircuit -> circuit components
 .. autofunction:: circuit_to_instruction
 .. autofunction:: circuit_to_gate
 
-QuantumCircuit <-> DagCircuit 
+QuantumCircuit <-> DagCircuit
 =============================
 
 .. autofunction:: circuit_to_dag
 .. autofunction:: dag_to_circuit
 
-QuantumCircuit <-> DagDependency 
+QuantumCircuit <-> DagDependency
 ================================
 
 .. autofunction:: dagdependency_to_circuit
 .. autofunction:: circuit_to_dagdependency
 
-DagCircuit <-> DagDependency 
+DagCircuit <-> DagDependency
 ============================
 
 .. autofunction:: dag_to_dagdependency
 .. autofunction:: dagdependency_to_dag
+.. autofunction:: dag_to_dagdependency_with_data
+
 """
 
 from .circuit_to_dag import circuit_to_dag
@@ -48,7 +50,7 @@ from .circuit_to_instruction import circuit_to_instruction
 from .circuit_to_gate import circuit_to_gate
 from .circuit_to_dagdependency import circuit_to_dagdependency
 from .dagdependency_to_circuit import dagdependency_to_circuit
-from .dag_to_dagdependency import dag_to_dagdependency
+from .dag_to_dagdependency import dag_to_dagdependency, dag_to_dagdependency_with_data
 from .dagdependency_to_dag import dagdependency_to_dag
 
 

--- a/qiskit/converters/circuit_conversion_data.py
+++ b/qiskit/converters/circuit_conversion_data.py
@@ -17,8 +17,8 @@ class CircuitConversionData:
     """Conversion data when switching between different circuit formats."""
 
     def __init__(self):
-        self._fwd_map = dict()
-        self._bwd_map = dict()
+        self._fwd_map = {}
+        self._bwd_map = {}
 
     def store_mapping(self, from_node, to_node):
         """Stores that ``from_node`` is mapped to ``to_node``."""

--- a/qiskit/converters/circuit_conversion_data.py
+++ b/qiskit/converters/circuit_conversion_data.py
@@ -1,0 +1,34 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Stores optional conversion data when switching between different circuit formats."""
+
+
+class CircuitConversionData:
+    """Conversion data when switching between different circuit formats."""
+
+    def __init__(self):
+        self._fwd_map = dict()
+        self._bwd_map = dict()
+
+    def store_mapping(self, from_node, to_node):
+        """Stores that ``from_node`` is mapped to ``to_node``."""
+        self._fwd_map[from_node] = to_node
+        self._bwd_map[to_node] = from_node
+
+    def forward_map(self, from_node):
+        """Returns the node ``from_node`` was mapped to, or ``None`` if not present."""
+        return self._fwd_map.get(from_node, None)
+
+    def backward_map(self, to_node):
+        """Returns the node that was mapped to ``to_node``, or ``None`` if not present."""
+        return self._bwd_map.get(to_node, None)

--- a/qiskit/converters/dag_to_dagdependency.py
+++ b/qiskit/converters/dag_to_dagdependency.py
@@ -27,11 +27,11 @@ def dag_to_dagdependency_with_data(
         create_conversion_data (bool): whether to construct mappings
             between nodes in the input and the output circuits.
 
-    Return:
-        DAGDependency: the DAG representing the input circuit as a dag dependency.
-        CircuitConversionData: data storing mappings between nodes
-            in the input and the output circuits when ``create_conversion_data``
-            is ``True``, and ``None`` otherwise.
+    Returns:
+        A tuple consisting of the DAGDependency representation of the input
+        circuit and the additional data. This data stores mappings between
+        nodes in the input and the output circuits when ``create_conversion_data``
+        is ``True`` and ``None`` otherwise.
 
     """
     conversion_data = CircuitConversionData() if create_conversion_data else None

--- a/qiskit/converters/dag_to_dagdependency.py
+++ b/qiskit/converters/dag_to_dagdependency.py
@@ -11,8 +11,8 @@
 # that they have been altered from the originals.
 
 """Helper function for converting a dag circuit to a dag dependency"""
-from .circuit_conversion_data import CircuitConversionData
 from qiskit.dagcircuit.dagdependency import DAGDependency
+from .circuit_conversion_data import CircuitConversionData
 
 
 def dag_to_dagdependency_with_data(
@@ -78,7 +78,7 @@ def dag_to_dagdependency(dag, create_preds_and_succs=True):
     Return:
         DAGDependency: the DAG representing the input circuit as a dag dependency.
     """
-    dagdependency, conversion_data = dag_to_dagdependency_with_data(
+    dagdependency, _ = dag_to_dagdependency_with_data(
         dag, create_preds_and_succs=create_preds_and_succs
     )
     return dagdependency

--- a/qiskit/converters/dag_to_dagdependency_v2.py
+++ b/qiskit/converters/dag_to_dagdependency_v2.py
@@ -12,17 +12,26 @@
 
 """Helper function for converting a dag circuit to a dag dependency"""
 from qiskit.dagcircuit.dagdependency_v2 import _DAGDependencyV2
+from .circuit_conversion_data import CircuitConversionData
 
 
-def _dag_to_dagdependency_v2(dag):
+def _dag_to_dagdependency_v2_with_data(dag, *, create_conversion_data=False):
     """Build a ``_DAGDependencyV2`` object from a ``DAGCircuit``.
 
     Args:
         dag (DAGCircuit): the input dag.
+        create_conversion_data (bool): whether to construct mappings
+            between nodes in the input and the output circuits.
 
     Return:
         _DAGDependencyV2: the DAG representing the input circuit as a dag dependency.
+        CircuitConversionData: data storing mappings between nodes
+            in the input and the output circuits when ``create_conversion_data``
+            is ``True``, and ``None`` otherwise.
+
     """
+    conversion_data = CircuitConversionData() if create_conversion_data else None
+
     dagdependency = _DAGDependencyV2()
     dagdependency.name = dag.name
     dagdependency.metadata = dag.metadata
@@ -38,7 +47,24 @@ def _dag_to_dagdependency_v2(dag):
     for register in dag.cregs.values():
         dagdependency.add_creg(register)
 
-    for node in dag.topological_op_nodes():
-        dagdependency.apply_operation_back(node.op.copy(), node.qargs, node.cargs)
+    for in_node in dag.topological_op_nodes():
+        out_node = dagdependency.apply_operation_back(
+            in_node.op.copy(), in_node.qargs, in_node.cargs
+        )
+        if create_conversion_data:
+            conversion_data.store_mapping(in_node, out_node)
 
+    return dagdependency, conversion_data
+
+
+def _dag_to_dagdependency_v2(dag):
+    """Build a ``_DAGDependencyV2`` object from a ``DAGCircuit``.
+
+    Args:
+        dag (DAGCircuit): the input dag.
+
+    Return:
+        _DAGDependencyV2: the DAG representing the input circuit as a dag dependency.
+    """
+    dagdependency, _ = _dag_to_dagdependency_v2_with_data(dag)
     return dagdependency

--- a/qiskit/converters/dag_to_dagdependency_v2.py
+++ b/qiskit/converters/dag_to_dagdependency_v2.py
@@ -23,11 +23,11 @@ def _dag_to_dagdependency_v2_with_data(dag, *, create_conversion_data=False):
         create_conversion_data (bool): whether to construct mappings
             between nodes in the input and the output circuits.
 
-    Return:
-        _DAGDependencyV2: the DAG representing the input circuit as a dag dependency.
-        CircuitConversionData: data storing mappings between nodes
-            in the input and the output circuits when ``create_conversion_data``
-            is ``True``, and ``None`` otherwise.
+    Returns:
+        A tuple consisting of the DAGDependency representation of the input
+        circuit and the additional data. This data stores mappings between
+        nodes in the input and the output circuits when ``create_conversion_data``
+        is ``True`` and ``None`` otherwise.
 
     """
     conversion_data = CircuitConversionData() if create_conversion_data else None

--- a/qiskit/dagcircuit/dagdependency.py
+++ b/qiskit/dagcircuit/dagdependency.py
@@ -430,10 +430,14 @@ class DAGDependency:
             operation (qiskit.circuit.Operation): operation as a quantum gate
             qargs (list[~qiskit.circuit.Qubit]): list of qubits on which the operation acts
             cargs (list[Clbit]): list of classical wires to attach to
+
+        Returns:
+            DAGDepNode: the newly added node.
         """
         new_node = self._create_op_node(operation, qargs, cargs)
         self._add_multi_graph_node(new_node)
         self._update_edges()
+        return new_node
 
     def _update_edges(self):
         """

--- a/qiskit/dagcircuit/dagdependency_v2.py
+++ b/qiskit/dagcircuit/dagdependency_v2.py
@@ -339,6 +339,9 @@ class _DAGDependencyV2:
             operation (qiskit.circuit.Operation): operation as a quantum gate
             qargs (list[~qiskit.circuit.Qubit]): list of qubits on which the operation acts
             cargs (list[Clbit]): list of classical wires to attach to
+
+        Returns:
+            DAGOpNode: the newly appended node
         """
         new_node = DAGOpNode(
             op=operation,
@@ -349,6 +352,7 @@ class _DAGDependencyV2:
         new_node._node_id = self._multi_graph.add_node(new_node)
         self._update_edges()
         self._increment_op(new_node.op)
+        return new_node
 
     def _update_edges(self):
         """

--- a/releasenotes/notes/add-dagcircuit-to-dagdependency-mapping-bf114a4a6c5cbc2f.yaml
+++ b/releasenotes/notes/add-dagcircuit-to-dagdependency-mapping-bf114a4a6c5cbc2f.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    The :meth:`.DAGDependency.add_op_node` method now returns the newly added node.
+  - |
+    Added a new class :class:`.CircuitConversionData` to return additional information when
+    switching between :class:`.DAGCircuit` and :class:`.DAGDependency` circuit representations,
+    such as the mappings between the nodes in :class:`.DAGCircuit` and :class:`.DAGDependency`.
+  - |
+    Added a new function :func:`dag_to_dagdependency_with_data` that converts a
+    :class:`.DAGCircuit` to :class:`.DAGDependency` and returns both the constructed
+    circuit and a :class:`.CircuitConversionData` object with the additional information
+    related to the translation.

--- a/test/python/converters/test_dag_to_dagdependency.py
+++ b/test/python/converters/test_dag_to_dagdependency.py
@@ -84,6 +84,24 @@ class TestCircuitToDagDependency(QiskitTestCase):
         dag_out = dagdependency_to_dag(dag_dependency)
         self.assertEqual(dag_out.metadata, meta_dict)
 
+    def test_conversion_data_not_created_by_default(self):
+        """Test that conversion data is not created by default."""
+        qr = QuantumRegister(3)
+        cr = ClassicalRegister(3)
+        circuit_in = QuantumCircuit(qr, cr)
+        circuit_in.h(qr[0])
+        circuit_in.h(qr[1])
+        circuit_in.measure(qr[0], cr[0])
+        circuit_in.measure(qr[1], cr[1])
+        circuit_in.x(qr[0]).c_if(cr, 0x3)
+        circuit_in.measure(qr[0], cr[0])
+        circuit_in.measure(qr[1], cr[1])
+        circuit_in.measure(qr[2], cr[2])
+        dag_in = circuit_to_dag(circuit_in)
+
+        _, conversion_data = dag_to_dagdependency_with_data(dag_in)
+        self.assertIsNone(conversion_data)
+
     def test_conversion_data(self):
         """Test that conversion data is created and is correct when
         ``create_conversion_data`` is ``True``.
@@ -101,9 +119,7 @@ class TestCircuitToDagDependency(QiskitTestCase):
         circuit_in.measure(qr[2], cr[2])
         dag_in = circuit_to_dag(circuit_in)
 
-        dag_dependency, conversion_data = dag_to_dagdependency_with_data(
-            dag_in, create_conversion_data=True
-        )
+        _, conversion_data = dag_to_dagdependency_with_data(dag_in, create_conversion_data=True)
         self.assertIsNotNone(conversion_data)
 
         # Check that mapping an op_node first forward and then backward gives back the same node.
@@ -112,24 +128,6 @@ class TestCircuitToDagDependency(QiskitTestCase):
             self.assertIsNotNone(out_node)
             in_out_node = conversion_data.backward_map(out_node)
             self.assertEqual(in_node, in_out_node)
-
-    def test_conversion_data_not_created_by_default(self):
-        """Test that conversion data is not created by default."""
-        qr = QuantumRegister(3)
-        cr = ClassicalRegister(3)
-        circuit_in = QuantumCircuit(qr, cr)
-        circuit_in.h(qr[0])
-        circuit_in.h(qr[1])
-        circuit_in.measure(qr[0], cr[0])
-        circuit_in.measure(qr[1], cr[1])
-        circuit_in.x(qr[0]).c_if(cr, 0x3)
-        circuit_in.measure(qr[0], cr[0])
-        circuit_in.measure(qr[1], cr[1])
-        circuit_in.measure(qr[2], cr[2])
-        dag_in = circuit_to_dag(circuit_in)
-
-        dag_dependency, conversion_data = dag_to_dagdependency_with_data(dag_in)
-        self.assertIsNone(conversion_data)
 
 
 if __name__ == "__main__":

--- a/test/python/converters/test_dag_to_dagdependency_v2.py
+++ b/test/python/converters/test_dag_to_dagdependency_v2.py
@@ -16,7 +16,10 @@ dag circuit to dag dependency."""
 import unittest
 
 from qiskit.converters.circuit_to_dag import circuit_to_dag
-from qiskit.converters.dag_to_dagdependency_v2 import _dag_to_dagdependency_v2
+from qiskit.converters.dag_to_dagdependency_v2 import (
+    _dag_to_dagdependency_v2,
+    _dag_to_dagdependency_v2_with_data,
+)
 from qiskit.converters.dagdependency_to_dag import dagdependency_to_dag
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
@@ -59,6 +62,51 @@ class TestCircuitToDagDependencyV2(QiskitTestCase):
         self.assertEqual(dag_dependency.metadata, meta_dict)
         dag_out = dagdependency_to_dag(dag_dependency)
         self.assertEqual(dag_out.metadata, meta_dict)
+
+    def test_conversion_data_not_created_by_default(self):
+        """Test that conversion data is not created by default."""
+        qr = QuantumRegister(3)
+        cr = ClassicalRegister(3)
+        circuit_in = QuantumCircuit(qr, cr)
+        circuit_in.h(qr[0])
+        circuit_in.h(qr[1])
+        circuit_in.measure(qr[0], cr[0])
+        circuit_in.measure(qr[1], cr[1])
+        circuit_in.x(qr[0]).c_if(cr, 0x3)
+        circuit_in.measure(qr[0], cr[0])
+        circuit_in.measure(qr[1], cr[1])
+        circuit_in.measure(qr[2], cr[2])
+        dag_in = circuit_to_dag(circuit_in)
+
+        _, conversion_data = _dag_to_dagdependency_v2_with_data(dag_in)
+        self.assertIsNone(conversion_data)
+
+    def test_conversion_data(self):
+        """Test that conversion data is created and is correct when
+        ``create_conversion_data`` is ``True``.
+        """
+        qr = QuantumRegister(3)
+        cr = ClassicalRegister(3)
+        circuit_in = QuantumCircuit(qr, cr)
+        circuit_in.h(qr[0])
+        circuit_in.h(qr[1])
+        circuit_in.measure(qr[0], cr[0])
+        circuit_in.measure(qr[1], cr[1])
+        circuit_in.x(qr[0]).c_if(cr, 0x3)
+        circuit_in.measure(qr[0], cr[0])
+        circuit_in.measure(qr[1], cr[1])
+        circuit_in.measure(qr[2], cr[2])
+        dag_in = circuit_to_dag(circuit_in)
+
+        _, conversion_data = _dag_to_dagdependency_v2_with_data(dag_in, create_conversion_data=True)
+        self.assertIsNotNone(conversion_data)
+
+        # Check that mapping an op_node first forward and then backward gives back the same node.
+        for in_node in dag_in.op_nodes():
+            out_node = conversion_data.forward_map(in_node)
+            self.assertIsNotNone(out_node)
+            in_out_node = conversion_data.backward_map(out_node)
+            self.assertEqual(in_node, in_out_node)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

When converting from a `DAGCircuit` to a `DAGDependency`, in some cases it would be useful to compute and return additional information related to this conversion, such as the mappings between the input `DAGOpNode`s and the output `DAGDepNode`s. In particular, this would allow analysis passes that translate a `DAGCircuit` to a `DAGDependency`, collect blocks of nodes from the `DAGDependency` (exploiting the commutativity information offered by the latter structure), find the lists of corresponding nodes in the origin `DAGCircuit` and (for example) resynthesize these nodes. A direct application would be to extend the new `StarPreRouting` pass to collect and resynthesize "star-shaped" pieces of the circuit while also exploiting the commutativity between the nodes.

This PR adds a new class `CircuitConversionData` that stores the mappings and extends the conversion functions to `dag_to_dagdependency_with_data` and `_dag_to_dagdependency_v2_with_data` (all of the code pertaining to `DAGDependency_V2` is private for now).

The reason that `CircuitConversionData` is a class rather than a mapping is that we might want to store more information in the future, and we would not need to keep extending the API. And it would also probably be easier to convert this to Rust in the future. 

I am wondering whether I should make the class `CircuitConversionData` also private or also extend other circuit converters such as `circuit_to_dagcircuit`, etc. What do you think?


