### PR TITLE
Allow `CircuitData` construction from `PackedOperation`s

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -105,6 +105,71 @@ pub struct CircuitData {
 
 impl CircuitData {
     /// An alternate constructor to build a new `CircuitData` from an iterator
+    /// of packed operations. This can be used to build a circuit from a sequence
+    /// of `PackedOperation` without needing to involve Python.
+    ///
+    /// This can be connected with the Python space
+    /// QuantumCircuit.from_circuit_data() constructor to build a full
+    /// QuantumCircuit from Rust.
+    ///
+    /// # Arguments
+    ///
+    /// * py: A GIL handle this is needed to instantiate Qubits in Python space
+    /// * num_qubits: The number of qubits in the circuit. These will be created
+    ///     in Python as loose bits without a register.
+    /// * num_clbits: The number of classical bits in the circuit. These will be created
+    ///     in Python as loose bits without a register.
+    /// * instructions: An iterator of the (packed operation, params, qubits, clbits) to
+    ///     add to the circuit
+    /// * global_phase: The global phase to use for the circuit
+    pub fn from_packed_operations<I>(
+        py: Python,
+        num_qubits: u32,
+        num_clbits: u32,
+        instructions: I,
+        global_phase: Param,
+    ) -> PyResult<Self>
+    where
+        I: IntoIterator<
+            Item = (
+                PackedOperation,
+                SmallVec<[Param; 3]>,
+                Vec<Qubit>,
+                Vec<Clbit>,
+            ),
+        >,
+    {
+        let instruction_iter = instructions.into_iter();
+        let mut res = Self::with_capacity(
+            py,
+            num_qubits,
+            num_clbits,
+            instruction_iter.size_hint().0,
+            global_phase,
+        )?;
+        for (operation, params, qargs, cargs) in instruction_iter {
+            let qubits = (&mut res.qargs_interner)
+                .intern(InternerKey::Value(qargs.to_vec()))?
+                .index;
+            let clbits = (&mut res.cargs_interner)
+                .intern(InternerKey::Value(cargs.to_vec()))?
+                .index;
+            let params = (!params.is_empty()).then(|| Box::new(params));
+            res.data.push(PackedInstruction {
+                op: operation,
+                qubits,
+                clbits,
+                params,
+                extra_attrs: None,
+                #[cfg(feature = "cache_pygates")]
+                py_op: RefCell::new(None),
+            });
+            res.track_instruction_parameters(py, res.data.len() - 1)?;
+        }
+        Ok(res)
+    }
+
+    /// An alternate constructor to build a new `CircuitData` from an iterator
     /// of standard gates. This can be used to build a circuit from a sequence
     /// of standard gates, such as for a `StandardGate` definition or circuit
     /// synthesis without needing to involve Python.

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -18,7 +18,7 @@ use crate::circuit_instruction::{CircuitInstruction, OperationFromPython};
 use crate::imports::{ANNOTATED_OPERATION, CLBIT, QUANTUM_CIRCUIT, QUBIT};
 use crate::interner::{IndexedInterner, Interner, InternerKey};
 use crate::operations::{Operation, OperationRef, Param, StandardGate};
-use crate::packed_instruction::PackedInstruction;
+use crate::packed_instruction::{PackedInstruction, PackedOperation};
 use crate::parameter_table::{ParameterTable, ParameterTableError, ParameterUse, ParameterUuid};
 use crate::slice::{PySequenceIndex, SequenceIndex};
 use crate::{Clbit, Qubit};

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -149,10 +149,10 @@ impl CircuitData {
         )?;
         for (operation, params, qargs, cargs) in instruction_iter {
             let qubits = (&mut res.qargs_interner)
-                .intern(InternerKey::Value(qargs.to_vec()))?
+                .intern(InternerKey::Value(qargs))?
                 .index;
             let clbits = (&mut res.cargs_interner)
-                .intern(InternerKey::Value(cargs.to_vec()))?
+                .intern(InternerKey::Value(cargs))?
                 .index;
             let params = (!params.is_empty()).then(|| Box::new(params));
             res.data.push(PackedInstruction {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

As the title says 🙂 This allows to construct more general circuits than using just `CircuitData::from_standard_gates`, including e.g. barriers.

### Details and comments

This is essentially a copy of `CircuitData::from_standard_gates`. Qubits and Clbits are now `Vec`, because
* `SmallVec` cannot be used as we cannot predict the maximum length
* arrays (`&[Qubit]`) turned out to be a bit restrictive as the length must be known at compile-time (but maybe there's some trick to use this in the signature but pass vectors or something?)

I didn't yet add a test since it's essentially a copy of the standard gates constructor, and this will be used a bunch by the circuit library refactor. But we could add some `cfg` test that maybe checks this gives the same circuit data as using the standard gates construct -- though not sure how difficult that comparison is 🙂 

Example usage:
```rust
let n = 50;  // number of qubits
let h_layer = (0..n).map(|i| (
    StandardGate::HGate.into(),  // PackedOperation
    smallvec![],  //  params
    vec![Qubit(i)],  // qubit
    vec![], // clbit
);
let barrier = (  // barrier on all qubits
    PyInstruction { /* define barrier by calling Python ... */ },
    smallvec![],
    (0..n).map(|i| Qubit(i)).collect(),  // all qubits
    vec![], 
);

let data = CircuitData::from_packed_operations(h_layer.chain(barrier));
```


