### PR TITLE
Deprecate `show_idle` and `show_barrier` in favor of `idle_wires` and `plot_barriers`

### DIFF
--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -1637,7 +1637,7 @@ def _common_method(*classes):
     return decorator
 
 
-@deprecate_arg("show_barriers", new_alias="plot_barriers", since="1.1.0")
+@deprecate_arg("show_barriers", new_alias="plot_barriers", since="1.4")
 @_common_method(Schedule, ScheduleBlock)
 def draw(
     self,

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -1637,7 +1637,7 @@ def _common_method(*classes):
     return decorator
 
 
-@deprecate_arg("show_barriers", new_alias="plot_barriers", since="1.1.0", pending=True)
+@deprecate_arg("show_barriers", new_alias="plot_barriers", since="1.1.0")
 @_common_method(Schedule, ScheduleBlock)
 def draw(
     self,

--- a/qiskit/visualization/pulse_v2/interface.py
+++ b/qiskit/visualization/pulse_v2/interface.py
@@ -32,7 +32,7 @@ from qiskit.utils.deprecate_pulse import deprecate_pulse_dependency
 
 
 @deprecate_pulse_dependency(moving_to_dynamics=True)
-@deprecate_arg("show_barrier", new_alias="plot_barrier", since="1.1.0", pending=True)
+@deprecate_arg("show_barrier", new_alias="plot_barrier", since="1.1.0")
 def draw(
     program: Union[Waveform, SymbolicPulse, Schedule, ScheduleBlock],
     style: Optional[Dict[str, Any]] = None,

--- a/qiskit/visualization/pulse_v2/interface.py
+++ b/qiskit/visualization/pulse_v2/interface.py
@@ -27,12 +27,10 @@ from qiskit.pulse.channels import Channel
 from qiskit.visualization.exceptions import VisualizationError
 from qiskit.visualization.pulse_v2 import core, device_info, stylesheet, types
 from qiskit.exceptions import MissingOptionalLibraryError
-from qiskit.utils import deprecate_arg
 from qiskit.utils.deprecate_pulse import deprecate_pulse_dependency
 
 
 @deprecate_pulse_dependency(moving_to_dynamics=True)
-@deprecate_arg("show_barrier", new_alias="plot_barrier", since="1.1.0")
 def draw(
     program: Union[Waveform, SymbolicPulse, Schedule, ScheduleBlock],
     style: Optional[Dict[str, Any]] = None,

--- a/qiskit/visualization/timeline/interface.py
+++ b/qiskit/visualization/timeline/interface.py
@@ -30,8 +30,8 @@ from qiskit.visualization.timeline import types, core, stylesheet
 from qiskit.utils import deprecate_arg
 
 
-@deprecate_arg("show_idle", new_alias="idle_wires", since="1.1.0", pending=True)
-@deprecate_arg("show_barriers", new_alias="plot_barriers", since="1.1.0", pending=True)
+@deprecate_arg("show_idle", new_alias="idle_wires", since="1.1.0")
+@deprecate_arg("show_barriers", new_alias="plot_barriers", since="1.1.0")
 def draw(
     program: circuit.QuantumCircuit,
     style: Optional[Dict[str, Any]] = None,

--- a/qiskit/visualization/timeline/interface.py
+++ b/qiskit/visualization/timeline/interface.py
@@ -30,8 +30,8 @@ from qiskit.visualization.timeline import types, core, stylesheet
 from qiskit.utils import deprecate_arg
 
 
-@deprecate_arg("show_idle", new_alias="idle_wires", since="1.1.0")
-@deprecate_arg("show_barriers", new_alias="plot_barriers", since="1.1.0")
+@deprecate_arg("show_idle", new_alias="idle_wires", since="1.4")
+@deprecate_arg("show_barriers", new_alias="plot_barriers", since="1.4")
 def draw(
     program: circuit.QuantumCircuit,
     style: Optional[Dict[str, Any]] = None,

--- a/releasenotes/notes/followup_11878-839c93ab3029d315.yaml
+++ b/releasenotes/notes/followup_11878-839c93ab3029d315.yaml
@@ -1,0 +1,6 @@
+---
+deprecations_visualization:
+  - |
+    The parameters ``show_idle`` and ``show_barrier`` in the timeline drawers had been replaced by ``idle_wires`` and ``plot_barriers``
+    respectively to match the circuit drawer parameters. Their previous names will be removed in Qiskit 2.0.
+    The new parameters are fully equivalent.


### PR DESCRIPTION
### Summary

Following up #11878, moving the `PendingDeprecationWarning` to `DeprecationWarning` in the timeline drawer parameters. For the pulse drawer, I just removed the deprecation, since the full module is deprecated.