### PR TITLE
Improve the performance of the `ProductFormula` synthesizers

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1596,11 +1596,12 @@ class QuantumCircuit:
             )
         return inverse_circ
 
-    def repeat(self, reps: int) -> "QuantumCircuit":
+    def repeat(self, reps: int, *, insert_barriers: bool = False) -> "QuantumCircuit":
         """Repeat this circuit ``reps`` times.
 
         Args:
             reps (int): How often this circuit should be repeated.
+            insert_barriers (bool): Whether to include barriers between circuit repetitions.
 
         Returns:
             QuantumCircuit: A circuit containing ``reps`` repetitions of this circuit.
@@ -1616,8 +1617,10 @@ class QuantumCircuit:
                 inst: Instruction = self.to_gate()
             except QiskitError:
                 inst = self.to_instruction()
-            for _ in range(reps):
+            for i in range(reps):
                 repeated_circ._append(inst, self.qubits, self.clbits)
+                if insert_barriers and i != reps - 1:
+                    repeated_circ.barrier()
 
         return repeated_circ
 

--- a/qiskit/synthesis/evolution/evolution_synthesis.py
+++ b/qiskit/synthesis/evolution/evolution_synthesis.py
@@ -12,8 +12,10 @@
 
 """Evolution synthesis."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any
 
 
 class EvolutionSynthesis(ABC):
@@ -32,7 +34,7 @@ class EvolutionSynthesis(ABC):
         raise NotImplementedError
 
     @property
-    def settings(self) -> Dict[str, Any]:
+    def settings(self) -> dict[str, Any]:
         """Return the settings in a dictionary, which can be used to reconstruct the object.
 
         Returns:

--- a/qiskit/synthesis/evolution/lie_trotter.py
+++ b/qiskit/synthesis/evolution/lie_trotter.py
@@ -14,11 +14,13 @@
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Callable
 from typing import Any
 import numpy as np
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.quantum_info.operators import SparsePauliOp, Pauli
+from qiskit.utils.deprecation import deprecate_arg
 
 from .product_formula import ProductFormula
 
@@ -50,12 +52,30 @@ class LieTrotter(ProductFormula):
         `arXiv:math-ph/0506007 <https://arxiv.org/pdf/math-ph/0506007.pdf>`_
     """
 
+    @deprecate_arg(
+        name="atomic_evolution",
+        since="1.2",
+        predicate=lambda callable: callable is not None
+        and len(inspect.signature(callable).parameters) == 2,
+        deprecation_description=(
+            "The 'Callable[[Pauli | SparsePauliOp, float], QuantumCircuit]' signature of the "
+            "'atomic_evolution' argument"
+        ),
+        additional_msg=(
+            "Instead you should update your 'atomic_evolution' function to be of the following "
+            "type: 'Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]'."
+        ),
+    )
     def __init__(
         self,
         reps: int = 1,
         insert_barriers: bool = False,
         cx_structure: str = "chain",
-        atomic_evolution: Callable[[Pauli | SparsePauliOp, float], QuantumCircuit] | None = None,
+        atomic_evolution: (
+            Callable[[Pauli | SparsePauliOp, float], QuantumCircuit]
+            | Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]
+            | None
+        ) = None,
         wrap: bool = False,
     ) -> None:
         """

--- a/qiskit/synthesis/evolution/lie_trotter.py
+++ b/qiskit/synthesis/evolution/lie_trotter.py
@@ -112,7 +112,7 @@ class LieTrotter(ProductFormula):
             if self.insert_barriers and i != len(pauli_list) - 1:
                 single_rep.barrier()
 
-        return single_rep.repeat(self.reps, insert_barriers=True).decompose()
+        return single_rep.repeat(self.reps, insert_barriers=self.insert_barriers).decompose()
 
     @property
     def settings(self) -> dict[str, Any]:

--- a/qiskit/synthesis/evolution/lie_trotter.py
+++ b/qiskit/synthesis/evolution/lie_trotter.py
@@ -92,7 +92,7 @@ class LieTrotter(ProductFormula):
                 three arguments: the circuit to append the evolution to, the Pauli operator to
                 evolve, and the evolution time. By default, a single Pauli evolution is decomposed
                 into a chain of ``CX`` gates and a single ``RZ`` gate.
-                **DEPRECATED:** The function takes only the Pauli operator and evolution time as
+                Alternatively, the function can also take Pauli operator and evolution time as
                 inputs and returns the circuit that will be appended to the overall circuit being
                 built.
             wrap: Whether to wrap the atomic evolutions into custom gate objects. This only takes

--- a/qiskit/synthesis/evolution/lie_trotter.py
+++ b/qiskit/synthesis/evolution/lie_trotter.py
@@ -86,9 +86,11 @@ class LieTrotter(ProductFormula):
                 ``"chain"``, where next neighbor connections are used, or ``"fountain"``,
                 where all qubits are connected to one. This only takes effect when
                 ``atomic_evolution is None``.
-            atomic_evolution: A function to construct the circuit for the evolution of single
-                Pauli string. Per default, a single Pauli evolution is decomposed in a CX chain
-                and a single qubit Z rotation.
+            atomic_evolution: A function to apply the evolution of a single :class:`.Pauli`, or
+                :class:`.SparsePauliOp` of only commuting terms, to a circuit. The function takes in
+                three arguments: the circuit to append the evolution to, the Pauli operator to
+                evolve, and the evolution time. By default, a single Pauli evolution is decomposed
+                into a chain of ``CX`` gates and a single ``RZ`` gate.
             wrap: Whether to wrap the atomic evolutions into custom gate objects. This only takes
                 effect when ``atomic_evolution is None``.
         """

--- a/qiskit/synthesis/evolution/lie_trotter.py
+++ b/qiskit/synthesis/evolution/lie_trotter.py
@@ -91,6 +91,9 @@ class LieTrotter(ProductFormula):
                 three arguments: the circuit to append the evolution to, the Pauli operator to
                 evolve, and the evolution time. By default, a single Pauli evolution is decomposed
                 into a chain of ``CX`` gates and a single ``RZ`` gate.
