### PR TITLE
Avoid exception in `Target.has_calibration` for instruction without properties

### DIFF
--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -892,7 +892,7 @@ class Target(Mapping):
             return False
         if qargs not in self._gate_map[operation_name]:
             return False
-        return getattr(self._gate_map[operation_name][qargs], "_calibration") is not None
+        return getattr(self._gate_map[operation_name][qargs], "_calibration", None) is not None
 
     def get_calibration(
         self,

--- a/releasenotes/notes/target-has-calibration-no-properties-f3be18f2d58f330a.yaml
+++ b/releasenotes/notes/target-has-calibration-no-properties-f3be18f2d58f330a.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    :meth:`.Target.has_calibration` has been updated so that it does not raise
+    an exception for an instruction that has been added to the target with
+    ``None`` for its instruction properties. Fixes
+    `#12525 <https://github.com/Qiskit/qiskit/issues/12525>`__.

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -1366,6 +1366,31 @@ Instructions:
 
         self.assertIsNone(target["x"][(0,)].calibration)
 
+    def test_has_calibration(self):
+        target = Target()
+        properties = {
+            (0,): InstructionProperties(duration=100, error=0.1),
+            (1,): None,
+        }
+        target.add_instruction(XGate(), properties)
+
+        # Test false for properties with no calibration
+        self.assertFalse(target.has_calibration("x", (0,)))
+        # Test false for no properties
+        self.assertFalse(target.has_calibration("x", (1,)))
+
+        properties = {
+            (0,): InstructionProperties(
+                duration=self.custom_sx_q0.duration,
+                error=None,
+                calibration=self.custom_sx_q0,
+            )
+        }
+        target.add_instruction(SXGate(), properties)
+
+        # Test true for properties with calibration
+        self.assertTrue(target.has_calibration("sx", (0,)))
+
     def test_loading_legacy_ugate_instmap(self):
         # This is typical IBM backend situation.
         # IBM provider used to have u1, u2, u3 in the basis gates and


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Avoid exception in `Target.has_calibration` for instruction without properties

### Details and comments

`Target.add_instruction` allows passing `None` in place of an `InstructionProperties` instance. In this case, there will be no `_calibration` attribute, so the `getattr` call properties needs to provide a default value, as done in this change.

Closes #12525 
