### PR TITLE
HLS fix to not synthesize instructions already supported

### DIFF
--- a/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
@@ -25,6 +25,7 @@ import numpy as np
 from qiskit.circuit.annotated_operation import Modifier
 from qiskit.circuit.operation import Operation
 from qiskit.circuit.instruction import Instruction
+from qiskit.circuit.controlflow import CONTROL_FLOW_OP_NAMES
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -813,7 +814,10 @@ class HighLevelSynthesis(TransformationPass):
             dag._has_calibration_for(node)
             or len(node.qargs) < self._min_qubits
             or node.is_directive()
-            or self._instruction_supported(node.name, qubits)
+            or (
+                self._instruction_supported(node.name, qubits)
+                and node.name not in CONTROL_FLOW_OP_NAMES
+            )
         ):
             return True
 

--- a/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
@@ -25,7 +25,6 @@ import numpy as np
 from qiskit.circuit.annotated_operation import Modifier
 from qiskit.circuit.operation import Operation
 from qiskit.circuit.instruction import Instruction
-from qiskit.circuit.controlflow import CONTROL_FLOW_OP_NAMES
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -814,10 +813,7 @@ class HighLevelSynthesis(TransformationPass):
             dag._has_calibration_for(node)
             or len(node.qargs) < self._min_qubits
             or node.is_directive()
-            or (
-                self._instruction_supported(node.name, qubits)
-                and node.name not in CONTROL_FLOW_OP_NAMES
-            )
+            or (self._instruction_supported(node.name, qubits) and not node.is_control_flow())
         ):
             return True
 

--- a/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
@@ -813,6 +813,7 @@ class HighLevelSynthesis(TransformationPass):
             dag._has_calibration_for(node)
             or len(node.qargs) < self._min_qubits
             or node.is_directive()
+            or self._instruction_supported(node.name, qubits)
         ):
             return True
 
@@ -830,15 +831,12 @@ class HighLevelSynthesis(TransformationPass):
             # If all the above constraints hold, and it's already supported or the basis translator
             # can handle it, we'll leave it be.
             and (
-                self._instruction_supported(node.name, qubits)
                 # This uses unfortunately private details of `EquivalenceLibrary`, but so does the
                 # `BasisTranslator`, and this is supposed to just be temporary til this is moved
                 # into Rust space.
-                or (
-                    self._equiv_lib is not None
-                    and equivalence.Key(name=node.name, num_qubits=node.num_qubits)
-                    in self._equiv_lib.keys()
-                )
+                self._equiv_lib is not None
+                and equivalence.Key(name=node.name, num_qubits=node.num_qubits)
+                in self._equiv_lib.keys()
             )
         )
 

--- a/releasenotes/notes/fix-hls-supported-instructions-0d80ea33b3d2257b.yaml
+++ b/releasenotes/notes/fix-hls-supported-instructions-0d80ea33b3d2257b.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Previously the :class:`.HighLevelSynthesis` transpiler pass synthesized an
+    instruction for which a synthesis plugin is available, regardless of
+    whether the instruction is already supported by the target or a part of
+    the explicitly passed ``basis_gates``. This behavior is now fixed, so that
+    such already supported instructions are no longer synthesized.

--- a/test/python/transpiler/test_high_level_synthesis.py
+++ b/test/python/transpiler/test_high_level_synthesis.py
@@ -669,7 +669,7 @@ class TestHighLevelSynthesisInterface(QiskitTestCase):
         """Test that a gate is not synthesized when it belongs to basis_gates,
         regardless of whether there is a plugin method available.
 
-        See: https://github.com/Qiskit/qiskit-terra/issues/13412 for more
+        See: https://github.com/Qiskit/qiskit/issues/13412 for more
         details.
         """
         qc = QAOAAnsatz(SparsePauliOp("Z"), initial_state=QuantumCircuit(1))

--- a/test/python/transpiler/test_high_level_synthesis.py
+++ b/test/python/transpiler/test_high_level_synthesis.py
@@ -46,6 +46,7 @@ from qiskit.circuit.library import (
     IGate,
     MCXGate,
     SGate,
+    QAOAAnsatz,
 )
 from qiskit.circuit.library import LinearFunction, PauliEvolutionGate
 from qiskit.quantum_info import Clifford, Operator, Statevector, SparsePauliOp
@@ -663,6 +664,18 @@ class TestHighLevelSynthesisInterface(QiskitTestCase):
         with self.subTest("unrolled w/ basis gates"):
             out = hls(circuit)
             self.assertEqual(out.count_ops(), {"u": 1})
+
+    def test_both_basis_gates_and_plugin_specified(self):
+        """Test that a gate is not synthesized when it belongs to basis_gates,
+        regardless of whether there is a plugin method available.
+
+        See: https://github.com/Qiskit/qiskit-terra/issues/13412 for more
+        details.
+        """
+        qc = QAOAAnsatz(SparsePauliOp("Z"), initial_state=QuantumCircuit(1))
+        pm = PassManager([HighLevelSynthesis(basis_gates=["PauliEvolution"])])
+        qct = pm.run(qc)
+        self.assertEqual(qct.count_ops()["PauliEvolution"], 2)
 
 
 class TestPMHSynthesisLinearFunctionPlugin(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #13412. 

Needs to be backported to 1.3.0.


### Details and comments

Previously `HighLevelSynthesis` synthesized an instruction for which a synthesis plugin was available, even when the instruction was already considered supported (either supported by the target or a part of `basis_gates`). This commit fixes this behavior. 
Update: the control-flow operations (e.g. `for-loop`) belong to `basis_gates` but need to be recursively synthesized. 

Even though the problem was only discovered for "PauliEvolution" gates also added for 1.3, the incorrect behavior for other high-level gates existed before, so I added release notes. I was not sure if they should be under `releasenotes/notes/1.3` or not.