### PR TITLE
Fixed the _skip_target argument in `generate_preset_pass_manager` 

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/__init__.py
+++ b/qiskit/transpiler/preset_passmanagers/__init__.py
@@ -389,7 +389,7 @@ def generate_preset_pass_manager(
 
     if backend is not None:
         pm_options["_skip_target"] = _skip_target
-        pm_config = PassManagerConfig.from_backend(backend, **pm_options)
+        pm_config = PassManagerConfig.from_backend(backend, _skip_target=_skip_target, **pm_options)
     else:
         pm_config = PassManagerConfig(**pm_options)
     if optimization_level == 0:


### PR DESCRIPTION
the _skip_target argument was set in config but was not exactly used

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The `generate_preset_pass_manager` configured Pass Manager configurations from backend but `_skip_target` parameter was not correctly configured. 


### Details and comments
While building the Pass Manager configurations from backend while generating the preset pass manager, the `_skip_target` parameter was not correctly configured. It was added in the `pm_options` but in `from_backend` function argument `_skip_target` was directly used instead of `_skip_target` from the `pm_options`. So, I passed the argument in the function and kept the original option in the `pm_options` just in case it is being used in future pass managers
