### PR TITLE
Promote `CONTROL_FLOW_OP_NAMES` to public API

### DIFF
--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -686,6 +686,13 @@ Within :class:`QuantumCircuit`, classical control flow is represented by specifi
 
     ControlFlowOp
 
+For convenience, there is a :class:`frozenset` instance containing the :attr:`.Instruction.name`
+attributes of each of the control-flow operations.
+
+.. data:: CONTROL_FLOW_OP_NAMES
+
+    Set of the instruction names of Qiskit's known control-flow operations.
+
 These control-flow operations (:class:`IfElseOp`, :class:`WhileLoopOp`,
 :class:`SwitchCaseOp` and :class:`ForLoopOp`) all have specific state that defines the branching
 conditions and strategies, but contain all the different subcircuit blocks that might be entered in
@@ -1257,6 +1264,7 @@ from .controlflow import (
     CASE_DEFAULT,
     BreakLoopOp,
     ContinueLoopOp,
+    CONTROL_FLOW_OP_NAMES,
 )
 
 from .annotated_operation import AnnotatedOperation, InverseModifier, ControlModifier, PowerModifier

--- a/qiskit/circuit/controlflow/__init__.py
+++ b/qiskit/circuit/controlflow/__init__.py
@@ -25,3 +25,4 @@ from .switch_case import SwitchCaseOp, CASE_DEFAULT
 
 
 CONTROL_FLOW_OP_NAMES = frozenset(("for_loop", "while_loop", "if_else", "switch_case"))
+"""Set of the instruction names of Qiskit's known control-flow operations."""

--- a/releasenotes/notes/control-flow-op-names-c66f38f8a0e15ce7.yaml
+++ b/releasenotes/notes/control-flow-op-names-c66f38f8a0e15ce7.yaml
@@ -1,0 +1,5 @@
+---
+features_circuits:
+  - |
+    A new data attribute, :data:`qiskit.circuit.CONTROL_FLOW_OP_NAMES`, is available to easily find
+    and check whether a given :class:`~.circuit.Instruction` is a control-flow operation by name.


### PR DESCRIPTION
### Summary

This is generally useful for Qiskit's built-in transpiler passes, and we've had some interest in using it for the same reasons from outside the library.  While the control-flow structure from within Rust might change in the future, in the immediate term and from Python space, it feels fair to expose this as public API, since all the information contained in it is certainly already public.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Minor request from @ihincks.
