### PR TITLE
Allow immutable borrow to access `QuantumCircuit.parameters`

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -343,7 +343,7 @@ impl CircuitData {
     /// Get a (cached) sorted list of the Python-space `Parameter` instances tracked by this circuit
     /// data's parameter table.
     #[getter]
-    pub fn get_parameters<'py>(&mut self, py: Python<'py>) -> Bound<'py, PyList> {
+    pub fn get_parameters<'py>(&self, py: Python<'py>) -> Bound<'py, PyList> {
         self.param_table.py_parameters(py)
     }
 

--- a/crates/circuit/src/parameter_table.rs
+++ b/crates/circuit/src/parameter_table.rs
@@ -216,7 +216,7 @@ impl ParameterTable {
                     None
                 };
                 self.by_name.insert(name.clone(), uuid);
-                self.order_cache.borrow_mut().invalidate();
+                self.order_cache.get_mut().invalidate();
                 let mut uses = HashSet::new();
                 if let Some(usage) = usage {
                     uses.insert_unique_unchecked(usage);
@@ -335,7 +335,7 @@ impl ParameterTable {
                     vec_entry.remove_entry();
                 }
             }
-            self.order_cache.borrow_mut().invalidate();
+            self.order_cache.get_mut().invalidate();
             entry.remove_entry();
         }
         Ok(())
@@ -361,7 +361,7 @@ impl ParameterTable {
                     (vector_info.refcount > 0).then_some(vector_info)
                 });
         }
-        self.order_cache.borrow_mut().invalidate();
+        self.order_cache.get_mut().invalidate();
         Ok(info.uses)
     }
 
@@ -371,7 +371,7 @@ impl ParameterTable {
     pub fn drain_ordered(
         &mut self,
     ) -> impl ExactSizeIterator<Item = (Py<PyAny>, HashSet<ParameterUse>)> {
-        let mut cache = self.order_cache.borrow_mut();
+        let cache = self.order_cache.get_mut();
         cache.py_parameters = None;
         let order = if cache.uuids.is_empty() {
             self.sorted_order()
@@ -393,7 +393,7 @@ impl ParameterTable {
         self.by_uuid.clear();
         self.by_name.clear();
         self.vectors.clear();
-        self.order_cache.borrow_mut().invalidate();
+        self.order_cache.get_mut().invalidate();
     }
 
     /// Expose the tracked data for a given parameter as directly as possible to Python space.


### PR DESCRIPTION
### Summary

`QuantumCircuit.parameters` is logically a read-only operation on `QuantumCircuit`.  For efficiency in multiple calls to `assign_parameters`, we actually cache the sort order of the internal `ParameterTable` on access.  This is purely a caching effect, and should not leak out to users.

The previous implementation took a Rust-space mutable borrow out in order to (potentially) mutate the cache.  This caused problems if multiple Python threads attempted to call `assign_parameters` simultaneously; it was possible for one thread to give up the GIL during its initial call to `CircuitData::copy` (so an immutable borrow was still live), allowing another thread to continue on to the getter `CircuitData::get_parameters`, which required a mutable borrow, which failed due to the paused thread in `copy`.

This moves the cache into a `RefCell`, allowing the parameter getters to take an immutable borrow as the receiver.  We now write the cache out only if we *can* take the mutable borrow out necessary.  This can mean that other threads will have to repeat the work of re-sorting the parameters, because their borrows were blocking the saving of the cache, but this will not cause failures.

The methods on `ParameterTable` that invalidate the cache all require a mutable borrow on the table itself.  This makes it impossible for an immutable borrow to exist simultaneously on the cache, so these methods should always succeed to acquire the cache lock to invalidate it.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

This won't be the last time we have problems with Python threading letting people see Rust reject conditions that allow data races. This particular case isn't the user's fault, though - `QuantumCircuit.parameters` _shouldn't_ need a mutable borrow, and should be thread-safe to be combined with other thread-safe methods on `QuantumCircuit`.  The issue was an internal caching detail, and that's something Qiskit should help.

An example script that produced errors before:
```python
from concurrent.futures import ThreadPoolExecutor
from qiskit.circuit import QuantumCircuit

qc = QuantumCircuit(1, 1)
for _ in [None]*100_000:
    qc.measure(0, 0)

workers = 2

with ThreadPoolExecutor(max_workers=workers) as executor:
    fs = [executor.submit(qc.assign_parameters, []) for _ in [None]*workers]
    for future in fs:
        future.result()
```
The thread workers in this example aren't doing anything wrong; `assign_parameters(inplace=False)` should be safe to run in multiple threads.  Before the Rust-space work, Python would silently ignore the potential data race, and the GIL would have prevented anything catastrophic happening (though multiple threads might have separately calculated the sort order).

In that example, the `QuantumCircuit.copy` call within `QuantumCircuit.assign_parameters` takes an immutable borrow in Rust space, but the Rust space method can become interrupted part way through, while copying the `Measure` instructions (since this requires yielding control to the Python interpreter to run `Measure.copy`).  This allows another thread to progress to `QuantumCircuit.parameters`, which needed a mutable borrow, which could not be taken out due to the other paused thread.