### PR TITLE
Update version of Coveralls GitHub Action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -71,7 +71,7 @@ jobs:
           lcov --add-tracefile python.info --add-tracefile rust.info --output-file coveralls.info
 
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2.3.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: coveralls.info


### PR DESCRIPTION
### Summary

We had this set to `master` in an attempt to use the rolling release, except Coveralls added a _new_ branch called `main` that is now the primary branch, so we had fallen out of date.  One of these effects is that the action was still attempting to use the deprecating Node 16 runners.

Since we now also have dependabot updating our Actions for us, this commit sets a fixed release of the Action for better reproducibility.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->



### Details and comments


