### PR TITLE
exclude lines from coverage report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,3 +232,12 @@ enable = [
 
 [tool.pylint.spelling]
 spelling-private-dict-file = ".local-spellings"
+
+[tool.coverage.report]
+exclude_also = [
+    "def __repr__",               # Printable epresentational string does not typically execute during testing
+    "raise NotImplementedError",  # Abstract methods are not testable
+    "raise RuntimeError",         # Exceptions for defensive programming that cannot be tested a head
+    "if TYPE_CHECKING:",          # Code that only runs during type checks
+    "@abstractmethod",            # Abstract methods are not testable
+    ]

--- a/qiskit/qasm3/exporter.py
+++ b/qiskit/qasm3/exporter.py
@@ -837,7 +837,7 @@ class QASM3Builder:
                     statements.append(self.build_if_statement(instruction))
                 elif isinstance(instruction.operation, SwitchCaseOp):
                     statements.extend(self.build_switch_statement(instruction))
-                else:  # pragma: no cover
+                else:
                     raise RuntimeError(f"unhandled control-flow construct: {instruction.operation}")
                 continue
             # Build the node, ignoring any condition.
@@ -1130,7 +1130,7 @@ def _build_ast_type(type_: types.Type) -> ast.ClassicalType:
         return ast.BoolType()
     if type_.kind is types.Uint:
         return ast.UintType(type_.width)
-    raise RuntimeError(f"unhandled expr type '{type_}'")  # pragma: no cover
+    raise RuntimeError(f"unhandled expr type '{type_}'")
 
 
 class _ExprBuilder(expr.ExprVisitor[ast.Expression]):

--- a/tox.ini
+++ b/tox.ini
@@ -83,6 +83,14 @@ commands =
   coverage3 combine
   coverage3 report
 
+[coverage:report]
+exclude_also =
+    def __repr__
+    raise NotImplementedError
+    raise RuntimeError
+    if TYPE_CHECKING:
+    @abstractmethod
+
 [testenv:docs]
 basepython = python3
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -83,14 +83,6 @@ commands =
   coverage3 combine
   coverage3 report
 
-[coverage:report]
-exclude_also =
-    def __repr__  # Printable epresentational string does not typically execute during testing
-    raise NotImplementedError  # Abstract methods are not testable
-    raise RuntimeError  # Exceptions for defensive programming that cannot be tested a head
-    if TYPE_CHECKING:  # Code that only runs during type checks
-    @abstractmethod  # Abstract methods are not testable
-
 [testenv:docs]
 basepython = python3
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -85,11 +85,11 @@ commands =
 
 [coverage:report]
 exclude_also =
-    def __repr__
-    raise NotImplementedError
-    raise RuntimeError
-    if TYPE_CHECKING:
-    @abstractmethod
+    def __repr__  # Printable epresentational string does not typically execute during testing
+    raise NotImplementedError  # Abstract methods are not testable
+    raise RuntimeError  # Exceptions for defensive programming that cannot be tested a head
+    if TYPE_CHECKING:  # Code that only runs during type checks
+    @abstractmethod  # Abstract methods are not testable
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
Excluding some lines (with their explanation) from the coverage report as they are not testable.