### PR TITLE
Add `get_parameter_by_uuid` to `CircuitData`

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -361,12 +361,6 @@ impl CircuitData {
             .map(|ob| ob.clone_ref(py))
     }
 
-    pub fn get_parameter_by_uuid(&self, py: Python, uuid: ParameterUuid) -> Option<Py<PyAny>> {
-        self.param_table
-            .py_parameter_by_uuid(uuid)
-            .map(|ob| ob.clone_ref(py))
-    }
-
     /// Return the width of the circuit. This is the number of qubits plus the
     /// number of clbits.
     ///
@@ -1238,6 +1232,11 @@ impl CircuitData {
             }
         }
         Ok(())
+    }
+
+    /// Retrieves the python `Param` object based on its `ParameterUuid`.
+    pub fn get_parameter_by_uuid(&self, uuid: ParameterUuid) -> Option<&Py<PyAny>> {
+        self.param_table.py_parameter_by_uuid(uuid)
     }
 }
 

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -361,6 +361,12 @@ impl CircuitData {
             .map(|ob| ob.clone_ref(py))
     }
 
+    pub fn get_parameter_by_uuid(&self, py: Python, uuid: ParameterUuid) -> Option<Py<PyAny>> {
+        self.param_table
+            .py_parameter_by_uuid(uuid)
+            .map(|ob| ob.clone_ref(py))
+    }
+
     /// Return the width of the circuit. This is the number of qubits plus the
     /// number of clbits.
     ///

--- a/crates/circuit/src/parameter_table.rs
+++ b/crates/circuit/src/parameter_table.rs
@@ -225,6 +225,11 @@ impl ParameterTable {
             .map(|uuid| &self.by_uuid[uuid].object)
     }
 
+    /// Lookup the Python parameter object by uuid.
+    pub fn py_parameter_by_uuid(&self, uuid: ParameterUuid) -> Option<&Py<PyAny>> {
+        self.by_uuid.get(&uuid).map(|param| &param.object)
+    }
+
     /// Get the (maybe cached) Python list of the sorted `Parameter` objects.
     pub fn py_parameters<'py>(&mut self, py: Python<'py>) -> Bound<'py, PyList> {
         if let Some(py_parameters) = self.py_parameters.as_ref() {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
The following commits add a method `get_parameter_by_uuid` to obtain the `Parameter` object from `CircuitData` by `uuid`.

### Details and comments
The method retrieves a `Parameter` object from the `ParameterTable` based on its `uuid` without exposing any extra data. This could be useful when performing mapping based parameter assignment (as one of the methods from #12913 attempts to do), from rust-space, without having to necessarily pass the a `Parameter` object  to do so.

### Known issues:
Nothing so far but, if anything is found, leave a comment or review. Thank you!

