### PR TITLE
Expose seed in `Estimator` and `StatevectorEstimator` 

### DIFF
--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -55,7 +55,7 @@ class Estimator(BaseEstimator[PrimitiveJob[EstimatorResult]]):
         The result of this class is exact if the circuit contains only unitary operations.
         On the other hand, the result could be stochastic if the circuit contains a non-unitary
         operation such as a reset for a some subsystems.
-        The stochastic result can be reproducible by setting ``seed``, e.g.,
+        The stochastic result can be made reproducible by setting ``seed``, e.g.,
         ``Estimator(options={"seed":123})``.
     """
 

--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -42,8 +42,9 @@ class Estimator(BaseEstimatorV1[PrimitiveJob[EstimatorResult]]):
     :Run Options:
 
         - **shots** (None or int) --
-          The number of shots. If None, it calculates the exact expectation
-          values. Otherwise, it samples from normal distributions with standard errors as standard
+          The number of shots. If None, it calculates the expectation values
+          with full state vector simulation.
+          Otherwise, it samples from normal distributions with standard errors as standard
           deviations using normal distribution approximation.
 
         - **seed** (np.random.Generator or int) --
@@ -111,7 +112,7 @@ class Estimator(BaseEstimatorV1[PrimitiveJob[EstimatorResult]]):
                     f"The number of qubits of a circuit ({circ.num_qubits}) does not match "
                     f"the number of qubits of a observable ({obs.num_qubits})."
                 )
-            final_state = _statevector_from_circuit(circ, seed)
+            final_state = _statevector_from_circuit(circ, rng)
             expectation_value = final_state.expectation_value(obs)
             if shots is None:
                 expectation_values.append(expectation_value)

--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -22,7 +22,6 @@ import numpy as np
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.exceptions import QiskitError
-from qiskit.quantum_info import Statevector
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.utils.deprecation import deprecate_func
 
@@ -31,7 +30,7 @@ from .primitive_job import PrimitiveJob
 from .utils import (
     _circuit_key,
     _observable_key,
-    bound_circuit_to_instruction,
+    _statevector_from_circuit,
     init_observable,
 )
 
@@ -112,7 +111,7 @@ class Estimator(BaseEstimatorV1[PrimitiveJob[EstimatorResult]]):
                     f"The number of qubits of a circuit ({circ.num_qubits}) does not match "
                     f"the number of qubits of a observable ({obs.num_qubits})."
                 )
-            final_state = Statevector(bound_circuit_to_instruction(circ))
+            final_state = _statevector_from_circuit(circ, seed)
             expectation_value = final_state.expectation_value(obs)
             if shots is None:
                 expectation_values.append(expectation_value)

--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -50,6 +50,13 @@ class Estimator(BaseEstimator[PrimitiveJob[EstimatorResult]]):
         - **seed** (np.random.Generator or int) --
           Set a fixed seed or generator for the normal distribution. If shots is None,
           this option is ignored.
+
+    .. note::
+        The result of this class is exact if the circuit contains only unitary operations.
+        On the other hand, the result could be stochastic if the circuit contains a non-unitary
+        operation such as a reset for a some subsystems.
+        The stochastic result can be reproducible by setting ``seed``, e.g.,
+        ``Estimator(options={"seed":123})``.
     """
 
     @deprecate_func(

--- a/qiskit/primitives/statevector_estimator.py
+++ b/qiskit/primitives/statevector_estimator.py
@@ -19,13 +19,13 @@ from collections.abc import Iterable
 
 import numpy as np
 
-from qiskit.quantum_info import SparsePauliOp, Statevector
+from qiskit.quantum_info import SparsePauliOp
 
 from .base import BaseEstimatorV2
 from .containers import DataBin, EstimatorPubLike, PrimitiveResult, PubResult
 from .containers.estimator_pub import EstimatorPub
 from .primitive_job import PrimitiveJob
-from .utils import bound_circuit_to_instruction
+from .utils import _statevector_from_circuit
 
 
 class StatevectorEstimator(BaseEstimatorV2):
@@ -151,7 +151,7 @@ class StatevectorEstimator(BaseEstimatorV2):
         for index in np.ndindex(*bc_circuits.shape):
             bound_circuit = bc_circuits[index]
             observable = bc_obs[index]
-            final_state = Statevector(bound_circuit_to_instruction(bound_circuit))
+            final_state = _statevector_from_circuit(bound_circuit, self._seed)
             paulis, coeffs = zip(*observable.items())
             obs = SparsePauliOp(paulis, coeffs)  # TODO: support non Pauli operators
             expectation_value = np.real_if_close(final_state.expectation_value(obs))

--- a/qiskit/primitives/statevector_estimator.py
+++ b/qiskit/primitives/statevector_estimator.py
@@ -45,7 +45,7 @@ class StatevectorEstimator(BaseEstimatorV2):
         The result of this class is exact if the circuit contains only unitary operations.
         On the other hand, the result could be stochastic if the circuit contains a non-unitary
         operation such as a reset for a some subsystems.
-        The stochastic result can be reproducible by setting ``seed``, e.g.,
+        The stochastic result can be made reproducible by setting ``seed``, e.g.,
         ``StatevectorEstimator(seed=123)``.
 
     .. plot::

--- a/qiskit/primitives/statevector_estimator.py
+++ b/qiskit/primitives/statevector_estimator.py
@@ -151,7 +151,7 @@ class StatevectorEstimator(BaseEstimatorV2):
         for index in np.ndindex(*bc_circuits.shape):
             bound_circuit = bc_circuits[index]
             observable = bc_obs[index]
-            final_state = _statevector_from_circuit(bound_circuit, self._seed)
+            final_state = _statevector_from_circuit(bound_circuit, rng)
             paulis, coeffs = zip(*observable.items())
             obs = SparsePauliOp(paulis, coeffs)  # TODO: support non Pauli operators
             expectation_value = np.real_if_close(final_state.expectation_value(obs))

--- a/qiskit/primitives/statevector_estimator.py
+++ b/qiskit/primitives/statevector_estimator.py
@@ -41,6 +41,13 @@ class StatevectorEstimator(BaseEstimatorV2):
     called an estimator primitive unified bloc (PUB), produces its own array-based result. The
     :meth:`~.EstimatorV2.run` method can be given a sequence of pubs to run in one call.
 
+    .. note::
+        The result of this class is exact if the circuit contains only unitary operations.
+        On the other hand, the result could be stochastic if the circuit contains a non-unitary
+        operation such as a reset for a some subsystems.
+        The stochastic result can be reproducible by setting ``seed``, e.g.,
+        ``StatevectorEstimator(seed=123)``.
+
     .. plot::
         :include-source:
 

--- a/qiskit/primitives/utils.py
+++ b/qiskit/primitives/utils.py
@@ -225,3 +225,21 @@ def bound_circuit_to_instruction(circuit: QuantumCircuit) -> Instruction:
     )
     inst.definition = circuit
     return inst
