### PR TITLE
Add `cache_pygates` feature to `accelerate` crate.

### DIFF
--- a/crates/accelerate/Cargo.toml
+++ b/crates/accelerate/Cargo.toml
@@ -58,3 +58,6 @@ features = ["ndarray"]
 [dependencies.pulp]
 version = "0.18.22"
 features = ["macro"]
+
+[features]
+cache_pygates = ["qiskit-circuit/cache_pygates"]

--- a/crates/pyext/Cargo.toml
+++ b/crates/pyext/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 # crates as standalone binaries, executables, we need `libpython` to be linked in, so we make the
 # feature a default, and run `cargo test --no-default-features` to turn it off.
 default = ["pyo3/extension-module"]
-cache_pygates = ["pyo3/extension-module", "qiskit-circuit/cache_pygates"]
+cache_pygates = ["pyo3/extension-module", "qiskit-circuit/cache_pygates", "qiskit-accelerate/cache_pygates"]
 
 [dependencies]
 pyo3.workspace = true


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
The following commits add the `cache_pygates` feature from the `circuit` crate into `accelerate`.


### Details and comments
Since we added rust native methods to add operations into the `DAGCircuit` (thanks in part to #13143), we make use of the `cache_pygate` feature which is only available in the `circuit` crate. A couple of transpiler passes which require building instances of `DAGCircuit` from Rust entirely (mainly #13141, and #13137) are using these functions, they need to respect the bounds this feature specifies or else they would not compile.

A couple of teammates have already implemented this flag as part of their PRs but, to prevent a future merge conflict debacle, I decided to put it in this PR. These commits add the feature to `accelerate` so that people don't have to worry about that in the future.

