### PR TITLE
Suppress nonsense `DeprecationWarning` caused by `unittest`

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -7,6 +7,10 @@ scipy<1.11; python_version<'3.12'
 # See https://github.com/Qiskit/qiskit/issues/12655 for current details.
 scipy==1.13.1; python_version=='3.12'
 
+# Rustworkx 0.15.0 contains a bug that breaks graphviz-related tests.
+# See https://github.com/Qiskit/rustworkx/pull/1229 for the fix.
+rustworkx==0.14.2
+
 # z3-solver from 4.12.3 onwards upped the minimum macOS API version for its
 # wheels to 11.7. The Azure VM images contain pre-built CPythons, of which at
 # least CPython 3.8 was compiled for an older macOS, so does not match a

--- a/test/utils/base.py
+++ b/test/utils/base.py
@@ -214,8 +214,7 @@ class QiskitTestCase(BaseQiskitTestCase):
         warnings.filterwarnings(
             "ignore",
             category=DeprecationWarning,
-            message="__warningregistry__",
-            module=r"numpy(\.\w+)*",
+            message=r".*numpy\.(\w+\.)*__warningregistry__",
         )
 
         # We only use pandas transitively through seaborn, so it's their responsibility to mark if

--- a/test/utils/base.py
+++ b/test/utils/base.py
@@ -211,6 +211,7 @@ class QiskitTestCase(BaseQiskitTestCase):
         # macOS ARM, we see some (we think harmless) warnings come out of `numpy.linalg._linalg` (a
         # now-private module) during transpilation, which means that subsequent `assertWarns` calls
         # can spuriously trick Numpy into sending out a nonsense `DeprecationWarning`.
+        # Tracking issue: https://github.com/Qiskit/qiskit/issues/12679
         warnings.filterwarnings(
             "ignore",
             category=DeprecationWarning,

--- a/test/utils/base.py
+++ b/test/utils/base.py
@@ -204,6 +204,20 @@ class QiskitTestCase(BaseQiskitTestCase):
         warnings.filterwarnings("error", category=DeprecationWarning)
         warnings.filterwarnings("error", category=QiskitWarning)
 
+        # Numpy 2 made a few new modules private, and have warnings that trigger if you try to
+        # access attributes that _would_ have existed.  Unfortunately, Python's `warnings` module
+        # adds a field called `__warningregistry__` to any module that triggers a warning, and
+        # `unittest.TestCase.assertWarns` then queries said fields on all existing modules.  On
+        # macOS ARM, we see some (we think harmless) warnings come out of `numpy.linalg._linalg` (a
+        # now-private module) during transpilation, which means that subsequent `assertWarns` calls
+        # can spuriously trick Numpy into sending out a nonsense `DeprecationWarning`.
+        warnings.filterwarnings(
+            "ignore",
+            category=DeprecationWarning,
+            message="__warningregistry__",
+            module=r"numpy(\.\w+)*",
+        )
+
         # We only use pandas transitively through seaborn, so it's their responsibility to mark if
         # their use of pandas would be a problem.
         warnings.filterwarnings(


### PR DESCRIPTION
### Summary

`unittest.TestCase.assertWarns` in context-manager form has an awkward habit of querying the `__warningregistry__` attribute on every module in existence.  This interacts poorly with a Numpy 2 deprecation warning trigger for code that's attempting to import functions from modules that became private in Numpy 2, if a warning has previously been triggered out of `numpy.linalg._linalg`.

This simply suppresses that particular warning from the test suite.


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments


