### PR TITLE
Deprecate more utils and parameters that depend on `qiskit.providers.models`

### DIFF
--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -261,14 +261,22 @@ def _assemble(
 
     # assemble either circuits or schedules
     if all(isinstance(exp, QuantumCircuit) for exp in experiments):
-        run_config = _parse_circuit_args(
-            parameter_binds,
-            backend,
-            meas_level,
-            meas_return,
-            parametric_pulses,
-            **run_config_common_dict,
-        )
+        with warnings.catch_warnings():
+            # Internally calls deprecated BasicSimulator.configuration()`
+            warnings.filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+                message=r".+\.basic_provider\.basic_simulator\.BasicSimulator\.configuration.+",
+                module="qiskit",
+            )
+            run_config = _parse_circuit_args(
+                parameter_binds,
+                backend,
+                meas_level,
+                meas_return,
+                parametric_pulses,
+                **run_config_common_dict,
+            )
 
         # If circuits are parameterized, bind parameters and remove from run_config
         bound_experiments, run_config = _expand_parameters(

--- a/qiskit/providers/backend_compat.py
+++ b/qiskit/providers/backend_compat.py
@@ -32,6 +32,12 @@ from qiskit.utils.deprecate_pulse import deprecate_pulse_arg, deprecate_pulse_de
 logger = logging.getLogger(__name__)
 
 
+@deprecate_func(
+    since="1.4",
+    removal_timeline="in the 2.0 release",
+    additional_msg="With the deprecation of `qiskit.providers.models` this utility function "
+    "is not needed.",
+)
 @deprecate_pulse_arg("defaults")
 def convert_to_target(
     configuration: BackendConfiguration,
@@ -317,6 +323,7 @@ def _convert_to_target(
 def qubit_props_list_from_props(
     properties: BackendProperties,
 ) -> List[QubitProperties]:
+    # TODO Remove this function with BackendProperties
     """Uses BackendProperties to construct
     and return a list of QubitProperties.
     """
@@ -433,14 +440,23 @@ class BackendV2Converter(BackendV2):
         :rtype: Target
         """
         if self._target is None:
-            self._target = _convert_to_target(
-                configuration=self._config,
-                properties=self._properties,
-                defaults=self._defaults,
-                custom_name_mapping=self._name_mapping,
-                add_delay=self._add_delay,
-                filter_faulty=self._filter_faulty,
-            )
+            with warnings.catch_warnings():
+                # convert_to_target is deprecated along BackendV2Converter
+                # They both need to be removed at the same time
+                warnings.filterwarnings(
+                    "ignore",
+                    category=DeprecationWarning,
+                    message=r".+qiskit\.providers\.backend_compat\.convert_to_target.+",
+                    module="qiskit",
+                )
+                self._target = convert_to_target(
+                    configuration=self._config,
+                    properties=self._properties,
+                    defaults=self._defaults,
+                    custom_name_mapping=self._name_mapping,
+                    add_delay=self._add_delay,
+                    filter_faulty=self._filter_faulty,
+                )
         return self._target
 
     @property

--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -357,6 +357,16 @@ def generate_preset_pass_manager(
                     message=".* ``backend_properties`` is deprecated as of Qiskit 1.4",
                     module="qiskit",
                 )
+                # TODO: This is a temporary usage of deprecated backend_properties in
+                #   Target.from_configuration. Probably the logic needs to be restructured
+                #   in a more target-centric transpiler
+                #   https://github.com/Qiskit/qiskit/issues/9256
+                warnings.filterwarnings(
+                    "ignore",
+                    category=DeprecationWarning,
+                    message=r".+qiskit\.transpiler\.target\.Target\.from_configuration.+",
+                    module="qiskit",
+                )
                 # Build target from constraints.
                 target = Target.from_configuration(
                     basis_gates=basis_gates,
@@ -409,7 +419,6 @@ def generate_preset_pass_manager(
     initial_layout = _parse_initial_layout(initial_layout)
     approximation_degree = _parse_approximation_degree(approximation_degree)
     seed_transpiler = _parse_seed_transpiler(seed_transpiler)
-
     pm_options = {
         "target": target,
         "basis_gates": basis_gates,

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -59,6 +59,7 @@ from qiskit.providers.models.backendproperties import BackendProperties
 from qiskit.utils import deprecate_func, deprecate_arg
 from qiskit.utils.deprecate_pulse import deprecate_pulse_dependency, deprecate_pulse_arg
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/releasenotes/notes/deprecate-convert-to-target-006e9715d95598e8.yaml
+++ b/releasenotes/notes/deprecate-convert-to-target-006e9715d95598e8.yaml
@@ -1,0 +1,5 @@
+---
+deprecations_providers:
+  - |
+    The function :func:`.convert_to_target` is deprecated from Qiskit 1.4, since it takes deprecated classes such as
+    :class:`.BackendConfiguration` and :class:`.BackendProperties` and :class:`.PulseDefaults`.

--- a/test/python/providers/test_faulty_backend.py
+++ b/test/python/providers/test_faulty_backend.py
@@ -51,14 +51,13 @@ class FaultyQubitBackendTestCase(QiskitTestCase):
         """
         with self.assertWarns(DeprecationWarning):
             properties = self.backend.properties()
-
-        # Filter out faulty Q1
-        target = convert_to_target(
-            configuration=self.backend.configuration(),
-            properties=properties,
-            add_delay=True,
-            filter_faulty=True,
-        )
+            # Filter out faulty Q1
+            target = convert_to_target(
+                configuration=self.backend.configuration(),
+                properties=properties,
+                add_delay=True,
+                filter_faulty=True,
+            )
         self.assertFalse(target.instruction_supported(operation_name="measure", qargs=(1,)))
         self.assertFalse(target.instruction_supported(operation_name="delay", qargs=(1,)))
 
@@ -67,14 +66,13 @@ class FaultyQubitBackendTestCase(QiskitTestCase):
 
         with self.assertWarns(DeprecationWarning):
             properties = self.backend.properties()
-
-        # Include faulty Q1 even though data could be incomplete
-        target = convert_to_target(
-            configuration=self.backend.configuration(),
-            properties=properties,
-            add_delay=True,
-            filter_faulty=False,
-        )
+            # Include faulty Q1 even though data could be incomplete
+            target = convert_to_target(
+                configuration=self.backend.configuration(),
+                properties=properties,
+                add_delay=True,
+                filter_faulty=False,
+            )
         self.assertTrue(target.instruction_supported(operation_name="measure", qargs=(1,)))
         self.assertTrue(target.instruction_supported(operation_name="delay", qargs=(1,)))
 
@@ -153,13 +151,12 @@ class MissingPropertyQubitBackendTestCase(QiskitTestCase):
 
         with self.assertWarns(DeprecationWarning):
             properties = self.backend.properties()
-
-        target = convert_to_target(
-            configuration=self.backend.configuration(),
-            properties=properties,
-            add_delay=True,
-            filter_faulty=True,
-        )
+            target = convert_to_target(
+                configuration=self.backend.configuration(),
+                properties=properties,
+                add_delay=True,
+                filter_faulty=True,
+            )
 
         self.assertIsNone(target.qubit_properties[1].t1)
         self.assertEqual(


### PR DESCRIPTION
As part of #12906 I found more places where object from the deprecated `qiskit.providers.models` are used, so they can be deprecated too.

### Summary



### Details and comments


