### PR TITLE
Fix custom basis gates deprecation warning in `generate_preset_pass_manager`

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -479,10 +479,11 @@ def _parse_basis_gates(basis_gates, backend, inst_map, skip_target):
             if inst not in standard_gates and inst not in default_gates:
                 warnings.warn(
                     category=DeprecationWarning,
-                    message="Providing custom gates through the ``basis_gates`` argument is deprecated "
-                    "for both ``transpile`` and ``generate_preset_pass_manager`` as of Qiskit 1.3.0. "
+                    message=f"Providing non-standard gates ({inst}) through the ``basis_gates`` "
+                    "argument is deprecated for both ``transpile`` and ``generate_preset_pass_manager`` "
+                    "as of Qiskit 1.3.0. "
                     "It will be removed in Qiskit 2.0. The ``target`` parameter should be used instead. "
-                    "You can build a target instance using ``Target.from_configuration()`` and provide"
+                    "You can build a target instance using ``Target.from_configuration()`` and provide "
                     "custom gate definitions with the ``custom_name_mapping`` argument.",
                 )
                 skip_target = True

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -163,7 +163,7 @@ class TestPresetPassManager(QiskitTestCase):
         qc.measure_all()
         with self.assertWarnsRegex(
             DeprecationWarning,
-            "Providing custom gates through the ``basis_gates`` argument is deprecated",
+            "Providing non-standard gates \\(unitary\\) through the ``basis_gates`` argument",
         ):
             result = transpile(qc, basis_gates=["cx", "u", "unitary"], optimization_level=level)
         self.assertEqual(result, qc)
@@ -185,7 +185,7 @@ class TestPresetPassManager(QiskitTestCase):
         qc.measure_all()
         with self.assertWarnsRegex(
             DeprecationWarning,
-            "Providing custom gates through the ``basis_gates`` argument is deprecated",
+            "Providing non-standard gates \\(unitary\\) through the ``basis_gates`` argument",
         ):
             result = transpile(
                 qc,
@@ -1761,7 +1761,7 @@ class TestIntegrationControlFlow(QiskitTestCase):
             basis_gates = ["my_gate"]
             with self.assertWarnsRegex(
                 DeprecationWarning,
-                "Providing custom gates through the ``basis_gates`` argument is deprecated",
+                "Providing non-standard gates \\(my_gate\\) through the ``basis_gates`` argument",
             ):
                 _ = generate_preset_pass_manager(
                     optimization_level=optimization_level, basis_gates=basis_gates


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Small improvements on custom basis gates deprecation message for `generate_preset_pass_manager`:

- fixed missing space that lead to "providecustom" instead of "provide custom"
- replaced "custom" with "non-standard" and added an explicit mention to the gate that triggers the deprecation warning after @Cryoris getting the message triggered with ``ccp`` and not being able to pinpoint why (it's not custom, but also not standard).


### Details and comments


