### PR TITLE
Fix performance regression in UnitarySynthesis

### DIFF
--- a/crates/accelerate/src/unitary_synthesis.rs
+++ b/crates/accelerate/src/unitary_synthesis.rs
@@ -27,7 +27,7 @@ use smallvec::{smallvec, SmallVec};
 
 use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::types::{IntoPyDict, PyDict, PyList, PyString};
+use pyo3::types::{IntoPyDict, PyDict, PyString};
 use pyo3::wrap_pyfunction;
 use pyo3::Python;
 
@@ -225,7 +225,7 @@ fn py_run_main_loop(
     qubit_indices: Vec<usize>,
     min_qubits: usize,
     target: &Target,
-    coupling_edges: &Bound<'_, PyList>,
+    coupling_edges: HashSet<[PhysicalQubit; 2]>,
     approximation_degree: Option<f64>,
     natural_direction: Option<bool>,
 ) -> PyResult<DAGCircuit> {
@@ -268,7 +268,7 @@ fn py_run_main_loop(
                     new_ids,
                     min_qubits,
                     target,
-                    coupling_edges,
+                    coupling_edges.clone(),
                     approximation_degree,
                     natural_direction,
                 )?;
@@ -352,7 +352,7 @@ fn py_run_main_loop(
                     py,
                     unitary,
                     ref_qubits,
-                    coupling_edges,
+                    &coupling_edges,
                     target,
                     approximation_degree,
                     natural_direction,
@@ -383,7 +383,7 @@ fn run_2q_unitary_synthesis(
     py: Python,
     unitary: Array2<Complex64>,
     ref_qubits: &[PhysicalQubit; 2],
-    coupling_edges: &Bound<'_, PyList>,
+    coupling_edges: &HashSet<[PhysicalQubit; 2]>,
     target: &Target,
     approximation_degree: Option<f64>,
     natural_direction: Option<bool>,
@@ -794,7 +794,7 @@ fn preferred_direction(
     decomposer: &DecomposerElement,
     ref_qubits: &[PhysicalQubit; 2],
     natural_direction: Option<bool>,
-    coupling_edges: &Bound<'_, PyList>,
+    coupling_edges: &HashSet<[PhysicalQubit; 2]>,
     target: &Target,
 ) -> PyResult<Option<bool>> {
     // Returns:
@@ -830,14 +830,8 @@ fn preferred_direction(
         Some(false) => None,
         _ => {
             // None or Some(true)
-            let mut edge_set = HashSet::new();
-            for item in coupling_edges.iter() {
-                if let Ok(tuple) = item.extract::<(usize, usize)>() {
-                    edge_set.insert(tuple);
-                }
-            }
-            let zero_one = edge_set.contains(&(qubits[0].0 as usize, qubits[1].0 as usize));
-            let one_zero = edge_set.contains(&(qubits[1].0 as usize, qubits[0].0 as usize));
+            let zero_one = coupling_edges.contains(&qubits);
+            let one_zero = coupling_edges.contains(&[qubits[1], qubits[0]]);
 
             match (zero_one, one_zero) {
                 (true, false) => Some(true),

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -457,37 +457,6 @@ class UnitarySynthesis(TransformationPass):
             default_kwargs = {}
             method_list = [(plugin_method, plugin_kwargs), (default_method, default_kwargs)]
 
-        for method, kwargs in method_list:
-            if method.supports_basis_gates:
-                kwargs["basis_gates"] = self._basis_gates
-            if method.supports_natural_direction:
-                kwargs["natural_direction"] = self._natural_direction
-            if method.supports_pulse_optimize:
-                kwargs["pulse_optimize"] = self._pulse_optimize
-            if method.supports_gate_lengths:
-                _gate_lengths = _gate_lengths or _build_gate_lengths(
-                    self._backend_props, self._target
-                )
-                kwargs["gate_lengths"] = _gate_lengths
-            if method.supports_gate_errors:
-                _gate_errors = _gate_errors or _build_gate_errors(self._backend_props, self._target)
-                kwargs["gate_errors"] = _gate_errors
-            if method.supports_gate_lengths_by_qubit:
-                _gate_lengths_by_qubit = _gate_lengths_by_qubit or _build_gate_lengths_by_qubit(
-                    self._backend_props, self._target
-                )
-                kwargs["gate_lengths_by_qubit"] = _gate_lengths_by_qubit
-            if method.supports_gate_errors_by_qubit:
-                _gate_errors_by_qubit = _gate_errors_by_qubit or _build_gate_errors_by_qubit(
-                    self._backend_props, self._target
-                )
-                kwargs["gate_errors_by_qubit"] = _gate_errors_by_qubit
-            supported_bases = method.supported_bases
-            if supported_bases is not None:
-                kwargs["matched_basis"] = _choose_bases(self._basis_gates, supported_bases)
-            if method.supports_target:
-                kwargs["target"] = self._target
-
         # Handle approximation degree as a special case for backwards compatibility, it's
         # not part of the plugin interface and only something needed for the default
         # pass.
@@ -503,7 +472,7 @@ class UnitarySynthesis(TransformationPass):
             else {}
         )
 
-        if self.method == "default" and isinstance(kwargs["target"], Target):
+        if self.method == "default" and self._target is not None:
             _coupling_edges = (
                 set(self._coupling_map.get_edges()) if self._coupling_map is not None else set()
             )
@@ -512,13 +481,46 @@ class UnitarySynthesis(TransformationPass):
                 dag,
                 list(qubit_indices.values()),
                 self._min_qubits,
-                kwargs["target"],
+                self._target,
                 _coupling_edges,
                 self._approximation_degree,
-                kwargs["natural_direction"],
+                self._natural_direction,
             )
             return out
         else:
+            for method, kwargs in method_list:
+                if method.supports_basis_gates:
+                    kwargs["basis_gates"] = self._basis_gates
+                if method.supports_natural_direction:
+                    kwargs["natural_direction"] = self._natural_direction
+                if method.supports_pulse_optimize:
+                    kwargs["pulse_optimize"] = self._pulse_optimize
+                if method.supports_gate_lengths:
+                    _gate_lengths = _gate_lengths or _build_gate_lengths(
+                        self._backend_props, self._target
+                    )
+                    kwargs["gate_lengths"] = _gate_lengths
+                if method.supports_gate_errors:
+                    _gate_errors = _gate_errors or _build_gate_errors(
+                        self._backend_props, self._target
+                    )
+                    kwargs["gate_errors"] = _gate_errors
+                if method.supports_gate_lengths_by_qubit:
+                    _gate_lengths_by_qubit = _gate_lengths_by_qubit or _build_gate_lengths_by_qubit(
+                        self._backend_props, self._target
+                    )
+                    kwargs["gate_lengths_by_qubit"] = _gate_lengths_by_qubit
+                if method.supports_gate_errors_by_qubit:
+                    _gate_errors_by_qubit = _gate_errors_by_qubit or _build_gate_errors_by_qubit(
+                        self._backend_props, self._target
+                    )
+                    kwargs["gate_errors_by_qubit"] = _gate_errors_by_qubit
+                supported_bases = method.supported_bases
+                if supported_bases is not None:
+                    kwargs["matched_basis"] = _choose_bases(self._basis_gates, supported_bases)
+                if method.supports_target:
+                    kwargs["target"] = self._target
+
             out = self._run_main_loop(
                 dag, qubit_indices, plugin_method, plugin_kwargs, default_method, default_kwargs
             )

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -505,7 +505,7 @@ class UnitarySynthesis(TransformationPass):
 
         if self.method == "default" and isinstance(kwargs["target"], Target):
             _coupling_edges = (
-                list(self._coupling_map.get_edges()) if self._coupling_map is not None else []
+                set(self._coupling_map.get_edges()) if self._coupling_map is not None else set()
             )
 
             out = run_default_main_loop(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes a performance regression that was introduced in PR #13141. When the pass is looking up the preferred synthesis direction for a unitary based on the connectvity constraints the connectivity was being provided as a PyList. To look up the edge in connectivity set this meant we needed to iterate over the list and then create a set that rust could lookup if it contains an edge or it's reverse. This has significant overhead because its iterating via python and also iterating per decomposition. This commit addresses this by changing the input type to be a HashSet from Python so Pyo3 will convert a pyset directly to a HashSet once at call time and that's used by reference for lookups directly instead of needing to iterate over the list each time.

### Details and comments