### PR TITLE
Show missing type hints & inline class base class in API docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,14 +102,21 @@ html_last_updated_fmt = "%Y/%m/%d"
 # documentation created by autosummary uses a template file (in autosummary in the templates path),
 # which likely overrides the autodoc defaults.
 
+# These options impact when using `.. autoclass::` manually.
+# They do not impact the `.. autosummary::` templates.
+autodoc_default_options = {
+    "show-inheritance": True,
+}
+
 # Move type hints from signatures to the parameter descriptions (except in overload cases, where
 # that's not possible).
 autodoc_typehints = "description"
-# Only add type hints from signature to description body if the parameter has documentation.  The
-# return type is always added to the description (if in the signature).
-autodoc_typehints_description_target = "documented_params"
-
 autoclass_content = "both"
+# Some type hints are too long to be understandable. So, we set up aliases to be used instead.
+autodoc_type_aliases = {
+    "EstimatorPubLike": "EstimatorPubLike",
+    "SamplerPubLike": "SamplerPubLike",
+}
 
 autosummary_generate = True
 autosummary_generate_overwrite = False

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -36,6 +36,7 @@ from qiskit.quantum_info.operators.base_operator import BaseOperator
 if TYPE_CHECKING:
     from qiskit import circuit
 
+
 class Chi(QuantumChannel):
     r"""Pauli basis Chi-matrix representation of a quantum channel.
 

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -18,6 +18,8 @@ Chi-matrix representation of a Quantum Channel.
 from __future__ import annotations
 import copy as _copy
 import math
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from qiskit import _numpy_compat
@@ -31,6 +33,8 @@ from qiskit.quantum_info.operators.channel.transformations import _to_chi
 from qiskit.quantum_info.operators.mixins import generate_apidocs
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 
+if TYPE_CHECKING:
+    from qiskit import circuit
 
 class Chi(QuantumChannel):
     r"""Pauli basis Chi-matrix representation of a quantum channel.
@@ -59,21 +63,16 @@ class Chi(QuantumChannel):
 
     def __init__(
         self,
-        data: QuantumCircuit | Instruction | BaseOperator | np.ndarray,
+        data: QuantumCircuit | circuit.instruction.Instruction | BaseOperator | np.ndarray,
         input_dims: int | tuple | None = None,
         output_dims: int | tuple | None = None,
     ):
         """Initialize a quantum channel Chi-matrix operator.
 
         Args:
-            data (QuantumCircuit or
-                  Instruction or
-                  BaseOperator or
-                  matrix): data to initialize superoperator.
-            input_dims (tuple): the input subsystem dimensions.
-                                [Default: None]
-            output_dims (tuple): the output subsystem dimensions.
-                                 [Default: None]
+            data: data to initialize superoperator.
+            input_dims: the input subsystem dimensions.
+            output_dims: the output subsystem dimensions.
 
         Raises:
             QiskitError: if input data is not an N-qubit channel or

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -18,6 +18,8 @@ Choi-matrix representation of a Quantum Channel.
 from __future__ import annotations
 import copy as _copy
 import math
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from qiskit import _numpy_compat
@@ -31,6 +33,9 @@ from qiskit.quantum_info.operators.channel.transformations import _to_choi
 from qiskit.quantum_info.operators.channel.transformations import _bipartite_tensor
 from qiskit.quantum_info.operators.mixins import generate_apidocs
 from qiskit.quantum_info.operators.base_operator import BaseOperator
+
+if TYPE_CHECKING:
+    from qiskit import circuit
 
 
 class Choi(QuantumChannel):
@@ -64,21 +69,16 @@ class Choi(QuantumChannel):
 
     def __init__(
         self,
-        data: QuantumCircuit | Instruction | BaseOperator | np.ndarray,
+        data: QuantumCircuit | circuit.instruction.Instruction | BaseOperator | np.ndarray,
         input_dims: int | tuple | None = None,
         output_dims: int | tuple | None = None,
     ):
         """Initialize a quantum channel Choi matrix operator.
 
         Args:
