### PR TITLE
Update dag_drawer Documentation to include DAGDependency on Allowed Types

### DIFF
--- a/qiskit/visualization/dag_visualization.py
+++ b/qiskit/visualization/dag_visualization.py
@@ -81,7 +81,7 @@ def dag_drawer(dag, scale=0.7, filename=None, style="color"):
     ``rustworkx`` package to draw the DAG.
 
     Args:
-        dag (DAGCircuit): The dag to draw.
+        dag (DAGCircuit or DAGDependency): The dag to draw.
         scale (float): scaling factor
         filename (str): file path to save image to (format inferred from name)
         style (str): 'plain': B&W graph


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes #13021 by updating the `dag_drawer` documentation to include `DAGDependency` on allowed types



### Details and comments
initial:
  ```
Args:
      dag (DAGCircuit): The dag to draw.
```
updated: 
```
Args:
      dag (DAGCircuit or DAGDependency): The dag to draw.
```