+                **DEPRECATED:** The function takes only the Pauli operator and evolution time as
+                inputs and returns the circuit that will be appended to the overall circuit being
+                built.
             wrap: Whether to wrap the atomic evolutions into custom gate objects. This only takes
                 effect when ``atomic_evolution is None``.
         """

--- a/qiskit/synthesis/evolution/lie_trotter.py
+++ b/qiskit/synthesis/evolution/lie_trotter.py
@@ -12,7 +12,10 @@
 
 """The Lie-Trotter product formula."""
 
-from typing import Callable, Optional, Union, Dict, Any
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
 import numpy as np
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.quantum_info.operators import SparsePauliOp, Pauli
@@ -52,9 +55,7 @@ class LieTrotter(ProductFormula):
         reps: int = 1,
         insert_barriers: bool = False,
         cx_structure: str = "chain",
-        atomic_evolution: Optional[
-            Callable[[Union[Pauli, SparsePauliOp], float], QuantumCircuit]
-        ] = None,
+        atomic_evolution: Callable[[Pauli | SparsePauliOp, float], QuantumCircuit] | None = None,
     ) -> None:
         """
         Args:
@@ -95,7 +96,7 @@ class LieTrotter(ProductFormula):
         return evolution_circuit.repeat(self.reps).decompose()
 
     @property
-    def settings(self) -> Dict[str, Any]:
+    def settings(self) -> dict[str, Any]:
         """Return the settings in a dictionary, which can be used to reconstruct the object.
 
         Returns:

--- a/qiskit/synthesis/evolution/lie_trotter.py
+++ b/qiskit/synthesis/evolution/lie_trotter.py
@@ -65,6 +65,7 @@ class LieTrotter(ProductFormula):
             "Instead you should update your 'atomic_evolution' function to be of the following "
             "type: 'Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]'."
         ),
+        pending=True,
     )
     def __init__(
         self,

--- a/qiskit/synthesis/evolution/lie_trotter.py
+++ b/qiskit/synthesis/evolution/lie_trotter.py
@@ -80,7 +80,7 @@ class LieTrotter(ProductFormula):
         time = evolution.time
 
         # construct the evolution circuit
-        evolution_circuit = QuantumCircuit(operators[0].num_qubits)
+        single_rep = QuantumCircuit(operators[0].num_qubits)
 
         if not isinstance(operators, list):
             pauli_list = [(Pauli(op), np.real(coeff)) for op, coeff in operators.to_list()]
@@ -88,11 +88,11 @@ class LieTrotter(ProductFormula):
             pauli_list = [(op, 1) for op in operators]
 
         for i, (op, coeff) in enumerate(pauli_list):
-            self.atomic_evolution(evolution_circuit, op, coeff * time / self.reps)
+            self.atomic_evolution(single_rep, op, coeff * time / self.reps)
             if self.insert_barriers and i != len(pauli_list) - 1:
-                evolution_circuit.barrier()
+                single_rep.barrier()
 
-        return evolution_circuit.repeat(self.reps, insert_barriers=True).decompose()
+        return single_rep.repeat(self.reps, insert_barriers=True).decompose()
 
     @property
     def settings(self) -> dict[str, Any]:

--- a/qiskit/synthesis/evolution/lie_trotter.py
+++ b/qiskit/synthesis/evolution/lie_trotter.py
@@ -87,9 +87,7 @@ class LieTrotter(ProductFormula):
         wrap = not (len(pauli_list) == 1 and self.reps == 1)
 
         for i, (op, coeff) in enumerate(pauli_list):
-            evolution_circuit.compose(
-                self.atomic_evolution(op, coeff * time / self.reps), wrap=wrap, inplace=True
-            )
+            self.atomic_evolution(evolution_circuit, op, coeff * time / self.reps)
             if self.insert_barriers and i != len(pauli_list) - 1:
                 evolution_circuit.barrier()
 

--- a/qiskit/synthesis/evolution/lie_trotter.py
+++ b/qiskit/synthesis/evolution/lie_trotter.py
@@ -92,7 +92,7 @@ class LieTrotter(ProductFormula):
             if self.insert_barriers and i != len(pauli_list) - 1:
                 evolution_circuit.barrier()
 
-        return evolution_circuit.repeat(self.reps).decompose()
+        return evolution_circuit.repeat(self.reps, insert_barriers=True).decompose()
 
     @property
     def settings(self) -> dict[str, Any]:

--- a/qiskit/synthesis/evolution/product_formula.py
+++ b/qiskit/synthesis/evolution/product_formula.py
@@ -74,6 +74,9 @@ class ProductFormula(EvolutionSynthesis):
                 three arguments: the circuit to append the evolution to, the Pauli operator to
                 evolve, and the evolution time. By default, a single Pauli evolution is decomposed
                 into a chain of ``CX`` gates and a single ``RZ`` gate.
+                **DEPRECATED:** The function takes only the Pauli operator and evolution time as
+                inputs and returns the circuit that will be appended to the overall circuit being
+                built.
             wrap: Whether to wrap the atomic evolutions into custom gate objects. This only takes
                 effect when ``atomic_evolution is None``.
         """

--- a/qiskit/synthesis/evolution/product_formula.py
+++ b/qiskit/synthesis/evolution/product_formula.py
@@ -199,9 +199,9 @@ def _single_qubit_evolution(output, pauli, time, wrap):
             label += "Z"
 
     if wrap:
-        dest.name = f"exp(it {label})"
+        gate = dest.to_gate(label=f"exp(it {label})")
         qubits = [output.qubits[q] for q in qubits]
-        output.compose(dest, qubits=qubits, wrap=True, inplace=True)
+        output.append(gate, qargs=qubits, copy=False)
 
 
 def _two_qubit_evolution(output, pauli, time, cx_structure, wrap):
@@ -231,9 +231,9 @@ def _two_qubit_evolution(output, pauli, time, cx_structure, wrap):
         return
 
     if wrap:
-        dest.name = f"exp(it {''.join(labels)})"
+        gate = dest.to_gate(label=f"exp(it {''.join(labels)})")
         qubits = [output.qubits[q] for q in qubits]
