### PR TITLE
Fix post-oxidization change in `ConsolidateBlocks` behavior 

### DIFF
--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -12,9 +12,11 @@
 
 """Replace each block of consecutive gates by a single Unitary node."""
 from __future__ import annotations
+from math import pi
 
 from qiskit.synthesis.two_qubit import TwoQubitBasisDecomposer
-from qiskit.circuit.library.standard_gates import CXGate, CZGate, iSwapGate, ECRGate
+from qiskit.circuit.library.standard_gates import CXGate, CZGate, iSwapGate, ECRGate, RXXGate
+
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.passmanager import PassManager
 from qiskit._accelerate.consolidate_blocks import consolidate_blocks
@@ -27,6 +29,7 @@ KAK_GATE_NAMES = {
     "cz": CZGate(),
     "iswap": iSwapGate(),
     "ecr": ECRGate(),
+    "rxx": RXXGate(pi / 2),
 }
 
 
@@ -70,7 +73,6 @@ class ConsolidateBlocks(TransformationPass):
         if basis_gates is not None:
             self.basis_gates = set(basis_gates)
         self.force_consolidate = force_consolidate
-
         if kak_basis_gate is not None:
             self.decomposer = TwoQubitBasisDecomposer(kak_basis_gate)
         elif basis_gates is not None:

--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -81,6 +81,10 @@ class ConsolidateBlocks(TransformationPass):
                 self.decomposer = TwoQubitBasisDecomposer(
                     KAK_GATE_NAMES[kak_gates.pop()], basis_fidelity=approximation_degree or 1.0
                 )
+            elif "rzx" in basis_gates:
+                self.decomposer = TwoQubitBasisDecomposer(
+                    CXGate(), basis_fidelity=approximation_degree or 1.0
+                )
             else:
                 self.decomposer = None
         else:

--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -80,7 +80,7 @@ class ConsolidateBlocks(TransformationPass):
                     KAK_GATE_NAMES[kak_gates.pop()], basis_fidelity=approximation_degree or 1.0
                 )
             else:
-                self.decomposer = TwoQubitBasisDecomposer(CXGate())
+                self.decomposer = None
         else:
             self.decomposer = TwoQubitBasisDecomposer(CXGate())
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes the behavioral difference introduced by #13368 that caused #13438. 

The original implementation of the pass used to set the `ConsolidateBlocks` internal decomposer calling `unitary_synthesis._decomposer_2q_from_basis_gates`, which, when `kak_basis` wasn't found, would return `None`. During the oxidization efforts, `unitary_synthesis._decomposer_2q_from_basis_gates` was replaced with inline code that didn't contemplate this path (always set a default decomposer), which in the reproducing example led to a longer output circuit (the gates were collected into a unitary block and then decomposed differently).

### Details and comments
Technically not a bugfix because the change wasn't released yet.

Using the example shown in the issue ->

`ConsolidateBlocks` output dag with 1.2.4:
![image](https://github.com/user-attachments/assets/d3d297fd-fc76-41f6-9ece-68d252596ad6)

`ConsolidateBlocks` output dag with 1.3.0rc1:
![image](https://github.com/user-attachments/assets/b56ab05e-e9ae-4f16-a730-944ebd491938)

`ConsolidateBlocks` output dag after this fix:
![image](https://github.com/user-attachments/assets/d3d297fd-fc76-41f6-9ece-68d252596ad6)
