### PR TITLE
Reformat `pyext` to avoid merge conflicts

### DIFF
--- a/crates/pyext/src/lib.rs
+++ b/crates/pyext/src/lib.rs
@@ -12,23 +12,6 @@
 
 use pyo3::prelude::*;
 
-use qiskit_accelerate::{
-    check_map::check_map_mod, circuit_library::circuit_library,
-    commutation_analysis::commutation_analysis, commutation_cancellation::commutation_cancellation,
-    commutation_checker::commutation_checker, convert_2q_block_matrix::convert_2q_block_matrix,
-    dense_layout::dense_layout, error_map::error_map,
-    euler_one_qubit_decomposer::euler_one_qubit_decomposer, filter_op_nodes::filter_op_nodes_mod,
-    gate_direction::gate_direction, inverse_cancellation::inverse_cancellation_mod,
-    isometry::isometry, nlayout::nlayout, optimize_1q_gates::optimize_1q_gates,
-    pauli_exp_val::pauli_expval,
-    remove_diagonal_gates_before_measure::remove_diagonal_gates_before_measure, results::results,
-    sabre::sabre, sampled_exp_val::sampled_exp_val, sparse_pauli_op::sparse_pauli_op,
-    split_2q_unitaries::split_2q_unitaries_mod, star_prerouting::star_prerouting,
-    stochastic_swap::stochastic_swap, synthesis::synthesis, target_transpiler::target,
-    two_qubit_decompose::two_qubit_decompose, uc_gate::uc_gate, utils::utils,
-    vf2_layout::vf2_layout,
-};
-
 #[inline(always)]
 #[doc(hidden)]
 fn add_submodule<F>(m: &Bound<PyModule>, constructor: F, name: &str) -> PyResult<()>
@@ -40,45 +23,44 @@ where
     m.add_submodule(&new_mod)
 }
 
