### PR TITLE
Fix clippy warnings with latest rust release

### DIFF
--- a/crates/accelerate/src/rayon_ext.rs
+++ b/crates/accelerate/src/rayon_ext.rs
@@ -52,7 +52,7 @@ pub struct ParUnevenChunksMut<'len, 'data, T> {
     data: &'data mut [T],
 }
 
-impl<'len, 'data, T: Send + 'data> ParallelIterator for ParUnevenChunksMut<'len, 'data, T> {
+impl<'data, T: Send + 'data> ParallelIterator for ParUnevenChunksMut<'_, 'data, T> {
     type Item = &'data mut [T];
 
     #[track_caller]
@@ -61,7 +61,7 @@ impl<'len, 'data, T: Send + 'data> ParallelIterator for ParUnevenChunksMut<'len,
     }
 }
 
-impl<'len, 'data, T: Send + 'data> IndexedParallelIterator for ParUnevenChunksMut<'len, 'data, T> {
+impl<'data, T: Send + 'data> IndexedParallelIterator for ParUnevenChunksMut<'_, 'data, T> {
     #[track_caller]
     fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
         bridge(self, consumer)
@@ -132,7 +132,7 @@ impl<'len, 'data, T> UnevenChunksMutIter<'len, 'data, T> {
     }
 }
 
-impl<'len, 'data, T> Iterator for UnevenChunksMutIter<'len, 'data, T> {
+impl<'data, T> Iterator for UnevenChunksMutIter<'_, 'data, T> {
     type Item = &'data mut [T];
 
     #[track_caller]
@@ -154,8 +154,8 @@ impl<'len, 'data, T> Iterator for UnevenChunksMutIter<'len, 'data, T> {
         (self.chunk_lengths.len(), Some(self.chunk_lengths.len()))
     }
 }
