### PR TITLE
Add config option to leverage all cores for sabre

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -12,6 +12,8 @@
 
 """Built-in transpiler stage plugins for preset pass managers."""
 
+import os
+
 from qiskit.transpiler.passmanager import PassManager
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.passes import BasicSwap
@@ -63,6 +65,10 @@ from qiskit.circuit.library.standard_gates import (
     SXGate,
     SXdgGate,
 )
+from qiskit.utils.parallel import CPU_COUNT
+from qiskit import user_config
+
+CONFIG = user_config.get_config()
 
 
 class DefaultInitPassManager(PassManagerStagePlugin):
@@ -397,11 +403,16 @@ class SabreSwapPassManager(PassManagerStagePlugin):
             pass_manager_config.initial_layout,
         )
         if optimization_level == 0:
+            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
+                trial_count = CPU_COUNT
+            else:
+                trial_count = 5
+
             routing_pass = SabreSwap(
                 coupling_map_routing,
                 heuristic="basic",
                 seed=seed_transpiler,
-                trials=5,
+                trials=trial_count,
             )
             return common.generate_routing_passmanager(
                 routing_pass,
@@ -411,11 +422,16 @@ class SabreSwapPassManager(PassManagerStagePlugin):
                 use_barrier_before_measurement=True,
             )
         if optimization_level == 1:
+            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
+                trial_count = CPU_COUNT
+            else:
+                trial_count = 5
+
             routing_pass = SabreSwap(
                 coupling_map_routing,
                 heuristic="decay",
                 seed=seed_transpiler,
-                trials=5,
+                trials=trial_count,
             )
             return common.generate_routing_passmanager(
                 routing_pass,
@@ -429,11 +445,16 @@ class SabreSwapPassManager(PassManagerStagePlugin):
                 use_barrier_before_measurement=True,
             )
         if optimization_level == 2:
+            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
+                trial_count = CPU_COUNT
+            else:
+                trial_count = 20
+
             routing_pass = SabreSwap(
                 coupling_map_routing,
                 heuristic="decay",
                 seed=seed_transpiler,
-                trials=10,
+                trials=trial_count,
             )
             return common.generate_routing_passmanager(
                 routing_pass,
@@ -446,11 +467,15 @@ class SabreSwapPassManager(PassManagerStagePlugin):
                 use_barrier_before_measurement=True,
             )
         if optimization_level == 3:
+            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
+                trial_count = CPU_COUNT
+            else:
+                trial_count = 20
             routing_pass = SabreSwap(
                 coupling_map_routing,
                 heuristic="decay",
                 seed=seed_transpiler,
-                trials=20,
+                trials=trial_count,
             )
             return common.generate_routing_passmanager(
                 routing_pass,
@@ -737,12 +762,18 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
                 max_trials=2500,  # Limits layout scoring to < 600ms on ~400 qubit devices
             )
             layout.append(ConditionalController(choose_layout_1, condition=_layout_not_perfect))
+
+            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
+                trial_count = CPU_COUNT
+            else:
+                trial_count = 5
+
             choose_layout_2 = SabreLayout(
                 coupling_map,
                 max_iterations=2,
                 seed=pass_manager_config.seed_transpiler,
-                swap_trials=5,
-                layout_trials=5,
+                swap_trials=trial_count,
+                layout_trials=trial_count,
                 skip_routing=pass_manager_config.routing_method is not None
                 and pass_manager_config.routing_method != "sabre",
             )
@@ -769,12 +800,17 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
             layout.append(
                 ConditionalController(choose_layout_0, condition=_choose_layout_condition)
             )
+            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
+                trial_count = CPU_COUNT
+            else:
+                trial_count = 20
+
             choose_layout_1 = SabreLayout(
                 coupling_map,
                 max_iterations=2,
                 seed=pass_manager_config.seed_transpiler,
-                swap_trials=20,
-                layout_trials=20,
+                swap_trials=trial_count,
+                layout_trials=trial_count,
                 skip_routing=pass_manager_config.routing_method is not None
                 and pass_manager_config.routing_method != "sabre",
             )
