### PR TITLE
Fix `synth_mcmt_vchain` for gates with parameters

### DIFF
--- a/crates/accelerate/src/synthesis/multi_controlled/mcmt.rs
+++ b/crates/accelerate/src/synthesis/multi_controlled/mcmt.rs
@@ -104,6 +104,7 @@ pub fn mcmt_v_chain(
     }
 
     let packed_controlled_gate = controlled_gate.operation;
+    let gate_params = controlled_gate.params;
     let num_qubits = if num_ctrl_qubits > 1 {
         2 * num_ctrl_qubits - 1 + num_target_qubits
     } else {
@@ -135,7 +136,7 @@ pub fn mcmt_v_chain(
     let targets = (0..num_target_qubits).map(|i| {
         Ok((
             packed_controlled_gate.clone(),
-            smallvec![] as SmallVec<[Param; 3]>,
+            gate_params.clone(),
             vec![Qubit::new(master_control), Qubit::new(num_ctrl_qubits + i)],
             vec![] as Vec<Clbit>,
         ))

--- a/qiskit/synthesis/multi_controlled/mcmt_vchain.py
+++ b/qiskit/synthesis/multi_controlled/mcmt_vchain.py
@@ -43,6 +43,9 @@ def synth_mcmt_vchain(
                   └───┘          └───┘
 
     """
+    if gate.num_qubits != 1:
+        raise ValueError("Only single qubit gates are supported as input.")
+
     circ = QuantumCircuit._from_circuit_data(
         mcmt_v_chain(gate.control(), num_ctrl_qubits, num_target_qubits, ctrl_state)
     )

--- a/releasenotes/notes/fix-mcmt-vchain-params-fa9d78a6587ff41e.yaml
+++ b/releasenotes/notes/fix-mcmt-vchain-params-fa9d78a6587ff41e.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.MCMTGate` when using the `"vchain"` synthesis, and
+    in :class:`.MCMTVChain`, where gates with parameters were not treated correctly.
+    Before, passing, e.g., `RYGate(0.2)` as base gate lead to inconsistent
+    circuit data where the controlled rotations did not have the correct parameters attached.
+    This now works correctly, also for the case of free parameters.

--- a/releasenotes/notes/fix-mcmt-vchain-params-fa9d78a6587ff41e.yaml
+++ b/releasenotes/notes/fix-mcmt-vchain-params-fa9d78a6587ff41e.yaml
@@ -1,8 +1,0 @@
----
-fixes:
-  - |
-    Fixed a bug in :class:`.MCMTGate` when using the `"vchain"` synthesis, and
-    in :class:`.MCMTVChain`, where gates with parameters were not treated correctly.
-    Before, passing, e.g., `RYGate(0.2)` as base gate lead to inconsistent
-    circuit data where the controlled rotations did not have the correct parameters attached.
-    This now works correctly, also for the case of free parameters.

--- a/test/python/circuit/library/test_mcmt.py
+++ b/test/python/circuit/library/test_mcmt.py
@@ -265,6 +265,13 @@ class TestMCMT(QiskitTestCase):
                 with self.assertRaises(ValueError):
                     _ = MCMTGate(gate, 10, 2)
 
+    def test_invalid_base_gate_width_synthfun(self):
+        """Test only 1-qubit base gates are accepted."""
+        for gate in [GlobalPhaseGate(0.2), SwapGate()]:
+            with self.subTest(gate=gate):
+                with self.assertRaises(ValueError):
+                    _ = synth_mcmt_vchain(gate, 10, 2)
+
     def test_gate_with_parameters_vchain(self):
         """Test a gate with parameters as base gate."""
         theta = Parameter("th")

--- a/test/python/circuit/library/test_mcmt.py
+++ b/test/python/circuit/library/test_mcmt.py
@@ -18,13 +18,14 @@ import numpy as np
 
 from qiskit.exceptions import QiskitError
 from qiskit.compiler import transpile
-from qiskit.circuit import QuantumCircuit, QuantumRegister
+from qiskit.circuit import QuantumCircuit, QuantumRegister, Parameter
 from qiskit.circuit.library import (
     MCMT,
     MCMTVChain,
     CHGate,
     XGate,
     ZGate,
+    RYGate,
     CXGate,
     CZGate,
     MCMTGate,
@@ -263,6 +264,17 @@ class TestMCMT(QiskitTestCase):
             with self.subTest(gate=gate):
                 with self.assertRaises(ValueError):
                     _ = MCMTGate(gate, 10, 2)
+
+    def test_gate_with_parameters_vchain(self):
+        """Test a gate with parameters as base gate."""
+        theta = Parameter("th")
+        gate = RYGate(theta)
+        num_target = 3
+        circuit = synth_mcmt_vchain(gate, num_ctrl_qubits=10, num_target_qubits=num_target)
+
+        self.assertEqual(circuit.count_ops().get("cry", 0), num_target)
+        self.assertEqual(circuit.num_parameters, 1)
+        self.assertIs(circuit.parameters[0], theta)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixed an issue in `synth_mcmt_vchain` (and thereby also in `MCMTVChain`) where the circuit data in Rust-space was constructed without the parameters of the base gate.

### Details

~~I'm not labelling this as stable backport as there's no 1.2.5 planned, right? (And I don't think we need a release just for this bug)~~ No reno as this bug has not yet been released.
