### PR TITLE
Pin nightly rust version to known working build

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -14,14 +14,15 @@ jobs:
     name: Miri
     runs-on: ubuntu-latest
     env:
-      RUSTUP_TOOLCHAIN: nightly
+      RUSTUP_TOOLCHAIN: nightly-2024-05-24
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain:  nightly-2024-05-24
           components: miri
 
       - name: Prepare Miri


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the past couple of days we've seen the miri tests fail in CI while attempting to build crossbeam-epoch from source. We need to do this to ensure that crossbeam-epoch is miri safe so that we can run our own tests of Qiskit's unsafe code in ci. This failure was likely an issue in the recent nightly builds so this commit pins the nightly rust version to one from last week when everything was known to be working. We can remove this specific pin when we know that upstream rust has fixed the issue.

### Details and comments


