### PR TITLE
Fix cargo clippy and rustfmt for Rust 1.79

### DIFF
--- a/crates/accelerate/src/synthesis/permutation/utils.rs
+++ b/crates/accelerate/src/synthesis/permutation/utils.rs
@@ -120,8 +120,10 @@ pub fn pattern_to_cycles(pattern: &ArrayView1<usize>) -> Vec<Vec<usize>> {
 /// Periodic (or Python-like) access to a vector.
 /// Util used below in ``decompose_cycles``.
 #[inline]
-fn pget(vec: &Vec<usize>, index: isize) -> Result<usize, PySequenceIndexError> {
-    let SequenceIndex::Int(wrapped) = PySequenceIndex::Int(index).with_len(vec.len())? else {unreachable!()};
+fn pget(vec: &[usize], index: isize) -> Result<usize, PySequenceIndexError> {
+    let SequenceIndex::Int(wrapped) = PySequenceIndex::Int(index).with_len(vec.len())? else {
+        unreachable!()
+    };
     Ok(vec[wrapped])
 }
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

After the recently merged #12543 when working with Rust 1.79 cargo fmt makes a small formatting change that rust 1.70 wouldn't and clippy makes flags a `&Vec<_>` that should be a slice `&[_]` instead. This commit makes these two small chagnes so they're not an issue for people building with the latest stable version of rust, not just our MSRV.

### Details and comments