### PR TITLE
Fix `ParameterVector` methods: `params` and `index`

### DIFF
--- a/qiskit/circuit/parametervector.py
+++ b/qiskit/circuit/parametervector.py
@@ -50,14 +50,14 @@ class ParameterVectorElement(Parameter):
 class ParameterVector:
     """ParameterVector class to quickly generate lists of parameters."""
 
-    __slots__ = ("_name", "_params", "_size", "_root_uuid")
+    __slots__ = ("_name", "_all_params", "_size", "_root_uuid")
 
     def __init__(self, name, length=0):
         self._name = name
         self._size = length
         self._root_uuid = uuid4()
         root_uuid_int = self._root_uuid.int
-        self._params = [
+        self._all_params = [
             ParameterVectorElement(self, i, UUID(int=root_uuid_int + i)) for i in range(length)
         ]
 
@@ -69,29 +69,23 @@ class ParameterVector:
     @property
     def params(self):
         """Returns the list of parameters in the ParameterVector."""
-        return self._params
+        return self._all_params[: self._size]
 
     def index(self, value):
         """Returns first index of value."""
-        return self._params.index(value)
+        return self.params.index(value)
 
     def __getitem__(self, key):
-        if isinstance(key, slice):
-            start, stop, step = key.indices(self._size)
-            return self.params[start:stop:step]
-
-        if key > self._size:
-            raise IndexError(f"Index out of range: {key} > {self._size}")
         return self.params[key]
 
     def __iter__(self):
-        return iter(self.params[: self._size])
+        return iter(self.params)
 
     def __len__(self):
         return self._size
 
     def __str__(self):
-        return f"{self.name}, {[str(item) for item in self.params[: self._size]]}"
+        return f"{self.name}, {[str(item) for item in self.params]}"
 
     def __repr__(self):
         return f"{self.__class__.__name__}(name={self.name}, length={len(self)})"
@@ -103,12 +97,12 @@ class ParameterVector:
         previous elements are cached and not re-generated if the vector is enlarged again.
         This is to ensure that the parameter instances do not change.
         """
-        if length > len(self._params):
+        if length > len(self._all_params):
             root_uuid_int = self._root_uuid.int
-            self._params.extend(
+            self._all_params.extend(
                 [
                     ParameterVectorElement(self, i, UUID(int=root_uuid_int + i))
-                    for i in range(len(self._params), length)
+                    for i in range(len(self._all_params), length)
                 ]
             )
         self._size = length

--- a/qiskit/circuit/parametervector.py
+++ b/qiskit/circuit/parametervector.py
@@ -50,14 +50,14 @@ class ParameterVectorElement(Parameter):
 class ParameterVector:
     """ParameterVector class to quickly generate lists of parameters."""
 
-    __slots__ = ("_name", "_all_params", "_size", "_root_uuid")
+    __slots__ = ("_name", "_all_historical_params", "_size", "_root_uuid")
 
     def __init__(self, name, length=0):
         self._name = name
         self._size = length
         self._root_uuid = uuid4()
         root_uuid_int = self._root_uuid.int
-        self._all_params = [
+        self._all_historical_params = [
             ParameterVectorElement(self, i, UUID(int=root_uuid_int + i)) for i in range(length)
         ]
 
@@ -69,7 +69,7 @@ class ParameterVector:
     @property
     def params(self):
         """Returns the list of parameters in the ParameterVector."""
-        return self._all_params[: self._size]
+        return self._all_historical_params[: self._size]
 
     def index(self, value):
         """Returns first index of value."""
@@ -97,12 +97,12 @@ class ParameterVector:
         previous elements are cached and not re-generated if the vector is enlarged again.
         This is to ensure that the parameter instances do not change.
         """
-        if length > len(self._all_params):
+        if length > len(self._all_historical_params):
             root_uuid_int = self._root_uuid.int
-            self._all_params.extend(
+            self._all_historical_params.extend(
                 [
                     ParameterVectorElement(self, i, UUID(int=root_uuid_int + i))
-                    for i in range(len(self._all_params), length)
+                    for i in range(len(self._all_historical_params), length)
                 ]
             )
         self._size = length

--- a/qiskit/qpy/binary_io/value.py
+++ b/qiskit/qpy/binary_io/value.py
@@ -243,7 +243,9 @@ def _read_parameter_vec(file_obj, vectors):
     vector = vectors[name][0]
     if vector[data.index].uuid != param_uuid:
         vectors[name][1].add(data.index)
-        vector._all_params[data.index] = ParameterVectorElement(vector, data.index, uuid=param_uuid)
+        vector._all_historical_params[data.index] = ParameterVectorElement(
+            vector, data.index, uuid=param_uuid
+        )
     return vector[data.index]
 
 

--- a/qiskit/qpy/binary_io/value.py
+++ b/qiskit/qpy/binary_io/value.py
@@ -243,7 +243,7 @@ def _read_parameter_vec(file_obj, vectors):
     vector = vectors[name][0]
     if vector[data.index].uuid != param_uuid:
         vectors[name][1].add(data.index)
-        vector._params[data.index] = ParameterVectorElement(vector, data.index, uuid=param_uuid)
+        vector._all_params[data.index] = ParameterVectorElement(vector, data.index, uuid=param_uuid)
     return vector[data.index]
 
 


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This changes the `params` and `index` methods on `ParameterVector` to _not_ return historical parameters, following
https://github.com/Qiskit/qiskit/issues/12541#issuecomment-2160631785.

Fixes #12541.


### Details and comments

I also simplified a bit of the implementation and renamed `_params` to `_all_params` so it is more unlikely someone might misuse it and create a similar problem in the future.  I would even be open to calling this `_all_historical_params` to be even more clear.



