### PR TITLE
Optimize DAGCircuit.collect_1q_runs() filter function

### DIFF
--- a/crates/accelerate/src/euler_one_qubit_decomposer.rs
+++ b/crates/accelerate/src/euler_one_qubit_decomposer.rs
@@ -1045,10 +1045,11 @@ fn matmul_1q(operator: &mut [[Complex64; 2]; 2], other: Array2<Complex64>) {
 }
 
 #[pyfunction]
-pub fn collect_1q_runs_filter(py: Python, node: PyObject) -> bool {
-    let op_node = node.extract::<PyRef<DAGOpNode>>(py);
+pub fn collect_1q_runs_filter(node: &Bound<PyAny>) -> bool {
+    let op_node = node.downcast::<DAGOpNode>();
     match op_node {
-        Ok(node) => {
+        Ok(bound_node) => {
+            let node = bound_node.borrow();
             node.instruction.operation.num_qubits() == 1
                 && node.instruction.operation.num_clbits() == 0
                 && node


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the recently merged #12650 a new rust function was added for the filter function of the collect_1q_runs() method's internal filter function. As part of this we need to do exclude any non-DAGOpNode dag nodes passed to the filter function. This was previously implemented using the pyo3 extract() method so that if the pyobject can be coerced into a DAGOpNode for later use we continue but if it errors we know the input object is not a DAGOpNode and return false. However, as we don't need to return the error to python we should be using downcast instead of extract (as per the pyo3 performance guide [1]) to avoid the error conversion cost. This was an oversight in #12650 and I only used extract() out of habit.

[1] https://pyo3.rs/v0.22.0/performance#extract-versus-downcast

### Details and comments


