### PR TITLE
Fix process-based non-determinism in `SparsePauliOp.to_matrix`

### DIFF
--- a/crates/accelerate/src/sparse_pauli_op.rs
+++ b/crates/accelerate/src/sparse_pauli_op.rs
@@ -20,6 +20,7 @@ use numpy::prelude::*;
 use numpy::{PyArray1, PyArray2, PyReadonlyArray1, PyReadonlyArray2, PyUntypedArrayMethods};
 
 use hashbrown::HashMap;
+use indexmap::IndexMap;
 use ndarray::{s, ArrayView1, ArrayView2, Axis};
 use num_complex::Complex64;
 use num_traits::Zero;
@@ -298,7 +299,7 @@ impl MatrixCompressedPaulis {
     /// explicitly stored operations, if there are duplicates.  After the summation, any terms that
     /// have become zero are dropped.
     pub fn combine(&mut self) {
-        let mut hash_table = HashMap::<(u64, u64), Complex64>::with_capacity(self.coeffs.len());
+        let mut hash_table = IndexMap::<(u64, u64), Complex64>::with_capacity(self.coeffs.len());
         for (key, coeff) in self
             .x_like
             .drain(..)

--- a/crates/accelerate/src/sparse_pauli_op.rs
+++ b/crates/accelerate/src/sparse_pauli_op.rs
@@ -10,6 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use ahash::RandomState;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
@@ -299,7 +300,11 @@ impl MatrixCompressedPaulis {
     /// explicitly stored operations, if there are duplicates.  After the summation, any terms that
     /// have become zero are dropped.
     pub fn combine(&mut self) {
-        let mut hash_table = IndexMap::<(u64, u64), Complex64>::with_capacity(self.coeffs.len());
+        let mut hash_table =
+            IndexMap::<(u64, u64), Complex64, RandomState>::with_capacity_and_hasher(
+                self.coeffs.len(),
+                RandomState::new(),
+            );
         for (key, coeff) in self
             .x_like
             .drain(..)

--- a/releasenotes/notes/spo-to-matrix-determinism-554389d6fc98627c.yaml
+++ b/releasenotes/notes/spo-to-matrix-determinism-554389d6fc98627c.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a per-process based non-determinism in `SparsePauliOp.to_matrix`.  The exact order of the
+    floating-point operations in the summation would previously vary per process, but will now be
+    identical between different invocations of the same script.  See `#13413 <https://github.com/Qiskit/qiskit/issues/13413>`__.


### PR DESCRIPTION
### Summary

The simplification step of the summed Pauli terms in `SparsePauliOp.to_matrix` had introduced a non-determinism via hash-map iteration.  In practice, the base hash seed was set per initialisation of the extension module, then stayed the same.  This is hard to detect from within tests, but caused unexpected numerical behaviour on different invocations of the same script.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

This fixes the bug part of #13413, but doesn't address the feature request.  It should be eligible for backport to either 1.3.0 or 1.3.1, depending on whether there's time to make 1.3.0.

Writing a test that would exercise this would be pretty complex, so I haven't done it.  I can if we feel strongly about it - we'd likely embed a little script into a test and spawn some `sys.executable` instances to run it and check the outputs all matched bit-for-bit.