### PR TITLE
Remove reference to `transpile` from Pulse docs

### DIFF
--- a/qiskit/pulse/builder.py
+++ b/qiskit/pulse/builder.py
@@ -74,8 +74,8 @@ a pulse:
 
 The builder initializes a :class:`.pulse.Schedule`, ``pulse_prog``
 and then begins to construct the program within the context. The output pulse
-schedule will survive after the context is exited and can be transpiled and executed like a
-normal Qiskit schedule using ``backend.run(transpile(pulse_prog, backend))``.
+schedule will survive after the context is exited and can be executed like a
+normal Qiskit schedule using ``backend.run(pulse_prog)``.
 
 Pulse programming has a simple imperative style. This leaves the programmer
 to worry about the raw experimental physics of pulse programming and not

--- a/qiskit/pulse/builder.py
+++ b/qiskit/pulse/builder.py
@@ -74,8 +74,8 @@ a pulse:
 
 The builder initializes a :class:`.pulse.Schedule`, ``pulse_prog``
 and then begins to construct the program within the context. The output pulse
-schedule will survive after the context is exited and can be executed like a
-normal Qiskit schedule using ``backend.run(pulse_prog)``.
+schedule will survive after the context is exited and can be used like a
+normal Qiskit schedule.
 
 Pulse programming has a simple imperative style. This leaves the programmer
 to worry about the raw experimental physics of pulse programming and not


### PR DESCRIPTION
### Summary

This reference to `transpile` was mistakenly inserted as part of 1a027ac (gh-11565); `execute` used to ignore the `transpile` step for `Schedule`/`ScheduleBlock` and submit directly to `backend.run`.

I am not clear if there are actually any backends that *accept* pulse jobs anymore, but if there are, this is what the text should have been translated to.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

It's not at all clear to me how accurate this documentation remains at all (if nothing else, doesn't the pulse builder return `ScheduleBlock` now?), but this is at least a fix for the change in #11565.

Fix #12447.