+
+
+def _statevector_from_circuit(circuit: QuantumCircuit, seed: int | None) -> Statevector:
+    """Generate a statevector from a circuit
+
+    If the input circuit includes any resets for a some subsystem,
+    :meth:`.Statevector.reset` behaves in a stochastic way in :meth:`.Statevector.evolve`.
+    This function sets a random seed to make it deterministic.
+
+    See :meth:`.Statevector.reset` for details.
+
+    Args:
+        circuit: The quantum circuit.
+        seed: The random seed number or None.
+    """
+    sv = Statevector.from_int(0, 2**circuit.num_qubits)
+    sv.seed(seed)
+    return sv.evolve(bound_circuit_to_instruction(circuit))

--- a/qiskit/primitives/utils.py
+++ b/qiskit/primitives/utils.py
@@ -227,19 +227,21 @@ def bound_circuit_to_instruction(circuit: QuantumCircuit) -> Instruction:
     return inst
 
 
-def _statevector_from_circuit(circuit: QuantumCircuit, seed: int | None) -> Statevector:
+def _statevector_from_circuit(
+    circuit: QuantumCircuit, rng: np.random.Generator | None
+) -> Statevector:
     """Generate a statevector from a circuit
 
     If the input circuit includes any resets for a some subsystem,
     :meth:`.Statevector.reset` behaves in a stochastic way in :meth:`.Statevector.evolve`.
-    This function sets a random seed to make it deterministic.
+    This function sets a random number generator to be reproducible.
 
     See :meth:`.Statevector.reset` for details.
 
     Args:
         circuit: The quantum circuit.
-        seed: The random seed number or None.
+        seed: The random number generator or None.
     """
     sv = Statevector.from_int(0, 2**circuit.num_qubits)
-    sv.seed(seed)
+    sv.seed(rng)
     return sv.evolve(bound_circuit_to_instruction(circuit))

