### PR TITLE
Remove legacy-editable option from setuptools builds

### DIFF
--- a/.azure/test-linux.yml
+++ b/.azure/test-linux.yml
@@ -92,8 +92,6 @@ jobs:
             # Build and install both qiskit and qiskit-terra so that any optionals
             # depending on `qiskit` will resolve correctly.
           displayName: "Install Terra directly"
-          env:
-            SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
 
       - ${{ if eq(parameters.installOptionals, true) }}:
         - bash: |
@@ -178,8 +176,6 @@ jobs:
             sudo apt-get install -y graphviz pandoc
             image_tests/bin/pip check
           displayName: 'Install dependencies'
-          env:
-            SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
 
         - bash: |
             echo "##vso[task.setvariable variable=HAVE_VISUAL_TESTS_RUN;]true"

--- a/.azure/test-macos.yml
+++ b/.azure/test-macos.yml
@@ -48,8 +48,6 @@ jobs:
             # depending on `qiskit` will resolve correctly.
           pip check
         displayName: 'Install dependencies'
-        env:
-          SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
 
       - ${{ if eq(parameters.installOptionals, true) }}:
         - bash: |

--- a/.azure/test-windows.yml
+++ b/.azure/test-windows.yml
@@ -47,8 +47,6 @@ jobs:
           # depending on `qiskit` will resolve correctly.
           pip check
         displayName: 'Install dependencies'
-        env:
-          SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
 
       - ${{ if eq(parameters.installOptionals, true) }}:
         - bash: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,7 +47,6 @@ jobs:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-Cinstrument-coverage"
           LLVM_PROFILE_FILE: "qiskit-%p-%m.profraw"
-          SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
 
       - name: Generate unittest coverage report
         run: |

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -21,8 +21,6 @@ jobs:
           python -m pip install -U -r requirements-dev.txt -c constraints.txt
           python -m pip install -c constraints.txt -e .
           python -m pip install "qiskit-aer" "z3-solver" "cplex" -c constraints.txt
-        env:
-          SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
       - name: Run all tests including slow
         run: stestr run
         env:


### PR DESCRIPTION
### Summary

We needed this back when `setuptools` first introduced the new editable installations, but at this point it should work more correctly without it; our non-CI configurations haven't included it for some time.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Let's just let CI run to ensure there's no further complications from this removal.
