### PR TITLE
Drop support for macOS 10.12 from wheel build.

### DIFF
--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -121,7 +121,7 @@ jobs:
           cat >>"$GITHUB_ENV" <<EOF
           CIBW_BEFORE_BUILD=bash ./tools/build_pgo.sh $PGO_WORK_DIR $PGO_OUT_PATH
           CIBW_ENVIRONMENT=RUSTUP_TOOLCHAIN=stable RUSTFLAGS='-Cprofile-use=$PGO_OUT_PATH -Cllvm-args=-pgo-warn-missing-function'
-          CIBW_ENVIRONMENT_MACOS=MACOSX_DEPLOYMENT_TARGET='10.12' RUSTUP_TOOLCHAIN=stable RUSTFLAGS='-Cprofile-use=$PGO_OUT_PATH -Cllvm-args=-pgo-warn-missing-function'
+          CIBW_ENVIRONMENT_MACOS=MACOSX_DEPLOYMENT_TARGET='10.13' RUSTUP_TOOLCHAIN=stable RUSTFLAGS='-Cprofile-use=$PGO_OUT_PATH -Cllvm-args=-pgo-warn-missing-function'
           CIBW_ENVIRONMENT_LINUX=RUSTUP_TOOLCHAIN=stable RUSTFLAGS='-Cprofile-use=$PGO_OUT_PATH -Cllvm-args=-pgo-warn-missing-function' PATH="\$PATH:\$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true"
           EOF
         env:

--- a/releasenotes/notes/drop-macos-10.12-fa73631d96ccc542.yaml
+++ b/releasenotes/notes/drop-macos-10.12-fa73631d96ccc542.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    For macOS users, the minimum version of macOS is now 10.13. Previously, the
+    precompiled binary wheel packages for macOS x86_64 were published with
+    support for >=10.12. However, we are no longer able to provide automated
+    builds for macOS versions older than 10.13. If you're using Qiskit on macOS
+    10.12, you can probably build Qiskit from source.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
We'd originally expected to build wheels for x86_64 macOS 10.12 in #13470, but it turns out that macOS 13 cannot build anything older than `10.13`:

![Screenshot 2024-12-12 at 4 18 23 PM](https://github.com/user-attachments/assets/037cfa08-b698-40ba-b5b1-1391df3f089f)

The automatic bump-up to `11` on ARM is presumably something we expect. Correct me if I'm wrong.

### Details and comments
This was noticed during the release of Qiskit 1.3.1.

Oddly, the wheel built for macOS ARM uses the bumped-up version of `11`:

https://pypi.org/project/qiskit/#qiskit-1.3.1-cp39-abi3-macosx_11_0_arm64.whl

But the x86_64 wheel uses the version `10.12` (even though supposedly it would've been built for `10.13`). I'm not sure what will happen, then, if this wheel gets pulled on macOS `10.12`. Unfortunately, the included release note should be present in the 1.3.1 release, but is not. Perhaps we can add it manually.

https://pypi.org/project/qiskit/#qiskit-1.3.1-cp39-abi3-macosx_10_12_x86_64.whl