--- a/releasenotes/notes/fix-estimator-reset-9e7539776df4cac4.yaml
+++ b/releasenotes/notes/fix-estimator-reset-9e7539776df4cac4.yaml
@@ -1,0 +1,16 @@
+---
+fixes:
+  - |
+    Fixed a bug of :class:`.Estimator` and :class:`.StatevectorEstimator` that
+    they may behave in a stochastic way if input circuits include resets for a some subsystems.
+    They behave in a deterministic way if a random seed is given. For example::
+
+      from qiskit.primitives import StatevectorEstimator
+
+      estimator = StatevectorEstimator(seed=123)
+
+    or::
+
+      from qiskit.primitives import Estimator
+
+      estimator = Estimator(options={"seed":123})

--- a/releasenotes/notes/fix-estimator-reset-9e7539776df4cac4.yaml
+++ b/releasenotes/notes/fix-estimator-reset-9e7539776df4cac4.yaml
@@ -1,9 +1,11 @@
 ---
-fixes:
+features_primitives:
   - |
-    Fixed a bug of :class:`.Estimator` and :class:`.StatevectorEstimator` that
-    the stochastic results due to resets for a some subsystems are not reproducible.
-    The results are now reproducible if a random seed is given. For example::
+    :class:`.Estimator` and :class:`.StatevectorEstimator` return
+    expectation values in a stochastic way if the input circuit includes
+    a reset for a some subsystems.
+    The result was not reproducible, but it is now reproducible
+    if a random seed is set. For example::
 
       from qiskit.primitives import StatevectorEstimator
 
@@ -14,3 +16,4 @@ fixes:
       from qiskit.primitives import Estimator
 
       estimator = Estimator(options={"seed":123})
+

--- a/releasenotes/notes/fix-estimator-reset-9e7539776df4cac4.yaml
+++ b/releasenotes/notes/fix-estimator-reset-9e7539776df4cac4.yaml
@@ -2,8 +2,8 @@
 fixes:
   - |
     Fixed a bug of :class:`.Estimator` and :class:`.StatevectorEstimator` that
-    they may behave in a stochastic way if input circuits include resets for a some subsystems.
-    They behave in a deterministic way if a random seed is given. For example::
+    the stochastic results due to resets for a some subsystems are not reproducible.
+    The results are now reproducible if a random seed is given. For example::
 
       from qiskit.primitives import StatevectorEstimator
 

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -370,8 +370,8 @@ class TestEstimator(QiskitTestCase):
         op = SparsePauliOp("ZI")
 
         with self.assertWarns(DeprecationWarning):
-            estimator = Estimator()
-            result = estimator.run(qc, op, seed=seed).result()
+            estimator = Estimator(options={"seed": seed})
+            result = estimator.run(qc, op).result()
         np.testing.assert_allclose(result.values, expect)
 
 

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -364,17 +364,31 @@ class TestEstimator(QiskitTestCase):
         op = SparsePauliOp("ZI")
 
         seed = 12
-        n = 250
-        with self.assertWarns(DeprecationWarning):
-            estimator = Estimator(options={"seed": seed})
-            result = estimator.run([qc for _ in range(n)], [op] * n).result()
-        # expectation values should be stochastic due to reset for subsystems
-        np.testing.assert_allclose(result.values.mean(), 0, atol=1e-1)
+        n = 1000
+        with self.subTest("shots=None"):
+            with self.assertWarns(DeprecationWarning):
+                estimator = Estimator(options={"seed": seed})
+                result = estimator.run([qc for _ in range(n)], [op] * n).result()
+            # expectation values should be stochastic due to reset for subsystems
+            np.testing.assert_allclose(result.values.mean(), 0, atol=1e-1)
 
-        with self.assertWarns(DeprecationWarning):
-            result2 = estimator.run([qc for _ in range(n)], [op] * n).result()
-        # expectation values should be reproducible due to seed
-        np.testing.assert_allclose(result.values, result2.values)
+            with self.assertWarns(DeprecationWarning):
+                result2 = estimator.run([qc for _ in range(n)], [op] * n).result()
+            # expectation values should be reproducible due to seed
+            np.testing.assert_allclose(result.values, result2.values)
+
+        with self.subTest("shots=10000"):
+            shots = 10000
+            with self.assertWarns(DeprecationWarning):
+                estimator = Estimator(options={"seed": seed})
+                result = estimator.run([qc for _ in range(n)], [op] * n, shots=shots).result()
+            # expectation values should be stochastic due to reset for subsystems
+            np.testing.assert_allclose(result.values.mean(), 0, atol=1e-1)
+
+            with self.assertWarns(DeprecationWarning):
+                result2 = estimator.run([qc for _ in range(n)], [op] * n, shots=shots).result()
+            # expectation values should be reproducible due to seed
+            np.testing.assert_allclose(result.values, result2.values)
 
 
 @ddt

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -13,6 +13,7 @@
 """Tests for Estimator."""
 
 import unittest
