### PR TITLE
Added `GenericBackendV2` properties

### DIFF
--- a/qiskit/providers/fake_provider/generic_backend_v2.py
+++ b/qiskit/providers/fake_provider/generic_backend_v2.py
@@ -604,28 +604,73 @@ class GenericBackendV2(BackendV2):
         return []
 
     def properties(self):
-        prop = {"backend_name": "GenericBackendV2",
-                "backend_version": "1.0.0",
-                "last_update_date": "2000-01-01T00:00:00Z",
-                "qubits": [
-                    [
-                        {"date": "2000-01-01 00:00:00Z", "name": "T1", "unit": "us", "value": qb.t1*1e6},
-                        {"date": "2000-01-01 00:00:00Z", "name": "T2", "unit": "us", "value": qb.t2*1e6},
-                        {"date": "2000-01-01 00:00:00Z", "name": "frequency", "unit": "GHz", "value": qb.frequency/1e9},
-                        {"date": "2000-01-01 00:00:00Z", "name": "readout_error", "unit": "", "value": meas.error},
-                        {"date": "2000-01-01 00:00:00Z", "name": "readout_length", "unit": "ns", "value": meas.duration*1e9}
-                    ] for qb, meas in zip(self.target.qubit_properties, self.target['measure'].values())
-                ],
-                "gates": [
+        """Return GenericBackendV2 properties"""
+        prop = {
+            "backend_name": "GenericBackendV2",
+            "backend_version": "1.0.0",
+            "last_update_date": "2000-01-01T00:00:00Z",
+            "qubits": [
+                [
                     {
-                        "qubits": list(qb),
-                        "gate": op,
-                        "parameters": [
-                            {"date": "2000-01-01 00:00:00Z", "name": "gate_error", "unit": "", "value": inst_props.error},
-                            {"date": "2000-01-01 00:00:00Z", "name": "gate_length", "unit": "ns", "value": inst_props.duration*1e9 if inst_props.duration is not None else None}
-                        ]
-                    } for op, properties_dict in self.target.items() for qb, inst_props in properties_dict.items() if op not in ['delay', 'reset']
-                ],
-                "general": [],
+                        "date": "2000-01-01 00:00:00Z",
+                        "name": "T1",
+                        "unit": "us",
+                        "value": qb.t1 * 1e6,
+                    },
+                    {
+                        "date": "2000-01-01 00:00:00Z",
+                        "name": "T2",
+                        "unit": "us",
+                        "value": qb.t2 * 1e6,
+                    },
+                    {
+                        "date": "2000-01-01 00:00:00Z",
+                        "name": "frequency",
+                        "unit": "GHz",
+                        "value": qb.frequency / 1e9,
+                    },
+                    {
+                        "date": "2000-01-01 00:00:00Z",
+                        "name": "readout_error",
+                        "unit": "",
+                        "value": meas.error,
+                    },
+                    {
+                        "date": "2000-01-01 00:00:00Z",
+                        "name": "readout_length",
+                        "unit": "ns",
+                        "value": meas.duration * 1e9,
+                    },
+                ]
+                for qb, meas in zip(self.target.qubit_properties, self.target["measure"].values())
+            ],
+            "gates": [
+                {
+                    "qubits": list(qb),
+                    "gate": op,
+                    "parameters": [
+                        {
+                            "date": "2000-01-01 00:00:00Z",
+                            "name": "gate_error",
+                            "unit": "",
+                            "value": inst_props.error,
+                        },
+                        {
+                            "date": "2000-01-01 00:00:00Z",
+                            "name": "gate_length",
+                            "unit": "ns",
+                            "value": (
+                                inst_props.duration * 1e9
+                                if inst_props.duration is not None
+                                else None
+                            ),
+                        },
+                    ],
                 }
+                for op, properties_dict in self.target.items()
+                for qb, inst_props in properties_dict.items()
+                if op not in ["delay", "reset"]
+            ],
+            "general": [],
+        }
         return BackendProperties.from_dict(prop)

--- a/qiskit/providers/fake_provider/generic_backend_v2.py
+++ b/qiskit/providers/fake_provider/generic_backend_v2.py
@@ -616,6 +616,16 @@ class GenericBackendV2(BackendV2):
                         {"date": "2000-01-01 00:00:00Z", "name": "readout_length", "unit": "ns", "value": meas.duration*1e9}
                     ] for qb, meas in zip(self.target.qubit_properties, self.target['measure'].values())
                 ],
-
+                "gates": [
+                    {
+                        "qubits": list(qb),
+                        "gate": op,
+                        "parameters": [
+                            {"date": "2000-01-01 00:00:00Z", "name": "gate_error", "unit": "", "value": inst_props.error},
+                            {"date": "2000-01-01 00:00:00Z", "name": "gate_length", "unit": "ns", "value": inst_props.duration*1e9 if inst_props.duration is not None else None}
+                        ]
+                    } for op, properties_dict in self.target.items() for qb, inst_props in properties_dict.items() if op not in ['delay', 'reset']
+                ],
+                "general": [],
                 }
         return BackendProperties.from_dict(prop)

--- a/qiskit/providers/fake_provider/generic_backend_v2.py
+++ b/qiskit/providers/fake_provider/generic_backend_v2.py
@@ -41,6 +41,7 @@ from qiskit.providers.models import (
 )
 from qiskit.qobj import PulseQobjInstruction, PulseLibraryItem
 from qiskit.utils import optionals as _optionals
+from qiskit.providers.models import BackendProperties
 
 # Noise default values/ranges for duration and error of supported
 # instructions. There are two possible formats:
@@ -601,3 +602,20 @@ class GenericBackendV2(BackendV2):
         if qubits in control_channels_map:
             return control_channels_map[qubits]
         return []
+
+    def properties(self):
+        prop = {"backend_name": "GenericBackendV2",
+                "backend_version": "1.0.0",
+                "last_update_date": "2000-01-01T00:00:00Z",
+                "qubits": [
+                    [
+                        {"date": "2000-01-01 00:00:00Z", "name": "T1", "unit": "us", "value": qb.t1*1e6},
+                        {"date": "2000-01-01 00:00:00Z", "name": "T2", "unit": "us", "value": qb.t2*1e6},
+                        {"date": "2000-01-01 00:00:00Z", "name": "frequency", "unit": "GHz", "value": qb.frequency/1e9},
+                        {"date": "2000-01-01 00:00:00Z", "name": "readout_error", "unit": "", "value": meas.error},
+                        {"date": "2000-01-01 00:00:00Z", "name": "readout_length", "unit": "ns", "value": meas.duration*1e9}
+                    ] for qb, meas in zip(self.target.qubit_properties, self.target['measure'].values())
+                ],
+
+                }
+        return BackendProperties.from_dict(prop)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes #12760 

I have added `properties` method to `GenericBackendV2` so that `InstructionDurations.from_backend` supports `BackendV2` instances. The below code now works as expected without throwing errors.
```
from qiskit.providers.fake_provider import GenericBackendV2
from qiskit.transpiler import InstructionDurations

backend = GenericBackendV2(num_qubits=2, calibrate_instructions=True, seed=42)
InstructionDurations.from_backend(backend)
```

@1ucian0 please review this let me know if I should make any further changes.


### Details and comments


