### PR TITLE
Use `OnceLock` in imports.

### DIFF
--- a/crates/accelerate/src/gate_direction.rs
+++ b/crates/accelerate/src/gate_direction.rs
@@ -219,11 +219,7 @@ fn py_fix_direction_target(
                             py,
                             None,
                             Some(qargs),
-                            Some(
-                                get_std_gate_class(py, std_gate)
-                                    .expect("These gates should have Python classes")
-                                    .bind(py),
-                            ),
+                            Some(get_std_gate_class(py, std_gate).bind(py)),
                             Some(inst.params_view().to_vec()),
                         )
                         .unwrap_or(false)

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -419,7 +419,7 @@ impl StandardGate {
         params: Option<&[Param]>,
         extra_attrs: &ExtraInstructionAttributes,
     ) -> PyResult<Py<PyAny>> {
-        let gate_class = get_std_gate_class(py, *self)?;
+        let gate_class = get_std_gate_class(py, *self);
         let args = match params.unwrap_or(&[]) {
             &[] => PyTuple::empty(py),
             params => PyTuple::new(py, params.iter().map(|x| x.into_pyobject(py).unwrap()))?,
@@ -715,7 +715,7 @@ impl StandardGate {
     }
 
     #[getter]
-    pub fn get_gate_class(&self, py: Python) -> PyResult<&'static Py<PyAny>> {
+    pub fn get_gate_class(&self, py: Python) -> &'static Py<PyAny> {
         get_std_gate_class(py, *self)
     }
 

--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -346,7 +346,7 @@ impl PackedOperation {
         let py = py_type.py();
         let py_op = match self.view() {
             OperationRef::Standard(standard) => {
-                return get_std_gate_class(py, standard)?
+                return get_std_gate_class(py, standard)
                     .bind(py)
                     .downcast::<PyType>()?
                     .is_subclass(py_type)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
It appears that `GILOnceCell` is not sufficient for module import and initialization. When running free-threaded Python in unit tests, CPython throws a `_DeadLockError` during module import. Even though `GILOnceCell` allows threads to race and the first one to finish gets the initialization, it appears that the import process itself is not reentrant.

### Details and comments
This may also require a bug report on PyO3, since its implementation of `GILOnceCell::import` does what we were doing previously.

This issue was discovered by @raynelfss when using Rust PyO3 tests on Linux.
