### PR TITLE
Improve public type annotations for `OneQubitEulerDecomposer`

### DIFF
--- a/qiskit/synthesis/one_qubit/one_qubit_decompose.py
+++ b/qiskit/synthesis/one_qubit/one_qubit_decompose.py
@@ -14,6 +14,7 @@
 Decompose a single-qubit unitary via Euler angles.
 """
 from __future__ import annotations
+from typing import TYPE_CHECKING
 import numpy as np
 
 from qiskit._accelerate import euler_one_qubit_decomposer
@@ -36,6 +37,9 @@ from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.operators.predicates import is_unitary_matrix
 from qiskit.circuit.gate import Gate
 from qiskit.quantum_info.operators.operator import Operator
+
+if TYPE_CHECKING:
+    from qiskit.dagcircuit import DAGCircuit
 
 DEFAULT_ATOL = 1e-12
 
@@ -150,7 +154,7 @@ class OneQubitEulerDecomposer:
         self.basis = basis  # sets: self._basis, self._params, self._circuit
         self.use_dag = use_dag
 
-    def build_circuit(self, gates, global_phase):
+    def build_circuit(self, gates, global_phase) -> QuantumCircuit | DAGCircuit:
         """Return the circuit or dag object from a list of gates."""
         qr = [Qubit()]
         lookup_gate = False
@@ -186,7 +190,7 @@ class OneQubitEulerDecomposer:
         unitary: Operator | Gate | np.ndarray,
         simplify: bool = True,
         atol: float = DEFAULT_ATOL,
-    ) -> QuantumCircuit:
+    ) -> QuantumCircuit | DAGCircuit:
         """Decompose single qubit gate into a circuit.
 
         Args:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

I noticed an incorrect/incomplete return type annotation for `OneQubitEulerDecomposer.__call__` and also added an annotation for `build_circuit`.

### Details and comments


