### PR TITLE
Improve error message on bad OpenQASM 3 `basis_gates` argument

### DIFF
--- a/qiskit/qasm3/exporter.py
+++ b/qiskit/qasm3/exporter.py
@@ -626,7 +626,13 @@ class QASM3Builder:
             if builtin in _BUILTIN_GATES:
                 # It's built into the langauge; we don't need to re-add it.
                 continue
-            self.symbols.register_gate_without_definition(builtin, None)
+            try:
+                self.symbols.register_gate_without_definition(builtin, None)
+            except QASM3ExporterError as exc:
+                raise QASM3ExporterError(
+                    f"Cannot use '{builtin}' as a basis gate for the reason in the prior exception."
+                    " Consider renaming the gate if needed, or omitting this basis gate if not."
+                ) from exc
 
         header = ast.Header(ast.Version("3.0"), list(self.build_includes()))
 

--- a/releasenotes/notes/qasm3-basis-gates-keyword-c5998bff1e178715.yaml
+++ b/releasenotes/notes/qasm3-basis-gates-keyword-c5998bff1e178715.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The OpenQASM 3 exporter will now correctly error when asked to use a keyword or other invalid
+    identifier as a "basis gate", as it has no way of putting out correct output in these cases.

--- a/test/python/qasm3/test_export.py
+++ b/test/python/qasm3/test_export.py
@@ -2699,3 +2699,11 @@ class TestQASM3ExporterFailurePaths(QiskitTestCase):
             QASM3ExporterError, "cannot export an inner scope.*as a top-level program"
         ):
             dumps(qc)
+
+    def test_no_basis_gate_with_keyword(self):
+        """Test that keyword cannot be used as a basis gate."""
+        qc = QuantumCircuit()
+        with self.assertRaisesRegex(QASM3ExporterError, "Cannot use 'reset' as a basis gate") as cm:
+            dumps(qc, basis_gates=["U", "reset"])
+        self.assertIsInstance(cm.exception.__cause__, QASM3ExporterError)
+        self.assertRegex(cm.exception.__cause__.message, "cannot use the keyword 'reset'")


### PR DESCRIPTION
### Summary

If the user requests a basis-gate name that cannot be used (like a keyword), there is nothing sensible we can output for a circuit that contains one of those operations.  The exporter was already correctly erroring in these cases, but the error message was quite opaque.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #12886