-        output.compose(dest, qubits=qubits, wrap=True, inplace=True)
+        output.append(gate, qargs=qubits, copy=False)
 
 
 def _multi_qubit_evolution(output, pauli, time, cx_structure, wrap):
@@ -264,8 +264,8 @@ def _multi_qubit_evolution(output, pauli, time, cx_structure, wrap):
     dest.compose(cliff.inverse(), inplace=True)
 
     if wrap:
-        dest.name = f"exp(it {pauli.to_label()})"
-        output.compose(dest, wrap=True, inplace=True)
+        gate = dest.to_gate(label=f"exp(it {pauli.to_label()})")
+        output.append(gate, qargs=output.qubits, copy=False)
 
 
 def diagonalizing_clifford(pauli: Pauli) -> QuantumCircuit:

--- a/qiskit/synthesis/evolution/product_formula.py
+++ b/qiskit/synthesis/evolution/product_formula.py
@@ -46,6 +46,7 @@ class ProductFormula(EvolutionSynthesis):
             "Instead you should update your 'atomic_evolution' function to be of the following "
             "type: 'Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]'."
         ),
+        pending=True,
     )
     def __init__(
         self,

--- a/qiskit/synthesis/evolution/product_formula.py
+++ b/qiskit/synthesis/evolution/product_formula.py
@@ -75,7 +75,7 @@ class ProductFormula(EvolutionSynthesis):
                 three arguments: the circuit to append the evolution to, the Pauli operator to
                 evolve, and the evolution time. By default, a single Pauli evolution is decomposed
                 into a chain of ``CX`` gates and a single ``RZ`` gate.
-                **DEPRECATED:** The function takes only the Pauli operator and evolution time as
+                Alternatively, the function can also take Pauli operator and evolution time as
                 inputs and returns the circuit that will be appended to the overall circuit being
                 built.
             wrap: Whether to wrap the atomic evolutions into custom gate objects. This only takes

--- a/qiskit/synthesis/evolution/product_formula.py
+++ b/qiskit/synthesis/evolution/product_formula.py
@@ -69,9 +69,11 @@ class ProductFormula(EvolutionSynthesis):
                 ``"chain"``, where next neighbor connections are used, or ``"fountain"``,
                 where all qubits are connected to one. This only takes effect when
                 ``atomic_evolution is None``.
-            atomic_evolution: A function to construct the circuit for the evolution of single
-                Pauli string. Per default, a single Pauli evolution is decomposed in a CX chain
-                and a single qubit Z rotation.
+            atomic_evolution: A function to apply the evolution of a single :class:`.Pauli`, or
+                :class:`.SparsePauliOp` of only commuting terms, to a circuit. The function takes in
+                three arguments: the circuit to append the evolution to, the Pauli operator to
+                evolve, and the evolution time. By default, a single Pauli evolution is decomposed
+                into a chain of ``CX`` gates and a single ``RZ`` gate.
             wrap: Whether to wrap the atomic evolutions into custom gate objects. This only takes
                 effect when ``atomic_evolution is None``.
         """

--- a/qiskit/synthesis/evolution/product_formula.py
+++ b/qiskit/synthesis/evolution/product_formula.py
@@ -176,20 +176,24 @@ def _single_qubit_evolution(output, pauli, time, wrap):
     # Note that all phases are removed from the pauli label and are only in the coefficients.
     # That's because the operators we evolved have all been translated to a SparsePauliOp.
     qubits = []
+    label = ""
     for i, pauli_i in enumerate(reversed(pauli.to_label())):
         idx = 0 if wrap else i
         if pauli_i == "X":
             dest.rx(2 * time, idx)
             qubits.append(i)
+            label += "X"
         elif pauli_i == "Y":
             dest.ry(2 * time, idx)
             qubits.append(i)
+            label += "Y"
         elif pauli_i == "Z":
             dest.rz(2 * time, idx)
             qubits.append(i)
+            label += "Z"
 
     if wrap:
-        dest.name = f"exp(it {pauli.to_label()})"
+        dest.name = f"exp(it {label})"
         qubits = [output.qubits[q] for q in qubits]
         output.compose(dest, qubits=qubits, wrap=True, inplace=True)
 
@@ -221,7 +225,7 @@ def _two_qubit_evolution(output, pauli, time, cx_structure, wrap):
         return
 
     if wrap:
-        dest.name = f"exp(it {pauli.to_label()})"
+        dest.name = f"exp(it {''.join(labels)})"
         qubits = [output.qubits[q] for q in qubits]
         output.compose(dest, qubits=qubits, wrap=True, inplace=True)
 

--- a/qiskit/synthesis/evolution/product_formula.py
+++ b/qiskit/synthesis/evolution/product_formula.py
@@ -14,7 +14,8 @@
 
 from __future__ import annotations
 
-from typing import Callable, Optional, Union, Any, Dict
+from collections.abc import Callable
+from typing import Any
 from functools import partial
 import numpy as np
 from qiskit.circuit.parameterexpression import ParameterExpression
@@ -36,9 +37,7 @@ class ProductFormula(EvolutionSynthesis):
         reps: int = 1,
         insert_barriers: bool = False,
         cx_structure: str = "chain",
-        atomic_evolution: Optional[
-            Callable[[Union[Pauli, SparsePauliOp], float], QuantumCircuit]
-        ] = None,
+        atomic_evolution: Callable[[Pauli | SparsePauliOp, float], QuantumCircuit] | None = None,
     ) -> None:
         """
         Args:
@@ -68,7 +67,7 @@ class ProductFormula(EvolutionSynthesis):
         self.atomic_evolution = atomic_evolution
 
     @property
-    def settings(self) -> Dict[str, Any]:
+    def settings(self) -> dict[str, Any]:
         """Return the settings in a dictionary, which can be used to reconstruct the object.
 
         Returns:
@@ -92,9 +91,9 @@ class ProductFormula(EvolutionSynthesis):
 
 def evolve_pauli(
     pauli: Pauli,
-    time: Union[float, ParameterExpression] = 1.0,
+    time: float | ParameterExpression = 1.0,
     cx_structure: str = "chain",
-    label: Optional[str] = None,
+    label: str | None = None,
     output: QuantumCircuit | None = None,
 ) -> QuantumCircuit | None:
     r"""Construct a circuit implementing the time evolution of a single Pauli string.

--- a/qiskit/synthesis/evolution/qdrift.py
+++ b/qiskit/synthesis/evolution/qdrift.py
@@ -41,6 +41,7 @@ class QDrift(ProductFormula):
         cx_structure: str = "chain",
         atomic_evolution: Callable[[Pauli | SparsePauliOp, float], QuantumCircuit] | None = None,
         seed: int | None = None,
+        wrap: bool = False,
     ) -> None:
         r"""
         Args:
@@ -48,13 +49,16 @@ class QDrift(ProductFormula):
             insert_barriers: Whether to insert barriers between the atomic evolutions.
             cx_structure: How to arrange the CX gates for the Pauli evolutions, can be
                 ``"chain"``, where next neighbor connections are used, or ``"fountain"``, where all
-                qubits are connected to one.
+                qubits are connected to one. This only takes effect when
+                ``atomic_evolution is None``.
             atomic_evolution: A function to construct the circuit for the evolution of single
                 Pauli string. Per default, a single Pauli evolution is decomposed in a CX chain
                 and a single qubit Z rotation.
             seed: An optional seed for reproducibility of the random sampling process.
+            wrap: Whether to wrap the atomic evolutions into custom gate objects. This only takes
+                effect when ``atomic_evolution is None``.
         """
