### PR TITLE
Fix type hint on find_basic_approximation in SolovayKitaevDecomposition

### DIFF
--- a/qiskit/synthesis/discrete_basis/solovay_kitaev.py
+++ b/qiskit/synthesis/discrete_basis/solovay_kitaev.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 
 import numpy as np
 
-from qiskit.circuit.gate import Gate
-
 from .gate_sequence import GateSequence
 from .commutator_decompose import commutator_decompose
 from .generate_basis_approximations import generate_basic_approximations, _1q_gates, _1q_inverses
@@ -157,14 +155,14 @@ class SolovayKitaevDecomposition:
         w_n1 = self._recurse(w_n, n - 1, check_input=check_input)
         return v_n1.dot(w_n1).dot(v_n1.adjoint()).dot(w_n1.adjoint()).dot(u_n1)
 
-    def find_basic_approximation(self, sequence: GateSequence) -> Gate:
-        """Finds gate in ``self._basic_approximations`` that best represents ``sequence``.
+    def find_basic_approximation(self, sequence: GateSequence) -> GateSequence:
+        """Find ``GateSequence`` in ``self._basic_approximations`` that approximates ``sequence``.
 
         Args:
-            sequence: The gate to find the approximation to.
+            sequence: ``GateSequence`` to find the approximation to.
 
         Returns:
-            Gate in basic approximations that is closest to ``sequence``.
+            ``GateSequence`` in ``self._basic_approximations`` that approximates ``sequence``.
         """
         # TODO explore using a k-d tree here
 


### PR DESCRIPTION
### Summary

The return type hint of `find_basic_approximation` method changes from `Gate` to `GateSequence` in `SolovayKitaevDecomposition` class, as implied by `self.basic_approximations`.

With no remaining mentions of `Gate`, its corresponding import statement is removed.

### Details and comments

Fixes #12559.
