### PR TITLE
Fixed ZZFeatureMap not accepting a list of entanglement

### DIFF
--- a/qiskit/circuit/library/data_preparation/pauli_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/pauli_feature_map.py
@@ -347,12 +347,27 @@ class PauliFeatureMap(NLocal):
                             raise ValueError(f"Invalid value of entanglement:{e3}")
                         e2[ind] = tuple(map(int, e3))
 
-            chosen_entanglement = self.entanglement[i % num_i][j % num_j]
+            # Unlike Twolocal where we can specify entanglement blocks and rotation
+            # blocks separately, for PauliFeatureMap, all the paulis are specified
+            # as a single list (like ['Z', 'ZZ', 'YY']) and so if we just use
+            # self.entanglement[i % num_i][j % num_j] as the entanglement we will be
+            # choosing incorrect entanglement from the specified entanglement. So,
+            # here we subtract the number of single-qubit paulis from the j % num_j
+            # to pick correct entanglement from the specified List[List[List[List[int]]]]
+            count_single_qubit_paulis = 0
+            for pauli in self.paulis:
+                if len(pauli) == 1:
+                    count_single_qubit_paulis += 1
+
+            chosen_entanglement = self.entanglement[i % num_i][
+                (j % num_j) - count_single_qubit_paulis
+            ]
             return self._selective_entangler_map(num_block_qubits, chosen_entanglement)
 
         else:
-            # if the entanglement is not List[List[int]] or List[List[List[int]]]
-            # then we fall back on the original `get_entangler_map()` method from NLocal
+            # if the entanglement is not List[List[int]] or List[List[List[int]]] or
+            # List[List[List[List[int]]]] then we fall back on the original
+            # `get_entangler_map()` method from NLocal
             return super().get_entangler_map(rep_num, block_num, num_block_qubits)
 
 

--- a/qiskit/circuit/library/data_preparation/pauli_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/pauli_feature_map.py
@@ -128,8 +128,11 @@ class PauliFeatureMap(NLocal):
         Args:
             feature_dimension: Number of qubits in the circuit.
             reps: The number of repeated circuits.
-            entanglement: Specifies the entanglement structure. Refer to
-                :class:`~qiskit.circuit.library.NLocal` for detail.
+            entanglement: Specifies the entanglement structure. Can be a string (``'full'``,
+                ``'linear'``, ``'reverse_linear'``, ``'circular'`` or ``'sca'``) or can be a
+                dictionary where the keys represent the number of qubits and the values are list
+                of integer-pairs specifying the indices of qubits that are entangled with one
+                another. For example: ``{1: [(0,), (2,)], 2: [(0,1), (2,0)]}``
             alpha: The Pauli rotation factor, multiplicative to the pauli rotations
             paulis: A list of strings for to-be-used paulis. If None are provided, ``['Z', 'ZZ']``
                 will be used.

--- a/qiskit/circuit/library/data_preparation/pauli_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/pauli_feature_map.py
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """The Pauli expansion circuit module."""
+import itertools
 
 from typing import Optional, Callable, List, Union, Sequence, Dict, Tuple
 from functools import reduce
@@ -296,12 +297,19 @@ class PauliFeatureMap(NLocal):
             ):
                 for qb, ent in self.entanglement.items():
                     for ind, en in enumerate(ent):
-                        if len(en) > qb:
+                        if len(en) != qb:
                             raise ValueError(
-                                f"Length of entanglement {en} cannot be greater than num_qubits {qb}"
+                                f"For num_qubits = {qb}, entanglement must be a "
+                                f"tuple of length {qb}. You specified {en}."
                             )
                         self.entanglement[qb][ind] = tuple(map(int, en))
-            return self.entanglement[num_block_qubits]
+
+            # if there is no entanglement specified for a pauli block then
+            # assume `full` entanglement (which is default for `PauliFeatureMap`)
+            if any(num_block_qubits == qb for qb in self.entanglement.keys()):
+                return self.entanglement[num_block_qubits]
+            else:
+                return itertools.combinations(list(range(self.feature_dimension)), num_block_qubits)
 
         else:
             # if the entanglement is not Dict[int, List[List[int]]] or

--- a/qiskit/circuit/library/data_preparation/pauli_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/pauli_feature_map.py
@@ -11,8 +11,6 @@
 # that they have been altered from the originals.
 
 """The Pauli expansion circuit module."""
-import itertools
-
 from typing import Optional, Callable, List, Union, Sequence, Dict, Tuple
 from functools import reduce
 import numpy as np
@@ -304,12 +302,12 @@ class PauliFeatureMap(NLocal):
                             )
                         self.entanglement[qb][ind] = tuple(map(int, en))
 
