### PR TITLE
Implement `__eq__` for remaining standard-library gates except `mcx`

### DIFF
--- a/qiskit/circuit/library/standard_gates/p.py
+++ b/qiskit/circuit/library/standard_gates/p.py
@@ -431,3 +431,11 @@ class MCPhaseGate(ControlledGate):
     def inverse(self, annotated: bool = False):
         r"""Return inverted MCPhase gate (:math:`MCPhase(\lambda)^{\dagger} = MCPhase(-\lambda)`)"""
         return MCPhaseGate(-self.params[0], self.num_ctrl_qubits)
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, MCPhaseGate)
+            and self.num_ctrl_qubits == other.num_ctrl_qubits
+            and self.ctrl_state == other.ctrl_state
+            and self._compare_parameters(other)
+        )

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -393,3 +393,10 @@ class CUGate(ControlledGate):
         out = super().__deepcopy__(memo)
         out._params = _copy.deepcopy(out._params, memo)
         return out
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, CUGate)
+            and self.ctrl_state == other.ctrl_state
+            and self._compare_parameters(other)
+        )

--- a/qiskit/circuit/library/standard_gates/u1.py
+++ b/qiskit/circuit/library/standard_gates/u1.py
@@ -170,6 +170,9 @@ class U1Gate(Gate):
         lam = float(self.params[0])
         return numpy.array([[1, 0], [0, numpy.exp(1j * lam)]], dtype=dtype)
 
+    def __eq__(self, other):
+        return isinstance(other, U1Gate) and self._compare_parameters(other)
+
 
 class CU1Gate(ControlledGate):
     r"""Controlled-U1 gate.
@@ -341,6 +344,13 @@ class CU1Gate(ControlledGate):
                 [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, eith, 0], [0, 0, 0, 1]], dtype=dtype
             )
 
+    def __eq__(self, other):
+        return (
+            isinstance(other, CU1Gate)
+            and self.ctrl_state == other.ctrl_state
+            and self._compare_parameters(other)
+        )
+
 
 class MCU1Gate(ControlledGate):
     r"""Multi-controlled-U1 gate.
@@ -481,3 +491,11 @@ class MCU1Gate(ControlledGate):
             MCU1Gate: inverse gate.
         """
         return MCU1Gate(-self.params[0], self.num_ctrl_qubits)
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, MCU1Gate)
+            and self.num_ctrl_qubits == other.num_ctrl_qubits
+            and self.ctrl_state == other.ctrl_state
+            and self._compare_parameters(other)
+        )

--- a/qiskit/circuit/library/standard_gates/u2.py
+++ b/qiskit/circuit/library/standard_gates/u2.py
@@ -144,3 +144,6 @@ class U2Gate(Gate):
             ],
             dtype=dtype or complex,
         )
+
+    def __eq__(self, other):
+        return isinstance(other, U2Gate) and self._compare_parameters(other)

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -178,6 +178,9 @@ class U3Gate(Gate):
             dtype=dtype or complex,
         )
 
+    def __eq__(self, other):
+        return isinstance(other, U3Gate) and self._compare_parameters(other)
+
 
 class CU3Gate(ControlledGate):
     r"""Controlled-U3 gate (3-parameter two-qubit gate).
@@ -367,6 +370,13 @@ class CU3Gate(ControlledGate):
                 ],
                 dtype=dtype or complex,
             )
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, CU3Gate)
+            and self.ctrl_state == other.ctrl_state
+            and self._compare_parameters(other)
+        )
 
 
 def _generate_gray_code(num_bits):

--- a/releasenotes/notes/circuit-library-missing-eq-568e7a72008c0ab2.yaml
+++ b/releasenotes/notes/circuit-library-missing-eq-568e7a72008c0ab2.yaml
@@ -1,0 +1,6 @@
+---
+features_circuits:
+  - |
+    Specialized implementations of :meth:`~object.__eq__` have been added for all standard-library circuit gates.
+    Most of the standard gates already specialized this method, but a few did not, and could cause significant
+    slowdowns in unexpected places.


### PR DESCRIPTION
### Summary

Most standard-library gates had a specialised `__eq__` added in gh-11370, but a small number were left over.  This adds specialisation to almost all the stragglers, which were mostly old soft-deperecated gates.  Despite not appearing in most circuits, these gates have an outsized effect on equality comparisons if they ever _do_ appear, because they involve construction of entire `definition` fields.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

You can see the improvement here in the OQ3 exporter for circuits containing some of the affected gates; it uses gate equality at one part of the symbol lookup.  For example, given this circuit:
```python
from qiskit.circuit.random import random_circuit
from qiskit import qasm3

circ = random_circuit(200, 200, seed=42)
```
The time of `qasm3.dumps(circ)` on my machine went from about 1.15(2)s to 0.76(2)s with this PR, despite only about 9% of the gates in the circuit being affected by this PR.