### PR TITLE
Deprecate use of `BackendProperties` (BackendV1) in transpilation pipeline

### DIFF
--- a/qiskit/transpiler/passes/layout/dense_layout.py
+++ b/qiskit/transpiler/passes/layout/dense_layout.py
@@ -21,6 +21,8 @@ from qiskit.transpiler.basepasses import AnalysisPass
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.passes.layout import disjoint_utils
 
+from qiskit.utils import deprecate_arg
+
 from qiskit._accelerate.dense_layout import best_subset
 
 
@@ -36,6 +38,13 @@ class DenseLayout(AnalysisPass):
         by being set in ``property_set``.
     """
 
+    @deprecate_arg(
+        name="backend_prop",
+        since="1.4",
+        package_name="Qiskit",
+        removal_timeline="in Qiskit 2.0",
+        additional_msg="The `target` parameter should be used instead.",
+    )
     def __init__(self, coupling_map=None, backend_prop=None, target=None):
         """DenseLayout initializer.
 

--- a/qiskit/transpiler/passes/layout/dense_layout.py
+++ b/qiskit/transpiler/passes/layout/dense_layout.py
@@ -43,7 +43,10 @@ class DenseLayout(AnalysisPass):
         since="1.4",
         package_name="Qiskit",
         removal_timeline="in Qiskit 2.0",
-        additional_msg="The `target` parameter should be used instead.",
+        additional_msg="The BackendProperties data structure has been deprecated and will be "
+        "removed in Qiskit 2.0. The `target` input argument should be used instead. "
+        "You can use Target.from_configuration() to build the target from the properties "
+        "object, but in 2.0 you will need to generate a target directly.",
     )
     def __init__(self, coupling_map=None, backend_prop=None, target=None):
         """DenseLayout initializer.

--- a/qiskit/transpiler/passes/layout/vf2_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_layout.py
@@ -79,7 +79,10 @@ class VF2Layout(AnalysisPass):
         since="1.4",
         package_name="Qiskit",
         removal_timeline="in Qiskit 2.0",
-        additional_msg="The `target` parameter should be used instead.",
+        additional_msg="The BackendProperties data structure has been deprecated and will be "
+        "removed in Qiskit 2.0. The `target` input argument should be used instead. "
+        "You can use Target.from_configuration() to build the target from the properties "
+        "object, but in 2.0 you will need to generate a target directly.",
     )
     def __init__(
         self,

--- a/qiskit/transpiler/passes/layout/vf2_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_layout.py
@@ -24,6 +24,7 @@ from qiskit.transpiler.basepasses import AnalysisPass
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.passes.layout import vf2_utils
 
+from qiskit.utils import deprecate_arg
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +74,13 @@ class VF2Layout(AnalysisPass):
     ``vf2_avg_error_map`` key in the property set when :class:`~.VF2Layout` is run.
     """
 
