### PR TITLE
Fix macOS deployment target config in cibuildwheel

### DIFF
--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -121,6 +121,7 @@ jobs:
           cat >>"$GITHUB_ENV" <<EOF
           CIBW_BEFORE_BUILD=bash ./tools/build_pgo.sh $PGO_WORK_DIR $PGO_OUT_PATH
           CIBW_ENVIRONMENT=RUSTUP_TOOLCHAIN=stable RUSTFLAGS='-Cprofile-use=$PGO_OUT_PATH -Cllvm-args=-pgo-warn-missing-function'
+          CIBW_ENVIRONMENT_MACOS=MACOSX_DEPLOYMENT_TARGET='10.12' RUSTUP_TOOLCHAIN=stable RUSTFLAGS='-Cprofile-use=$PGO_OUT_PATH -Cllvm-args=-pgo-warn-missing-function'
           CIBW_ENVIRONMENT_LINUX=RUSTUP_TOOLCHAIN=stable RUSTFLAGS='-Cprofile-use=$PGO_OUT_PATH -Cllvm-args=-pgo-warn-missing-function' PATH="\$PATH:\$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true"
           EOF
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,6 @@ environment = 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true"
 repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} && pipx run abi3audit --strict --report {wheel}"
 
 [tool.cibuildwheel.macos]
-environment = "MACOSX_DEPLOYMENT_TARGET=10.12"
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} && pipx run abi3audit --strict --report {wheel}"
 
 [tool.cibuildwheel.windows]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Looking at the 1.3.0 release build the build failed during the audit stage checking the shared object file that was built. This was failing because the macOS target version in the binary was 10.12 but the environment variable to override the default target of 10.9 was not getting set properly. We set this in the pyproject.toml but it is getting overridden by the PGO settings via CIBW_ENVIRONMENT in the github actions config. If you look at the recent builds we were publishing 10.9 target wheels on pypi despite documenting we target 10.12. The CI job logs also show that env variable is never being set during the cibuildwheel process.

The release of rust 1.83 in the last 24 hrs probably is what changed the output here causing the failure, although rust was supposed to raise it's minimum target to 10.12 in 1.74 [1] something probably changed in the release today which is tripping up the audit now.

This PR updates the CI configuration as was done to hotfix the deployment job temporarily during the 1.3.0 release process [2] to ensure we're setting our macOS deployment target correctly on x86_64 macOS builds to 10.12.

### Details and comments

[1] https://blog.rust-lang.org/2023/09/25/Increasing-Apple-Version-Requirements.html
[2] https://github.com/Qiskit/qiskit/actions/runs/12075613320