### PR TITLE
Deprecate `qiskit.circuit.classicalfunction`

### DIFF
--- a/qiskit/circuit/classicalfunction/__init__.py
+++ b/qiskit/circuit/classicalfunction/__init__.py
@@ -128,7 +128,9 @@ from .boolean_expression import BooleanExpression
 @deprecate_func(
     since="1.4",
     removal_timeline="in Qiskit 2.0",
-    additional_msg="Use `PhaseOracle` or `BitFlipOracle` instead",
+    additional_msg="Use `PhaseOracle` instead, which can be turned into a "
+    "bit-flip oracle by applying Hadamard gates on the target "
+    "qubit before and after the instruction.",
 )
 def classical_function(func):
     """

--- a/qiskit/circuit/classicalfunction/__init__.py
+++ b/qiskit/circuit/classicalfunction/__init__.py
@@ -130,7 +130,8 @@ from .boolean_expression import BooleanExpression
     removal_timeline="in Qiskit 2.0",
     additional_msg="Use `PhaseOracle` instead, which can be turned into a "
     "bit-flip oracle by applying Hadamard gates on the target "
-    "qubit before and after the instruction.",
+    "qubit before and after the instruction, and conditioning."
+    "the instruction on the target qubit.",
 )
 def classical_function(func):
     """

--- a/qiskit/circuit/classicalfunction/__init__.py
+++ b/qiskit/circuit/classicalfunction/__init__.py
@@ -20,6 +20,10 @@ ClassicalFunction compiler (:mod:`qiskit.circuit.classicalfunction`)
 Overview
 ========
 
+.. warning::
+    
+    This module is deprecated as of qiskit 1.4.0 version. It will be removed in the Qiskit 2.0 release.
+
 The classical function compiler provides the necessary tools to map a classical
 potentially irreversible functions into quantum circuits.  Below is a simple example of
 how to synthesize a simple boolean function defined using Python into a

--- a/qiskit/circuit/classicalfunction/__init__.py
+++ b/qiskit/circuit/classicalfunction/__init__.py
@@ -128,7 +128,7 @@ from .boolean_expression import BooleanExpression
 @deprecate_func(
     since="1.4",
     removal_timeline="in Qiskit 2.0",
-    additional_msg="Use `BooleanExpression` instead",
+    additional_msg="Use `PhaseOracle` or `BitFlipOracle` instead",
 )
 def classical_function(func):
     """

--- a/qiskit/circuit/classicalfunction/__init__.py
+++ b/qiskit/circuit/classicalfunction/__init__.py
@@ -22,7 +22,7 @@ Overview
 
 .. warning::
     
-    This module is deprecated as of qiskit 1.4.0 version. It will be removed in the Qiskit 2.0 release.
+    This module is deprecated as of Qiskit 1.4.0. It will be removed in the Qiskit 2.0 release.
 
 The classical function compiler provides the necessary tools to map a classical
 potentially irreversible functions into quantum circuits.  Below is a simple example of

--- a/qiskit/circuit/classicalfunction/__init__.py
+++ b/qiskit/circuit/classicalfunction/__init__.py
@@ -111,7 +111,7 @@ Exceptions
    ClassicalFunctionCompilerTypeError
 
 """
