### PR TITLE
Check for gate parameter

### DIFF
--- a/qiskit/transpiler/passes/calibration/pulse_gate.py
+++ b/qiskit/transpiler/passes/calibration/pulse_gate.py
@@ -100,5 +100,3 @@ class PulseGates(CalibrationBuilder):
         return self.target.get_calibration(
             node_op.name, tuple(qubits), operation_params=None, *node_op.params
         )
-
-

--- a/qiskit/transpiler/passes/calibration/pulse_gate.py
+++ b/qiskit/transpiler/passes/calibration/pulse_gate.py
@@ -97,6 +97,4 @@ class PulseGates(CalibrationBuilder):
         Raises:
             TranspilerError: When node is parameterized and calibration is raw schedule object.
         """
-        return self.target.get_calibration(
-            node_op.name, tuple(qubits), operation_params=None, *node_op.params
-        )
+        return self.target.get_calibration(node_op.name, tuple(qubits), *node_op.params)

--- a/qiskit/transpiler/passes/calibration/pulse_gate.py
+++ b/qiskit/transpiler/passes/calibration/pulse_gate.py
@@ -97,4 +97,8 @@ class PulseGates(CalibrationBuilder):
         Raises:
             TranspilerError: When node is parameterized and calibration is raw schedule object.
         """
-        return self.target._get_calibration(node_op.name, tuple(qubits), *node_op.params)
+        return self.target.get_calibration(
+            node_op.name, tuple(qubits), operation_params=None, *node_op.params
+        )
+
+

--- a/qiskit/transpiler/passes/calibration/pulse_gate.py
+++ b/qiskit/transpiler/passes/calibration/pulse_gate.py
@@ -97,4 +97,4 @@ class PulseGates(CalibrationBuilder):
         Raises:
             TranspilerError: When node is parameterized and calibration is raw schedule object.
         """
-        return self.target.get_calibration(node_op.name, tuple(qubits), *node_op.params)
+        return self.target._get_calibration(node_op.name, tuple(qubits), *node_op.params)

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -676,10 +676,9 @@ class Target(BaseTarget):
     def _has_calibration(
         self,
         operation_name: str,
-        qargs: tuple[int, ...] | list[int, ...],
+        qargs: tuple[int, ...],
         operation_params: list[float] | float | None = None,
     ) -> bool:
-        qargs = tuple(qargs)
         if operation_params is not None and not isinstance(operation_params, list):
             operation_params = [operation_params]
 
@@ -734,7 +733,6 @@ class Target(BaseTarget):
         operation_params: list[float] | float | None = None,
         **kwargs: ParameterValueType,
     ) -> Schedule | ScheduleBlock:
-        qargs = tuple(qargs)
         if not self._has_calibration(operation_name, qargs, operation_params):
             raise KeyError(
                 f"Calibration of instruction: `{operation_name}`, with params: "

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -687,9 +687,8 @@ class Target(BaseTarget):
         if qargs not in self._gate_map[operation_name]:
             return False
 
-        if (
-            operation_params is not None
-            and operation_params not in self._gate_name_map[operation_name].params
+        if operation_params is not None and not (
+            operation_params == self._gate_name_map[operation_name].params
         ):
             return False
 
@@ -733,7 +732,8 @@ class Target(BaseTarget):
     ) -> Schedule | ScheduleBlock:
         if not self._has_calibration(operation_name, qargs, operation_params):
             raise KeyError(
-                f"Calibration of instruction {operation_name} for qubit {qargs} is not defined."
+                f"Calibration of instruction: `{operation_name}`, with params: "
+                f"`{operation_params}` for qubit: {qargs} is not defined."
             )
         cal_entry = getattr(self._gate_map[operation_name][qargs], "_calibration")
         return cal_entry.get_schedule(*args, **kwargs)

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -662,6 +662,7 @@ class Target(BaseTarget):
         Args:
             operation_name: The name of the operation for the instruction.
             qargs: The tuple of qubit indices for the instruction.
+            operation_params: The parameters for the Instruction.
 
         Returns:
             Returns ``True`` if the calibration is supported and ``False`` if it isn't.
@@ -678,6 +679,10 @@ class Target(BaseTarget):
             return False
         if qargs not in self._gate_map[operation_name]:
             return False
+
+        if operation_params is not None and operation_params not in self._gate_name_map[operation_name].params:
+            return False
+
         return getattr(self._gate_map[operation_name][qargs], "_calibration", None) is not None
 
     @deprecate_pulse_dependency
@@ -702,7 +707,9 @@ class Target(BaseTarget):
         Returns:
             Calibrated pulse schedule of corresponding instruction.
         """
