### PR TITLE
Fix `CircuitInstruction` legacy iterable typing

### DIFF
--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -542,7 +542,11 @@ impl CircuitInstruction {
 
         Ok(PyTuple::new_bound(
             py,
-            [op, self.qubits.to_object(py), self.clbits.to_object(py)],
+            [
+                op,
+                self.qubits.bind(py).to_list().into(),
+                self.clbits.bind(py).to_list().into(),
+            ],
         ))
     }
 
@@ -558,7 +562,11 @@ impl CircuitInstruction {
         };
         Ok(PyTuple::new_bound(
             py,
-            [op, self.qubits.to_object(py), self.clbits.to_object(py)],
+            [
+                op,
+                self.qubits.bind(py).to_list().into(),
+                self.clbits.bind(py).to_list().into(),
+            ],
         ))
     }
 

--- a/test/python/circuit/test_circuit_data.py
+++ b/test/python/circuit/test_circuit_data.py
@@ -403,6 +403,22 @@ class TestQuantumCircuitInstructionData(QiskitTestCase):
     # but are included as tests to maintain compatability with the previous
     # list interface of circuit.data.
 
+    def test_iteration_of_data_entry(self):
+        """Verify that the base types of the legacy tuple iteration are correct, since they're
+        different to attribute access."""
+        qc = QuantumCircuit(3, 3)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+        qc.measure([0, 1, 2], [0, 1, 2])
+
+        def to_legacy(instruction):
+            return (instruction.operation, list(instruction.qubits), list(instruction.clbits))
+
+        expected = [to_legacy(instruction) for instruction in qc.data]
+        actual = [tuple(instruction) for instruction in qc.data]
+        self.assertEqual(actual, expected)
+
     def test_getitem_by_insertion_order(self):
         """Verify one can get circuit.data items in insertion order."""
         qr = QuantumRegister(2)


### PR DESCRIPTION
### Summary

The legacy 3-tuple format of `CircuitInstruction` still exposes the object in the old tuple-like way of `(Operation, list[Qubit], list[Clbit])`, rather than the new-style attribute access using tuples for the qargs and cargs.  This was inadvertantly changed when it moved to Rust.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Fix #12626.

No changelog because it's not in a release version of Qiskit.
