### PR TITLE
Fix equality typos in Documentation for `Ryy`, `Rxx` and `Rzx` gates

### DIFF
--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -63,7 +63,7 @@ class RXXGate(Gate):
 
         .. math::
 
-            R_{XX}(\theta = \pi) = i X \otimes X
+            R_{XX}(\theta = \pi) = -i X \otimes X
 
         .. math::
 

--- a/qiskit/circuit/library/standard_gates/ryy.py
+++ b/qiskit/circuit/library/standard_gates/ryy.py
@@ -63,7 +63,7 @@ class RYYGate(Gate):
 
         .. math::
 
-            R_{YY}(\theta = \pi) = i Y \otimes Y
+            R_{YY}(\theta = \pi) = -i Y \otimes Y
 
         .. math::
 

--- a/qiskit/circuit/library/standard_gates/rzx.py
+++ b/qiskit/circuit/library/standard_gates/rzx.py
@@ -108,7 +108,7 @@ class RZXGate(Gate):
 
         .. math::
 
-            R_{ZX}(\theta = \pi) = -i Z \otimes X
+            R_{ZX}(\theta = \pi) = -i X \otimes Z
 
         .. math::
 


### PR DESCRIPTION
### Summary
This PR resolves #13225 by fixing the typos in the documentation for the `Ryy`, `Rxx` and `Rzx` gates.

### Details and comments
If I am not mistaken, these are the proper equalities. I also checked the result with `numpy`:
```python
>>> import qiskit
>>> import numpy as np
>>> Ryy = qiskit.circuit.library.standard_gates.RYYGate(theta=np.pi)
>>> np.isclose(np.array(Ryy), -1j*np.kron(np.array(Y), np.array(Y)))
array([[ True,  True,  True,  True],
       [ True,  True,  True,  True],
       [ True,  True,  True,  True],
       [ True,  True,  True,  True]])
>>> Rxx = qiskit.circuit.library.standard_gates.RXXGate(theta=np.pi)
>>> np.isclose(np.array(Rxx), -1j*np.kron(np.array(X), np.array(X)))
array([[ True,  True,  True,  True],
       [ True,  True,  True,  True],
       [ True,  True,  True,  True],
       [ True,  True,  True,  True]])
>>> Rzx = qiskit.circuit.library.standard_gates.RZXGate(theta=np.pi)
>>> np.isclose(np.array(Rzx), -1j*np.kron(np.array(X), np.array(Z)))
array([[ True,  True,  True,  True],
       [ True,  True,  True,  True],
       [ True,  True,  True,  True],
       [ True,  True,  True,  True]])
```