### PR TITLE
Added new way to assign parameters to pulse schedule,

### DIFF
--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -121,6 +121,11 @@ class Schedule:
     # Counter to count instance number.
     instances_counter = itertools.count()
 
+    # Disable parameter validation. If set to True, there will not be any validation of
+    # parameters in the schedule. This is useful if schedule is used within a jit-compiled
+    # function.
+    disable_parameter_validation = False
+
     def __init__(
         self,
         *schedules: "ScheduleComponent" | tuple[int, "ScheduleComponent"],
@@ -148,6 +153,7 @@ class Schedule:
                 name += f"-{mp.current_process().pid}"
 
         self._name = name
+        ParameterManager.disable_parameter_validation = self.disable_parameter_validation
         self._parameter_manager = ParameterManager()
 
         if not isinstance(metadata, dict) and metadata is not None:
@@ -705,8 +711,8 @@ class Schedule:
     def assign_parameters(
         self,
         value_dict: dict[
-            ParameterExpression | ParameterVector | str,
-            ParameterValueType | Sequence[ParameterValueType],
+            Parameter | ParameterVector | str | Sequence[str | Parameter | ParameterVector],
+            ParameterValueType | Sequence[ParameterValueType | Sequence[ParameterValueType]],
         ],
         inplace: bool = True,
     ) -> "Schedule":
@@ -982,6 +988,11 @@ class ScheduleBlock:
     # Counter to count instance number.
     instances_counter = itertools.count()
 
+    # Disable parameter validation. If set to True, there will not be any validation of
+    # parameters in the schedule. This is useful if schedule is used within a jit-compiled
+    # function.
+    disable_parameter_validation = False
+
     def __init__(
         self, name: str | None = None, metadata: dict | None = None, alignment_context=None
     ):
@@ -1016,6 +1027,7 @@ class ScheduleBlock:
         self._parent: ScheduleBlock | None = None
 
         self._name = name
+        ParameterManager.disable_parameter_validation = self.disable_parameter_validation
         self._parameter_manager = ParameterManager()
         self._reference_manager = ReferenceManager()
         self._alignment_context = alignment_context or AlignLeft()
@@ -1404,8 +1416,8 @@ class ScheduleBlock:
     def assign_parameters(
         self,
         value_dict: dict[
-            ParameterExpression | ParameterVector | str,
-            ParameterValueType | Sequence[ParameterValueType],
+            Parameter | ParameterVector | str | Sequence[str | Parameter | ParameterVector],
+            ParameterValueType | Sequence[ParameterValueType | Sequence[ParameterValueType]],
         ],
         inplace: bool = True,
     ) -> "ScheduleBlock":

--- a/releasenotes/notes/assign_pulse_params_by_sequence-934f0d278ab909b7.yaml
+++ b/releasenotes/notes/assign_pulse_params_by_sequence-934f0d278ab909b7.yaml
@@ -5,8 +5,9 @@ features_pulse:
     It is now possible to assign pulse parameters to a pulse schedule using a sequence
     of parameter names or parameters as keys to the value_dict argument of the `assign_parameters` method.
     This allows for more flexible assignment of parameters to pulse schedules. Notably, it is possible to directly
-    assign parameters through slices of a `BindingsArray` class, used in the primitives interface for binding parameters.
-    This could be useful for future implementations in Qiskit Dynamics of custom pulse-based primitives implementations.
+    assign parameters through slices of a `BindingsArray` class, used in the primitives interface for assigning
+    parameters. This could be useful for future implementations custom pulse-based primitives implementations (e.g.
+    Qiskit Dynamics custom primitive implementation).
     Moreover, we have a new class attribute for `Schedule` and `ScheduleBlock` enabling the disabling of parameter
     validation when assigning parameters to a schedule. This is useful for advanced users who want to integrate Qiskit
     Pulse schedule creations within a JIT compiled function (notably to accelerate simulations in Qiskit Dynamics).

--- a/releasenotes/notes/assign_pulse_params_by_sequence-934f0d278ab909b7.yaml
+++ b/releasenotes/notes/assign_pulse_params_by_sequence-934f0d278ab909b7.yaml
@@ -1,0 +1,12 @@
+---
+
+features_pulse:
+  - |
+    It is now possible to assign pulse parameters to a pulse schedule using a sequence
+    of parameter names or parameters as keys to the value_dict argument of the `assign_parameters` method.
+    This allows for more flexible assignment of parameters to pulse schedules. Notably, it is possible to directly
+    assign parameters through slices of a `BindingsArray` class, used in the primitives interface for binding parameters.
+    This could be useful for future implementations in Qiskit Dynamics of custom pulse-based primitives implementations.
+    Moreover, we have a new class attribute for `Schedule` and `ScheduleBlock` enabling the disabling of parameter
+    validation when assigning parameters to a schedule. This is useful for advanced users who want to integrate Qiskit
+    Pulse schedule creations within a JIT compiled function (notably to accelerate simulations in Qiskit Dynamics).

--- a/test/python/pulse/test_parameter_manager.py
+++ b/test/python/pulse/test_parameter_manager.py
@@ -553,6 +553,58 @@ class TestAssignFromProgram(QiskitTestCase):
         self.assertEqual(sched1.instructions[2][1].phase, 3.14)
         self.assertEqual(sched1.instructions[3][1].phase, 1.57)
 
+    def test_pulse_assignment_with_parameter_sequence(self):
+        """
+        Test pulse assignment with parameter sequence. Sequence can be a list or tuple of parameters,
+        parameter names, or parameter vectors. This is useful when using BindingsArray in
+        conjunction with Pulse.
+        """
+
+        sigma = Parameter("sigma")
+        amp = Parameter("amp")
+        param_vec = ParameterVector("param_vec", 2)
+
+        waveform = pulse.library.Gaussian(duration=128, sigma=sigma, amp=amp)
+        waveform2 = pulse.library.Gaussian(duration=128, sigma=40, amp=amp)
+        block = pulse.ScheduleBlock()
+        block += pulse.Play(waveform, pulse.DriveChannel(10))
+        block += pulse.Play(waveform2, pulse.DriveChannel(10))
+        block += pulse.ShiftPhase(param_vec[0], pulse.DriveChannel(10))
+        block += pulse.ShiftPhase(param_vec[1], pulse.DriveChannel(10))
+        block1 = block.assign_parameters(
+            {("amp", "sigma", "param_vec[0]", "param_vec[1]"): [0.2, 4, 3.14, 1.57]}, inplace=False
+        )
+
+        self.assertEqual(block1.blocks[0].pulse.amp, 0.2)
+        self.assertEqual(block1.blocks[0].pulse.sigma, 4.0)
+        self.assertEqual(block1.blocks[1].pulse.amp, 0.2)
+        self.assertEqual(block1.blocks[2].phase, 3.14)
+        self.assertEqual(block1.blocks[3].phase, 1.57)
+
+        sched = pulse.Schedule()
+        sched += pulse.Play(waveform, pulse.DriveChannel(10))
+        sched += pulse.Play(waveform2, pulse.DriveChannel(10))
+        sched += pulse.ShiftPhase(param_vec[0], pulse.DriveChannel(10))
+        sched += pulse.ShiftPhase(param_vec[1], pulse.DriveChannel(10))
+        sched1 = sched.assign_parameters(
+            {("amp", "sigma", "param_vec[0]", "param_vec[1]"): [0.2, 4, 3.14, 1.57]}, inplace=False
+        )
+
+        self.assertEqual(sched1.instructions[0][1].pulse.amp, 0.2)
+        self.assertEqual(sched1.instructions[0][1].pulse.sigma, 4.0)
+        self.assertEqual(sched1.instructions[1][1].pulse.amp, 0.2)
+        self.assertEqual(sched1.instructions[2][1].phase, 3.14)
+        self.assertEqual(sched1.instructions[3][1].phase, 1.57)
+
+        sched2 = sched.assign_parameters(
+            {("amp", "sigma", "param_vec"): [0.2, 4, [3.14, 1.57]]}, inplace=False
+        )
+        self.assertEqual(sched2.instructions[0][1].pulse.amp, 0.2)
+        self.assertEqual(sched2.instructions[0][1].pulse.sigma, 4.0)
+        self.assertEqual(sched2.instructions[1][1].pulse.amp, 0.2)
+        self.assertEqual(sched2.instructions[2][1].phase, 3.14)
+        self.assertEqual(sched2.instructions[3][1].phase, 1.57)
+
 
 class TestScheduleTimeslots(QiskitTestCase):
     """Test for edge cases of timing overlap on parametrized channels.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

It is now possible to assign pulse parameters to a pulse schedule using a sequence
    of parameter names or parameters as keys to the value_dict argument of the `assign_parameters` method.
    This allows for more flexible assignment of parameters to pulse schedules. Notably, it is possible to directly
    assign parameters through slices of a `BindingsArray` class, used in the primitives interface for assigning
    parameters. This could be useful for future implementations custom pulse-based primitives implementations (e.g.
    Qiskit Dynamics custom primitive implementation).
    Moreover, we have a new class attribute for `Schedule` and `ScheduleBlock` enabling the disabling of parameter
    validation when assigning parameters to a schedule. This is useful for advanced users who want to integrate Qiskit
    Pulse schedule creations within a JIT compiled function (notably to accelerate simulations in Qiskit Dynamics).


