### PR TITLE
Relax CI constraint on Rustworkx 0.15.0

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -7,10 +7,6 @@ scipy<1.11; python_version<'3.12'
 # See https://github.com/Qiskit/qiskit/issues/12655 for current details.
 scipy==1.13.1; python_version=='3.12'
 
-# Rustworkx 0.15.0 contains a bug that breaks graphviz-related tests.
-# See https://github.com/Qiskit/rustworkx/pull/1229 for the fix.
-rustworkx==0.14.2
-
 # z3-solver from 4.12.3 onwards upped the minimum macOS API version for its
 # wheels to 11.7. The Azure VM images contain pre-built CPythons, of which at
 # least CPython 3.8 was compiled for an older macOS, so does not match a


### PR DESCRIPTION
### Summary

The release of Rustworkx 0.15.1 fixes the bug that was previously blocking CI.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments


