### PR TITLE
Avoid exporting incorrect PyInit_* symbols (0.46.3)

### DIFF
--- a/crates/accelerate/src/convert_2q_block_matrix.rs
+++ b/crates/accelerate/src/convert_2q_block_matrix.rs
@@ -66,7 +66,6 @@ fn change_basis(matrix: ArrayView2<Complex64>) -> Array2<Complex64> {
     trans_matrix
 }
 
-#[pymodule]
 pub fn convert_2q_block_matrix(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(blocks_to_matrix))?;
     Ok(())

--- a/crates/accelerate/src/dense_layout.rs
+++ b/crates/accelerate/src/dense_layout.rs
@@ -223,7 +223,6 @@ pub fn best_subset(
     ))
 }
 
-#[pymodule]
 pub fn dense_layout(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(best_subset))?;
     Ok(())

--- a/crates/accelerate/src/error_map.rs
+++ b/crates/accelerate/src/error_map.rs
@@ -111,7 +111,6 @@ impl ErrorMap {
     }
 }
 
-#[pymodule]
 pub fn error_map(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<ErrorMap>()?;
     Ok(())

--- a/crates/accelerate/src/euler_one_qubit_decomposer.rs
+++ b/crates/accelerate/src/euler_one_qubit_decomposer.rs
@@ -791,7 +791,6 @@ pub fn params_zxz(unitary: PyReadonlyArray2<Complex64>) -> [f64; 4] {
     params_zxz_inner(mat)
 }
 
-#[pymodule]
 pub fn euler_one_qubit_decomposer(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(params_zyz))?;
     m.add_wrapped(wrap_pyfunction!(params_xyx))?;

--- a/crates/accelerate/src/lib.rs
+++ b/crates/accelerate/src/lib.rs
@@ -13,7 +13,6 @@
 use std::env;
 
 use pyo3::prelude::*;
-use pyo3::wrap_pymodule;
 use pyo3::Python;
 
 mod convert_2q_block_matrix;
@@ -45,25 +44,47 @@ pub fn getenv_use_multiple_threads() -> bool {
     !parallel_context || force_threads
 }
 
+#[inline(always)]
+#[doc(hidden)]
+fn add_submodule<F>(py: Python, m: &PyModule, constructor: F, name: &str) -> PyResult<()>
+where
+    F: FnOnce(Python, &PyModule) -> PyResult<()>,
+{
+    let new_mod = PyModule::new(py, name)?;
+    constructor(py, new_mod)?;
+    m.add_submodule(new_mod)
+}
+
 #[pymodule]
-fn _accelerate(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
-    m.add_wrapped(wrap_pymodule!(nlayout::nlayout))?;
-    m.add_wrapped(wrap_pymodule!(stochastic_swap::stochastic_swap))?;
-    m.add_wrapped(wrap_pymodule!(sabre_swap::sabre_swap))?;
-    m.add_wrapped(wrap_pymodule!(pauli_exp_val::pauli_expval))?;
-    m.add_wrapped(wrap_pymodule!(dense_layout::dense_layout))?;
-    m.add_wrapped(wrap_pymodule!(error_map::error_map))?;
-    m.add_wrapped(wrap_pymodule!(sparse_pauli_op::sparse_pauli_op))?;
-    m.add_wrapped(wrap_pymodule!(results::results))?;
-    m.add_wrapped(wrap_pymodule!(optimize_1q_gates::optimize_1q_gates))?;
-    m.add_wrapped(wrap_pymodule!(sampled_exp_val::sampled_exp_val))?;
-    m.add_wrapped(wrap_pymodule!(sabre_layout::sabre_layout))?;
-    m.add_wrapped(wrap_pymodule!(vf2_layout::vf2_layout))?;
-    m.add_wrapped(wrap_pymodule!(
-        euler_one_qubit_decomposer::euler_one_qubit_decomposer
-    ))?;
-    m.add_wrapped(wrap_pymodule!(
-        convert_2q_block_matrix::convert_2q_block_matrix
-    ))?;
+fn _accelerate(py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    add_submodule(py, m, nlayout::nlayout, "nlayout")?;
+    add_submodule(py, m, stochastic_swap::stochastic_swap, "stochastic_swap")?;
+    add_submodule(py, m, sabre_swap::sabre_swap, "sabre_swap")?;
+    add_submodule(py, m, pauli_exp_val::pauli_expval, "pauli_expval")?;
+    add_submodule(py, m, dense_layout::dense_layout, "dense_layout")?;
+    add_submodule(py, m, error_map::error_map, "error_map")?;
+    add_submodule(py, m, sparse_pauli_op::sparse_pauli_op, "sparse_pauli_op")?;
+    add_submodule(py, m, results::results, "results")?;
+    add_submodule(
+        py,
+        m,
+        optimize_1q_gates::optimize_1q_gates,
+        "optimize_1q_gates",
+    )?;
+    add_submodule(py, m, sampled_exp_val::sampled_exp_val, "sampled_exp_val")?;
+    add_submodule(py, m, sabre_layout::sabre_layout, "sabre_layout")?;
+    add_submodule(py, m, vf2_layout::vf2_layout, "vf2_layout")?;
+    add_submodule(
+        py,
+        m,
+        euler_one_qubit_decomposer::euler_one_qubit_decomposer,
+        "euler_one_qubit_decomposer",
+    )?;
+    add_submodule(
+        py,
+        m,
+        convert_2q_block_matrix::convert_2q_block_matrix,
+        "convert_2q_block_matrix",
+    )?;
     Ok(())
 }

--- a/crates/accelerate/src/nlayout.rs
+++ b/crates/accelerate/src/nlayout.rs
@@ -215,7 +215,6 @@ impl NLayout {
     }
 }
 
-#[pymodule]
 pub fn nlayout(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<NLayout>()?;
     Ok(())

--- a/crates/accelerate/src/optimize_1q_gates.rs
+++ b/crates/accelerate/src/optimize_1q_gates.rs
@@ -91,7 +91,6 @@ pub fn compose_u3_rust(
     out_angles
 }
 
-#[pymodule]
 pub fn optimize_1q_gates(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(compose_u3_rust))?;
     Ok(())

--- a/crates/accelerate/src/pauli_exp_val.rs
+++ b/crates/accelerate/src/pauli_exp_val.rs
@@ -208,7 +208,6 @@ pub fn density_expval_pauli_with_x(
     }
 }
 
-#[pymodule]
 pub fn pauli_expval(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(expval_pauli_no_x))?;
     m.add_wrapped(wrap_pyfunction!(expval_pauli_with_x))?;

--- a/crates/accelerate/src/results/mod.rs
+++ b/crates/accelerate/src/results/mod.rs
@@ -16,7 +16,6 @@ pub mod marginalization;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 
-#[pymodule]
 pub fn results(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(marginalization::marginal_counts))?;
     m.add_wrapped(wrap_pyfunction!(marginalization::marginal_distribution))?;

--- a/crates/accelerate/src/sabre_layout.rs
+++ b/crates/accelerate/src/sabre_layout.rs
@@ -215,7 +215,6 @@ fn layout_trial(
     (initial_layout, final_permutation, sabre_result)
 }
 
-#[pymodule]
 pub fn sabre_layout(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(sabre_layout_and_routing))?;
     Ok(())

--- a/crates/accelerate/src/sabre_swap/mod.rs
+++ b/crates/accelerate/src/sabre_swap/mod.rs
@@ -741,7 +741,6 @@ fn choose_best_swap(
     *best_swaps.choose(rng).unwrap()
 }
 
-#[pymodule]
 pub fn sabre_swap(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(build_swap_map))?;
     m.add_class::<Heuristic>()?;

--- a/crates/accelerate/src/sampled_exp_val.rs
+++ b/crates/accelerate/src/sampled_exp_val.rs
@@ -86,7 +86,6 @@ pub fn sampled_expval_complex(
     Ok(out.re)
 }
 
-#[pymodule]
 pub fn sampled_exp_val(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(sampled_expval_float))?;
     m.add_wrapped(wrap_pyfunction!(sampled_expval_complex))?;

--- a/crates/accelerate/src/sparse_pauli_op.rs
+++ b/crates/accelerate/src/sparse_pauli_op.rs
@@ -60,7 +60,6 @@ pub fn unordered_unique(py: Python, array: PyReadonlyArray2<u16>) -> (PyObject, 
     )
 }
 
-#[pymodule]
 pub fn sparse_pauli_op(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(unordered_unique))?;
     Ok(())

--- a/crates/accelerate/src/stochastic_swap.rs
+++ b/crates/accelerate/src/stochastic_swap.rs
@@ -336,7 +336,6 @@ pub fn swap_trials(
     Ok((best_edges, best_layout, best_depth))
 }
 
-#[pymodule]
 pub fn stochastic_swap(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(swap_trials))?;
     m.add_class::<EdgeCollection>()?;

--- a/crates/accelerate/src/vf2_layout.rs
+++ b/crates/accelerate/src/vf2_layout.rs
@@ -106,7 +106,6 @@ pub fn score_layout(
     Ok(1. - fidelity)
 }
 
-#[pymodule]
 pub fn vf2_layout(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(score_layout))?;
     m.add_class::<EdgeList>()?;


### PR DESCRIPTION
This is a manual backport of the change introduced in PR #12889. It is done manually since in 0.46 we are using PyO3 version 0.19.2 which does not yet have the `Bound` concept PR #12889 relies on in the `add_submodule` helper function. In this branch we also need to handle just a subset of submodule functions compared to the ones in #12889.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


