### PR TITLE
fixing deprecated methods and incorrect dag state

### DIFF
--- a/test/benchmarks/mapping_passes.py
+++ b/test/benchmarks/mapping_passes.py
@@ -124,12 +124,12 @@ class PassBenchmarks:
     def time_layout_2q_distance(self, _, __):
         layout = Layout2qDistance(self.coupling_map)
         layout.property_set["layout"] = self.layout
-        layout.run(self.enlarge_dag )
+        layout.run(self.enlarge_dag)
 
     def time_apply_layout(self, _, __):
         layout = ApplyLayout()
         layout.property_set["layout"] = self.layout
-        layout.run(self.enlarge_dag )
+        layout.run(self.enlarge_dag)
 
     def time_full_ancilla_allocation(self, _, __):
         ancilla = FullAncillaAllocation(self.coupling_map)

--- a/test/benchmarks/mapping_passes.py
+++ b/test/benchmarks/mapping_passes.py
@@ -124,12 +124,12 @@ class PassBenchmarks:
     def time_layout_2q_distance(self, _, __):
         layout = Layout2qDistance(self.coupling_map)
         layout.property_set["layout"] = self.layout
-        layout.run(self.dag)
+        layout.run(self.enlarge_dag )
 
     def time_apply_layout(self, _, __):
         layout = ApplyLayout()
         layout.property_set["layout"] = self.layout
-        layout.run(self.dag)
+        layout.run(self.enlarge_dag )
 
     def time_full_ancilla_allocation(self, _, __):
         ancilla = FullAncillaAllocation(self.coupling_map)

--- a/test/benchmarks/mapping_passes.py
+++ b/test/benchmarks/mapping_passes.py
@@ -232,12 +232,6 @@ class RoutedPassBenchmarks:
         self.backend_props = Fake20QV1().properties()
         self.routed_dag = StochasticSwap(self.coupling_map, seed=42).run(self.dag)
 
-    def time_cxdirection(self, _, __):
-        CXDirection(self.coupling_map).run(self.routed_dag)
-
-    def time_check_cx_direction(self, _, __):
-        CheckCXDirection(self.coupling_map).run(self.routed_dag)
-
     def time_gate_direction(self, _, __):
         GateDirection(self.coupling_map).run(self.routed_dag)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
 - Removed deprecated `CXDirection`, and `CheckCXDirection` passes, and tests associated
- Changed incorrect dag in `time_layout_2q_distance`, and `time_apply_layout`

### Details and comments
- Per release note 0.45 `qiskit.transpiler.passes.CXDirection` and `qiskit.transplier.passes.CheckCXDirection` and can be replaced with generic class `~.GateDirection`, and `~.CheckGateDirection`

- In `mapping_passses.PassBenchmarks.time_layout_2q_distance` and `mapping_passses.PassBenchmarks.time_layout_2q_distance `were running on a dag state that had already been through a layout pass (`self.dag`), and producing no results when params for `n_qubits` were 5, and 14. Dag state in both tests have been set to the dag before the layout pass in setup (`self.enlarge_dag`)

Fixes #12504 