### PR TITLE
Fix `CollectCliffords` to index nodes using their ids

### DIFF
--- a/qiskit/dagcircuit/collect_blocks.py
+++ b/qiskit/dagcircuit/collect_blocks.py
@@ -80,7 +80,7 @@ class BlockCollector:
         self._in_degree = {}
         for node in self._op_nodes():
             deg = len(self._direct_preds(node))
-            self._in_degree[node._node_id] = deg
+            self._in_degree[self._get_node_id(node)] = deg
             if deg == 0:
                 self._pending_nodes.append(node)
 
@@ -90,6 +90,13 @@ class BlockCollector:
             return self.dag.op_nodes()
         else:
             return self.dag.get_nodes()
+
+    def _get_node_id(self, node):
+        """Returns the id of the given node."""
+        if not self.is_dag_dependency:
+            return node._node_id
+        else:
+            return node.node_id
 
     def _direct_preds(self, node):
         """Returns direct predecessors of a node. This function takes into account the
@@ -165,8 +172,8 @@ class BlockCollector:
 
                     # update the _in_degree of node's successors
                     for suc in self._direct_succs(node):
-                        self._in_degree[suc._node_id] -= 1
-                        if self._in_degree[suc._node_id] == 0:
+                        self._in_degree[self._get_node_id(suc)] -= 1
+                        if self._in_degree[self._get_node_id(suc)] == 0:
                             new_pending_nodes.append(suc)
                 else:
                     self._pending_nodes.append(node)

--- a/qiskit/dagcircuit/collect_blocks.py
+++ b/qiskit/dagcircuit/collect_blocks.py
@@ -54,7 +54,7 @@ class BlockCollector:
 
         self.dag = dag
         self._pending_nodes: list[DAGOpNode | DAGDepNode] | None = None
-        self._in_degree: dict[DAGOpNode | DAGDepNode, int] | None = None
+        self._in_degree: dict[int, int] | None = None
         self._collect_from_back = False
 
         if isinstance(dag, DAGCircuit):
@@ -80,7 +80,7 @@ class BlockCollector:
         self._in_degree = {}
         for node in self._op_nodes():
             deg = len(self._direct_preds(node))
-            self._in_degree[node] = deg
+            self._in_degree[node._node_id] = deg
             if deg == 0:
                 self._pending_nodes.append(node)
 
@@ -165,8 +165,8 @@ class BlockCollector:
 
                     # update the _in_degree of node's successors
                     for suc in self._direct_succs(node):
-                        self._in_degree[suc] -= 1
-                        if self._in_degree[suc] == 0:
+                        self._in_degree[suc._node_id] -= 1
+                        if self._in_degree[suc._node_id] == 0:
                             new_pending_nodes.append(suc)
                 else:
                     self._pending_nodes.append(node)

--- a/releasenotes/notes/fix-collect-cliffords-82b8c476e6542b36.yaml
+++ b/releasenotes/notes/fix-collect-cliffords-82b8c476e6542b36.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a problem in :class:`~BlockCollector`, by hashing the nodes using their
+    integer ids.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #13457.

This PR changes the internal field ``in_degree`` in ``BlockCollector`` to be indexed by the ids of the nodes rather than by nodes themselves. See also #13424 for a related discussion.

In particular, this avoids hashing the nodes as python objects, both making the code faster and avoiding problems for things like `PauliLindbladError` coming from `qiskit_aer`.

### Details and comments

I am not sure if this change really deserves a release note, but I have decided to add one, given that it does address a reported bug.
