### PR TITLE
Move mcx synthesis methods with ancillas to the synthesis library

### DIFF
--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -1372,9 +1372,9 @@ class MCXRecursive(MCXGate):
     def _define(self):
         """Define the MCX gate using recursion."""
 
-        from qiskit.synthesis.multi_controlled import synth_mcx_one_clean_ancilla_bbcdmssw
+        from qiskit.synthesis.multi_controlled import synth_mcx_1_clean_b95
 
-        qc = synth_mcx_one_clean_ancilla_bbcdmssw(self.num_ctrl_qubits)
+        qc = synth_mcx_1_clean_b95(self.num_ctrl_qubits)
         self.definition = qc
 
 
@@ -1479,17 +1479,17 @@ class MCXVChain(MCXGate):
         """Define the MCX gate using a V-chain of CX gates."""
 
         if self._dirty_ancillas:
-            from qiskit.synthesis.multi_controlled import synth_mcx_n_dirty_ancillas_ickhc
+            from qiskit.synthesis.multi_controlled import synth_mcx_n_dirty_i15
 
-            qc = synth_mcx_n_dirty_ancillas_ickhc(
+            qc = synth_mcx_n_dirty_i15(
                 self.num_ctrl_qubits,
                 self._relative_phase,
                 self._action_only,
             )
 
         else:  # use clean ancillas
-            from qiskit.synthesis.multi_controlled import synth_mcx_n_clean_ancillas
+            from qiskit.synthesis.multi_controlled import synth_mcx_n_clean_m15
 
-            qc = synth_mcx_n_clean_ancillas(self.num_ctrl_qubits)
+            qc = synth_mcx_n_clean_m15(self.num_ctrl_qubits)
 
         self.definition = qc

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -1513,31 +1513,18 @@ class MCXVChain(MCXGate):
 
     def _define(self):
         """Define the MCX gate using a V-chain of CX gates."""
-        # pylint: disable=cyclic-import
-        from qiskit.circuit.quantumcircuit import QuantumCircuit
-
-        q = QuantumRegister(self.num_qubits, name="q")
-        qc = QuantumCircuit(q, name=self.name)
-        q_controls = q[: self.num_ctrl_qubits]
-        q_target = q[self.num_ctrl_qubits]
-        q_ancillas = q[self.num_ctrl_qubits + 1 :]
 
         if self._dirty_ancillas:
-            if self.num_ctrl_qubits < 3:
-                qc.mcx(q_controls, q_target)
-            elif not self._relative_phase and self.num_ctrl_qubits == 3:
-                qc._append(C3XGate(), [*q_controls, q_target], [])
-            else:
-                from qiskit.synthesis.multi_controlled import synth_mcx_n_dirty_ancillas_ickhc
+            from qiskit.synthesis.multi_controlled import synth_mcx_n_dirty_ancillas_ickhc
 
-                qc = synth_mcx_n_dirty_ancillas_ickhc(
-                    self.num_qubits,
-                    self.num_ctrl_qubits,
-                    self._relative_phase,
-                    self._action_only,
-                )
+            qc = synth_mcx_n_dirty_ancillas_ickhc(
+                self.num_qubits,
+                self.num_ctrl_qubits,
+                self._relative_phase,
+                self._action_only,
+            )
 
-        else:
+        else:  # use clean ancillas
             from qiskit.synthesis.multi_controlled import synth_mcx_n_clean_ancillas
 
             qc = synth_mcx_n_clean_ancillas(self.num_qubits, self.num_ctrl_qubits)

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -1372,6 +1372,7 @@ class MCXRecursive(MCXGate):
     def _define(self):
         """Define the MCX gate using recursion."""
 
+        # pylint: disable=cyclic-import
         from qiskit.synthesis.multi_controlled import synth_mcx_1_clean_b95
 
         qc = synth_mcx_1_clean_b95(self.num_ctrl_qubits)
@@ -1479,6 +1480,7 @@ class MCXVChain(MCXGate):
         """Define the MCX gate using a V-chain of CX gates."""
 
         if self._dirty_ancillas:
+            # pylint: disable=cyclic-import
             from qiskit.synthesis.multi_controlled import synth_mcx_n_dirty_i15
 
             qc = synth_mcx_n_dirty_i15(
@@ -1488,6 +1490,7 @@ class MCXVChain(MCXGate):
             )
 
         else:  # use clean ancillas
+            # pylint: disable=cyclic-import
             from qiskit.synthesis.multi_controlled import synth_mcx_n_clean_m15
 
             qc = synth_mcx_n_clean_m15(self.num_ctrl_qubits)

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -1528,13 +1528,11 @@ class MCXVChain(MCXGate):
             elif not self._relative_phase and self.num_ctrl_qubits == 3:
                 qc._append(C3XGate(), [*q_controls, q_target], [])
             else:
-                from qiskit.synthesis.multi_controlled import synth_mcx_n_dirty_ancillas_ICKHC
+                from qiskit.synthesis.multi_controlled import synth_mcx_n_dirty_ancillas_ickhc
 
-                qc = synth_mcx_n_dirty_ancillas_ICKHC(
+                qc = synth_mcx_n_dirty_ancillas_ickhc(
                     self.num_qubits,
                     self.num_ctrl_qubits,
-                    self.label,
-                    self.ctrl_state,
                     self._relative_phase,
                     self._action_only,
                 )

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -13,7 +13,7 @@
 """X, CX, CCX and multi-controlled X gates."""
 from __future__ import annotations
 from typing import Optional, Union, Type
-from math import ceil, pi
+from math import pi
 import numpy
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate, stdlib_singleton_key
@@ -1374,7 +1374,7 @@ class MCXRecursive(MCXGate):
 
         from qiskit.synthesis.multi_controlled import synth_mcx_one_clean_ancilla_bbcdmssw
 
-        qc = synth_mcx_one_clean_ancilla_bbcdmssw(self.num_qubits, self.num_ctrl_qubits)
+        qc = synth_mcx_one_clean_ancilla_bbcdmssw(self.num_ctrl_qubits)
         self.definition = qc
 
 
@@ -1490,6 +1490,6 @@ class MCXVChain(MCXGate):
         else:  # use clean ancillas
             from qiskit.synthesis.multi_controlled import synth_mcx_n_clean_ancillas
 
-            qc = synth_mcx_n_clean_ancillas(self.num_qubits, self.num_ctrl_qubits)
+            qc = synth_mcx_n_clean_ancillas(self.num_ctrl_qubits)
 
         self.definition = qc

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -1538,20 +1538,8 @@ class MCXVChain(MCXGate):
                 )
 
         else:
-            qc.rccx(q_controls[0], q_controls[1], q_ancillas[0])
-            i = 0
-            for j in range(2, self.num_ctrl_qubits - 1):
-                qc.rccx(q_controls[j], q_ancillas[i], q_ancillas[i + 1])
+            from qiskit.synthesis.multi_controlled import synth_mcx_n_clean_ancillas
 
-                i += 1
-
-            qc.ccx(q_controls[-1], q_ancillas[i], q_target)
-
-            for j in reversed(range(2, self.num_ctrl_qubits - 1)):
-                qc.rccx(q_controls[j], q_ancillas[i - 1], q_ancillas[i])
-
-                i -= 1
-
-            qc.rccx(q_controls[0], q_controls[1], q_ancillas[i])
+            qc = synth_mcx_n_clean_ancillas(self.num_qubits, self.num_ctrl_qubits)
 
         self.definition = qc

--- a/qiskit/synthesis/__init__.py
+++ b/qiskit/synthesis/__init__.py
@@ -173,4 +173,7 @@ from .two_qubit.two_qubit_decompose import (
     two_qubit_cnot_decompose,
     TwoQubitWeylDecomposition,
 )
-from .multi_controlled.mcx_with_ancillas_synth import synth_mcx_n_dirty_ancillas_ickhc
+from .multi_controlled.mcx_with_ancillas_synth import (
+    synth_mcx_n_dirty_ancillas_ickhc,
+    synth_mcx_n_clean_ancillas,
+)

--- a/qiskit/synthesis/__init__.py
+++ b/qiskit/synthesis/__init__.py
@@ -174,7 +174,7 @@ from .two_qubit.two_qubit_decompose import (
     TwoQubitWeylDecomposition,
 )
 from .multi_controlled.mcx_with_ancillas_synth import (
-    synth_mcx_n_dirty_ancillas_ickhc,
-    synth_mcx_n_clean_ancillas,
-    synth_mcx_one_clean_ancilla_bbcdmssw,
+    synth_mcx_n_dirty_i15,
+    synth_mcx_n_clean_m15,
+    synth_mcx_1_clean_b95,
 )

--- a/qiskit/synthesis/__init__.py
+++ b/qiskit/synthesis/__init__.py
@@ -176,4 +176,5 @@ from .two_qubit.two_qubit_decompose import (
 from .multi_controlled.mcx_with_ancillas_synth import (
     synth_mcx_n_dirty_ancillas_ickhc,
     synth_mcx_n_clean_ancillas,
+    synth_mcx_one_clean_ancilla_bbcdmssw,
 )

--- a/qiskit/synthesis/__init__.py
+++ b/qiskit/synthesis/__init__.py
@@ -122,6 +122,13 @@ Two-Qubit Synthesis
 
 .. autofunction:: two_qubit_cnot_decompose
 
+Multi Controlled Synthesis
+==========================
+
+.. autofunction:: synth_mcx_n_dirty_i15,
+.. autofunction:: synth_mcx_n_clean_m15,
+.. autofunction:: synth_mcx_1_clean_b95,
+
 """
 
 from .evolution import (

--- a/qiskit/synthesis/__init__.py
+++ b/qiskit/synthesis/__init__.py
@@ -125,9 +125,9 @@ Two-Qubit Synthesis
 Multi Controlled Synthesis
 ==========================
 
-.. autofunction:: synth_mcx_n_dirty_i15,
-.. autofunction:: synth_mcx_n_clean_m15,
-.. autofunction:: synth_mcx_1_clean_b95,
+.. autofunction:: synth_mcx_n_dirty_i15
+.. autofunction:: synth_mcx_n_clean_m15
+.. autofunction:: synth_mcx_1_clean_b95
 
 """
 

--- a/qiskit/synthesis/__init__.py
+++ b/qiskit/synthesis/__init__.py
@@ -173,3 +173,4 @@ from .two_qubit.two_qubit_decompose import (
     two_qubit_cnot_decompose,
     TwoQubitWeylDecomposition,
 )
+from .multi_controlled.mcx_with_ancillas_synth import synth_mcx_n_dirty_ancillas_ICKHC

--- a/qiskit/synthesis/__init__.py
+++ b/qiskit/synthesis/__init__.py
@@ -173,4 +173,4 @@ from .two_qubit.two_qubit_decompose import (
     two_qubit_cnot_decompose,
     TwoQubitWeylDecomposition,
 )
-from .multi_controlled.mcx_with_ancillas_synth import synth_mcx_n_dirty_ancillas_ICKHC
+from .multi_controlled.mcx_with_ancillas_synth import synth_mcx_n_dirty_ancillas_ickhc

--- a/qiskit/synthesis/multi_controlled/__init__.py
+++ b/qiskit/synthesis/multi_controlled/__init__.py
@@ -1,0 +1,14 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Module containing multi-controlled circuits"""
+from .mcx_with_ancillas_synth import synth_mcx_n_dirty_ancillas_ICKHC

--- a/qiskit/synthesis/multi_controlled/__init__.py
+++ b/qiskit/synthesis/multi_controlled/__init__.py
@@ -12,4 +12,4 @@
 
 """Module containing multi-controlled circuits synthesis"""
 
-from .mcx_with_ancillas_synth import synth_mcx_n_dirty_ancillas_ickhc
+from .mcx_with_ancillas_synth import synth_mcx_n_dirty_ancillas_ickhc, synth_mcx_n_clean_ancillas

--- a/qiskit/synthesis/multi_controlled/__init__.py
+++ b/qiskit/synthesis/multi_controlled/__init__.py
@@ -12,4 +12,8 @@
 
 """Module containing multi-controlled circuits synthesis"""
 
-from .mcx_with_ancillas_synth import synth_mcx_n_dirty_ancillas_ickhc, synth_mcx_n_clean_ancillas
+from .mcx_with_ancillas_synth import (
+    synth_mcx_n_dirty_ancillas_ickhc,
+    synth_mcx_n_clean_ancillas,
+    synth_mcx_one_clean_ancilla_bbcdmssw,
+)

--- a/qiskit/synthesis/multi_controlled/__init__.py
+++ b/qiskit/synthesis/multi_controlled/__init__.py
@@ -13,7 +13,7 @@
 """Module containing multi-controlled circuits synthesis"""
 
 from .mcx_with_ancillas_synth import (
-    synth_mcx_n_dirty_ancillas_ickhc,
-    synth_mcx_n_clean_ancillas,
-    synth_mcx_one_clean_ancilla_bbcdmssw,
+    synth_mcx_n_dirty_i15,
+    synth_mcx_n_clean_m15,
+    synth_mcx_1_clean_b95,
 )

--- a/qiskit/synthesis/multi_controlled/__init__.py
+++ b/qiskit/synthesis/multi_controlled/__init__.py
@@ -10,5 +10,6 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Module containing multi-controlled circuits"""
-from .mcx_with_ancillas_synth import synth_mcx_n_dirty_ancillas_ICKHC
+"""Module containing multi-controlled circuits synthesis"""
+
+from .mcx_with_ancillas_synth import synth_mcx_n_dirty_ancillas_ickhc

--- a/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
+++ b/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
@@ -107,7 +107,7 @@ def synth_mcx_n_dirty_ancillas_ickhc(
     return qc
 
 
-def synth_mcx_n_clean_ancillas(num_qubits: int, num_ctrl_qubits: int = None):
+def synth_mcx_n_clean_ancillas(num_ctrl_qubits: int):
     """Synthesis of an MCX gate with n controls and n-2 clean ancillary qubits,
     producing a circuit with at most 6*n-6 CX gates"""
 
@@ -115,6 +115,7 @@ def synth_mcx_n_clean_ancillas(num_qubits: int, num_ctrl_qubits: int = None):
     from qiskit.circuit.quantumregister import QuantumRegister
     from qiskit.circuit.quantumcircuit import QuantumCircuit
 
+    num_qubits = 2 * num_ctrl_qubits - 1
     q = QuantumRegister(num_qubits, name="q")
     qc = QuantumCircuit(q, name="mcx_vchain")
     q_controls = q[:num_ctrl_qubits]
@@ -140,7 +141,7 @@ def synth_mcx_n_clean_ancillas(num_qubits: int, num_ctrl_qubits: int = None):
     return qc
 
 
-def synth_mcx_one_clean_ancilla_bbcdmssw(num_qubits, num_ctrl: int):
+def synth_mcx_one_clean_ancilla_bbcdmssw(num_ctrl_qubits: int):
     """Implement an MCX gate with n controls using one clean ancilla qubit,
     producing a circuit with at most 16*n-8 CX gates."""
 
@@ -149,16 +150,21 @@ def synth_mcx_one_clean_ancilla_bbcdmssw(num_qubits, num_ctrl: int):
     from qiskit.circuit.quantumcircuit import QuantumCircuit
     from qiskit.circuit.library.standard_gates.x import C3XGate, C4XGate
 
-    q = QuantumRegister(num_qubits, name="q")
-    qc = QuantumCircuit(q, name="mcx_recursive")
-
-    if num_ctrl == 3:
+    if num_ctrl_qubits == 3:
+        q = QuantumRegister(4, name="q")
+        qc = QuantumCircuit(q, name="mcx_recursive")
         qc._append(C3XGate(), q[:], [])
         return qc
 
-    elif num_ctrl == 4:
+    elif num_ctrl_qubits == 4:
+        q = QuantumRegister(5, name="q")
+        qc = QuantumCircuit(q, name="mcx_recursive")
         qc._append(C4XGate(), q[:], [])
         return qc
+
+    num_qubits = num_ctrl_qubits + 2
+    q = QuantumRegister(num_qubits, name="q")
+    qc = QuantumCircuit(q, name="mcx_recursive")
 
     num_ctrl_qubits = len(q) - 1
     q_ancilla = q[-1]

--- a/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
+++ b/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
@@ -10,15 +10,15 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+"""Module containing multi-controlled circuits synthesis with ancillary qubits."""
+
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 
 
-def synth_mcx_n_dirty_ancillas_ICKHC(
-    num_qubits,
-    num_ctrl_qubits=None,
-    label=None,
-    ctrl_state=None,
+def synth_mcx_n_dirty_ancillas_ickhc(
+    num_qubits: int,
+    num_ctrl_qubits: int = None,
     relative_phase: bool = False,
     action_only: bool = False,
 ):

--- a/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
+++ b/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
@@ -20,9 +20,27 @@ def synth_mcx_n_dirty_i15(
     relative_phase: bool = False,
     action_only: bool = False,
 ):
-    """Synthesis of an MCX gate with n controls and n-2 dirty ancillary qubits,
-    producing a circuit with at most 8*n-6 CX gates.
-    By Iten et. al. http://arxiv.org/abs/1501.06911"""
+    """
+    Synthesize a multi-controlled X gate with :math:`k` controls using :math:`k - 2`
+    dirty ancillary qubits producing a circuit with at most :math:`8 * k - 6` CX gates,
+    by Iten et. al. [1].
+
+    Args:
+        num_ctrl_qubits: The number of control qubits.
+
+        relative_phase: when set to ``True``, the method applies the optimized multi-controlled X gate
+            up to a relative phase, in a way that, by lemma 8 of [1], the relative
+            phases of the ``action part`` cancel out with the phases of the ``reset part``.
+
+        action_only: when set to ``True``, the method applies only the ``action part`` of lemma 8 of [1].
+
+    Returns:
+        The synthesized quantum circuit.
+
+    References:
+        1. Iten et. al., *Quantum Circuits for Isometries*, Phys. Rev. A 93, 032318 (2016),
+           `arXiv:1501.06911 <http://arxiv.org/abs/1501.06911>`_
+    """
 
     # pylint: disable=cyclic-import
     from qiskit.circuit.quantumregister import QuantumRegister
@@ -109,9 +127,21 @@ def synth_mcx_n_dirty_i15(
 
 
 def synth_mcx_n_clean_m15(num_ctrl_qubits: int):
-    """Synthesis of an MCX gate with n controls and n-2 clean ancillary qubits,
-    producing a circuit with at most 6*n-6 CX gates.
-    Based on Maslov, https://arxiv.org/pdf/1508.03273"""
+    """
+    Synthesize a multi-controlled X gate with :math:`k` controls using :math:`k - 2`
+    clean ancillary qubits producing a circuit with at most :math:`6 * k - 6` CX gates,
+    by Maslov [1].
+
+    Args:
+        num_ctrl_qubits: The number of control qubits.
+
+    Returns:
+        The synthesized quantum circuit.
+
+    References:
+        1. Maslov., Phys. Rev. A 93, 022311 (2016),
+           `arXiv:1508.03273 <https://arxiv.org/pdf/1508.03273>`_
+    """
 
     # pylint: disable=cyclic-import
     from qiskit.circuit.quantumregister import QuantumRegister
@@ -144,9 +174,21 @@ def synth_mcx_n_clean_m15(num_ctrl_qubits: int):
 
 
 def synth_mcx_1_clean_b95(num_ctrl_qubits: int):
-    """Implement an MCX gate with n controls using one clean ancilla qubit,
-    producing a circuit with at most 16*n-8 CX gates.
-    Based on Barenco et al., 1995. https://arxiv.org/pdf/quant-ph/9503016.pdf"""
+    """
+    Synthesize a multi-controlled X gate with :math:`k` controls using a single
+    clean ancillary qubit producing a circuit with at most :math:`16 * k - 8` CX gates,
+    by Barenco et al. [1].
+
+    Args:
+        num_ctrl_qubits: The number of control qubits.
+
+    Returns:
+        The synthesized quantum circuit.
+
+    References:
+        1. Barenco et. al., Phys.Rev. A52 3457 (1995),
+           `arXiv:quant-ph/9503016 <https://arxiv.org/abs/quant-ph/9503016>`_
+    """
 
     # pylint: disable=cyclic-import
     from qiskit.circuit.quantumregister import QuantumRegister

--- a/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
+++ b/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
@@ -1,0 +1,91 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+from qiskit.circuit.quantumregister import QuantumRegister
+from qiskit.circuit.quantumcircuit import QuantumCircuit
+
+
+def synth_mcx_n_dirty_ancillas_ICKHC(
+    num_qubits,
+    num_ctrl_qubits=None,
+    label=None,
+    ctrl_state=None,
+    relative_phase: bool = False,
+    action_only: bool = False,
+):
+    """Synthesis of an MCX gate with n controls and n-2 dirty ancillary qubits,
+    producing a circuit with at most 8*n-6 CX gates"""
+
+    q = QuantumRegister(num_qubits, name="q")
+    qc = QuantumCircuit(q, name="mcx_vchain")
+    q_controls = q[:num_ctrl_qubits]
+    q_target = q[num_ctrl_qubits]
+    q_ancillas = q[num_ctrl_qubits + 1 :]
+
+    num_ancillas = num_ctrl_qubits - 2
+    targets = [q_target] + q_ancillas[:num_ancillas][::-1]
+
+    for j in range(2):
+        for i in range(num_ctrl_qubits):  # action part
+            if i < num_ctrl_qubits - 2:
+                if targets[i] != q_target or relative_phase:
+                    # gate cancelling
+
+                    # cancel rightmost gates of action part
+                    # with leftmost gates of reset part
+                    if relative_phase and targets[i] == q_target and j == 1:
+                        qc.cx(q_ancillas[num_ancillas - i - 1], targets[i])
+                        qc.t(targets[i])
+                        qc.cx(q_controls[num_ctrl_qubits - i - 1], targets[i])
+                        qc.tdg(targets[i])
+                        qc.h(targets[i])
+                    else:
+                        qc.h(targets[i])
+                        qc.t(targets[i])
+                        qc.cx(q_controls[num_ctrl_qubits - i - 1], targets[i])
+                        qc.tdg(targets[i])
+                        qc.cx(q_ancillas[num_ancillas - i - 1], targets[i])
+                else:
+                    controls = [
+                        q_controls[num_ctrl_qubits - i - 1],
+                        q_ancillas[num_ancillas - i - 1],
+                    ]
+
+                    qc.ccx(controls[0], controls[1], targets[i])
+            else:
+                # implements an optimized toffoli operation
+                # up to a diagonal gate, akin to lemma 6 of arXiv:1501.06911
+                qc.h(targets[i])
+                qc.t(targets[i])
+                qc.cx(q_controls[num_ctrl_qubits - i - 2], targets[i])
+                qc.tdg(targets[i])
+                qc.cx(q_controls[num_ctrl_qubits - i - 1], targets[i])
+                qc.t(targets[i])
+                qc.cx(q_controls[num_ctrl_qubits - i - 2], targets[i])
+                qc.tdg(targets[i])
+                qc.h(targets[i])
+
+                break
+
+        for i in range(num_ancillas - 1):  # reset part
+            qc.cx(q_ancillas[i], q_ancillas[i + 1])
+            qc.t(q_ancillas[i + 1])
+            qc.cx(q_controls[2 + i], q_ancillas[i + 1])
+            qc.tdg(q_ancillas[i + 1])
+            qc.h(q_ancillas[i + 1])
+
+        if action_only:
+            qc.ccx(q_controls[-1], q_ancillas[-1], q_target)
+
+            break
+
+    return qc

--- a/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
+++ b/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
@@ -21,7 +21,8 @@ def synth_mcx_n_dirty_ancillas_ickhc(
     action_only: bool = False,
 ):
     """Synthesis of an MCX gate with n controls and n-2 dirty ancillary qubits,
-    producing a circuit with at most 8*n-6 CX gates"""
+    producing a circuit with at most 8*n-6 CX gates.
+    By Iten et. al. http://arxiv.org/abs/1501.06911"""
 
     # pylint: disable=cyclic-import
     from qiskit.circuit.quantumregister import QuantumRegister
@@ -29,7 +30,7 @@ def synth_mcx_n_dirty_ancillas_ickhc(
 
     num_qubits = 2 * num_ctrl_qubits - 1
     q = QuantumRegister(num_qubits, name="q")
-    qc = QuantumCircuit(q, name="mcx_vchain")
+    qc = QuantumCircuit(q, name="mcx_n_dirty_ancillas")
     q_controls = q[:num_ctrl_qubits]
     q_target = q[num_ctrl_qubits]
     q_ancillas = q[num_ctrl_qubits + 1 :]
@@ -109,7 +110,7 @@ def synth_mcx_n_dirty_ancillas_ickhc(
 
 def synth_mcx_n_clean_ancillas(num_ctrl_qubits: int):
     """Synthesis of an MCX gate with n controls and n-2 clean ancillary qubits,
-    producing a circuit with at most 6*n-6 CX gates"""
+    producing a circuit with at most 6*n-6 CX gates."""
 
     # pylint: disable=cyclic-import
     from qiskit.circuit.quantumregister import QuantumRegister
@@ -117,7 +118,7 @@ def synth_mcx_n_clean_ancillas(num_ctrl_qubits: int):
 
     num_qubits = 2 * num_ctrl_qubits - 1
     q = QuantumRegister(num_qubits, name="q")
-    qc = QuantumCircuit(q, name="mcx_vchain")
+    qc = QuantumCircuit(q, name="mcx_n_clean_ancillas")
     q_controls = q[:num_ctrl_qubits]
     q_target = q[num_ctrl_qubits]
     q_ancillas = q[num_ctrl_qubits + 1 :]
@@ -143,7 +144,8 @@ def synth_mcx_n_clean_ancillas(num_ctrl_qubits: int):
 
 def synth_mcx_one_clean_ancilla_bbcdmssw(num_ctrl_qubits: int):
     """Implement an MCX gate with n controls using one clean ancilla qubit,
-    producing a circuit with at most 16*n-8 CX gates."""
+    producing a circuit with at most 16*n-8 CX gates.
+    Based on Barenco et al., 1995. https://arxiv.org/pdf/quant-ph/9503016.pdf"""
 
     # pylint: disable=cyclic-import
     from qiskit.circuit.quantumregister import QuantumRegister
@@ -152,19 +154,19 @@ def synth_mcx_one_clean_ancilla_bbcdmssw(num_ctrl_qubits: int):
 
     if num_ctrl_qubits == 3:
         q = QuantumRegister(4, name="q")
-        qc = QuantumCircuit(q, name="mcx_recursive")
+        qc = QuantumCircuit(q, name="mcx")
         qc._append(C3XGate(), q[:], [])
         return qc
 
     elif num_ctrl_qubits == 4:
         q = QuantumRegister(5, name="q")
-        qc = QuantumCircuit(q, name="mcx_recursive")
+        qc = QuantumCircuit(q, name="mcx")
         qc._append(C4XGate(), q[:], [])
         return qc
 
     num_qubits = num_ctrl_qubits + 2
     q = QuantumRegister(num_qubits, name="q")
-    qc = QuantumCircuit(q, name="mcx_recursive")
+    qc = QuantumCircuit(q, name="mcx_one_clean_ancilla")
 
     num_ctrl_qubits = len(q) - 1
     q_ancilla = q[-1]

--- a/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
+++ b/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
@@ -30,7 +30,7 @@ def synth_mcx_n_dirty_ancillas_ickhc(
 
     num_qubits = 2 * num_ctrl_qubits - 1
     q = QuantumRegister(num_qubits, name="q")
-    qc = QuantumCircuit(q, name="mcx_n_dirty_ancillas")
+    qc = QuantumCircuit(q, name="mcx_vchain")
     q_controls = q[:num_ctrl_qubits]
     q_target = q[num_ctrl_qubits]
     q_ancillas = q[num_ctrl_qubits + 1 :]
@@ -118,7 +118,7 @@ def synth_mcx_n_clean_ancillas(num_ctrl_qubits: int):
 
     num_qubits = 2 * num_ctrl_qubits - 1
     q = QuantumRegister(num_qubits, name="q")
-    qc = QuantumCircuit(q, name="mcx_n_clean_ancillas")
+    qc = QuantumCircuit(q, name="mcx_vchain")
     q_controls = q[:num_ctrl_qubits]
     q_target = q[num_ctrl_qubits]
     q_ancillas = q[num_ctrl_qubits + 1 :]
@@ -166,7 +166,7 @@ def synth_mcx_one_clean_ancilla_bbcdmssw(num_ctrl_qubits: int):
 
     num_qubits = num_ctrl_qubits + 2
     q = QuantumRegister(num_qubits, name="q")
-    qc = QuantumCircuit(q, name="mcx_one_clean_ancilla")
+    qc = QuantumCircuit(q, name="mcx_recursive")
 
     num_ctrl_qubits = len(q) - 1
     q_ancilla = q[-1]

--- a/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
+++ b/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
@@ -31,6 +31,19 @@ def synth_mcx_n_dirty_ancillas_ickhc(
     q_target = q[num_ctrl_qubits]
     q_ancillas = q[num_ctrl_qubits + 1 :]
 
+    if num_ctrl_qubits == 1:
+        qc.cx(q_controls, q_target)
+        return qc
+    elif num_ctrl_qubits == 2:
+        qc.ccx(q_controls[0], q_controls[1], q_target)
+        return qc
+    elif not relative_phase and num_ctrl_qubits == 3:
+        # pylint: disable=cyclic-import
+        from qiskit.circuit.library.standard_gates.x import C3XGate
+
+        qc._append(C3XGate(), [*q_controls, q_target], [])
+        return qc
+
     num_ancillas = num_ctrl_qubits - 2
     targets = [q_target] + q_ancillas[:num_ancillas][::-1]
 

--- a/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
+++ b/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
@@ -22,8 +22,8 @@ def synth_mcx_n_dirty_i15(
 ):
     """
     Synthesize a multi-controlled X gate with :math:`k` controls using :math:`k - 2`
-    dirty ancillary qubits producing a circuit with at most :math:`8 * k - 6` CX gates,
-    by Iten et. al. [1].
+    dirty ancillary qubits producing a circuit with :math:`2 * k - 1` qubits and at most
+    :math:`8 * k - 6` CX gates, by Iten et. al. [1].
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -129,8 +129,8 @@ def synth_mcx_n_dirty_i15(
 def synth_mcx_n_clean_m15(num_ctrl_qubits: int):
     """
     Synthesize a multi-controlled X gate with :math:`k` controls using :math:`k - 2`
-    clean ancillary qubits producing a circuit with at most :math:`6 * k - 6` CX gates,
-    by Maslov [1].
+    clean ancillary qubits with producing a circuit with :math:`2 * k - 1` qubits
+    and at most :math:`6 * k - 6` CX gates, by Maslov [1].
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -176,8 +176,8 @@ def synth_mcx_n_clean_m15(num_ctrl_qubits: int):
 def synth_mcx_1_clean_b95(num_ctrl_qubits: int):
     """
     Synthesize a multi-controlled X gate with :math:`k` controls using a single
-    clean ancillary qubit producing a circuit with at most :math:`16 * k - 8` CX gates,
-    by Barenco et al. [1].
+    clean ancillary qubit producing a circuit with :math:`k + 2` qubits and at most
+    :math:`16 * k - 8` CX gates, by Barenco et al. [1].
 
     Args:
         num_ctrl_qubits: The number of control qubits.

--- a/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
+++ b/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017, 2019.
+# (C) Copyright IBM 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
+++ b/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
@@ -12,9 +12,6 @@
 
 """Module containing multi-controlled circuits synthesis with ancillary qubits."""
 
-from qiskit.circuit.quantumregister import QuantumRegister
-from qiskit.circuit.quantumcircuit import QuantumCircuit
-
 
 def synth_mcx_n_dirty_ancillas_ickhc(
     num_qubits: int,
@@ -24,6 +21,10 @@ def synth_mcx_n_dirty_ancillas_ickhc(
 ):
     """Synthesis of an MCX gate with n controls and n-2 dirty ancillary qubits,
     producing a circuit with at most 8*n-6 CX gates"""
+
+    # pylint: disable=cyclic-import
+    from qiskit.circuit.quantumregister import QuantumRegister
+    from qiskit.circuit.quantumcircuit import QuantumCircuit
 
     q = QuantumRegister(num_qubits, name="q")
     qc = QuantumCircuit(q, name="mcx_vchain")
@@ -107,6 +108,10 @@ def synth_mcx_n_dirty_ancillas_ickhc(
 def synth_mcx_n_clean_ancillas(num_qubits: int, num_ctrl_qubits: int = None):
     """Synthesis of an MCX gate with n controls and n-2 clean ancillary qubits,
     producing a circuit with at most 6*n-6 CX gates"""
+
+    # pylint: disable=cyclic-import
+    from qiskit.circuit.quantumregister import QuantumRegister
+    from qiskit.circuit.quantumcircuit import QuantumCircuit
 
     q = QuantumRegister(num_qubits, name="q")
     qc = QuantumCircuit(q, name="mcx_vchain")

--- a/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
+++ b/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
@@ -89,3 +89,32 @@ def synth_mcx_n_dirty_ancillas_ickhc(
             break
 
     return qc
+
+
+def synth_mcx_n_clean_ancillas(num_qubits: int, num_ctrl_qubits: int = None):
+    """Synthesis of an MCX gate with n controls and n-2 clean ancillary qubits,
+    producing a circuit with at most 6*n-6 CX gates"""
+
+    q = QuantumRegister(num_qubits, name="q")
+    qc = QuantumCircuit(q, name="mcx_vchain")
+    q_controls = q[:num_ctrl_qubits]
+    q_target = q[num_ctrl_qubits]
+    q_ancillas = q[num_ctrl_qubits + 1 :]
+
+    qc.rccx(q_controls[0], q_controls[1], q_ancillas[0])
+    i = 0
+    for j in range(2, num_ctrl_qubits - 1):
+        qc.rccx(q_controls[j], q_ancillas[i], q_ancillas[i + 1])
+
+        i += 1
+
+    qc.ccx(q_controls[-1], q_ancillas[i], q_target)
+
+    for j in reversed(range(2, num_ctrl_qubits - 1)):
+        qc.rccx(q_controls[j], q_ancillas[i - 1], q_ancillas[i])
+
+        i -= 1
+
+    qc.rccx(q_controls[0], q_controls[1], q_ancillas[i])
+
+    return qc

--- a/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
+++ b/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
@@ -15,7 +15,7 @@
 from math import ceil
 
 
-def synth_mcx_n_dirty_ancillas_ickhc(
+def synth_mcx_n_dirty_i15(
     num_ctrl_qubits: int,
     relative_phase: bool = False,
     action_only: bool = False,
@@ -108,9 +108,10 @@ def synth_mcx_n_dirty_ancillas_ickhc(
     return qc
 
 
-def synth_mcx_n_clean_ancillas(num_ctrl_qubits: int):
+def synth_mcx_n_clean_m15(num_ctrl_qubits: int):
     """Synthesis of an MCX gate with n controls and n-2 clean ancillary qubits,
-    producing a circuit with at most 6*n-6 CX gates."""
+    producing a circuit with at most 6*n-6 CX gates.
+    Based on Maslov, https://arxiv.org/pdf/1508.03273"""
 
     # pylint: disable=cyclic-import
     from qiskit.circuit.quantumregister import QuantumRegister
@@ -142,7 +143,7 @@ def synth_mcx_n_clean_ancillas(num_ctrl_qubits: int):
     return qc
 
 
-def synth_mcx_one_clean_ancilla_bbcdmssw(num_ctrl_qubits: int):
+def synth_mcx_1_clean_b95(num_ctrl_qubits: int):
     """Implement an MCX gate with n controls using one clean ancilla qubit,
     producing a circuit with at most 16*n-8 CX gates.
     Based on Barenco et al., 1995. https://arxiv.org/pdf/quant-ph/9503016.pdf"""
@@ -175,8 +176,8 @@ def synth_mcx_one_clean_ancilla_bbcdmssw(num_ctrl_qubits: int):
     first_half = [*q[:middle]]
     second_half = [*q[middle : num_ctrl_qubits - 1], q_ancilla]
 
-    qc_first_half = synth_mcx_n_dirty_ancillas_ickhc(num_ctrl_qubits=len(first_half))
-    qc_second_half = synth_mcx_n_dirty_ancillas_ickhc(num_ctrl_qubits=len(second_half))
+    qc_first_half = synth_mcx_n_dirty_i15(num_ctrl_qubits=len(first_half))
+    qc_second_half = synth_mcx_n_dirty_i15(num_ctrl_qubits=len(second_half))
 
     qc.append(
         qc_first_half,

--- a/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
+++ b/qiskit/synthesis/multi_controlled/mcx_with_ancillas_synth.py
@@ -13,6 +13,9 @@
 """Module containing multi-controlled circuits synthesis with ancillary qubits."""
 
 from math import ceil
+from qiskit.circuit.quantumregister import QuantumRegister
+from qiskit.circuit.quantumcircuit import QuantumCircuit
+from qiskit.circuit.library.standard_gates.x import C3XGate, C4XGate
 
 
 def synth_mcx_n_dirty_i15(
@@ -42,10 +45,6 @@ def synth_mcx_n_dirty_i15(
            `arXiv:1501.06911 <http://arxiv.org/abs/1501.06911>`_
     """
 
-    # pylint: disable=cyclic-import
-    from qiskit.circuit.quantumregister import QuantumRegister
-    from qiskit.circuit.quantumcircuit import QuantumCircuit
-
     num_qubits = 2 * num_ctrl_qubits - 1
     q = QuantumRegister(num_qubits, name="q")
     qc = QuantumCircuit(q, name="mcx_vchain")
@@ -60,9 +59,6 @@ def synth_mcx_n_dirty_i15(
         qc.ccx(q_controls[0], q_controls[1], q_target)
         return qc
     elif not relative_phase and num_ctrl_qubits == 3:
-        # pylint: disable=cyclic-import
-        from qiskit.circuit.library.standard_gates.x import C3XGate
-
         qc._append(C3XGate(), [*q_controls, q_target], [])
         return qc
 
@@ -143,10 +139,6 @@ def synth_mcx_n_clean_m15(num_ctrl_qubits: int):
            `arXiv:1508.03273 <https://arxiv.org/pdf/1508.03273>`_
     """
 
-    # pylint: disable=cyclic-import
-    from qiskit.circuit.quantumregister import QuantumRegister
-    from qiskit.circuit.quantumcircuit import QuantumCircuit
-
     num_qubits = 2 * num_ctrl_qubits - 1
     q = QuantumRegister(num_qubits, name="q")
     qc = QuantumCircuit(q, name="mcx_vchain")
@@ -189,11 +181,6 @@ def synth_mcx_1_clean_b95(num_ctrl_qubits: int):
         1. Barenco et. al., Phys.Rev. A52 3457 (1995),
            `arXiv:quant-ph/9503016 <https://arxiv.org/abs/quant-ph/9503016>`_
     """
-
-    # pylint: disable=cyclic-import
-    from qiskit.circuit.quantumregister import QuantumRegister
-    from qiskit.circuit.quantumcircuit import QuantumCircuit
-    from qiskit.circuit.library.standard_gates.x import C3XGate, C4XGate
 
     if num_ctrl_qubits == 3:
         q = QuantumRegister(4, name="q")

--- a/releasenotes/notes/add-synth-mcx-with-ancillas-6a92078d6b0e1de4.yaml
+++ b/releasenotes/notes/add-synth-mcx-with-ancillas-6a92078d6b0e1de4.yaml
@@ -4,14 +4,14 @@ features_synthesis:
     Add a synthesis function :func:`.synth_mcx_n_dirty_i15` that
     synthesizes a multi-controlled X gate with :math:`k` controls using :math:`k - 2`
     dirty ancillary qubits producing a circuit with at most :math:`8 * k - 6` CX gates,
-    by Iten et. al.
+    by Iten et. al. (arXiv:1501.06911).
   - |
     Add a synthesis function :func:`.synth_mcx_n_clean_m15` that
     synthesizes a multi-controlled X gate with :math:`k` controls using :math:`k - 2`
     clean ancillary qubits producing a circuit with at most :math:`6 * k - 6` CX gates,
-    by Maslov.
+    by Maslov (arXiv:1508.03273).
   - |
     Add a synthesis function :func:`.synth_mcx_1_clean_b95` that
     synthesizes a multi-controlled X gate with :math:`k` controls using a single
     clean ancillary qubit producing a circuit with at most :math:`16 * k - 8` CX gates,
-    by Barenco et al.
+    by Barenco et al. (arXiv:quant-ph/9503016).

--- a/releasenotes/notes/add-synth-mcx-with-ancillas-6a92078d6b0e1de4.yaml
+++ b/releasenotes/notes/add-synth-mcx-with-ancillas-6a92078d6b0e1de4.yaml
@@ -1,0 +1,17 @@
+---
+features_synthesis:
+  - |
+    Add a synthesis function :func:`.synth_mcx_n_dirty_i15` that
+    synthesizes a multi-controlled X gate with :math:`k` controls using :math:`k - 2`
+    dirty ancillary qubits producing a circuit with at most :math:`8 * k - 6` CX gates,
+    by Iten et. al.
+  - |
+    Add a synthesis function :func:`.synth_mcx_n_clean_m15` that
+    synthesizes a multi-controlled X gate with :math:`k` controls using :math:`k - 2`
+    clean ancillary qubits producing a circuit with at most :math:`6 * k - 6` CX gates,
+    by Maslov.
+  - |
+    Add a synthesis function :func:`.synth_mcx_1_clean_b95` that
+    synthesizes a multi-controlled X gate with :math:`k` controls using a single
+    clean ancillary qubit producing a circuit with at most :math:`16 * k - 8` CX gates,
+    by Barenco et al.

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -823,6 +823,20 @@ class TestControlledGate(QiskitTestCase):
 
         self.assertLessEqual(cx_count, 8 * num_ctrl_qubits - 6)
 
+    @data(5, 10, 15)
+    def test_mcxvchain_clean_ancilla_cx_count(self, num_ctrl_qubits):
+        """Test if cx count of the v-chain mcx with clean ancilla
+        is less than upper bound."""
+        mcx_vchain = MCXVChain(num_ctrl_qubits, dirty_ancillas=False)
+        qc = QuantumCircuit(mcx_vchain.num_qubits)
+
+        qc.append(mcx_vchain, list(range(mcx_vchain.num_qubits)))
+
+        tr_mcx_vchain = transpile(qc, basis_gates=["u", "cx"])
+        cx_count = tr_mcx_vchain.count_ops()["cx"]
+
+        self.assertLessEqual(cx_count, 6 * num_ctrl_qubits - 6)
+
     @data(7, 10, 15)
     def test_mcxrecursive_clean_ancilla_cx_count(self, num_ctrl_qubits):
         """Test if cx count of the mcx with one clean ancilla

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -508,7 +508,7 @@ class TestControlledGate(QiskitTestCase):
                 self.assertTrue(matrix_equal(simulated, expected))
 
     @combine(
-        num_controls=[2, 3, 4, 5, 6, 7],
+        num_controls=[2, 3, 4, 5, 6],
         mode=[
             "noancilla",
             "recursion",

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -507,112 +507,41 @@ class TestControlledGate(QiskitTestCase):
             with self.subTest(msg=f"control state = {ctrl_state}"):
                 self.assertTrue(matrix_equal(simulated, expected))
 
-    @data(1, 2, 3, 4)
-    def test_multi_control_toffoli_matrix_clean_ancillas(self, num_controls):
-        """Test the multi-control Toffoli gate with clean ancillas.
-
-        Based on the test moved here from Aqua:
-        https://github.com/Qiskit/qiskit-aqua/blob/769ca8f/test/aqua/test_mct.py
-        """
-        # set up circuit
-        q_controls = QuantumRegister(num_controls)
-        q_target = QuantumRegister(1)
-        qc = QuantumCircuit(q_controls, q_target)
-
-        if num_controls > 2:
-            num_ancillas = num_controls - 2
-            q_ancillas = QuantumRegister(num_controls)
-            qc.add_register(q_ancillas)
-        else:
-            num_ancillas = 0
-            q_ancillas = None
-
-        # apply hadamard on control qubits and toffoli gate
-        qc.mcx(q_controls, q_target[0], q_ancillas, mode="basic")
-
-        # obtain unitary for circuit
-        simulated = Operator(qc).data
-
-        # compare to expectation
-        if num_ancillas > 0:
-            simulated = simulated[: 2 ** (num_controls + 1), : 2 ** (num_controls + 1)]
-
-        base = XGate().to_matrix()
-        expected = _compute_control_matrix(base, num_controls)
-        self.assertTrue(matrix_equal(simulated, expected))
-
-    @data(1, 2, 3, 4, 5)
-    def test_multi_control_toffoli_matrix_basic_dirty_ancillas(self, num_controls):
-        """Test the multi-control Toffoli gate with dirty ancillas (basic-dirty-ancilla).
-
-        Based on the test moved here from Aqua:
-        https://github.com/Qiskit/qiskit-aqua/blob/769ca8f/test/aqua/test_mct.py
-        """
+    @combine(
+        num_controls=[2, 3, 4, 5, 6, 7],
+        mode=[
+            "noancilla",
+            "recursion",
+            "v-chain",
+            "v-chain-dirty",
+            "advanced",
+            "basic",
+            "basic-dirty-ancilla",
+        ],
+    )
+    def test_multi_control_toffoli_matrix_advanced_num_ancillas(self, num_controls, mode):
+        """Test the multi-control Toffoli gate methods with and w/o ancillas."""
         q_controls = QuantumRegister(num_controls)
         q_target = QuantumRegister(1)
         qc = QuantumCircuit(q_controls, q_target)
 
         q_ancillas = None
-        if num_controls <= 2:
+        if mode == "noancilla":
             num_ancillas = 0
-        else:
-            num_ancillas = num_controls - 2
+        if mode in ["recursion", "advanced"]:
+            num_ancillas = int(num_controls > 4)
+            q_ancillas = QuantumRegister(num_ancillas)
+            qc.add_register(q_ancillas)
+        if mode[:7] == "v-chain" or mode[:5] == "basic":
+            num_ancillas = max(0, num_controls - 2)
             q_ancillas = QuantumRegister(num_ancillas)
             qc.add_register(q_ancillas)
 
-        qc.mcx(q_controls, q_target[0], q_ancillas, mode="basic-dirty-ancilla")
+        qc.mcx(q_controls, q_target[0], q_ancillas, mode=mode)
 
         simulated = Operator(qc).data
         if num_ancillas > 0:
             simulated = simulated[: 2 ** (num_controls + 1), : 2 ** (num_controls + 1)]
-
-        base = XGate().to_matrix()
-        expected = _compute_control_matrix(base, num_controls)
-        self.assertTrue(matrix_equal(simulated, expected, atol=1e-8))
-
-    @data(1, 2, 3, 4, 5)
-    def test_multi_control_toffoli_matrix_advanced_dirty_ancillas(self, num_controls):
-        """Test the multi-control Toffoli gate with dirty ancillas (advanced).
-
-        Based on the test moved here from Aqua:
-        https://github.com/Qiskit/qiskit-aqua/blob/769ca8f/test/aqua/test_mct.py
-        """
-        q_controls = QuantumRegister(num_controls)
-        q_target = QuantumRegister(1)
-        qc = QuantumCircuit(q_controls, q_target)
-
-        q_ancillas = None
-        if num_controls <= 4:
-            num_ancillas = 0
-        else:
-            num_ancillas = 1
-            q_ancillas = QuantumRegister(num_ancillas)
-            qc.add_register(q_ancillas)
-
-        qc.mcx(q_controls, q_target[0], q_ancillas, mode="advanced")
-
-        simulated = Operator(qc).data
-        if num_ancillas > 0:
-            simulated = simulated[: 2 ** (num_controls + 1), : 2 ** (num_controls + 1)]
-
-        base = XGate().to_matrix()
-        expected = _compute_control_matrix(base, num_controls)
-        self.assertTrue(matrix_equal(simulated, expected, atol=1e-8))
-
-    @data(1, 2, 3)
-    def test_multi_control_toffoli_matrix_noancilla_dirty_ancillas(self, num_controls):
-        """Test the multi-control Toffoli gate with dirty ancillas (noancilla).
-
-        Based on the test moved here from Aqua:
-        https://github.com/Qiskit/qiskit-aqua/blob/769ca8f/test/aqua/test_mct.py
-        """
-        q_controls = QuantumRegister(num_controls)
-        q_target = QuantumRegister(1)
-        qc = QuantumCircuit(q_controls, q_target)
-
-        qc.mcx(q_controls, q_target[0], None, mode="noancilla")
-
-        simulated = Operator(qc)
 
         base = XGate().to_matrix()
         expected = _compute_control_matrix(base, num_controls)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
See details in issue #12863.
In this PR we transfer the mcx synthesis methods with clean and dirty ancillas to the synthesis library.


### Details and comments

Added 3 functions in the `qiskit/synthesis/multi-controlled` library:

- `synth_mcx_1_clean_b95`
- `synth_n_dirty_i15`
- `synth_n_clean_m15`
