### PR TITLE
Use rustworkx 0.15.0 features in DAGCircuit.remove_op_node

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1986,9 +1986,7 @@ class DAGCircuit:
                 "node type was wrongly provided."
             )
 
-        self._multi_graph.remove_node_retain_edges(
-            node._node_id, use_outgoing=False, condition=lambda edge1, edge2: edge1 == edge2
-        )
+        self._multi_graph.remove_node_retain_edges_by_id(node._node_id)
         self._decrement_op(node.name)
 
     def remove_ancestors_of(self, node):

--- a/releasenotes/notes/update-rustworkx-min-version-4f07aacfebccae80.yaml
+++ b/releasenotes/notes/update-rustworkx-min-version-4f07aacfebccae80.yaml
@@ -1,0 +1,7 @@
+---
+upgrade_misc:
+  - |
+    The minimum version of rustworkx required to run this release has been
+    increased from 0.14.0 to 0.15.0. This is required because Qiskit is now
+    using new functionality added in the rustworkx 0.15.0 release which
+    improves performance.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-rustworkx>=0.14.0
+rustworkx>=0.15.0
 numpy>=1.17,<3
 scipy>=1.5
 sympy>=1.3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the minimum rustworkx version to 0.15.0 to pull in the new PyDiGraph.remove_node_retain_edges_by_id() method introduced in that release. This new function is used for the DAGCircuit.remove_op_node() method instead of the
PyDiGraph.remove_node_retain_edges() function. This new method has much better scaling characteristics and should improve the performance characteristics of removing very wide operations from a DAGCircuit.

Fixes #11677
Part of #12156

### Details and comments