### PR TITLE
Remove errant `print` statements from tests

### DIFF
--- a/test/python/circuit/test_circuit_data.py
+++ b/test/python/circuit/test_circuit_data.py
@@ -320,10 +320,6 @@ class TestQuantumCircuitData(QiskitTestCase):
 
         del data_list[sli]
         del data[sli]
-        if data_list[sli] != data[sli]:
-            print(f"data_list: {data_list}")
-            print(f"data: {list(data)}")
-
         self.assertEqual(data[sli], data_list[sli])
 
     @ddt.data(

--- a/test/python/transpiler/test_vf2_post_layout.py
+++ b/test/python/transpiler/test_vf2_post_layout.py
@@ -267,7 +267,9 @@ class TestVF2PostLayout(QiskitTestCase):
             f"is >= configured max trials {max_trials}",
             cm.output,
         )
-        print(pass_.property_set["VF2PostLayout_stop_reason"])
+        self.assertEqual(
+            pass_.property_set["VF2PostLayout_stop_reason"], VF2PostLayoutStopReason.SOLUTION_FOUND
+        )
         self.assertLayout(dag, cmap, pass_.property_set)
         self.assertNotEqual(pass_.property_set["post_layout"], initial_layout)
 


### PR DESCRIPTION
If any `print` is necessary for debugging failed test cases, we probably ought to reconfigure the test runner's display mechanisms, or use the built-in configuration of the `unittest` assert methods to produce better results.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


