### PR TITLE
Reduce parallelism for qpy tests

### DIFF
--- a/test/qpy_compat/run_tests.sh
+++ b/test/qpy_compat/run_tests.sh
@@ -42,7 +42,7 @@ python -m venv "$qiskit_venv"
 "$qiskit_venv/bin/pip" install -c "$repo_root/constraints.txt" "$qiskit_dev_wheel" packaging
 
 # Run all of the tests of cross-Qiskit-version compatibility.
-"$qiskit_python" "$our_dir/get_versions.py" | parallel --colsep=" " bash "$our_dir/process_version.sh" -p "$qiskit_python"
+"$qiskit_python" "$our_dir/get_versions.py" | parallel -j 2 --colsep=" " bash "$our_dir/process_version.sh" -p "$qiskit_python"
 
 # Test dev compatibility with itself.
 dev_version="$("$qiskit_python" -c 'import qiskit; print(qiskit.__version__)')"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #13506 the QPY backwards compatibility tests are failing because the image is running out of disk space and github actions is killing the runner. The qpy files themselves should be fairly small and will be dwarfed by the virtual environments created to install old versions of qiskit to generate old QPY payloads. We use GNU parallel to speed up the testing, however by doing this we end up having multiple venvs at once which increases the disk space usage. This commit attempts to reduce the pressure on the disk space usage by decreasing the parallelism from N cpus (which is currently 4 for linux runners according to [1]) to 2. This will increase the runtime for this job but if we have insufficient disk space on the image to generate new qpy files there isn't really a choice.

### Details and comments

[1] https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories