### PR TITLE
Ignoring unsupported gates for Solovay-Kitaev transpiler pass

### DIFF
--- a/qiskit/transpiler/passes/synthesis/solovay_kitaev_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/solovay_kitaev_synthesis.py
@@ -170,7 +170,7 @@ class SolovayKitaev(TransformationPass):
 
             # ignore operations on which the algorithm cannot run
             if (
-                (not node.op.num_qubits == 1)
+                (node.op.num_qubits != 1)
                 or node.is_parameterized()
                 or (not hasattr(node.op, "to_matrix"))
             ):

--- a/qiskit/transpiler/passes/synthesis/solovay_kitaev_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/solovay_kitaev_synthesis.py
@@ -33,6 +33,7 @@ from qiskit.synthesis.discrete_basis.generate_basis_approximations import (
     generate_basic_approximations,
 )
 from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.transpiler.passes.utils.control_flow import trivial_recurse
 
 from .plugin import UnitarySynthesisPlugin
 
@@ -154,6 +155,7 @@ class SolovayKitaev(TransformationPass):
         self.recursion_degree = recursion_degree
         self._sk = SolovayKitaevDecomposition(basic_approximations)
 
+    @trivial_recurse
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         """Run the ``SolovayKitaev`` pass on `dag`.
 

--- a/releasenotes/notes/sk-ignore-unsupported-ops-8d7d5f6fca255ffb.yaml
+++ b/releasenotes/notes/sk-ignore-unsupported-ops-8d7d5f6fca255ffb.yaml
@@ -1,0 +1,6 @@
+---
+upgrade_transpiler:
+  - |
+    The :class:`.SolovayKitaev` transpiler pass no longer raises an exception on circuits
+    that contain single-qubit operations without a ``to_matrix`` method (such as measures,
+    barriers, control-flow operations) or parameterized single-qubit operations.

--- a/releasenotes/notes/sk-ignore-unsupported-ops-8d7d5f6fca255ffb.yaml
+++ b/releasenotes/notes/sk-ignore-unsupported-ops-8d7d5f6fca255ffb.yaml
@@ -3,4 +3,5 @@ upgrade_transpiler:
   - |
     The :class:`.SolovayKitaev` transpiler pass no longer raises an exception on circuits
     that contain single-qubit operations without a ``to_matrix`` method (such as measures,
-    barriers, control-flow operations) or parameterized single-qubit operations.
+    barriers, control-flow operations) or parameterized single-qubit operations,
+    but will leave them unchanged.

--- a/test/python/transpiler/test_solovay_kitaev.py
+++ b/test/python/transpiler/test_solovay_kitaev.py
@@ -275,16 +275,20 @@ class TestSolovayKitaev(QiskitTestCase):
         cr = ClassicalRegister(1)
         qc = QuantumCircuit(qr, cr)
 
-        qc.x(0)
         with qc.if_test((cr[0], 0)) as else_:
             qc.y(0)
         with else_:
             qc.z(0)
         transpiled = SolovayKitaev()(qc)
-        self.assertEqual(set(transpiled.count_ops()), {"h", "t", "if_else"})
+
+        # check that we still have an if-else block and all the operations within
+        # have been recursively synthesized
+        self.assertEqual(transpiled[0].name, "if_else")
+        for block in transpiled[0].operation.blocks:
+            self.assertLessEqual(set(block.count_ops()), {"h", "t", "tdg"})
 
     def test_no_to_matrix(self):
-        """Test the Solovay-Kitaev transpiler pass on circuits with gates without to_matrix."""
+        """Test the Solovay-Kitaev transpiler pass ignores gates without to_matrix."""
         qc = QuantumCircuit(1)
         qc.initialize("0")
 

--- a/test/python/transpiler/test_solovay_kitaev.py
+++ b/test/python/transpiler/test_solovay_kitaev.py
@@ -22,8 +22,10 @@ import scipy
 from ddt import ddt, data
 
 from qiskit import transpile
-from qiskit.circuit import QuantumCircuit
+from qiskit.circuit import QuantumCircuit, Parameter
+from qiskit.circuit.classicalregister import ClassicalRegister
 from qiskit.circuit.library import TGate, TdgGate, HGate, SGate, SdgGate, IGate, QFT
+from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.quantum_info import Operator
 from qiskit.synthesis.discrete_basis.generate_basis_approximations import (
@@ -32,7 +34,6 @@ from qiskit.synthesis.discrete_basis.generate_basis_approximations import (
 from qiskit.synthesis.discrete_basis.commutator_decompose import commutator_decompose
 from qiskit.synthesis.discrete_basis.gate_sequence import GateSequence
 from qiskit.transpiler import PassManager
-from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.passes import UnitarySynthesis, Collect1qRuns, ConsolidateBlocks
 from qiskit.transpiler.passes.synthesis import SolovayKitaev, SolovayKitaevSynthesis
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
@@ -152,23 +153,6 @@ class TestSolovayKitaev(QiskitTestCase):
         decomposed_circuit = dag_to_circuit(decomposed_dag)
         self.assertEqual(circuit, decomposed_circuit)
 
-    def test_fails_with_no_to_matrix(self):
-        """Test failer if gate does not have to_matrix."""
-        circuit = QuantumCircuit(1)
-        circuit.initialize("0")
-
-        synth = SolovayKitaev(3, self.basic_approx)
-
-        dag = circuit_to_dag(circuit)
-
-        with self.assertRaises(TranspilerError) as cm:
-            _ = synth.run(dag)
-
-        self.assertEqual(
-            "SolovayKitaev does not support gate without to_matrix method: initialize",
-            cm.exception.message,
-        )
-
     def test_str_basis_gates(self):
         """Test specifying the basis gates by string works."""
         circuit = QuantumCircuit(1)
@@ -260,6 +244,52 @@ class TestSolovayKitaev(QiskitTestCase):
             discretized = skd(circuit)
 
         self.assertEqual(discretized, reference)
+
+    def test_measure(self):
+        """Test the Solovay-Kitaev transpiler pass on circuits with measure operators."""
+        qc = QuantumCircuit(1, 1)
+        qc.x(0)
+        qc.measure(0, 0)
+        transpiled = SolovayKitaev()(qc)
+        self.assertEqual(set(transpiled.count_ops()), {"h", "t", "measure"})
+
+    def test_barrier(self):
+        """Test the Solovay-Kitaev transpiler pass on circuits with barriers."""
+        qc = QuantumCircuit(1)
+        qc.x(0)
+        qc.barrier(0)
+        transpiled = SolovayKitaev()(qc)
+        self.assertEqual(set(transpiled.count_ops()), {"h", "t", "barrier"})
+
+    def test_parameterized_gates(self):
+        """Test the Solovay-Kitaev transpiler pass on circuits with parameterized gates."""
+        qc = QuantumCircuit(1)
+        qc.x(0)
+        qc.rz(Parameter("t"), 0)
+        transpiled = SolovayKitaev()(qc)
+        self.assertEqual(set(transpiled.count_ops()), {"h", "t", "rz"})
+
+    def test_control_flow_if(self):
+        """Test the Solovay-Kitaev transpiler pass on circuits with control flow ops"""
+        qr = QuantumRegister(1)
+        cr = ClassicalRegister(1)
+        qc = QuantumCircuit(qr, cr)
+
+        qc.x(0)
+        with qc.if_test((cr[0], 0)) as else_:
+            qc.y(0)
+        with else_:
+            qc.z(0)
+        transpiled = SolovayKitaev()(qc)
+        self.assertEqual(set(transpiled.count_ops()), {"h", "t", "if_else"})
+
+    def test_no_to_matrix(self):
+        """Test the Solovay-Kitaev transpiler pass on circuits with gates without to_matrix."""
+        qc = QuantumCircuit(1)
+        qc.initialize("0")
+
+        transpiled = SolovayKitaev()(qc)
+        self.assertEqual(set(transpiled.count_ops()), {"initialize"})
 
 
 @ddt


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

The Solovay-Kitaev transpiler pass (i.e. the standalone pass and not the unitary synthesis plugin) previously considered all operations over $1$ qubit and ignored all operations over $k$ qubits for $k\ne 1$. In doing so, it raised a transpiler error for circuits with single-qubit operations that are either parameterized or don't have a ``to_matrix`` method (these include barriers, measures, control-flow ops and more). This PR changes the default behavior to ignore such operations instead of raising an error. 

