### PR TITLE
Run unittests as wheel build validation

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -175,6 +175,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.19.2
         env:
           CIBW_ARCHS_LINUX: aarch64
+          CIBW_TEST_COMMAND: cp -r {project}/test . && QISKIT_PARALLEL=FALSE stestr --test-path test/python run --abbreviate -n test.python.compiler.test_transpiler
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.os }}-aarch64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,12 +146,12 @@ manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
 skip = "pp* cp36-* cp37-* cp38-* *musllinux* *win32 *i686 cp38-macosx_arm64"
 test-skip = "*win32 *linux_i686"
-test-command = "python {project}/examples/python/stochastic_swap.py"
+test-command = "cp -r {project}/test . && QISKIT_PARALLEL=FALSE stestr --test-path test/python run --abbreviate"
 # We need to use pre-built versions of Numpy and Scipy in the tests; they have a
 # tendency to crash if they're installed from source by `pip install`, and since
 # Numpy 1.22 there are no i686 wheels, so we force pip to use older ones without
 # restricting any dependencies that Numpy and Scipy might have.
-before-test = "pip install --only-binary=numpy,scipy numpy scipy"
+before-test = "pip install --prefer-binary --only-binary=numpy,scipy numpy scipy -c constraints.txt -r requirements-dev.txt"
 # Some jobs locally override the before-build and environment configuration if a
 # specific job override is needed. For example tier 1 platforms locally override
 # the before-build and environment configuration to enable PGO,
@@ -168,6 +168,7 @@ environment = "MACOSX_DEPLOYMENT_TARGET=10.12"
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} && pipx run abi3audit --strict --report {wheel}"
 
 [tool.cibuildwheel.windows]
+test-command = "cp -r {project}/test . && stestr --test-path test/python run --abbreviate"
 repair-wheel-command = "cp {wheel} {dest_dir}/. && pipx run abi3audit --strict --report {wheel}"
 
 [tool.ruff]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the cibuildwheel configuration to run the unittests as the test/validation step after building and auditing the wheels. Previously we were running a standalone "example" script as the validation because at one time many years ago StochasticSwap was the only compiled code in qiskit so this was sufficient coverage. But now that Qiskit is >16% written in Rust as of this commit this script is not sufficient to validate the wheels are functional prior to uploading to pypi. For tier 1 platforms this updates the cibuildwheel configuration to run the full unit test suite, on tier 2 platforms (which is currently only linux aarch64) we run just the transpiler integration tests as we have more time pressure to run the tests on those platforms and don't have the budget to run the full test suite on all supported python versions.

### Details and comments

Fixes #12202

I did a test run in my fork here: https://github.com/mtreinish/qiskit-core/actions/runs/10967730306 everything worked as expected. The smoke tests for the tier 2 aarch64 linux took ~15min per python version to run which seems like an acceptable tradeoff between runtime and coverage.

Closes #12908
Closes #12551