### PR TITLE
Missing backport for `generate_preset_pass_manager` docs

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/__init__.py
+++ b/qiskit/transpiler/preset_passmanagers/__init__.py
@@ -96,8 +96,8 @@ def generate_preset_pass_manager(
 ):
     """Generate a preset :class:`~.PassManager`
 
-    This function is used to quickly generate a preset pass manager. A preset pass
-    manager are the default pass managers used by the :func:`~.transpile`
+    This function is used to quickly generate a preset pass manager. Preset pass
+    managers are the default pass managers used by the :func:`~.transpile`
     function. This function provides a convenient and simple method to construct
     a standalone :class:`~.PassManager` object that mirrors what the :func:`~.transpile`
     function internally builds and uses.


### PR DESCRIPTION
This PR fixes the docs for the `generate_preset_pass_manager` method. The [main](https://github.com/Qiskit/qiskit/blob/main/qiskit/transpiler/preset_passmanagers/__init__.py#L109) branch was changed to say `Preset pass managers` instead of `A preset pass manager`, so I'm bringing this change to `stable/1.1`.

This will need backport to `stable/0.46` as well.