### PR TITLE
Test wheel builds during PR CI on demand

### DIFF
--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -1,0 +1,247 @@
+name: Build release artifacts
+on:
+  workflow_call:
+    inputs:
+      default-action:
+        description: >-
+          The default action for each artifact.
+          Choose from 'build' (default) or 'skip'.
+        type: string
+        default: "build"
+        required: false
+
+      sdist:
+        description: >-
+          The action to take for the sdist.
+          Choose from 'default', 'build' or 'skip'.
+        type: string
+        default: "default"
+        required: false
+
+      wheels-tier-1:
+        description: >-
+          The action to take for Tier 1 wheels.
+          Choose from 'default', 'build' or 'skip'.
+          This builds multiple artifacts, which all match 'wheels-tier-1-*'.
+        type: string
+        default: "default"
+        required: false
+
+      wheels-32bit: 
+        description: >-
+          The action to take for Tier 1 wheels.
+          Choose from 'default', 'build' or 'skip'.
+          This builds multiple artifacts, which all match 'wheels-32bit-*'.
+        type: string
+        default: "default"
+        required: false
+
+      wheels-linux-s390x: 
+        description: >-
+          The action to take for Linux s390x wheels.
+          Choose from 'default', 'build' or 'skip'.
+        type: string
+        default: "default"
+        required: false
+
+      wheels-linux-ppc64le: 
+        description: >-
+          The action to take for Linux ppc64le wheels.
+          Choose from 'default', 'build' or 'skip'.
+        type: string
+        default: "default"
+        required: false
+
+      wheels-linux-aarch64: 
+        description: >-
+          The action to take for Linux AArch64 wheels.
+          Choose from 'default', 'build' or 'skip'.
+        type: string
+        default: "default"
+        required: false
+
+      artifact-prefix:
+        description: "A prefix to give all artifacts uploaded with 'actions/upload-artifact'."
+        type: string
+        default: ""
+        required: false
+
+      python-version:
+        description: "The Python version to use to host the build runner."
+        type: string
+        default: "3.10"
+        required: false
+
+      pgo:
+        description: "Whether to enable profile-guided optimizations for supported platforms."
+        type: boolean
+        default: true
+        required: false
+      
+
+jobs:
+  wheels-tier-1:
+    name: "Wheels / Tier 1"
+    if: (inputs.wheels-tier-1 == 'default' && inputs.default-action || inputs.wheels-tier-1) == 'build'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          # Used for the x86_64 builds.
+          - macos-12
+          # Used for the ARM builds.
+          - macos-14
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+          architecture: ${{ matrix.os == 'macos-14' && 'arm64' || 'x64' }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - name: Configure PGO
+        shell: bash
+        if: inputs.pgo
+        # The `$GITHUB_ENV` magic file uses some sort of custom parsing, so the variables shouldn't
+        # be quoted like they would be if bash were interpreting them.  You still need to use quotes
+        # to avoid word splitting where appropriate in compound environment variables.
+        #
+        # Beware that the heredoc is configured to expand bash variables, but cibuildwheel has
+        # special handling for certain variables (`$PATH`, in particular), so you may need to escape
+        # some dollar signs to pass those through to cibuildwheel as variables, or use single quotes
+        # to prevent shell expansion.
+        run: |
+          set -e
+          mkdir -p "$PGO_WORK_DIR"
+
+          cat >>"$GITHUB_ENV" <<EOF
+          CIBW_BEFORE_BUILD=bash ./tools/build_pgo.sh $PGO_WORK_DIR $PGO_OUT_PATH
+          CIBW_ENVIRONMENT=RUSTUP_TOOLCHAIN=stable RUSTFLAGS='-Cprofile-use=$PGO_OUT_PATH -Cllvm-args=-pgo-warn-missing-function'
+          CIBW_ENVIRONMENT_LINUX=RUSTUP_TOOLCHAIN=stable RUSTFLAGS='-Cprofile-use=$PGO_OUT_PATH -Cllvm-args=-pgo-warn-missing-function' PATH="\$PATH:\$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true"
+          EOF
+        env:
+          PGO_WORK_DIR: ${{ github.workspace }}/pgo-data
+          PGO_OUT_PATH: ${{ github.workspace }}/merged.profdata
+      - uses: pypa/cibuildwheel@v2.19.2
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: ${{ inputs.artifact-prefix }}wheels-tier-1-${{ matrix.os }}
+
+  wheels-32bit:
+    name: "Wheels / 32bit"
+    if: (inputs.wheels-32bit == 'default' && inputs.default-action || inputs.wheels-32bit) == 'build'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.19.2
+        env:
+          CIBW_SKIP: 'pp* cp36-* cp37-* cp38-* *musllinux* *amd64 *x86_64'
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: ${{ inputs.artifact-prefix }}wheels-32bit-${{ matrix.os }}
+
+  wheels-linux-s390x:
+    name: "Wheels / Linux s390x"
+    if: (inputs.wheels-linux-s390x == 'default' && inputs.default-action || inputs.wheels-linux-s390x) == 'build'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: ${{ inputs.python-version }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+      - uses: pypa/cibuildwheel@v2.19.2
+        env:
+          CIBW_ARCHS_LINUX: s390x
+          CIBW_TEST_SKIP: "cp*"
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: ${{ inputs.artifact-prefix }}wheels-linux-s390x
+
+  wheels-linux-ppc64le:
+    name: "Wheels / Linux ppc64le"
+    if: (inputs.wheels-linux-ppc64le == 'default' && inputs.default-action || inputs.wheels-linux-ppc64le) == 'build'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: ${{ inputs.python-version }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+      - uses: pypa/cibuildwheel@v2.19.2
+        env:
+          CIBW_ARCHS_LINUX: ppc64le
+          CIBW_TEST_SKIP: "cp*"
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: ${{ inputs.artifact-prefix }}wheels-linux-ppc64le
+
+  wheels-linux-aarch64:
+    name: "Wheels / Linux AArch64"
+    if: (inputs.wheels-linux-aarch64 == 'default' && inputs.default-action || inputs.wheels-linux-aarch64) == 'build'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+      - uses: pypa/cibuildwheel@v2.19.2
+        env:
+          CIBW_ARCHS_LINUX: aarch64
+          CIBW_TEST_COMMAND: cp -r {project}/test . && QISKIT_PARALLEL=FALSE stestr --test-path test/python run --abbreviate -n test.python.compiler.test_transpiler
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: ${{ inputs.artifact-prefix }}wheels-linux-aarch64
+
+  sdist:
+    name: "sdist"
+    if: (inputs.sdist == 'default' && inputs.default-action || inputs.sdist) == 'build'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: Build sdist
+        run: |
+          set -e
+          python -m pip install -U build
+          python -m build --sdist .
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./dist/*.tar.gz
+          name: ${{ inputs.artifact-prefix }}sdist

--- a/.github/workflows/wheels-pr.yml
+++ b/.github/workflows/wheels-pr.yml
@@ -1,0 +1,23 @@
+name: Build wheels
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      # Above are the defaults for the PR trigger, below are our insertions.
+      # Trigger on 'labeled' so we catch the initial manual labelling event.
+      - labeled
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref_name }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  test-wheels:
+    name: Build
+    if: '${{ contains(github.event.pull_request.labels.*.name, ''ci: test wheels'') }}'
+    uses: './.github/workflows/wheels-build.yml'
+    with:
+      default-action: "build"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,209 +1,59 @@
 ---
-name: Wheel Builds
+name: Deploy release artifacts
 on:
   push:
     tags:
       - '*'
 jobs:
-  build_wheels:
-    name: Build wheels
-    runs-on: ${{ matrix.os }}
-    environment: release
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-12, windows-latest, macos-14]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        name: Install Python
-        with:
-          python-version: '3.10'
-        if: matrix.os != 'macos-14'
-      - uses: actions/setup-python@v5
-        name: Install Python
-        with:
-          python-version: '3.10'
-          architecture: arm64
-        if: matrix.os == 'macos-14'
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools-preview
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.2
-        env:
-          CIBW_BEFORE_BUILD: 'bash ./tools/build_pgo.sh /tmp/pgo-data/merged.profdata'
-          CIBW_BEFORE_BUILD_WINDOWS: 'bash ./tools/build_pgo.sh /tmp/pgo-data/merged.profdata && cp /tmp/pgo-data/merged.profdata ~/.'
-          CIBW_ENVIRONMENT: 'RUSTUP_TOOLCHAIN="stable" RUSTFLAGS="-Cprofile-use=/tmp/pgo-data/merged.profdata -Cllvm-args=-pgo-warn-missing-function"'
-          CIBW_ENVIRONMENT_LINUX: 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true" RUSTUP_TOOLCHAIN="stable" RUSTFLAGS="-Cprofile-use=/tmp/pgo-data/merged.profdata -Cllvm-args=-pgo-warn-missing-function"'
-          CIBW_ENVIRONMENT_WINDOWS: 'RUSTUP_TOOLCHAIN="stable" RUSTFLAGS="-Cprofile-use=c:\\Users\\runneradmin\\merged.profdata -Cllvm-args=-pgo-warn-missing-function"'
-      - uses: actions/upload-artifact@v4
-        with:
-          path: ./wheelhouse/*.whl
-          name: wheels-${{ matrix.os }}
-  build_wheels_32bit:
-    name: Build wheels 32bit
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        name: Install Python
-        with:
-          python-version: '3.10'
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools-preview
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.2
-        env:
-          CIBW_SKIP: 'pp* cp36-* cp37-* cp38-* *musllinux* *amd64 *x86_64'
-      - uses: actions/upload-artifact@v4
-        with:
-          path: ./wheelhouse/*.whl
-          name: wheels-${{ matrix.os }}-32
-  upload_shared_wheels:
-    name: Upload shared build wheels
+  build-core:
+    name: Build core
+    uses: ./.github/workflows/wheels-build.yml
+    with:
+      artifact-prefix: "deploy-core-"
+      default-action: "skip"
+      wheels-tier-1: "build"
+      wheels-32bit: "build"
+      sdist: "build"
+  upload-core:
+    name: Deploy core
+    needs: ["build-core"]
     runs-on: ubuntu-latest
     environment: release
     permissions:
       id-token: write
-    needs: ["build_wheels", "build_wheels_32bit"]
     steps:
       - uses: actions/download-artifact@v4
         with:
-          pattern: 'wheels-*'
+          pattern: 'deploy-core-*'
           merge-multiple: true
           path: deploy
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: deploy
-  build_wheels_s390x:
-    name: Build wheels on s390x
-    runs-on: ${{ matrix.os }}
+
+  build-others:
+    name: Build others
+    needs: ["upload-core"]
+    uses: ./.github/workflows/wheels-build.yml
+    with:
+      artifact-prefix: "deploy-others-"
+      default-action: "build"
+      wheels-tier-1: "skip"
+      wheels-32bit: "skip"
+      sdist: "skip"
+  upload-others:
+    name: Deploy other
+    needs: ["build-others"]
+    runs-on: ubuntu-latest
     environment: release
     permissions:
       id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        name: Install Python
+      - uses: actions/download-artifact@v4
         with:
-          python-version: '3.10'
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+          pattern: 'deploy-others-*'
+          merge-multiple: true
+          path: deploy
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          platforms: all
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.2
-        env:
-          CIBW_ARCHS_LINUX: s390x
-          CIBW_TEST_SKIP: "cp*"
-      - uses: actions/upload-artifact@v4
-        with:
-          name: wheels-${{ matrix.os }}-s390x
-          path: ./wheelhouse/*.whl
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: wheelhouse/
-  build_wheels_ppc64le:
-    name: Build wheels on ppc64le
-    runs-on: ${{ matrix.os }}
-    environment: release
-    permissions:
-      id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        name: Install Python
-        with:
-          python-version: '3.10'
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.2
-        env:
-          CIBW_ARCHS_LINUX: ppc64le
-          CIBW_TEST_SKIP: "cp*"
-      - uses: actions/upload-artifact@v4
-        with:
-          name: wheels-${{ matrix.os }}-ppc64le
-          path: ./wheelhouse/*.whl
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: wheelhouse/
-  build_wheels_aarch64:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    environment: release
-    permissions:
-      id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        name: Install Python
-        with:
-          python-version: '3.10'
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.2
-        env:
-          CIBW_ARCHS_LINUX: aarch64
-          CIBW_TEST_COMMAND: cp -r {project}/test . && QISKIT_PARALLEL=FALSE stestr --test-path test/python run --abbreviate -n test.python.compiler.test_transpiler
-      - uses: actions/upload-artifact@v4
-        with:
-          name: wheels-${{ matrix.os }}-aarch64
-          path: ./wheelhouse/*.whl
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: wheelhouse/
-  sdist:
-    name: Build and publish sdist
-    runs-on: ${{ matrix.os }}
-    needs: ["upload_shared_wheels"]
-    environment: release
-    permissions:
-      id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        name: Install Python
-        with:
-          python-version: '3.10'
-      - name: Install deps
-        run: pip install -U build
-      - name: Build sdist
-        run: python -m build . --sdist
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+          packages-dir: deploy

--- a/tools/build_pgo.sh
+++ b/tools/build_pgo.sh
@@ -2,16 +2,15 @@
 
 set -x
 
-merged_path=$1
-
-python -c 'import sys;assert sys.platform == "win32"'
-is_win=$?
+work_dir="$1"
+out_path="$2"
 
 set -e
+
 # Create venv for instrumented build and test
 python -m venv build_pgo
 
-if [[ $is_win -eq 0 ]]; then
+if python -c 'import sys; assert sys.platform == "win32"'; then
     source build_pgo/Scripts/activate
 else
     source build_pgo/bin/activate
@@ -25,8 +24,8 @@ fi
 
 # Build with instrumentation
 pip install -U -c constraints.txt setuptools-rust wheel setuptools
-RUSTFLAGS="-Cprofile-generate=/tmp/pgo-data" pip install --prefer-binary -c constraints.txt -r requirements-dev.txt -e .
-RUSTFLAGS="-Cprofile-generate=/tmp/pgo-data" python setup.py build_rust --release --inplace
+RUSTFLAGS="-Cprofile-generate=$work_dir" pip install --prefer-binary -c constraints.txt -r requirements-dev.txt -e .
+RUSTFLAGS="-Cprofile-generate=$work_dir" python setup.py build_rust --release --inplace
 # Run profile data generation
 
 QISKIT_PARALLEL=FALSE stestr run --abbreviate
@@ -35,4 +34,4 @@ python tools/pgo_scripts/test_utility_scale.py
 
 deactivate
 
-${HOME}/.rustup/toolchains/*$arch*/lib/rustlib/$arch*/bin/llvm-profdata merge -o $merged_path /tmp/pgo-data
+${HOME}/.rustup/toolchains/*$arch*/lib/rustlib/$arch*/bin/llvm-profdata merge -o "$out_path" "$work_dir"


### PR DESCRIPTION
### Summary

Refactor the wheels-build and deployment workflow into one re-usable "build wheels" workflow and two orchestration workflows.  The orchestration workflows are the existing "tag push" event, which also deploys the wheels to PyPI, and a new "PR" trigger that runs the all-wheels build if the PR is labelled with `ci: test wheels`. PGO can be turned on or off based on the workflow inputs.

The deployment job is slightly reorganised so that all the "core" platforms build and deploy before the less common platforms even begin the build.  The core platforms are all tier 1 platforms, the 32-bit platforms, and the sdist.  These core platforms were already tied together, but the other platforms ran concurrently with them.  This could lead to other projects' CI failing when Qiskit was part way through a deployment.

The "other" wheels are all tied together in this PR mostly as a convenience to avoid repetition.  They could easily be untied from each other (as the parent commit does).

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

The idea of this is that we can now use https://github.com/Qiskit/qiskit/labels/ci%3A%20test%20wheels to tag PRs that affect the deployment process (like dependabot PRs to cibuildwheel, or #13309 adding Python 3.13).  The CI run isn't required to pass to allow merge, but it significantly lowers the barrier to entry for testing a PR, compared to the prior system of somebody needing to manually push a branch that fiddled with the script triggers to test a build.

I've attached the label to this PR, so it should trigger the additional checks.  Removing the label should mean the runs stop happening on PR syncs.

We can, in a follow-up, potentially add a weekly or nightly job to build the Qiskit release artifacts (with or without PGO as we choose) for downstream consumption.  This in particular might be helpful around major-version changes, to make it easier for other projects to build against a recent Qiskit without needing to build from source.

Testing on my own fork shows that the Windows 32-bit builds are currently broken.