### PR TITLE
Improve speed of `Pauli.to_label`

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -33,6 +33,8 @@ if TYPE_CHECKING:
 
 # utility for _to_matrix
 _PARITY = np.array([-1 if bin(i).count("1") % 2 else 1 for i in range(256)], dtype=complex)
+# Utility for `_to_label`
+_TO_LABEL_CHARS = np.array([ord("I"), ord("X"), ord("Z"), ord("Y")], dtype=np.uint8)
 
 
 class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
@@ -496,25 +498,15 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
                             the phase ``q`` for the coefficient :math:`(-i)^(q + x.z)`
                             for the label from the full Pauli group.
         """
-        num_qubits = z.size
-        phase = int(phase)
-        coeff_labels = {0: "", 1: "-i", 2: "-", 3: "i"}
-        label = ""
-        for i in range(num_qubits):
-            if not z[num_qubits - 1 - i]:
-                if not x[num_qubits - 1 - i]:
-                    label += "I"
-                else:
-                    label += "X"
-            elif not x[num_qubits - 1 - i]:
-                label += "Z"
-            else:
-                label += "Y"
-                if not group_phase:
-                    phase -= 1
-        phase %= 4
+        # Map each qubit to the {I: 0, X: 1, Z: 2, Y: 3} integer form, then use Numpy advanced
+        # indexing to get a new data buffer which is compatible with an ASCII string label.
+        index = z << 1
+        index += x
+        ascii_label = _TO_LABEL_CHARS[index[::-1]].data.tobytes()
+        phase = (int(phase) if group_phase else int(phase) - ascii_label.count(b"Y")) % 4
+        label = ascii_label.decode("ascii")
         if phase and full_group:
-            label = coeff_labels[phase] + label
+            label = ("", "-i", "-", "i")[phase] + label
         if return_phase:
             return label, phase
         return label

--- a/releasenotes/notes/pauli-label-perf-b704cbcc5ef92794.yaml
+++ b/releasenotes/notes/pauli-label-perf-b704cbcc5ef92794.yaml
@@ -1,0 +1,4 @@
+---
+features_quantum_info:
+  - |
+    The performance of :meth:`.Pauli.to_label` has significantly improved for large Paulis.


### PR DESCRIPTION
### Summary

This uses Numpy vectorised operations and builtin Python tooling to remove Python-space loops from the Pauli label creation.  This is a speed up of around 40x on my 2020 Intel MacBook Pro for most Paulis.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Fix #13355
