### PR TITLE
Fix ``CommutationChecker`` for comparison with rotation gates on angles $k\pi$

### DIFF
--- a/crates/accelerate/src/commutation_checker.rs
+++ b/crates/accelerate/src/commutation_checker.rs
@@ -43,6 +43,8 @@ static SUPPORTED_OP: Lazy<HashSet<&str>> = Lazy::new(|| {
     ])
 });
 
+const TWOPI: f64 = 2.0 * std::f64::consts::PI;
+
 // map rotation gates to their generators, or to ``None`` if we cannot currently efficiently
 // represent the generator in Rust and store the commutation relation in the commutation dictionary
 static SUPPORTED_ROTATIONS: Lazy<HashMap<&str, Option<OperationRef>>> = Lazy::new(|| {
@@ -632,7 +634,7 @@ fn map_rotation<'a>(
         // commute with everything, and we simply return the operation with the flag that
         // it commutes trivially
         if let Param::Float(angle) = params[0] {
-            if (angle % std::f64::consts::PI).abs() < tol {
+            if (angle % TWOPI).abs() < tol {
                 return (op, params, true);
             };
         };


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #13302 a mistake creeped in, accidentally stating that rotation gates commute for angles that are multiples of $\pi$ instead of $2\pi$. I would've expected this to break somewhere in the test suite, now explicit tests are added. No reno as this is not yet released.
