### PR TITLE
Expose `CircuitData` interners and registers to the `qiskit-circuit` crate

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -1142,7 +1142,7 @@ impl CircuitData {
         &self.qargs_interner
     }
 
-    /// Returns an immutable view of the Interner used for Qargs
+    /// Returns an immutable view of the Interner used for Cargs
     pub(crate) fn view_cargs_interner(&self) -> &IndexedInterner<Vec<Clbit>> {
         &self.cargs_interner
     }

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -91,13 +91,13 @@ pub struct CircuitData {
     /// The packed instruction listing.
     data: Vec<PackedInstruction>,
     /// The cache used to intern instruction bits.
-    qargs_interner: IndexedInterner<Vec<Qubit>>,
+    pub(crate) qargs_interner: IndexedInterner<Vec<Qubit>>,
     /// The cache used to intern instruction bits.
-    cargs_interner: IndexedInterner<Vec<Clbit>>,
+    pub(crate) cargs_interner: IndexedInterner<Vec<Clbit>>,
     /// Qubits registered in the circuit.
-    qubits: BitData<Qubit>,
+    pub(crate) qubits: BitData<Qubit>,
     /// Clbits registered in the circuit.
-    clbits: BitData<Clbit>,
+    pub(crate) clbits: BitData<Clbit>,
     param_table: ParameterTable,
     #[pyo3(get)]
     global_phase: Param,
@@ -1133,7 +1133,7 @@ impl CircuitData {
     }
 
     /// Returns an iterator over all the instructions present in the circuit.
-    pub fn iter(&self) -> impl Iterator<Item = &PackedInstruction> {
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &PackedInstruction> {
         self.data.iter()
     }
 

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -1152,12 +1152,12 @@ impl CircuitData {
         &self.global_phase
     }
 
-    /// Returns an immutable view of the Qubit register of the circuit
+    /// Returns an immutable view of the Qubits registered in the circuit
     pub fn qubits(&self) -> &BitData<Qubit> {
         &self.qubits
     }
 
-    /// Returns an immutable view of the Classical register of the circuit
+    /// Returns an immutable view of the Classical bits registered in the circuit
     pub fn clbits(&self) -> &BitData<Clbit> {
         &self.clbits
     }

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -399,8 +399,8 @@ impl CircuitData {
     ///
     /// Returns:
     ///     list(:class:`.Qubit`): The current sequence of registered qubits.
-    #[getter]
-    pub fn qubits(&self, py: Python<'_>) -> Py<PyList> {
+    #[getter("qubits")]
+    pub fn py_qubits(&self, py: Python<'_>) -> Py<PyList> {
         self.qubits.cached().clone_ref(py)
     }
 
@@ -424,8 +424,8 @@ impl CircuitData {
     ///
     /// Returns:
     ///     list(:class:`.Clbit`): The current sequence of registered clbits.
-    #[getter]
-    pub fn clbits(&self, py: Python<'_>) -> Py<PyList> {
+    #[getter("clbits")]
+    pub fn py_clbits(&self, py: Python<'_>) -> Py<PyList> {
         self.clbits.cached().clone_ref(py)
     }
 
@@ -1138,44 +1138,38 @@ impl CircuitData {
     }
 
     /// Returns an immutable view of the Interner used for Qargs
-    pub(crate) fn view_qargs_interner(&self) -> &IndexedInterner<Vec<Qubit>> {
+    pub fn qargs_interner(&self) -> &IndexedInterner<Vec<Qubit>> {
         &self.qargs_interner
     }
 
     /// Returns an immutable view of the Interner used for Cargs
-    pub(crate) fn view_cargs_interner(&self) -> &IndexedInterner<Vec<Clbit>> {
+    pub fn cargs_interner(&self) -> &IndexedInterner<Vec<Clbit>> {
         &self.cargs_interner
     }
 
-    // TODO: Remove once consumed
-    #[allow(dead_code)]
     /// Returns an immutable view of the Global Phase `Param` of the circuit
-    pub(crate) fn view_global_phase(&self) -> &Param {
+    pub fn global_phase(&self) -> &Param {
         &self.global_phase
     }
 
-    // TODO: Remove once consumed
-    #[allow(dead_code)]
     /// Returns an immutable view of the Qubit register of the circuit
-    pub(crate) fn view_qubits(&self) -> &BitData<Qubit> {
+    pub fn qubits(&self) -> &BitData<Qubit> {
         &self.qubits
     }
 
-    // TODO: Remove once consumed
-    #[allow(dead_code)]
     /// Returns an immutable view of the Classical register of the circuit
-    pub(crate) fn view_clbits(&self) -> &BitData<Clbit> {
+    pub fn clbits(&self) -> &BitData<Clbit> {
         &self.clbits
     }
 
     /// Unpacks from InternerIndex to `[Qubit]`
     pub fn get_qargs(&self, index: Index) -> &[Qubit] {
-        self.view_qargs_interner().intern(index)
+        self.qargs_interner().intern(index)
     }
 
     /// Unpacks from InternerIndex to `[Clbit]`
     pub fn get_cargs(&self, index: Index) -> &[Clbit] {
-        self.view_cargs_interner().intern(index)
+        self.cargs_interner().intern(index)
     }
 
     fn assign_parameters_inner<I>(&mut self, py: Python, iter: I) -> PyResult<()>


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Tracked by #13001 
This commit adds small changes to the visibility of the internal data of the `CircuitData` object, which would allow for an easier conversion into a `DAGCircuit` once #13001 is completed.

### Details and comments:
- Make `qargs_interner`, `cargs_interner`, `qubits` and `clbits` attributes visible to the rest of the `qiskit-circuit` crate. This could allow for easier transfer of data when converting from `CircuitData` to `DAGCircuuit`.
- Make `CircuitData::iter()` method return an exact-size iterator. Which would allow us to determine the size of the circuit without needing to collect the iterator.

### Suggestions
Leave any suggestions in a comment here.