### PR TITLE
Uppercase `Qiskit` in deprecation warnings

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -414,7 +414,7 @@ impl DAGCircuit {
                 py,
                 concat!(
                     "The property ``qiskit.dagcircuit.dagcircuit.DAGCircuit.duration`` is ",
-                    "deprecated as of qiskit 1.3.0. It will be removed in Qiskit 2.0.0.",
+                    "deprecated as of Qiskit 1.3.0. It will be removed in Qiskit 2.0.0.",
                 )
             ),
             py.get_type_bound::<PyDeprecationWarning>(),
@@ -433,7 +433,7 @@ impl DAGCircuit {
                 py,
                 concat!(
                     "The property ``qiskit.dagcircuit.dagcircuit.DAGCircuit.unit`` is ",
-                    "deprecated as of qiskit 1.3.0. It will be removed in Qiskit 2.0.0.",
+                    "deprecated as of Qiskit 1.3.0. It will be removed in Qiskit 2.0.0.",
                 )
             ),
             py.get_type_bound::<PyDeprecationWarning>(),
@@ -7039,7 +7039,7 @@ fn emit_pulse_dependency_deprecation(py: Python, msg: &str) {
         PyString::new_bound(
             py,
             &format!(
-                "The {} is deprecated as of qiskit 1.3.0. It will be removed in Qiskit 2.0.0. \
+                "The {} is deprecated as of Qiskit 1.3.0. It will be removed in Qiskit 2.0.0. \
                 The entire Qiskit Pulse package is being deprecated \
                 and this is a dependency on the package.",
                 msg

--- a/qiskit/utils/deprecation.py
+++ b/qiskit/utils/deprecation.py
@@ -109,7 +109,7 @@ def deprecate_arg(
     additional_msg: str | None = None,
     deprecation_description: str | None = None,
     pending: bool = False,
-    package_name: str = "qiskit",
+    package_name: str = "Qiskit",
     new_alias: str | None = None,
     predicate: Callable[[Any], bool] | None = None,
     removal_timeline: str = "no earlier than 3 months after the release date",

--- a/qiskit/utils/deprecation.py
+++ b/qiskit/utils/deprecation.py
@@ -45,7 +45,7 @@ def deprecate_func(
             For example, "Instead, use the function ``new_func`` from the module
             ``<my_module>.<my_submodule>``, which is similar but uses GPU acceleration."
         pending: Set to ``True`` if the deprecation is still pending.
-        package_name: The PyPI package name, e.g. "qiskit-nature".
+        package_name: The package name shown in the deprecation message (e.g. the PyPI package name).
         removal_timeline: How soon can this deprecation be removed? Expects a value
             like "no sooner than 6 months after the latest release" or "in release 9.99".
         is_property: If the deprecated function is a `@property`, set this to True so that the
@@ -130,7 +130,7 @@ def deprecate_arg(
             (if new_alias is not set). For example, "Instead, use the argument `new_arg`,
             which is similar but does not impact the circuit's setup."
         pending: Set to `True` if the deprecation is still pending.
-        package_name: The PyPI package name, e.g. "qiskit-nature".
+        package_name: The package name shown in the deprecation message (e.g. the PyPI package name).
         new_alias: If the arg has simply been renamed, set this to the new name. The decorator will
             dynamically update the `kwargs` so that when the user sets the old arg, it will be
             passed in as the `new_alias` arg.

--- a/qiskit/utils/deprecation.py
+++ b/qiskit/utils/deprecation.py
@@ -26,7 +26,7 @@ def deprecate_func(
     since: str,
     additional_msg: str | None = None,
     pending: bool = False,
-    package_name: str = "qiskit",
+    package_name: str = "Qiskit",
     removal_timeline: str = "no earlier than 3 months after the release date",
     is_property: bool = False,
     stacklevel: int = 2,

--- a/test/python/utils/test_deprecation.py
+++ b/test/python/utils/test_deprecation.py
@@ -73,7 +73,7 @@ class TestDeprecationDecorators(QiskitTestCase):
                 f"""\
 
                 .. deprecated:: 9.99
-                  The function ``{__name__}._deprecated_func()`` is deprecated as of qiskit \
+                  The function ``{__name__}._deprecated_func()`` is deprecated as of Qiskit \
 9.99. It will be removed in 2 releases. Instead, use new_func().
                 """
             ),
@@ -84,7 +84,7 @@ class TestDeprecationDecorators(QiskitTestCase):
                 f"""\
 
                 .. deprecated:: 9.99_pending
-                  The class ``{__name__}._Foo`` is pending deprecation as of qiskit 9.99. It \
+                  The class ``{__name__}._Foo`` is pending deprecation as of Qiskit 9.99. It \
 will be marked deprecated in a future release, and then removed no earlier than 3 months after \
 the release date.
                 """
@@ -97,7 +97,7 @@ the release date.
                 Method.
 
                 .. deprecated:: 9.99
-                  The method ``{__name__}._Foo.my_method()`` is deprecated as of qiskit \
+                  The method ``{__name__}._Foo.my_method()`` is deprecated as of Qiskit \
 9.99. It will be removed no earlier than 3 months after the release date. Stop using this!
                 """
             ),
@@ -109,11 +109,21 @@ the release date.
                 Property.
 
                 .. deprecated:: 9.99
-                  The property ``{__name__}._Foo.my_property`` is deprecated as of qiskit \
+                  The property ``{__name__}._Foo.my_property`` is deprecated as of Qiskit \
 9.99. It will be removed no earlier than 3 months after the release date.
                 """
             ),
         )
+
+    def test_deprecate_func_package_name(self) -> None:
+        """Test setting the package name works."""
+
+        @deprecate_func(since="9.99", package_name="riskit")
+        def my_func() -> None:
+            pass
+
+        with self.assertWarnsRegex(DeprecationWarning, "is deprecated as of riskit 9.99"):
+            my_func()
 
     def test_deprecate_arg_docstring(self) -> None:
         """Test that `@deprecate_arg` adds the correct message to the docstring."""
@@ -144,22 +154,22 @@ the release date.
 
                 .. deprecated:: 9.99
                   ``{__name__}.{my_func.__qualname__}()``'s argument ``arg4`` is deprecated as of \
-qiskit 9.99. It will be removed no earlier than 3 months after the release date. Instead, \
+Qiskit 9.99. It will be removed no earlier than 3 months after the release date. Instead, \
 use foo.
 
                 .. deprecated:: 9.99
-                  Using the argument arg3 is deprecated as of qiskit 9.99. It will be \
+                  Using the argument arg3 is deprecated as of Qiskit 9.99. It will be \
 removed no earlier than 3 months after the release date. Instead, use the argument ``new_arg3``, \
 which behaves identically.
 
                 .. deprecated:: 9.99_pending
                   ``{__name__}.{my_func.__qualname__}()``'s argument ``arg2`` is pending \
-deprecation as of qiskit 9.99. It will be marked deprecated in a future release, and then \
+deprecation as of Qiskit 9.99. It will be marked deprecated in a future release, and then \
 removed no earlier than 3 months after the release date.
 
                 .. deprecated:: 9.99
                   ``{__name__}.{my_func.__qualname__}()``'s argument ``arg1`` is deprecated as of \
-qiskit 9.99. It will be removed in 2 releases.
+Qiskit 9.99. It will be removed in 2 releases.
                 """
             ),
         )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This is a suggestion to change the default deprecation message to use `Qiskit 1.x` instead of `qiskit 1.x`, since we commonly refer to this package in uppercase spelling.

### Details and comments

This means the message is changed e.g. from
```
The property ``qiskit.dagcircuit.dagcircuit.DAGCircuit.unit`` is deprecated as of qiskit 1.3.0.
```
to
```
The property ``qiskit.dagcircuit.dagcircuit.DAGCircuit.unit`` is deprecated as of Qiskit 1.3.0.
```

The old format can still be obtained by explicitly setting `package_name="qiskit"` in the deprecation decorators.



