### PR TITLE
Fix `random_clifford`

### DIFF
--- a/crates/accelerate/src/synthesis/clifford/random_clifford.rs
+++ b/crates/accelerate/src/synthesis/clifford/random_clifford.rs
@@ -125,9 +125,7 @@ pub fn random_clifford_tableau_inner(num_qubits: usize, seed: Option<u64>) -> Ar
 
     // Compute the full stabilizer tableau
 
-    // The code below is identical to the Python implementation, but is based on the original
-    // code in the paper.
-
+    // The code below is based on the original code in the referenced paper.
     let mut table = Array2::from_elem((2 * num_qubits, 2 * num_qubits), false);
 
     // Apply qubit permutation

--- a/crates/accelerate/src/synthesis/clifford/random_clifford.rs
+++ b/crates/accelerate/src/synthesis/clifford/random_clifford.rs
@@ -132,10 +132,10 @@ pub fn random_clifford_tableau_inner(num_qubits: usize, seed: Option<u64>) -> Ar
 
     // Apply qubit permutation
     for i in 0..num_qubits {
-        replace_row_inner(table.view_mut(), i, table2.slice(s![i, ..]));
+        replace_row_inner(table.view_mut(), i, table2.slice(s![perm[i], ..]));
         replace_row_inner(
             table.view_mut(),
-            perm[i] + num_qubits,
+            i + num_qubits,
             table2.slice(s![perm[i] + num_qubits, ..]),
         );
     }

--- a/releasenotes/notes/fix-random-clifford-c0394becbdd7db50.yaml
+++ b/releasenotes/notes/fix-random-clifford-c0394becbdd7db50.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a bug in :func:`~qiskit.quantum_info.random_clifford` that stopped it
+    from sampling the full Clifford group.

--- a/test/python/quantum_info/operators/symplectic/test_clifford.py
+++ b/test/python/quantum_info/operators/symplectic/test_clifford.py
@@ -473,7 +473,12 @@ class TestCliffordGates(QiskitTestCase):
         # and even circuits with other clifford objects.
         linear_function = LinearFunction([[0, 1], [1, 1]])
         pauli_gate = PauliGate("YZ")
-        cliff = random_clifford(2, seed=777)
+
+        qc_cliff = QuantumCircuit(2)
+        qc_cliff.h(0)
+        qc_cliff.cx(0, 1)
+        cliff = Clifford(qc_cliff)
+
         qc = QuantumCircuit(2)
         qc.cx(0, 1)
         qc.append(random_clifford(1, seed=999), [1])
@@ -493,8 +498,8 @@ class TestCliffordGates(QiskitTestCase):
 
         # Additionally, make sure that it produces the correct clifford.
         expected_clifford_dict = {
-            "stabilizer": ["-IZX", "+XXZ", "-YYZ"],
-            "destabilizer": ["-YYI", "-XZI", "-ZXY"],
+            "stabilizer": ["-IZX", "+ZYZ", "+XZI"],
+            "destabilizer": ["+XZZ", "-XII", "+IXY"],
         }
         expected_clifford = Clifford.from_dict(expected_clifford_dict)
         self.assertEqual(combined_clifford, expected_clifford)

--- a/test/python/quantum_info/operators/test_random.py
+++ b/test/python/quantum_info/operators/test_random.py
@@ -181,7 +181,7 @@ class TestRandomClifford(QiskitTestCase):
         self.assertEqual(value1, value2)
 
     def test_not_global_seed(self):
-        """Test fixing random_hermitian seed is locally scoped."""
+        """Test fixing random_seed is locally scoped."""
         seed = 314159
         test_cases = 100
         random_hermitian(2, seed=seed)
@@ -189,6 +189,26 @@ class TestRandomClifford(QiskitTestCase):
         random_hermitian(2, seed=seed)
         rng_after = np.random.randint(1000, size=test_cases)
         self.assertFalse(np.all(rng_before == rng_after))
+
+    def test_cliffords_2q(self):
+        """Test that we get all 2-qubit Cliffords (actually symplectic
+        matrices) with sufficiently many trials.
+        """
+        seen = set()
+        for seed in range(10000):
+            cliff = random_clifford(2, seed)
+            seen.add(cliff.symplectic_matrix.tobytes())
+        self.assertEqual(len(seen), 720)
+
+    def test_clifford_2q_decompositions(self):
+        """Test that we get all possible CX-counts for 2q-random cliffords
+        with sufficiently many trials.
+        """
+        seen = set()
+        for seed in range(100):
+            cliff = random_clifford(2, seed)
+            seen.add(cliff.to_circuit().count_ops().get("cx", 0))
+        self.assertEqual(seen, {0, 1, 2, 3})
 
 
 @ddt

--- a/test/python/quantum_info/operators/test_random.py
+++ b/test/python/quantum_info/operators/test_random.py
@@ -210,6 +210,16 @@ class TestRandomClifford(QiskitTestCase):
             seen.add(cliff.to_circuit().count_ops().get("cx", 0))
         self.assertEqual(seen, {0, 1, 2, 3})
 
+    def test_clifford_3q_decompositions(self):
+        """Test that we get all possible CX-counts for 3q-random cliffords
+        with sufficiently many trials.
+        """
+        seen = set()
+        for seed in range(10000):
+            cliff = random_clifford(3, seed)
+            seen.add(cliff.to_circuit().count_ops().get("cx", 0))
+        self.assertEqual(seen, {0, 1, 2, 3, 4, 5, 6})
+
 
 @ddt
 class TestRandomPauliList(QiskitTestCase):

--- a/test/python/quantum_info/operators/test_random.py
+++ b/test/python/quantum_info/operators/test_random.py
@@ -181,7 +181,7 @@ class TestRandomClifford(QiskitTestCase):
         self.assertEqual(value1, value2)
 
     def test_not_global_seed(self):
-        """Test fixing random_seed is locally scoped."""
+        """Test fixing random_hermitian seed is locally scoped."""
         seed = 314159
         test_cases = 100
         random_hermitian(2, seed=seed)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #13590.

### Details and comments

The bug was introduced when porting `random_clifford` to Rust in https://github.com/Qiskit/qiskit/pull/12695.

I have added tests that ensure that for 2-qubits Cliffords, `random_clifford` produces Cliffords with all possible symplectic matrices (there should be 720) and all possible CX counts (should be {0, 1, 2, 3}). @ShellyGarion, can you think of other tests that we may wish to add?
