### PR TITLE
Create custom 4x4 and 2x2 linalg operations (matmul, kron, determinant)

### DIFF
--- a/crates/accelerate/src/common.rs
+++ b/crates/accelerate/src/common.rs
@@ -1,0 +1,113 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2024
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use num_complex::Complex64;
+use numpy::ndarray::{array, Array2, ArrayView2};
+
+#[inline]
+pub fn kron_matrix_x_identity(lhs: ArrayView2<Complex64>) -> Array2<Complex64> {
+    let zero = Complex64::new(0., 0.);
+    array![
+        [lhs[(0, 0)], zero, lhs[(0, 1)], zero],
+        [zero, lhs[(0, 0)], zero, lhs[(0, 1)]],
+        [lhs[(1, 0)], zero, lhs[(1, 1)], zero],
+        [zero, lhs[(1, 0)], zero, lhs[(1, 1)]],
+    ]
+}
+
+#[inline]
+pub fn kron_identity_x_matrix(rhs: ArrayView2<Complex64>) -> Array2<Complex64> {
+    let zero = Complex64::new(0., 0.);
+    array![
+        [rhs[(0, 0)], rhs[(0, 1)], zero, zero],
+        [rhs[(1, 0)], rhs[(1, 1)], zero, zero],
+        [zero, zero, rhs[(0, 0)], rhs[(0, 1)]],
+        [zero, zero, rhs[(1, 0)], rhs[(1, 1)]],
+    ]
+}
+
+#[inline]
+pub fn matrix_multiply_2x2(
+    a: ArrayView2<Complex64>,
+    b: ArrayView2<Complex64>,
+) -> Array2<Complex64> {
+    let mut result = Array2::uninit((2, 2));
+
+    result[(0, 0)].write(a[(0, 0)] * b[(0, 0)] + a[(0, 1)] * b[(1, 0)]);
+    result[(0, 1)].write(a[(0, 0)] * b[(0, 1)] + a[(0, 1)] * b[(1, 1)]);
+    result[(1, 0)].write(a[(1, 0)] * b[(0, 0)] + a[(1, 1)] * b[(1, 0)]);
+    result[(1, 1)].write(a[(1, 0)] * b[(0, 1)] + a[(1, 1)] * b[(1, 1)]);
+
+    unsafe { result.assume_init() }
+}
+
+#[inline]
+pub fn matrix_multiply_4x4(
+    a: ArrayView2<Complex64>,
+    b: ArrayView2<Complex64>,
+) -> Array2<Complex64> {
+    let mut result = Array2::uninit((4, 4));
+
+    for i in 0..4 {
+        for j in 0..4 {
+            let mut sum = Complex64::new(0., 0.);
+            for k in 0..4 {
+                sum += a[(i, k)] * b[(k, j)]
+            }
+            result[(i, j)].write(sum);
+        }
+    }
+
+    unsafe { result.assume_init() }
+}
+
+#[inline]
+pub fn determinant_4x4(a: ArrayView2<Complex64>) -> Complex64 {
+    a[(0, 3)] * a[(1, 2)] * a[(2, 1)] * a[(3, 0)]
+        - a[(0, 2)] * a[(1, 3)] * a[(2, 1)] * a[(3, 0)]
+        - a[(0, 3)] * a[(1, 1)] * a[(2, 2)] * a[(3, 0)]
+        + a[(0, 1)] * a[(1, 3)] * a[(2, 2)] * a[(3, 0)]
+        + a[(0, 2)] * a[(1, 1)] * a[(2, 3)] * a[(3, 0)]
+        - a[(0, 1)] * a[(1, 2)] * a[(2, 3)] * a[(3, 0)]
+        - a[(0, 3)] * a[(1, 2)] * a[(2, 0)] * a[(3, 1)]
+        + a[(0, 2)] * a[(1, 3)] * a[(2, 0)] * a[(3, 1)]
+        + a[(0, 3)] * a[(1, 0)] * a[(2, 2)] * a[(3, 1)]
+        - a[(0, 0)] * a[(1, 3)] * a[(2, 2)] * a[(3, 1)]
+        - a[(0, 2)] * a[(1, 0)] * a[(2, 3)] * a[(3, 1)]
+        + a[(0, 0)] * a[(1, 2)] * a[(2, 3)] * a[(3, 1)]
+        + a[(0, 3)] * a[(1, 1)] * a[(2, 0)] * a[(3, 2)]
+        - a[(0, 1)] * a[(1, 3)] * a[(2, 0)] * a[(3, 2)]
+        - a[(0, 3)] * a[(1, 0)] * a[(2, 1)] * a[(3, 2)]
+        + a[(0, 0)] * a[(1, 3)] * a[(2, 1)] * a[(3, 2)]
+        + a[(0, 1)] * a[(1, 0)] * a[(2, 3)] * a[(3, 2)]
+        - a[(0, 0)] * a[(1, 1)] * a[(2, 3)] * a[(3, 2)]
+        - a[(0, 2)] * a[(1, 1)] * a[(2, 0)] * a[(3, 3)]
+        + a[(0, 1)] * a[(1, 2)] * a[(2, 0)] * a[(3, 3)]
+        + a[(0, 2)] * a[(1, 0)] * a[(2, 1)] * a[(3, 3)]
+        - a[(0, 0)] * a[(1, 2)] * a[(2, 1)] * a[(3, 3)]
+        - a[(0, 1)] * a[(1, 0)] * a[(2, 2)] * a[(3, 3)]
+        + a[(0, 0)] * a[(1, 1)] * a[(2, 2)] * a[(3, 3)]
+}
+
+/// Switches the order of qubits in a two qubit operation.
+#[inline]
+pub fn change_basis(matrix: ArrayView2<Complex64>) -> Array2<Complex64> {
+    let mut trans_matrix: Array2<Complex64> = matrix.reversed_axes().to_owned();
+    for index in 0..trans_matrix.ncols() {
+        trans_matrix.swap([1, index], [2, index]);
+    }
+    trans_matrix = trans_matrix.reversed_axes();
+    for index in 0..trans_matrix.ncols() {
+        trans_matrix.swap([1, index], [2, index]);
+    }
+    trans_matrix
+}

