### PR TITLE
Reduce non-determinism in `UnitarySynthesis` pass

### DIFF
--- a/crates/accelerate/src/unitary_synthesis.rs
+++ b/crates/accelerate/src/unitary_synthesis.rs
@@ -17,7 +17,7 @@ use std::sync::OnceLock;
 
 use approx::relative_eq;
 use hashbrown::{HashMap, HashSet};
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use ndarray::prelude::*;
 use num_complex::{Complex, Complex64};
@@ -627,8 +627,8 @@ fn get_2q_decomposers_from_target(
     }
 
     let target_basis_set = get_target_basis_set(target, qubits[0]);
-    let available_1q_basis: HashSet<&str> =
-        HashSet::from_iter(target_basis_set.get_bases().map(|basis| basis.as_str()));
+    let available_1q_basis: IndexSet<&str> =
+        IndexSet::from_iter(target_basis_set.get_bases().map(|basis| basis.as_str()));
     let mut decomposers: Vec<DecomposerElement> = Vec::new();
 
     #[inline]
@@ -689,10 +689,10 @@ fn get_2q_decomposers_from_target(
     // If our 2q basis gates are a subset of cx, ecr, or cz then we know TwoQubitBasisDecomposer
     // is an ideal decomposition and there is no need to bother calculating the XX embodiments
     // or try the XX decomposer
-    let available_basis_set: HashSet<&str> = available_2q_basis.keys().copied().collect();
+    let available_basis_set: IndexSet<&str> = available_2q_basis.keys().copied().collect();
 
     #[inline]
-    fn check_goodbye(basis_set: &HashSet<&str>) -> bool {
+    fn check_goodbye(basis_set: &IndexSet<&str>) -> bool {
         basis_set.iter().all(|gate| GOODBYE_SET.contains(gate))
     }
 

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -21,7 +21,7 @@ import numpy as np
 import scipy
 from ddt import ddt, data
 
-from qiskit import transpile
+from qiskit import transpile, generate_preset_pass_manager
 from qiskit.providers.fake_provider import Fake5QV1, GenericBackendV2
 from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit.circuit.library import quantum_volume
@@ -921,7 +921,6 @@ class TestUnitarySynthesisTarget(QiskitTestCase):
 
     def test_target_with_global_gates(self):
         """Test that 2q decomposition can handle a target with global gates."""
-
         basis_gates = ["h", "p", "cp", "rz", "cx", "ccx", "swap"]
         target = Target.from_configuration(basis_gates=basis_gates)
 
@@ -931,8 +930,27 @@ class TestUnitarySynthesisTarget(QiskitTestCase):
         bell_op = Operator(bell)
         qc = QuantumCircuit(2)
         qc.unitary(bell_op, [0, 1])
+
         tqc = transpile(qc, target=target)
         self.assertTrue(set(tqc.count_ops()).issubset(basis_gates))
+
+    def test_determinism(self):
+        """Test that the decomposition is deterministic."""
+        gate_counts = {"rx": 6, "rz": 12, "iswap": 2}
+        basis_gates = ["rx", "rz", "iswap"]
+        target = Target.from_configuration(basis_gates=basis_gates)
+        pm = generate_preset_pass_manager(target=target, optimization_level=2, seed_transpiler=42)
+
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+
+        for _ in range(10):
+            out = pm.run(qc)
+            self.assertTrue(Operator(out).equiv(qc))
+            self.assertTrue(set(out.count_ops()).issubset(basis_gates))
+            for basis_gate in basis_gates:
+                self.assertLessEqual(out.count_ops()[basis_gate], gate_counts[basis_gate])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR proposes the use of an `IndexMap` in the Rust implementation of `UnitarySynthesis` to allow for a more deterministic output of the pass, and to ensure that the Python and Rust codes produce the same outputs when facing the same inputs. While this is not a guarantee we make, I believe it is good to have, makes testing much easier, and will smoothen the path for the transition to always using the target as a transpilation constraint "vehicle" (this PR fixes an issue found in a test in #12850).

### Details and comments


