### PR TITLE
Fix `BitArray.from_counts`/`from_samples` to not fail for input with only `0` outcome and `num_bits=None`

### DIFF
--- a/qiskit/primitives/containers/bit_array.py
+++ b/qiskit/primitives/containers/bit_array.py
@@ -230,7 +230,7 @@ class BitArray(ShapedMixin):
         Args:
             counts: One or more counts-like mappings with the same number of shots.
             num_bits: The desired number of bits per shot. If unset, the biggest value found sets
-                this value.
+                this value, with a minimum of one bit.
 
         Returns:
             A new bit array with shape ``()`` for single input counts, or ``(N,)`` for an iterable
@@ -274,7 +274,7 @@ class BitArray(ShapedMixin):
         Args:
             samples: A list of bitstrings, a list of integers, or a list of hexstrings.
             num_bits: The desired number of bits per sample. If unset, the biggest sample provided
-                is used to determine this value.
+                is used to determine this value, with a minimum of one bit.
 
         Returns:
             A new bit array.
@@ -297,6 +297,9 @@ class BitArray(ShapedMixin):
             # we are forced to prematurely look at every iterand in this case
             ints = list(ints)
             num_bits = max(map(int.bit_length, ints))
+            # convention: if the only value is 0, represent with one bit:
+            if num_bits == 0:
+                num_bits = 1
 
         num_bytes = _min_num_bytes(num_bits)
         data = b"".join(val.to_bytes(num_bytes, "big") for val in ints)

--- a/releasenotes/notes/fix-bitarray-fromcounts-nobits-82958a596b3489ec.yaml
+++ b/releasenotes/notes/fix-bitarray-fromcounts-nobits-82958a596b3489ec.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a bug in :meth:`.BitArray.from_counts` and :meth:`.BitArray.from_samples`.
+    Previously these would raise an error if given data containing only zeros, and no
+    value for the optional argument ``num_bits``. Now they produce a :class:`.BitArray`
+    with :attr:`.BitArray.num_bits` set to 1.

--- a/test/python/primitives/containers/test_bit_array.py
+++ b/test/python/primitives/containers/test_bit_array.py
@@ -222,6 +222,7 @@ class BitArrayTestCase(QiskitTestCase):
 
         counts1 = convert(Counts({"0b101010": 2, "0b1": 3, "0x010203": 4}))
         counts2 = convert(Counts({1: 3, 2: 6}))
+        counts3 = convert(Counts({0: 2}))
 
         bit_array = BitArray.from_counts(counts1)
         expected = BitArray(u_8([[0, 0, 42]] * 2 + [[0, 0, 1]] * 3 + [[1, 2, 3]] * 4), 17)
@@ -238,6 +239,10 @@ class BitArrayTestCase(QiskitTestCase):
         ]
         self.assertEqual(bit_array, BitArray(u_8(expected), 17))
 
+        bit_array = BitArray.from_counts(counts3)
+        expected = BitArray(u_8([[0], [0]]), 1)
+        self.assertEqual(bit_array, expected)
+
     def test_from_samples_bitstring(self):
         """Test the from_samples static constructor."""
         bit_array = BitArray.from_samples(["110", "1", "1111111111"])
@@ -245,6 +250,9 @@ class BitArrayTestCase(QiskitTestCase):
 
         bit_array = BitArray.from_samples(["110", "1", "1111111111"], 20)
         self.assertEqual(bit_array, BitArray(u_8([[0, 0, 6], [0, 0, 1], [0, 3, 255]]), 20))
+
+        bit_array = BitArray.from_samples(["000", "0"])
+        self.assertEqual(bit_array, BitArray(u_8([[0], [0]]), 1))
 
     def test_from_samples_hex(self):
         """Test the from_samples static constructor."""
@@ -254,6 +262,9 @@ class BitArrayTestCase(QiskitTestCase):
         bit_array = BitArray.from_samples(["0x01", "0x0a12", "0x0105"], 20)
         self.assertEqual(bit_array, BitArray(u_8([[0, 0, 1], [0, 10, 18], [0, 1, 5]]), 20))
 
+        bit_array = BitArray.from_samples(["0x0", "0x0"])
+        self.assertEqual(bit_array, BitArray(u_8([[0], [0]]), 1))
+
     def test_from_samples_int(self):
         """Test the from_samples static constructor."""
         bit_array = BitArray.from_samples([1, 2578, 261])
@@ -261,6 +272,9 @@ class BitArrayTestCase(QiskitTestCase):
 
         bit_array = BitArray.from_samples([1, 2578, 261], 20)
         self.assertEqual(bit_array, BitArray(u_8([[0, 0, 1], [0, 10, 18], [0, 1, 5]]), 20))
+
+        bit_array = BitArray.from_samples([0, 0, 0])
+        self.assertEqual(bit_array, BitArray(u_8([[0], [0], [0]]), 1))
 
     def test_reshape(self):
         """Test the reshape method."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
Partial fix for #12765.

That issue points out two problems with `BitArray.from_counts` / `BitArray.from_samples`. The more severe problem is that these methods fail with an error if the input (e.g. a counts dictionary) contains only the `0` outcome, and `num_bits` is left at the default value of `None`. 

The methods try to infer `num_bits` as the number of bits needed to represent the largest outcome (e.g. bitstring) contained in the input data. If the largest outcome is `0` when converted to an integer (e.g. the bitstring `"0"`), the number of bits inferred is `0`, which can be surprising, and also leads to an error.

This small PR interprets `0` as represented by 1 bit instead of by 0 bits, the suggested correct behavior in #12765.

The less severe problem, not fixed here, is that currently any information about `num_bits` present in the input bitstring lengths gets ignored. That problem seemed less trivial to me. I put some thoughts [here](https://github.com/Qiskit/qiskit/issues/12765#issuecomment-2240676887).