-
+from qiskit.utils.deprecation import deprecate_func
 from .classicalfunction import ClassicalFunction
 from .exceptions import (
     ClassicalFunctionParseError,
@@ -121,6 +121,11 @@ from .exceptions import (
 from .boolean_expression import BooleanExpression
 
 
+@deprecate_func(
+    since="1.4",
+    removal_timeline="in Qiskit 2.0",
+    additional_msg="Use `BooleanExpression` instead",
+)
 def classical_function(func):
     """
     Parses and type checks the callable ``func`` to compile it into an ``ClassicalFunction``

--- a/qiskit/circuit/classicalfunction/boolean_expression.py
+++ b/qiskit/circuit/classicalfunction/boolean_expression.py
@@ -15,15 +15,20 @@
 from os.path import basename, isfile
 from typing import Callable, Optional
 
+from qiskit.utils.deprecation import deprecate_func
 from qiskit.circuit import QuantumCircuit
 from qiskit.utils.optionals import HAS_TWEEDLEDUM
 from .classical_element import ClassicalElement
 
-
-@HAS_TWEEDLEDUM.require_in_instance
 class BooleanExpression(ClassicalElement):
     """The Boolean Expression gate."""
 
+    @HAS_TWEEDLEDUM.require_in_instance
+    @deprecate_func(
+        since="1.4",
+        removal_timeline="in Qiskit 2.0",
+        additional_msg="Use `PhaseOracle` or `BitFlipOracle` instead",
+    )
     def __init__(self, expression: str, name: str = None, var_order: list = None) -> None:
         """
         Args:

--- a/qiskit/circuit/classicalfunction/boolean_expression.py
+++ b/qiskit/circuit/classicalfunction/boolean_expression.py
@@ -20,6 +20,7 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.utils.optionals import HAS_TWEEDLEDUM
 from .classical_element import ClassicalElement
 
+
 class BooleanExpression(ClassicalElement):
     """The Boolean Expression gate."""
 

--- a/qiskit/circuit/classicalfunction/boolean_expression.py
+++ b/qiskit/circuit/classicalfunction/boolean_expression.py
@@ -30,7 +30,8 @@ class BooleanExpression(ClassicalElement):
         removal_timeline="in Qiskit 2.0",
         additional_msg="Use `PhaseOracle` instead, which can be turned into a "
         "bit-flip oracle by applying Hadamard gates on the target "
-        "qubit before and after the instruction.",
+        "qubit before and after the instruction, and conditioning."
+        "the instruction on the target qubit.",
     )
     def __init__(self, expression: str, name: str = None, var_order: list = None) -> None:
         """

--- a/qiskit/circuit/classicalfunction/boolean_expression.py
+++ b/qiskit/circuit/classicalfunction/boolean_expression.py
@@ -28,7 +28,9 @@ class BooleanExpression(ClassicalElement):
     @deprecate_func(
         since="1.4",
         removal_timeline="in Qiskit 2.0",
-        additional_msg="Use `PhaseOracle` or `BitFlipOracle` instead",
+        additional_msg="Use `PhaseOracle` instead, which can be turned into a "
+        "bit-flip oracle by applying Hadamard gates on the target "
+        "qubit before and after the instruction.",
     )
     def __init__(self, expression: str, name: str = None, var_order: list = None) -> None:
         """

--- a/qiskit/circuit/classicalfunction/classicalfunction.py
+++ b/qiskit/circuit/classicalfunction/classicalfunction.py
@@ -31,7 +31,9 @@ class ClassicalFunction(ClassicalElement):
     @deprecate_func(
         since="1.4",
         removal_timeline="in Qiskit 2.0",
-        additional_msg="Use `PhaseOracle` or `BitFlipOracle` instead",
+        additional_msg="Use `PhaseOracle` instead, which can be turned into a "
+        "bit-flip oracle by applying Hadamard gates on the target "
+        "qubit before and after the instruction.",
     )
     def __init__(self, source, name=None):
         """Creates a ``ClassicalFunction`` from Python source code in ``source``.

--- a/qiskit/circuit/classicalfunction/classicalfunction.py
+++ b/qiskit/circuit/classicalfunction/classicalfunction.py
@@ -15,6 +15,7 @@
 import ast
 from typing import Callable, Optional
 
+from qiskit.utils.deprecation import deprecate_func
 from qiskit.circuit import QuantumCircuit, QuantumRegister
 from qiskit.exceptions import QiskitError
 from qiskit.utils.optionals import HAS_TWEEDLEDUM
@@ -23,10 +24,15 @@ from .classical_function_visitor import ClassicalFunctionVisitor
 from .utils import tweedledum2qiskit
 
 
-@HAS_TWEEDLEDUM.require_in_instance
 class ClassicalFunction(ClassicalElement):
     """Represent a classical function and its logic network."""
 
+    @HAS_TWEEDLEDUM.require_in_instance
+    @deprecate_func(
+        since="1.4",
+        removal_timeline="in Qiskit 2.0",
+        additional_msg="Use `BooleanExpression` instead",
+    )
     def __init__(self, source, name=None):
         """Creates a ``ClassicalFunction`` from Python source code in ``source``.
 

--- a/qiskit/circuit/classicalfunction/classicalfunction.py
+++ b/qiskit/circuit/classicalfunction/classicalfunction.py
@@ -33,7 +33,8 @@ class ClassicalFunction(ClassicalElement):
         removal_timeline="in Qiskit 2.0",
         additional_msg="Use `PhaseOracle` instead, which can be turned into a "
         "bit-flip oracle by applying Hadamard gates on the target "
-        "qubit before and after the instruction.",
+        "qubit before and after the instruction, and conditioning."
+        "the instruction on the target qubit.",
     )
     def __init__(self, source, name=None):
         """Creates a ``ClassicalFunction`` from Python source code in ``source``.

--- a/qiskit/circuit/classicalfunction/classicalfunction.py
+++ b/qiskit/circuit/classicalfunction/classicalfunction.py
@@ -31,7 +31,7 @@ class ClassicalFunction(ClassicalElement):
     @deprecate_func(
         since="1.4",
         removal_timeline="in Qiskit 2.0",
-        additional_msg="Use `BooleanExpression` instead",
+        additional_msg="Use `PhaseOracle` or `BitFlipOracle` instead",
     )
     def __init__(self, source, name=None):
         """Creates a ``ClassicalFunction`` from Python source code in ``source``.

