### PR TITLE
Extended the `from_backend` method of `InstructionDurations` to support both `BackendV1` and `BackendV2`

### DIFF
--- a/qiskit/transpiler/instruction_durations.py
+++ b/qiskit/transpiler/instruction_durations.py
@@ -18,6 +18,7 @@ import qiskit.circuit
 from qiskit.circuit import Barrier, Delay, Instruction, ParameterExpression
 from qiskit.circuit.duration import duration_in_dt
 from qiskit.providers import Backend
+from qiskit.providers.backend import BackendV2
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.utils.units import apply_prefix
 
@@ -62,7 +63,7 @@ class InstructionDurations:
         return string
 
     @classmethod
-    def from_backend(cls, backend: Backend):
+    def from_backend(cls, backend: Backend | BackendV2):
         """Construct an :class:`InstructionDurations` object from the backend.
 
         Args:
@@ -76,24 +77,51 @@ class InstructionDurations:
         """
         # All durations in seconds in gate_length
         instruction_durations = []
-        backend_properties = backend.properties()
-        if hasattr(backend_properties, "_gates"):
-            for gate, insts in backend_properties._gates.items():
-                for qubits, props in insts.items():
-                    if "gate_length" in props:
-                        gate_length = props["gate_length"][0]  # Throw away datetime at index 1
-                        instruction_durations.append((gate, qubits, gate_length, "s"))
-            for q, props in backend.properties()._qubits.items():
-                if "readout_length" in props:
-                    readout_length = props["readout_length"][0]  # Throw away datetime at index 1
-                    instruction_durations.append(("measure", [q], readout_length, "s"))
+        if hasattr(backend, "properties"):
+            backend_properties = backend.properties()
+            if hasattr(backend_properties, "_gates"):
+                for gate, insts in backend_properties._gates.items():
+                    for qubits, props in insts.items():
+                        if "gate_length" in props:
+                            gate_length = props["gate_length"][0]  # Throw away datetime at index 1
+                            instruction_durations.append((gate, qubits, gate_length, "s"))
+                for q, props in backend.properties()._qubits.items():
+                    if "readout_length" in props:
+                        readout_length = props["readout_length"][
+                            0
+                        ]  # Throw away datetime at index 1
+                        instruction_durations.append(("measure", [q], readout_length, "s"))
 
-        try:
-            dt = backend.configuration().dt
-        except AttributeError:
-            dt = None
+            try:
+                dt = backend.configuration().dt
+            except AttributeError:
+                dt = None
 
-        return cls(instruction_durations, dt=dt)
+            return cls(instruction_durations, dt=dt)
+
+        elif isinstance(backend, BackendV2):
+            for gate, insts in backend.target.items():
+                for qb, inst_prop in insts.items():
+                    # `duration` and `error` are defined as `None` for `delay` and `reset` in
+                    # `GenericBackendV2`and due to that the `update()` method from `InstructionDurations`
+                    # raises an error, so here we will skip adding instructions whose duration is `None`.
+                    # Also, the `target` of `GenericBackendV2` includes the duration of `measure` so
+                    # there is no need to access `readout_length` separately (like above).
+                    if inst_prop.duration is not None:
+                        gate_length = inst_prop.duration
+                        instruction_durations.append((gate, qb, gate_length, "s"))
+
+            try:
+                dt = backend.target.dt
+            except AttributeError:
+                dt = None
+
+            return cls(instruction_durations, dt=dt)
+
+        else:
+            raise TranspilerError(
+                "Unsupported backend type. The backend has to to be either a backend V1 or a backend V2"
+            )
 
     def update(self, inst_durations: "InstructionDurationsType" | None, dt: float = None):
         """Update self with inst_durations (inst_durations overwrite self).

--- a/releasenotes/notes/fix-InstructionDurations-b47a9770b424d7a0.yaml
+++ b/releasenotes/notes/fix-InstructionDurations-b47a9770b424d7a0.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    The `from_backend` method of :class:`.InstructionDurations` now allows extracting instruction durations from both `BackendV1` and `BackendV2`.

--- a/releasenotes/notes/fix-InstructionDurations-b47a9770b424d7a0.yaml
+++ b/releasenotes/notes/fix-InstructionDurations-b47a9770b424d7a0.yaml
@@ -1,4 +1,5 @@
 ---
 fixes:
   - |
-    The `from_backend` method of :class:`.InstructionDurations` now allows extracting instruction durations from both `BackendV1` and `BackendV2`.
+    Fixed a bug where :meth:`.InstructionDurations.from_backend` did not work for :class:`.BackendV2` backends.
+    Fixed `#12760 <https://github.com/Qiskit/qiskit/issues/12760>`.

--- a/test/python/transpiler/test_instruction_durations.py
+++ b/test/python/transpiler/test_instruction_durations.py
@@ -16,6 +16,7 @@
 
 from qiskit.circuit import Delay, Parameter
 from qiskit.providers.fake_provider import Fake27QPulseV1
+from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.instruction_durations import InstructionDurations
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
@@ -92,3 +93,10 @@ class TestInstructionDurationsClass(QiskitTestCase):
         parameterized_delay = Delay(param, "s")
         with self.assertRaises(TranspilerError):
             InstructionDurations().get(parameterized_delay, 0)
+
+    def test_from_backend_with_backendv2(self):
+        """Test if `from_backend()` method allows using BackendV2"""
+        backend = GenericBackendV2(num_qubits=4, calibrate_instructions=True, seed=42)
+        inst_durations = InstructionDurations.from_backend(backend)
+        self.assertEqual(inst_durations, backend.target.durations())
+        self.assertIsInstance(inst_durations, InstructionDurations)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes #12760 

I have extended the `from_backend` method of `InstructionDurations` so that it supports both `BackendV1` and `BackendV2` (also `GenericBackendV2`). To get the instruction durations from the `BackendV2`, I have used the attribute `target`. Also, in [`GenericBackendV2`](https://github.com/Qiskit/qiskit/blob/main/qiskit/providers/fake_provider/generic_backend_v2.py#L59), the `(duration, error)` for `delay` and `reset` is set to `(None, None)` and this `None` value raises an error in the `update()` method of `InstructionDurations`. So, I am skipping the instructions which have `None` as the duration (let me know if this is not what we want).

@1ucian0, please review this and let me know if this is acceptable. If you want I can also add tests and/or new release notes for the changes I have made.

Thanks


### Details and comments


