### PR TITLE
Invalidate `parameters` cache on circuit copy

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3674,6 +3674,8 @@ class QuantumCircuit:
         cpy._data = CircuitData(
             self._data.qubits, self._data.clbits, global_phase=self._data.global_phase
         )
+        # Invalidate parameters caching.
+        cpy._parameters = None
 
         cpy._calibrations = _copy.deepcopy(self._calibrations)
         cpy._metadata = _copy.deepcopy(self._metadata)

--- a/releasenotes/notes/fix-parameter-cache-05eac2f24477ccb8.yaml
+++ b/releasenotes/notes/fix-parameter-cache-05eac2f24477ccb8.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The :attr:`.QuantumCircuit.parameters` attribute will now correctly be empty
+    when using :meth:`.QuantumCircuit.copy_empty_like` on a parametric circuit.
+    Previously, an internal cache would be copied over without invalidation.
+    Fix `#12617 <https://github.com/Qiskit/qiskit/issues/12617>`__.

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -203,6 +203,29 @@ class TestParameters(QiskitTestCase):
         for i, vi in enumerate(v):
             self.assertEqual(vi, qc.parameters[i])
 
+    def test_parameters_property_independent_after_copy(self):
+        """Test that any `parameters` property caching is invalidated after a copy operation."""
+        a = Parameter("a")
+        b = Parameter("b")
+        c = Parameter("c")
+
+        qc1 = QuantumCircuit(1)
+        qc1.rz(a, 0)
+        self.assertEqual(set(qc1.parameters), {a})
+
+        qc2 = qc1.copy_empty_like()
+        self.assertEqual(set(qc2.parameters), set())
+
+        qc3 = qc1.copy()
+        self.assertEqual(set(qc3.parameters), {a})
+        qc3.rz(b, 0)
+        self.assertEqual(set(qc3.parameters), {a, b})
+        self.assertEqual(set(qc1.parameters), {a})
+
+        qc1.rz(c, 0)
+        self.assertEqual(set(qc1.parameters), {a, c})
+        self.assertEqual(set(qc3.parameters), {a, b})
+
     def test_get_parameter(self):
         """Test the `get_parameter` method."""
         x = Parameter("x")


### PR DESCRIPTION
### Summary

Previously, the caching of the parameter view could persist between copies of the circuit because it was part of the `copy.copy`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #12617.

I verified that this is present in 1.1.0 as well.