### PR TITLE
Change the default `routing_method` to `sabre`

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -48,7 +48,7 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     initial_layout = pass_manager_config.initial_layout
     init_method = pass_manager_config.init_method or "default"
     layout_method = pass_manager_config.layout_method or "default"
-    routing_method = pass_manager_config.routing_method or "stochastic"
+    routing_method = pass_manager_config.routing_method or "sabre"
     translation_method = pass_manager_config.translation_method or "translator"
     optimization_method = pass_manager_config.optimization_method or "default"
     scheduling_method = pass_manager_config.scheduling_method or "default"

--- a/releasenotes/notes/sabre_level0-1524f01965257f3f.yaml
+++ b/releasenotes/notes/sabre_level0-1524f01965257f3f.yaml
@@ -1,5 +1,13 @@
 ---
-features_transpiler:
+upgrade_transpiler:
   - |
-    The default `routing_method` for optimization level 0 was changed from ``stochastic`` to ``sabre``.
-    The pass :class:`.SabreSwap` fully supersedes :class:`.StochasticSwap` and the latter will be deprecated in a future release.
+    The default routing pass used by optimization level 0 for :func:`.generate_preset_pass_manager`
+    and :func:`.transpile` has been changed from :class:`.StochasticSwap` to :class:`.SabreSwap`.
+    The :class:`.SabreSwap` pass performs exactly the same function but performs better in both
+    runtime and output quality (in number of swap gates and depth) compared to
+    :class:`.StochasticSwap`. For ``optimization_level=0`` this shouldn't matter because it's not
+    expected to run routing for the typical use case of level 0.
+       
+    If you were relying on the previous default routing algorithm for any reason you can use the
+    ``routing_method`` argument for :func:`.transpile` and :func:`.generate_preset_pass_manager`
+    to ``"stochastic"`` to use the :class:`.StochasticSwap` pass.

--- a/releasenotes/notes/sabre_level0-1524f01965257f3f.yaml
+++ b/releasenotes/notes/sabre_level0-1524f01965257f3f.yaml
@@ -1,0 +1,5 @@
+---
+features_transpiler:
+  - |
+    The default `routing_method` for optimization level 0 was changed from ``stochastic`` to ``sabre``.
+    The pass :class:`.SabreSwap` fully supersedes :class:`.StochasticSwap` and the latter will be deprecated in a future release.


### PR DESCRIPTION
In order to get ready [for deprecating `StochasticSwap`](https://github.com/Qiskit/qiskit/issues/12552) the only default pipeline that uses is level 0. Changing it to `sabre`.
