### PR TITLE
Port `circuit_to_dag` to Rust

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -96,9 +96,9 @@ pub struct CircuitData {
     /// The cache used to intern instruction bits.
     cargs_interner: Interner<[Clbit]>,
     /// Qubits registered in the circuit.
-    pub(crate) qubits: BitData<Qubit>,
+    qubits: BitData<Qubit>,
     /// Clbits registered in the circuit.
-    pub(crate) clbits: BitData<Clbit>,
+    clbits: BitData<Clbit>,
     param_table: ParameterTable,
     #[pyo3(get)]
     global_phase: Param,
@@ -1136,7 +1136,7 @@ impl CircuitData {
     }
 
     /// Returns an iterator over all the instructions present in the circuit.
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = &PackedInstruction> {
+    pub fn iter(&self) -> impl Iterator<Item = &PackedInstruction> {
         self.data.iter()
     }
 
@@ -1194,18 +1194,24 @@ impl CircuitData {
         &self.cargs_interner
     }
 
+    // TODO: Remove once consumed
+    #[allow(dead_code)]
     /// Returns an immutable view of the Global Phase `Param` of the circuit
-    pub fn global_phase(&self) -> &Param {
+    pub(crate) fn view_global_phase(&self) -> &Param {
         &self.global_phase
     }
 
-    /// Returns an immutable view of the Qubits registered in the circuit
-    pub fn qubits(&self) -> &BitData<Qubit> {
+    // TODO: Remove once consumed
+    #[allow(dead_code)]
+    /// Returns an immutable view of the Qubit register of the circuit
+    pub(crate) fn view_qubits(&self) -> &BitData<Qubit> {
         &self.qubits
     }
 
-    /// Returns an immutable view of the Classical bits registered in the circuit
-    pub fn clbits(&self) -> &BitData<Clbit> {
+    // TODO: Remove once consumed
+    #[allow(dead_code)]
+    /// Returns an immutable view of the Classical register of the circuit
+    pub(crate) fn view_clbits(&self) -> &BitData<Clbit> {
         &self.clbits
     }
 

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -1199,12 +1199,12 @@ impl CircuitData {
         &self.global_phase
     }
 
-    /// Returns an immutable view of the Qubit register of the circuit
+    /// Returns an immutable view of the Qubits registered in the circuit
     pub fn qubits(&self) -> &BitData<Qubit> {
         &self.qubits
     }
 
-    /// Returns an immutable view of the Classical register of the circuit
+    /// Returns an immutable view of the Classical bits registered in the circuit
     pub fn clbits(&self) -> &BitData<Clbit> {
         &self.clbits
     }

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -1194,24 +1194,18 @@ impl CircuitData {
         &self.cargs_interner
     }
 
-    // TODO: Remove once consumed
-    #[allow(dead_code)]
     /// Returns an immutable view of the Global Phase `Param` of the circuit
-    pub(crate) fn view_global_phase(&self) -> &Param {
+    pub fn global_phase(&self) -> &Param {
         &self.global_phase
     }
 
-    // TODO: Remove once consumed
-    #[allow(dead_code)]
     /// Returns an immutable view of the Qubit register of the circuit
-    pub(crate) fn view_qubits(&self) -> &BitData<Qubit> {
+    pub fn qubits(&self) -> &BitData<Qubit> {
         &self.qubits
     }
 
-    // TODO: Remove once consumed
-    #[allow(dead_code)]
     /// Returns an immutable view of the Classical register of the circuit
-    pub(crate) fn view_clbits(&self) -> &BitData<Clbit> {
+    pub fn clbits(&self) -> &BitData<Clbit> {
         &self.clbits
     }
 

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -96,9 +96,9 @@ pub struct CircuitData {
     /// The cache used to intern instruction bits.
     cargs_interner: Interner<[Clbit]>,
     /// Qubits registered in the circuit.
-    qubits: BitData<Qubit>,
+    pub(crate) qubits: BitData<Qubit>,
     /// Clbits registered in the circuit.
-    clbits: BitData<Clbit>,
+    pub(crate) clbits: BitData<Clbit>,
     param_table: ParameterTable,
     #[pyo3(get)]
     global_phase: Param,
@@ -1136,7 +1136,7 @@ impl CircuitData {
     }
 
     /// Returns an iterator over all the instructions present in the circuit.
-    pub fn iter(&self) -> impl Iterator<Item = &PackedInstruction> {
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &PackedInstruction> {
         self.data.iter()
     }
 

--- a/crates/circuit/src/converters.rs
+++ b/crates/circuit/src/converters.rs
@@ -18,12 +18,8 @@ use crate::{circuit_data::CircuitData, dag_circuit::DAGCircuit};
 
 /// An extractable representation of a QuantumCircuit reserved only for
 /// conversion purposes.
-///
-/// ## Notes:
-/// This structure does not implement `Clone`, this is the intended behavior as
-/// it contains callbacks to Python and should not be stored anywhere.
-#[derive(Debug)]
-struct QuantumCircuitData<'py> {
+#[derive(Debug, Clone)]
+pub struct QuantumCircuitData<'py> {
     data: CircuitData,
     name: Option<Bound<'py, PyAny>>,
     calibrations: Option<HashMap<String, Py<PyDict>>>,
@@ -63,7 +59,7 @@ impl<'py> FromPyObject<'py> for QuantumCircuitData<'py> {
 }
 
 #[pyfunction(signature = (quantum_circuit, copy_operations = true, qubit_order = None, clbit_order = None))]
-fn circuit_to_dag(
+pub fn circuit_to_dag(
     py: Python,
     quantum_circuit: QuantumCircuitData,
     copy_operations: bool,

--- a/crates/circuit/src/converters.rs
+++ b/crates/circuit/src/converters.rs
@@ -23,15 +23,15 @@ use crate::{circuit_data::CircuitData, dag_circuit::DAGCircuit};
 /// conversion purposes.
 #[derive(Debug, Clone)]
 pub struct QuantumCircuitData<'py> {
-    data: CircuitData,
-    name: Option<Bound<'py, PyAny>>,
-    calibrations: Option<HashMap<String, Py<PyDict>>>,
-    metadata: Option<Bound<'py, PyAny>>,
-    qregs: Option<Bound<'py, PyList>>,
-    cregs: Option<Bound<'py, PyList>>,
-    input_vars: Vec<Bound<'py, PyAny>>,
-    captured_vars: Vec<Bound<'py, PyAny>>,
-    declared_vars: Vec<Bound<'py, PyAny>>,
+    pub data: CircuitData,
+    pub name: Option<Bound<'py, PyAny>>,
+    pub calibrations: Option<HashMap<String, Py<PyDict>>>,
+    pub metadata: Option<Bound<'py, PyAny>>,
+    pub qregs: Option<Bound<'py, PyList>>,
+    pub cregs: Option<Bound<'py, PyList>>,
+    pub input_vars: Vec<Bound<'py, PyAny>>,
+    pub captured_vars: Vec<Bound<'py, PyAny>>,
+    pub declared_vars: Vec<Bound<'py, PyAny>>,
 }
 
 impl<'py> FromPyObject<'py> for QuantumCircuitData<'py> {
@@ -78,18 +78,8 @@ pub fn circuit_to_dag(
 ) -> PyResult<DAGCircuit> {
     DAGCircuit::from_circuit(
         py,
-        &quantum_circuit.data,
+        quantum_circuit,
         copy_operations,
-        Some([
-            quantum_circuit.declared_vars,
-            quantum_circuit.input_vars,
-            quantum_circuit.captured_vars,
-        ]),
-        quantum_circuit.qregs,
-        quantum_circuit.cregs,
-        quantum_circuit.metadata,
-        quantum_circuit.name,
-        quantum_circuit.calibrations,
         qubit_order,
         clbit_order,
     )

--- a/crates/circuit/src/converters.rs
+++ b/crates/circuit/src/converters.rs
@@ -58,8 +58,8 @@ fn circuit_to_dag(
     py: Python,
     quantum_circuit: QuantumCircuitData,
     copy_operations: bool,
-    qubit_order: Option<Vec<PyObject>>,
-    clbit_order: Option<Vec<PyObject>>,
+    qubit_order: Option<Vec<Bound<PyAny>>>,
+    clbit_order: Option<Vec<Bound<PyAny>>>,
 ) -> PyResult<DAGCircuit> {
     DAGCircuit::from_quantum_circuit(
         py,

--- a/crates/circuit/src/converters.rs
+++ b/crates/circuit/src/converters.rs
@@ -1,0 +1,69 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2023, 2024
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use ::pyo3::prelude::*;
+use hashbrown::HashMap;
+use pyo3::types::{PyDict, PyList};
+
+use crate::{circuit_data::CircuitData, dag_circuit::DAGCircuit};
+
+/// An extractable representation of a QuantumCircuit reserved only for
+/// conversion purposes.
+///
+/// ## Notes:
+/// This structure does not implement `Clone`, this is the intended behavior as
+/// it contains callbacks to Python and should not be stored anywhere.
+#[derive(Debug)]
+pub(crate) struct QuantumCircuitData<'py> {
+    pub data: PyRef<'py, CircuitData>,
+    pub name: Option<Bound<'py, PyAny>>,
+    pub calibrations: HashMap<String, Py<PyDict>>,
+    pub metadata: Option<Bound<'py, PyAny>>,
+    pub qregs: Option<Bound<'py, PyList>>,
+    pub cregs: Option<Bound<'py, PyList>>,
+    pub input_vars: Option<Bound<'py, PyAny>>,
+    pub captured_vars: Option<Bound<'py, PyAny>>,
+    pub declared_vars: Option<Bound<'py, PyAny>>,
+}
+
+impl<'py> FromPyObject<'py> for QuantumCircuitData<'py> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        let circuit_data = ob.getattr("_data")?;
+        let data_borrowed = circuit_data.downcast::<CircuitData>()?.borrow();
+        Ok(QuantumCircuitData {
+            data: data_borrowed,
+            name: ob.getattr("name").ok(),
+            calibrations: ob.getattr("calibrations")?.extract()?,
+            metadata: ob.getattr("metadata").ok(),
+            qregs: ob.getattr("qregs").map(|ob| ob.downcast_into())?.ok(),
+            cregs: ob.getattr("cregs").map(|ob| ob.downcast_into())?.ok(),
+            input_vars: ob.call_method0("iter_input_vars").ok(),
+            captured_vars: ob.call_method0("iter_captured_vars").ok(),
+            declared_vars: ob.call_method0("iter_declared_vars").ok(),
+        })
+    }
+}
+
+#[pyfunction]
+fn circuit_to_dag(
+    py: Python,
+    quantum_circuit: QuantumCircuitData,
+    qubit_order: Option<Vec<PyObject>>,
+    clbit_order: Option<Vec<PyObject>>,
+) -> PyResult<DAGCircuit> {
+    DAGCircuit::from_quantum_circuit(py, quantum_circuit, qubit_order, clbit_order)
+}
+
+pub fn converters(m: &Bound<PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(circuit_to_dag, m)?)?;
+    Ok(())
+}

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6644,11 +6644,6 @@ impl DAGCircuit {
 
         // Pre-process the instructions
         let qubit_set: Vec<Qubit> = if let Some(qubit_ordering) = &qubit_order {
-            if qubit_ordering.len() != num_qubits {
-                return Err(PyValueError::new_err(
-                    "'qubit_order' does not contain exactly the same qubits as the circuit",
-                ));
-            };
             let mut qubits = vec![];
             for qubit in qubit_ordering {
                 let bound = qubit.bind(py);
@@ -6669,11 +6664,6 @@ impl DAGCircuit {
             (0..num_qubits as u32).map(Qubit).collect()
         };
         let clbit_set: Vec<Clbit> = if let Some(clbit_ordering) = &clbit_order {
-            if clbit_ordering.len() != num_clbits {
-                return Err(PyValueError::new_err(
-                    "'clbit_order' does not contain exactly the same clbits as the circuit",
-                ));
-            };
             let mut clbits = vec![];
             for clbit in clbit_ordering {
                 let bound = clbit.bind(py);
@@ -6731,7 +6721,7 @@ impl DAGCircuit {
             num_clbits,
             Some(num_ops),
             Some(num_vars),
-            Some(num_edges),
+            Some(num_edges + (num_ops / 2) * num_vars),
         )?;
 
         // Assign other necessary data

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6462,14 +6462,15 @@ impl DAGCircuit {
         // Create HashSets to keep track of each bit/var's last node
         let mut qubit_last_nodes: HashMap<Qubit, (NodeIndex, Wire)> = HashMap::default();
         let mut clbit_last_nodes: HashMap<Clbit, (NodeIndex, Wire)> = HashMap::default();
-        // TODO: Keep track of vars
+        // TODO: Refactor once Vars are in rust
+        // Dict [ Var: (int, VarWeight)]
+        let vars_last_nodes: Bound<PyDict> = PyDict::new_bound(py);
 
         // Store new nodes to return
         let mut new_nodes = vec![];
         for instr in iter {
             let op_name = instr.op.name();
-            // TODO: Use _vars
-            let (all_cbits, _vars): (Vec<Clbit>, Option<Vec<PyObject>>) = {
+            let (all_cbits, vars): (Vec<Clbit>, Option<Vec<PyObject>>) = {
                 // Check if the clbits are already included
                 if self.may_have_additional_wires(py, &instr) {
                     let mut clbits: HashSet<Clbit> =
@@ -6515,7 +6516,6 @@ impl DAGCircuit {
                 };
                 qubit_last_nodes
                     .entry(*qubit)
-                    .and_modify(|val| *val = (new_node, qubit_last_node.1.clone()))
                     .or_insert((new_node, qubit_last_node.1.clone()));
                 nodes_to_connect.insert(qubit_last_node);
             }
@@ -6537,38 +6537,63 @@ impl DAGCircuit {
                 };
                 clbit_last_nodes
                     .entry(clbit)
-                    .and_modify(|val| *val = (new_node, clbit_last_node.1.clone()))
                     .or_insert((new_node, clbit_last_node.1.clone()));
                 nodes_to_connect.insert(clbit_last_node);
             }
 
-            // TODO: Check all the vars in this instruction.
+            // If available, check all the vars in this instruction
+            if let Some(vars_available) = vars {
+                for var in vars_available {
+                    let var_last_node = if vars_last_nodes.contains(&var)? {
+                        let (node, wire): (usize, PyObject) =
+                            vars_last_nodes.get_item(&var)?.unwrap().extract()?;
+                        (NodeIndex::new(node), Wire::Var(wire))
+                    } else {
+                        let output_node = self.var_output_map.get(py, &var).unwrap();
+                        let (edge_id, predecessor_node) = self
+                            .dag
+                            .edges_directed(output_node, Incoming)
+                            .next()
+                            .map(|edge| (edge.id(), (edge.source(), edge.weight().clone())))
+                            .unwrap();
+                        self.dag.remove_edge(edge_id);
+                        predecessor_node
+                    };
 
+                    if let Wire::Var(var) = &var_last_node.1 {
+                        vars_last_nodes.set_item(var, (new_node.index(), var))?
+                    }
+                    nodes_to_connect.insert(var_last_node);
+                }
+            }
+
+            // Add all of the new edges
             for (node, wire) in nodes_to_connect {
                 self.dag.add_edge(node, new_node, wire);
             }
         }
 
-        // Add the output_nodes back
+        // Add the output_nodes back to qargs
         for (qubit, (node, wire)) in qubit_last_nodes {
             let output_node = self.qubit_io_map[qubit.0 as usize][1];
             self.dag.add_edge(node, output_node, wire);
         }
 
+        // Add the output_nodes back to cargs
         for (clbit, (node, wire)) in clbit_last_nodes {
             let output_node = self.clbit_io_map[clbit.0 as usize][1];
             self.dag.add_edge(node, output_node, wire);
         }
 
-        Ok(new_nodes)
-    }
+        // Add the output_nodes back to vars
+        for item in vars_last_nodes.items() {
+            let (var, (node, wire)): (PyObject, (usize, PyObject)) = item.extract()?;
+            let output_node = self.var_output_map.get(py, &var).unwrap();
+            self.dag
+                .add_edge(NodeIndex::new(node), output_node, Wire::Var(wire));
+        }
 
-    /// Creates an instance of DAGCircuit from an iterator over `PackedInstruction`.
-    fn from_iter<I>(_py: Python, _iter: I) -> PyResult<Self>
-    where
-        I: IntoIterator<Item = PackedInstruction>,
-    {
-        todo!()
+        Ok(new_nodes)
     }
 }
 

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6516,6 +6516,7 @@ impl DAGCircuit {
                 };
                 qubit_last_nodes
                     .entry(*qubit)
+                    .and_modify(|entry| *entry = (new_node, qubit_last_node.1.clone()))
                     .or_insert((new_node, qubit_last_node.1.clone()));
                 nodes_to_connect.insert(qubit_last_node);
             }
@@ -6537,6 +6538,7 @@ impl DAGCircuit {
                 };
                 clbit_last_nodes
                     .entry(clbit)
+                    .and_modify(|entry| *entry = (new_node, clbit_last_node.1.clone()))
                     .or_insert((new_node, clbit_last_node.1.clone()));
                 nodes_to_connect.insert(clbit_last_node);
             }
@@ -6561,7 +6563,7 @@ impl DAGCircuit {
                     };
 
                     if let Wire::Var(var) = &var_last_node.1 {
-                        vars_last_nodes.set_item(var, (new_node.index(), var))?
+                        vars_last_nodes.set_item(var, (new_node.index(), var))?;
                     }
                     nodes_to_connect.insert(var_last_node);
                 }

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6792,9 +6792,9 @@ impl DAGCircuit {
             metadata: None,
             qregs: None,
             cregs: None,
-            input_vars: Vec::with_capacity(0),
-            captured_vars: Vec::with_capacity(0),
-            declared_vars: Vec::with_capacity(0),
+            input_vars: Vec::new(),
+            captured_vars: Vec::new(),
+            declared_vars: Vec::new(),
         };
         Self::from_circuit(py, circ, copy_op, None, None)
     }

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6590,6 +6590,14 @@ impl DAGCircuit {
 
         Ok(new_nodes)
     }
+
+    /// Creates an instance of DAGCircuit from an iterator over `PackedInstruction`.
+    fn from_iter<I>(_py: Python, _iter: I) -> PyResult<Self>
+    where
+        I: IntoIterator<Item = PackedInstruction>,
+    {
+        todo!()
+    }
 }
 
 /// Add to global phase. Global phase can only be Float or ParameterExpression so this

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6555,10 +6555,6 @@ impl DAGCircuit {
                 };
 
                 vars_last_nodes.set_item(var, new_node.index())?;
-                if var_last_node == new_node {
-                    // TODO: Fix instances of duplicate nodes for Vars
-                    continue;
-                }
                 self.dag
                     .add_edge(var_last_node, new_node, Wire::Var(var.clone_ref(py)));
             }

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6471,7 +6471,6 @@ impl DAGCircuit {
         for instr in iter {
             let op_name = instr.op.name();
             let (all_cbits, vars): (Vec<Clbit>, Option<Vec<PyObject>>) = {
-                // Check if the clbits are already included
                 if self.may_have_additional_wires(py, &instr) {
                     let mut clbits: HashSet<Clbit> =
                         HashSet::from_iter(self.cargs_interner.get(instr.clbits).iter().copied());

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6466,8 +6466,10 @@ impl DAGCircuit {
         // Dict [ Var: (int, VarWeight)]
         let vars_last_nodes: Bound<PyDict> = PyDict::new_bound(py);
 
+        // Consume into iterator to obtain size hint
+        let iter = iter.into_iter();
         // Store new nodes to return
-        let mut new_nodes = vec![];
+        let mut new_nodes = Vec::with_capacity(iter.size_hint().1.unwrap_or_default());
         for instr in iter {
             let op_name = instr.op.name();
             let (all_cbits, vars): (Vec<Clbit>, Option<Vec<PyObject>>) = {
@@ -6498,9 +6500,9 @@ impl DAGCircuit {
             // Check all the qubits in this instruction.
             for qubit in self.qargs_interner.get(qubits_id) {
                 // Retrieve each qubit's last node
-                let qubit_last_node = if let Some(node) = qubit_last_nodes.remove(qubit) {
-                    node
-                } else {
+                let qubit_last_node = *qubit_last_nodes.entry(*qubit).or_insert({
+                    // If the qubit is not in the last nodes collection, the edge between the output node and its predecessor.
+                    // Then, store the predecessor's NodeIndex in the last nodes collection.
                     let output_node = self.qubit_io_map[qubit.0 as usize][1];
                     let (edge_id, predecessor_node) = self
                         .dag
@@ -6510,17 +6512,19 @@ impl DAGCircuit {
                         .unwrap();
                     self.dag.remove_edge(edge_id);
                     predecessor_node
-                };
-                qubit_last_nodes.entry(*qubit).or_insert(new_node);
+                });
+                qubit_last_nodes
+                    .entry(*qubit)
+                    .and_modify(|val| *val = new_node);
                 self.dag
                     .add_edge(qubit_last_node, new_node, Wire::Qubit(*qubit));
             }
 
             // Check all the clbits in this instruction.
             for clbit in all_cbits {
-                let clbit_last_node = if let Some(node) = clbit_last_nodes.remove(&clbit) {
-                    node
-                } else {
+                let clbit_last_node = *clbit_last_nodes.entry(clbit).or_insert({
+                    // If the qubit is not in the last nodes collection, the edge between the output node and its predecessor.
+                    // Then, store the predecessor's NodeIndex in the last nodes collection.
                     let output_node = self.clbit_io_map[clbit.0 as usize][1];
                     let (edge_id, predecessor_node) = self
                         .dag
@@ -6530,8 +6534,10 @@ impl DAGCircuit {
                         .unwrap();
                     self.dag.remove_edge(edge_id);
                     predecessor_node
-                };
-                clbit_last_nodes.entry(clbit).or_insert(new_node);
+                });
+                clbit_last_nodes
+                    .entry(clbit)
+                    .and_modify(|val| *val = new_node);
                 self.dag
                     .add_edge(clbit_last_node, new_node, Wire::Clbit(clbit));
             }
@@ -6543,6 +6549,8 @@ impl DAGCircuit {
                     vars_last_nodes.del_item(var)?;
                     NodeIndex::new(node)
                 } else {
+                    // If the var is not in the last nodes collection, the edge between the output node and its predecessor.
+                    // Then, store the predecessor's NodeIndex in the last nodes collection.
                     let output_node = self.var_output_map.get(py, var).unwrap();
                     let (edge_id, predecessor_node) = self
                         .dag

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6500,7 +6500,7 @@ impl DAGCircuit {
             // Check all the qubits in this instruction.
             for qubit in self.qargs_interner.get(qubits_id) {
                 // Retrieve each qubit's last node
-                let qubit_last_node = *qubit_last_nodes.entry(*qubit).or_insert({
+                let qubit_last_node = *qubit_last_nodes.entry(*qubit).or_insert_with(|| {
                     // If the qubit is not in the last nodes collection, the edge between the output node and its predecessor.
                     // Then, store the predecessor's NodeIndex in the last nodes collection.
                     let output_node = self.qubit_io_map[qubit.0 as usize][1];
@@ -6522,7 +6522,7 @@ impl DAGCircuit {
 
             // Check all the clbits in this instruction.
             for clbit in all_cbits {
-                let clbit_last_node = *clbit_last_nodes.entry(clbit).or_insert({
+                let clbit_last_node = *clbit_last_nodes.entry(clbit).or_insert_with(|| {
                     // If the qubit is not in the last nodes collection, the edge between the output node and its predecessor.
                     // Then, store the predecessor's NodeIndex in the last nodes collection.
                     let output_node = self.clbit_io_map[clbit.0 as usize][1];

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6496,8 +6496,6 @@ impl DAGCircuit {
             let new_node = self.dag.add_node(NodeType::Operation(instr));
             new_nodes.push(new_node);
 
-            // For each qubit and cl_bit retrieve the last_nodes
-            let mut nodes_to_connect: HashSet<NodeIndex> = HashSet::default();
             // Check all the qubits in this instruction.
             for qubit in self.qargs_interner.get(qubits_id) {
                 // Retrieve each qubit's last node
@@ -6515,11 +6513,8 @@ impl DAGCircuit {
                     predecessor_node
                 };
                 qubit_last_nodes.entry(*qubit).or_insert(new_node);
-                if !nodes_to_connect.contains(&qubit_last_node) {
-                    self.dag
-                        .add_edge(qubit_last_node, new_node, Wire::Qubit(*qubit));
-                    nodes_to_connect.insert(qubit_last_node);
-                }
+                self.dag
+                    .add_edge(qubit_last_node, new_node, Wire::Qubit(*qubit));
             }
 
             // Check all the clbits in this instruction.
@@ -6538,11 +6533,8 @@ impl DAGCircuit {
                     predecessor_node
                 };
                 clbit_last_nodes.entry(clbit).or_insert(new_node);
-                if !nodes_to_connect.contains(&clbit_last_node) {
-                    self.dag
-                        .add_edge(clbit_last_node, new_node, Wire::Clbit(clbit));
-                    nodes_to_connect.insert(clbit_last_node);
-                }
+                self.dag
+                    .add_edge(clbit_last_node, new_node, Wire::Clbit(clbit));
             }
 
             // If available, check all the vars in this instruction
@@ -6564,15 +6556,12 @@ impl DAGCircuit {
                 };
 
                 vars_last_nodes.set_item(var, new_node.index())?;
-                if !nodes_to_connect.contains(&var_last_node) {
-                    if var_last_node == new_node {
-                        // TODO: Fix instances of duplicate nodes for Vars
-                        continue;
-                    }
-                    self.dag
-                        .add_edge(var_last_node, new_node, Wire::Var(var.clone_ref(py)));
-                    nodes_to_connect.insert(var_last_node);
+                if var_last_node == new_node {
+                    // TODO: Fix instances of duplicate nodes for Vars
+                    continue;
                 }
+                self.dag
+                    .add_edge(var_last_node, new_node, Wire::Var(var.clone_ref(py)));
             }
         }
 

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6750,7 +6750,7 @@ impl DAGCircuit {
             .collect::<PyResult<Vec<_>>>()?;
 
         // Finally add all the instructions back
-        new_dag.add_from_iter(py, instructions)?;
+        new_dag.extend(py, instructions)?;
 
         Ok(new_dag)
     }

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -4343,7 +4343,7 @@ def _format(operand):
 
             let mut new_layer = self.copy_empty_like(py, vars_mode)?;
 
-            new_layer.add_from_iter(py, op_nodes.iter().map(|(inst, _)| (*inst).clone()))?;
+            new_layer.extend(py, op_nodes.iter().map(|(inst, _)| (*inst).clone()))?;
 
             let new_layer_op_nodes = new_layer.op_nodes(false).filter_map(|node_index| {
                 match new_layer.dag.node_weight(node_index) {

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -4343,7 +4343,7 @@ def _format(operand):
 
             let mut new_layer = self.copy_empty_like(py, vars_mode)?;
 
-            new_layer.extend(py, op_nodes.iter().map(|(inst, _)| (*inst).clone()))?;
+            new_layer.add_from_iter(py, op_nodes.iter().map(|(inst, _)| (*inst).clone()))?;
 
             let new_layer_op_nodes = new_layer.op_nodes(false).filter_map(|node_index| {
                 match new_layer.dag.node_weight(node_index) {
@@ -6515,7 +6515,8 @@ impl DAGCircuit {
                 };
                 qubit_last_nodes
                     .entry(*qubit)
-                    .and_modify(|val| *val = (new_node, qubit_last_node.1.clone()));
+                    .and_modify(|val| *val = (new_node, qubit_last_node.1.clone()))
+                    .or_insert((new_node, qubit_last_node.1.clone()));
                 nodes_to_connect.insert(qubit_last_node);
             }
 
@@ -6536,7 +6537,8 @@ impl DAGCircuit {
                 };
                 clbit_last_nodes
                     .entry(clbit)
-                    .and_modify(|val| *val = (new_node, clbit_last_node.1.clone()));
+                    .and_modify(|val| *val = (new_node, clbit_last_node.1.clone()))
+                    .or_insert((new_node, clbit_last_node.1.clone()));
                 nodes_to_connect.insert(clbit_last_node);
             }
 

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6694,7 +6694,7 @@ impl DAGCircuit {
         let instructions: Vec<PackedInstruction> = qc_data
             .iter()
             .cloned()
-            .map(|instr| -> PyResult<PackedInstruction> {
+            .map(|mut instr| -> PyResult<PackedInstruction> {
                 // Re-map the qubits
                 let qargs: Vec<Qubit> = qc_data.get_qargs(instr.qubits).to_vec();
                 if qubit_order.is_some() {
@@ -6702,7 +6702,7 @@ impl DAGCircuit {
                         .iter()
                         .map(|index| qubit_set[index.0 as usize])
                         .collect();
-                    qubit_interner.insert_owned(ordered_qargs);
+                    instr.qubits = qubit_interner.insert_owned(ordered_qargs);
                 }
                 // Remap the clbits
                 let cargs: Vec<Clbit> = qc_data.get_cargs(instr.clbits).to_vec();
@@ -6711,7 +6711,7 @@ impl DAGCircuit {
                         .iter()
                         .map(|index| clbit_set[index.0 as usize])
                         .collect();
-                    clbit_interner.insert_owned(ordered_cargs);
+                    instr.clbits = clbit_interner.insert_owned(ordered_cargs);
                 }
 
                 num_edges += qargs.len() + cargs.len();

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod bit_data;
 pub mod circuit_data;
 pub mod circuit_instruction;
+pub mod converters;
 pub mod dag_circuit;
 pub mod dag_node;
 mod dot_utils;
@@ -80,6 +81,17 @@ impl From<Clbit> for BitType {
     }
 }
 
+#[inline(always)]
+#[doc(hidden)]
+fn add_submodule<F>(m: &Bound<PyModule>, constructor: F, name: &str) -> PyResult<()>
+where
+    F: FnOnce(&Bound<PyModule>) -> PyResult<()>,
+{
+    let new_mod = PyModule::new_bound(m.py(), name)?;
+    constructor(&new_mod)?;
+    m.add_submodule(&new_mod)
+}
+
 pub fn circuit(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<circuit_data::CircuitData>()?;
     m.add_class::<circuit_instruction::CircuitInstruction>()?;
@@ -89,5 +101,6 @@ pub fn circuit(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<dag_node::DAGOutNode>()?;
     m.add_class::<dag_node::DAGOpNode>()?;
     m.add_class::<operations::StandardGate>()?;
+    add_submodule(m, converters::converters, "converters")?;
     Ok(())
 }

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -81,17 +81,6 @@ impl From<Clbit> for BitType {
     }
 }
 
-#[inline(always)]
-#[doc(hidden)]
-fn add_submodule<F>(m: &Bound<PyModule>, constructor: F, name: &str) -> PyResult<()>
-where
-    F: FnOnce(&Bound<PyModule>) -> PyResult<()>,
-{
-    let new_mod = PyModule::new_bound(m.py(), name)?;
-    constructor(&new_mod)?;
-    m.add_submodule(&new_mod)
-}
-
 pub fn circuit(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<circuit_data::CircuitData>()?;
     m.add_class::<circuit_instruction::CircuitInstruction>()?;
@@ -101,6 +90,5 @@ pub fn circuit(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<dag_node::DAGOutNode>()?;
     m.add_class::<dag_node::DAGOpNode>()?;
     m.add_class::<operations::StandardGate>()?;
-    add_submodule(m, converters::converters, "converters")?;
     Ok(())
 }

--- a/crates/pyext/src/lib.rs
+++ b/crates/pyext/src/lib.rs
@@ -42,6 +42,7 @@ where
 #[pymodule]
 fn _accelerate(m: &Bound<PyModule>) -> PyResult<()> {
     add_submodule(m, qiskit_circuit::circuit, "circuit")?;
+    add_submodule(m, qiskit_circuit::converters::converters, "converters")?;
     add_submodule(m, qiskit_qasm2::qasm2, "qasm2")?;
     add_submodule(m, qiskit_qasm3::qasm3, "qasm3")?;
     add_submodule(m, circuit_library, "circuit_library")?;

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -61,6 +61,7 @@ import qiskit._numpy_compat
 # and not have to rely on attribute access.  No action needed for top-level extension packages.
 sys.modules["qiskit._accelerate.circuit"] = _accelerate.circuit
 sys.modules["qiskit._accelerate.circuit_library"] = _accelerate.circuit_library
+sys.modules["qiskit._accelerate.circuit.converters"] = _accelerate.circuit.converters
 sys.modules["qiskit._accelerate.convert_2q_block_matrix"] = _accelerate.convert_2q_block_matrix
 sys.modules["qiskit._accelerate.dense_layout"] = _accelerate.dense_layout
 sys.modules["qiskit._accelerate.error_map"] = _accelerate.error_map

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -61,7 +61,7 @@ import qiskit._numpy_compat
 # and not have to rely on attribute access.  No action needed for top-level extension packages.
 sys.modules["qiskit._accelerate.circuit"] = _accelerate.circuit
 sys.modules["qiskit._accelerate.circuit_library"] = _accelerate.circuit_library
-sys.modules["qiskit._accelerate.circuit.converters"] = _accelerate.circuit.converters
+sys.modules["qiskit._accelerate.converters"] = _accelerate.converters
 sys.modules["qiskit._accelerate.convert_2q_block_matrix"] = _accelerate.convert_2q_block_matrix
 sys.modules["qiskit._accelerate.dense_layout"] = _accelerate.dense_layout
 sys.modules["qiskit._accelerate.error_map"] = _accelerate.error_map

--- a/qiskit/converters/circuit_to_dag.py
+++ b/qiskit/converters/circuit_to_dag.py
@@ -13,7 +13,7 @@
 """Helper function for converting a circuit to a dag"""
 
 from qiskit.circuit.library.blueprintcircuit import BlueprintCircuit
-from qiskit._accelerate.circuit.converters import circuit_to_dag as core_circuit_to_dag
+from qiskit._accelerate.converters import circuit_to_dag as core_circuit_to_dag
 
 
 def circuit_to_dag(circuit, copy_operations=True, *, qubit_order=None, clbit_order=None):

--- a/qiskit/converters/circuit_to_dag.py
+++ b/qiskit/converters/circuit_to_dag.py
@@ -14,6 +14,7 @@
 
 from qiskit.dagcircuit.dagcircuit import DAGCircuit
 from qiskit.dagcircuit.dagnode import DAGOpNode
+from qiskit._accelerate.circuit.converters import circuit_to_dag as core_circuit_to_dag
 
 
 def circuit_to_dag(circuit, copy_operations=True, *, qubit_order=None, clbit_order=None):
@@ -56,46 +57,7 @@ def circuit_to_dag(circuit, copy_operations=True, *, qubit_order=None, clbit_ord
             circ.rz(0.5, q[1]).c_if(c, 2)
             dag = circuit_to_dag(circ)
     """
-    dagcircuit = DAGCircuit()
-    dagcircuit.name = circuit.name
-    dagcircuit.global_phase = circuit.global_phase
-    dagcircuit.calibrations = circuit.calibrations
-    dagcircuit.metadata = circuit.metadata
-
-    if qubit_order is None:
-        qubits = circuit.qubits
-    elif len(qubit_order) != circuit.num_qubits or set(qubit_order) != set(circuit.qubits):
-        raise ValueError("'qubit_order' does not contain exactly the same qubits as the circuit")
-    else:
-        qubits = qubit_order
-
-    if clbit_order is None:
-        clbits = circuit.clbits
-    elif len(clbit_order) != circuit.num_clbits or set(clbit_order) != set(circuit.clbits):
-        raise ValueError("'clbit_order' does not contain exactly the same clbits as the circuit")
-    else:
-        clbits = clbit_order
-
-    dagcircuit.add_qubits(qubits)
-    dagcircuit.add_clbits(clbits)
-
-    for var in circuit.iter_input_vars():
-        dagcircuit.add_input_var(var)
-    for var in circuit.iter_captured_vars():
-        dagcircuit.add_captured_var(var)
-    for var in circuit.iter_declared_vars():
-        dagcircuit.add_declared_var(var)
-
-    for register in circuit.qregs:
-        dagcircuit.add_qreg(register)
-
-    for register in circuit.cregs:
-        dagcircuit.add_creg(register)
-
-    for instruction in circuit.data:
-        dagcircuit._apply_op_node_back(
-            DAGOpNode.from_instruction(instruction, deepcopy=copy_operations)
-        )
+    dagcircuit = core_circuit_to_dag(circuit, qubit_order, clbit_order)
 
     dagcircuit.duration = circuit.duration
     dagcircuit.unit = circuit.unit

--- a/qiskit/converters/circuit_to_dag.py
+++ b/qiskit/converters/circuit_to_dag.py
@@ -57,6 +57,20 @@ def circuit_to_dag(circuit, copy_operations=True, *, qubit_order=None, clbit_ord
             circ.rz(0.5, q[1]).c_if(c, 2)
             dag = circuit_to_dag(circ)
     """
+    if qubit_order is None:
+        qubits = circuit.qubits
+    elif len(qubit_order) != circuit.num_qubits or set(qubit_order) != set(circuit.qubits):
+        raise ValueError("'qubit_order' does not contain exactly the same qubits as the circuit")
+    else:
+        qubits = qubit_order
+
+    if clbit_order is None:
+        clbits = circuit.clbits
+    elif len(clbit_order) != circuit.num_clbits or set(clbit_order) != set(circuit.clbits):
+        raise ValueError("'clbit_order' does not contain exactly the same clbits as the circuit")
+    else:
+        clbits = clbit_order
+
     dagcircuit = core_circuit_to_dag(circuit, qubit_order, clbit_order)
 
     dagcircuit.duration = circuit.duration


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->
Is tracked by and resolves #13001 and #13004

### Summary
These commits bring `circuit_to_dag` into rust, leveraging all of the api's introduced by #12550. This also resulted in the addition of a rust-native method. `DAGCircuit::from_circuit_data` to convert from `CircuitData` to `DAGCircuit` from Rust alone.

### Details and comments
The following commits aim to add the circuit converter `circuit_to_dag` to rust while leveraging the rust-side logic for `DAGCircuit`. This is originally used to turn an instance of `QuantumCircuit` into `DAGCircuit`. A rust method to convert `CircuitData` to `DAGCircuit` was also added.

#### Inital changes
- Add new method `DAGCircuit::from_quantum_circuit` which uses the data from a `QuantumCircuit` instance to build a dag_circuit.
   - This method uses the API's introduced by #13006 which exposes the `Interner`s and `BitData` instances for qubits and clbits from the `CircuitData` struct for public view.
   - The generated `DAGCircuit` instances has an estimated capacity that should be enough for most `DAGCircuit` instances with the number of operations provided. Uses #12975.
   - After adding up the inner data, each instruction from the `CircuitData` instance is added onto the `DAGCircuit` by using `.add_from_iter()` (introduced by #13032).
- A new method `DAGCircuit::from_circuit_data` uses the previously describe method to create a `DAGCircuit` based only on the `CircuitData` from a circuit.
   - This method aims to focus on the core structure of the circuit and not any of the other attributes that are only used through python (such as Registers, Variables, Calibrations, etc.)
   - Should be used with caution as `CircuitData != QuantumCircuit` and results may differ.
- Expose the method through a `Python` interface with `circuit_to_dag` which goes by the alias of `core_circuit_to_dag` and is called by the original method.
- Add an arbitrary structure `QuantumCircuitData` that extract attributes from the python `QuantumCircuit` instance and makes it easier to access in rust.
   - This structure is for attribute extraction only and is not clonable/copyable.
- Expose a new module `converters` which should store all of the rust-side converters whenever they get brought into rust.

### Tasks
- [x] Fix the testing suite.
- [x] Clean up API
- [x] Benchmark

### Blockers
- [x] #13032 
- [x] #12975 
- [x] #13006 

### Questions and suggestions
Feel free to ask any questions and give any feedback below, thank you! 🚀 