+from test import QiskitTestCase
 
 import numpy as np
 from ddt import data, ddt, unpack
@@ -24,9 +25,9 @@ from qiskit.primitives import Estimator, EstimatorResult
 from qiskit.primitives.base import validation
 from qiskit.primitives.utils import _observable_key
 from qiskit.quantum_info import Pauli, SparsePauliOp
-from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
 
+@ddt
 class TestEstimator(QiskitTestCase):
     """Test Estimator"""
 
@@ -354,6 +355,24 @@ class TestEstimator(QiskitTestCase):
 
         keys = [_observable_key(get_op(i)) for i in range(5)]
         self.assertEqual(len(keys), len(set(keys)))
+
+    @unpack
+    @data(
+        {"seed": 12, "expect": 1},
+        {"seed": 13, "expect": -1},
+    )
+    def test_reset(self, seed, expect):
+        """Test for circuits with reset."""
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.reset(0)
+        op = SparsePauliOp("ZI")
+
+        with self.assertWarns(DeprecationWarning):
+            estimator = Estimator()
+            result = estimator.run(qc, op, seed=seed).result()
+        np.testing.assert_allclose(result.values, expect)
 
 
 @ddt

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -369,10 +369,18 @@ class TestEstimator(QiskitTestCase):
         qc.reset(0)
         op = SparsePauliOp("ZI")
 
-        with self.assertWarns(DeprecationWarning):
-            estimator = Estimator(options={"seed": seed})
-            result = estimator.run(qc, op).result()
-        np.testing.assert_allclose(result.values, expect)
+        with self.subTest("single"):
+            with self.assertWarns(DeprecationWarning):
+                estimator = Estimator(options={"seed": seed})
+                result = estimator.run(qc, op).result()
+            np.testing.assert_allclose(result.values, expect)
+
+        with self.subTest("multiple"):
+            with self.assertWarns(DeprecationWarning):
+                estimator = Estimator(options={"seed": seed})
+                n = 250
+                result = estimator.run([qc for _ in range(n)], [op] * n).result()
+            np.testing.assert_allclose(result.values.mean(), 0, atol=1e-1)
 
 
 @ddt

--- a/test/python/primitives/test_statevector_estimator.py
+++ b/test/python/primitives/test_statevector_estimator.py
@@ -316,15 +316,26 @@ class TestStatevectorEstimator(QiskitTestCase):
         op = SparsePauliOp("ZI")
 
         seed = 12
-        n = 250
+        n = 1000
         estimator = StatevectorEstimator(seed=seed)
-        result = estimator.run([(qc, [op] * n)]).result()
-        # expectation values should be stochastic due to reset for subsystems
-        np.testing.assert_allclose(result[0].data.evs.mean(), 0, atol=1e-1)
+        with self.subTest("precision=0"):
+            result = estimator.run([(qc, [op] * n)]).result()
+            # expectation values should be stochastic due to reset for subsystems
+            np.testing.assert_allclose(result[0].data.evs.mean(), 0, atol=1e-1)
 
-        result2 = estimator.run([(qc, [op] * n)]).result()
-        # expectation values should be reproducible due to seed
-        np.testing.assert_allclose(result[0].data.evs, result2[0].data.evs)
+            result2 = estimator.run([(qc, [op] * n)]).result()
+            # expectation values should be reproducible due to seed
+            np.testing.assert_allclose(result[0].data.evs, result2[0].data.evs)
+
+        with self.subTest("precision=0.01"):
+            precision = 0.01
+            result = estimator.run([(qc, [op] * n)], precision=precision).result()
+            # expectation values should be stochastic due to reset for subsystems
+            np.testing.assert_allclose(result[0].data.evs.mean(), 0, atol=1e-1)
+
+            result2 = estimator.run([(qc, [op] * n)], precision=precision).result()
+            # expectation values should be reproducible due to seed
+            np.testing.assert_allclose(result[0].data.evs, result2[0].data.evs)
 
 
 if __name__ == "__main__":

--- a/test/python/primitives/test_statevector_estimator.py
+++ b/test/python/primitives/test_statevector_estimator.py
@@ -322,9 +322,16 @@ class TestStatevectorEstimator(QiskitTestCase):
         qc.reset(0)
         op = SparsePauliOp("ZI")
 
