### PR TITLE
Fix the sign in `SparseObservable.as_paulis`

### DIFF
--- a/crates/accelerate/src/sparse_observable.rs
+++ b/crates/accelerate/src/sparse_observable.rs
@@ -687,10 +687,10 @@ impl SparseObservable {
                 .multi_cartesian_product();
 
             for combination in combinations {
-                let mut positive = true;
+                let mut positive = true; // keep track of the global sign
 
                 for (index, (sign, bit)) in combination.iter().enumerate() {
-                    positive &= sign;
+                    positive ^= !sign; // accumulate the sign; global_sign *= local_sign
                     if let Some(bit) = bit {
                         paulis.push(*bit);
                         indices.push(view.indices[index]);
@@ -2499,11 +2499,11 @@ impl PySparseObservable {
             // we reverse the order of bits and indices so the Pauli string comes out in
             // "reading order", consistent with how one would write the label in
             // SparseObservable.from_list or .from_label
-            for bit in view.bit_terms.iter().rev() {
+            for bit in view.bit_terms.iter() {
                 pauli_string.push_str(bit.py_label());
             }
             let py_string = PyString::new(py, &pauli_string).unbind();
-            let py_indices = PyList::new(py, view.indices.iter().rev())?.unbind();
+            let py_indices = PyList::new(py, view.indices.iter())?.unbind();
             let py_coeff = view.coeff.into_py_any(py)?;
 
             PyTuple::new(py, vec![py_string.as_any(), py_indices.as_any(), &py_coeff])

--- a/crates/accelerate/src/sparse_observable.rs
+++ b/crates/accelerate/src/sparse_observable.rs
@@ -2481,7 +2481,7 @@ impl PySparseObservable {
     /// list and back.
     ///
     /// Examples:
-    ///     
+    ///
     ///     >>> obs = SparseObservable.from_list([("IIXIZ", 2j), ("IIZIX", 2j)])
     ///     >>> reconstructed = SparseObservable.from_sparse_list(obs.to_sparse_list(), obs.num_qubits)
     ///
@@ -2499,11 +2499,11 @@ impl PySparseObservable {
             // we reverse the order of bits and indices so the Pauli string comes out in
             // "reading order", consistent with how one would write the label in
             // SparseObservable.from_list or .from_label
-            for bit in view.bit_terms.iter() {
+            for bit in view.bit_terms.iter().rev() {
                 pauli_string.push_str(bit.py_label());
             }
             let py_string = PyString::new(py, &pauli_string).unbind();
-            let py_indices = PyList::new(py, view.indices.iter())?.unbind();
+            let py_indices = PyList::new(py, view.indices.iter().rev())?.unbind();
             let py_coeff = view.coeff.into_py_any(py)?;
 
             PyTuple::new(py, vec![py_string.as_any(), py_indices.as_any(), &py_coeff])

--- a/test/python/quantum_info/test_sparse_observable.py
+++ b/test/python/quantum_info/test_sparse_observable.py
@@ -2100,6 +2100,25 @@ class TestSparseObservable(QiskitTestCase):
             )
             self.assertEqual(expected.simplify(), obs_paulis.simplify())
 
+        # test multiple negative projectors with a positive
+        with self.subTest(msg="011"):
+            obs = SparseObservable("011")
+            obs_paulis = obs.as_paulis()
+            expected = SparseObservable.from_sparse_list(
+                [
+                    ("", [], 1 / 8),
+                    ("Z", [0], -1 / 8),
+                    ("Z", [1], -1 / 8),
+                    ("Z", [2], 1 / 8),
+                    ("ZZ", [0, 1], 1 / 8),
+                    ("ZZ", [0, 2], -1 / 8),
+                    ("ZZ", [1, 2], -1 / 8),
+                    ("ZZZ", [0, 1, 2], 1 / 8),
+                ],
+                3,
+            )
+            self.assertEqual(expected.simplify(), obs_paulis.simplify())
+
         # test explicitly on written-out projector
         with self.subTest(msg="lrI0"):
             obs = SparseObservable("lrI0")

--- a/test/python/quantum_info/test_sparse_observable.py
+++ b/test/python/quantum_info/test_sparse_observable.py
@@ -2055,6 +2055,51 @@ class TestSparseObservable(QiskitTestCase):
             obs_paulis = obs.as_paulis()
             self.assertEqual(obs, obs_paulis)
 
+        # test multiple +1 projectors
+        with self.subTest(msg="00"):
+            obs = SparseObservable("00")
+            obs_paulis = obs.as_paulis()
+            expected = SparseObservable.from_sparse_list(
+                [
+                    ("", [], 1 / 4),
+                    ("Z", [0], 1 / 4),
+                    ("Z", [1], 1 / 4),
+                    ("ZZ", [0, 1], 1 / 4),
+                ],
+                2,
+            )
+            self.assertEqual(expected.simplify(), obs_paulis.simplify())
+
+        # test multiple -1 projectors
+        with self.subTest(msg="11"):
+            obs = SparseObservable("11")
+            obs_paulis = obs.as_paulis()
+            expected = SparseObservable.from_sparse_list(
+                [
+                    ("", [], 1 / 4),
+                    ("Z", [0], -1 / 4),
+                    ("Z", [1], -1 / 4),
+                    ("ZZ", [0, 1], 1 / 4),
+                ],
+                2,
+            )
+            self.assertEqual(expected.simplify(), obs_paulis.simplify())
+
+        # test +1 -1 projector
+        with self.subTest(msg="01"):
+            obs = SparseObservable("01")
+            obs_paulis = obs.as_paulis()
+            expected = SparseObservable.from_sparse_list(
+                [
+                    ("", [], 1 / 4),
+                    ("Z", [0], -1 / 4),
+                    ("Z", [1], 1 / 4),
+                    ("ZZ", [0, 1], -1 / 4),
+                ],
+                2,
+            )
+            self.assertEqual(expected.simplify(), obs_paulis.simplify())
+
         # test explicitly on written-out projector
         with self.subTest(msg="lrI0"):
             obs = SparseObservable("lrI0")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

`echo $issue_title`

### Details and comments

In my mind `{1, -1} *= {1, -1}` translated to `bool &= bool` -- but it doesn't. Instead it should be `bool ^= !bool`. This would come up when an observable has more than a single -1 eigenvalue projector (e.g. `"11"`). Explicit tests for this are added, while a reno is not, since it's not yet released 🙂 