--- a/crates/accelerate/src/convert_2q_block_matrix.rs
+++ b/crates/accelerate/src/convert_2q_block_matrix.rs
@@ -15,15 +15,13 @@ use pyo3::wrap_pyfunction;
 use pyo3::Python;
 
 use num_complex::Complex64;
-use numpy::ndarray::linalg::kron;
-use numpy::ndarray::{aview2, Array2, ArrayView2};
+use numpy::ndarray::Array2;
 use numpy::{IntoPyArray, PyArray2, PyReadonlyArray2};
 use smallvec::SmallVec;
 
-static ONE_QUBIT_IDENTITY: [[Complex64; 2]; 2] = [
-    [Complex64::new(1., 0.), Complex64::new(0., 0.)],
-    [Complex64::new(0., 0.), Complex64::new(1., 0.)],
-];
+use crate::common::{
+    change_basis, kron_identity_x_matrix, kron_matrix_x_identity, matrix_multiply_4x4,
+};
 
 /// Return the matrix Operator resulting from a block of Instructions.
 #[pyfunction]
@@ -32,11 +30,10 @@ pub fn blocks_to_matrix(
     py: Python,
     op_list: Vec<(PyReadonlyArray2<Complex64>, SmallVec<[u8; 2]>)>,
 ) -> PyResult<Py<PyArray2<Complex64>>> {
-    let identity = aview2(&ONE_QUBIT_IDENTITY);
     let input_matrix = op_list[0].0.as_array();
     let mut matrix: Array2<Complex64> = match op_list[0].1.as_slice() {
-        [0] => kron(&identity, &input_matrix),
-        [1] => kron(&input_matrix, &identity),
+        [0] => kron_identity_x_matrix(input_matrix),
+        [1] => kron_matrix_x_identity(input_matrix),
         [0, 1] => input_matrix.to_owned(),
         [1, 0] => change_basis(input_matrix),
         [] => Array2::eye(4),
@@ -46,32 +43,18 @@ pub fn blocks_to_matrix(
         let op_matrix = op_matrix.as_array();
 
         let result = match q_list.as_slice() {
-            [0] => Some(kron(&identity, &op_matrix)),
-            [1] => Some(kron(&op_matrix, &identity)),
+            [0] => Some(kron_identity_x_matrix(op_matrix.view())),
+            [1] => Some(kron_matrix_x_identity(op_matrix.view())),
             [1, 0] => Some(change_basis(op_matrix)),
             [] => Some(Array2::eye(4)),
             _ => None,
         };
         matrix = match result {
-            Some(result) => result.dot(&matrix),
-            None => op_matrix.dot(&matrix),
+            Some(result) => matrix_multiply_4x4(result.view(), matrix.view()),
+            None => matrix_multiply_4x4(op_matrix.view(), matrix.view()),
         };
     }
     Ok(matrix.into_pyarray_bound(py).unbind())
-}
-
-/// Switches the order of qubits in a two qubit operation.
-#[inline]
-pub fn change_basis(matrix: ArrayView2<Complex64>) -> Array2<Complex64> {
-    let mut trans_matrix: Array2<Complex64> = matrix.reversed_axes().to_owned();
-    for index in 0..trans_matrix.ncols() {
-        trans_matrix.swap([1, index], [2, index]);
-    }
-    trans_matrix = trans_matrix.reversed_axes();
-    for index in 0..trans_matrix.ncols() {
-        trans_matrix.swap([1, index], [2, index]);
-    }
-    trans_matrix
 }
 
 #[pymodule]

--- a/crates/accelerate/src/lib.rs
+++ b/crates/accelerate/src/lib.rs
@@ -14,6 +14,7 @@ use std::env;
 
 use pyo3::import_exception;
 
+pub mod common;
 pub mod convert_2q_block_matrix;
 pub mod dense_layout;
 pub mod edge_collections;

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -144,10 +144,6 @@ fn magic_basis_transform(
     }
 }
 
