### PR TITLE
Move the circuit library's entanglement logic to Rust

### DIFF
--- a/crates/accelerate/src/circuit_library/entanglement.rs
+++ b/crates/accelerate/src/circuit_library/entanglement.rs
@@ -175,8 +175,7 @@ pub fn get_entanglement<'a>(
     if let Ok(strategy) = entanglement.downcast::<PyString>() {
         let as_str = strategy.to_string();
         return Ok(Box::new(
-            get_entanglement_from_str(num_qubits, block_size, as_str.as_str(), offset)?
-                .map(|connections| Ok(connections)),
+            get_entanglement_from_str(num_qubits, block_size, as_str.as_str(), offset)?.map(Ok),
         ));
     } else if let Ok(list) = entanglement.downcast::<PyList>() {
         let entanglement_iter = list.iter().map(move |el| {

--- a/crates/accelerate/src/circuit_library/entanglement.rs
+++ b/crates/accelerate/src/circuit_library/entanglement.rs
@@ -33,8 +33,8 @@ pub fn linear(num_qubits: u32, block_size: u32) -> impl DoubleEndedIterator<Item
 
 /// Get a reversed linear entanglement. This is like linear entanglement but in reversed order:
 /// [(n-m..n-1), ..., (1..m), (0..m-1)]
-/// This is particularly interesting, as CX+"full" equals CX+"reverse_linear", even though the
-/// latter uses a quadratically less number of gates.
+/// This is particularly interesting, as CX+"full" uses n(n-1)/2 gates, but operationally equals
+/// CX+"reverse_linear", which needs only n-1 gates.
 pub fn reverse_linear(num_qubits: u32, block_size: u32) -> impl Iterator<Item = Vec<u32>> {
     linear(num_qubits, block_size).rev()
 }

--- a/crates/accelerate/src/circuit_library/entanglement.rs
+++ b/crates/accelerate/src/circuit_library/entanglement.rs
@@ -10,37 +10,19 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::QiskitError;
+use itertools::Itertools;
 use pyo3::{
     types::{PyAnyMethods, PyInt, PyList, PyListMethods, PyString, PyTuple},
     Bound, PyAny, PyResult,
 };
 use qiskit_circuit::slice::PySequenceIndex;
 
-/// Get all combinations of length ``repetitions`` of numbers ``(0..n)``. This is like
-/// Python's ``itertools.combinations``.
-fn _combinations(n: u32, repetitions: u32) -> Vec<Vec<u32>> {
-    if repetitions == 1 {
-        (0..n).map(|index| vec![index]).collect()
-    } else {
-        let mut result = Vec::new();
-        for indices in _combinations(n, repetitions - 1) {
-            let last_element = indices[indices.len() - 1];
-            for index in last_element + 1..n {
-                let mut extended_indices = indices.clone();
-                extended_indices.push(index);
-                result.push(extended_indices);
-            }
-        }
-        result
-    }
-}
+use crate::QiskitError;
 
 /// Get all-to-all entanglement. For 4 qubits and block size 2 we have:
 /// [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
 pub fn full(num_qubits: u32, block_size: u32) -> impl Iterator<Item = Vec<u32>> {
-    // this should be equivalent to itertools.combinations(list(range(n)), m)
-    _combinations(num_qubits, block_size).into_iter()
+    (0..num_qubits).combinations(block_size as usize)
 }
 
 /// Get a linear entanglement structure. For ``n`` qubits and block size ``m`` we have:

--- a/crates/accelerate/src/circuit_library/entanglement.rs
+++ b/crates/accelerate/src/circuit_library/entanglement.rs
@@ -17,6 +17,8 @@ use pyo3::{
 };
 use qiskit_circuit::slice::PySequenceIndex;
 
+/// Get all combinations of length ``repetitions`` of numbers ``(0..n)``. This is like
+/// Python's ``itertools.combinations``.
 fn _combinations(n: u32, repetitions: u32) -> Vec<Vec<u32>> {
     if repetitions == 1 {
         (0..n).map(|index| vec![index]).collect()
@@ -34,19 +36,24 @@ fn _combinations(n: u32, repetitions: u32) -> Vec<Vec<u32>> {
     }
 }
 
+/// Get all-to-all entanglement. For 4 qubits and block size 2 we have:
+/// [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
 pub fn full(num_qubits: u32, block_size: u32) -> impl Iterator<Item = Vec<u32>> {
     // this should be equivalent to itertools.combinations(list(range(n)), m)
     _combinations(num_qubits, block_size).into_iter()
 }
 
-/// Return the qubit indices for linear entanglement.
-/// For a block_size of ``m``, this is defined as [(0..m-1), (1..m), (2..m+1), ..., (n-m..n-1)]
+/// Get a linear entanglement structure. For ``n`` qubits and block size ``m`` we have:
+/// [(0..m-1), (1..m), (2..m+1), ..., (n-m..n-1)]
 pub fn linear(num_qubits: u32, block_size: u32) -> impl DoubleEndedIterator<Item = Vec<u32>> {
     (0..num_qubits - block_size + 1)
         .map(move |start_index| (start_index..start_index + block_size).collect())
 }
 
-/// Return the qubit indices for a reversed linear entanglement.
+/// Get a reversed linear entanglement. This is like linear entanglement but in reversed order:
+/// [(n-m..n-1), ..., (1..m), (0..m-1)]
+/// This is particularly interesting, as CX+"full" equals CX+"reverse_linear", even though the
+/// latter uses a quadratically less number of gates.
 pub fn reverse_linear(num_qubits: u32, block_size: u32) -> impl Iterator<Item = Vec<u32>> {
     linear(num_qubits, block_size).rev()
 }
@@ -68,6 +75,9 @@ pub fn circular(num_qubits: u32, block_size: u32) -> Box<dyn Iterator<Item = Vec
     }
 }
 
+/// Get pairwise entanglement. This is typically used on 2 qubits and only has a depth of 2, as
+/// first all odd pairs, and then even pairs are entangled. For example on 6 qubits:
+/// [(0, 1), (2, 3), (4, 5), /* now the even pairs */ (1, 2), (3, 4)]
 pub fn pairwise(num_qubits: u32) -> impl Iterator<Item = Vec<u32>> {
     // for Python-folks (like me): pairwise is equal to linear[::2] + linear[1::2]
     linear(num_qubits, 2)
@@ -75,6 +85,14 @@ pub fn pairwise(num_qubits: u32) -> impl Iterator<Item = Vec<u32>> {
         .chain(linear(num_qubits, 2).skip(1).step_by(2))
 }
 
+/// The shifted, circular, alternating (sca) entanglement is motivated from circuits 14/15 of
+/// https://arxiv.org/abs/1905.10876. It corresponds to circular entanglement, with the difference
+/// that in each layer (controlled by ``offset``) the entanglement gates are shifted by one, plus
+/// in each second layer, the entanglement gate is turned upside down.
+/// Offset 0 -> [(2,3,0), (3,0,1), (0,1,2), (1,2,3)]
+/// Offset 1 -> [(3,2,1), (0,3,2), (1,0,3), (2,1,0)]
+/// Offset 2 -> [(0,1,2), (1,2,3), (2,3,0), (3,0,1)]
+/// ...
 pub fn shift_circular_alternating(
     num_qubits: u32,
     block_size: u32,

--- a/crates/accelerate/src/circuit_library/mod.rs
+++ b/crates/accelerate/src/circuit_library/mod.rs
@@ -15,12 +15,35 @@ use pyo3::types::PyTuple;
 
 mod entanglement;
 
+/// Get the entanglement for given number of qubits and block size.
+///
+/// Args:
+///     num_qubits: The number of qubits to entangle.
+///     block_size: The entanglement block size (e.g. 2 for CX or 3 for CCX).
+///     entanglement: The entanglement strategy. This can be one of:
+///
+///         * string: Available options are ``"linear"``, ``"reverse_linear"``, ``"circular"``,
+///             ``"pairwise"`` or ``"sca"``.
+///         * list of tuples: A list of entanglements given as tuple, e.g. [(0, 1), (1, 2)].
+///         * callable: A callable that takes as input an offset as ``int`` (usually the layer
+///             in the variational circuit) and returns a string or list of tuples to use as
+///             entanglement in this layer.
+///
+///     offset: An offset used by certain entanglement strategies (e.g. ``"sca"``) or if the
+///         entanglement is given as callable. This is typically used to have different
+///         entanglement structures in different layers of variational quantum circuits.
+///
+/// Returns:
+///     The entanglement as list of tuples.
+///
+/// Raises:
+///     QiskitError: In case the entanglement is invalid.
 #[pyfunction]
-#[pyo3(signature = (block_size, num_qubits, entanglement, offset=0))]
+#[pyo3(signature = (num_qubits, block_size, entanglement, offset=0))]
 pub fn get_entangler_map<'py>(
     py: Python<'py>,
-    block_size: u32,
     num_qubits: u32,
+    block_size: u32,
     entanglement: &Bound<PyAny>,
     offset: usize,
 ) -> PyResult<Vec<Bound<'py, PyTuple>>> {

--- a/crates/accelerate/src/circuit_library/mod.rs
+++ b/crates/accelerate/src/circuit_library/mod.rs
@@ -1,0 +1,46 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2024
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use pyo3::prelude::*;
+use pyo3::types::PyTuple;
+
+mod entanglement;
+
+#[pyfunction]
+#[pyo3(signature = (block_size, num_qubits, entanglement, offset=0))]
+pub fn get_entangler_map<'py>(
+    py: Python<'py>,
+    block_size: u32,
+    num_qubits: u32,
+    entanglement: &Bound<PyAny>,
+    offset: usize,
+) -> PyResult<Vec<Bound<'py, PyTuple>>> {
+    // The entanglement is Result<impl Iterator<Item = Result<Vec<u32>>>>, so there's two
+    // levels of errors we must handle: the outer error is handled by the outer match statement,
+    // and the inner (Result<Vec<u32>>) is handled upon the PyTuple creation.
+    match entanglement::get_entanglement(num_qubits, block_size, entanglement, offset) {
+        Ok(entanglement) => entanglement
+            .into_iter()
+            .map(|vec| match vec {
+                Ok(vec) => Ok(PyTuple::new_bound(py, vec)),
+                Err(e) => Err(e),
+            })
+            .collect::<Result<Vec<_>, _>>(),
+        Err(e) => Err(e),
+    }
+}
+
+#[pymodule]
+pub fn circuit_library(m: &Bound<PyModule>) -> PyResult<()> {
+    m.add_wrapped(wrap_pyfunction!(get_entangler_map))?;
+    Ok(())
+}

--- a/crates/accelerate/src/circuit_library/mod.rs
+++ b/crates/accelerate/src/circuit_library/mod.rs
@@ -11,7 +11,6 @@
 // that they have been altered from the originals.
 
 use pyo3::prelude::*;
-use pyo3::types::PyTuple;
 
 mod entanglement;
 

--- a/crates/accelerate/src/circuit_library/mod.rs
+++ b/crates/accelerate/src/circuit_library/mod.rs
@@ -15,55 +15,8 @@ use pyo3::types::PyTuple;
 
 mod entanglement;
 
-/// Get the entanglement for given number of qubits and block size.
-///
-/// Args:
-///     num_qubits: The number of qubits to entangle.
-///     block_size: The entanglement block size (e.g. 2 for CX or 3 for CCX).
-///     entanglement: The entanglement strategy. This can be one of:
-///
-///         * string: Available options are ``"full"``, ``"linear"``, ``"pairwise"``
-///             ``"reverse_linear"``, ``"circular"``, or ``"sca"``.
-///         * list of tuples: A list of entanglements given as tuple, e.g. [(0, 1), (1, 2)].
-///         * callable: A callable that takes as input an offset as ``int`` (usually the layer
-///             in the variational circuit) and returns a string or list of tuples to use as
-///             entanglement in this layer.
-///
-///     offset: An offset used by certain entanglement strategies (e.g. ``"sca"``) or if the
-///         entanglement is given as callable. This is typically used to have different
-///         entanglement structures in different layers of variational quantum circuits.
-///
-/// Returns:
-///     The entanglement as list of tuples.
-///
-/// Raises:
-///     QiskitError: In case the entanglement is invalid.
-#[pyfunction]
-#[pyo3(signature = (num_qubits, block_size, entanglement, offset=0))]
-pub fn get_entangler_map<'py>(
-    py: Python<'py>,
-    num_qubits: u32,
-    block_size: u32,
-    entanglement: &Bound<PyAny>,
-    offset: usize,
-) -> PyResult<Vec<Bound<'py, PyTuple>>> {
-    // The entanglement is Result<impl Iterator<Item = Result<Vec<u32>>>>, so there's two
-    // levels of errors we must handle: the outer error is handled by the outer match statement,
-    // and the inner (Result<Vec<u32>>) is handled upon the PyTuple creation.
-    match entanglement::get_entanglement(num_qubits, block_size, entanglement, offset) {
-        Ok(entanglement) => entanglement
-            .into_iter()
-            .map(|vec| match vec {
-                Ok(vec) => Ok(PyTuple::new_bound(py, vec)),
-                Err(e) => Err(e),
-            })
-            .collect::<Result<Vec<_>, _>>(),
-        Err(e) => Err(e),
-    }
-}
-
 #[pymodule]
 pub fn circuit_library(m: &Bound<PyModule>) -> PyResult<()> {
-    m.add_wrapped(wrap_pyfunction!(get_entangler_map))?;
+    m.add_wrapped(wrap_pyfunction!(entanglement::get_entangler_map))?;
     Ok(())
 }

