### PR TITLE
Make `CircuitData` inner data accessible in Rust

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -1167,4 +1167,9 @@ impl CircuitData {
             py_op: RefCell::new(inst.py_op.clone()),
         })
     }
+
+    /// Rust native method, returns an iterator over all the instructions present in the circuit.
+    pub fn iter(&self) -> impl Iterator<Item = &PackedInstruction> {
+        self.data.iter()
+    }
 }

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -1168,7 +1168,7 @@ impl CircuitData {
         })
     }
 
-    /// Rust native method, returns an iterator over all the instructions present in the circuit.
+    /// Returns an iterator over all the instructions present in the circuit.
     pub fn iter(&self) -> impl Iterator<Item = &PackedInstruction> {
         self.data.iter()
     }

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -44,7 +44,7 @@ pub struct ExtraInstructionAttributes {
 
 /// Private type used to store instructions with interned arg lists.
 #[derive(Clone, Debug)]
-pub(crate) struct PackedInstruction {
+pub struct PackedInstruction {
     /// The Python-side operation instance.
     pub op: OperationType,
     /// The index under which the interner has stored `qubits`.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
The following commits aim to add a way to iterate through all the instructions contained in `CircuitData` to make these instructions accessible through Rust.

### Details and comments
- Implement an `iter()` method that iterates through the instructions in `CircuitData` in Rust.
- Make `PackedInstruction` public:
   This class is being made public and reorganized by #12730.

### Use cases:
In #12585 there's a temporary struct called `CircuitRep` which aims to represent the circuit. This struct has a `data()` method that retrieves the data from the circuit once and stores it as a `Vec<CircuitInstruction>`.
https://github.com/raynelfss/qiskit/blob/bf9aedd72b019600b223e71f46e0107a295457b3/crates/circuit/src/equivalence.rs#L311-L319
```rust
    pub fn data(&mut self, py: Python) -> PyResult<&[CircuitInstruction]> {
        if self.data.is_none() {
            let data = self.object.bind(py).getattr("data")?.extract()?;
            self.data = Some(data);
            return Ok(self.data.as_ref().unwrap());
        }
        return Ok(self.data.as_ref().unwrap());
    }
```

The method is used once to create a set of instructions based on their name and the number of qubits they affect. https://github.com/raynelfss/qiskit/blob/bf9aedd72b019600b223e71f46e0107a295457b3/crates/circuit/src/equivalence.rs#L448-L452

```rust
        let sources: HashSet<Key> =
            HashSet::from_iter(equivalent_circuit.data(py)?.iter().map(|inst| Key {
                name: inst.operation.name().to_string(),
                num_qubits: inst.operation.num_qubits(),
            }));
```
By extracting from `CircuitData` and avoiding an extra conversion to a different DataType, it will be easier for us to access those instruction attributes from the Rust side of things without needing to invoke Python.