### PR TITLE
Remove extended support reference in README

### DIFF
--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -1,6 +1,6 @@
 # Deprecation Policy
 
-Starting from the 1.0.0 release, Qiskit follows semantic versioning, with a yearly release cycle for major releases.
+Starting from the 1.0 release, Qiskit follows semantic versioning, with a yearly release cycle for major releases.
 [Full details of the scheduling are hosted with the external public documentation](https://docs.quantum.ibm.com/open-source/qiskit-sdk-version-strategy).
 
 This document is primarily intended for developers of Qiskit themselves.
@@ -150,11 +150,11 @@ and add the deprecation to that function's docstring so that it shows up in the 
 ```python
 from qiskit.utils.deprecation import deprecate_arg, deprecate_func
 
-@deprecate_func(since="0.24.0", additional_msg="No replacement is provided.")
+@deprecate_func(since="1.2", additional_msg="No replacement is provided.")
 def deprecated_func():
     pass
 
-@deprecate_arg("bad_arg", new_alias="new_name", since="0.24.0")
+@deprecate_arg("bad_arg", new_alias="new_name", since="1.2")
 def another_func(bad_arg: str, new_name: str):
     pass
 ```
@@ -178,7 +178,7 @@ import warnings
 def deprecated_function():
    warnings.warn(
       "The function qiskit.deprecated_function() is deprecated since "
-      "Qiskit 0.44.0, and will be removed 3 months or more later. "
+      "Qiskit 1.2, and will be removed in 2.0 or a later major release."
       "Instead, you should use qiskit.other_function().",
       category=DeprecationWarning,
       stacklevel=2,
@@ -235,9 +235,9 @@ def deprecated_function():
     """
     Short description of the deprecated function.
 
-    .. deprecated:: 0.44.0
+    .. deprecated:: 1.2
        The function qiskit.deprecated_function() is deprecated since
-       Qiskit 0.44.0, and will be removed 3 months or more later.
+       Qiskit 1.2, and will be removed in 2.0 or a later major release.
        Instead, you should use qiskit.other_function().
 
     <rest of the docstring>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/github/license/Qiskit/qiskit.svg?)](https://opensource.org/licenses/Apache-2.0) <!--- long-description-skip-begin -->
 [![Current Release](https://img.shields.io/github/release/Qiskit/qiskit.svg?logo=Qiskit)](https://github.com/Qiskit/qiskit/releases)
-[![Extended Support Release](https://img.shields.io/github/v/release/Qiskit/qiskit?sort=semver&filter=0.*&logo=Qiskit&label=extended%20support)](https://github.com/Qiskit/qiskit/releases?q=tag%3A0)
+<!-- [![Extended Support Release](https://img.shields.io/github/v/release/Qiskit/qiskit?sort=semver&filter=0.*&logo=Qiskit&label=extended%20support)](https://github.com/Qiskit/qiskit/releases?q=tag%3A0) -->
 [![Downloads](https://img.shields.io/pypi/dm/qiskit.svg)](https://pypi.org/project/qiskit/)
 [![Coverage Status](https://coveralls.io/repos/github/Qiskit/qiskit/badge.svg?branch=main)](https://coveralls.io/github/Qiskit/qiskit?branch=main)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/qiskit)
@@ -21,9 +21,6 @@ For more details on how to use Qiskit, refer to the documentation located here:
 
 
 ## Installation
-
-> [!WARNING]
-> Do not try to upgrade an existing Qiskit 0.* environment to Qiskit 1.0 in-place. [Read more](https://docs.quantum.ibm.com/migration-guides/qiskit-1.0-installation).
 
 We encourage installing Qiskit via ``pip``:
 
@@ -146,9 +143,9 @@ to the project at different levels. If you use Qiskit, please cite as per the in
 
 The changelog for a particular release is dynamically generated and gets
 written to the release page on Github for each release. For example, you can
-find the page for the `0.46.0` release here:
+find the page for the `1.2.0` release here:
 
-<https://github.com/Qiskit/qiskit/releases/tag/0.46.0>
+<https://github.com/Qiskit/qiskit/releases/tag/1.2.0>
 
 The changelog for the current release can be found in the releases tab:
 [![Releases](https://img.shields.io/github/release/Qiskit/qiskit.svg?style=flat&label=)](https://github.com/Qiskit/qiskit/releases)


### PR DESCRIPTION
### Summary

Removes "extended support" and 0.* references.

### Details and comments

With the end of life of 0.* last September, this PR removes the badge for `extended support` and the warning on how to migrate from 0.*.