### PR TITLE
Use relative import for `_accelerate`

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -60,9 +60,7 @@ import qiskit._numpy_compat
 # We manually define them on import so people can directly import qiskit._accelerate.* submodules
 # and not have to rely on attribute access.  No action needed for top-level extension packages.
 sys.modules["qiskit._accelerate.circuit"] = _accelerate.circuit
-sys.modules["qiskit._accelerate.convert_2q_block_matrix"] = (
-    _accelerate.convert_2q_block_matrix
-)
+sys.modules["qiskit._accelerate.convert_2q_block_matrix"] = _accelerate.convert_2q_block_matrix
 sys.modules["qiskit._accelerate.dense_layout"] = _accelerate.dense_layout
 sys.modules["qiskit._accelerate.error_map"] = _accelerate.error_map
 sys.modules["qiskit._accelerate.isometry"] = _accelerate.isometry

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -52,37 +52,37 @@ if sys.version_info < (3, 9):
     )
 
 
-import qiskit._accelerate
+from . import _accelerate
 import qiskit._numpy_compat
 
 # Globally define compiled submodules. The normal import mechanism will not find compiled submodules
 # in _accelerate because it relies on file paths, but PyO3 generates only one shared library file.
 # We manually define them on import so people can directly import qiskit._accelerate.* submodules
 # and not have to rely on attribute access.  No action needed for top-level extension packages.
-sys.modules["qiskit._accelerate.circuit"] = qiskit._accelerate.circuit
+sys.modules["qiskit._accelerate.circuit"] = _accelerate.circuit
 sys.modules["qiskit._accelerate.convert_2q_block_matrix"] = (
-    qiskit._accelerate.convert_2q_block_matrix
+    _accelerate.convert_2q_block_matrix
 )
-sys.modules["qiskit._accelerate.dense_layout"] = qiskit._accelerate.dense_layout
-sys.modules["qiskit._accelerate.error_map"] = qiskit._accelerate.error_map
-sys.modules["qiskit._accelerate.isometry"] = qiskit._accelerate.isometry
-sys.modules["qiskit._accelerate.uc_gate"] = qiskit._accelerate.uc_gate
+sys.modules["qiskit._accelerate.dense_layout"] = _accelerate.dense_layout
+sys.modules["qiskit._accelerate.error_map"] = _accelerate.error_map
+sys.modules["qiskit._accelerate.isometry"] = _accelerate.isometry
+sys.modules["qiskit._accelerate.uc_gate"] = _accelerate.uc_gate
 sys.modules["qiskit._accelerate.euler_one_qubit_decomposer"] = (
-    qiskit._accelerate.euler_one_qubit_decomposer
+    _accelerate.euler_one_qubit_decomposer
 )
-sys.modules["qiskit._accelerate.nlayout"] = qiskit._accelerate.nlayout
-sys.modules["qiskit._accelerate.optimize_1q_gates"] = qiskit._accelerate.optimize_1q_gates
-sys.modules["qiskit._accelerate.pauli_expval"] = qiskit._accelerate.pauli_expval
-sys.modules["qiskit._accelerate.qasm2"] = qiskit._accelerate.qasm2
-sys.modules["qiskit._accelerate.qasm3"] = qiskit._accelerate.qasm3
-sys.modules["qiskit._accelerate.results"] = qiskit._accelerate.results
-sys.modules["qiskit._accelerate.sabre"] = qiskit._accelerate.sabre
-sys.modules["qiskit._accelerate.sampled_exp_val"] = qiskit._accelerate.sampled_exp_val
-sys.modules["qiskit._accelerate.sparse_pauli_op"] = qiskit._accelerate.sparse_pauli_op
-sys.modules["qiskit._accelerate.stochastic_swap"] = qiskit._accelerate.stochastic_swap
-sys.modules["qiskit._accelerate.two_qubit_decompose"] = qiskit._accelerate.two_qubit_decompose
-sys.modules["qiskit._accelerate.vf2_layout"] = qiskit._accelerate.vf2_layout
-sys.modules["qiskit._accelerate.permutation"] = qiskit._accelerate.permutation
+sys.modules["qiskit._accelerate.nlayout"] = _accelerate.nlayout
+sys.modules["qiskit._accelerate.optimize_1q_gates"] = _accelerate.optimize_1q_gates
+sys.modules["qiskit._accelerate.pauli_expval"] = _accelerate.pauli_expval
+sys.modules["qiskit._accelerate.qasm2"] = _accelerate.qasm2
+sys.modules["qiskit._accelerate.qasm3"] = _accelerate.qasm3
+sys.modules["qiskit._accelerate.results"] = _accelerate.results
+sys.modules["qiskit._accelerate.sabre"] = _accelerate.sabre
+sys.modules["qiskit._accelerate.sampled_exp_val"] = _accelerate.sampled_exp_val
+sys.modules["qiskit._accelerate.sparse_pauli_op"] = _accelerate.sparse_pauli_op
+sys.modules["qiskit._accelerate.stochastic_swap"] = _accelerate.stochastic_swap
+sys.modules["qiskit._accelerate.two_qubit_decompose"] = _accelerate.two_qubit_decompose
+sys.modules["qiskit._accelerate.vf2_layout"] = _accelerate.vf2_layout
+sys.modules["qiskit._accelerate.permutation"] = _accelerate.permutation
 
 from qiskit.exceptions import QiskitError, MissingOptionalLibraryError
 

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# pylint: disable=wrong-import-position
+# pylint: disable=wrong-import-position,wrong-import-order
 
 """Main Qiskit public functionality."""
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

