### PR TITLE
Skip test unless has optional pillow dependency

### DIFF
--- a/test/python/visualization/test_dag_drawer.py
+++ b/test/python/visualization/test_dag_drawer.py
@@ -46,6 +46,7 @@ class TestDagDrawer(QiskitVisualizationTestCase):
             dag_drawer(self.dag, style="multicolor")
 
     @unittest.skipUnless(_optionals.HAS_GRAPHVIZ, "Graphviz not installed")
+    @unittest.skipUnless(_optionals.HAS_PIL, "PIL not installed")
     def test_dag_drawer_checks_filename_correct_format(self):
         """filename must contain name and extension"""
         with self.assertRaisesRegex(


### PR DESCRIPTION
Fixes #13076.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.

### Summary

Skip test `test_dag_drawer_checks_filename_correct_format` unless pillow dependency is found

### Details and comments

None.
