### PR TITLE
Remove the duplicated docs for a `BackendV1` classmethod

### DIFF
--- a/qiskit/providers/backend.py
+++ b/qiskit/providers/backend.py
@@ -88,12 +88,6 @@ class BackendV1(Backend, ABC):
             This next bit is necessary just because autosummary generally won't summarise private
             methods; changing that behaviour would have annoying knock-on effects through all the
             rest of the documentation, so instead we just hard-code the automethod directive.
-
-        In addition to the public abstract methods, subclasses should also implement the following
-        private methods:
-
-        .. automethod:: _default_options
-           :noindex:
         """
         self._configuration = configuration
         self._options = self._default_options()


### PR DESCRIPTION
The `BackendV1` [page](https://docs.quantum.ibm.com/api/qiskit/qiskit.providers.BackendV1#_default_options) has a duplicated entry for the `_default_options()` method as we can see in this screenshot highlight it with two red arrows.

![323689526-2d78f5f6-ab3f-402c-a53d-d684078c208f](https://github.com/Qiskit/qiskit/assets/47946624/899b39dc-728a-4131-b91b-5a4710b41530)

This PR removes the duplicated autoclass directive for `_default_options()` and the line of documentation explaining that subclasses need to implement it, as it is also explained in line 66. 

https://github.com/Qiskit/qiskit/blob/a83c99b7f8f0bf03dd2513e7410fc1575e30d284/qiskit/providers/backend.py#L66-L69

With this removal, the docs will match the documentation of `BackendV2` where we use the same explanation once:

https://github.com/Qiskit/qiskit/blob/a83c99b7f8f0bf03dd2513e7410fc1575e30d284/qiskit/providers/backend.py#L316-L319

The change will need backport to `stable/1.1`, `stable/1.0`, and `stable/0.46`