### PR TITLE
raise DeprecationWarning for a targetless timeline drawer

### DIFF
--- a/qiskit/visualization/timeline/interface.py
+++ b/qiskit/visualization/timeline/interface.py
@@ -369,7 +369,7 @@ def draw(
         warnings.warn(
             "Target is not specified. In Qiskit 2.0.0 this will be required to get the duration of "
             "instructions.",
-            PendingDeprecationWarning,
+            DeprecationWarning,
             stacklevel=2,
         )
 

--- a/releasenotes/notes/followup_13247-9511e4e8d3d88a42.yaml
+++ b/releasenotes/notes/followup_13247-9511e4e8d3d88a42.yaml
@@ -1,0 +1,5 @@
+---
+deprecations_visualization:
+  - |
+    The timeline drawer :func:`~qiskit.visualization.timeline.interface.draw` now needs a ``target``
+    to get the duration of instructions. From Qiskit 2.0 on, ``target`` will be required and fail if not specified.


### PR DESCRIPTION
### Summary

In #13247, the timeline drawer was raising a `PendingDeprecationWarning` when `target` was not specified. Can it be moved to `DeprecationWarning` in 1.4?

cc: @mtreinish 