+    @deprecate_arg(
+        name="properties",
+        since="1.4",
+        package_name="Qiskit",
+        removal_timeline="in Qiskit 2.0",
+        additional_msg="The `target` parameter should be used instead.",
+    )
     def __init__(
         self,
         coupling_map=None,

--- a/qiskit/transpiler/passes/layout/vf2_post_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_post_layout.py
@@ -105,7 +105,10 @@ class VF2PostLayout(AnalysisPass):
         since="1.4",
         package_name="Qiskit",
         removal_timeline="in Qiskit 2.0",
-        additional_msg="The `target` parameter should be used instead.",
+        additional_msg="The BackendProperties data structure has been deprecated and will be "
+        "removed in Qiskit 2.0. The `target` input argument should be used instead. "
+        "You can use Target.from_configuration() to build the target from the properties "
+        "object, but in 2.0 you will need to generate a target directly.",
     )
     def __init__(
         self,

--- a/qiskit/transpiler/passes/layout/vf2_post_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_post_layout.py
@@ -26,6 +26,7 @@ from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.providers.exceptions import BackendPropertyError
 from qiskit.transpiler.passes.layout import vf2_utils
 
+from qiskit.utils import deprecate_arg
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +100,13 @@ class VF2PostLayout(AnalysisPass):
     is run.
     """
 
+    @deprecate_arg(
+        name="properties",
+        since="1.4",
+        package_name="Qiskit",
+        removal_timeline="in Qiskit 2.0",
+        additional_msg="The `target` parameter should be used instead.",
+    )
     def __init__(
         self,
         target=None,

--- a/qiskit/transpiler/passes/layout/vf2_post_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_post_layout.py
@@ -110,6 +110,17 @@ class VF2PostLayout(AnalysisPass):
         "You can use Target.from_configuration() to build the target from the properties "
         "object, but in 2.0 you will need to generate a target directly.",
     )
+    @deprecate_arg(
+        name="coupling_map",
+        since="1.4",
+        package_name="Qiskit",
+        removal_timeline="in Qiskit 2.0",
+        additional_msg="This argument was only used with `properties`, which relied on "
+        "the deprecated BackendProperties data structure. The `target` input argument "
+        "should be used instead. "
+        "You can use Target.from_configuration() to build the target from coupling "
+        "map + properties, but in 2.0 you will need to generate a target directly.",
+    )
     def __init__(
         self,
         target=None,

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -73,6 +73,7 @@ from qiskit.transpiler.passes.optimization.optimize_1q_decomposition import (
 from qiskit.transpiler.passes.synthesis import plugin
 from qiskit.transpiler.target import Target
 
+from qiskit.utils.deprecation import deprecate_arg
 from qiskit._accelerate.unitary_synthesis import run_default_main_loop
 
 GATE_NAME_MAP = {
@@ -315,6 +316,13 @@ def _preferred_direction(
 class UnitarySynthesis(TransformationPass):
     """Synthesize gates according to their basis gates."""
 
+    @deprecate_arg(
+        name="backend_props",
+        since="1.4",
+        package_name="Qiskit",
+        removal_timeline="in Qiskit 2.0",
+        additional_msg="The `target` parameter should be used instead",
+    )
     def __init__(
         self,
         basis_gates: list[str] = None,

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -321,7 +321,10 @@ class UnitarySynthesis(TransformationPass):
         since="1.4",
         package_name="Qiskit",
         removal_timeline="in Qiskit 2.0",
-        additional_msg="The `target` parameter should be used instead",
+        additional_msg="The BackendProperties data structure has been deprecated and will be "
+        "removed in Qiskit 2.0. The `target` input argument should be used instead. "
+        "You can use Target.from_configuration() to build the target from the properties "
+        "object, but in 2.0 you will need to generate a target directly.",
     )
     def __init__(
         self,

--- a/qiskit/transpiler/passmanager_config.py
+++ b/qiskit/transpiler/passmanager_config.py
@@ -18,11 +18,19 @@ import warnings
 from qiskit.transpiler.coupling import CouplingMap
 from qiskit.transpiler.instruction_durations import InstructionDurations
 from qiskit.utils.deprecate_pulse import deprecate_pulse_arg
+from qiskit.utils.deprecation import deprecate_arg
 
 
 class PassManagerConfig:
     """Pass Manager Configuration."""
 
+    @deprecate_arg(
+        name="backend_properties",
+        since="1.4",
+        package_name="Qiskit",
+        removal_timeline="in Qiskit 2.0",
+        additional_msg="The `target` parameter should be used instead.",
+    )
     @deprecate_pulse_arg("inst_map", predicate=lambda inst_map: inst_map is not None)
     def __init__(
         self,

--- a/qiskit/transpiler/passmanager_config.py
+++ b/qiskit/transpiler/passmanager_config.py
@@ -29,7 +29,10 @@ class PassManagerConfig:
         since="1.4",
         package_name="Qiskit",
         removal_timeline="in Qiskit 2.0",
-        additional_msg="The `target` parameter should be used instead.",
+        additional_msg="The BackendProperties data structure has been deprecated and will be "
+        "removed in Qiskit 2.0. The `target` input argument should be used instead. "
+        "You can use Target.from_configuration() to build the target from the properties "
+        "object, but in 2.0 you will need to generate a target directly.",
     )
     @deprecate_pulse_arg("inst_map", predicate=lambda inst_map: inst_map is not None)
     def __init__(

--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -201,18 +201,25 @@ class BasisTranslatorPassManager(PassManagerStagePlugin):
     """Plugin class for translation stage with :class:`~.BasisTranslator`"""
 
     def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
-        return common.generate_translation_passmanager(
-            pass_manager_config.target,
-            basis_gates=pass_manager_config.basis_gates,
-            method="translator",
-            approximation_degree=pass_manager_config.approximation_degree,
-            coupling_map=pass_manager_config.coupling_map,
-            backend_props=pass_manager_config.backend_properties,
-            unitary_synthesis_method=pass_manager_config.unitary_synthesis_method,
-            unitary_synthesis_plugin_config=pass_manager_config.unitary_synthesis_plugin_config,
-            hls_config=pass_manager_config.hls_config,
-            qubits_initially_zero=pass_manager_config.qubits_initially_zero,
-        )
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+                message=".*argument ``backend_properties`` is deprecated as of Qiskit 1.4",
+                module="qiskit",
+            )
+            return common.generate_translation_passmanager(
+                pass_manager_config.target,
+                basis_gates=pass_manager_config.basis_gates,
+                method="translator",
+                approximation_degree=pass_manager_config.approximation_degree,
+                coupling_map=pass_manager_config.coupling_map,
+                backend_props=pass_manager_config.backend_properties,
+                unitary_synthesis_method=pass_manager_config.unitary_synthesis_method,
+                unitary_synthesis_plugin_config=pass_manager_config.unitary_synthesis_plugin_config,
+                hls_config=pass_manager_config.hls_config,
+                qubits_initially_zero=pass_manager_config.qubits_initially_zero,
+            )
 
 
 class UnitarySynthesisPassManager(PassManagerStagePlugin):
@@ -459,17 +466,24 @@ class SabreSwapPassManager(PassManagerStagePlugin):
                 seed=seed_transpiler,
                 trials=trial_count,
             )
-            return common.generate_routing_passmanager(
-                routing_pass,
-                target,
-                coupling_map,
-                vf2_call_limit=vf2_call_limit,
-                vf2_max_trials=vf2_max_trials,
-                backend_properties=backend_properties,
-                seed_transpiler=seed_transpiler,
-                check_trivial=True,
-                use_barrier_before_measurement=True,
-            )
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    category=DeprecationWarning,
+                    message=".*argument ``backend_properties`` is deprecated as of Qiskit 1.4",
+                    module="qiskit",
+                )
+                return common.generate_routing_passmanager(
+                    routing_pass,
+                    target,
+                    coupling_map,
+                    vf2_call_limit=vf2_call_limit,
+                    vf2_max_trials=vf2_max_trials,
+                    backend_properties=backend_properties,
+                    seed_transpiler=seed_transpiler,
+                    check_trivial=True,
+                    use_barrier_before_measurement=True,
+                )
         if optimization_level == 2:
             trial_count = _get_trial_count(20)
 
@@ -479,16 +493,23 @@ class SabreSwapPassManager(PassManagerStagePlugin):
                 seed=seed_transpiler,
                 trials=trial_count,
             )
-            return common.generate_routing_passmanager(
-                routing_pass,
-                target,
-                coupling_map=coupling_map,
-                vf2_call_limit=vf2_call_limit,
-                vf2_max_trials=vf2_max_trials,
-                backend_properties=backend_properties,
-                seed_transpiler=seed_transpiler,
-                use_barrier_before_measurement=True,
-            )
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    category=DeprecationWarning,
+                    message=".*argument ``backend_properties`` is deprecated as of Qiskit 1.4",
+                    module="qiskit",
+                )
+                return common.generate_routing_passmanager(
+                    routing_pass,
+                    target,
+                    coupling_map=coupling_map,
+                    vf2_call_limit=vf2_call_limit,
+                    vf2_max_trials=vf2_max_trials,
+                    backend_properties=backend_properties,
+                    seed_transpiler=seed_transpiler,
+                    use_barrier_before_measurement=True,
+                )
         if optimization_level == 3:
             trial_count = _get_trial_count(20)
             routing_pass = SabreSwap(
@@ -497,16 +518,23 @@ class SabreSwapPassManager(PassManagerStagePlugin):
                 seed=seed_transpiler,
                 trials=trial_count,
             )
-            return common.generate_routing_passmanager(
-                routing_pass,
-                target,
-                coupling_map=coupling_map,
-                vf2_call_limit=vf2_call_limit,
-                vf2_max_trials=vf2_max_trials,
-                backend_properties=backend_properties,
-                seed_transpiler=seed_transpiler,
-                use_barrier_before_measurement=True,
-            )
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    category=DeprecationWarning,
+                    message=".*argument ``backend_properties`` is deprecated as of Qiskit 1.4",
+                    module="qiskit",
+                )
+                return common.generate_routing_passmanager(
+                    routing_pass,
+                    target,
+                    coupling_map=coupling_map,
+                    vf2_call_limit=vf2_call_limit,
+                    vf2_max_trials=vf2_max_trials,
+                    backend_properties=backend_properties,
+                    seed_transpiler=seed_transpiler,
+                    use_barrier_before_measurement=True,
+                )
         raise TranspilerError(f"Invalid optimization level specified: {optimization_level}")
 
 
@@ -599,30 +627,37 @@ class OptimizationPassManager(PassManagerStagePlugin):
                 ]
             elif optimization_level == 3:
                 # Steps for optimization level 3
-                _opt = [
-                    ConsolidateBlocks(
-                        basis_gates=pass_manager_config.basis_gates,
-                        target=pass_manager_config.target,
-                        approximation_degree=pass_manager_config.approximation_degree,
-                    ),
-                    UnitarySynthesis(
-                        pass_manager_config.basis_gates,
-                        approximation_degree=pass_manager_config.approximation_degree,
-                        coupling_map=pass_manager_config.coupling_map,
-                        backend_props=pass_manager_config.backend_properties,
-                        method=pass_manager_config.unitary_synthesis_method,
-                        plugin_config=pass_manager_config.unitary_synthesis_plugin_config,
-                        target=pass_manager_config.target,
-                    ),
-                    RemoveIdentityEquivalent(
-                        approximation_degree=pass_manager_config.approximation_degree,
-                        target=pass_manager_config.target,
-                    ),
-                    Optimize1qGatesDecomposition(
-                        basis=pass_manager_config.basis_gates, target=pass_manager_config.target
-                    ),
-                    CommutativeCancellation(target=pass_manager_config.target),
-                ]
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore",
+                        category=DeprecationWarning,
+                        message=".*argument ``backend_props`` is deprecated as of Qiskit 1.4",
+                        module="qiskit",
+                    )
+                    _opt = [
+                        ConsolidateBlocks(
+                            basis_gates=pass_manager_config.basis_gates,
+                            target=pass_manager_config.target,
+                            approximation_degree=pass_manager_config.approximation_degree,
+                        ),
+                        UnitarySynthesis(
+                            pass_manager_config.basis_gates,
+                            approximation_degree=pass_manager_config.approximation_degree,
+                            coupling_map=pass_manager_config.coupling_map,
+                            backend_props=pass_manager_config.backend_properties,
+                            method=pass_manager_config.unitary_synthesis_method,
+                            plugin_config=pass_manager_config.unitary_synthesis_plugin_config,
+                            target=pass_manager_config.target,
+                        ),
+                        RemoveIdentityEquivalent(
+                            approximation_degree=pass_manager_config.approximation_degree,
+                            target=pass_manager_config.target,
+                        ),
+                        Optimize1qGatesDecomposition(
+                            basis=pass_manager_config.basis_gates, target=pass_manager_config.target
+                        ),
+                        CommutativeCancellation(target=pass_manager_config.target),
+                    ]
 
                 def _opt_control(property_set):
                     return not property_set["optimization_loop_minimum_point"]
@@ -645,24 +680,31 @@ class OptimizationPassManager(PassManagerStagePlugin):
             if optimization_level == 3:
                 optimization.append(_minimum_point_check)
             elif optimization_level == 2:
-                optimization.append(
-                    [
-                        ConsolidateBlocks(
-                            basis_gates=pass_manager_config.basis_gates,
-                            target=pass_manager_config.target,
-                            approximation_degree=pass_manager_config.approximation_degree,
-                        ),
-                        UnitarySynthesis(
-                            pass_manager_config.basis_gates,
-                            approximation_degree=pass_manager_config.approximation_degree,
-                            coupling_map=pass_manager_config.coupling_map,
-                            backend_props=pass_manager_config.backend_properties,
-                            method=pass_manager_config.unitary_synthesis_method,
-                            plugin_config=pass_manager_config.unitary_synthesis_plugin_config,
-                            target=pass_manager_config.target,
-                        ),
-                    ]
-                )
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore",
+                        category=DeprecationWarning,
+                        message=".*argument ``backend_props`` is deprecated as of Qiskit 1.4",
+                        module="qiskit",
+                    )
+                    optimization.append(
+                        [
+                            ConsolidateBlocks(
+                                basis_gates=pass_manager_config.basis_gates,
+                                target=pass_manager_config.target,
+                                approximation_degree=pass_manager_config.approximation_degree,
+                            ),
+                            UnitarySynthesis(
+                                pass_manager_config.basis_gates,
+                                approximation_degree=pass_manager_config.approximation_degree,
+                                coupling_map=pass_manager_config.coupling_map,
+                                backend_props=pass_manager_config.backend_properties,
+                                method=pass_manager_config.unitary_synthesis_method,
+                                plugin_config=pass_manager_config.unitary_synthesis_plugin_config,
+                                target=pass_manager_config.target,
+                            ),
+                        ]
+                    )
                 optimization.append(_depth_check + _size_check)
             else:
                 optimization.append(_depth_check + _size_check)
@@ -791,14 +833,21 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
                     condition=_choose_layout_condition,
                 )
             )
-            choose_layout_1 = VF2Layout(
-                coupling_map=pass_manager_config.coupling_map,
-                seed=pass_manager_config.seed_transpiler,
-                call_limit=int(5e4),  # Set call limit to ~100ms with rustworkx 0.10.2
-                properties=pass_manager_config.backend_properties,
-                target=pass_manager_config.target,
-                max_trials=2500,  # Limits layout scoring to < 600ms on ~400 qubit devices
-            )
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    category=DeprecationWarning,
+                    message=".*argument ``properties`` is deprecated as of Qiskit 1.4",
+                    module="qiskit",
+                )
+                choose_layout_1 = VF2Layout(
+                    coupling_map=pass_manager_config.coupling_map,
+                    seed=pass_manager_config.seed_transpiler,
+                    call_limit=int(5e4),  # Set call limit to ~100ms with rustworkx 0.10.2
+                    properties=pass_manager_config.backend_properties,
+                    target=pass_manager_config.target,
+                    max_trials=2500,  # Limits layout scoring to < 600ms on ~400 qubit devices
+                )
             layout.append(ConditionalController(choose_layout_1, condition=_layout_not_perfect))
 
             trial_count = _get_trial_count(5)
@@ -824,14 +873,21 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
                 )
             )
         elif optimization_level == 2:
-            choose_layout_0 = VF2Layout(
-                coupling_map=pass_manager_config.coupling_map,
-                seed=pass_manager_config.seed_transpiler,
-                call_limit=int(5e6),  # Set call limit to ~10s with rustworkx 0.10.2
-                properties=pass_manager_config.backend_properties,
-                target=pass_manager_config.target,
-                max_trials=2500,  # Limits layout scoring to < 600ms on ~400 qubit devices
-            )
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    category=DeprecationWarning,
+                    message=".*argument ``properties`` is deprecated as of Qiskit 1.4",
+                    module="qiskit",
+                )
+                choose_layout_0 = VF2Layout(
+                    coupling_map=pass_manager_config.coupling_map,
+                    seed=pass_manager_config.seed_transpiler,
+                    call_limit=int(5e6),  # Set call limit to ~10s with rustworkx 0.10.2
+                    properties=pass_manager_config.backend_properties,
+                    target=pass_manager_config.target,
+                    max_trials=2500,  # Limits layout scoring to < 600ms on ~400 qubit devices
+                )
             layout.append(
                 ConditionalController(choose_layout_0, condition=_choose_layout_condition)
             )
@@ -859,14 +915,21 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
                 )
             )
         elif optimization_level == 3:
-            choose_layout_0 = VF2Layout(
-                coupling_map=pass_manager_config.coupling_map,
-                seed=pass_manager_config.seed_transpiler,
-                call_limit=int(3e7),  # Set call limit to ~60s with rustworkx 0.10.2
-                properties=pass_manager_config.backend_properties,
-                target=pass_manager_config.target,
-                max_trials=250000,  # Limits layout scoring to < 60s on ~400 qubit devices
-            )
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    category=DeprecationWarning,
+                    message=".*argument ``properties`` is deprecated as of Qiskit 1.4",
+                    module="qiskit",
+                )
+                choose_layout_0 = VF2Layout(
+                    coupling_map=pass_manager_config.coupling_map,
+                    seed=pass_manager_config.seed_transpiler,
+                    call_limit=int(3e7),  # Set call limit to ~60s with rustworkx 0.10.2
+                    properties=pass_manager_config.backend_properties,
+                    target=pass_manager_config.target,
+                    max_trials=250000,  # Limits layout scoring to < 60s on ~400 qubit devices
+                )
             layout.append(
                 ConditionalController(choose_layout_0, condition=_choose_layout_condition)
             )
@@ -940,16 +1003,23 @@ class DenseLayoutPassManager(PassManagerStagePlugin):
 
         layout = PassManager()
         layout.append(_given_layout)
-        layout.append(
-            ConditionalController(
-                DenseLayout(
-                    coupling_map=pass_manager_config.coupling_map,
-                    backend_prop=pass_manager_config.backend_properties,
-                    target=pass_manager_config.target,
-                ),
-                condition=_choose_layout_condition,
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+                message=".*argument ``backend_prop`` is deprecated as of Qiskit 1.4",
+                module="qiskit",
             )
-        )
+            layout.append(
+                ConditionalController(
+                    DenseLayout(
+                        coupling_map=pass_manager_config.coupling_map,
+                        backend_prop=pass_manager_config.backend_properties,
+                        target=pass_manager_config.target,
+                    ),
+                    condition=_choose_layout_condition,
+                )
+            )
         layout += common.generate_embed_passmanager(coupling_map)
         return layout
 

--- a/qiskit/transpiler/preset_passmanagers/common.py
+++ b/qiskit/transpiler/preset_passmanagers/common.py
@@ -281,7 +281,10 @@ def _apply_post_layout_condition(property_set):
     since="1.4",
     package_name="Qiskit",
     removal_timeline="in Qiskit 2.0",
-    additional_msg="The `target` parameter should be used instead.",
+    additional_msg="The BackendProperties data structure has been deprecated and will be "
+    "removed in Qiskit 2.0. The required `target` input argument should be used "
+    "instead. You can use Target.from_configuration() to build the target from the properties "
+    "object, but in 2.0 you will need to generate a target directly.",
 )
 def generate_routing_passmanager(
     routing_pass,
@@ -429,7 +432,10 @@ def generate_pre_op_passmanager(target=None, coupling_map=None, remove_reset_in_
     since="1.4",
     package_name="Qiskit",
     removal_timeline="in Qiskit 2.0",
-    additional_msg="The `target` parameter should be used instead.",
+    additional_msg="The BackendProperties data structure has been deprecated and will be "
+    "removed in Qiskit 2.0. The required `target` input argument should be used "
+    "instead. You can use Target.from_configuration() to build the target from the properties "
+    "object, but in 2.0 you will need to generate a target directly.",
 )
 def generate_translation_passmanager(
     target,

--- a/qiskit/transpiler/preset_passmanagers/common.py
+++ b/qiskit/transpiler/preset_passmanagers/common.py
@@ -14,6 +14,7 @@
 """Common preset passmanager generators."""
 
 import collections
+import warnings
 from typing import Optional
 
 from qiskit.circuit.equivalence_library import SessionEquivalenceLibrary as sel
@@ -53,7 +54,7 @@ from qiskit.transpiler.passes.layout.vf2_post_layout import VF2PostLayoutStopRea
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.layout import Layout
 from qiskit.utils.deprecate_pulse import deprecate_pulse_arg
-
+from qiskit.utils.deprecation import deprecate_arg
 
 _ControlFlowState = collections.namedtuple("_ControlFlowState", ("working", "not_working"))
 
@@ -275,6 +276,13 @@ def _apply_post_layout_condition(property_set):
     )
 
 
+@deprecate_arg(
+    name="backend_properties",
+    since="1.4",
+    package_name="Qiskit",
+    removal_timeline="in Qiskit 2.0",
+    additional_msg="The `target` parameter should be used instead.",
+)
 def generate_routing_passmanager(
     routing_pass,
     target,
@@ -352,20 +360,27 @@ def generate_routing_passmanager(
 
     is_vf2_fully_bounded = vf2_call_limit and vf2_max_trials
     if (target is not None or backend_properties is not None) and is_vf2_fully_bounded:
-        routing.append(
-            ConditionalController(
-                VF2PostLayout(
-                    target,
-                    coupling_map,
-                    backend_properties,
-                    seed_transpiler,
-                    call_limit=vf2_call_limit,
-                    max_trials=vf2_max_trials,
-                    strict_direction=False,
-                ),
-                condition=_run_post_layout_condition,
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+                message=".*argument ``properties`` is deprecated as of Qiskit 1.4",
+                module="qiskit",
             )
-        )
+            routing.append(
+                ConditionalController(
+                    VF2PostLayout(
+                        target,
+                        coupling_map,
+                        backend_properties,
+                        seed_transpiler,
+                        call_limit=vf2_call_limit,
+                        max_trials=vf2_max_trials,
+                        strict_direction=False,
+                    ),
+                    condition=_run_post_layout_condition,
+                )
+            )
         routing.append(ConditionalController(ApplyLayout(), condition=_apply_post_layout_condition))
 
     def filter_fn(node):
@@ -409,6 +424,13 @@ def generate_pre_op_passmanager(target=None, coupling_map=None, remove_reset_in_
     return pre_opt
 
 
+@deprecate_arg(
+    name="backend_properties",
+    since="1.4",
+    package_name="Qiskit",
+    removal_timeline="in Qiskit 2.0",
+    additional_msg="The `target` parameter should be used instead.",
+)
 def generate_translation_passmanager(
     target,
     basis_gates=None,
@@ -455,76 +477,92 @@ def generate_translation_passmanager(
         TranspilerError: If the ``method`` kwarg is not a valid value
     """
     if method == "translator":
-        unroll = [
-            # Use unitary synthesis for basis aware decomposition of
-            # UnitaryGates before custom unrolling
-            UnitarySynthesis(
-                basis_gates,
-                approximation_degree=approximation_degree,
-                coupling_map=coupling_map,
-                backend_props=backend_props,
-                plugin_config=unitary_synthesis_plugin_config,
-                method=unitary_synthesis_method,
-                target=target,
-            ),
-            HighLevelSynthesis(
-                hls_config=hls_config,
-                coupling_map=coupling_map,
-                target=target,
-                use_qubit_indices=True,
-                equivalence_library=sel,
-                basis_gates=basis_gates,
-                qubits_initially_zero=qubits_initially_zero,
-            ),
-            BasisTranslator(sel, basis_gates, target),
-        ]
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+                message=".*argument ``backend_props`` is deprecated as of Qiskit 1.4",
+                module="qiskit",
+            )
+            unroll = [
+                # Use unitary synthesis for basis aware decomposition of
+                # UnitaryGates before custom unrolling
+                UnitarySynthesis(
+                    basis_gates,
+                    approximation_degree=approximation_degree,
+                    coupling_map=coupling_map,
+                    backend_props=backend_props,
+                    plugin_config=unitary_synthesis_plugin_config,
+                    method=unitary_synthesis_method,
+                    target=target,
+                ),
+                HighLevelSynthesis(
+                    hls_config=hls_config,
+                    coupling_map=coupling_map,
+                    target=target,
+                    use_qubit_indices=True,
+                    equivalence_library=sel,
+                    basis_gates=basis_gates,
+                    qubits_initially_zero=qubits_initially_zero,
+                ),
+                BasisTranslator(sel, basis_gates, target),
+            ]
     elif method == "synthesis":
