### PR TITLE
Bump pylint to 3.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,6 +213,7 @@ disable = [
     "docstring-first-line-empty", # relax docstring style
     "import-outside-toplevel", "import-error", # overzealous with our optionals/dynamic packages
     "nested-min-max", # this gives false equivalencies if implemented for the current lint version
+    "consider-using-max-builtin", "consider-using-min-builtin",  # unnecessary stylistic opinion
 # TODO(#9614): these were added in modern Pylint. Decide if we want to enable them. If so,
 #  remove from here and fix the issues. Else, move it above this section and add a comment
 #  with the rationale
@@ -222,6 +223,7 @@ disable = [
     "no-member",
     "no-value-for-parameter",
     "not-context-manager",
+    "possibly-used-before-assignment",
     "unexpected-keyword-arg",
     "unnecessary-dunder-call",
     "unnecessary-lambda-assignment",

--- a/qiskit/passmanager/flow_controllers.py
+++ b/qiskit/passmanager/flow_controllers.py
@@ -46,7 +46,7 @@ class FlowControllerLinear(BaseController):
 
     def iter_tasks(self, state: PassManagerState) -> Generator[Task, PassManagerState, None]:
         for task in self.tasks:
-            state = yield task  # pylint: disable=use-yield-from
+            state = yield task
 
 
 class DoWhileController(BaseController):
@@ -79,7 +79,7 @@ class DoWhileController(BaseController):
         max_iteration = self._options.get("max_iteration", 1000)
         for _ in range(max_iteration):
             for task in self.tasks:
-                state = yield task  # pylint: disable=use-yield-from
+                state = yield task
             if not self.do_while(state.property_set):
                 return
             # Remove stored tasks from the completed task collection for next loop
@@ -113,4 +113,4 @@ class ConditionalController(BaseController):
     def iter_tasks(self, state: PassManagerState) -> Generator[Task, PassManagerState, None]:
         if self.condition(state.property_set):
             for task in self.tasks:
-                state = yield task  # pylint: disable=use-yield-from
+                state = yield task

--- a/qiskit/passmanager/flow_controllers.py
+++ b/qiskit/passmanager/flow_controllers.py
@@ -46,7 +46,7 @@ class FlowControllerLinear(BaseController):
 
     def iter_tasks(self, state: PassManagerState) -> Generator[Task, PassManagerState, None]:
         for task in self.tasks:
-            state = yield task
+            state = yield task  # pylint: disable=use-yield-from
 
 
 class DoWhileController(BaseController):
@@ -79,7 +79,7 @@ class DoWhileController(BaseController):
         max_iteration = self._options.get("max_iteration", 1000)
         for _ in range(max_iteration):
             for task in self.tasks:
-                state = yield task
+                state = yield task  # pylint: disable=use-yield-from
             if not self.do_while(state.property_set):
                 return
             # Remove stored tasks from the completed task collection for next loop
@@ -113,4 +113,4 @@ class ConditionalController(BaseController):
     def iter_tasks(self, state: PassManagerState) -> Generator[Task, PassManagerState, None]:
         if self.condition(state.property_set):
             for task in self.tasks:
-                state = yield task
+                state = yield task  # pylint: disable=use-yield-from

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -18,7 +18,7 @@ import io
 import re
 from collections.abc import Iterator, Iterable, Callable
 from functools import wraps
-from typing import Union, List, Any
+from typing import Union, List, Any, TypeVar
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.converters import circuit_to_dag, dag_to_circuit
@@ -31,7 +31,7 @@ from .basepasses import BasePass
 from .exceptions import TranspilerError
 from .layout import TranspileLayout, Layout
 
-_CircuitsT = Union[List[QuantumCircuit], QuantumCircuit]
+_CircuitsT = TypeVar("_CircuitsT", bound=Union[List[QuantumCircuit], QuantumCircuit])
 
 
 class PassManager(BasePassManager):

--- a/qiskit/visualization/circuit/text.py
+++ b/qiskit/visualization/circuit/text.py
@@ -739,13 +739,7 @@ class TextDrawing:
         self._wire_map = {}
         self.cregbundle = cregbundle
 
-        if encoding:
-            self.encoding = encoding
-        else:
-            if sys.stdout.encoding:
-                self.encoding = sys.stdout.encoding
-            else:
-                self.encoding = "utf8"
+        self.encoding = encoding or sys.stdout.encoding or "utf8"
 
         self._nest_depth = 0  # nesting depth for control flow ops
         self._expr_text = ""  # expression text to display

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,8 +17,8 @@ black[jupyter]~=24.1
 #
 # These versions are pinned precisely because pylint frequently includes new
 # on-by-default lint failures in new versions, which breaks our CI.
-astroid==2.14.2
-pylint==2.16.2
+astroid==3.2.2
+pylint==3.2.2
 ruff==0.0.267
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ black[jupyter]~=24.1
 # These versions are pinned precisely because pylint frequently includes new
 # on-by-default lint failures in new versions, which breaks our CI.
 astroid==3.2.2
-pylint==3.2.2
+pylint==3.2.3
 ruff==0.0.267
 
 


### PR DESCRIPTION
### Summary

This upgrades pylint to a version compatible with Python 3.8 through 3.12, like Qiskit.  There are a couple of false positives (pylint is incorrect about its `use-yield-from` in the cases it flags), and has included a couple of new stylistic opinions that are not necessary to enforce.

The `possibly-used-before-assignment` lint is quite possibly a good one, but there are far too many instances in the Qiskit codebase right now to fix, whereas our current version of pylint is preventing us from running it with Python 3.12.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

pylint-dev/pylint#9700 will fix the `use-yield-from` false positives we're suppressing here, but there's probably no need to wait for 3.2.3 to release for this PR; we can remove the suppressions later.

- Close #12320 (obsolete)
- Fix #12510