### PR TITLE
Deprecates `StochasticSwap` and suggests the use of `SabreSwap`

### DIFF
--- a/qiskit/transpiler/passes/routing/stochastic_swap.py
+++ b/qiskit/transpiler/passes/routing/stochastic_swap.py
@@ -38,6 +38,7 @@ from qiskit.circuit import (
 from qiskit._accelerate import stochastic_swap as stochastic_swap_rs
 from qiskit._accelerate import nlayout
 from qiskit.transpiler.passes.layout import disjoint_utils
+from qiskit.utils import deprecate_func
 
 from .utils import get_swap_map_dag
 
@@ -58,7 +59,12 @@ class StochasticSwap(TransformationPass):
         2. We do not use the fact that the input state is zero to simplify
            the circuit.
     """
-
+    @deprecate_func(
+        since="1.3",
+        removal_timeline="in the 2.0 release",
+        additional_msg="The `StochasticSwap` tranpilation pass is a suboptimal "
+        "routing algorithm and will has been superseded by :class:`.SabreSwap` pass.",
+    )
     def __init__(self, coupling_map, trials=20, seed=None, fake_run=False, initial_layout=None):
         """StochasticSwap initializer.
 
@@ -76,6 +82,7 @@ class StochasticSwap(TransformationPass):
             initial_layout (Layout): starting layout at beginning of pass.
         """
         super().__init__()
+
         if isinstance(coupling_map, Target):
             self.target = coupling_map
             self.coupling_map = self.target.build_coupling_map()

--- a/qiskit/transpiler/passes/routing/stochastic_swap.py
+++ b/qiskit/transpiler/passes/routing/stochastic_swap.py
@@ -64,7 +64,7 @@ class StochasticSwap(TransformationPass):
         since="1.3",
         removal_timeline="in the 2.0 release",
         additional_msg="The `StochasticSwap` tranpilation pass is a suboptimal "
-        "routing algorithm and will has been superseded by :class:`.SabreSwap` pass.",
+        "routing algorithm and has been superseded by :class:`.SabreSwap` pass.",
     )
     def __init__(self, coupling_map, trials=20, seed=None, fake_run=False, initial_layout=None):
         """StochasticSwap initializer.

--- a/qiskit/transpiler/passes/routing/stochastic_swap.py
+++ b/qiskit/transpiler/passes/routing/stochastic_swap.py
@@ -59,6 +59,7 @@ class StochasticSwap(TransformationPass):
         2. We do not use the fact that the input state is zero to simplify
            the circuit.
     """
+
     @deprecate_func(
         since="1.3",
         removal_timeline="in the 2.0 release",

--- a/qiskit/transpiler/passes/routing/stochastic_swap.py
+++ b/qiskit/transpiler/passes/routing/stochastic_swap.py
@@ -63,8 +63,8 @@ class StochasticSwap(TransformationPass):
     @deprecate_func(
         since="1.3",
         removal_timeline="in the 2.0 release",
-        additional_msg="The `StochasticSwap` tranpilation pass is a suboptimal "
-        "routing algorithm and has been superseded by :class:`.SabreSwap` pass.",
+        additional_msg="The `StochasticSwap` transpilation pass is a suboptimal "
+        "routing algorithm and has been superseded by the :class:`.SabreSwap` pass.",
     )
     def __init__(self, coupling_map, trials=20, seed=None, fake_run=False, initial_layout=None):
         """StochasticSwap initializer.

--- a/releasenotes/notes/deprecate-StochasticSwap-451f46b273602b7b.yaml
+++ b/releasenotes/notes/deprecate-StochasticSwap-451f46b273602b7b.yaml
@@ -1,0 +1,40 @@
+---
+deprecations_transpiler:
+  - |
+    Deprecated ``StochasticSwap`` which has been superseded by :class:`.SabreSwap`. 
+    If the class is called from the transpile method, the change would be, for example:: 
+      tqc = transpile(
+        circuit,
+        routing_method="stochastic",
+        layout_method="dense",
+        seed_transpiler=12342,
+        target=GenericBackendV2(
+            num_qubits=27,
+            coupling_map=MUMBAI_CMAP,
+        ).target,
+        ) 
+    to::
+      tqc = transpile(
+        circuit,
+        routing_method="sabre",
+        layout_method="sabre",
+        seed_transpiler=12342,
+        target=GenericBackendV2(
+            num_qubits=27,
+            coupling_map=MUMBAI_CMAP,
+        ).target,
+        )   
+
+    While for a pass mananager change::
+      qr = QuantumRegister(4, "q")
+      qc = QuantumCircuit(qr)
+      dag = circuit_to_dag(qc)
+      passmanager = StochasticSwap(coupling, 20, 13)
+      new_qc = passmanager.run(dag)
+    to::
+      qr = QuantumRegister(5, "q")
+      qc = QuantumCircuit(qr) 
+      passmanager = PassManager(SabreSwap(target, "basic"))
+      new_qc = passmanager.run(qc)
+
+

--- a/releasenotes/notes/deprecate-StochasticSwap-451f46b273602b7b.yaml
+++ b/releasenotes/notes/deprecate-StochasticSwap-451f46b273602b7b.yaml
@@ -2,7 +2,7 @@
 deprecations_transpiler:
   - |
     Deprecated ``StochasticSwap`` which has been superseded by :class:`.SabreSwap`. 
-    If the class is called from the transpile method, the change would be, for example:: 
+    If the class is called from the transpile function, the change would be, for example:: 
 
       tqc = transpile(
         circuit,

--- a/releasenotes/notes/deprecate-StochasticSwap-451f46b273602b7b.yaml
+++ b/releasenotes/notes/deprecate-StochasticSwap-451f46b273602b7b.yaml
@@ -3,6 +3,7 @@ deprecations_transpiler:
   - |
     Deprecated ``StochasticSwap`` which has been superseded by :class:`.SabreSwap`. 
     If the class is called from the transpile method, the change would be, for example:: 
+
       tqc = transpile(
         circuit,
         routing_method="stochastic",
@@ -13,7 +14,9 @@ deprecations_transpiler:
             coupling_map=MUMBAI_CMAP,
         ).target,
         ) 
+    
     to::
+
       tqc = transpile(
         circuit,
         routing_method="sabre",
@@ -26,14 +29,18 @@ deprecations_transpiler:
         )   
 
     While for a pass mananager change::
+
       qr = QuantumRegister(4, "q")
       qc = QuantumCircuit(qr)
       passmanager = StochasticSwap(coupling, 20, 13)
       new_qc = passmanager.run(qc)
+
     to::
+
       qr = QuantumRegister(5, "q")
       qc = QuantumCircuit(qr) 
       passmanager = PassManager(SabreSwap(target, "basic"))
       new_qc = passmanager.run(qc)
+      
 
 

--- a/releasenotes/notes/deprecate-StochasticSwap-451f46b273602b7b.yaml
+++ b/releasenotes/notes/deprecate-StochasticSwap-451f46b273602b7b.yaml
@@ -32,7 +32,7 @@ deprecations_transpiler:
 
       qr = QuantumRegister(4, "q")
       qc = QuantumCircuit(qr)
-      passmanager = StochasticSwap(coupling, 20, 13)
+      passmanager = PassManager(StochasticSwap(coupling, 20, 13))
       new_qc = passmanager.run(qc)
 
     to::

--- a/releasenotes/notes/deprecate-StochasticSwap-451f46b273602b7b.yaml
+++ b/releasenotes/notes/deprecate-StochasticSwap-451f46b273602b7b.yaml
@@ -28,9 +28,8 @@ deprecations_transpiler:
     While for a pass mananager change::
       qr = QuantumRegister(4, "q")
       qc = QuantumCircuit(qr)
-      dag = circuit_to_dag(qc)
       passmanager = StochasticSwap(coupling, 20, 13)
-      new_qc = passmanager.run(dag)
+      new_qc = passmanager.run(qc)
     to::
       qr = QuantumRegister(5, "q")
       qc = QuantumCircuit(qr) 

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -3733,14 +3733,15 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
         qc.cy(20, 28)
         qc.cy(20, 29)
         qc.measure_all()
-        with self.assertRaises(TranspilerError):
-            transpile(
-                qc,
-                self.backend,
-                layout_method="trivial",
-                routing_method=routing_method,
-                seed_transpiler=42,
-            )
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(TranspilerError):
+                transpile(
+                    qc,
+                    self.backend,
+                    layout_method="trivial",
+                    routing_method=routing_method,
+                    seed_transpiler=42,
+                )
 
     # Lookahead swap skipped for performance reasons, stochastic moved to new test due to deprecation
     @data("sabre", "basic")

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -929,7 +929,9 @@ class TestTranspile(QiskitTestCase):
 
         lay = [0, 1, 15, 2, 14, 3, 13, 4, 12, 5, 11, 6]
         with self.assertWarns(DeprecationWarning):
-            out = transpile(circ, initial_layout=lay, coupling_map=cmap, routing_method="stochastic")
+            out = transpile(
+                circ, initial_layout=lay, coupling_map=cmap, routing_method="stochastic"
+            )
         out_dag = circuit_to_dag(out)
         meas_nodes = out_dag.named_nodes("measure")
         for meas_node in meas_nodes:
@@ -3536,11 +3538,11 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
         qc.measure_all()
         with self.assertWarns(DeprecationWarning):
             tqc = transpile(
-            qc,
-            self.backend,
-            layout_method="dense",
-            routing_method=routing_method,
-            seed_transpiler=42,
+                qc,
+                self.backend,
+                layout_method="dense",
+                routing_method=routing_method,
+                seed_transpiler=42,
             )
         for inst in tqc.data:
             qubits = tuple(tqc.find_bit(x).index for x in inst.qubits)
@@ -3638,11 +3640,11 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
         qc.measure_all()
         with self.assertWarns(DeprecationWarning):
             tqc = transpile(
-            qc,
-            self.backend,
-            layout_method="dense",
-            routing_method=routing_method,
-            seed_transpiler=42,
+                qc,
+                self.backend,
+                layout_method="dense",
+                routing_method=routing_method,
+                seed_transpiler=42,
             )
         for inst in tqc.data:
             qubits = tuple(tqc.find_bit(x).index for x in inst.qubits)
@@ -3698,7 +3700,7 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
     @data("stochastic")
     def test_triple_circuit_invalid_layout_stochastic(self, routing_method):
         """Test a split circuit with one circuit component per chip for deprecated ``StochasticSwap``"""
-        #TODO remove when StochasticSwap deprecated
+        # TODO remove when StochasticSwap deprecated
         qc = QuantumCircuit(30)
         qc.h(0)
         qc.h(10)
@@ -3739,7 +3741,6 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
                 routing_method=routing_method,
                 seed_transpiler=42,
             )
