### PR TITLE
Add `Operation::blocks` method.

### DIFF
--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -2123,6 +2123,8 @@ impl Operation for PyInstruction {
             return vec![];
         }
         Python::with_gil(|py| -> Vec<CircuitData> {
+            // We expect that if PyInstruction::control_flow is true then the operation WILL
+            // have a 'blocks' attribute which is a tuple of the Python QuantumCircuit.
             let raw_blocks = self.instruction.getattr(py, "blocks").unwrap();
             let blocks: &Bound<PyTuple> = raw_blocks.downcast_bound::<PyTuple>(py).unwrap();
             blocks

--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -395,6 +395,10 @@ impl Operation for PackedOperation {
         self.view().control_flow()
     }
     #[inline]
+    fn blocks(&self) -> Vec<CircuitData> {
+        self.view().blocks()
+    }
+    #[inline]
     fn matrix(&self, params: &[Param]) -> Option<Array2<Complex64>> {
         self.view().matrix(params)
     }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This gives us a way to get the blocks of a control flow operation as an iterator of `CircuitData`. If called on a non-control-flow instruction, it returns an empty `Vec`.

### Details and comments

This is not intended as a final API for this, which will likely instead return an iterator of `&CircuitData` once control flow operations have been fully ported to Rust and own their blocks without requiring conversion.

