### PR TITLE
Fix type of `basis_gates` in `BasicSimulator` configuration

### DIFF
--- a/qiskit/providers/basic_provider/basic_simulator.py
+++ b/qiskit/providers/basic_provider/basic_simulator.py
@@ -257,7 +257,7 @@ class BasicSimulator(BackendV2):
                 backend_name=self.name,
                 backend_version=self.backend_version,
                 n_qubits=self.num_qubits,
-                basis_gates=self.target.operation_names,
+                basis_gates=list(self.target.operation_names),
                 gates=gates,
                 local=True,
                 simulator=True,

--- a/releasenotes/notes/basicsimulator-config-copy-5ecdfdf161e488f2.yaml
+++ b/releasenotes/notes/basicsimulator-config-copy-5ecdfdf161e488f2.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    For :class:`~.BasicSimulator`, the ``basis_gates`` entry in the
+    configuration instance returned by the ``configuration()`` is now a list
+    rather than a ``dict_keys`` instance, matching the expected type and
+    allowing for configuration instance to be deep copied.


### PR DESCRIPTION
`basis_gates` was getting set to `Target.operation_names`, which is a `dict_keys` instance (maybe that should be changed to a more basic type?), while typically `basis_gates` is a list. `dict_keys` instances can not be deep copied, so code that usually deep copies a backend's configuration could not work. Deep copying the configuration can happen for example when using the `BasicSimulator` with sampler class like `qiskit_ibm_runtime.SamplerV2` that puts the backend into its options and then tries to deep copy the options.