### PR TITLE
Make `ImportOneCell::new` method public.

### DIFF
--- a/crates/circuit/src/imports.rs
+++ b/crates/circuit/src/imports.rs
@@ -28,7 +28,7 @@ pub struct ImportOnceCell {
 }
 
 impl ImportOnceCell {
-    const fn new(module: &'static str, object: &'static str) -> Self {
+    pub const fn new(module: &'static str, object: &'static str) -> Self {
         Self {
             module,
             object,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
The following commits aim to make this custom `ImportOneCell` structure more publicly available by exposing the `::new()` method public.

### Details and comments
As we move continue to connect more parts of Python to Rust, there are parts of our code that still live in python and we will need to access these modules/classes through the `PyO3` import API. For these tasks we have the `GILOneCell` that allows us to access python once and keep a reference whatever we call/do. 

To make the import process more accessible, the `ImportOneCell` struct was created with the purpose of creating imports more easily. Since it's already been implemented once, it would be beneficial for us to expose it more to other crates within `qiskit._accelerate`.

