### PR TITLE
Store Vars by index in `DAGCircuit`

### DIFF
--- a/crates/circuit/src/bit_data.rs
+++ b/crates/circuit/src/bit_data.rs
@@ -29,7 +29,7 @@ use std::hash::{Hash, Hasher};
 /// it call `repr()` on both sides, which has a significant
 /// performance advantage.
 #[derive(Clone, Debug)]
-struct BitAsKey {
+pub struct BitAsKey {
     /// Python's `hash()` of the wrapped instance.
     hash: isize,
     /// The wrapped instance.

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -5445,7 +5445,7 @@ impl DAGCircuit {
             .any(|x| self.op_names.contains_key(&x.to_string()))
     }
 
-    fn is_wire_idle(&self, py: Python, wire: &Wire) -> PyResult<bool> {
+    fn is_wire_idle(&self, _py: Python, wire: &Wire) -> PyResult<bool> {
         let (input_node, output_node) = match wire {
             Wire::Qubit(qubit) => (
                 self.qubit_io_map[qubit.0 as usize][0],
@@ -5603,7 +5603,7 @@ impl DAGCircuit {
     ///
     /// Raises:
     ///     DAGCircuitError: if trying to add duplicate wire
-    fn add_wire(&mut self, py: Python, wire: Wire) -> PyResult<()> {
+    fn add_wire(&mut self, _py: Python, wire: Wire) -> PyResult<()> {
         let (in_node, out_node) = match wire {
             Wire::Qubit(qubit) => {
                 if (qubit.0 as usize) >= self.qubit_io_map.len() {
@@ -5656,7 +5656,7 @@ impl DAGCircuit {
     /// Get the nodes on the given wire.
     ///
     /// Note: result is empty if the wire is not in the DAG.
-    fn nodes_on_wire(&self, py: Python, wire: &Wire, only_ops: bool) -> Vec<NodeIndex> {
+    fn nodes_on_wire(&self, _py: Python, wire: &Wire, only_ops: bool) -> Vec<NodeIndex> {
         let mut nodes = Vec::new();
         let mut current_node = match wire {
             Wire::Qubit(qubit) => self.qubit_io_map.get(qubit.0 as usize).map(|x| x[0]),
@@ -5687,7 +5687,7 @@ impl DAGCircuit {
         nodes
     }
 
-    fn remove_idle_wire(&mut self, py: Python, wire: Wire) -> PyResult<()> {
+    fn remove_idle_wire(&mut self, _py: Python, wire: Wire) -> PyResult<()> {
         let [in_node, out_node] = match wire {
             Wire::Qubit(qubit) => self.qubit_io_map[qubit.0 as usize],
             Wire::Clbit(clbit) => self.clbit_io_map[clbit.0 as usize],
@@ -5986,7 +5986,7 @@ impl DAGCircuit {
 
     fn substitute_node_with_subgraph(
         &mut self,
-        py: Python,
+        _py: Python,
         node: NodeIndex,
         other: &DAGCircuit,
         qubit_map: &HashMap<Qubit, Qubit>,

--- a/crates/circuit/src/dot_utils.rs
+++ b/crates/circuit/src/dot_utils.rs
@@ -59,7 +59,8 @@ where
         let edge_weight = match edge.weight() {
             Wire::Qubit(qubit) => dag.qubits.get(*qubit).unwrap(),
             Wire::Clbit(clbit) => dag.clbits.get(*clbit).unwrap(),
-            Wire::Var(var) => var,
+            Wire::Var(var) => dag.vars.get(*var).unwrap(),
+//            Wire::Var(var) => var, GJL
         };
         writeln!(
             file,

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -36,6 +36,8 @@ pub type BitType = u32;
 pub struct Qubit(pub BitType);
 #[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq)]
 pub struct Clbit(pub BitType);
+#[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq)]
+pub struct Var(pub BitType);
 
 pub struct TupleLikeArg<'py> {
     value: Bound<'py, PyTuple>,
@@ -77,6 +79,18 @@ impl From<BitType> for Clbit {
 impl From<Clbit> for BitType {
     fn from(value: Clbit) -> Self {
         value.0
+    }
+}
+
+impl From<Var> for BitType {
+    fn from(value: Var) -> Self {
+        value.0
+    }
+}
+
+impl From<BitType> for Var {
+    fn from(value: BitType) -> Self {
+        Var(value)
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # Keep in sync with Cargo.toml's `rust-version`.
-channel = "1.70"
+# channel = "1.70"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
Closes  #13027

### Summary

This follows the plan in #1307. This PR is centered on augmenting this
https://github.com/Qiskit/qiskit/blob/cc2edc9f7172d75ec454fdaf5748326cd3720f90/crates/circuit/src/dag_circuit.rs#L237-L240

with
```rust
pub vars: BitData<Var>,
```
That is, we use a Rust data structure `BitData` to store and manipulate variables, although the individual variables are still `PyObject`s. Previously, the Python-side containers and methods for manipulating variables were used.

### Status

Most of this is done, modulo debugging because it does not yet successfully compile. The part that is left is in
https://github.com/Qiskit/qiskit/blob/cc2edc9f7172d75ec454fdaf5748326cd3720f90/crates/circuit/src/dag_circuit.rs#L2866
This is a bit more work than all the rest because it involves iteration over the `Var`s and logic on the contents. For example, a set difference implemented as a Python call must be translated to or otherwise replaced in Rust.

It would be easier to a PR like this if there were some refactoring in dag_circuit.rs. For example, `fn substitute_node_with_dag` is over 500 lines long. One problem is the scope of local variables is not clear from the syntactic clues.
