### PR TITLE
Make fewer accesses, `instruction.operation`, in exporter.py

### DIFF
--- a/qiskit/qasm3/exporter.py
+++ b/qiskit/qasm3/exporter.py
@@ -907,6 +907,7 @@ class QASM3Builder:
 
     def build_switch_statement(self, instruction: CircuitInstruction) -> Iterable[ast.Statement]:
         """Build a :obj:`.SwitchCaseOp` into a :class:`.ast.SwitchStatement`."""
+        operation = instruction.operation
         real_target = self.build_expression(expr.lift(operation.target))
         global_scope = self.global_scope()
         target = self._reserve_variable_name(
@@ -935,7 +936,7 @@ class QASM3Builder:
                     target,
                     (
                         case(values, block)
-                        for values, block in instruction.operation.cases_specifier()
+                        for values, block in operation.cases_specifier()
                     ),
                 ),
             ]
@@ -943,7 +944,7 @@ class QASM3Builder:
         # Handle the stabilised syntax.
         cases = []
         default = None
-        for values, block in instruction.operation.cases_specifier():
+        for values, block in operation.cases_specifier():
             self.push_scope(block, instruction.qubits, instruction.clbits)
             case_body = ast.ProgramBlock(self.build_current_scope())
             self.pop_scope()
@@ -972,6 +973,7 @@ class QASM3Builder:
 
     def build_for_loop(self, instruction: CircuitInstruction) -> ast.ForLoopStatement:
         """Build a :obj:`.ForLoopOp` into a :obj:`.ast.ForLoopStatement`."""
+        operation = instruction.operation
         indexset, loop_parameter, loop_circuit = operation.params
         self.push_scope(loop_circuit, instruction.qubits, instruction.clbits)
         scope = self.current_scope()

--- a/qiskit/qasm3/exporter.py
+++ b/qiskit/qasm3/exporter.py
@@ -507,9 +507,7 @@ class QASM3Builder:
                 for block in operation.blocks:
                     self.hoist_declarations(block.data, opaques=opaques, gates=gates)
                 continue
-            if operation in self.global_namespace or isinstance(
-                operation, self.builtins
-            ):
+            if operation in self.global_namespace or isinstance(operation, self.builtins):
                 continue
 
             if isinstance(operation, standard_gates.CXGate):
@@ -525,9 +523,7 @@ class QASM3Builder:
             elif not isinstance(operation, Gate):
                 raise QASM3ExporterError("Exporting non-unitary instructions is not yet supported.")
             else:
-                self.hoist_declarations(
-                    operation.definition.data, opaques=opaques, gates=gates
-                )
+                self.hoist_declarations(operation.definition.data, opaques=opaques, gates=gates)
                 self._register_gate(operation)
                 gates.append(operation)
         return opaques, gates
@@ -934,10 +930,7 @@ class QASM3Builder:
                 ast.AssignmentStatement(target, real_target),
                 ast.SwitchStatementPreview(
                     target,
-                    (
-                        case(values, block)
-                        for values, block in operation.cases_specifier()
-                    ),
+                    (case(values, block) for values, block in operation.cases_specifier()),
                 ),
             ]
 


### PR DESCRIPTION
EDIT: To clarify the motivation. This fixes a bug in the exporter that is exposed by #12459 .

Code in qiskit/qasm3/exporter.py uses the object id to track processing gates. But with upcoming changes in #12459 a new object is created every time an operation is accessed within an instruction. Python allows an object's id to be reused after its reference count goes to zero. As a result, sometimes a stored id refers to two different gates (one of them no longer exists as an object) This will cause errors to be raised.

This PR replaces several repeated accesses with a single access. This is also more efficient since each access actually constructs an object.

In particular when testing https://github.com/Qiskit/qiskit/pull/12459  a code path is found in which a gate is accessed, its id is cached, it is freed, and another gate is accessed; all with no intervening statements. This PR prevents the first gate object from being freed until after the second gate is accessed and analyzed.

However, this PR does not remove all possible recycling of ids during a code section that uses them to track gate processing. This design should be replaced with a new approach.