### PR TITLE
Fix: Formatting errors in `InverseCancellation` release note

### DIFF
--- a/releasenotes/notes/fix-inverse-cancellation-c7f4debcde4a705a.yaml
+++ b/releasenotes/notes/fix-inverse-cancellation-c7f4debcde4a705a.yaml
@@ -1,6 +1,6 @@
 fixes:
   - |
     The transpilation pass :class:`.InverseCancellation` now runs inside of flow
-    controlled blocks. Previously, it ignores the pairs of gates in classical blocks
-    that can be cancelled. Refer to `#13437 <https://github.com/Qiskit/qiskit/issues/13437>`__ 
+    controlled blocks. Previously, it ignored the pairs of gates in classical blocks
+    that could be cancelled. Refer to `#13437 <https://github.com/Qiskit/qiskit/issues/13437>`__ 
     for more details.

--- a/releasenotes/notes/fix-inverse-cancellation-c7f4debcde4a705a.yaml
+++ b/releasenotes/notes/fix-inverse-cancellation-c7f4debcde4a705a.yaml
@@ -1,3 +1,6 @@
 fixes:
   - |
-    The transpilation pass :class`.InverseCancellation` now runs inside of flow controlled blocks. Previously, it ignores the pairs of gates in classical blocks that can be cancelled. Refer to `#13437 <https://github.com/Qiskit/qiskit/issues/13437>` for more details.
+    The transpilation pass :class:`.InverseCancellation` now runs inside of flow
+    controlled blocks. Previously, it ignores the pairs of gates in classical blocks
+    that can be cancelled. Refer to `#13437 <https://github.com/Qiskit/qiskit/issues/13437>`__ 
+    for more details.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The following commits fix a couple formatting errors on the release note attached to #13454 

### Details and comments


