### PR TITLE
Add Rust quantum volume function

### DIFF
--- a/crates/accelerate/src/circuit_library/mod.rs
+++ b/crates/accelerate/src/circuit_library/mod.rs
@@ -14,9 +14,11 @@ use pyo3::prelude::*;
 
 mod entanglement;
 mod pauli_feature_map;
+mod quantum_volume;
 
 pub fn circuit_library(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(pauli_feature_map::pauli_feature_map))?;
     m.add_wrapped(wrap_pyfunction!(entanglement::get_entangler_map))?;
+    m.add_wrapped(wrap_pyfunction!(quantum_volume::quantum_volume))?;
     Ok(())
 }

--- a/crates/accelerate/src/circuit_library/pauli_feature_map.rs
+++ b/crates/accelerate/src/circuit_library/pauli_feature_map.rs
@@ -138,7 +138,7 @@ fn pauli_evolution(
 ///     insert_barriers: Whether to insert barriers in between the Hadamard and evolution layers.
 ///     data_map_func: An accumulation function that takes as input a vector of parameters the
 ///         current gate acts on and returns a scalar.
-///     
+///
 /// Returns:
 ///     The ``CircuitData`` to construct the Pauli feature map.
 #[pyfunction]
@@ -207,7 +207,13 @@ pub fn pauli_feature_map(
         }
     }
 