@@ -801,12 +837,17 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
             layout.append(
                 ConditionalController(choose_layout_0, condition=_choose_layout_condition)
             )
+            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
+                trial_count = CPU_COUNT
+            else:
+                trial_count = 20
+
             choose_layout_1 = SabreLayout(
                 coupling_map,
                 max_iterations=4,
                 seed=pass_manager_config.seed_transpiler,
-                swap_trials=20,
-                layout_trials=20,
+                swap_trials=trial_count,
+                layout_trials=trial_count,
                 skip_routing=pass_manager_config.routing_method is not None
                 and pass_manager_config.routing_method != "sabre",
             )
@@ -902,42 +943,62 @@ class SabreLayoutPassManager(PassManagerStagePlugin):
         layout = PassManager()
         layout.append(_given_layout)
         if optimization_level == 0:
+            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
+                trial_count = CPU_COUNT
+            else:
+                trial_count = 5
+
             layout_pass = SabreLayout(
                 coupling_map,
                 max_iterations=1,
                 seed=pass_manager_config.seed_transpiler,
-                swap_trials=5,
-                layout_trials=5,
+                swap_trials=trial_count,
+                layout_trials=trial_count,
                 skip_routing=pass_manager_config.routing_method is not None
                 and pass_manager_config.routing_method != "sabre",
             )
         elif optimization_level == 1:
+            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
+                trial_count = CPU_COUNT
+            else:
+                trial_count = 5
+
             layout_pass = SabreLayout(
                 coupling_map,
                 max_iterations=2,
                 seed=pass_manager_config.seed_transpiler,
-                swap_trials=5,
-                layout_trials=5,
+                swap_trials=trial_count,
+                layout_trials=trial_count,
                 skip_routing=pass_manager_config.routing_method is not None
                 and pass_manager_config.routing_method != "sabre",
             )
         elif optimization_level == 2:
+            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
+                trial_count = CPU_COUNT
+            else:
+                trial_count = 20
+
             layout_pass = SabreLayout(
                 coupling_map,
                 max_iterations=2,
                 seed=pass_manager_config.seed_transpiler,
-                swap_trials=20,
-                layout_trials=20,
+                swap_trials=trial_count,
+                layout_trials=trial_count,
                 skip_routing=pass_manager_config.routing_method is not None
                 and pass_manager_config.routing_method != "sabre",
             )
         elif optimization_level == 3:
+            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
+                trial_count = CPU_COUNT
+            else:
+                trial_count = 20
+
             layout_pass = SabreLayout(
                 coupling_map,
                 max_iterations=4,
                 seed=pass_manager_config.seed_transpiler,
-                swap_trials=20,
-                layout_trials=20,
+                swap_trials=trial_count,
+                layout_trials=trial_count,
                 skip_routing=pass_manager_config.routing_method is not None
                 and pass_manager_config.routing_method != "sabre",
             )

--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -403,11 +403,7 @@ class SabreSwapPassManager(PassManagerStagePlugin):
             pass_manager_config.initial_layout,
         )
         if optimization_level == 0:
-            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
-                trial_count = CPU_COUNT
-            else:
-                trial_count = 5
-
+            trial_count = _get_trial_count(5)
             routing_pass = SabreSwap(
                 coupling_map_routing,
                 heuristic="basic",
@@ -422,11 +418,7 @@ class SabreSwapPassManager(PassManagerStagePlugin):
                 use_barrier_before_measurement=True,
             )
         if optimization_level == 1:
-            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
-                trial_count = CPU_COUNT
-            else:
-                trial_count = 5
-
+            trial_count = _get_trial_count(5)
             routing_pass = SabreSwap(
                 coupling_map_routing,
                 heuristic="decay",
@@ -445,10 +437,7 @@ class SabreSwapPassManager(PassManagerStagePlugin):
                 use_barrier_before_measurement=True,
             )
         if optimization_level == 2:
-            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
-                trial_count = CPU_COUNT
-            else:
-                trial_count = 20
+            trial_count = _get_trial_count(20)
 
             routing_pass = SabreSwap(
                 coupling_map_routing,
@@ -467,10 +456,7 @@ class SabreSwapPassManager(PassManagerStagePlugin):
                 use_barrier_before_measurement=True,
             )
         if optimization_level == 3:
