### PR TITLE
Fix the calculation for identity operator's expectation value

### DIFF
--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -476,7 +476,7 @@ class Statevector(QuantumState, TolerancesMixin):
         pauli_phase = (-1j) ** pauli.phase if pauli.phase else 1
 
         if x_mask + z_mask == 0:
-            return pauli_phase * np.linalg.norm(self.data)
+            return pauli_phase * np.linalg.norm(self.data) ** 2
 
         if x_mask == 0:
             return pauli_phase * expval_pauli_no_x(self.data, self.num_qubits, z_mask)

--- a/releasenotes/notes/fix_identity_operator_9e2ec9770ac046a6.yaml
+++ b/releasenotes/notes/fix_identity_operator_9e2ec9770ac046a6.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Fixed a bug that caused :meth:`Statevector.expectation_value` to yield incorrect results
+    Fixed a bug that caused :meth:`.Statevector.expectation_value` to yield incorrect results
     for the identity operator when the statevector was not normalized.

--- a/releasenotes/notes/fix_identity_operator_9e2ec9770ac046a6.yaml
+++ b/releasenotes/notes/fix_identity_operator_9e2ec9770ac046a6.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Fix a bug that causes Statevector.expectation_value to yield incorrect result
-    for the identity operator when the statevector is not normalized to 1.
+    Fixed a bug that caused :meth:`Statevector.expectation_value` to yield incorrect results
+    for the identity operator when the statevector was not normalized.

--- a/releasenotes/notes/fix_identity_operator_9e2ec9770ac046a6.yaml
+++ b/releasenotes/notes/fix_identity_operator_9e2ec9770ac046a6.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a bug that causes Statevector.expectation_value to yield incorrect result
+    for the identity operator when the statevector is not normalized to 1.

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -1152,6 +1152,37 @@ class TestStatevector(QiskitTestCase):
         expval = state.expectation_value(op, qubits)
         self.assertAlmostEqual(expval, target)
 
+
+    def test_expval_identity(self):
+        # Test whether the calculation for identity operator has been fixed
+
+        # 1 qubit case test
+        state_1 = Statevector.from_label("0")
+        state_1_n1 = 2 * state_1 # test the same state with different norms
+        state_1_n2 = (1+2j) * state_1
+        identity_op_1 = SparsePauliOp.from_list([("I", 1)])
+        expval_state_1 = state_1.expectation_value(identity_op_1)
+        expval_state_1_n1 = state_1_n1.expectation_value(identity_op_1)
+        expval_state_1_n2 = state_1_n2.expectation_value(identity_op_1)
+        self.assertAlmostEqual(expval_state_1, 1.0+0j)
+        self.assertAlmostEqual(expval_state_1_n1, 4+0j)
+        self.assertAlmostEqual(expval_state_1_n2, 5+0j)
+
+
+        # Let's try a multi-qubit case
+        n_qubits = 3
+        state_coeff = (3-4j)
+        op_coeff = (2-2j)
+        state_test = state_coeff * Statevector.from_label("0" * n_qubits)
+        op_test = SparsePauliOp.from_list([ ("I"*n_qubits, op_coeff) ])
+        expval = state_test.expectation_value(op_test)
+        target = op_coeff * np.abs(state_coeff)**2
+        self.assertAlmostEqual(expval, target)
+        
+
+        
+
+
     @data(*(qargs for i in range(4) for qargs in permutations(range(4), r=i + 1)))
     def test_probabilities_qargs(self, qargs):
         """Test probabilities method with qargs"""

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -1153,7 +1153,7 @@ class TestStatevector(QiskitTestCase):
         self.assertAlmostEqual(expval, target)
 
     def test_expval_identity(self):
-        # Test whether the calculation for identity operator has been fixed
+        """Test whether the calculation for identity operator has been fixed"""
 
         # 1 qubit case test
         state_1 = Statevector.from_label("0")

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -1152,36 +1152,30 @@ class TestStatevector(QiskitTestCase):
         expval = state.expectation_value(op, qubits)
         self.assertAlmostEqual(expval, target)
 
-
     def test_expval_identity(self):
         # Test whether the calculation for identity operator has been fixed
 
         # 1 qubit case test
         state_1 = Statevector.from_label("0")
-        state_1_n1 = 2 * state_1 # test the same state with different norms
-        state_1_n2 = (1+2j) * state_1
+        state_1_n1 = 2 * state_1  # test the same state with different norms
+        state_1_n2 = (1 + 2j) * state_1
         identity_op_1 = SparsePauliOp.from_list([("I", 1)])
         expval_state_1 = state_1.expectation_value(identity_op_1)
         expval_state_1_n1 = state_1_n1.expectation_value(identity_op_1)
         expval_state_1_n2 = state_1_n2.expectation_value(identity_op_1)
-        self.assertAlmostEqual(expval_state_1, 1.0+0j)
-        self.assertAlmostEqual(expval_state_1_n1, 4+0j)
-        self.assertAlmostEqual(expval_state_1_n2, 5+0j)
-
+        self.assertAlmostEqual(expval_state_1, 1.0 + 0j)
+        self.assertAlmostEqual(expval_state_1_n1, 4 + 0j)
+        self.assertAlmostEqual(expval_state_1_n2, 5 + 0j)
 
         # Let's try a multi-qubit case
         n_qubits = 3
-        state_coeff = (3-4j)
-        op_coeff = (2-2j)
+        state_coeff = 3 - 4j
+        op_coeff = 2 - 2j
         state_test = state_coeff * Statevector.from_label("0" * n_qubits)
-        op_test = SparsePauliOp.from_list([ ("I"*n_qubits, op_coeff) ])
+        op_test = SparsePauliOp.from_list([("I" * n_qubits, op_coeff)])
         expval = state_test.expectation_value(op_test)
-        target = op_coeff * np.abs(state_coeff)**2
+        target = op_coeff * np.abs(state_coeff) ** 2
         self.assertAlmostEqual(expval, target)
-        
-
-        
-
 
     @data(*(qargs for i in range(4) for qargs in permutations(range(4), r=i + 1)))
     def test_probabilities_qargs(self, qargs):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the CONTRIBUTING document.
-->

### Summary

Fix a bug in `qiskit.quantum_info` in the calculation of expectation value of the identity operator.

Fixes #13029 



### Details and comments
Currently,  `qiskit.quantum_info` yields incorrect results for the expectation value of an identity operator for a given state vector. It returns the norm of the state vector; however, it ought to return the square of the norm.

Therefore, I am changing the following line  

https://github.com/Qiskit/qiskit/blob/1be2c5aa103f1991f2fdc75a77a09f82635b8431/qiskit/quantum_info/states/statevector.py#L478-L479

to 
```Python
   if x_mask + z_mask == 0: 
       return pauli_phase * np.linalg.norm(self.data) ** 2
```
