### PR TITLE
fixing docstrings for PauliEvolutionGate plugins

### DIFF
--- a/qiskit/transpiler/passes/synthesis/hls_plugins.py
+++ b/qiskit/transpiler/passes/synthesis/hls_plugins.py
@@ -263,11 +263,11 @@ Pauli Evolution Synthesis
       - Targeted connectivity
     * - ``"rustiq"``
       - :class:`~.PauliEvolutionSynthesisRustiq`
-      - use a diagonalizing Clifford per Pauli term
+      - use the synthesis method from https://github.com/smartiel/rustiq-core
       - all-to-all
     * - ``"default"``
       - :class:`~.PauliEvolutionSynthesisDefault`
-      - use ``rustiq_core`` synthesis library
+      - use a diagonalizing Clifford per Pauli term
       - all-to-all
 
 .. autosummary::

--- a/qiskit/transpiler/passes/synthesis/hls_plugins.py
+++ b/qiskit/transpiler/passes/synthesis/hls_plugins.py
@@ -263,7 +263,7 @@ Pauli Evolution Synthesis
       - Targeted connectivity
     * - ``"rustiq"``
       - :class:`~.PauliEvolutionSynthesisRustiq`
-      - use the synthesis method from `this quantum circuit synthesis library <https://github.com/smartiel/rustiq-core>`_
+      - use the synthesis method from `Rustiq circuit synthesis library <https://github.com/smartiel/rustiq-core>`_
       - all-to-all
     * - ``"default"``
       - :class:`~.PauliEvolutionSynthesisDefault`

--- a/qiskit/transpiler/passes/synthesis/hls_plugins.py
+++ b/qiskit/transpiler/passes/synthesis/hls_plugins.py
@@ -263,7 +263,7 @@ Pauli Evolution Synthesis
       - Targeted connectivity
     * - ``"rustiq"``
       - :class:`~.PauliEvolutionSynthesisRustiq`
-      - use the synthesis method from https://github.com/smartiel/rustiq-core
+      - use the synthesis method from `this quantum circuit synthesis library <https://github.com/smartiel/rustiq-core>`_
       - all-to-all
     * - ``"default"``
       - :class:`~.PauliEvolutionSynthesisDefault`

--- a/qiskit/transpiler/passes/synthesis/hls_plugins.py
+++ b/qiskit/transpiler/passes/synthesis/hls_plugins.py
@@ -263,7 +263,8 @@ Pauli Evolution Synthesis
       - Targeted connectivity
     * - ``"rustiq"``
       - :class:`~.PauliEvolutionSynthesisRustiq`
-      - use the synthesis method from `Rustiq circuit synthesis library <https://github.com/smartiel/rustiq-core>`_
+      - use the synthesis method from `Rustiq circuit synthesis library 
+        <https://github.com/smartiel/rustiq-core>`_
       - all-to-all
     * - ``"default"``
       - :class:`~.PauliEvolutionSynthesisDefault`


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Matthew has noticed that the descriptions for the two PauliEvolutionGate plugins were swapped -- this commit fixes this. In addition, Matthew commented that it's better to provide a link to the rustiq-core library than to say the "rustiq-core library", as this probably doesn't make too much sense for the users.


### Details and comments