--- a/qiskit/circuit/classicalfunction/exceptions.py
+++ b/qiskit/circuit/classicalfunction/exceptions.py
@@ -10,7 +10,13 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Exceptions for ClassicalFunction compiler"""
+"""Exceptions for ClassicalFunction compiler
+
+.. warning::
+    
+    This module is deprecated as of qiskit 1.4.0 version. It will be removed in the Qiskit 2.0 release.
+
+"""
 
 from qiskit.exceptions import QiskitError
 

--- a/qiskit/circuit/library/phase_oracle.py
+++ b/qiskit/circuit/library/phase_oracle.py
@@ -63,6 +63,11 @@ class PhaseOracle(QuantumCircuit):
             var_order(list): A list with the order in which variables will be created.
                (default: by appearance)
         """
+        # ignore deprecation warning for BooleanExpression; implementation is changing in 2.0
+        import warnings
+
+        warnings.simplefilter("ignore", DeprecationWarning)
+
         from qiskit.circuit.classicalfunction.boolean_expression import BooleanExpression
         from qiskit.circuit.classicalfunction.classical_element import ClassicalElement
 

--- a/releasenotes/notes/deprecate-classical-function-3bf44ef26d984366.yaml
+++ b/releasenotes/notes/deprecate-classical-function-3bf44ef26d984366.yaml
@@ -2,10 +2,11 @@
 deprecations_circuits:
   - |
     The :mod:`qiskit.circuit.classicalfunction` and with it
-    the :class:`.ClassicalFunction` and its related :func:`.classical_function`
-    have been deprecated as of Qiskit 1.4 and will be removed in Qiskit 2.0.
-    This change is done to avoid a dependency on the external library `tweedledum`,
-    which is no longer compatible with all of Qiskit's supported platforms and 
-    Python versions.
-    For a similar functionality please use the :class:`.BooleanExpression` which
-    is going to have a `tweedledum` independent implementation..
+    the :class:`.ClassicalFunction`, its related :func:`.classical_function`
+    and :class:`.BooleanExpression` have been deprecated as of Qiskit 1.4 
+    and will be removed in Qiskit 2.0. This change is done to avoid a 
+    dependency on the external library `tweedledum`, which is no longer 
+    compatible with all of Qiskit's supported platforms and Python versions.
+    For a similar functionality please use the :class:`.PhaseOracle` which
+    is going to have a `tweedledum` independent implementation, and
+    the :class:`.BitFlipOracle` which will be added in Qiskit 2.0.

--- a/releasenotes/notes/deprecate-classical-function-3bf44ef26d984366.yaml
+++ b/releasenotes/notes/deprecate-classical-function-3bf44ef26d984366.yaml
@@ -1,0 +1,5 @@
+---
+deprecations_circuits:
+  - |
+    The :class:`.ClassicalFunction` and its related :meth:`.classical_function`
+    have been deprecated as of Qiskit 1.4 and will be removed in Qiskit 2.0.

--- a/releasenotes/notes/deprecate-classical-function-3bf44ef26d984366.yaml
+++ b/releasenotes/notes/deprecate-classical-function-3bf44ef26d984366.yaml
@@ -4,6 +4,8 @@ deprecations_circuits:
     The :mod:`qiskit.circuit.classicalfunction` and with it
     the :class:`.ClassicalFunction` and its related :func:`.classical_function`
     have been deprecated as of Qiskit 1.4 and will be removed in Qiskit 2.0.
-    This change is done to stop relying on the `tweedledum` external library.
+    This change is done to avoid a dependency on the external library `tweedledum`,
+    which is no longer compatible with all of Qiskit's supported platforms and 
+    Python versions.
     For a similar functionality please use the :class:`.BooleanExpression` which
     is going to have a `tweedledum` independent implementation..

--- a/releasenotes/notes/deprecate-classical-function-3bf44ef26d984366.yaml
+++ b/releasenotes/notes/deprecate-classical-function-3bf44ef26d984366.yaml
@@ -10,3 +10,16 @@ deprecations_circuits:
     For a similar functionality please use the :class:`.PhaseOracle` which
     is going to have a `tweedledum` independent implementation, and
     the :class:`.BitFlipOracle` which will be added in Qiskit 2.0.
+
+    Until :class:`.BitFlipOracle` is added, a phase flip oracle can be converted
+    to a bit flip oracle by conditioning it on the result qubit, and applying 
+    Hadamard gate before and after the application of the oracle, as in the
+    following example (where the oracle is on `qr_x` and the result is on `qr_y`):
+
+    .. code-block:: python
+    
+        phase_flip_oracle = PhaseOracle(bool_expr)
+        controlled_phase_flip_oracle = phase_flip_oracle.control(1)
+        qc.h(qr_y)
+        qc.compose(controlled_phase_flip_oracle, qubits=[*qr_y, *qr_x], inplace=True)
+        qc.h(qr_y)

--- a/releasenotes/notes/deprecate-classical-function-3bf44ef26d984366.yaml
+++ b/releasenotes/notes/deprecate-classical-function-3bf44ef26d984366.yaml
@@ -5,5 +5,5 @@ deprecations_circuits:
     the :class:`.ClassicalFunction` and its related :func:`.classical_function`
     have been deprecated as of Qiskit 1.4 and will be removed in Qiskit 2.0.
     This change is done to stop relying on the `tweedledum` external library.
