### PR TITLE
function added to tally operations in circuit with associated qubits fixes #12972

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -513,21 +513,24 @@ impl CircuitData {
     pub fn add_clbit(&mut self, py: Python, bit: &Bound<PyAny>, strict: bool) -> PyResult<()> {
         self.clbits.add(py, bit, strict)
     }
-    
+
     /// Lists all operations along with the qubits involved in those operations.
     ///
     /// Returns:
     ///     list.
     #[pyo3(signature = ())]
     pub fn operations_with_qubits(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
-        let mut ret1 : Vec<(Option<String>, Option<String>)> = vec![];
-        for (index,inst) in self.data.iter().enumerate() {
+        let mut ret: Vec<(Option<String>, Option<String>)> = vec![];
+        for (_index, inst) in self.data.iter().enumerate() {
             let op_str = inst.op.view().name().to_string();
             for b in self.qargs_interner.intern(inst.qubits).value.iter() {
-                ret1.push((Some(op_str.to_string()), Some(self.qubits.get(*b).unwrap().to_string())));
+                ret.push((
+                    Some(op_str.to_string()),
+                    Some(self.qubits.get(*b).unwrap().to_string()),
+                ));
             }
         }
-        Ok(ret1.into_py(py))
+        Ok(ret.into_py(py))
     }
 
     /// Performs a shallow copy.

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -513,6 +513,22 @@ impl CircuitData {
     pub fn add_clbit(&mut self, py: Python, bit: &Bound<PyAny>, strict: bool) -> PyResult<()> {
         self.clbits.add(py, bit, strict)
     }
+    
+    /// Lists all operations along with the qubits involved in those operations.
+    ///
+    /// Returns:
+    ///     list.
+    #[pyo3(signature = ())]
+    pub fn operations_with_qubits(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let mut ret1 : Vec<(Option<String>, Option<String>)> = vec![];
+        for (index,inst) in self.data.iter().enumerate() {
+            let op_str = inst.op.view().name().to_string();
+            for b in self.qargs_interner.intern(inst.qubits).value.iter() {
+                ret1.push((Some(op_str.to_string()), Some(self.qubits.get(*b).unwrap().to_string())));
+            }
+        }
+        Ok(ret1.into_py(py))
+    }
 
     /// Performs a shallow copy.
     ///

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3514,6 +3514,17 @@ class QuantumCircuit:
             count_ops[instruction.operation.name] = count_ops.get(instruction.operation.name, 0) + 1
         return OrderedDict(sorted(count_ops.items(), key=lambda kv: kv[1], reverse=True))
 
+    # The stringified return type is because OrderedDict can't be subscripted before Python 3.9, and
+    # typing.OrderedDict wasn't added until 3.7.2.  It can be turned into a proper type once 3.6
+    # support is dropped.
+    def count_ops_with_qubits(self) -> list:
+        """Count each operation kind in the circuit, along with the qubits used in those operations.
+
+        Returns:
+            str: a breakdown of how many operations of each kind, along with .
+        """
+        return self._data.operations_with_qubits()
+
     def num_nonlocal_gates(self) -> int:
         """Return number of non-local gates (i.e. involving 2+ qubits).
 

--- a/test/python/circuit/test_circuit_data.py
+++ b/test/python/circuit/test_circuit_data.py
@@ -395,6 +395,25 @@ class TestQuantumCircuitData(QiskitTestCase):
             qr_foreign = QuantumRegister(1)
             data[0] = CircuitInstruction(XGate(), [qr_foreign[0]], [])
 
+    def test_count_ops_with_qubits(self):
+        """test count_ops_with_qubits() in quantumcircuit.py
+        which in turn uses fn operations_with_qubits in circuit_data.rs
+        """
+        a = QuantumCircuit(3, 3)
+        a.h(0)
+        a.x(1)
+        a.h(1)
+        # a.h(3)
+        a.cx(1, 0)
+        b = a.count_ops_with_qubits()
+        assert b == [
+            ("h", "Qubit(QuantumRegister(3, 'q'), 0)"),
+            ("x", "Qubit(QuantumRegister(3, 'q'), 1)"),
+            ("h", "Qubit(QuantumRegister(3, 'q'), 1)"),
+            ("cx", "Qubit(QuantumRegister(3, 'q'), 1)"),
+            ("cx", "Qubit(QuantumRegister(3, 'q'), 0)"),
+        ]
+
 
 class TestQuantumCircuitInstructionData(QiskitTestCase):
     """QuantumCircuit.data operation tests."""


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Added function to tally operations in circuit with associated qubits 
fixes #12972 


### Details and comments
-Added function count_ops_with_qubits() in quantumcircuit.py, this returns the operations in the QuantumCircuit along with the qubits associated with those operations.
-The abovementioned function uses the Rust function fn operations_with_qubits in circuit_data.rs
-A test (test_count_ops_with_qubits()) has been added to file test/python/circuit/test_circuit_data.py 
-tox has been run -- no test failures reported
-tox -eblack run to reformat files 

- [Yes ] I have added the tests to cover my changes.
- [Yes ] I have updated the documentation accordingly.
- [Yes ] I have read the CONTRIBUTING document.