-            data (QuantumCircuit or
-                  Instruction or
-                  BaseOperator or
-                  matrix): data to initialize superoperator.
-            input_dims (tuple): the input subsystem dimensions.
-                                [Default: None]
-            output_dims (tuple): the output subsystem dimensions.
-                                 [Default: None]
+            data: data to initialize superoperator.
+            input_dims: the input subsystem dimensions.
+            output_dims: the output subsystem dimensions.
 
         Raises:
             QiskitError: if input data cannot be initialized as a

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -18,6 +18,8 @@ Pauli Transfer Matrix (PTM) representation of a Quantum Channel.
 from __future__ import annotations
 import copy as _copy
 import math
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from qiskit import _numpy_compat
@@ -30,6 +32,8 @@ from qiskit.quantum_info.operators.channel.transformations import _to_ptm
 from qiskit.quantum_info.operators.mixins import generate_apidocs
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 
+if TYPE_CHECKING:
+    from qiskit import circuit
 
 class PTM(QuantumChannel):
     r"""Pauli Transfer Matrix (PTM) representation of a Quantum Channel.
@@ -67,21 +71,16 @@ class PTM(QuantumChannel):
 
     def __init__(
         self,
-        data: QuantumCircuit | Instruction | BaseOperator | np.ndarray,
+        data: QuantumCircuit | circuit.instruction.Instruction | BaseOperator | np.ndarray,
         input_dims: int | tuple | None = None,
         output_dims: int | tuple | None = None,
     ):
         """Initialize a PTM quantum channel operator.
 
         Args:
-            data (QuantumCircuit or
-                  Instruction or
-                  BaseOperator or
-                  matrix): data to initialize superoperator.
-            input_dims (tuple): the input subsystem dimensions.
-                                [Default: None]
-            output_dims (tuple): the output subsystem dimensions.
-                                 [Default: None]
+            data: data to initialize superoperator.
+            input_dims: the input subsystem dimensions.
+            output_dims: the output subsystem dimensions.
 
         Raises:
             QiskitError: if input data is not an N-qubit channel or

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -35,6 +35,7 @@ from qiskit.quantum_info.operators.base_operator import BaseOperator
 if TYPE_CHECKING:
     from qiskit import circuit
 
+
 class PTM(QuantumChannel):
     r"""Pauli Transfer Matrix (PTM) representation of a Quantum Channel.
 

--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -53,9 +53,9 @@ class QuantumChannel(LinearOp):
         """Initialize a quantum channel Superoperator operator.
 
         Args:
-            data (array or list): quantum channel data array.
-            op_shape (OpShape): the operator shape of the channel.
-            num_qubits (int): the number of qubits if the channel is N-qubit.
+            data: quantum channel data array.
+            op_shape: the operator shape of the channel.
+            num_qubits: the number of qubits if the channel is N-qubit.
 
         Raises:
             QiskitError: if arguments are invalid.

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import copy
 import math
 from numbers import Number
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -32,6 +34,8 @@ from qiskit.quantum_info.operators.channel.transformations import _to_stinesprin
 from qiskit.quantum_info.operators.mixins import generate_apidocs
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 
+if TYPE_CHECKING:
+    from qiskit import circuit
 
 class Stinespring(QuantumChannel):
     r"""Stinespring representation of a quantum channel.
@@ -64,21 +68,16 @@ class Stinespring(QuantumChannel):
 
     def __init__(
         self,
-        data: QuantumCircuit | Instruction | BaseOperator | np.ndarray,
+        data: QuantumCircuit | circuit.instruction.Instruction | BaseOperator | np.ndarray,
         input_dims: int | tuple | None = None,
         output_dims: int | tuple | None = None,
     ):
         """Initialize a quantum channel Stinespring operator.
 
         Args:
-            data (QuantumCircuit or
-                  Instruction or
-                  BaseOperator or
-                  matrix): data to initialize superoperator.
-            input_dims (tuple): the input subsystem dimensions.
-                                [Default: None]
-            output_dims (tuple): the output subsystem dimensions.
-                                 [Default: None]
+            data: data to initialize superoperator.
+            input_dims: the input subsystem dimensions.
+            output_dims: the output subsystem dimensions.
 
         Raises:
             QiskitError: if input data cannot be initialized as a

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -37,6 +37,7 @@ from qiskit.quantum_info.operators.base_operator import BaseOperator
 if TYPE_CHECKING:
     from qiskit import circuit
 
+
 class Stinespring(QuantumChannel):
     r"""Stinespring representation of a quantum channel.
 

--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -33,6 +33,7 @@ from qiskit.quantum_info.operators.op_shape import OpShape
 from qiskit.quantum_info.operators.operator import Operator
 
 if TYPE_CHECKING:
+    from qiskit import circuit
     from qiskit.quantum_info.states.densitymatrix import DensityMatrix
     from qiskit.quantum_info.states.statevector import Statevector
 
@@ -62,21 +63,16 @@ class SuperOp(QuantumChannel):
 
     def __init__(
         self,
-        data: QuantumCircuit | Instruction | BaseOperator | np.ndarray,
+        data: QuantumCircuit | circuit.instruction.Instruction | BaseOperator | np.ndarray,
         input_dims: tuple | None = None,
         output_dims: tuple | None = None,
     ):
         """Initialize a quantum channel Superoperator operator.
 
         Args:
