### PR TITLE
Temporarily pin ``symengine==0.11.0`` to unblock CI

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -19,3 +19,7 @@ z3-solver==4.12.2.0; platform_system=="Darwin"
 # usage, but our test suite uses an exact reference file that uses the
 # pydot 3 output, so we need to enforce that during tests.
 pydot>=3.0.0
+
+# Pin Symengine for incompatibilites loading and storing data in between
+# versions 0.13 and before.
+symengine==0.11.0

--- a/test/qpy_compat/qpy_test_constraints.txt
+++ b/test/qpy_compat/qpy_test_constraints.txt
@@ -1,2 +1,6 @@
 numpy===1.24.4
 scipy===1.10.1
+
+# Pin Symengine for incompatibilites loading and storing data in between
+# versions 0.13 and before.
+symengine==0.11.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

With the release of symengine 0.13 we're running into incompatibility issues when loading/storing data in between symengine versions (e.g. in between 0.11 and 0.13). This commit pins temporarily pins the version to unblock CI, until a more permanent solution is found.


