### PR TITLE
Build `ibm-platform-services` with known-good setuptools

### DIFF
--- a/.azure/lint_docs_qpy-linux.yml
+++ b/.azure/lint_docs_qpy-linux.yml
@@ -28,7 +28,7 @@ jobs:
           .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
           .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
           rm -rf .build-deps
-        displayName: Prebuild old-setuptools dependencies
+        displayName: "Prebuild old-setuptools dependencies"
 
       - bash: tools/install_ubuntu_docs_dependencies.sh
         displayName: 'Install docs dependencies'

--- a/.azure/lint_docs_qpy-linux.yml
+++ b/.azure/lint_docs_qpy-linux.yml
@@ -20,6 +20,16 @@ jobs:
           versionSpec: '${{ parameters.pythonVersion }}'
         displayName: 'Use Python ${{ parameters.pythonVersion }}'
 
+      # This can be removed when `ibm-platform-services` can build/install with the most recent of
+      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+      - bash: |
+          set -e
+          python -m venv .build-deps
+          .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+          .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+          rm -rf .build-deps
+        displayName: Prebuild old-setuptools dependencies
+
       - bash: tools/install_ubuntu_docs_dependencies.sh
         displayName: 'Install docs dependencies'
 

--- a/.azure/test-linux.yml
+++ b/.azure/test-linux.yml
@@ -70,7 +70,7 @@ jobs:
           .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
           .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
           rm -rf .build-deps
-        displayName: Prebuild old-setuptools dependencies
+        displayName: "Prebuild old-setuptools dependencies"
 
       - ${{ if eq(parameters.installFromSdist, true) }}:
         - bash: |

--- a/.azure/test-linux.yml
+++ b/.azure/test-linux.yml
@@ -62,6 +62,16 @@ jobs:
           virtualenv test-job
         displayName: "Prepare venv"
 
+      # This can be removed when `ibm-platform-services` can build/install with the most recent of
+      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+      - bash: |
+          set -e
+          python -m venv .build-deps
+          .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+          .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+          rm -rf .build-deps
+        displayName: Prebuild old-setuptools dependencies
+
       - ${{ if eq(parameters.installFromSdist, true) }}:
         - bash: |
             set -e

--- a/.azure/test-macos.yml
+++ b/.azure/test-macos.yml
@@ -41,7 +41,7 @@ jobs:
           .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
           .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
           rm -rf .build-deps
-        displayName: Prebuild old-setuptools dependencies
+        displayName: "Prebuild old-setuptools dependencies"
 
       - bash: |
           set -e

--- a/.azure/test-macos.yml
+++ b/.azure/test-macos.yml
@@ -33,6 +33,16 @@ jobs:
           path: .stestr
         displayName: "Cache stestr"
 
+      # This can be removed when `ibm-platform-services` can build/install with the most recent of
+      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+      - bash: |
+          set -e
+          python -m venv .build-deps
+          .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+          .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+          rm -rf .build-deps
+        displayName: Prebuild old-setuptools dependencies
+
       - bash: |
           set -e
           python -m pip install --upgrade pip setuptools wheel virtualenv

--- a/.azure/test-windows.yml
+++ b/.azure/test-windows.yml
@@ -32,6 +32,16 @@ jobs:
           path: .stestr
         displayName: Cache stestr
 
+      # This can be removed when `ibm-platform-services` can build/install with the most recent of
+      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+      - bash: |
+          set -e
+          python -m venv .build-deps
+          .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
+          .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
+          rm -rf .build-deps
+        displayName: Prebuild old-setuptools dependencies
+
       - bash: |
           set -e
           python -m pip install --upgrade pip setuptools wheel virtualenv

--- a/.azure/test-windows.yml
+++ b/.azure/test-windows.yml
@@ -40,7 +40,7 @@ jobs:
           .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
           .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
           rm -rf .build-deps
-        displayName: Prebuild old-setuptools dependencies
+        displayName: "Prebuild old-setuptools dependencies"
 
       - bash: |
           set -e

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,6 +41,23 @@ jobs:
       - name: Ensure basic build requirements
         run: python -m pip install -c constraints.txt --upgrade pip setuptools wheel
 
+      # This can be removed when `ibm-platform-services` can build/install with the most recent of
+      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+      - name: Prebuild old-setuptools dependencies
+        shell: bash
+        run: |
+          set -e
+          python -m venv .build-deps
+          if [[ ${{ runner.os }} =~ [wW]indows ]]; then
+            .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
+          else
+            .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+          fi
+          rm -rf .build-deps
+
+
       - name: Build and install qiskit-terra
         run: python -m pip install -c constraints.txt -e .
         env:

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -26,6 +26,23 @@ jobs:
           # Sync with 'documentationPythonVersion' in 'azure-pipelines.yml'.
           python-version: '3.9'
 
+      # This can be removed when `ibm-platform-services` can build/install with the most recent of
+      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+      - name: Prebuild old-setuptools dependencies
+        shell: bash
+        run: |
+          set -e
+          python -m venv .build-deps
+          if [[ ${{ runner.os }} =~ [wW]indows ]]; then
+            .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
+          else
+            .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+          fi
+          rm -rf .build-deps
+
+
       - name: Install dependencies
         run: tools/install_ubuntu_docs_dependencies.sh
 

