### PR TITLE
Add test for exceptional behavior when initializing `PauliList.from_symplectic`

### DIFF
--- a/test/python/quantum_info/operators/symplectic/test_pauli_list.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli_list.py
@@ -222,14 +222,12 @@ class TestPauliListInit(QiskitTestCase):
         self.assertEqual(pauli_list, from_settings)
 
     def test_from_symplectic_phase_check(self):
+        """Test the from_symplectic method of PauliList for phase dimension check."""
         z = np.array([[0], [0]])
         x = np.array([[0], [0]])
         phase = np.array([[0], [0]])  # 2D phase
-        try:
+        with self.assertRaisesRegex(ValueError, "phase should be at most 1D but has 2 dimensions."):
             PauliList.from_symplectic(z, x, phase)
-            assert False, "Expected ValueError for 2D phase"
-        except ValueError as e:
-            assert str(e) == "phase should be at most 1D but has 2 dimensions."
 
 
 @ddt

--- a/test/python/quantum_info/operators/symplectic/test_pauli_list.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli_list.py
@@ -231,6 +231,7 @@ class TestPauliListInit(QiskitTestCase):
         except ValueError as e:
             assert str(e) == "phase should be at most 1D but has 2 dimensions."
 
+
 @ddt
 class TestPauliListProperties(QiskitTestCase):
     """Tests for PauliList properties."""

--- a/test/python/quantum_info/operators/symplectic/test_pauli_list.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli_list.py
@@ -221,6 +221,15 @@ class TestPauliListInit(QiskitTestCase):
         from_settings = PauliList(**pauli_list.settings)
         self.assertEqual(pauli_list, from_settings)
 
+    def test_from_symplectic_phase_check(self):
+        z = np.array([[0], [0]])
+        x = np.array([[0], [0]])
+        phase = np.array([[0], [0]])  # 2D phase
+        try:
+            PauliList.from_symplectic(z, x, phase)
+            assert False, "Expected ValueError for 2D phase"
+        except ValueError as e:
+            assert str(e) == "phase should be at most 1D but has 2 dimensions."
 
 @ddt
 class TestPauliListProperties(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
### Summary
Improve Test Coverage for `PauliList` Exceptional Behavior

This pull request addresses a testing gap in the `PauliList` object's `from_symplectic` method, which was introduced in a previous pull request ([#13624](https://github.com/Qiskit/qiskit/pull/13624)). The new test ensures that the exceptional behavior is thoroughly tested, enhancing the overall reliability of the Qiskit library.

### Details and Comments

To verify the effectiveness of this change, I have run the entire test suite locally and measured the test coverage using the following command (note that I also run the entire testing suite):
```shell
pytest --cov=$PWD/. --cov-report=xml test/python/quantum_info/operators/symplectic/test_pauli_list.py
```
The results demonstrate a notable improvement in test coverage:

#### Coverage Comparison
Before: 
![test_pr_13624_coverage_before](https://github.com/user-attachments/assets/0facdbce-7dbb-4c3f-aec6-d179dbe61efa)
After: 
![test_pr_13624_coverage_after](https://github.com/user-attachments/assets/92e1c3fe-6052-4360-86ec-7a599c74f406)

Please let me know if there's anything else I can provide to facilitate the review of this pull request.