### PR TITLE
Fix annotation

### DIFF
--- a/qiskit/providers/providerutils.py
+++ b/qiskit/providers/providerutils.py
@@ -21,7 +21,9 @@ from qiskit.providers.backend import Backend
 logger = logging.getLogger(__name__)
 
 
-def filter_backends(backends: list[Backend], filters: Callable[[Backend], bool] | None = None, **kwargs) -> list[Backend]:
+def filter_backends(
+    backends: list[Backend], filters: Callable[[Backend], bool] | None = None, **kwargs
+) -> list[Backend]:
     """Return the backends matching the specified filtering.
 
     Filter the `backends` list by their `configuration` or `status`

--- a/qiskit/providers/providerutils.py
+++ b/qiskit/providers/providerutils.py
@@ -21,7 +21,7 @@ from qiskit.providers.backend import Backend
 logger = logging.getLogger(__name__)
 
 
-def filter_backends(backends: list[Backend], filters: Callable = None, **kwargs) -> list[Backend]:
+def filter_backends(backends: list[Backend], filters: Callable[[Backend], bool] | None = None, **kwargs) -> list[Backend]:
     """Return the backends matching the specified filtering.
 
     Filter the `backends` list by their `configuration` or `status`


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fix the annotated type of `filters` argument.

### Details and comments

This PR is consisting of two parts:

#### Narrow types

As `filters` is used as the first argument of `filter` function against `list[Backends]`, we can narrow the type of `filters`.

#### Use `| None` explicitly

It is explicitly specified in PEP484 (see [here](https://docs.astral.sh/ruff/rules/implicit-optional/) for information/reference).