### PR TITLE
Deny use of `println!` and related write macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ qiskit-qasm3 = { path = "crates/qasm3" }
 # which uses the `::std::cmp::Ordering` enum as a return.  Both styles are acceptable, and the `if`
 # chain can be more legible to people.
 comparison-chain = "allow"
+# Forbid `{,e}print{,ln}!` calls.  These can be allowed locally if absolutely required, but the
+# vast majority of these are debug statements that we forget about.
+print_stdout = "deny"
+print_stderr = "deny"
 
 [workspace.lints.rust]
 # In Rust 2021, the bodies of `unsafe fn` may use `unsafe` functions themselves without marking

--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -821,11 +821,9 @@ impl PackedInstruction {
             }
             // Handle the case we end up with a pyinstruction for a standard instruction
             (OperationRef::StandardInstruction(_left), OperationRef::Instruction(right)) => {
-                println!("RHS is just instruction...");
                 self.unpack_py_op(py)?.bind(py).eq(&right.instruction)
             }
             (OperationRef::Instruction(left), OperationRef::StandardInstruction(_right)) => {
-                println!("LHS is just instruction...");
                 other.unpack_py_op(py)?.bind(py).eq(&left.instruction)
             }
             _ => Ok(false),


### PR DESCRIPTION
### Summary

We lint against the `print` builtin in Python space, since it's a debugging artifact almost all of the time.  This is the equivalent lint, but for Rust space.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Goes on top of #13797 to enforce the lint properly, once that's fixed.
