### PR TITLE
Fix clippy issues flagged by latest rust version

### DIFF
--- a/crates/accelerate/src/circuit_library/pauli_evolution.rs
+++ b/crates/accelerate/src/circuit_library/pauli_evolution.rs
@@ -254,12 +254,7 @@ pub fn py_pauli_evolution(
         |(((i, pauli), qubits), time)| {
             let as_packed = pauli_evolution(pauli, qubits, time, false, do_fountain).map(
                 |(gate, params, qubits)| -> PyResult<Instruction> {
-                    Ok((
-                        gate.into(),
-                        params,
-                        Vec::from_iter(qubits.into_iter()),
-                        Vec::new(),
-                    ))
+                    Ok((gate.into(), params, Vec::from_iter(qubits), Vec::new()))
                 },
             );
 
@@ -294,7 +289,7 @@ pub fn py_pauli_evolution(
 ///     q_3: ┤ X ├──■───────
 ///          └─┬─┘
 ///     q_4: ──■────────────
-///     
+///
 fn cx_chain(
     active_paulis: Vec<(char, Qubit)>,
 ) -> Box<dyn DoubleEndedIterator<Item = StandardInstruction>> {
@@ -308,17 +303,17 @@ fn cx_chain(
 
 /// Build a CX fountain over the active qubits. E.g. with q_1 inactive, this would return
 ///
-////         ┌───┐┌───┐┌───┐
-////    q_0: ┤ X ├┤ X ├┤ X ├
-////         └─┬─┘└─┬─┘└─┬─┘
-////    q_1: ──┼────┼────┼──
-////           │    │    │
-////    q_2: ──■────┼────┼──
-////                │    │
-////    q_3: ───────■────┼──
-////                     │
-////    q_4: ────────────■──
-///     
+///         ┌───┐┌───┐┌───┐
+///    q_0: ┤ X ├┤ X ├┤ X ├
+///         └─┬─┘└─┬─┘└─┬─┘
+///    q_1: ──┼────┼────┼──
+///           │    │    │
+///    q_2: ──■────┼────┼──
+///                │    │
+///    q_3: ───────■────┼──
+///                     │
+///    q_4: ────────────■──
+///
 fn cx_fountain(
     active_paulis: Vec<(char, Qubit)>,
 ) -> Box<dyn DoubleEndedIterator<Item = StandardInstruction>> {

--- a/crates/accelerate/src/synthesis/evolution/pauli_network.rs
+++ b/crates/accelerate/src/synthesis/evolution/pauli_network.rs
@@ -15,7 +15,6 @@ use crate::synthesis::clifford::greedy_synthesis::resynthesize_clifford_circuit;
 use pyo3::prelude::*;
 use pyo3::types::{PyList, PyString, PyTuple};
 use smallvec::{smallvec, SmallVec};
-use std::borrow::Borrow;
 
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::operations::{multiply_param, radd_param, Param, StandardGate};
@@ -334,7 +333,7 @@ pub fn pauli_network_synthesis_inner(
     // go over the input pauli network and extract a list of pauli rotations and
     // the corresponding rotation angles
     for item in pauli_network {
-        let tuple = item.downcast::<PyTuple>()?.borrow();
+        let tuple = item.downcast::<PyTuple>()?;
 
         let sparse_pauli: String = tuple.get_item(0)?.downcast::<PyString>()?.extract()?;
         let qubits: Vec<u32> = tuple.get_item(1)?.extract()?;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes 2 issues flagged by running by clippy with Rust 1.82. We run clippy in CI with Qiskit's MSRV of 1.70, as sometimes clippy will flag failures for not using a syntax which isn't compatible with the MSRV. These issues flagged here are real, and good to fix, especially the docstring one, the `////` comment isn't a docstring and that excludes the circuit diagram from the docs which wasn't the intent there.

### Details and comments
