### PR TITLE
Avoid unnecessary matrix construction in `Split2qUnitaries`

### DIFF
--- a/crates/accelerate/src/split_2q_unitaries.rs
+++ b/crates/accelerate/src/split_2q_unitaries.rs
@@ -33,15 +33,18 @@ pub fn split_2q_unitaries(
     for node in nodes {
         if let NodeType::Operation(inst) = &dag.dag()[node] {
             let qubits = dag.get_qargs(inst.qubits).to_vec();
-            let matrix = inst.op.matrix(inst.params_view());
             // We only attempt to split UnitaryGate objects, but this could be extended in future
             // -- however we need to ensure that we can compile the resulting single-qubit unitaries
             // to the supported basis gate set.
             if qubits.len() != 2 || inst.op.name() != "unitary" {
                 continue;
             }
+            let matrix = inst
+                .op
+                .matrix(inst.params_view())
+                .expect("'unitary' gates should always have a matrix form");
             let decomp = TwoQubitWeylDecomposition::new_inner(
-                matrix.unwrap().view(),
+                matrix.view(),
                 Some(requested_fidelity),
                 None,
             )?;


### PR DESCRIPTION
### Summary

During the transition of this pass to Rust, the matrix creation was accidentally moved before the check of whether the pass would operate on the node.  This wastes time and allocations on creating matrices that will not be further examined.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


