### PR TITLE
Fix typing of inserted UnitaryGates in quantum_volume

### DIFF
--- a/crates/accelerate/src/circuit_library/quantum_volume.rs
+++ b/crates/accelerate/src/circuit_library/quantum_volume.rs
@@ -27,7 +27,7 @@ use rayon::prelude::*;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::imports::UNITARY_GATE;
 use qiskit_circuit::operations::Param;
-use qiskit_circuit::operations::PyInstruction;
+use qiskit_circuit::operations::PyGate;
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::{Clbit, Qubit};
 use smallvec::{smallvec, SmallVec};
@@ -127,17 +127,16 @@ pub fn quantum_volume(
         let unitary_gate = UNITARY_GATE
             .get_bound(py)
             .call((unitary.clone(), py.None(), false), Some(&kwargs))?;
-        let instruction = PyInstruction {
+        let instruction = PyGate {
             qubits: 2,
             clbits: 0,
             params: 1,
             op_name: "unitary".to_string(),
-            control_flow: false,
-            instruction: unitary_gate.unbind(),
+            gate: unitary_gate.unbind(),
         };
         let qubit = layer_index * 2;
         Ok((
-            PackedOperation::from_instruction(Box::new(instruction)),
+            PackedOperation::from_gate(Box::new(instruction)),
             smallvec![Param::Obj(unitary.unbind().into())],
             vec![permutation[qubit], permutation[qubit + 1]],
             vec![],


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

There was a small typing issue in the quantum_volume implementation where there was a mismatch in the Python type and the rust type. The UnitaryGate were being added to the circuit as a rust space PyInstruction instead of a PyGate. This was incorrect as UnitaryGate is unitary and a gate type in python, this mismatch was causing subsequent transpilation or anything working with the unitaries in the quantum volume circuit from rust to mischaracterize the operations as non-unitary so things like getting the matrix would fail. This commit corrects the typing so the gates are added as a unitary operation in the rust typing.

This will get much simpler and less error prone when #13272 is implemented and we have a rust native UnitaryGate type.

### Details and comments