### PR TITLE
Deprecate `EchoRZXWeylDecomposition` (Pulse)

### DIFF
--- a/qiskit/transpiler/passes/optimization/echo_rzx_weyl_decomposition.py
+++ b/qiskit/transpiler/passes/optimization/echo_rzx_weyl_decomposition.py
@@ -21,6 +21,7 @@ from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.passes.calibration.rzx_builder import _check_calibration_type, CRCalType
+from qiskit.utils.deprecate_pulse import deprecate_pulse_dependency
 
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.converters import circuit_to_dag
@@ -34,6 +35,7 @@ class EchoRZXWeylDecomposition(TransformationPass):
     Each pair of RZXGates forms an echoed RZXGate.
     """
 
+    @deprecate_pulse_dependency
     def __init__(self, instruction_schedule_map=None, target=None):
         """EchoRZXWeylDecomposition pass.
 

--- a/releasenotes/notes/deprecate-pulse-package-07a621be1db7fa30.yaml
+++ b/releasenotes/notes/deprecate-pulse-package-07a621be1db7fa30.yaml
@@ -40,6 +40,7 @@ deprecations_transpiler:
       * :class:`~qiskit.transpiler.passes.ValidatePulseGates`
       * :class:`~qiskit.transpiler.passes.RXCalibrationBuilder`
       * :class:`~qiskit.transpiler.passes.RZXCalibrationBuilder`
+      * :class:`~qiskit.transpiler.passes.EchoRZXWeylDecomposition`
   - |
     The `inst_map` argument in :func:`~qiskit.transpiler.generate_preset_pass_manager`,
     :meth:`~transpiler.target.Target.from_configuration` and :func:`~qiskit.transpiler.preset_passmanagers.common.generate_scheduling`

--- a/test/python/transpiler/test_echo_rzx_weyl_decomposition.py
+++ b/test/python/transpiler/test_echo_rzx_weyl_decomposition.py
@@ -74,8 +74,11 @@ class TestEchoRZXWeylDecomposition(QiskitTestCase):
         circuit.cx(qr[0], qr[1])
 
         unitary_circuit = qi.Operator(circuit).data
-
-        after = EchoRZXWeylDecomposition(self.inst_map)(circuit)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="The entire Qiskit Pulse package",
+        ):
+            after = EchoRZXWeylDecomposition(self.inst_map)(circuit)
 
         unitary_after = qi.Operator(after).data
 
@@ -97,11 +100,19 @@ class TestEchoRZXWeylDecomposition(QiskitTestCase):
         circuit_non_native.rzz(theta, qr[1], qr[0])
 
         dag = circuit_to_dag(circuit)
-        pass_ = EchoRZXWeylDecomposition(self.inst_map)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="The entire Qiskit Pulse package",
+        ):
+            pass_ = EchoRZXWeylDecomposition(self.inst_map)
         after = dag_to_circuit(pass_.run(dag))
 
         dag_non_native = circuit_to_dag(circuit_non_native)
-        pass_ = EchoRZXWeylDecomposition(self.inst_map)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="The entire Qiskit Pulse package",
+        ):
+            pass_ = EchoRZXWeylDecomposition(self.inst_map)
         after_non_native = dag_to_circuit(pass_.run(dag_non_native))
 
         circuit_rzx_number = self.count_gate_number("rzx", after)
@@ -127,11 +138,19 @@ class TestEchoRZXWeylDecomposition(QiskitTestCase):
         circuit_non_native.swap(qr[1], qr[0])
 
         dag = circuit_to_dag(circuit)
-        pass_ = EchoRZXWeylDecomposition(self.inst_map)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="The entire Qiskit Pulse package",
+        ):
+            pass_ = EchoRZXWeylDecomposition(self.inst_map)
         after = dag_to_circuit(pass_.run(dag))
 
         dag_non_native = circuit_to_dag(circuit_non_native)
-        pass_ = EchoRZXWeylDecomposition(self.inst_map)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="The entire Qiskit Pulse package",
+        ):
+            pass_ = EchoRZXWeylDecomposition(self.inst_map)
         after_non_native = dag_to_circuit(pass_.run(dag_non_native))
 
         circuit_rzx_number = self.count_gate_number("rzx", after)
@@ -166,7 +185,11 @@ class TestEchoRZXWeylDecomposition(QiskitTestCase):
             unitary_circuit = qi.Operator(circuit).data
 
             dag = circuit_to_dag(circuit)
-            pass_ = EchoRZXWeylDecomposition(self.inst_map)
+            with self.assertWarnsRegex(
+                DeprecationWarning,
+                expected_regex="The entire Qiskit Pulse package",
+            ):
+                pass_ = EchoRZXWeylDecomposition(self.inst_map)
             after = dag_to_circuit(pass_.run(dag))
             dag_after = circuit_to_dag(after)
 
@@ -221,7 +244,11 @@ class TestEchoRZXWeylDecomposition(QiskitTestCase):
         unitary_circuit = qi.Operator(circuit).data
 
         dag = circuit_to_dag(circuit)
-        pass_ = EchoRZXWeylDecomposition(self.inst_map)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="The entire Qiskit Pulse package",
+        ):
+            pass_ = EchoRZXWeylDecomposition(self.inst_map)
         after = dag_to_circuit(pass_.run(dag))
 
         unitary_after = qi.Operator(after).data


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Follow-up to [#pulse](https://github.com/Qiskit/qiskit/pull/13164), closes #12759.
`EchoRZXWeylDecomposition` relies on the deprecated pulse functionality, so it should be deprecated with the rest of the package. 


### Details and comments


