### PR TITLE
Avoid iterating over nodes in Split2QUnitaries if there are no unitaries

### DIFF
--- a/crates/accelerate/src/split_2q_unitaries.rs
+++ b/crates/accelerate/src/split_2q_unitaries.rs
@@ -28,6 +28,9 @@ pub fn split_2q_unitaries(
     dag: &mut DAGCircuit,
     requested_fidelity: f64,
 ) -> PyResult<()> {
+    if !dag.get_op_counts().contains_key("unitary") {
+        return Ok(());
+    }
     let nodes: Vec<NodeIndex> = dag.op_nodes(false).collect();
 
     for node in nodes {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a check to the start of the split_2q_unitaries rust function that is the core of the Split2QUnitaries transpiler pass to do a lookup if there are any `UnitaryGate` objects in the dag without iterating over the dag. The pass only will split unitary gates so we can avoid checking the name of each gate individually if we know there aren't any up front.

### Details and comments