-        super().__init__(1, reps, insert_barriers, cx_structure, atomic_evolution)
+        super().__init__(1, reps, insert_barriers, cx_structure, atomic_evolution, wrap)
         self.sampled_ops = None
         self.rng = np.random.default_rng(seed)
 

--- a/qiskit/synthesis/evolution/qdrift.py
+++ b/qiskit/synthesis/evolution/qdrift.py
@@ -76,6 +76,9 @@ class QDrift(ProductFormula):
                 three arguments: the circuit to append the evolution to, the Pauli operator to
                 evolve, and the evolution time. By default, a single Pauli evolution is decomposed
                 into a chain of ``CX`` gates and a single ``RZ`` gate.
+                **DEPRECATED:** The function takes only the Pauli operator and evolution time as
+                inputs and returns the circuit that will be appended to the overall circuit being
+                built.
             seed: An optional seed for reproducibility of the random sampling process.
             wrap: Whether to wrap the atomic evolutions into custom gate objects. This only takes
                 effect when ``atomic_evolution is None``.

--- a/qiskit/synthesis/evolution/qdrift.py
+++ b/qiskit/synthesis/evolution/qdrift.py
@@ -14,11 +14,13 @@
 
 from __future__ import annotations
 
+import inspect
 import math
 from collections.abc import Callable
 import numpy as np
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.quantum_info.operators import SparsePauliOp, Pauli
+from qiskit.utils.deprecation import deprecate_arg
 
 from .product_formula import ProductFormula
 from .lie_trotter import LieTrotter
@@ -34,12 +36,30 @@ class QDrift(ProductFormula):
         `arXiv:quant-ph/1811.08017 <https://arxiv.org/abs/1811.08017>`_
     """
 
+    @deprecate_arg(
+        name="atomic_evolution",
+        since="1.2",
+        predicate=lambda callable: callable is not None
+        and len(inspect.signature(callable).parameters) == 2,
+        deprecation_description=(
+            "The 'Callable[[Pauli | SparsePauliOp, float], QuantumCircuit]' signature of the "
+            "'atomic_evolution' argument"
+        ),
+        additional_msg=(
+            "Instead you should update your 'atomic_evolution' function to be of the following "
+            "type: 'Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]'."
+        ),
+    )
     def __init__(
         self,
         reps: int = 1,
         insert_barriers: bool = False,
         cx_structure: str = "chain",
-        atomic_evolution: Callable[[Pauli | SparsePauliOp, float], QuantumCircuit] | None = None,
+        atomic_evolution: (
+            Callable[[Pauli | SparsePauliOp, float], QuantumCircuit]
+            | Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]
+            | None
+        ) = None,
         seed: int | None = None,
         wrap: bool = False,
     ) -> None:

--- a/qiskit/synthesis/evolution/qdrift.py
+++ b/qiskit/synthesis/evolution/qdrift.py
@@ -71,9 +71,11 @@ class QDrift(ProductFormula):
                 ``"chain"``, where next neighbor connections are used, or ``"fountain"``, where all
                 qubits are connected to one. This only takes effect when
                 ``atomic_evolution is None``.
-            atomic_evolution: A function to construct the circuit for the evolution of single
-                Pauli string. Per default, a single Pauli evolution is decomposed in a CX chain
-                and a single qubit Z rotation.
+            atomic_evolution: A function to apply the evolution of a single :class:`.Pauli`, or
+                :class:`.SparsePauliOp` of only commuting terms, to a circuit. The function takes in
+                three arguments: the circuit to append the evolution to, the Pauli operator to
+                evolve, and the evolution time. By default, a single Pauli evolution is decomposed
+                into a chain of ``CX`` gates and a single ``RZ`` gate.
             seed: An optional seed for reproducibility of the random sampling process.
             wrap: Whether to wrap the atomic evolutions into custom gate objects. This only takes
                 effect when ``atomic_evolution is None``.

--- a/qiskit/synthesis/evolution/qdrift.py
+++ b/qiskit/synthesis/evolution/qdrift.py
@@ -12,8 +12,10 @@
 
 """QDrift Class"""
 
+from __future__ import annotations
+
 import math
-from typing import Union, Optional, Callable
+from collections.abc import Callable
 import numpy as np
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.quantum_info.operators import SparsePauliOp, Pauli
@@ -37,10 +39,8 @@ class QDrift(ProductFormula):
         reps: int = 1,
         insert_barriers: bool = False,
         cx_structure: str = "chain",
-        atomic_evolution: Optional[
-            Callable[[Union[Pauli, SparsePauliOp], float], QuantumCircuit]
-        ] = None,
-        seed: Optional[int] = None,
+        atomic_evolution: Callable[[Pauli | SparsePauliOp, float], QuantumCircuit] | None = None,
+        seed: int | None = None,
     ) -> None:
         r"""
         Args:

