### PR TITLE
Build Linux AArch64 wheels natively without QEMU

### DIFF
--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -181,8 +181,6 @@ jobs:
           python-version: ${{ inputs.python-version }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: pypa/cibuildwheel@v2.22.0
-        env:
-          CIBW_ARCHS_LINUX: aarch64
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -173,16 +173,13 @@ jobs:
   wheels-linux-aarch64:
     name: "Wheels / Linux AArch64"
     if: (inputs.wheels-linux-aarch64 == 'default' && inputs.default-action || inputs.wheels-linux-aarch64) == 'build'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
       - uses: dtolnay/rust-toolchain@stable
-      - uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
       - uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_ARCHS_LINUX: aarch64

--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -183,7 +183,6 @@ jobs:
       - uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_ARCHS_LINUX: aarch64
-          CIBW_TEST_COMMAND: cp -r {project}/test . && QISKIT_PARALLEL=FALSE stestr --test-path test/python run --abbreviate -n test.python.compiler.test_transpiler
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
GitHub Actions now provides Linux runner images on native arm64 hardware[^1], which means we should be able to build the wheels natively, without requiring QEMU.  This potentially paves the way (pending a more complete move of CI to GHA) for Linux on AArch64 to potentially gain Tier 1 platforma support.

[^1]: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