--- a/crates/accelerate/src/circuit_library/mod.rs
+++ b/crates/accelerate/src/circuit_library/mod.rs
@@ -22,8 +22,8 @@ mod entanglement;
 ///     block_size: The entanglement block size (e.g. 2 for CX or 3 for CCX).
 ///     entanglement: The entanglement strategy. This can be one of:
 ///
-///         * string: Available options are ``"linear"``, ``"reverse_linear"``, ``"circular"``,
-///             ``"pairwise"`` or ``"sca"``.
+///         * string: Available options are ``"full"``, ``"linear"``, ``"pairwise"``
+///             ``"reverse_linear"``, ``"circular"``, or ``"sca"``.
 ///         * list of tuples: A list of entanglements given as tuple, e.g. [(0, 1), (1, 2)].
 ///         * callable: A callable that takes as input an offset as ``int`` (usually the layer
 ///             in the variational circuit) and returns a string or list of tuples to use as

--- a/crates/accelerate/src/lib.rs
+++ b/crates/accelerate/src/lib.rs
@@ -14,6 +14,7 @@ use std::env;
 
 use pyo3::import_exception;
 
+pub mod circuit_library;
 pub mod convert_2q_block_matrix;
 pub mod dense_layout;
 pub mod edge_collections;

--- a/crates/pyext/src/lib.rs
+++ b/crates/pyext/src/lib.rs
@@ -13,14 +13,14 @@
 use pyo3::prelude::*;
 
 use qiskit_accelerate::{
-    convert_2q_block_matrix::convert_2q_block_matrix, dense_layout::dense_layout,
-    error_map::error_map, euler_one_qubit_decomposer::euler_one_qubit_decomposer,
-    isometry::isometry, nlayout::nlayout, optimize_1q_gates::optimize_1q_gates,
-    pauli_exp_val::pauli_expval, results::results, sabre::sabre, sampled_exp_val::sampled_exp_val,
-    sparse_pauli_op::sparse_pauli_op, star_prerouting::star_prerouting,
-    stochastic_swap::stochastic_swap, synthesis::synthesis, target_transpiler::target,
-    two_qubit_decompose::two_qubit_decompose, uc_gate::uc_gate, utils::utils,
-    vf2_layout::vf2_layout,
+    circuit_library::circuit_library, convert_2q_block_matrix::convert_2q_block_matrix,
+    dense_layout::dense_layout, error_map::error_map,
+    euler_one_qubit_decomposer::euler_one_qubit_decomposer, isometry::isometry, nlayout::nlayout,
+    optimize_1q_gates::optimize_1q_gates, pauli_exp_val::pauli_expval, results::results,
+    sabre::sabre, sampled_exp_val::sampled_exp_val, sparse_pauli_op::sparse_pauli_op,
+    star_prerouting::star_prerouting, stochastic_swap::stochastic_swap, synthesis::synthesis,
+    target_transpiler::target, two_qubit_decompose::two_qubit_decompose, uc_gate::uc_gate,
+    utils::utils, vf2_layout::vf2_layout,
 };
 
 #[inline(always)]
