### PR TITLE
+= depreciated changed to &=

### DIFF
--- a/qiskit/circuit/library/n_local/two_local.py
+++ b/qiskit/circuit/library/n_local/two_local.py
@@ -87,7 +87,7 @@ class TwoLocal(NLocal):
 
         >>> two = TwoLocal(3, ['ry','rz'], 'cz', 'full', reps=1, insert_barriers=True)
         >>> qc = QuantumCircuit(3)
-        >>> qc += two
+        >>> qc &= two
         >>> print(qc.decompose().draw())
              ┌──────────┐┌──────────┐ ░           ░ ┌──────────┐ ┌──────────┐
         q_0: ┤ Ry(θ[0]) ├┤ Rz(θ[3]) ├─░──■──■─────░─┤ Ry(θ[6]) ├─┤ Rz(θ[9]) ├

--- a/test/benchmarks/utils.py
+++ b/test/benchmarks/utils.py
@@ -213,7 +213,7 @@ def build_ripple_adder_circuit(size):
     qc.x(a[0])  # Set input a = 0...0001
     qc.x(b)  # Set input b = 1...1111
     # Apply the adder
-    qc += adder_subcircuit
+    qc &= adder_subcircuit
 
     # Measure the output register in the computational basis
     for j in range(n):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Changed the deprecated adder `+=` to `&=`

### Details and comments
Per release note 0.23 the removal of `extend` in the :`class: .QuantumCircuit` means the that `+=` is no longer defined 

Fixes #12502 