### PR TITLE
Copy circuits and parameters when adding them to the `EquivalenceLibrary` in Rust.

### DIFF
--- a/crates/accelerate/src/equivalence.rs
+++ b/crates/accelerate/src/equivalence.rs
@@ -37,7 +37,7 @@ use rustworkx_core::petgraph::{
 
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
-use qiskit_circuit::imports::{COPY, PYDIGRAPH, QUANTUM_CIRCUIT};
+use qiskit_circuit::imports::{PYDIGRAPH, QUANTUM_CIRCUIT};
 use qiskit_circuit::operations::Param;
 use qiskit_circuit::operations::{Operation, OperationRef};
 use qiskit_circuit::packed_instruction::PackedOperation;
@@ -605,12 +605,7 @@ impl EquivalenceLibrary {
         let key: Key = Key::from_operation(gate);
         let equiv = Equivalence {
             circuit: CircuitFromPython(equivalent_circuit.0.copy(py, true, false)?),
-            params: params
-                .iter()
-                .map(|param| -> PyResult<Param> {
-                    COPY.get_bound(py).call1((param.to_object(py),))?.extract()
-                })
-                .collect::<PyResult<SmallVec<[Param; 3]>>>()?,
+            params: params.into(),
         };
 
         let target = self.set_default_node(key);

--- a/crates/accelerate/src/equivalence.rs
+++ b/crates/accelerate/src/equivalence.rs
@@ -37,7 +37,7 @@ use rustworkx_core::petgraph::{
 
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
-use qiskit_circuit::imports::{ImportOnceCell, QUANTUM_CIRCUIT};
+use qiskit_circuit::imports::{COPY, PYDIGRAPH, QUANTUM_CIRCUIT};
 use qiskit_circuit::operations::Param;
 use qiskit_circuit::operations::{Operation, OperationRef};
 use qiskit_circuit::packed_instruction::PackedOperation;
@@ -46,7 +46,6 @@ mod exceptions {
     use pyo3::import_exception_bound;
     import_exception_bound! {qiskit.circuit.exceptions, CircuitError}
 }
-pub static PYDIGRAPH: ImportOnceCell = ImportOnceCell::new("rustworkx", "PyDiGraph");
 
 // Custom Structs
 
@@ -605,8 +604,13 @@ impl EquivalenceLibrary {
         raise_if_param_mismatch(py, params, equivalent_circuit.0.unsorted_parameters(py)?)?;
         let key: Key = Key::from_operation(gate);
         let equiv = Equivalence {
-            circuit: equivalent_circuit.clone(),
-            params: params.into(),
+            circuit: CircuitFromPython(equivalent_circuit.0.copy(py, true, false)?),
+            params: params
+                .iter()
+                .map(|param| -> PyResult<Param> {
+                    COPY.get_bound(py).call1((param.to_object(py),))?.extract()
+                })
+                .collect::<PyResult<SmallVec<[Param; 3]>>>()?,
         };
 
         let target = self.set_default_node(key);

--- a/crates/circuit/src/imports.rs
+++ b/crates/circuit/src/imports.rs
@@ -58,6 +58,7 @@ impl ImportOnceCell {
 
 pub static BUILTIN_LIST: ImportOnceCell = ImportOnceCell::new("builtins", "list");
 pub static BUILTIN_SET: ImportOnceCell = ImportOnceCell::new("builtins", "set");
+pub static COPY: ImportOnceCell = ImportOnceCell::new("copy", "copy");
 pub static OPERATION: ImportOnceCell = ImportOnceCell::new("qiskit.circuit.operation", "Operation");
 pub static INSTRUCTION: ImportOnceCell =
     ImportOnceCell::new("qiskit.circuit.instruction", "Instruction");
@@ -74,6 +75,7 @@ pub static PARAMETER_EXPRESSION: ImportOnceCell =
     ImportOnceCell::new("qiskit.circuit.parameterexpression", "ParameterExpression");
 pub static PARAMETER_VECTOR: ImportOnceCell =
     ImportOnceCell::new("qiskit.circuit.parametervector", "ParameterVector");
+pub static PYDIGRAPH: ImportOnceCell = ImportOnceCell::new("rustworkx", "PyDiGraph");
 pub static QUANTUM_CIRCUIT: ImportOnceCell =
     ImportOnceCell::new("qiskit.circuit.quantumcircuit", "QuantumCircuit");
 pub static SINGLETON_GATE: ImportOnceCell =

--- a/crates/circuit/src/imports.rs
+++ b/crates/circuit/src/imports.rs
@@ -58,7 +58,6 @@ impl ImportOnceCell {
 
 pub static BUILTIN_LIST: ImportOnceCell = ImportOnceCell::new("builtins", "list");
 pub static BUILTIN_SET: ImportOnceCell = ImportOnceCell::new("builtins", "set");
-pub static COPY: ImportOnceCell = ImportOnceCell::new("copy", "copy");
 pub static OPERATION: ImportOnceCell = ImportOnceCell::new("qiskit.circuit.operation", "Operation");
 pub static INSTRUCTION: ImportOnceCell =
     ImportOnceCell::new("qiskit.circuit.instruction", "Instruction");

--- a/releasenotes/notes/fix-equivalence-copy-205adf94f0380219.yaml
+++ b/releasenotes/notes/fix-equivalence-copy-205adf94f0380219.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Add missing calls to `copy` to the :class:`.Parameter` and :class:`.CircuitData` instances
+    being added to an `Equivalence` when calling :meth:`.EquivalenceLibrary.add_equivalence` in
+    :class:`.EquivalenceLibrary`.

--- a/test/python/transpiler/test_basis_translator.py
+++ b/test/python/transpiler/test_basis_translator.py
@@ -486,8 +486,6 @@ class TestBasisTranslator(QiskitTestCase):
     def test_equivalence_library_serialization(self):
         """Test correct serialization of the EquivalenceLibrart that the BasisTranslator
         depends on."""
-        backend = GenericBackendV2(5)
-        # Create a single step PassManager that runs the basis translator
         pass_ = BasisTranslator(
             equivalence_library=std_eq_lib, target_basis=["cx", "id", "rz", "sx", "x"]
         )

--- a/test/python/transpiler/test_basis_translator.py
+++ b/test/python/transpiler/test_basis_translator.py
@@ -488,7 +488,9 @@ class TestBasisTranslator(QiskitTestCase):
         depends on."""
         backend = GenericBackendV2(5)
         # Create a single step PassManager that runs the basis translator
-        pass_ = BasisTranslator(equivalence_library=std_eq_lib, target_basis=backend._basis_gates)
+        pass_ = BasisTranslator(
+            equivalence_library=std_eq_lib, target_basis=["cx", "id", "rz", "sx", "x"]
+        )
 
         # Add a parameter a which we will share between circuits
         param = Parameter("a")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Fixes #13504
### Summary
Adds a missing call to `copy` when adding equivalencies in the `EquivalenceLibrary`, which solves the parallel failures happening with #13504.


### Details and comments
When `EquivalenceLibrary` was ported to rust, we missed the [specific calls to `copy()`](https://github.com/Qiskit/qiskit/blob/cd26d498c9b74475753b9179ac2b7f84122ffe81/qiskit/circuit/equivalence.py#L94-L95) when adding an instance of `Equivalence` into the graph. This although harmless at first could break operability in parallel because, during serialization and de-serialization, the memory slot occupied by said parameter would not be available anymore and, therefore, when the `BasisTranslator` tries to re-assign this parameter via lookup, the search would fail due to said parameter being linked to a memory address that may not exist in that instance.

The following commits add the missing `copy()` calls for both the parameters and the instance of `CircuitData`, but also add a test-case for it in the `BasisTranslator`. Although the failure happens within the `EquivalenceLibrary`, we should keep the test there because the `BasisTranslator` is what detects the dead parameter trying to be replaced.

### Tasks
- [x] Add release note

Co-authored-by: Julien Gacon <gaconju@gmail.com>