### PR TITLE
Update docs links for new URL structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ the code. It also lets the community know what you're working on, and if you
 need help, you can reference the issue when discussing it with other community
 and team members.
 
-* For documentation issues relating to pages in the Start, Build, Transpile, Verify, Run, and Migration guides sections of [docs.quantum.ibm.com](https://docs.quantum.ibm.com/), please open an issue in the [Qiskit/documentation repo](https://github.com/Qiskit/documentation/issues/new/choose) rather than the Qiskit/qiskit repo. In other words, any page that DOES NOT have `/api/` in the url should be addressed in the Qiskit/documentation repo. (Exception: the [Migration guide](https://docs.quantum.ibm.com/api/migration-guides) urls contain `/api/` but are managed in the Qiskit/documentation repo.)
+* For documentation issues relating to pages in the Start, Build, Transpile, Verify, Run, and Migration guides sections of [docs.quantum.ibm.com](https://docs.quantum.ibm.com/), please open an issue in the [Qiskit/documentation repo](https://github.com/Qiskit/documentation/issues/new/choose) rather than the Qiskit/qiskit repo. In other words, any page that DOES NOT have `/api/` in the url should be addressed in the Qiskit/documentation repo.
 * For issues relating to API reference pages (any page that contains `/api/` in the url), please open an issue in the repo specific to that API reference, for example [Qiskit/qiskit](https://github.com/Qiskit/qiskit/issues/new/choose), [Qiskit/qiskit-aer](https://github.com/Qiskit/qiskit-aer/issues/new/choose), or [Qiskit/qiskit-ibm-runtime](https://github.com/Qiskit/qiskit-ibm-runtime/issues/new/choose).
 
 If you've written some code but need help finishing it, want to get initial

--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -1,7 +1,7 @@
 # Deprecation Policy
 
 Starting from the 1.0.0 release, Qiskit follows semantic versioning, with a yearly release cycle for major releases.
-[Full details of the scheduling are hosted with the external public documentation](https://docs.quantum.ibm.com/start/install#release-schedule).
+[Full details of the scheduling are hosted with the external public documentation](https://docs.quantum.ibm.com/open-source/qiskit-sdk-version-strategy).
 
 This document is primarily intended for developers of Qiskit themselves.
 
@@ -42,7 +42,7 @@ Similarly, while it is permissible where necessary for behavior to change with n
 ## What is the public interface?
 
 > [!NOTE]
-> This section should be in sync with [the release schedule documentation of Qiskit](https://docs.quantum.ibm.com/start/install#release-schedule).
+> This section should be in sync with [the release schedule documentation of Qiskit](https://docs.quantum.ibm.com/open-source/qiskit-sdk-version-strategy).
 > Please [open an issue against Qiskit](https://github.com/Qiskit/qiskit/issues/new/choose) if there are discrepancies so we can clarify them.
 
 For the purposes of semantic versioning, the Qiskit public API comprises all *publicly documented* packages, modules, classes, functions, methods, and attributes.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For more details on how to use Qiskit, refer to the documentation located here:
 ## Installation
 
 > [!WARNING]
-> Do not try to upgrade an existing Qiskit 0.* environment to Qiskit 1.0 in-place. [Read more](https://docs.quantum.ibm.com/api/migration-guides/qiskit-1.0-installation).
+> Do not try to upgrade an existing Qiskit 0.* environment to Qiskit 1.0 in-place. [Read more](https://docs.quantum.ibm.com/migration-guides/qiskit-1.0-installation).
 
 We encourage installing Qiskit via ``pip``:
 
@@ -33,7 +33,7 @@ pip install qiskit
 
 Pip will handle all dependencies automatically and you will always install the latest (and well-tested) version.
 
-To install from source, follow the instructions in the [documentation](https://docs.quantum.ibm.com/start/install-qiskit-source).
+To install from source, follow the instructions in the [documentation](https://docs.quantum.ibm.com/guides/install-qiskit-source).
 
 ## Create your first quantum program in Qiskit
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ For example, if the most recent release is 1.0.1, then the current major release
 The 1.0.x series will be supported with bug fixes, until the release of 1.1.0, which will include new features.
 The last version of the previous major release, 0.46.x, is supported with bugfixes only until six months after the final release of 1.0.0.
 
-We provide more detail on [the release and support schedule of Qiskit in our documentation](https://docs.quantum.ibm.com/start/install#release-schedule).
+We provide more detail on [the release and support schedule of Qiskit in our documentation](https://docs.quantum.ibm.com/open-source/qiskit-sdk-version-strategy).
 
 ## Reporting a Vulnerability
 

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -774,7 +774,7 @@ In addition, new payload MAP_ITEM is defined to implement the :ref:`qpy_mapping`
 
 With the support of :class:`.~ScheduleBlock`, now :class:`~.QuantumCircuit` can be
 serialized together with :attr:`~.QuantumCircuit.calibrations`, or
-`Pulse Gates <https://docs.quantum.ibm.com/build/pulse>`_.
+`Pulse Gates <https://docs.quantum.ibm.com/guides/pulse>`_.
 In QPY version 5 and above, :ref:`qpy_circuit_calibrations` payload is
 packed after the :ref:`qpy_instructions` block.
 

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -937,7 +937,7 @@ class SparsePauliOp(LinearOp):
                 array (the default).
             force_serial: if ``True``, use an unthreaded implementation, regardless of the state of
                 the `Qiskit threading-control environment variables
-                <https://docs.quantum.ibm.com/start/configure-qiskit-local#environment-variables>`__.
+                <https://docs.quantum.ibm.com/guides/configure-qiskit-local#environment-variables>`__.
                 By default, this will use threaded parallelism over the available CPUs.
 
         Returns:

--- a/qiskit/transpiler/passes/scheduling/alignments/pulse_gate_validation.py
+++ b/qiskit/transpiler/passes/scheduling/alignments/pulse_gate_validation.py
@@ -31,7 +31,7 @@ class ValidatePulseGates(AnalysisPass):
 
     In Qiskit SDK, we can define the pulse-level implementation of custom quantum gate
     instructions, as a `pulse gate
-    <https://docs.quantum.ibm.com/build/pulse>`__,
+    <https://docs.quantum.ibm.com/guides/pulse>`__,
     thus user gates should satisfy all waveform memory constraints imposed by the backend.
 
     This pass validates all attached calibration entries and raises ``TranspilerError`` to

--- a/releasenotes/notes/1.0/platform-support-f7f693aaf5dec044.yaml
+++ b/releasenotes/notes/1.0/platform-support-f7f693aaf5dec044.yaml
@@ -13,7 +13,7 @@ upgrade:
   - |
     Support for 32 bit platforms, i686 Linux and 32 bit Windows, on
     Python < 3.10 has been downgraded from Tier 2 to Tier 3, as documented in
-    the `platform support page <https://docs.quantum.ibm.com/start/install#operating-system-support>`_. This is a consequence of making
+    the `platform support page <https://docs.quantum.ibm.com/guides/install-qiskit#operating-system-support>`_. This is a consequence of making
     ``symengine`` required for all users, as there is a lack of pre-compiled packages
     available for these platforms, so users will need to build Symengine from
     source.

--- a/releasenotes/notes/1.0/psutil-dependancy-removed-bf5366f516d92378.yaml
+++ b/releasenotes/notes/1.0/psutil-dependancy-removed-bf5366f516d92378.yaml
@@ -11,5 +11,5 @@ upgrade:
     number of processes used you can use the new ``num_processes`` argument to those functions, or
     the ``QISKIT_NUM_PROCS`` environment variable or ``num_processes`` field in a user configuration
     file (see the `local configuration guide
-    <https://docs.quantum.ibm.com/start/configure-qiskit-local>`__
+    <https://docs.quantum.ibm.com/guides/configure-qiskit-local>`__
     for more details) if you need to adjust the number of processes that Qiskit potentially uses.


### PR DESCRIPTION
Part of https://github.com/Qiskit/documentation/issues/1461. Even though these pages have redirects, it's better to go straight to the page we want.