### PR TITLE
Fix ABI3 issues identified during 1.3.0b1 release attempt

### DIFF
--- a/crates/accelerate/src/circuit_library/mod.rs
+++ b/crates/accelerate/src/circuit_library/mod.rs
@@ -14,7 +14,6 @@ use pyo3::prelude::*;
 
 mod entanglement;
 
-#[pymodule]
 pub fn circuit_library(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(entanglement::get_entangler_map))?;
     Ok(())

--- a/crates/accelerate/src/commutation_analysis.rs
+++ b/crates/accelerate/src/commutation_analysis.rs
@@ -12,7 +12,7 @@
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::PyModule;
-use pyo3::{pyfunction, pymodule, wrap_pyfunction, Bound, PyResult, Python};
+use pyo3::{pyfunction, wrap_pyfunction, Bound, PyResult, Python};
 use qiskit_circuit::Qubit;
 
 use crate::commutation_checker::CommutationChecker;
@@ -185,7 +185,6 @@ pub(crate) fn analyze_commutations(
     Ok(out_dict.unbind())
 }
 
-#[pymodule]
 pub fn commutation_analysis(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(analyze_commutations))?;
     Ok(())

--- a/crates/accelerate/src/commutation_cancellation.rs
+++ b/crates/accelerate/src/commutation_cancellation.rs
@@ -15,7 +15,7 @@ use std::f64::consts::PI;
 use hashbrown::{HashMap, HashSet};
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
-use pyo3::{pyfunction, pymodule, wrap_pyfunction, Bound, PyResult, Python};
+use pyo3::{pyfunction, wrap_pyfunction, Bound, PyResult, Python};
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 use smallvec::{smallvec, SmallVec};
 
@@ -273,7 +273,6 @@ pub(crate) fn cancel_commutations(
     Ok(())
 }
 
-#[pymodule]
 pub fn commutation_cancellation(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(cancel_commutations))?;
     Ok(())

--- a/crates/accelerate/src/commutation_checker.rs
+++ b/crates/accelerate/src/commutation_checker.rs
@@ -767,7 +767,6 @@ fn hashable_params(params: &[Param]) -> PyResult<SmallVec<[ParameterKey; 3]>> {
         .collect()
 }
 
-#[pymodule]
 pub fn commutation_checker(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<CommutationLibrary>()?;
     m.add_class::<CommutationChecker>()?;

--- a/crates/accelerate/src/gate_direction.rs
+++ b/crates/accelerate/src/gate_direction.rs
@@ -142,7 +142,6 @@ where
     Ok(true)
 }
 
-#[pymodule]
 pub fn gate_direction(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(py_check_with_coupling_map))?;
     m.add_wrapped(wrap_pyfunction!(py_check_with_target))?;

--- a/crates/accelerate/src/remove_diagonal_gates_before_measure.rs
+++ b/crates/accelerate/src/remove_diagonal_gates_before_measure.rs
@@ -102,7 +102,6 @@ fn run_remove_diagonal_before_measure(dag: &mut DAGCircuit) -> PyResult<()> {
     Ok(())
 }
 
-#[pymodule]
 pub fn remove_diagonal_gates_before_measure(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(run_remove_diagonal_before_measure))?;
     Ok(())

--- a/setup.py
+++ b/setup.py
@@ -51,5 +51,5 @@ setup(
             features=features,
         )
     ],
-    options={"bdist_wheel": {"py_limited_api": "cp38"}},
+    options={"bdist_wheel": {"py_limited_api": "cp39"}},
 )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

We recently tried to publish the 1.3.0b1 release unsucessfully. During the wheel build jobs abi3audit was failing because it correctly identified a couple of abi violations in the builds. The first was we were tagging the package incorrectly as being with a minimum level of Python 3.8 instead of the correct minimum of 3.9. This commit updates the setup.py tag to match the package metadata with the binary.

The second issue is we were creating `PyInit_*` symbols for submodules which goes against the abi3 naming recomendations and abi3 audit flags it as a violation. We had this issue previously in 1.2.0 but was fixed for that release. However since 1.2.0 and now several stray usages of `#[pymodule]` on submodules slipped in during development. This commit fixes those so the bad symbol names won't be created anymore.

Once this commit merges we should tag the new commit as 1.3.0b1.

### Details and comments

Co-authored-by: Raynel Sanchez <87539502+raynelfss@users.noreply.github.com>