-        unroll = [
-            # # Use unitary synthesis for basis aware decomposition of
-            # UnitaryGates > 2q before collection
-            UnitarySynthesis(
-                basis_gates,
-                approximation_degree=approximation_degree,
-                coupling_map=coupling_map,
-                backend_props=backend_props,
-                plugin_config=unitary_synthesis_plugin_config,
-                method=unitary_synthesis_method,
-                min_qubits=3,
-                target=target,
-            ),
-            HighLevelSynthesis(
-                hls_config=hls_config,
-                coupling_map=coupling_map,
-                target=target,
-                use_qubit_indices=True,
-                basis_gates=basis_gates,
-                min_qubits=3,
-                qubits_initially_zero=qubits_initially_zero,
-            ),
-            Unroll3qOrMore(target=target, basis_gates=basis_gates),
-            Collect2qBlocks(),
-            Collect1qRuns(),
-            ConsolidateBlocks(
-                basis_gates=basis_gates, target=target, approximation_degree=approximation_degree
-            ),
-            UnitarySynthesis(
-                basis_gates=basis_gates,
-                approximation_degree=approximation_degree,
-                coupling_map=coupling_map,
-                backend_props=backend_props,
-                plugin_config=unitary_synthesis_plugin_config,
-                method=unitary_synthesis_method,
-                target=target,
-            ),
-            HighLevelSynthesis(
-                hls_config=hls_config,
-                coupling_map=coupling_map,
-                target=target,
-                use_qubit_indices=True,
-                basis_gates=basis_gates,
-                qubits_initially_zero=qubits_initially_zero,
-            ),
-        ]
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+                message=".*argument ``backend_props`` is deprecated as of Qiskit 1.4",
+                module="qiskit",
+            )
+            unroll = [
+                # Use unitary synthesis for basis aware decomposition of
+                # UnitaryGates > 2q before collection
+                UnitarySynthesis(
+                    basis_gates,
+                    approximation_degree=approximation_degree,
+                    coupling_map=coupling_map,
+                    backend_props=backend_props,
+                    plugin_config=unitary_synthesis_plugin_config,
+                    method=unitary_synthesis_method,
+                    min_qubits=3,
+                    target=target,
+                ),
+                HighLevelSynthesis(
+                    hls_config=hls_config,
+                    coupling_map=coupling_map,
+                    target=target,
+                    use_qubit_indices=True,
+                    basis_gates=basis_gates,
+                    min_qubits=3,
+                    qubits_initially_zero=qubits_initially_zero,
+                ),
+                Unroll3qOrMore(target=target, basis_gates=basis_gates),
+                Collect2qBlocks(),
+                Collect1qRuns(),
+                ConsolidateBlocks(
+                    basis_gates=basis_gates,
+                    target=target,
+                    approximation_degree=approximation_degree,
+                ),
+                UnitarySynthesis(
+                    basis_gates=basis_gates,
+                    approximation_degree=approximation_degree,
+                    coupling_map=coupling_map,
+                    backend_props=backend_props,
+                    plugin_config=unitary_synthesis_plugin_config,
+                    method=unitary_synthesis_method,
+                    target=target,
+                ),
+                HighLevelSynthesis(
+                    hls_config=hls_config,
+                    coupling_map=coupling_map,
+                    target=target,
+                    use_qubit_indices=True,
+                    basis_gates=basis_gates,
+                    qubits_initially_zero=qubits_initially_zero,
+                ),
+            ]
     else:
         raise TranspilerError(f"Invalid translation method {method}.")
     return PassManager(unroll)

