### PR TITLE
Have `BlueprintCircuit.copy_empty_like` return an empty `QuantumCircuit`

### DIFF
--- a/qiskit/circuit/library/blueprintcircuit.py
+++ b/qiskit/circuit/library/blueprintcircuit.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 from qiskit._accelerate.circuit import CircuitData
-from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister
+from qiskit.circuit import QuantumRegister, ClassicalRegister
 from qiskit.circuit.parametertable import ParameterView
+from qiskit.circuit.quantumcircuit import QuantumCircuit, _copy_metadata
 
 
 class BlueprintCircuit(QuantumCircuit, ABC):
@@ -263,13 +264,8 @@ class BlueprintCircuit(QuantumCircuit, ABC):
         return super().num_connected_components(unitary_only=unitary_only)
 
     def copy_empty_like(self, name=None, *, vars_mode="alike"):
-        if not self._is_built:
-            self._build()
-        cpy = super().copy_empty_like(name=name, vars_mode=vars_mode)
-        # The base `copy_empty_like` will typically trigger code that `BlueprintCircuit` treats as
-        # an "invalidation", so we have to manually restore properties deleted by that that
-        # `copy_empty_like` is supposed to propagate.
-        cpy.global_phase = self.global_phase
+        cpy = QuantumCircuit(*self.qregs, *self.cregs, name=name, global_phase=self.global_phase)
+        _copy_metadata(self, cpy, vars_mode)
         return cpy
 
     def copy(self, name=None):

--- a/releasenotes/notes/fix-blueprint-copy-empty-a35d6b01cf1edf62.yaml
+++ b/releasenotes/notes/fix-blueprint-copy-empty-a35d6b01cf1edf62.yaml
@@ -1,7 +1,9 @@
 ---
-fixes:
+upgrade:
   - |
-    Fixed a bug with :meth:`.BlueprintCircuit.copy_empty_like`, where the supposedly empty copy
-    would rebuild the original circuit. The method now returns a plain :class:`.QuantumCircuit`
-    instead of a :meth:`.BlueprintCircuit`, which guarantees that the output circuit is indeed empty.
-    Fixed `#13535 <https://github.com/Qiskit/qiskit/issues/13535>`__.
+    :meth:`.BlueprintCircuit.copy_empty_like` now returns an empty :class:`.QuantumCircuit` 
+    with the same number of qubits/clbits and the same metadata as the original circuit, instead 
+    of a :class:`.BlueprintCircuit`. This change is to mitigate unexpected behavior where dealing 
+    with an "empty" copy of a blueprint circuit would re-build the circuit data.
+    Note that :meth:`.BlueprintCircuit.copy` still returns a :class:`.BlueprintCircuit`.
+    Related: `#13535 <https://github.com/Qiskit/qiskit/issues/13535>`__

--- a/releasenotes/notes/fix-blueprint-copy-empty-a35d6b01cf1edf62.yaml
+++ b/releasenotes/notes/fix-blueprint-copy-empty-a35d6b01cf1edf62.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a bug with :meth:`.BlueprintCircuit.copy_empty_like`, where the supposedly empty copy
+    would rebuild the original circuit. The method now returns a plain :class:`.QuantumCircuit`
+    instead of a :meth:`.BlueprintCircuit`, which guarantees that the output circuit is indeed empty.
+    Fixed `#13535 <https://github.com/Qiskit/qiskit/issues/13535>`__.

--- a/test/python/circuit/library/test_blueprintcircuit.py
+++ b/test/python/circuit/library/test_blueprintcircuit.py
@@ -219,23 +219,30 @@ class TestBlueprintCircuit(QiskitTestCase):
         circuit.metadata = {"my_legacy": "i was a blueprintcircuit once"}
 
         cpy = circuit.copy_empty_like()
+        cpy.x(0)  # if it were a BlueprintCircuit, this would trigger the building
+
         expected = QuantumCircuit(
             circuit.num_qubits, global_phase=circuit.global_phase, metadata=circuit.metadata
         )
+        expected.x(0)
+
         self.assertEqual(cpy, expected)
         self.assertNotIsInstance(cpy, BlueprintCircuit)
 
     def test_copy_empty_like_post_build(self):
         """Test copying empty-like after building the circuit."""
         circuit = EfficientSU2(2)
-        _ = circuit.count_ops()  # trigger building the circuit
+        num_params = circuit.num_parameters  # trigger building the circuit
 
         cpy = circuit.copy_empty_like()
+        cpy_num_params = cpy.num_parameters  # if it were a BP circuit, this would trigger the build
 
         circuit.num_qubits = 3  # change the original circuit
 
         expected = QuantumCircuit(2)  # we still expect an empty 2-qubit circuit
         self.assertEqual(cpy, expected)
+        self.assertEqual(cpy_num_params, 0)
+        self.assertEqual(num_params, 16)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #13535.

### Details and comments

The `BlueprintCircuit.copy_empty_like` method currently returns another instance of a `BlueprintCircuit` with it's definition wiped. That means that the definition would just be re-built if any circuit method was called, and the circuit wasn't really empty. As discussed in #13535 fixes this by returning a `QuantumCircuit` type, not a `BlueprintCircuit` anymore.
