### PR TITLE
Fix `Target.instruction_supported` when `target.num_qubits == None`

### DIFF
--- a/crates/accelerate/src/target_transpiler/mod.rs
+++ b/crates/accelerate/src/target_transpiler/mod.rs
@@ -1163,6 +1163,7 @@ impl Target {
                         match obj {
                             TargetOperation::Variadic(_) => {
                                 return qargs.is_none()
+                                    || self.num_qubits == None
                                     || _qargs.iter().all(|qarg| {
                                         qarg.index() <= self.num_qubits.unwrap_or_default()
                                     }) && qarg_set.len() == _qargs.len();
@@ -1171,7 +1172,8 @@ impl Target {
                                 let qubit_comparison = obj.operation.num_qubits();
                                 return qubit_comparison == _qargs.len() as u32
                                     && _qargs.iter().all(|qarg| {
-                                        qarg.index() < self.num_qubits.unwrap_or_default()
+                                        (qarg.index() < self.num_qubits.unwrap_or_default())
+                                            || self.num_qubits == None
                                     });
                             }
                         }
@@ -1182,6 +1184,7 @@ impl Target {
                     match obj {
                         TargetOperation::Variadic(_) => {
                             return qargs.is_none()
+                                || self.num_qubits == None
                                 || _qargs.iter().all(|qarg| {
                                     qarg.index() <= self.num_qubits.unwrap_or_default()
                                 }) && qarg_set.len() == _qargs.len();
@@ -1190,7 +1193,8 @@ impl Target {
                             let qubit_comparison = obj.operation.num_qubits();
                             return qubit_comparison == _qargs.len() as u32
                                 && _qargs.iter().all(|qarg| {
-                                    qarg.index() < self.num_qubits.unwrap_or_default()
+                                    (qarg.index() < self.num_qubits.unwrap_or_default())
+                                        || self.num_qubits == None
                                 });
                         }
                     }

--- a/crates/accelerate/src/target_transpiler/mod.rs
+++ b/crates/accelerate/src/target_transpiler/mod.rs
@@ -1151,6 +1151,12 @@ impl Target {
 
     /// Checks whether an instruction is supported by the Target based on instruction name and qargs.
     pub fn instruction_supported(&self, operation_name: &str, qargs: Option<&Qargs>) -> bool {
+        // Handle case where num_qubits is None by checking globally supported operations
+        let qargs: Option<&Qargs> = if self.num_qubits.is_none() {
+            None
+        } else {
+            qargs
+        };
         if self.gate_map.contains_key(operation_name) {
             if let Some(_qargs) = qargs {
                 let qarg_set: HashSet<&PhysicalQubit> = _qargs.iter().collect();
@@ -1163,7 +1169,6 @@ impl Target {
                         match obj {
                             TargetOperation::Variadic(_) => {
                                 return qargs.is_none()
-                                    || self.num_qubits == None
                                     || _qargs.iter().all(|qarg| {
                                         qarg.index() <= self.num_qubits.unwrap_or_default()
                                     }) && qarg_set.len() == _qargs.len();
@@ -1172,8 +1177,7 @@ impl Target {
                                 let qubit_comparison = obj.operation.num_qubits();
                                 return qubit_comparison == _qargs.len() as u32
                                     && _qargs.iter().all(|qarg| {
-                                        (qarg.index() < self.num_qubits.unwrap_or_default())
-                                            || self.num_qubits == None
+                                        qarg.index() < self.num_qubits.unwrap_or_default()
                                     });
                             }
                         }
@@ -1184,7 +1188,6 @@ impl Target {
                     match obj {
                         TargetOperation::Variadic(_) => {
                             return qargs.is_none()
-                                || self.num_qubits == None
                                 || _qargs.iter().all(|qarg| {
                                     qarg.index() <= self.num_qubits.unwrap_or_default()
                                 }) && qarg_set.len() == _qargs.len();
@@ -1193,8 +1196,7 @@ impl Target {
                             let qubit_comparison = obj.operation.num_qubits();
                             return qubit_comparison == _qargs.len() as u32
                                 && _qargs.iter().all(|qarg| {
-                                    (qarg.index() < self.num_qubits.unwrap_or_default())
-                                        || self.num_qubits == None
+                                    qarg.index() < self.num_qubits.unwrap_or_default()
                                 });
                         }
                     }

--- a/releasenotes/notes/fix-target-instr-supported-900a1caa76e30655.yaml
+++ b/releasenotes/notes/fix-target-instr-supported-900a1caa76e30655.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug in the :meth:`.Target.instruction_supported` method where 
+    targets with ``self.num_qubits==None`` would always return ``false`` 
+    independently of the  supported basis set. 

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -1173,9 +1173,9 @@ Instructions:
         """Checks that instruction supported works when target.num_qubits is None."""
         target = Target.from_configuration(["u", "cx", "rxx"])
         self.assertTrue(target.instruction_supported("u", (0,)))
-        self.assertTrue(target.instruction_supported("cx", (0,1)))
+        self.assertTrue(target.instruction_supported("cx", (0, 1)))
         self.assertTrue(target.instruction_supported("cx", None))
-        self.assertTrue(target.instruction_supported("rxx", (2,3)))
+        self.assertTrue(target.instruction_supported("rxx", (2, 3)))
 
     def test_target_serialization_preserve_variadic(self):
         """Checks that variadics are still seen as variadic after serialization"""

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -1169,6 +1169,14 @@ Instructions:
     def test_instruction_supported_no_operation(self):
         self.assertFalse(self.ibm_target.instruction_supported(qargs=(0,), parameters=[math.pi]))
 
+    def test_instruction_supported_no_qubits(self):
+        """Checks that instruction supported works when target.num_qubits is None."""
+        target = Target.from_configuration(["u", "cx", "rxx"])
+        self.assertTrue(target.instruction_supported("u", (0,)))
+        self.assertTrue(target.instruction_supported("cx", (0,1)))
+        self.assertTrue(target.instruction_supported("cx", None))
+        self.assertTrue(target.instruction_supported("rxx", (2,3)))
+
     def test_target_serialization_preserve_variadic(self):
         """Checks that variadics are still seen as variadic after serialization"""
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes a small bug found in `Target.instruction_supported`, where  `target.num_qubits == None` would cause `Target.instruction_supported` to always evaluate to `False`. This was handled in the [original Python implementation by artificially overwriting `qargs`](https://github.com/Qiskit/qiskit/blob/53667d167e2de2f841d3b781877427f0b459289b/qiskit/transpiler/target.py#L786-L788), but this would require a mutable variable in Rust, so I just added an additional condition to account for this case.

### Details and comments
Bug discovered through [#12850](https://github.com/Qiskit/qiskit/pull/12850).
