### PR TITLE
Fix `UnitarySynthesis` pass bug when target contains global gates

### DIFF
--- a/crates/accelerate/src/unitary_synthesis.rs
+++ b/crates/accelerate/src/unitary_synthesis.rs
@@ -600,7 +600,7 @@ fn get_2q_decomposers_from_target(
                     }
                     // Filter out non-2q-gate candidates
                     if op.operation.num_qubits() != 2 {
-                        continue
+                        continue;
                     }
                     available_2q_basis.insert(key, replace_parametrized_gate(op.clone()));
 

--- a/crates/accelerate/src/unitary_synthesis.rs
+++ b/crates/accelerate/src/unitary_synthesis.rs
@@ -599,9 +599,8 @@ fn get_2q_decomposers_from_target(
                         _ => continue,
                     }
                     // Filter out non-2q-gate candidates
-                    match op.operation.num_qubits() {
-                        2 => (),
-                        _ => continue,
+                    if op.operation.num_qubits() != 2 {
+                        continue
                     }
                     available_2q_basis.insert(key, replace_parametrized_gate(op.clone()));
 

--- a/crates/accelerate/src/unitary_synthesis.rs
+++ b/crates/accelerate/src/unitary_synthesis.rs
@@ -545,6 +545,7 @@ fn get_2q_decomposers_from_target(
     let mut available_2q_props: IndexMap<&str, (Option<f64>, Option<f64>)> = IndexMap::new();
 
     let mut qubit_gate_map = IndexMap::new();
+
     match target.operation_names_for_qargs(Some(&qubits)) {
         Ok(direct_keys) => {
             qubit_gate_map.insert(&qubits, direct_keys);
@@ -597,7 +598,11 @@ fn get_2q_decomposers_from_target(
                         OperationRef::Standard(_) => (),
                         _ => continue,
                     }
-
+                    // Filter out non-2q-gate candidates
+                    match op.operation.num_qubits() {
+                        2 => (),
+                        _ => continue,
+                    }
                     available_2q_basis.insert(key, replace_parametrized_gate(op.clone()));
 
                     if target.contains_key(key) {

--- a/releasenotes/notes/fix-unitary-synthesis-global-gates-19b93840b28cfcf7.yaml
+++ b/releasenotes/notes/fix-unitary-synthesis-global-gates-19b93840b28cfcf7.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a bug in the :class:`.UnitarySynthesis` transpiler pass where 
+    non-2-qubit gates would be incuded in the available 2 qubit basis,
+    causing the ``TwoQubitWeylDecomposition`` to panic because of 
+    the dimension mismatch.

--- a/releasenotes/notes/fix-unitary-synthesis-global-gates-19b93840b28cfcf7.yaml
+++ b/releasenotes/notes/fix-unitary-synthesis-global-gates-19b93840b28cfcf7.yaml
@@ -2,6 +2,6 @@
 fixes:
   - |
     Fixed a bug in the :class:`.UnitarySynthesis` transpiler pass where 
-    non-2-qubit gates would be incuded in the available 2 qubit basis,
+    non-2-qubit gates would be included in the available 2 qubit basis,
     causing the ``TwoQubitWeylDecomposition`` to panic because of 
     the dimension mismatch.

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -1101,6 +1101,21 @@ class TestUnitarySynthesis(QiskitTestCase):
         self.assertIn("cx", ops)
         self.assertIn("measure", ops)
 
+    def test_target_with_global_gates(self):
+        """Test that 2q decomposition can handle a target with global gates."""
+
+        basis_gates = ["h", "p", "cp", "rz", "cx", "ccx", "swap"]
+        target = Target.from_configuration(basis_gates=basis_gates)
+
+        bell = QuantumCircuit(2)
+        bell.h(0)
+        bell.cx(0, 1)
+        bell_op = Operator(bell)
+        qc = QuantumCircuit(2)
+        qc.unitary(bell_op, [0, 1])
+        tqc = transpile(qc, target=target)
+        self.assertTrue(set(tqc.count_ops()).issubset(basis_gates))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
While working on https://github.com/Qiskit/qiskit/pull/12850 I realized that the `UnitarySynthesis` Rust implementation  would sometimes append non-2q-gates to the basis set and panic over the dimension mismatch. I had assumed that `target.operation_names_for_qargs(Some(&qubits))` would only return gates whose number of qubits matched `len(qubits)`, but this assumption is incorrect. It will return any gate with **some** overlap with the provided qargs, independently of the number of qubits of the gate. This bug would come up often when the target contained global gates. 

I believe that the fix is as simple as making sure the 2q basis contains only 2q gates, at least for the cases I found.

### Details and comments