-            # if there is no entanglement specified for a pauli block then
-            # assume `full` entanglement (which is default for `PauliFeatureMap`)
-            if any(num_block_qubits == qb for qb in self.entanglement.keys()):
-                return self.entanglement[num_block_qubits]
-            else:
-                return itertools.combinations(list(range(self.feature_dimension)), num_block_qubits)
+            # Check if the entanglement is specified for all the pauli blocks being used
+            for pauli in self.paulis:
+                if len(pauli) not in self.entanglement.keys():
+                    raise ValueError(f"No entanglement specified for {pauli} pauli.")
+
+            return self.entanglement[num_block_qubits]
 
         else:
             # if the entanglement is not Dict[int, List[List[int]]] or

--- a/qiskit/circuit/library/data_preparation/pauli_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/pauli_feature_map.py
@@ -118,8 +118,7 @@ class PauliFeatureMap(NLocal):
         entanglement: Union[
             str,
             Dict[int, List[Tuple[int]]],
-            Dict[int, List[List[int]]],
-            Callable[[int], Union[str, Dict[int, List[Tuple[int]]], Dict[int, List[List[int]]]]],
+            Callable[[int], Union[str, Dict[int, List[Tuple[int]]]]],
         ] = "full",
         alpha: float = 2.0,
         paulis: Optional[List[str]] = None,

--- a/qiskit/circuit/library/data_preparation/zz_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/zz_feature_map.py
@@ -75,7 +75,12 @@ class ZZFeatureMap(PauliFeatureMap):
         self,
         feature_dimension: int,
         reps: int = 2,
-        entanglement: Union[str, Dict[int, List[Tuple[int]]], Dict[int, List[List[int]]]] = "full",
+        entanglement: Union[
+            str,
+            Dict[int, List[Tuple[int]]],
+            Dict[int, List[List[int]]],
+            Callable[[int], Union[str, Dict[int, List[Tuple[int]]], Dict[int, List[List[int]]]]],
+        ] = "full",
         data_map_func: Optional[Callable[[np.ndarray], float]] = None,
         parameter_prefix: str = "x",
         insert_barriers: bool = False,

--- a/qiskit/circuit/library/data_preparation/zz_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/zz_feature_map.py
@@ -78,8 +78,7 @@ class ZZFeatureMap(PauliFeatureMap):
         entanglement: Union[
             str,
             Dict[int, List[Tuple[int]]],
-            Dict[int, List[List[int]]],
-            Callable[[int], Union[str, Dict[int, List[Tuple[int]]], Dict[int, List[List[int]]]]],
+            Callable[[int], Union[str, Dict[int, List[Tuple[int]]]]],
         ] = "full",
         data_map_func: Optional[Callable[[np.ndarray], float]] = None,
         parameter_prefix: str = "x",

--- a/qiskit/circuit/library/data_preparation/zz_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/zz_feature_map.py
@@ -12,7 +12,7 @@
 
 """Second-order Pauli-Z expansion circuit."""
 
-from typing import Callable, List, Union, Optional
+from typing import Callable, List, Union, Optional, Dict, Tuple
 import numpy as np
 from .pauli_feature_map import PauliFeatureMap
 
@@ -75,7 +75,7 @@ class ZZFeatureMap(PauliFeatureMap):
         self,
         feature_dimension: int,
         reps: int = 2,
-        entanglement: Union[str, List[List[int]], Callable[[int], List[int]]] = "full",
+        entanglement: Union[str, Dict[int, List[Tuple[int]]], Dict[int, List[List[int]]]] = "full",
         data_map_func: Optional[Callable[[np.ndarray], float]] = None,
         parameter_prefix: str = "x",
         insert_barriers: bool = False,
@@ -87,7 +87,7 @@ class ZZFeatureMap(PauliFeatureMap):
             feature_dimension: Number of features.
             reps: The number of repeated circuits, has a min. value of 1.
             entanglement: Specifies the entanglement structure. Refer to
-                :class:`~qiskit.circuit.library.NLocal` for detail.
+                :class:`~qiskit.circuit.library.PauliFeatureMap` for detail.
             data_map_func: A mapping function for data x.
             parameter_prefix: The prefix used if default parameters are generated.
             insert_barriers: If True, barriers are inserted in between the evolution instructions

--- a/releasenotes/notes/paulifeaturemap-takes-dictionary-as-entanglement-02037cb2d46e1c41.yaml
+++ b/releasenotes/notes/paulifeaturemap-takes-dictionary-as-entanglement-02037cb2d46e1c41.yaml
@@ -6,16 +6,16 @@ features_circuits:
     the number of qubits, and the values are lists of integer tuples that define which qubits are entangled with one another. This
     allows for more flexibility in constructing feature maps tailored to specific quantum algorithms.
     Example usage::
