### PR TITLE
Use hashbrown::HashSet instead of ahash::HashSet

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,6 @@
+disallowed-types = [
+    "std::collections::HashSet",
+    "std::collections::HashMap",
+    "ahash::HashSet",
+    "ahash::HashMap",
+]

--- a/crates/accelerate/src/target_transpiler/mod.rs
+++ b/crates/accelerate/src/target_transpiler/mod.rs
@@ -20,7 +20,7 @@ use std::ops::Index;
 
 use ahash::RandomState;
 
-use ahash::HashSet;
+use hashbrown::HashSet;
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use nullable_index_map::NullableIndexMap;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the `target_transpiler/mod.rs` module we were using ahash::HashSet for a hash set implementation, but the rest of Qiskit has standardized on using hashbrown for the `HashSet` and `HashMap` types. Hashbrown uses ahash for it's hashing algorithm but it also provides other advantages. To ensure that hash sets are compatible across the library we should be using the same library for everything. To support this goal, this commit also adds a clippy rule that raises a warning if the std library hashmap or hashset is used, or the versions from ahash. This means with our current dependency set the only allowed hashset types are `hashbrown::HashMap`/`HashSet` and `indexmap::IndexMap`/`IndexSet` (for where we need to maintain insertion order). Ideally we'd have a rule that forces the use of ahash with `IndexMap` and `IndexSet` (see #12935) but I don't think clippy exposes an option to enable something like that.

### Details and comments