--- a/.github/workflows/randomized_tests.yml
+++ b/.github/workflows/randomized_tests.yml
@@ -14,6 +14,23 @@ jobs:
         name: Install Python
         with:
           python-version: '3.8'
+
+      # This can be removed when `ibm-platform-services` can build/install with the most recent of
+      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+      - name: Prebuild old-setuptools dependencies
+        shell: bash
+        run: |
+          set -e
+          python -m venv .build-deps
+          if [[ ${{ runner.os }} =~ [wW]indows ]]; then
+            .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
+          else
+            .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+          fi
+          rm -rf .build-deps
+
       - name: Install dependencies
         run: |
           python -m pip install -U pip setuptools wheel

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -14,6 +14,23 @@ jobs:
         name: Install Python
         with:
           python-version: '3.10'
+
+      # This can be removed when `ibm-platform-services` can build/install with the most recent of
+      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+      - name: Prebuild old-setuptools dependencies
+        shell: bash
+        run: |
+          set -e
+          python -m venv .build-deps
+          if [[ ${{ runner.os }} =~ [wW]indows ]]; then
+            .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
+          else
+            .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+          fi
+          rm -rf .build-deps
+
       - name: Install dependencies
         run: |
           python -m pip install -U pip setuptools wheel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,23 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: arm64
+
+      # This can be removed when `ibm-platform-services` can build/install with the most recent of
+      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+      - name: Prebuild old-setuptools dependencies
+        shell: bash
+        run: |
+          set -e
+          python -m venv .build-deps
+          if [[ ${{ runner.os }} =~ [wW]indows ]]; then
+            .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
+          else
+            .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+          fi
+          rm -rf .build-deps
+
       - name: 'Install dependencies'
         run: |
           python -m pip install -U -r requirements.txt -c constraints.txt

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,6 +29,23 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
+
+      # This can be removed when `ibm-platform-services` can build/install with the most recent of
+      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+      - name: Prebuild old-setuptools dependencies
+        shell: bash
+        run: |
+          set -e
+          python -m venv .build-deps
+          if [[ ${{ runner.os }} =~ [wW]indows ]]; then
+            .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
+          else
+            .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+          fi
+          rm -rf .build-deps
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.2
         env:
@@ -57,6 +74,23 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
+
+      # This can be removed when `ibm-platform-services` can build/install with the most recent of
+      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+      - name: Prebuild old-setuptools dependencies
+        shell: bash
+        run: |
+          set -e
+          python -m venv .build-deps
+          if [[ ${{ runner.os }} =~ [wW]indows ]]; then
+            .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
+          else
+            .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+          fi
+          rm -rf .build-deps
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.2
         env:
@@ -86,6 +120,23 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
+
+      # This can be removed when `ibm-platform-services` can build/install with the most recent of
+      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+      - name: Prebuild old-setuptools dependencies
+        shell: bash
+        run: |
+          set -e
+          python -m venv .build-deps
+          if [[ ${{ runner.os }} =~ [wW]indows ]]; then
+            .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
+          else
+            .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+          fi
+          rm -rf .build-deps
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.2
         env:
@@ -132,6 +183,23 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
+
+      # This can be removed when `ibm-platform-services` can build/install with the most recent of
+      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+      - name: Prebuild old-setuptools dependencies
+        shell: bash
+        run: |
+          set -e
+          python -m venv .build-deps
+          if [[ ${{ runner.os }} =~ [wW]indows ]]; then
+            .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
+          else
+            .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+          fi
+          rm -rf .build-deps
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.2
         env:
@@ -166,6 +234,23 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
+
+      # This can be removed when `ibm-platform-services` can build/install with the most recent of
+      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+      - name: Prebuild old-setuptools dependencies
+        shell: bash
+        run: |
+          set -e
+          python -m venv .build-deps
+          if [[ ${{ runner.os }} =~ [wW]indows ]]; then
+            .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
+          else
+            .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+          fi
+          rm -rf .build-deps
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.2
         env:
@@ -200,6 +285,23 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
+
+      # This can be removed when `ibm-platform-services` can build/install with the most recent of
+      # `setuptools`. `setuptools==72.0.0` and `ibm-platform-services==0.55.1` are a known-bad combo.
+      - name: Prebuild old-setuptools dependencies
+        shell: bash
+        run: |
+          set -e
+          python -m venv .build-deps
+          if [[ ${{ runner.os }} =~ [wW]indows ]]; then
+            .build-deps/Scripts/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/Scripts/python -m pip wheel --no-build-isolation ibm-platform-services
+          else
+            .build-deps/bin/python -m pip install 'setuptools<72.0' wheel
+            .build-deps/bin/python -m pip wheel --no-build-isolation ibm-platform-services
+          fi
+          rm -rf .build-deps
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.2
         env:


### PR DESCRIPTION
### Summary

`ibm-platform-services<=0.55.1` only supply an `sdist` on PyPI, and the `setup.py` of that sdist imports the deprecated
`setuptools.commands.test`, which is removed in `setuptools==72.0.0`. This makes the package unbuildable with the latest `setuptools`, and it's hard to thread through a constraint on build dependencies right into the depths of recursive pip/tox/whatever commands.

This commit forcibly builds the bad dependency with an older version of `setuptools` and adds the wheel to the pip cache, so subsequent installation commands will be able to install from a pre-built wheel regardless of the `setuptools` version.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

See IBM/python-sdk-core#202 and IBM/platform-services-python-sdk#268 for the tracking issues on the particular repos.
