### PR TITLE
Change docs formatting of style dict details

### DIFF
--- a/qiskit/visualization/circuit/qcstyle.py
+++ b/qiskit/visualization/circuit/qcstyle.py
@@ -29,138 +29,138 @@ class DefaultStyle:
     output circuit visualization. The style dict is used by the `mpl` or
     `latex` output. The options available in the style dict are defined below:
 
-    name (str): the name of the style. The name can be set to ``iqp``,
-        ``iqp-dark``, ``textbook``, ``bw``, ``clifford``, or the name of a
-        user-created json file. This overrides the setting in the user config
-        file (usually ``~/.qiskit/settings.conf``).
+    **name (str)**: the name of the style. The name can be set to ``iqp``,
+    ``iqp-dark``, ``textbook``, ``bw``, ``clifford``, or the name of a
+    user-created json file. This overrides the setting in the user config
+    file (usually ``~/.qiskit/settings.conf``).
 
-    textcolor (str): the color code to use for all text not inside a gate.
-        Defaults to ``#000000``
+    **textcolor (str)**: the color code to use for all text not inside a gate.
+    Defaults to ``#000000``
 
-    subtextcolor (str): the color code to use for subtext. Defaults to
-        ``#000000``
+    **subtextcolor (str)**: the color code to use for subtext. Defaults to
+    ``#000000``
 
-    linecolor (str): the color code to use for lines. Defaults to
-        ``#000000``
+    **linecolor (str)**: the color code to use for lines. Defaults to
+    ``#000000``
 
-    creglinecolor (str): the color code to use for classical register
-        lines. Defaults to ``#778899``
+    **creglinecolor (str)**: the color code to use for classical register
+    lines. Defaults to ``#778899``
 
-    gatetextcolor (str): the color code to use for gate text. Defaults to
-        ``#000000``
+    **gatetextcolor (str)**: the color code to use for gate text. Defaults to
+    ``#000000``
 
-    gatefacecolor (str): the color code to use for a gate if no color
-        specified in the 'displaycolor' dict. Defaults to ``#BB8BFF``
+    **gatefacecolor (str)**: the color code to use for a gate if no color
+    specified in the 'displaycolor' dict. Defaults to ``#BB8BFF``
 
-    barrierfacecolor (str): the color code to use for barriers. Defaults to
-        ``#BDBDBD``
+    **barrierfacecolor (str)**: the color code to use for barriers. Defaults to
+    ``#BDBDBD``
 
-    backgroundcolor (str): the color code to use for the background.
-        Defaults to ``#FFFFFF``
+    **backgroundcolor (str)**: the color code to use for the background.
+    Defaults to ``#FFFFFF``
 
-    edgecolor (str): the color code to use for gate edges when using the
-        `bw` style. Defaults to ``#000000``.
+    **edgecolor (str)**: the color code to use for gate edges when using the
+    `bw` style. Defaults to ``#000000``.
 
-    fontsize (int): the font size to use for text. Defaults to 13.
+    **fontsize (int)**: the font size to use for text. Defaults to 13.
 
-    subfontsize (int): the font size to use for subtext. Defaults to 8.
+    **subfontsize (int)**: the font size to use for subtext. Defaults to 8.
 
-    showindex (bool): if set to True, show the index numbers at the top.
-        Defaults to False.
+    **showindex (bool)**: if set to True, show the index numbers at the top.
+    Defaults to False.
 
-    figwidth (int): the maximum width (in inches) for the output figure.
-        If set to -1, the maximum displayable width will be used.
-        Defaults to -1.
+    **figwidth (int)**: the maximum width (in inches) for the output figure.
+    If set to -1, the maximum displayable width will be used.
+    Defaults to -1.
 
-    dpi (int): the DPI to use for the output image. Defaults to 150.
+    **dpi (int)**: the DPI to use for the output image. Defaults to 150.
 
-    margin (list): a list of margin values to adjust spacing around output
-        image. Takes a list of 4 ints: [x left, x right, y bottom, y top].
-        Defaults to [2.0, 0.1, 0.1, 0.3].
+    **margin (list)**: a list of margin values to adjust spacing around output
+    image. Takes a list of 4 ints: [x left, x right, y bottom, y top].
+    Defaults to [2.0, 0.1, 0.1, 0.3].
 
