### PR TITLE
`StabilizerState.expectation_value` can also accept `SparsePauliOp`

### DIFF
--- a/qiskit/quantum_info/states/stabilizerstate.py
+++ b/qiskit/quantum_info/states/stabilizerstate.py
@@ -263,11 +263,11 @@ class StabilizerState(QuantumState):
         """Compute the expectation value of a Pauli or SparsePauliOp operator.
 
         Args:
-            oper (Pauli or SparsePauliOp): a Pauli or SparsePauliOp operator to evaluate expval.
-            qargs (None or list): subsystems to apply the operator on.
+            oper: A Pauli or SparsePauliOp operator to evaluate the expectation value.
+            qargs: Subsystems to apply the operator on.
 
         Returns:
-            complex: the expectation value.
+            The expectation value.
 
         Raises:
             QiskitError: if oper is not a Pauli or SparsePauliOp operator.
@@ -281,10 +281,10 @@ class StabilizerState(QuantumState):
                 for z, x, coeff in zip(oper.paulis.z, oper.paulis.x, oper.coeffs)
             )
 
-        else:
-            raise QiskitError(
-                "Operator for expectation value is not a Pauli or SparsePauliOp operator."
-            )
+        raise QiskitError(
+            "Operator for expectation value is not a Pauli or SparsePauliOp operator, "
+            f"but {type(oper)}."
+        )
 
     def _expectation_value_pauli(self, oper: Pauli, qargs: None | list = None) -> complex:
         """Compute the expectation value of a Pauli operator.

--- a/releasenotes/notes/stabilizerstate-expval-sparsepauliop-3e32a871d8e908ce.yaml
+++ b/releasenotes/notes/stabilizerstate-expval-sparsepauliop-3e32a871d8e908ce.yaml
@@ -2,4 +2,4 @@
 features_quantum_info:
   - |
     The method :meth:`.StabilizerState.expectation_value` can now accept an operator of type
-    :class:`SparsePauliOp`.
+    :class:`.SparsePauliOp`.

--- a/releasenotes/notes/stabilizerstate-expval-sparsepauliop-3e32a871d8e908ce.yaml
+++ b/releasenotes/notes/stabilizerstate-expval-sparsepauliop-3e32a871d8e908ce.yaml
@@ -1,0 +1,5 @@
+---
+features_quantum_info:
+  - |
+    The method :meth:`.StabilizerState.expectation_value` can now accept an operator of type
+    :class:`SparsePauliOp`.

--- a/test/python/quantum_info/states/test_stabilizerstate.py
+++ b/test/python/quantum_info/states/test_stabilizerstate.py
@@ -25,7 +25,7 @@ from qiskit import QuantumCircuit
 from qiskit.quantum_info.random import random_clifford, random_pauli
 from qiskit.quantum_info.states import StabilizerState, Statevector
 from qiskit.circuit.library import IGate, XGate, HGate
-from qiskit.quantum_info.operators import Clifford, Pauli, Operator
+from qiskit.quantum_info.operators import Clifford, Pauli, Operator, SparsePauliOp
 from test import combine  # pylint: disable=wrong-import-order
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
@@ -1100,6 +1100,18 @@ class TestStabilizerStateExpectationValue(QiskitTestCase):
             exp_val = stab.expectation_value(op, qargs)
             target = Statevector(qc).expectation_value(op, qargs)
             self.assertAlmostEqual(exp_val, target)
+
+    def test_expval_sparsepauliop(self):
+        """Test expectation_value method of SparsePauliOp"""
+        cliff = random_clifford(num_qubits=3, seed=1234)
+        stab = StabilizerState(cliff)
+        labels = ["XXX", "IXI", "YYY", "III"]
+        coeffs = [3.0, 5.5, -1j, 23]
+        spp_op = SparsePauliOp.from_list(list(zip(labels, coeffs)))
+        expval = stab.expectation_value(spp_op)
+        qc = cliff.to_circuit()
+        target = Statevector(qc).expectation_value(spp_op)
+        self.assertAlmostEqual(expval, target)
 
     def test_stabilizer_bell_equiv(self):
         """Test that two circuits produce the same stabilizer group."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

close #12422

### Details and comments