-	    from qiskit.circuit.library import PauliFeatureMap
+            from qiskit.circuit.library import PauliFeatureMap
 
-	    entanglement = {
-    		    1: [(0,), (2,)],
-    		    2: [(0, 1), (1, 2)],
-    		    3: [(0, 1, 2)],
-	    }
-	    params=[0, 1, 3.14]
-	    qc = PauliFeatureMap(3, reps=2, paulis=['Z', 'ZZ', 'ZZZ'], entanglement=entanglement, insert_barriers=True)
-	    qc.decompose().draw('mpl')
+            entanglement = {
+                    1: [(0,), (2,)],
+                    2: [(0, 1), (1, 2)],
+                    3: [(0, 1, 2)],
+            }
+            params=[0, 1, 3.14]
+            qc = PauliFeatureMap(3, reps=2, paulis=['Z', 'ZZ', 'ZZZ'], entanglement=entanglement, insert_barriers=True)
+            qc.decompose().draw('mpl')
 
 
 

--- a/releasenotes/notes/paulifeaturemap-takes-dictionary-as-entanglement-02037cb2d46e1c41.yaml
+++ b/releasenotes/notes/paulifeaturemap-takes-dictionary-as-entanglement-02037cb2d46e1c41.yaml
@@ -1,9 +1,15 @@
 ---
+fixes:
+  - |
+    Fixed that the entanglement in :class:`.PauliFeatureMap` and :class:`.ZZFeatureMap`
+    could be given as ``List[int]`` or ``List[List[int]]``, which was incompatible with the fact
+    that entanglement blocks of different sizes are used. Instead, the entanglement can be 
+    given as dictionary with ``{block_size: entanglement}`` pairs.
 features_circuits:
   - |
-    The entanglement argument in :class:`.PauliFeatureMap` and :class:`.ZZFeatureMap` will no longer support ``List[int]`` or ``List[List[int]]``. Instead,
-    the entanglement structure in :class:`.PauliFeatureMap` and :class:`.ZZFeatureMap` can now be specified as a dictionary where the keys represent  
-    the number of qubits, and the values are lists of integer tuples that define which qubits are entangled with one another. This
+    :class:`.PauliFeatureMap` and :class:`.ZZFeatureMap` now support specifying the 
+    entanglement as a dictionary where the keys represent the number of qubits, and 
+    the values are lists of integer tuples that define which qubits are entangled with one another. This
     allows for more flexibility in constructing feature maps tailored to specific quantum algorithms. 
     Example usage::
 

--- a/releasenotes/notes/paulifeaturemap-takes-dictionary-as-entanglement-02037cb2d46e1c41.yaml
+++ b/releasenotes/notes/paulifeaturemap-takes-dictionary-as-entanglement-02037cb2d46e1c41.yaml
@@ -1,0 +1,21 @@
+---
+features_circuits:
+  - |
+    The entanglement argument in `PauliFeatureMap` and `ZZFeatureMap` will no longer support List[int] or List[List[int]]. Instead,
+    the entanglement structure in `PauliFeatureMap` and `ZZFeatureMap` can now be specified as a dictionary where the keys represent  
+    the number of qubits, and the values are lists of integer tuples that define which qubits are entangled with one another. This
+    allows for more flexibility in constructing feature maps tailored to specific quantum algorithms.
+    Example usage::
+	    from qiskit.circuit.library import PauliFeatureMap
+
+	    entanglement = {
+    		    1: [(0,), (2,)],
+    		    2: [(0, 1), (1, 2)],
+    		    3: [(0, 1, 2)],
+	    }
+	    params=[0, 1, 3.14]
+	    qc = PauliFeatureMap(3, reps=2, paulis=['Z', 'ZZ', 'ZZZ'], entanglement=entanglement, insert_barriers=True)
+	    qc.decompose().draw('mpl')
+
+
+

--- a/releasenotes/notes/paulifeaturemap-takes-dictionary-as-entanglement-02037cb2d46e1c41.yaml
+++ b/releasenotes/notes/paulifeaturemap-takes-dictionary-as-entanglement-02037cb2d46e1c41.yaml
@@ -1,21 +1,20 @@
 ---
 features_circuits:
   - |
