### PR TITLE
GenericBackendV2 should fail when the backend cannot allocate the basis gate because its size

### DIFF
--- a/qiskit/providers/fake_provider/generic_backend_v2.py
+++ b/qiskit/providers/fake_provider/generic_backend_v2.py
@@ -375,6 +375,11 @@ class GenericBackendV2(BackendV2):
                     f"in the standard qiskit circuit library."
                 )
             gate = self._supported_gates[name]
+            if self.num_qubits < gate.num_qubits:
+                raise QiskitError(
+                    f"Provided basis gate {name} needs more qubits than {self.num_qubits}, "
+                    f"which is the size of the backend."
+                )
             noise_params = self._get_noise_defaults(name, gate.num_qubits)
             self._add_noisy_instruction_to_target(gate, noise_params, calibration_inst_map)
 

--- a/releasenotes/notes/fixes_GenericBackendV2-668e40596e1f070d.yaml
+++ b/releasenotes/notes/fixes_GenericBackendV2-668e40596e1f070d.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    The constructor :class:`.GenericBackendV2` was allowing to create malformed backends because accepted backend sizes that cannot allocate basis gates. That is, a backend with a single qubit should not accept a basis with two-qubit gates.
+    The constructor :class:`.GenericBackendV2` was allowing to create malformed backends because it accepted basis gates that couldn't be allocated in the backend size . That is, a backend with a single qubit should not accept a basis with two-qubit gates.

--- a/releasenotes/notes/fixes_GenericBackendV2-668e40596e1f070d.yaml
+++ b/releasenotes/notes/fixes_GenericBackendV2-668e40596e1f070d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    The constructor :class:`.GenericBackendV2` was allowing to create malformed backends because accepted backend sizes that cannot allocate basis gates. That is, a backend with a single qubit should not accept a basis with two-qubit gates.

--- a/test/python/providers/fake_provider/test_generic_backend_v2.py
+++ b/test/python/providers/fake_provider/test_generic_backend_v2.py
@@ -35,6 +35,16 @@ class TestGenericBackendV2(QiskitTestCase):
         with self.assertRaises(QiskitError):
             GenericBackendV2(num_qubits=8, basis_gates=["cx", "id", "rz", "sx", "zz"])
 
+    def test_cx_1Q(self):
+        """Test failing with a backend with single qubit but with a two-qubit basis gate"""
+        with self.assertRaises(QiskitError):
+            GenericBackendV2(num_qubits=1, basis_gates=["cx", "id"])
+
+    def test_ccx_2Q(self):
+        """Test failing with a backend with two qubits but with a three-qubit basis gate"""
+        with self.assertRaises(QiskitError):
+            GenericBackendV2(num_qubits=2, basis_gates=["ccx", "id"])
+
     def test_operation_names(self):
         """Test that target basis gates include "delay", "measure" and "reset" even
         if not provided by user."""

--- a/test/visual/mpl/graph/test_graph_matplotlib_drawer.py
+++ b/test/visual/mpl/graph/test_graph_matplotlib_drawer.py
@@ -389,7 +389,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
         """Test plot_gate_map using 1 qubit backend"""
         # getting the mock backend from FakeProvider
 
-        backend = GenericBackendV2(num_qubits=1)
+        backend = GenericBackendV2(num_qubits=1, basis_gates=["id", "rz", "sx", "x"])
 
         fname = "1_qubit_gate_map.png"
         self.graph_plot_gate_map(backend=backend, filename=fname)


### PR DESCRIPTION
### Summary

GenericBackendV2 should not accept backends that are too small for certain gates. The following examples should be rejected:

`GenericBackendV2(num_qubits=1, basis_gates=["cx", "id"])`

`GenericBackendV2(num_qubits=2, basis_gates=["ccx", "id"])`

@ElePT found this!
