### PR TITLE
Fix GitHub source code links for decorated functions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -173,6 +173,10 @@ def linkcode_resolve(domain, info):
         except AttributeError:
             return None
 
+    # Unwrap decorators. This requires they used `functools.wrap()`.
+    while hasattr(obj, "__wrapped__"):
+        obj = getattr(obj, "__wrapped__")
+
     try:
         full_file_name = inspect.getsourcefile(obj)
     except TypeError:


### PR DESCRIPTION
Closes https://github.com/Qiskit/documentation/issues/2060. We were linking to the source code of the decorator, rather than the original function/method.