### PR TITLE
Add remaining tests for `ParameterVector` and tweak its `repr`

### DIFF
--- a/qiskit/circuit/parametervector.py
+++ b/qiskit/circuit/parametervector.py
@@ -87,7 +87,7 @@ class ParameterVector:
         return f"{self.name}, {[str(item) for item in self.params]}"
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(name={self.name}, length={len(self)})"
+        return f"{self.__class__.__name__}(name={repr(self.name)}, length={len(self)})"
 
     def resize(self, length):
         """Resize the parameter vector.  If necessary, new elements are generated.

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -1376,6 +1376,21 @@ class TestParameters(QiskitTestCase):
             self.assertEqual(element, vec[1])
             self.assertListEqual([param.name for param in vec], _paramvec_names("x", 3))
 
+    def test_parametervector_repr(self):
+        """Test the __repr__ method of the parameter vector."""
+        vec = ParameterVector("x", 2)
+        self.assertEqual(repr(vec), "ParameterVector(name='x', length=2)")
+
+    def test_parametervector_str(self):
+        """Test the __str__ method of the parameter vector."""
+        vec = ParameterVector("x", 2)
+        self.assertEqual(str(vec), "x, ['x[0]', 'x[1]']")
+
+    def test_parametervector_index(self):
+        """Test the index method of the parameter vector."""
+        vec = ParameterVector("x", 2)
+        self.assertEqual(vec.index(vec[1]), 1)
+
     def test_raise_if_sub_unknown_parameters(self):
         """Verify we raise if asked to sub a parameter not in self."""
         x = Parameter("x")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR adds a few tests to bring `parametervector.py` to 100% test coverage.

### Details and comments

I also tweaked `ParameterVector`'s `__repr__` so that it puts quotes around the `name`.  Before this, one would get

```
>>> repr(ParameterVector("x", 2))
'ParameterVector(name=x, length=2)'
```
