### PR TITLE
Simplify QuantumCircuit._from_circuit_data bit handling

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1162,10 +1162,8 @@ class QuantumCircuit:
         """A private constructor from rust space circuit data."""
         out = QuantumCircuit()
         out._data = data
-        for index, bit in enumerate(data.qubits):
-            out._qubit_indices[bit] = BitLocations(index, [])
-        for index, bit in enumerate(data.clbits):
-            out._clbit_indices[bit] = BitLocations(index, [])
+        out._qubit_indices = {bit: BitLocations(index, []) for index, bit in enumerate(data.qubits)}
+        out._clbit_indices = {bit: BitLocations(index, []) for index, bit in enumerate(data.clbits)}
         return out
 
     @staticmethod

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1161,9 +1161,11 @@ class QuantumCircuit:
     def _from_circuit_data(cls, data: CircuitData) -> typing.Self:
         """A private constructor from rust space circuit data."""
         out = QuantumCircuit()
-        out.add_bits(data.qubits)
-        out.add_bits(data.clbits)
         out._data = data
+        for index, bit in enumerate(data.qubits):
+            out._qubit_indices[bit] = BitLocations(index, [])
+        for index, bit in enumerate(data.clbits):
+            out._clbit_indices[bit] = BitLocations(index, [])
         return out
 
     @staticmethod


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit simplifies the logic around bit handling in the `QuantumCircuit._from_circuit_data()` constructor. Previously it was calling `add_bits()` for each bit in the `CircuitData` object to update the output circuit's accounting for each qubit. But this was needlessly heavy as the `CircuitData` is already the source of truth for the bits in a circuit and we just need to update the indices dictionary. The `add_bits()` method attempts to add the bits to the `CircuitData` too but this is wasted overhead because the `CircuitData` already has the bits as that's where the came from. This changes the constructor to just directly set the bit indices as needed and return the circuit.

### Details and comments