-    For a similar functionality please use the :class:`BooleanExpression` which
+    For a similar functionality please use the :class:`.BooleanExpression` which
     is going to have a `tweedledum` independent implementation..

--- a/releasenotes/notes/deprecate-classical-function-3bf44ef26d984366.yaml
+++ b/releasenotes/notes/deprecate-classical-function-3bf44ef26d984366.yaml
@@ -1,5 +1,9 @@
 ---
 deprecations_circuits:
   - |
-    The :class:`.ClassicalFunction` and its related :meth:`.classical_function`
+    The :mod:`qiskit.circuit.classicalfunction` and with it
+    the :class:`.ClassicalFunction` and its related :func:`.classical_function`
     have been deprecated as of Qiskit 1.4 and will be removed in Qiskit 2.0.
+    This change is done to stop relying on the `tweedledum` external library.
+    For a similar functionality please use the :class:`BooleanExpression` which
+    is going to have a `tweedledum` independent implementation..

--- a/releasenotes/notes/deprecate-classical-function-3bf44ef26d984366.yaml
+++ b/releasenotes/notes/deprecate-classical-function-3bf44ef26d984366.yaml
@@ -37,6 +37,7 @@ deprecations_circuits:
     Which results in
 
     .. code-block:: text
+    
                 ┌───────────────┐     
       x_0: ─────┤0              ├─────
                 │               │     

--- a/releasenotes/notes/deprecate-classical-function-3bf44ef26d984366.yaml
+++ b/releasenotes/notes/deprecate-classical-function-3bf44ef26d984366.yaml
@@ -18,8 +18,33 @@ deprecations_circuits:
 
     .. code-block:: python
     
-        phase_flip_oracle = PhaseOracle(bool_expr)
-        controlled_phase_flip_oracle = phase_flip_oracle.control(1)
-        qc.h(qr_y)
-        qc.compose(controlled_phase_flip_oracle, qubits=[*qr_y, *qr_x], inplace=True)
-        qc.h(qr_y)
+      from qiskit import QuantumRegister, QuantumCircuit
+      from qiskit.circuit.library.phase_oracle import PhaseOracle
+
+      bool_expr = "(x0 & x1 | ~x2) & x4"
+      qr_x = QuantumRegister(4, "x")
+      qr_y = QuantumRegister(1, "y")
+
+      bit_flip_oracle = QuantumCircuit(qr_x, qr_y)
+      phase_flip_oracle = PhaseOracle(bool_expr)
+      controlled_phase_flip_oracle = phase_flip_oracle.control(1)
+      bit_flip_oracle.h(qr_y)
+      bit_flip_oracle.compose(controlled_phase_flip_oracle, qubits=[*qr_y, *qr_x], inplace=True)
+      bit_flip_oracle.h(qr_y)
+
+      print(bit_flip_oracle)
+    
+    Which results in
+
+    .. code-block:: text
+                ┌───────────────┐     
+      x_0: ─────┤0              ├─────
+                │               │     
+      x_1: ─────┤1              ├─────
+                │  Phase Oracle │     
+      x_2: ─────┤2              ├─────
+                │               │     
+      x_3: ─────┤3              ├─────
+          ┌───┐└───────┬───────┘┌───┐
+       y: ┤ H ├────────■────────┤ H ├
+          └───┘                 └───┘

--- a/test/python/circuit/library/test_phase_oracle.py
+++ b/test/python/circuit/library/test_phase_oracle.py
@@ -39,7 +39,7 @@ class TestPhaseOracle(QiskitTestCase):
         """PhaseOracle(...).evaluate_bitstring"""
         with self.assertWarnsRegex(
             DeprecationWarning,
-            expected_regex="BooleanExpression`` is deprecated as of Qiskit 1.4",
+            expected_regex="BooleanExpression`` is deprecated as of qiskit 1.4",
         ):
             oracle = PhaseOracle(expression)
         result = oracle.evaluate_bitstring(input_bitstring)
@@ -56,7 +56,7 @@ class TestPhaseOracle(QiskitTestCase):
         """Circuit generation"""
         with self.assertWarnsRegex(
             DeprecationWarning,
-            expected_regex="BooleanExpression`` is deprecated as of Qiskit 1.4",
+            expected_regex="BooleanExpression`` is deprecated as of qiskit 1.4",
         ):
             oracle = PhaseOracle(expression)
         num_qubits = oracle.num_qubits
@@ -86,7 +86,7 @@ class TestPhaseOracle(QiskitTestCase):
         """Circuit generation"""
         with self.assertWarnsRegex(
             DeprecationWarning,
-            expected_regex="BooleanExpression`` is deprecated as of Qiskit 1.4",
+            expected_regex="BooleanExpression`` is deprecated as of qiskit 1.4",
         ):
             oracle = PhaseOracle(expression, var_order=var_order)
         num_qubits = oracle.num_qubits

