### PR TITLE
Fix phase of `pauli_list.insert(..., qubit=True)` for length-1 `pauli_list`

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -455,7 +455,6 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
             #  Blocks are already correct size
             value_x = value.x
             value_z = value.z
-            value_phase = value.phase
         elif len(value) == 1:
             # Pad blocks to correct size
             value_x = np.vstack(size * [value.x])

--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -1130,6 +1130,8 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         Returns:
             PauliList: the constructed PauliList.
         """
+        if isinstance(phase, np.ndarray) and np.ndim(phase) > 1:
+            raise ValueError(f"phase should be at most 1D but has {np.ndim(phase)} dimensions.")
         base_z, base_x, base_phase = cls._from_array(z, x, phase)
         return cls(BasePauli(base_z, base_x, base_phase))
 

--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -451,16 +451,16 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
                 f"Index {ind} is greater than number of qubits"
                 f" in the PauliList ({self.num_qubits})"
             )
-        if len(value) == 1:
-            # Pad blocks to correct size
-            value_x = np.vstack(size * [value.x])
-            value_z = np.vstack(size * [value.z])
-            value_phase = np.vstack(size * [value.phase])
-        elif len(value) == size:
+        if len(value) == size:
             #  Blocks are already correct size
             value_x = value.x
             value_z = value.z
             value_phase = value.phase
+        elif len(value) == 1:
+            # Pad blocks to correct size
+            value_x = np.vstack(size * [value.x])
+            value_z = np.vstack(size * [value.z])
+            value_phase = np.vstack(size * [value.phase])
         else:
             # Blocks are incorrect size
             raise QiskitError(

--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -460,7 +460,6 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
             # Pad blocks to correct size
             value_x = np.vstack(size * [value.x])
             value_z = np.vstack(size * [value.z])
-            value_phase = np.vstack(size * [value.phase])
         else:
             # Blocks are incorrect size
             raise QiskitError(
@@ -471,7 +470,7 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         # Build new array by blocks
         z = np.hstack([self.z[:, :ind], value_z, self.z[:, ind:]])
         x = np.hstack([self.x[:, :ind], value_x, self.x[:, ind:]])
-        phase = self.phase + value_phase
+        phase = self.phase + value.phase
 
         return PauliList.from_symplectic(z, x, phase)
 

--- a/releasenotes/notes/fix-paulilist-length1-phase-688d0e3a64ec9a9f.yaml
+++ b/releasenotes/notes/fix-paulilist-length1-phase-688d0e3a64ec9a9f.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    Fixed a bug that caused :meth:`.PauliList.insert(..., qubit=True)` to produce a `phase`
+    Fixed a bug that caused :meth:`.PauliList.insert` with ``qubit=True`` to produce a `phase`
     attribute with the wrong shape when the original object was length 1.
     Fixed `#13623 <https://github.com/Qiskit/qiskit/issues/13623>`__.

--- a/releasenotes/notes/fix-paulilist-length1-phase-688d0e3a64ec9a9f.yaml
+++ b/releasenotes/notes/fix-paulilist-length1-phase-688d0e3a64ec9a9f.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug that caused :meth:`.PauliList.insert(..., qubit=True)` to produce a `phase`
+    attribute with the wrong shape when the original object was length 1.
+    Fixed `#13623 <https://github.com/Qiskit/qiskit/issues/13623>`__.

--- a/test/python/quantum_info/operators/symplectic/test_pauli_list.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli_list.py
@@ -1568,7 +1568,7 @@ class TestPauliListMethods(QiskitTestCase):
             value0 = pauli.insert(1, insert, qubit=True)
             self.assertEqual(value0, target0)
             self.assertEqual(value0.phase.shape, (1,))
-        
+
         # Insert single column
         pauli = PauliList(["X", "Y", "Z", "-iI"])
         for i in ["I", "X", "Y", "Z", "iY"]:

--- a/test/python/quantum_info/operators/symplectic/test_pauli_list.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli_list.py
@@ -1560,6 +1560,15 @@ class TestPauliListMethods(QiskitTestCase):
                 value1 = pauli.insert(1, insert)
                 self.assertEqual(value1, target1)
 
+        # Insert single column to length-1 PauliList:
+        with self.subTest(msg="length-1, single-column, single-val"):
+            pauli = PauliList(["X"])
+            insert = PauliList(["Y"])
+            target0 = PauliList(["YX"])
+            value0 = pauli.insert(1, insert, qubit=True)
+            self.assertEqual(value0, target0)
+            self.assertEqual(value0.phase.shape, (1,))
+        
         # Insert single column
         pauli = PauliList(["X", "Y", "Z", "-iI"])
         for i in ["I", "X", "Y", "Z", "iY"]:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fix #13623.


### Details and comments
Fixes bug in `PauliList.insert(..., qubit=True)` method, where the output `PauliList` would have a 2D `phase` attribute (should be 1D).

The bug was in a line of code manually broadcasting the `phase` of the `PauliList` being inserted to match the shape of the `phase` of the original `PauliList`. This PR removes this line of code, and lets numpy handle the broadcasting of `phase`.

This PR also adds a check in `PauliList.from_symplectic(..., phase)` to reject `phase` if it is a multi-dimensional array, and a test for issue #13623.

(For the record, I messed up the commit message in 92161ec. The simpler `if/elif` case is indeed moved to be first, but in the commit message I mixed up the two cases).
