### PR TITLE
Fix filesystem case sensitivity issue with IQP docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,6 +120,14 @@ autosummary_generate_overwrite = False
 napoleon_google_docstring = True
 napoleon_numpy_docstring = False
 
+# Autosummary generates stub filenames based on the import name.
+# Sometimes, two distinct interfaces only differ in capitalization; this
+# creates a problem on case-insensitive OS/filesystems like macOS. So,
+# we manually avoid the clash by renaming one of the files.
+autosummary_filename_map = {
+    "qiskit.circuit.library.iqp": "qiskit.circuit.library.iqp_function",
+}
+
 
 # ----------------------------------------------------------------------------------
 # Doctest


### PR DESCRIPTION
This is breaking the documentation on macOS for the 1.3.0rc1 release because `qiskit.circuit.library.iqp` and `qiskit.circuit.library.IQP` are ambiguous on case-insensitive operating systems.

I renamed `qiskit.circuit.library.iqp` because that is the old API and I don't want to break the stable URL `qiskit.circuit.library.IQP`.