### PR TITLE
Fix `C3SXGate` `to_matrix` method

### DIFF
--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -22,6 +22,7 @@ from qiskit.circuit._utils import _ctrl_state_to_int, with_gate_array, with_cont
 from qiskit._accelerate.circuit import StandardGate
 
 _X_ARRAY = [[0, 1], [1, 0]]
+_SX_ARRAY = [[0.5 + 0.5j, 0.5 - 0.5j], [0.5 - 0.5j, 0.5 + 0.5j]]
 
 
 @with_gate_array(_X_ARRAY)
@@ -571,6 +572,7 @@ class RCCXGate(SingletonGate):
         return isinstance(other, RCCXGate)
 
 
+@with_controlled_gate_array(_SX_ARRAY, num_ctrl_qubits=3, cached_states=(7,))
 class C3SXGate(SingletonControlledGate):
     """The 3-qubit controlled sqrt-X gate.
 

--- a/releasenotes/notes/fix-c3sx-gate-matrix-050cf9f9ac3b2b82.yaml
+++ b/releasenotes/notes/fix-c3sx-gate-matrix-050cf9f9ac3b2b82.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a missing decorator in :class:`.C3SXGate` that made it fail if `gate.to_matrix()` was called.
+    The gate matrix is now return as expected.

--- a/releasenotes/notes/fix-c3sx-gate-matrix-050cf9f9ac3b2b82.yaml
+++ b/releasenotes/notes/fix-c3sx-gate-matrix-050cf9f9ac3b2b82.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Fixed a missing decorator in :class:`.C3SXGate` that made it fail if `gate.to_matrix()` was called.
+    Fixed a missing decorator in :class:`.C3SXGate` that made it fail if :meth:`.Gate.to_matrix` was called.
     The gate matrix is now return as expected.

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -230,6 +230,12 @@ class TestControlledGate(QiskitTestCase):
                 # Ensure that both the array form (if the gate overrides `__array__`) and the
                 # circuit-definition form are tested.
                 self.assertTrue(Operator(special_case_gate).equiv(naive_operator))
+                if not isinstance(special_case_gate, (MCXGate, MCPhaseGate, MCU1Gate)):
+                    # Ensure that the to_matrix method yields the same result
+                    np.testing.assert_allclose(
+                        special_case_gate.to_matrix(), naive_operator.to_matrix(), atol=1e-8
+                    )
+
                 if not isinstance(special_case_gate, CXGate):
                     # CX is treated like a primitive within Terra, and doesn't have a definition.
                     self.assertTrue(Operator(special_case_gate.definition).equiv(naive_operator))

--- a/test/python/circuit/test_rust_equivalence.py
+++ b/test/python/circuit/test_rust_equivalence.py
@@ -26,7 +26,6 @@ from qiskit.quantum_info import Operator
 
 SKIP_LIST = {"rx", "ry", "ecr"}
 CUSTOM_NAME_MAPPING = {"mcx": C3XGate()}
-MATRIX_SKIP_LIST = {"c3sx"}
 
 
 class TestRustGateEquivalence(QiskitTestCase):
@@ -141,9 +140,6 @@ class TestRustGateEquivalence(QiskitTestCase):
         """Test matrices are the same in rust space."""
         for name, gate_class in self.standard_gates.items():
             standard_gate = getattr(gate_class, "_standard_gate", None)
-            if name in MATRIX_SKIP_LIST:
-                # to_matrix not defined for type
-                continue
             if standard_gate is None:
                 # gate is not in rust yet
                 continue


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR adds the `with_controlled_gate_array` decorator missing in `C3SXGate` that enables the `to_matrix` method. This bug was found while porting `C3SXGate` to Rust (https://github.com/Qiskit/qiskit/pull/12659).


### Details and comments
I have also noticed that the path of `C3SXGate` is incorrect. It's currently in `qiskit/circuit/library/standard_gates/x.py` while it should be in `qiskit/circuit/library/standard_gates/sx.py`. I did not address this issue in the current PR because I believe the move to the correct location is a breaking change and should probably be left for 2.0 (although most users won't import gates directly from the file).