### PR TITLE
Deprecate `BasicSimulator.run_experiment`

### DIFF
--- a/qiskit/providers/basic_provider/basic_simulator.py
+++ b/qiskit/providers/basic_provider/basic_simulator.py
@@ -593,6 +593,13 @@ class BasicSimulator(BackendV2):
 
         return Result.from_dict(result)
 
+    @deprecate_func(
+        since="1.4.0",
+        removal_timeline="in Qiskit 2.0.0",
+        additional_msg="This method takes a `QasmQobjExperiment` as input argument. "
+        "The `Qobj` class and related functionality are part of the deprecated "
+        "`BackendV1` workflow,  and no longer necessary for `BackendV2`. Use `run` instead.",
+    )
     def run_experiment(self, experiment: QasmQobjExperiment) -> dict[str, ...]:
         """Run an experiment (circuit) and return a single experiment result.
 

--- a/qiskit/providers/basic_provider/basic_simulator.py
+++ b/qiskit/providers/basic_provider/basic_simulator.py
@@ -576,8 +576,14 @@ class BasicSimulator(BackendV2):
         self._memory = getattr(qobj.config, "memory", False)
         self._qobj_config = qobj.config
         start = time.time()
-        for experiment in qobj.experiments:
-            result_list.append(self.run_experiment(experiment))
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+                message=r".+qiskit\.providers\.basic_provider\.basic_simulator\..+",
+            )
+            for experiment in qobj.experiments:
+                result_list.append(self.run_experiment(experiment))
         end = time.time()
         result = {
             "backend_name": self.name,

--- a/releasenotes/notes/deprecate-run-experiment-f37b3f35724bc6bb.yaml
+++ b/releasenotes/notes/deprecate-run-experiment-f37b3f35724bc6bb.yaml
@@ -2,5 +2,6 @@
 deprecations_providers:
   - |
     The :meth:`.BasicSimulator.run_experiment` method has been deprecated and will be removed in Qiskit 2.0.0.
-    The method takes `QasmQobjExperiment` as input argument, which has been deprecated together with the `Qobj` 
-    class and other related functionality. You can `run` with a :class:`.QuantumCircuit` input instead.
+    The method takes :class:`.QasmQobjExperiment` as input argument, which has been deprecated together
+    with the :class:`.Qobj` class and other related functionality. You can call :class:`.BasicSimulator.run` 
+    with a :class:`.QuantumCircuit` input instead.

--- a/releasenotes/notes/deprecate-run-experiment-f37b3f35724bc6bb.yaml
+++ b/releasenotes/notes/deprecate-run-experiment-f37b3f35724bc6bb.yaml
@@ -1,0 +1,6 @@
+---
+deprecations_providers:
+  - |
+    The :meth:`.BasicSimulator.run_experiment` method has been deprecated and will be removed in Qiskit 2.0.0.
+    The method takes `QasmQobjExperiment` as input argument, which has been deprecated together with the `Qobj` 
+    class and other related functionality. You can `run` with a :class:`.QuantumCircuit` input instead.

--- a/releasenotes/notes/deprecate-run-experiment-f37b3f35724bc6bb.yaml
+++ b/releasenotes/notes/deprecate-run-experiment-f37b3f35724bc6bb.yaml
@@ -3,5 +3,5 @@ deprecations_providers:
   - |
     The :meth:`.BasicSimulator.run_experiment` method has been deprecated and will be removed in Qiskit 2.0.0.
     The method takes :class:`.QasmQobjExperiment` as input argument, which has been deprecated together
-    with the :class:`.Qobj` class and other related functionality. You can call :class:`.BasicSimulator.run` 
+    with the :class:`.Qobj` class and other related functionality. You can call :meth:`.BasicSimulator.run` 
     with a :class:`.QuantumCircuit` input instead.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The method wasn't used in any test but was part of the public API. It gets removed in #13743.


### Details and comments


