### PR TITLE
Use `{integer}::div_ceil` where appropriate

### DIFF
--- a/crates/accelerate/src/sparse_pauli_op.rs
+++ b/crates/accelerate/src/sparse_pauli_op.rs
@@ -1161,7 +1161,7 @@ macro_rules! impl_to_matrix_sparse {
             // to keep threads busy by subdivision with minimizing overhead; we're setting the
             // chunk size such that the iterator will have as many elements as there are threads.
             let num_threads = rayon::current_num_threads();
-            let chunk_size = (side + num_threads - 1) / num_threads;
+            let chunk_size = side.div_ceil(num_threads);
             let mut values_chunks = Vec::with_capacity(num_threads);
             let mut indices_chunks = Vec::with_capacity(num_threads);
             // SAFETY: the slice here is uninitialised data; it must not be read.


### PR DESCRIPTION
The method was added in Rust 1.73, which was previously above our MSRV. Recent clippy versions now warn against the workaround on complexity grounds, since our MSRV indicates we can use the built-in version.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


