### PR TITLE
Fixes typo on api/qiskit/providers page

### DIFF
--- a/qiskit/providers/__init__.py
+++ b/qiskit/providers/__init__.py
@@ -307,7 +307,7 @@ Custom Basis Gates
 
            def _define(self):
                qc = QuantumCircuit(1)
-               q.ry(np.pi / 2, 0)
+               qc.ry(np.pi / 2, 0)
                self.definition = qc
 
    The key thing to ensure is that for any custom gates in your Backend's basis set

--- a/releasenotes/notes/fix-api-qiskit-providers-page.yaml
+++ b/releasenotes/notes/fix-api-qiskit-providers-page.yaml
@@ -1,4 +1,0 @@
-fixes:
-  - |
-    Fixes a typo where QuantumCircuit variable was incorrectly called as c instead of qc on the Qiskit Providers page.
-    Refer to `#13211 <hhttps://github.com/Qiskit/qiskit/issues/13211>` for more details.

--- a/releasenotes/notes/fix-api-qiskit-providers-page.yaml
+++ b/releasenotes/notes/fix-api-qiskit-providers-page.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    Fixes a typo where QuantumCircuit variable was incorrectly called as c instead of qc on the Qiskit Providers page.
+    Refer to `#13211 <hhttps://github.com/Qiskit/qiskit/issues/13211>` for more details.


### PR DESCRIPTION
### Summary
Fixes #13211 

Fixed typo on the api/qiskit/providers page where the QuantumCircuit variable qc was incorrectly called as c.

No tests are needed.


### Details and comments
---


