### PR TITLE
Fix `InverseCancellation` to run in classical blocks

### DIFF
--- a/qiskit/transpiler/passes/optimization/inverse_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/inverse_cancellation.py
@@ -19,6 +19,7 @@ from qiskit.circuit import Gate
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
+from qiskit.transpiler.passes.utils import control_flow
 
 from qiskit._accelerate.inverse_cancellation import inverse_cancellation
 
@@ -74,6 +75,7 @@ class InverseCancellation(TransformationPass):
 
         super().__init__()
 
+    @control_flow.trivial_recurse
     def run(self, dag: DAGCircuit):
         """Run the InverseCancellation pass on `dag`.
 

--- a/releasenotes/notes/fix-inverse-cancellation-c7f4debcde4a705a.yaml
+++ b/releasenotes/notes/fix-inverse-cancellation-c7f4debcde4a705a.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    The transpilation pass :class`.InverseCancellation` now runs inside of flow controlled blocks. Previously, it ignores the pairs of gates in classical blocks that can be cancelled. Refer to `#13437 <https://github.com/Qiskit/qiskit/issues/13437>` for more details.

--- a/test/python/transpiler/test_inverse_cancellation.py
+++ b/test/python/transpiler/test_inverse_cancellation.py
@@ -399,58 +399,59 @@ class TestInverseCancellation(QiskitTestCase):
         new_circ = inverse_pass(qc)
         self.assertEqual(new_circ, QuantumCircuit(1))
 
-    def test_if_else(self): 
-        """Test that the pass recurses in a simple if-else.""" 
-        pass_ = InverseCancellation([CXGate()]) 
-
-        inner_test = QuantumCircuit(4, 1) 
-        inner_test.cx(0, 1) 
-        inner_test.cx(0, 1) 
-        inner_test.cx(2, 3) 
-
-        inner_expected = QuantumCircuit(4, 1) 
-        inner_expected.cx(2, 3) 
-
-        test = QuantumCircuit(4, 1) 
-        test.h(0) 
-        test.measure(0, 0) 
-        test.if_else((0, True), inner_test.copy(), inner_test.copy(), range(4), [0]) 
-
-        expected = QuantumCircuit(4, 1) 
-        expected.h(0) 
-        expected.measure(0, 0) 
-        expected.if_else((0, True), inner_expected, inner_expected, range(4), [0]) 
-
-        self.assertEqual(pass_(test), expected) 
-
-    def test_nested_control_flow(self): 
-        """Test that collection recurses into nested control flow.""" 
+    def test_if_else(self):
+        """Test that the pass recurses in a simple if-else."""
         pass_ = InverseCancellation([CXGate()])
-        qubits = [Qubit() for _ in [None] * 4] 
-        clbit = Clbit() 
-    
-        inner_test = QuantumCircuit(qubits, [clbit]) 
-        inner_test.cx(0, 1) 
-        inner_test.cx(0, 1) 
-        inner_test.cx(2, 3) 
-    
-        inner_expected = QuantumCircuit(qubits, [clbit]) 
-        inner_expected.cx(2, 3) 
-    
-        true_body = QuantumCircuit(qubits, [clbit]) 
-        true_body.while_loop((clbit, True), inner_test.copy(), [0, 1, 2, 3], [0]) 
-    
-        test = QuantumCircuit(qubits, [clbit]) 
-        test.for_loop(range(2), None, inner_test.copy(), [0, 1, 2, 3], [0]) 
-        test.if_else((clbit, True), true_body, None, [0, 1, 2, 3], [0]) 
-    
-        expected_if_body = QuantumCircuit(qubits, [clbit]) 
-        expected_if_body.while_loop((clbit, True), inner_expected, [0, 1, 2, 3], [0]) 
-        expected = QuantumCircuit(qubits, [clbit]) 
-        expected.for_loop(range(2), None, inner_expected, [0, 1, 2, 3], [0]) 
-        expected.if_else((clbit, True), expected_if_body, None, [0, 1, 2, 3], [0]) 
-    
+
+        inner_test = QuantumCircuit(4, 1)
+        inner_test.cx(0, 1)
+        inner_test.cx(0, 1)
+        inner_test.cx(2, 3)
+
+        inner_expected = QuantumCircuit(4, 1)
+        inner_expected.cx(2, 3)
+
+        test = QuantumCircuit(4, 1)
+        test.h(0)
+        test.measure(0, 0)
+        test.if_else((0, True), inner_test.copy(), inner_test.copy(), range(4), [0])
+
+        expected = QuantumCircuit(4, 1)
+        expected.h(0)
+        expected.measure(0, 0)
+        expected.if_else((0, True), inner_expected, inner_expected, range(4), [0])
+
         self.assertEqual(pass_(test), expected)
+
+    def test_nested_control_flow(self):
+        """Test that collection recurses into nested control flow."""
+        pass_ = InverseCancellation([CXGate()])
+        qubits = [Qubit() for _ in [None] * 4]
+        clbit = Clbit()
+
+        inner_test = QuantumCircuit(qubits, [clbit])
+        inner_test.cx(0, 1)
+        inner_test.cx(0, 1)
+        inner_test.cx(2, 3)
+
+        inner_expected = QuantumCircuit(qubits, [clbit])
+        inner_expected.cx(2, 3)
+
+        true_body = QuantumCircuit(qubits, [clbit])
+        true_body.while_loop((clbit, True), inner_test.copy(), [0, 1, 2, 3], [0])
+
+        test = QuantumCircuit(qubits, [clbit])
+        test.for_loop(range(2), None, inner_test.copy(), [0, 1, 2, 3], [0])
+        test.if_else((clbit, True), true_body, None, [0, 1, 2, 3], [0])
+
+        expected_if_body = QuantumCircuit(qubits, [clbit])
+        expected_if_body.while_loop((clbit, True), inner_expected, [0, 1, 2, 3], [0])
+        expected = QuantumCircuit(qubits, [clbit])
+        expected.for_loop(range(2), None, inner_expected, [0, 1, 2, 3], [0])
+        expected.if_else((clbit, True), expected_if_body, None, [0, 1, 2, 3], [0])
+
+        self.assertEqual(pass_(test), expected)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/transpiler/test_inverse_cancellation.py
+++ b/test/python/transpiler/test_inverse_cancellation.py
@@ -21,6 +21,7 @@ from qiskit import QuantumCircuit
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.passes import InverseCancellation
 from qiskit.transpiler import PassManager
+from qiskit.circuit import Clbit, Qubit
 from qiskit.circuit.library import (
     RXGate,
     HGate,
@@ -398,6 +399,58 @@ class TestInverseCancellation(QiskitTestCase):
         new_circ = inverse_pass(qc)
         self.assertEqual(new_circ, QuantumCircuit(1))
 
+    def test_if_else(self): 
+        """Test that the pass recurses in a simple if-else.""" 
+        pass_ = InverseCancellation([CXGate()]) 
+
+        inner_test = QuantumCircuit(4, 1) 
+        inner_test.cx(0, 1) 
+        inner_test.cx(0, 1) 
+        inner_test.cx(2, 3) 
+
+        inner_expected = QuantumCircuit(4, 1) 
+        inner_expected.cx(2, 3) 
+
+        test = QuantumCircuit(4, 1) 
+        test.h(0) 
+        test.measure(0, 0) 
+        test.if_else((0, True), inner_test.copy(), inner_test.copy(), range(4), [0]) 
+
+        expected = QuantumCircuit(4, 1) 
+        expected.h(0) 
+        expected.measure(0, 0) 
+        expected.if_else((0, True), inner_expected, inner_expected, range(4), [0]) 
+
+        self.assertEqual(pass_(test), expected) 
+
+    def test_nested_control_flow(self): 
+        """Test that collection recurses into nested control flow.""" 
+        pass_ = InverseCancellation([CXGate()])
+        qubits = [Qubit() for _ in [None] * 4] 
+        clbit = Clbit() 
+    
+        inner_test = QuantumCircuit(qubits, [clbit]) 
+        inner_test.cx(0, 1) 
+        inner_test.cx(0, 1) 
+        inner_test.cx(2, 3) 
+    
+        inner_expected = QuantumCircuit(qubits, [clbit]) 
+        inner_expected.cx(2, 3) 
+    
+        true_body = QuantumCircuit(qubits, [clbit]) 
+        true_body.while_loop((clbit, True), inner_test.copy(), [0, 1, 2, 3], [0]) 
+    
+        test = QuantumCircuit(qubits, [clbit]) 
+        test.for_loop(range(2), None, inner_test.copy(), [0, 1, 2, 3], [0]) 
+        test.if_else((clbit, True), true_body, None, [0, 1, 2, 3], [0]) 
+    
+        expected_if_body = QuantumCircuit(qubits, [clbit]) 
+        expected_if_body.while_loop((clbit, True), inner_expected, [0, 1, 2, 3], [0]) 
+        expected = QuantumCircuit(qubits, [clbit]) 
+        expected.for_loop(range(2), None, inner_expected, [0, 1, 2, 3], [0]) 
+        expected.if_else((clbit, True), expected_if_body, None, [0, 1, 2, 3], [0]) 
+    
+        self.assertEqual(pass_(test), expected)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fix issue #13437.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The `InverseCancellation` pass cancels pairs of gates that are inverses of each other; it now behaves as expected when running inside classical blocks of a control flow.

### Details and comments

This PR fixed the bug reported in #13437 by adding the decorator `@control_flow.trivial_recurse` so that the pass can be iterated over all control-flow nodes. 