-            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
-                trial_count = CPU_COUNT
-            else:
-                trial_count = 20
+            trial_count = _get_trial_count(20)
             routing_pass = SabreSwap(
                 coupling_map_routing,
                 heuristic="decay",
@@ -763,10 +749,7 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
             )
             layout.append(ConditionalController(choose_layout_1, condition=_layout_not_perfect))
 
-            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
-                trial_count = CPU_COUNT
-            else:
-                trial_count = 5
+            trial_count = _get_trial_count(5)
 
             choose_layout_2 = SabreLayout(
                 coupling_map,
@@ -800,10 +783,8 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
             layout.append(
                 ConditionalController(choose_layout_0, condition=_choose_layout_condition)
             )
-            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
-                trial_count = CPU_COUNT
-            else:
-                trial_count = 20
+
+            trial_count = _get_trial_count(20)
 
             choose_layout_1 = SabreLayout(
                 coupling_map,
@@ -837,10 +818,8 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
             layout.append(
                 ConditionalController(choose_layout_0, condition=_choose_layout_condition)
             )
-            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
-                trial_count = CPU_COUNT
-            else:
-                trial_count = 20
+
+            trial_count = _get_trial_count(20)
 
             choose_layout_1 = SabreLayout(
                 coupling_map,
@@ -943,10 +922,7 @@ class SabreLayoutPassManager(PassManagerStagePlugin):
         layout = PassManager()
         layout.append(_given_layout)
         if optimization_level == 0:
-            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
-                trial_count = CPU_COUNT
-            else:
-                trial_count = 5
+            trial_count = _get_trial_count(5)
 
             layout_pass = SabreLayout(
                 coupling_map,
@@ -958,10 +934,7 @@ class SabreLayoutPassManager(PassManagerStagePlugin):
                 and pass_manager_config.routing_method != "sabre",
             )
         elif optimization_level == 1:
-            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
-                trial_count = CPU_COUNT
-            else:
-                trial_count = 5
+            trial_count = _get_trial_count(5)
 
             layout_pass = SabreLayout(
                 coupling_map,
@@ -973,10 +946,7 @@ class SabreLayoutPassManager(PassManagerStagePlugin):
                 and pass_manager_config.routing_method != "sabre",
             )
         elif optimization_level == 2:
-            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
-                trial_count = CPU_COUNT
-            else:
-                trial_count = 20
+            trial_count = _get_trial_count(20)
 
             layout_pass = SabreLayout(
                 coupling_map,
@@ -988,10 +958,7 @@ class SabreLayoutPassManager(PassManagerStagePlugin):
                 and pass_manager_config.routing_method != "sabre",
             )
         elif optimization_level == 3:
-            if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
-                trial_count = CPU_COUNT
-            else:
-                trial_count = 20
+            trial_count = _get_trial_count(20)
 
             layout_pass = SabreLayout(
                 coupling_map,
@@ -1018,3 +985,9 @@ class SabreLayoutPassManager(PassManagerStagePlugin):
         embed = common.generate_embed_passmanager(coupling_map)
         layout.append(ConditionalController(embed.to_flow_controller(), condition=_swap_mapped))
         return layout
+
+
+def _get_trial_count(default_trials=5):
+    if CONFIG.get("sabre_all_threads", None) or os.getenv("QISKIT_SABRE_ALL_THREADS"):
+        return max(CPU_COUNT, default_trials)
+    return default_trials

--- a/qiskit/user_config.py
+++ b/qiskit/user_config.py
@@ -35,6 +35,7 @@ class UserConfig:
     transpile_optimization_level = 1
     parallel = False
     num_processes = 4
+    sabre_all_threads = true
 
     """
 
@@ -168,6 +169,13 @@ class UserConfig:
                     )
                 self.settings["num_processes"] = num_processes
 
+            # Parse sabre_all_threads
+            sabre_all_threads = self.config_parser.getboolean(
+                "default", "sabre_all_threads", fallback=None
+            )
+            if sabre_all_threads is not None:
+                self.settings["sabre_all_threads"] = sabre_all_threads
+
 
 def set_config(key, value, section=None, file_path=None):
     """Adds or modifies a user configuration
@@ -208,6 +216,7 @@ def set_config(key, value, section=None, file_path=None):
         "transpile_optimization_level",
         "parallel",
         "num_processes",
+        "sabre_all_threads",
     }
 
     if section in [None, "default"]:

--- a/releasenotes/notes/add-sabre-all-threads-option-ad4ff7a4d045cb2b.yaml
+++ b/releasenotes/notes/add-sabre-all-threads-option-ad4ff7a4d045cb2b.yaml
@@ -21,6 +21,6 @@ features_transpiler:
     local CPUs available the results would different when running between
     different computers.
 
-    It is not recommended you use this option if your local computer has
-    less than 20 CPUs as this will result in potentially degraded results
-    compared to the default.
+    If the default number of trials for a given optimization level is higher
+    than the number of local CPUs it will use the optimization level default
+    which is higher.

--- a/releasenotes/notes/add-sabre-all-threads-option-ad4ff7a4d045cb2b.yaml
+++ b/releasenotes/notes/add-sabre-all-threads-option-ad4ff7a4d045cb2b.yaml
@@ -10,9 +10,9 @@ features_transpiler:
     output with fewer :class:`.SwapGate`\s.
 
     These transpiler passes run multiple random trials in parallel and pick
-    the result which results in the fewest :class:`.SwapGate`\s. As a rule of
-    thumb if you run more trials the provides the algorithm more opportunities
-    to find a better result. By default the preset pass managers used a fixed
+    the output which results in the fewest :class:`.SwapGate`\s. As a rule of
+    thumb, if you run more trials, this provides the algorithm more opportunities
+    to find a better result. By default, the preset pass managers use a fixed
     number of trials, in this release 5 trials for levels 0 and 1, and 20
     trials for levels 2 and 3, but these numbers may change in future releases
     (and were different in historical releases). Using a fixed number of

--- a/releasenotes/notes/add-sabre-all-threads-option-ad4ff7a4d045cb2b.yaml
+++ b/releasenotes/notes/add-sabre-all-threads-option-ad4ff7a4d045cb2b.yaml
@@ -1,0 +1,26 @@
+---
+features_transpiler:
+  - |
+    Added a new user config file option ``sabre_all_threads`` and a
+    corresponding environment variable ``QISKIT_SABRE_ALL_THREADS``. When this
+    flag is set the preset pass managers will run the :class:`.SabreLayout`
+    and :class:`.SabreSwap` transpiler passes using all the available
+    CPUs on the local system. Using this option is a tradeoff between
+    determinism of output between different computers and potentially better
+    output with fewer :class:`.SwapGate`\s.
+
+    These transpiler passes run multiple random trials in parallel and pick
+    the result which results in the fewest :class:`.SwapGate`\s. As a rule of
+    thumb if you run more trials the provides the algorithm more opportunities
+    to find a better result. By default the preset pass managers used a fixed
+    number of trials, in this release 5 trials for levels 0 and 1, and 20
+    trials for levels 2 and 3, but these numbers may change in future releases
+    (and were different in historical releases). Using a fixed number of
+    trials results in deterministic results regardless of the local system,
+    because even with a fixed seed if you were to default to the number of
+    local CPUs available the results would different when running between
+    different computers.
+
+    It is not recommended you use this option if your local computer has
+    less than 20 CPUs as this will result in potentially degraded results
+    compared to the default.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

By default when running sabre in parallel we use a fixed number of threads (depending on optimization level). This was a tradeoff made for having deterministic results across multiple systems with a fixed seed set. However when running qiskit on systems with a lot of CPUs available we're leaving potential performance on the table by not using all the available cores. This new flag lets users opt-in to running sabre with n trials for n CPUs to potentially get better output results from the transpiler, with minimal to no runtime overhead, at the cost of the results not necessarily being reproducible when run on a different computer.

### Details and comments