### PR TITLE
Fix  use of `node.op` in `Split2QUnitaries`

### DIFF
--- a/qiskit/transpiler/passes/optimization/split_2q_unitaries.py
+++ b/qiskit/transpiler/passes/optimization/split_2q_unitaries.py
@@ -50,7 +50,7 @@ class Split2QUnitaries(TransformationPass):
             ):
                 continue
 
-            decomp = TwoQubitWeylDecomposition(node.op, fidelity=self.requested_fidelity)
+            decomp = TwoQubitWeylDecomposition(node.matrix, fidelity=self.requested_fidelity)
             if (
                 decomp._inner_decomposition.specialization
                 == TwoQubitWeylDecomposition._specializations.IdEquiv

--- a/releasenotes/notes/fix-split-2q-unitaries-custom-gate-d10f7670a35548f4.yaml
+++ b/releasenotes/notes/fix-split-2q-unitaries-custom-gate-d10f7670a35548f4.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.Split2QUnitaries` where it would fail to run on circuits
+    with custom gates that didn't implement :meth:`__array__`.
+    See `#12984 <https://github.com/Qiskit/qiskit/issues/12970>`__.

--- a/test/python/transpiler/test_split_2q_unitaries.py
+++ b/test/python/transpiler/test_split_2q_unitaries.py
@@ -234,6 +234,7 @@ class TestSplit2QUnitaries(QiskitTestCase):
 
         class MyGate(Gate):
             """Custom gate"""
+
             def __init__(self):
                 super().__init__("mygate", 2, [])
 

--- a/test/python/transpiler/test_split_2q_unitaries.py
+++ b/test/python/transpiler/test_split_2q_unitaries.py
@@ -233,6 +233,7 @@ class TestSplit2QUnitaries(QiskitTestCase):
         """
 
         class MyGate(Gate):
+            """Custom gate"""
             def __init__(self):
                 super().__init__("mygate", 2, [])
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
I believe this PR addresses the first point from #12970 but doesn't fully close the issue, there is still some digging to do in the pipeline.


### Details and comments


