### PR TITLE
Add merge queue to required tests on github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main, 'stable/*' ]
   pull_request:
     branches: [ main, 'stable/*' ]
+  merge_group:
 
 concurrency:
   group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds the missing config to the github actions workflow for running required tests (currently only arm64 macOS test jobs) to the merge queue. This is necessary to make the job required in the branch protection rules, because the jobs will need to pass as part of the merge queue too.

### Details and comments