### PR TITLE
Fix ``AnnotatedOperation`` being modified during parameter assignment

### DIFF
--- a/qiskit/circuit/annotated_operation.py
+++ b/qiskit/circuit/annotated_operation.py
@@ -133,7 +133,7 @@ class AnnotatedOperation(Operation):
 
     def copy(self) -> "AnnotatedOperation":
         """Return a copy of the :class:`~.AnnotatedOperation`."""
-        return AnnotatedOperation(base_op=self.base_op, modifiers=self.modifiers.copy())
+        return AnnotatedOperation(base_op=self.base_op.copy(), modifiers=self.modifiers.copy())
 
     def to_matrix(self):
         """Return a matrix representation (allowing to construct Operator)."""

--- a/test/python/circuit/test_annotated_operation.py
+++ b/test/python/circuit/test_annotated_operation.py
@@ -204,6 +204,17 @@ class TestAnnotatedOperationClass(QiskitTestCase):
             with self.assertRaises(AttributeError):
                 _ = annotated.validate_parameter(1.2)
 
+    def test_invariant_under_assign(self):
+        """Test the annotated operation is not changed by assigning."""
+        p = Parameter("p")
+        annotated = RXGate(p).control(2, annotated=True)
+        circuit = QuantumCircuit(annotated.num_qubits)
+        circuit.append(annotated, circuit.qubits)
+        bound = circuit.assign_parameters([1.23])
+
+        self.assertEqual(list(circuit.parameters), [p])
+        self.assertEqual(len(bound.parameters), 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Copying an annotated operation currently does not copy the underlying `base_op`. This leads to problems down the line, as we have multiple annotated operations referencing the same `base_op`, for example in parameter assignment. This PR copies the `base_op` upon copying the annotated operation to fix this problem.

### Details and comments

No reno (yet), as this bug was probably mostly noticable in this release (1.2) which adds parameter handling to `AnnotatedOperation`.

Here's a minimal breaking example, which is fixed by this PR.
```python
from qiskit.circuit import Parameter, QuantumCircuit
from qiskit.circuit.library import RYGate

theta = Parameter("theta")
ry = RYGate(theta)
qc = QuantumCircuit(5)
qc.append(ry.control(4, annotated=True), qc.qubits)
qc.assign_parameters([1.23], inplace=True)
print(qc)  # prints the circuit, which should be unmodified, with a bound parameter

qc.assign_parameters([1.23])  # fails as the parameter is already bound
```
