### PR TITLE
Fix `StatevectorSampler` to raise an error if a circuit with  c_if is passed

### DIFF
--- a/qiskit/primitives/statevector_sampler.py
+++ b/qiskit/primitives/statevector_sampler.py
@@ -207,7 +207,7 @@ def _preprocess_circuit(circuit: QuantumCircuit):
     qargs_index = {v: k for k, v in enumerate(qargs)}
     circuit = circuit.remove_final_measurements(inplace=False)
     if _has_control_flow(circuit):
-        raise QiskitError("StatevectorSampler cannot handle ControlFlowOp")
+        raise QiskitError("StatevectorSampler cannot handle ControlFlowOp and c_if")
     if _has_measure(circuit):
         raise QiskitError("StatevectorSampler cannot handle mid-circuit measurements")
     # num_qubits is used as sentinel to fill 0 in _samples_to_packed_array
@@ -283,4 +283,7 @@ def _final_measurement_mapping(circuit: QuantumCircuit) -> dict[tuple[ClassicalR
 
 
 def _has_control_flow(circuit: QuantumCircuit) -> bool:
-    return any(isinstance(instruction.operation, ControlFlowOp) for instruction in circuit)
+    return any(
+        isinstance((op := instruction.operation), ControlFlowOp) or op.condition
+        for instruction in circuit
+    )

--- a/releasenotes/notes/fix-statevector-sampler-c_if-9753f8f97a3d0ff5.yaml
+++ b/releasenotes/notes/fix-statevector-sampler-c_if-9753f8f97a3d0ff5.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a bug of :class:`.StatevectorSampler` that ignored gates with ``c_if``.
+    It will raise an error because :class:`.Statevector` cannot handle ``c_if``.

--- a/test/python/primitives/test_statevector_sampler.py
+++ b/test/python/primitives/test_statevector_sampler.py
@@ -592,16 +592,12 @@ class TestStatevectorSampler(QiskitTestCase):
         c2 = ClassicalRegister(1, "c2")
 
         qc = QuantumCircuit(q, c1, c2)
-        qc.ry(np.pi / 4, 2)
-        qc.cx(2, 1)
-        qc.cx(0, 1)
-        qc.h(0)
-        qc.measure(0, c1)
-        qc.measure(1, c2)
         qc.z(2).c_if(c1, 1)
         qc.x(2).c_if(c2, 1)
         qc2 = QuantumCircuit(5, 5)
         qc2.compose(qc, [0, 2, 3], [2, 4], inplace=True)
+        # Note: qc2 has aliased cregs, c0 -> c[2] and c1 -> c[4].
+        # copy_empty_like copies the aliased cregs of qc2 to qc3.
         qc3 = QuantumCircuit.copy_empty_like(qc2)
         qc3.ry(np.pi / 4, 2)
         qc3.cx(2, 1)
@@ -609,6 +605,7 @@ class TestStatevectorSampler(QiskitTestCase):
         qc3.h(0)
         qc3.measure(0, 2)
         qc3.measure(1, 4)
+        self.assertEqual(len(qc3.cregs), 3)
         cregs = [creg.name for creg in qc3.cregs]
         target = {
             cregs[0]: {0: 4255, 4: 4297, 16: 720, 20: 726},


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

`StatevectorSampler` cannot handle both control flow and c_if because `Statevector` cannot.
But, it ignores `c_if` by mistake. This PR makes `StatevectorSampler` raise an error if a circuit with c_if is passed.
A unit test of `StatevectorSampler` used `c_if` accidentally. So, this PR also fixes the case without passing c_if to `StatevectorSampler`.

Fixed #12281

### Details and comments


