### PR TITLE
Replace circuit library pending deprecated classes

### DIFF
--- a/qiskit/circuit/library/data_preparation/pauli_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/pauli_feature_map.py
@@ -125,9 +125,9 @@ def pauli_feature_map(
         q_1: ┤ H ├────────────┤ X ├┤ P(2.0*(pi - x[0])*(pi - x[1])) ├┤ X ├─────────────
              └───┘            └───┘└────────────────────────────────┘└───┘
 
-        >>> from qiskit.circuit.library import EfficientSU2
+        >>> from qiskit.circuit.library import efficient_su2
         >>> prep = pauli_feature_map(3, reps=3, paulis=["Z", "YY", "ZXZ"])
-        >>> wavefunction = EfficientSU2(3)
+        >>> wavefunction = efficient_su2(3)
         >>> classifier = prep.compose(wavefunction)
         >>> classifier.num_parameters
         27
@@ -286,8 +286,8 @@ def zz_feature_map(
         q_1: ┤ H ├┤ P(2.0*x[1]) ├┤ X ├┤ P(2.0*(pi - x[0])*(pi - x[1])) ├┤ X ├
              └───┘└─────────────┘└───┘└────────────────────────────────┘└───┘
 
-        >>> from qiskit.circuit.library import EfficientSU2
-        >>> classifier = zz_feature_map(3) + EfficientSU2(3)
+        >>> from qiskit.circuit.library import efficient_su2
+        >>> classifier = zz_feature_map(3).compose(efficient_su2(3))
         >>> classifier.num_parameters
         15
         >>> classifier.parameters  # 'x' for the data preparation, 'θ' for the SU2 parameters

--- a/qiskit/circuit/library/generalized_gates/uc.py
+++ b/qiskit/circuit/library/generalized_gates/uc.py
@@ -34,7 +34,7 @@ from qiskit.circuit.exceptions import CircuitError
 from qiskit.exceptions import QiskitError
 from qiskit._accelerate import uc_gate
 
-from .diagonal import Diagonal
+from .diagonal import DiagonalGate
 
 _EPS = 1e-10  # global variable used to chop very small numbers to zero
 
@@ -276,7 +276,7 @@ class UCGate(Gate):
             # Important: the diagonal gate is given in the computational basis of the qubits
             # q[k-1],...,q[0],q_target (ordered with decreasing significance),
             # where q[i] are the control qubits and t denotes the target qubit.
-            diagonal = Diagonal(diag)
+            diagonal = DiagonalGate(diag)
 
             circuit.append(diagonal, [q_target] + q_controls)
         return circuit, diag

--- a/qiskit/circuit/library/overlap.py
+++ b/qiskit/circuit/library/overlap.py
@@ -131,10 +131,10 @@ def unitary_overlap(
         :include-source:
 
         import numpy as np
-        from qiskit.circuit.library import EfficientSU2, unitary_overlap
+        from qiskit.circuit.library import efficient_su2, unitary_overlap
 
         # get two circuit to prepare states of which we compute the overlap
-        circuit = EfficientSU2(2, reps=1)
+        circuit = efficient_su2(2, reps=1)
         unitary1 = circuit.assign_parameters(np.random.random(circuit.num_parameters))
         unitary2 = circuit.assign_parameters(np.random.random(circuit.num_parameters))
 

--- a/test/benchmarks/circuit_construction.py
+++ b/test/benchmarks/circuit_construction.py
@@ -19,7 +19,7 @@ import itertools
 from qiskit.quantum_info import random_clifford
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.circuit import Parameter
-from qiskit.circuit.library import EfficientSU2, QuantumVolume
+from qiskit.circuit.library import efficient_su2, quantum_volume
 from .utils import dtc_unitary, multi_control_circuit
 
 SEED = 12345
@@ -112,7 +112,7 @@ class ParamaterizedDifferentCircuit:
         """Measures an SDKs ability to build a 100Q
         QV circit from scratch.
         """
-        return QuantumVolume(circuit_size, num_qubits, seed=SEED)
+        return quantum_volume(circuit_size, num_qubits, seed=SEED)
 
     def time_DTC100_set_build(self, circuit_size, num_qubits):
         """Measures an SDKs ability to build a set
@@ -154,7 +154,7 @@ class ParameterizedCirc:
         over 100Q utilizing 4 repetitions.  This will yield a
         circuit with 1000 parameters
         """
-        out = EfficientSU2(num_qubits, reps=4, entanglement="circular", flatten=True)
+        out = efficient_su2(num_qubits, reps=4, entanglement="circular")
         out._build()
         return out
 

--- a/test/benchmarks/utility_scale.py
+++ b/test/benchmarks/utility_scale.py
@@ -16,7 +16,7 @@
 import os
 
 from qiskit import QuantumCircuit
-from qiskit.circuit.library import EfficientSU2
+from qiskit.circuit.library import efficient_su2
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.transpiler import CouplingMap
@@ -48,7 +48,7 @@ class UtilityScaleBenchmarks:
         self.qaoa_qasm = os.path.join(qasm_dir, "qaoa_barabasi_albert_N100_3reps.qasm")
         self.qaoa_qc = QuantumCircuit.from_qasm_file(self.qaoa_qasm)
         self.qv_qc = build_qv_model_circuit(50, 50, SEED)
-        self.circSU2 = EfficientSU2(100, reps=3, entanglement="circular")
+        self.circSU2 = efficient_su2(100, reps=3, entanglement="circular")
         self.bv_100 = bv_all_ones(100)
         self.bv_like_100 = trivial_bvlike_circuit(100)
 

--- a/test/python/quantum_info/operators/symplectic/test_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli.py
@@ -30,7 +30,7 @@ from qiskit.circuit.library import (
     CYGate,
     CZGate,
     ECRGate,
-    EfficientSU2,
+    efficient_su2,
     HGate,
     IGate,
     SdgGate,
@@ -515,7 +515,7 @@ class TestPauli(QiskitTestCase):
 
     def test_apply_layout_with_transpile(self):
         """Test the apply_layout method with a transpiler layout."""
-        psi = EfficientSU2(4, reps=4, entanglement="circular")
+        psi = efficient_su2(4, reps=4, entanglement="circular")
         op = Pauli("IZZZ")
         backend = GenericBackendV2(num_qubits=7)
         transpiled_psi = transpile(psi, backend, optimization_level=3, seed_transpiler=12345)
@@ -530,7 +530,7 @@ class TestPauli(QiskitTestCase):
 
     def test_apply_layout_consistency(self):
         """Test that the Pauli apply_layout() is consistent with the SparsePauliOp apply_layout()."""
-        psi = EfficientSU2(4, reps=4, entanglement="circular")
+        psi = efficient_su2(4, reps=4, entanglement="circular")
         op = Pauli("IZZZ")
         sparse_op = SparsePauliOp(op)
         backend = GenericBackendV2(num_qubits=7)
@@ -541,7 +541,7 @@ class TestPauli(QiskitTestCase):
 
     def test_permute_pauli_estimator_example(self):
         """Test using the apply_layout method with an estimator workflow."""
-        psi = EfficientSU2(4, reps=4, entanglement="circular")
+        psi = efficient_su2(4, reps=4, entanglement="circular")
         op = Pauli("XXXI")
         backend = GenericBackendV2(num_qubits=7, seed=0)
         backend.set_options(seed_simulator=123)

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -23,7 +23,7 @@ import ddt
 
 from qiskit import QiskitError
 from qiskit.circuit import Parameter, ParameterExpression, ParameterVector
-from qiskit.circuit.library import EfficientSU2
+from qiskit.circuit.library import efficient_su2
 from qiskit.circuit.parametertable import ParameterView
 from qiskit.compiler.transpiler import transpile
 from qiskit.primitives import BackendEstimator
@@ -1148,7 +1148,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
 
     def test_apply_layout_with_transpile(self):
         """Test the apply_layout method with a transpiler layout."""
-        psi = EfficientSU2(4, reps=4, entanglement="circular")
+        psi = efficient_su2(4, reps=4, entanglement="circular")
         op = SparsePauliOp.from_list([("IIII", 1), ("IZZZ", 2), ("XXXI", 3)])
         backend = GenericBackendV2(num_qubits=7)
         transpiled_psi = transpile(psi, backend, optimization_level=3, seed_transpiler=12345)
@@ -1163,7 +1163,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
 
     def test_permute_sparse_pauli_op_estimator_example(self):
         """Test using the apply_layout method with an estimator workflow."""
-        psi = EfficientSU2(4, reps=4, entanglement="circular")
+        psi = efficient_su2(4, reps=4, entanglement="circular")
         op = SparsePauliOp.from_list([("IIII", 1), ("IZZZ", 2), ("XXXI", 3)])
         backend = GenericBackendV2(num_qubits=7, seed=0)
         backend.set_options(seed_simulator=123)

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -28,7 +28,7 @@ import scipy.linalg
 from qiskit import QiskitError
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.circuit import library
-from qiskit.circuit.library import HGate, CHGate, CXGate, QFT
+from qiskit.circuit.library import HGate, CHGate, CXGate, QFTGate
 from qiskit.transpiler import CouplingMap
 from qiskit.transpiler.layout import Layout, TranspileLayout
 from qiskit.quantum_info.operators import Operator, ScalarOp
@@ -743,7 +743,7 @@ class TestOperator(OperatorTestCase):
 
     def test_reverse_qargs(self):
         """Test reverse_qargs method"""
-        circ1 = QFT(5)
+        circ1 = QFTGate(5).definition
         circ2 = circ1.reverse_bits()
 
         state1 = Operator(circ1)
@@ -752,7 +752,7 @@ class TestOperator(OperatorTestCase):
 
     def test_drawings(self):
         """Test draw method"""
-        qc1 = QFT(5)
+        qc1 = QFTGate(5).definition
         op = Operator.from_circuit(qc1)
         with self.subTest(msg="str(operator)"):
             str(op)

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -20,7 +20,7 @@ from ddt import data, ddt
 from numpy.testing import assert_allclose
 
 from qiskit import QiskitError, QuantumCircuit, QuantumRegister
-from qiskit.circuit.library import QFT, HGate
+from qiskit.circuit.library import QFTGate, HGate
 from qiskit.quantum_info.operators.operator import Operator
 from qiskit.quantum_info.operators.symplectic import Pauli, SparsePauliOp
 from qiskit.quantum_info.random import random_density_matrix, random_pauli, random_unitary
@@ -1186,7 +1186,7 @@ class TestDensityMatrix(QiskitTestCase):
 
     def test_reverse_qargs(self):
         """Test reverse_qargs method"""
-        circ1 = QFT(5)
+        circ1 = QFTGate(5).definition
         circ2 = circ1.reverse_bits()
 
         state1 = DensityMatrix.from_instruction(circ1)
@@ -1197,7 +1197,7 @@ class TestDensityMatrix(QiskitTestCase):
     @unittest.skipUnless(optionals.HAS_PYLATEX, "requires pylatexenc")
     def test_drawings(self):
         """Test draw method"""
-        qc1 = QFT(5)
+        qc1 = QFTGate(5).definition
         dm = DensityMatrix.from_instruction(qc1)
         with self.subTest(msg="str(density_matrix)"):
             str(dm)

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -23,7 +23,7 @@ from numpy.testing import assert_allclose
 from qiskit import QiskitError
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit import transpile
-from qiskit.circuit.library import HGate, QFT, GlobalPhaseGate
+from qiskit.circuit.library import HGate, QFTGate, GlobalPhaseGate
 from qiskit.providers.basic_provider import BasicSimulator
 from qiskit.utils import optionals
 from qiskit.quantum_info.random import random_unitary, random_statevector, random_pauli
@@ -1218,7 +1218,7 @@ class TestStatevector(QiskitTestCase):
 
     def test_reverse_qargs(self):
         """Test reverse_qargs method"""
-        circ1 = QFT(5)
+        circ1 = QFTGate(5).definition
         circ2 = circ1.reverse_bits()
 
         state1 = Statevector.from_instruction(circ1)
@@ -1229,7 +1229,7 @@ class TestStatevector(QiskitTestCase):
     @unittest.skipUnless(optionals.HAS_PYLATEX, "requires pylatexenc")
     def test_drawings(self):
         """Test draw method"""
-        qc1 = QFT(5)
+        qc1 = QFTGate(5).definition
         sv = Statevector.from_instruction(qc1)
         with self.subTest(msg="str(statevector)"):
             str(sv)

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -1045,11 +1045,9 @@ class TestFinalLayouts(QiskitTestCase):
         rows = [x[0] for x in backend.coupling_map]
         cols = [x[1] for x in backend.coupling_map]
 
-        num_qubits = 20
-        adjacency_matrix = np.zeros((num_qubits, num_qubits))
-        qc = QuantumCircuit(num_qubits)
+        adjacency_matrix = np.zeros((20, 20))
         adjacency_matrix[rows, cols] = 1
-        qc.append(GraphStateGate(adjacency_matrix), range(num_qubits))
+        qc = GraphStateGate(adjacency_matrix).definition
         qc.measure_all()
         expected = {
             0: Qubit(QuantumRegister(20, "q"), 0),

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -22,10 +22,9 @@ import numpy as np
 
 from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister
 from qiskit.circuit import Qubit, Gate, ControlFlowOp, ForLoopOp
-from qiskit.circuit.library import quantum_volume
 from qiskit.compiler import transpile
 from qiskit.transpiler import CouplingMap, Layout, PassManager, TranspilerError, Target
-from qiskit.circuit.library import U2Gate, U3Gate, QuantumVolume, CXGate, CZGate, XGate
+from qiskit.circuit.library import U2Gate, U3Gate, quantum_volume, CXGate, CZGate, XGate
 from qiskit.transpiler.passes import (
     ALAPScheduleAnalysis,
     PadDynamicalDecoupling,
@@ -33,7 +32,7 @@ from qiskit.transpiler.passes import (
 )
 from qiskit.providers.fake_provider import Fake5QV1, Fake20QV1, GenericBackendV2
 from qiskit.converters import circuit_to_dag
-from qiskit.circuit.library import GraphState
+from qiskit.circuit.library import GraphStateGate
 from qiskit.quantum_info import random_unitary
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit.transpiler.preset_passmanagers import level0, level1, level2, level3
@@ -269,7 +268,7 @@ class TestPresetPassManager(QiskitTestCase):
             basis_gates=["id", "u1", "u2", "u3", "cx"],
             seed=42,
         )
-        qv_circuit = QuantumVolume(3)
+        qv_circuit = quantum_volume(3)
         gates_in_basis_true_count = 0
         consolidate_blocks_count = 0
 
@@ -1046,9 +1045,11 @@ class TestFinalLayouts(QiskitTestCase):
         rows = [x[0] for x in backend.coupling_map]
         cols = [x[1] for x in backend.coupling_map]
 
-        adjacency_matrix = np.zeros((20, 20))
+        num_qubits = 20
+        adjacency_matrix = np.zeros((num_qubits, num_qubits))
+        qc = QuantumCircuit(num_qubits)
         adjacency_matrix[rows, cols] = 1
-        qc = GraphState(adjacency_matrix)
+        qc.append(GraphStateGate(adjacency_matrix), range(num_qubits))
         qc.measure_all()
         expected = {
             0: Qubit(QuantumRegister(20, "q"), 0),

--- a/test/python/transpiler/test_sabre_layout.py
+++ b/test/python/transpiler/test_sabre_layout.py
@@ -18,7 +18,7 @@ import math
 
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.circuit.classical import expr, types
-from qiskit.circuit.library import EfficientSU2, QuantumVolume
+from qiskit.circuit.library import efficient_su2, quantum_volume
 from qiskit.transpiler import CouplingMap, AnalysisPass, PassManager
 from qiskit.transpiler.passes import SabreLayout, DenseLayout, StochasticSwap, Unroll3qOrMore
 from qiskit.transpiler.exceptions import TranspilerError
@@ -321,7 +321,7 @@ barrier q18585[5],q18585[2],q18585[8],q18585[3],q18585[6];
 
         Regression test of #13081.
         """
-        qv = QuantumVolume(500, seed=42)
+        qv = quantum_volume(500, seed=42)
         qv.measure_all()
         qc = Unroll3qOrMore()(qv)
 
@@ -476,7 +476,7 @@ class TestSabrePreLayout(QiskitTestCase):
 
     def setUp(self):
         super().setUp()
-        circuit = EfficientSU2(16, entanglement="circular", reps=6, flatten=True)
+        circuit = efficient_su2(16, entanglement="circular", reps=6)
         circuit.assign_parameters([math.pi / 2] * len(circuit.parameters), inplace=True)
         circuit.measure_all()
         self.circuit = circuit

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -24,7 +24,7 @@ from ddt import ddt, data
 from qiskit import transpile
 from qiskit.providers.fake_provider import Fake5QV1, GenericBackendV2
 from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister
-from qiskit.circuit.library import QuantumVolume
+from qiskit.circuit.library import quantum_volume
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.transpiler.passes import UnitarySynthesis
 from qiskit.quantum_info.operators import Operator
@@ -558,7 +558,7 @@ class TestUnitarySynthesis(QiskitTestCase):
 
     def test_qv_natural(self):
         """check that quantum volume circuit compiles for natural direction"""
-        qv64 = QuantumVolume(5, seed=15)
+        qv64 = quantum_volume(5, seed=15)
 
         def construct_passmanager(basis_gates, coupling_map, synthesis_fidelity, pulse_optimize):
             seed = 2

--- a/test/python/transpiler/test_vf2_layout.py
+++ b/test/python/transpiler/test_vf2_layout.py
@@ -295,10 +295,7 @@ class TestVF2LayoutLattice(LayoutTestCase):
     def graph_state_from_pygraph(self, graph):
         """Creates a GraphStateGate circuit from a PyGraph"""
         adjacency_matrix = rustworkx.adjacency_matrix(graph)
-        num_qubits = adjacency_matrix.shape[0]
-        qc = QuantumCircuit(num_qubits)
-        qc.append(GraphStateGate(adjacency_matrix), range(num_qubits))
-        return qc.decompose()
+        return GraphStateGate(adjacency_matrix).definition
 
     def test_hexagonal_lattice_graph_20_in_25(self):
         """A 20x20 interaction map in 25x25 coupling map"""
@@ -515,10 +512,8 @@ class TestVF2LayoutBackend(LayoutTestCase):
         num_qubits = 65
         adj_matrix = numpy.zeros((num_qubits, num_qubits))
         adj_matrix[rows, cols] = 1
-        circuit = QuantumCircuit(num_qubits)
 
-        circuit.append(GraphStateGate(adj_matrix), range(num_qubits))
-        circuit = circuit.decompose()
+        circuit = GraphStateGate(adj_matrix).definition
         circuit.measure_all()
 
         dag = circuit_to_dag(circuit)

--- a/test/python/visualization/test_circuit_latex.py
+++ b/test/python/visualization/test_circuit_latex.py
@@ -30,9 +30,9 @@ from qiskit.circuit.library import (
     CPhaseGate,
     HamiltonianGate,
     Isometry,
+    iqp,
 )
 from qiskit.circuit import Parameter, Qubit, Clbit
-from qiskit.circuit.library import IQP
 from qiskit.quantum_info.random import random_unitary
 from qiskit.utils import optionals
 from .visualization import QiskitVisualizationTestCase
@@ -295,7 +295,7 @@ class TestLatexSourceGenerator(QiskitVisualizationTestCase):
         filename = self._get_resource_path("test_latex_big_gates.tex")
         qr = QuantumRegister(6, "q")
         circuit = QuantumCircuit(qr)
-        circuit.append(IQP([[6, 5, 3], [5, 4, 5], [3, 5, 1]]), [0, 1, 2])
+        circuit.append(iqp([[6, 5, 3], [5, 4, 5], [3, 5, 1]]), [0, 1, 2])
 
         desired_vector = [
             1 / math.sqrt(16) * complex(0, 1),

--- a/test/visual/mpl/circuit/test_circuit_matplotlib_drawer.py
+++ b/test/visual/mpl/circuit/test_circuit_matplotlib_drawer.py
@@ -37,8 +37,8 @@ from qiskit.circuit.library import (
     CPhaseGate,
     HamiltonianGate,
     Isometry,
+    iqp,
 )
-from qiskit.circuit.library import MCXVChain
 from qiskit.circuit.annotated_operation import (
     AnnotatedOperation,
     InverseModifier,
@@ -46,7 +46,6 @@ from qiskit.circuit.annotated_operation import (
     PowerModifier,
 )
 from qiskit.circuit import Parameter, Qubit, Clbit, IfElseOp, SwitchCaseOp
-from qiskit.circuit.library import IQP
 from qiskit.circuit.classical import expr, types
 from qiskit.quantum_info import random_clifford
 from qiskit.quantum_info.random import random_unitary
@@ -543,7 +542,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         """Test large gates with params"""
         qr = QuantumRegister(6, "q")
         circuit = QuantumCircuit(qr)
-        circuit.append(IQP([[6, 5, 3], [5, 4, 5], [3, 5, 1]]), [0, 1, 2])
+        circuit.append(iqp([[6, 5, 3], [5, 4, 5], [3, 5, 1]]), [0, 1, 2])
 
         desired_vector = [
             1 / math.sqrt(16) * complex(0, 1),
@@ -585,7 +584,6 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.ccx(0, 1, 2)
         circuit.append(XGate().control(3, ctrl_state="010"), [qr[2], qr[3], qr[0], qr[1]])
         circuit.append(MCXGate(num_ctrl_qubits=3, ctrl_state="101"), [qr[0], qr[1], qr[2], qr[4]])
-        circuit.append(MCXVChain(3, dirty_ancillas=True), [qr[0], qr[1], qr[2], qr[3], qr[5]])
 
         fname = "cnot.png"
         self.circuit_drawer(circuit, output="mpl", filename=fname)

--- a/test/visual/mpl/circuit/test_circuit_matplotlib_drawer.py
+++ b/test/visual/mpl/circuit/test_circuit_matplotlib_drawer.py
@@ -39,6 +39,7 @@ from qiskit.circuit.library import (
     Isometry,
     iqp,
 )
+from qiskit.circuit.library import MCXVChain
 from qiskit.circuit.annotated_operation import (
     AnnotatedOperation,
     InverseModifier,
@@ -584,6 +585,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.ccx(0, 1, 2)
         circuit.append(XGate().control(3, ctrl_state="010"), [qr[2], qr[3], qr[0], qr[1]])
         circuit.append(MCXGate(num_ctrl_qubits=3, ctrl_state="101"), [qr[0], qr[1], qr[2], qr[4]])
+        circuit.append(MCXVChain(3, dirty_ancillas=True), [qr[0], qr[1], qr[2], qr[3], qr[5]])
 
         fname = "cnot.png"
         self.circuit_drawer(circuit, output="mpl", filename=fname)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Replace circuit library pending deprecated classes following https://github.com/Qiskit/qiskit/issues/13046.

- Diagonal --> DiagonalGate
- EfficientSU2 --> efficient_su2
- GraphState --> GraphStateGate
- QuantumVolume --> quantum_volume
- IQP --> iqp
- QFT --> QFTGate

### Details and comments


