### PR TITLE
Fix OpenQASM 2 `gate` definitions following a shadowed built-in `gate`

### DIFF
--- a/crates/qasm2/src/parse.rs
+++ b/crates/qasm2/src/parse.rs
@@ -827,8 +827,16 @@ impl State {
         }
         bc.push(Some(InternalBytecode::EndDeclareGate {}));
         self.gate_symbols.clear();
-        self.define_gate(Some(&gate_token), name, num_params, num_qubits)?;
-        Ok(statements + 2)
+        let num_bytecode = statements + 2;
+        if self.define_gate(Some(&gate_token), name, num_params, num_qubits)? {
+            Ok(num_bytecode)
+        } else {
+            // The gate was built-in, so we don't actually need to emit the bytecode.  This is
+            // uncommon, so it doesn't matter too much that we throw away allocation work we did -
+            // it still helps that we verified that the gate body was valid OpenQASM 2.
+            bc.truncate(bc.len() - num_bytecode);
+            Ok(0)
+        }
     }
 
     /// Parse an `opaque` statement.  This assumes that the `opaque` token is still in the token
@@ -1634,6 +1642,9 @@ impl State {
     /// bytecode because not all gate definitions need something passing to Python.  For example,
     /// the Python parser initializes its state including the built-in gates `U` and `CX`, and
     /// handles the `qelib1.inc` include specially as well.
+    ///
+    /// Returns whether the gate needs to be defined in Python space (`true`) or if it was some sort
+    /// of built-in that doesn't need the definition (`false`).
     fn define_gate(
         &mut self,
         owner: Option<&Token>,
@@ -1685,12 +1696,14 @@ impl State {
             }
             match self.symbols.get(&name) {
                 None => {
+                    // The gate wasn't a built-in, so we need to move the symbol in, but we don't
+                    // need to increment the number of gates because it's already got a gate ID
+                    // assigned.
                     self.symbols.insert(name, symbol.into());
-                    self.num_gates += 1;
-                    Ok(true)
+                    Ok(false)
                 }
                 Some(GlobalSymbol::Gate { .. }) => {
-                    self.symbols.insert(name, symbol.into());
+                    // The gate was built-in and we can ignore the new definition (it's the same).
                     Ok(false)
                 }
                 _ => already_defined(self, name),

--- a/releasenotes/notes/qasm2-builtin-gate-d80c2868cdf5f958.yaml
+++ b/releasenotes/notes/qasm2-builtin-gate-d80c2868cdf5f958.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The OpenQASM 2 importer previously would output incorrect :class:`.Gate` instances for gate
+    calls referring to a ``gate`` definition that followed a prior ``gate`` definition that was
+    being treated as a built-in operation by a :class:`~.qasm2.CustomInstruction`.  See
+    `#13339 <https://github.com/Qiskit/qiskit/issues/13339>`__ for more detail.


### PR DESCRIPTION
### Summary

Previously, when given an OpenQASM 2 program such as

    OPENQASM 2.0;
    gate builtin a { U(0, 0, 0) a; }
    gate not_builtin a { U(pi, pi, pi) a; }
    qreg q[1];

    not_builtin q[0];

and a set of `custom_instructions` including a `builtin=True` definition for `builtin` (but not for `not_builtin`), the Rust and Python sides would get themselves out-of-sync and output a gate that matched a prior definition, rather than `not_builtin`.

This was because the Rust side was still issuing `DefineGate` bytecode instructions, even for gates whose OpenQASM 2 definitions should have been ignored, so Python-space thought there were more gates than Rust-space thought there were.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Fix #13339.
