### PR TITLE
Add spaces to deprecation warning about `qiskit.providers.models`

### DIFF
--- a/qiskit/providers/models/__init__.py
+++ b/qiskit/providers/models/__init__.py
@@ -54,10 +54,10 @@ from .pulsedefaults import PulseDefaults, Command
 
 
 warnings.warn(
-    "qiskit.providers.models is deprecated since Qiskit 1.2 and will be removed in Qiskit 2.0."
-    "With the removal of Qobj, there is no need for these schema-conformant objects. If you still need"
-    "to use them, it could be because you are using a BackendV1, which is also deprecated in favor"
-    "of BackendV2",
+    "qiskit.providers.models is deprecated since Qiskit 1.2 and will be removed in Qiskit 2.0. "
+    "With the removal of Qobj, there is no need for these schema-conformant objects. If you still need "
+    "to use them, it could be because you are using a BackendV1, which is also deprecated in favor "
+    "of BackendV2.",
     DeprecationWarning,
     2,
 )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This adds some spaces that are currently missing in a deprecation warning.

### Details and comments

I reviewed the other warnings added as part of the same PR (#12629), and all the others looked correct to me.