-
 
     # Lookahead swap skipped for performance reasons, stochastic moved to new test due to deprecation
     @data("sabre", "basic")
@@ -3807,7 +3808,7 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
     @data("stochastic")
     def test_six_component_circuit_dense_layout_stochastic(self, routing_method):
         """Test input circuit with more than 1 component per backend component for deprecated ``StochasticSwap``."""
-        #TODO remove when StochasticSwap will is removed
+        # TODO remove when StochasticSwap will is removed
         qc = QuantumCircuit(42)
         qc.h(0)
         qc.h(10)
@@ -3854,11 +3855,11 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
         qc.measure_all()
         with self.assertWarns(DeprecationWarning):
             tqc = transpile(
-            qc,
-            self.backend,
-            layout_method="dense",
-            routing_method=routing_method,
-            seed_transpiler=42,
+                qc,
+                self.backend,
+                layout_method="dense",
+                routing_method=routing_method,
+                seed_transpiler=42,
             )
         for inst in tqc.data:
             qubits = tuple(tqc.find_bit(x).index for x in inst.qubits)

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -3601,7 +3601,6 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
                 continue
             self.assertIn(qubits, self.backend.target[op_name])
 
-    # Lookahead swap skipped for performance
     @data("stochastic")
     def test_triple_circuit_dense_layout_stochastic(self, routing_method):
         """Test a split circuit with one circuit component per chip for deprecated StochasticSwap."""

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -928,7 +928,8 @@ class TestTranspile(QiskitTestCase):
         circ = QuantumCircuit.from_qasm_file(os.path.join(qasm_dir, "move_measurements.qasm"))
 
         lay = [0, 1, 15, 2, 14, 3, 13, 4, 12, 5, 11, 6]
-        out = transpile(circ, initial_layout=lay, coupling_map=cmap, routing_method="stochastic")
+        with self.assertWarns(DeprecationWarning):
+            out = transpile(circ, initial_layout=lay, coupling_map=cmap, routing_method="stochastic")
         out_dag = circuit_to_dag(out)
         meas_nodes = out_dag.named_nodes("measure")
         for meas_node in meas_nodes:
@@ -3498,7 +3499,7 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
             )[0]
         self.assertIn(qubit_map[op_node.qargs[0]], components[2])
 
-    @data("sabre", "stochastic", "basic", "lookahead")
+    @data("sabre", "basic", "lookahead")
     def test_basic_connected_circuit_dense_layout(self, routing_method):
         """Test basic connected circuit on disjoint backend"""
         qc = QuantumCircuit(5)
@@ -3522,8 +3523,34 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
                 continue
             self.assertIn(qubits, self.backend.target[op_name])
 
+    @data("stochastic")
+    def test_basic_connected_circuit_dense_layout_stochastic(self, routing_method):
+        """Test basic connected circuit on disjoint backend for deprecated stochastic swap"""
+        # Remove when stochastic is deprecated
+        qc = QuantumCircuit(5)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.cx(0, 2)
+        qc.cx(0, 3)
+        qc.cx(0, 4)
+        qc.measure_all()
+        with self.assertWarns(DeprecationWarning):
+            tqc = transpile(
+            qc,
+            self.backend,
+            layout_method="dense",
+            routing_method=routing_method,
+            seed_transpiler=42,
+            )
+        for inst in tqc.data:
+            qubits = tuple(tqc.find_bit(x).index for x in inst.qubits)
+            op_name = inst.operation.name
+            if op_name == "barrier":
+                continue
+            self.assertIn(qubits, self.backend.target[op_name])
+
     # Lookahead swap skipped for performance
-    @data("sabre", "stochastic", "basic")
+    @data("sabre", "basic")
     def test_triple_circuit_dense_layout(self, routing_method):
         """Test a split circuit with one circuit component per chip."""
         qc = QuantumCircuit(30)
@@ -3572,7 +3599,59 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
                 continue
             self.assertIn(qubits, self.backend.target[op_name])
 
-    @data("sabre", "stochastic", "basic", "lookahead")
+    # Lookahead swap skipped for performance
+    @data("stochastic")
+    def test_triple_circuit_dense_layout_stochastic(self, routing_method):
+        """Test a split circuit with one circuit component per chip for deprecated StochasticSwap."""
+        # Remove when stochastic swap deprecated
+        qc = QuantumCircuit(30)
+        qc.h(0)
+        qc.h(10)
+        qc.h(20)
+        qc.cx(0, 1)
+        qc.cx(0, 2)
+        qc.cx(0, 3)
+        qc.cx(0, 4)
+        qc.cx(0, 5)
+        qc.cx(0, 6)
+        qc.cx(0, 7)
+        qc.cx(0, 8)
+        qc.cx(0, 9)
+        qc.ecr(10, 11)
+        qc.ecr(10, 12)
+        qc.ecr(10, 13)
+        qc.ecr(10, 14)
+        qc.ecr(10, 15)
+        qc.ecr(10, 16)
+        qc.ecr(10, 17)
+        qc.ecr(10, 18)
+        qc.ecr(10, 19)
+        qc.cy(20, 21)
+        qc.cy(20, 22)
+        qc.cy(20, 23)
+        qc.cy(20, 24)
+        qc.cy(20, 25)
+        qc.cy(20, 26)
+        qc.cy(20, 27)
+        qc.cy(20, 28)
+        qc.cy(20, 29)
+        qc.measure_all()
+        with self.assertWarns(DeprecationWarning):
+            tqc = transpile(
+            qc,
+            self.backend,
+            layout_method="dense",
+            routing_method=routing_method,
+            seed_transpiler=42,
+            )
+        for inst in tqc.data:
+            qubits = tuple(tqc.find_bit(x).index for x in inst.qubits)
+            op_name = inst.operation.name
+            if op_name == "barrier":
+                continue
+            self.assertIn(qubits, self.backend.target[op_name])
+
+    @data("sabre", "basic", "lookahead")
     def test_triple_circuit_invalid_layout(self, routing_method):
         """Test a split circuit with one circuit component per chip."""
         qc = QuantumCircuit(30)
@@ -3616,8 +3695,54 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
                 seed_transpiler=42,
             )
 
