### PR TITLE
Add no-hash-lookup way to retrieve the default interned value

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -199,7 +199,7 @@ impl CircuitData {
             instruction_iter.size_hint().0,
             global_phase,
         )?;
-        let no_clbit_index = res.cargs_interner.insert(&[]);
+        let no_clbit_index = res.cargs_interner.get_default();
         for (operation, params, qargs) in instruction_iter {
             let qubits = res.qargs_interner.insert(&qargs);
             let params = (!params.is_empty()).then(|| Box::new(params));
@@ -258,7 +258,7 @@ impl CircuitData {
         params: &[Param],
         qargs: &[Qubit],
     ) -> PyResult<()> {
-        let no_clbit_index = self.cargs_interner.insert(&[]);
+        let no_clbit_index = self.cargs_interner.get_default();
         let params = (!params.is_empty()).then(|| Box::new(params.iter().cloned().collect()));
         let qubits = self.qargs_interner.insert(qargs);
         self.data.push(PackedInstruction {

--- a/crates/circuit/src/interner.rs
+++ b/crates/circuit/src/interner.rs
@@ -75,7 +75,7 @@ where
 /// itself (the `Interned` type), rather than raw references; the `Interned` type is narrower than a
 /// true reference.
 ///
-/// This can only be implemented for owned types that implement `Default`, so that the convenience
+/// This is only implemented for owned types that implement `Default`, so that the convenience
 /// method `Interner::get_default` can work reliably and correctly; the "default" index needs to be
 /// guaranteed to be reserved and present for safety.
 ///

--- a/crates/circuit/src/interner.rs
+++ b/crates/circuit/src/interner.rs
@@ -43,31 +43,6 @@ impl<T: ?Sized> Copy for Interned<T> {}
 unsafe impl<T: ?Sized> Send for Interned<T> {}
 unsafe impl<T: ?Sized> Sync for Interned<T> {}
 
-impl<T> Interned<T>
-where
-    T: ?Sized + ToOwned,
-    <T as ToOwned>::Owned: Default,
-{
-    /// Get the interned key of the default value for the interned type.  The interner of a type
-    /// with a default value always includes a statically known key that is valid for the default,
-    /// so this is safe to construct even in the absence of an actual interner.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use crate::interner::{Interner, Interned};
-    /// let interner = Interner<[usize]>;
-    /// assert_eq!(interner.get(Interned::of_default()), &[]);
-    /// ```
-    #[inline(always)]
-    pub fn of_default() -> Self {
-        Self {
-            index: 0,
-            _type: PhantomData,
-        }
-    }
-}
-
 /// An append-only data structure for interning generic Rust types.
 ///
 /// The interner can lookup keys using a reference type, and will create the corresponding owned
@@ -140,14 +115,15 @@ where
     /// slice `&[]`.  This is a common operation with the cargs interner, for things like pushing
     /// gates.
     ///
-    /// This can also be retrieved without a reference to an interner by `Interned::of_default`.
-    ///
     /// In an ideal world, we wouldn't have the `Default` trait bound on `new`, but would use
     /// specialisation to insert the default key only if the stored value implemented `Default`
     /// (we'd still trait-bound this method).
     #[inline(always)]
     pub fn get_default(&self) -> Interned<T> {
-        Interned::of_default()
+        Interned {
+            index: 0,
+            _type: PhantomData,
+        }
     }
 }
 

--- a/crates/circuit/src/interner.rs
+++ b/crates/circuit/src/interner.rs
@@ -50,17 +50,23 @@ unsafe impl<T: ?Sized> Sync for Interned<T> {}
 /// itself (the `Interned` type), rather than raw references; the `Interned` type is narrower than a
 /// true reference.
 ///
+/// This can only be implemented for owned types that implement `Default`, so that the convenience
+/// method `Interner::get_default` can work reliably and correctly; the "default" index needs to be
+/// guaranteed to be reserved and present for safety.
+///
 /// # Examples
 ///
 /// ```rust
 /// let mut interner = Interner::<[usize]>::new();
 ///
 /// // These are of type `Interned<[usize]>`.
+/// let default_empty = interner.get_default();
 /// let empty = interner.insert(&[]);
 /// let other_empty = interner.insert(&[]);
 /// let key = interner.insert(&[0, 1, 2, 3, 4]);
 ///
 /// assert_eq!(empty, other_empty);
+/// assert_eq!(empty, default_empty);
 /// assert_ne!(empty, key);
 ///
 /// assert_eq!(interner.get(empty), &[]);
@@ -93,9 +99,31 @@ where
 impl<T> Interner<T>
 where
     T: ?Sized + ToOwned,
+    <T as ToOwned>::Owned: Hash + Eq + Default,
 {
+    /// Construct a new interner.  The stored type must have a default value, in order for
+    /// `Interner::get_default` to reliably work correctly without a hash lookup (though ideally
+    /// we'd just use specialisation to do that).
     pub fn new() -> Self {
-        Self(Default::default())
+        let mut set = IndexSet::with_capacity_and_hasher(1, Default::default());
+        set.insert(Default::default());
+        Self(set)
+    }
+
+    /// Retrieve the key corresponding to the default store, without any hash or equality lookup.
+    /// For example, if the interned type is `[Clbit]`, the default key corresponds to the empty
+    /// slice `&[]`.  This is a common operation with the cargs interner, for things like pushing
+    /// gates.
+    ///
+    /// In an ideal world, we wouldn't have the `Default` trait bound on `new`, but would use
+    /// specialisation to insert the default key only if the stored value implemented `Default`
+    /// (we'd still trait-bound this method).
+    #[inline(always)]
+    pub fn get_default(&self) -> Interned<T> {
+        Interned {
+            index: 0,
+            _type: PhantomData,
+        }
     }
 }
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This makes it possible to do `Interner::get_default()` without any value, in order to retrieve a key pointing to the default allocation without making any hash lookups.  While the hashing and equality check of the default allocation is typically very cheap (like the empty slice), acquiring it still generally required a function call, which often needed to be paid frequently.


### Details and comments

Built on top of #13033, so depends on it.
