### PR TITLE
Removes unused imports from code block

### DIFF
--- a/qiskit/visualization/circuit/circuit_visualization.py
+++ b/qiskit/visualization/circuit/circuit_visualization.py
@@ -191,7 +191,7 @@ def circuit_drawer(
         .. plot::
             :include-source:
 
-            from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
+            from qiskit import QuantumCircuit
             qc = QuantumCircuit(1, 1)
             qc.h(0)
             qc.measure(0, 0)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Removed unused variable from code block.

### Details and comments

QuantumRegister and ClassicalRegister are imported in example, but not otherwise used in the code example.

(Also resolves issue opened in https://github.com/Qiskit/documentation/pull/2056)