### PR TITLE
Fix a bug in isometry.rs

### DIFF
--- a/crates/accelerate/src/isometry.rs
+++ b/crates/accelerate/src/isometry.rs
@@ -212,7 +212,6 @@ fn construct_basis_states(
         } else if i == target_label {
             e2 += 1;
         } else {
-            assert!(j <= 1);
             e1 += state_free[j] as usize;
             e2 += state_free[j] as usize;
             j += 1

--- a/releasenotes/notes/fix-isometry-rust-adf0eed09c6611f1.yaml
+++ b/releasenotes/notes/fix-isometry-rust-adf0eed09c6611f1.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     Fix a bug in :class:`~.library.Isometry` due to an unnecessary assertion,
-    that led to an error in :method:`~.library.UnitaryGate.control(num_controls)`
+    that led to an error in :meth:`~.library.UnitaryGate.control`
     when :class:`~.library.UnitaryGate` had more that two qubits.

--- a/releasenotes/notes/fix-isometry-rust-adf0eed09c6611f1.yaml
+++ b/releasenotes/notes/fix-isometry-rust-adf0eed09c6611f1.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     Fix a bug in :class:`~.library.Isometry` due to an unnecessary assertion,
-    that led to an error in :meth:`~.library.UnitaryGate.control`
+    that led to an error in :meth:`.UnitaryGate.control`
     when :class:`~.library.UnitaryGate` had more that two qubits.

--- a/releasenotes/notes/fix-isometry-rust-adf0eed09c6611f1.yaml
+++ b/releasenotes/notes/fix-isometry-rust-adf0eed09c6611f1.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix a bug in :class:`~.library.Isometry` due to an unnecessary assertion,
+    that led to an error in :method:`~.library.UnitaryGate.control(num_controls)`
+    when :class:`~.library.UnitaryGate` had more that two qubits.

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -852,10 +852,9 @@ class TestControlledGate(QiskitTestCase):
         self.assertTrue(is_unitary_matrix(base_mat))
         self.assertTrue(matrix_equal(cop_mat, test_op.data))
 
-    @data(1, 2, 3, 4, 5)
-    def test_controlled_random_unitary(self, num_ctrl_qubits):
+    @combine(num_ctrl_qubits=(1, 2, 3, 4, 5), num_target=(2, 3))
+    def test_controlled_random_unitary(self, num_ctrl_qubits, num_target):
         """Test the matrix data of an Operator based on a random UnitaryGate."""
-        num_target = 2
         base_gate = random_unitary(2**num_target).to_instruction()
         base_mat = base_gate.to_matrix()
         cgate = base_gate.control(num_ctrl_qubits)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
After PR #12197 was merged, there is a bug with the following code:

```
num_qubits = 3
num_controls = 4
u = random_unitary(2 ** num_qubits)
ug = UnitaryGate(u)
cug = ug.control(num_controls)
cug 
```

The code is working for `num_qubits = 1` or `2` but not for `3` or `4` or `5`, and raises the following error:

```
/qiskit/circuit/library/generalized_gates/isometry.py:221, in Isometry._disentangle(self, circuit, q, diag, remaining_isometry, column_index, s)
    217 diagonal_mcg = self._append_mcg_up_to_diagonal(
    218     circuit, q, gate, control_labels, target_label
    219 )
    220 # apply the MCG to the remaining isometry
--> 221 v = isometry_rs.apply_multi_controlled_gate(v, control_labels, target_label, gate)
    222 # correct for the implementation "up to diagonal"
    223 diag_mcg_inverse = np.conj(diagonal_mcg).astype(complex, copy=False)

PanicException: assertion failed: j <= 1
```
### Details and comments
The solution is to remove the assertion `assert!(j <= 1)` in `crates/accelerate/src/isometry.rs:215:13`

