### PR TITLE
Fix the text drawer with partially idle wires

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -2090,7 +2090,7 @@ class DAGCircuit:
             new_layer = self.copy_empty_like(vars_mode=vars_mode)
 
             for node in op_nodes:
-                new_layer._apply_op_node_back(node, check=False)
+                new_layer.apply_operation_back(node.op, node.qargs, node.cargs, check=False)
 
             # The quantum registers that have an operation in this layer.
             support_list = [

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -2090,7 +2090,7 @@ class DAGCircuit:
             new_layer = self.copy_empty_like(vars_mode=vars_mode)
 
             for node in op_nodes:
-                new_layer.apply_operation_back(node.op, node.qargs, node.cargs, check=False)
+                new_layer._apply_op_node_back(copy.copy(node), check=False)
 
             # The quantum registers that have an operation in this layer.
             support_list = [

--- a/releasenotes/notes/fix-textdrawer-idle-layer-91e6c3c6d7656e98.yaml
+++ b/releasenotes/notes/fix-textdrawer-idle-layer-91e6c3c6d7656e98.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug in the circuit text drawer, which could fail if the circuit
+    had an initial layer with idle wires.
+    Fixed `#13128 <https://github.com/Qiskit/qiskit/issues/13128>`__.

--- a/releasenotes/notes/fix-textdrawer-idle-layer-91e6c3c6d7656e98.yaml
+++ b/releasenotes/notes/fix-textdrawer-idle-layer-91e6c3c6d7656e98.yaml
@@ -1,6 +1,5 @@
 ---
 fixes:
   - |
-    Fixed a bug in the circuit text drawer, which could fail if the circuit
-    had an initial layer with idle wires.
-    Fixed `#13128 <https://github.com/Qiskit/qiskit/issues/13128>`__.
+    Fixed a bug in the circuit drawers, which could fail or omit wires if ``idle_wires=False``.
+    Fixed `#13128 <https://github.com/Qiskit/qiskit/issues/13128>`__ and `#13146 <https://github.com/Qiskit/qiskit/issues/13146>`__.

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -4092,6 +4092,26 @@ class TestTextIdleWires(QiskitTestCase):
         circuit.draw(idle_wires=False)
         self.assertEqual(circuit.num_qubits, before_qubits)
 
+    def test_wires_only_initially_idle(self):
+        """Test a circuit where wires are only idle in the first layer.
+        
+        Regression test of 
+        """
+        expected = "\n".join(["     ┌───┐ ░ ┌───┐",
+                              "q_0: ┤ X ├─░─┤ H ├",
+                              "     └───┘ ░ ├───┤",
+                              "q_1: ──────░─┤ H ├",
+                              "           ░ └───┘"])
+        qc = QuantumCircuit(2)
+        qc.x(0)
+        qc.barrier([0, 1])
+        qc.h(range(2))
+
+        self.assertEqual(
+            str(circuit_drawer(qc, output="text", idle_wires=False)),
+            expected,
+        )
+
 
 class TestTextNonRational(QiskitTestCase):
     """non-rational numbers are correctly represented"""

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -4095,7 +4095,7 @@ class TestTextIdleWires(QiskitTestCase):
     def test_wires_only_initially_idle(self):
         """Test a circuit where wires are only idle in the first layer.
         
-        Regression test of 
+        Regression test for https://github.com/Qiskit/qiskit/issues/13128
         """
         expected = "\n".join(["     ┌───┐ ░ ┌───┐",
                               "q_0: ┤ X ├─░─┤ H ├",

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -4094,14 +4094,18 @@ class TestTextIdleWires(QiskitTestCase):
 
     def test_wires_only_initially_idle(self):
         """Test a circuit where wires are only idle in the first layer.
-        
+
         Regression test for https://github.com/Qiskit/qiskit/issues/13128
         """
-        expected = "\n".join(["     ┌───┐ ░ ┌───┐",
-                              "q_0: ┤ X ├─░─┤ H ├",
-                              "     └───┘ ░ ├───┤",
-                              "q_1: ──────░─┤ H ├",
-                              "           ░ └───┘"])
+        expected = "\n".join(
+            [
+                "     ┌───┐ ░ ┌───┐",
+                "q_0: ┤ X ├─░─┤ H ├",
+                "     └───┘ ░ ├───┤",
+                "q_1: ──────░─┤ H ├",
+                "           ░ └───┘",
+            ]
+        )
         qc = QuantumCircuit(2)
         qc.x(0)
         qc.barrier([0, 1])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #13128.

### Details and comments

We think the issue is that the `layers` method adds the node by reference instead of a copy, which causes the `_LayerSpooler` to mutate the DAG while building the visualization layers. 