-    CircuitData::from_packed_operations(py, feature_dimension, 0, packed_insts, Param::Float(0.0))
+    CircuitData::from_packed_operations(
+        py,
+        feature_dimension,
+        0,
+        packed_insts.into_iter().map(Ok),
+        Param::Float(0.0),
+    )
 }
 
 fn _get_h_layer(feature_dimension: u32) -> impl Iterator<Item = Instruction> {

--- a/crates/accelerate/src/circuit_library/quantum_volume.rs
+++ b/crates/accelerate/src/circuit_library/quantum_volume.rs
@@ -33,6 +33,10 @@ use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::Qubit;
 use smallvec::smallvec;
 
+// This function's implementation was modeled off of the algorithm used in the
+// `scipy.stats.unitary_group.rvs()` function defined here:
+//
+// https://github.com/scipy/scipy/blob/v1.14.1/scipy/stats/_multivariate.py#L4224-L4256
 #[inline]
 fn random_unitaries(seed: u64, size: usize) -> impl Iterator<Item = Array2<Complex64>> {
     let mut rng = Pcg64Mcg::seed_from_u64(seed);

--- a/crates/accelerate/src/circuit_library/quantum_volume.rs
+++ b/crates/accelerate/src/circuit_library/quantum_volume.rs
@@ -172,11 +172,15 @@ pub fn quantum_volume(
             None => Pcg64Mcg::from_entropy(),
         };
         let seed: u64 = outer_rng.sample(rand::distributions::Standard);
+
+        let unitaries: Vec<Array2<Complex64>> = random_unitaries(seed, num_unitaries).collect();
+
         CircuitData::from_packed_operations(
             py,
             num_qubits,
             0,
-            random_unitaries(seed, num_unitaries)
+            unitaries
+                .into_iter()
                 .enumerate()
                 .map(|x| build_instruction(x, &mut outer_rng)),
             Param::Float(0.),

--- a/crates/accelerate/src/circuit_library/quantum_volume.rs
+++ b/crates/accelerate/src/circuit_library/quantum_volume.rs
@@ -1,0 +1,149 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2024
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use std::thread::available_parallelism;
+
+use qiskit_circuit::imports::UNITARY_GATE;
+
+use pyo3::prelude::*;
+
+use crate::getenv_use_multiple_threads;
+use faer_ext::{IntoFaerComplex, IntoNdarrayComplex};
+use ndarray::prelude::*;
+use num_complex::Complex64;
+use numpy::IntoPyArray;
+use rand::prelude::*;
+use rand_distr::Normal;
+use rand_pcg::Pcg64Mcg;
+use rayon::prelude::*;
+
+use qiskit_circuit::circuit_data::CircuitData;
+use qiskit_circuit::operations::Param;
+use qiskit_circuit::operations::PyInstruction;
+use qiskit_circuit::packed_instruction::PackedOperation;
+use qiskit_circuit::Qubit;
+use smallvec::smallvec;
+
+#[inline]
+fn random_unitaries(seed: u64, size: usize) -> impl Iterator<Item = Array2<Complex64>> {
+    let mut rng = Pcg64Mcg::seed_from_u64(seed);
+    let dist = Normal::new(0., 1.0).unwrap();
+
+    (0..size).map(move |_| {
+        let mut z: Array2<Complex64> = Array2::from_shape_simple_fn((4, 4), || {
+            Complex64::new(dist.sample(&mut rng), dist.sample(&mut rng))
+        });
+        z.mapv_inplace(|x| x * std::f64::consts::FRAC_1_SQRT_2);
+        let qr = z.view().into_faer_complex().qr();
+        let r = qr.compute_r().as_ref().into_ndarray_complex().to_owned();
+        let mut d = r.into_diag();
+        d.mapv_inplace(|d| d / d.norm());
+        let mut q = qr.compute_q().as_ref().into_ndarray_complex().to_owned();
+        q.axis_iter_mut(Axis(0)).for_each(|mut row| {
+            row.iter_mut()
+                .enumerate()
+                .for_each(|(index, val)| *val *= d.diag()[index])
+        });
+        q
+    })
+}
+
+#[pyfunction]
+pub fn quantum_volume(
+    py: Python,
+    num_qubits: u32,
+    depth: usize,
+    seed: Option<u64>,
+) -> PyResult<CircuitData> {
+    let width = num_qubits as usize / 2;
+    let num_unitaries = width * depth;
+    let mut permutation: Vec<Qubit> = (0..num_qubits).map(Qubit).collect();
+
+    let mut build_instruction = |(unitary_index, unitary_array): (usize, Array2<Complex64>),
+                                 rng: &mut Pcg64Mcg| {
+        let layer_index = unitary_index % width;
+        if layer_index == 0 {
+            permutation.shuffle(rng);
+        }
+        let unitary = unitary_array.into_pyarray_bound(py);
+        let unitary_gate = UNITARY_GATE
+            .get_bound(py)
+            .call1((unitary.clone(), py.None(), false))
+            .unwrap();
+        let instruction = PyInstruction {
+            qubits: 2,
+            clbits: 0,
+            params: 1,
+            op_name: "unitary".to_string(),
+            control_flow: false,
+            instruction: unitary_gate.unbind(),
+        };
+        let qubit = layer_index * 2;
+        (
+            PackedOperation::from_instruction(Box::new(instruction)),
+            smallvec![Param::Obj(unitary.unbind().into())],
+            vec![permutation[qubit], permutation[qubit + 1]],
+            vec![],
+        )
+    };
+
+    if getenv_use_multiple_threads() {
+        let mut per_thread = num_unitaries / available_parallelism().unwrap();
+        if per_thread == 0 {
+            if num_unitaries > 10 {
+                per_thread = 10
+            } else {
+                per_thread = num_unitaries
+            }
+        }
+
+        let mut outer_rng = match seed {
+            Some(seed) => Pcg64Mcg::seed_from_u64(seed),
+            None => Pcg64Mcg::from_entropy(),
+        };
+        let seed_vec: Vec<u64> = outer_rng
+            .clone()
+            .sample_iter(&rand::distributions::Standard)
+            .take(num_unitaries)
+            .collect();
+        let unitaries: Vec<Array2<Complex64>> = seed_vec
+            .into_par_iter()
+            .chunks(per_thread)
+            .flat_map_iter(|seeds| random_unitaries(seeds[0], seeds.len()))
+            .collect();
+        CircuitData::from_packed_operations(
+            py,
+            num_qubits,
+            0,
+            unitaries
+                .into_iter()
+                .enumerate()
+                .map(|x| build_instruction(x, &mut outer_rng)),
+            Param::Float(0.),
+        )
+    } else {
+        let mut outer_rng = match seed {
+            Some(seed) => Pcg64Mcg::seed_from_u64(seed),
+            None => Pcg64Mcg::from_entropy(),
+        };
+        let seed: u64 = outer_rng.sample(rand::distributions::Standard);
+        CircuitData::from_packed_operations(
+            py,
+            num_qubits,
+            0,
+            random_unitaries(seed, num_unitaries)
+                .enumerate()
+                .map(|x| build_instruction(x, &mut outer_rng)),
+            Param::Float(0.),
+        )
+    }
+}

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -2165,18 +2165,18 @@ impl TwoQubitBasisDecomposer {
                     .gates
                     .into_iter()
                     .map(|(gate, params, qubits)| match gate {
-                        Some(gate) => (
+                        Some(gate) => Ok((
                             PackedOperation::from_standard(gate),
                             params.into_iter().map(Param::Float).collect(),
                             qubits.into_iter().map(|x| Qubit(x.into())).collect(),
                             Vec::new(),
-                        ),
-                        None => (
+                        )),
+                        None => Ok((
                             kak_gate.operation.clone(),
                             kak_gate.params.clone(),
                             qubits.into_iter().map(|x| Qubit(x.into())).collect(),
                             Vec::new(),
-                        ),
+                        )),
                     }),
                 Param::Float(sequence.global_phase),
             ),

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -134,12 +134,12 @@ impl CircuitData {
     ) -> PyResult<Self>
     where
         I: IntoIterator<
-            Item = (
+            Item = PyResult<(
                 PackedOperation,
                 SmallVec<[Param; 3]>,
                 Vec<Qubit>,
                 Vec<Clbit>,
-            ),
+            )>,
         >,
     {
         let instruction_iter = instructions.into_iter();
@@ -150,7 +150,8 @@ impl CircuitData {
             instruction_iter.size_hint().0,
             global_phase,
         )?;
-        for (operation, params, qargs, cargs) in instruction_iter {
+        for item in instruction_iter {
+            let (operation, params, qargs, cargs) = item?;
             let qubits = res.qargs_interner.insert_owned(qargs);
             let clbits = res.cargs_interner.insert_owned(cargs);
             let params = (!params.is_empty()).then(|| Box::new(params));

--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -318,6 +318,7 @@ Particular Quantum Circuits
    HiddenLinearFunction
    IQP
    QuantumVolume
+   quantum_volume
    PhaseEstimation
    GroverOperator
    PhaseOracle
@@ -564,7 +565,7 @@ from .data_preparation import (
     StatePreparation,
     Initialize,
 )
-from .quantum_volume import QuantumVolume
+from .quantum_volume import QuantumVolume, quantum_volume
 from .fourier_checking import FourierChecking
 from .graph_state import GraphState
 from .hidden_linear_function import HiddenLinearFunction

--- a/qiskit/circuit/library/quantum_volume.py
+++ b/qiskit/circuit/library/quantum_volume.py
@@ -149,7 +149,7 @@ def quantum_volume(
 
     [1] A. Cross et al. Validating quantum computers using
     randomized model circuits, Phys. Rev. A 100, 032328 (2019).
-    [`arXiv:1811.12926 <https://arxiv.org/abs/1811.12926>`_]
+    `arXiv:1811.12926 <https://arxiv.org/abs/1811.12926>`__
     """
     if isinstance(seed, np.random.Generator):
         seed = seed.integers(0, dtype=np.uint64)

--- a/qiskit/circuit/library/quantum_volume.py
+++ b/qiskit/circuit/library/quantum_volume.py
@@ -132,6 +132,11 @@ def quantum_volume(
     elements of SU(4) applied between corresponding pairs
     of qubits in a random bipartition.
 
+    This function is multithreaded and will launch a thread pool with threads equal to the number
+    of CPUs by default. You can tune the number of threads with the ``RAYON_NUM_THREADS``
+    environment variable. For example, setting ``RAYON_NUM_THREADS=4`` would limit the thread pool
+    to 4 threads.
+
     **Reference Circuit:**
 
     .. plot::

--- a/qiskit/circuit/library/quantum_volume.py
+++ b/qiskit/circuit/library/quantum_volume.py
@@ -12,6 +12,8 @@
 
 """Quantum Volume model circuit."""
 
+from __future__ import annotations
+
 from typing import Optional, Union
 
 import numpy as np

--- a/qiskit/circuit/library/quantum_volume.py
+++ b/qiskit/circuit/library/quantum_volume.py
@@ -118,8 +118,8 @@ class QuantumVolume(QuantumCircuit):
 
 def quantum_volume(
     num_qubits: int,
-    depth: Optional[int] = None,
-    seed: Optional[Union[int, np.random.Generator]] = None,
+    depth: int | None = None,
+    seed: int | np.random.Generator | None = None,
 ) -> QuantumCircuit:
     """A quantum volume model circuit.
 

--- a/qiskit/circuit/library/quantum_volume.py
+++ b/qiskit/circuit/library/quantum_volume.py
@@ -17,6 +17,7 @@ from typing import Optional, Union
 import numpy as np
 from qiskit.circuit import QuantumCircuit, CircuitInstruction
 from qiskit.circuit.library.generalized_gates import PermutationGate, UnitaryGate
+from qiskit._accelerate.circuit_library import quantum_volume as qv_rs
 
 
 class QuantumVolume(QuantumCircuit):
@@ -113,3 +114,37 @@ class QuantumVolume(QuantumCircuit):
                     base._append(CircuitInstruction(gate, qubits[qubit : qubit + 2]))
         if not flatten:
             self._append(CircuitInstruction(base.to_instruction(), tuple(self.qubits)))
+
+
+def quantum_volume(
+    num_qubits: int,
+    depth: Optional[int] = None,
+    seed: Optional[Union[int, np.random.Generator]] = None,
+) -> QuantumCircuit:
+    """A quantum volume model circuit.
+
+    The model circuits are random instances of circuits used to measure
+    the Quantum Volume metric, as introduced in [1].
+
+    The model circuits consist of layers of Haar random
+    elements of SU(4) applied between corresponding pairs
+    of qubits in a random bipartition.
+
+    **Reference Circuit:**
+
+    .. plot::
+
+       from qiskit.circuit.library import quantum_volume
+       circuit = quantum_volume(5, 6, seed=10)
+       circuit.draw('mpl')
+
+    **References:**
+
+    [1] A. Cross et al. Validating quantum computers using
+    randomized model circuits, Phys. Rev. A 100, 032328 (2019).
+    [`arXiv:1811.12926 <https://arxiv.org/abs/1811.12926>`_]
+    """
+    if isinstance(seed, np.random.Generator):
+        seed = seed.integers(0, dtype=np.uint64)
+    depth = depth or num_qubits
+    return QuantumCircuit._from_circuit_data(qv_rs(num_qubits, depth, seed))

--- a/releasenotes/notes/add-qv-function-a8990e248d5e7e1a.yaml
+++ b/releasenotes/notes/add-qv-function-a8990e248d5e7e1a.yaml
@@ -1,0 +1,11 @@
+---
+features_circuits:
+  - |
+    Added a new function :func:`.quantum_volume` for generating a quantum volume
+    :class:`.QuantumCircuit` object as defined in A. Cross et al. Validating quantum computers
+    using randomized model circuits, Phys. Rev. A 100, 032328 (2019)
+    `https://link.aps.org/doi/10.1103/PhysRevA.100.032328 <https://link.aps.org/doi/10.1103/PhysRevA.100.032328>`__.
+    This new function differs from the existing :class:`.QuantumVolume` class in that it returns
+    a :class:`.QuantumCircuit` object instead of building a subclass object. The second is
+    that this new function is multithreaded and implemented in rust so it generates the output
+    circuit ~10x faster than the :class:`.QuantumVolume` class.

--- a/test/python/circuit/library/test_quantum_volume.py
+++ b/test/python/circuit/library/test_quantum_volume.py
@@ -16,6 +16,7 @@ import unittest
 
 from test.utils.base import QiskitTestCase
 from qiskit.circuit.library import QuantumVolume
+from qiskit.circuit.library.quantum_volume import quantum_volume
 
 
 class TestQuantumVolumeLibrary(QiskitTestCase):
@@ -33,6 +34,20 @@ class TestQuantumVolumeLibrary(QiskitTestCase):
 
         left = QuantumVolume(4, 4, seed=2024, flatten=True)
         right = QuantumVolume(4, 4, seed=2024, flatten=True)
+        self.assertEqual(left, right)
+
+    def test_qv_function_seed_reproducibility(self):
+        """Test qv circuit."""
+        left = quantum_volume(10, 10, seed=128)
+        right = quantum_volume(10, 10, seed=128)
+        self.assertEqual(left, right)
+
+        left = quantum_volume(10, 10, seed=256)
+        right = quantum_volume(10, 10, seed=256)
+        self.assertEqual(left, right)
+
+        left = quantum_volume(10, 10, seed=4196)
+        right = quantum_volume(10, 10, seed=4196)
         self.assertEqual(left, right)
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new function quantum_volume used for generating a quantum volume model circuit. This new function is defined in Rust and multithreaded to improve the throughput of the circuit generation. This new function will eventually replace the existing QuantumVolume class as part of #13046. Since quantum volume is a circuit defined by it's structure using a generator function is inline with the goals of #13046.

Right now the performance is bottlenecked by the creation of the UnitaryGate objects as these are still defined solely in Python. We'll likely need to port the class to have a rust native representation to further speed up the construction of the circuit.

### Details and comments