-            data (QuantumCircuit or
-                  Instruction or
-                  BaseOperator or
-                  matrix): data to initialize superoperator.
-            input_dims (tuple): the input subsystem dimensions.
-                                [Default: None]
-            output_dims (tuple): the output subsystem dimensions.
-                                 [Default: None]
+            data: data to initialize superoperator.
+            input_dims: the input subsystem dimensions.
+            output_dims: the output subsystem dimensions.
 
         Raises:
             QiskitError: if input data cannot be initialized as a

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -17,9 +17,11 @@ DensityMatrix quantum state class.
 from __future__ import annotations
 import copy as _copy
 from numbers import Number
+from typing import TYPE_CHECKING
+
 import numpy as np
 
-from qiskit import _numpy_compat
+from qiskit import _numpy_compat, circuit
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit.instruction import Instruction
 from qiskit.exceptions import QiskitError
@@ -37,27 +39,26 @@ from qiskit.quantum_info.operators.channel.superop import SuperOp
 from qiskit._accelerate.pauli_expval import density_expval_pauli_no_x, density_expval_pauli_with_x
 from qiskit.quantum_info.states.statevector import Statevector
 
+if TYPE_CHECKING:
+    from qiskit import circuit
 
 class DensityMatrix(QuantumState, TolerancesMixin):
     """DensityMatrix class"""
 
     def __init__(
         self,
-        data: np.ndarray | list | QuantumCircuit | Instruction | QuantumState,
+        data: np.ndarray | list | QuantumCircuit | circuit.instruction.Instruction | QuantumState,
         dims: int | tuple | list | None = None,
     ):
         """Initialize a density matrix object.
 
         Args:
-            data (np.ndarray or list or matrix_like or QuantumCircuit or
-                  qiskit.circuit.Instruction):
-                A statevector, quantum instruction or an object with a ``to_operator`` or
+            data: A statevector, quantum instruction or an object with a ``to_operator`` or
                 ``to_matrix`` method from which the density matrix can be constructed.
                 If a vector the density matrix is constructed as the projector of that vector.
                 If a quantum instruction, the density matrix is constructed by assuming all
                 qubits are initialized in the zero state.
-            dims (int or tuple or list): Optional. The subsystem dimension
-                    of the state (See additional information).
+            dims: The subsystem dimension of the state (See additional information).
 
         Raises:
             QiskitError: if input data is not valid.

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -305,19 +305,17 @@ class DensityMatrix(QuantumState, TolerancesMixin):
 
     def evolve(
         self,
-        other: Operator | QuantumChannel | Instruction | QuantumCircuit,
+        other: Operator | QuantumChannel | circuit.instruction.Instruction | QuantumCircuit,
         qargs: list[int] | None = None,
     ) -> DensityMatrix:
         """Evolve a quantum state by an operator.
 
         Args:
-            other (Operator or QuantumChannel
-                   or Instruction or Circuit): The operator to evolve by.
-            qargs (list): a list of QuantumState subsystem positions to apply
-                           the operator on.
+            other: The operator to evolve by.
+            qargs: a list of QuantumState subsystem positions to apply the operator on.
 
         Returns:
-            DensityMatrix: the output density matrix.
+            The output density matrix.
 
         Raises:
             QiskitError: if the operator dimension does not match the
@@ -600,7 +598,9 @@ class DensityMatrix(QuantumState, TolerancesMixin):
         return DensityMatrix(state, dims=dims)
 
     @classmethod
-    def from_instruction(cls, instruction: Instruction | QuantumCircuit) -> DensityMatrix:
+    def from_instruction(
+        cls, instruction: circuit.instruction.Instruction | QuantumCircuit
+    ) -> DensityMatrix:
         """Return the output density matrix of an instruction.
 
         The statevector is initialized in the state :math:`|{0,\\ldots,0}\\rangle` of
@@ -608,10 +608,10 @@ class DensityMatrix(QuantumState, TolerancesMixin):
         by the input instruction, and the output statevector returned.
 
         Args:
-            instruction (qiskit.circuit.Instruction or QuantumCircuit): instruction or circuit
+            instruction: instruction or circuit
 
         Returns:
-            DensityMatrix: the final density matrix.
+            The final density matrix.
 
         Raises:
             QiskitError: if the instruction contains invalid instructions for

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from qiskit import _numpy_compat, circuit
+from qiskit import _numpy_compat
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit.instruction import Instruction
 from qiskit.exceptions import QiskitError
@@ -41,6 +41,7 @@ from qiskit.quantum_info.states.statevector import Statevector
 
 if TYPE_CHECKING:
     from qiskit import circuit
+
 
 class DensityMatrix(QuantumState, TolerancesMixin):
     """DensityMatrix class"""

--- a/qiskit/quantum_info/states/stabilizerstate.py
+++ b/qiskit/quantum_info/states/stabilizerstate.py
@@ -17,6 +17,7 @@ Stabilizer state class.
 from __future__ import annotations
 
 from collections.abc import Collection
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -28,6 +29,8 @@ from qiskit.quantum_info.operators.symplectic.clifford_circuits import _append_x
 from qiskit.quantum_info.states.quantum_state import QuantumState
 from qiskit.circuit import QuantumCircuit, Instruction
 
+if TYPE_CHECKING:
+    from qiskit import circuit
 
 class StabilizerState(QuantumState):
     """StabilizerState class.
