### PR TITLE
unwrapped DAGCircuit::collect_runs() to not return an Option

### DIFF
--- a/crates/accelerate/src/inverse_cancellation.rs
+++ b/crates/accelerate/src/inverse_cancellation.rs
@@ -59,7 +59,7 @@ fn run_on_self_inverse(
         }
         let mut collect_set: HashSet<String> = HashSet::with_capacity(1);
         collect_set.insert(gate.operation.name().to_string());
-        let gate_runs: Vec<Vec<NodeIndex>> = dag.collect_runs(collect_set).unwrap().collect();
+        let gate_runs: Vec<Vec<NodeIndex>> = dag.collect_runs(collect_set).collect();
         for gate_cancel_run in gate_runs {
             let mut partitions: Vec<Vec<NodeIndex>> = Vec::new();
             let mut chunk: Vec<NodeIndex> = Vec::new();
@@ -128,7 +128,7 @@ fn run_on_inverse_pairs(
             .iter()
             .map(|x| x.operation.name().to_string())
             .collect();
-        let runs: Vec<Vec<NodeIndex>> = dag.collect_runs(names).unwrap().collect();
+        let runs: Vec<Vec<NodeIndex>> = dag.collect_runs(names).collect();
         for nodes in runs {
             let mut i = 0;
             while i < nodes.len() - 1 {

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -4948,7 +4948,7 @@ impl DAGCircuit {
     pub fn collect_runs(
         &self,
         namelist: HashSet<String>,
-    ) -> impl Iterator<Item = Vec<NodeIndex>> {
+    ) -> impl Iterator<Item = Vec<NodeIndex>> + '_ {
         let filter_fn = move |node_index: NodeIndex| -> Result<bool, Infallible> {
             let node = &self.dag[node_index];
             match node {

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -4375,25 +4375,18 @@ def _format(operand):
         for name in namelist.iter() {
             name_list_set.insert(name.extract::<String>()?);
         }
-        match self.collect_runs(name_list_set) {
-            Ok(runs) => {
-                let run_iter = runs.map(|node_indices| {
-                    PyTuple::new_bound(
-                        py,
-                        node_indices
-                            .into_iter()
-                            .map(|node_index| self.get_node(py, node_index).unwrap()),
-                    )
-                    .unbind()
-                });
-                let out_set = PySet::empty_bound(py)?;
-                for run_tuple in run_iter {
-                    out_set.add(run_tuple)?;
-                }
-                Ok(out_set.unbind())
-            }
-            Err(e) => Err(PyRuntimeError::new_err(e.to_string())),
+
+        let out_set = PySet::empty_bound(py)?;
+
+        for run in self.collect_runs(name_list_set) {
+            let run_tuple = PyTuple::new_bound(
+                py,
+                run.into_iter()
+                    .map(|node_index| self.get_node(py, node_index).unwrap()),
+            );
+            out_set.add(run_tuple)?;
         }
+        Ok(out_set.unbind())
     }
 
     /// Return a set of non-conditional runs of 1q "op" nodes.

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -4955,7 +4955,7 @@ impl DAGCircuit {
     pub fn collect_runs(
         &self,
         namelist: HashSet<String>,
-    ) -> PyResult<impl Iterator<Item = Vec<NodeIndex>> + '_> {
+    ) -> impl Iterator<Item = Vec<NodeIndex>> {
         let filter_fn = move |node_index: NodeIndex| -> Result<bool, Infallible> {
             let node = &self.dag[node_index];
             match node {
@@ -4967,10 +4967,8 @@ impl DAGCircuit {
         };
 
         match rustworkx_core::dag_algo::collect_runs(&self.dag, filter_fn) {
-            Some(iter) => Ok(iter.filter_map(|result| result.ok())),
-            None => Err(PyRuntimeError::new_err(
-                "Invalid DAGCircuit, cycle encountered",
-            )),
+            Some(iter) => iter.map(|result| result.unwrap()),
+            None => panic!("invalid DAG: cycle(s) detected!"),
         }
     }
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.



- [ x ] I have added the tests to cover my changes.
- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the CONTRIBUTING document.
-->

### Summary
This change updates the collect_runs function to return a PyResult instead of an Option so that error can be routed by to DAGCircuit when invalid states are present.


### Details and comments
fixes #13109

