### PR TITLE
Remove init peephole optimization discrete basis check

### DIFF
--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -28,6 +28,7 @@ from qiskit.transpiler.passmanager import PassManager
 from qiskit.transpiler.passes.synthesis import unitary_synthesis
 from qiskit.circuit.controlflow import CONTROL_FLOW_OP_NAMES
 from qiskit._accelerate.convert_2q_block_matrix import blocks_to_matrix
+from qiskit.exceptions import QiskitError
 
 from .collect_1q_runs import Collect1qRuns
 from .collect_2q_blocks import Collect2qBlocks
@@ -125,7 +126,12 @@ class ConsolidateBlocks(TransformationPass):
                         qc.append(nd.op, [q[block_index_map[i]] for i in nd.qargs])
                     unitary = UnitaryGate(Operator(qc), check_input=False)
                 else:
-                    matrix = blocks_to_matrix(block, block_index_map)
+                    try:
+                        matrix = blocks_to_matrix(block, block_index_map)
+                    except QiskitError:
+                        # If building a matrix for the block fails we should not consolidate it
+                        # because there is nothing we can do with it.
+                        continue
                     unitary = UnitaryGate(matrix, check_input=False)
 
                 max_2q_depth = 20  # If depth > 20, there will be 1q gates to consolidate.

--- a/releasenotes/notes/fix-consolidate-blocks-custom-gate-no-target-e2d1e0b0ee7ace11.yaml
+++ b/releasenotes/notes/fix-consolidate-blocks-custom-gate-no-target-e2d1e0b0ee7ace11.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed a bug in the :class:`.ConsolidateBlocks` transpiler pass, when the
+    input circuit contains a custom opaque gate and neither the
+    ``basis_gates`` or ``target`` options are set the pass would raise a
+    ``QiskitError`` and fail. This has been corrected so that the in these
+    situations the transpiler pass will not consolidate the block identified
+    containing a custom gate instead of failing.

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -84,7 +84,6 @@ from qiskit.utils import parallel
 from qiskit.transpiler import CouplingMap, Layout, PassManager, TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError, CircuitTooWideForTarget
 from qiskit.transpiler.passes import BarrierBeforeFinalMeasurements, GateDirection, VF2PostLayout
-from qiskit.transpiler.passes.optimization.split_2q_unitaries import Split2QUnitaries
 
 from qiskit.transpiler.passmanager_config import PassManagerConfig
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager, level_0_pass_manager
@@ -873,42 +872,6 @@ class TestTranspile(QiskitTestCase):
         with patch.object(GateDirection, "run", wraps=orig_pass.run) as mock_pass:
             transpile(circ, coupling_map=coupling_map, initial_layout=layout)
             self.assertFalse(mock_pass.called)
-
-    def tests_conditional_run_split_2q_unitaries(self):
-        """Tests running `Split2QUnitaries` when basis gate set is (non-) discrete"""
-        qc = QuantumCircuit(3)
-        qc.sx(0)
-        qc.t(0)
-        qc.cx(0, 1)
-        qc.cx(1, 2)
-
-        orig_pass = Split2QUnitaries()
-        with patch.object(Split2QUnitaries, "run", wraps=orig_pass.run) as mock_pass:
-            basis = ["t", "sx", "cx"]
-            backend = GenericBackendV2(3, basis_gates=basis)
-            transpile(qc, backend=backend)
-            transpile(qc, basis_gates=basis)
-            transpile(qc, target=backend.target)
-            self.assertFalse(mock_pass.called)
-
-        orig_pass = Split2QUnitaries()
-        with patch.object(Split2QUnitaries, "run", wraps=orig_pass.run) as mock_pass:
-            basis = ["rz", "sx", "cx"]
-            backend = GenericBackendV2(3, basis_gates=basis)
-            transpile(qc, backend=backend, optimization_level=2)
-            self.assertTrue(mock_pass.called)
-            mock_pass.called = False
-            transpile(qc, basis_gates=basis, optimization_level=2)
-            self.assertTrue(mock_pass.called)
-            mock_pass.called = False
-            transpile(qc, target=backend.target, optimization_level=2)
-            self.assertTrue(mock_pass.called)
-            mock_pass.called = False
-            transpile(qc, backend=backend, optimization_level=3)
-            self.assertTrue(mock_pass.called)
-            mock_pass.called = False
-            transpile(qc, basis_gates=basis, optimization_level=3)
-            self.assertTrue(mock_pass.called)
 
     def test_optimize_to_nothing(self):
         """Optimize gates up to fixed point in the default pipeline

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -17,7 +17,7 @@ Tests for the ConsolidateBlocks transpiler pass.
 import unittest
 import numpy as np
 
-from qiskit.circuit import QuantumCircuit, QuantumRegister, IfElseOp
+from qiskit.circuit import QuantumCircuit, QuantumRegister, IfElseOp, Gate
 from qiskit.circuit.library import U2Gate, SwapGate, CXGate, CZGate, UnitaryGate
 from qiskit.converters import circuit_to_dag
 from qiskit.transpiler.passes import ConsolidateBlocks
@@ -552,6 +552,23 @@ class TestConsolidateBlocks(QiskitTestCase):
                 )
             )
         self.assertEqual(expected, actual)
+
+    def test_custom_no_target(self):
+        """Test pass doesn't fail with custom gate."""
+
+        class MyCustomGate(Gate):
+            """Custom gate."""
+
+            def __init__(self):
+                super().__init__(name="my_custom", num_qubits=2, params=[])
+
+        qc = QuantumCircuit(2)
+        qc.append(MyCustomGate(), [0, 1])
+
+        pm = PassManager([Collect2qBlocks(), ConsolidateBlocks()])
+        res = pm.run(qc)
+
+        self.assertEqual(res, qc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #12727 a check was added to the default init stage's construction to avoid running 2q gate consolidation in the presence of targets with only discrete gates. However the way the target was being used in this check was incorrect. The name for an instruction in the target should be used as its identifier and then if we need the object representation that should query the target for that object based on the name. However the check was doing this backwards getting a list of operation objects and then using the name contained in the object. This will cause issues for instructions that use custom names such as when there are tuned variants or a custom gate instance with a unique name.

While there is some question over whether we need this check as we will run the consolidate 2q blocks pass as part of the optimization stage which will have the same effect, this opts to just fix the target usage for it to minimize the diff. Also while not the explicit goal of this check it is protecting against some bugs in the consolidate blocks pass that occur when custom gates are used. So for the short term this check is retained, but in the future when these bugs in consolidate blocks are fixed we can revisit whether we want to remove the conditional logic.

### Details and comments