### PR TITLE
Fix version table in qpy docs

### DIFF
--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -127,7 +127,7 @@ with. The following table lists the QPY versions that were supported in every
 Qiskit (and qiskit-terra prior to Qiskit 1.0.0) release going back to the introduction
 of QPY in qiskit-terra 0.18.0.
 
-.. list-table: QPY Format Version History
+.. list-table:: QPY Format Version History
    :header-rows: 1
 
    * - Qiskit (qiskit-terra for < 1.0.0) version
@@ -138,7 +138,7 @@ of QPY in qiskit-terra 0.18.0.
      - 12
    * - 1.0.2
      - 10, 11
-     - 12
+     - 11
    * - 1.0.1
      - 10, 11
      - 11


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The QPY docs included a format version table that matched up the Qiskit releases to the supported QPY format versions for that release. However, a typo resulted in it being treated as a comment instead of table this commit fixes this and a small copy paste error in one of the versions listed in the table.

### Details and comments