@@ -39,6 +39,7 @@ fn _accelerate(m: &Bound<PyModule>) -> PyResult<()> {
     add_submodule(m, qiskit_circuit::circuit, "circuit")?;
     add_submodule(m, qiskit_qasm2::qasm2, "qasm2")?;
     add_submodule(m, qiskit_qasm3::qasm3, "qasm3")?;
+    add_submodule(m, circuit_library, "circuit_library")?;
     add_submodule(m, convert_2q_block_matrix, "convert_2q_block_matrix")?;
     add_submodule(m, dense_layout, "dense_layout")?;
     add_submodule(m, error_map, "error_map")?;

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -60,6 +60,7 @@ import qiskit._numpy_compat
 # We manually define them on import so people can directly import qiskit._accelerate.* submodules
 # and not have to rely on attribute access.  No action needed for top-level extension packages.
 sys.modules["qiskit._accelerate.circuit"] = _accelerate.circuit
+sys.modules["qiskit._accelerate.circuit_library"] = _accelerate.circuit_library
 sys.modules["qiskit._accelerate.convert_2q_block_matrix"] = _accelerate.convert_2q_block_matrix
 sys.modules["qiskit._accelerate.dense_layout"] = _accelerate.dense_layout
 sys.modules["qiskit._accelerate.error_map"] = _accelerate.error_map

--- a/qiskit/circuit/library/n_local/n_local.py
+++ b/qiskit/circuit/library/n_local/n_local.py
@@ -31,8 +31,10 @@ from qiskit.circuit import (
 )
 from qiskit.exceptions import QiskitError
 from qiskit.circuit.library.standard_gates import get_standard_gate_name_mapping
+from qiskit._accelerate.circuit_library import get_entangler_map as fast_entangler_map
 
 from ..blueprintcircuit import BlueprintCircuit
+
 
 if typing.TYPE_CHECKING:
     import qiskit  # pylint: disable=cyclic-import
@@ -1037,51 +1039,11 @@ def get_entangler_map(
     Raises:
         ValueError: If the entanglement mode ist not supported.
     """
-    n, m = num_circuit_qubits, num_block_qubits
-    if m > n:
-        raise ValueError(
-            "The number of block qubits must be smaller or equal to the number of "
-            "qubits in the circuit."
-        )
-
-    if entanglement == "pairwise" and num_block_qubits > 2:
-        raise ValueError("Pairwise entanglement is not defined for blocks with more than 2 qubits.")
-
-    if entanglement == "full":
-        return list(itertools.combinations(list(range(n)), m))
-    elif entanglement == "reverse_linear":
-        # reverse linear connectivity. In the case of m=2 and the entanglement_block='cx'
-        # then it's equivalent to 'full' entanglement
-        reverse = [tuple(range(n - i - m, n - i)) for i in range(n - m + 1)]
-        return reverse
-    elif entanglement in ["linear", "circular", "sca", "pairwise"]:
-        linear = [tuple(range(i, i + m)) for i in range(n - m + 1)]
-        # if the number of block qubits is 1, we don't have to add the 'circular' part
-        if entanglement == "linear" or m == 1:
-            return linear
-
-        if entanglement == "pairwise":
-            return linear[::2] + linear[1::2]
-
-        # circular equals linear plus top-bottom entanglement (if there's space for it)
-        if n > m:
-            circular = [tuple(range(n - m + 1, n)) + (0,)] + linear
-        else:
-            circular = linear
-        if entanglement == "circular":
-            return circular
-
-        # sca is circular plus shift and reverse
-        shifted = circular[-offset:] + circular[:-offset]
-        if offset % 2 == 1:  # if odd, reverse the qubit indices
-            sca = [ind[::-1] for ind in shifted]
-        else:
-            sca = shifted
-
-        return sca
-
-    else:
-        raise ValueError(f"Unsupported entanglement type: {entanglement}")
+    try:
+        return fast_entangler_map(num_block_qubits, num_circuit_qubits, entanglement, offset)
+    except Exception as exc:
+        # need this as Rust is now raising a QiskitError, where this function was raising ValueError
+        raise ValueError("Something went wrong in Rust space, here's the error:") from exc
 
 
 _StdlibGateResult = collections.namedtuple("_StdlibGateResult", ("gate", "num_params"))

--- a/qiskit/circuit/library/n_local/n_local.py
+++ b/qiskit/circuit/library/n_local/n_local.py
@@ -1040,7 +1040,7 @@ def get_entangler_map(
         ValueError: If the entanglement mode ist not supported.
     """
     try:
-        return fast_entangler_map(num_block_qubits, num_circuit_qubits, entanglement, offset)
+        return fast_entangler_map(num_circuit_qubits, num_block_qubits, entanglement, offset)
     except Exception as exc:
         # need this as Rust is now raising a QiskitError, where this function was raising ValueError
         raise ValueError("Something went wrong in Rust space, here's the error:") from exc

--- a/releasenotes/notes/fix-circular-entanglement-5aadd5adf75c0c13.yaml
+++ b/releasenotes/notes/fix-circular-entanglement-5aadd5adf75c0c13.yaml
@@ -1,0 +1,16 @@
+fixes:
+  - |
+    Fixed a bug with the ``"circular"`` and ``"sca"`` entanglement for
+    :class:`.NLocal` circuits and its derivatives. For entanglement blocks
+    of more than 2 qubits, the circular entanglement was previously missing
+    some connections. For example, for 4 qubits and a block size of 3 the
+    code previously used::
+
+      [(2, 3, 0), (0, 1, 2), (1, 2, 3)]
+
+    but now is correctly adding the ``(3, 0, 1)`` connections, that is::
+
+      [(2, 3, 0), (3, 0, 1), (0, 1, 2), (1, 2, 3)]
+
+    As such, the ``"circular"`` and ``"sca"`` entanglements use ``num_qubits``
+    entangling blocks per layer.

--- a/test/python/circuit/library/test_nlocal.py
+++ b/test/python/circuit/library/test_nlocal.py
@@ -1006,7 +1006,7 @@ class TestEntanglement(QiskitTestCase):
             _ = fast_entangler_map(num_qubits=2, block_size=3, entanglement="linear", offset=0)
 
     def test_invalid_entanglement_str(self):
-        """Go drunk, you're home"""
+        """Test invalid entanglement string."""
         with self.assertRaises(QiskitError):
             _ = fast_entangler_map(num_qubits=4, block_size=2, entanglement="lniaer", offset=0)
 

--- a/test/python/circuit/library/test_nlocal.py
+++ b/test/python/circuit/library/test_nlocal.py
@@ -42,6 +42,10 @@ from qiskit.circuit.library import (
 from qiskit.circuit.random.utils import random_circuit
 from qiskit.converters.circuit_to_dag import circuit_to_dag
 from qiskit.quantum_info import Operator
+from qiskit.exceptions import QiskitError
+
+from qiskit._accelerate.circuit_library import get_entangler_map as fast_entangler_map
+
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
 
@@ -339,7 +343,7 @@ class TestNLocal(QiskitTestCase):
                     (2, 3, 4),
                 ]
             else:
-                circular = [(3, 4, 0), (0, 1, 2), (1, 2, 3), (2, 3, 4)]
+                circular = [(3, 4, 0), (4, 0, 1), (0, 1, 2), (1, 2, 3), (2, 3, 4)]
                 if mode == "circular":
                     return circular
                 sca = circular[-rep_num:] + circular[:-rep_num]
@@ -926,6 +930,128 @@ class TestTwoLocal(QiskitTestCase):
         reverse.assign_parameters(params, inplace=True)
 
         self.assertEqual(Operator(full), Operator(reverse))
+
+
+@ddt
+class TestEntanglement(QiskitTestCase):
+    """Test getting the entanglement structure."""
+
+    @data(
+        ("linear", [(0, 1), (1, 2), (2, 3)]),
+        ("reverse_linear", [(2, 3), (1, 2), (0, 1)]),
+        ("pairwise", [(0, 1), (2, 3), (1, 2)]),
+        ("circular", [(3, 0), (0, 1), (1, 2), (2, 3)]),
+        ("full", [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]),
+    )
+    @unpack
+    def test_2q_str(self, strategy, expected):
+        """Test getting by string."""
+        entanglement = fast_entangler_map(
+            num_qubits=4, block_size=2, entanglement=strategy, offset=0
+        )
+        self.assertEqual(expected, entanglement)
+
+    @data(
+        ("linear", [(0, 1, 2), (1, 2, 3)]),
+        ("reverse_linear", [(1, 2, 3), (0, 1, 2)]),
+        ("circular", [(2, 3, 0), (3, 0, 1), (0, 1, 2), (1, 2, 3)]),
+        ("full", [(0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3)]),
+    )
+    @unpack
+    def test_3q_str(self, strategy, expected):
+        """Test getting by string."""
+        entanglement = fast_entangler_map(
+            num_qubits=4, block_size=3, entanglement=strategy, offset=0
+        )
+        self.assertEqual(expected, entanglement)
+
+    def test_2q_sca(self):
+        """Test shift, circular, alternating on 2-qubit blocks."""
+        expected = {  # offset: result
+            0: [(3, 0), (0, 1), (1, 2), (2, 3)],
+            1: [(3, 2), (0, 3), (1, 0), (2, 1)],
+            2: [(1, 2), (2, 3), (3, 0), (0, 1)],
+            3: [(1, 0), (2, 1), (3, 2), (0, 3)],
+        }
+        for offset in range(8):
+            with self.subTest(offset=offset):
+                entanglement = fast_entangler_map(
+                    num_qubits=4, block_size=2, entanglement="sca", offset=offset
+                )
+                self.assertEqual(expected[offset % 4], entanglement)
+
+    def test_3q_sca(self):
+        """Test shift, circular, alternating on 3-qubit blocks."""
+        circular = [(2, 3, 0), (3, 0, 1), (0, 1, 2), (1, 2, 3)]
+        for offset in range(8):
+            expected = circular[-(offset % 4) :] + circular[: -(offset % 4)]
+            if offset % 2 == 1:
+                expected = [tuple(reversed(indices)) for indices in expected]
+            with self.subTest(offset=offset):
+                entanglement = fast_entangler_map(
+                    num_qubits=4, block_size=3, entanglement="sca", offset=offset
+                )
+                self.assertEqual(expected, entanglement)
+
+    def test_pairwise_limit(self):
+        """Test pairwise raises an error above 2 qubits."""
+        _ = fast_entangler_map(num_qubits=4, block_size=1, entanglement="pairwise", offset=0)
+        _ = fast_entangler_map(num_qubits=4, block_size=2, entanglement="pairwise", offset=0)
+        with self.assertRaises(QiskitError):
+            _ = fast_entangler_map(num_qubits=4, block_size=3, entanglement="pairwise", offset=0)
+
+    def test_invalid_blocksize(self):
+        """Test the block size being too large."""
+        with self.assertRaises(QiskitError):
+            _ = fast_entangler_map(num_qubits=2, block_size=3, entanglement="linear", offset=0)
+
+    def test_invalid_entanglement_str(self):
+        """Go drunk, you're home"""
+        with self.assertRaises(QiskitError):
+            _ = fast_entangler_map(num_qubits=4, block_size=2, entanglement="lniaer", offset=0)
+
+    def test_as_list(self):
+        """Test passing a list just returns the list."""
+        expected = [(0, 1), (1, 10), (2, 10)]
+        out = fast_entangler_map(num_qubits=20, block_size=2, entanglement=expected, offset=0)
+        self.assertEqual(expected, out)
+
+    def test_invalid_list(self):
+        """Test passing a list that does not match the block size."""
+
+        # TODO this test fails, somehow the error is not propagated correctly!
+        expected = [(0, 1), (1, 2, 10)]
+        with self.assertRaises(QiskitError):
+            _ = fast_entangler_map(num_qubits=20, block_size=2, entanglement=expected, offset=0)
+
+    def test_callable_list(self):
+        """Test using a callable."""
+
+        def my_entanglement(offset):
+            return [(0, 1)] if offset % 2 == 0 else [(1, 2)]
+
+        for offset in range(3):
+            with self.subTest(offset=offset):
+                expect = my_entanglement(offset)
+                result = fast_entangler_map(
+                    num_qubits=3, block_size=2, entanglement=my_entanglement, offset=offset
+                )
+                self.assertEqual(expect, result)
+
+    def test_callable_str(self):
+        """Test using a callable."""
+
+        def my_entanglement(offset):
+            return "linear" if offset % 2 == 0 else "pairwise"
+
+        expected = {"linear": [(0, 1), (1, 2), (2, 3)], "pairwise": [(0, 1), (2, 3), (1, 2)]}
+
+        for offset in range(3):
+            with self.subTest(offset=offset):
+                result = fast_entangler_map(
+                    num_qubits=4, block_size=2, entanglement=my_entanglement, offset=offset
+                )
+                self.assertEqual(expected["linear" if offset % 2 == 0 else "pairwise"], result)
 
 
 if __name__ == "__main__":

--- a/test/python/circuit/library/test_nlocal.py
+++ b/test/python/circuit/library/test_nlocal.py
@@ -993,6 +993,35 @@ class TestEntanglement(QiskitTestCase):
                 )
                 self.assertEqual(expected, entanglement)
 
+    @data("full", "reverse_linear", "linear", "circular", "sca", "pairwise")
+    def test_0q(self, entanglement):
+        """Test the corner case of a single qubit block."""
+        entanglement = fast_entangler_map(
+            num_qubits=3, block_size=0, entanglement=entanglement, offset=0
+        )
+        expect = []
+        self.assertEqual(entanglement, expect)
+
+    @data("full", "reverse_linear", "linear", "circular", "sca", "pairwise")
+    def test_1q(self, entanglement):
+        """Test the corner case of a single qubit block."""
+        entanglement = fast_entangler_map(
+            num_qubits=3, block_size=1, entanglement=entanglement, offset=0
+        )
+        expect = [(i,) for i in range(3)]
+
+        self.assertEqual(set(entanglement), set(expect))  # order does not matter for 1 qubit
+
+    @data("full", "reverse_linear", "linear", "circular", "sca")
+    def test_full_block(self, entanglement):
+        """Test the corner case of the block size equal the number of qubits."""
+        entanglement = fast_entangler_map(
+            num_qubits=5, block_size=5, entanglement=entanglement, offset=0
+        )
+        expect = [tuple(range(5))]
+
+        self.assertEqual(entanglement, expect)
+
     def test_pairwise_limit(self):
         """Test pairwise raises an error above 2 qubits."""
         _ = fast_entangler_map(num_qubits=4, block_size=1, entanglement="pairwise", offset=0)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Move the entanglement logic used in the circuit library's `NLocal` circuits & friends to Rust. This PR is also the basis to move frequently used circuits, such as `EfficientSU2`, `TwoLocal` or `ZZFeatureMap` to Rust.

This also fixes a bug in the `circular` entanglement which missed some entanglement blocks for entangling gates with 3+ qubits.

### Details and comments

`NLocal` will directly use this function, but there's also a series of tests to check the different errors and possible input types. 

The attentive reader might notice that handling elaborate constructs such as `list[list[list[int]]]` are not handled, which does not affect the current code, but will change what we accept once the circuit library is moved to Rust. That's an intentional change as these types were used to allow different entanglements for different circuit layers (controlled by `offset`), but this was redundantly covered by passing a callable. Moving forward, the suggestion is to only allow a callable in these cases to have only 1 method of doing 1 thing 🙂 