--- a/qiskit/transpiler/preset_passmanagers/common.py
+++ b/qiskit/transpiler/preset_passmanagers/common.py
@@ -370,6 +370,12 @@ def generate_routing_passmanager(
                 message=".*argument ``properties`` is deprecated as of Qiskit 1.4",
                 module="qiskit",
             )
+            warnings.filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+                message=".*argument ``coupling_map`` is deprecated as of Qiskit 1.4",
+                module="qiskit",
+            )
             routing.append(
                 ConditionalController(
                     VF2PostLayout(

--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -344,11 +344,17 @@ def generate_preset_pass_manager(
             # preserve the former behavior of transpile.
             backend_properties = _parse_backend_properties(backend_properties, backend)
             with warnings.catch_warnings():
-                # TODO: inst_map will be removed in 2.0
+                # TODO: inst_map and backend_properties will be removed in 2.0
                 warnings.filterwarnings(
                     "ignore",
                     category=DeprecationWarning,
                     message=".*``inst_map`` is deprecated as of Qiskit 1.3.*",
+                    module="qiskit",
+                )
+                warnings.filterwarnings(
+                    "ignore",
+                    category=DeprecationWarning,
+                    message=".* ``backend_properties`` is deprecated as of Qiskit 1.4",
                     module="qiskit",
                 )
                 # Build target from constraints.
@@ -428,11 +434,17 @@ def generate_preset_pass_manager(
     }
 
     with warnings.catch_warnings():
-        # inst_map is deprecated in the PassManagerConfig initializer
+        # inst_map and backend_properties are deprecated in the PassManagerConfig initializer
         warnings.filterwarnings(
             "ignore",
             category=DeprecationWarning,
             message=".*argument ``inst_map`` is deprecated as of Qiskit 1.3",
+        )
+        warnings.filterwarnings(
+            "ignore",
+            category=DeprecationWarning,
+            message=".*argument ``backend_properties`` is deprecated as of Qiskit 1.4",
+            module="qiskit",
         )
         if backend is not None:
             pm_options["_skip_target"] = _skip_target

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -56,7 +56,7 @@ from qiskit.exceptions import QiskitError
 # full target
 from qiskit.providers.backend import QubitProperties  # pylint: disable=unused-import
 from qiskit.providers.models.backendproperties import BackendProperties
-from qiskit.utils import deprecate_func
+from qiskit.utils import deprecate_func, deprecate_arg
 from qiskit.utils.deprecate_pulse import deprecate_pulse_dependency, deprecate_pulse_arg
 
 logger = logging.getLogger(__name__)
@@ -994,6 +994,14 @@ class Target(BaseTarget):
 
     @classmethod
     @deprecate_pulse_arg("inst_map")
+    @deprecate_arg(
+        name="backend_properties",
+        since="1.4",
+        package_name="Qiskit",
+        removal_timeline="in Qiskit 2.0",
+        additional_msg="To add instructions with specific properties "
+        "use Target.add_instruction(instruction, properties, name).",
+    )
     def from_configuration(
         cls,
         basis_gates: list[str],

--- a/releasenotes/notes/deprecate-backend-v1-props-09481526448e6bfd.yaml
+++ b/releasenotes/notes/deprecate-backend-v1-props-09481526448e6bfd.yaml
@@ -1,0 +1,20 @@
+---
+deprecations_transpiler:
+  - |
+    The following uses of the ``BackendProperties`` object in the transpilation
+    pipeline have been deprecated as of Qiskit 1.4 and will be removed in Qiskit 2.0:
+
+    * ``backend_prop`` input argument in :class:`.DenseLayout`
+    * ``properties`` input argument in :class:`.VF2Layout`
+    * ``properties`` input argument in :class:`.VF2PostLayout`
+    * ``backend_props`` input argument in :class:`.UnitarySynthesis`
+    * ``backend_properties`` in :class:`.PassManagerConfig`
+    * ``backend_properties`` in :func:`.generate_routing_passmanager`
+    * ``backend_properties`` in :func:`.generate_translation_passmanager`
+    * ``backend_properties`` in  :meth:`.Target.from_configuration`
+
+    The ``BackendProperties`` class has been deprecated since Qiskit 1.2, as it was part
+    of the BackendV1 workflow. Specific instruction properties such as gate errors or 
+    durations can be added to a :class:`.Target` upon construction through the 
+    :meth:`.Target.add_instruction` method, and communicated to the relevant transpiler
+    passes through the `target` input argument.

--- a/releasenotes/notes/deprecate-backend-v1-props-09481526448e6bfd.yaml
+++ b/releasenotes/notes/deprecate-backend-v1-props-09481526448e6bfd.yaml
@@ -8,7 +8,7 @@ deprecations_transpiler:
     * ``properties`` input argument in :class:`.VF2Layout`
     * ``properties`` input argument in :class:`.VF2PostLayout`
     * ``backend_props`` input argument in :class:`.UnitarySynthesis`
-    * ``backend_properties`` in :class:`.PassManagerConfig`
+    * ``backend_properties`` input argument in :class:`.PassManagerConfig`
     * ``backend_properties`` in  :meth:`.Target.from_configuration`
     * ``backend_properties`` in :func:`.generate_routing_passmanager`
     * ``backend_properties`` in :func:`.generate_translation_passmanager`
@@ -17,7 +17,7 @@ deprecations_transpiler:
     of the :class:`.BackendV1` workflow, and will be removed in Qiskit 2.0. Specific instruction 
     properties such as gate errors or durations can be added to a :class:`.Target` upon 
     construction through the :meth:`.Target.add_instruction` method, and communicated to 
-    the relevant transpiler passes through the `target` input argument.
+    the relevant transpiler passes through the ``target`` input argument.
 
     In the case of :func:`.generate_routing_passmanager` and :func:`.generate_translation_passmanager`,
     the ``backend_properties`` argument is optional and is superseded when the required ``target`` 

--- a/releasenotes/notes/deprecate-backend-v1-props-09481526448e6bfd.yaml
+++ b/releasenotes/notes/deprecate-backend-v1-props-09481526448e6bfd.yaml
@@ -6,7 +6,7 @@ deprecations_transpiler:
 
     * ``backend_prop`` input argument in :class:`.DenseLayout`
     * ``properties`` input argument in :class:`.VF2Layout`
-    * ``properties`` input argument in :class:`.VF2PostLayout`
+    * ``properties`` and ``coupling_map`` input arguments in :class:`.VF2PostLayout`. Note that ``coupling_map`` was only used in the presence of ``properties``.
     * ``backend_props`` input argument in :class:`.UnitarySynthesis`
     * ``backend_properties`` in :class:`.PassManagerConfig`
     * ``backend_properties`` in  :meth:`.Target.from_configuration`

--- a/releasenotes/notes/deprecate-backend-v1-props-09481526448e6bfd.yaml
+++ b/releasenotes/notes/deprecate-backend-v1-props-09481526448e6bfd.yaml
@@ -9,12 +9,17 @@ deprecations_transpiler:
     * ``properties`` input argument in :class:`.VF2PostLayout`
     * ``backend_props`` input argument in :class:`.UnitarySynthesis`
     * ``backend_properties`` in :class:`.PassManagerConfig`
+    * ``backend_properties`` in  :meth:`.Target.from_configuration`
     * ``backend_properties`` in :func:`.generate_routing_passmanager`
     * ``backend_properties`` in :func:`.generate_translation_passmanager`
-    * ``backend_properties`` in  :meth:`.Target.from_configuration`
 
-    The ``BackendProperties`` class has been deprecated since Qiskit 1.2, as it was part
-    of the BackendV1 workflow. Specific instruction properties such as gate errors or 
-    durations can be added to a :class:`.Target` upon construction through the 
-    :meth:`.Target.add_instruction` method, and communicated to the relevant transpiler
-    passes through the `target` input argument.
+    The :class:`.BackendProperties` class has been deprecated since Qiskit 1.2, as it was part
+    of the :class:`.BackendV1` workflow, and will be removed in Qiskit 2.0. Specific instruction 
+    properties such as gate errors or durations can be added to a :class:`.Target` upon 
+    construction through the :meth:`.Target.add_instruction` method, and communicated to 
+    the relevant transpiler passes through the `target` input argument.
+
+    In the case of :func:`.generate_routing_passmanager` and :func:`.generate_translation_passmanager`,
+    the ``backend_properties`` argument is optional and is superseded when the required ``target`` 
+    argument is populated. Usage of the argument can safely be removed in 1.x as long as you were 
+    passing in a target.

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -2742,14 +2742,17 @@ class TestTranspileCustomPM(QiskitTestCase):
         qc = QuantumCircuit(2)
         qc.h(0)
         qc.cx(0, 1)
-
-        pm_conf = PassManagerConfig(
-            initial_layout=None,
-            basis_gates=["u1", "u2", "u3", "cx"],
-            coupling_map=CouplingMap([[0, 1]]),
-            backend_properties=None,
-            seed_transpiler=1,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_properties`` is deprecated as of Qiskit 1.4",
+        ):
+            pm_conf = PassManagerConfig(
+                initial_layout=None,
+                basis_gates=["u1", "u2", "u3", "cx"],
+                coupling_map=CouplingMap([[0, 1]]),
+                backend_properties=None,
+                seed_transpiler=1,
+            )
         passmanager = level_0_pass_manager(pm_conf)
 
         transpiled = passmanager.run([qc, qc])

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -2081,12 +2081,16 @@ class TestTargetFromConfiguration(QiskitTestCase):
             fake_backend = Fake5QV1()
         config = fake_backend.configuration()
         properties = fake_backend.properties()
-        target = Target.from_configuration(
-            basis_gates=config.basis_gates,
-            num_qubits=config.num_qubits,
-            coupling_map=CouplingMap(config.coupling_map),
-            backend_properties=properties,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_properties`` is deprecated as of Qiskit 1.4",
+        ):
+            target = Target.from_configuration(
+                basis_gates=config.basis_gates,
+                num_qubits=config.num_qubits,
+                coupling_map=CouplingMap(config.coupling_map),
+                backend_properties=properties,
+            )
         self.assertEqual(0, target["rz"][(0,)].error)
         self.assertEqual(0, target["rz"][(0,)].duration)
 
@@ -2096,15 +2100,19 @@ class TestTargetFromConfiguration(QiskitTestCase):
         config = fake_backend.configuration()
         properties = fake_backend.properties()
         durations = InstructionDurations([("rz", 0, 0.5)], dt=1.0)
-        target = Target.from_configuration(
-            basis_gates=config.basis_gates,
-            num_qubits=config.num_qubits,
-            coupling_map=CouplingMap(config.coupling_map),
-            backend_properties=properties,
-            instruction_durations=durations,
-            dt=config.dt,
-        )
-        self.assertEqual(0.5, target["rz"][(0,)].duration)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_properties`` is deprecated as of Qiskit 1.4",
+        ):
+            target = Target.from_configuration(
+                basis_gates=config.basis_gates,
+                num_qubits=config.num_qubits,
+                coupling_map=CouplingMap(config.coupling_map),
+                backend_properties=properties,
+                instruction_durations=durations,
+                dt=config.dt,
+            )
+            self.assertEqual(0.5, target["rz"][(0,)].duration)
 
     def test_inst_map(self):
         with self.assertWarns(DeprecationWarning):

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -161,23 +161,31 @@ class TestUnitarySynthesis(QiskitTestCase):
         triv_layout_pass = TrivialLayout(coupling_map)
         qc = QuantumCircuit(qr)
         qc.unitary(random_unitary(4, seed=12), [0, 1])
-        unisynth_pass = UnitarySynthesis(
-            basis_gates=conf.basis_gates,
-            coupling_map=None,
-            backend_props=backend.properties(),
-            pulse_optimize=True,
-            natural_direction=False,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_props`` is deprecated as of Qiskit 1.4",
+        ):
+            unisynth_pass = UnitarySynthesis(
+                basis_gates=conf.basis_gates,
+                coupling_map=None,
+                backend_props=backend.properties(),
+                pulse_optimize=True,
+                natural_direction=False,
+            )
         pm = PassManager([triv_layout_pass, unisynth_pass])
         qc_out = pm.run(qc)
 
-        unisynth_pass_nat = UnitarySynthesis(
-            basis_gates=conf.basis_gates,
-            coupling_map=None,
-            backend_props=backend.properties(),
-            pulse_optimize=True,
-            natural_direction=True,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_props`` is deprecated as of Qiskit 1.4",
+        ):
+            unisynth_pass_nat = UnitarySynthesis(
+                basis_gates=conf.basis_gates,
+                coupling_map=None,
+                backend_props=backend.properties(),
+                pulse_optimize=True,
+                natural_direction=True,
+            )
 
         pm_nat = PassManager([triv_layout_pass, unisynth_pass_nat])
         qc_out_nat = pm_nat.run(qc)
@@ -196,24 +204,31 @@ class TestUnitarySynthesis(QiskitTestCase):
         triv_layout_pass = TrivialLayout(coupling_map)
         qc = QuantumCircuit(qr)
         qc.swap(qr[0], qr[1])
-        unisynth_pass = UnitarySynthesis(
-            basis_gates=conf.basis_gates,
-            coupling_map=None,
-            backend_props=backend.properties(),
-            pulse_optimize=True,
-            natural_direction=False,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_props`` is deprecated as of Qiskit 1.4",
+        ):
+            unisynth_pass = UnitarySynthesis(
+                basis_gates=conf.basis_gates,
+                coupling_map=None,
+                backend_props=backend.properties(),
+                pulse_optimize=True,
+                natural_direction=False,
+            )
         pm = PassManager([triv_layout_pass, unisynth_pass])
         qc_out = pm.run(qc)
 
-        unisynth_pass_nat = UnitarySynthesis(
-            basis_gates=conf.basis_gates,
-            coupling_map=None,
-            backend_props=backend.properties(),
-            pulse_optimize=True,
-            natural_direction=True,
-        )
-
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_props`` is deprecated as of Qiskit 1.4",
+        ):
+            unisynth_pass_nat = UnitarySynthesis(
+                basis_gates=conf.basis_gates,
+                coupling_map=None,
+                backend_props=backend.properties(),
+                pulse_optimize=True,
+                natural_direction=True,
+            )
         pm_nat = PassManager([triv_layout_pass, unisynth_pass_nat])
         qc_out_nat = pm_nat.run(qc)
 
@@ -234,23 +249,30 @@ class TestUnitarySynthesis(QiskitTestCase):
         triv_layout_pass = TrivialLayout(coupling_map)
         qc = QuantumCircuit(qr0, qr1)
         qc.unitary(random_unitary(4, seed=12), [qr0[0], qr1[0]])
-        unisynth_pass = UnitarySynthesis(
-            basis_gates=conf.basis_gates,
-            coupling_map=None,
-            backend_props=backend.properties(),
-            pulse_optimize=True,
-            natural_direction=False,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_props`` is deprecated as of Qiskit 1.4",
+        ):
+            unisynth_pass = UnitarySynthesis(
+                basis_gates=conf.basis_gates,
+                coupling_map=None,
+                backend_props=backend.properties(),
+                pulse_optimize=True,
+                natural_direction=False,
+            )
         pm = PassManager([triv_layout_pass, unisynth_pass])
         qc_out = pm.run(qc)
-
-        unisynth_pass_nat = UnitarySynthesis(
-            basis_gates=conf.basis_gates,
-            coupling_map=None,
-            backend_props=backend.properties(),
-            pulse_optimize=True,
-            natural_direction=True,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_props`` is deprecated as of Qiskit 1.4",
+        ):
+            unisynth_pass_nat = UnitarySynthesis(
+                basis_gates=conf.basis_gates,
+                coupling_map=None,
+                backend_props=backend.properties(),
+                pulse_optimize=True,
+                natural_direction=True,
+            )
 
         pm_nat = PassManager([triv_layout_pass, unisynth_pass_nat])
         qc_out_nat = pm_nat.run(qc)
@@ -269,23 +291,30 @@ class TestUnitarySynthesis(QiskitTestCase):
         triv_layout_pass = TrivialLayout(coupling_map)
         qc = QuantumCircuit(qr)
         qc.unitary(random_unitary(4, seed=12), [0, 1])
-        unisynth_pass = UnitarySynthesis(
-            basis_gates=conf.basis_gates,
-            coupling_map=coupling_map,
-            backend_props=backend.properties(),
-            pulse_optimize=True,
-            natural_direction=False,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_props`` is deprecated as of Qiskit 1.4",
+        ):
+            unisynth_pass = UnitarySynthesis(
+                basis_gates=conf.basis_gates,
+                coupling_map=coupling_map,
+                backend_props=backend.properties(),
+                pulse_optimize=True,
+                natural_direction=False,
+            )
         pm = PassManager([triv_layout_pass, unisynth_pass])
         qc_out = pm.run(qc)
-
-        unisynth_pass_nat = UnitarySynthesis(
-            basis_gates=conf.basis_gates,
-            coupling_map=coupling_map,
-            backend_props=backend.properties(),
-            pulse_optimize=True,
-            natural_direction=True,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_props`` is deprecated as of Qiskit 1.4",
+        ):
+            unisynth_pass_nat = UnitarySynthesis(
+                basis_gates=conf.basis_gates,
+                coupling_map=coupling_map,
+                backend_props=backend.properties(),
+                pulse_optimize=True,
+                natural_direction=True,
+            )
 
         pm_nat = PassManager([triv_layout_pass, unisynth_pass_nat])
         qc_out_nat = pm_nat.run(qc)
@@ -313,23 +342,31 @@ class TestUnitarySynthesis(QiskitTestCase):
         triv_layout_pass = TrivialLayout(coupling_map)
         qc = QuantumCircuit(qr)
         qc.unitary(random_unitary(4, seed=12), [0, 1])
-        unisynth_pass = UnitarySynthesis(
-            basis_gates=conf.basis_gates,
-            coupling_map=coupling_map,
-            backend_props=backend.properties(),
-            pulse_optimize=True,
-            natural_direction=False,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_props`` is deprecated as of Qiskit 1.4",
+        ):
+            unisynth_pass = UnitarySynthesis(
+                basis_gates=conf.basis_gates,
+                coupling_map=coupling_map,
+                backend_props=backend.properties(),
+                pulse_optimize=True,
+                natural_direction=False,
+            )
         pm = PassManager([triv_layout_pass, unisynth_pass])
         qc_out = pm.run(qc)
 
-        unisynth_pass_nat = UnitarySynthesis(
-            basis_gates=conf.basis_gates,
-            coupling_map=coupling_map,
-            backend_props=backend.properties(),
-            pulse_optimize=True,
-            natural_direction=None,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_props`` is deprecated as of Qiskit 1.4",
+        ):
+            unisynth_pass_nat = UnitarySynthesis(
+                basis_gates=conf.basis_gates,
+                coupling_map=coupling_map,
+                backend_props=backend.properties(),
+                pulse_optimize=True,
+                natural_direction=None,
+            )
 
         pm_nat = PassManager([triv_layout_pass, unisynth_pass_nat])
         qc_out_nat = pm_nat.run(qc)
@@ -357,23 +394,31 @@ class TestUnitarySynthesis(QiskitTestCase):
         triv_layout_pass = TrivialLayout(coupling_map)
         qc = QuantumCircuit(qr)
         qc.unitary(random_unitary(4, seed=12), [0, 1])
-        unisynth_pass = UnitarySynthesis(
-            basis_gates=conf.basis_gates,
-            coupling_map=coupling_map,
-            backend_props=backend.properties(),
-            pulse_optimize=True,
-            natural_direction=False,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_props`` is deprecated as of Qiskit 1.4",
+        ):
+            unisynth_pass = UnitarySynthesis(
+                basis_gates=conf.basis_gates,
+                coupling_map=coupling_map,
+                backend_props=backend.properties(),
+                pulse_optimize=True,
+                natural_direction=False,
+            )
         pm = PassManager([triv_layout_pass, unisynth_pass])
         qc_out = pm.run(qc)
 
-        unisynth_pass_nat = UnitarySynthesis(
-            basis_gates=conf.basis_gates,
-            coupling_map=coupling_map,
-            backend_props=backend.properties(),
-            pulse_optimize=True,
-            natural_direction=False,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_props`` is deprecated as of Qiskit 1.4",
+        ):
+            unisynth_pass_nat = UnitarySynthesis(
+                basis_gates=conf.basis_gates,
+                coupling_map=coupling_map,
+                backend_props=backend.properties(),
+                pulse_optimize=True,
+                natural_direction=False,
+            )
 
         pm_nat = PassManager([triv_layout_pass, unisynth_pass_nat])
         qc_out_nat = pm_nat.run(qc)
@@ -397,30 +442,38 @@ class TestUnitarySynthesis(QiskitTestCase):
         qc = QuantumCircuit(qr)
         qc.unitary(random_unitary(4, seed=12), [0, 1])
         coupling_map = CouplingMap([[0, 1]])
-        pm_nonoptimal = PassManager(
-            [
-                TrivialLayout(coupling_map),
-                UnitarySynthesis(
-                    basis_gates=conf.basis_gates,
-                    coupling_map=coupling_map,
-                    backend_props=backend.properties(),
-                    pulse_optimize=False,
-                    natural_direction=True,
-                ),
-            ]
-        )
-        pm_optimal = PassManager(
-            [
-                TrivialLayout(coupling_map),
-                UnitarySynthesis(
-                    basis_gates=conf.basis_gates,
-                    coupling_map=coupling_map,
-                    backend_props=backend.properties(),
-                    pulse_optimize=True,
-                    natural_direction=True,
-                ),
-            ]
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_props`` is deprecated as of Qiskit 1.4",
+        ):
+            pm_nonoptimal = PassManager(
+                [
+                    TrivialLayout(coupling_map),
+                    UnitarySynthesis(
+                        basis_gates=conf.basis_gates,
+                        coupling_map=coupling_map,
+                        backend_props=backend.properties(),
+                        pulse_optimize=False,
+                        natural_direction=True,
+                    ),
+                ]
+            )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_props`` is deprecated as of Qiskit 1.4",
+        ):
+            pm_optimal = PassManager(
+                [
+                    TrivialLayout(coupling_map),
+                    UnitarySynthesis(
+                        basis_gates=conf.basis_gates,
+                        coupling_map=coupling_map,
+                        backend_props=backend.properties(),
+                        pulse_optimize=True,
+                        natural_direction=True,
+                    ),
+                ]
+            )
         qc_nonoptimal = pm_nonoptimal.run(qc)
         qc_optimal = pm_optimal.run(qc)
         self.assertGreater(qc_nonoptimal.count_ops()["sx"], qc_optimal.count_ops()["sx"])
@@ -437,13 +490,17 @@ class TestUnitarySynthesis(QiskitTestCase):
         triv_layout_pass = TrivialLayout(coupling_map)
         qc = QuantumCircuit(qr)
         qc.unitary(random_unitary(4, seed=12), [0, 1])
-        unisynth_pass = UnitarySynthesis(
-            basis_gates=conf.basis_gates,
-            coupling_map=coupling_map,
-            backend_props=backend.properties(),
-            pulse_optimize=True,
-            natural_direction=True,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_props`` is deprecated as of Qiskit 1.4",
+        ):
+            unisynth_pass = UnitarySynthesis(
+                basis_gates=conf.basis_gates,
+                coupling_map=coupling_map,
+                backend_props=backend.properties(),
+                pulse_optimize=True,
+                natural_direction=True,
+            )
         pm = PassManager([triv_layout_pass, unisynth_pass])
         with self.assertRaises(QiskitError):
             pm.run(qc)
@@ -460,13 +517,17 @@ class TestUnitarySynthesis(QiskitTestCase):
         triv_layout_pass = TrivialLayout(coupling_map)
         qc = QuantumCircuit(qr)
         qc.unitary(random_unitary(4, seed=12), [0, 1])
-        unisynth_pass = UnitarySynthesis(
-            basis_gates=conf.basis_gates,
-            coupling_map=coupling_map,
-            backend_props=backend.properties(),
-            pulse_optimize=True,
-            natural_direction=True,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_props`` is deprecated as of Qiskit 1.4",
+        ):
+            unisynth_pass = UnitarySynthesis(
+                basis_gates=conf.basis_gates,
+                coupling_map=coupling_map,
+                backend_props=backend.properties(),
+                pulse_optimize=True,
+                natural_direction=True,
+            )
         pm = PassManager([triv_layout_pass, unisynth_pass])
         qc_out = pm.run(qc)
         self.assertTrue(
@@ -487,12 +548,16 @@ class TestUnitarySynthesis(QiskitTestCase):
         triv_layout_pass = TrivialLayout(coupling_map)
         qc = QuantumCircuit(qr)
         qc.unitary(random_unitary(4, seed=12), [0, 1])
-        unisynth_pass = UnitarySynthesis(
-            basis_gates=conf.basis_gates,
-            backend_props=backend.properties(),
-            pulse_optimize=True,
-            natural_direction=True,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_props`` is deprecated as of Qiskit 1.4",
+        ):
+            unisynth_pass = UnitarySynthesis(
+                basis_gates=conf.basis_gates,
+                backend_props=backend.properties(),
+                pulse_optimize=True,
+                natural_direction=True,
+            )
         pm = PassManager([triv_layout_pass, unisynth_pass])
         with self.assertRaises(TranspilerError):
             pm.run(qc)
@@ -508,13 +573,17 @@ class TestUnitarySynthesis(QiskitTestCase):
         triv_layout_pass = TrivialLayout(coupling_map)
         qc = QuantumCircuit(qr)
         qc.unitary(random_unitary(4, seed=12), [0, 1])
-        unisynth_pass = UnitarySynthesis(
-            basis_gates=conf.basis_gates,
-            coupling_map=coupling_map,
-            backend_props=backend.properties(),
-            pulse_optimize=None,
-            natural_direction=True,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_props`` is deprecated as of Qiskit 1.4",
+        ):
+            unisynth_pass = UnitarySynthesis(
+                basis_gates=conf.basis_gates,
+                coupling_map=coupling_map,
+                backend_props=backend.properties(),
+                pulse_optimize=None,
+                natural_direction=True,
+            )
         pm = PassManager([triv_layout_pass, unisynth_pass])
         qc_out = pm.run(qc)
         if isinstance(qc_out, QuantumCircuit):
@@ -537,13 +606,17 @@ class TestUnitarySynthesis(QiskitTestCase):
         triv_layout_pass = TrivialLayout(coupling_map)
         qc = QuantumCircuit(qr)
         qc.unitary(random_unitary(4, seed=12), [0, 1])
-        unisynth_pass = UnitarySynthesis(
-            basis_gates=conf.basis_gates,
-            coupling_map=coupling_map,
-            backend_props=backend.properties(),
-            pulse_optimize=None,
-            natural_direction=True,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``backend_props`` is deprecated as of Qiskit 1.4",
+        ):
+            unisynth_pass = UnitarySynthesis(
+                basis_gates=conf.basis_gates,
+                coupling_map=coupling_map,
+                backend_props=backend.properties(),
+                pulse_optimize=None,
+                natural_direction=True,
+            )
         pm = PassManager([triv_layout_pass, unisynth_pass])
         try:
             qc_out = pm.run(qc)

--- a/test/python/transpiler/test_vf2_layout.py
+++ b/test/python/transpiler/test_vf2_layout.py
@@ -638,7 +638,11 @@ class TestMultipleTrials(QiskitTestCase):
         qc.measure_all()
         cmap = CouplingMap(backend.configuration().coupling_map)
         properties = backend.properties()
-        vf2_pass = VF2Layout(cmap, properties=properties)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``properties`` is deprecated as of Qiskit 1.4",
+        ):
+            vf2_pass = VF2Layout(cmap, properties=properties)
         property_set = {}
         vf2_pass(qc, property_set)
         self.assertEqual(set(property_set["layout"].get_physical_bits()), {1, 3})
@@ -654,7 +658,11 @@ class TestMultipleTrials(QiskitTestCase):
         qc.measure_all()
         cmap = CouplingMap(backend.configuration().coupling_map)
         properties = backend.properties()
-        vf2_pass = VF2Layout(cmap, properties=properties, seed=-1, max_trials=1)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``properties`` is deprecated as of Qiskit 1.4",
+        ):
+            vf2_pass = VF2Layout(cmap, properties=properties, seed=-1, max_trials=1)
         property_set = {}
         with self.assertLogs("qiskit.transpiler.passes.layout.vf2_layout", level="DEBUG") as cm:
             vf2_pass(qc, property_set)
@@ -675,7 +683,11 @@ class TestMultipleTrials(QiskitTestCase):
         qc.measure_all()
         cmap = CouplingMap(backend.configuration().coupling_map)
         properties = backend.properties()
-        vf2_pass = VF2Layout(cmap, properties=properties, seed=-1, time_limit=0.0)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``properties`` is deprecated as of Qiskit 1.4",
+        ):
+            vf2_pass = VF2Layout(cmap, properties=properties, seed=-1, time_limit=0.0)
         property_set = {}
         with self.assertLogs("qiskit.transpiler.passes.layout.vf2_layout", level="DEBUG") as cm:
             vf2_pass(qc, property_set)
