### PR TITLE
Fix twirling asv benchmark

### DIFF
--- a/test/benchmarks/manipulate.py
+++ b/test/benchmarks/manipulate.py
@@ -17,7 +17,8 @@
 import os
 
 from qiskit import QuantumCircuit
-from qiskit.circuit import twirl_circuit
+
+from qiskit.circuit import pauli_twirl_2q_gates
 from qiskit.passmanager import PropertySet
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from .utils import multi_control_circuit
@@ -38,7 +39,7 @@ class TestCircuitManipulate:
         """Perform Pauli-twirling on a 100Q QV
         circuit
         """
-        out = twirl_circuit(self.dtc_qc, seed=12345678942)
+        out = pauli_twirl_2q_gates(self.dtc_qc, seed=12345678942)
         return out
 
     def time_multi_control_decompose(self):

--- a/test/benchmarks/manipulate.py
+++ b/test/benchmarks/manipulate.py
@@ -17,7 +17,6 @@
 import os
 
 from qiskit import QuantumCircuit
-
 from qiskit.circuit import pauli_twirl_2q_gates
 from qiskit.passmanager import PropertySet
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Since #13331 merged the nightly asv runs have been failing. This is because the asv twirling benchmark code was updated in that PR to use the new twirling function instead of the embedded equivalent. However, in the PR the name of that function was renamed from twirl_circuit to pauli_twirl_2q_gates during the development of the feature. This rename was missed in the asv benchmark, and as nothing executes the asv code in CI this went uncaught until the asv nightly runs. This commit fixes this oversight and updates the function name to the correct name so that the asv benchmarks no longer fail on import.

### Details and comments


