### PR TITLE
Removal of MCMT and MCMTVChain, deprecated in qiskit 1.4

### DIFF
--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -575,8 +575,6 @@ from .blueprintcircuit import BlueprintCircuit
 from .generalized_gates import (
     Diagonal,
     DiagonalGate,
-    MCMT,
-    MCMTVChain,
     Permutation,
     PermutationGate,
     GMS,

--- a/qiskit/circuit/library/generalized_gates/__init__.py
+++ b/qiskit/circuit/library/generalized_gates/__init__.py
@@ -14,7 +14,7 @@
 
 from .diagonal import Diagonal, DiagonalGate
 from .permutation import Permutation, PermutationGate
-from .mcmt import MCMT, MCMTVChain, MCMTGate
+from .mcmt import MCMTGate
 from .gms import GMS, MSGate
 from .gr import GR, GRX, GRY, GRZ
 from .pauli import PauliGate

--- a/releasenotes/notes/removal_MCMTV-291077b3362c22c0.yaml
+++ b/releasenotes/notes/removal_MCMTV-291077b3362c22c0.yaml
@@ -1,0 +1,4 @@
+---
+upgrade_circuits:
+  - |
+    The classes ``MCMT`` and ``MCMTVChain`` had been removed in favor of :class:`~MCMTGate`. 


### PR DESCRIPTION
Blocked by https://github.com/Qiskit/qiskit/pull/13584

The classes ``MCMT`` and ``MCMTVChain`` had been deprecated in favor of `MCMTGate`.