-    The entanglement argument in `PauliFeatureMap` and `ZZFeatureMap` will no longer support List[int] or List[List[int]]. Instead,
-    the entanglement structure in `PauliFeatureMap` and `ZZFeatureMap` can now be specified as a dictionary where the keys represent  
+    The entanglement argument in :class:`.PauliFeatureMap` and :class:`.ZZFeatureMap` will no longer support ``List[int]`` or ``List[List[int]]``. Instead,
+    the entanglement structure in :class:`.PauliFeatureMap` and :class:`.ZZFeatureMap` can now be specified as a dictionary where the keys represent  
     the number of qubits, and the values are lists of integer tuples that define which qubits are entangled with one another. This
-    allows for more flexibility in constructing feature maps tailored to specific quantum algorithms.
+    allows for more flexibility in constructing feature maps tailored to specific quantum algorithms. 
     Example usage::
-            from qiskit.circuit.library import PauliFeatureMap
 
-            entanglement = {
-                    1: [(0,), (2,)],
-                    2: [(0, 1), (1, 2)],
-                    3: [(0, 1, 2)],
-            }
-            params=[0, 1, 3.14]
-            qc = PauliFeatureMap(3, reps=2, paulis=['Z', 'ZZ', 'ZZZ'], entanglement=entanglement, insert_barriers=True)
-            qc.decompose().draw('mpl')
+      from qiskit.circuit.library import PauliFeatureMap
+      entanglement = {
+        1: [(0,), (2,)],
+        2: [(0, 1), (1, 2)],
+        3: [(0, 1, 2)],
+      }
+      qc = PauliFeatureMap(3, reps=2, paulis=['Z', 'ZZ', 'ZZZ'], entanglement=entanglement, insert_barriers=True)
+      qc.decompose().draw('mpl')
 
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This pull request fixes #12432 

When a List[List(int)] or List[List[List[int]]] or List[List[List[List[int]]]] is passed to the entanglement in `ZZFeatureMap`, it returns an error. This should work like `TwoLocal` does. 

### Details and comments

Because both `ZFeatureMap` and `ZZFeatureMap` inherits from the `PauliFeatureMap` the problem was with how `PauliFeatureMap` handles the entanglement lists.  To generate proper entanglement layers `PauliFeatureMap` relies on the `get_entangler_map()` (the method which takes 3 arguments) method from `NLocal` which handles invalid inputs and generates properly formatted entanglement layers. But unlike `TwoLocal` where we specify rotation blocks and the entanglement blocks as separate arguments, for `PauliFeatureMap` the paulis are specified as a single list. Due to this, we need some additional logic to handle how entanglement layers are generated from the user specified entanglement list. 

To fix this I have added a helper method `_selective_entangler_map()` and also added `get_entangler_map()` method to `PauliFeatureMap`. The newly specified `get_entangler_map()` method will override the `get_entangler_map()` method from the `NLocal` class for List[List(int)] or List[List[List[int]]] or List[List[List[List[int]]]] but if any other input is passed to entanglement (like a str `full`) then we fall back on the method from `NLocal` to handle those cases.

With my fix all the below examples work as expected:

- If entanglement is a List[List(int)]:
```
N = 5
layer1 = (0,1)
layer2 = (1,0)

qc = PauliFeatureMap(N, reps=2, paulis=['Z', 'ZZ'], entanglement=[layer1, layer3], insert_barriers=True)
qc.decompose().draw('mpl')
```
<img width="939" alt="List List int" src="https://github.com/user-attachments/assets/9e9e58ad-7777-4dac-9ab8-96211286b68b">

-  If entanglement is a List[List[List[int]]] (This means that entanglement will change according to reps):
```
N = 5
layer1 = [(0,1,2)]
layer2 = [(3,2,1)]

qc = PauliFeatureMap(N, reps=3, paulis=['Z', 'ZZZ'], entanglement=[layer1, layer2], insert_barriers=True)
qc.decompose().draw('mpl', fold=-1)
```
<img width="940" alt="List List List int" src="https://github.com/user-attachments/assets/f2e60f67-ced4-47f5-9241-44b51c8a9e15">

- If entanglement is List[List[List[List[int]]]] (This means that entanglement will change according to reps and paulis):
```
N = 5
layers = [[[(0,1), (2,3)], [(1,2), (3,4)]], [[(1,0), (3,2)] , [(2,1), (4,3)]]]

qc = PauliFeatureMap(N, reps=3, paulis=['Z', 'ZZ', 'XX'], entanglement=layers, insert_barriers=True)
qc.decompose().draw('mpl')
```
<img width="940" alt="List List List List int" src="https://github.com/user-attachments/assets/12ccc706-5804-422e-999a-486f5fa41d90">

@nonhermitian please review this and let me know if I should make any further changes.




