### PR TITLE
adapting test/randomized/test_transpiler_equivalence.py to #12640

### DIFF
--- a/test/randomized/test_transpiler_equivalence.py
+++ b/test/randomized/test_transpiler_equivalence.py
@@ -258,9 +258,9 @@ class QCircuitMachine(RuleBasedStateMachine):
         last_gate = self.qc.data[-1]
 
         # Conditional instructions are not supported
-        assume(isinstance(last_gate[0], Gate))
+        assume(isinstance(last_gate.operation, Gate))
 
-        last_gate[0].c_if(creg, val)
+        last_gate.operation.c_if(creg, val)
 
     # Properties to check
 

--- a/test/randomized/test_transpiler_equivalence.py
+++ b/test/randomized/test_transpiler_equivalence.py
@@ -269,7 +269,7 @@ class QCircuitMachine(RuleBasedStateMachine):
         """After each circuit operation, it should be possible to build QASM."""
         qasm2.dumps(self.qc)
 
-    @precondition(lambda self: any(isinstance(d[0], Measure) for d in self.qc.data))
+    @precondition(lambda self: any(isinstance(d.operation, Measure) for d in self.qc.data))
     @rule(kwargs=transpiler_conf())
     def equivalent_transpile(self, kwargs):
         """Simulate, transpile and simulate the present circuit. Verify that the


### PR DESCRIPTION
### Summary

Randomized testing is failing because is calling deprecated functionality (introduced in #12640) 

### Details and comments

https://github.com/Qiskit/qiskit/issues/2645#issuecomment-2187912250

