### PR TITLE
Fix a docstring rst link rendering within an inline literal

### DIFF
--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -725,7 +725,7 @@ class Target(BaseTarget):
 
     @property
     def instructions(self):
-        """Get the list of tuples ``(:class:`~qiskit.circuit.Instruction`, (qargs))``
+        """Get the list of tuples (:class:`~qiskit.circuit.Instruction`, (qargs))
         for the target
 
         For globally defined variable width operations the tuple will be of the form


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
Changing from this: 

![image](https://github.com/user-attachments/assets/2fa31c94-542f-4ec7-8829-f458b7c42f84)

to this: 

![image](https://github.com/user-attachments/assets/24bd9bc2-3eff-4297-8c9c-276dc071e079)

If someone knows if there is a way to properly render an rst link within an inline literal text, I'd love to know. 
