### PR TITLE
remove mentioning ``unroller`` translation in docstrings

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -191,7 +191,7 @@ def transpile(  # pylint: disable=too-many-return-statements
             This can also be the external plugin name to use for the ``routing`` stage.
             You can see a list of installed plugins by using :func:`~.list_stage_plugins` with
             ``"routing"`` for the ``stage_name`` argument.
-        translation_method: Name of translation pass ('translator', 'synthesis')
+        translation_method: Name of translation pass (``"translator"`` or ``"synthesis"``)
             This can also be the external plugin name to use for the ``translation`` stage.
             You can see a list of installed plugins by using :func:`~.list_stage_plugins` with
             ``"translation"`` for the ``stage_name`` argument.

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -191,7 +191,7 @@ def transpile(  # pylint: disable=too-many-return-statements
             This can also be the external plugin name to use for the ``routing`` stage.
             You can see a list of installed plugins by using :func:`~.list_stage_plugins` with
             ``"routing"`` for the ``stage_name`` argument.
-        translation_method: Name of translation pass ('unroller', 'translator', 'synthesis')
+        translation_method: Name of translation pass ('translator', 'synthesis')
             This can also be the external plugin name to use for the ``translation`` stage.
             You can see a list of installed plugins by using :func:`~.list_stage_plugins` with
             ``"translation"`` for the ``stage_name`` argument.

--- a/qiskit/transpiler/preset_passmanagers/plugin.py
+++ b/qiskit/transpiler/preset_passmanagers/plugin.py
@@ -79,7 +79,7 @@ load external plugins via corresponding entry points.
        ``second_final_layout.compose(first_final_layout, dag.qubits)``).
    * - ``translation``
      - ``qiskit.transpiler.translation``
-     - ``translator``, ``synthesis``, ``unroller``
+     - ``translator``, ``synthesis``
      - The output of this stage is expected to have every operation be a native
         instruction on the target backend.
    * - ``optimization``


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

The ``Unroller`` pass was removed in #11581, its registration as an entrypoint was removed in #11684, it's probably time to remove it from being mentioned in the documentation (e.g. see https://docs.quantum.ibm.com/api/qiskit/transpiler_plugins). 


