### PR TITLE
Bump version of macOS used on Azure

### DIFF
--- a/.azure/test-macos.yml
+++ b/.azure/test-macos.yml
@@ -10,7 +10,7 @@ parameters:
 jobs:
   - job: "MacOS_Tests_Python${{ replace(parameters.pythonVersion, '.', '') }}"
     displayName: "Test macOS Python ${{ parameters.pythonVersion }}"
-    pool: {vmImage: 'macOS-11'}
+    pool: {vmImage: 'macOS-13'}
 
     variables:
       QISKIT_SUPPRESS_PACKAGING_WARNINGS: Y


### PR DESCRIPTION
### Summary

The macOS 11 runners are deprecated pending removal.  While macOS 14 is available, it's still marked as in preview on Azure, so macOS 13 is the current "latest" stable version.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

macOS 11 images are pending removal on the 28th of June, and will be subject to a brownout on the 17th.
