### PR TITLE
ASV `time_param_circSU2_100_build` no longer needs to call `_build`.

### DIFF
--- a/test/benchmarks/circuit_construction.py
+++ b/test/benchmarks/circuit_construction.py
@@ -155,7 +155,6 @@ class ParameterizedCirc:
         circuit with 1000 parameters
         """
         out = efficient_su2(num_qubits, reps=4, entanglement="circular")
-        out._build()
         return out
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [xI have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
The following commits remove an invalid function call that would make `circuit_construction` tests fail on ASV.


### Details and comments

In the ASV test bench, a circuit construction test, `time_param_circSU2_100_build` which used to be implemented on top of a `BlueprintCircuit` no longer needs to call `_build`. The following commits remove this function call.
