### PR TITLE
Improve `clifford_decompose_greedy` algorithm`

### DIFF
--- a/qiskit/synthesis/clifford/clifford_decompose_greedy.py
+++ b/qiskit/synthesis/clifford/clifford_decompose_greedy.py
@@ -75,11 +75,21 @@ def synth_clifford_greedy(clifford: Clifford) -> QuantumCircuit:
 
         list_greedy_cost = []
         for qubit in qubit_list:
-            pauli_x = Pauli("I" * (num_qubits - qubit - 1) + "X" + "I" * qubit)
-            pauli_x = pauli_x.evolve(clifford_adj, frame="s")
+            pauli_x = Pauli(
+                (
+                    clifford_adj.destab_z[qubit],
+                    clifford_adj.destab_x[qubit],
+                    2 * clifford_adj.phase[qubit],
+                )
+            )
+            pauli_z = Pauli(
+                (
+                    clifford_adj.stab_z[qubit],
+                    clifford_adj.stab_x[qubit],
+                    2 * clifford_adj.phase[num_qubits + qubit],
+                )
+            )
 
-            pauli_z = Pauli("I" * (num_qubits - qubit - 1) + "Z" + "I" * qubit)
-            pauli_z = pauli_z.evolve(clifford_adj, frame="s")
             list_pairs = []
             pauli_count = 0
 

--- a/qiskit/synthesis/clifford/clifford_decompose_greedy.py
+++ b/qiskit/synthesis/clifford/clifford_decompose_greedy.py
@@ -31,7 +31,7 @@ from qiskit.quantum_info.operators.symplectic.clifford_circuits import (
 )
 
 
-def synth_clifford_greedy(clifford_original: Clifford) -> QuantumCircuit:
+def synth_clifford_greedy(clifford: Clifford) -> QuantumCircuit:
     """Decompose a :class:`.Clifford` operator into a :class:`.QuantumCircuit` based
     on the greedy Clifford compiler that is described in Appendix A of
     Bravyi, Hu, Maslov and Shaydulin [1].
@@ -57,10 +57,10 @@ def synth_clifford_greedy(clifford_original: Clifford) -> QuantumCircuit:
            `arXiv:2105.02291 [quant-ph] <https://arxiv.org/abs/2105.02291>`_
     """
 
-    num_qubits = clifford_original.num_qubits
-    circ = QuantumCircuit(num_qubits, name=str(clifford_original))
+    num_qubits = clifford.num_qubits
+    circ = QuantumCircuit(num_qubits, name=str(clifford))
     qubit_list = list(range(num_qubits))
-    clifford_current = clifford_original.copy()
+    clifford_current = clifford.copy()
 
     # Reducing the original Clifford to identity
     # via symplectic Gaussian elimination

--- a/qiskit/synthesis/clifford/clifford_decompose_greedy.py
+++ b/qiskit/synthesis/clifford/clifford_decompose_greedy.py
@@ -104,11 +104,20 @@ def synth_clifford_greedy(clifford: Clifford) -> QuantumCircuit:
         _, min_qubit = (sorted(list_greedy_cost))[0]
 
         # Gaussian elimination step for the qubit with minimal CNOT cost
-        pauli_x = Pauli("I" * (num_qubits - min_qubit - 1) + "X" + "I" * min_qubit)
-        pauli_x = pauli_x.evolve(clifford_adj, frame="s")
-
-        pauli_z = Pauli("I" * (num_qubits - min_qubit - 1) + "Z" + "I" * min_qubit)
-        pauli_z = pauli_z.evolve(clifford_adj, frame="s")
+        pauli_x = Pauli(
+            (
+                clifford_adj.destab_z[min_qubit],
+                clifford_adj.destab_x[min_qubit],
+                2 * clifford_adj.phase[min_qubit],
+            )
+        )
+        pauli_z = Pauli(
+            (
+                clifford_adj.stab_z[min_qubit],
+                clifford_adj.stab_x[min_qubit],
+                2 * clifford_adj.phase[num_qubits + min_qubit],
+            )
+        )
 
         # Compute the decoupling operator of cliff_ox and cliff_oz
         decouple_circ, decouple_cliff = _calc_decoupling(

--- a/releasenotes/notes/improve-greedy-clifford-python-cd7ba454ffdd4793.yaml
+++ b/releasenotes/notes/improve-greedy-clifford-python-cd7ba454ffdd4793.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Improved the performance of :func:`qiskit.synthesis.synth_clifford_greedy`
+    by replacing unnecessary evolution operations by directly considering the
+    columns of the clifford's symplectic matrix.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This PR improves the performance of the `clifford_decompose_greedy` algorithm by noticing that evolving a Pauli of the form `I..IXI...I` or of the form `I..IZI...I` by a Clifford `C` is essentially equivalent to grabbing a row from `C`'s tableau representation, except that the phase needs to be multiplied by 2. (In fact, we can think of the tableau of `C` as representing how `C` acts on the basis Pauli strings `I..IXI...I` and `I..IZI...`). As a sanity check, I have also verified this experimentally on random cliffords of various sizes.

### Details and comments

Here is the data for running the synthesis algorithm for 10 random Cliffords of various sizes. 
Before this PR:
```
Num-qubits 5 => total time 0.18
Num-qubits 10 => total time 0.70
Num-qubits 15 => total time 1.91
Num-qubits 20 => total time 4.91
Num-qubits 50 => total time 39.91
Num-qubits 100 => total time 288.60
```

With this PR:
```
Num-qubits 5 => total time 0.09
Num-qubits 10 => total time 0.32
Num-qubits 15 => total time 0.73
Num-qubits 20 => total time 1.51
Num-qubits 50 => total time 13.63
Num-qubits 100 => total time 101.92
```
The runtime improvement is at least 2x. 
