### PR TITLE
Fixed typos leading to missing examples

### DIFF
--- a/qiskit/transpiler/layout.py
+++ b/qiskit/transpiler/layout.py
@@ -454,7 +454,7 @@ class TranspileLayout:
     qubits in the circuit as it fits the circuit to the target backend. For example,
     let the input circuit be:
 
-    .. plot:
+    .. plot::
        :include-source:
 
        from qiskit.circuit import QuantumCircuit, QuantumRegister
@@ -469,7 +469,7 @@ class TranspileLayout:
 
     Suppose that during the layout stage the transpiler reorders the qubits to be:
 
-    .. plot:
+    .. plot::
        :include-source:
 
        from qiskit import QuantumCircuit
@@ -497,7 +497,7 @@ class TranspileLayout:
     the transpiler needs to insert swap gates, and the output circuit
     becomes:
 
-    .. plot:
+    .. plot::
        :include-source:
 
        from qiskit import QuantumCircuit


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Added `::` that was missing in documentation, which led to code examples and plots to be missing
Fixes #12683 


### Details and comments


