### PR TITLE
Implement RGate in Rust

### DIFF
--- a/crates/circuit/src/gate_matrix.rs
+++ b/crates/circuit/src/gate_matrix.rs
@@ -25,6 +25,19 @@ pub static ONE_QUBIT_IDENTITY: [[Complex64; 2]; 2] =
     [[c64(1., 0.), c64(0., 0.)], [c64(0., 0.), c64(1., 0.)]];
 
 #[inline]
+pub fn r_gate(theta: f64, phi: f64) -> [[Complex64; 2]; 2] {
+    let half_theta = theta / 2.;
+    let cost = c64(half_theta.cos(), 0.);
+    let sint = half_theta.sin();
+    let cosphi = phi.cos();
+    let sinphi = phi.sin();
+    [
+        [cost, c64(-sint * sinphi, -sint * cosphi)],
+        [c64(sint * sinphi, -sint * cosphi), cost],
+    ]
+}
+
+#[inline]
 pub fn rx_gate(theta: f64) -> [[Complex64; 2]; 2] {
     let half_theta = theta / 2.;
     let cos = c64(half_theta.cos(), 0.);

--- a/crates/circuit/src/imports.rs
+++ b/crates/circuit/src/imports.rs
@@ -157,7 +157,7 @@ static STDGATE_IMPORT_PATHS: [[&str; 2]; STANDARD_GATE_SIZE] = [
     // CRZGate = 31
     ["placeholder", "placeholder"],
     // RGate 32
-    ["placeholder", "placeholder"],
+    ["qiskit.circuit.library.standard_gates.r", "RGate"],
     // CHGate = 33
     ["qiskit.circuit.library.standard_gates.h", "CHGate"],
     // CPhaseGate = 34

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -968,7 +968,7 @@ impl Operation for StandardGate {
                     Param::Obj(_) => unreachable!(),
                 };
                 let (phi_expr1, phi_expr2) = match &params[1] {
-                    Param::Float(phi) => (Param::Float(*phi - 1.0), Param::Float(-*phi + 1.0)),
+                    Param::Float(phi) => (Param::Float(*phi - PI2), Param::Float(-*phi + PI2)),
                     Param::ParameterExpression(phi) => {
                         let phiexpr1 = phi
                             .call_method1(py, intern!(py, "__add__"), ((-PI / 2.0),))

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -967,7 +967,7 @@ impl Operation for StandardGate {
                     }
                     Param::Obj(_) => unreachable!(),
                 };
-                let (phi_expr1, phi_expr2) = match &params[0] {
+                let (phi_expr1, phi_expr2) = match &params[1] {
                     Param::Float(phi) => (Param::Float(*phi - 1.0), Param::Float(-*phi + 1.0)),
                     Param::ParameterExpression(phi) => {
                         let phiexpr1 = phi

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -960,13 +960,7 @@ impl Operation for StandardGate {
             }),
             Self::CRXGate | Self::CRYGate | Self::CRZGate => todo!(),
             Self::RGate => Python::with_gil(|py| -> Option<CircuitData> {
-                let theta_expr = match &params[0] {
-                    Param::Float(theta) => Param::Float(*theta),
-                    Param::ParameterExpression(theta) => {
-                        Param::ParameterExpression(theta.clone_ref(py))
-                    }
-                    Param::Obj(_) => unreachable!(),
-                };
+                let theta_expr = clone_param(&params[0], py);
                 let (phi_expr1, phi_expr2) = match &params[1] {
                     Param::Float(phi) => (Param::Float(*phi - PI2), Param::Float(-*phi + PI2)),
                     Param::ParameterExpression(phi) => {
@@ -1018,6 +1012,18 @@ impl Operation for StandardGate {
 }
 
 const FLOAT_ZERO: Param = Param::Float(0.0);
+
+// Return explictly requested copy of `param`, handling
+// each variant separately.
+fn clone_param(param: &Param, py: Python) -> Param {
+    match param {
+        Param::Float(theta) => Param::Float(*theta),
+        Param::ParameterExpression(theta) => {
+            Param::ParameterExpression(theta.clone_ref(py))
+        }
+        Param::Obj(_) => unreachable!(),
+    }
+}
 
 fn multiply_param(param: &Param, mult: f64, py: Python) -> Param {
     match param {

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -239,7 +239,7 @@ static STANDARD_GATE_NUM_QUBITS: [u32; STANDARD_GATE_SIZE] = [
     1, 1, 1, 2, 2, 2, 3, 1, 1, 1, // 0-9
     2, 2, 1, 0, 1, 1, 1, 1, 1, 1, // 10-19
     1, 1, 1, 2, 2, 2, 1, 1, 1, 34, // 20-29
-    34, 34, 34, 2, 2, 2, 2, 2, 3, 2, // 30-39
+    34, 34, 1, 2, 2, 2, 2, 2, 3, 2, // 30-39
     2, 2, 34, 34, 34, 34, 34, 34, 34, 34, // 40-49
     34, 34, 34, // 50-52
 ];
@@ -249,7 +249,7 @@ static STANDARD_GATE_NUM_PARAMS: [u32; STANDARD_GATE_SIZE] = [
     0, 0, 0, 0, 0, 0, 0, 1, 1, 1, // 0-9
     0, 0, 0, 1, 0, 0, 1, 3, 0, 0, // 10-19
     0, 0, 0, 0, 2, 2, 1, 2, 3, 34, // 20-29
-    34, 34, 34, 0, 1, 0, 0, 0, 0, 3, // 30-39
+    34, 34, 2, 0, 1, 0, 0, 0, 0, 3, // 30-39
     1, 3, 34, 34, 34, 34, 34, 34, 34, 34, // 40-49
     34, 34, 34, // 50-52
 ];
@@ -514,7 +514,12 @@ impl Operation for StandardGate {
                 _ => None,
             },
             Self::CRXGate | Self::CRYGate | Self::CRZGate => todo!(),
-            Self::RGate => todo!(),
+            Self::RGate => match params {
+                [Param::Float(theta), Param::Float(phi)] => {
+                    Some(aview2(&gate_matrix::r_gate(*theta, *phi)).to_owned())
+                }
+                _ => None,
+            },
             Self::CHGate => todo!(),
             Self::CPhaseGate => todo!(),
             Self::CSGate => todo!(),
@@ -954,7 +959,41 @@ impl Operation for StandardGate {
                 )
             }),
             Self::CRXGate | Self::CRYGate | Self::CRZGate => todo!(),
-            Self::RGate => todo!(),
+            Self::RGate => Python::with_gil(|py| -> Option<CircuitData> {
+                let theta_expr = match &params[0] {
+                    Param::Float(theta) => Param::Float(*theta),
+                    Param::ParameterExpression(theta) => {
+                        Param::ParameterExpression(theta.clone_ref(py))
+                    }
+                    Param::Obj(_) => unreachable!(),
+                };
+                let (phi_expr1, phi_expr2) = match &params[0] {
+                    Param::Float(phi) => (Param::Float(*phi - 1.0), Param::Float(-*phi + 1.0)),
+                    Param::ParameterExpression(phi) => {
+                        let phiexpr1 = phi
+                            .call_method1(py, intern!(py, "__add__"), ((-PI / 2.0),))
+                            .expect("Unexpected Qiskit python bug");
+                        let phiexpr2 = phiexpr1
+                            .call_method1(py, intern!(py, "__rmul__"), (-1.0,))
+                            .expect("Unexpected Qiskit python bug");
+                        (
+                            Param::ParameterExpression(phiexpr1),
+                            Param::ParameterExpression(phiexpr2),
+                        )
+                    }
+                    Param::Obj(_) => unreachable!(),
+                };
+                let defparams = smallvec![theta_expr, phi_expr1, phi_expr2];
+                Some(
+                    CircuitData::from_standard_gates(
+                        py,
+                        1,
+                        [(Self::UGate, defparams, smallvec![Qubit(0)])],
+                        FLOAT_ZERO,
+                    )
+                    .expect("Unexpected Qiskit python bug"),
+                )
+            }),
             Self::CHGate => todo!(),
             Self::CPhaseGate => todo!(),
             Self::CSGate => todo!(),

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -1018,9 +1018,7 @@ const FLOAT_ZERO: Param = Param::Float(0.0);
 fn clone_param(param: &Param, py: Python) -> Param {
     match param {
         Param::Float(theta) => Param::Float(*theta),
-        Param::ParameterExpression(theta) => {
-            Param::ParameterExpression(theta.clone_ref(py))
-        }
+        Param::ParameterExpression(theta) => Param::ParameterExpression(theta.clone_ref(py)),
         Param::Obj(_) => unreachable!(),
     }
 }

--- a/qiskit/circuit/library/standard_gates/r.py
+++ b/qiskit/circuit/library/standard_gates/r.py
@@ -20,6 +20,7 @@ import numpy
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.parameterexpression import ParameterValueType
+from qiskit._accelerate.circuit import StandardGate
 
 
 class RGate(Gate):
@@ -48,6 +49,8 @@ class RGate(Gate):
                 -i e^{i \phi} \sin\left(\rotationangle\right) & \cos\left(\rotationangle\right)
             \end{pmatrix}
     """
+
+    _standard_gate = StandardGate.RGate
 
     def __init__(
         self,

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -4649,9 +4649,7 @@ class QuantumCircuit:
         Returns:
             A handle to the instructions created.
         """
-        from .library.standard_gates.r import RGate
-
-        return self.append(RGate(theta, phi), [qubit], [], copy=False)
+        return self._append_standard_gate(StandardGate.RGate, [theta, phi], qargs=[qubit])
 
     def rv(
         self,

--- a/test/python/circuit/test_rust_equivalence.py
+++ b/test/python/circuit/test_rust_equivalence.py
@@ -21,7 +21,7 @@ import numpy as np
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library.standard_gates import get_standard_gate_name_mapping
 
-SKIP_LIST = {"rx", "ry", "ecr", "r"}
+SKIP_LIST = {"rx", "ry", "ecr"}
 CUSTOM_MAPPING = {"x", "rz"}
 
 

--- a/test/python/circuit/test_rust_equivalence.py
+++ b/test/python/circuit/test_rust_equivalence.py
@@ -21,7 +21,7 @@ import numpy as np
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library.standard_gates import get_standard_gate_name_mapping
 
-SKIP_LIST = {"rx", "ry", "ecr"}
+SKIP_LIST = {"rx", "ry", "ecr", "r"}
 CUSTOM_MAPPING = {"x", "rz"}
 
 


### PR DESCRIPTION
This completes all tasks of implementing `RGate` in Rust rather than Python.

This replaces 
* #12507

#12507 has been modified and split into the present PR and #12651

