### PR TITLE
Add option ``collect_from_back`` to ``CollectMultiQBlocks``

### DIFF
--- a/qiskit/transpiler/passes/optimization/collect_multiqubit_blocks.py
+++ b/qiskit/transpiler/passes/optimization/collect_multiqubit_blocks.py
@@ -33,14 +33,15 @@ class CollectMultiQBlocks(AnalysisPass):
     Some gates may not be present in any block (e.g. if the number
     of operands is greater than ``max_block_size``)
 
+    By default, blocks are collected in the direction from the inputs towards the
+    outputs of the DAG. The option ``collect_from_back`` allows to change this
+    direction, that is to collect blocks from the outputs towards the inputs.
+    Note that the blocks are still reported in a valid topological order.
+
     A Disjoint Set Union data structure (DSU) is used to maintain blocks as
     gates are processed. This data structure points each qubit to a set at all
     times and the sets correspond to current blocks. These change over time
     and the data structure allows these changes to be done quickly.
-
-    By default, blocks are collected in the direction from the inputs towards the
-    outputs of the DAG. The option ``collect_from_back`` allows to change this
-    direction, that is collect blocks from the outputs towards the inputs of the DAG.
     """
 
     def __init__(self, max_block_size=2, collect_from_back=False):

--- a/releasenotes/notes/add-option-collect-from-back-cde10ee5e2e4ea9f.yaml
+++ b/releasenotes/notes/add-option-collect-from-back-cde10ee5e2e4ea9f.yaml
@@ -1,0 +1,11 @@
+---
+features_transpiler:
+  - |
+    Added a new option, ``collect_from_back``, to 
+    :class:`~qiskit.transpiler.passes.CollectMultiQBlocks`.
+    When set to ``True``, the blocks are collected in the reverse direction, 
+    from the outputs towards the inputs of the circuit. The blocks are still
+    reported following the normal topological order. 
+    This leads to an additional flexibility provided by the pass, and 
+    additional optimization opportunities when combined with a circuit 
+    resynthesis method.

--- a/test/python/transpiler/test_collect_multiq_blocks.py
+++ b/test/python/transpiler/test_collect_multiq_blocks.py
@@ -319,8 +319,8 @@ class TestCollect2qBlocks(QiskitTestCase):
 
         block_list = pass_manager.property_set["block_list"]
         self.assertEqual(len(block_list), 2)
-        self.assertEq(len(block_list[0]), 3)
-        self.assertEq(len(block_list[1]), 2)
+        self.assertEqual(len(block_list[0]), 3)
+        self.assertEqual(len(block_list[1]), 2)
 
         # When collecting blocks of size-3 using the opposite direction,
         # the first block should contain the H-gate and a single CX-gate,

--- a/test/python/transpiler/test_collect_multiq_blocks.py
+++ b/test/python/transpiler/test_collect_multiq_blocks.py
@@ -310,29 +310,25 @@ class TestCollect2qBlocks(QiskitTestCase):
         qc.cx(0, 3)
         qc.h(3)
 
+        dag = circuit_to_dag(qc)
+        # For the circuit above, the topological order is unique
+        topo_ops = list(dag.topological_op_nodes())
+
         # When collecting blocks of size-3 using the default direction,
         # the first block should contain the H-gate and two CX-gates,
         # and the second block should contain a single CX-gate and an H-gate.
-        pass_manager = PassManager()
-        pass_manager.append(CollectMultiQBlocks(max_block_size=3, collect_from_back=False))
-        pass_manager.run(qc)
-
-        block_list = pass_manager.property_set["block_list"]
-        self.assertEqual(len(block_list), 2)
-        self.assertEqual(len(block_list[0]), 3)
-        self.assertEqual(len(block_list[1]), 2)
+        pass_ = CollectMultiQBlocks(max_block_size=3, collect_from_back=False)
+        pass_.run(dag)
+        expected_blocks = [[topo_ops[0], topo_ops[1], topo_ops[2]], [topo_ops[3], topo_ops[4]]]
+        self.assertTrue(pass_.property_set["block_list"], expected_blocks)
 
         # When collecting blocks of size-3 using the opposite direction,
         # the first block should contain the H-gate and a single CX-gate,
         # and the second block should contain two CX-gates and an H-gate.
-        pass_manager = PassManager()
-        pass_manager.append(CollectMultiQBlocks(max_block_size=3, collect_from_back=True))
-        pass_manager.run(qc)
-
-        block_list = pass_manager.property_set["block_list"]
-        self.assertEqual(len(block_list), 2)
-        self.assertEqual(len(block_list[0]), 2)
-        self.assertEqual(len(block_list[1]), 3)
+        pass_ = CollectMultiQBlocks(max_block_size=3, collect_from_back=True)
+        pass_.run(dag)
+        expected_blocks = [[topo_ops[0], topo_ops[1]], [topo_ops[2], topo_ops[3], topo_ops[4]]]
+        self.assertTrue(pass_.property_set["block_list"], expected_blocks)
 
 
 if __name__ == "__main__":

--- a/test/python/transpiler/test_collect_multiq_blocks.py
+++ b/test/python/transpiler/test_collect_multiq_blocks.py
@@ -320,7 +320,7 @@ class TestCollect2qBlocks(QiskitTestCase):
         pass_ = CollectMultiQBlocks(max_block_size=3, collect_from_back=False)
         pass_.run(dag)
         expected_blocks = [[topo_ops[0], topo_ops[1], topo_ops[2]], [topo_ops[3], topo_ops[4]]]
-        self.assertTrue(pass_.property_set["block_list"], expected_blocks)
+        self.assertEqual(pass_.property_set["block_list"], expected_blocks)
 
         # When collecting blocks of size-3 using the opposite direction,
         # the first block should contain the H-gate and a single CX-gate,
@@ -328,7 +328,7 @@ class TestCollect2qBlocks(QiskitTestCase):
         pass_ = CollectMultiQBlocks(max_block_size=3, collect_from_back=True)
         pass_.run(dag)
         expected_blocks = [[topo_ops[0], topo_ops[1]], [topo_ops[2], topo_ops[3], topo_ops[4]]]
-        self.assertTrue(pass_.property_set["block_list"], expected_blocks)
+        self.assertEqual(pass_.property_set["block_list"], expected_blocks)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This PR adds a new option ``collect_from_back`` to the transpiler pass ``CollectMultiQBlocks``, leading to an increased flexibility of the pass. As an example, on the following circuit
```
             ┌───┐
        q_0: ┤ H ├──■────■────■───────
             └───┘┌─┴─┐  │    │
        q_1: ─────┤ X ├──┼────┼───────
                  └───┘┌─┴─┐  │
        q_2: ──────────┤ X ├──┼───────
                       └───┘┌─┴─┐┌───┐
        q_3: ───────────────┤ X ├┤ H ├
                            └───┘└───┘
```
running the pass with ``max_block_size=3`` and ``collect_from_back=False`` (default), collects the first three gates (the H-gate and the two following CX-gates) into the first block, and the two remaining gates into the second block, while running the pass with ``max_block_size=3`` and ``collect_from_back=True`` (new), collects the last three gates into the second block, and the remaining two gates into the first block.

