### PR TITLE
Fix registering `global_phase` parameters when creating `CircuitData`

### DIFF
--- a/crates/accelerate/src/twirling.rs
+++ b/crates/accelerate/src/twirling.rs
@@ -267,7 +267,7 @@ fn generate_twirled_circuit(
     custom_gate_map: Option<&CustomGateTwirlingMap>,
     optimizer_target: Option<&Target>,
 ) -> PyResult<CircuitData> {
-    let mut out_circ = CircuitData::clone_empty_like(circ, None);
+    let mut out_circ = CircuitData::clone_empty_like(py, circ, None)?;
 
     for inst in circ.data() {
         if let Some(custom_gate_map) = custom_gate_map {

--- a/releasenotes/notes/fix-global-phase-assign-d05f182ed9ddcf57.yaml
+++ b/releasenotes/notes/fix-global-phase-assign-d05f182ed9ddcf57.yaml
@@ -1,0 +1,14 @@
+---
+fixes:
+  - |
+    Fixed a series of bugs when processing circuit with parameterized global phases,
+    where upon assignment the global phase was not correctly assigned.
+    Known cases this affected include:
+
+    * assigning parameters after calling :meth:`.QuantumCircuit.decompose` on a circuit, 
+      where the decomposition introduces a global phase
+    * assigning parameters on a circuit constructed from a DAG via :func:`.dag_to_circuit`
+    * assigning parameters on circuits created with :func:`.pauli_twirl_2q_gates`, where 
+      the circuit to be twirled had a parameterized global phase
+
+    Fixed `#13534 <https://github.com/Qiskit/qiskit/issues/13534>`__.

--- a/test/python/circuit/test_twirling.py
+++ b/test/python/circuit/test_twirling.py
@@ -15,7 +15,7 @@
 import ddt
 import numpy as np
 
-from qiskit.circuit import QuantumCircuit, pauli_twirl_2q_gates, Gate
+from qiskit.circuit import QuantumCircuit, pauli_twirl_2q_gates, Gate, Parameter
 from qiskit.circuit.library import (
     CXGate,
     ECRGate,
@@ -210,3 +210,13 @@ class TestTwirling(QiskitTestCase):
         qc = QuantumCircuit(5)
         with self.assertRaises(QiskitError):
             pauli_twirl_2q_gates(qc, [RZXGate(3.24)])
+
+    def test_with_global_phase(self):
+        """Test twirling a circuit with parameterized global phase."""
+
+        x = Parameter("x")
+        qc = QuantumCircuit(2, global_phase=x)
+        res = pauli_twirl_2q_gates(qc, seed=2)
+        bound = res.assign_parameters([1])
+
+        self.assertEqual(bound.global_phase, 1)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix a series of bugs caused by not correctly registering the parameters in the ``CircuitData``s parameter table upon creation. This led to the `QuantumCircuit.global_phase` attribute not being assigned upon calling ``assign_parameters``. Fixes #13534.

### Details and comments

I checked for all constructors that take in a `global_phase` and tried to add tests for each (e.g. `pauli_twirl_2q_gates` invokes `clone_empty_like`).

