### PR TITLE
Fix GitHub source code links on Windows docs builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,7 +185,7 @@ def linkcode_resolve(domain, info):
         return None
     try:
         relative_file_name = Path(full_file_name).resolve().relative_to(REPO_ROOT)
-        file_name = re.sub(r"\.tox\/.+\/site-packages\/", "", str(relative_file_name))
+        file_name = re.sub(r"\.tox\/.+\/site-packages\/", "", relative_file_name.as_posix())
     except ValueError:
         return None
 


### PR DESCRIPTION
Per https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.as_posix, calling `str()` on a Windows `Path` object uses `\` as the separator. We need to use `/` for the GitHub URL to work properly.