### PR TITLE
Updated bit.py Bit._repr when no register is assigned

### DIFF
--- a/qiskit/circuit/bit.py
+++ b/qiskit/circuit/bit.py
@@ -36,6 +36,7 @@ class Bit:
             # To sidestep the overridden Bit.__hash__ and use the default hash
             # algorithm (only new-style Bits), call default object hash method.
             self._hash = object.__hash__(self)
+            self._repr = f"{self.__class__.__name__}(no register assigned)"
         else:
             try:
                 index = int(index)
@@ -59,9 +60,6 @@ class Bit:
 
     def __repr__(self):
         """Return the official string representing the bit."""
-        if (self._register, self._index) == (None, None):
-            # Similar to __hash__, use default repr method for new-style Bits.
-            return object.__repr__(self)
         return self._repr
 
     def __hash__(self):


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
bit.py Bit._repr with or without a provided register should be consistent.


### Details and comments
When a Bit is created without providing a register and index, ```Bit._repr``` is not set and ```Bit.__repr__(self)``` returns the default string representation of the object. This seems inconsistent to me. I suggest that in this case, ```Bit._repr``` is set to ```f"{self.__class__.__name__}(no register assigned)"``` (or something similar).

