### PR TITLE
Fix skipping of slow tests

### DIFF
--- a/test/utils/decorators.py
+++ b/test/utils/decorators.py
@@ -33,7 +33,7 @@ def slow_test(func):
 
     @functools.wraps(func)
     def _wrapper(*args, **kwargs):
-        if "run_slow" in os.environ.get("QISKIT_TESTS", ""):
+        if "run_slow" not in os.environ.get("QISKIT_TESTS", ""):
             raise unittest.SkipTest("Skipping slow tests")
         return func(*args, **kwargs)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Tests with the `@slow_test` decorators should only be run on-demand, but currently are executed in every CI run. We likely didn't notice this since there is only a single slow test at the moment.

### Details and comments

It looks like a tiny logic bug, missing a `not` 🙂 If necessary, we could maybe add a test setting the environment variable `QISKIT_TEST`, but it seems straightforward enough as fix and works as expected locally.

No reno as this is not user facing.