### PR TITLE
Fix error message upon misalignment in `PadDynamicalDecoupling`

### DIFF
--- a/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
@@ -329,11 +329,9 @@ class PadDynamicalDecoupling(BasePadding):
         # As you can see, constraints on t0 are all satisfied without explicit scheduling.
         time_interval = t_end - t_start
         if time_interval % self._alignment != 0:
-            prev_name, prev_qargs = _format_node(prev_node)
-            next_name, next_qargs = _format_node(next_node)
             raise TranspilerError(
                 f"Time interval {time_interval} is not divisible by alignment {self._alignment} "
-                f"between {prev_name} on qargs {prev_qargs} and {next_name} on qargs {next_qargs}."
+                f"between {_format_node(prev_node)} and {_format_node(next_node)}."
             )
 
         if not self.__is_dd_qubit(dag.qubits.index(qubit)):
@@ -433,10 +431,8 @@ class PadDynamicalDecoupling(BasePadding):
         return tuple(params)
 
 
-def _format_node(node: DAGNode) -> tuple[str, str]:
-    """Util to format the DAGNode and DAGInNode."""
-    if isinstance(node, DAGInNode):
-        return "the DAGInNode", node.wire
-    if isinstance(node, DAGOutNode):
-        return "the DAGOutNode", node.wire
-    return f"DAGNode {node.name}", node.qargs
+def _format_node(node: DAGNode) -> str:
+    """Util to format the DAGNode, DAGInNode, and DAGOutNode."""
+    if isinstance(node, (DAGInNode, DAGOutNode)):
+        return f"{node.__class__.__name__} on qarg {node.wire}"
+    return f"DAGNode {node.name} on qargs {node.qargs}"

--- a/releasenotes/notes/fix-dd-misalignment-msg-76fe16e5eb4ae670.yaml
+++ b/releasenotes/notes/fix-dd-misalignment-msg-76fe16e5eb4ae670.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.PadDynamicalDecoupling`, which previously
+    did not correctly display the error message that a delay is not
+    pulse-aligned, if the previous or following node was a input/output
+    node. Now, the error message is correctly displayed.

--- a/releasenotes/notes/fix-dd-misalignment-msg-76fe16e5eb4ae670.yaml
+++ b/releasenotes/notes/fix-dd-misalignment-msg-76fe16e5eb4ae670.yaml
@@ -3,5 +3,5 @@ fixes:
   - |
     Fixed a bug in :class:`.PadDynamicalDecoupling`, which previously
     did not correctly display the error message that a delay is not
-    pulse-aligned, if the previous or following node was a input/output
+    pulse-aligned, if the previous or following node was an input/output
     node. Now, the error message is correctly displayed.

--- a/test/python/transpiler/test_dynamical_decoupling.py
+++ b/test/python/transpiler/test_dynamical_decoupling.py
@@ -1051,6 +1051,23 @@ class TestPadDynamicalDecoupling(QiskitTestCase):
 
         self.assertEqual(qc.global_phase + np.pi, pm.run(qc).global_phase)
 
+    def test_misalignment_at_boundaries(self):
+        """Test the correct error message is raised for misalignments at In/Out nodes."""
+        # a circuit where the previous node is DAGInNode, and the next DAGOutNode
+        circuit = QuantumCircuit(1)
+        circuit.delay(101)
+
+        dd_sequence = [XGate(), XGate()]
+        pm = PassManager(
+            [
+                ALAPScheduleAnalysis(self.durations),
+                PadDynamicalDecoupling(self.durations, dd_sequence, pulse_alignment=2),
+            ]
+        )
+
+        with self.assertRaises(TranspilerError):
+            _ = pm.run(circuit)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

If a delay is misaligned and following a `DAGInNode` (or preceding a `DAGOutNode`), the error message in `PadDynamicalDecoupling` previously failed, as it was trying to access non-existing attributes. This is because, unlike `DAGOpNode`, the in and out nodes do not have a `name` or `qargs` attribute.


