### PR TITLE
Represent variables with BitData in DAGCircuit.

### DIFF
--- a/crates/accelerate/src/commutation_analysis.rs
+++ b/crates/accelerate/src/commutation_analysis.rs
@@ -61,7 +61,7 @@ pub(crate) fn analyze_commutations_inner(
     for qubit in 0..dag.num_qubits() {
         let wire = Wire::Qubit(Qubit(qubit as u32));
 
-        for current_gate_idx in dag.nodes_on_wire(py, &wire, false) {
+        for current_gate_idx in dag.nodes_on_wire(&wire, false) {
             // get the commutation set associated with the current wire, or create a new
             // index set containing the current gate
             let commutation_entry = commutation_set

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -5892,19 +5892,14 @@ impl DAGCircuit {
     }
 
     /// Returns an iterator over the first layer of the `DAGCircuit``.
-    pub fn front_layer(&self) -> impl Iterator<Item = NodeIndex> {
+    pub fn front_layer(&self) -> impl Iterator<Item = NodeIndex> + '_ {
         let mut graph_layers = self.multigraph_layers();
         graph_layers.next();
-
-        let next_layer = graph_layers.next();
-        match next_layer {
-            Some(layer) => Box::new(layer.into_iter().filter(|node| {
-                matches!(self.dag.node_weight(*node).unwrap(), NodeType::Operation(_))
-            }))
-            .collect(),
-            None => vec![],
-        }
-        .into_iter()
+        graph_layers
+            .next()
+            .into_iter()
+            .flatten()
+            .filter(|node| matches!(self.dag.node_weight(*node).unwrap(), NodeType::Operation(_)))
     }
 
     fn substitute_node_with_subgraph(

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -493,7 +493,7 @@ impl DAGCircuit {
                 .iter()
                 .enumerate()
                 .map(|(k, v)| (k, [v[0].index(), v[1].index()]))
-                .collect::<IndexMap<_, _, RandomState>>(),
+                .into_py_dict_bound(py),
         )?;
         out_dict.set_item(
             "clbit_io_map",
@@ -501,7 +501,7 @@ impl DAGCircuit {
                 .iter()
                 .enumerate()
                 .map(|(k, v)| (k, [v[0].index(), v[1].index()]))
-                .collect::<IndexMap<_, _, RandomState>>(),
+                .into_py_dict_bound(py),
         )?;
         out_dict.set_item(
             "var_io_map",
@@ -509,7 +509,7 @@ impl DAGCircuit {
                 .iter()
                 .enumerate()
                 .map(|(k, v)| (k, [v[0].index(), v[1].index()]))
-                .collect::<IndexMap<_, _, RandomState>>(),
+                .into_py_dict_bound(py),
         )?;
         out_dict.set_item("op_name", self.op_names.clone())?;
         out_dict.set_item(
@@ -527,7 +527,7 @@ impl DAGCircuit {
                         ),
                     )
                 })
-                .collect::<HashMap<_, _>>(),
+                .into_py_dict_bound(py),
         )?;
         out_dict.set_item("vars_by_type", self.vars_by_type.clone())?;
         out_dict.set_item("qubits", self.qubits.bits())?;

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6195,7 +6195,7 @@ impl DAGCircuit {
     /// Retrieve a variable given its unique [Var] key within the DAG.
     ///
     /// The provided [Var] must be from this [DAGCircuit].
-    pub fn get_var(&self, py: Python, var: Var) -> Option<Bound<PyAny>> {
+    pub fn get_var<'py>(&self, py: Python<'py>, var: Var) -> Option<Bound<'py, PyAny>> {
         self.vars.get(var).map(|v| v.bind(py).clone())
     }
 

--- a/crates/circuit/src/dot_utils.rs
+++ b/crates/circuit/src/dot_utils.rs
@@ -59,7 +59,7 @@ where
         let edge_weight = match edge.weight() {
             Wire::Qubit(qubit) => dag.qubits().get(*qubit).unwrap(),
             Wire::Clbit(clbit) => dag.clbits().get(*clbit).unwrap(),
-            Wire::Var(var) => var,
+            Wire::Var(var) => dag.vars().get(*var).unwrap(),
         };
         writeln!(
             file,

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -79,30 +79,6 @@ impl Clbit {
     }
 }
 
-// Note: Var is meant to be opaque outside of this crate, i.e.
-// users have no business creating them directly and should instead
-// get them from the containing circuit.
-#[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq)]
-pub struct Var(pub(crate) BitType);
-
-impl Var {
-    /// Construct a new [Var] object from a usize. if you have a u32 you can
-    /// create a [Var] object directly with `Var(0u32)`. This will panic
-    /// if the `usize` index exceeds `u32::MAX`.
-    #[inline(always)]
-    pub fn new(index: usize) -> Self {
-        Var(index
-            .try_into()
-            .unwrap_or_else(|_| panic!("Index value '{}' exceeds the maximum bit width!", index)))
-    }
-
-    /// Get the index of the [Var]
-    #[inline(always)]
-    pub fn index(&self) -> usize {
-        self.0 as usize
-    }
-}
-
 pub struct TupleLikeArg<'py> {
     value: Bound<'py, PyTuple>,
 }
@@ -142,18 +118,6 @@ impl From<BitType> for Clbit {
 
 impl From<Clbit> for BitType {
     fn from(value: Clbit) -> Self {
-        value.0
-    }
-}
-
-impl From<BitType> for Var {
-    fn from(value: BitType) -> Self {
-        Var(value)
-    }
-}
-
-impl From<Var> for BitType {
-    fn from(value: Var) -> Self {
         value.0
     }
 }

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -79,6 +79,30 @@ impl Clbit {
     }
 }
 
+// Note: Var is meant to be opaque outside of this crate, i.e.
+// users have no business creating them directly and should instead
+// get them from the containing circuit.
+#[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq)]
+pub struct Var(pub(crate) BitType);
+
+impl Var {
+    /// Construct a new [Var] object from a usize. if you have a u32 you can
+    /// create a [Var] object directly with `Var(0u32)`. This will panic
+    /// if the `usize` index exceeds `u32::MAX`.
+    #[inline(always)]
+    pub fn new(index: usize) -> Self {
+        Var(index
+            .try_into()
+            .unwrap_or_else(|_| panic!("Index value '{}' exceeds the maximum bit width!", index)))
+    }
+
+    /// Get the index of the [Var]
+    #[inline(always)]
+    pub fn index(&self) -> usize {
+        self.0 as usize
+    }
+}
+
 pub struct TupleLikeArg<'py> {
     value: Bound<'py, PyTuple>,
 }
@@ -118,6 +142,18 @@ impl From<BitType> for Clbit {
 
 impl From<Clbit> for BitType {
     fn from(value: Clbit) -> Self {
+        value.0
+    }
+}
+
+impl From<BitType> for Var {
+    fn from(value: BitType) -> Self {
+        Var(value)
+    }
+}
+
+impl From<Var> for BitType {
+    fn from(value: Var) -> Self {
         value.0
     }
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

This PR builds on the work done by @jlapeyre (added as a co-author on the original commit). Thanks John! 😄

### Summary
Introduces a new `Var` type which, similarly to the existing `Qubit` and `Clbit` types, represents a variable in the DAG as an index. With this change, the size of the `Wire` type used for edge data in `DAGCircuit` should be halved. See #13027 for details.

### Details and comments
The semantics of the new `Var` type differ from those of `Qubit` and `Clbit`, in that the latter types the index has a meaning. As such, I'd think that `Var` should be completely opaque (and not constructible) outside of `qiskit-circuit`. Thoughts?

#### Todo
~- [ ] Change `BitData` to `WireData`.~
~- [ ] Resolve any visibility concerns noted above.~

> [!NOTE]
> We can resolve these to-dos in a follow-on PR, since a lot of these structures will change soon in anticipation of migrating toward a native Rust source of truth for bits.

Resolves #13027
Closes #13048 