@@ -700,7 +712,11 @@ class TestMultipleTrials(QiskitTestCase):
         cmap = CouplingMap(backend.configuration().coupling_map)
         properties = backend.properties()
         # Run without any limits set
-        vf2_pass = VF2Layout(cmap, properties=properties, seed=42)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``properties`` is deprecated as of Qiskit 1.4",
+        ):
+            vf2_pass = VF2Layout(cmap, properties=properties, seed=42)
         property_set = {}
         with self.assertLogs("qiskit.transpiler.passes.layout.vf2_layout", level="DEBUG") as cm:
             vf2_pass(qc, property_set)
@@ -738,12 +754,16 @@ class TestMultipleTrials(QiskitTestCase):
         cmap = CouplingMap(backend.configuration().coupling_map)
         properties = backend.properties()
         # Run without any limits set
-        vf2_pass = VF2Layout(
-            cmap,
-            properties=properties,
-            seed=42,
-            max_trials=0,
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``properties`` is deprecated as of Qiskit 1.4",
+        ):
+            vf2_pass = VF2Layout(
+                cmap,
+                properties=properties,
+                seed=42,
+                max_trials=0,
+            )
         property_set = {}
         with self.assertLogs("qiskit.transpiler.passes.layout.vf2_layout", level="DEBUG") as cm:
             vf2_pass(qc, property_set)

