### PR TITLE
Barebone generic backend options

### DIFF
--- a/qiskit/providers/fake_provider/generic_backend_v2.py
+++ b/qiskit/providers/fake_provider/generic_backend_v2.py
@@ -161,7 +161,9 @@ class GenericBackendV2(BackendV2):
                 None by default.
 
             seed: Optional seed for generation of default values.
+
             pulse_channels: If true, sets default pulse channel information on the backend.
+
             noise_info: If true, associates gates and qubits with default noise information.
         """
 
@@ -179,7 +181,7 @@ class GenericBackendV2(BackendV2):
         self._control_flow = control_flow
         self._calibrate_instructions = calibrate_instructions
         self._supported_gates = get_standard_gate_name_mapping()
-        self._include_errors = noise_info
+        self._noise_info = noise_info
 
         if calibrate_instructions and not noise_info:
             raise QiskitError("Must set parameter noise_info when calibrating instructions.")
@@ -208,6 +210,8 @@ class GenericBackendV2(BackendV2):
         self._build_generic_target()
         if pulse_channels:
             self._build_default_channels()
+        else:
+            self.channels_map = {}
 
     @property
     def target(self):
@@ -349,7 +353,7 @@ class GenericBackendV2(BackendV2):
         """
         # the qubit properties are sampled from default ranges
         properties = _QUBIT_PROPERTIES
-        if not self._include_errors:
+        if not self._noise_info:
             self._target = Target(
                 description=f"Generic Target with {self._num_qubits} qubits",
                 num_qubits=self._num_qubits,
@@ -398,7 +402,7 @@ class GenericBackendV2(BackendV2):
                     f"Provided basis gate {name} needs more qubits than {self.num_qubits}, "
                     f"which is the size of the backend."
                 )
-            if self._include_errors:
+            if self._noise_info:
                 noise_params = self._get_noise_defaults(name, gate.num_qubits)
                 self._add_noisy_instruction_to_target(gate, noise_params, calibration_inst_map)
             else:

--- a/qiskit/providers/fake_provider/generic_backend_v2.py
+++ b/qiskit/providers/fake_provider/generic_backend_v2.py
@@ -112,8 +112,8 @@ class GenericBackendV2(BackendV2):
         calibrate_instructions: bool | InstructionScheduleMap | None = None,
         dtm: float | None = None,
         seed: int | None = None,
