### PR TITLE
Add placeholders for all mising standard gates in Rust

### DIFF
--- a/crates/circuit/src/imports.rs
+++ b/crates/circuit/src/imports.rs
@@ -79,6 +79,7 @@ pub static SINGLETON_CONTROLLED_GATE: ImportOnceCell =
 ///
 /// NOTE: the order here is significant, the StandardGate variant's number must match
 /// index of it's entry in this table. This is all done statically for performance
+// TODO: replace placeholders with actual implementation
 static STDGATE_IMPORT_PATHS: [[&str; 2]; STANDARD_GATE_SIZE] = [
     // ZGate = 0
     ["qiskit.circuit.library.standard_gates.z", "ZGate"],
@@ -131,16 +132,70 @@ static STDGATE_IMPORT_PATHS: [[&str; 2]; STANDARD_GATE_SIZE] = [
     ["qiskit.circuit.library.standard_gates.sx", "SXdgGate"],
     // iSWAPGate = 23
     ["qiskit.circuit.library.standard_gates.iswap", "iSwapGate"],
-    //XXMinusYYGate = 24
+    // XXMinusYYGate = 24
     [
         "qiskit.circuit.library.standard_gates.xx_minus_yy",
         "XXMinusYYGate",
     ],
-    //XXPlusYYGate = 25
+    // XXPlusYYGate = 25
     [
         "qiskit.circuit.library.standard_gates.xx_plus_yy",
         "XXPlusYYGate",
     ],
+    // U1Gate = 26
+    ["qiskit.circuit.library.standard_gates.u1", "U1Gate"],
+    // U2Gate = 27
+    ["qiskit.circuit.library.standard_gates.u2", "U2Gate"],
+    // U3Gate = 28
+    ["qiskit.circuit.library.standard_gates.u3", "U3Gate"],
+    // CRXGate = 29
+    ["placeholder", "placeholder"],
+    // CRYGate = 30
+    ["placeholder", "placeholder"],
+    // CRZGate = 31
+    ["placeholder", "placeholder"],
+    // RGate 32
+    ["placeholder", "placeholder"],
+    // CHGate = 33
+    ["qiskit.circuit.library.standard_gates.h", "CHGate"],
+    // CPhaseGate = 34
+    ["qiskit.circuit.library.standard_gates.p", "CPhaseGate"],
+    // CSGate = 35
+    ["qiskit.circuit.library.standard_gates.s", "CSGate"],
+    // CSdgGate = 36
+    ["qiskit.circuit.library.standard_gates.s", "CSdgGate"],
+    // CSXGate = 37
+    ["qiskit.circuit.library.standard_gates.sx", "CSXGate"],
+    // CSwapGate = 38
+    ["qiskit.circuit.library.standard_gates.swap", "CSwapGate"],
+    // CUGate = 39
+    ["qiskit.circuit.library.standard_gates.u", "CUGate"],
+    // CU1Gate = 40
+    ["qiskit.circuit.library.standard_gates.u1", "CU1Gate"],
+    // CU3Gate = 41
+    ["qiskit.circuit.library.standard_gates.u3", "CU3Gate"],
+    // C3XGate = 42
+    ["placeholder", "placeholder"],
+    // C3SXGate = 43
+    ["placeholder", "placeholder"],
+    // C4XGate = 44
+    ["placeholder", "placeholder"],
+    // DCXGate = 45
+    ["placeholder", "placeholder"],
+    // CCZGate = 46
+    ["placeholder", "placeholder"],
+    // RCCXGate = 47
+    ["placeholder", "placeholder"],
+    // RC3XGate = 48
+    ["placeholder", "placeholder"],
+    // RXXGate = 49
+    ["placeholder", "placeholder"],
+    // RYYGate = 50
+    ["placeholder", "placeholder"],
+    // RZZGate = 51
+    ["placeholder", "placeholder"],
+    // RZXGate = 52
+    ["placeholder", "placeholder"],
 ];
 
 /// A mapping from the enum variant in crate::operations::StandardGate to the python object for the

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -205,43 +205,109 @@ pub enum StandardGate {
     ISwapGate = 23,
     XXMinusYYGate = 24,
     XXPlusYYGate = 25,
+    U1Gate = 26,
+    U2Gate = 27,
+    U3Gate = 28,
+    CRXGate = 29,
+    CRYGate = 30,
+    CRZGate = 31,
+    RGate = 32,
+    CHGate = 33,
+    CPhaseGate = 34,
+    CSGate = 35,
+    CSdgGate = 36,
+    CSXGate = 37,
+    CSwapGate = 38,
+    CUGate = 39,
+    CU1Gate = 40,
+    CU3Gate = 41,
+    C3XGate = 42,
+    C3SXGate = 43,
+    C4XGate = 44,
+    DCXGate = 45,
+    CCZGate = 46,
+    RCCXGate = 47,
+    RC3XGate = 48,
+    RXXGate = 49,
+    RYYGate = 50,
+    RZZGate = 51,
+    RZXGate = 52,
 }
 
+// TODO: replace all 34s (placeholders) with actual number
 static STANDARD_GATE_NUM_QUBITS: [u32; STANDARD_GATE_SIZE] = [
-    1, 1, 1, 2, 2, 2, 3, 1, 1, 1, 2, 2, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2,
+    1, 1, 1, 2, 2, 2, 3, 1, 1, 1, // 0-9
+    2, 2, 1, 0, 1, 1, 1, 1, 1, 1, // 10-19
+    1, 1, 1, 2, 2, 2, 1, 1, 1, 34, // 20-29
+    34, 34, 34, 2, 2, 2, 2, 2, 3, 2, // 30-39
+    2, 2, 34, 34, 34, 34, 34, 34, 34, 34, // 40-49
+    34, 34, 34, // 50-52
 ];
 
+// TODO: replace all 34s (placeholders) with actual number
 static STANDARD_GATE_NUM_PARAMS: [u32; STANDARD_GATE_SIZE] = [
-    0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1, 3, 0, 0, 0, 0, 0, 0, 2, 2,
+    0, 0, 0, 0, 0, 0, 0, 1, 1, 1, // 0-9
+    0, 0, 0, 1, 0, 0, 1, 3, 0, 0, // 10-19
+    0, 0, 0, 0, 2, 2, 1, 2, 3, 34, // 20-29
+    34, 34, 34, 0, 1, 0, 0, 0, 0, 3, // 30-39
+    1, 3, 34, 34, 34, 34, 34, 34, 34, 34, // 40-49
+    34, 34, 34, // 50-52
 ];
 
 static STANDARD_GATE_NAME: [&str; STANDARD_GATE_SIZE] = [
-    "z",
-    "y",
-    "x",
-    "cz",
-    "cy",
-    "cx",
-    "ccx",
-    "rx",
-    "ry",
-    "rz",
-    "ecr",
-    "swap",
-    "sx",
-    "global_phase",
-    "id",
-    "h",
-    "p",
-    "u",
-    "s",
-    "sdg",
-    "t",
-    "tdg",
-    "sxdg",
-    "iswap",
-    "xx_minus_yy",
-    "xx_plus_yy",
+    "z",            // 0
+    "y",            // 1
+    "x",            // 2
+    "cz",           // 3
+    "cy",           // 4
+    "cx",           // 5
+    "ccx",          // 6
+    "rx",           // 7
+    "ry",           // 8
+    "rz",           // 9
+    "ecr",          // 10
+    "swap",         // 11
+    "sx",           // 12
+    "global_phase", // 13
+    "id",           // 14
+    "h",            // 15
+    "p",            // 16
+    "u",            // 17
+    "s",            // 18
+    "sdg",          // 19
+    "t",            // 20
+    "tdg",          // 21
+    "sxdg",         // 22
+    "iswap",        // 23
+    "xx_minus_yy",  // 24
+    "xx_plus_yy",   // 25
+    "u1",           // 26
+    "u2",           // 27
+    "u3",           // 28
+    "crx",          // 29
+    "cry",          // 30
+    "crz",          // 31
+    "r",            // 32
+    "ch",           // 33
+    "cphase",       // 34
+    "cs",           // 35
+    "csdg",         // 36
+    "csx",          // 37
+    "cswap",        // 38
+    "cu",           // 39
+    "cu1",          // 40
+    "cu3",          // 41
+    "c3x",          // 42
+    "c3sx",         // 43
+    "c4x",          // 44
+    "dcx",          // 45
+    "ccz",          // 46
+    "rccx",         // 47
+    "rc3x",         // 48
+    "rxx",          // 49
+    "ryy",          // 50
+    "rzz",          // 51
+    "rzx",          // 52
 ];
 
 #[pymethods]
@@ -291,7 +357,7 @@ impl StandardGate {
 // Remove this when std::mem::variant_count() is stabilized (see
 // https://github.com/rust-lang/rust/issues/73662 )
 
-pub const STANDARD_GATE_SIZE: usize = 26;
+pub const STANDARD_GATE_SIZE: usize = 53;
 
 impl Operation for StandardGate {
     fn name(&self) -> &str {
@@ -432,6 +498,22 @@ impl Operation for StandardGate {
                 }
                 _ => None,
             },
+            Self::U1Gate | Self::U2Gate | Self::U3Gate => todo!(),
+            Self::CRXGate | Self::CRYGate | Self::CRZGate => todo!(),
+            Self::RGate => todo!(),
+            Self::CHGate => todo!(),
+            Self::CPhaseGate => todo!(),
+            Self::CSGate => todo!(),
+            Self::CSdgGate => todo!(),
+            Self::CSXGate => todo!(),
+            Self::CSwapGate => todo!(),
+            Self::CUGate | Self::CU1Gate | Self::CU3Gate => todo!(),
+            Self::C3XGate | Self::C3SXGate | Self::C4XGate => todo!(),
+            Self::DCXGate => todo!(),
+            Self::CCZGate => todo!(),
+            Self::RCCXGate | Self::RC3XGate => todo!(),
+            Self::RXXGate | Self::RYYGate | Self::RZZGate => todo!(),
+            Self::RZXGate => todo!(),
         }
     }
 
@@ -812,6 +894,24 @@ impl Operation for StandardGate {
                     .expect("Unexpected Qiskit python bug"),
                 )
             }),
