### PR TITLE
Pylint configuration to prevent accidentally committing debugging print statements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,7 +215,7 @@ extension-pkg-allow-list = [
     "rustworkx",
     "tweedledum",
 ]
-load-plugins = ["pylint.extensions.docparams", "pylint.extensions.docstyle"]
+load-plugins = ["pylint.extensions.docparams", "pylint.extensions.docstyle", "pylint.extensions.bad_builtin"]
 py-version = "3.9"  # update it when bumping minimum supported python version
 
 [tool.pylint.basic]
@@ -267,3 +267,6 @@ exclude_also = [
     "if TYPE_CHECKING:",          # Code that only runs during type checks
     "@abstractmethod",            # Abstract methods are not testable
     ]
+
+[tool.pylint.deprecated_builtins]
+bad-functions = ["print"]

--- a/qiskit/qasm2/export.py
+++ b/qiskit/qasm2/export.py
@@ -116,10 +116,10 @@ def dump(circuit: QuantumCircuit, filename_or_stream: os.PathLike | io.TextIOBas
         QASM2ExportError: if the circuit cannot be represented by OpenQASM 2.
     """
     if isinstance(filename_or_stream, io.TextIOBase):
-        print(dumps(circuit), file=filename_or_stream)
+        print(dumps(circuit), file=filename_or_stream)  # pylint: disable=bad-builtin
         return
     with open(filename_or_stream, "w") as stream:
-        print(dumps(circuit), file=stream)
+        print(dumps(circuit), file=stream)  # pylint: disable=bad-builtin
 
 
 def dumps(circuit: QuantumCircuit, /) -> str:

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -238,7 +238,7 @@ class Operator(LinearOp):
     def _ipython_display_(self):
         out = self.draw()
         if isinstance(out, str):
-            print(out)
+            print(out)  # pylint: disable=bad-builtin
         else:
             from IPython.display import display
 

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -180,7 +180,7 @@ class DensityMatrix(QuantumState, TolerancesMixin):
     def _ipython_display_(self):
         out = self.draw()
         if isinstance(out, str):
-            print(out)
+            print(out)  # pylint: disable=bad-builtin
         else:
             from IPython.display import display
 

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -198,7 +198,7 @@ class Statevector(QuantumState, TolerancesMixin):
     def _ipython_display_(self):
         out = self.draw()
         if isinstance(out, str):
-            print(out)
+            print(out)  # pylint: disable=bad-builtin
         else:
             from IPython.display import display
 

--- a/qiskit/visualization/circuit/matplotlib.py
+++ b/qiskit/visualization/circuit/matplotlib.py
@@ -1074,7 +1074,7 @@ class MatplotlibDrawer:
                 self._get_colors(node, node_data)
 
                 if verbose:
-                    print(op)
+                    print(op)  # pylint: disable=bad-builtin
 
                 # add conditional
                 if getattr(op, "condition", None) or isinstance(op, SwitchCaseOp):

--- a/test/randomized/test_transpiler_equivalence.py
+++ b/test/randomized/test_transpiler_equivalence.py
@@ -288,7 +288,7 @@ class QCircuitMachine(RuleBasedStateMachine):
             + ", ".join(f"{key:s}={value!r}" for key, value in kwargs.items() if value is not None)
             + ")"
         )
-        print(f"Evaluating {call} for:\n{qasm2.dumps(self.qc)}")
+        print(f"Evaluating {call} for:\n{qasm2.dumps(self.qc)}")  # pylint: disable=bad-builtin
 
         shots = 4096
 

--- a/tools/find_deprecated.py
+++ b/tools/find_deprecated.py
@@ -10,6 +10,7 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+# pylint: disable=bad-builtin
 
 """List deprecated decorators."""
 from __future__ import annotations

--- a/tools/find_optional_imports.py
+++ b/tools/find_optional_imports.py
@@ -10,6 +10,7 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+# pylint: disable=bad-builtin
 
 """Utility to check that slow imports are not used in the default path."""
 

--- a/tools/fix_mailmap.py
+++ b/tools/fix_mailmap.py
@@ -12,6 +12,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+# pylint: disable=bad-builtin
+
 """Check and fixup mailmaps files against git log."""
 
 from __future__ import annotations

--- a/tools/pgo_scripts/test_utility_scale.py
+++ b/tools/pgo_scripts/test_utility_scale.py
@@ -11,6 +11,7 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+# pylint: disable=bad-builtin
 
 """Script to generate 'utility scale' load for profiling in a PGO context"""
 

--- a/tools/pylint_incr.py
+++ b/tools/pylint_incr.py
@@ -12,6 +12,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+# pylint: disable=bad-builtin
+
 """Run pylint incrementally on only changed files"""
 
 import subprocess

--- a/tools/verify_images.py
+++ b/tools/verify_images.py
@@ -10,6 +10,7 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+# pylint: disable=bad-builtin
 
 """Utility script to verify that all images have alt text"""
 


### PR DESCRIPTION
### Summary

Adds the `bad_builtin` extension to pylint and raise a warning when `print` is used. Add a `disable` for current cases.

### Details and comments

It happens from time to time that we accidentally push for code with debugging `print` statements. [Many](https://github.com/Qiskit/qiskit/pull/12850/commits/6204af45fa43e6219fdeb842f31211e1679b6143) [times](https://github.com/Qiskit/qiskit/pull/13545/commits/a9c5bc7e644ebc0d7de8947ebbe6670fa080ddd6), they are captured during revision. However, [sometimes](https://github.com/Qiskit/qiskit/pull/13702) they end up in `main`. Maybe it helps if pylint tell us.

out-of-scope: evaluate if the current prints are justify. Issues can be submitted for them independently.