--- a/test/python/circuit/library/test_phase_oracle.py
+++ b/test/python/circuit/library/test_phase_oracle.py
@@ -37,7 +37,11 @@ class TestPhaseOracle(QiskitTestCase):
     @unpack
     def test_evaluate_bitstring(self, expression, input_bitstring, expected):
         """PhaseOracle(...).evaluate_bitstring"""
-        oracle = PhaseOracle(expression)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="BooleanExpression`` is deprecated as of Qiskit 1.4",
+        ):
+            oracle = PhaseOracle(expression)
         result = oracle.evaluate_bitstring(input_bitstring)
         self.assertEqual(result, expected)
 
@@ -50,7 +54,11 @@ class TestPhaseOracle(QiskitTestCase):
     @unpack
     def test_statevector(self, expression, good_states):
         """Circuit generation"""
-        oracle = PhaseOracle(expression)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="BooleanExpression`` is deprecated as of Qiskit 1.4",
+        ):
+            oracle = PhaseOracle(expression)
         num_qubits = oracle.num_qubits
         circuit = QuantumCircuit(num_qubits)
         circuit.h(range(num_qubits))
@@ -76,7 +84,11 @@ class TestPhaseOracle(QiskitTestCase):
     @unpack
     def test_variable_order(self, expression, var_order, good_states):
         """Circuit generation"""
-        oracle = PhaseOracle(expression, var_order=var_order)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="BooleanExpression`` is deprecated as of Qiskit 1.4",
+        ):
+            oracle = PhaseOracle(expression, var_order=var_order)
         num_qubits = oracle.num_qubits
         circuit = QuantumCircuit(num_qubits)
         circuit.h(range(num_qubits))

--- a/test/python/circuit/library/test_phase_oracle.py
+++ b/test/python/circuit/library/test_phase_oracle.py
@@ -37,11 +37,7 @@ class TestPhaseOracle(QiskitTestCase):
     @unpack
     def test_evaluate_bitstring(self, expression, input_bitstring, expected):
         """PhaseOracle(...).evaluate_bitstring"""
-        with self.assertWarnsRegex(
-            DeprecationWarning,
-            expected_regex="BooleanExpression`` is deprecated as of qiskit 1.4",
-        ):
-            oracle = PhaseOracle(expression)
+        oracle = PhaseOracle(expression)
         result = oracle.evaluate_bitstring(input_bitstring)
         self.assertEqual(result, expected)
 
@@ -54,11 +50,7 @@ class TestPhaseOracle(QiskitTestCase):
     @unpack
     def test_statevector(self, expression, good_states):
         """Circuit generation"""
-        with self.assertWarnsRegex(
-            DeprecationWarning,
-            expected_regex="BooleanExpression`` is deprecated as of qiskit 1.4",
-        ):
-            oracle = PhaseOracle(expression)
+        oracle = PhaseOracle(expression)
         num_qubits = oracle.num_qubits
         circuit = QuantumCircuit(num_qubits)
         circuit.h(range(num_qubits))
@@ -84,11 +76,7 @@ class TestPhaseOracle(QiskitTestCase):
     @unpack
     def test_variable_order(self, expression, var_order, good_states):
         """Circuit generation"""
-        with self.assertWarnsRegex(
-            DeprecationWarning,
-            expected_regex="BooleanExpression`` is deprecated as of qiskit 1.4",
-        ):
-            oracle = PhaseOracle(expression, var_order=var_order)
+        oracle = PhaseOracle(expression, var_order=var_order)
         num_qubits = oracle.num_qubits
         circuit = QuantumCircuit(num_qubits)
         circuit.h(range(num_qubits))

--- a/test/python/classical_function_compiler/test_boolean_expression.py
+++ b/test/python/classical_function_compiler/test_boolean_expression.py
@@ -42,7 +42,7 @@ class TestBooleanExpression(QiskitTestCase):
         """Test simulate"""
         with self.assertWarnsRegex(
             DeprecationWarning,
-            expected_regex="BooleanExpression`` is deprecated as of Qiskit 1.4",
+            expected_regex="BooleanExpression`` is deprecated as of qiskit 1.4",
         ):
             expression = BooleanExpression(expression)
         result = expression.simulate(input_bitstring)
@@ -59,7 +59,7 @@ class TestBooleanExpression(QiskitTestCase):
         """Test synth"""
         with self.assertWarnsRegex(
             DeprecationWarning,
-            expected_regex="BooleanExpression`` is deprecated as of Qiskit 1.4",
+            expected_regex="BooleanExpression`` is deprecated as of qiskit 1.4",
         ):
             expression = BooleanExpression(expression)
         expr_circ = expression.synth()

--- a/test/python/classical_function_compiler/test_boolean_expression.py
+++ b/test/python/classical_function_compiler/test_boolean_expression.py
@@ -40,7 +40,11 @@ class TestBooleanExpression(QiskitTestCase):
     @unpack
     def test_evaluate(self, expression, input_bitstring, expected):
         """Test simulate"""
