### PR TITLE
Switch issue templates to use new-style issue types

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yaml
@@ -1,6 +1,6 @@
 name: 🐛 Bug report
 description: Create a report to help us improve 🤔.
-labels: ["bug"]
+type: Bug
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/02-feature.yaml
+++ b/.github/ISSUE_TEMPLATE/02-feature.yaml
@@ -1,6 +1,6 @@
 name: 🚀 Feature request
 description: Suggest an idea for this project 💡!
-labels: ["type: feature request"]
+type: Enhancement
 
 body:
   - type: markdown


### PR DESCRIPTION
### Summary

Qiskit is part of the new-style GitHub issues beta[^1], which gives us access to a special kind of "super" label: the issue "type".  We've previously used two special labels ("bug" and "type: feature request") to categorise the resulting issues from the issue template.  This commit leans into this new system, setting the issue type, rather than the custom labels.

The new issues also specifies that the templates will be displayed in sorted order by file name.  This commit makes that ordering more explicit for us.

[^1]: https://github.blog/changelog/2024-10-01-evolving-github-issues-public-beta/

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

If we choose to merge this, I can bulk update all our issues to use the new "types" rather than the magic labels, so we'll have a more consistent experience across our tracker.  The new "subissues" system is pushing us towards using these types, so it feels cleaner to centralise.
