### PR TITLE
Deprecate loose custom basis gates in preset pm pipieline

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -394,9 +394,38 @@ def transpile(  # pylint: disable=too-many-return-statements
     # Edge cases require using the old model (loose constraints) instead of building a target,
     # but we don't populate the passmanager config with loose constraints unless it's one of
     # the known edge cases to control the execution path.
+    # Filter instruction_durations, timing_constraints, backend_properties and inst_map deprecation
     with warnings.catch_warnings():
-        warnings.simplefilter(action="ignore", category=DeprecationWarning)
-        # Filter instruction_durations, timing_constraints and backend_properties deprecation
+        warnings.filterwarnings(
+            "ignore",
+            category=DeprecationWarning,
+            message=".*``inst_map`` is deprecated as of Qiskit 1.3.*",
+            module="qiskit",
+        )
+        warnings.filterwarnings(
+            "ignore",
+            category=DeprecationWarning,
+            message=".*``timing_constraints`` is deprecated as of Qiskit 1.3.*",
+            module="qiskit",
+        )
+        warnings.filterwarnings(
+            "ignore",
+            category=DeprecationWarning,
+            message=".*``instruction_durations`` is deprecated as of Qiskit 1.3.*",
+            module="qiskit",
+        )
+        warnings.filterwarnings(
+            "ignore",
+            category=DeprecationWarning,
+            message=".*``backend_properties`` is deprecated as of Qiskit 1.3.*",
+            module="qiskit",
+        )
+        warnings.filterwarnings(
+            "ignore",
+            category=DeprecationWarning,
+            message=".*``qiskit.transpiler.target.target_to_backend_properties()`` is deprecated as of qiskit 1.2.*",
+            module="qiskit",
+        )
         pm = generate_preset_pass_manager(
             optimization_level,
             target=target,

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -420,12 +420,6 @@ def transpile(  # pylint: disable=too-many-return-statements
             message=".*``backend_properties`` is deprecated as of Qiskit 1.3.*",
             module="qiskit",
         )
-        warnings.filterwarnings(
-            "ignore",
-            category=DeprecationWarning,
-            message=".*``qiskit.transpiler.target.target_to_backend_properties()`` is deprecated as of qiskit 1.2.*",
-            module="qiskit",
-        )
         pm = generate_preset_pass_manager(
             optimization_level,
             target=target,

--- a/qiskit/pulse/instruction_schedule_map.py
+++ b/qiskit/pulse/instruction_schedule_map.py
@@ -169,12 +169,22 @@ class InstructionScheduleMap:
         """
         instruction = _get_instruction_string(instruction)
         if not self.has(instruction, _to_tuple(qubits)):
-            if instruction in self._map:
-                raise PulseError(
-                    f"Operation '{instruction}' exists, but is only defined for qubits "
-                    f"{self.qubits_with_instruction(instruction)}."
+            # TODO: PulseError is deprecated, this code will be removed in 2.0.
+            # In the meantime, we catch the deprecation
+            # warning not to overload users with non-actionable messages
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    category=DeprecationWarning,
+                    message=".*The entire Qiskit Pulse package*",
+                    module="qiskit",
                 )
-            raise PulseError(f"Operation '{instruction}' is not defined for this system.")
+                if instruction in self._map:
+                    raise PulseError(
+                        f"Operation '{instruction}' exists, but is only defined for qubits "
+                        f"{self.qubits_with_instruction(instruction)}."
+                    )
+                raise PulseError(f"Operation '{instruction}' is not defined for this system.")
 
     def get(
         self,

--- a/qiskit/synthesis/unitary/qsd.py
+++ b/qiskit/synthesis/unitary/qsd.py
@@ -251,14 +251,13 @@ def _get_ucry_cz(nqubits, angles):
 
 
 def _apply_a2(circ):
-    from qiskit.compiler import transpile
     from qiskit.quantum_info import Operator
     from qiskit.circuit.library.generalized_gates.unitary import UnitaryGate
+    from qiskit.transpiler.passes.synthesis import HighLevelSynthesis
 
     decomposer = two_qubit_decompose_up_to_diagonal
-    ccirc = transpile(
-        circ, basis_gates=["u", "cx", "qsd2q"], optimization_level=0, qubits_initially_zero=False
-    )
+    hls = HighLevelSynthesis(basis_gates=["u", "cx", "qsd2q"], qubits_initially_zero=False)
+    ccirc = hls(circ)
     ind2q = []
     # collect 2q instrs
     for i, instruction in enumerate(ccirc.data):

--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -446,7 +446,6 @@ def generate_preset_pass_manager(
 
 
 def _parse_basis_gates(basis_gates, backend, inst_map, skip_target):
-    name_mapping = {}
     standard_gates = get_standard_gate_name_mapping()
     # Add control flow gates by default to basis set and name mapping
     default_gates = {"measure", "delay", "reset"}.union(CONTROL_FLOW_OP_NAMES)

--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -526,8 +526,15 @@ def _parse_inst_map(inst_map, backend):
 def _parse_backend_properties(backend_properties, backend):
     # try getting backend_props from user, else backend
     if backend_properties is None and backend is not None:
-        backend_properties = target_to_backend_properties(backend.target)
-    return backend_properties
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+                message=".*``qiskit.transpiler.target.target_to_backend_properties()`` is deprecated as of qiskit 1.2.*",
+                module="qiskit",
+            )
+            backend_properties = target_to_backend_properties(backend.target)
+            return backend_properties
 
 
 def _parse_dt(dt, backend):

--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -343,24 +343,31 @@ def generate_preset_pass_manager(
             # Only parse backend properties when the target isn't skipped to
             # preserve the former behavior of transpile.
             backend_properties = _parse_backend_properties(backend_properties, backend)
-
-            # Build target from constraints.
-            target = Target.from_configuration(
-                basis_gates=basis_gates,
-                num_qubits=backend.num_qubits if backend is not None else None,
-                coupling_map=coupling_map,
-                # If the instruction map has custom gates, do not give as config, the information
-                # will be added to the target with update_from_instruction_schedule_map
-                inst_map=inst_map if inst_map and not inst_map.has_custom_gate() else None,
-                backend_properties=backend_properties,
-                instruction_durations=instruction_durations,
-                concurrent_measurements=(
-                    backend.target.concurrent_measurements if backend is not None else None
-                ),
-                dt=dt,
-                timing_constraints=timing_constraints,
-                custom_name_mapping=name_mapping,
-            )
+            with warnings.catch_warnings():
+                # TODO: inst_map will be removed in 2.0
+                warnings.filterwarnings(
+                    "ignore",
+                    category=DeprecationWarning,
+                    message=".*``inst_map`` is deprecated as of Qiskit 1.3.*",
+                    module="qiskit",
+                )
+                # Build target from constraints.
+                target = Target.from_configuration(
+                    basis_gates=basis_gates,
+                    num_qubits=backend.num_qubits if backend is not None else None,
+                    coupling_map=coupling_map,
+                    # If the instruction map has custom gates, do not give as config, the information
+                    # will be added to the target with update_from_instruction_schedule_map
+                    inst_map=inst_map if inst_map and not inst_map.has_custom_gate() else None,
+                    backend_properties=backend_properties,
+                    instruction_durations=instruction_durations,
+                    concurrent_measurements=(
+                        backend.target.concurrent_measurements if backend is not None else None
+                    ),
+                    dt=dt,
+                    timing_constraints=timing_constraints,
+                    custom_name_mapping=name_mapping,
+                )
 
     # Update target with custom gate information. Note that this is an exception to the priority
     # order (target > loose constraints), added to handle custom gates for scheduling passes.

--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -531,11 +531,11 @@ def _parse_backend_properties(backend_properties, backend):
             warnings.filterwarnings(
                 "ignore",
                 category=DeprecationWarning,
-                message=".*``qiskit.transpiler.target.target_to_backend_properties\\(\\)`` is deprecated as of qiskit 1.2.*",
+                message=".*``qiskit.transpiler.target.target_to_backend_properties\\(\\)``.*",
                 module="qiskit",
             )
             backend_properties = target_to_backend_properties(backend.target)
-            return backend_properties
+    return backend_properties
 
 
 def _parse_dt(dt, backend):

--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -527,10 +527,11 @@ def _parse_backend_properties(backend_properties, backend):
     # try getting backend_props from user, else backend
     if backend_properties is None and backend is not None:
         with warnings.catch_warnings():
+            # filter target_to_backend_properties warning
             warnings.filterwarnings(
                 "ignore",
                 category=DeprecationWarning,
-                message=".*``qiskit.transpiler.target.target_to_backend_properties()`` is deprecated as of qiskit 1.2.*",
+                message=".*``qiskit.transpiler.target.target_to_backend_properties\\(\\)`` is deprecated as of qiskit 1.2.*",
                 module="qiskit",
             )
             backend_properties = target_to_backend_properties(backend.target)

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -1156,9 +1156,16 @@ class Target(BaseTarget):
                     if error is None and duration is None and calibration is None:
                         gate_properties[(qubit,)] = None
                     else:
-                        gate_properties[(qubit,)] = InstructionProperties(
-                            duration=duration, error=error, calibration=calibration
-                        )
+                        with warnings.catch_warnings():
+                            warnings.filterwarnings(
+                                "ignore",
+                                category=DeprecationWarning,
+                                message=".*``calibration`` is deprecated as of Qiskit 1.3.*",
+                                module="qiskit",
+                            )
+                            gate_properties[(qubit,)] = InstructionProperties(
+                                duration=duration, error=error, calibration=calibration
+                            )
                 target.add_instruction(name_mapping[gate], properties=gate_properties, name=gate)
             edges = list(coupling_map.get_edges())
             for gate in two_qubit_gates:
@@ -1198,9 +1205,16 @@ class Target(BaseTarget):
                     if error is None and duration is None and calibration is None:
                         gate_properties[edge] = None
                     else:
-                        gate_properties[edge] = InstructionProperties(
-                            duration=duration, error=error, calibration=calibration
-                        )
+                        with warnings.catch_warnings():
+                            warnings.filterwarnings(
+                                "ignore",
+                                category=DeprecationWarning,
+                                message=".*``calibration`` is deprecated as of Qiskit 1.3.*",
+                                module="qiskit",
+                            )
+                            gate_properties[edge] = InstructionProperties(
+                                duration=duration, error=error, calibration=calibration
+                            )
                 target.add_instruction(name_mapping[gate], properties=gate_properties, name=gate)
             for gate in global_ideal_variable_width_gates:
                 target.add_instruction(name_mapping[gate], name=gate)

--- a/releasenotes/notes/deprecate-custom-basis-gates-transpile-e4b5893377f23acb.yaml
+++ b/releasenotes/notes/deprecate-custom-basis-gates-transpile-e4b5893377f23acb.yaml
@@ -1,0 +1,17 @@
+---
+deprecations_transpiler:
+  - |
+    Providing custom gates through the ``basis_gates`` argument is deprecated 
+    for both :func:`.transpile` and :func:`generate_preset_pass_manager`, this functionality
+    will be removed in Qiskit 2.0. Custom gates are still supported in the :class:`.Target` model,
+    and can be provided through the ``target`` argument. One can build a :class:`.Target` instance
+    from scratch or use the :meth:`.Target.from_configuration` method with the ``custom_name_mapping`` 
+    argument. For example::
+        from qiskit.circuit.library import XGate
+        from qiskit.transpiler.target import Target
+        
+        basis_gates = ["my_x", "cx"]
+        custom_name_mapping = {"my_x": XGate()}
+        target = Target.from_configuration(
+            basis_gates=basis_gates, num_qubits=2, custom_name_mapping=custom_name_mapping
+        )

--- a/releasenotes/notes/deprecate-custom-basis-gates-transpile-e4b5893377f23acb.yaml
+++ b/releasenotes/notes/deprecate-custom-basis-gates-transpile-e4b5893377f23acb.yaml
@@ -7,6 +7,7 @@ deprecations_transpiler:
     and can be provided through the ``target`` argument. One can build a :class:`.Target` instance
     from scratch or use the :meth:`.Target.from_configuration` method with the ``custom_name_mapping`` 
     argument. For example::
+    
         from qiskit.circuit.library import XGate
         from qiskit.transpiler.target import Target
         

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -3797,13 +3797,26 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
                 DeprecationWarning,
                 expected_regex="The `target` parameter should be used instead",
             ):
-                transpile(
-                    qc,
-                    self.backend,
-                    layout_method="trivial",
-                    routing_method=routing_method,
-                    seed_transpiler=42,
-                )
+                if routing_method == "stochastic":
+                    with self.assertWarnsRegex(
+                        DeprecationWarning,
+                        expected_regex="The StochasticSwap transpilation pass is a suboptimal",
+                    ):
+                        transpile(
+                            qc,
+                            self.backend,
+                            layout_method="trivial",
+                            routing_method=routing_method,
+                            seed_transpiler=42,
+                        )
+                else:
+                    transpile(
+                        qc,
+                        self.backend,
+                        layout_method="trivial",
+                        routing_method=routing_method,
+                        seed_transpiler=42,
+                    )
 
     @data("stochastic")
     def test_triple_circuit_invalid_layout_stochastic(self, routing_method):
@@ -3842,13 +3855,26 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
         qc.cy(20, 29)
         qc.measure_all()
         with self.assertRaises(TranspilerError):
-            transpile(
-                qc,
-                self.backend,
-                layout_method="trivial",
-                routing_method=routing_method,
-                seed_transpiler=42,
-            )
+            if routing_method == "stochastic":
+                with self.assertWarnsRegex(
+                    DeprecationWarning,
+                    expected_regex="The StochasticSwap transpilation pass is a suboptimal",
+                ):
+                    transpile(
+                        qc,
+                        self.backend,
+                        layout_method="trivial",
+                        routing_method=routing_method,
+                        seed_transpiler=42,
+                    )
+            else:
+                transpile(
+                    qc,
+                    self.backend,
+                    layout_method="trivial",
+                    routing_method=routing_method,
+                    seed_transpiler=42,
+                )
 
     # Lookahead swap skipped for performance reasons, stochastic moved to new test due to deprecation
     @data("sabre", "basic")

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -161,7 +161,11 @@ class TestPresetPassManager(QiskitTestCase):
         qc = QuantumCircuit(2)
         qc.unitary(random_unitary(4, seed=42), [0, 1])
         qc.measure_all()
-        result = transpile(qc, basis_gates=["cx", "u", "unitary"], optimization_level=level)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            "Providing custom gates through the ``basis_gates`` argument is deprecated",
+        ):
+            result = transpile(qc, basis_gates=["cx", "u", "unitary"], optimization_level=level)
         self.assertEqual(result, qc)
 
     @combine(level=[0, 1, 2, 3], name="level{level}")
@@ -179,12 +183,16 @@ class TestPresetPassManager(QiskitTestCase):
         qc = QuantumCircuit(2)
         qc.unitary(random_unitary(4, seed=424242), [0, 1])
         qc.measure_all()
-        result = transpile(
-            qc,
-            basis_gates=["cx", "u", "unitary"],
-            optimization_level=level,
-            translation_method="synthesis",
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            "Providing custom gates through the ``basis_gates`` argument is deprecated",
+        ):
+            result = transpile(
+                qc,
+                basis_gates=["cx", "u", "unitary"],
+                optimization_level=level,
+                translation_method="synthesis",
+            )
         self.assertEqual(result, qc)
 
     @combine(level=[0, 1, 2, 3], name="level{level}")

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -1735,3 +1735,40 @@ class TestIntegrationControlFlow(QiskitTestCase):
             pass
         with self.assertRaisesRegex(TranspilerError, "The control-flow construct.*not supported"):
             transpile(qc, target=target, optimization_level=optimization_level)
+
+    @data(0, 1, 2, 3)
+    def test_custom_basis_gates_raise(self, optimization_level):
+        """Test that trying to provide a list of custom basis gates to generate_preset_pass_manager
+        raises a deprecation warning."""
+
+        with self.subTest(msg="no warning"):
+            # check that the warning isn't raised if the basis gates aren't custom
+            basis_gates = ["x", "cx"]
+            _ = generate_preset_pass_manager(
+                optimization_level=optimization_level, basis_gates=basis_gates
+            )
+
+        with self.subTest(msg="warning only basis gates"):
+            # check that the warning is raised if they are custom
+            basis_gates = ["my_gate"]
+            with self.assertWarnsRegex(
+                DeprecationWarning,
+                "Providing custom gates through the ``basis_gates`` argument is deprecated",
+            ):
+                _ = generate_preset_pass_manager(
+                    optimization_level=optimization_level, basis_gates=basis_gates
+                )
+
+        with self.subTest(msg="no warning custom basis gates in backend"):
+            # check that the warning is not raised if a loose custom gate is found in the backend
+            backend = GenericBackendV2(num_qubits=2)
+            gate = Gate(name="my_gate", num_qubits=1, params=[])
+            backend.target.add_instruction(gate)
+            self.assertEqual(
+                backend.operation_names,
+                ["cx", "id", "rz", "sx", "x", "reset", "delay", "measure", "my_gate"],
+            )
+            basis_gates = ["my_gate"]
+            _ = generate_preset_pass_manager(
+                optimization_level=optimization_level, basis_gates=basis_gates, backend=backend
+            )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR is a spinoff of #12850 that introduces the deprecation warning for loose custom basis gates as an input to transpile/generate_preset_pm. This is a pre-requisite for eventually merging #12850. Moving forward, users can still provide custom basis gates but they need to be included as part of a `Target` instance.


### Details and comments
The PR also modifies a few oversights found in `generate_preset_pass_manager` that didn't have user impact but should be corrected to set the stage for a target-only pipeline:

- we were "over-skipping" the target by having a condition with an `or` instead of an `and` (fixed in L453/466)
- control flow ops were not included by default in the custom name mapping (this would raise a warning if control flow ops were provided as loose basis gates). This didn't cause issues because the target was often skipped with the previous oversight.

