### PR TITLE
Fix barrier label position when bits are reversed

### DIFF
--- a/qiskit/visualization/circuit/text.py
+++ b/qiskit/visualization/circuit/text.py
@@ -1153,7 +1153,7 @@ class TextDrawing:
             if not self.plotbarriers:
                 return layer, current_cons, current_cons_cond, connection_label
 
-            top_qubit = min(node.qargs, key=lambda q: self._wire_map.get(q, float('inf')))
+            top_qubit = min(node.qargs, key=lambda q: self._wire_map.get(q, float("inf")))
             for qubit in node.qargs:
                 if qubit in self.qubits:
                     label = op.label if qubit == top_qubit else ""

--- a/qiskit/visualization/circuit/text.py
+++ b/qiskit/visualization/circuit/text.py
@@ -1153,9 +1153,9 @@ class TextDrawing:
             if not self.plotbarriers:
                 return layer, current_cons, current_cons_cond, connection_label
 
-            for i, qubit in enumerate(node.qargs):
+            for qubit in node.qargs:
                 if qubit in self.qubits:
-                    label = op.label if i == 0 else ""
+                    label = op.label if self._wire_map[qubit] == 0 else ""
                     layer.set_qubit(qubit, Barrier(label))
 
         elif isinstance(op, SwapGate):

--- a/qiskit/visualization/circuit/text.py
+++ b/qiskit/visualization/circuit/text.py
@@ -1153,9 +1153,10 @@ class TextDrawing:
             if not self.plotbarriers:
                 return layer, current_cons, current_cons_cond, connection_label
 
+            top_qubit = min(node.qargs, key=lambda q: self._wire_map.get(q, float('inf')))
             for qubit in node.qargs:
                 if qubit in self.qubits:
-                    label = op.label if self._wire_map[qubit] == 0 else ""
+                    label = op.label if qubit == top_qubit else ""
                     layer.set_qubit(qubit, Barrier(label))
 
         elif isinstance(op, SwapGate):

--- a/releasenotes/notes/barrier-label-position-reverse-bits-41819043ebb3d701.yaml
+++ b/releasenotes/notes/barrier-label-position-reverse-bits-41819043ebb3d701.yaml
@@ -2,7 +2,7 @@
 fixes:
   - |
     Fixed a bug where the barrier labels were incorrectly positioned when
-    using the ``reverse_bits = True`` parameter in the :meth:`.QuantumCircuit.draw()`
+    using the ``reverse_bits = True`` parameter in the :meth:`.QuantumCircuit.draw`
     method. The bug caused the labels on barrier operations to be misaligned,
     leading to potential confusion in circuit visualizations.
     Fixed `#13609 <https://github.com/Qiskit/qiskit/issues/13609>`__.

--- a/releasenotes/notes/barrier-label-position-reverse-bits-41819043ebb3d701.yaml
+++ b/releasenotes/notes/barrier-label-position-reverse-bits-41819043ebb3d701.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a bug where the barrier labels were incorrectly positioned when
+    using the ``reverse_bits = True`` parameter in the :meth:`.QuantumCircuit.draw()`
+    method. The bug caused the labels on barrier operations to be misaligned,
+    leading to potential confusion in circuit visualizations.
+    Fixed `#13609 <https://github.com/Qiskit/qiskit/issues/13609>`__.

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -1240,6 +1240,30 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit.barrier(label="End Y/X")
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
+    def test_text_barrier_label_reversed_bits(self):
+        """Show barrier label with reversed bits"""
+        expected = "\n".join(
+            [
+                "              ░ ┌───┐ End Y/X ",
+                "q_2: |0>──────░─┤ X ├────░────",
+                "        ┌───┐ ░ ├───┤    ░    ",
+                "q_1: |0>┤ Y ├─░─┤ Y ├────░────",
+                "        ├───┤ ░ └───┘    ░    ",
+                "q_0: |0>┤ X ├─░───────────────",
+                "        └───┘ ░               "
+            ]
+        )
+
+        qr = QuantumRegister(3, "q")
+        circuit = QuantumCircuit(qr)
+        circuit.x(0)
+        circuit.y(1)
+        circuit.barrier()
+        circuit.y(1)
+        circuit.x(2)
+        circuit.barrier([1, 2], label="End Y/X")
+        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True, reverse_bits=True)), expected)
+
     def test_text_overlap_cx(self):
         """Overlapping CX gates are drawn not overlapping"""
         expected = "\n".join(

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -1250,7 +1250,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
                 "q_1: |0>┤ Y ├─░─┤ Y ├────░────",
                 "        ├───┤ ░ └───┘    ░    ",
                 "q_0: |0>┤ X ├─░───────────────",
-                "        └───┘ ░               "
+                "        └───┘ ░               ",
             ]
         )
 
@@ -1262,7 +1262,10 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit.y(1)
         circuit.x(2)
         circuit.barrier([1, 2], label="End Y/X")
-        self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True, reverse_bits=True)), expected)
+        self.assertEqual(
+            str(circuit_drawer(circuit, output="text", initial_state=True, reverse_bits=True)),
+            expected,
+        )
 
     def test_text_overlap_cx(self):
         """Overlapping CX gates are drawn not overlapping"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Fixes: #13609 
Changed the way the barrier label is applied to qubits. Previously, we used the index of the qubit in `qargs` list to decide if a label should be added [here](https://github.com/Qiskit/qiskit/blob/52ba2a9ad81b21b77c1cbe9e9264358ec1cc50ad/qiskit/visualization/circuit/text.py#L1158). Now, the label is applied to the qubit with the smallest index in `_wire_map`, ensuring the label is based on the qubit's position in the `_wire_map` rather than its position in the `node.qargs` list


### Details and comments

Output:
```
      init ┌───┐      final 
q_0: ──░───┤ H ├──■─────░───
       ░   └───┘┌─┴─┐   ░   
q_1: ──░────────┤ X ├───░───
       ░        └───┘   ░   
      init      ┌───┐ final 
q_1: ──░────────┤ X ├───░───
       ░   ┌───┐└─┬─┘   ░   
q_0: ──░───┤ H ├──■─────░───
       ░   └───┘        ░   
```