I don't understand the python import mechanism enough to understand _why_, but this PR fixes some problems for me with importing from Rust code when on Fedora or RHEL.

### Details and comments

If one tries to run `tox -epy` from a dependent of Qiskit on Fedora or RHEL, there will be lots of errors about `qiskit._accelerate`.  For the sake of example, we will use the circuit-knitting-toolbox as an example of a Qiskit dependent, but I've also been able to reproduce this with qiskit-experiments.

Here is a Dockerfile that tries to do this using the current latest commit on Qiskit `main`:

```dockerfile
FROM fedora:40
RUN dnf install -y pip git rust cargo
RUN pip install tox
RUN git clone https://github.com/Qiskit-Extensions/circuit-knitting-toolbox.git
WORKDIR /circuit-knitting-toolbox
RUN echo '[tool.hatch.metadata]' >> pyproject.toml && \
    echo 'allow-direct-references = true' >> pyproject.toml && \
    sed -i 's/qiskit>=1.0.0, <2.0/qiskit @ git+https:\/\/github.com\/Qiskit\/qiskit.git@03d107e1f68f2a47ffdcf5599f906120e4efba63/' pyproject.toml && \
    cat pyproject.toml
RUN tox -epy
```

When one attempts to build this image using `docker build -f Dockerfile.qiskit-main .`, the following error is raised repeatedly:

```
    from qiskit.circuit import (
.tox/py/lib64/python3.12/site-packages/qiskit/__init__.py:62: in <module>
    sys.modules["qiskit._accelerate.circuit"] = qiskit._accelerate.circuit
E   AttributeError: partially initialized module 'qiskit' has no attribute '_accelerate' (most likely due to a circular import)
```

If one instead uses a Dockerfile that points to this fork (same as above except one line),

```dockerfile
FROM fedora:40
RUN dnf install -y pip git rust cargo
RUN pip install tox
RUN git clone https://github.com/Qiskit-Extensions/circuit-knitting-toolbox.git
WORKDIR /circuit-knitting-toolbox
RUN echo '[tool.hatch.metadata]' >> pyproject.toml && \
    echo 'allow-direct-references = true' >> pyproject.toml && \
    sed -i 's/qiskit>=1.0.0, <2.0/qiskit @ git+https:\/\/github.com\/garrison\/qiskit.git@relative-toplevel-imports/' pyproject.toml && \
    cat pyproject.toml
RUN tox -epy
```

then the errors are very different:

```
ImportError while importing test module '/circuit-knitting-toolbox/test/utils/test_transforms.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib64/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
test/utils/test_transforms.py:17: in <module>
    from qiskit.circuit import (
.tox/py/lib64/python3.12/site-packages/qiskit/__init__.py:90: in <module>
    from qiskit.circuit import ClassicalRegister
.tox/py/lib64/python3.12/site-packages/qiskit/circuit/__init__.py:1213: in <module>
    from . import _utils
.tox/py/lib64/python3.12/site-packages/qiskit/circuit/_utils.py:22: in <module>
    from .parametervector import ParameterVectorElement
.tox/py/lib64/python3.12/site-packages/qiskit/circuit/parametervector.py:17: in <module>
    from .parameter import Parameter
.tox/py/lib64/python3.12/site-packages/qiskit/circuit/parameter.py:20: in <module>
    import symengine
.tox/py/lib/python3.12/site-packages/symengine/__init__.py:12: in <module>
    import symengine.lib.symengine_wrapper as wrapper
E   ModuleNotFoundError: No module named 'symengine.lib.symengine_wrapper'
```

which is a different, known, issue (but I am having a hard time finding a link at the moment).  EDIT: I believe it may be related to https://github.com/symengine/symengine-wheels/issues/16.

Thus, I propose that the current PR is merged to get Qiskit one step closer to working properly on Fedora and RHEL.