### PR TITLE
Use PyO3 0.22 and rust-numpy 0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,12 +1431,13 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rowan"
-version = "0.15.16"
+version = "0.15.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a542b0253fa46e632d27a1dc5cf7b930de4df8659dc6e720b647fc72147ae3d"
+checksum = "32a58fa8a7ccff2aec4f39cc45bf5f985cec7125ab271cf681c279fd00192b49"
 dependencies = [
  "countme",
  "hashbrown 0.14.5",
+ "memoffset",
  "rustc-hash",
  "text-size",
 ]
@@ -1604,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "triomphe"
-version = "0.1.14"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
+checksum = "859eb650cfee7434994602c3a68b25d77ad9e68c8a6cd491616ef86661382eb3"
 
 [[package]]
 name = "typenum"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
@@ -129,13 +129,13 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc8b54b395f2fcfbb3d90c47b01c7f444d94d05bdeb775811dec868ac3bbc26"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -291,10 +291,10 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -323,7 +323,7 @@ checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -334,7 +334,7 @@ checksum = "5322a90066ddae2b705096eb9e10c465c0498ae93bf9bdd6437415327c88e3bb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -582,12 +582,6 @@ checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -667,25 +661,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
-
-[[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -894,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec170733ca37175f5d75a5bea5911d6ff45d2cd52849ce98b685394e4f2f37f4"
+checksum = "cf314fca279e6e6ac2126a4ff98f26d88aa4ad06bc68fb6ae5cf4bd706758311"
 dependencies = [
  "libc",
  "ndarray",
@@ -980,29 +964,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,9 +971,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pest"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
+checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
 dependencies = [
  "memchr",
  "thiserror",
@@ -1021,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664d22978e2815783adbdd2c588b455b1bd625299ce36b2a99881ac9627e6d8d"
+checksum = "4d3a6e3394ec80feb3b6393c725571754c6188490265c61aaf260810d6b95aa0"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1031,22 +992,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d5487022d5d33f4c30d91c22afa240ce2a644e87fe08caad974d4eab6badbe"
+checksum = "94429506bde1ca69d1b5601962c73f4172ab4726571a59ea95931218cb0e930e"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0091754bbd0ea592c4deb3a122ce8ecbb0753b738aa82bc055fcc2eccc8d8174"
+checksum = "ac8a071862e93690b6e34e9a5fb8e33ff3734473ac0245b27232222c4906a33f"
 dependencies = [
  "once_cell",
  "pest",
@@ -1065,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "ppv-lite86"
@@ -1080,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "priority-queue"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560bcab673ff7f6ca9e270c17bf3affd8a05e3bd9207f123b0d45076fd8197e8"
+checksum = "714c75db297bc88a63783ffc6ab9f830698a6705aa0201416931759ef4c8183d"
 dependencies = [
  "autocfg",
  "equivalent",
@@ -1115,9 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]
@@ -1143,7 +1104,7 @@ checksum = "d315b3197b780e4873bc0e11251cb56a33f65a6032a3d39b8d1405c255513766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1161,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.21.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
+checksum = "15ee168e30649f7f234c3d49ef5a7a6cbf5134289bc46c29ff3155fa3221c225"
 dependencies = [
  "cfg-if",
  "hashbrown 0.14.5",
@@ -1173,7 +1134,7 @@ dependencies = [
  "memoffset",
  "num-bigint",
  "num-complex",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -1184,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.21.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
+checksum = "e61cef80755fe9e46bb8a0b8f20752ca7676dcc07a5277d8b7768c6172e529b3"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1194,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.21.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
+checksum = "67ce096073ec5405f5ee2b8b31f03a68e02aa10d5d4f565eca04acc41931fa1c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1204,27 +1165,27 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.21.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
+checksum = "2440c6d12bc8f3ae39f1e775266fa5122fd0c8891ce7520fa6048e683ad3de28"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.21.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
+checksum = "1be962f0e06da8f8465729ea2cb71a416d2257dff56cbe40a70d3e62a93ae5d1"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1440,19 +1401,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
-dependencies = [
- "bitflags 2.6.0",
-]
-
-[[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1462,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1473,19 +1425,18 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rowan"
-version = "0.15.15"
+version = "0.15.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a58fa8a7ccff2aec4f39cc45bf5f985cec7125ab271cf681c279fd00192b49"
+checksum = "0a542b0253fa46e632d27a1dc5cf7b930de4df8659dc6e720b647fc72147ae3d"
 dependencies = [
  "countme",
  "hashbrown 0.14.5",
- "memoffset",
  "rustc-hash",
  "text-size",
 ]
@@ -1532,12 +1483,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "seq-macro"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1560,7 +1505,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1602,9 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1654,14 +1599,14 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "triomphe"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859eb650cfee7434994602c3a68b25d77ad9e68c8a6cd491616ef86661382eb3"
+checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
 
 [[package]]
 name = "typenum"
@@ -1671,9 +1616,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
@@ -1683,21 +1628,21 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-properties"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ea75f83c0137a9b98608359a5f1af8144876eb67bcb1ce837368e906a9f524"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unindent"
@@ -1960,5 +1905,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ indexmap.version = "2.6.0"
 hashbrown.version = "0.14.5"
 num-bigint = "0.4"
 num-complex = "0.4"
-ndarray = "^0.15.6"
-numpy = "0.21.0"
+ndarray = "0.15"
+numpy = "0.22.0"
 smallvec = "1.13"
 thiserror = "1.0"
 rustworkx-core = "0.15"
@@ -34,7 +34,7 @@ rayon = "1.10"
 # distributions).  We only activate that feature when building the C extension module; we still need
 # it disabled for Rust-only tests to avoid linker errors with it not being loaded.  See
 # https://pyo3.rs/main/features#extension-module for more.
-pyo3 = { version = "0.21.2", features = ["abi3-py39"] }
+pyo3 = { version = "0.22.3", features = ["abi3-py39"] }
 
 # These are our own crates.
 qiskit-accelerate = { path = "crates/accelerate" }

--- a/crates/accelerate/Cargo.toml
+++ b/crates/accelerate/Cargo.toml
@@ -33,7 +33,7 @@ features = ["union"]
 
 [dependencies.pyo3]
 workspace = true
-features = ["hashbrown", "indexmap", "num-complex", "num-bigint", "smallvec", "py-clone"]
+features = ["hashbrown", "indexmap", "num-complex", "num-bigint", "smallvec"]
 
 [dependencies.ndarray]
 workspace = true

--- a/crates/accelerate/Cargo.toml
+++ b/crates/accelerate/Cargo.toml
@@ -33,7 +33,7 @@ features = ["union"]
 
 [dependencies.pyo3]
 workspace = true
-features = ["hashbrown", "indexmap", "num-complex", "num-bigint", "smallvec"]
+features = ["hashbrown", "indexmap", "num-complex", "num-bigint", "smallvec", "py-clone"]
 
 [dependencies.ndarray]
 workspace = true

--- a/crates/accelerate/src/barrier_before_final_measurement.rs
+++ b/crates/accelerate/src/barrier_before_final_measurement.rs
@@ -24,6 +24,7 @@ use qiskit_circuit::Qubit;
 static FINAL_OP_NAMES: [&str; 2] = ["measure", "barrier"];
 
 #[pyfunction]
+#[pyo3(signature=(dag, label=None))]
 pub fn barrier_before_final_measurements(
     py: Python,
     dag: &mut DAGCircuit,

--- a/crates/accelerate/src/circuit_library/quantum_volume.rs
+++ b/crates/accelerate/src/circuit_library/quantum_volume.rs
@@ -102,6 +102,7 @@ fn random_unitaries(seed: u64, size: usize) -> impl Iterator<Item = Array2<Compl
 const UNITARY_PER_SEED: usize = 50;
 
 #[pyfunction]
+#[pyo3(signature=(num_qubits, depth, seed=None))]
 pub fn quantum_volume(
     py: Python,
     num_qubits: u32,

--- a/crates/accelerate/src/commutation_checker.rs
+++ b/crates/accelerate/src/commutation_checker.rs
@@ -613,6 +613,7 @@ impl CommutationLibrary {
 #[pymethods]
 impl CommutationLibrary {
     #[new]
+    #[pyo3(signature=(py_any=None))]
     fn new(py_any: Option<Bound<PyAny>>) -> Self {
         match py_any {
             Some(pyob) => CommutationLibrary {

--- a/crates/accelerate/src/equivalence.rs
+++ b/crates/accelerate/src/equivalence.rs
@@ -286,7 +286,7 @@ pub struct GateOper {
 }
 
 impl<'py> FromPyObject<'py> for GateOper {
-    fn extract(ob: &'py PyAny) -> PyResult<Self> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let op_struct: OperationFromPython = ob.extract()?;
         Ok(Self {
             operation: op_struct.operation,

--- a/crates/accelerate/src/error_map.rs
+++ b/crates/accelerate/src/error_map.rs
@@ -42,7 +42,7 @@ pub struct ErrorMap {
 #[pymethods]
 impl ErrorMap {
     #[new]
-    #[pyo3(text_signature = "(/, size=None)")]
+    #[pyo3(signature=(size=None))]
     fn new(size: Option<usize>) -> Self {
         match size {
             Some(size) => ErrorMap {
@@ -100,6 +100,7 @@ impl ErrorMap {
         Ok(self.error_map.contains_key(&key))
     }
 
+    #[pyo3(signature=(key, default=None))]
     fn get(&self, py: Python, key: [PhysicalQubit; 2], default: Option<PyObject>) -> PyObject {
         match self.error_map.get(&key).copied() {
             Some(val) => val.to_object(py),

--- a/crates/accelerate/src/euler_one_qubit_decomposer.rs
+++ b/crates/accelerate/src/euler_one_qubit_decomposer.rs
@@ -52,6 +52,7 @@ pub struct OneQubitGateErrorMap {
 #[pymethods]
 impl OneQubitGateErrorMap {
     #[new]
+    #[pyo3(signature=(num_qubits=None))]
     fn new(num_qubits: Option<usize>) -> Self {
         OneQubitGateErrorMap {
             error_map: match num_qubits {
@@ -392,6 +393,7 @@ fn circuit_rr(
 }
 
 #[pyfunction]
+#[pyo3(signature=(target_basis, theta, phi, lam, phase, simplify, atol=None))]
 pub fn generate_circuit(
     target_basis: &EulerBasis,
     theta: f64,
@@ -673,7 +675,7 @@ impl Default for EulerBasisSet {
 }
 
 #[derive(Clone, Debug, Copy, Eq, Hash, PartialEq)]
-#[pyclass(module = "qiskit._accelerate.euler_one_qubit_decomposer")]
+#[pyclass(module = "qiskit._accelerate.euler_one_qubit_decomposer", eq, eq_int)]
 pub enum EulerBasis {
     U3 = 0,
     U321 = 1,
@@ -808,6 +810,7 @@ fn compute_error_str(
 }
 
 #[pyfunction]
+#[pyo3(signature=(circuit, qubit, error_map=None))]
 pub fn compute_error_list(
     circuit: Vec<PyRef<DAGOpNode>>,
     qubit: usize,

--- a/crates/accelerate/src/nlayout.rs
+++ b/crates/accelerate/src/nlayout.rs
@@ -49,7 +49,7 @@ macro_rules! qubit_newtype {
         }
 
         impl pyo3::FromPyObject<'_> for $id {
-            fn extract(ob: &PyAny) -> PyResult<Self> {
+            fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
                 Ok(Self(ob.extract()?))
             }
         }
@@ -59,6 +59,10 @@ macro_rules! qubit_newtype {
 
             fn get_dtype_bound(py: Python<'_>) -> Bound<'_, numpy::PyArrayDescr> {
                 u32::get_dtype_bound(py)
+            }
+
+            fn clone_ref(&self, _py: Python<'_>) -> Self {
+                *self
             }
         }
     };

--- a/crates/accelerate/src/results/marginalization.rs
+++ b/crates/accelerate/src/results/marginalization.rs
@@ -62,6 +62,7 @@ fn marginalize<T: std::ops::AddAssign + Copy>(
 }
 
 #[pyfunction]
+#[pyo3(signature=(counts, indices=None))]
 pub fn marginal_counts(
     counts: HashMap<String, u64>,
     indices: Option<Vec<usize>>,
@@ -70,6 +71,7 @@ pub fn marginal_counts(
 }
 
 #[pyfunction]
+#[pyo3(signature=(counts, indices=None))]
 pub fn marginal_distribution(
     counts: HashMap<String, f64>,
     indices: Option<Vec<usize>>,

--- a/crates/accelerate/src/sabre/heuristic.rs
+++ b/crates/accelerate/src/sabre/heuristic.rs
@@ -17,7 +17,7 @@ use pyo3::Python;
 
 /// Affect the dynamic scaling of the weight of node-set-based heuristics (basic and lookahead).
 #[pyclass]
-#[pyo3(module = "qiskit._accelerate.sabre", frozen)]
+#[pyo3(module = "qiskit._accelerate.sabre", frozen, eq)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum SetScaling {
     /// No dynamic scaling of the weight.

--- a/crates/accelerate/src/sabre/neighbor_table.rs
+++ b/crates/accelerate/src/sabre/neighbor_table.rs
@@ -67,7 +67,7 @@ impl std::ops::Index<PhysicalQubit> for NeighborTable {
 #[pymethods]
 impl NeighborTable {
     #[new]
-    #[pyo3(text_signature = "(/, adjacency_matrix=None)")]
+    #[pyo3(signature = (adjacency_matrix=None))]
     pub fn new(adjacency_matrix: Option<PyReadonlyArray2<f64>>) -> PyResult<Self> {
         let run_in_parallel = getenv_use_multiple_threads();
         let neighbors = match adjacency_matrix {

--- a/crates/accelerate/src/sabre/route.rs
+++ b/crates/accelerate/src/sabre/route.rs
@@ -442,6 +442,7 @@ impl<'a, 'b> RoutingState<'a, 'b> {
 ///     logical position of the qubit that began in position `i`.
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
+#[pyo3(signature=(dag, neighbor_table, distance_matrix, heuristic, initial_layout, num_trials, seed=None, run_in_parallel=None))]
 pub fn sabre_routing(
     py: Python,
     dag: &SabreDAG,

--- a/crates/accelerate/src/stochastic_swap.rs
+++ b/crates/accelerate/src/stochastic_swap.rs
@@ -236,7 +236,7 @@ fn swap_trial(
 ///         will be ``(None, None, max int)``.
 #[pyfunction]
 #[pyo3(
-    text_signature = "(num_trials, num_qubits, int_layout, int_qubit_subset, int_gates, cdist, cdist2, edges, /, seed=None)"
+    signature = (num_trials, num_qubits, int_layout, int_qubit_subset, int_gates, cdist, cdist2, edges, seed=None)
 )]
 pub fn swap_trials(
     num_trials: u64,

--- a/crates/accelerate/src/target_transpiler/mod.rs
+++ b/crates/accelerate/src/target_transpiler/mod.rs
@@ -109,12 +109,12 @@ pub(crate) struct NormalOperation {
 }
 
 impl<'py> FromPyObject<'py> for NormalOperation {
-    fn extract(ob: &'py PyAny) -> PyResult<Self> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let operation: OperationFromPython = ob.extract()?;
         Ok(Self {
             operation: operation.operation,
             params: operation.params,
-            op_object: ob.into(),
+            op_object: ob.clone().unbind(),
         })
     }
 }
@@ -371,7 +371,7 @@ impl Target {
     ///     properties (InstructionProperties): The properties to set for this instruction
     /// Raises:
     ///     KeyError: If ``instruction`` or ``qarg`` are not in the target
-    #[pyo3(text_signature = "(instruction, qargs, properties, /,)")]
+    #[pyo3(signature = (instruction, qargs=None, properties=None))]
     fn update_instruction_properties(
         &mut self,
         instruction: String,

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -407,8 +407,8 @@ fn compute_unitary(sequence: &TwoQubitSequenceVec, global_phase: f64) -> Array2<
 
 const DEFAULT_FIDELITY: f64 = 1.0 - 1.0e-9;
 
-#[derive(Clone, Debug, Copy)]
-#[pyclass(module = "qiskit._accelerate.two_qubit_decompose")]
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+#[pyclass(module = "qiskit._accelerate.two_qubit_decompose", eq)]
 pub enum Specialization {
     General,
     IdEquiv,
@@ -1030,6 +1030,7 @@ static IPX: GateArray1Q = [[C_ZERO, IM], [IM, C_ZERO]];
 #[pymethods]
 impl TwoQubitWeylDecomposition {
     #[staticmethod]
+    #[pyo3(signature=(angles, matrices, specialization, default_euler_basis, calculated_fidelity, requested_fidelity=None))]
     fn _from_state(
         angles: [f64; 4],
         matrices: [PyReadonlyArray2<Complex64>; 5],

--- a/crates/circuit/Cargo.toml
+++ b/crates/circuit/Cargo.toml
@@ -23,7 +23,7 @@ itertools.workspace = true
 
 [dependencies.pyo3]
 workspace = true
-features = ["hashbrown", "indexmap", "num-complex", "num-bigint", "smallvec"]
+features = ["hashbrown", "indexmap", "num-complex", "num-bigint", "smallvec", "py-clone"]
 
 [dependencies.hashbrown]
 workspace = true

--- a/crates/circuit/src/bit_data.rs
+++ b/crates/circuit/src/bit_data.rs
@@ -61,6 +61,7 @@ impl PartialEq for BitAsKey {
                     .bind(py)
                     .repr()
                     .unwrap()
+                    .as_any()
                     .eq(other.bit.bind(py).repr().unwrap())
                     .unwrap()
             })

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -898,6 +898,7 @@ impl CircuitData {
         Ok(())
     }
 
+    #[pyo3(signature = (index=None))]
     pub fn pop(&mut self, py: Python<'_>, index: Option<PySequenceIndex>) -> PyResult<PyObject> {
         let index = index.unwrap_or(PySequenceIndex::Int(-1));
         let native_index = index.with_len(self.data.len())?;

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -424,6 +424,7 @@ impl CircuitInstruction {
     ///
     /// Returns:
     ///     CircuitInstruction: A new instance with the given fields replaced.
+    #[pyo3(signature=(operation=None, qubits=None, clbits=None, params=None))]
     pub fn replace(
         &self,
         py: Python,

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -889,6 +889,7 @@ impl DAGCircuit {
     ///
     /// Raises:
     ///     Exception: if the gate is of type string and params is None.
+    #[pyo3(signature=(gate, qubits, schedule, params=None))]
     fn add_calibration<'py>(
         &mut self,
         py: Python<'py>,
@@ -2144,6 +2145,7 @@ def _format(operand):
     ///
     /// Raises:
     ///     DAGCircuitError: If the DAG is invalid
+    #[pyo3(signature=(ignore=None))]
     fn idle_wires(&self, py: Python, ignore: Option<&Bound<PyList>>) -> PyResult<Py<PyIterator>> {
         let mut result: Vec<PyObject> = Vec::new();
         let wires = (0..self.qubit_io_map.len())
@@ -2650,7 +2652,7 @@ def _format(operand):
     ///
     /// Returns:
     ///     generator(DAGOpNode, DAGInNode, or DAGOutNode): node in topological order
-    #[pyo3(name = "topological_nodes")]
+    #[pyo3(name = "topological_nodes", signature=(key=None))]
     fn py_topological_nodes(
         &self,
         py: Python,
@@ -2686,7 +2688,7 @@ def _format(operand):
     ///
     /// Returns:
     ///     generator(DAGOpNode): op node in topological order
-    #[pyo3(name = "topological_op_nodes")]
+    #[pyo3(name = "topological_op_nodes", signature=(key=None))]
     fn py_topological_op_nodes(
         &self,
         py: Python,
@@ -3813,7 +3815,8 @@ def _format(operand):
     /// Yield:
     ///     edge: the edge as a tuple with the format
     ///         (source node, destination node, edge wire)
-    fn edges(&self, nodes: Option<Bound<PyAny>>, py: Python) -> PyResult<Py<PyIterator>> {
+    #[pyo3(signature=(nodes=None))]
+    fn edges(&self, py: Python, nodes: Option<Bound<PyAny>>) -> PyResult<Py<PyIterator>> {
         let get_node_index = |obj: &Bound<PyAny>| -> PyResult<NodeIndex> {
             Ok(obj.downcast::<DAGNode>()?.borrow().node.unwrap())
         };
@@ -4717,6 +4720,7 @@ def _format(operand):
         module.call_method1("dag_drawer", (slf, scale, filename, style))
     }
 
+    #[pyo3(signature=(graph_attrs=None, node_attrs=None, edge_attrs=None))]
     fn _to_dot<'py>(
         &self,
         py: Python<'py>,

--- a/crates/circuit/src/dag_node.rs
+++ b/crates/circuit/src/dag_node.rs
@@ -85,6 +85,7 @@ impl DAGNode {
         self.node.map(|node| node.index())
     }
 
+    #[pyo3(signature=(index=None))]
     fn __setstate__(&mut self, index: Option<usize>) {
         self.node = index.map(NodeIndex::new);
     }

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -278,7 +278,7 @@ impl<'a> Operation for OperationRef<'a> {
 
 #[derive(Clone, Debug, Copy, Eq, PartialEq, Hash)]
 #[repr(u8)]
-#[pyclass(module = "qiskit._accelerate.circuit")]
+#[pyclass(module = "qiskit._accelerate.circuit", eq, eq_int)]
 pub enum StandardGate {
     GlobalPhaseGate = 0,
     HGate = 1,
@@ -718,14 +718,6 @@ impl StandardGate {
     #[getter]
     pub fn get_name(&self) -> &str {
         self.name()
-    }
-
-    pub fn __eq__(&self, other: &Bound<PyAny>) -> Py<PyAny> {
-        let py = other.py();
-        let Ok(other) = other.extract::<Self>() else {
-            return py.NotImplemented();
-        };
-        (*self == other).into_py(py)
     }
 
     pub fn __hash__(&self) -> isize {

--- a/crates/circuit/src/slice.rs
+++ b/crates/circuit/src/slice.rs
@@ -51,7 +51,7 @@ impl<'py> PySequenceIndex<'py> {
             }
             PySequenceIndex::Slice(slice) => {
                 let indices = slice
-                    .indices(len as ::std::os::raw::c_long)
+                    .indices(len as isize)
                     .map_err(PySequenceIndexError::from)?;
                 if indices.step > 0 {
                     Ok(SequenceIndex::PosRange {

--- a/crates/qasm2/src/bytecode.rs
+++ b/crates/qasm2/src/bytecode.rs
@@ -32,8 +32,8 @@ pub struct Bytecode {
 }
 
 /// The operations that are represented by the "bytecode" passed to Python.
-#[pyclass(module = "qiskit._accelerate.qasm2", frozen)]
-#[derive(Clone)]
+#[pyclass(module = "qiskit._accelerate.qasm2", frozen, eq)]
+#[derive(Clone, Eq, PartialEq)]
 pub enum OpCode {
     // There is only a `Gate` here, not a `GateInBasis`, because in Python space we don't have the
     // same strict typing requirements to satisfy.
@@ -113,8 +113,8 @@ pub struct ExprCustom {
 /// each of these, but this way involves fewer imports in Python, and also serves to split up the
 /// option tree at the top level, so we don't have to test every unary operator before testing
 /// other operations.
-#[pyclass(module = "qiskit._accelerate.qasm2", frozen)]
-#[derive(Clone)]
+#[pyclass(module = "qiskit._accelerate.qasm2", frozen, eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum UnaryOpCode {
     Negate,
     Cos,
@@ -129,8 +129,8 @@ pub enum UnaryOpCode {
 /// each of these, but this way involves fewer imports in Python, and also serves to split up the
 /// option tree at the top level, so we don't have to test every binary operator before testing
 /// other operations.
-#[pyclass(module = "qiskit._accelerate.qasm2", frozen)]
-#[derive(Clone)]
+#[pyclass(module = "qiskit._accelerate.qasm2", frozen, eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum BinaryOpCode {
     Add,
     Subtract,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary


This commit migrates to using PyO3 0.22 and rust-numpy and updates all the deprecated and changed interfaces in the libraries to their new syntax. No new or alternative interfaces are used as part of this PR except for where deprecation warnings pointed to do so.

One thing to note is that in pyo3 0.22 a new feature py-clone was added to re-enable `Py<T>::clone()`. This was disabled by default in pyo3 0.22 because of a soundness issue around calling that in situations when the GIL was not held. [1] Right now qiskit relies on using `Clone` on `Py` objects because we have container types that own a `PyObject` that we sometimes clone at the top level so this flag needs to be set. This only occurs in the `circuit` crate. In the future we can look at adding interfaces to avoid needing this flag in the future.

Another thing to note is that rust-numpy includes support for ndarray 0.16, however this PR doesn't migrate to it because `ndarray_einsum_beta` used in the `qiskit_accelerate::unitary_compose` module still depends on ndarray 0.15 and we can't upgrade until that does.


### Details and comments

[1] https://pyo3.rs/v0.22.3/migration#pyclone-is-now-gated-behind-the-py-clone-feature
