### PR TITLE
Fix the possibly-used-before-assignment in pylint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,7 +223,6 @@ disable = [
     "no-member",
     "no-value-for-parameter",
     "not-context-manager",
-    "possibly-used-before-assignment",
     "unexpected-keyword-arg",
     "unnecessary-dunder-call",
     "unnecessary-lambda-assignment",

--- a/qiskit/primitives/backend_estimator.py
+++ b/qiskit/primitives/backend_estimator.py
@@ -65,6 +65,8 @@ def _run_circuits(
         max_circuits = getattr(backend.configuration(), "max_experiments", None)
     elif isinstance(backend, BackendV2):
         max_circuits = backend.max_circuits
+    else:  # pragma: no cover
+        raise QiskitError("Backend version not supported")
     if max_circuits:
         jobs = [
             backend.run(circuits[pos : pos + max_circuits], **run_options)

--- a/qiskit/primitives/backend_estimator.py
+++ b/qiskit/primitives/backend_estimator.py
@@ -65,8 +65,8 @@ def _run_circuits(
         max_circuits = getattr(backend.configuration(), "max_experiments", None)
     elif isinstance(backend, BackendV2):
         max_circuits = backend.max_circuits
-    else:  # pragma: no cover
-        raise QiskitError("Backend version not supported")
+    else:
+        raise RuntimeError("Backend version not supported")
     if max_circuits:
         jobs = [
             backend.run(circuits[pos : pos + max_circuits], **run_options)

--- a/qiskit/pulse/macros.py
+++ b/qiskit/pulse/macros.py
@@ -124,8 +124,13 @@ def _measure_v1(
     for qubit in qubits:
         measure_groups.add(tuple(meas_map[qubit]))
     for measure_group_qubits in measure_groups:
-        if qubit_mem_slots is not None:
-            unused_mem_slots = set(measure_group_qubits) - set(qubit_mem_slots.values())
+
+        unused_mem_slots = (
+            set()
+            if qubit_mem_slots is None
+            else set(measure_group_qubits) - set(qubit_mem_slots.values())
+        )
+
         try:
             default_sched = inst_map.get(measure_name, measure_group_qubits)
         except exceptions.PulseError as ex:

--- a/qiskit/qpy/binary_io/circuits.py
+++ b/qiskit/qpy/binary_io/circuits.py
@@ -446,6 +446,7 @@ def _parse_custom_operation(
         ) = custom_operations[gate_name]
     else:
         type_str, num_qubits, num_clbits, definition = custom_operations[gate_name]
+        base_gate_raw = ctrl_state = num_ctrl_qubits = None
     # Strip the trailing "_{uuid}" from the gate name if the version >=11
     if version >= 11:
         gate_name = "_".join(gate_name.split("_")[:-1])

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -430,11 +430,10 @@ class Operator(LinearOp):
                 final_permutation_inverse = _inverse_pattern(final_permutation)
                 op = op.apply_permutation(final_permutation_inverse, False)
             op = op.apply_permutation(initial_permutation_inverse, False)
-        else:
-            if final_layout is not None:
-                final_permutation = final_layout.to_permutation(circuit.qubits)
-                final_permutation_inverse = _inverse_pattern(final_permutation)
-                op = op.apply_permutation(final_permutation_inverse, False)
+        elif final_layout is not None:
+            final_permutation = final_layout.to_permutation(circuit.qubits)
+            final_permutation_inverse = _inverse_pattern(final_permutation)
+            op = op.apply_permutation(final_permutation_inverse, False)
 
         return op
 

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -414,6 +414,8 @@ class Operator(LinearOp):
 
         from qiskit.synthesis.permutation.permutation_utils import _inverse_pattern
 
+        op = Operator(circuit)
+
         if initial_layout is not None:
             input_qubits = [None] * len(layout.input_qubit_mapping)
             for q, p in layout.input_qubit_mapping.items():
@@ -421,21 +423,18 @@ class Operator(LinearOp):
 
             initial_permutation = initial_layout.to_permutation(input_qubits)
             initial_permutation_inverse = _inverse_pattern(initial_permutation)
-
-        if final_layout is not None:
-            final_permutation = final_layout.to_permutation(circuit.qubits)
-            final_permutation_inverse = _inverse_pattern(final_permutation)
-
-        op = Operator(circuit)
-
-        if initial_layout:
             op = op.apply_permutation(initial_permutation, True)
 
-        if final_layout:
-            op = op.apply_permutation(final_permutation_inverse, False)
-
-        if initial_layout:
+            if final_layout is not None:
+                final_permutation = final_layout.to_permutation(circuit.qubits)
+                final_permutation_inverse = _inverse_pattern(final_permutation)
+                op = op.apply_permutation(final_permutation_inverse, False)
             op = op.apply_permutation(initial_permutation_inverse, False)
+        else:
+            if final_layout is not None:
+                final_permutation = final_layout.to_permutation(circuit.qubits)
+                final_permutation_inverse = _inverse_pattern(final_permutation)
+                op = op.apply_permutation(final_permutation_inverse, False)
 
         return op
 

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -137,7 +137,7 @@ class SparsePauliOp(LinearOp):
 
         if isinstance(coeffs, np.ndarray):
             dtype = object if coeffs.dtype == object else complex
-        elif coeffs is not None:
+        else:  # coeffs is not None
             if not isinstance(coeffs, (np.ndarray, Sequence)):
                 coeffs = [coeffs]
             if any(isinstance(coeff, ParameterExpression) for coeff in coeffs):

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -135,19 +135,18 @@ class SparsePauliOp(LinearOp):
 
         pauli_list = PauliList(data.copy() if copy and hasattr(data, "copy") else data)
 
-        if isinstance(coeffs, np.ndarray):
-            dtype = object if coeffs.dtype == object else complex
-        else:  # coeffs is not None
-            if not isinstance(coeffs, (np.ndarray, Sequence)):
-                coeffs = [coeffs]
-            if any(isinstance(coeff, ParameterExpression) for coeff in coeffs):
-                dtype = object
-            else:
-                dtype = complex
-
         if coeffs is None:
             coeffs = np.ones(pauli_list.size, dtype=complex)
         else:
+            if isinstance(coeffs, np.ndarray):
+                dtype = object if coeffs.dtype == object else complex
+            else:
+                if any(isinstance(coeff, ParameterExpression) for coeff in coeffs):
+                    dtype = object
+                else:
+                    dtype = complex
+                if not isinstance(coeffs, (np.ndarray, Sequence)):
+                    coeffs = [coeffs]
             coeffs_asarray = np.asarray(coeffs, dtype=dtype)
             coeffs = (
                 coeffs_asarray.copy()

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -141,12 +141,13 @@ class SparsePauliOp(LinearOp):
             if isinstance(coeffs, np.ndarray):
                 dtype = object if coeffs.dtype == object else complex
             else:
+                if not isinstance(coeffs, Sequence):
+                    coeffs = [coeffs]
                 if any(isinstance(coeff, ParameterExpression) for coeff in coeffs):
                     dtype = object
                 else:
                     dtype = complex
-                if not isinstance(coeffs, (np.ndarray, Sequence)):
-                    coeffs = [coeffs]
+
             coeffs_asarray = np.asarray(coeffs, dtype=dtype)
             coeffs = (
                 coeffs_asarray.copy()

--- a/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
+++ b/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
@@ -60,9 +60,9 @@ class UnrollCustomDefinitions(TransformationPass):
         if self._basis_gates is None and self._target is None:
             return dag
 
-        basic_insts = {"measure", "reset", "barrier", "snapshot", "delay", "store"}
+        device_insts = {"measure", "reset", "barrier", "snapshot", "delay", "store"}
         if self._target is None:
-            basic_insts |= set(self._basis_gates)
+            device_insts |= set(self._basis_gates)
 
         for node in dag.op_nodes():
             if isinstance(node.op, ControlFlowOp):
@@ -83,7 +83,7 @@ class UnrollCustomDefinitions(TransformationPass):
                         qargs=tuple(dag.find_bit(x).index for x in node.qargs),
                     )
                 else:
-                    inst_supported = node.name in basic_insts
+                    inst_supported = node.name in device_insts
 
                 if inst_supported or self._equiv_lib.has_entry(node.op):
                     continue

--- a/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
+++ b/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
@@ -60,9 +60,9 @@ class UnrollCustomDefinitions(TransformationPass):
         if self._basis_gates is None and self._target is None:
             return dag
 
+        basic_insts = {"measure", "reset", "barrier", "snapshot", "delay", "store"}
         if self._target is None:
-            basic_insts = {"measure", "reset", "barrier", "snapshot", "delay", "store"}
-            device_insts = basic_insts | set(self._basis_gates)
+            basic_insts |= set(self._basis_gates)
 
         for node in dag.op_nodes():
             if isinstance(node.op, ControlFlowOp):
@@ -77,14 +77,14 @@ class UnrollCustomDefinitions(TransformationPass):
 
             controlled_gate_open_ctrl = isinstance(node.op, ControlledGate) and node.op._open_ctrl
             if not controlled_gate_open_ctrl:
-                inst_supported = (
-                    self._target.instruction_supported(
+                if self._target is not None:
+                    inst_supported = self._target.instruction_supported(
                         operation_name=node.op.name,
                         qargs=tuple(dag.find_bit(x).index for x in node.qargs),
                     )
-                    if self._target is not None
-                    else node.name in device_insts
-                )
+                else:
+                    inst_supported = node.name in basic_insts
+
                 if inst_supported or self._equiv_lib.has_entry(node.op):
                     continue
             try:

--- a/qiskit/transpiler/passes/optimization/commutative_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/commutative_cancellation.py
@@ -156,6 +156,10 @@ class CommutativeCancellation(TransformationPass):
                         current_angle = np.pi / 4
                     elif current_node.name == "s":
                         current_angle = np.pi / 2
+                    else:
+                        raise TranspilerError(
+                            f"Angle for operation {current_node.name } is not defined"
+                        )
 
                     # Compose gates
                     total_angle = current_angle + total_angle
@@ -167,6 +171,8 @@ class CommutativeCancellation(TransformationPass):
                     new_op = var_z_gate(total_angle)
                 elif cancel_set_key[0] == "x_rotation":
                     new_op = RXGate(total_angle)
+                else:  # pragma: no cover
+                    raise TranspilerError("impossible case")
 
                 new_op_phase = 0
                 if np.mod(total_angle, (2 * np.pi)) > _CUTOFF_PRECISION:

--- a/qiskit/visualization/circuit/matplotlib.py
+++ b/qiskit/visualization/circuit/matplotlib.py
@@ -1584,6 +1584,8 @@ class MatplotlibDrawer:
                 flow_text = " For"
             elif isinstance(node.op, SwitchCaseOp):
                 flow_text = "Switch"
+            else:
+                flow_text = node.op.name
 
             # Some spacers. op_spacer moves 'Switch' back a bit for alignment,
             # expr_spacer moves the expr over to line up with 'Switch' and

--- a/test/benchmarks/randomized_benchmarking.py
+++ b/test/benchmarks/randomized_benchmarking.py
@@ -105,6 +105,7 @@ def clifford_2_qubit_circuit(num):
     qc = QuantumCircuit(2)
     if vals[0] == 0 or vals[0] == 3:
         (form, i0, i1, j0, j1, p0, p1) = vals
+        k0, k1 = (None, None)
     else:
         (form, i0, i1, j0, j1, k0, k1, p0, p1) = vals
     if i0 == 1:

--- a/test/benchmarks/utils.py
+++ b/test/benchmarks/utils.py
@@ -126,6 +126,8 @@ def random_circuit(
                 operation = rng.choice(two_q_ops)
             elif num_operands == 3:
                 operation = rng.choice(three_q_ops)
+            else:
+                raise RuntimeError("not supported number of operands")
             if operation in one_param:
                 num_angles = 1
             elif operation in two_param:

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -1091,7 +1091,7 @@ class TestParameters(QiskitTestCase):
 
         if target_type == "gate":
             inst = qc.to_gate()
-        elif target_type == "instruction":
+        else:  # target_type == "instruction":
             inst = qc.to_instruction()
 
         qc2 = QuantumCircuit(1)
@@ -1132,7 +1132,7 @@ class TestParameters(QiskitTestCase):
 
         if target_type == "gate":
             inst = qc1.to_gate()
-        elif target_type == "instruction":
+        else:  # target_type == "instruction":
             inst = qc1.to_instruction()
 
         qc2 = QuantumCircuit(1)
@@ -1188,7 +1188,7 @@ class TestParameters(QiskitTestCase):
 
         if target_type == "gate":
             sub_inst = sub_qc.to_gate()
-        elif target_type == "instruction":
+        else:  # target_type == "instruction":
             sub_inst = sub_qc.to_instruction()
 
         unbound_qc = QuantumCircuit(2, 1)
@@ -1407,6 +1407,7 @@ def _paramvec_names(prefix, length):
 
 @ddt
 class TestParameterExpressions(QiskitTestCase):
+    # pylint: disable=possibly-used-before-assignment
     """Test expressions of Parameters."""
 
     # supported operations dictionary operation : accuracy (0=exact match)

--- a/test/python/classical_function_compiler/test_boolean_expression.py
+++ b/test/python/classical_function_compiler/test_boolean_expression.py
@@ -28,6 +28,7 @@ if HAS_TWEEDLEDUM:
 @unittest.skipUnless(HAS_TWEEDLEDUM, "Tweedledum is required for these tests.")
 @ddt
 class TestBooleanExpression(QiskitTestCase):
+    # pylint: disable=possibly-used-before-assignment
     """Test boolean expression."""
 
     @data(

--- a/test/python/classical_function_compiler/test_classical_function.py
+++ b/test/python/classical_function_compiler/test_classical_function.py
@@ -26,6 +26,7 @@ if HAS_TWEEDLEDUM:
 
 @unittest.skipUnless(HAS_TWEEDLEDUM, "Tweedledum is required for these tests.")
 class TestOracleDecomposition(QiskitTestCase):
+    # pylint: disable=possibly-used-before-assignment
     """Tests ClassicalFunction.decomposition."""
 
     def test_grover_oracle(self):

--- a/test/python/classical_function_compiler/test_parse.py
+++ b/test/python/classical_function_compiler/test_parse.py
@@ -25,6 +25,7 @@ if HAS_TWEEDLEDUM:
 
 @unittest.skipUnless(HAS_TWEEDLEDUM, "Tweedledum is required for these tests.")
 class TestParseFail(QiskitTestCase):
+    # pylint: disable=possibly-used-before-assignment
     """Tests bad_examples with the classicalfunction parser."""
 
     def assertExceptionMessage(self, context, message):

--- a/test/python/classical_function_compiler/test_simulate.py
+++ b/test/python/classical_function_compiler/test_simulate.py
@@ -26,6 +26,7 @@ if HAS_TWEEDLEDUM:
 @unittest.skipUnless(HAS_TWEEDLEDUM, "Tweedledum is required for these tests.")
 @ddt
 class TestSimulate(QiskitTestCase):
+    # pylint: disable=possibly-used-before-assignment
     """Tests LogicNetwork.simulate method"""
 
     @data(*utils.example_list())

--- a/test/python/classical_function_compiler/test_synthesis.py
+++ b/test/python/classical_function_compiler/test_synthesis.py
@@ -26,6 +26,7 @@ if HAS_TWEEDLEDUM:
 
 @unittest.skipUnless(HAS_TWEEDLEDUM, "Tweedledum is required for these tests.")
 class TestSynthesis(QiskitTestCase):
+    # pylint: disable=possibly-used-before-assignment
     """Tests ClassicalFunction.synth method."""
 
     def test_grover_oracle(self):

--- a/test/python/classical_function_compiler/test_tweedledum2qiskit.py
+++ b/test/python/classical_function_compiler/test_tweedledum2qiskit.py
@@ -29,6 +29,7 @@ if HAS_TWEEDLEDUM:
 
 @unittest.skipUnless(HAS_TWEEDLEDUM, "Tweedledum is required for these tests.")
 class TestTweedledum2Qiskit(QiskitTestCase):
+    # pylint: disable=possibly-used-before-assignment
     """Tests qiskit.transpiler.classicalfunction.utils.tweedledum2qiskit function."""
 
     def test_x(self):

--- a/test/python/classical_function_compiler/test_typecheck.py
+++ b/test/python/classical_function_compiler/test_typecheck.py
@@ -25,6 +25,7 @@ if HAS_TWEEDLEDUM:
 
 @unittest.skipUnless(HAS_TWEEDLEDUM, "Tweedledum is required for these tests.")
 class TestTypeCheck(QiskitTestCase):
+    # pylint: disable=possibly-used-before-assignment
     """Tests classicalfunction compiler type checker (good examples)."""
 
     def test_id(self):
@@ -74,6 +75,7 @@ class TestTypeCheck(QiskitTestCase):
 
 @unittest.skipUnless(HAS_TWEEDLEDUM, "Tweedledum is required for these tests.")
 class TestTypeCheckFail(QiskitTestCase):
+    # pylint: disable=possibly-used-before-assignment
     """Tests classicalfunction compiler type checker (bad examples)."""
 
     def assertExceptionMessage(self, context, message):

--- a/test/python/visualization/test_circuit_drawer.py
+++ b/test/python/visualization/test_circuit_drawer.py
@@ -55,6 +55,7 @@ class TestCircuitDrawer(QiskitTestCase):
 
     @unittest.skipUnless(optionals.HAS_MATPLOTLIB, "Skipped because matplotlib is not available")
     def test_mpl_config_with_path(self):
+        # pylint: disable=possibly-used-before-assignment
         # It's too easy to get too nested in a test with many context managers.
         tempdir = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
         self.addCleanup(tempdir.cleanup)
@@ -128,6 +129,7 @@ class TestCircuitDrawer(QiskitTestCase):
 
     @_latex_drawer_condition
     def test_latex_output_file_correct_format(self):
+        # pylint: disable=possibly-used-before-assignment
         with patch("qiskit.user_config.get_config", return_value={"circuit_drawer": "latex"}):
             circuit = QuantumCircuit()
             filename = "file.gif"

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -185,6 +185,7 @@ class TestTextDrawerElement(QiskitTestCase):
 
 
 class TestTextDrawerGatesInCircuit(QiskitTestCase):
+    # pylint: disable=possibly-used-before-assignment
     """Gate by gate checks in different settings."""
 
     def test_text_measure_cregbundle(self):

--- a/test/python/visualization/test_gate_map.py
+++ b/test/python/visualization/test_gate_map.py
@@ -45,6 +45,7 @@ if optionals.HAS_PIL:
 @unittest.skipUnless(optionals.HAS_PIL, "PIL not available")
 @unittest.skipUnless(optionals.HAS_SEABORN, "seaborn not available")
 class TestGateMap(QiskitVisualizationTestCase):
+    # pylint: disable=possibly-used-before-assignment
     """visual tests for plot_gate_map"""
 
     backends = [Fake5QV1(), Fake20QV1(), Fake7QPulseV1()]

--- a/test/python/visualization/test_plot_histogram.py
+++ b/test/python/visualization/test_plot_histogram.py
@@ -28,6 +28,7 @@ if optionals.HAS_PIL:
 
 @unittest.skipUnless(optionals.HAS_MATPLOTLIB, "matplotlib not available.")
 class TestPlotHistogram(QiskitVisualizationTestCase):
+    # pylint: disable=possibly-used-before-assignment
     """Qiskit plot_histogram tests."""
 
     def test_different_counts_lengths(self):

--- a/tools/build_standard_commutations.py
+++ b/tools/build_standard_commutations.py
@@ -102,11 +102,11 @@ def _generate_commutation_dict(considered_gates: List[Gate] = None) -> dict:
                     commutation_relation = cc.commute(
                         op1, qargs1, cargs1, op2, qargs2, cargs2, max_num_qubits=4
                     )
+
+                    gate_pair_commutation[relative_placement] = commutation_relation
                 else:
                     pass
                     # TODO
-
-                gate_pair_commutation[relative_placement] = commutation_relation
 
             commutations[gate0.name, gate1.name] = gate_pair_commutation
     return commutations


### PR DESCRIPTION
In https://github.com/Qiskit/qiskit/pull/12520 @jakelishman mentioned that would be great to enable `possibly-used-before-assignment` introduced in pylint 3.2

Here it is.