-        expression = BooleanExpression(expression)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="BooleanExpression`` is deprecated as of Qiskit 1.4",
+        ):
+            expression = BooleanExpression(expression)
         result = expression.simulate(input_bitstring)
         self.assertEqual(result, expected)
 
@@ -53,7 +57,11 @@ class TestBooleanExpression(QiskitTestCase):
     @unpack
     def test_synth(self, expression, expected):
         """Test synth"""
-        expression = BooleanExpression(expression)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="BooleanExpression`` is deprecated as of Qiskit 1.4",
+        ):
+            expression = BooleanExpression(expression)
         expr_circ = expression.synth()
 
         new_creg = expr_circ._create_creg(1, "c")

--- a/test/python/classical_function_compiler/test_classical_function.py
+++ b/test/python/classical_function_compiler/test_classical_function.py
@@ -33,7 +33,7 @@ class TestOracleDecomposition(QiskitTestCase):
         """grover_oracle.decomposition"""
         with self.assertWarnsRegex(
             DeprecationWarning,
-            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+            expected_regex="ClassicalFunction`` is deprecated as of qiskit 1.4",
         ):
             oracle = compile_classical_function(examples.grover_oracle)
         quantum_circuit = QuantumCircuit(5)

--- a/test/python/classical_function_compiler/test_classical_function.py
+++ b/test/python/classical_function_compiler/test_classical_function.py
@@ -31,7 +31,11 @@ class TestOracleDecomposition(QiskitTestCase):
 
     def test_grover_oracle(self):
         """grover_oracle.decomposition"""
-        oracle = compile_classical_function(examples.grover_oracle)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+        ):
+            oracle = compile_classical_function(examples.grover_oracle)
         quantum_circuit = QuantumCircuit(5)
         quantum_circuit.append(oracle, [2, 1, 0, 3, 4])
 

--- a/test/python/classical_function_compiler/test_parse.py
+++ b/test/python/classical_function_compiler/test_parse.py
@@ -35,23 +35,39 @@ class TestParseFail(QiskitTestCase):
     def test_id_bad_return(self):
         """Trying to parse examples.id_bad_return raises ClassicalFunctionParseError"""
         with self.assertRaises(ClassicalFunctionParseError) as context:
-            compile_classical_function(examples.id_bad_return)
+            with self.assertWarnsRegex(
+                DeprecationWarning,
+                expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+            ):
+                compile_classical_function(examples.id_bad_return)
         self.assertExceptionMessage(context, "return type error")
 
     def test_id_no_type_arg(self):
         """Trying to parse examples.id_no_type_arg raises ClassicalFunctionParseError"""
         with self.assertRaises(ClassicalFunctionParseError) as context:
-            compile_classical_function(examples.id_no_type_arg)
+            with self.assertWarnsRegex(
+                DeprecationWarning,
+                expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+            ):
+                compile_classical_function(examples.id_no_type_arg)
         self.assertExceptionMessage(context, "argument type is needed")
 
     def test_id_no_type_return(self):
         """Trying to parse examples.id_no_type_return raises ClassicalFunctionParseError"""
         with self.assertRaises(ClassicalFunctionParseError) as context:
-            compile_classical_function(examples.id_no_type_return)
+            with self.assertWarnsRegex(
+                DeprecationWarning,
+                expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+            ):
+                compile_classical_function(examples.id_no_type_return)
         self.assertExceptionMessage(context, "return type is needed")
 
     def test_out_of_scope(self):
         """Trying to parse examples.out_of_scope raises ClassicalFunctionParseError"""
         with self.assertRaises(ClassicalFunctionParseError) as context:
-            compile_classical_function(examples.out_of_scope)
+            with self.assertWarnsRegex(
+                DeprecationWarning,
+                expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+            ):
+                compile_classical_function(examples.out_of_scope)
         self.assertExceptionMessage(context, "out of scope: c")

--- a/test/python/classical_function_compiler/test_simulate.py
+++ b/test/python/classical_function_compiler/test_simulate.py
@@ -34,7 +34,7 @@ class TestSimulate(QiskitTestCase):
         """Tests LogicSimulate.simulate() on all the examples"""
         with self.assertWarnsRegex(
             DeprecationWarning,
-            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+            expected_regex="ClassicalFunction`` is deprecated as of qiskit 1.4",
         ):
             network = compile_classical_function(a_callable)
         truth_table = network.simulate_all()

--- a/test/python/classical_function_compiler/test_simulate.py
+++ b/test/python/classical_function_compiler/test_simulate.py
@@ -32,6 +32,10 @@ class TestSimulate(QiskitTestCase):
     @data(*utils.example_list())
     def test_(self, a_callable):
         """Tests LogicSimulate.simulate() on all the examples"""
