### PR TITLE
Sections in docs.quantum.ibm.com have been renamed

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Non-API docs issues
     url: https://github.com/Qiskit/documentation/issues/new/choose
-    about: Open an issue about documentation in the Start, Build, Transpile, Verify, Run, or Migration guides sections of docs.quantum.ibm.com (non-API documentation)
+    about: Open an issue about documentation in the guides and additional resources sections of docs.quantum.ibm.com (non-API documentation)


### PR DESCRIPTION
### Summary

Reword issue template description

### Details and comments

Now that we no longer have the Start, Build, Run, etc. sections in the docs.quantum.ibm.com documentation, need to reword the issue template description that points users to the non-API repo.
