### PR TITLE
Fix `UnitarySynthesis` for 3+ qubits when compiled for a backend

### DIFF
--- a/crates/accelerate/src/unitary_synthesis.rs
+++ b/crates/accelerate/src/unitary_synthesis.rs
@@ -372,7 +372,8 @@ fn py_run_main_loop(
                     None,
                     None,
                 )?;
-                out_dag = synth_dag;
+                let out_qargs = dag.get_qargs(packed_instr.qubits);
+                apply_synth_dag(py, &mut out_dag, out_qargs, &synth_dag)?;
             }
         }
     }

--- a/releasenotes/notes/fix-unitary-synthesis-3q-2b2de5305bfd11ff.yaml
+++ b/releasenotes/notes/fix-unitary-synthesis-3q-2b2de5305bfd11ff.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a bug in the :class:`.UnitarySynthesis` transpiler pass, where blocks of
+    :class:`.UnitaryGate`\s of 3 qubits or more were not correctly synthesized.
+    This lead e.g. to the circuit being overwritten with the last processed block or
+    to internal panics when encountering measurements after a such a block.
+    Fixed `#13586 <https://github.com/Qiskit/qiskit/issues/13586>`__.

--- a/releasenotes/notes/fix-unitary-synthesis-3q-2b2de5305bfd11ff.yaml
+++ b/releasenotes/notes/fix-unitary-synthesis-3q-2b2de5305bfd11ff.yaml
@@ -2,7 +2,7 @@
 fixes:
   - |
     Fixed a bug in the :class:`.UnitarySynthesis` transpiler pass, where blocks of
-    :class:`.UnitaryGate`\s of 3 qubits or more were not correctly synthesized.
-    This lead e.g. to the circuit being overwritten with the last processed block or
-    to internal panics when encountering measurements after a such a block.
+    :class:`.UnitaryGate`\s on 3 qubits or more were not correctly synthesized.
+    This led, e.g., to the circuit being overwritten with the last processed block or
+    to internal panics when encountering measurements after such a block.
     Fixed `#13586 <https://github.com/Qiskit/qiskit/issues/13586>`__.

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -1079,7 +1079,7 @@ class TestUnitarySynthesis(QiskitTestCase):
         tqc = transpile(qc, backend, optimization_level=0, initial_layout=[0, 1, 2])
 
         expected = np.kron(np.eye(2**2), x_mat)
-        self.assertTrue(Operator(tqc).equiv(expected))
+        self.assertEqual(Operator(tqc), Operator(expected))
 
     def test_3q_measure_all(self):
         """Regression test of #13586."""

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -1050,6 +1050,18 @@ class TestUnitarySynthesis(QiskitTestCase):
         qc_transpiled = transpile(qc, target=target, optimization_level=opt)
         self.assertTrue(np.allclose(mat, Operator(qc_transpiled).data))
 
+    def test_3q_with_measure(self):
+        """Test 3-qubit synthesis with measurements."""
+        backend = FakeBackend5QV2()
+
+        qc = QuantumCircuit(3, 1)
+        qc.unitary(np.eye(2**3), range(3))
+        qc.measure(0, 0)
+
+        qc_transpiled = transpile(qc, backend)
+        self.assertTrue(qc_transpiled.size, 1)
+        self.assertTrue(qc_transpiled.count_ops().get("measure", 0), 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

When encountering a 3+ qubit `UnitaryGate`, `UnitarySynthesis` currently replaces the whole dag with the definition of the block instead of appending it, see
https://github.com/Qiskit/qiskit/blob/079f69f7dd906299dfdf8c1262fa9bc1d75e478b/crates/accelerate/src/unitary_synthesis.rs#L375

### Details and comments

This also leads to #13586 because the qubit/clbit interners are overwritten, but maybe more importantly this can lead to issues when multiple 3-qubit blocks are present in the circuit. E.g. running
```python
import numpy as np
from qiskit.quantum_info import Operator
from qiskit.circuit.library import UnitaryGate
from qiskit import QuantumCircuit, transpile
from qiskit_ibm_runtime.fake_provider import FakeSherbrooke

backend = FakeSherbrooke()

x = QuantumCircuit(3)
x.x(2)
x_mat = Operator(x)

qc = QuantumCircuit(3, 1)
qc.unitary(x_mat, range(3))
qc.unitary(np.eye(2 ** 3), range(3))

tqc = transpile(qc, backend, optimization_level=0)
print(tqc.count_ops())
```
produces an _empty_ circuit, since the last block implements the identity.

Some additional tests, such as the precise case of #13586 and a series of 3q `UnitaryGate`s, should be added.