--- a/test/python/transpiler/test_vf2_post_layout.py
+++ b/test/python/transpiler/test_vf2_post_layout.py
@@ -98,7 +98,11 @@ class TestVF2PostLayout(QiskitTestCase):
     def test_no_backend_properties(self):
         """Test we raise at runtime if no properties are provided with a coupling graph."""
         qc = QuantumCircuit(2)
-        empty_pass = VF2PostLayout(coupling_map=CouplingMap([(0, 1), (1, 2)]))
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``coupling_map`` is deprecated as of Qiskit 1.4",
+        ):
+            empty_pass = VF2PostLayout(coupling_map=CouplingMap([(0, 1), (1, 2)]))
         with self.assertRaises(TranspilerError):
             empty_pass.run(circuit_to_dag(qc))
 
@@ -612,9 +616,13 @@ class TestVF2PostLayoutUndirected(QiskitTestCase):
     def test_no_backend_properties(self):
         """Test we raise at runtime if no properties are provided with a coupling graph."""
         qc = QuantumCircuit(2)
-        empty_pass = VF2PostLayout(
-            coupling_map=CouplingMap([(0, 1), (1, 2)]), strict_direction=False
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``coupling_map`` is deprecated as of Qiskit 1.4",
+        ):
+            empty_pass = VF2PostLayout(
+                coupling_map=CouplingMap([(0, 1), (1, 2)]), strict_direction=False
+            )
         with self.assertRaises(TranspilerError):
             empty_pass.run(circuit_to_dag(qc))
 

