### PR TITLE
Avoid checking if matrix is unitary in Split2qUnitaries

### DIFF
--- a/crates/accelerate/src/split_2q_unitaries.rs
+++ b/crates/accelerate/src/split_2q_unitaries.rs
@@ -45,8 +45,12 @@ pub fn split_2q_unitaries(
             if matches!(decomp.specialization, Specialization::IdEquiv) {
                 let k1r_arr = decomp.K1r(py);
                 let k1l_arr = decomp.K1l(py);
-                let k1r_gate = UNITARY_GATE.get_bound(py).call1((k1r_arr,))?;
-                let k1l_gate = UNITARY_GATE.get_bound(py).call1((k1l_arr,))?;
+                let k1r_gate = UNITARY_GATE
+                    .get_bound(py)
+                    .call1((k1r_arr, py.None(), false))?;
+                let k1l_gate = UNITARY_GATE
+                    .get_bound(py)
+                    .call1((k1l_arr, py.None(), false))?;
                 let insert_fn = |edge: &Wire| -> PyResult<OperationFromPython> {
                     if let Wire::Qubit(qubit) = edge {
                         if *qubit == qubits[0] {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes a small oversight in the Split2QUnitaries transpiler pass. When it does decide to split the unitary into two single qubit unitary gates it was creating a new UnitaryGate object. When these UnitaryGate objects were created we weren't setting the check_input flag to false. This meant we were spending time validating the matrix was a unitary, but in the context the matrix is known to be unitary already, so we don't need to spend the time doing this checking.

### Details and comments