### PR TITLE
Fix some bugs in loading Solovay Kitaev decompositions

### DIFF
--- a/qiskit/synthesis/discrete_basis/generate_basis_approximations.py
+++ b/qiskit/synthesis/discrete_basis/generate_basis_approximations.py
@@ -156,7 +156,7 @@ def generate_basic_approximations(
         data = {}
         for sequence in sequences:
             gatestring = sequence.name
-            data[gatestring] = sequence.product
+            data[gatestring] = (sequence.product, sequence.global_phase)
 
         np.save(filename, data)
 

--- a/qiskit/synthesis/discrete_basis/solovay_kitaev.py
+++ b/qiskit/synthesis/discrete_basis/solovay_kitaev.py
@@ -198,7 +198,6 @@ def _remove_inverse_follows_gate(sequence):
             remove = curr_gate.inverse() == next_gate
 
         if remove:
-            print(index, len(sequence.gates))
             # remove gates at index and index + 1
             sequence.remove_cancelling_pair([index, index + 1])
             # take a step back to see if we have uncovered a new pair, e.g.

--- a/releasenotes/notes/fix-sk-load-from-file-02c6eabbbd7fcda3.yaml
+++ b/releasenotes/notes/fix-sk-load-from-file-02c6eabbbd7fcda3.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fix the :class:`.SolovayKitaev` transpiler pass when loading basic
+    approximations from an exising ``.npy`` file. Previously, loading
+    stored approximation which allowed for further reductions (e.g. due
+    to gate cancellations) could cause a runtime failure.
+    Additionally, the global phase difference of the U(2) gate product
+    and SO(3) representation was lost during a save-reload procedure.
+    Fixes `Qiskit/qiskit#12576 <https://github.com/Qiskit/qiskit/issues/12576>`_.

--- a/releasenotes/notes/fix-sk-load-from-file-02c6eabbbd7fcda3.yaml
+++ b/releasenotes/notes/fix-sk-load-from-file-02c6eabbbd7fcda3.yaml
@@ -3,7 +3,7 @@ fixes:
   - |
     Fix the :class:`.SolovayKitaev` transpiler pass when loading basic
     approximations from an exising ``.npy`` file. Previously, loading
-    stored approximation which allowed for further reductions (e.g. due
+    a stored approximation which allowed for further reductions (e.g. due
     to gate cancellations) could cause a runtime failure.
     Additionally, the global phase difference of the U(2) gate product
     and SO(3) representation was lost during a save-reload procedure.

--- a/test/python/transpiler/test_solovay_kitaev.py
+++ b/test/python/transpiler/test_solovay_kitaev.py
@@ -15,9 +15,9 @@
 import os
 import unittest
 import math
+import tempfile
 import numpy as np
 import scipy
-import tempfile
 
 from ddt import ddt, data
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #12576 and some other small bugs in storing & loading basic approximations for the Solovay Kitaev algorithm.

### Details and comments

* as #12576 mentioned, there is a missing `.item()` unwrapping when loading the dictionary from the `npy` file
* reloading the gate sequence also missed the correct `labels` and `global_phase`
* a test is now checking all of the above works correctly
