### PR TITLE
Fix clippy warnings on latest stable rust

### DIFF
--- a/crates/accelerate/src/dense_layout.rs
+++ b/crates/accelerate/src/dense_layout.rs
@@ -197,7 +197,7 @@ pub fn best_subset_inner(
         SubsetResult {
             count: 0,
             map: Vec::new(),
-            error: std::f64::INFINITY,
+            error: f64::INFINITY,
             subgraph: Vec::new(),
         }
     };

--- a/crates/accelerate/src/nlayout.rs
+++ b/crates/accelerate/src/nlayout.rs
@@ -107,8 +107,8 @@ impl NLayout {
         physical_qubits: usize,
     ) -> Self {
         let mut res = NLayout {
-            virt_to_phys: vec![PhysicalQubit(std::u32::MAX); virtual_qubits],
-            phys_to_virt: vec![VirtualQubit(std::u32::MAX); physical_qubits],
+            virt_to_phys: vec![PhysicalQubit(u32::MAX); virtual_qubits],
+            phys_to_virt: vec![VirtualQubit(u32::MAX); physical_qubits],
         };
         for (virt, phys) in qubit_indices {
             res.virt_to_phys[virt.index()] = phys;
@@ -184,7 +184,7 @@ impl NLayout {
 
     #[staticmethod]
     pub fn from_virtual_to_physical(virt_to_phys: Vec<PhysicalQubit>) -> PyResult<Self> {
-        let mut phys_to_virt = vec![VirtualQubit(std::u32::MAX); virt_to_phys.len()];
+        let mut phys_to_virt = vec![VirtualQubit(u32::MAX); virt_to_phys.len()];
         for (virt, phys) in virt_to_phys.iter().enumerate() {
             phys_to_virt[phys.index()] = VirtualQubit(virt.try_into()?);
         }

--- a/crates/accelerate/src/stochastic_swap.rs
+++ b/crates/accelerate/src/stochastic_swap.rs
@@ -112,10 +112,10 @@ fn swap_trial(
     let mut new_cost: f64;
     let mut dist: f64;
 
-    let mut optimal_start = PhysicalQubit::new(std::u32::MAX);
-    let mut optimal_end = PhysicalQubit::new(std::u32::MAX);
-    let mut optimal_start_qubit = VirtualQubit::new(std::u32::MAX);
-    let mut optimal_end_qubit = VirtualQubit::new(std::u32::MAX);
+    let mut optimal_start = PhysicalQubit::new(u32::MAX);
+    let mut optimal_end = PhysicalQubit::new(u32::MAX);
+    let mut optimal_start_qubit = VirtualQubit::new(u32::MAX);
+    let mut optimal_end_qubit = VirtualQubit::new(u32::MAX);
 
     let mut scale = Array2::zeros((num_qubits, num_qubits));
 
@@ -270,7 +270,7 @@ pub fn swap_trials(
     // unless force threads is set.
     let run_in_parallel = getenv_use_multiple_threads();
 
-    let mut best_depth = std::usize::MAX;
+    let mut best_depth = usize::MAX;
     let mut best_edges: Option<EdgeCollection> = None;
     let mut best_layout: Option<NLayout> = None;
     if run_in_parallel {

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -825,10 +825,7 @@ pub(crate) fn convert_py_to_operation_type(
     };
     let op_type: Bound<PyType> = raw_op_type.into_bound(py);
     let mut standard: Option<StandardGate> = match op_type.getattr(attr) {
-        Ok(stdgate) => match stdgate.extract().ok() {
-            Some(gate) => gate,
-            None => None,
-        },
+        Ok(stdgate) => stdgate.extract().ok().unwrap_or_default(),
         Err(_) => None,
     };
     // If the input instruction is a standard gate and a singleton instance


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In Rust 1.79.0 several new clippy rules were added and/or enabled by default. This was causing some new issues to be flagged when building qiskit with the this release of Rust. This commit fixes these issues flagged by clippy.

### Details and comments