--- a/qiskit/synthesis/evolution/qdrift.py
+++ b/qiskit/synthesis/evolution/qdrift.py
@@ -49,6 +49,7 @@ class QDrift(ProductFormula):
             "Instead you should update your 'atomic_evolution' function to be of the following "
             "type: 'Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]'."
         ),
+        pending=True,
     )
     def __init__(
         self,

--- a/qiskit/synthesis/evolution/qdrift.py
+++ b/qiskit/synthesis/evolution/qdrift.py
@@ -77,7 +77,7 @@ class QDrift(ProductFormula):
                 three arguments: the circuit to append the evolution to, the Pauli operator to
                 evolve, and the evolution time. By default, a single Pauli evolution is decomposed
                 into a chain of ``CX`` gates and a single ``RZ`` gate.
-                **DEPRECATED:** The function takes only the Pauli operator and evolution time as
+                Alternatively, the function can also take Pauli operator and evolution time as
                 inputs and returns the circuit that will be appended to the overall circuit being
                 built.
             seed: An optional seed for reproducibility of the random sampling process.

--- a/qiskit/synthesis/evolution/suzuki_trotter.py
+++ b/qiskit/synthesis/evolution/suzuki_trotter.py
@@ -100,32 +100,13 @@ class SuzukiTrotter(ProductFormula):
 
         # construct the evolution circuit
         single_rep = QuantumCircuit(operators[0].num_qubits)
-        first_barrier = False
 
-        for op, coeff in ops_to_evolve:
-            # add barriers
-            if first_barrier:
-                if self.insert_barriers:
-                    single_rep.barrier()
-            else:
-                first_barrier = True
-
+        for i, (op, coeff) in enumerate(ops_to_evolve):
             self.atomic_evolution(single_rep, op, coeff)
+            if self.insert_barriers and i != len(ops_to_evolve) - 1:
+                single_rep.barrier()
 
-        evolution_circuit = QuantumCircuit(operators[0].num_qubits)
-        first_barrier = False
-
-        for _ in range(self.reps):
-            # add barriers
-            if first_barrier:
-                if self.insert_barriers:
-                    single_rep.barrier()
-            else:
-                first_barrier = True
-
-            evolution_circuit.compose(single_rep, inplace=True)
-
-        return evolution_circuit
+        return single_rep.repeat(self.reps, insert_barriers=True).decompose()
 
     @staticmethod
     def _recurse(order, time, pauli_list):

--- a/qiskit/synthesis/evolution/suzuki_trotter.py
+++ b/qiskit/synthesis/evolution/suzuki_trotter.py
@@ -96,7 +96,7 @@ class SuzukiTrotter(ProductFormula):
                 three arguments: the circuit to append the evolution to, the Pauli operator to
                 evolve, and the evolution time. By default, a single Pauli evolution is decomposed
                 into a chain of ``CX`` gates and a single ``RZ`` gate.
-                **DEPRECATED:** The function takes only the Pauli operator and evolution time as
+                Alternatively, the function can also take Pauli operator and evolution time as
                 inputs and returns the circuit that will be appended to the overall circuit being
                 built.
             wrap: Whether to wrap the atomic evolutions into custom gate objects. This only takes

--- a/qiskit/synthesis/evolution/suzuki_trotter.py
+++ b/qiskit/synthesis/evolution/suzuki_trotter.py
@@ -14,12 +14,14 @@
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Callable
 
 import numpy as np
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.quantum_info.operators import SparsePauliOp, Pauli
+from qiskit.utils.deprecation import deprecate_arg
 
 
 from .product_formula import ProductFormula
@@ -53,13 +55,31 @@ class SuzukiTrotter(ProductFormula):
         `arXiv:math-ph/0506007 <https://arxiv.org/pdf/math-ph/0506007.pdf>`_
     """
 
+    @deprecate_arg(
+        name="atomic_evolution",
+        since="1.2",
+        predicate=lambda callable: callable is not None
+        and len(inspect.signature(callable).parameters) == 2,
+        deprecation_description=(
+            "The 'Callable[[Pauli | SparsePauliOp, float], QuantumCircuit]' signature of the "
+            "'atomic_evolution' argument"
+        ),
+        additional_msg=(
+            "Instead you should update your 'atomic_evolution' function to be of the following "
+            "type: 'Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]'."
+        ),
+    )
     def __init__(
         self,
         order: int = 2,
         reps: int = 1,
         insert_barriers: bool = False,
         cx_structure: str = "chain",
-        atomic_evolution: Callable[[Pauli | SparsePauliOp, float], QuantumCircuit] | None = None,
+        atomic_evolution: (
+            Callable[[Pauli | SparsePauliOp, float], QuantumCircuit]
+            | Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]
+            | None
+        ) = None,
         wrap: bool = False,
     ) -> None:
         """

--- a/qiskit/synthesis/evolution/suzuki_trotter.py
+++ b/qiskit/synthesis/evolution/suzuki_trotter.py
@@ -60,6 +60,7 @@ class SuzukiTrotter(ProductFormula):
         insert_barriers: bool = False,
         cx_structure: str = "chain",
         atomic_evolution: Callable[[Pauli | SparsePauliOp, float], QuantumCircuit] | None = None,
+        wrap: bool = False,
     ) -> None:
         """
         Args:
@@ -68,10 +69,12 @@ class SuzukiTrotter(ProductFormula):
             insert_barriers: Whether to insert barriers between the atomic evolutions.
             cx_structure: How to arrange the CX gates for the Pauli evolutions, can be ``"chain"``,
                 where next neighbor connections are used, or ``"fountain"``, where all qubits are
-                connected to one.
+                connected to one. This only takes effect when ``atomic_evolution is None``.
             atomic_evolution: A function to construct the circuit for the evolution of single
                 Pauli string. Per default, a single Pauli evolution is decomposed in a CX chain
                 and a single qubit Z rotation.
+            wrap: Whether to wrap the atomic evolutions into custom gate objects. This only takes
+                effect when ``atomic_evolution is None``.
         Raises:
             ValueError: If order is not even
         """

