### PR TITLE
Discard cache for standard gates in `assign_parameters`

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -1392,8 +1392,11 @@ impl CircuitData {
                             #[cfg(feature = "cache_pygates")]
                             {
                                 // Standard gates can all rebuild their definitions, so if the
-                                // cached py_op exists, update the `params` attribute and clear out
-                                // any existing cache.
+                                // cached py_op exists, discard it to prompt the instruction
+                                // to rebuild its cached python gate upon request later on. This is
+                                // done to avoid an unintentional duplicated reference to the same gate
+                                // instance in python. For more information, see
+                                // https://github.com/Qiskit/qiskit/issues/13504
                                 previous.py_op.take();
                             }
                         } else {

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -1394,13 +1394,7 @@ impl CircuitData {
                                 // Standard gates can all rebuild their definitions, so if the
                                 // cached py_op exists, update the `params` attribute and clear out
                                 // any existing cache.
-                                if let Some(borrowed) = previous.py_op.get() {
-                                    borrowed
-                                        .bind(py)
-                                        .getattr(params_attr)?
-                                        .set_item(parameter, new_param)?;
-                                    borrowed.bind(py).setattr("_definition", py.None())?
-                                }
+                                previous.py_op.take();
                             }
                         } else {
                             // Track user operations we've seen so we can rebind their definitions.

--- a/releasenotes/notes/fix-assign-parameters-ffa284ebde429704.yaml
+++ b/releasenotes/notes/fix-assign-parameters-ffa284ebde429704.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix incorrect behavior in :class:`.CircuitData` in which, upon parameter assignment,
+    we attempted to modify the cached operation inside of a ``PackedInstruction``. Now
+    we instead discard said cache prompting the ``PackedInstruction`` to build a new Python
+    operation should it be needed.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
This is an initial fix to #13504, and should precede #13543.

The following commits discard the cached gate when assigning parameters for a standard gate rather than trying to modify the Python object.


### Details and comments

A more in-depth fix is present in #13543, but since it is such a big change, we've decided to include this smaller fix to allow more time to re-evaluate our approach.

When retrieving a `PackedInstruction` from the `EquivalenceLibrary` during the `compose_transforms` phase of the `BasisTranslator` the parameter modifications done in other places are not reflected on the cached gate, therefore leading to issues when running `QISKIT_PARALLEL=TRUE` due to a modified object reference when calling `CircuitData::assign_parameters()`. 

In the case of a standard gate, we were not removing the old cache but instead modifying it in place (which would not result in the expected outcome), while for other gate instances, we rebuild the non-cached item. Now we instead discard the cache in the `StandardGate` case too, getting rid of the stale shared reference.

