### PR TITLE
Fix future rustc lint rule on named lifetime elision

### DIFF
--- a/crates/qasm3/src/circuit.rs
+++ b/crates/qasm3/src/circuit.rs
@@ -21,7 +21,7 @@ pub trait PyRegister {
     // or at a minimum
     //      fn iter<'a>(&'a self, py: Python<'a>) -> ::pyo3::types::iter::PyListIterator<'a>;
     // but we can't use the former before Rust 1.75 and the latter before PyO3 0.21.
-    fn bit_list<'a>(&'a self, py: Python<'a>) -> &Bound<'a, PyList>;
+    fn bit_list<'a>(&'a self, py: Python<'a>) -> &'a Bound<'a, PyList>;
 }
 
 macro_rules! register_type {
@@ -38,7 +38,7 @@ macro_rules! register_type {
         }
 
         impl PyRegister for $name {
-            fn bit_list<'a>(&'a self, py: Python<'a>) -> &Bound<'a, PyList> {
+            fn bit_list<'a>(&'a self, py: Python<'a>) -> &'a Bound<'a, PyList> {
                 self.items.bind(py)
             }
         }
@@ -297,7 +297,7 @@ pub struct PyCircuit(Py<PyAny>);
 
 impl PyCircuit {
     /// Untyped access to the inner Python object.
-    pub fn inner<'a>(&'a self, py: Python<'a>) -> &Bound<'a, PyAny> {
+    pub fn inner<'a>(&'a self, py: Python<'a>) -> &'a Bound<'a, PyAny> {
         self.0.bind(py)
     }
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes a future lint rule that will appear in future version of the rust compiler. The new rule will raise a warning at compile time if the code used an elided lifetime resolves to a named lifetime. While this typically would only cause an issue in unsafe rust, it can cause a confusing error message in cases when using functions like this in a safe context. This fixes the code violating this future rule to get ahead of any potential errors when compiling with a release of Rust from the near future.

This rule is documented here:

https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/builtin/static.ELIDED_NAMED_LIFETIMES.html

### Details and comments