### PR TITLE
fixed circuit_drawer example in qiskit/visualization/circuit/circuit_visualization.py

### DIFF
--- a/qiskit/visualization/circuit/circuit_visualization.py
+++ b/qiskit/visualization/circuit/circuit_visualization.py
@@ -195,7 +195,7 @@ def circuit_drawer(
             qc = QuantumCircuit(1, 1)
             qc.h(0)
             qc.measure(0, 0)
-            circuit_drawer(qc, output="mpl", style={"backgroundcolor":"#EEEEEE"})
+            circuit_drawer(qc, output="mpl", style={"backgroundcolor": "#EEEEEE"})
     """
     image = None
     expr_len = max(expr_len, 0)

--- a/qiskit/visualization/circuit/circuit_visualization.py
+++ b/qiskit/visualization/circuit/circuit_visualization.py
@@ -192,6 +192,7 @@ def circuit_drawer(
             :include-source:
 
             from qiskit import QuantumCircuit
+            from qiskit.visualization import circuit_drawer
             qc = QuantumCircuit(1, 1)
             qc.h(0)
             qc.measure(0, 0)

--- a/qiskit/visualization/circuit/circuit_visualization.py
+++ b/qiskit/visualization/circuit/circuit_visualization.py
@@ -195,7 +195,7 @@ def circuit_drawer(
             qc = QuantumCircuit(1, 1)
             qc.h(0)
             qc.measure(0, 0)
-            qc.draw(output='mpl', style={'backgroundcolor': '#EEEEEE'})
+            circuit_drawer(qc, output="mpl", style={"backgroundcolor":"#EEEEEE"})
     """
     image = None
     expr_len = max(expr_len, 0)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixed the circuit visualization function example.
#Resolves #13233

### Details and comments
Earlier the example used _draw_ method where it should have been _circuit_drawer_.

