### PR TITLE
Add rust representation for the u1, u2, and u3 gates

### DIFF
--- a/crates/circuit/src/gate_matrix.rs
+++ b/crates/circuit/src/gate_matrix.rs
@@ -274,8 +274,8 @@ pub fn xx_minus_yy_gate(theta: f64, beta: f64) -> [[Complex64; 4]; 4] {
 #[inline]
 pub fn u1_gate(lam: f64) -> [[Complex64; 2]; 2] {
     [
-        [Complex64::new(1., 0.), Complex64::new(0., 0.)],
-        [Complex64::new(0., 0.), Complex64::new(0., lam).exp()],
+        [c64(1., 0.), c64(0., 0.)],
+        [c64(0., 0.), c64(0., lam).exp()],
     ]
 }
 
@@ -283,12 +283,12 @@ pub fn u1_gate(lam: f64) -> [[Complex64; 2]; 2] {
 pub fn u2_gate(phi: f64, lam: f64) -> [[Complex64; 2]; 2] {
     [
         [
-            Complex64::new(FRAC_1_SQRT_2, 0.),
-            (-Complex64::new(0., lam).exp()) * FRAC_1_SQRT_2,
+            c64(FRAC_1_SQRT_2, 0.),
+            (-c64(0., lam).exp()) * FRAC_1_SQRT_2,
         ],
         [
-            Complex64::new(0., phi).exp() * FRAC_1_SQRT_2,
-            Complex64::new(0., phi + lam).exp() * FRAC_1_SQRT_2,
+            c64(0., phi).exp() * FRAC_1_SQRT_2,
+            c64(0., phi + lam).exp() * FRAC_1_SQRT_2,
         ],
     ]
 }
@@ -298,14 +298,8 @@ pub fn u3_gate(theta: f64, phi: f64, lam: f64) -> [[Complex64; 2]; 2] {
     let cos = (theta / 2.).cos();
     let sin = (theta / 2.).sin();
     [
-        [
-            Complex64::new(cos, 0.),
-            (-Complex64::new(0., lam).exp()) * sin,
-        ],
-        [
-            Complex64::new(0., phi).exp() * sin,
-            Complex64::new(0., phi + lam).exp() * cos,
-        ],
+        [c64(cos, 0.), -(c64(0., lam).exp()) * sin],
+        [c64(0., phi).exp() * sin, c64(0., phi + lam).exp() * cos],
     ]
 }
 

--- a/crates/circuit/src/gate_matrix.rs
+++ b/crates/circuit/src/gate_matrix.rs
@@ -272,6 +272,44 @@ pub fn xx_minus_yy_gate(theta: f64, beta: f64) -> [[Complex64; 4]; 4] {
 }
 
 #[inline]
+pub fn u1_gate(lam: f64) -> [[Complex64; 2]; 2] {
+    [
+        [Complex64::new(1., 0.), Complex64::new(0., 0.)],
+        [Complex64::new(0., 0.), Complex64::new(0., lam).exp()],
+    ]
+}
+
+#[inline]
+pub fn u2_gate(phi: f64, lam: f64) -> [[Complex64; 2]; 2] {
+    [
+        [
+            Complex64::new(FRAC_1_SQRT_2, 0.),
+            (-Complex64::new(0., lam).exp()) * FRAC_1_SQRT_2,
+        ],
+        [
+            Complex64::new(0., phi).exp() * FRAC_1_SQRT_2,
+            Complex64::new(0., phi + lam).exp() * FRAC_1_SQRT_2,
+        ],
+    ]
+}
+
+#[inline]
+pub fn u3_gate(theta: f64, phi: f64, lam: f64) -> [[Complex64; 2]; 2] {
+    let cos = (theta / 2.).cos();
+    let sin = (theta / 2.).sin();
+    [
+        [
+            Complex64::new(cos, 0.),
+            (-Complex64::new(0., lam).exp()) * sin,
+        ],
+        [
+            Complex64::new(0., phi).exp() * sin,
+            Complex64::new(0., phi + lam).exp() * cos,
+        ],
+    ]
+}
+
+#[inline]
 pub fn xx_plus_yy_gate(theta: f64, beta: f64) -> [[Complex64; 4]; 4] {
     let cos = (theta / 2.).cos();
     let sin = (theta / 2.).sin();

--- a/crates/circuit/src/imports.rs
+++ b/crates/circuit/src/imports.rs
@@ -143,9 +143,9 @@ static STDGATE_IMPORT_PATHS: [[&str; 2]; STANDARD_GATE_SIZE] = [
     ],
     // U1Gate = 26
     ["qiskit.circuit.library.standard_gates.u1", "U1Gate"],
-    // U1Gate = 27
+    // U2Gate = 27
     ["qiskit.circuit.library.standard_gates.u2", "U2Gate"],
-    // U1Gate = 28
+    // U3Gate = 28
     ["qiskit.circuit.library.standard_gates.u3", "U3Gate"],
 ];
 

--- a/crates/circuit/src/imports.rs
+++ b/crates/circuit/src/imports.rs
@@ -141,6 +141,12 @@ static STDGATE_IMPORT_PATHS: [[&str; 2]; STANDARD_GATE_SIZE] = [
         "qiskit.circuit.library.standard_gates.xx_plus_yy",
         "XXPlusYYGate",
     ],
+    // U1Gate = 26
+    ["qiskit.circuit.library.standard_gates.u1", "U1Gate"],
+    // U1Gate = 27
+    ["qiskit.circuit.library.standard_gates.u2", "U2Gate"],
+    // U1Gate = 28
+    ["qiskit.circuit.library.standard_gates.u3", "U3Gate"],
 ];
 
 /// A mapping from the enum variant in crate::operations::StandardGate to the python object for the

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -205,14 +205,17 @@ pub enum StandardGate {
     ISwapGate = 23,
     XXMinusYYGate = 24,
     XXPlusYYGate = 25,
+    U1Gate = 26,
+    U2Gate = 27,
+    U3Gate = 28,
 }
 
 static STANDARD_GATE_NUM_QUBITS: [u32; STANDARD_GATE_SIZE] = [
-    1, 1, 1, 2, 2, 2, 3, 1, 1, 1, 2, 2, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2,
+    1, 1, 1, 2, 2, 2, 3, 1, 1, 1, 2, 2, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 1, 1, 1,
 ];
 
 static STANDARD_GATE_NUM_PARAMS: [u32; STANDARD_GATE_SIZE] = [
-    0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1, 3, 0, 0, 0, 0, 0, 0, 2, 2,
+    0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1, 3, 0, 0, 0, 0, 0, 0, 2, 2, 1, 2, 3,
 ];
 
 static STANDARD_GATE_NAME: [&str; STANDARD_GATE_SIZE] = [
@@ -242,6 +245,9 @@ static STANDARD_GATE_NAME: [&str; STANDARD_GATE_SIZE] = [
     "iswap",
     "xx_minus_yy",
     "xx_plus_yy",
+    "u1",
+    "u2",
+    "u3",
 ];
 
 #[pymethods]
@@ -290,8 +296,7 @@ impl StandardGate {
 //
 // Remove this when std::mem::variant_count() is stabilized (see
 // https://github.com/rust-lang/rust/issues/73662 )
-
-pub const STANDARD_GATE_SIZE: usize = 26;
+pub const STANDARD_GATE_SIZE: usize = 29;
 
 impl Operation for StandardGate {
     fn name(&self) -> &str {
@@ -429,6 +434,22 @@ impl Operation for StandardGate {
             Self::XXPlusYYGate => match params {
                 [Param::Float(theta), Param::Float(beta)] => {
                     Some(aview2(&gate_matrix::xx_plus_yy_gate(*theta, *beta)).to_owned())
+                }
+                _ => None,
+            },
+            Self::U1Gate => match params[0] {
+                Param::Float(val) => Some(aview2(&gate_matrix::u1_gate(val)).to_owned()),
+                _ => None,
+            },
+            Self::U2Gate => match params {
+                [Param::Float(phi), Param::Float(lam)] => {
+                    Some(aview2(&gate_matrix::u2_gate(*phi, *lam)).to_owned())
+                }
+                _ => None,
+            },
+            Self::U3Gate => match params {
+                [Param::Float(theta), Param::Float(phi), Param::Float(lam)] => {
+                    Some(aview2(&gate_matrix::u3_gate(*theta, *phi, *lam)).to_owned())
                 }
                 _ => None,
             },
@@ -667,6 +688,21 @@ impl Operation for StandardGate {
                     .expect("Unexpected Qiskit python bug"),
                 )
             }),
+            Self::U1Gate => Python::with_gil(|py| -> Option<CircuitData> {
+                Some(
+                    CircuitData::from_standard_gates(
+                        py,
+                        1,
+                        [(
+                            Self::PhaseGate,
+                            params.iter().cloned().collect(),
+                            smallvec![Qubit(0)],
+                        )],
+                        FLOAT_ZERO,
+                    )
+                    .expect("Unexpected Qiskit python bug"),
+                )
+            }),
             Self::SdgGate => Python::with_gil(|py| -> Option<CircuitData> {
                 Some(
                     CircuitData::from_standard_gates(
@@ -682,6 +718,21 @@ impl Operation for StandardGate {
                     .expect("Unexpected Qiskit python bug"),
                 )
             }),
+            Self::U2Gate => Python::with_gil(|py| -> Option<CircuitData> {
+                Some(
+                    CircuitData::from_standard_gates(
+                        py,
+                        1,
+                        [(
+                            Self::UGate,
+                            smallvec![Param::Float(PI / 2.), params[0].clone(), params[1].clone()],
+                            smallvec![Qubit(0)],
+                        )],
+                        FLOAT_ZERO,
+                    )
+                    .expect("Unexpected Qiskit python bug"),
+                )
+            }),
             Self::TGate => Python::with_gil(|py| -> Option<CircuitData> {
                 Some(
                     CircuitData::from_standard_gates(
@@ -690,6 +741,21 @@ impl Operation for StandardGate {
                         [(
                             Self::PhaseGate,
                             smallvec![Param::Float(PI4)],
+                            smallvec![Qubit(0)],
+                        )],
+                        FLOAT_ZERO,
+                    )
+                    .expect("Unexpected Qiskit python bug"),
+                )
+            }),
+            Self::U3Gate => Python::with_gil(|py| -> Option<CircuitData> {
+                Some(
+                    CircuitData::from_standard_gates(
+                        py,
+                        1,
+                        [(
+                            Self::UGate,
+                            params.iter().cloned().collect(),
                             smallvec![Qubit(0)],
                         )],
                         FLOAT_ZERO,

--- a/qiskit/circuit/library/standard_gates/u1.py
+++ b/qiskit/circuit/library/standard_gates/u1.py
@@ -19,6 +19,7 @@ from qiskit.circuit.gate import Gate
 from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit._utils import _ctrl_state_to_int
+from qiskit._accelerate.circuit import StandardGate
 
 
 class U1Gate(Gate):
@@ -91,6 +92,8 @@ class U1Gate(Gate):
         Reference for virtual Z gate implementation:
         `1612.00858 <https://arxiv.org/abs/1612.00858>`_
     """
+
+    _standard_gate = StandardGate.U1Gate
 
     def __init__(
         self, theta: ParameterValueType, label: str | None = None, *, duration=None, unit="dt"

--- a/qiskit/circuit/library/standard_gates/u2.py
+++ b/qiskit/circuit/library/standard_gates/u2.py
@@ -18,6 +18,7 @@ import numpy
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit.circuit.quantumregister import QuantumRegister
+from qiskit._accelerate.circuit import StandardGate
 
 
 class U2Gate(Gate):
@@ -85,6 +86,8 @@ class U2Gate(Gate):
         U3 is a generalization of U2 that covers all single-qubit rotations,
         using two X90 pulses.
     """
+
+    _standard_gate = StandardGate.U2Gate
 
     def __init__(
         self,

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -19,6 +19,7 @@ from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit.circuit.quantumregister import QuantumRegister
+from qiskit._accelerate.circuit import StandardGate
 
 
 class U3Gate(Gate):
@@ -79,6 +80,8 @@ class U3Gate(Gate):
 
         U3(\theta, 0, 0) = RY(\theta)
     """
+
+    _standard_gate = StandardGate.U3Gate
 
     def __init__(
         self,

--- a/test/python/circuit/test_rust_equivalence.py
+++ b/test/python/circuit/test_rust_equivalence.py
@@ -79,12 +79,23 @@ class TestRustGateEquivalence(QiskitTestCase):
                             )
                         # Rust uses P but python still uses u1
                         elif rs_inst.operation.name == "p":
-                            self.assertEqual(py_inst.operation.name, "u1")
-                            self.assertEqual(rs_inst.operation.params, py_inst.operation.params)
-                            self.assertEqual(
-                                [py_def.find_bit(x).index for x in py_inst.qubits],
-                                [rs_def.find_bit(x).index for x in rs_inst.qubits],
-                            )
+                            if py_inst.operation.name == "u1":
+                                self.assertEqual(py_inst.operation.name, "u1")
+                                self.assertEqual(rs_inst.operation.params, py_inst.operation.params)
+                                self.assertEqual(
+                                    [py_def.find_bit(x).index for x in py_inst.qubits],
+                                    [rs_def.find_bit(x).index for x in rs_inst.qubits],
+                                )
+                            else:
+                                self.assertEqual(py_inst.operation.name, "u3")
+                                self.assertEqual(
+                                    rs_inst.operation.params[0], py_inst.operation.params[2]
+                                )
+                                self.assertEqual(
+                                    [py_def.find_bit(x).index for x in py_inst.qubits],
+                                    [rs_def.find_bit(x).index for x in rs_inst.qubits],
+                                )
+
                         else:
                             self.assertEqual(py_inst.operation.name, rs_inst.operation.name)
                             self.assertEqual(rs_inst.operation.params, py_inst.operation.params)

--- a/test/python/circuit/test_rust_equivalence.py
+++ b/test/python/circuit/test_rust_equivalence.py
@@ -113,7 +113,7 @@ class TestRustGateEquivalence(QiskitTestCase):
                 continue
 
             with self.subTest(name=name):
-                params = [pi] * standard_gate._num_params()
+                params = [0.1] * standard_gate._num_params()
                 py_def = gate_class.base_class(*params).to_matrix()
                 rs_def = standard_gate._to_matrix(params)
                 np.testing.assert_allclose(rs_def, py_def)

--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -325,6 +325,8 @@ class TestOptimize1qGates(QiskitTestCase):
         """Check proper phase accumulation with instruction with no definition."""
 
         class CustomGate(Gate):
+            """Custom u1 gate definition."""
+
             def __init__(self, lam):
                 super().__init__("u1", 1, [lam])
 
@@ -352,6 +354,8 @@ class TestOptimize1qGates(QiskitTestCase):
         """Check proper phase accumulation with instruction with no definition."""
 
         class CustomGate(Gate):
+            """Custom u1 gate."""
+
             def __init__(self, lam):
                 super().__init__("u1", 1, [lam])
 

--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -19,7 +19,7 @@ from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.passes import Optimize1qGates, BasisTranslator
 from qiskit.converters import circuit_to_dag
-from qiskit.circuit import Parameter
+from qiskit.circuit import Parameter, Gate
 from qiskit.circuit.library import U1Gate, U2Gate, U3Gate, UGate, PhaseGate
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.target import Target
@@ -323,9 +323,22 @@ class TestOptimize1qGates(QiskitTestCase):
 
     def test_global_phase_u3_on_left(self):
         """Check proper phase accumulation with instruction with no definition."""
+
+        class CustomGate(Gate):
+            def __init__(self, lam):
+                super().__init__("u1", 1, [lam])
+
+            def _define(self):
+                qc = QuantumCircuit(1)
+                qc.p(*self.params, 0)
+                self.definition = qc
+
+            def _matrix(self):
+                return U1Gate(*self.params).to_matrix()
+
         qr = QuantumRegister(1)
         qc = QuantumCircuit(qr)
-        u1 = U1Gate(0.1)
+        u1 = CustomGate(0.1)
         u1.definition.global_phase = np.pi / 2
         qc.append(u1, [0])
         qc.global_phase = np.pi / 3
@@ -337,9 +350,22 @@ class TestOptimize1qGates(QiskitTestCase):
 
     def test_global_phase_u_on_left(self):
         """Check proper phase accumulation with instruction with no definition."""
+
+        class CustomGate(Gate):
+            def __init__(self, lam):
+                super().__init__("u1", 1, [lam])
+
+            def _define(self):
+                qc = QuantumCircuit(1)
+                qc.p(*self.params, 0)
+                self.definition = qc
+
+            def _matrix(self):
+                return U1Gate(*self.params).to_matrix()
+
         qr = QuantumRegister(1)
         qc = QuantumCircuit(qr)
-        u1 = U1Gate(0.1)
+        u1 = CustomGate(0.1)
         u1.definition.global_phase = np.pi / 2
         qc.append(u1, [0])
         qc.global_phase = np.pi / 3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds the rust representation of the U1Gate, U2Gate, and U3Gate to the `StandardGates` enum in rust.

### Details and comments

Part of #12566