### PR TITLE
Revert base class change introduced in Primitives V1 deprecation

### DIFF
--- a/qiskit/primitives/backend_estimator.py
+++ b/qiskit/primitives/backend_estimator.py
@@ -36,7 +36,7 @@ from qiskit.transpiler.passes import (
 )
 from qiskit.utils.deprecation import deprecate_func
 
-from .base import BaseEstimatorV1, EstimatorResult
+from .base import BaseEstimator, EstimatorResult
 from .primitive_job import PrimitiveJob
 from .utils import _circuit_key, _observable_key, init_observable
 
@@ -88,17 +88,18 @@ def _prepare_counts(results: list[Result]):
     return counts
 
 
-class BackendEstimator(BaseEstimatorV1[PrimitiveJob[EstimatorResult]]):
+class BackendEstimator(BaseEstimator[PrimitiveJob[EstimatorResult]]):
     """Evaluates expectation value using Pauli rotation gates.
 
     The :class:`~.BackendEstimator` class is a generic implementation of the
-    :class:`~.BaseEstimatorV1` interface that is used to wrap a :class:`~.BackendV2`
-    (or :class:`~.BackendV1`) object in the :class:`~.BaseEstimatorV1` API. It
+    :class:`~.BaseEstimator` (V1) interface that is used to wrap a :class:`~.BackendV2`
+    (or :class:`~.BackendV1`) object in the :class:`~.BaseEstimator` V1 API. It
     facilitates using backends that do not provide a native
-    :class:`~.BaseEstimatorV1` implementation in places that work with
-    :class:`~.BaseEstimatorV1`.
+    :class:`~.BaseEstimator` V1 implementation in places that work with
+    :class:`~.BaseEstimator` V1.
     However, if you're using a provider that has a native implementation of
-    :class:`~.BaseEstimatorV1` or :class:`~.BaseEstimatorV2`, it is a better
+    :class:`~.BaseEstimatorV1` ( :class:`~.BaseEstimator`) or
+    :class:`~.BaseEstimatorV2`, it is a better
     choice to leverage that native implementation as it will likely include
     additional optimizations and be a more efficient implementation.
     The generic nature of this class precludes doing any provider- or

--- a/qiskit/primitives/backend_sampler.py
+++ b/qiskit/primitives/backend_sampler.py
@@ -26,22 +26,23 @@ from qiskit.transpiler.passmanager import PassManager
 from qiskit.utils.deprecation import deprecate_func
 
 from .backend_estimator import _prepare_counts, _run_circuits
-from .base import BaseSamplerV1, SamplerResult
+from .base import BaseSampler, SamplerResult
 from .primitive_job import PrimitiveJob
 from .utils import _circuit_key
 
 
-class BackendSampler(BaseSamplerV1[PrimitiveJob[SamplerResult]]):
-    """A :class:`~.BaseSamplerV1` implementation that provides a wrapper for
+class BackendSampler(BaseSampler[PrimitiveJob[SamplerResult]]):
+    """A :class:`~.BaseSampler` (V1) implementation that provides a wrapper for
     leveraging the Sampler V1 interface from any backend.
 
     This class provides a sampler interface from any backend and doesn't do
     any measurement mitigation, it just computes the probability distribution
     from the counts. It facilitates using backends that do not provide a
-    native :class:`~.BaseSamplerV1` implementation in places that work with
-    :class:`~.BaseSamplerV1`.
+    native :class:`~.BaseSampler` V1 implementation in places that work with
+    :class:`~.BaseSampler` V1.
     However, if you're using a provider that has a native implementation of
-    :class:`~.BaseSamplerV1` or :class:`~.BaseESamplerV2`, it is a better
+    :class:`~.BaseSamplerV1` ( :class:`~.BaseSampler`) or
+    :class:`~.BaseESamplerV2`, it is a better
     choice to leverage that native implementation as it will likely include
     additional optimizations and be a more efficient implementation.
     The generic nature of this class precludes doing any provider- or

--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -26,7 +26,7 @@ from qiskit.quantum_info import Statevector
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.utils.deprecation import deprecate_func
 
-from .base import BaseEstimatorV1, EstimatorResult
+from .base import BaseEstimator, EstimatorResult
 from .primitive_job import PrimitiveJob
 from .utils import (
     _circuit_key,
@@ -36,9 +36,9 @@ from .utils import (
 )
 
 
-class Estimator(BaseEstimatorV1[PrimitiveJob[EstimatorResult]]):
+class Estimator(BaseEstimator[PrimitiveJob[EstimatorResult]]):
     """
-    Reference implementation of :class:`BaseEstimatorV1`.
+    Reference implementation of :class:`BaseEstimator` (V1).
 
     :Run Options:
 

--- a/qiskit/primitives/sampler.py
+++ b/qiskit/primitives/sampler.py
@@ -26,7 +26,7 @@ from qiskit.quantum_info import Statevector
 from qiskit.result import QuasiDistribution
 from qiskit.utils.deprecation import deprecate_func
 
-from .base import BaseSamplerV1, SamplerResult
+from .base import BaseSampler, SamplerResult
 from .primitive_job import PrimitiveJob
 from .utils import (
     _circuit_key,
@@ -36,11 +36,11 @@ from .utils import (
 )
 
 
-class Sampler(BaseSamplerV1[PrimitiveJob[SamplerResult]]):
+class Sampler(BaseSampler[PrimitiveJob[SamplerResult]]):
     """
     Sampler V1 class.
 
-    :class:`~Sampler` is a reference implementation of :class:`~BaseSamplerV1`.
+    :class:`~Sampler` is a reference implementation of :class:`~BaseSampler` (V1).
 
     :Run Options:
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
https://github.com/Qiskit/qiskit/pull/12575 deprecated the non-versioned aliases for the V1 interfaces of the primitives as well as the V1 implementations. The base class of the deprecated implementations was changed from the non-versioned to the versioned class, and looking back I think this change should be reverted.

This change breaks instance checks on implementations based on the primitives, and prevents the deprecation warning from being raised properly. Given that the implementations are deprecated and will be removed as the same time as the base class aliases, we didn't really gain much from changing to an un-deprecated base class, and I think it is safer to keep the base classes unchanged and preserve the instance checks.

### Details and comments


