### PR TITLE
Change Qiskit bot for docs team

### DIFF
--- a/qiskit_bot.yaml
+++ b/qiskit_bot.yaml
@@ -31,6 +31,7 @@ notifications:
     "(?!.*pulse.*)\\bvisualization\\b":
         - "@enavarro51"
     "^docs/":
-        - "@javabster"
         - "@Eric-Arellano"
+        - "@abbycross"
+        - "@beckykd"
 always_notify: true


### PR DESCRIPTION
Abby C and Becky (technical writers) want to start copy editing release notes before the final release. We can use Qiskit Bot to notify them.

Meanwhile, it's noisy for Abby M to get notifications.