-fn transform_from_magic_basis(unitary: ArrayView2<Complex64>) -> Array2<Complex64> {
-    magic_basis_transform(unitary, MagicBasisTransform::OutOf)
-}
-
 // faer::c64 and num_complex::Complex<f64> are both structs
 // holding two f64's. But several functions are not defined for
 // c64. So we implement them here. These things should be contribute
@@ -228,7 +224,7 @@ fn decompose_two_qubit_product_gate(
 
 fn __weyl_coordinates(unitary: ArrayView2<Complex64>) -> [f64; 3] {
     let uscaled = (C1 / determinant_4x4(unitary).powf(0.25)) * &unitary;
-    let uup = transform_from_magic_basis(uscaled.view());
+    let uup = magic_basis_transform(uscaled.view(), MagicBasisTransform::OutOf);
     let mut darg: Vec<_> = matrix_multiply_4x4(uup.t(), uup.view())
         .view()
         .into_faer_complex()


### PR DESCRIPTION
Closes #12120

This is an alternative to #12193, where instead of using `faer` for matrix multiplications, we have a new module with some functions implemented by hand to calculate the kronecker product, determinant, and matmul using `ndarray` data types.

In the new module we can find the following functions:

- **kron_matrix_x_identity():** A kron function that performs the product of a given matrix and the identity
- **kron_identity_x_matrix():** A kron function that performs the product of the identity and a given matrix.
- **matrix_multiply_2x2():** A 2x2 matmul completely unrolled
- **matrix_multiply_4x4():** A 4x4 matmul using three for loops which I think are easily vectorizable/unrolled for the compiler
- **determinant_4x4():** A function to calculate the determinant of a 4x4 matrix
- **change_basis():** The same function previously living on `convert_2q_block_matrix.rs` and moved here to be reused in more scripts

Running the transpiler benchmarks we can see how the performance has increased:
```
Benchmarks that have improved:

| Change   | Before [9d03b4bf] <main>   | After [a650f588] <AC/custom-linalg>   |   Ratio | Benchmark (Parameter)                                                                                      |
|----------|----------------------------|---------------------------------------|---------|------------------------------------------------------------------------------------------------------------|
| -        | 126±0.8ms                  | 109±0.7ms                             |    0.86 | transpiler_qualitative.TranspilerQualitativeBench.time_transpile_time_cnt3_5_179(2, 'sabre', 'dense')      |
| -        | 161±1ms                    | 125±0.4ms                             |    0.78 | transpiler_qualitative.TranspilerQualitativeBench.time_transpile_time_cnt3_5_179(3, 'sabre', 'dense')      |
| -        | 158±0.4ms                  | 133±0.3ms                             |    0.84 | transpiler_qualitative.TranspilerQualitativeBench.time_transpile_time_cnt3_5_179(3, 'sabre', 'sabre')      |
| -        | 249±0.4ms                  | 212±0.9ms                             |    0.85 | transpiler_qualitative.TranspilerQualitativeBench.time_transpile_time_cnt3_5_179(3, 'stochastic', 'sabre') |
| -        | 264±0.7ms                  | 222±3ms                               |    0.84 | transpiler_qualitative.TranspilerQualitativeBench.time_transpile_time_cnt3_5_180(2, 'sabre', 'dense')      |
| -        | 302±0.2ms                  | 264±0.5ms                             |    0.87 | transpiler_qualitative.TranspilerQualitativeBench.time_transpile_time_cnt3_5_180(2, 'sabre', 'sabre')      |
| -        | 564±2ms                    | 512±0.8ms                             |    0.91 | transpiler_qualitative.TranspilerQualitativeBench.time_transpile_time_cnt3_5_180(2, 'stochastic', 'sabre') |
| -        | 347±0.7ms                  | 259±0.4ms                             |    0.75 | transpiler_qualitative.TranspilerQualitativeBench.time_transpile_time_cnt3_5_180(3, 'sabre', 'dense')      |
| -        | 391±0.5ms                  | 306±0.5ms                             |    0.78 | transpiler_qualitative.TranspilerQualitativeBench.time_transpile_time_cnt3_5_180(3, 'sabre', 'sabre')      |
| -        | 719±0.9ms                  | 599±0.2ms                             |    0.83 | transpiler_qualitative.TranspilerQualitativeBench.time_transpile_time_cnt3_5_180(3, 'stochastic', 'sabre') |
```

See this comment to see the benchmarks of all the operations and for more information about the other approach.