--- a/qiskit/synthesis/evolution/suzuki_trotter.py
+++ b/qiskit/synthesis/evolution/suzuki_trotter.py
@@ -68,6 +68,7 @@ class SuzukiTrotter(ProductFormula):
             "Instead you should update your 'atomic_evolution' function to be of the following "
             "type: 'Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]'."
         ),
+        pending=True,
     )
     def __init__(
         self,

--- a/qiskit/synthesis/evolution/suzuki_trotter.py
+++ b/qiskit/synthesis/evolution/suzuki_trotter.py
@@ -90,9 +90,11 @@ class SuzukiTrotter(ProductFormula):
             cx_structure: How to arrange the CX gates for the Pauli evolutions, can be ``"chain"``,
                 where next neighbor connections are used, or ``"fountain"``, where all qubits are
                 connected to one. This only takes effect when ``atomic_evolution is None``.
-            atomic_evolution: A function to construct the circuit for the evolution of single
-                Pauli string. Per default, a single Pauli evolution is decomposed in a CX chain
-                and a single qubit Z rotation.
+            atomic_evolution: A function to apply the evolution of a single :class:`.Pauli`, or
+                :class:`.SparsePauliOp` of only commuting terms, to a circuit. The function takes in
+                three arguments: the circuit to append the evolution to, the Pauli operator to
+                evolve, and the evolution time. By default, a single Pauli evolution is decomposed
+                into a chain of ``CX`` gates and a single ``RZ`` gate.
             wrap: Whether to wrap the atomic evolutions into custom gate objects. This only takes
                 effect when ``atomic_evolution is None``.
         Raises:

--- a/qiskit/synthesis/evolution/suzuki_trotter.py
+++ b/qiskit/synthesis/evolution/suzuki_trotter.py
@@ -107,7 +107,7 @@ class SuzukiTrotter(ProductFormula):
             else:
                 first_barrier = True
 
-            single_rep.compose(self.atomic_evolution(op, coeff), wrap=True, inplace=True)
+            self.atomic_evolution(single_rep, op, coeff)
 
         evolution_circuit = QuantumCircuit(operators[0].num_qubits)
         first_barrier = False

--- a/qiskit/synthesis/evolution/suzuki_trotter.py
+++ b/qiskit/synthesis/evolution/suzuki_trotter.py
@@ -95,6 +95,9 @@ class SuzukiTrotter(ProductFormula):
                 three arguments: the circuit to append the evolution to, the Pauli operator to
                 evolve, and the evolution time. By default, a single Pauli evolution is decomposed
                 into a chain of ``CX`` gates and a single ``RZ`` gate.
+                **DEPRECATED:** The function takes only the Pauli operator and evolution time as
+                inputs and returns the circuit that will be appended to the overall circuit being
+                built.
             wrap: Whether to wrap the atomic evolutions into custom gate objects. This only takes
                 effect when ``atomic_evolution is None``.
         Raises:

--- a/qiskit/synthesis/evolution/suzuki_trotter.py
+++ b/qiskit/synthesis/evolution/suzuki_trotter.py
@@ -126,7 +126,7 @@ class SuzukiTrotter(ProductFormula):
             if self.insert_barriers and i != len(ops_to_evolve) - 1:
                 single_rep.barrier()
 
-        return single_rep.repeat(self.reps, insert_barriers=True).decompose()
+        return single_rep.repeat(self.reps, insert_barriers=self.insert_barriers).decompose()
 
     @staticmethod
     def _recurse(order, time, pauli_list):

--- a/qiskit/synthesis/evolution/suzuki_trotter.py
+++ b/qiskit/synthesis/evolution/suzuki_trotter.py
@@ -104,7 +104,7 @@ class SuzukiTrotter(ProductFormula):
                 "Suzuki product formulae are symmetric and therefore only defined "
                 "for even orders."
             )
-        super().__init__(order, reps, insert_barriers, cx_structure, atomic_evolution)
+        super().__init__(order, reps, insert_barriers, cx_structure, atomic_evolution, wrap)
 
     def synthesize(self, evolution):
         # get operators and time to evolve

--- a/qiskit/synthesis/evolution/suzuki_trotter.py
+++ b/qiskit/synthesis/evolution/suzuki_trotter.py
@@ -12,7 +12,9 @@
 
 """The Suzuki-Trotter product formula."""
 
-from typing import Callable, Optional, Union
+from __future__ import annotations
+
+from collections.abc import Callable
 
 import numpy as np
 
@@ -57,9 +59,7 @@ class SuzukiTrotter(ProductFormula):
         reps: int = 1,
         insert_barriers: bool = False,
         cx_structure: str = "chain",
