### PR TITLE
Fix `replace_block_with_op` on operations with wrong number of qubits

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1336,6 +1336,16 @@ class DAGCircuit:
                 else:
                     block_cargs.update(node_resources(nd.op.target).clbits)
 
+        # check the op to insert matches the number of qubits we put it on
+        print("replacing", op.num_qubits, "on", len(block_qargs))
+        print(op)
+        print()
+        if op.num_qubits != len(block_qargs):
+            raise DAGCircuitError(
+                f"Number of qubits in the replacement operation ({op.num_qubits}) does not match "
+                f"the number of qubits ({len(block_qargs)})!"
+            )
+
         block_qargs = [bit for bit in block_qargs if bit in wire_pos_map]
         block_qargs.sort(key=wire_pos_map.get)
         block_cargs = [bit for bit in block_cargs if bit in wire_pos_map]

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1345,8 +1345,8 @@ class DAGCircuit:
         # check the op to insert matches the number of qubits we put it on
         if op.num_qubits != len(block_qargs):
             raise DAGCircuitError(
-                f"Number of qubits in the replacement operation ({op.num_qubits}) does not match "
-                f"the number of qubits ({len(block_qargs)})!"
+                f"Number of qubits in the replacement operation ({op.num_qubits}) is not equal to "
+                f"the number of qubits in the block ({len(block_qargs)})!"
             )
 
         try:

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1336,18 +1336,18 @@ class DAGCircuit:
                 else:
                     block_cargs.update(node_resources(nd.op.target).clbits)
 
+        block_qargs = [bit for bit in block_qargs if bit in wire_pos_map]
+        block_qargs.sort(key=wire_pos_map.get)
+        block_cargs = [bit for bit in block_cargs if bit in wire_pos_map]
+        block_cargs.sort(key=wire_pos_map.get)
+        new_node = DAGOpNode(op, block_qargs, block_cargs, dag=self)
+
         # check the op to insert matches the number of qubits we put it on
         if op.num_qubits != len(block_qargs):
             raise DAGCircuitError(
                 f"Number of qubits in the replacement operation ({op.num_qubits}) does not match "
                 f"the number of qubits ({len(block_qargs)})!"
             )
-
-        block_qargs = [bit for bit in block_qargs if bit in wire_pos_map]
-        block_qargs.sort(key=wire_pos_map.get)
-        block_cargs = [bit for bit in block_cargs if bit in wire_pos_map]
-        block_cargs.sort(key=wire_pos_map.get)
-        new_node = DAGOpNode(op, block_qargs, block_cargs, dag=self)
 
         try:
             new_node._node_id = self._multi_graph.contract_nodes(

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1337,9 +1337,6 @@ class DAGCircuit:
                     block_cargs.update(node_resources(nd.op.target).clbits)
 
         # check the op to insert matches the number of qubits we put it on
-        print("replacing", op.num_qubits, "on", len(block_qargs))
-        print(op)
-        print()
         if op.num_qubits != len(block_qargs):
             raise DAGCircuitError(
                 f"Number of qubits in the replacement operation ({op.num_qubits}) does not match "

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/pauli_2q_evolution_commutation.py
@@ -51,7 +51,11 @@ class FindCommutingPauliEvolutions(TransformationPass):
                     sub_dag = self._decompose_to_2q(dag, node.op)
 
                     block_op = Commuting2qBlock(set(sub_dag.op_nodes()))
-                    wire_order = {wire: idx for idx, wire in enumerate(dag.qubits)}
+                    wire_order = {
+                        wire: idx
+                        for idx, wire in enumerate(sub_dag.qubits)
+                        if wire not in sub_dag.idle_wires()
+                    }
                     dag.replace_block_with_op([node], block_op, wire_order)
 
         return dag

--- a/releasenotes/notes/raise-on-illegal-replace-block-50cef8da757a580a.yaml
+++ b/releasenotes/notes/raise-on-illegal-replace-block-50cef8da757a580a.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Previously, :meth:`.DAGCircuit.replace_block_with_op` allowed to place an
+    ``n``-qubit operation onto a block of ``m`` qubits, leaving the DAG in an
+    invalid state. This behavior has been fixed, and the attempt will raise
+    a :class:`.DAGCircuitError`.

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -2903,6 +2903,22 @@ class TestReplaceBlock(QiskitTestCase):
         self.assertEqual(expected_dag.count_ops(), dag.count_ops())
         self.assertIsInstance(new_node.op, XGate)
 
+    def test_invalid_replacement_size(self):
+        """Test inserting an operation on a wrong number of qubits raises."""
+
+        # two X gates, normal circuit
+        qc = QuantumCircuit(2)
+        qc.x(range(2))
+
+        # mutilate the DAG
+        dag = circuit_to_dag(qc)
+        to_replace = list(dag.op_nodes())
+        new_node = XGate()
+        idx_map = {node.qargs[0]: i for i, node in enumerate(to_replace)}
+
+        with self.assertRaises(DAGCircuitError):
+            dag.replace_block_with_op(to_replace, new_node, idx_map)
+
     def test_replace_control_flow_block(self):
         """Test that we can replace a block of control-flow nodes with a single one."""
         body = QuantumCircuit(1)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Previously, `DAGCircuit.replace_block_with_op` allowed to place an
``n``-qubit operation onto a block of ``m`` qubits, leaving the DAG in an
invalid state. This behavior has been fixed, and the attempt will raise
a `DAGCircuitError`.

### Details and comments

For example, this is currently possible:
```python
from qiskit import transpile
from qiskit.circuit import QuantumCircuit
from qiskit.converters import circuit_to_dag, dag_to_circuit
from qiskit.circuit.library import XGate

# i am fine
qc = QuantumCircuit(2)
qc.x(range(2))

# a bit of dag mutilation
dag = circuit_to_dag(qc)
to_replace = list(dag.op_nodes())
new_node = XGate()
idx_map = {node.qargs[0]: i for i, node in enumerate(to_replace)}
dag.replace_block_with_op(to_replace, new_node, idx_map)

# the result
midlifecrisis = dag_to_circuit(dag)
print(midlifecrisis)

# naturally breaks
tqc = transpile(midlifecrisis, basis_gates=["u", "cx"])
print(tqc)
```
which prints
```
     ┌────┐
q_0: ┤0   ├
     │  X │
q_1: ┤1   ├
     └────┘
# and then breaks upon transpilation
```