-    creglinestyle (str): The style of line to use for classical registers.
-        Choices are ``solid``, ``doublet``, or any valid matplotlib
-        `linestyle` kwarg value. Defaults to ``doublet``.
+    **creglinestyle (str)**: The style of line to use for classical registers.
+    Choices are ``solid``, ``doublet``, or any valid matplotlib
+    `linestyle` kwarg value. Defaults to ``doublet``.
 
-    displaytext (dict): a dictionary of the text to use for certain element
-        types in the output visualization. These items allow the use of
-        LaTeX formatting for gate names. The 'displaytext' dict can contain
-        any number of elements. User created names and labels may be used as
-        keys, which allow these to have Latex formatting. The default
-        values are (`default.json`)::
+    **displaytext (dict)**: a dictionary of the text to use for certain element
+    types in the output visualization. These items allow the use of
+    LaTeX formatting for gate names. The 'displaytext' dict can contain
+    any number of elements. User created names and labels may be used as
+    keys, which allow these to have Latex formatting. The default
+    values are (`default.json`)::
 
-            {
-                'u1': 'U_1',
-                'u2': 'U_2',
-                'u3': 'U_3',
-                'sdg': 'S^\\dagger',
-                'sx': '\\sqrt{X}',
-                'sxdg': '\\sqrt{X}^\\dagger',
-                't': 'T',
-                'tdg': 'T^\\dagger',
-                'dcx': 'Dcx',
-                'iswap': 'Iswap',
-                'ms': 'MS',
-                'rx': 'R_X',
-                'ry': 'R_Y',
-                'rz': 'R_Z',
-                'rxx': 'R_{XX}',
-                'ryy': 'R_{YY}',
-                'rzx': 'R_{ZX}',
-                'rzz': 'ZZ',
-                'reset': '\\left|0\\right\\rangle',
-                'initialize': '|\\psi\\rangle'
-            }
+        {
+            'u1': 'U_1',
+            'u2': 'U_2',
+            'u3': 'U_3',
+            'sdg': 'S^\\dagger',
+            'sx': '\\sqrt{X}',
+            'sxdg': '\\sqrt{X}^\\dagger',
+            't': 'T',
+            'tdg': 'T^\\dagger',
+            'dcx': 'Dcx',
+            'iswap': 'Iswap',
+            'ms': 'MS',
+            'rx': 'R_X',
+            'ry': 'R_Y',
+            'rz': 'R_Z',
+            'rxx': 'R_{XX}',
+            'ryy': 'R_{YY}',
+            'rzx': 'R_{ZX}',
+            'rzz': 'ZZ',
+            'reset': '\\left|0\\right\\rangle',
+            'initialize': '|\\psi\\rangle'
+        }
 
-    displaycolor (dict): the color codes to use for each circuit element in
-        the form (gate_color, text_color). Colors can also be entered without
-        the text color, such as 'u1': '#FA74A6', in which case the text color
-        will always be `gatetextcolor`. The `displaycolor` dict can contain
-        any number of elements. User names and labels may be used as keys,
-        which allows for custom colors for user-created gates. The default
-        values are (`default.json`)::
+    **displaycolor (dict)**: the color codes to use for each circuit element in
+    the form (gate_color, text_color). Colors can also be entered without
+    the text color, such as 'u1': '#FA74A6', in which case the text color
+    will always be `gatetextcolor`. The `displaycolor` dict can contain
+    any number of elements. User names and labels may be used as keys,
+    which allows for custom colors for user-created gates. The default
+    values are (`default.json`)::
 
