### PR TITLE
Fix `StatePreparation`'s ``normalize`` argument

### DIFF
--- a/qiskit/circuit/library/data_preparation/state_preparation.py
+++ b/qiskit/circuit/library/data_preparation/state_preparation.py
@@ -173,7 +173,7 @@ class StatePreparation(Gate):
         q = QuantumRegister(self.num_qubits, "q")
         initialize_circuit = QuantumCircuit(q, name="init_def")
 
-        isom = Isometry(self._params_arg, 0, 0)
+        isom = Isometry(self.params, 0, 0)
         initialize_circuit.append(isom, q[:])
 
         # invert the circuit to create the desired vector from zero (assuming

--- a/releasenotes/notes/fix-stateprep-normalize-a8057c339ba619bd.yaml
+++ b/releasenotes/notes/fix-stateprep-normalize-a8057c339ba619bd.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.StatePreparation` where the ``normalize`` 
+    argument was ignored for input arrays.
+    Fixed `#12984 <https://github.com/Qiskit/qiskit/issues/12984>`__.

--- a/test/python/circuit/library/test_state_preparation.py
+++ b/test/python/circuit/library/test_state_preparation.py
@@ -113,6 +113,16 @@ class TestStatePreparation(QiskitTestCase):
         qc.append(StatePreparation("01").repeat(2), [0, 1])
         self.assertEqual(qc.decompose().count_ops()["state_preparation"], 2)
 
+    def test_normalize(self):
+        """Test the normalization.
+
+        Regression test of #12984.
+        """
+        qc = QuantumCircuit(1)
+        qc.compose(StatePreparation([1, 1], normalize=True), range(1), inplace=True)
+
+        self.assertTrue(Statevector(qc).equiv(np.array([1, 1]) / np.sqrt(2)))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #12984. The definition didn't use the normalized parameters, if the input is synthesized by isometry.



