### PR TITLE
Small formatting issue in `qiskit.qpy` docs

### DIFF
--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -574,7 +574,7 @@ Type code  Meaning
 Changes to EXPR_VAR
 ~~~~~~~~~~~~~~~~~~~
 
-The EXPR_VAR variable has gained a new type code and payload, in addition to the pre-existing ones:
+The ``EXPR_VAR`` variable has gained a new type code and payload, in addition to the pre-existing ones:
 
 ===========================  =========  ============================================================
 Python class                 Type code  Payload
@@ -721,9 +721,9 @@ Each of these are described in the following table:
 ======================  =========  =======================================================  ========
 Qiskit class            Type code  Payload                                                  Children
 ======================  =========  =======================================================  ========
-:class:`~.expr.Var`     ``x``      One EXPR_VAR.                                            0
+:class:`~.expr.Var`     ``x``      One ``EXPR_VAR``.                                        0
 
-:class:`~.expr.Value`   ``v``      One EXPR_VALUE.                                          0
+:class:`~.expr.Value`   ``v``      One ``EXPR_VALUE``.                                      0
 
 :class:`~.expr.Cast`    ``c``      One ``_Bool``  that corresponds to the value of          1
                                    ``implicit``.

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -475,8 +475,8 @@ characters:
    * - ``u``
      - substitution
 
-If the type value is ``f``, ``c``, or ``i``, the corresponding ``lhs`` or `rhs``
-field widths are 128 bits ach. In the case of floats, the literal value is encoded as a double
+If the type value is ``f``, ``c``, or ``i``, the corresponding ``lhs`` or ``rhs``
+field widths are 128 bits each. In the case of floats, the literal value is encoded as a double
 with 0 padding, while complex numbers are encoded as real part followed by imaginary part,
 taking up 64 bits each. For ``i``, the value is encoded as a 64 bit signed integer with 0 padding
 for the full 128 bit width. ``n`` is used to represent a ``None`` and typically isn't directly used

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -475,10 +475,10 @@ characters:
    * - ``u``
      - substitution
 
-If the type value is ``f`` ,``c`` or ``i``, the corresponding ``lhs`` or `rhs``
-field widths are 128 bits each. In the case of floats, the literal value is encoded as a double
+If the type value is ``f``, ``c``, or ``i``, the corresponding ``lhs`` or `rhs``
+field widths are 128 bits ach. In the case of floats, the literal value is encoded as a double
 with 0 padding, while complex numbers are encoded as real part followed by imaginary part,
-taking up 64 bits each. For ``i`, the value is encoded as a 64 bit signed integer with 0 padding
+taking up 64 bits each. For ``i``, the value is encoded as a 64 bit signed integer with 0 padding
 for the full 128 bit width. ``n`` is used to represent a ``None`` and typically isn't directly used
 as it indicates an argument that's not used. For ``p`` the data is the UUID for the
 :class:`.Parameter` which can be looked up in the symbol map described in the


### PR DESCRIPTION
### Summary

There are some small formatting issues in  https://docs.quantum.ibm.com/api/qiskit/qpy :

![Screenshot 2024-12-10 at 23 19 59](https://github.com/user-attachments/assets/a4595a2e-6c05-4d09-af4a-486ef990a1d6)

With this PR:

![Screenshot 2024-12-11 at 10 57 36](https://github.com/user-attachments/assets/396853b3-5865-448c-bb8b-368fa83ac155)
