### PR TITLE
Fixed incorrect behavior of scheduling benchmarks

### DIFF
--- a/test/benchmarks/scheduling_passes.py
+++ b/test/benchmarks/scheduling_passes.py
@@ -108,7 +108,6 @@ class SchedulingPassBenchmarks:
             ],
             dt=1e-9,
         )
-        self.timed_dag = TimeUnitConversion(self.durations).run(self.dag)
 
     def time_time_unit_conversion_pass(self, _, __):
         TimeUnitConversion(self.durations).run(self.dag)

--- a/test/benchmarks/scheduling_passes.py
+++ b/test/benchmarks/scheduling_passes.py
@@ -109,14 +109,6 @@ class SchedulingPassBenchmarks:
             dt=1e-9,
         )
         self.timed_dag = TimeUnitConversion(self.durations).run(self.dag)
-        dd_sequence = [XGate(), XGate()]
-        pm = PassManager(
-            [
-                ALAPScheduleAnalysis(self.durations),
-                PadDynamicalDecoupling(self.durations, dd_sequence),
-            ]
-        )
-        self.scheduled_dag = pm.run(self.timed_dag)
 
     def time_time_unit_conversion_pass(self, _, __):
         TimeUnitConversion(self.durations).run(self.dag)
@@ -140,8 +132,3 @@ class SchedulingPassBenchmarks:
             ]
         )
         pm.run(self.transpiled_circuit)
-
-    def time_dynamical_decoupling_pass(self, _, __):
-        PadDynamicalDecoupling(self.durations, dd_sequence=[XGate(), XGate()]).run(
-            self.timed_dag
-        )

--- a/test/benchmarks/scheduling_passes.py
+++ b/test/benchmarks/scheduling_passes.py
@@ -37,7 +37,7 @@ class SchedulingPassBenchmarks:
     def setup(self, n_qubits, depth):
         seed = 42
         self.circuit = random_circuit(
-            n_qubits, depth, measure=True, conditional=True, reset=True, seed=seed, max_operands=2
+            n_qubits, depth, measure=True, conditional=False, reset=False, seed=seed, max_operands=2
         )
         self.basis_gates = ["rz", "sx", "x", "cx", "id", "reset"]
         self.cmap = [
@@ -129,7 +129,7 @@ class SchedulingPassBenchmarks:
                 PadDynamicalDecoupling(self.durations, dd_sequence),
             ]
         )
-        pm.run(self.timed_dag)
+        pm.run(self.transpiled_circuit)
 
     def time_asap_schedule_pass(self, _, __):
         dd_sequence = [XGate(), XGate()]
@@ -139,9 +139,9 @@ class SchedulingPassBenchmarks:
                 PadDynamicalDecoupling(self.durations, dd_sequence),
             ]
         )
-        pm.run(self.timed_dag)
+        pm.run(self.transpiled_circuit)
 
     def time_dynamical_decoupling_pass(self, _, __):
         PadDynamicalDecoupling(self.durations, dd_sequence=[XGate(), XGate()]).run(
-            self.scheduled_dag
+            self.timed_dag
         )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Changed in random circuit parameters: `conditional`, and `reset` to false from true. Removed deprecated `time_dynamical_decoupling_pass` test


### Details and comments
`ALAP` and `ASAP` do not support conditional reset in `random_circuit`. `time_dynamical_decoupling_pass` test is deprecated as the process of running a scheduling, and padding pass cannot be broken up to individually time the `PadDynamicalDecoupling` pass, refer to previous PR's to see changes in `ALAP` and `ASAP` tests to include PadDD in the pass manager.

Fixed #12505 
