### PR TITLE
Make `BitArray.{slice_bits,slice_shots,__getitem__}` raise `IndexError` when indices are not valid

### DIFF
--- a/qiskit/primitives/containers/bit_array.py
+++ b/qiskit/primitives/containers/bit_array.py
@@ -130,10 +130,15 @@ class BitArray(ShapedMixin):
         return f"BitArray({desc})"
 
     def __getitem__(self, indices):
-        if isinstance(indices, tuple) and len(indices) >= self.ndim + 2:
-            raise ValueError(
-                "BitArrays cannot be sliced along the bits axis, see slice_bits() instead."
-            )
+        if isinstance(indices, tuple):
+            if len(indices) == self.ndim + 1:
+                raise IndexError(
+                    "BitArray cannot be sliced along the shots axis, use slice_shots() instead."
+                )
+            if len(indices) >= self.ndim + 2:
+                raise IndexError(
+                    "BitArray cannot be sliced along the bits axis, use slice_bits() instead."
+                )
         return BitArray(self._array[indices], self.num_bits)
 
     @property

--- a/qiskit/primitives/containers/bit_array.py
+++ b/qiskit/primitives/containers/bit_array.py
@@ -424,13 +424,13 @@ class BitArray(ShapedMixin):
             A bit array sliced along the bit axis.
 
         Raises:
-            ValueError: If there are any invalid indices of the bit axis.
+            IndexError: If there are any invalid indices of the bit axis.
         """
         if isinstance(indices, int):
             indices = (indices,)
         for index in indices:
             if index < 0 or index >= self.num_bits:
-                raise ValueError(
+                raise IndexError(
                     f"index {index} is out of bounds for the number of bits {self.num_bits}."
                 )
         # This implementation introduces a temporary 8x memory overhead due to bit
@@ -451,13 +451,13 @@ class BitArray(ShapedMixin):
             A bit array sliced along the shots axis.
 
         Raises:
-            ValueError: If there are any invalid indices of the shots axis.
+            IndexError: If there are any invalid indices of the shots axis.
         """
         if isinstance(indices, int):
             indices = (indices,)
         for index in indices:
             if index < 0 or index >= self.num_shots:
-                raise ValueError(
+                raise IndexError(
                     f"index {index} is out of bounds for the number of shots {self.num_shots}."
                 )
         arr = self._array

--- a/releasenotes/notes/fix-bitarray-slice-bits-shots-c9cb7e5d907722f5.yaml
+++ b/releasenotes/notes/fix-bitarray-slice-bits-shots-c9cb7e5d907722f5.yaml
@@ -1,0 +1,6 @@
+---
+upgrade_primitives:
+  - |
+    :meth:`.BitArray.slice_bits` and :meth:`.BitArray.slice_shots`
+    will now raise ``IndexError`` when indices are out of bounds.
+    They used to raise ``ValueError`` in the case.

--- a/releasenotes/notes/fix-bitarray-slice-bits-shots-c9cb7e5d907722f5.yaml
+++ b/releasenotes/notes/fix-bitarray-slice-bits-shots-c9cb7e5d907722f5.yaml
@@ -4,3 +4,8 @@ upgrade_primitives:
     :meth:`.BitArray.slice_bits` and :meth:`.BitArray.slice_shots`
     will now raise ``IndexError`` when indices are out of bounds.
     They used to raise ``ValueError`` in the case.
+  - |
+    :meth:`.BitArray.__getitem__` will now raise ``IndexError``
+    when indices are out of bounds or the number of dimensions
+    of indices does not match that of BitArray.
+    They used to raise ``ValueError`` in the case.

--- a/test/python/primitives/containers/test_bit_array.py
+++ b/test/python/primitives/containers/test_bit_array.py
@@ -557,9 +557,9 @@ class BitArrayTestCase(QiskitTestCase):
                 self.assertEqual(ba2.get_counts((i, j, k)), expect)
 
         with self.subTest("errors"):
-            with self.assertRaisesRegex(ValueError, "index -1 is out of bounds"):
+            with self.assertRaisesRegex(IndexError, "index -1 is out of bounds"):
                 _ = ba.slice_bits(-1)
-            with self.assertRaisesRegex(ValueError, "index 9 is out of bounds"):
+            with self.assertRaisesRegex(IndexError, "index 9 is out of bounds"):
                 _ = ba.slice_bits(9)
 
     def test_slice_shots(self):
@@ -607,9 +607,9 @@ class BitArrayTestCase(QiskitTestCase):
                 self.assertEqual(ba2.get_bitstrings((i, j, k)), expected)
 
         with self.subTest("errors"):
-            with self.assertRaisesRegex(ValueError, "index -1 is out of bounds"):
+            with self.assertRaisesRegex(IndexError, "index -1 is out of bounds"):
                 _ = ba.slice_shots(-1)
-            with self.assertRaisesRegex(ValueError, "index 10 is out of bounds"):
+            with self.assertRaisesRegex(IndexError, "index 10 is out of bounds"):
                 _ = ba.slice_shots(10)
 
     def test_expectation_values(self):

--- a/test/python/primitives/containers/test_bit_array.py
+++ b/test/python/primitives/containers/test_bit_array.py
@@ -513,6 +513,20 @@ class BitArrayTestCase(QiskitTestCase):
             for j in range(2):
                 self.assertEqual(ba.get_counts((0, j, 2)), ba2.get_counts(j))
 
+        with self.subTest("errors"):
+            with self.assertRaisesRegex(IndexError, "index 2 is out of bounds"):
+                _ = ba[0, 2, 2]
+            with self.assertRaisesRegex(IndexError, "index -3 is out of bounds"):
+                _ = ba[0, -3, 2]
+            with self.assertRaisesRegex(
+                IndexError, "BitArray cannot be sliced along the shots axis"
+            ):
+                _ = ba[0, 1, 2, 3]
+            with self.assertRaisesRegex(
+                IndexError, "BitArray cannot be sliced along the bits axis"
+            ):
+                _ = ba[0, 1, 2, 3, 4]
+
     def test_slice_bits(self):
         """Test the slice_bits method."""
         # this creates incrementing bitstrings from 0 to 59


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

This PR updates `BitArray.{slice_bits,slice_shots,__getitem__}` to raise `IndexError` if indices are not valid.

Especially, `__getitem__` raise IndexError with appropriate message as follows (`ba[0, 0, 0]` case).

```python
from qiskit.primitives.containers import BitArray

ba = BitArray.from_counts({"0": 2, "1": 3})
ba = ba.reshape(1, 1)

try:
    ba[1]
except Exception as ex:
    print(type(ex), ex)
try:
    ba[0, 0, 0]
except Exception as ex:
    print(type(ex), ex)
try:
    ba[0, 0, 0, 0]
except Exception as ex:
    print(type(ex), ex)
```

main branch
```
<class 'IndexError'> index 1 is out of bounds for axis 0 with size 1
<class 'ValueError'> The input array must have at least two axes.
<class 'ValueError'> BitArrays cannot be sliced along the bits axis, see slice_bits() instead.
```

this PR
```
<class 'IndexError'> index 1 is out of bounds for axis 0 with size 1
<class 'IndexError'> BitArray cannot be sliced along the shots axis, use slice_shots() instead.
<class 'IndexError'> BitArray cannot be sliced along the bits axis, use slice_bits() instead.
```


### Details and comments