-    # Lookahead swap skipped for performance reasons
-    @data("sabre", "stochastic", "basic")
+    @data("stochastic")
+    def test_triple_circuit_invalid_layout_stochastic(self, routing_method):
+        """Test a split circuit with one circuit component per chip for deprecated ``StochasticSwap``"""
+        #TODO remove when StochasticSwap deprecated
+        qc = QuantumCircuit(30)
+        qc.h(0)
+        qc.h(10)
+        qc.h(20)
+        qc.cx(0, 1)
+        qc.cx(0, 2)
+        qc.cx(0, 3)
+        qc.cx(0, 4)
+        qc.cx(0, 5)
+        qc.cx(0, 6)
+        qc.cx(0, 7)
+        qc.cx(0, 8)
+        qc.cx(0, 9)
+        qc.ecr(10, 11)
+        qc.ecr(10, 12)
+        qc.ecr(10, 13)
+        qc.ecr(10, 14)
+        qc.ecr(10, 15)
+        qc.ecr(10, 16)
+        qc.ecr(10, 17)
+        qc.ecr(10, 18)
+        qc.ecr(10, 19)
+        qc.cy(20, 21)
+        qc.cy(20, 22)
+        qc.cy(20, 23)
+        qc.cy(20, 24)
+        qc.cy(20, 25)
+        qc.cy(20, 26)
+        qc.cy(20, 27)
+        qc.cy(20, 28)
+        qc.cy(20, 29)
+        qc.measure_all()
+        with self.assertRaises(TranspilerError):
+            transpile(
+                qc,
+                self.backend,
+                layout_method="trivial",
+                routing_method=routing_method,
+                seed_transpiler=42,
+            )
+
+
+    # Lookahead swap skipped for performance reasons, stochastic moved to new test due to deprecation
+    @data("sabre", "basic")
     def test_six_component_circuit_dense_layout(self, routing_method):
         """Test input circuit with more than 1 component per backend component."""
         qc = QuantumCircuit(42)
@@ -3671,6 +3796,70 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
             routing_method=routing_method,
             seed_transpiler=42,
         )
+        for inst in tqc.data:
+            qubits = tuple(tqc.find_bit(x).index for x in inst.qubits)
+            op_name = inst.operation.name
+            if op_name == "barrier":
+                continue
+            self.assertIn(qubits, self.backend.target[op_name])
+
+    # Lookahead swap skipped for performance reasons
+    @data("stochastic")
+    def test_six_component_circuit_dense_layout_stochastic(self, routing_method):
+        """Test input circuit with more than 1 component per backend component for deprecated ``StochasticSwap``."""
+        #TODO remove when StochasticSwap will is removed
+        qc = QuantumCircuit(42)
+        qc.h(0)
+        qc.h(10)
+        qc.h(20)
+        qc.cx(0, 1)
+        qc.cx(0, 2)
+        qc.cx(0, 3)
+        qc.cx(0, 4)
+        qc.cx(0, 5)
+        qc.cx(0, 6)
+        qc.cx(0, 7)
+        qc.cx(0, 8)
+        qc.cx(0, 9)
+        qc.ecr(10, 11)
+        qc.ecr(10, 12)
+        qc.ecr(10, 13)
+        qc.ecr(10, 14)
+        qc.ecr(10, 15)
+        qc.ecr(10, 16)
+        qc.ecr(10, 17)
+        qc.ecr(10, 18)
+        qc.ecr(10, 19)
+        qc.cy(20, 21)
+        qc.cy(20, 22)
+        qc.cy(20, 23)
+        qc.cy(20, 24)
+        qc.cy(20, 25)
+        qc.cy(20, 26)
+        qc.cy(20, 27)
+        qc.cy(20, 28)
+        qc.cy(20, 29)
+        qc.h(30)
+        qc.cx(30, 31)
+        qc.cx(30, 32)
+        qc.cx(30, 33)
+        qc.h(34)
+        qc.cx(34, 35)
+        qc.cx(34, 36)
+        qc.cx(34, 37)
+        qc.h(38)
+        qc.cx(38, 39)
+        qc.cx(39, 40)
+        qc.cx(39, 41)
+        qc.measure_all()
+        with self.assertWarns(DeprecationWarning):
+            tqc = transpile(
+            qc,
+            self.backend,
+            layout_method="dense",
+            routing_method=routing_method,
+            seed_transpiler=42,
+            )
         for inst in tqc.data:
             qubits = tuple(tqc.find_bit(x).index for x in inst.qubits)
             op_name = inst.operation.name

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -3808,7 +3808,8 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
     # Lookahead swap skipped for performance reasons
     @data("stochastic")
     def test_six_component_circuit_dense_layout_stochastic(self, routing_method):
-        """Test input circuit with more than 1 component per backend component for deprecated ``StochasticSwap``."""
+        """Test input circuit with more than 1 component per backend component
+        for deprecated ``StochasticSwap``."""
         # TODO remove when StochasticSwap will is removed
         qc = QuantumCircuit(42)
         qc.h(0)

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -3528,7 +3528,7 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
     @data("stochastic")
     def test_basic_connected_circuit_dense_layout_stochastic(self, routing_method):
         """Test basic connected circuit on disjoint backend for deprecated stochastic swap"""
-        # Remove when stochastic is deprecated
+        # TODO: Remove when StochasticSwap is removed
         qc = QuantumCircuit(5)
         qc.h(0)
         qc.cx(0, 1)
@@ -3604,7 +3604,7 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
     @data("stochastic")
     def test_triple_circuit_dense_layout_stochastic(self, routing_method):
         """Test a split circuit with one circuit component per chip for deprecated StochasticSwap."""
-        # Remove when stochastic swap deprecated
+        # TODO: Remove when StochasticSwap is removed
         qc = QuantumCircuit(30)
         qc.h(0)
         qc.h(10)
@@ -3699,7 +3699,7 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
     @data("stochastic")
     def test_triple_circuit_invalid_layout_stochastic(self, routing_method):
         """Test a split circuit with one circuit component per chip for deprecated ``StochasticSwap``"""
-        # TODO remove when StochasticSwap deprecated
+        # TODO: Remove when StochasticSwap is removed
         qc = QuantumCircuit(30)
         qc.h(0)
         qc.h(10)
@@ -3809,7 +3809,7 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
     def test_six_component_circuit_dense_layout_stochastic(self, routing_method):
         """Test input circuit with more than 1 component per backend component
         for deprecated ``StochasticSwap``."""
-        # TODO remove when StochasticSwap will is removed
+        # TODO: Remove when StochasticSwap is removed
         qc = QuantumCircuit(42)
         qc.h(0)
         qc.h(10)

--- a/test/python/transpiler/test_mappers.py
+++ b/test/python/transpiler/test_mappers.py
@@ -106,7 +106,7 @@ class CommonUtilitiesMixin:
             passmanager.append(SetLayout(Layout(initial_layout)))
 
         with warnings.catch_warnings():
-            # TODO remove this filter when StochasticSwap is removed,
+            # TODO: remove this filter when StochasticSwap is removed
             warnings.filterwarnings(
                 "ignore",
                 category=DeprecationWarning,

--- a/test/python/transpiler/test_mappers.py
+++ b/test/python/transpiler/test_mappers.py
@@ -76,7 +76,7 @@ from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit, transpile
 from qiskit.providers.basic_provider import BasicSimulator
 from qiskit.qasm2 import dump
 from qiskit.transpiler import PassManager
-from qiskit.transpiler.passes import BasicSwap, LookaheadSwap, StochasticSwap, SabreSwap
+from qiskit.transpiler.passes import BasicSwap, LookaheadSwap, SabreSwap
 from qiskit.transpiler.passes import SetLayout
 from qiskit.transpiler import CouplingMap, Layout
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
@@ -280,12 +280,12 @@ class TestsLookaheadSwap(SwapperCommonTestCases, QiskitTestCase):
 
     pass_class = LookaheadSwap
 
+### Commented out as StochasticSwap is deprecated
+# class TestsStochasticSwap(SwapperCommonTestCases, QiskitTestCase):
+#     """Test SwapperCommonTestCases using StochasticSwap."""
 
-class TestsStochasticSwap(SwapperCommonTestCases, QiskitTestCase):
-    """Test SwapperCommonTestCases using StochasticSwap."""
-
-    pass_class = StochasticSwap
-    additional_args = {"seed": 0}
+#     pass_class = StochasticSwap
+#     additional_args = {"seed": 0}
 
 
 class TestsSabreSwap(SwapperCommonTestCases, QiskitTestCase):

--- a/test/python/transpiler/test_mappers.py
+++ b/test/python/transpiler/test_mappers.py
@@ -280,6 +280,7 @@ class TestsLookaheadSwap(SwapperCommonTestCases, QiskitTestCase):
 
     pass_class = LookaheadSwap
 
+
 ### Commented out as StochasticSwap is deprecated
 # class TestsStochasticSwap(SwapperCommonTestCases, QiskitTestCase):
 #     """Test SwapperCommonTestCases using StochasticSwap."""

--- a/test/python/transpiler/test_mappers.py
+++ b/test/python/transpiler/test_mappers.py
@@ -71,12 +71,13 @@ For example::
 import unittest
 import os
 import sys
+import warnings
 
 from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit, transpile
 from qiskit.providers.basic_provider import BasicSimulator
 from qiskit.qasm2 import dump
 from qiskit.transpiler import PassManager
-from qiskit.transpiler.passes import BasicSwap, LookaheadSwap, SabreSwap
+from qiskit.transpiler.passes import BasicSwap, LookaheadSwap, SabreSwap, StochasticSwap
 from qiskit.transpiler.passes import SetLayout
 from qiskit.transpiler import CouplingMap, Layout
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
@@ -104,8 +105,15 @@ class CommonUtilitiesMixin:
         if initial_layout:
             passmanager.append(SetLayout(Layout(initial_layout)))
 
-        # pylint: disable=not-callable
-        passmanager.append(self.pass_class(CouplingMap(coupling_map), **self.additional_args))
+        with warnings.catch_warnings():
+            # TODO remove this filter when StochasticSwap is removed,
+            warnings.filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+                message=r".*StochasticSwap.*",
+            )
+            # pylint: disable=not-callable
+            passmanager.append(self.pass_class(CouplingMap(coupling_map), **self.additional_args))
         return passmanager
 
     def create_backend(self):
