### PR TITLE
Stop using deprecated U3 gate in random hex benchmarks

### DIFF
--- a/test/benchmarks/random_circuit_hex.py
+++ b/test/benchmarks/random_circuit_hex.py
@@ -41,7 +41,7 @@ def make_circuit_ring(nq, depth, seed):
         for i in range(nq):  # round of single-qubit unitaries
             u = random_unitary(2, seed).data
             angles = decomposer.angles(u)
-            qc.u3(angles[0], angles[1], angles[2], q[i])
+            qc.u(angles[0], angles[1], angles[2], q[i])
 
     # insert the final measurements
     qcm = copy.deepcopy(qc)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Changed in the code `qc.U3` to `qc.U` as the U3Gate is deprecated

### Details and comments
Per the U3Gate documentation: https://docs.quantum.ibm.com/api/qiskit/qiskit.circuit.library.U3Gate this gate is deprecated and instead should be replaced by the`qc.U`

Fixes #12503 
