### PR TITLE
Filter aer warnings in deprecated `FakeBackend` V1 class

### DIFF
--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -65,7 +65,13 @@ class FakeBackend(BackendV1):
 
             self.sim = AerSimulator()
             if self.properties():
-                noise_model = NoiseModel.from_backend(self)
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore",
+                        category=DeprecationWarning,
+                        message=r".*from_backend using V1 based backend is deprecated as of Aer 0.15*",
+                    )
+                    noise_model = NoiseModel.from_backend(self)
                 self.sim.set_options(noise_model=noise_model)
                 # Update fake backend default options too to avoid overwriting
                 # it when run() is called

--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -65,13 +65,7 @@ class FakeBackend(BackendV1):
 
             self.sim = AerSimulator()
             if self.properties():
-                with warnings.catch_warnings():
-                    warnings.filterwarnings(
-                        "ignore",
-                        category=DeprecationWarning,
-                        message=r".*from_backend using V1 based backend is deprecated as of Aer 0.15*",
-                    )
-                    noise_model = NoiseModel.from_backend(self)
+                noise_model = NoiseModel.from_backend(self)
                 self.sim.set_options(noise_model=noise_model)
                 # Update fake backend default options too to avoid overwriting
                 # it when run() is called

--- a/test/utils/base.py
+++ b/test/utils/base.py
@@ -156,6 +156,14 @@ class QiskitTestCase(BaseTestCase):
             module="qiskit_aer",
         )
 
+        # Safe to remove once `FakeBackend` is removed (2.0)
+        warnings.filterwarnings(
+            "ignore",  # If "default", it floods the CI output
+            category=DeprecationWarning,
+            message=r".*from_backend using V1 based backend is deprecated as of Aer 0.15*",
+            module="qiskit.providers.fake_provider.fake_backend",
+        )
+
         allow_DeprecationWarning_message = [
             r"The property ``qiskit\.circuit\.bit\.Bit\.(register|index)`` is deprecated.*",
         ]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The recent qiskit-aer 0.15 release has introduced deprecation warnings for `BackendV1` inputs in `NoiseModel.from_backend`. We were using this method in the deprecated `FakeBackend` class (which is, by definition, V1) and this is triggering test failures. I suggest filtering the warnings in `FakeBackend` until the class is removed in 2.0.


### Details and comments


