### PR TITLE
Avoid overhead for synthesized nodes lookup

### DIFF
--- a/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
@@ -382,7 +382,7 @@ class HighLevelSynthesis(TransformationPass):
 
             # If the synthesis changed the operation (i.e. it is not None), store the result.
             if synthesized is not None:
-                synthesized_nodes[node] = (synthesized, synthesized_context)
+                synthesized_nodes[node._node_id] = (synthesized, synthesized_context)
 
             # If the synthesis did not change anything, just update the qubit tracker.
             elif not processed:
@@ -407,8 +407,9 @@ class HighLevelSynthesis(TransformationPass):
         outer_to_local = context.to_local_mapping()
 
         for node in dag.topological_op_nodes():
-            if node in synthesized_nodes:
-                op, op_context = synthesized_nodes[node]
+
+            if op_tuple := synthesized_nodes.get(node._node_id, None):
+                op, op_context = op_tuple
 
                 if isinstance(op, Operation):
                     out.apply_operation_back(op, node.qargs, node.cargs)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

After #12550 a hash implementation was added to the implementation of DAGOpNode to be able to have identical instances of dag nodes used be usable in a set or dict. This is because after #12550 changed the DAGCircuit so the DAGOpNode instances were just a python view of the data contained in the nodes of a dag. While prior to #12550 the actual DAGOpNode objects were returned by reference from DAG methods. However, this hash implementation has additional overhead compared to the object identity based version used before. This has caused a regression in some cases for high level synthesis when it's checking for nodes it's already synthesized. This commit addresses this by changing the dict key to be the node id instead of the node object. The integer hashing is significantly faster than the object hashing.

### Details and comments