### PR TITLE
More conservative caching in the ``CommutationChecker``

### DIFF
--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -431,6 +431,11 @@ static STANDARD_GATE_NAME: [&str; STANDARD_GATE_SIZE] = [
     "rcccx",        // 51 ("rc3x")
 ];
 
+/// Get a slice of all standard gate names.
+pub fn get_standard_gate_names() -> &'static [&'static str] {
+    &STANDARD_GATE_NAME
+}
+
 impl StandardGate {
     pub fn create_py_op(
         &self,

--- a/releasenotes/notes/conservative-commutation-checking-b728e7b6e1645615.yaml
+++ b/releasenotes/notes/conservative-commutation-checking-b728e7b6e1645615.yaml
@@ -15,3 +15,4 @@ fixes:
     with non-numeric values in the :attr:`~.circuit.Instruction.params` attribute (such as the
     :class:`.PauliGate`) could raise an error.
     Fixed `#13570 <https://github.com/Qiskit/qiskit/issues/13570>`__.
+

--- a/test/benchmarks/releasenotes/notes/conservative-commutation-checking-e1ca8501416119a1.yaml
+++ b/test/benchmarks/releasenotes/notes/conservative-commutation-checking-e1ca8501416119a1.yaml
@@ -1,0 +1,17 @@
+---
+fixes:
+  - |
+    Commutation relations of :class:`~.circuit.Instruction`\ s with float-only ``params``
+    were eagerly cached by the :class:`.CommutationChecker`, using the ``params`` as key to
+    query the relation. This could lead to faulty results, if the instruction's definition
+    depended on additional information that just the :attr:`~.circuit.Instruction.params`
+    attribute, such as e.g. the case for :class:`.PauliEvolutionGate`.
+    This behavior is now fixed, and the commutation checker only conservatively caches
+    commutations for Qiskit-native standard gates. This can incur a performance cost if you were
+    relying on your custom gates being cached, however, we cannot guarantee safe caching for
+    custom gates, as they might rely on information beyond :attr:`~.circuit.Instruction.params`.
+  - |
+    Fixed a bug in the :class:`.CommmutationChecker`, where checking commutation of instruction
+    with non-numeric values in the :attr:`~.circuit.Instruction.params` attribute (such as the
+    :class:`.PauliGate`) could raise an error.
+    Fixed `#13570 <https://github.com/Qiskit/qiskit/issues/13570>`__.

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -27,6 +27,7 @@ from qiskit.circuit import (
     Parameter,
     QuantumRegister,
     Qubit,
+    QuantumCircuit,
 )
 from qiskit.circuit.commutation_library import SessionCommutationChecker as scc
 from qiskit.circuit.library import (
@@ -37,9 +38,11 @@ from qiskit.circuit.library import (
     CRYGate,
     CRZGate,
     CXGate,
+    CUGate,
     LinearFunction,
     MCXGate,
     Measure,
+    PauliGate,
     PhaseGate,
     Reset,
     RXGate,
@@ -80,6 +83,22 @@ class NewGateCX(Gate):
 
     def to_matrix(self):
         return np.array([[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0]], dtype=complex)
+
+
+class MyEvilRXGate(Gate):
+    """A RX gate designed to annoy the caching mechanism (but a realistic gate nevertheless)."""
+
+    def __init__(self, evil_input_not_in_param: float):
+        """
+        Args:
+            evil_input_not_in_param: The RX rotation angle.
+        """
+        self.value = evil_input_not_in_param
+        super().__init__("<evil laugh here>", 1, [])
+
+    def _define(self):
+        self.definition = QuantumCircuit(1)
+        self.definition.rx(self.value, 0)
 
 
 @ddt
@@ -137,7 +156,7 @@ class TestCommutationChecker(QiskitTestCase):
     def test_caching_positive_results(self):
         """Check that hashing positive results in commutativity checker works as expected."""
         scc.clear_cached_commutations()
-        self.assertTrue(scc.commute(ZGate(), [0], [], NewGateCX(), [0, 1], []))
+        self.assertTrue(scc.commute(ZGate(), [0], [], CUGate(1, 2, 3, 0), [0, 1], []))
         self.assertGreater(scc.num_cached_entries(), 0)
 
     def test_caching_lookup_with_non_overlapping_qubits(self):
@@ -150,16 +169,17 @@ class TestCommutationChecker(QiskitTestCase):
     def test_caching_store_and_lookup_with_non_overlapping_qubits(self):
         """Check that commutations storing and lookup with non-overlapping qubits works as expected."""
         scc_lenm = scc.num_cached_entries()
-        self.assertTrue(scc.commute(NewGateCX(), [0, 2], [], CXGate(), [0, 1], []))
-        self.assertFalse(scc.commute(NewGateCX(), [0, 1], [], CXGate(), [1, 2], []))
-        self.assertTrue(scc.commute(NewGateCX(), [1, 4], [], CXGate(), [1, 6], []))
-        self.assertFalse(scc.commute(NewGateCX(), [5, 3], [], CXGate(), [3, 1], []))
+        cx_like = CUGate(np.pi, 0, np.pi, 0)
+        self.assertTrue(scc.commute(cx_like, [0, 2], [], CXGate(), [0, 1], []))
+        self.assertFalse(scc.commute(cx_like, [0, 1], [], CXGate(), [1, 2], []))
+        self.assertTrue(scc.commute(cx_like, [1, 4], [], CXGate(), [1, 6], []))
+        self.assertFalse(scc.commute(cx_like, [5, 3], [], CXGate(), [3, 1], []))
         self.assertEqual(scc.num_cached_entries(), scc_lenm + 2)
 
     def test_caching_negative_results(self):
         """Check that hashing negative results in commutativity checker works as expected."""
         scc.clear_cached_commutations()
-        self.assertFalse(scc.commute(XGate(), [0], [], NewGateCX(), [0, 1], []))
+        self.assertFalse(scc.commute(XGate(), [0], [], CUGate(1, 2, 3, 0), [0, 1], []))
         self.assertGreater(scc.num_cached_entries(), 0)
 
     def test_caching_different_qubit_sets(self):
@@ -167,10 +187,11 @@ class TestCommutationChecker(QiskitTestCase):
         scc.clear_cached_commutations()
         # All the following should be cached in the same way
         # though each relation gets cached twice: (A, B) and (B, A)
-        scc.commute(XGate(), [0], [], NewGateCX(), [0, 1], [])
-        scc.commute(XGate(), [10], [], NewGateCX(), [10, 20], [])
-        scc.commute(XGate(), [10], [], NewGateCX(), [10, 5], [])
-        scc.commute(XGate(), [5], [], NewGateCX(), [5, 7], [])
+        cx_like = CUGate(np.pi, 0, np.pi, 0)
+        scc.commute(XGate(), [0], [], cx_like, [0, 1], [])
+        scc.commute(XGate(), [10], [], cx_like, [10, 20], [])
+        scc.commute(XGate(), [10], [], cx_like, [10, 5], [])
+        scc.commute(XGate(), [5], [], cx_like, [5, 7], [])
         self.assertEqual(scc.num_cached_entries(), 1)
 
     def test_zero_rotations(self):
@@ -377,12 +398,14 @@ class TestCommutationChecker(QiskitTestCase):
         """Test that the commutation checker is correctly serialized"""
         import pickle
 
+        cx_like = CUGate(np.pi, 0, np.pi, 0)
+
         scc.clear_cached_commutations()
-        self.assertTrue(scc.commute(ZGate(), [0], [], NewGateCX(), [0, 1], []))
+        self.assertTrue(scc.commute(ZGate(), [0], [], cx_like, [0, 1], []))
         cc2 = pickle.loads(pickle.dumps(scc))
         self.assertEqual(cc2.num_cached_entries(), 1)
         dop1 = DAGOpNode(ZGate(), qargs=[0], cargs=[])
-        dop2 = DAGOpNode(NewGateCX(), qargs=[0, 1], cargs=[])
+        dop2 = DAGOpNode(cx_like, qargs=[0, 1], cargs=[])
         cc2.commute_nodes(dop1, dop2)
         dop1 = DAGOpNode(ZGate(), qargs=[0], cargs=[])
         dop2 = DAGOpNode(CXGate(), qargs=[0, 1], cargs=[])
@@ -429,6 +452,25 @@ class TestCommutationChecker(QiskitTestCase):
                 self.assertFalse(
                     scc.commute(generic_gate, [0], [], gate, list(range(gate.num_qubits)), [])
                 )
+
+    def test_custom_gate_caching(self):
+        """Test a custom gate is correctly handled on consecutive runs."""
+
+        all_commuter = MyEvilRXGate(0)  # this will with anything
+        some_rx = MyEvilRXGate(1.6192)  # this should not commute with H
+
+        # the order here is important: we're testing whether the gate that commutes with
+        # everything is used after the first commutation check, regardless of the internal
+        # gate parameters
+        self.assertTrue(scc.commute(all_commuter, [0], [], HGate(), [0], []))
+        self.assertFalse(scc.commute(some_rx, [0], [], HGate(), [0], []))
+
+    def test_nonfloat_param(self):
+        """Test commutation-checking on a gate that has non-float ``params``."""
+        pauli_gate = PauliGate("XX")
+        rx_gate_theta = RXGate(Parameter("Theta"))
+        self.assertTrue(scc.commute(pauli_gate, [0, 1], [], rx_gate_theta, [0], []))
+        self.assertTrue(scc.commute(rx_gate_theta, [0], [], pauli_gate, [0, 1], []))
 
 
 if __name__ == "__main__":

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -453,10 +453,21 @@ class TestCommutationChecker(QiskitTestCase):
                     scc.commute(generic_gate, [0], [], gate, list(range(gate.num_qubits)), [])
                 )
 
+    def test_custom_gate(self):
+        """Test a custom gate."""
+        my_cx = NewGateCX()
+
+        self.assertTrue(scc.commute(my_cx, [0, 1], [], XGate(), [1], []))
+        self.assertFalse(scc.commute(my_cx, [0, 1], [], XGate(), [0], []))
+        self.assertTrue(scc.commute(my_cx, [0, 1], [], ZGate(), [0], []))
+
+        self.assertFalse(scc.commute(my_cx, [0, 1], [], my_cx, [1, 0], []))
+        self.assertTrue(scc.commute(my_cx, [0, 1], [], my_cx, [0, 1], []))
+
     def test_custom_gate_caching(self):
         """Test a custom gate is correctly handled on consecutive runs."""
 
-        all_commuter = MyEvilRXGate(0)  # this will with anything
+        all_commuter = MyEvilRXGate(0)  # this will commute with anything
         some_rx = MyEvilRXGate(1.6192)  # this should not commute with H
 
         # the order here is important: we're testing whether the gate that commutes with


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #13570. 

This PR might require some discussion on what assumptions we have on custom `Instruction`s. However, if we cannot assume that an instruction's definition is fully specified by it's ``params``, then we cannot use the ``params`` as key in the commutation library. (We also sometimes put additional information outside of ``params``.)
This PR makes the commutation cache more conservative, by only additionally caching standard gate relations, where we know the instructions are defined by it's ``params``.

### Details and comments

The commutation checker currently caches commutations of any instruction with float-only ``params`` (with some hardcoded exceptions). This leads to problems if the instruction's definition depends on more than just the ``params``, e.g. we could have a custom gate defined as 
```python
class MyEvilRXGate(Gate):
    """A RX gate designed to annoy the caching mechanism (but a realistic gate nevertheless)."""

    def __init__(self, evil_input_not_in_param: float):
        """
        Args:
            evil_input_not_in_param: The RX rotation angle.
        """
        self.value = evil_input_not_in_param
        super().__init__("<evil laugh here>", 1, [])

    def _define(self):
        self.definition = QuantumCircuit(1)
        self.definition.rx(self.value, 0) 
```
Calling the commutation checker with an instance of this gate will then cache the first commutation, under the key `[]` (since the ``params`` are empty) and subsequent queries of the cache return the first commutation, regardless of the evil rotation angle. For example
```python

all_commuter = MyEvilRXGate(0)  # this will with anything
some_rx = MyEvilRXGate(1.6192)  # this should not commute with H

print(scc.commute(all_commuter, [0], [], HGate(), [0], []))  # True, as we expect
# this should be False, but queries the first occurence of MyEvilRXGate(0) and is True!
print(scc.commute(some_rx, [0], [], HGate(), [0], []))
```

Another solution could be to explicitly state the assumption that the gate must be fully specified by the ``params`` attribute, and we'd have to update some gates in the library. 

I ran the `test/benchmarks/utility_scale.py` benchmarks and could not see a regression on my laptop.