### PR TITLE
Configure workspace-level Rust lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,19 @@ qiskit-circuit = { path = "crates/circuit" }
 qiskit-qasm2 = { path = "crates/qasm2" }
 qiskit-qasm3 = { path = "crates/qasm3" }
 
+[workspace.lints.clippy]
+# The lint forbids things like `if a < b {} else if a == b {}`, and suggests matching on `a.cmp(&b)`
+# which uses the `::std::cmp::Ordering` enum as a return.  Both styles are acceptable, and the `if`
+# chain can be more legible to people.
+comparison-chain = "allow"
+
+[workspace.lints.rust]
+# In Rust 2021, the bodies of `unsafe fn` may use `unsafe` functions themselves without marking
+# them.  This is an overload of the word: `unsafe fn` is documenting something for the caller, but
+# that doesn't mean the entire function body is unsafe.  Denying this lint (which becomes
+# warn-by-default in Rust 2024) means `unsafe fn` bodies still must use `unsafe {}` like normal.
+unsafe_op_in_unsafe_fn = "deny"
+
 [profile.release]
 lto = 'fat'
 codegen-units = 1

--- a/crates/accelerate/Cargo.toml
+++ b/crates/accelerate/Cargo.toml
@@ -9,6 +9,9 @@ license.workspace = true
 name = "qiskit_accelerate"
 doctest = false
 
+[lints]
+workspace = true
+
 [dependencies]
 rayon.workspace = true
 numpy.workspace = true

--- a/crates/accelerate/src/lib.rs
+++ b/crates/accelerate/src/lib.rs
@@ -10,10 +10,6 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-// This stylistic lint suppression should be in `Cargo.toml`, but we can't do that until we're at an
-// MSRV of 1.74 or greater.
-#![allow(clippy::comparison_chain)]
-
 use std::env;
 
 use pyo3::import_exception;

--- a/crates/accelerate/src/sparse_observable.rs
+++ b/crates/accelerate/src/sparse_observable.rs
@@ -1999,7 +1999,6 @@ impl SparseObservable {
     ///         >>> boundaries = np.arange(num_qubits + 1, dtype=np.uintp)
     ///         >>> SparseObservable.from_raw_parts(num_qubits, coeffs, terms, indices, boundaries)
     ///         <SparseObservable with 100 terms on 100 qubits: (1+0j)(Z_0) + ... + (1+0j)(Z_99)>
-    #[deny(unsafe_op_in_unsafe_fn)]
     #[staticmethod]
     #[pyo3(
         signature = (/, num_qubits, coeffs, bit_terms, indices, boundaries, check=true),

--- a/crates/circuit/Cargo.toml
+++ b/crates/circuit/Cargo.toml
@@ -9,6 +9,9 @@ license.workspace = true
 name = "qiskit_circuit"
 doctest = false
 
+[lints]
+workspace = true
+
 [dependencies]
 rayon.workspace = true
 ahash.workspace = true

--- a/crates/pyext/Cargo.toml
+++ b/crates/pyext/Cargo.toml
@@ -10,6 +10,9 @@ name = "qiskit_pyext"
 doctest = false
 crate-type = ["cdylib"]
 
+[lints]
+workspace = true
+
 [features]
 # We always need to activate PyO3's `extension-module` for this crate to be useful at all, but we
 # need it *not* to be active for the tests of other crates to work.  If the feature is active,

--- a/crates/qasm2/Cargo.toml
+++ b/crates/qasm2/Cargo.toml
@@ -9,6 +9,9 @@ license.workspace = true
 name = "qiskit_qasm2"
 doctest = false
 
+[lints]
+workspace = true
+
 [dependencies]
 num-bigint.workspace = true
 hashbrown.workspace = true

--- a/crates/qasm3/Cargo.toml
+++ b/crates/qasm3/Cargo.toml
@@ -9,6 +9,9 @@ license.workspace = true
 name = "qiskit_qasm3"
 doctest = false
 
+[lints]
+workspace = true
+
 [dependencies]
 indexmap.workspace = true
 hashbrown.workspace = true


### PR DESCRIPTION
This configures each of the workspace packges to inherit the `lints` table from the top-level `Cargo.toml`.  This feature is only available from Rust 1.74+, which is now within our MSRV.

This commit is mostly setting up the infrastructure; we can discuss more lints as a team if/when they come up.  The two configured in this commit are an "allow" that is already global over `accelerate`, and a "deny" that will become a warning with Rust 2024 (it's allow-by-default in Rust 2021).

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


