### PR TITLE
Fix ``CommutationChecker`` for 2q Pauli rotations

### DIFF
--- a/crates/accelerate/src/commutation_checker.rs
+++ b/crates/accelerate/src/commutation_checker.rs
@@ -339,13 +339,17 @@ impl CommutationChecker {
 
         // For our cache to work correctly, we require the gate's definition to only depend on the
         // ``params`` attribute. This cannot be guaranteed for custom gates, so we only check
-        // the cache for our standard gates, which we know are defined by the ``params`` AND
-        // that the ``params`` are float-only at this point.
-        let whitelist = get_standard_gate_names();
-        let check_cache = whitelist.contains(&first_op.name())
-            && whitelist.contains(&second_op.name())
-            && first_params.iter().all(|p| matches!(p, Param::Float(_)))
-            && second_params.iter().all(|p| matches!(p, Param::Float(_)));
+        // the cache for
+        //  * gates we know are in the cache (SUPPORTED_OPS), or
+        //  * standard gates with float params (otherwise we cannot cache them)
+        let standard_gates = get_standard_gate_names();
+        let is_cachable = |name: &str, params: &[Param]| {
+            SUPPORTED_OP.contains(name)
+                || (standard_gates.contains(&name)
+                    && params.iter().all(|p| matches!(p, Param::Float(_))))
+        };
+        let check_cache = is_cachable(first_op.name(), first_params)
+            && is_cachable(second_op.name(), second_params);
 
         if !check_cache {
             return self.commute_matmul(
@@ -666,7 +670,6 @@ fn map_rotation<'a>(
         if let Some(gate) = generator {
             return (gate, &[], false);
         };
-        return (op, &[], false);
     }
     (op, params, false)
 }

--- a/releasenotes/notes/fix-commchecker-2q-paulis-bcadef25247c7288.yaml
+++ b/releasenotes/notes/fix-commchecker-2q-paulis-bcadef25247c7288.yaml
@@ -1,0 +1,16 @@
+---
+fixes:
+  - |
+    Fixed a bug in the :class:`.CommutationChecker` which could fail upon checking the commutation
+    relation of a two-qubit Pauli rotation with a gate that is not in the commutation cache.
+    For example::
+
+      import numpy as np
+      from qiskit.circuit.library import RXXGate, RGate
+      from qiskit.circuit.commutation_library import SessionCommutationChecker as scc
+
+      res = scc.commute(RGate(2, 2), [1], [], RXXGate(np.pi / 2), [0, 1], [])
+
+    This behavior is now resolved and the commutation relation correctly computed.
+    Fixed `#13742 <https://github.com/Qiskit/qiskit/issues/13742>`__.
+

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -490,11 +490,13 @@ class TestCommutationChecker(QiskitTestCase):
         x_equiv = UGate(np.pi, -np.pi / 2, np.pi / 2)
         self.assertTrue(scc.commute(x_equiv, [0], [], RXXGate(np.pi / 2), [0, 1], []))
         self.assertTrue(scc.commute(x_equiv, [1], [], RXXGate(np.pi / 2), [0, 1], []))
+        self.assertFalse(scc.commute(x_equiv, [0], [], RYYGate(np.pi), [1, 0], []))
+        self.assertFalse(scc.commute(x_equiv, [1], [], RYYGate(np.pi), [1, 0], []))
 
         something_else = RGate(1, 2)
-        self.assertTrue(scc.commute(x_equiv, [1], [], RXXGate(np.pi / 2), [0, 1], []))
-
-        self.assertFalse(scc.commute(something_else, [1], [], RYYGate(np.pi), [1, 0], []))
+        self.assertFalse(scc.commute(something_else, [0], [], RXXGate(np.pi / 2), [0, 1], []))
+        self.assertFalse(scc.commute(something_else, [1], [], RXXGate(np.pi / 2), [0, 1], []))
+        self.assertFalse(scc.commute(something_else, [0], [], RYYGate(np.pi), [1, 0], []))
         self.assertFalse(scc.commute(something_else, [1], [], RYYGate(np.pi), [1, 0], []))
 
 

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -45,6 +45,7 @@ from qiskit.circuit.library import (
     PauliGate,
     PhaseGate,
     Reset,
+    RGate,
     RXGate,
     RXXGate,
     RYGate,
@@ -57,6 +58,7 @@ from qiskit.circuit.library import (
     ZGate,
     HGate,
     UnitaryGate,
+    UGate,
 )
 from qiskit.dagcircuit import DAGOpNode
 
@@ -482,6 +484,18 @@ class TestCommutationChecker(QiskitTestCase):
         rx_gate_theta = RXGate(Parameter("Theta"))
         self.assertTrue(scc.commute(pauli_gate, [0, 1], [], rx_gate_theta, [0], []))
         self.assertTrue(scc.commute(rx_gate_theta, [0], [], pauli_gate, [0, 1], []))
+
+    def test_2q_pauli_rot_with_non_cached(self):
+        """Test the 2q-Pauli rotations with a gate that is not cached."""
+        x_equiv = UGate(np.pi, -np.pi / 2, np.pi / 2)
+        self.assertTrue(scc.commute(x_equiv, [0], [], RXXGate(np.pi / 2), [0, 1], []))
+        self.assertTrue(scc.commute(x_equiv, [1], [], RXXGate(np.pi / 2), [0, 1], []))
+
+        something_else = RGate(1, 2)
+        self.assertTrue(scc.commute(x_equiv, [1], [], RXXGate(np.pi / 2), [0, 1], []))
+
+        self.assertFalse(scc.commute(something_else, [1], [], RYYGate(np.pi), [1, 0], []))
+        self.assertFalse(scc.commute(something_else, [1], [], RYYGate(np.pi), [1, 0], []))
 
 
 if __name__ == "__main__":

--- a/test/python/transpiler/test_commutative_inverse_cancellation.py
+++ b/test/python/transpiler/test_commutative_inverse_cancellation.py
@@ -19,7 +19,7 @@ import numpy as np
 from ddt import data, ddt
 
 from qiskit.circuit import Parameter, QuantumCircuit
-from qiskit.circuit.library import RZGate, UnitaryGate
+from qiskit.circuit.library import RZGate, UnitaryGate, U2Gate
 from qiskit.quantum_info import Operator
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.passes import CommutativeInverseCancellation
@@ -889,6 +889,21 @@ class TestCommutativeInverseCancellation(QiskitTestCase):
         passmanager = PassManager(CommutativeInverseCancellation(matrix_based=True, max_qubits=2))
         new_circuit = passmanager.run(circuit)
         self.assertEqual(circuit, new_circuit)
+
+    def test_2q_pauli_rot_with_non_cached(self):
+        """Test a cached 2q-Pauli rotation with a non-cached gate.
+
+        Regression test of #13742.
+        """
+        circuit = QuantumCircuit(2)
+        circuit.rxx(np.pi / 2, 1, 0)
+        circuit.append(U2Gate(np.pi / 2, -np.pi), [1])
+
+        pm = PassManager(CommutativeInverseCancellation())
+        tqc = pm.run(circuit)
+
+        self.assertEqual(tqc.count_ops().get("u2", 0), 1)
+        self.assertEqual(tqc.count_ops().get("rxx", 0), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #13742.

### Details and comments

Fix a bug ``CommutationChecker`` for `[2q Pauli rotations, a gate that is not in the cache]`, such as `[RXX, U]`. The issue was that the parameters of the Pauli rotations were set to `[]` because we assumed we can find the relation in the cache. However that's obviously not true, as there are gates that are neither rotations, nor in the cache.

