### PR TITLE
[WIP] transpiling to discrete basis sets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ default = "qiskit.transpiler.preset_passmanagers.builtin_plugins:DefaultInitPass
 [project.entry-points."qiskit.transpiler.translation"]
 synthesis = "qiskit.transpiler.preset_passmanagers.builtin_plugins:UnitarySynthesisPassManager"
 translator = "qiskit.transpiler.preset_passmanagers.builtin_plugins:BasisTranslatorPassManager"
+default = "qiskit.transpiler.preset_passmanagers.builtin_plugins:DefaultTranslatorPassManager"
 
 [project.entry-points."qiskit.transpiler.routing"]
 basic = "qiskit.transpiler.preset_passmanagers.builtin_plugins:BasicSwapPassManager"

--- a/qiskit/transpiler/passmanager_config.py
+++ b/qiskit/transpiler/passmanager_config.py
@@ -182,7 +182,7 @@ class PassManagerConfig:
                 res.target = backend.target
         if res.scheduling_method is None and hasattr(backend, "get_scheduling_stage_plugin"):
             res.scheduling_method = backend.get_scheduling_stage_plugin()
-        if res.translation_method is None and hasattr(backend, "get_translation_stage_plugin"):
+        if res.translation_method == "default" and hasattr(backend, "get_translation_stage_plugin"):
             res.translation_method = backend.get_translation_stage_plugin()
         return res
 

--- a/qiskit/transpiler/passmanager_config.py
+++ b/qiskit/transpiler/passmanager_config.py
@@ -32,7 +32,7 @@ class PassManagerConfig:
         coupling_map=None,
         layout_method=None,
         routing_method=None,
-        translation_method=None,
+        translation_method="default",
         scheduling_method=None,
         instruction_durations=None,
         backend_properties=None,

--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -263,7 +263,9 @@ class DefaultTranslatorPassManager(PassManagerStagePlugin):
         return True
 
     def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
-        if self._is_discrete_basis(pass_manager_config.basis_gates):
+        if (pass_manager_config.basis_gates is not None) and self._is_discrete_basis(
+            pass_manager_config.basis_gates
+        ):
             pm = common.generate_translation_passmanager(
                 pass_manager_config.target,
                 basis_gates=pass_manager_config.basis_gates,

--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -84,7 +84,7 @@ def generate_preset_pass_manager(
     initial_layout=None,
     layout_method=None,
     routing_method=None,
-    translation_method=None,
+    translation_method="default",
     scheduling_method=None,
     approximation_degree=1.0,
     seed_transpiler=None,

--- a/test/python/transpiler/test_passmanager_config.py
+++ b/test/python/transpiler/test_passmanager_config.py
@@ -134,7 +134,7 @@ class TestPassManagerConfig(QiskitTestCase):
 \tcoupling_map: None
 \tlayout_method: None
 \trouting_method: None
-\ttranslation_method: None
+\ttranslation_method: default
 \tscheduling_method: None
 \tinstruction_durations:\u0020
 \tbackend_properties: None

--- a/test/python/transpiler/test_star_prerouting.py
+++ b/test/python/transpiler/test_star_prerouting.py
@@ -253,7 +253,10 @@ class TestStarPreRouting(QiskitTestCase):
         for i in range(num_qubits - 1):
             qc.measure(i, i)
         pm = generate_preset_pass_manager(
-            opt_level, basis_gates=["h", "cx", "x"], coupling_map=coupling_map
+            opt_level,
+            basis_gates=["h", "cx", "x"],
+            coupling_map=coupling_map,
+            translation_method="translator",
         )
         pm.init += StarPreRouting()
         result = pm.run(qc)
@@ -293,7 +296,10 @@ class TestStarPreRouting(QiskitTestCase):
         for i in range(num_qubits - 1):
             qc.measure(i, i)
         pm = generate_preset_pass_manager(
-            opt_level, basis_gates=["h", "cx", "x"], coupling_map=coupling_map
+            opt_level,
+            basis_gates=["h", "cx", "x"],
+            coupling_map=coupling_map,
+            translation_method="translator",
         )
         pm.init += StarPreRouting()
         result = pm.run(qc)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

I am opening this (work-in-progress) PR to start a more detailed discussion on how the transpilation pipeline to a discrete basis set (and in particular to Clifford+T) should look like, see issue #13695 + the related discussion in #13517.

The current tentative implementation is based on a discussion with @Cryoris and @jakelishman, and on @jakelishman's suggestion [here](https://github.com/Qiskit/qiskit/issues/13695#issuecomment-2603235121).

### Details and comments

We introduce.a new translation stage method plugin called "default", and default the translation stage pass manager to it. This default pass manager checks if the given basis set is "discrete" (currently: there are no custom gates in this set, and all the standard gates are non-parameterized), in which case calls ``generate_translation_passmanager(..., method="discrete", ...)``. Otherwise, it essentially calls ``generate_translation_passmanager(..., method="translator", ...)``, as was done before. 

For experimenting with this, one can run the following code:
```
def callback_func(pass_, dag, time, property_set, count):
    print(f"PASS [{count}] {pass_.name()}: {dag.count_ops() = }")

coupling_map = CouplingMap.from_line(8)
pm = generate_preset_pass_manager(optimization_level=2, basis_gates=["cz", "s", "sdg", "t", "tdg", "z", "h"], coupling_map=coupling_map)

qc = QuantumCircuit(8)
qc.cp(np.pi/4, 0, 1)
qc.append(MCXGate(3), [0, 1, 3, 4])
qc.measure_all()

qct = pm.run(qc, callback=callback_func)
```

Note that previously this would raise an error message since ``BasisTranslator`` is not able to convert the circuit into the given basis.

It is likely that we will also need to adjust/improve some of the other pass manager's stages for the discrete basis transpilation flow. I am especially thinking of adjusting the optimization stage, however surprisingly the code already works as the builtin ``OptimizationPassManager`` calls ``plugin_manager.get_passmanager_stage("translation", ...)`` with the ``"default"`` value for ``translation``.

Comments/suggestions/etc. are highly appreciated.