--- a/test/python/transpiler/test_vf2_post_layout.py
+++ b/test/python/transpiler/test_vf2_post_layout.py
@@ -109,7 +109,11 @@ class TestVF2PostLayout(QiskitTestCase):
         qc = QuantumCircuit(2, 2)
         cmap = CouplingMap(backend.configuration().coupling_map)
         props = backend.properties()
-        vf2_pass = VF2PostLayout(coupling_map=cmap, properties=props)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``properties`` is deprecated as of Qiskit 1.4",
+        ):
+            vf2_pass = VF2PostLayout(coupling_map=cmap, properties=props)
         vf2_pass.run(circuit_to_dag(qc))
         self.assertEqual(
             vf2_pass.property_set["VF2PostLayout_stop_reason"],
@@ -137,7 +141,11 @@ class TestVF2PostLayout(QiskitTestCase):
         qc.ccx(0, 1, 2)
         cmap = CouplingMap(backend.configuration().coupling_map)
         props = backend.properties()
-        vf2_pass = VF2PostLayout(coupling_map=cmap, properties=props)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``properties`` is deprecated as of Qiskit 1.4",
+        ):
+            vf2_pass = VF2PostLayout(coupling_map=cmap, properties=props)
         vf2_pass.run(circuit_to_dag(qc))
         self.assertEqual(
             vf2_pass.property_set["VF2PostLayout_stop_reason"], VF2PostLayoutStopReason.MORE_THAN_2Q
@@ -152,7 +160,11 @@ class TestVF2PostLayout(QiskitTestCase):
             qc.ccx(0, 1, 2)
         cmap = CouplingMap(backend.configuration().coupling_map)
         props = backend.properties()
-        vf2_pass = VF2PostLayout(coupling_map=cmap, properties=props)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``properties`` is deprecated as of Qiskit 1.4",
+        ):
+            vf2_pass = VF2PostLayout(coupling_map=cmap, properties=props)
         vf2_pass.run(circuit_to_dag(qc))
         self.assertEqual(
             vf2_pass.property_set["VF2PostLayout_stop_reason"], VF2PostLayoutStopReason.MORE_THAN_2Q
@@ -206,7 +218,11 @@ class TestVF2PostLayout(QiskitTestCase):
         dag = circuit_to_dag(tqc)
         cmap = CouplingMap(backend.configuration().coupling_map)
         props = backend.properties()
-        pass_ = VF2PostLayout(coupling_map=cmap, properties=props, seed=self.seed)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``properties`` is deprecated as of Qiskit 1.4",
+        ):
+            pass_ = VF2PostLayout(coupling_map=cmap, properties=props, seed=self.seed)
         pass_.run(dag)
         self.assertLayout(dag, cmap, pass_.property_set)
         self.assertNotEqual(pass_.property_set["post_layout"], initial_layout)