-            {
-                'u1': ('#FA74A6', '#000000'),
-                'u2': ('#FA74A6', '#000000'),
-                'u3': ('#FA74A6', '#000000'),
-                'id': ('#05BAB6', '#000000'),
-                'u': ('#BB8BFF', '#000000'),
-                'p': ('#BB8BFF', '#000000'),
-                'x': ('#05BAB6', '#000000'),
-                'y': ('#05BAB6', '#000000'),
-                'z': ('#05BAB6', '#000000'),
-                'h': ('#6FA4FF', '#000000'),
-                'cx': ('#6FA4FF', '#000000'),
-                'ccx': ('#BB8BFF', '#000000'),
-                'mcx': ('#BB8BFF', '#000000'),
-                'mcx_gray': ('#BB8BFF', '#000000'),
-                'cy': ('#6FA4FF', '#000000'),
-                'cz': ('#6FA4FF', '#000000'),
-                'swap': ('#6FA4FF', '#000000'),
-                'cswap': ('#BB8BFF', '#000000'),
-                'ccswap': ('#BB8BFF', '#000000'),
-                'dcx': ('#6FA4FF', '#000000'),
-                'cdcx': ('#BB8BFF', '#000000'),
-                'ccdcx': ('#BB8BFF', '#000000'),
-                'iswap': ('#6FA4FF', '#000000'),
-                's': ('#6FA4FF', '#000000'),
-                'sdg': ('#6FA4FF', '#000000'),
-                't': ('#BB8BFF', '#000000'),
-                'tdg': ('#BB8BFF', '#000000'),
-                'sx': ('#6FA4FF', '#000000'),
-                'sxdg': ('#6FA4FF', '#000000')
-                'r': ('#BB8BFF', '#000000'),
-                'rx': ('#BB8BFF', '#000000'),
-                'ry': ('#BB8BFF', '#000000'),
-                'rz': ('#BB8BFF', '#000000'),
-                'rxx': ('#BB8BFF', '#000000'),
-                'ryy': ('#BB8BFF', '#000000'),
-                'rzx': ('#BB8BFF', '#000000'),
-                'reset': ('#000000', '#FFFFFF'),
-                'target': ('#FFFFFF', '#FFFFFF'),
-                'measure': ('#000000', '#FFFFFF'),
-            }
+        {
+            'u1': ('#FA74A6', '#000000'),
+            'u2': ('#FA74A6', '#000000'),
+            'u3': ('#FA74A6', '#000000'),
+            'id': ('#05BAB6', '#000000'),
+            'u': ('#BB8BFF', '#000000'),
+            'p': ('#BB8BFF', '#000000'),
+            'x': ('#05BAB6', '#000000'),
+            'y': ('#05BAB6', '#000000'),
+            'z': ('#05BAB6', '#000000'),
+            'h': ('#6FA4FF', '#000000'),
+            'cx': ('#6FA4FF', '#000000'),
+            'ccx': ('#BB8BFF', '#000000'),
+            'mcx': ('#BB8BFF', '#000000'),
+            'mcx_gray': ('#BB8BFF', '#000000'),
+            'cy': ('#6FA4FF', '#000000'),
+            'cz': ('#6FA4FF', '#000000'),
+            'swap': ('#6FA4FF', '#000000'),
+            'cswap': ('#BB8BFF', '#000000'),
+            'ccswap': ('#BB8BFF', '#000000'),
+            'dcx': ('#6FA4FF', '#000000'),
+            'cdcx': ('#BB8BFF', '#000000'),
+            'ccdcx': ('#BB8BFF', '#000000'),
+            'iswap': ('#6FA4FF', '#000000'),
+            's': ('#6FA4FF', '#000000'),
+            'sdg': ('#6FA4FF', '#000000'),
+            't': ('#BB8BFF', '#000000'),
+            'tdg': ('#BB8BFF', '#000000'),
+            'sx': ('#6FA4FF', '#000000'),
+            'sxdg': ('#6FA4FF', '#000000')
+            'r': ('#BB8BFF', '#000000'),
+            'rx': ('#BB8BFF', '#000000'),
+            'ry': ('#BB8BFF', '#000000'),
+            'rz': ('#BB8BFF', '#000000'),
+            'rxx': ('#BB8BFF', '#000000'),
+            'ryy': ('#BB8BFF', '#000000'),
+            'rzx': ('#BB8BFF', '#000000'),
+            'reset': ('#000000', '#FFFFFF'),
+            'target': ('#FFFFFF', '#FFFFFF'),
+            'measure': ('#000000', '#FFFFFF'),
+        }
 
     """
 


### PR DESCRIPTION
### Summary
Change formatting of style dict arguments in documentation of `DefaultStyle` class (issue #11037).

### Details and comments
Formatting of arguments before:
Full first line of argument description is in bold.

<img width="729" alt="docs_before" src="https://github.com/user-attachments/assets/627ecd82-f2c9-4927-b474-d44c7b416ef1">

Formatting of arguments after change (local build):
Only the argument name is in bold and the rest is correctly formatted as text.

<img width="634" alt="local_build" src="https://github.com/user-attachments/assets/15f9aaee-b06f-43b4-86b4-0a02dae845e3">
