### PR TITLE
Adds various convenience functions to qiskit

### DIFF
--- a/qiskit/circuit/library/blueprintcircuit.py
+++ b/qiskit/circuit/library/blueprintcircuit.py
@@ -190,10 +190,10 @@ class BlueprintCircuit(QuantumCircuit, ABC):
             self._build()
         return super().count_ops()
 
-    def num_nonlocal_gates(self):
+    def num_nonlocal_gates(self, n=2):
         if not self._is_built:
             self._build()
-        return super().num_nonlocal_gates()
+        return super().num_nonlocal_gates(n)
 
     def num_connected_components(self, unitary_only=False):
         if not self._is_built:

--- a/qiskit/circuit/library/blueprintcircuit.py
+++ b/qiskit/circuit/library/blueprintcircuit.py
@@ -191,6 +191,7 @@ class BlueprintCircuit(QuantumCircuit, ABC):
         return super().count_ops()
 
     def num_nonlocal_gates(self, n=2):
+        """Returns the number of n-qubit gates that contain at least n qubits."""
         if not self._is_built:
             self._build()
         return super().num_nonlocal_gates(n)

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3398,10 +3398,10 @@ class QuantumCircuit:
         """
         if not include_directives:
             return self.depth(
-                lambda x: not getattr(x.operation, "_directive", False) and x.qubits >= n
+                lambda x: not getattr(x.operation, "_directive", False) and len(x.qubits) >= n
             )
         else:
-            return self.depth(lambda x: x.qubits >= n)
+            return self.depth(lambda x: len(x.qubits) >= n)
 
     def num_nq_gates(self, n: int = 2, include_directives: bool = False) -> int:
         """Returns the number of gates with exactly n qubits (default: n=2), excluding directives by
@@ -3417,10 +3417,10 @@ class QuantumCircuit:
         """
         if not include_directives:
             return self.size(
-                lambda x: not getattr(x.operation, "_directive", False) and x.qubits == n
+                lambda x: not getattr(x.operation, "_directive", False) and len(x.qubits) == n
             )
         else:
-            return self.size(lambda x: x.qubits == n)
+            return self.size(lambda x: len(x.qubits) == n)
 
     def num_nonidle_qubits(self) -> int:
         """Returns the number of qubits in the quantum circuit that are non-idle,

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3394,7 +3394,7 @@ class QuantumCircuit:
             include_directives (bool): Whether to include directives such as barriers
 
         Returns:
-            int: Quantum circuit depth in terms of two-qubit gates
+            int: Quantum circuit depth in terms of two or more qubit gates
         """
         if not include_directives:
             return self.depth(

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3394,7 +3394,7 @@ class QuantumCircuit:
             n (int): The minimum number of qubits in an instruction that counts towards the depth.
             include_directives (bool): Whether to include directives such as barriers
         Returns:
-            int: Quantum circuit depth in terms of n-qubit gates (default n=2).
+            int: Quantum circuit depth in terms of gates with at least n qubits (default n=2).
         """
         if not include_directives:
             return self.depth(

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3386,6 +3386,90 @@ class QuantumCircuit:
 
         return max(op_stack)
 
+    def depth_2q(self, include_directives: bool = False) -> int:
+        """Returns the depth in terms of two-qubit quantum gates, excluding directives by default.
+
+        Args:
+            include_directives (bool): Whether to include directives such as barriers
+
+        Returns:
+            int: Quantum circuit depth in terms of two-qubit gates
+        """
+        if not include_directives:
+            return self.depth(
+                lambda x: not getattr(x.operation, "_directive", False) and x.qubits == 2
+            )
+        else:
+            return self.depth(lambda x: x.qubits == 2)
+
+    def depth_nq(self, n: int, include_directives: bool = False) -> int:
+        """Returns the depth in terms of quantum gates with at least n-qubits,
+        excluding directives by default.
+
+        Args:
+            n (int): The minimum number of qubits in an instruction that counts towards the depth.
+            include_directives (bool): Whether to include directives such as barriers
+        Returns:
+            int: Quantum circuit depth in terms of n-qubit gates
+        """
+        if not include_directives:
+            return self.depth(
+                lambda x: not getattr(x.operation, "_directive", False) and x.qubits >= n
+            )
+        else:
+            return self.depth(lambda x: x.qubits >= n)
+
+    def num_2q_gates(self, include_directives: bool = False) -> int:
+        """Returns the number of gates with exactly 2-qubits, excluding directives by default.
+
+        Args:
+            include_directives (bool): Whether to include directives such as barriers
+
+        Returns:
+            int: The number of gates in the quantum circuit with exactly n-qubits.
+        """
+        if not include_directives:
+            return self.size(
+                lambda x: not getattr(x.operation, "_directive", False) and x.qubits == 2
+            )
+        else:
+            return self.size(lambda x: x.qubits == 2)
+
+    def num_nq_gates(self, n: int, include_directives: bool = False) -> int:
+        """Returns the number of gates with exactly n-qubits, excluding directives by default.
+        See :meth:`.num_nonlocal_gates` to retrieve the number of gates with at least two-qubits,
+        (excluding directives).
+
+        Args:
+            n (int): The exact number of qubits in an instruction.
+            include_directives (bool): Whether to include directives such as barriers
+
+        Returns:
+            int: The number of gates in the quantum circuit with exactly n-qubits.
+        """
+        if not include_directives:
+            return self.size(
+                lambda x: not getattr(x.operation, "_directive", False) and x.qubits == n
+            )
+        else:
+            return self.size(lambda x: x.qubits == n)
+
+    def num_nonidle_qubits(self) -> int:
+        """Returns the number of qubits in the quantum circuit that are non-idle,
+        i.e. are part of at least one gate.
+
+        Returns:
+            int: The number of non-idle qubits in the quantum circuit.
+        """
+        return len(
+            {
+                qubit
+                for inst in self.data
+                for qubit in inst.qubits
+                if not getattr(inst.operation, "_directive", False)
+            }
+        )
+
     def width(self) -> int:
         """Return number of qubits plus clbits in circuit.
 

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3411,7 +3411,7 @@ class QuantumCircuit:
             n (int): The minimum number of qubits in an instruction that counts towards the depth.
             include_directives (bool): Whether to include directives such as barriers
         Returns:
-            int: Quantum circuit depth in terms of n-qubit gates
+            int: Quantum circuit depth in terms of n-qubit gates.
         """
         if not include_directives:
             return self.depth(
@@ -3421,13 +3421,13 @@ class QuantumCircuit:
             return self.depth(lambda x: x.qubits >= n)
 
     def num_2q_gates(self, include_directives: bool = False) -> int:
-        """Returns the number of gates with exactly 2-qubits, excluding directives by default.
+        """Returns the number of gates with exactly two qubits, excluding directives by default.
 
         Args:
             include_directives (bool): Whether to include directives such as barriers
 
         Returns:
-            int: The number of gates in the quantum circuit with exactly n-qubits.
+            int: The number of gates in the quantum circuit with exactly two qubits.
         """
         if not include_directives:
             return self.size(
@@ -3437,7 +3437,7 @@ class QuantumCircuit:
             return self.size(lambda x: x.qubits == 2)
 
     def num_nq_gates(self, n: int, include_directives: bool = False) -> int:
-        """Returns the number of gates with exactly n-qubits, excluding directives by default.
+        """Returns the number of gates with exactly n qubits, excluding directives by default.
         See :meth:`.num_nonlocal_gates` to retrieve the number of gates with at least two-qubits,
         (excluding directives).
 
@@ -3446,7 +3446,7 @@ class QuantumCircuit:
             include_directives (bool): Whether to include directives such as barriers
 
         Returns:
-            int: The number of gates in the quantum circuit with exactly n-qubits.
+            int: The number of gates in the quantum circuit with exactly n qubits.
         """
         if not include_directives:
             return self.size(
@@ -3509,14 +3509,19 @@ class QuantumCircuit:
             count_ops[instruction.operation.name] = count_ops.get(instruction.operation.name, 0) + 1
         return OrderedDict(sorted(count_ops.items(), key=lambda kv: kv[1], reverse=True))
 
-    def num_nonlocal_gates(self) -> int:
-        """Return number of non-local gates (i.e. involving 2+ qubits).
+    def num_nonlocal_gates(self, n: int = 2) -> int:
+        """Returns the number of non-local gates (gates with at least n qubits), excluding directives and
+        including conditional gates. By default, returns the number of non-local gates with at least two
+        qubits.
 
-        Conditional nonlocal gates are also included.
+        Args:
+            n (int): The minimum number of qubits in a gate to count towards the returned quantity.
+        Returns:
+            int: Number of gates in the quantum circuit with at least n qubits (default n=2).
         """
         multi_qubit_gates = 0
         for instruction in self._data:
-            if instruction.operation.num_qubits > 1 and not getattr(
+            if instruction.operation.num_qubits >= n and not getattr(
                 instruction.operation, "_directive", False
             ):
                 multi_qubit_gates += 1

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3386,41 +3386,33 @@ class QuantumCircuit:
 
         return max(op_stack)
 
-    def depth_nq(self, n: int = 2, include_directives: bool = False) -> int:
+    def depth_nq(self, n: int = 2) -> int:
         """Returns the depth in terms of quantum gates with at least n qubits (default n=2),
-        excluding directives by default.
+        excluding directives.
 
         Args:
             n (int): The minimum number of qubits in an instruction that counts towards the depth.
-            include_directives (bool): Whether to include directives such as barriers
         Returns:
             int: Quantum circuit depth in terms of gates with at least n qubits (default n=2).
         """
-        if not include_directives:
-            return self.depth(
-                lambda x: not getattr(x.operation, "_directive", False) and len(x.qubits) >= n
-            )
-        else:
-            return self.depth(lambda x: len(x.qubits) >= n)
+        return self.depth(
+            lambda x: not getattr(x.operation, "_directive", False) and len(x.qubits) >= n
+        )
 
-    def num_nq_gates(self, n: int = 2, include_directives: bool = False) -> int:
-        """Returns the number of gates with exactly n qubits (default: n=2), excluding directives by
-        default. See :meth:`.num_nonlocal_gates` to retrieve the number of gates with at least two-qubits
+    def num_nq_gates(self, n: int = 2) -> int:
+        """Returns the number of gates with exactly n qubits (default: n=2), excluding directives.
+        See :meth:`.num_nonlocal_gates` to retrieve the number of gates with at least two-qubits
         (excluding directives).
 
         Args:
             n (int): The exact number of qubits in an instruction.
-            include_directives (bool): Whether to include directives such as barriers
 
         Returns:
             int: The number of gates in the quantum circuit with exactly n qubits (default n=2).
         """
-        if not include_directives:
-            return self.size(
-                lambda x: not getattr(x.operation, "_directive", False) and len(x.qubits) == n
-            )
-        else:
-            return self.size(lambda x: len(x.qubits) == n)
+        return self.size(
+            lambda x: not getattr(x.operation, "_directive", False) and len(x.qubits) == n
+        )
 
     def num_nonidle_qubits(self) -> int:
         """Returns the number of qubits in the quantum circuit that are non-idle,

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3387,7 +3387,8 @@ class QuantumCircuit:
         return max(op_stack)
 
     def depth_2q(self, include_directives: bool = False) -> int:
-        """Returns the depth in terms of two-qubit quantum gates, excluding directives by default.
+        """Returns the depth in terms of quantum gates with at least 2-qubits,
+        excluding directives by default.
 
         Args:
             include_directives (bool): Whether to include directives such as barriers
@@ -3397,10 +3398,10 @@ class QuantumCircuit:
         """
         if not include_directives:
             return self.depth(
-                lambda x: not getattr(x.operation, "_directive", False) and x.qubits == 2
+                lambda x: not getattr(x.operation, "_directive", False) and x.qubits >= 2
             )
         else:
-            return self.depth(lambda x: x.qubits == 2)
+            return self.depth(lambda x: x.qubits >= 2)
 
     def depth_nq(self, n: int, include_directives: bool = False) -> int:
         """Returns the depth in terms of quantum gates with at least n-qubits,

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3386,32 +3386,15 @@ class QuantumCircuit:
 
         return max(op_stack)
 
-    def depth_2q(self, include_directives: bool = False) -> int:
-        """Returns the depth in terms of quantum gates with at least 2-qubits,
-        excluding directives by default.
-
-        Args:
-            include_directives (bool): Whether to include directives such as barriers
-
-        Returns:
-            int: Quantum circuit depth in terms of two-qubit gates
-        """
-        if not include_directives:
-            return self.depth(
-                lambda x: not getattr(x.operation, "_directive", False) and x.qubits >= 2
-            )
-        else:
-            return self.depth(lambda x: x.qubits >= 2)
-
-    def depth_nq(self, n: int, include_directives: bool = False) -> int:
-        """Returns the depth in terms of quantum gates with at least n-qubits,
+    def depth_nq(self, n: int = 2, include_directives: bool = False) -> int:
+        """Returns the depth in terms of quantum gates with at least n qubits (default n=2),
         excluding directives by default.
 
         Args:
             n (int): The minimum number of qubits in an instruction that counts towards the depth.
             include_directives (bool): Whether to include directives such as barriers
         Returns:
-            int: Quantum circuit depth in terms of n-qubit gates.
+            int: Quantum circuit depth in terms of n-qubit gates (default n=2).
         """
         if not include_directives:
             return self.depth(
@@ -3420,25 +3403,9 @@ class QuantumCircuit:
         else:
             return self.depth(lambda x: x.qubits >= n)
 
-    def num_2q_gates(self, include_directives: bool = False) -> int:
-        """Returns the number of gates with exactly two qubits, excluding directives by default.
-
-        Args:
-            include_directives (bool): Whether to include directives such as barriers
-
-        Returns:
-            int: The number of gates in the quantum circuit with exactly two qubits.
-        """
-        if not include_directives:
-            return self.size(
-                lambda x: not getattr(x.operation, "_directive", False) and x.qubits == 2
-            )
-        else:
-            return self.size(lambda x: x.qubits == 2)
-
-    def num_nq_gates(self, n: int, include_directives: bool = False) -> int:
-        """Returns the number of gates with exactly n qubits, excluding directives by default.
-        See :meth:`.num_nonlocal_gates` to retrieve the number of gates with at least two-qubits,
+    def num_nq_gates(self, n: int = 2, include_directives: bool = False) -> int:
+        """Returns the number of gates with exactly n qubits (default: n=2), excluding directives by
+        default. See :meth:`.num_nonlocal_gates` to retrieve the number of gates with at least two-qubits
         (excluding directives).
 
         Args:
@@ -3446,7 +3413,7 @@ class QuantumCircuit:
             include_directives (bool): Whether to include directives such as barriers
 
         Returns:
-            int: The number of gates in the quantum circuit with exactly n qubits.
+            int: The number of gates in the quantum circuit with exactly n qubits (default n=2).
         """
         if not include_directives:
             return self.size(

--- a/releasenotes/notes/adds-convenience-functions-f14907a13fcb7929.yaml
+++ b/releasenotes/notes/adds-convenience-functions-f14907a13fcb7929.yaml
@@ -1,7 +1,7 @@
 ---
 features:
   - |
-    Added convenience functions to the :class:`.QuantumCircuit` class that return the depth in terms of
+    Added convenience methods to the :class:`.QuantumCircuit` class that return the depth in terms of
     gates that have exactly two-qubits (:meth:`.QuantumCircuit.depth_2q`) or at least n-qubits (:meth:`.QuantumCircuit.depth_nq`).
-    This also added convenience functions for determining the number of 2-qubit (:meth:`.QuantumCircuit.num_2q_gates`) and n-qubit gates (:meth:`.QuantumCircuit.num_nq_gates`).
-    Added a function that returns the number of non-idle qubits in an operation, i.e. qubits that are part of at least one gate (:meth:`.QuantumCircuit.num_nonidle_qubits`).
+    Also, convenience methods were added for determining the number of 2-qubit (:meth:`.QuantumCircuit.num_2q_gates`) and n-qubit gates (:meth:`.QuantumCircuit.num_nq_gates`).
+    Another method was added that returns the number of non-idle qubits in the quantum circuit, i.e. qubits that are part of at least one gate (:meth:`.QuantumCircuit.num_nonidle_qubits`).

--- a/releasenotes/notes/adds-convenience-functions-f14907a13fcb7929.yaml
+++ b/releasenotes/notes/adds-convenience-functions-f14907a13fcb7929.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Added convenience functions to the :class:`.QuantumCircuit` class that return the depth in terms of
+    gates that have exactly two-qubits (:meth:`.QuantumCircuit.depth_2q`) or at least n-qubits (:meth:`.QuantumCircuit.depth_nq`).
+    This also added convenience functions for determining the number of 2-qubit (:meth:`.QuantumCircuit.num_2q_gates`) and n-qubit gates (:meth:`.QuantumCircuit.num_nq_gates`).
+    Added a function that returns the number of non-idle qubits in an operation, i.e. qubits that are part of at least one gate (:meth:`.QuantumCircuit.num_nonidle_qubits`).

--- a/releasenotes/notes/adds-convenience-functions-f14907a13fcb7929.yaml
+++ b/releasenotes/notes/adds-convenience-functions-f14907a13fcb7929.yaml
@@ -1,7 +1,7 @@
 ---
 features:
   - |
-    Added convenience methods to the :class:`.QuantumCircuit` class that return the depth in terms of
-    gates that have at least two-qubits (:meth:`.QuantumCircuit.depth_2q`) or at least n-qubits (:meth:`.QuantumCircuit.depth_nq`).
-    Also, convenience methods were added for determining the number of 2-qubit (:meth:`.QuantumCircuit.num_2q_gates`) and n-qubit gates (:meth:`.QuantumCircuit.num_nq_gates`).
+    Added convenience methods to the :class:`.QuantumCircuit` class that return the depth in terms of gates that have at least n-qubits (:meth:`.QuantumCircuit.depth_nq`).
+    Also, convenience methods were added for determining the number of n-qubit gates (:meth:`.QuantumCircuit.num_nq_gates`).
+    Both of these methods assume a default of n=2, i.e. the depth in terms of two-qubit gates and the number of two-qubit gates excluding directives are returned if no parameters are specified.
     Another method was added that returns the number of non-idle qubits in the quantum circuit, i.e. qubits that are part of at least one gate (:meth:`.QuantumCircuit.num_nonidle_qubits`).

--- a/releasenotes/notes/adds-convenience-functions-f14907a13fcb7929.yaml
+++ b/releasenotes/notes/adds-convenience-functions-f14907a13fcb7929.yaml
@@ -2,6 +2,6 @@
 features:
   - |
     Added convenience methods to the :class:`.QuantumCircuit` class that return the depth in terms of gates that have at least n-qubits (:meth:`.QuantumCircuit.depth_nq`).
-    Also, convenience methods were added for determining the number of n-qubit gates (:meth:`.QuantumCircuit.num_nq_gates`).
-    Both of these methods assume a default of n=2, i.e. the depth in terms of two-qubit gates and the number of two-qubit gates excluding directives are returned if no parameters are specified.
+    Further convenience methods were added for determining the number of n-qubit gates (:meth:`.QuantumCircuit.num_nq_gates`).
+    Both of these methods assume a default of n=2, i.e. the depth in terms of two-qubit gates and the number of two-qubit gates excluding directives are returned.
     Another method was added that returns the number of non-idle qubits in the quantum circuit, i.e. qubits that are part of at least one gate (:meth:`.QuantumCircuit.num_nonidle_qubits`).

--- a/releasenotes/notes/adds-convenience-functions-f14907a13fcb7929.yaml
+++ b/releasenotes/notes/adds-convenience-functions-f14907a13fcb7929.yaml
@@ -2,6 +2,6 @@
 features:
   - |
     Added convenience methods to the :class:`.QuantumCircuit` class that return the depth in terms of
-    gates that have exactly two-qubits (:meth:`.QuantumCircuit.depth_2q`) or at least n-qubits (:meth:`.QuantumCircuit.depth_nq`).
+    gates that have at least two-qubits (:meth:`.QuantumCircuit.depth_2q`) or at least n-qubits (:meth:`.QuantumCircuit.depth_nq`).
     Also, convenience methods were added for determining the number of 2-qubit (:meth:`.QuantumCircuit.num_2q_gates`) and n-qubit gates (:meth:`.QuantumCircuit.num_nq_gates`).
     Another method was added that returns the number of non-idle qubits in the quantum circuit, i.e. qubits that are part of at least one gate (:meth:`.QuantumCircuit.num_nonidle_qubits`).


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This PR adds some convenience functions to Qiskit's `QuantumCircuit` class. The functionality was previously available but required users to dive into the API before determining the wanted quantities. The new 'depth' and 'number of gates' methods were previously available by defining a custom filter function for `depth` and `size` methods of `QuantumCircuit` but I thought it might be worthwhile for new users to have a convenience function that defines such a filter function for them (and saves them e.g. from accidentally counting barriers towards their metrics).