### PR TITLE
Add `default` translation stage plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ sk = "qiskit.transpiler.passes.synthesis.solovay_kitaev_synthesis:SolovayKitaevS
 default = "qiskit.transpiler.preset_passmanagers.builtin_plugins:DefaultInitPassManager"
 
 [project.entry-points."qiskit.transpiler.translation"]
+default = "qiskit.transpiler.preset_passmanagers.builtin_plugins:DefaultTranslationPassManager"
 synthesis = "qiskit.transpiler.preset_passmanagers.builtin_plugins:UnitarySynthesisPassManager"
 translator = "qiskit.transpiler.preset_passmanagers.builtin_plugins:BasisTranslatorPassManager"
 

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -191,10 +191,10 @@ def transpile(  # pylint: disable=too-many-return-statements
             This can also be the external plugin name to use for the ``routing`` stage.
             You can see a list of installed plugins by using :func:`~.list_stage_plugins` with
             ``"routing"`` for the ``stage_name`` argument.
-        translation_method: Name of translation pass (``"translator"`` or ``"synthesis"``)
-            This can also be the external plugin name to use for the ``translation`` stage.
-            You can see a list of installed plugins by using :func:`~.list_stage_plugins` with
-            ``"translation"`` for the ``stage_name`` argument.
+        translation_method: Name of translation pass (``"default"``, ``"translator"`` or
+            ``"synthesis"``). This can also be the external plugin name to use for the
+            ``translation`` stage.  You can see a list of installed plugins by using
+            :func:`~.list_stage_plugins` with ``"translation"`` for the ``stage_name`` argument.
         scheduling_method: Name of scheduling pass.
             * ``'as_soon_as_possible'``: Schedule instructions greedily, as early as possible
             on a qubit resource. (alias: ``'asap'``)

--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -643,12 +643,24 @@ When writing :ref:`stage plugins <transpiler-preset-stage-plugins>`, the entry p
     * - Method
       - Summary
 
+    * - :ref:`default <transpiler-preset-stage-translation-translator>`
+      - Use a Qiskit-chosen default translation method.
+
     * - :ref:`translator <transpiler-preset-stage-translation-translator>`
       - Symbolic translation of gates to the target basis using known equivalences.
 
     * - :ref:`synthesis <transpiler-preset-stage-translation-synthesis>`
       - Collect each run of one- and two-qubit gates into a matrix representation, and resynthesize
         from there.
+
+.. _transpiler-preset-stage-translation-default:
+
+Built-in ``default`` plugin
+...........................
+
+Use a Qiskit-chosen default method for translation.  As of Qiskit 2.0, this is the same as
+:ref:`transpiler-preset-stage-translation-translator`, but the chosen algorithm might change during
+the 2.x series, either for all targets, or only for certain classes of target.
 
 .. _transpiler-preset-stage-translation-synthesis:
 

--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -197,6 +197,17 @@ class DefaultInitPassManager(PassManagerStagePlugin):
         return init
 
 
+class DefaultTranslationPassManager(PassManagerStagePlugin):
+    """Plugin class for the default-method translation stage."""
+
+    def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
+        # For now, this is just a wrapper around the `BasisTranslator`.  It might expand in the
+        # future if we want to change the default method to do more context-aware switching, or to
+        # start transitioning the default method without breaking the semantics of the default
+        # string referring to the `BasisTranslator`.
+        return BasisTranslatorPassManager().pass_manager(pass_manager_config, optimization_level)
+
+
 class BasisTranslatorPassManager(PassManagerStagePlugin):
     """Plugin class for translation stage with :class:`~.BasisTranslator`"""
 
@@ -535,7 +546,7 @@ class OptimizationPassManager(PassManagerStagePlugin):
     def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
         """Build pass manager for optimization stage."""
         # Obtain the translation method required for this pass to work
-        translation_method = pass_manager_config.translation_method or "translator"
+        translation_method = pass_manager_config.translation_method or "default"
         optimization = PassManager()
         if optimization_level != 0:
             plugin_manager = PassManagerStagePluginManager()

--- a/qiskit/transpiler/preset_passmanagers/common.py
+++ b/qiskit/transpiler/preset_passmanagers/common.py
@@ -60,15 +60,17 @@ _ControlFlowState = collections.namedtuple("_ControlFlowState", ("working", "not
 # Any method neither known good nor known bad (i.e. not a Terra-internal pass) is passed through
 # without error, since it is being supplied by a plugin and we don't have any knowledge of these.
 _CONTROL_FLOW_STATES = {
-    "layout_method": _ControlFlowState(working={"trivial", "dense", "sabre"}, not_working=set()),
+    "layout_method": _ControlFlowState(
+        working={"default", "trivial", "dense", "sabre"}, not_working=set()
+    ),
     "routing_method": _ControlFlowState(
         working={"none", "stochastic", "sabre"}, not_working={"lookahead", "basic"}
     ),
     "translation_method": _ControlFlowState(
-        working={"translator", "synthesis"},
+        working={"default", "translator", "synthesis"},
         not_working=set(),
     ),
-    "optimization_method": _ControlFlowState(working=set(), not_working=set()),
+    "optimization_method": _ControlFlowState(working={"default"}, not_working=set()),
     "scheduling_method": _ControlFlowState(working=set(), not_working={"alap", "asap"}),
 }
 

--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -49,7 +49,7 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     init_method = pass_manager_config.init_method or "default"
     layout_method = pass_manager_config.layout_method or "default"
     routing_method = pass_manager_config.routing_method or "sabre"
-    translation_method = pass_manager_config.translation_method or "translator"
+    translation_method = pass_manager_config.translation_method or "default"
     optimization_method = pass_manager_config.optimization_method or "default"
     scheduling_method = pass_manager_config.scheduling_method or "default"
     target = pass_manager_config.target

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -53,7 +53,7 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     # based on whether the input circuit has control flow.
     layout_method = pass_manager_config.layout_method or "default"
     routing_method = pass_manager_config.routing_method or "sabre"
-    translation_method = pass_manager_config.translation_method or "translator"
+    translation_method = pass_manager_config.translation_method or "default"
     optimization_method = pass_manager_config.optimization_method or "default"
     scheduling_method = pass_manager_config.scheduling_method or "default"
     target = pass_manager_config.target

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -54,7 +54,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     init_method = pass_manager_config.init_method or "default"
     layout_method = pass_manager_config.layout_method or "default"
     routing_method = pass_manager_config.routing_method or "sabre"
-    translation_method = pass_manager_config.translation_method or "translator"
+    translation_method = pass_manager_config.translation_method or "default"
     optimization_method = pass_manager_config.optimization_method or "default"
     scheduling_method = pass_manager_config.scheduling_method or "default"
     target = pass_manager_config.target

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -54,7 +54,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     init_method = pass_manager_config.init_method or "default"
     layout_method = pass_manager_config.layout_method or "default"
     routing_method = pass_manager_config.routing_method or "sabre"
-    translation_method = pass_manager_config.translation_method or "translator"
+    translation_method = pass_manager_config.translation_method or "default"
     scheduling_method = pass_manager_config.scheduling_method
     optimization_method = pass_manager_config.optimization_method or "default"
     scheduling_method = pass_manager_config.scheduling_method or "default"

--- a/qiskit/transpiler/preset_passmanagers/plugin.py
+++ b/qiskit/transpiler/preset_passmanagers/plugin.py
@@ -71,7 +71,7 @@ in the stages' names to the full documentation.
 
    * - :ref:`translation <transpiler-preset-stage-translation>`
      - ``qiskit.transpiler.translation``
-     - ``translator``, ``synthesis``
+     - ``default``, ``translator``, ``synthesis``
      - Rewrite all gates outside the target ISA to use only gates within the ISA.
 
    * - :ref:`optimization <transpiler-preset-stage-optimization>`

--- a/releasenotes/notes/default-translation-stage-9d0335e354751af0.yaml
+++ b/releasenotes/notes/default-translation-stage-9d0335e354751af0.yaml
@@ -1,0 +1,18 @@
+---
+features_transpiler:
+  - |
+    A new :ref:`translation plugin stage <transpiler-preset-stage-translation>` is added, called
+    ``"default"``.  In Qiskit 2.0, this is simply an alias for the previous default ``"translator"``.
+    The underlying default algorithm may change over the course of the Qiskit 2.x series for some or
+    all targets, but you can always set ``translation_method=="translator"`` explicitly to maintain
+    the current behavior.
+upgrade_transpiler:
+  - |
+    The :ref:`translation plugin stage <transpiler-preset-stage-translation>` name ``default`` is
+    now reserved for the Qiskit built-in plugin of the same name.
+  - |
+    The default :ref:`translation plugin stage <transpiler-preset-stage-translation>` is now
+    ``"default"``.  In Qiskit 2.0, this is simply an alias for the previous default ``"translator"``.
+    The underlying default algorithm may change over the course of the Qiskit 2.x series for some or
+    all targets, but you can always set ``translation_method=="translator"`` explicitly to maintain
+    the current behavior.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This is added to give us semantic room to play with the default translation algorithm during the 2.x series.  It starts life as an alias to `translator`, but may change to improve support for fractional-gate translation, more optimized synthesis routines, or discrete-basis translations (like a SK-based 1q translator for logical backends).

This makes it programmatically possible to distinguish the "default" plugin choice from an explicit "translator" choice, even when (as right now) those are the same thing.  Note that `pass_manager_config` uses `None` as an implicit default, but we active suggest using the plugin-stage getters, which need an actual plugin name.


### Details and comments

Close #13788.

Built on top of the enhanced documentation #13620.