### PR TITLE
Drop support for 32bit x86 linux and windows

### DIFF
--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -27,15 +27,6 @@ on:
         default: "default"
         required: false
 
-      wheels-32bit:
-        description: >-
-          The action to take for Tier 1 wheels.
-          Choose from 'default', 'build' or 'skip'.
-          This builds multiple artifacts, which all match 'wheels-32bit-*'.
-        type: string
-        default: "default"
-        required: false
-
       wheels-linux-s390x:
         description: >-
           The action to take for Linux s390x wheels.
@@ -132,33 +123,6 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
           name: ${{ inputs.artifact-prefix }}wheels-tier-1-${{ matrix.os }}
-
-  wheels-32bit:
-    name: "Wheels / 32bit"
-    if: (inputs.wheels-32bit == 'default' && inputs.default-action || inputs.wheels-32bit) == 'build'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ inputs.python-version }}
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools-preview
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
-        env:
-          CIBW_SKIP: 'pp* cp36-* cp37-* cp38-* *musllinux* *amd64 *x86_64'
-      - uses: actions/upload-artifact@v4
-        with:
-          path: ./wheelhouse/*.whl
-          name: ${{ inputs.artifact-prefix }}wheels-32bit-${{ matrix.os }}
 
   wheels-linux-s390x:
     name: "Wheels / Linux s390x"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,7 +12,6 @@ jobs:
       artifact-prefix: "deploy-core-"
       default-action: "skip"
       wheels-tier-1: "build"
-      wheels-32bit: "build"
       sdist: "build"
   upload-core:
     name: Deploy core
@@ -39,7 +38,6 @@ jobs:
       artifact-prefix: "deploy-others-"
       default-action: "build"
       wheels-tier-1: "skip"
-      wheels-32bit: "skip"
       sdist: "skip"
   upload-others:
     name: Deploy other

--- a/releasenotes/notes/64-bit-only-4132f330ec7804b3.yaml
+++ b/releasenotes/notes/64-bit-only-4132f330ec7804b3.yaml
@@ -10,5 +10,7 @@ upgrade:
     scientific/numeric Python community's trend away from 32 bit platform
     support maintaining support for 32bit platforms is no longer viable.
     Qiskit 1.x will still continue to support 32 bit platforms, but starting
-    in this 2.0.0 release Qiskit no longer supports these platforms, and will
-    not publish pre-compiled binaries for these platforms any longer.
+    in this 2.0.0 release Qiskit no longer supports these platforms, will
+    not publish pre-compiled binaries for these platforms any longer, and
+    there is no longer any guarantee of being able to build from source on
+    32 bit platforms.

--- a/releasenotes/notes/64-bit-only-4132f330ec7804b3.yaml
+++ b/releasenotes/notes/64-bit-only-4132f330ec7804b3.yaml
@@ -1,0 +1,14 @@
+---
+upgrade:
+  - |
+    Qiskit no longer supports Linux i686 and 32 bit Windows. Starting in Qiskit
+    2.0 a 64 bit platform is needed to run Qiskit. The user base for 32bit
+    architectures is relatively small and as Qiskit continues to focus on
+    improving performance to handle the increased scale in the complexity
+    of quantum computing hardware maintaining support for 32 bit platforms
+    is proving increasingly difficult. This coupled with the larger
+    scientific/numeric Python community's trend away from 32 bit platform
+    support maintaining support for 32bit platforms is no longer viable.
+    Qiskit 1.x will still continue to support 32 bit platforms, but starting
+    in this 2.0.0 release Qiskit no longer supports these platforms, and will
+    not publish pre-compiled binaries for these platforms any longer.


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Going into Qiskit 2.0 we decided to drop support for windows 32 bit and linux i686 platforms. Right now the maintainence burden for continuing to support these platforms is becoming increasingly high, as we're increasing writing low level rust code to improve performance where we have to limit ourselves to continue to ensure 32bit platforms work. The user base for these platforms is quite small small; in the last 150 days there were only 7 downloads for i686 out of 221,992 total downloads from PyPI (there is no metadata field in PyPI's database to differentiate between windows 32bit and 64bit if the CPU is 64bit capable it uses AMD64 for the CPU field), 5 downloads where the CPU type was: "x86" (I'm not sure which platform uses that string, linux uses x86_64 for 64bit intel, but i686, i586, i486, etc for 32bit systems), and 35 downloads were armv7l which is not an official supported platform but is 32bit and you could build from source (this is typically raspberry pi users). When combining this with the lack of wider ecosystem support for 32bit platforms, numpy, scipy, etc all have dropped 32bit support already, keeping support for 32bit platforms is no longer tenable. This commit updates the wheel building configuration to drop the 32bit platform builds and adds a release note documenting the change in status for these platforms in 2.0.

A separate Qiskit/documentation PR will be opened to update our platform support documentation here:

https://docs.quantum.ibm.com/guides/install-qiskit#operating-system-support

closer to the final 2.0 release to remove the 32bit platforms from the list. Although we likely should update that page to have a subsection for 2.x and 1.x while both are supported.

### Details and comments