### PR TITLE
Fix `QuantumCircuit.depth` with zero-operands and `Expr` nodes

### DIFF
--- a/releasenotes/notes/fix-qc-depth-0q-cdcc9aa14e237e68.yaml
+++ b/releasenotes/notes/fix-qc-depth-0q-cdcc9aa14e237e68.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    :meth:`.QuantumCircuit.depth` will now correctly handle operations that
+    do not have operands, such as :class:`.GlobalPhaseGate`.
+  - |
+    :meth:`.QuantumCircuit.depth` will now count the variables and clbits
+    used in real-time expressions as part of the depth calculation.


### PR DESCRIPTION
### Summary

This causes `QuantumCircuit.depth` to correctly handle cases where a circuit instruction has zero operands (such as `GlobalPhaseGate`), and to treat classical bits and real-time variables used inside `Expr` conditions as part of the depth calculations.  This is in line with `DAGCircuit`.

This commit still does not add the same `recurse` argument from `DAGCircuit.depth`, because the arguments for not adding it to `QuantumCircuit.depth` at the time still hold; there is no clear meaning to it for general control flow from a user's perspective, and it was only added to the `DAGCircuit` methods because there it is more of a proxy for optimising over all possible inner blocks.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #12426.
