### PR TITLE
fixing synthesis release notes

### DIFF
--- a/releasenotes/notes/oxidize-acg-0294a87c0d5974fa.yaml
+++ b/releasenotes/notes/oxidize-acg-0294a87c0d5974fa.yaml
@@ -1,5 +1,5 @@
 ---
-upgrade_synthesis:
+features_synthesis:
   - |
     Port :func:`.synth_permutation_acg`, used to synthesize qubit permutations, to Rust.
     This produces an approximate 3x performance improvement on 1000 qubit circuits.

--- a/releasenotes/notes/oxidize-permbasic-be27578187ac472f.yaml
+++ b/releasenotes/notes/oxidize-permbasic-be27578187ac472f.yaml
@@ -1,4 +1,4 @@
 ---
-upgrade_synthesis:
+features_synthesis:
   - |
     Port :func:`.synth_permutation_basic`, used to synthesize qubit permutations, to Rust.

--- a/releasenotes/notes/oxidize-synth-clifford-greedy-0739e9688bc4eedd.yaml
+++ b/releasenotes/notes/oxidize-synth-clifford-greedy-0739e9688bc4eedd.yaml
@@ -1,5 +1,5 @@
 ---
-upgrade_synthesis:
+features_synthesis:
   - |
     The function :func:`.synth_clifford_greedy` that synthesizes :class:`.Clifford` operators
     was ported to Rust, leading to a significant increase in performance for all numbers of


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Just a few days ago @mtreinish has reminded me (yet again) about the difference between an upgrade note and a feature note:

> An upgrade note is reserved for something that we want to document might require user input when upgrading from the previous release to the new one. Examples would be a breaking api change, minimum dependency version bump, etc.

and of course we forgot about this in some of the recently merged PRs (probably because we keep copying and adapting the notes from previously merged PRs). 

This tiny PRs classifies the release notes correctly. And attention @Cryoris with #12588.