-        network = compile_classical_function(a_callable)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+        ):
+            network = compile_classical_function(a_callable)
         truth_table = network.simulate_all()
         self.assertEqual(truth_table, utils.get_truthtable_from_function(a_callable))

--- a/test/python/classical_function_compiler/test_synthesis.py
+++ b/test/python/classical_function_compiler/test_synthesis.py
@@ -31,7 +31,11 @@ class TestSynthesis(QiskitTestCase):
 
     def test_grover_oracle(self):
         """Synthesis of grover_oracle example"""
-        oracle = compile_classical_function(examples.grover_oracle)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+        ):
+            oracle = compile_classical_function(examples.grover_oracle)
         quantum_circuit = oracle.synth()
 
         expected = QuantumCircuit(5)
@@ -42,7 +46,11 @@ class TestSynthesis(QiskitTestCase):
 
     def test_grover_oracle_arg_regs(self):
         """Synthesis of grover_oracle example with arg_regs"""
-        oracle = compile_classical_function(examples.grover_oracle)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+        ):
+            oracle = compile_classical_function(examples.grover_oracle)
         quantum_circuit = oracle.synth(registerless=False)
 
         qr_a = QuantumRegister(1, "a")

--- a/test/python/classical_function_compiler/test_synthesis.py
+++ b/test/python/classical_function_compiler/test_synthesis.py
@@ -33,7 +33,7 @@ class TestSynthesis(QiskitTestCase):
         """Synthesis of grover_oracle example"""
         with self.assertWarnsRegex(
             DeprecationWarning,
-            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+            expected_regex="ClassicalFunction`` is deprecated as of qiskit 1.4",
         ):
             oracle = compile_classical_function(examples.grover_oracle)
         quantum_circuit = oracle.synth()
@@ -48,7 +48,7 @@ class TestSynthesis(QiskitTestCase):
         """Synthesis of grover_oracle example with arg_regs"""
         with self.assertWarnsRegex(
             DeprecationWarning,
-            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+            expected_regex="ClassicalFunction`` is deprecated as of qiskit 1.4",
         ):
             oracle = compile_classical_function(examples.grover_oracle)
         quantum_circuit = oracle.synth(registerless=False)

--- a/test/python/classical_function_compiler/test_typecheck.py
+++ b/test/python/classical_function_compiler/test_typecheck.py
@@ -30,19 +30,31 @@ class TestTypeCheck(QiskitTestCase):
 
     def test_id(self):
         """Tests examples.identity type checking"""
-        network = compile_classical_function(examples.identity)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+        ):
+            network = compile_classical_function(examples.identity)
         self.assertEqual(network.args, ["a"])
         self.assertEqual(network.types, [{"Int1": "type", "a": "Int1", "return": "Int1"}])
 
     def test_bool_not(self):
         """Tests examples.bool_not type checking"""
-        network = compile_classical_function(examples.bool_not)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+        ):
+            network = compile_classical_function(examples.bool_not)
         self.assertEqual(network.args, ["a"])
         self.assertEqual(network.types, [{"Int1": "type", "a": "Int1", "return": "Int1"}])
 
     def test_id_assign(self):
         """Tests examples.id_assing type checking"""
