### PR TITLE
Stop shuffling coupling map node indices in VF2 passes

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -238,7 +238,6 @@ class BasicSwapPassManager(PassManagerStagePlugin):
 
     def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
         """Build routing stage PassManager."""
-        seed_transpiler = pass_manager_config.seed_transpiler
         target = pass_manager_config.target
         coupling_map = pass_manager_config.coupling_map
         backend_properties = pass_manager_config.backend_properties
@@ -257,7 +256,7 @@ class BasicSwapPassManager(PassManagerStagePlugin):
                 routing_pass,
                 target,
                 coupling_map=coupling_map,
-                seed_transpiler=seed_transpiler,
+                seed_transpiler=-1,
                 use_barrier_before_measurement=True,
             )
         if optimization_level == 1:
@@ -268,7 +267,7 @@ class BasicSwapPassManager(PassManagerStagePlugin):
                 vf2_call_limit=vf2_call_limit,
                 vf2_max_trials=vf2_max_trials,
                 backend_properties=backend_properties,
-                seed_transpiler=seed_transpiler,
+                seed_transpiler=-1,
                 check_trivial=True,
                 use_barrier_before_measurement=True,
             )
@@ -280,7 +279,7 @@ class BasicSwapPassManager(PassManagerStagePlugin):
                 vf2_call_limit=vf2_call_limit,
                 vf2_max_trials=vf2_max_trials,
                 backend_properties=backend_properties,
-                seed_transpiler=seed_transpiler,
+                seed_transpiler=-1,
                 use_barrier_before_measurement=True,
             )
         if optimization_level == 3:
@@ -291,7 +290,7 @@ class BasicSwapPassManager(PassManagerStagePlugin):
                 vf2_call_limit=vf2_call_limit,
                 vf2_max_trials=vf2_max_trials,
                 backend_properties=backend_properties,
-                seed_transpiler=seed_transpiler,
+                seed_transpiler=-1,
                 use_barrier_before_measurement=True,
             )
         raise TranspilerError(f"Invalid optimization level specified: {optimization_level}")
@@ -324,7 +323,7 @@ class StochasticSwapPassManager(PassManagerStagePlugin):
                 routing_pass,
                 target,
                 coupling_map=coupling_map,
-                seed_transpiler=seed_transpiler,
+                seed_transpiler=-1,
                 use_barrier_before_measurement=True,
             )
         if optimization_level == 1:
@@ -335,7 +334,7 @@ class StochasticSwapPassManager(PassManagerStagePlugin):
                 vf2_call_limit=vf2_call_limit,
                 vf2_max_trials=vf2_max_trials,
                 backend_properties=backend_properties,
-                seed_transpiler=seed_transpiler,
+                seed_transpiler=-1,
                 check_trivial=True,
                 use_barrier_before_measurement=True,
             )
@@ -347,7 +346,7 @@ class StochasticSwapPassManager(PassManagerStagePlugin):
                 vf2_call_limit=vf2_call_limit,
                 vf2_max_trials=vf2_max_trials,
                 backend_properties=backend_properties,
-                seed_transpiler=seed_transpiler,
+                seed_transpiler=-1,
                 use_barrier_before_measurement=True,
             )
         raise TranspilerError(f"Invalid optimization level specified: {optimization_level}")
@@ -358,7 +357,6 @@ class LookaheadSwapPassManager(PassManagerStagePlugin):
 
     def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
         """Build routing stage PassManager."""
-        seed_transpiler = pass_manager_config.seed_transpiler
         target = pass_manager_config.target
         coupling_map = pass_manager_config.coupling_map
         coupling_map_routing = target
@@ -376,7 +374,7 @@ class LookaheadSwapPassManager(PassManagerStagePlugin):
                 routing_pass,
                 target,
                 coupling_map=coupling_map,
-                seed_transpiler=seed_transpiler,
+                seed_transpiler=-1,
                 use_barrier_before_measurement=True,
             )
         if optimization_level == 1:
@@ -388,7 +386,7 @@ class LookaheadSwapPassManager(PassManagerStagePlugin):
                 vf2_call_limit=vf2_call_limit,
                 vf2_max_trials=vf2_max_trials,
                 backend_properties=backend_properties,
-                seed_transpiler=seed_transpiler,
+                seed_transpiler=-1,
                 check_trivial=True,
                 use_barrier_before_measurement=True,
             )
@@ -401,7 +399,7 @@ class LookaheadSwapPassManager(PassManagerStagePlugin):
                 vf2_call_limit=vf2_call_limit,
                 vf2_max_trials=vf2_max_trials,
                 backend_properties=backend_properties,
-                seed_transpiler=seed_transpiler,
+                seed_transpiler=-1,
                 use_barrier_before_measurement=True,
             )
         if optimization_level == 3:
@@ -413,7 +411,7 @@ class LookaheadSwapPassManager(PassManagerStagePlugin):
                 vf2_call_limit=vf2_call_limit,
                 vf2_max_trials=vf2_max_trials,
                 backend_properties=backend_properties,
-                seed_transpiler=seed_transpiler,
+                seed_transpiler=-1,
                 use_barrier_before_measurement=True,
             )
         raise TranspilerError(f"Invalid optimization level specified: {optimization_level}")
@@ -448,7 +446,7 @@ class SabreSwapPassManager(PassManagerStagePlugin):
                 routing_pass,
                 target,
                 coupling_map=coupling_map,
-                seed_transpiler=seed_transpiler,
+                seed_transpiler=-1,
                 use_barrier_before_measurement=True,
             )
         if optimization_level == 1:
@@ -466,7 +464,7 @@ class SabreSwapPassManager(PassManagerStagePlugin):
                 vf2_call_limit=vf2_call_limit,
                 vf2_max_trials=vf2_max_trials,
                 backend_properties=backend_properties,
