### PR TITLE
Remove qiskit-bot notification rule for rust changes

### DIFF
--- a/qiskit_bot.yaml
+++ b/qiskit_bot.yaml
@@ -25,9 +25,6 @@ notifications:
         - "`@t-imamichi`"
         - "`@ajavadia`"
         - "`@levbishop`"
-    ".*\\.rs$|^Cargo":
-        - "`@mtreinish`"
-        - "`@kevinhartman`"
     "(?!.*pulse.*)\\bvisualization\\b":
         - "@enavarro51"
     "^docs/":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

We previously had a qiskit-bot notification trigger for changes to the rust source or cargo configuration that would list myself and `@kevinhartman` as the relevant reviewers. While this is still true, as Qiskit is now >16% Rust (by lines of code, excluding tests) and that ratio will only grow over time, the two of us are hardly the only people worth calling out specifically as reviewers of rust code. Instead of expanding the list to include the entirety of the terra-core team individually this just removes the custom notification rule and opts to fallback to the default terra-core entry.

### Details and comments