@@ -281,12 +289,11 @@ class TestsLookaheadSwap(SwapperCommonTestCases, QiskitTestCase):
     pass_class = LookaheadSwap
 
 
-### Commented out as StochasticSwap is deprecated
-# class TestsStochasticSwap(SwapperCommonTestCases, QiskitTestCase):
-#     """Test SwapperCommonTestCases using StochasticSwap."""
+class TestsStochasticSwap(SwapperCommonTestCases, QiskitTestCase):
+    """Test SwapperCommonTestCases using StochasticSwap."""
 
-#     pass_class = StochasticSwap
-#     additional_args = {"seed": 0}
+    pass_class = StochasticSwap
+    additional_args = {"seed": 0}
 
 
 class TestsSabreSwap(SwapperCommonTestCases, QiskitTestCase):

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -497,7 +497,7 @@ class TestPassesInspection(QiskitTestCase):
         self.assertNotIn("SabreSwap", self.passes)
 
     def test_level1_runs_vf2post_layout_when_routing_method_set_and_required(self):
-        """Test that if we run routing as part of sabre layout VF2PostLayout runs."""
+        """Test that if we run routing as part of sabre layout then VF2PostLayout runs."""
         target = GenericBackendV2(num_qubits=7, coupling_map=LAGOS_CMAP, seed=42)
         qc = QuantumCircuit(5)
         qc.h(0)
@@ -507,7 +507,7 @@ class TestPassesInspection(QiskitTestCase):
         qc.cy(0, 4)
         qc.measure_all()
         _ = transpile(
-            qc, target, optimization_level=1, routing_method="stochastic", callback=self.callback
+            qc, target, optimization_level=1, routing_method="sabre", callback=self.callback
         )
         # Expected call path for layout and routing is:
         # 1. TrivialLayout (no perfect match)
@@ -518,7 +518,6 @@ class TestPassesInspection(QiskitTestCase):
         self.assertIn("VF2Layout", self.passes)
         self.assertIn("SabreLayout", self.passes)
         self.assertIn("VF2PostLayout", self.passes)
-        self.assertIn("StochasticSwap", self.passes)
 
     def test_level1_not_runs_vf2post_layout_when_layout_method_set(self):
         """Test that if we don't run VF2PostLayout with custom layout_method."""

--- a/test/python/transpiler/test_sabre_layout.py
+++ b/test/python/transpiler/test_sabre_layout.py
@@ -261,12 +261,12 @@ barrier q18585[5],q18585[2],q18585[8],q18585[3],q18585[6];
         )
         with self.assertWarns(DeprecationWarning):
             res = transpile(
-            qc,
-            backend,
-            layout_method="sabre",
-            routing_method="stochastic",
-            seed_transpiler=12345,
-            optimization_level=1,
+                qc,
+                backend,
+                layout_method="sabre",
+                routing_method="stochastic",
+                seed_transpiler=12345,
+                optimization_level=1,
             )
         self.assertIsInstance(res, QuantumCircuit)
         layout = res._layout.initial_layout
@@ -309,7 +309,7 @@ barrier q18585[5],q18585[2],q18585[8],q18585[3],q18585[6];
         cm = CouplingMap.from_line(8)
         with self.assertWarns(DeprecationWarning):
             pass_ = SabreLayout(
-            cm, seed=0, routing_pass=StochasticSwap(cm, trials=1, seed=0, fake_run=True)
+                cm, seed=0, routing_pass=StochasticSwap(cm, trials=1, seed=0, fake_run=True)
             )
             _ = pass_(qc)
         layout = pass_.property_set["layout"]

--- a/test/python/transpiler/test_sabre_layout.py
+++ b/test/python/transpiler/test_sabre_layout.py
@@ -259,14 +259,15 @@ barrier q18585[5],q18585[2],q18585[8],q18585[3],q18585[6];
             coupling_map=MUMBAI_CMAP,
             seed=42,
         )