@@ -79,17 +82,14 @@ class StabilizerState(QuantumState):
 
     def __init__(
         self,
-        data: StabilizerState | Clifford | Pauli | QuantumCircuit | Instruction,
+        data: StabilizerState | Clifford | Pauli | QuantumCircuit | circuit.instruction.Instruction,
         validate: bool = True,
     ):
         """Initialize a StabilizerState object.
 
         Args:
-            data (StabilizerState or Clifford or Pauli or QuantumCircuit or
-                  qiskit.circuit.Instruction):
-                Data from which the stabilizer state can be constructed.
-            validate (boolean): validate that the stabilizer state data is
-                a valid Clifford.
+            data: Data from which the stabilizer state can be constructed.
+            validate: validate that the stabilizer state data is a valid Clifford.
         """
 
         # Initialize from another StabilizerState

--- a/qiskit/quantum_info/states/stabilizerstate.py
+++ b/qiskit/quantum_info/states/stabilizerstate.py
@@ -32,6 +32,7 @@ from qiskit.circuit import QuantumCircuit, Instruction
 if TYPE_CHECKING:
     from qiskit import circuit
 
+
 class StabilizerState(QuantumState):
     """StabilizerState class.
     Stabilizer simulator using the convention from reference [1].

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -18,6 +18,7 @@ import copy as _copy
 import math
 import re
 from numbers import Number
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -37,27 +38,26 @@ from qiskit._accelerate.pauli_expval import (
     expval_pauli_with_x,
 )
 
+if TYPE_CHECKING:
+    from qiskit import circuit
 
 class Statevector(QuantumState, TolerancesMixin):
     """Statevector class"""
 
     def __init__(
         self,
-        data: np.ndarray | list | Statevector | Operator | QuantumCircuit | Instruction,
+        data: np.ndarray | list | Statevector | Operator | QuantumCircuit | circuit.instruction.Instruction,
         dims: int | tuple | list | None = None,
     ):
         """Initialize a statevector object.
 
         Args:
-            data (np.array or list or Statevector or Operator or QuantumCircuit or
-                  qiskit.circuit.Instruction):
-                Data from which the statevector can be constructed. This can be either a complex
+            data: Data from which the statevector can be constructed. This can be either a complex
                 vector, another statevector, a ``Operator`` with only one column or a
                 ``QuantumCircuit`` or ``Instruction``.  If the data is a circuit or instruction,
                 the statevector is constructed by assuming that all qubits are initialized to the
                 zero state.
-            dims (int or tuple or list): Optional. The subsystem dimension of
-                                         the state (See additional information).
+            dims: The subsystem dimension of the state (See additional information).
 
         Raises:
             QiskitError: if input data is not valid.

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -41,12 +41,20 @@ from qiskit._accelerate.pauli_expval import (
 if TYPE_CHECKING:
     from qiskit import circuit
 
+
 class Statevector(QuantumState, TolerancesMixin):
     """Statevector class"""
 
     def __init__(
         self,
-        data: np.ndarray | list | Statevector | Operator | QuantumCircuit | circuit.instruction.Instruction,
+        data: (
+            np.ndarray
+            | list
+            | Statevector
+            | Operator
+            | QuantumCircuit
+            | circuit.instruction.Instruction
+        ),
         dims: int | tuple | list | None = None,
     ):
         """Initialize a statevector object.


### PR DESCRIPTION
The API docs were leaving off some important information:

* For inlined classes, we weren't showing the parent class. This impacts when using `.. autoclass::` on a module page; it was already fine for `.. autosummary::`.
* Generally, we left off type hints for parameters without docstring, along with some return types like `None`. These type hints are useful.

To land this PR, I had to make a fix similar to https://github.com/Qiskit/qiskit/pull/10772 to fix ambiguous type hints.

I also set up aliases for the extremely long types for `EstimatorPubLike` and `SamplerPubLike`. See https://github.com/Qiskit/qiskit-ibm-runtime/issues/1877 for more context on that problem.