-        network = compile_classical_function(examples.id_assing)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+        ):
+            network = compile_classical_function(examples.id_assing)
         self.assertEqual(network.args, ["a"])
         self.assertEqual(
             network.types, [{"Int1": "type", "a": "Int1", "b": "Int1", "return": "Int1"}]
@@ -50,7 +62,11 @@ class TestTypeCheck(QiskitTestCase):
 
     def test_bit_and(self):
         """Tests examples.bit_and type checking"""
-        network = compile_classical_function(examples.bit_and)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+        ):
+            network = compile_classical_function(examples.bit_and)
         self.assertEqual(network.args, ["a", "b"])
         self.assertEqual(
             network.types, [{"Int1": "type", "a": "Int1", "b": "Int1", "return": "Int1"}]
@@ -58,7 +74,11 @@ class TestTypeCheck(QiskitTestCase):
 
     def test_bit_or(self):
         """Tests examples.bit_or type checking"""
-        network = compile_classical_function(examples.bit_or)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+        ):
+            network = compile_classical_function(examples.bit_or)
         self.assertEqual(network.args, ["a", "b"])
         self.assertEqual(
             network.types, [{"Int1": "type", "a": "Int1", "b": "Int1", "return": "Int1"}]
@@ -66,7 +86,11 @@ class TestTypeCheck(QiskitTestCase):
 
     def test_bool_or(self):
         """Tests examples.bool_or type checking"""
-        network = compile_classical_function(examples.bool_or)
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+        ):
+            network = compile_classical_function(examples.bool_or)
         self.assertEqual(network.args, ["a", "b"])
         self.assertEqual(
             network.types, [{"Int1": "type", "a": "Int1", "b": "Int1", "return": "Int1"}]
@@ -88,5 +112,9 @@ class TestTypeCheckFail(QiskitTestCase):
         ~False  # -1
         """
         with self.assertRaises(ClassicalFunctionCompilerTypeError) as context:
-            compile_classical_function(bad_examples.bit_not)
+            with self.assertWarnsRegex(
+                DeprecationWarning,
+                expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+            ):
+                compile_classical_function(bad_examples.bit_not)
         self.assertExceptionMessage(context, "does not operate with Int1 type")

--- a/test/python/classical_function_compiler/test_typecheck.py
+++ b/test/python/classical_function_compiler/test_typecheck.py
@@ -32,7 +32,7 @@ class TestTypeCheck(QiskitTestCase):
         """Tests examples.identity type checking"""
         with self.assertWarnsRegex(
             DeprecationWarning,
-            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+            expected_regex="ClassicalFunction`` is deprecated as of qiskit 1.4",
         ):
             network = compile_classical_function(examples.identity)
         self.assertEqual(network.args, ["a"])
@@ -42,7 +42,7 @@ class TestTypeCheck(QiskitTestCase):
         """Tests examples.bool_not type checking"""
         with self.assertWarnsRegex(
             DeprecationWarning,
-            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+            expected_regex="ClassicalFunction`` is deprecated as of qiskit 1.4",
         ):
             network = compile_classical_function(examples.bool_not)
         self.assertEqual(network.args, ["a"])
@@ -52,7 +52,7 @@ class TestTypeCheck(QiskitTestCase):
         """Tests examples.id_assing type checking"""
         with self.assertWarnsRegex(
             DeprecationWarning,
-            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+            expected_regex="ClassicalFunction`` is deprecated as of qiskit 1.4",
         ):
             network = compile_classical_function(examples.id_assing)
         self.assertEqual(network.args, ["a"])
@@ -64,7 +64,7 @@ class TestTypeCheck(QiskitTestCase):
         """Tests examples.bit_and type checking"""
         with self.assertWarnsRegex(
             DeprecationWarning,
-            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+            expected_regex="ClassicalFunction`` is deprecated as of qiskit 1.4",
         ):
             network = compile_classical_function(examples.bit_and)
         self.assertEqual(network.args, ["a", "b"])
@@ -76,7 +76,7 @@ class TestTypeCheck(QiskitTestCase):
         """Tests examples.bit_or type checking"""
         with self.assertWarnsRegex(
             DeprecationWarning,
-            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+            expected_regex="ClassicalFunction`` is deprecated as of qiskit 1.4",
         ):
             network = compile_classical_function(examples.bit_or)
         self.assertEqual(network.args, ["a", "b"])
@@ -88,7 +88,7 @@ class TestTypeCheck(QiskitTestCase):
         """Tests examples.bool_or type checking"""
         with self.assertWarnsRegex(
             DeprecationWarning,
-            expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+            expected_regex="ClassicalFunction`` is deprecated as of qiskit 1.4",
         ):
             network = compile_classical_function(examples.bool_or)
         self.assertEqual(network.args, ["a", "b"])
@@ -114,7 +114,7 @@ class TestTypeCheckFail(QiskitTestCase):
         with self.assertRaises(ClassicalFunctionCompilerTypeError) as context:
             with self.assertWarnsRegex(
                 DeprecationWarning,
-                expected_regex="ClassicalFunction`` is deprecated as of Qiskit 1.4",
+                expected_regex="ClassicalFunction`` is deprecated as of qiskit 1.4",
             ):
                 compile_classical_function(bad_examples.bit_not)
         self.assertExceptionMessage(context, "does not operate with Int1 type")

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -1399,7 +1399,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         )
         with self.assertWarnsRegex(
             DeprecationWarning,
-            expected_regex=r"classical_function\(\)`` is deprecated as of Qiskit 1.4",
+            expected_regex=r"classical_function\(\)`` is deprecated as of qiskit 1.4",
         ):
 
             @classical_function

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -1397,12 +1397,16 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
                 "           └───┘",
             ]
         )
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            expected_regex=r"classical_function\(\)`` is deprecated as of Qiskit 1.4",
+        ):
 
-        @classical_function
-        def grover_oracle(a: Int1, b: Int1, c: Int1) -> Int1:
-            return a and b and not c
+            @classical_function
+            def grover_oracle(a: Int1, b: Int1, c: Int1) -> Int1:
+                return a and b and not c
 
-        circuit = grover_oracle.synth(registerless=False)
+            circuit = grover_oracle.synth(registerless=False)
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
 


### PR DESCRIPTION
### Summary
This PR deprecates the `ClassicalFunction` class and related `classical_function` method, to be removed in 2.0.

Partially addresses #13755 


### Details and comments
`ClassicalFunction` is a useful class, but it relies on the `tweedledum` library which is dropped from qiskit in 2.0. Most of the functionality enabled by `ClassicalFunction` is also supplied by `BooleanExpression` that is made independent from `tweedledum` in #13769 and it's not clear if there is demand for the extra functionality at this stage.