@@ -232,7 +248,11 @@ class TestVF2PostLayout(QiskitTestCase):
         dag = circuit_to_dag(circuit)
         cmap = CouplingMap(backend.configuration().coupling_map)
         props = backend.properties()
-        pass_ = VF2PostLayout(coupling_map=cmap, properties=props, seed=self.seed)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``properties`` is deprecated as of Qiskit 1.4",
+        ):
+            pass_ = VF2PostLayout(coupling_map=cmap, properties=props, seed=self.seed)
         pass_.run(dag)
         self.assertLayout(dag, cmap, pass_.property_set)
         self.assertNotEqual(pass_.property_set["post_layout"], initial_layout)
@@ -293,9 +313,13 @@ class TestVF2PostLayout(QiskitTestCase):
         dag = circuit_to_dag(tqc)
         cmap = CouplingMap(backend.configuration().coupling_map)
         props = backend.properties()
-        pass_ = VF2PostLayout(
-            coupling_map=cmap, properties=props, seed=self.seed, max_trials=max_trials
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``properties`` is deprecated as of Qiskit 1.4",
+        ):
+            pass_ = VF2PostLayout(
+                coupling_map=cmap, properties=props, seed=self.seed, max_trials=max_trials
+            )
 
         with self.assertLogs(
             "qiskit.transpiler.passes.layout.vf2_post_layout", level="DEBUG"
@@ -602,7 +626,11 @@ class TestVF2PostLayoutUndirected(QiskitTestCase):
         qc = QuantumCircuit(2, 2)
         cmap = CouplingMap(backend.configuration().coupling_map)
         props = backend.properties()
-        vf2_pass = VF2PostLayout(coupling_map=cmap, properties=props, strict_direction=False)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``properties`` is deprecated as of Qiskit 1.4",
+        ):
+            vf2_pass = VF2PostLayout(coupling_map=cmap, properties=props, strict_direction=False)
         vf2_pass.run(circuit_to_dag(qc))
         self.assertEqual(
             vf2_pass.property_set["VF2PostLayout_stop_reason"],
@@ -634,7 +662,11 @@ class TestVF2PostLayoutUndirected(QiskitTestCase):
         qc.ccx(0, 1, 2)
         cmap = CouplingMap(backend.configuration().coupling_map)
         props = backend.properties()
-        vf2_pass = VF2PostLayout(coupling_map=cmap, properties=props, strict_direction=False)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``properties`` is deprecated as of Qiskit 1.4",
+        ):
+            vf2_pass = VF2PostLayout(coupling_map=cmap, properties=props, strict_direction=False)
         vf2_pass.run(circuit_to_dag(qc))
         self.assertEqual(
             vf2_pass.property_set["VF2PostLayout_stop_reason"],
@@ -707,9 +739,13 @@ class TestVF2PostLayoutUndirected(QiskitTestCase):
         dag = circuit_to_dag(tqc)
         cmap = CouplingMap(backend.configuration().coupling_map)
         props = backend.properties()
-        pass_ = VF2PostLayout(
-            coupling_map=cmap, properties=props, seed=self.seed, strict_direction=False
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``properties`` is deprecated as of Qiskit 1.4",
+        ):
+            pass_ = VF2PostLayout(
+                coupling_map=cmap, properties=props, seed=self.seed, strict_direction=False
+            )
         pass_.run(dag)
         self.assertLayout(dag, cmap, pass_.property_set)
         self.assertNotEqual(pass_.property_set["post_layout"], initial_layout)
@@ -758,9 +794,13 @@ class TestVF2PostLayoutUndirected(QiskitTestCase):
         dag = circuit_to_dag(tqc)
         cmap = CouplingMap(backend.configuration().coupling_map)
         props = backend.properties()
-        pass_ = VF2PostLayout(
-            coupling_map=cmap, properties=props, seed=self.seed, strict_direction=False
-        )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=".*``properties`` is deprecated as of Qiskit 1.4",
+        ):
+            pass_ = VF2PostLayout(
+                coupling_map=cmap, properties=props, seed=self.seed, strict_direction=False
+            )
         pass_.run(dag)
         self.assertLayout(dag, cmap, pass_.property_set)
         self.assertNotEqual(pass_.property_set["post_layout"], initial_layout)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR deprecates the following uses of `BackendProperties` to be removed in 2.0:

- `backend_prop` input argument in `DenseLayout`
- `properties` input argument in `VF2Layout`
- `properties` input argument in `VF2PostLayout`
- `backend_props` input argument in `UnitarySynthesis`
- `backend_properties` in `PassManagerConfig`
- `backend_properties` in `generate_routing_passmanager`
- `backend_properties` in `generate_translation_passmanager`
- `backend_properties` in  `Target.from_configuration`

### Details and comments
This PR unblocks #13706 and further 2.0 removals.

