### PR TITLE
Fix an error in qasm3 exporter when operating on unitary gates

### DIFF
--- a/qiskit/circuit/library/generalized_gates/permutation.py
+++ b/qiskit/circuit/library/generalized_gates/permutation.py
@@ -182,7 +182,7 @@ class PermutationGate(Gate):
 
         return PermutationGate(pattern=_inverse_pattern(self.pattern))
 
-    def _qasm2_decomposition(self):
+    def _qasm_decomposition(self):
         # pylint: disable=cyclic-import
         from qiskit.synthesis.permutation import synth_permutation_basic
 

--- a/qiskit/circuit/library/generalized_gates/unitary.py
+++ b/qiskit/circuit/library/generalized_gates/unitary.py
@@ -202,7 +202,7 @@ class UnitaryGate(Gate):
             )
         return gate
 
-    def _qasm2_decomposition(self):
+    def _qasm_decomposition(self):
         """Return an unparameterized version of ourselves, so the OQ2 exporter doesn't choke on the
         non-standard things in our `params` field."""
         out = self.definition.to_gate()

--- a/qiskit/qasm2/export.py
+++ b/qiskit/qasm2/export.py
@@ -314,8 +314,8 @@ def _define_custom_operation(operation, gates_to_define):
     # definition, but still continue to return the given object as the call-site object.
     if operation.base_class in known_good_parameterized:
         parameterized_operation = type(operation)(*_FIXED_PARAMETERS[: len(operation.params)])
-    elif hasattr(operation, "_qasm2_decomposition"):
-        new_op = operation._qasm2_decomposition()
+    elif hasattr(operation, "_qasm_decomposition"):
+        new_op = operation._qasm_decomposition()
         parameterized_operation = operation = new_op.copy(name=_escape_name(new_op.name, "gate_"))
     else:
         parameterized_operation = operation

--- a/qiskit/qasm3/exporter.py
+++ b/qiskit/qasm3/exporter.py
@@ -1180,13 +1180,16 @@ class QASM3Builder:
 
         This will also push the gate into the symbol table (if required), including recursively
         defining the gate blocks."""
-        ident = self.symbols.get_gate(instruction.operation)
+        operation = instruction.operation
+        if hasattr(operation, "_qasm_decomposition"):
+            operation = operation._qasm_decomposition()
+        ident = self.symbols.get_gate(operation)
         if ident is None:
-            ident = self.define_gate(instruction.operation)
+            ident = self.define_gate(operation)
         qubits = [self._lookup_bit(qubit) for qubit in instruction.qubits]
         parameters = [
             ast.StringifyAndPray(self._rebind_scoped_parameters(param))
-            for param in instruction.operation.params
+            for param in operation.params
         ]
         if not self.disable_constants:
             for parameter in parameters:

--- a/releasenotes/notes/fix-qasm-3-unitary-2da190be6ba25bbd.yaml
+++ b/releasenotes/notes/fix-qasm-3-unitary-2da190be6ba25bbd.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Fix a bug in :class:`qasm3.Exporter` that caused the exporter to crash when
-    handling a unitary gate due to incorrect processing of its `params` field.
+    Fix a bug in :class:`.qasm3.Exporter` that caused the exporter to crash when
+    handling a unitary gate due to incorrect processing of its ``params`` field.

--- a/releasenotes/notes/fix-qasm-3-unitary-2da190be6ba25bbd.yaml
+++ b/releasenotes/notes/fix-qasm-3-unitary-2da190be6ba25bbd.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a bug in :class:`qasm3.Exporter` that caused the exporter to crash when
+    handling a unitary gate due to incorrect processing of its `params` field.

--- a/test/python/qasm3/test_export.py
+++ b/test/python/qasm3/test_export.py
@@ -2665,6 +2665,24 @@ switch (switch_dummy_0) {
         test = dumps(qc, experimental=ExperimentalFeatures.SWITCH_CASE_V1)
         self.assertEqual(test, expected)
 
+    def test_circuit_with_unitary(self):
+        """Test that circuits with `unitary` gate are correctly handled"""
+        matrix = [[0, 1], [1, 0]]
+        qc = QuantumCircuit(1)
+        qc.unitary(matrix, [0])
+        expected = """\
+OPENQASM 3.0;
+include "stdgates.inc";
+gate unitary _gate_q_0 {
+  U(pi, -pi, 0) _gate_q_0;
+}
+qubit[1] q;
+unitary q[0];
+"""
+        test = dumps(qc)
+        print(test)
+        self.assertEqual(test, expected)
+
 
 @ddt
 class TestQASM3ExporterFailurePaths(QiskitTestCase):

--- a/test/python/qasm3/test_export.py
+++ b/test/python/qasm3/test_export.py
@@ -2680,7 +2680,6 @@ qubit[1] q;
 unitary q[0];
 """
         test = dumps(qc)
-        print(test)
         self.assertEqual(test, expected)
 
 


### PR DESCRIPTION
### Summary
Fixes a bug causing the qasm3 exporter to crash on circuits containing a unitary gate.

Fixes #13362.


### Details and comments
The bug results from the `params` field of the unitary `operation` being handled incorrectly, due to it being a somewhat nonstandard field (as opposed to the `params` field of `u` gate, for instance, which is used differently).

This problem was already handled in the `qasm2` exporter by a call to `_qasm2_decomposition` in the operation, if present. This PR integrates the same solution in the qasm3 exporter, renaming the method to `_qasm_decomposition`.