+// Formatting is off here so every module import can just be a single line in sorted order, to help
+// avoid merge conflicts as modules are added.
+#[rustfmt::skip]
 #[pymodule]
 fn _accelerate(m: &Bound<PyModule>) -> PyResult<()> {
-    add_submodule(m, qiskit_circuit::circuit, "circuit")?;
-    add_submodule(m, qiskit_circuit::converters::converters, "converters")?;
-    add_submodule(m, qiskit_qasm2::qasm2, "qasm2")?;
-    add_submodule(m, qiskit_qasm3::qasm3, "qasm3")?;
-    add_submodule(m, circuit_library, "circuit_library")?;
-    add_submodule(m, check_map_mod, "check_map")?;
-    add_submodule(m, convert_2q_block_matrix, "convert_2q_block_matrix")?;
-    add_submodule(m, dense_layout, "dense_layout")?;
-    add_submodule(m, error_map, "error_map")?;
-    add_submodule(m, euler_one_qubit_decomposer, "euler_one_qubit_decomposer")?;
-    add_submodule(m, inverse_cancellation_mod, "inverse_cancellation")?;
-    add_submodule(m, filter_op_nodes_mod, "filter_op_nodes")?;
-    add_submodule(m, isometry, "isometry")?;
-    add_submodule(m, nlayout, "nlayout")?;
-    add_submodule(m, optimize_1q_gates, "optimize_1q_gates")?;
-    add_submodule(m, pauli_expval, "pauli_expval")?;
-    add_submodule(m, synthesis, "synthesis")?;
-    add_submodule(
-        m,
-        remove_diagonal_gates_before_measure,
-        "remove_diagonal_gates_before_measure",
-    )?;
-    add_submodule(m, results, "results")?;
-    add_submodule(m, sabre, "sabre")?;
-    add_submodule(m, sampled_exp_val, "sampled_exp_val")?;
-    add_submodule(m, sparse_pauli_op, "sparse_pauli_op")?;
-    add_submodule(m, split_2q_unitaries_mod, "split_2q_unitaries")?;
-    add_submodule(m, star_prerouting, "star_prerouting")?;
-    add_submodule(m, stochastic_swap, "stochastic_swap")?;
-    add_submodule(m, target, "target")?;
-    add_submodule(m, two_qubit_decompose, "two_qubit_decompose")?;
-    add_submodule(m, uc_gate, "uc_gate")?;
-    add_submodule(m, utils, "utils")?;
-    add_submodule(m, vf2_layout, "vf2_layout")?;
-    add_submodule(m, gate_direction, "gate_direction")?;
-    add_submodule(m, commutation_checker, "commutation_checker")?;
-    add_submodule(m, commutation_analysis, "commutation_analysis")?;
-    add_submodule(m, commutation_cancellation, "commutation_cancellation")?;
+    add_submodule(m, ::qiskit_accelerate::check_map::check_map_mod, "check_map")?;
+    add_submodule(m, ::qiskit_accelerate::circuit_library::circuit_library, "circuit_library")?;
+    add_submodule(m, ::qiskit_accelerate::commutation_analysis::commutation_analysis, "commutation_analysis")?;
+    add_submodule(m, ::qiskit_accelerate::commutation_cancellation::commutation_cancellation, "commutation_cancellation")?;
+    add_submodule(m, ::qiskit_accelerate::commutation_checker::commutation_checker, "commutation_checker")?;
+    add_submodule(m, ::qiskit_accelerate::convert_2q_block_matrix::convert_2q_block_matrix, "convert_2q_block_matrix")?;
+    add_submodule(m, ::qiskit_accelerate::dense_layout::dense_layout, "dense_layout")?;
+    add_submodule(m, ::qiskit_accelerate::error_map::error_map, "error_map")?;
+    add_submodule(m, ::qiskit_accelerate::euler_one_qubit_decomposer::euler_one_qubit_decomposer, "euler_one_qubit_decomposer")?;
+    add_submodule(m, ::qiskit_accelerate::filter_op_nodes::filter_op_nodes_mod, "filter_op_nodes")?;
+    add_submodule(m, ::qiskit_accelerate::gate_direction::gate_direction, "gate_direction")?;
+    add_submodule(m, ::qiskit_accelerate::inverse_cancellation::inverse_cancellation_mod, "inverse_cancellation")?;
+    add_submodule(m, ::qiskit_accelerate::isometry::isometry, "isometry")?;
+    add_submodule(m, ::qiskit_accelerate::nlayout::nlayout, "nlayout")?;
+    add_submodule(m, ::qiskit_accelerate::optimize_1q_gates::optimize_1q_gates, "optimize_1q_gates")?;
+    add_submodule(m, ::qiskit_accelerate::pauli_exp_val::pauli_expval, "pauli_expval")?;
+    add_submodule(m, ::qiskit_accelerate::remove_diagonal_gates_before_measure::remove_diagonal_gates_before_measure, "remove_diagonal_gates_before_measure")?;
+    add_submodule(m, ::qiskit_accelerate::results::results, "results")?;
+    add_submodule(m, ::qiskit_accelerate::sabre::sabre, "sabre")?;
+    add_submodule(m, ::qiskit_accelerate::sampled_exp_val::sampled_exp_val, "sampled_exp_val")?;
+    add_submodule(m, ::qiskit_accelerate::sparse_pauli_op::sparse_pauli_op, "sparse_pauli_op")?;
+    add_submodule(m, ::qiskit_accelerate::split_2q_unitaries::split_2q_unitaries_mod, "split_2q_unitaries")?;
+    add_submodule(m, ::qiskit_accelerate::star_prerouting::star_prerouting, "star_prerouting")?;
+    add_submodule(m, ::qiskit_accelerate::stochastic_swap::stochastic_swap, "stochastic_swap")?;
+    add_submodule(m, ::qiskit_accelerate::synthesis::synthesis, "synthesis")?;
+    add_submodule(m, ::qiskit_accelerate::target_transpiler::target, "target")?;
+    add_submodule(m, ::qiskit_accelerate::two_qubit_decompose::two_qubit_decompose, "two_qubit_decompose")?;
+    add_submodule(m, ::qiskit_accelerate::uc_gate::uc_gate, "uc_gate")?;
+    add_submodule(m, ::qiskit_accelerate::utils::utils, "utils")?;
+    add_submodule(m, ::qiskit_accelerate::vf2_layout::vf2_layout, "vf2_layout")?;
+    add_submodule(m, ::qiskit_circuit::circuit, "circuit")?;
+    add_submodule(m, ::qiskit_circuit::converters::converters, "converters")?;
+    add_submodule(m, ::qiskit_qasm2::qasm2, "qasm2")?;
+    add_submodule(m, ::qiskit_qasm3::qasm3, "qasm3")?;
     Ok(())
 }


### PR DESCRIPTION
### Summary

Since we're still in a phase of adding many new extension modules to `pyext`, the current structure of the file is causing problems with most commits hitting merge conflicts in the `use` block.  This changes the style of the file so that each new module takes only a single line, which is more friendly to avoiding merge conflicts, and fixing them when they arise.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

I don't feel super strongly about this, just it's been a slight annoyance I've seen a few people have, and I just did too.
