### PR TITLE
Allow arbitrary iterables in `assign_parameters`

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -4188,7 +4188,7 @@ class QuantumCircuit:
     @overload
     def assign_parameters(
         self,
-        parameters: Union[Mapping[Parameter, ParameterValueType], Sequence[ParameterValueType]],
+        parameters: Union[Mapping[Parameter, ParameterValueType], Iterable[ParameterValueType]],
         inplace: Literal[False] = ...,
         *,
         flat_input: bool = ...,
@@ -4198,7 +4198,7 @@ class QuantumCircuit:
     @overload
     def assign_parameters(
         self,
-        parameters: Union[Mapping[Parameter, ParameterValueType], Sequence[ParameterValueType]],
+        parameters: Union[Mapping[Parameter, ParameterValueType], Iterable[ParameterValueType]],
         inplace: Literal[True] = ...,
         *,
         flat_input: bool = ...,
@@ -4207,7 +4207,7 @@ class QuantumCircuit:
 
     def assign_parameters(  # pylint: disable=missing-raises-doc
         self,
-        parameters: Union[Mapping[Parameter, ParameterValueType], Sequence[ParameterValueType]],
+        parameters: Union[Mapping[Parameter, ParameterValueType], Iterable[ParameterValueType]],
         inplace: bool = False,
         *,
         flat_input: bool = False,
@@ -4317,7 +4317,7 @@ class QuantumCircuit:
             target._data.assign_parameters_mapping(parameter_binds)
         else:
             parameter_binds = _ParameterBindsSequence(target._data.parameters, parameters)
-            target._data.assign_parameters_sequence(parameters)
+            target._data.assign_parameters_iterable(parameters)
 
         # Finally, assign the parameters inside any of the calibrations.  We don't track these in
         # the `ParameterTable`, so we manually reconstruct things.

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -347,6 +347,20 @@ class TestParameters(QiskitTestCase):
             qc.assign_parameters({a: 1, b: 2, c: 3}), qc.assign_parameters({"a": 1, "b": 2, "c": 3})
         )
 
+    def test_assign_parameters_by_iterable(self):
+        """Assignment works with weird iterables."""
+        a, b, c = Parameter("a"), Parameter("b"), Parameter("c")
+        qc = QuantumCircuit(1)
+        qc.rz(a, 0)
+        qc.rz(b + c, 0)
+
+        binds = [1.25, 2.5, 0.125]
+        expected = qc.assign_parameters(dict(zip(qc.parameters, binds)))
+        self.assertEqual(qc.assign_parameters(iter(binds)), expected)
+        self.assertEqual(qc.assign_parameters(dict.fromkeys(binds).keys()), expected)
+        self.assertEqual(qc.assign_parameters(dict(zip(qc.parameters, binds)).values()), expected)
+        self.assertEqual(qc.assign_parameters(bind for bind in binds), expected)
+
     def test_bind_parameters_custom_definition_global_phase(self):
         """Test that a custom gate with a parametrized `global_phase` is assigned correctly."""
         x = Parameter("x")


### PR DESCRIPTION
### Summary

In Qiskit 1.1, it was possible to give any object that was iterable and had a `__len__` as the binding sequence for `assign_parameters`.  The move to Rust space inadvertantly limited that to things that fulfilled the sequence API.  This commit restores the ability to use general iterables, and removes the need to have a `__len__`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Fix #12885, but no release note because the bug isn't in a final release.
