### PR TITLE
Brand operation indices with `OperationIndex`

### DIFF
--- a/crates/accelerate/src/basis/basis_translator/compose_transforms.rs
+++ b/crates/accelerate/src/basis/basis_translator/compose_transforms.rs
@@ -112,7 +112,7 @@ pub(super) fn compose_transforms<'a>(
                         .assign_parameters_from_mapping(py, param_mapping)?;
                     let replace_dag: DAGCircuit =
                         DAGCircuit::from_circuit_data(py, replacement.0, true)?;
-                    let op_node = dag.get_node(py, node)?;
+                    let op_node = dag.get_node(py, node.node())?;
                     dag.py_substitute_node_with_dag(
                         py,
                         op_node.bind(py),

--- a/crates/accelerate/src/basis/basis_translator/mod.rs
+++ b/crates/accelerate/src/basis/basis_translator/mod.rs
@@ -212,8 +212,8 @@ fn extract_basis(
         basis: &mut HashSet<GateIdentifier>,
         min_qubits: usize,
     ) -> PyResult<()> {
-        for (node, operation) in circuit.op_nodes(true) {
-            if !circuit.has_calibration_for_index(py, node)?
+        for (_, operation) in circuit.op_nodes(true) {
+            if !circuit.has_calibration_for_instruction(py, operation)?
                 && circuit.get_qargs(operation.qubits).len() >= min_qubits
             {
                 basis.insert((operation.op.name().to_string(), operation.op.num_qubits()));
@@ -278,9 +278,9 @@ fn extract_basis_target(
     min_qubits: usize,
     qargs_with_non_global_operation: &HashMap<Option<Qargs>, HashSet<String>>,
 ) -> PyResult<()> {
-    for (node, node_obj) in dag.op_nodes(true) {
+    for (_, node_obj) in dag.op_nodes(true) {
         let qargs: &[Qubit] = dag.get_qargs(node_obj.qubits);
-        if dag.has_calibration_for_index(py, node)? || qargs.len() < min_qubits {
+        if qargs.len() < min_qubits || dag.has_calibration_for_instruction(py, node_obj)? {
             continue;
         }
         // Treat the instruction as on an incomplete basis if the qargs are in the
@@ -428,7 +428,7 @@ fn apply_translation(
     let mut is_updated = false;
     let mut out_dag = dag.copy_empty_like(py, "alike")?;
     for node in dag.topological_op_nodes()? {
-        let node_obj = dag[node].unwrap_operation();
+        let node_obj = &dag[node];
         let node_qarg = dag.get_qargs(node_obj.qubits);
         let node_carg = dag.get_cargs(node_obj.clbits);
         let qubit_set: HashSet<Qubit> = HashSet::from_iter(node_qarg.iter().copied());
@@ -535,7 +535,7 @@ fn apply_translation(
             continue;
         }
 
-        if dag.has_calibration_for_index(py, node)? {
+        if dag.has_calibration_for_instruction(py, node_obj)? {
             out_dag.apply_operation_back(
                 py,
                 node_obj.op.clone(),
@@ -606,7 +606,7 @@ fn replace_node(
     }
     if node.params_view().is_empty() {
         for inner_index in target_dag.topological_op_nodes()? {
-            let inner_node = &target_dag[inner_index].unwrap_operation();
+            let inner_node = &target_dag[inner_index];
             let old_qargs = dag.get_qargs(node.qubits);
             let old_cargs = dag.get_cargs(node.clbits);
             let new_qubits: Vec<Qubit> = target_dag
@@ -667,7 +667,7 @@ fn replace_node(
             .zip(node.params_view())
             .into_py_dict_bound(py);
         for inner_index in target_dag.topological_op_nodes()? {
-            let inner_node = &target_dag[inner_index].unwrap_operation();
+            let inner_node = &target_dag[inner_index];
             let old_qargs = dag.get_qargs(node.qubits);
             let old_cargs = dag.get_cargs(node.clbits);
             let new_qubits: Vec<Qubit> = target_dag

--- a/crates/accelerate/src/check_map.rs
+++ b/crates/accelerate/src/check_map.rs
@@ -36,7 +36,7 @@ fn recurse<'py>(
             None => edge_set.contains(&[qubits[0].into(), qubits[1].into()]),
         }
     };
-    for (node, inst) in dag.op_nodes(false) {
+    for (_, inst) in dag.op_nodes(false) {
         let qubits = dag.get_qargs(inst.qubits);
         if inst.op.control_flow() {
             if let OperationRef::Instruction(py_inst) = inst.op.view() {
@@ -66,7 +66,7 @@ fn recurse<'py>(
                 }
             }
         } else if qubits.len() == 2
-            && (dag.calibrations_empty() || !dag.has_calibration_for_index(py, node)?)
+            && (dag.calibrations_empty() || !dag.has_calibration_for_instruction(py, inst)?)
             && !check_qubits(qubits)
         {
             return Ok(Some((

--- a/crates/accelerate/src/convert_2q_block_matrix.rs
+++ b/crates/accelerate/src/convert_2q_block_matrix.rs
@@ -18,9 +18,8 @@ use num_complex::Complex64;
 use numpy::ndarray::linalg::kron;
 use numpy::ndarray::{aview2, Array2, ArrayView2};
 use numpy::PyReadonlyArray2;
-use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
-use qiskit_circuit::dag_circuit::DAGCircuit;
+use qiskit_circuit::dag_circuit::{DAGCircuit, OperationIndex};
 use qiskit_circuit::gate_matrix::ONE_QUBIT_IDENTITY;
 use qiskit_circuit::imports::QI_OPERATOR;
 use qiskit_circuit::operations::{Operation, OperationRef};
@@ -57,7 +56,7 @@ pub fn get_matrix_from_inst(py: Python, inst: &PackedInstruction) -> PyResult<Ar
 pub fn blocks_to_matrix(
     py: Python,
     dag: &DAGCircuit,
-    op_list: &[NodeIndex],
+    op_list: &[OperationIndex],
     block_index_map: [Qubit; 2],
 ) -> PyResult<Array2<Complex64>> {
     let map_bits = |bit: &Qubit| -> u8 {
@@ -72,7 +71,7 @@ pub fn blocks_to_matrix(
     let mut one_qubit_components_modified = false;
     let mut output_matrix: Option<Array2<Complex64>> = None;
     for node in op_list {
-        let inst = dag[*node].unwrap_operation();
+        let inst = &dag[*node];
         let op_matrix = get_matrix_from_inst(py, inst)?;
         match dag
             .get_qargs(inst.qubits)

--- a/crates/accelerate/src/elide_permutations.rs
+++ b/crates/accelerate/src/elide_permutations.rs
@@ -13,7 +13,7 @@
 use numpy::PyReadonlyArray1;
 use pyo3::prelude::*;
 
-use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType};
+use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_circuit::operations::{Operation, Param};
 use qiskit_circuit::Qubit;
 
@@ -39,63 +39,60 @@ fn run(py: Python, dag: &mut DAGCircuit) -> PyResult<Option<(DAGCircuit, Vec<usi
     // note that DAGCircuit::copy_empty_like clones the interners
     let mut new_dag = dag.copy_empty_like(py, "alike")?;
     for node_index in dag.topological_op_nodes()? {
-        if let NodeType::Operation(inst) = &dag[node_index] {
-            match (inst.op.name(), inst.condition()) {
-                ("swap", None) => {
-                    let qargs = dag.get_qargs(inst.qubits);
-                    let index0 = qargs[0].index();
-                    let index1 = qargs[1].index();
-                    mapping.swap(index0, index1);
-                }
-                ("permutation", None) => {
-                    if let Param::Obj(ref pyobj) = inst.params.as_ref().unwrap()[0] {
-                        let pyarray: PyReadonlyArray1<i32> = pyobj.extract(py)?;
-                        let pattern = pyarray.as_array();
+        let inst = &dag[node_index];
+        match (inst.op.name(), inst.condition()) {
+            ("swap", None) => {
+                let qargs = dag.get_qargs(inst.qubits);
+                let index0 = qargs[0].index();
+                let index1 = qargs[1].index();
+                mapping.swap(index0, index1);
+            }
+            ("permutation", None) => {
+                if let Param::Obj(ref pyobj) = inst.params.as_ref().unwrap()[0] {
+                    let pyarray: PyReadonlyArray1<i32> = pyobj.extract(py)?;
+                    let pattern = pyarray.as_array();
 
-                        let qindices: Vec<usize> = dag
-                            .get_qargs(inst.qubits)
-                            .iter()
-                            .map(|q| q.index())
-                            .collect();
-
-                        let remapped_qindices: Vec<usize> = (0..qindices.len())
-                            .map(|i| pattern[i])
-                            .map(|i| qindices[i as usize])
-                            .collect();
-
-                        qindices
-                            .iter()
-                            .zip(remapped_qindices.iter())
-                            .for_each(|(old, new)| {
-                                mapping[*old] = *new;
-                            });
-                    } else {
-                        unreachable!();
-                    }
-                }
-                _ => {
-                    // General instruction
-                    let qargs = dag.get_qargs(inst.qubits);
-                    let cargs = dag.get_cargs(inst.clbits);
-                    let mapped_qargs: Vec<Qubit> = qargs
+                    let qindices: Vec<usize> = dag
+                        .get_qargs(inst.qubits)
                         .iter()
-                        .map(|q| Qubit::new(mapping[q.index()]))
+                        .map(|q| q.index())
                         .collect();
 
-                    new_dag.apply_operation_back(
-                        py,
-                        inst.op.clone(),
-                        &mapped_qargs,
-                        cargs,
-                        inst.params.as_deref().cloned(),
-                        inst.extra_attrs.clone(),
-                        #[cfg(feature = "cache_pygates")]
-                        inst.py_op.get().map(|x| x.clone_ref(py)),
-                    )?;
+                    let remapped_qindices: Vec<usize> = (0..qindices.len())
+                        .map(|i| pattern[i])
+                        .map(|i| qindices[i as usize])
+                        .collect();
+
+                    qindices
+                        .iter()
+                        .zip(remapped_qindices.iter())
+                        .for_each(|(old, new)| {
+                            mapping[*old] = *new;
+                        });
+                } else {
+                    unreachable!();
                 }
             }
-        } else {
-            unreachable!();
+            _ => {
+                // General instruction
+                let qargs = dag.get_qargs(inst.qubits);
+                let cargs = dag.get_cargs(inst.clbits);
+                let mapped_qargs: Vec<Qubit> = qargs
+                    .iter()
+                    .map(|q| Qubit::new(mapping[q.index()]))
+                    .collect();
+
+                new_dag.apply_operation_back(
+                    py,
+                    inst.op.clone(),
+                    &mapped_qargs,
+                    cargs,
+                    inst.params.as_deref().cloned(),
+                    inst.extra_attrs.clone(),
+                    #[cfg(feature = "cache_pygates")]
+                    inst.py_op.get().map(|x| x.clone_ref(py)),
+                )?;
+            }
         }
     }
     Ok(Some((new_dag, mapping)))

--- a/crates/accelerate/src/filter_op_nodes.rs
+++ b/crates/accelerate/src/filter_op_nodes.rs
@@ -13,9 +13,8 @@
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 
-use qiskit_circuit::dag_circuit::DAGCircuit;
+use qiskit_circuit::dag_circuit::{DAGCircuit, OperationIndex};
 use qiskit_circuit::packed_instruction::PackedInstruction;
-use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
 #[pyfunction]
 #[pyo3(name = "filter_op_nodes")]
@@ -24,11 +23,11 @@ pub fn py_filter_op_nodes(
     dag: &mut DAGCircuit,
     predicate: &Bound<PyAny>,
 ) -> PyResult<()> {
-    let callable = |node: NodeIndex| -> PyResult<bool> {
-        let dag_op_node = dag.get_node(py, node)?;
+    let callable = |node: OperationIndex| -> PyResult<bool> {
+        let dag_op_node = dag.get_node(py, node.node())?;
         predicate.call1((dag_op_node,))?.extract()
     };
-    let mut remove_nodes: Vec<NodeIndex> = Vec::new();
+    let mut remove_nodes = Vec::new();
     for node in dag.op_node_indices(true) {
         if !callable(node)? {
             remove_nodes.push(node);

--- a/crates/accelerate/src/remove_identity_equiv.rs
+++ b/crates/accelerate/src/remove_identity_equiv.rs
@@ -13,11 +13,10 @@
 use num_complex::Complex64;
 use num_complex::ComplexFloat;
 use pyo3::prelude::*;
-use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
 use crate::nlayout::PhysicalQubit;
 use crate::target_transpiler::Target;
-use qiskit_circuit::dag_circuit::DAGCircuit;
+use qiskit_circuit::dag_circuit::{DAGCircuit, OperationIndex};
 use qiskit_circuit::operations::Operation;
 use qiskit_circuit::operations::OperationRef;
 use qiskit_circuit::operations::Param;
@@ -31,7 +30,7 @@ fn remove_identity_equiv(
     approx_degree: Option<f64>,
     target: Option<&Target>,
 ) {
-    let mut remove_list: Vec<NodeIndex> = Vec::new();
+    let mut remove_list: Vec<OperationIndex> = Vec::new();
 
     let get_error_cutoff = |inst: &PackedInstruction| -> f64 {
         match approx_degree {

--- a/crates/accelerate/src/split_2q_unitaries.rs
+++ b/crates/accelerate/src/split_2q_unitaries.rs
@@ -13,10 +13,9 @@
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
 use qiskit_circuit::circuit_instruction::OperationFromPython;
-use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType, Wire};
+use qiskit_circuit::dag_circuit::{DAGCircuit, Wire};
 use qiskit_circuit::imports::UNITARY_GATE;
 use qiskit_circuit::operations::{Operation, Param};
 
@@ -31,55 +30,51 @@ pub fn split_2q_unitaries(
     if !dag.get_op_counts().contains_key("unitary") {
         return Ok(());
     }
-    let nodes: Vec<NodeIndex> = dag.op_node_indices(false).collect();
+    let nodes: Vec<_> = dag.op_node_indices(false).collect();
 
     for node in nodes {
-        if let NodeType::Operation(inst) = &dag[node] {
-            let qubits = dag.get_qargs(inst.qubits).to_vec();
-            // We only attempt to split UnitaryGate objects, but this could be extended in future
-            // -- however we need to ensure that we can compile the resulting single-qubit unitaries
-            // to the supported basis gate set.
-            if qubits.len() != 2 || inst.op.name() != "unitary" {
-                continue;
-            }
-            let matrix = inst
-                .op
-                .matrix(inst.params_view())
-                .expect("'unitary' gates should always have a matrix form");
-            let decomp = TwoQubitWeylDecomposition::new_inner(
-                matrix.view(),
-                Some(requested_fidelity),
-                None,
-            )?;
-            if matches!(decomp.specialization, Specialization::IdEquiv) {
-                let k1r_arr = decomp.K1r(py);
-                let k1l_arr = decomp.K1l(py);
-                let kwargs = PyDict::new_bound(py);
-                kwargs.set_item(intern!(py, "num_qubits"), 1)?;
-                let k1r_gate = UNITARY_GATE
-                    .get_bound(py)
-                    .call((k1r_arr, py.None(), false), Some(&kwargs))?;
-                let k1l_gate = UNITARY_GATE
-                    .get_bound(py)
-                    .call((k1l_arr, py.None(), false), Some(&kwargs))?;
-                let insert_fn = |edge: &Wire| -> PyResult<OperationFromPython> {
-                    if let Wire::Qubit(qubit) = edge {
-                        if *qubit == qubits[0] {
-                            k1r_gate.extract()
-                        } else {
-                            k1l_gate.extract()
-                        }
-                    } else {
-                        unreachable!("This will only be called on ops with no classical wires.");
-                    }
-                };
-                dag.replace_node_with_1q_ops(py, node, insert_fn)?;
-                dag.add_global_phase(py, &Param::Float(decomp.global_phase))?;
-            }
-            // TODO: also look into splitting on Specialization::Swap and just
-            // swap the virtual qubits. Doing this we will need to update the
-            // permutation like in ElidePermutations
+        let inst = &dag[node];
+        let qubits = dag.get_qargs(inst.qubits).to_vec();
+        // We only attempt to split UnitaryGate objects, but this could be extended in future
+        // -- however we need to ensure that we can compile the resulting single-qubit unitaries
+        // to the supported basis gate set.
+        if qubits.len() != 2 || inst.op.name() != "unitary" {
+            continue;
         }
+        let matrix = inst
+            .op
+            .matrix(inst.params_view())
+            .expect("'unitary' gates should always have a matrix form");
+        let decomp =
+            TwoQubitWeylDecomposition::new_inner(matrix.view(), Some(requested_fidelity), None)?;
+        if matches!(decomp.specialization, Specialization::IdEquiv) {
+            let k1r_arr = decomp.K1r(py);
+            let k1l_arr = decomp.K1l(py);
+            let kwargs = PyDict::new_bound(py);
+            kwargs.set_item(intern!(py, "num_qubits"), 1)?;
+            let k1r_gate = UNITARY_GATE
+                .get_bound(py)
+                .call((k1r_arr, py.None(), false), Some(&kwargs))?;
+            let k1l_gate = UNITARY_GATE
+                .get_bound(py)
+                .call((k1l_arr, py.None(), false), Some(&kwargs))?;
+            let insert_fn = |edge: &Wire| -> PyResult<OperationFromPython> {
+                if let Wire::Qubit(qubit) = edge {
+                    if *qubit == qubits[0] {
+                        k1r_gate.extract()
+                    } else {
+                        k1l_gate.extract()
+                    }
+                } else {
+                    unreachable!("This will only be called on ops with no classical wires.");
+                }
+            };
+            dag.replace_node_with_1q_ops(py, node, insert_fn)?;
+            dag.add_global_phase(py, &Param::Float(decomp.global_phase))?;
+        }
+        // TODO: also look into splitting on Specialization::Swap and just
+        // swap the virtual qubits. Doing this we will need to update the
+        // permutation like in ElidePermutations
     }
     Ok(())
 }

--- a/crates/circuit/src/converters.rs
+++ b/crates/circuit/src/converters.rs
@@ -21,7 +21,7 @@ use pyo3::{
 };
 
 use crate::circuit_data::CircuitData;
-use crate::dag_circuit::{DAGCircuit, NodeType};
+use crate::dag_circuit::DAGCircuit;
 use crate::packed_instruction::PackedInstruction;
 
 /// An extractable representation of a QuantumCircuit reserved only for
@@ -106,11 +106,7 @@ pub fn dag_to_circuit(
         dag.qargs_interner().clone(),
         dag.cargs_interner().clone(),
         dag.topological_op_nodes()?.map(|node_index| {
-            let NodeType::Operation(ref instr) = dag[node_index] else {
-                unreachable!(
-                    "The received node from topological_op_nodes() is not an Operation node."
-                )
-            };
+            let instr = &dag[node_index];
             if copy_operations {
                 let op = instr.op.py_deepcopy(py, None)?;
                 Ok(PackedInstruction {


### PR DESCRIPTION
### Summary

Operations on the `DAGCircuit` that return `NodeIndex`s that are known to refer to `Operation` instances now return a transparent wrapper type, `OperationIndex`.  `DAGCircuit` can be indexed with an `OperationIndex`, which returns the `&PackedInstruction` directly, rather than requiring the caller to indirect through the `OperationType` enum, which 99% of the time they don't care about.

`DAGCircuit` methods that are required to act on operations now take `OperationIndex` arguments, shifting the typing validation left; the compiler now effectively tracks provenance of indices in the type system. You can convert a `NodeIndex` into an `OperationIndex` as part of a DAG lookup by using `DAGCircuit::get_operation`, which returns the `&PackedInstruction` (if available), and upgrades the `NodeIndex` into an `OperationIndex` at the same time.  Most of the time this is not necessary, as the methods that can only return operation nodes now return `OperationIndex`.

Most of the changes in this commit are simplifying relevant call sites, and removing `if let NodeType::Operation(inst) = &dag[node_index] { }` constructs, since they were automatically flattened into `let inst = &dag[op_index]`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

This was the goal I had in mind at the end of my little sequence of patches late last week (#13680, #13681, #13682, #13683).  I don't love the `unsafe` casting of the `Vec` for `collect_1q_runs` etc - perhaps we can extend the rustworkx API to allow a mapping function, so we can do it all in safe no-copy Rust.

A little over one third of the diff of this PR is whitespace-only changes where the level of indent is reduced.  For example, `elide_permutations.rs` claims a diffstat of +49,-52, but with `git diff -b` it reduces to +2,-5.