### PR TITLE
Add equivalence-library rules between `rzz` and `cp`

### DIFF
--- a/qiskit/circuit/library/standard_gates/equivalence_library.py
+++ b/qiskit/circuit/library/standard_gates/equivalence_library.py
@@ -189,6 +189,21 @@ cphase_to_cu1 = QuantumCircuit(q)
 cphase_to_cu1.append(CU1Gate(theta), [0, 1])
 _sel.add_equivalence(CPhaseGate(theta), cphase_to_cu1)
 
+# CPhaseGate
+#
+#                  global phase: ϴ/4
+#                                  ┌─────────┐
+#  q_0: ─■────     q_0: ─■─────────┤ Rz(ϴ/2) ├
+#        │P(ϴ)  ≡        │ZZ(-ϴ/2) ├─────────┤
+#  q_1: ─■────     q_1: ─■─────────┤ Rz(ϴ/2) ├
+#                                  └─────────┘
+theta = Parameter("theta")
+cphase_to_rzz = QuantumCircuit(2, global_phase=theta / 4)
+cphase_to_rzz.rzz(-theta / 2, 0, 1)
+cphase_to_rzz.rz(theta / 2, 0)
+cphase_to_rzz.rz(theta / 2, 1)
+_sel.add_equivalence(CPhaseGate(theta), cphase_to_rzz)
+
 # RGate
 #
 #    ┌────────┐        ┌───────────────────────┐
@@ -393,6 +408,19 @@ for inst, qargs, cargs in [
 ]:
     def_rzx.append(inst, qargs, cargs)
 _sel.add_equivalence(RZXGate(theta), def_rzx)
+
+# RZXGate to RZZGate
+#      ┌─────────┐
+# q_0: ┤0        ├     q_0: ──────■───────────
+#      │  Rzx(ϴ) │  ≡       ┌───┐ │ZZ(ϴ) ┌───┐
+# q_1: ┤1        ├     q_1: ┤ H ├─■──────┤ H ├
+#      └─────────┘          └───┘        └───┘
+theta = Parameter("theta")
+rzx_to_rzz = QuantumCircuit(2)
+rzx_to_rzz.h(1)
+rzx_to_rzz.rzz(theta, 0, 1)
+rzx_to_rzz.h(1)
+_sel.add_equivalence(RZXGate(theta), rzx_to_rzz)
 
 
 # RYGate
@@ -653,6 +681,21 @@ rzz_to_rzx.h(1)
 rzz_to_rzx.rzx(theta, 0, 1)
 rzz_to_rzx.h(1)
 _sel.add_equivalence(RZZGate(theta), rzz_to_rzx)
+
+# RZZ to CPhase
+#
+#                 global phase: ϴ/2
+#                                ┌───────┐
+#  q_0: ─■─────   q_0: ─■────────┤ Rz(ϴ) ├
+#        │ZZ(ϴ) ≡       │P(-2*ϴ) ├───────┤
+#  q_1: ─■─────   q_1: ─■────────┤ Rz(ϴ) ├
+#                                └───────┘
+theta = Parameter("theta")
+rzz_to_cphase = QuantumCircuit(2, global_phase=theta / 2)
+rzz_to_cphase.cp(-theta * 2, 0, 1)
+rzz_to_cphase.rz(theta, 0)
+rzz_to_cphase.rz(theta, 1)
+_sel.add_equivalence(RZZGate(theta), rzz_to_cphase)
 
 # RZZ to RYY
 q = QuantumRegister(2, "q")

--- a/releasenotes/notes/cphase-rzz-equivalence-e8afc37b71a74366.yaml
+++ b/releasenotes/notes/cphase-rzz-equivalence-e8afc37b71a74366.yaml
@@ -1,6 +1,17 @@
 ---
 features_circuits:
   - |
-    New equivalence rules in the standard equivalence library mean that the transpiler can now
-    directly convert between two-qubit continuous Pauli rotations, rather than always decomposing
-    into a discrete two-CX-based solution.
+    The standard equivalence library (:data:`.SessionEquivalenceLibrary`) now has rules that can
+    directly convert between Qiskit's standard-library 2q continuous Ising-type interactions (e.g.
+    :class:`.CPhaseGate`, :class:`.RZZGate`, :class:`.RZXGate`, and so on) using local equivalence
+    relations.  Previously, several of these conversions would go via a 2-CX form, which resulted
+    in less efficient circuit generation.
+
+    .. note::
+
+      In general, the :class:`.BasisTranslator` is not guaranteed to find the "best" equivalence
+      relation for a given :class:`.Target`, but will always find an equivalence if one exists.  We
+      rely on more expensive resynthesis and gate-optimization passes in the transpiler to improve
+      the output.  These passes are currently not as effective for basis sets with a continuously
+      parametrized two-qubit interaction as they are for discrete super-controlled two-qubit
+      interactions.

--- a/releasenotes/notes/cphase-rzz-equivalence-e8afc37b71a74366.yaml
+++ b/releasenotes/notes/cphase-rzz-equivalence-e8afc37b71a74366.yaml
@@ -1,0 +1,6 @@
+---
+features_circuits:
+  - |
+    New equivalence rules in the standard equivalence library mean that the transpiler can now
+    directly convert between two-qubit continuous Pauli rotations, rather than always decomposing
+    into a discrete two-CX-based solution.

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -1438,7 +1438,6 @@ class TestControlledGate(QiskitTestCase):
     @data(
         RXGate,
         RYGate,
-        RZGate,
         RXXGate,
         RYYGate,
         RZXGate,


### PR DESCRIPTION
### Summary

These gates are locally equivalence (as are all the Ising-interaction gates), and this simple additional rule lets things like QFT, which are defined by Qiskit's default constructor in terms of `cp`, get converted into `rzz` or `rzx`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

I also have a complete rewrite of the equivalence library that is complete and in theory optimal (in 2q gate count) for translations at jakelishman/qiskit-terra@6654059193, but the current `BasisTranslator` algorithm does not work as well with the structuring of the rules.  I have a new algorithm for translation in mind that I'm calling the `BasisConstructor`, which will solve that problem, and also make basis translation for overcomplete basis sets and heterogeneous architectures more accurate, reliable and performant (hopefully!), but I haven't had chance to write it up yet.