### PR TITLE
doc formating issue in qiskit.pulse.library.Square_fun.rst

### DIFF
--- a/qiskit/pulse/library/symbolic_pulses.py
+++ b/qiskit/pulse/library/symbolic_pulses.py
@@ -1773,12 +1773,13 @@ def Square(
     is the sign function with the convention :math:`\\text{sign}\\left(0\\right)=1`.
 
     Args:
-        duration: Pulse length in terms of the sampling period `dt`.
-        amp: The magnitude of the amplitude of the square wave. Wave range is [-`amp`,`amp`].
+        duration: Pulse length in terms of the sampling period ``dt``.
+        amp: The magnitude of the amplitude of the square wave. Wave range is
+            :math:`\\left[-\\texttt{amp},\\texttt{amp}\\right]`.
         phase: The phase of the square wave (note that this is not equivalent to the angle of
             the complex amplitude).
         freq: The frequency of the square wave, in terms of 1 over sampling period.
-            If not provided defaults to a single cycle (i.e :math:'\\frac{1}{\\text{duration}}').
+            If not provided defaults to a single cycle (i.e :math:`\\frac{1}{\\text{duration}}`).
             The frequency is limited to the range :math:`\\left(0,0.5\\right]` (the Nyquist frequency).
         angle: The angle in radians of the complex phase factor uniformly
             scaling the pulse. Default value 0.


### PR DESCRIPTION
### Summary

There ar
![Screenshot 2024-08-21 at 16 41 47](https://github.com/user-attachments/assets/5c8a1f14-fc28-4aad-8454-53ca9f225c43)
e some formatting issues in https://docs.quantum.ibm.com/api/qiskit/qiskit.pulse.library.Square_fun.rst


### Details and comments

With this PR, the doc looks like this:
![Screenshot 2024-08-21 at 16 42 00](https://github.com/user-attachments/assets/9dfd871c-722b-47f5-906a-1903cfea78b3)