-                seed_transpiler=seed_transpiler,
+                seed_transpiler=-1,
                 check_trivial=True,
                 use_barrier_before_measurement=True,
             )
@@ -486,7 +484,7 @@ class SabreSwapPassManager(PassManagerStagePlugin):
                 vf2_call_limit=vf2_call_limit,
                 vf2_max_trials=vf2_max_trials,
                 backend_properties=backend_properties,
-                seed_transpiler=seed_transpiler,
+                seed_transpiler=-1,
                 use_barrier_before_measurement=True,
             )
         if optimization_level == 3:
@@ -504,7 +502,7 @@ class SabreSwapPassManager(PassManagerStagePlugin):
                 vf2_call_limit=vf2_call_limit,
                 vf2_max_trials=vf2_max_trials,
                 backend_properties=backend_properties,
-                seed_transpiler=seed_transpiler,
+                seed_transpiler=-1,
                 use_barrier_before_measurement=True,
             )
         raise TranspilerError(f"Invalid optimization level specified: {optimization_level}")
@@ -515,7 +513,6 @@ class NoneRoutingPassManager(PassManagerStagePlugin):
 
     def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
         """Build routing stage PassManager."""
-        seed_transpiler = pass_manager_config.seed_transpiler
         target = pass_manager_config.target
         coupling_map = pass_manager_config.coupling_map
         routing_pass = Error(
@@ -527,7 +524,7 @@ class NoneRoutingPassManager(PassManagerStagePlugin):
             routing_pass,
             target,
             coupling_map=coupling_map,
-            seed_transpiler=seed_transpiler,
+            seed_transpiler=-1,
             use_barrier_before_measurement=True,
         )
 
@@ -793,7 +790,7 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
             )
             choose_layout_1 = VF2Layout(
                 coupling_map=pass_manager_config.coupling_map,
-                seed=pass_manager_config.seed_transpiler,
+                seed=-1,
                 call_limit=int(5e4),  # Set call limit to ~100ms with rustworkx 0.10.2
                 properties=pass_manager_config.backend_properties,
                 target=pass_manager_config.target,
@@ -826,7 +823,7 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
         elif optimization_level == 2:
             choose_layout_0 = VF2Layout(
                 coupling_map=pass_manager_config.coupling_map,
-                seed=pass_manager_config.seed_transpiler,
+                seed=-1,
                 call_limit=int(5e6),  # Set call limit to ~10s with rustworkx 0.10.2
                 properties=pass_manager_config.backend_properties,
                 target=pass_manager_config.target,
@@ -861,7 +858,7 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
         elif optimization_level == 3:
             choose_layout_0 = VF2Layout(
                 coupling_map=pass_manager_config.coupling_map,
-                seed=pass_manager_config.seed_transpiler,
+                seed=-1,
                 call_limit=int(3e7),  # Set call limit to ~60s with rustworkx 0.10.2
                 properties=pass_manager_config.backend_properties,
                 target=pass_manager_config.target,

--- a/test/python/primitives/test_backend_estimator.py
+++ b/test/python/primitives/test_backend_estimator.py
@@ -440,7 +440,7 @@ class TestBackendEstimator(QiskitTestCase):
                 estimator.set_transpile_options(seed_transpiler=15, optimization_level=1)
                 value = estimator.run(qc, op, shots=10000).result().values[0]
             if optionals.HAS_AER:
-                ref_value = -0.9954 if isinstance(backend, GenericBackendV2) else -0.916
+                ref_value = -0.9954 if isinstance(backend, GenericBackendV2) else -0.934
             else:
                 ref_value = -1
             self.assertEqual(value, ref_value)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the preset pass manager construction usage of the VF2Layout and VF2PostLayout to stop shuffling the coupling map nodes by default. The theory behind the node shuffling is that since we limit the search space in the interest of runtime shuffling the node indices would change the search order to hopefully find a match that would be otherwise missed because we hit the internal state visit limit. However, this is showing in practice not to having a huge impact, especially since we're using the ordering heuristic from vf2++ that orders nodes by degree for the vf2 search. However, in the case of a circuit that was hardware efficient this can have the negative effect of making it harder for vf2 to find potential matches, especially on regular lattices. For example, in cases of a square grid lattice coupling map, and a path interaction graph (e.g. 0->1->2->3) the shuffling makes it much harder to find the mapping. This is because the lattice graphs the node degree is the same (or fall into the same few types of nodes) so the influence of the vf2++ heuristic isn't as significant and the index order has a larger impact because it is the search order for vf2. For smaller graphs this wasn't as noticeable but as devices scale up this effect has more of an impact.

Since we rely solely on VF2 to find a perfect layout at higher optimization levels this shuffling is not desirable because we always want to find the perfect layout if it exists, especially for hardware efficient circuits that are constructed to not require swaps. So prioritizing the results for hardware efficient circuits is desirable by default. Especially since most connectivity graphs are lattices and will exhibit the negative impacts for hardware efficient circuits.

From an API impact perspective this doesn't change any of the interfaces or defaults for the VF2 passes in the interest of backwards compatibility. The only change is that this updates how we instantiate the VF2 passes to always use a deterministic node ordering independent of any user specified seed. This will be fully deterministic even in cases the user specifies a seed value for the transpilation, the output just might not be the same as before with the fixed seed; which is not guaranteed between releases.

### Details and comments

This is a partial backport of #13492 without the API implications on the generate function from the original PR because that is only valid for 2.0. The change in what the preset pass managers do when running VF2 is valid though because it doesn't change our API guarantees around the transpilation, it just increases the likelihood of a match being found.