### PR TITLE
[WIP] refactor *_inner pattern in accelerate crate

### DIFF
--- a/crates/accelerate/src/euler_one_qubit_decomposer.rs
+++ b/crates/accelerate/src/euler_one_qubit_decomposer.rs
@@ -826,8 +826,8 @@ pub fn compute_error_list(
 }
 
 #[pyfunction]
-#[pyo3(signature = (unitary, target_basis_list, qubit, error_map=None, simplify=true, atol=None))]
-pub fn unitary_to_gate_sequence(
+#[pyo3(name = "unitary_to_gate_sequence", signature = (unitary, target_basis_list, qubit, error_map=None, simplify=true, atol=None))]
+pub fn py_unitary_to_gate_sequence(
     unitary: PyReadonlyArray2<Complex64>,
     target_basis_list: Vec<PyBackedStr>,
     qubit: usize,
@@ -842,7 +842,7 @@ pub fn unitary_to_gate_sequence(
     {
         target_basis_set.add_basis(basis?);
     }
-    Ok(unitary_to_gate_sequence_inner(
+    Ok(unitary_to_gate_sequence(
         unitary.as_array(),
         &target_basis_set,
         qubit,
@@ -853,7 +853,7 @@ pub fn unitary_to_gate_sequence(
 }
 
 #[inline]
-pub fn unitary_to_gate_sequence_inner(
+pub fn unitary_to_gate_sequence(
     unitary_mat: ArrayView2<Complex64>,
     target_basis_list: &EulerBasisSet,
     qubit: usize,
@@ -892,7 +892,7 @@ pub fn unitary_to_circuit(
     {
         target_basis_set.add_basis(basis?);
     }
-    let circuit_sequence = unitary_to_gate_sequence_inner(
+    let circuit_sequence = unitary_to_gate_sequence(
         unitary.as_array(),
         &target_basis_set,
         qubit,
@@ -1198,7 +1198,7 @@ pub(crate) fn optimize_1q_gates_decomposition(
         } else {
             (error, raw_run.len())
         };
-        let sequence = unitary_to_gate_sequence_inner(
+        let sequence = unitary_to_gate_sequence(
             aview2(&operator),
             target_basis_set,
             qubit.0 as usize,
@@ -1260,7 +1260,7 @@ pub fn euler_one_qubit_decomposer(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(params_u3))?;
     m.add_wrapped(wrap_pyfunction!(params_u1x))?;
     m.add_wrapped(wrap_pyfunction!(generate_circuit))?;
-    m.add_wrapped(wrap_pyfunction!(unitary_to_gate_sequence))?;
+    m.add_wrapped(wrap_pyfunction!(py_unitary_to_gate_sequence))?;
     m.add_wrapped(wrap_pyfunction!(unitary_to_circuit))?;
     m.add_wrapped(wrap_pyfunction!(compute_error_list))?;
     m.add_wrapped(wrap_pyfunction!(optimize_1q_gates_decomposition))?;

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -41,7 +41,7 @@ use pyo3::types::PyList;
 
 use crate::convert_2q_block_matrix::change_basis;
 use crate::euler_one_qubit_decomposer::{
-    angles_from_unitary, det_one_qubit, unitary_to_gate_sequence_inner, EulerBasis, EulerBasisSet,
+    angles_from_unitary, det_one_qubit, unitary_to_gate_sequence, EulerBasis, EulerBasisSet,
     OneQubitGateSequence, ANGLE_ZERO_EPSILON,
 };
 use crate::utils;
@@ -1066,7 +1066,7 @@ impl TwoQubitWeylDecomposition {
         let mut gate_sequence = CircuitData::with_capacity(py, 2, 0, 21, Param::Float(0.))?;
         let mut global_phase: f64 = self.global_phase;
 
-        let c2r = unitary_to_gate_sequence_inner(
+        let c2r = unitary_to_gate_sequence(
             self.K2r.view(),
             &target_1q_basis_list,
             0,
@@ -1083,7 +1083,7 @@ impl TwoQubitWeylDecomposition {
             )?
         }
         global_phase += c2r.global_phase;
-        let c2l = unitary_to_gate_sequence_inner(
+        let c2l = unitary_to_gate_sequence(
             self.K2l.view(),
             &target_1q_basis_list,
             1,
@@ -1106,7 +1106,7 @@ impl TwoQubitWeylDecomposition {
             atol.unwrap_or(ANGLE_ZERO_EPSILON),
             &mut global_phase,
         )?;
-        let c1r = unitary_to_gate_sequence_inner(
+        let c1r = unitary_to_gate_sequence(
             self.K1r.view(),
             &target_1q_basis_list,
             0,
@@ -1123,7 +1123,7 @@ impl TwoQubitWeylDecomposition {
             )?
         }
         global_phase += c2r.global_phase;
-        let c1l = unitary_to_gate_sequence_inner(
+        let c1l = unitary_to_gate_sequence(
             self.K1l.view(),
             &target_1q_basis_list,
             1,
@@ -1510,7 +1510,7 @@ impl TwoQubitBasisDecomposer {
     ) {
         let mut target_1q_basis_list = EulerBasisSet::new();
         target_1q_basis_list.add_basis(self.euler_basis);
-        let sequence = unitary_to_gate_sequence_inner(
+        let sequence = unitary_to_gate_sequence(
             unitary,
             &target_1q_basis_list,
             qubit as usize,
@@ -1758,7 +1758,7 @@ impl TwoQubitBasisDecomposer {
         let euler_decompositions: SmallVec<[Option<OneQubitGateSequence>; 8]> = decomposition
             .iter()
             .map(|decomp| {
-                unitary_to_gate_sequence_inner(
+                unitary_to_gate_sequence(
                     decomp.view(),
                     &target_1q_basis_list,
                     0,
@@ -2001,7 +2001,7 @@ impl TwoQubitBasisDecomposer {
         let euler_decompositions: SmallVec<[Option<OneQubitGateSequence>; 8]> = decomposition
             .iter()
             .map(|decomp| {
-                unitary_to_gate_sequence_inner(
+                unitary_to_gate_sequence(
                     decomp.view(),
                     &target_1q_basis_list,
                     0,


### PR DESCRIPTION
Fixes #12936

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.

### Summary

Refactor the accelerate crate to match new conventions such as in the circuit crate.

### Details and comments

refactor names python-only interfacing rust functions to  py_* and modify the corresponding *_inner functions.


