### PR TITLE
Fix clippy failures with Rust 1.81.0

### DIFF
--- a/crates/accelerate/src/remove_diagonal_gates_before_measure.rs
+++ b/crates/accelerate/src/remove_diagonal_gates_before_measure.rs
@@ -49,7 +49,9 @@ fn run_remove_diagonal_before_measure(dag: &mut DAGCircuit) -> PyResult<()> {
     let mut nodes_to_remove = Vec::new();
     for index in dag.op_nodes(true) {
         let node = &dag.dag[index];
-        let NodeType::Operation(inst) = node else {panic!()};
+        let NodeType::Operation(inst) = node else {
+            panic!()
+        };
 
         if inst.op.name() == "measure" {
             let predecessor = (dag.quantum_predecessors(index))

--- a/crates/accelerate/src/results/marginalization.rs
+++ b/crates/accelerate/src/results/marginalization.rs
@@ -26,16 +26,11 @@ fn marginalize<T: std::ops::AddAssign + Copy>(
     indices: Option<Vec<usize>>,
 ) -> HashMap<String, T> {
     let mut out_counts: HashMap<String, T> = HashMap::with_capacity(counts.len());
-    let clbit_size = counts
-        .keys()
-        .next()
-        .unwrap()
-        .replace(|c| c == '_' || c == ' ', "")
-        .len();
+    let clbit_size = counts.keys().next().unwrap().replace(['_', ' '], "").len();
     let all_indices: Vec<usize> = (0..clbit_size).collect();
     counts
         .iter()
-        .map(|(k, v)| (k.replace(|c| c == '_' || c == ' ', ""), *v))
+        .map(|(k, v)| (k.replace(['_', ' '], ""), *v))
         .for_each(|(k, v)| match &indices {
             Some(indices) => {
                 if all_indices == *indices {

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -2225,10 +2225,7 @@ impl Operation for PyGate {
     fn standard_gate(&self) -> Option<StandardGate> {
         Python::with_gil(|py| -> Option<StandardGate> {
             match self.gate.getattr(py, intern!(py, "_standard_gate")) {
-                Ok(stdgate) => match stdgate.extract(py) {
-                    Ok(out_gate) => out_gate,
-                    Err(_) => None,
-                },
+                Ok(stdgate) => stdgate.extract(py).unwrap_or_default(),
                 Err(_) => None,
             }
         })


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The recently released Rust 1.81.0 introduced some new on by default clippy rules and these rules are flagging issues in the rust code in the library. While we use Rust 1.70 for clippy in CI and these won't cause failures until we raise our MSRV to >= 1.81.0 these clippy warnings/failures are still good to fix as the either make the code more consise and/or efficient. This commit fixes these issues identified by clippy.

### Details and comments


