### PR TITLE
docs: clarify method purpose

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -184,7 +184,7 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return BasePauli(self._z, self._x, np.mod(self._phase + phase, 4))
 
     def conjugate(self):
-        """Return the complex conjugate of each Pauli in the list."""
+        """Return the complex conjugate of the Pauli with respect to the Z basis."""
         complex_phase = np.mod(self._phase, 2)
         if np.all(complex_phase == 0):
             return self

--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -184,7 +184,7 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return BasePauli(self._z, self._x, np.mod(self._phase + phase, 4))
 
     def conjugate(self):
-        """Return the conjugate of each Pauli in the list."""
+        """Return the complex conjugate of each Pauli in the list."""
         complex_phase = np.mod(self._phase, 2)
         if np.all(complex_phase == 0):
             return self


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes https://github.com/Qiskit/qiskit/issues/13051.

### Details and comments
Update the doc string for the Pauli operator method `conjugate` to clarify that it returns the complex conjugate and not the conjugate transpose.

