### PR TITLE
Fix repeated plots in docs

### DIFF
--- a/qiskit/circuit/library/grover_operator.py
+++ b/qiskit/circuit/library/grover_operator.py
@@ -118,7 +118,7 @@ def grover_operator(
 
         .. plot::
             :include-source:
-            :context:
+            :context: close-figs
 
             oracle = QuantumCircuit(1)
             oracle.z(0)  # the qubit state |1> is the good state
@@ -133,7 +133,7 @@ def grover_operator(
 
         .. plot::
             :include-source:
-            :context:
+            :context: close-figs
 
             oracle = QuantumCircuit(4)
             oracle.z(3)
@@ -150,7 +150,7 @@ def grover_operator(
 
         .. plot::
             :include-source:
-            :context:
+            :context: close-figs
 
             from qiskit.quantum_info import Statevector, DensityMatrix, Operator
 

--- a/qiskit/circuit/library/n_local/efficient_su2.py
+++ b/qiskit/circuit/library/n_local/efficient_su2.py
@@ -85,7 +85,7 @@ def efficient_su2(
 
         .. plot::
             :include-source:
-            :context:
+            :context: close-figs
 
             circuit = efficient_su2(4, su2_gates=["rx", "y"], entanglement="circular", reps=1)
             circuit.draw("mpl")

--- a/qiskit/circuit/library/n_local/excitation_preserving.py
+++ b/qiskit/circuit/library/n_local/excitation_preserving.py
@@ -71,7 +71,7 @@ def excitation_preserving(
 
         .. plot::
             :include-source:
-            :context:
+            :context: close-figs
 
             from qiskit.circuit.library import excitation_preserving
 

--- a/qiskit/circuit/library/n_local/n_local.py
+++ b/qiskit/circuit/library/n_local/n_local.py
@@ -161,7 +161,7 @@ def n_local(
 
         .. plot::
             :include-source:
-            :context:
+            :context: close-figs
 
             circuit = n_local(3, ["ry", "rz"], "cz", "full", reps=1, insert_barriers=True)
             circuit.draw("mpl")
@@ -170,7 +170,7 @@ def n_local(
 
         .. plot::
             :include-source:
-            :context:
+            :context: close-figs
 
             circuit = n_local(4, [], "cry", reps=2)
             circuit.draw("mpl")
@@ -179,7 +179,7 @@ def n_local(
 
         .. plot::
             :include-source:
-            :context:
+            :context: close-figs
 
             entangler_map = [[0, 1], [2, 0]]
             circuit = n_local(3, "x", "crx", entangler_map, reps=2)
@@ -191,7 +191,7 @@ def n_local(
 
         .. plot:
             :include-source:
-            :context:
+            :context: close-figs
 
             def entanglement(layer_index):
                 if layer_index % 2 == 0:

--- a/qiskit/circuit/library/n_local/real_amplitudes.py
+++ b/qiskit/circuit/library/n_local/real_amplitudes.py
@@ -78,21 +78,21 @@ def real_amplitudes(
 
         .. plot::
            :include-source:
-           :context:
+           :context: close-figs
 
            ansatz = real_amplitudes(3, entanglement="full", reps=2)  # it is the same unitary as above
            ansatz.draw("mpl")
 
         .. plot::
            :include-source:
-           :context:
+           :context: close-figs
 
            ansatz = real_amplitudes(3, entanglement="linear", reps=2, insert_barriers=True)
            ansatz.draw("mpl")
 
         .. plot::
            :include-source:
-           :context:
+           :context: close-figs
 
            ansatz = real_amplitudes(4, reps=2, entanglement=[[0,3], [0,2]], skip_unentangled_qubits=True)
            ansatz.draw("mpl")

--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -620,7 +620,7 @@ It is important to highlight two special cases:
 
       ['id', 'rz', 'sx', 'x', 'cx', 'measure', 'delay']
 
-   .. plot:
+   .. plot::
       :include-source:
 
       from qiskit.circuit import QuantumCircuit


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The use of `:context:` in pages with several plots was causing an accumulation of figures, this PR fixes this issue by adding `:context: close-figs`. For example, the `grover_operator` docs before this PR showed:
![Screenshot 2025-01-08 at 17 37 30](https://github.com/user-attachments/assets/660ce0d6-6183-45f1-af06-5b42c12f30b2)

While after the fix there is only one figure per snippet (as expected):

 
![Screenshot 2025-01-08 at 17 36 34](https://github.com/user-attachments/assets/a05c3708-4650-4c6d-b085-5882a3b28cfb)



### Details and comments