-        estimator = StatevectorEstimator(seed=seed)
-        result = estimator.run([(qc, op)]).result()
-        np.testing.assert_allclose(result[0].data.evs, expect)
+        with self.subTest("single"):
+            estimator = StatevectorEstimator(seed=seed)
+            result = estimator.run([(qc, op)]).result()
+            np.testing.assert_allclose(result[0].data.evs, expect)
+
+        with self.subTest("multiple"):
+            estimator = StatevectorEstimator(seed=seed)
+            n = 250
+            result = estimator.run([(qc, [op] * n)]).result()
+            np.testing.assert_allclose(result[0].data.evs.mean(), 0, atol=1e-1)
 
 
 if __name__ == "__main__":

--- a/test/python/primitives/test_statevector_estimator.py
+++ b/test/python/primitives/test_statevector_estimator.py
@@ -13,19 +13,21 @@
 """Tests for Estimator."""
 
 import unittest
+from test import QiskitTestCase
 
 import numpy as np
+from ddt import data, ddt, unpack
 
 from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.primitives import StatevectorEstimator
+from qiskit.primitives.containers.bindings_array import BindingsArray
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
 from qiskit.primitives.containers.observables_array import ObservablesArray
-from qiskit.primitives.containers.bindings_array import BindingsArray
 from qiskit.quantum_info import SparsePauliOp
-from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
 
+@ddt
 class TestStatevectorEstimator(QiskitTestCase):
     """Test Estimator"""
 
@@ -306,6 +308,23 @@ class TestStatevectorEstimator(QiskitTestCase):
         self.assertEqual(
             result[1].metadata, {"target_precision": 0.1, "circuit_metadata": qc2.metadata}
         )
+
+    @unpack
+    @data(
+        {"seed": 12, "expect": 1},
+        {"seed": 13, "expect": -1},
+    )
+    def test_reset(self, seed, expect):
+        """Test for circuits with reset."""
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.reset(0)
+        op = SparsePauliOp("ZI")
+
+        estimator = StatevectorEstimator(seed=seed)
+        result = estimator.run([(qc, op)]).result()
+        np.testing.assert_allclose(result[0].data.evs, expect)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

The Estimator implementations based on `Statevector`, i.e., `Estimator` and `StatevectorEstimator` may return expectation values in a stochastic way if input circuits include reset gates for a some subsystems.
This is because `Statevector` behaves in a stochastic way in such a situation and we need to set a random seed to make it reproducible. Here are the details.

https://github.com/Qiskit/qiskit/blob/b75c2e093ebd4417906edfb159e557f3585b7c4e/qiskit/quantum_info/states/statevector.py#L611-L616

This PR introduces a private utility to function to set a random number generator to make the output reprodicible.


Fixes #12519 (result with this PR https://github.com/Qiskit/qiskit/issues/12519#issuecomment-2262272093)

### Details and comments

Based on https://github.com/Qiskit/qiskit/pull/12862#issuecomment-2260809268

```python
import numpy as np
from qiskit.circuit import QuantumCircuit
from qiskit.primitives import Estimator, StatevectorEstimator
from qiskit.quantum_info import SparsePauliOp

qc = QuantumCircuit(2)
qc.h(0)
qc.cx(0, 1)
qc.reset(0)

op = SparsePauliOp("ZI")

n = 500

for seed in [123, None]:
    print("seed", seed)
    est1 = Estimator(options={"seed": seed})
    est2 = StatevectorEstimator(seed=seed)
    for _ in range(3):
        result = est1.run([qc for _ in range(n)], n * [op]).result()
        values = result.values
        print("Estimator\t\t", np.mean(values))

        result = est2.run([(qc, n * [op])]).result()
        values = result[0].data.evs
        print("StatevectorEstimator\t", np.mean(values))
    print()
```

main (the values are close to zero, but random)
```
seed 123
Estimator		 0.012
StatevectorEstimator	 0.016
Estimator		 0.008
StatevectorEstimator	 0.04
Estimator		 -0.008
StatevectorEstimator	 -0.008

seed None
Estimator		 0.012
StatevectorEstimator	 0.024
Estimator		 0.028
StatevectorEstimator	 -0.04
Estimator		 0.048
StatevectorEstimator	 -0.02
```

this PR (the values are close to zero and reproducible thanks to `seed=123`)
```
seed 123
Estimator		 0.04
StatevectorEstimator	 0.04
Estimator		 0.04
StatevectorEstimator	 0.04
Estimator		 0.04
StatevectorEstimator	 0.04

seed None
Estimator		 0.068
StatevectorEstimator	 0.012
Estimator		 -0.02
StatevectorEstimator	 0.06
Estimator		 0.04
StatevectorEstimator	 0.032
```