-        res = transpile(
+        with self.assertWarns(DeprecationWarning):
+            res = transpile(
             qc,
             backend,
             layout_method="sabre",
             routing_method="stochastic",
             seed_transpiler=12345,
             optimization_level=1,
-        )
+            )
         self.assertIsInstance(res, QuantumCircuit)
         layout = res._layout.initial_layout
         self.assertEqual(
@@ -306,10 +307,11 @@ barrier q18585[5],q18585[2],q18585[8],q18585[3],q18585[6];
         qc.cx(4, 0)
 
         cm = CouplingMap.from_line(8)
-        pass_ = SabreLayout(
+        with self.assertWarns(DeprecationWarning):
+            pass_ = SabreLayout(
             cm, seed=0, routing_pass=StochasticSwap(cm, trials=1, seed=0, fake_run=True)
-        )
-        _ = pass_(qc)
+            )
+            _ = pass_(qc)
         layout = pass_.property_set["layout"]
         self.assertEqual([layout[q] for q in qc.qubits], [2, 3, 4, 1, 5])
 

--- a/test/python/transpiler/test_stage_plugin.py
+++ b/test/python/transpiler/test_stage_plugin.py
@@ -102,7 +102,7 @@ class TestBuiltinPlugins(QiskitTestCase):
 
     @combine(
         optimization_level=list(range(4)),
-        routing_method=["basic", "lookahead", "sabre", "stochastic"],
+        routing_method=["basic", "lookahead", "sabre"],
     )
     def test_routing_plugins(self, optimization_level, routing_method):
         """Test all routing plugins (excluding error)."""
@@ -122,6 +122,32 @@ class TestBuiltinPlugins(QiskitTestCase):
         backend = BasicSimulator()
         counts = backend.run(tqc, shots=1000).result().get_counts()
         self.assertDictAlmostEqual(counts, {"0000": 500, "1111": 500}, delta=100)
+
+    @combine(
+        optimization_level=list(range(4)),
+        routing_method=["stochastic"],
+    )
+    def test_routing_plugin_stochastic(self, optimization_level, routing_method):
+        """Test stoc routing plugins (excluding error)."""
+        # Note remove once StochasticSwap gets removed
+        qc = QuantumCircuit(4)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.cx(0, 2)
+        qc.cx(0, 3)
+        qc.measure_all()
+        with self.assertWarns(DeprecationWarning):
+            tqc = transpile(
+            qc,
+            basis_gates=["cx", "sx", "x", "rz"],
+            coupling_map=CouplingMap.from_line(4),
+            optimization_level=optimization_level,
+            routing_method=routing_method,
+            )
+        backend = BasicSimulator()
+        counts = backend.run(tqc, shots=1000).result().get_counts()
+        self.assertDictAlmostEqual(counts, {"0000": 500, "1111": 500}, delta=100)
+
 
     @combine(
         optimization_level=list(range(4)),

--- a/test/python/transpiler/test_stage_plugin.py
+++ b/test/python/transpiler/test_stage_plugin.py
@@ -138,16 +138,15 @@ class TestBuiltinPlugins(QiskitTestCase):
         qc.measure_all()
         with self.assertWarns(DeprecationWarning):
             tqc = transpile(
-            qc,
-            basis_gates=["cx", "sx", "x", "rz"],
-            coupling_map=CouplingMap.from_line(4),
-            optimization_level=optimization_level,
-            routing_method=routing_method,
+                qc,
+                basis_gates=["cx", "sx", "x", "rz"],
+                coupling_map=CouplingMap.from_line(4),
+                optimization_level=optimization_level,
+                routing_method=routing_method,
             )
         backend = BasicSimulator()
         counts = backend.run(tqc, shots=1000).result().get_counts()
         self.assertDictAlmostEqual(counts, {"0000": 500, "1111": 500}, delta=100)
-
 
     @combine(
         optimization_level=list(range(4)),

--- a/test/python/transpiler/test_stochastic_swap.py
+++ b/test/python/transpiler/test_stochastic_swap.py
@@ -60,7 +60,8 @@ class TestStochasticSwap(QiskitTestCase):
         circuit.cx(qr[0], qr[2])
 
         dag = circuit_to_dag(circuit)
-        pass_ = StochasticSwap(coupling, 20, 13)
+        with self.assetWarns(DeprecationWarning):
+            pass_ = StochasticSwap(coupling, 20, 13)
         after = pass_.run(dag)
 
         self.assertEqual(dag, after)
@@ -83,7 +84,8 @@ class TestStochasticSwap(QiskitTestCase):
         circuit.cx(qr[0], qr[1])
 
         dag = circuit_to_dag(circuit)
-        pass_ = StochasticSwap(coupling, 20, 13)
+        with self.assetWarns(DeprecationWarning):
+            pass_ = StochasticSwap(coupling, 20, 13)
         after = pass_.run(dag)
 
         self.assertEqual(dag, after)
@@ -109,7 +111,8 @@ class TestStochasticSwap(QiskitTestCase):
         circuit.cx(qr[1], qr[2])
         dag = circuit_to_dag(circuit)
 
-        pass_ = StochasticSwap(coupling, 20, 11)
+        with self.assetWarns(DeprecationWarning):
+            pass_ = StochasticSwap(coupling, 20, 11)
         after = pass_.run(dag)
 
         expected = QuantumCircuit(qr)
@@ -140,7 +143,8 @@ class TestStochasticSwap(QiskitTestCase):
         circuit.h(qr[0])
         dag = circuit_to_dag(circuit)
 
-        pass_ = StochasticSwap(coupling, 20, 11)
+        with self.assetWarns(DeprecationWarning):
+            pass_ = StochasticSwap(coupling, 20, 11)
         after = pass_.run(dag)
 
         expected = QuantumCircuit(qr)
@@ -176,7 +180,8 @@ class TestStochasticSwap(QiskitTestCase):
         circuit.cx(qr[3], qr[0])
         dag = circuit_to_dag(circuit)
 
-        pass_ = StochasticSwap(coupling, 20, 13)
+        with self.assetWarns(DeprecationWarning):
+            pass_ = StochasticSwap(coupling, 20, 13)
         after = pass_.run(dag)
 
         expected = QuantumCircuit(qr)
@@ -215,7 +220,8 @@ class TestStochasticSwap(QiskitTestCase):
         circuit.cx(qr[3], qr[0])
         dag = circuit_to_dag(circuit)
 
-        pass_ = StochasticSwap(coupling, 20, 13)
+        with self.assetWarns(DeprecationWarning):
+            pass_ = StochasticSwap(coupling, 20, 13)
         after = pass_.run(dag)
 
         expected = QuantumCircuit(qr)
@@ -254,7 +260,8 @@ class TestStochasticSwap(QiskitTestCase):
         circuit.h(qr[3])
         dag = circuit_to_dag(circuit)
 
-        pass_ = StochasticSwap(coupling, 20, 13)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = StochasticSwap(coupling, 20, 13)
         after = pass_.run(dag)
 
         expected = QuantumCircuit(qr)
@@ -283,7 +290,8 @@ class TestStochasticSwap(QiskitTestCase):
         circ.measure(qr[3], cr[3])
         dag = circuit_to_dag(circ)
 
-        pass_ = StochasticSwap(coupling, 20, 13)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = StochasticSwap(coupling, 20, 13)
         after = pass_.run(dag)
         self.assertEqual(dag, after)
 
@@ -363,7 +371,8 @@ class TestStochasticSwap(QiskitTestCase):
         #  qr[1]: 1,
         #  qr[2]: 2,
         #  qr[3]: 3}
-        pass_ = StochasticSwap(coupling, 20, 19)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = StochasticSwap(coupling, 20, 19)
         after = pass_.run(dag)
 
         self.assertEqual(expected_dag, after)
@@ -389,7 +398,8 @@ class TestStochasticSwap(QiskitTestCase):
 
         dag = circuit_to_dag(circ)
 
-        pass_ = StochasticSwap(coupling, 20, 13)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = StochasticSwap(coupling, 20, 13)
         after = pass_.run(dag)
         self.assertEqual(circuit_to_dag(circ), after)
 
@@ -465,7 +475,8 @@ class TestStochasticSwap(QiskitTestCase):
         expected.measure(qr[1], cr[1])
         expected_dag = circuit_to_dag(expected)
 
-        pass_ = StochasticSwap(coupling, 20, 999)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = StochasticSwap(coupling, 20, 999)
         after = pass_.run(dag)
         self.assertEqual(expected_dag, after)
 
@@ -483,7 +494,8 @@ class TestStochasticSwap(QiskitTestCase):
         circuit.measure(qr, cr)
         dag = circuit_to_dag(circuit)
 
-        pass_ = StochasticSwap(coupling, 20, 5)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = StochasticSwap(coupling, 20, 5)
         after = pass_.run(dag)
 
         valid_couplings = [{qr[a], qr[b]} for (a, b) in coupling.get_edges()]
@@ -505,7 +517,8 @@ class TestStochasticSwap(QiskitTestCase):
         circuit.measure(qr, cr)
         dag = circuit_to_dag(circuit)
 
-        pass_ = StochasticSwap(coupling)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = StochasticSwap(coupling)
         with self.assertRaises(TranspilerError):
             _ = pass_.run(dag)
 
@@ -549,7 +562,8 @@ class TestStochasticSwap(QiskitTestCase):
 
         expected_dag = circuit_to_dag(expected)
 
-        stochastic = StochasticSwap(CouplingMap(coupling_map), seed=0)
+        with self.assertWarns(DeprecationWarning):
+            stochastic = StochasticSwap(CouplingMap(coupling_map), seed=0)
         after = PassManager(stochastic).run(circuit)
         after = circuit_to_dag(after)
         self.assertEqual(expected_dag, after)
@@ -578,7 +592,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.measure(qreg, creg)
 
         dag = circuit_to_dag(qc)
-        cdag = StochasticSwap(coupling, seed=82).run(dag)
+        with self.assertWarns(DeprecationWarning):
+            cdag = StochasticSwap(coupling, seed=82).run(dag)
         check_map_pass = CheckMap(coupling)
         check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
@@ -618,7 +633,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.measure(qreg, creg)
 
         dag = circuit_to_dag(qc)
-        cdag = StochasticSwap(coupling, seed=431).run(dag)
+        with self.assertWarns(DeprecationWarning):
+            cdag = StochasticSwap(coupling, seed=431).run(dag)
         check_map_pass = CheckMap(coupling)
         check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
@@ -660,7 +676,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.measure(qreg, creg)
 
         dag = circuit_to_dag(qc)
-        cdag = StochasticSwap(coupling, seed=6508).run(dag)
+        with self.assertWarns(DeprecationWarning):
+            cdag = StochasticSwap(coupling, seed=6508).run(dag)
         check_map_pass = CheckMap(coupling)
         check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
@@ -700,7 +717,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.measure(qreg, creg)
 
         dag = circuit_to_dag(qc)
-        cdag = StochasticSwap(coupling, seed=38).run(dag)
+        with self.assertWarns(DeprecationWarning):
+            cdag = StochasticSwap(coupling, seed=38).run(dag)
         check_map_pass = CheckMap(coupling)
         check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
@@ -738,7 +756,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.measure(qreg, creg)
 
         dag = circuit_to_dag(qc)
-        cdag = StochasticSwap(coupling, seed=8).run(dag)
+        with self.assertWarns(DeprecationWarning):
+            cdag = StochasticSwap(coupling, seed=8).run(dag)
         check_map_pass = CheckMap(coupling)
         check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
@@ -781,7 +800,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.measure(qreg, creg)
 
         dag = circuit_to_dag(qc)
-        cdag = StochasticSwap(coupling, seed=2, trials=20).run(dag)
+        with self.assertWarns(DeprecationWarning):
+            cdag = StochasticSwap(coupling, seed=2, trials=20).run(dag)
         check_map_pass = CheckMap(coupling)
         check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
@@ -829,7 +849,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.measure(qreg, creg)
 
         dag = circuit_to_dag(qc)
-        cdag = StochasticSwap(coupling, seed=1).run(dag)
+        with self.assertWarns(DeprecationWarning):
+            cdag = StochasticSwap(coupling, seed=1).run(dag)
         check_map_pass = CheckMap(coupling)
         check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
@@ -871,7 +892,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.if_test(expr.logic_and(qc.clbits[0], qc.clbits[1]), body, [0, 1, 2, 3], [])
 
         dag = circuit_to_dag(qc)
-        cdag = StochasticSwap(coupling, seed=58).run(dag)
+        with self.assertWarns(DeprecationWarning):
+            cdag = StochasticSwap(coupling, seed=58).run(dag)
         check_map_pass = CheckMap(coupling)
         check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
@@ -892,7 +914,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.if_else(expr.logic_and(qc.clbits[0], qc.clbits[1]), true, false, [0, 1, 2, 3], [])
 
         dag = circuit_to_dag(qc)
-        cdag = StochasticSwap(coupling, seed=58).run(dag)
+        with self.assertWarns(DeprecationWarning):
+            cdag = StochasticSwap(coupling, seed=58).run(dag)
         check_map_pass = CheckMap(coupling)
         check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
@@ -935,7 +958,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
                 qc.cx(3, 1)
 
         cm = CouplingMap.from_line(5)
-        pm = PassManager([StochasticSwap(cm, seed=0), CheckMap(cm)])
+        with self.assertWarns(DeprecationWarning):
+            pm = PassManager([StochasticSwap(cm, seed=0), CheckMap(cm)])
         _ = pm.run(qc)
         self.assertTrue(pm.property_set["is_swap_mapped"])
 
@@ -959,7 +983,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.measure(qreg, creg)
 
         dag = circuit_to_dag(qc)
-        cdag = StochasticSwap(coupling, seed=23).run(dag)
+        with self.assertWarns(DeprecationWarning):
+            cdag = StochasticSwap(coupling, seed=23).run(dag)
         check_map_pass = CheckMap(coupling)
         check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
@@ -999,7 +1024,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.measure(qreg, creg)
 
         dag = circuit_to_dag(qc)
-        cdag = StochasticSwap(coupling, seed=687).run(dag)
+        with self.assertWarns(DeprecationWarning):
+            cdag = StochasticSwap(coupling, seed=687).run(dag)
         check_map_pass = CheckMap(coupling)
         check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
@@ -1033,7 +1059,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.measure(qreg, creg)
 
         dag = circuit_to_dag(qc)
-        cdag = StochasticSwap(coupling, seed=58).run(dag)
+        with self.assertWarns(DeprecationWarning):
+            cdag = StochasticSwap(coupling, seed=58).run(dag)
         check_map_pass = CheckMap(coupling)
         check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
@@ -1065,7 +1092,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.while_loop(expr.logic_and(qc.clbits[0], qc.clbits[1]), body, [0, 1, 2, 3], [])
 
         dag = circuit_to_dag(qc)
-        cdag = StochasticSwap(coupling, seed=58).run(dag)
+        with self.assertWarns(DeprecationWarning):
+            cdag = StochasticSwap(coupling, seed=58).run(dag)
         check_map_pass = CheckMap(coupling)
         check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
@@ -1083,7 +1111,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.switch(creg, [(0, case0)], qreg[[0, 1, 2]], creg)
 
         coupling = CouplingMap.from_line(len(qreg))
-        pass_ = StochasticSwap(coupling, seed=58)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = StochasticSwap(coupling, seed=58)
         test = pass_(qc)
 
         check = CheckMap(coupling)
@@ -1122,7 +1151,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.switch(creg, [(0, case0), ((1, 2), case1), (3, case2)], qreg, creg)
 
         coupling = CouplingMap.from_line(len(qreg))
-        pass_ = StochasticSwap(coupling, seed=58)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = StochasticSwap(coupling, seed=58)
         test = pass_(qc)
 
         check = CheckMap(coupling)
@@ -1167,7 +1197,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.switch(creg, [(labels, case0)], qreg[[0, 1, 2]], creg)
 
         coupling = CouplingMap.from_line(len(qreg))
-        pass_ = StochasticSwap(coupling, seed=58)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = StochasticSwap(coupling, seed=58)
         test = pass_(qc)
 
         check = CheckMap(coupling)
@@ -1205,7 +1236,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.switch(expr.bit_or(creg, 5), [(0, case0), ((1, 2), case1), (3, case2)], qreg, creg)
 
         coupling = CouplingMap.from_line(len(qreg))
-        pass_ = StochasticSwap(coupling, seed=58)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = StochasticSwap(coupling, seed=58)
         test = pass_(qc)
 
         check = CheckMap(coupling)
@@ -1250,7 +1282,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.switch(expr.bit_or(creg, 3), [(labels, case0)], qreg[[0, 1, 2]], creg)
 
         coupling = CouplingMap.from_line(len(qreg))
-        pass_ = StochasticSwap(coupling, seed=58)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = StochasticSwap(coupling, seed=58)
         test = pass_(qc)
 
         check = CheckMap(coupling)
@@ -1295,7 +1328,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.measure(qreg, creg)
 
         dag = circuit_to_dag(qc)
-        cdag = StochasticSwap(coupling, seed=seed).run(dag)
+        with self.assertWarns(DeprecationWarning):
+            cdag = StochasticSwap(coupling, seed=seed).run(dag)
         check_map_pass = CheckMap(coupling)
         check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
@@ -1350,7 +1384,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.measure(qreg, creg)
 
         dag = circuit_to_dag(qc)
-        cdag = StochasticSwap(coupling, seed=seed).run(dag)
+        with self.assertWarns(DeprecationWarning):
+            cdag = StochasticSwap(coupling, seed=seed).run(dag)
         check_map_pass = CheckMap(coupling)
         check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
@@ -1386,7 +1421,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         loop_body = QuantumCircuit(2)
         loop_body.cx(0, 1)
         qc.for_loop((0,), None, loop_body, [0, 2], [])
-        cqc = StochasticSwap(cm, seed=0)(qc)
+        with self.assertWarns(DeprecationWarning):
+            cqc = StochasticSwap(cm, seed=0)(qc)
 
         expected = QuantumCircuit(qr)
         efor_body = QuantumCircuit(qr[[0, 1, 2]])
@@ -1408,7 +1444,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         false_body = QuantumCircuit(3, 1)
         false_body.cx(0, 2)
         qc.if_else((cr[0], 1), true_body, false_body, [0, 1, 2], [0])
-        cqc = StochasticSwap(cm, seed=353)(qc)
+        with self.assertWarns(DeprecationWarning):
+            cqc = StochasticSwap(cm, seed=353)(qc)
 
         expected = QuantumCircuit(qr, cr)
         etrue_body = QuantumCircuit(qr[[0, 1, 2]], cr[[0]])
@@ -1431,7 +1468,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         qc.cx(0, 2)
         with qc.for_loop((0,)):
             qc.cx(3, 5)
-        cqc = StochasticSwap(coupling, seed=0)(qc)
+        with self.assertWarns(DeprecationWarning):
+            cqc = StochasticSwap(coupling, seed=0)(qc)
         check_map_pass(cqc)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
@@ -1465,7 +1503,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
             qc.cx(2, 0)
             qc.cx(7, 6)
         coupling = CouplingMap.from_line(8)
-        pass_ = StochasticSwap(coupling, seed=2022_10_13)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = StochasticSwap(coupling, seed=2022_10_13)
         transpiled = pass_(qc)
 
         # Check the pass claims to have done things right.
@@ -1532,20 +1571,22 @@ class TestStochasticSwapRandomCircuitValidOutput(QiskitTestCase):
     def test_random_circuit_no_control_flow(self, size):
         """Test that transpiled random circuits without control flow are physical circuits."""
         circuit = random_circuit(size, 3, measure=True, seed=12342)
-        tqc = transpile(
+        with self.assertWarns(DeprecationWarning):
+            tqc = transpile(
             circuit,
             self.backend,
             routing_method="stochastic",
             layout_method="dense",
             seed_transpiler=12342,
-        )
+            )
         self.assert_valid_circuit(tqc)
 
     @data(*range(1, 27))
     def test_random_circuit_no_control_flow_target(self, size):
         """Test that transpiled random circuits without control flow are physical circuits."""
         circuit = random_circuit(size, 3, measure=True, seed=12342)
-        tqc = transpile(
+        with self.assertWarns(DeprecationWarning):
+            tqc = transpile(
             circuit,
             routing_method="stochastic",
             layout_method="dense",
@@ -1554,7 +1595,7 @@ class TestStochasticSwapRandomCircuitValidOutput(QiskitTestCase):
                 num_qubits=27,
                 coupling_map=MUMBAI_CMAP,
             ).target,
-        )
+            )
         self.assert_valid_circuit(tqc)
 
     @data(*range(4, 27))
@@ -1569,14 +1610,15 @@ class TestStochasticSwapRandomCircuitValidOutput(QiskitTestCase):
             circuit.append(for_block, [1, 0, 2])
         circuit.measure_all()
 
-        tqc = transpile(
+        with self.assertWarns(DeprecationWarning):
+            tqc = transpile(
             circuit,
             self.backend,
             basis_gates=list(self.basis_gates),
             routing_method="stochastic",
             layout_method="dense",
             seed_transpiler=12342,
-        )
+            )
         self.assert_valid_circuit(tqc)
 
     @data(*range(6, 27))
@@ -1598,14 +1640,15 @@ class TestStochasticSwapRandomCircuitValidOutput(QiskitTestCase):
         with else_:
             circuit.append(else_block, [2, 5], clbit_indices[: else_block.num_clbits])
 
-        tqc = transpile(
+        with self.assertWarns(DeprecationWarning):
+            tqc = transpile(
             circuit,
             self.backend,
             basis_gates=list(self.basis_gates),
             routing_method="stochastic",
             layout_method="dense",
             seed_transpiler=12342,
-        )
+            )
         self.assert_valid_circuit(tqc)
 
 

--- a/test/python/transpiler/test_stochastic_swap.py
+++ b/test/python/transpiler/test_stochastic_swap.py
@@ -1573,11 +1573,11 @@ class TestStochasticSwapRandomCircuitValidOutput(QiskitTestCase):
         circuit = random_circuit(size, 3, measure=True, seed=12342)
         with self.assertWarns(DeprecationWarning):
             tqc = transpile(
-            circuit,
-            self.backend,
-            routing_method="stochastic",
-            layout_method="dense",
-            seed_transpiler=12342,
+                circuit,
+                self.backend,
+                routing_method="stochastic",
+                layout_method="dense",
+                seed_transpiler=12342,
             )
         self.assert_valid_circuit(tqc)
 
@@ -1587,14 +1587,14 @@ class TestStochasticSwapRandomCircuitValidOutput(QiskitTestCase):
         circuit = random_circuit(size, 3, measure=True, seed=12342)
         with self.assertWarns(DeprecationWarning):
             tqc = transpile(
-            circuit,
-            routing_method="stochastic",
-            layout_method="dense",
-            seed_transpiler=12342,
-            target=GenericBackendV2(
-                num_qubits=27,
-                coupling_map=MUMBAI_CMAP,
-            ).target,
+                circuit,
+                routing_method="stochastic",
+                layout_method="dense",
+                seed_transpiler=12342,
+                target=GenericBackendV2(
+                    num_qubits=27,
+                    coupling_map=MUMBAI_CMAP,
+                ).target,
             )
         self.assert_valid_circuit(tqc)
 
@@ -1612,12 +1612,12 @@ class TestStochasticSwapRandomCircuitValidOutput(QiskitTestCase):
 
         with self.assertWarns(DeprecationWarning):
             tqc = transpile(
-            circuit,
-            self.backend,
-            basis_gates=list(self.basis_gates),
-            routing_method="stochastic",
-            layout_method="dense",
-            seed_transpiler=12342,
+                circuit,
+                self.backend,
+                basis_gates=list(self.basis_gates),
+                routing_method="stochastic",
+                layout_method="dense",
+                seed_transpiler=12342,
             )
         self.assert_valid_circuit(tqc)
 
@@ -1642,12 +1642,12 @@ class TestStochasticSwapRandomCircuitValidOutput(QiskitTestCase):
 
         with self.assertWarns(DeprecationWarning):
             tqc = transpile(
-            circuit,
-            self.backend,
-            basis_gates=list(self.basis_gates),
-            routing_method="stochastic",
-            layout_method="dense",
-            seed_transpiler=12342,
+                circuit,
+                self.backend,
+                basis_gates=list(self.basis_gates),
+                routing_method="stochastic",
+                layout_method="dense",
+                seed_transpiler=12342,
             )
         self.assert_valid_circuit(tqc)
 

--- a/test/python/transpiler/test_stochastic_swap.py
+++ b/test/python/transpiler/test_stochastic_swap.py
@@ -60,9 +60,9 @@ class TestStochasticSwap(QiskitTestCase):
         circuit.cx(qr[0], qr[2])
 
         dag = circuit_to_dag(circuit)
-        with self.assetWarns(DeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             pass_ = StochasticSwap(coupling, 20, 13)
-        after = pass_.run(dag)
+            after = pass_.run(dag)
 
         self.assertEqual(dag, after)
 
@@ -84,9 +84,9 @@ class TestStochasticSwap(QiskitTestCase):
         circuit.cx(qr[0], qr[1])
 
         dag = circuit_to_dag(circuit)
-        with self.assetWarns(DeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             pass_ = StochasticSwap(coupling, 20, 13)
-        after = pass_.run(dag)
+            after = pass_.run(dag)
 
         self.assertEqual(dag, after)
 
@@ -111,9 +111,9 @@ class TestStochasticSwap(QiskitTestCase):
         circuit.cx(qr[1], qr[2])
         dag = circuit_to_dag(circuit)
 
-        with self.assetWarns(DeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             pass_ = StochasticSwap(coupling, 20, 11)
-        after = pass_.run(dag)
+            after = pass_.run(dag)
 
         expected = QuantumCircuit(qr)
         expected.swap(qr[0], qr[2])
@@ -143,9 +143,9 @@ class TestStochasticSwap(QiskitTestCase):
         circuit.h(qr[0])
         dag = circuit_to_dag(circuit)
 
-        with self.assetWarns(DeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             pass_ = StochasticSwap(coupling, 20, 11)
-        after = pass_.run(dag)
+            after = pass_.run(dag)
 
         expected = QuantumCircuit(qr)
         expected.swap(qr[1], qr[2])
@@ -180,9 +180,9 @@ class TestStochasticSwap(QiskitTestCase):
         circuit.cx(qr[3], qr[0])
         dag = circuit_to_dag(circuit)
 
-        with self.assetWarns(DeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             pass_ = StochasticSwap(coupling, 20, 13)
-        after = pass_.run(dag)
+            after = pass_.run(dag)
 
         expected = QuantumCircuit(qr)
         expected.swap(qr[0], qr[1])
@@ -220,9 +220,9 @@ class TestStochasticSwap(QiskitTestCase):
         circuit.cx(qr[3], qr[0])
         dag = circuit_to_dag(circuit)
 
-        with self.assetWarns(DeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             pass_ = StochasticSwap(coupling, 20, 13)
-        after = pass_.run(dag)
+            after = pass_.run(dag)
 
         expected = QuantumCircuit(qr)
         expected.h(qr[3])
@@ -262,7 +262,7 @@ class TestStochasticSwap(QiskitTestCase):
 
         with self.assertWarns(DeprecationWarning):
             pass_ = StochasticSwap(coupling, 20, 13)
-        after = pass_.run(dag)
+            after = pass_.run(dag)
 
         expected = QuantumCircuit(qr)
         expected.swap(qr[0], qr[1])
@@ -292,7 +292,7 @@ class TestStochasticSwap(QiskitTestCase):
 
         with self.assertWarns(DeprecationWarning):
             pass_ = StochasticSwap(coupling, 20, 13)
-        after = pass_.run(dag)
+            after = pass_.run(dag)
         self.assertEqual(dag, after)
 
     def test_overoptimization_case(self):
@@ -373,7 +373,7 @@ class TestStochasticSwap(QiskitTestCase):
         #  qr[3]: 3}
         with self.assertWarns(DeprecationWarning):
             pass_ = StochasticSwap(coupling, 20, 19)
-        after = pass_.run(dag)
+            after = pass_.run(dag)
 
         self.assertEqual(expected_dag, after)
 
@@ -400,7 +400,7 @@ class TestStochasticSwap(QiskitTestCase):
 
         with self.assertWarns(DeprecationWarning):
             pass_ = StochasticSwap(coupling, 20, 13)
-        after = pass_.run(dag)
+            after = pass_.run(dag)
         self.assertEqual(circuit_to_dag(circ), after)
 
     def test_congestion(self):
@@ -477,7 +477,7 @@ class TestStochasticSwap(QiskitTestCase):
 
         with self.assertWarns(DeprecationWarning):
             pass_ = StochasticSwap(coupling, 20, 999)
-        after = pass_.run(dag)
+            after = pass_.run(dag)
         self.assertEqual(expected_dag, after)
 
     def test_only_output_cx_and_swaps_in_coupling_map(self):
@@ -496,7 +496,7 @@ class TestStochasticSwap(QiskitTestCase):
 
         with self.assertWarns(DeprecationWarning):
             pass_ = StochasticSwap(coupling, 20, 5)
-        after = pass_.run(dag)
+            after = pass_.run(dag)
 
         valid_couplings = [{qr[a], qr[b]} for (a, b) in coupling.get_edges()]
 
@@ -564,7 +564,7 @@ class TestStochasticSwap(QiskitTestCase):
 
         with self.assertWarns(DeprecationWarning):
             stochastic = StochasticSwap(CouplingMap(coupling_map), seed=0)
-        after = PassManager(stochastic).run(circuit)
+            after = PassManager(stochastic).run(circuit)
         after = circuit_to_dag(after)
         self.assertEqual(expected_dag, after)
 
@@ -594,8 +594,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         dag = circuit_to_dag(qc)
         with self.assertWarns(DeprecationWarning):
             cdag = StochasticSwap(coupling, seed=82).run(dag)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(cdag)
+            check_map_pass = CheckMap(coupling)
+            check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
@@ -635,8 +635,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         dag = circuit_to_dag(qc)
         with self.assertWarns(DeprecationWarning):
             cdag = StochasticSwap(coupling, seed=431).run(dag)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(cdag)
+            check_map_pass = CheckMap(coupling)
+            check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
@@ -678,8 +678,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         dag = circuit_to_dag(qc)
         with self.assertWarns(DeprecationWarning):
             cdag = StochasticSwap(coupling, seed=6508).run(dag)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(cdag)
+            check_map_pass = CheckMap(coupling)
+            check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
@@ -719,8 +719,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         dag = circuit_to_dag(qc)
         with self.assertWarns(DeprecationWarning):
             cdag = StochasticSwap(coupling, seed=38).run(dag)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(cdag)
+            check_map_pass = CheckMap(coupling)
+            check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
@@ -758,8 +758,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         dag = circuit_to_dag(qc)
         with self.assertWarns(DeprecationWarning):
             cdag = StochasticSwap(coupling, seed=8).run(dag)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(cdag)
+            check_map_pass = CheckMap(coupling)
+            check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
@@ -802,8 +802,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         dag = circuit_to_dag(qc)
         with self.assertWarns(DeprecationWarning):
             cdag = StochasticSwap(coupling, seed=2, trials=20).run(dag)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(cdag)
+            check_map_pass = CheckMap(coupling)
+            check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
@@ -851,8 +851,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         dag = circuit_to_dag(qc)
         with self.assertWarns(DeprecationWarning):
             cdag = StochasticSwap(coupling, seed=1).run(dag)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(cdag)
+            check_map_pass = CheckMap(coupling)
+            check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
@@ -894,8 +894,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         dag = circuit_to_dag(qc)
         with self.assertWarns(DeprecationWarning):
             cdag = StochasticSwap(coupling, seed=58).run(dag)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(cdag)
+            check_map_pass = CheckMap(coupling)
+            check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
     def test_if_else_expr(self):
@@ -916,8 +916,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         dag = circuit_to_dag(qc)
         with self.assertWarns(DeprecationWarning):
             cdag = StochasticSwap(coupling, seed=58).run(dag)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(cdag)
+            check_map_pass = CheckMap(coupling)
+            check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
     def test_standalone_vars(self):
@@ -960,7 +960,7 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         cm = CouplingMap.from_line(5)
         with self.assertWarns(DeprecationWarning):
             pm = PassManager([StochasticSwap(cm, seed=0), CheckMap(cm)])
-        _ = pm.run(qc)
+            _ = pm.run(qc)
         self.assertTrue(pm.property_set["is_swap_mapped"])
 
     def test_no_layout_change(self):
@@ -985,8 +985,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         dag = circuit_to_dag(qc)
         with self.assertWarns(DeprecationWarning):
             cdag = StochasticSwap(coupling, seed=23).run(dag)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(cdag)
+            check_map_pass = CheckMap(coupling)
+            check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
@@ -1026,8 +1026,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         dag = circuit_to_dag(qc)
         with self.assertWarns(DeprecationWarning):
             cdag = StochasticSwap(coupling, seed=687).run(dag)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(cdag)
+            check_map_pass = CheckMap(coupling)
+            check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
@@ -1061,8 +1061,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         dag = circuit_to_dag(qc)
         with self.assertWarns(DeprecationWarning):
             cdag = StochasticSwap(coupling, seed=58).run(dag)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(cdag)
+            check_map_pass = CheckMap(coupling)
+            check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
@@ -1094,8 +1094,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         dag = circuit_to_dag(qc)
         with self.assertWarns(DeprecationWarning):
             cdag = StochasticSwap(coupling, seed=58).run(dag)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(cdag)
+            check_map_pass = CheckMap(coupling)
+            check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
     def test_switch_single_case(self):
@@ -1113,7 +1113,7 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         coupling = CouplingMap.from_line(len(qreg))
         with self.assertWarns(DeprecationWarning):
             pass_ = StochasticSwap(coupling, seed=58)
-        test = pass_(qc)
+            test = pass_(qc)
 
         check = CheckMap(coupling)
         check(test)
@@ -1153,7 +1153,7 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         coupling = CouplingMap.from_line(len(qreg))
         with self.assertWarns(DeprecationWarning):
             pass_ = StochasticSwap(coupling, seed=58)
-        test = pass_(qc)
+            test = pass_(qc)
 
         check = CheckMap(coupling)
         check(test)
@@ -1199,7 +1199,7 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         coupling = CouplingMap.from_line(len(qreg))
         with self.assertWarns(DeprecationWarning):
             pass_ = StochasticSwap(coupling, seed=58)
-        test = pass_(qc)
+            test = pass_(qc)
 
         check = CheckMap(coupling)
         check(test)
@@ -1238,7 +1238,7 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         coupling = CouplingMap.from_line(len(qreg))
         with self.assertWarns(DeprecationWarning):
             pass_ = StochasticSwap(coupling, seed=58)
-        test = pass_(qc)
+            test = pass_(qc)
 
         check = CheckMap(coupling)
         check(test)
@@ -1284,7 +1284,7 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         coupling = CouplingMap.from_line(len(qreg))
         with self.assertWarns(DeprecationWarning):
             pass_ = StochasticSwap(coupling, seed=58)
-        test = pass_(qc)
+            test = pass_(qc)
 
         check = CheckMap(coupling)
         check(test)
@@ -1330,8 +1330,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         dag = circuit_to_dag(qc)
         with self.assertWarns(DeprecationWarning):
             cdag = StochasticSwap(coupling, seed=seed).run(dag)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(cdag)
+            check_map_pass = CheckMap(coupling)
+            check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
@@ -1386,8 +1386,8 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         dag = circuit_to_dag(qc)
         with self.assertWarns(DeprecationWarning):
             cdag = StochasticSwap(coupling, seed=seed).run(dag)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(cdag)
+            check_map_pass = CheckMap(coupling)
+            check_map_pass.run(cdag)
         self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
@@ -1505,7 +1505,7 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         coupling = CouplingMap.from_line(8)
         with self.assertWarns(DeprecationWarning):
             pass_ = StochasticSwap(coupling, seed=2022_10_13)
-        transpiled = pass_(qc)
+            transpiled = pass_(qc)
 
         # Check the pass claims to have done things right.
         initial_layout = Layout.generate_trivial_layout(*qc.qubits)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
I added depreciation warnings for issue #12552 and modified unit tests to capture the new errors. Documentation with examples has also been added.


### Details and comments

I have added a deprecation warning to the ``StochasticSwap`` class and a description of how to change things. All relevant tests were made to capture the warning, but some tests which check all different types of these passes (i.e. Sabre, look ahead) where split so that the stochastic method may easily be removed in future. In one class of test (test_mappers.py) StochasticSwap had to be removed, as the method used to run the tests made it prohibitively hard to easily check for warnings in the stochastic case exclusively. 

