### PR TITLE
Pin scipy to 1.13.1 to bypass CI failures

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -3,7 +3,8 @@
 # https://github.com/Qiskit/qiskit-terra/issues/10345 for current details.
 scipy<1.11; python_version<'3.12'
 
-# Temporary pin to avoid CI issues caused by scipy 0.14.0
+# Temporary pin to avoid CI issues caused by scipy 1.14.0
+# See https://github.com/Qiskit/qiskit/issues/12655 for current details.
 scipy==1.13.1; python_version=='3.12'
 
 # z3-solver from 4.12.3 onwards upped the minimum macOS API version for its

--- a/constraints.txt
+++ b/constraints.txt
@@ -3,6 +3,9 @@
 # https://github.com/Qiskit/qiskit-terra/issues/10345 for current details.
 scipy<1.11; python_version<'3.12'
 
+# Temporary pin to avoid CI issues caused by scipy 0.14.0
+scipy==1.13.1
+
 # z3-solver from 4.12.3 onwards upped the minimum macOS API version for its
 # wheels to 11.7. The Azure VM images contain pre-built CPythons, of which at
 # least CPython 3.8 was compiled for an older macOS, so does not match a

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,7 +4,7 @@
 scipy<1.11; python_version<'3.12'
 
 # Temporary pin to avoid CI issues caused by scipy 0.14.0
-scipy==1.13.1
+scipy==1.13.1; python_version=='3.12'
 
 # z3-solver from 4.12.3 onwards upped the minimum macOS API version for its
 # wheels to 11.7. The Azure VM images contain pre-built CPythons, of which at


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Temporary scipy pin to get CI going.


### Details and comments