-        return self._get_calibration(operation_name, qargs, *args, *kwargs)
+        return self._get_calibration(
+            operation_name, qargs, *args, operation_params=operation_params, **kwargs
+        )
 
     def _get_calibration(
         self,

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -655,7 +655,7 @@ class Target(BaseTarget):
     def has_calibration(
         self,
         operation_name: str,
-        qargs: tuple[int, ...] | list[int, ...],
+        qargs: tuple[int, ...],
         operation_params: list[float] | float | None = None,
     ) -> bool:
         """Return whether the instruction (operation + operation_params + qubits) defines
@@ -664,7 +664,9 @@ class Target(BaseTarget):
         Args:
             operation_name: The name of the operation for the instruction.
             qargs: The qubit indices for the instruction.
-            operation_params: The parameters for the Instruction.
+            operation_params: The parameters for the Instruction. In case
+            of multi-parameter gates, the order of parameters in the tuple
+            must match the order of the gate parameters.
 
         Returns:
             Returns ``True`` if the calibration is supported and ``False`` if it isn't.
@@ -698,7 +700,7 @@ class Target(BaseTarget):
     def get_calibration(
         self,
         operation_name: str,
-        qargs: tuple[int, ...] | list[int, ...],
+        qargs: tuple[int, ...],
         *args: ParameterValueType,
         operation_params: list[float] | float | None = None,
         **kwargs: ParameterValueType,
@@ -712,7 +714,9 @@ class Target(BaseTarget):
             operation_name: The name of the operation for the instruction.
             qargs: The qubit indices for the instruction.
             args: Parameter values to build schedule if any.
-            operation_params: The parameters for the Instruction.
+            operation_params: The parameters for the Instruction. In case
+            of multi-parameter gate, the order of parameters in the tuple
+            must match the order of the gate parameters.
             kwargs: Parameter values with name to build schedule if any.
 
         Returns:
@@ -725,7 +729,7 @@ class Target(BaseTarget):
     def _get_calibration(
         self,
         operation_name: str,
-        qargs: tuple[int, ...] | list[int, ...],
+        qargs: tuple[int, ...],
         *args: ParameterValueType,
         operation_params: list[float] | float | None = None,
         **kwargs: ParameterValueType,

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -655,7 +655,7 @@ class Target(BaseTarget):
     def has_calibration(
         self,
         operation_name: str,
-        qargs: tuple[int, ...],
+        qargs: tuple[int, ...] | list[int, ...],
         operation_params: list[float] | float | None = None,
     ) -> bool:
         """Return whether the instruction (operation + operation_params + qubits) defines
@@ -663,7 +663,7 @@ class Target(BaseTarget):
 
         Args:
             operation_name: The name of the operation for the instruction.
-            qargs: The tuple of qubit indices for the instruction.
+            qargs: The qubit indices for the instruction.
             operation_params: The parameters for the Instruction.
 
         Returns:
@@ -674,7 +674,7 @@ class Target(BaseTarget):
     def _has_calibration(
         self,
         operation_name: str,
-        qargs: tuple[int, ...],
+        qargs: tuple[int, ...] | list[int, ...],
         operation_params: list[float] | float | None = None,
     ) -> bool:
         qargs = tuple(qargs)
@@ -698,7 +698,7 @@ class Target(BaseTarget):
     def get_calibration(
         self,
         operation_name: str,
-        qargs: tuple[int, ...],
+        qargs: tuple[int, ...] | list[int, ...],
         *args: ParameterValueType,
         operation_params: list[float] | float | None = None,
         **kwargs: ParameterValueType,
@@ -710,7 +710,7 @@ class Target(BaseTarget):
 
         Args:
             operation_name: The name of the operation for the instruction.
-            qargs: The tuple of qubit indices for the instruction.
+            qargs: The qubit indices for the instruction.
             args: Parameter values to build schedule if any.
             operation_params: The parameters for the Instruction.
             kwargs: Parameter values with name to build schedule if any.
@@ -725,11 +725,12 @@ class Target(BaseTarget):
     def _get_calibration(
         self,
         operation_name: str,
-        qargs: tuple[int, ...],
+        qargs: tuple[int, ...] | list[int, ...],
         *args: ParameterValueType,
         operation_params: list[float] | float | None = None,
         **kwargs: ParameterValueType,
     ) -> Schedule | ScheduleBlock:
+        qargs = tuple(qargs)
         if not self._has_calibration(operation_name, qargs, operation_params):
             raise KeyError(
                 f"Calibration of instruction: `{operation_name}`, with params: "

--- a/releasenotes/notes/Fixed-param-gate-target-has-and-get_calibration-d2b9e38d63592b3c.yaml
+++ b/releasenotes/notes/Fixed-param-gate-target-has-and-get_calibration-d2b9e38d63592b3c.yaml
@@ -1,8 +1,8 @@
 ---
 fixes:
   - |
-    Fixes an issue with :func:`Target.has_calibration` and :func:`Target.get_calibration` 
+    Fixed an issue with :func:`Target.has_calibration` and :func:`Target.get_calibration` 
     when passed with a parameterized Gate doesn't work as expected.
-    Refer to `qiskit/#11657 <https://github.com/Qiskit/qiskit/issues/11657>` and, 
-    `qiskit/#11658 <https://github.com/Qiskit/qiskit/issues/11658>` for more information.
+    Refer to `qiskit/#11657 <https://github.com/Qiskit/qiskit/issues/11657>`__ and, 
+    `qiskit/#11658 <https://github.com/Qiskit/qiskit/issues/11658>`__ for more information.
 

--- a/releasenotes/notes/Fixed-param-gate-target-has-and-get_calibration-d2b9e38d63592b3c.yaml
+++ b/releasenotes/notes/Fixed-param-gate-target-has-and-get_calibration-d2b9e38d63592b3c.yaml
@@ -1,8 +1,8 @@
 ---
 fixes:
   - |
-    Fixed an issue with :func:`Target.has_calibration` and :func:`Target.get_calibration` 
-    when passed with a parameterized Gate doesn't work as expected.
+    Fixed an issue with :meth:`.Target.has_calibration` and :meth:`.Target.get_calibration` 
+    where passing a parameterized Gate doesn't work as expected.
     Refer to `qiskit/#11657 <https://github.com/Qiskit/qiskit/issues/11657>`__ and, 
     `qiskit/#11658 <https://github.com/Qiskit/qiskit/issues/11658>`__ for more information.
 

--- a/releasenotes/notes/Fixed-param-gate-target-has-and-get_calibration-d2b9e38d63592b3c.yaml
+++ b/releasenotes/notes/Fixed-param-gate-target-has-and-get_calibration-d2b9e38d63592b3c.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixes an issue with :func:`Target.has_calibration` and :func:`Target.get_calibration` 
+    when passed with a parameterized Gate doesn't work as expected.
+    Refer to `qiskit/#11657 <https://github.com/Qiskit/qiskit/issues/11657>` and, 
+    `qiskit/#11658 <https://github.com/Qiskit/qiskit/issues/11658>` for more information.
+

--- a/test/python/transpiler/test_pulse_gate_pass.py
+++ b/test/python/transpiler/test_pulse_gate_pass.py
@@ -159,8 +159,6 @@ class TestPulseGate(QiskitTestCase):
         qc.sx(1)
         qc.measure_all()
 
-        transpiled_qc = transpile(qc, initial_layout=[0, 1], target=target)
-
         ref_calibration = {
             "sx": {
                 ((0,), ()): self.custom_sx_q0,
@@ -168,6 +166,7 @@ class TestPulseGate(QiskitTestCase):
             }
         }
         with self.assertWarns(DeprecationWarning):
+            transpiled_qc = transpile(qc, initial_layout=[0, 1], target=target)
             self.assertDictEqual(transpiled_qc.calibrations, ref_calibration)
 
     def test_transpile_with_instmap(self):

--- a/test/python/transpiler/test_pulse_gate_pass.py
+++ b/test/python/transpiler/test_pulse_gate_pass.py
@@ -165,8 +165,8 @@ class TestPulseGate(QiskitTestCase):
                 ((1,), ()): self.custom_sx_q1,
             }
         }
+        transpiled_qc = transpile(qc, initial_layout=[0, 1], target=target)
         with self.assertWarns(DeprecationWarning):
-            transpiled_qc = transpile(qc, initial_layout=[0, 1], target=target)
             self.assertDictEqual(transpiled_qc.calibrations, ref_calibration)
 
     def test_transpile_with_instmap(self):

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -1485,8 +1485,9 @@ Instructions:
 
 class TestHasCalibrationAndGetCalibration(QiskitTestCase):
     """
-    This test is to make sure meth:`.has_calibration` and meth:`.get_schedule`
-    works for parameterized gates.
+    This test is to make sure :func:`Target.has_calibration` and 
+    :func:`Target.get_schedule` works for parameterized gates.
+
     Follow below mentiond issues for more information.
     Refer to `#11657 <https://github.com/Qiskit/qiskit/issues/11657>`
     and, `#11658 <https://github.com/Qiskit/qiskit/issues/11658>`

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -1489,8 +1489,8 @@ class TestHasCalibrationAndGetCalibration(QiskitTestCase):
     :func:`Target.get_schedule` works for parameterized gates.
 
     Follow below mentiond issues for more information.
-    Refer to `#11657 <https://github.com/Qiskit/qiskit/issues/11657>`
-    and, `#11658 <https://github.com/Qiskit/qiskit/issues/11658>`
+    Refer to `#11657 <https://github.com/Qiskit/qiskit/issues/11657>`__
+    and, `#11658 <https://github.com/Qiskit/qiskit/issues/11658>`__
     """
 
     def setUp(self):
@@ -1503,49 +1503,60 @@ class TestHasCalibrationAndGetCalibration(QiskitTestCase):
         self.target = Target()
 
         # Setting an arbitrary Pulse Schedule just for the sake of testing.
-        self.calibration = pulse.Schedule(
-            pulse.Play(
-                pulse.Drag(
-                    duration=1700, amp=self.amp, sigma=self.sigma, beta=self.beta, angle=0.3
+        with self.assertWarns(DeprecationWarning):
+            self.calibration = pulse.Schedule(
+                pulse.Play(
+                    pulse.Drag(
+                        duration=1700, amp=self.amp, sigma=self.sigma, beta=self.beta, angle=0.3
+                    ),
+                    pulse.channels.DriveChannel(0),
                 ),
-                pulse.channels.DriveChannel(0),
-            ),
-            name="my_test_schedule",
-        )
-        rx_props = {
-            (0,): InstructionProperties(duration=1700, error=1.2e-6, calibration=self.calibration)
-        }
-        self.target.add_instruction(RXGate(self.theta), rx_props)
+                name="my_test_schedule",
+            )
+
+            rx_props = {
+                (0,): InstructionProperties(
+                    duration=1700, error=1.2e-6, calibration=self.calibration
+                )
+            }
+            self.target.add_instruction(RXGate(self.theta), rx_props)
 
     def test_has_calibration_for_oper_with_right_param(self):
-        self.assertTrue(
-            self.target.has_calibration(
-                operation_name="rx", qargs=(0,), operation_params=self.theta
+        with self.assertWarns(DeprecationWarning):
+            self.assertTrue(
+                self.target.has_calibration(
+                    operation_name="rx", qargs=(0,), operation_params=self.theta
+                )
             )
-        )
 
     def test_has_calibration_for_oper_with_wrong_param(self):
-        self.assertFalse(
-            self.target.has_calibration(operation_name="rx", qargs=(0,), operation_params=0.55)
-        )
+        with self.assertWarns(DeprecationWarning):
+            self.assertFalse(
+                self.target.has_calibration(operation_name="rx", qargs=(0,), operation_params=0.55)
+            )
 
     def test_get_calibration_raise_oper_with_wrong_param(self):
-        with self.assertRaisesRegex(KeyError, ".is not defined."):
-            self.target.get_calibration(operation_name="rx", qargs=(0,), operation_params=0.55)
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaisesRegex(KeyError, ".is not defined."):
+                self.target.get_calibration(operation_name="rx", qargs=(0,), operation_params=0.55)
 
     def test_get_calibration_for_oper_with_param(self):
-        self.assertEqual(
-            self.target.get_calibration(
-                operation_name="rx", qargs=(0,), operation_params=self.theta
-            ).name,
-            "my_test_schedule",
-        )
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(
+                self.target.get_calibration(
+                    operation_name="rx", qargs=(0,), operation_params=self.theta
+                ).name,
+                "my_test_schedule",
+            )
 
     def test_get_calibration_for_oper_with_param_pulse_with_param(self):
         args = {0.23, 0.123, 0.2}
-        self.assertFalse(
-            self.target.get_calibration("rx", (0,), self.theta, *args).is_parameterized()
-        )
+        with self.assertWarns(DeprecationWarning):
+            self.assertFalse(
+                self.target.get_calibration(
+                    "rx", (0,), operation_params=self.theta, *args
+                ).is_parameterized()
+            )
 
 
 class TestGlobalVariableWidthOperations(QiskitTestCase):

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -1485,7 +1485,7 @@ Instructions:
 
 class TestHasCalibrationAndGetCalibration(QiskitTestCase):
     """
-    This test is to make sure :func:`Target.has_calibration` and 
+    This test is to make sure :func:`Target.has_calibration` and
     :func:`Target.get_schedule` works for parameterized gates.
 
     Follow below mentiond issues for more information.

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -1483,6 +1483,70 @@ Instructions:
         self.assertSetEqual(names_before, names_after)
 
 
+class TestHasCalibrationAndGetCalibration(QiskitTestCase):
+    """
+    This test is to make sure meth:`.has_calibration` and meth:`.get_schedule`
+    works for parameterized gates.
+    Follow below mentiond issues for more information.
+    Refer to `#11657 <https://github.com/Qiskit/qiskit/issues/11657>`
+    and, `#11658 <https://github.com/Qiskit/qiskit/issues/11658>`
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.theta = Parameter("theta")
+        self.amp = Parameter("amp")
+        self.sigma = Parameter("sigma")
+        self.beta = Parameter("beta")
+
+        self.target = Target()
+
+        # Setting an arbitrary Pulse Schedule just for the sake of testing.
+        self.calibration = pulse.Schedule(
+            pulse.Play(
+                pulse.Drag(
+                    duration=1700, amp=self.amp, sigma=self.sigma, beta=self.beta, angle=0.3
+                ),
+                pulse.channels.DriveChannel(0),
+            ),
+            name="my_test_schedule",
+        )
+        rx_props = {
+            (0,): InstructionProperties(duration=1700, error=1.2e-6, calibration=self.calibration)
+        }
+        self.target.add_instruction(RXGate(self.theta), rx_props)
+
+    def test_has_calibration_for_oper_with_right_param(self):
+        self.assertTrue(
+            self.target.has_calibration(
+                operation_name="rx", qargs=(0,), operation_params=self.theta
+            )
+        )
+
+    def test_has_calibration_for_oper_with_wrong_param(self):
+        self.assertFalse(
+            self.target.has_calibration(operation_name="rx", qargs=(0,), operation_params=0.55)
+        )
+
+    def test_get_calibration_raise_oper_with_wrong_param(self):
+        with self.assertRaisesRegex(KeyError, ".is not defined."):
+            self.target.get_calibration(operation_name="rx", qargs=(0,), operation_params=0.55)
+
+    def test_get_calibration_for_oper_with_param(self):
+        self.assertEqual(
+            self.target.get_calibration(
+                operation_name="rx", qargs=(0,), operation_params=self.theta
+            ).name,
+            "my_test_schedule",
+        )
+
+    def test_get_calibration_for_oper_with_param_pulse_with_param(self):
+        args = {0.23, 0.123, 0.2}
+        self.assertFalse(
+            self.target.get_calibration("rx", (0,), self.theta, *args).is_parameterized()
+        )
+
+
 class TestGlobalVariableWidthOperations(QiskitTestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR aims to fix an issue with`Target.has_calibration()` and `Target.get_calibration()` when passed with parameterized gates didn't work as expected.

Refer to issues for more information.
#11658 
#11657 



### Details and comments



To be precise, `Target.has_calibration()` didn't check if the calibration if present is present for a particular gate with a particular parameter,
and,
`Target.get_calibration()` didn't get the calibration for the gate if present is present for a particular gate with a particular parameter, when passed as a parameter as `args`, the method tried to bind this `args` with a parameter in the schedule, which was not the intention of this particular `args`.

So, the signature of `Target.has_calibration` includes a new argument `operation_params` which has to be passed with the parameter of the `Gate` if the Gate is parameterized.

Similarly, the signature of `Target.get_calibration` also includes a new argument `operation_params` which has to be passed with the parameter of the `Gate` if the Gate is parameterized. In the case of `args` argument in this function, it should be passed with the values to be bound with the parameter of the schedule which has been attached to this particular gate as its calibration.

fixes #11658 
fixes #11657 