+            Self::U1Gate | Self::U2Gate | Self::U3Gate => todo!(),
+            Self::CRXGate | Self::CRYGate | Self::CRZGate => todo!(),
+            Self::RGate => todo!(),
+            Self::CHGate => todo!(),
+            Self::CPhaseGate => todo!(),
+            Self::CSGate => todo!(),
+            Self::CSdgGate => todo!(),
+            Self::CSXGate => todo!(),
+            Self::CSwapGate => todo!(),
+            Self::CUGate => todo!(),
+            Self::CU1Gate => todo!(),
+            Self::CU3Gate => todo!(),
+            Self::C3XGate | Self::C3SXGate | Self::C4XGate => todo!(),
+            Self::DCXGate => todo!(),
+            Self::CCZGate => todo!(),
+            Self::RCCXGate | Self::RC3XGate => todo!(),
+            Self::RXXGate | Self::RYYGate | Self::RZZGate => todo!(),
+            Self::RZXGate => todo!(),
         }
     }
 

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -953,7 +953,6 @@ impl Operation for StandardGate {
                     .expect("Unexpected Qiskit python bug"),
                 )
             }),
-            Self::U1Gate | Self::U2Gate | Self::U3Gate => todo!(),
             Self::CRXGate | Self::CRYGate | Self::CRZGate => todo!(),
             Self::RGate => todo!(),
             Self::CHGate => todo!(),

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -289,7 +289,7 @@ static STANDARD_GATE_NAME: [&str; STANDARD_GATE_SIZE] = [
     "crz",          // 31
     "r",            // 32
     "ch",           // 33
-    "cphase",       // 34
+    "cp",           // 34
     "cs",           // 35
     "csdg",         // 36
     "csx",          // 37


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR proposes placeholders for all missing gates in https://github.com/Qiskit/qiskit/issues/12566 with a dummy number of qubits and number of parameters (34) that should be replaced with the actual number when implemented. The idea of this proposal is to allow for a better parallelization of the work that avoids conflicts. Note that I don't particularly like this order, and I think we should reorder the lists once the implementations are completed, but I think this order is better than having to resolve conflicts every time we merge a new PR. I have also added annotations in the static vectors to increase readability.

### Details and comments


