### PR TITLE
Deprecate 2-argument callable for ``atomic_evolution`` parameter

### DIFF
--- a/qiskit/synthesis/evolution/product_formula.py
+++ b/qiskit/synthesis/evolution/product_formula.py
@@ -44,7 +44,7 @@ class ProductFormula(EvolutionSynthesis):
 
     @deprecate_arg(
         name="atomic_evolution",
-        since="1.2",
+        since="1.4",
         predicate=lambda callable: callable is not None
         and len(inspect.signature(callable).parameters) == 2,
         deprecation_description=(
@@ -55,7 +55,6 @@ class ProductFormula(EvolutionSynthesis):
             "Instead you should update your 'atomic_evolution' function to be of the following "
             "type: 'Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]'."
         ),
-        pending=True,
     )
     def __init__(
         self,

--- a/qiskit/synthesis/evolution/qdrift.py
+++ b/qiskit/synthesis/evolution/qdrift.py
@@ -43,7 +43,7 @@ class QDrift(ProductFormula):
 
     @deprecate_arg(
         name="atomic_evolution",
-        since="1.2",
+        since="1.4",
         predicate=lambda callable: callable is not None
         and len(inspect.signature(callable).parameters) == 2,
         deprecation_description=(
@@ -54,7 +54,6 @@ class QDrift(ProductFormula):
             "Instead you should update your 'atomic_evolution' function to be of the following "
             "type: 'Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]'."
         ),
-        pending=True,
     )
     def __init__(
         self,

--- a/qiskit/synthesis/evolution/suzuki_trotter.py
+++ b/qiskit/synthesis/evolution/suzuki_trotter.py
@@ -60,7 +60,7 @@ class SuzukiTrotter(ProductFormula):
 
     @deprecate_arg(
         name="atomic_evolution",
-        since="1.2",
+        since="1.4",
         predicate=lambda callable: callable is not None
         and len(inspect.signature(callable).parameters) == 2,
         deprecation_description=(
@@ -71,7 +71,6 @@ class SuzukiTrotter(ProductFormula):
             "Instead you should update your 'atomic_evolution' function to be of the following "
             "type: 'Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]'."
         ),
-        pending=True,
     )
     def __init__(
         self,

--- a/releasenotes/notes/followup_12724-59acaeb333788396.yaml
+++ b/releasenotes/notes/followup_12724-59acaeb333788396.yaml
@@ -1,0 +1,8 @@
+---
+deprecations_synthesis:
+  - |
+    The argument ``atomic_evolution`` in the constructor for the classes
+    :class:`.LieTrotter`, :class:`.ProductFormula`, and :class:`.SuzukiTrotter`
+    is a callable with a different signature now: from
+    ``Callable[[Pauli | SparsePauliOp, float], QuantumCircuit]`` to
+    ``Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]``.

--- a/test/python/circuit/library/test_evolution_gate.py
+++ b/test/python/circuit/library/test_evolution_gate.py
@@ -470,7 +470,7 @@ class TestEvolutionGate(QiskitTestCase):
         op = (X ^ X ^ X) + (Y ^ Y ^ Y) + (Z ^ Z ^ Z)
         time = 0.123
         reps = 4
-        with self.assertWarns(PendingDeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             evo_gate = PauliEvolutionGate(
                 op,
                 time,


### PR DESCRIPTION

### Summary

Following up #12724, the `PendingDeprecationWarning` there are now moved to `DeprecationWarning`

### Details and comments

The argument `atomic_evolution` in the constructor for the classes `LieTrotter`, `ProductFormula`, and `SuzukiTrotter` is a callable with a different signature now: from`Callable[[Pauli | SparsePauliOp, float], QuantumCircuit]` to `Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]`.
