### PR TITLE
Avoid `ExtraInstructionAttributes` allocation on `unit="dt"`

### DIFF
--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -435,7 +435,7 @@ impl StandardGate {
         if let Some(extra) = extra_attrs {
             let kwargs = [
                 ("label", extra.label.to_object(py)),
-                ("unit", extra.unit.to_object(py)),
+                ("unit", extra.py_unit(py).into_any()),
                 ("duration", extra.duration.to_object(py)),
             ]
             .into_py_dict_bound(py);


### PR DESCRIPTION
### Summary

The default value for `Instruction.unit` is `"dt"`.  Previously, the `OperationFromPython` extraction logic would only suppress allocation of the extra instruction attributes if all the contained fields were `None`, but `None` is not actually a valid value of `Instruction.unit` (which must be a string).  This meant that `OperationFromPython` would always allocate and store extra attributes, even for the default cases. This did not affect standard gates appended using their corresponding `QuantumCircuit` methods (since no Python-space extraction is performed in that case), but did affect standard calls to `append`, or anything else that entered from Python space.

This drastically reduces the memory usage of circuits built by `append`-like methods. Ignoring the inefficiency factor of the heap-allocation implementation, this saves 66 bytes plus small-allocation overhead for 2-byte heap allocations (another 14 bytes on macOS, but will vary depending on the allocator) per standard instruction, which is on the order of 40% memory-usage reduction.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

I'm using the same sort of microbenchmarking script I've been using since #12730, but now modified to use `append` instead of the special methods on `QuantumCircuit`:
```python
from qiskit.circuit import QuantumCircuit, library

QUBITS = 1000
REPS = 3000

def main_methods():
    qc = QuantumCircuit(QUBITS)
    for _ in range(REPS):
        for q in qc.qubits:
            qc.rz(0.0, q)
        for q in qc.qubits:
            qc.rx(0.0, q)
        for q in qc.qubits:
            qc.rz(0.0, q)
        for a, b in zip(qc.qubits[:-1], qc.qubits[1:]):
            qc.cx(a, b)


def main_append():
    qc = QuantumCircuit(QUBITS)
    rz = library.RZGate(0.0)
    rx = library.RXGate(0.0)
    cx = library.CXGate()
    for _ in range(REPS):
        for q in qc.qubits:
            qc.append(rz, (q,))
        for q in qc.qubits:
            qc.append(rx, (q,))
        for q in qc.qubits:
            qc.append(rz, (q,))
        for qs in zip(qc.qubits[:-1], qc.qubits[1:]):
            qc.append(cx, qs)
```

The memory usage of `main_append` for the parent of this PR is approximately 2.3GB on both macOS, and Linux with glibc, whereas with the PR it drops to 1.35GB on macOS and 1.06GB on Linux/glibc.  I suspect there's something additional going on in the macOS one, because while the Linux/glibc one drops to match the memory usage of `main_methods` (as expected), macOS remains 300MB higher.  It might have been different Python versions - I used 3.10 on macOS and 3.12 on Linux.