### PR TITLE
Use hash of numeric value for bound parameter expressions

### DIFF
--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -439,6 +439,9 @@ class ParameterExpression:
             raise TypeError("could not cast expression to int") from exc
 
     def __hash__(self):
+        if not self._parameter_symbols:
+            # For fully bound expressions, fall back to the underlying value
+            return hash(self.numeric())
         return hash((self._parameter_keys, self._symbol_expr))
 
     def __copy__(self):

--- a/releasenotes/notes/parameterexpression-hash-d2593ab1715aa42c.yaml
+++ b/releasenotes/notes/parameterexpression-hash-d2593ab1715aa42c.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    :class:`.ParameterExpression` was updated so that fully bound instances
+    that compare equal to instances of Python's built-in numeric types (like
+    ``float`` and ``int``) also have hash values that match those of the other
+    instances. This change ensures that these types can be used interchangeably
+    as dictionary keys. See `#12488 <https://github.com/Qiskit/qiskit/pull/12488>`__.

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -1425,6 +1425,7 @@ class TestParameterExpressions(QiskitTestCase):
         x = Parameter("x")
         bound_expr = x.bind({x: 2.3})
         self.assertEqual(bound_expr, 2.3)
+        self.assertEqual(hash(bound_expr), hash(2.3))
 
     def test_abs_function_when_bound(self):
         """Verify expression can be used with


### PR DESCRIPTION



<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

If a `ParameterExpression` has no unbound parameters, the underlying bound value can be hashed instead of the tuple that accounts for the symbolic expression. Doing this allows for the `ParameterExpression` to match the hash for the numeric value it compares equal to.

### Details and comments

Closes #12487