### PR TITLE
Fix short circuit detection for basis translator

### DIFF
--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -162,7 +162,8 @@ class BasisTranslator(TransformationPass):
         # If the source basis is a subset of the target basis and we have no circuit
         # instructions on qargs that have non-global operations there is nothing to
         # translate and we can exit early.
-        if source_basis.issubset(target_basis) and not qargs_local_source_basis:
+        source_basis_names = {x[0] for x in source_basis}
+        if source_basis_names.issubset(target_basis) and not qargs_local_source_basis:
             return dag
 
         logger.info(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The BasisTranslator transpiler pass has a check at the very start that is designed to return fast if there is nothing to translate; in other words if the instructions in the circuit are already a subset of instructions supported by the target. This avoid doing a lot of unecessary work to determine this later during the operation of the pass. However, this check was not correctly constructed because of a type mismatch and would only ever get triggered if the input circuit was empty. The source basis is collected as a `Set[Tuple[str, int]]` where each tuple is the name and num of qubits for each operation in the circuit. While the target basis is just a `Set[str]` for the names supported on the target. This mismatch caused the subset check to never return True unless it was empty thereby bypassing the intent of the short circuit path. This commit fixes the logic by constructing a temporary set of just the source names to evaluate whether we should return early or not.

### Details and comments