### PR TITLE
Add missing pulse-related deprecation

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -888,6 +888,8 @@ impl DAGCircuit {
     ///
     /// Raises:
     ///     Exception: if the gate is of type string and params is None.
+    ///
+    /// DEPRECATED since Qiskit 1.3.0 and will be removed in Qiskit 2.0.0
     #[pyo3(signature=(gate, qubits, schedule, params=None))]
     fn add_calibration<'py>(
         &mut self,

--- a/qiskit/transpiler/passmanager_config.py
+++ b/qiskit/transpiler/passmanager_config.py
@@ -17,11 +17,13 @@ import warnings
 
 from qiskit.transpiler.coupling import CouplingMap
 from qiskit.transpiler.instruction_durations import InstructionDurations
+from qiskit.utils.deprecate_pulse import deprecate_pulse_arg
 
 
 class PassManagerConfig:
     """Pass Manager Configuration."""
 
+    @deprecate_pulse_arg("inst_map", predicate=lambda inst_map: inst_map is not None)
     def __init__(
         self,
         initial_layout=None,

--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -412,21 +412,28 @@ def generate_preset_pass_manager(
         "qubits_initially_zero": qubits_initially_zero,
     }
 
-    if backend is not None:
-        pm_options["_skip_target"] = _skip_target
-        pm_config = PassManagerConfig.from_backend(backend, **pm_options)
-    else:
-        pm_config = PassManagerConfig(**pm_options)
-    if optimization_level == 0:
-        pm = level_0_pass_manager(pm_config)
-    elif optimization_level == 1:
-        pm = level_1_pass_manager(pm_config)
-    elif optimization_level == 2:
-        pm = level_2_pass_manager(pm_config)
-    elif optimization_level == 3:
-        pm = level_3_pass_manager(pm_config)
-    else:
-        raise ValueError(f"Invalid optimization level {optimization_level}")
+    with warnings.catch_warnings():
+        # inst_map is deprecated in the PassManagerConfig initializer
+        warnings.filterwarnings(
+            "ignore",
+            category=DeprecationWarning,
+            message=".*argument ``inst_map`` is deprecated as of Qiskit 1.3",
+        )
+        if backend is not None:
+            pm_options["_skip_target"] = _skip_target
+            pm_config = PassManagerConfig.from_backend(backend, **pm_options)
+        else:
+            pm_config = PassManagerConfig(**pm_options)
+        if optimization_level == 0:
+            pm = level_0_pass_manager(pm_config)
+        elif optimization_level == 1:
+            pm = level_1_pass_manager(pm_config)
+        elif optimization_level == 2:
+            pm = level_2_pass_manager(pm_config)
+        elif optimization_level == 3:
+            pm = level_3_pass_manager(pm_config)
+        else:
+            raise ValueError(f"Invalid optimization level {optimization_level}")
     return pm
 
 

--- a/releasenotes/notes/deprecate-pulse-package-07a621be1db7fa30.yaml
+++ b/releasenotes/notes/deprecate-pulse-package-07a621be1db7fa30.yaml
@@ -43,8 +43,8 @@ deprecations_transpiler:
       * :class:`~qiskit.transpiler.passes.EchoRZXWeylDecomposition`
   - |
     The `inst_map` argument in :func:`~qiskit.transpiler.generate_preset_pass_manager`,
-    :meth:`~transpiler.target.Target.from_configuration` and :func:`~qiskit.transpiler.preset_passmanagers.common.generate_scheduling`
-    is being deprecated.
+    :meth:`~transpiler.target.Target.from_configuration`, :class:`~qiskit.transpiler.PassManagerConfig` initializer
+    and :func:`~qiskit.transpiler.preset_passmanagers.common.generate_scheduling` is being deprecated.
   - |
     The `calibration` argument in :func:`~qiskit.transpiler.target.InstructionProperties` initializer methods is being
     deprecated.


### PR DESCRIPTION
This commit deprecates `inst_map` in `PassManagerConfig.__init__`. It should have been part of the pulse deprecation PR #13164 but I somehow missed to cover it. We're already in our feature freeze period for version 1.3 but since this is not a new feature but rather an addendum to the pulse deprecation PR  we should squeeze this in as well.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->