-impl<'len, 'data, T> ExactSizeIterator for UnevenChunksMutIter<'len, 'data, T> {}
-impl<'len, 'data, T> DoubleEndedIterator for UnevenChunksMutIter<'len, 'data, T> {
+impl<T> ExactSizeIterator for UnevenChunksMutIter<'_, '_, T> {}
+impl<T> DoubleEndedIterator for UnevenChunksMutIter<'_, '_, T> {
     #[track_caller]
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.chunk_lengths.is_empty() {

--- a/crates/accelerate/src/sabre/route.rs
+++ b/crates/accelerate/src/sabre/route.rs
@@ -83,7 +83,7 @@ struct RoutingState<'a, 'b> {
     seed: u64,
 }
 
-impl<'a, 'b> RoutingState<'a, 'b> {
+impl RoutingState<'_, '_> {
     /// Apply a swap to the program-state structures (front layer, extended set and current
     /// layout).
     #[inline]

--- a/crates/accelerate/src/sparse_observable.rs
+++ b/crates/accelerate/src/sparse_observable.rs
@@ -2520,7 +2520,7 @@ pub struct SparseTermView<'a> {
     pub bit_terms: &'a [BitTerm],
     pub indices: &'a [u32],
 }
-impl<'a> SparseTermView<'a> {
+impl SparseTermView<'_> {
     /// Convert this `SparseTermView` into an owning [SparseTerm] of the same data.
     pub fn to_term(&self) -> SparseTerm {
         SparseTerm {
@@ -2618,8 +2618,8 @@ impl<'a> Iterator for IterMut<'a> {
         (self.coeffs.len(), Some(self.coeffs.len()))
     }
 }
-impl<'a> ExactSizeIterator for IterMut<'a> {}
-impl<'a> ::std::iter::FusedIterator for IterMut<'a> {}
+impl ExactSizeIterator for IterMut<'_> {}
+impl ::std::iter::FusedIterator for IterMut<'_> {}
 
 /// Helper class of `ArrayView` that denotes the slot of the `SparseObservable` we're looking at.
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/crates/accelerate/src/sparse_pauli_op.rs
+++ b/crates/accelerate/src/sparse_pauli_op.rs
@@ -216,7 +216,7 @@ pub struct ZXPaulisView<'py> {
     coeffs: ArrayView1<'py, Complex64>,
 }
 
-impl<'py> ZXPaulisView<'py> {
+impl ZXPaulisView<'_> {
     /// The number of qubits this operator acts on.
     pub fn num_qubits(&self) -> usize {
         self.x.shape()[1]

--- a/crates/accelerate/src/synthesis/multi_controlled/mcmt.rs
+++ b/crates/accelerate/src/synthesis/multi_controlled/mcmt.rs
@@ -20,6 +20,13 @@ use smallvec::{smallvec, SmallVec};
 
 use crate::QiskitError;
 
+type CCXChainItem = PyResult<(
+    PackedOperation,
+    SmallVec<[Param; 3]>,
+    Vec<Qubit>,
+    Vec<Clbit>,
+)>;
+
 /// A Toffoli chain, implementing a multi-control condition on all controls using
 /// ``controls.len() - 1`` auxiliary qubits.
 ///
@@ -42,14 +49,7 @@ use crate::QiskitError;
 fn ccx_chain<'a>(
     controls: &'a [usize],
     auxiliaries: &'a [usize],
-) -> impl DoubleEndedIterator<
-    Item = PyResult<(
-        PackedOperation,
-        SmallVec<[Param; 3]>,
-        Vec<Qubit>,
-        Vec<Clbit>,
-    )>,
-> + 'a {
+) -> impl DoubleEndedIterator<Item = CCXChainItem> + 'a {
     let n = controls.len() - 1; // number of chain elements
     std::iter::once((controls[0], controls[1], auxiliaries[0]))
         .chain((0..n - 1).map(|i| (controls[i + 2], auxiliaries[i], auxiliaries[i + 1])))

--- a/crates/accelerate/src/target_transpiler/mod.rs
+++ b/crates/accelerate/src/target_transpiler/mod.rs
@@ -934,10 +934,10 @@ impl Target {
     // TODO: Remove once `Target` is being consumed.
     #[allow(dead_code)]
     pub fn operations(&self) -> impl Iterator<Item = &NormalOperation> {
-        return self._gate_name_map.values().filter_map(|oper| match oper {
+        self._gate_name_map.values().filter_map(|oper| match oper {
             TargetOperation::Normal(oper) => Some(oper),
             _ => None,
-        });
+        })
     }
 
     /// Get the error rate of a given instruction in the target
@@ -1025,7 +1025,7 @@ impl Target {
         } else if self.non_global_basis.is_some() {
             return self.non_global_basis.as_deref();
         }
-        return Some(self.generate_non_global_op_names(strict_direction));
+        Some(self.generate_non_global_op_names(strict_direction))
     }
 
     /// Gets all the operation names that use these qargs. Rust native equivalent of ``BaseTarget.operation_names_for_qargs()``

--- a/crates/accelerate/src/target_transpiler/nullable_index_map.rs
+++ b/crates/accelerate/src/target_transpiler/nullable_index_map.rs
@@ -234,7 +234,7 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
     }
 }
 
-impl<'a, K, V> ExactSizeIterator for Iter<'a, K, V> {
+impl<K, V> ExactSizeIterator for Iter<'_, K, V> {
     fn len(&self) -> usize {
         self.map.len() + self.null_value.is_some() as usize
     }
@@ -318,7 +318,7 @@ impl<'a, K, V> Iterator for Keys<'a, K, V> {
     }
 }
 
-impl<'a, K, V> ExactSizeIterator for Keys<'a, K, V> {
+impl<K, V> ExactSizeIterator for Keys<'_, K, V> {
     fn len(&self) -> usize {
         self.map_keys.len() + self.null_value as usize
     }
@@ -356,7 +356,7 @@ impl<'a, K, V> Iterator for Values<'a, K, V> {
     }
 }
 
-impl<'a, K, V> ExactSizeIterator for Values<'a, K, V> {
+impl<K, V> ExactSizeIterator for Values<'_, K, V> {
     fn len(&self) -> usize {
         self.map_values.len() + self.null_value.is_some() as usize
     }

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -183,7 +183,7 @@ pub enum OperationRef<'a> {
     Operation(&'a PyOperation),
 }
 
-impl<'a> Operation for OperationRef<'a> {
+impl Operation for OperationRef<'_> {
     #[inline]
     fn name(&self) -> &str {
         match self {

--- a/crates/circuit/src/slice.rs
+++ b/crates/circuit/src/slice.rs
@@ -41,7 +41,7 @@ impl<'py> FromPyObject<'py> for PySequenceIndex<'py> {
     }
 }
 
-impl<'py> PySequenceIndex<'py> {
+impl PySequenceIndex<'_> {
     /// Specialize this index to a collection of the given `len`, returning a Rust-native type.
     pub fn with_len(&self, len: usize) -> Result<SequenceIndex, PySequenceIndexError> {
         match self {

--- a/crates/qasm2/src/error.rs
+++ b/crates/qasm2/src/error.rs
@@ -30,7 +30,7 @@ impl<'a> Position<'a> {
     }
 }
 
-impl<'a> std::fmt::Display for &Position<'a> {
+impl std::fmt::Display for &Position<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,

--- a/crates/qasm2/src/expr.rs
+++ b/crates/qasm2/src/expr.rs
@@ -242,7 +242,7 @@ pub struct ExprParser<'a> {
     pub strict: bool,
 }
 
-impl<'a> ExprParser<'a> {
+impl ExprParser<'_> {
     /// Get the next token available in the stack of token streams, popping and removing any
     /// complete streams, except the base case.  Will only return `None` once all streams are
     /// exhausted.

--- a/crates/qasm3/Cargo.toml
+++ b/crates/qasm3/Cargo.toml
@@ -10,8 +10,11 @@ name = "qiskit_qasm3"
 doctest = false
 
 [dependencies]
-pyo3.workspace = true
 indexmap.workspace = true
 hashbrown.workspace = true
 oq3_semantics = "0.7.0"
 ahash.workspace = true
+
+[dependencies.pyo3]
+workspace = true
+features = ["py-clone"]

--- a/crates/qasm3/src/expr.rs
+++ b/crates/qasm3/src/expr.rs
@@ -132,7 +132,7 @@ impl<'py> Iterator for BroadcastQubitsIter<'py> {
         (self.len - self.offset, Some(self.len - self.offset))
     }
 }
-impl<'py> ExactSizeIterator for BroadcastQubitsIter<'py> {}
+impl ExactSizeIterator for BroadcastQubitsIter<'_> {}
 
 struct BroadcastMeasureIter<'a, 'py> {
     py: Python<'py>,
@@ -142,7 +142,7 @@ struct BroadcastMeasureIter<'a, 'py> {
     carg: &'a BroadcastItem,
 }
 
-impl<'a, 'py> Iterator for BroadcastMeasureIter<'a, 'py> {
+impl<'py> Iterator for BroadcastMeasureIter<'_, 'py> {
     type Item = (Bound<'py, PyTuple>, Bound<'py, PyTuple>);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -165,7 +165,7 @@ impl<'a, 'py> Iterator for BroadcastMeasureIter<'a, 'py> {
         (self.len - self.offset, Some(self.len - self.offset))
     }
 }
-impl<'a, 'py> ExactSizeIterator for BroadcastMeasureIter<'a, 'py> {}
+impl ExactSizeIterator for BroadcastMeasureIter<'_, '_> {}
 
 fn broadcast_bits_for_identifier<T: PyRegister>(
     py: Python,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The recent rust release 1.83 introduced a few new clippy warnings and tweaks to existing checks that are triggering warnings in Qiskit's source. While we run clippy in CI it is with our MSRV of 1.70 for stability to avoid periodic CI outages when a new rust reversion is released. But for those who develop locally using the latest stable version of rust these warnings can make it hard to find issues in under development code. The new clippy rules are also real issues in the code that would be good to fix even if it's not a hard requirement yet.


### Details and comments


