### PR TITLE
Support `SparseObservable` to `SparsePauliOp` conversions

### DIFF
--- a/crates/accelerate/src/sparse_observable.rs
+++ b/crates/accelerate/src/sparse_observable.rs
@@ -1800,7 +1800,7 @@ impl PySparseTerm {
 /// You can put a :class:`SparseObservable` in canonical form by using the :meth:`simplify` method.
 /// The precise ordering of terms in canonical ordering is not specified, and may change between
 /// versions of Qiskit.  Within the same version of Qiskit, however, you can compare two observables
-/// structurally by comparing their simplified forms.
+/// structurally by comparing their simplified forms.  
 ///
 /// .. note::
 ///
@@ -1812,10 +1812,11 @@ impl PySparseTerm {
 ///
 /// .. note::
 ///
-///     The canonical form produced by :meth:`simplify` will still not universally detect all
-///     observables that are equivalent due to the over-complete basis alphabet; it is not
-///     computationally feasible to do this at scale.  For example, on observable built from ``+``
-///     and ``-`` components will not canonicalize to a single ``X`` term.
+///     The canonical form produced by :meth:`simplify` alone will not universally detect all
+///     observables that are equivalent due to the over-complete basis alphabet. To obtain a
+///     unique expression, you can first represent the observable using Pauli terms only by
+///     calling :meth:`as_paulis`, followed by :meth:`simplify`. Note that the projector
+///     expansion (e.g. ``+`` into ``I`` and ``X``) is not computationally feasible at scale.
 ///
 /// Indexing
 /// --------
@@ -1895,6 +1896,21 @@ impl PySparseTerm {
 ///   :meth:`identity`              The identity operator on a given number of qubits.
 ///   ============================  ================================================================
 ///
+/// Conversions
+/// ===========
+///
+/// An existing :class:`SparseObservable` can be converted into other :mod:`~qiskit.quantum_info`
+/// operators or generic formats.
+///
+///   ============================================  ================================================
+///   Method                                        Summary
+///   ============================================  ================================================
+///   :meth:`SparsePauliOp.from_sparse_observable`  Construct a :class:`.SparsePauliOp` from a
+///                                                 :class:`SparseObservable`.
+///
+///   :meth:`to_sparse_list`                        Express the observable in a sparse list format
+///                                                 with elements ``(bit_terms, indices, coeff)``.
+///   ============================================  ================================================
 ///
 /// Mathematical manipulation
 /// =========================

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -948,7 +948,7 @@ class SparsePauliOp(LinearOp):
         Returns:
             A :class:`.SparsePauliOp` version of the observable.
         """
-        as_sparse_list = obs.to_paulis().to_sparse_list()
+        as_sparse_list = obs.as_paulis().to_sparse_list()
         return SparsePauliOp.from_sparse_list(as_sparse_list, obs.num_qubits)
 
     def to_list(self, array: bool = False):

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -967,7 +967,7 @@ class SparsePauliOp(LinearOp):
                     category=RuntimeWarning,
                 )
 
-        as_sparse_list = obs.to_sparse_list()
+        as_sparse_list = obs.to_sparse_list(only_paulis=True)
         return SparsePauliOp.from_sparse_list(as_sparse_list, obs.num_qubits)
 
     def to_list(self, array: bool = False):

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -15,7 +15,6 @@ N-Qubit Sparse Pauli Operator class.
 
 from __future__ import annotations
 from typing import TYPE_CHECKING, List
-import warnings
 
 from collections.abc import Mapping, Sequence, Iterable
 from numbers import Number
@@ -932,9 +931,7 @@ class SparsePauliOp(LinearOp):
         return SparsePauliOp(paulis, coeffs, copy=False)
 
     @staticmethod
-    def from_sparse_observable(
-        obs: SparseObservable, warn_if_expensive: bool = True
-    ) -> SparsePauliOp:
+    def from_sparse_observable(obs: SparseObservable) -> SparsePauliOp:
         r"""Initialize from a :class:`.SparseObservable`.
 
         .. warning::
@@ -947,27 +944,11 @@ class SparsePauliOp(LinearOp):
 
         Args:
             obs: The :class:`.SparseObservable` to convert.
-            warn_if_expensive: Triggers a warning if the input observable contains a
-                large number of projectors. Defaults to ``True``, but set to ``False`` to for more
-                efficiency.
 
         Returns:
             A :class:`.SparsePauliOp` version of the observable.
         """
-        if warn_if_expensive:
-            bterm = SparseObservable.BitTerm
-            num_projectors = sum(bit not in [bterm.X, bterm.Y, bterm.Z] for bit in obs.bit_terms)
-
-            # 16 is an arbitrary threshold, but at this point please use a SparseObservable
-            if num_projectors > 16:
-                warnings.warn(
-                    f"SparseObservable contains a lot of projectors ({num_projectors}), which will "
-                    f"lead to at least {2 ** num_projectors} terms.",
-                    stacklevel=2,
-                    category=RuntimeWarning,
-                )
-
-        as_sparse_list = obs.to_sparse_list(only_paulis=True)
+        as_sparse_list = obs.to_paulis().to_sparse_list()
         return SparsePauliOp.from_sparse_list(as_sparse_list, obs.num_qubits)
 
     def to_list(self, array: bool = False):

--- a/releasenotes/notes/sparse-obs-to-sparse-list-5b7c17c5d7cffd72.yaml
+++ b/releasenotes/notes/sparse-obs-to-sparse-list-5b7c17c5d7cffd72.yaml
@@ -1,17 +1,23 @@
 ---
 features_quantum_info:
   - |
-    Added :meth:`.SparseObservable.to_sparse_list` to obtain a sparse Pauli list representation
-    of a :class:`.SparseObservable`. Note, that this format is inefficient in representing
-    projectors. For example::
+    Added :meth:`.SparseObservable.to_sparse_list` to obtain a sparse list representation
+    of a :class:`.SparseObservable`. For example::
 
       from qiskit.quantum_info import SparseObservable
 
-      obs = SparseObservable("ZZXI")
-      print(obs.to_sparse_list())  # [("XZZ", [1, 2, 3], 1)]
+      obs = SparseObservable.from_list([("+II", 1), ("-II", 1)])
+      print(obs.to_sparse_list())  # [("+", [2], 1), ("-", [2], 1)]
+
+  - | 
+    Added :meth:`.SparseObservable.to_paulis` to express a sparse observable in terms of Paulis
+    only by expanding all projectors. For example::
+
+      from qiskit.quantum_info import SparseObservable
 
       obs = SparseObservable("+-")
-      print(obs.to_sparse_list())  # [("", [], 1/4), ("X", [1], 1/4), ("X", [0], -1/4), ("XX", [0, 1], -1/4)]
+      obs_paulis = obs.to_paulis()  # 1/4 ( II + XI - IX - XX )
+
   - |
     Support construction of a :class:`.SparsePauliOp` from a :class:`.SparseObservable`
     via the new method :class:`.SparsePauliOp.from_sparse_observable`. It is important

--- a/releasenotes/notes/sparse-obs-to-sparse-list-5b7c17c5d7cffd72.yaml
+++ b/releasenotes/notes/sparse-obs-to-sparse-list-5b7c17c5d7cffd72.yaml
@@ -1,0 +1,19 @@
+---
+features_quantum_info:
+  - |
+    Added :meth:`.SparseObservable.to_sparse_list` to obtain a sparse Pauli list representation
+    of a :class:`.SparseObservable`. Note, that this format is inefficient in representing
+    projectors. For example::
+
+      from qiskit.quantum_info import SparseObservable
+
+      obs = SparseObservable("ZZXI")
+      print(obs.to_sparse_list())  # [("XZZ", [1, 2, 3], 1)]
+
+      obs = SparseObservable("+-")
+      print(obs.to_sparse_list())  # [("", [], 1/4), ("X", [1], 1/4), ("X", [0], -1/4), ("XX", [0, 1], -1/4)]
+  - |
+    Support construction of a :class:`.SparsePauliOp` from a :class:`.SparseObservable`
+    via the new method :class:`.SparsePauliOp.from_sparse_observable`. It is important
+    to remember that :class:`.SparseObservable`\ s can efficiently represent projectors,
+    which require an exponential number of terms in the :class:`.SparsePauliOp`.

--- a/releasenotes/notes/sparse-obs-to-sparse-list-5b7c17c5d7cffd72.yaml
+++ b/releasenotes/notes/sparse-obs-to-sparse-list-5b7c17c5d7cffd72.yaml
@@ -10,13 +10,13 @@ features_quantum_info:
       print(obs.to_sparse_list())  # [("+", [2], 1), ("-", [2], 1)]
 
   - | 
-    Added :meth:`.SparseObservable.to_paulis` to express a sparse observable in terms of Paulis
+    Added :meth:`.SparseObservable.as_paulis` to express a sparse observable in terms of Paulis
     only by expanding all projectors. For example::
 
       from qiskit.quantum_info import SparseObservable
 
       obs = SparseObservable("+-")
-      obs_paulis = obs.to_paulis()  # 1/4 ( II + XI - IX - XX )
+      obs_paulis = obs.as_paulis()  # 1/4 ( II + XI - IX - XX )
 
   - |
     Support construction of a :class:`.SparsePauliOp` from a :class:`.SparseObservable`

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -369,16 +369,33 @@ class TestSparsePauliOpConversions(QiskitTestCase):
 
     def test_from_sparse_observable(self):
         """Test from a SparseObservable."""
+        obs = SparseObservable.zero(10)
+        expected = SparsePauliOp(["I" * 10], coeffs=[0])
+        self.assertEqual(expected, SparsePauliOp.from_sparse_observable(obs))
+
         obs = SparseObservable("XrZ")
         expected = SparsePauliOp(["XIZ", "XYZ"], coeffs=[0.5, -0.5])
         self.assertEqual(expected, SparsePauliOp.from_sparse_observable(obs))
 
     def test_sparse_observable_roundtrip(self):
         """Test SPO -> OBS -> SPO."""
-        op = SparsePauliOp(["ZZI", "IZZ", "IIX", "IXI", "YII"])
-        obs = SparseObservable.from_sparse_pauli_op(op)
-        roundtrip = SparsePauliOp.from_sparse_observable(obs)
-        self.assertEqual(op, roundtrip)
+        with self.subTest(msg="zero"):
+            op = SparsePauliOp(["I"], coeffs=[0])
+            obs = SparseObservable.from_sparse_pauli_op(op)
+            roundtrip = SparsePauliOp.from_sparse_observable(obs)
+            self.assertEqual(op, roundtrip)
+
+        with self.subTest(msg="identity"):
+            op = SparsePauliOp(["I" * 25])
+            obs = SparseObservable.from_sparse_pauli_op(op)
+            roundtrip = SparsePauliOp.from_sparse_observable(obs)
+            self.assertEqual(op, roundtrip)
+
+        with self.subTest(msg="ising like"):
+            op = SparsePauliOp(["ZZI", "IZZ", "IIX", "IXI", "YII"])
+            obs = SparseObservable.from_sparse_pauli_op(op)
+            roundtrip = SparsePauliOp.from_sparse_observable(obs)
+            self.assertEqual(op, roundtrip)
 
 
 class TestSparsePauliOpIteration(QiskitTestCase):

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -28,7 +28,13 @@ from qiskit.circuit.parametertable import ParameterView
 from qiskit.compiler.transpiler import transpile
 from qiskit.primitives import BackendEstimator
 from qiskit.providers.fake_provider import GenericBackendV2
-from qiskit.quantum_info.operators import Operator, Pauli, PauliList, SparsePauliOp
+from qiskit.quantum_info import SparseObservable
+from qiskit.quantum_info.operators import (
+    Operator,
+    Pauli,
+    PauliList,
+    SparsePauliOp,
+)
 from qiskit.utils import optionals
 
 
@@ -360,6 +366,19 @@ class TestSparsePauliOpConversions(QiskitTestCase):
         op = SparsePauliOp(labels, coeffs)
         target = list(zip(labels, coeffs))
         self.assertEqual(op.to_list(), target)
+
+    def test_from_sparse_observable(self):
+        """Test from a SparseObservable."""
+        obs = SparseObservable("XrZ")
+        expected = SparsePauliOp(["XIZ", "XYZ"], coeffs=[0.5, -0.5])
+        self.assertEqual(expected, SparsePauliOp.from_sparse_observable(obs))
+
+    def test_sparse_observable_roundtrip(self):
+        """Test SPO -> OBS -> SPO."""
+        op = SparsePauliOp(["ZZI", "IZZ", "IIX", "IXI", "YII"])
+        obs = SparseObservable.from_sparse_pauli_op(op)
+        roundtrip = SparsePauliOp.from_sparse_observable(obs)
+        self.assertEqual(op, roundtrip)
 
 
 class TestSparsePauliOpIteration(QiskitTestCase):

--- a/test/python/quantum_info/test_sparse_observable.py
+++ b/test/python/quantum_info/test_sparse_observable.py
@@ -2030,36 +2030,35 @@ class TestSparseObservable(QiskitTestCase):
 
         with self.subTest(msg="multiple"):
             obs = SparseObservable.from_list([("lrI0", 0.5), ("YYIZ", -1j)])
-            # expected = [("ZYY", [0, 2, 3], -1j), ("lr0", [3, 2, 0], 0.5)]
             expected = [("lr0", [3, 2, 0], 0.5), ("ZYY", [0, 2, 3], -1j)]
             self.assertEqual(
                 canonicalize_sparse_list(expected), canonicalize_sparse_list(obs.to_sparse_list())
             )
 
-    def test_to_paulis(self):
+    def test_as_paulis(self):
         """Test converting to Paulis."""
         # test on zero operator
         with self.subTest(msg="zero"):
             obs = SparseObservable.zero(10)
-            obs_paulis = obs.to_paulis()
+            obs_paulis = obs.as_paulis()
             self.assertEqual(obs, obs_paulis)
 
         # test on identity operator
         with self.subTest(msg="identity"):
             obs = SparseObservable.identity(10)
-            obs_paulis = obs.to_paulis()
+            obs_paulis = obs.as_paulis()
             self.assertEqual(obs, obs_paulis)
 
         # test it does nothing on Paulis
         with self.subTest(msg="paulis"):
             obs = SparseObservable.from_list([("IIX", 1), ("ZZY", -1)])
-            obs_paulis = obs.to_paulis()
+            obs_paulis = obs.as_paulis()
             self.assertEqual(obs, obs_paulis)
 
         # test explicitly on written-out projector
         with self.subTest(msg="lrI0"):
             obs = SparseObservable("lrI0")
-            obs_paulis = obs.to_paulis()
+            obs_paulis = obs.as_paulis()
             expected = SparseObservable.from_sparse_list(
                 [
                     ("", [], 1 / 8),
@@ -2078,7 +2077,7 @@ class TestSparseObservable(QiskitTestCase):
         # test multiple terms
         with self.subTest(msg="+X + lY - ZI"):
             obs = SparseObservable.from_list([("+X", 1), ("rY", 1), ("ZI", -1)])
-            obs_paulis = obs.to_paulis()
+            obs_paulis = obs.as_paulis()
 
             expected = SparseObservable.from_list(
                 [("IX", 0.5), ("XX", 0.5), ("IY", 0.5), ("YY", -0.5), ("ZI", -1)]

--- a/test/python/quantum_info/test_sparse_observable.py
+++ b/test/python/quantum_info/test_sparse_observable.py
@@ -2115,4 +2115,4 @@ def canonicalize_sparse_list(sparse_list):
     # sort a sparse list representation by canonicalizing the terms and then applying
     # Python's built-in sort
     canonicalized_terms = [canonicalize_term(*term) for term in sparse_list]
-    return list(sorted(canonicalized_terms))
+    return sorted(canonicalized_terms)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Add `SparseObservable.to_sparse_list` to generate a sparse Pauli list representation, which is used to implement `SparsePauliOp.from_sparse_observable`. This method will also allow using `SparseObservable`s in a `PauliEvolutionGate` (follow up PR).

### Details and comments

In as many places as I could, I added a warning that this conversion will blow up if one attempts to convert a large number of projectors to a Pauli representation.
