### PR TITLE
Add `copy` method to SparsePauliOp, replacing inherited generic `copy` method

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -232,6 +232,10 @@ class SparsePauliOp(LinearOp):
             atol = self.atol
         return np.allclose((self - other).simplify().coeffs, 0.0, atol=atol)
 
+    def copy(self):
+        """Return a copy of the SparsePauliOp."""
+        return SparsePauliOp(self, copy=True)
+
     @property
     def settings(self) -> dict:
         """Return settings."""


### PR DESCRIPTION
Addresses issue #13687. Shadows generic inherited `copy` method. This avoids overhead of using `deepcopy`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
