### PR TITLE
Remove dead code branch from `Optimize1qDecomposition` Python code

### DIFF
--- a/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
@@ -222,18 +222,12 @@ class Optimize1qGatesDecomposition(TransformationPass):
     def _error(self, circuit, qubit):
         """
         Calculate a rough error for a `circuit` that runs on a specific
-        `qubit` of `target` (`circuit` can either be an OneQubitGateSequence
-        from Rust or a list of DAGOPNodes).
+        `qubit` of `target` (`circuit` is a list of DAGOPNodes).
 
         Use basis errors from target if available, otherwise use length
         of circuit as a weak proxy for error.
         """
-        if isinstance(circuit, euler_one_qubit_decomposer.OneQubitGateSequence):
-            return euler_one_qubit_decomposer.compute_error_one_qubit_sequence(
-                circuit, qubit, self.error_map
-            )
-        else:
-            return euler_one_qubit_decomposer.compute_error_list(circuit, qubit, self.error_map)
+        return euler_one_qubit_decomposer.compute_error_list(circuit, qubit, self.error_map)
 
 
 def _possible_decomposers(basis_set):


### PR DESCRIPTION
### Summary

Since 8e5fab6c (gh-12959), this branch has been dead, and the Rust method alluded to in it (`compute_error_one_qubit_sequence`) was removed.  This is occasionally - but for some reason not always - detected by `pylint`, and it's a true error so should be removed.

In fact, almost all of the Python code in `Optimize1qDecomposition` is dead from the perspective of that transpiler pass.  However, `Optimize1qCommutation` has no concept of safe API boundaries, and is in fact still using all of these methods (and the default `UnitarySynthesis` plugin does a little too).  A follow-up commit can reorganise the code to fix this, but this commit is intended to be mergeable faster, to unblock a couple of PRs that are triggering the pylint failure.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


This is the blocker on #13147 at the moment, and has occasionally appeared in other PRs.  I'll follow this with a proper refactoring commit to sort out how the split between `Optimize1qDecomposition`, `DefaultUnitarySynthesisPlugin` and `Optimize1qCommutation` _should_ work.