### PR TITLE
Implement `SparseObservable.apply_layout`

### DIFF
--- a/crates/accelerate/src/lib.rs
+++ b/crates/accelerate/src/lib.rs
@@ -10,6 +10,10 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+// This stylistic lint suppression should be in `Cargo.toml`, but we can't do that until we're at an
+// MSRV of 1.74 or greater.
+#![allow(clippy::comparison_chain)]
+
 use std::env;
 
 use pyo3::import_exception;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This is one more usability method to bring `SparseObservable` closer inline with `SparsePauliOp`. The same functionality is relatively easily implementable by the user by iterating through the terms, mapping the indices, and putting the output back into `SparseObservable.from_sparse_list`, but given how heavily we promote the method for `SparsePauliOp`, it probably forms part of the core of user expectations.


### Details and comments

Built on top of #13298 (though mostly just because it touches similar changes to the error structs).

I only finalised this after the 1.3 feature-freeze period.  There's probably no _huge_ necessity to rush it in since it's not going to be used by the primitives before Qiskit 2.0 anyway, though it's nice to get these things early.

There's still `compose` and `evolve` to go for `SparseObservable`, but those are definitely for a later release, because I haven't written them yet, and the tests will take a good amount of time to write still.

