### PR TITLE
Adding new arithmetic gates to toctree 

### DIFF
--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -221,10 +221,10 @@ or of a set of qubit states.
    OrGate
    XOR
    BitwiseXorGate
+   random_bitwise_xor
    InnerProduct
    InnerProductGate
 
-.. autofunction:: random_bitwise_xor
 
 Basis Change Circuits
 =====================

--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -36,7 +36,7 @@ For example, to append a multi-controlled CNOT:
    circuit.append(gate, [0, 1, 4, 2, 3])
    circuit.draw('mpl')
 
-The library is organized in several sections. The function 
+The library is organized in several sections. The function
 :func:`.get_standard_gate_name_mapping` allows you to see the available standard gates and operations.
 
 .. autofunction:: get_standard_gate_name_mapping
@@ -280,6 +280,9 @@ Adders
    CDKMRippleCarryAdder
    VBERippleCarryAdder
    WeightedAdder
+   ModularAdderGate
+   HalfAdderGate
+   FullAdderGate
 
 Multipliers
 -----------
@@ -290,6 +293,7 @@ Multipliers
 
    HRSCumulativeMultiplier
    RGQFTMultiplier
+   MultiplierGate
 
 Comparators
 -----------
@@ -386,7 +390,7 @@ They are heavily used in near-term algorithms in e.g. Chemistry, Physics or Opti
 Data encoding circuits
 ======================
 
-The following functions return a parameterized :class:`.QuantumCircuit` to use as data 
+The following functions return a parameterized :class:`.QuantumCircuit` to use as data
 encoding circuits in a series of variational quantum algorithms:
 
 .. autosummary::

--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -325,29 +325,40 @@ Other arithmetic functions
 Particular Quantum Circuits
 ===========================
 
+The following gates and quantum circuits define specific
+quantum circuits of interest:
+
 .. autosummary::
    :toctree: ../stubs/
    :template: autosummary/class_no_inherited_members.rst
 
    FourierChecking
-   fourier_checking
    GraphState
    GraphStateGate
    HiddenLinearFunction
-   hidden_linear_function
    IQP
-   iqp
-   random_iqp
    QuantumVolume
-   quantum_volume
    PhaseEstimation
-   phase_estimation
    GroverOperator
-   grover_operator
    PhaseOracle
    PauliEvolutionGate
    HamiltonianGate
    UnitaryOverlap
+
+For circuits that have a well-defined structure it is preferrable
+to use the following functions to construct them:
+
+.. autosummary::
+   :toctree: ../stubs/
+   :template: autosummary/class_no_inherited_members.rst
+
+   fourier_checking
+   hidden_linear_function
+   iqp
+   random_iqp
+   quantum_volume
+   phase_estimation
+   grover_operator
    unitary_overlap
 
 
@@ -412,6 +423,17 @@ data in quantum states and are used as feature maps for classification.
    PauliFeatureMap
    ZFeatureMap
    ZZFeatureMap
+
+
+Data preparation circuits
+=========================
+
+The following operations are used for state preparation:
+
+.. autosummary::
+   :toctree: ../stubs/
+   :template: autosummary/class_no_inherited_members.rst
+
    StatePreparation
    Initialize
 

--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -366,6 +366,7 @@ a broad set of variational quantum algorithms:
    real_amplitudes
    pauli_two_design
    excitation_preserving
+   qaoa_ansatz
    hamiltonian_variational_ansatz
    evolved_operator_ansatz
 

--- a/qiskit/circuit/library/arithmetic/adders/adder.py
+++ b/qiskit/circuit/library/arithmetic/adders/adder.py
@@ -21,7 +21,7 @@ from qiskit.utils.deprecation import deprecate_func
 class Adder(QuantumCircuit):
     r"""Compute the sum of two equally sized qubit registers.
 
-    For two registers :math:`|a\rangle_n` and :math:|b\rangle_n` with :math:`n` qubits each, an
+    For two registers :math:`|a\rangle_n` and :math:`|b\rangle_n` with :math:`n` qubits each, an
     adder performs the following operation
 
     .. math::
@@ -74,7 +74,7 @@ class Adder(QuantumCircuit):
 class HalfAdderGate(Gate):
     r"""Compute the sum of two equally-sized qubit registers, including a carry-out bit.
 
-    For two registers :math:`|a\rangle_n` and :math:|b\rangle_n` with :math:`n` qubits each, an
+    For two registers :math:`|a\rangle_n` and :math:`|b\rangle_n` with :math:`n` qubits each, an
     adder performs the following operation
 
     .. math::
@@ -120,7 +120,7 @@ class HalfAdderGate(Gate):
 class ModularAdderGate(Gate):
     r"""Compute the sum modulo :math:`2^n` of two :math:`n`-sized qubit registers.
 
-    For two registers :math:`|a\rangle_n` and :math:|b\rangle_n` with :math:`n` qubits each, an
+    For two registers :math:`|a\rangle_n` and :math:`|b\rangle_n` with :math:`n` qubits each, an
     adder performs the following operation
 
     .. math::
@@ -166,7 +166,7 @@ class ModularAdderGate(Gate):
 class FullAdderGate(Gate):
     r"""Compute the sum of two :math:`n`-sized qubit registers, including carry-in and -out bits.
 
-    For two registers :math:`|a\rangle_n` and :math:|b\rangle_n` with :math:`n` qubits each, an
+    For two registers :math:`|a\rangle_n` and :math:`|b\rangle_n` with :math:`n` qubits each, an
     adder performs the following operation
 
     .. math::

--- a/qiskit/circuit/library/arithmetic/adders/adder.py
+++ b/qiskit/circuit/library/arithmetic/adders/adder.py
@@ -171,7 +171,7 @@ class FullAdderGate(Gate):
 
     .. math::
 
-        |c_{\text{in}\rangle_1 |a\rangle_n |b\rangle_n
+        |c_{\text{in}}\rangle_1 |a\rangle_n |b\rangle_n
         \mapsto |a\rangle_n |c_{\text{in}} + a + b \rangle_{n + 1}.
 
     The quantum register :math:`|a\rangle_n` (and analogously :math:`|b\rangle_n`)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Addresses #13407.

Should be backported to 1.3.

These fixes the docstrings for arithmetic gates and adds these gates to the toctree.

### Details and comments


