### PR TITLE
Extending control flow op names

### DIFF
--- a/qiskit/circuit/controlflow/__init__.py
+++ b/qiskit/circuit/controlflow/__init__.py
@@ -24,4 +24,5 @@ from .for_loop import ForLoopOp
 from .switch_case import SwitchCaseOp, CASE_DEFAULT
 
 
-CONTROL_FLOW_OP_NAMES = frozenset(("for_loop", "while_loop", "if_else", "switch_case"))
+CONTROL_FLOW_OP_NAMES = frozenset(("for_loop", "while_loop", "if_else", "switch_case", "continue_loop",
+                                   "break_loop"))

--- a/qiskit/circuit/controlflow/__init__.py
+++ b/qiskit/circuit/controlflow/__init__.py
@@ -24,5 +24,6 @@ from .for_loop import ForLoopOp
 from .switch_case import SwitchCaseOp, CASE_DEFAULT
 
 
-CONTROL_FLOW_OP_NAMES = frozenset(("for_loop", "while_loop", "if_else", "switch_case", "continue_loop",
-                                   "break_loop"))
+CONTROL_FLOW_OP_NAMES = frozenset(
+    ("for_loop", "while_loop", "if_else", "switch_case", "continue_loop", "break_loop")
+)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

I think `CONTROL_FLOW_OP_NAMES` should contain all control flow operations currently available to qiskit by default. :-)


### Details and comments