-        atomic_evolution: Optional[
-            Callable[[Union[Pauli, SparsePauliOp], float], QuantumCircuit]
-        ] = None,
+        atomic_evolution: Callable[[Pauli | SparsePauliOp, float], QuantumCircuit] | None = None,
     ) -> None:
         """
         Args:

--- a/releasenotes/notes/product-formula-improvements-1bc40650151cf107.yaml
+++ b/releasenotes/notes/product-formula-improvements-1bc40650151cf107.yaml
@@ -1,0 +1,29 @@
+---
+features_circuits:
+  - |
+    Added the ``insert_barriers`` keyword argument to the
+    :meth:`~.QuantumCircuit.repeat` method. Setting it to ``True`` will insert
+    barriers between circuit repetitions.
+features_synthesis:
+  - |
+    Added the ``wrap`` keyword argument to the :class:`~ProductFormula` classes
+    which (when enabled) wraps individual Pauli evolution terms. This can be
+    useful when visualizing circuits.
+upgrade_synthesis:
+  - |
+    The ``atomic_evolution`` argument to :class:`~ProductFormula` (and its
+    subclasses) has a new function signature. Rather than taking some Pauli
+    operator and time coefficient and returning the evolution circuit, the new
+    function takes in an existing circuit and should append the evolution of the
+    provided Pauli and given time to this circuit. This new implementation
+    benefits from significantly better performance.
+  - |
+    :class:`~LieTrotter` and :class:`~SuzukiTrotter` no longer wrap the
+    individually evolved Pauli terms into gate definitions. If you rely on a
+    certain decomposition level of your circuit, you have to remove one level of
+    :meth:`~.QuantumCircuit.decompose` or add the ``wrap=True`` keyword argument
+    to your synthesis object.
+deprecations_synthesis:
+  - |
+    The ``atomic_evolution`` argument to :class:`~ProductFormula` (and its
+    subclasses) has deprecated its old function signature.

--- a/releasenotes/notes/product-formula-improvements-1bc40650151cf107.yaml
+++ b/releasenotes/notes/product-formula-improvements-1bc40650151cf107.yaml
@@ -11,20 +11,23 @@ features_synthesis:
     useful when visualizing circuits.
 upgrade_synthesis:
   - |
-    The ``atomic_evolution`` argument to :class:`~ProductFormula` (and its
+    The ``atomic_evolution`` argument to :class:`.ProductFormula` (and its
     subclasses) has a new function signature. Rather than taking some Pauli
     operator and time coefficient and returning the evolution circuit, the new
     function takes in an existing circuit and should append the evolution of the
     provided Pauli and given time to this circuit. This new implementation
     benefits from significantly better performance.
   - |
-    :class:`~LieTrotter` and :class:`~SuzukiTrotter` no longer wrap the
+    :class:`.LieTrotter` and :class:`.SuzukiTrotter` no longer wrap the
     individually evolved Pauli terms into gate definitions. If you rely on a
     certain decomposition level of your circuit, you have to remove one level of
     :meth:`~.QuantumCircuit.decompose` or add the ``wrap=True`` keyword argument
     to your synthesis object.
 deprecations_synthesis:
   - |
-    In :class:`.ProductFormula` and subclasses, it is deprecated that ``atomic_evolution``
-    returns a new circuit implementing the evolution. Instead, the evolution must be done
-    in place, which allows for a performance benefit.
+    In :class:`.ProductFormula` and subclasses, it is deprecated that
+    ``atomic_evolution`` returns a new circuit implementing the evolution.
+    Instead, the evolution must be done in place, which allows for a performance
+    benefit. For more details refer to the documentation of the
+    ``atomic_evolution`` argument of the :class:`.ProductFormula` and its
+    subclasses.

--- a/releasenotes/notes/product-formula-improvements-1bc40650151cf107.yaml
+++ b/releasenotes/notes/product-formula-improvements-1bc40650151cf107.yaml
@@ -6,7 +6,7 @@ features_circuits:
     barriers between circuit repetitions.
 features_synthesis:
   - |
-    Added the ``wrap`` keyword argument to the :class:`~ProductFormula` classes
+    Added the ``wrap`` keyword argument to the :class:`.ProductFormula` classes
     which (when enabled) wraps individual Pauli evolution terms. This can be
     useful when visualizing circuits.
 upgrade_synthesis:
@@ -25,5 +25,6 @@ upgrade_synthesis:
     to your synthesis object.
 deprecations_synthesis:
   - |
-    The ``atomic_evolution`` argument to :class:`~ProductFormula` (and its
-    subclasses) has deprecated its old function signature.
+    In :class:`.ProductFormula` and subclasses, it is deprecated that ``atomic_evolution``
+    returns a new circuit implementing the evolution. Instead, the evolution must be done
+    in place, which allows for a performance benefit.

--- a/releasenotes/notes/product-formula-improvements-1bc40650151cf107.yaml
+++ b/releasenotes/notes/product-formula-improvements-1bc40650151cf107.yaml
@@ -23,11 +23,3 @@ upgrade_synthesis:
     certain decomposition level of your circuit, you have to remove one level of
     :meth:`~.QuantumCircuit.decompose` or add the ``wrap=True`` keyword argument
     to your synthesis object.
-deprecations_synthesis:
-  - |
-    In :class:`.ProductFormula` and subclasses, it is deprecated that
-    ``atomic_evolution`` returns a new circuit implementing the evolution.
-    Instead, the evolution must be done in place, which allows for a performance
-    benefit. For more details refer to the documentation of the
-    ``atomic_evolution`` argument of the :class:`.ProductFormula` and its
-    subclasses.

--- a/test/python/circuit/library/test_evolution_gate.py
+++ b/test/python/circuit/library/test_evolution_gate.py
@@ -176,11 +176,15 @@ class TestEvolutionGate(QiskitTestCase):
 
         self.assertAlmostEqual(energy(exact), np.average(qdrift_energy), places=2)
 
-    def test_passing_grouped_paulis(self):
+    @data(True, False)
+    def test_passing_grouped_paulis(self, wrap):
         """Test passing a list of already grouped Paulis."""
         grouped_ops = [(X ^ Y) + (Y ^ X), (Z ^ I) + (Z ^ Z) + (I ^ Z), (X ^ X)]
-        evo_gate = PauliEvolutionGate(grouped_ops, time=0.12, synthesis=LieTrotter())
-        decomposed = evo_gate.definition
+        evo_gate = PauliEvolutionGate(grouped_ops, time=0.12, synthesis=LieTrotter(wrap=wrap))
+        if wrap:
+            decomposed = evo_gate.definition.decompose()
+        else:
+            decomposed = evo_gate.definition
         self.assertEqual(decomposed.count_ops()["rz"], 4)
         self.assertEqual(decomposed.count_ops()["rzz"], 1)
         self.assertEqual(decomposed.count_ops()["rxx"], 1)

--- a/test/python/circuit/library/test_evolution_gate.py
+++ b/test/python/circuit/library/test_evolution_gate.py
@@ -130,7 +130,7 @@ class TestEvolutionGate(QiskitTestCase):
             expected.ry(2 * p_4 * time, 0)
             expected.rx(p_4 * time, 0)
 
-        self.assertEqual(evo_gate.definition.decompose(), expected)
+        self.assertEqual(evo_gate.definition, expected)
 
     @data(
         (X + Y, 0.5, 1, [(Pauli("X"), 0.5), (Pauli("X"), 0.5)]),
@@ -179,7 +179,7 @@ class TestEvolutionGate(QiskitTestCase):
         """Test passing a list of already grouped Paulis."""
         grouped_ops = [(X ^ Y) + (Y ^ X), (Z ^ I) + (Z ^ Z) + (I ^ Z), (X ^ X)]
         evo_gate = PauliEvolutionGate(grouped_ops, time=0.12, synthesis=LieTrotter())
-        decomposed = evo_gate.definition.decompose()
+        decomposed = evo_gate.definition
         self.assertEqual(decomposed.count_ops()["rz"], 4)
         self.assertEqual(decomposed.count_ops()["rzz"], 1)
         self.assertEqual(decomposed.count_ops()["rxx"], 1)

--- a/test/python/circuit/library/test_evolution_gate.py
+++ b/test/python/circuit/library/test_evolution_gate.py
@@ -357,7 +357,7 @@ class TestEvolutionGate(QiskitTestCase):
         op = (X ^ X ^ X) + (Y ^ Y ^ Y) + (Z ^ Z ^ Z)
         time = 0.123
         reps = 4
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarns(PendingDeprecationWarning):
             evo_gate = PauliEvolutionGate(
                 op, time, synthesis=LieTrotter(reps=reps, atomic_evolution=atomic_evolution)
             )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR implements the suggestion made in https://github.com/Qiskit/qiskit/pull/12021#discussion_r1528762352.

### Details and comments

I ran a very simple benchmark to showcase the performance improvements of this PR. Below you can see that we get a ~30x performance improvement (note the logarithmic y axis).

![benchmark](https://github.com/Qiskit/qiskit/assets/21973473/cbaab056-1026-4c36-882f-50ad6178b0d6)

<details>
<summary>Here is the code which builds a heavy-hex graph of a given size, constructs an XYZ model Hamiltonian on its connectivity, and builds a LieTrotter and SuzukiTrotter circuit.</summary>

```python
import sys
import time

import numpy as np
import rustworkx as rx
from qiskit import QuantumCircuit, transpile
from qiskit.circuit.library import PauliEvolutionGate
from qiskit.quantum_info import SparsePauliOp
from qiskit.synthesis import LieTrotter, SuzukiTrotter

for size in range(3, 10, 2):
    graph = rx.generators.heavy_hex_graph(size, multigraph=False)

    num_qubits = graph.num_nodes()

    sparse_pauli_list = []
    for edge in graph.edge_list():
        for p in ("XX", "YY", "ZZ"):
            sparse_pauli_list.append((p, [edge[0], edge[1]], 1.0))
    for qubit in range(num_qubits):
        for p in "XYZ":
            sparse_pauli_list.append((p, [qubit], 1.0))

    hamil = SparsePauliOp.from_sparse_list(sparse_pauli_list, num_qubits=num_qubits)

    print("starting LieTrotter with 10 reps", file=sys.stderr)
    t1 = time.time()
    circuit = QuantumCircuit(num_qubits)
    circuit.append(
        PauliEvolutionGate(hamil, time=0.5, synthesis=LieTrotter(reps=10)),
        qargs=circuit.qubits,
    )
    transpiled = transpile(circuit, basis_gates=["rz", "x", "sx", "cx"])
    t2 = time.time()
    lie = t2 - t1
    print(f"took {lie}s", file=sys.stderr)

    print("starting SuzukiTrotter with 10 reps", file=sys.stderr)
    t1 = time.time()
    circuit = QuantumCircuit(num_qubits)
    circuit.append(
        PauliEvolutionGate(hamil, time=0.5, synthesis=SuzukiTrotter(reps=10)),
        qargs=circuit.qubits,
    )
    transpiled = transpile(circuit, basis_gates=["rz", "x", "sx", "cx"])
    t2 = time.time()
    suzuki = t2 - t1
    print(f"took {suzuki}s", file=sys.stderr)
```
</details>

As part of this improvement, I also aligned the implementations of `LieTrotter` and `SuzukiTrotter` which partially diverged in #12021. I also handle the wrapping of the individually time-evolved Pauli terms in a new way, which results in a different (but imo improved) visualization of a circuit. Below you can see the same circuit drawn with Qiskit 1.1.1 and this PR, side by side:

| **Qiskit 1.1.1** | This PR |
|:-:|:-:|
| ![circuit_qiskit_1 1 1](https://github.com/Qiskit/qiskit/assets/21973473/e55f11de-b2b3-4e78-adc8-127474000c25) | ![circuit_branch](https://github.com/Qiskit/qiskit/assets/21973473/f672db79-05b0-46d3-a7e6-886935069d6b) |

<details>
<summary>Here is the code to plot the circuit above</summary>

```python
import numpy as np
from qiskit import QuantumCircuit
from qiskit.circuit.library import PauliEvolutionGate
from qiskit.quantum_info import SparsePauliOp
from qiskit.synthesis import LieTrotter, SuzukiTrotter

num_qubits = 10
edges = [(i, i + 1) for i in range(0, num_qubits - 1, 2)]
edges += [(i, i + 1) for i in range(1, num_qubits - 1, 2)]

sparse_pauli_list = []
for edge in edges:
    for p in ("XX", "YY", "ZZ"):
        sparse_pauli_list.append((p, [edge[0], edge[1]], 1.0))
for qubit in range(num_qubits):
    for p in "XYZ":
        sparse_pauli_list.append((p, [qubit], 1.0))

hamil = SparsePauliOp.from_sparse_list(sparse_pauli_list, num_qubits=num_qubits)

circuit = QuantumCircuit(num_qubits)
circuit.append(
    PauliEvolutionGate(hamil, time=0.5, synthesis=LieTrotter(wrap=True)),
    qargs=circuit.qubits,
)
circuit = circuit.decompose()
circuit.draw("mpl", filename="circuit_branch.png")
```
</details>