-        include_channels: bool = True,
-        include_errors: bool = True,
+        pulse_channels: bool = True,
+        noise_info: bool = True,
     ):
         """
         Args:
@@ -161,6 +161,8 @@ class GenericBackendV2(BackendV2):
                 None by default.
 
             seed: Optional seed for generation of default values.
+            pulse_channels: If true, sets default pulse channel information on the backend.
+            noise_info: If true, associates gates and qubits with default noise information.
         """
 
         super().__init__(
@@ -177,7 +179,10 @@ class GenericBackendV2(BackendV2):
         self._control_flow = control_flow
         self._calibrate_instructions = calibrate_instructions
         self._supported_gates = get_standard_gate_name_mapping()
-        self._include_errors = include_errors
+        self._include_errors = noise_info
+
+        if calibrate_instructions and not noise_info:
+            raise QiskitError("Must set parameter noise_info when calibrating instructions.")
 
         if coupling_map is None:
             self._coupling_map = CouplingMap().from_full(num_qubits)
@@ -201,7 +206,7 @@ class GenericBackendV2(BackendV2):
                 self._basis_gates.append(name)
 
         self._build_generic_target()
-        if include_channels:
+        if pulse_channels:
             self._build_default_channels()
 
     @property

--- a/qiskit/providers/fake_provider/generic_backend_v2.py
+++ b/qiskit/providers/fake_provider/generic_backend_v2.py
@@ -112,8 +112,8 @@ class GenericBackendV2(BackendV2):
         calibrate_instructions: bool | InstructionScheduleMap | None = None,
         dtm: float | None = None,
         seed: int | None = None,
-        include_channels: bool = False,
-        include_errors: bool = False
+        include_channels: bool = True,
+        include_errors: bool = True,
     ):
         """
         Args:

--- a/releasenotes/notes/barebone-backend-option-675c86df4382a443.yaml
+++ b/releasenotes/notes/barebone-backend-option-675c86df4382a443.yaml
@@ -1,0 +1,6 @@
+---
+prelude: >
+    Added two parameters to :class:`.GenericBackendV2` to exclude error (`include_errors`) and
+    pulse channel information (`include_channels`) from the construction of the backend. These parameters
+    are true by default, replicating the initial default behavior of the constructor. A memory-sensitive
+    user may set these options to `False` to save one order of magnitude in memory allocations.

--- a/releasenotes/notes/barebone-backend-option-675c86df4382a443.yaml
+++ b/releasenotes/notes/barebone-backend-option-675c86df4382a443.yaml
@@ -1,8 +1,8 @@
 ---
 features:
   - |
-    Added two parameters to :class:`.GenericBackendV2` to exclude error (`include_errors`) and
-    pulse channel information (`include_channels`) from the construction of the backend. These parameters
+    Added two parameters to :class:`.GenericBackendV2` to exclude error (`noise_info`) and
+    pulse channel information (`pulse_channels`) from the construction of the backend. These parameters
     are true by default, replicating the initial default behavior of the constructor. A memory-sensitive
     user may set these options to `False` to reduce the memory overhead by 40x when transpiling on large-
     scale :class:`.GenericBackendV2`.

--- a/releasenotes/notes/barebone-backend-option-675c86df4382a443.yaml
+++ b/releasenotes/notes/barebone-backend-option-675c86df4382a443.yaml
@@ -1,7 +1,8 @@
 ---
-prelude: >
+features:
+  - |
     Added two parameters to :class:`.GenericBackendV2` to exclude error (`include_errors`) and
     pulse channel information (`include_channels`) from the construction of the backend. These parameters
     are true by default, replicating the initial default behavior of the constructor. A memory-sensitive
     user may set these options to `False` to reduce the memory overhead by 40x when transpiling on large-
-    scale `GenericBackendV2`s.
+    scale :class:`.GenericBackendV2`.

--- a/releasenotes/notes/barebone-backend-option-675c86df4382a443.yaml
+++ b/releasenotes/notes/barebone-backend-option-675c86df4382a443.yaml
@@ -3,4 +3,5 @@ prelude: >
     Added two parameters to :class:`.GenericBackendV2` to exclude error (`include_errors`) and
     pulse channel information (`include_channels`) from the construction of the backend. These parameters
     are true by default, replicating the initial default behavior of the constructor. A memory-sensitive
-    user may set these options to `False` to save one order of magnitude in memory allocations.
+    user may set these options to `False` to reduce the memory overhead by 40x when transpiling on large-
+    scale `GenericBackendV2`s.

--- a/test/python/providers/fake_provider/test_generic_backend_v2.py
+++ b/test/python/providers/fake_provider/test_generic_backend_v2.py
@@ -45,6 +45,26 @@ class TestGenericBackendV2(QiskitTestCase):
         with self.assertRaises(QiskitError):
             GenericBackendV2(num_qubits=2, basis_gates=["ccx", "id"])
 
+    def test_calibration_no_noise_info(self):
+        """Test failing with a backend with calibration and no noise info"""
+        with self.assertRaises(QiskitError):
+            GenericBackendV2(
+                num_qubits=2,
+                basis_gates=["ccx", "id"],
+                calibrate_instructions=True,
+                noise_info=False,
+            )
+
+    def test_no_noise(self):
+        """Test no noise info when parameter is false"""
+        backend = GenericBackendV2(num_qubits=2, noise_info=False)
+        self.assertEqual(backend.target.qubit_properties, None)
+
+    def test_no_pulse_channels(self):
+        """Test no/empty pulse channels when parameter is false"""
+        backend = GenericBackendV2(num_qubits=2, pulse_channels=False)
+        self.assertTrue(len(backend.channels_map) == 0)
+
     def test_operation_names(self):
         """Test that target basis gates include "delay", "measure" and "reset" even
         if not provided by user."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Added two options to the constructor of `GenericBackendV2` that reduce the memory overhead from ~12GB to 300MB when set and transpiling on a 2000 qubit device.

### Details and comments
Code:
```
be = GenericBackendV2(2000)

qc = QuantumCircuit(4)
qc.h(0)
qc.cx(0, 1)
qc.cx(1, 2)
qc.cx(2, 3)

qc_r = transpile(qc, backend=be)
```
Old:
![image](https://github.com/Qiskit/qiskit/assets/148463728/c8af395a-1464-48a8-82e5-91aa076363e1)

New (setting `include_channels=False` and `include_errors=False`):
![image](https://github.com/Qiskit/qiskit/assets/148463728/d805c619-45d1-4e1d-a1b5-924c1eb6e037)

