### PR TITLE
add a new parameter num_qubits_distribution to random_circuit

### DIFF
--- a/qiskit/circuit/random/utils.py
+++ b/qiskit/circuit/random/utils.py
@@ -12,8 +12,8 @@
 
 """Utility functions for generating random circuits."""
 
-import numpy as np
 from math import isclose
+import numpy as np
 
 from qiskit.circuit import ClassicalRegister, QuantumCircuit, CircuitInstruction
 from qiskit.circuit import Reset

--- a/qiskit/circuit/random/utils.py
+++ b/qiskit/circuit/random/utils.py
@@ -13,6 +13,7 @@
 """Utility functions for generating random circuits."""
 
 import numpy as np
+from math import isclose
 
 from qiskit.circuit import ClassicalRegister, QuantumCircuit, CircuitInstruction
 from qiskit.circuit import Reset
@@ -60,7 +61,7 @@ def random_circuit(
         CircuitError: when invalid options given
     """
     if num_operand_distribution is not None:
-        if sum(num_operand_distribution.values()) != 1.0:
+        if not isclose(sum(num_operand_distribution.values()), 1.0, rel_tol=1e-7):
             raise CircuitError("The sum of num_operand_distribution values must be 1.0.")
         if max_operands is not None:
             raise CircuitError(

--- a/releasenotes/notes/add-num-operand-distribution-to-random-circuit-57e40db98db01358.yaml
+++ b/releasenotes/notes/add-num-operand-distribution-to-random-circuit-57e40db98db01358.yaml
@@ -1,0 +1,9 @@
+---
+features_circuits:
+  - |
+    Add the `num_qubits_distribution` parameter. This parameter allows users
+    to specify the ratio of 1-qubit, 2-qubit, ..., n-qubit gates in the 
+    generated random circuit. For example, `random_circuit` with 
+    `num_operand_distribution={1: 0.4, 2: 0.6}` will yield random circuits with
+    approximately 40% 1-qubit gates and 60% 2-qubit gates, while disallowing
+    gates with more than 2 qubits.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
fixes #12059 
This PR extends the random_circuit function in Qiskit to allow users to specify a distribution num_operand_distribution that defines the ratio of 1-qubit, 2-qubit, ..., n-qubit gates in the generated random circuit. For example, calling random_circuit with num_operand_distribution={1: 0.5, 2: 0.5} will produce random circuits with approximately 50% single-qubit gates and 50% two-qubit gates, while disallowing gates with more than 2 qubits.

Additionally, the following points have been addressed:
> The parameter max_operands should take precedence, i.e. if max_operands is set, draw a random distribution num_operand_distribution. Raise an error if sum(num_operand_distribution.values()) != 1.0 or if max_operands is set at the same time as num_operand_distribution or if any key in num_operand_distribution is larger than the largest available n-qubit gate (see get_standard_gate_name_mapping).

### Details and comments
I worked on this issue as part of [unitaryHACK](https://unitaryhack.dev/), so please assign this issue to me if this PR is accepted.
