### PR TITLE
Remove redundant `CODEOWNERS` entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,11 +24,8 @@
 
 # Qiskit folders (also their corresponding tests)
 providers/            @Qiskit/terra-core @jyu00
-quantum_info/         @Qiskit/terra-core
-qpy/                  @Qiskit/terra-core
-pulse/                @Qiskit/terra-core @eggerdj @wshanks
-synthesis/            @Qiskit/terra-core @alexanderivrii @ShellyGarion
-scheduler/            @Qiskit/terra-core @eggerdj @wshanks
+pulse/                @Qiskit/terra-core @eggerdj @wshanks @nkanazawa1989
+scheduler/            @Qiskit/terra-core @eggerdj @wshanks @nkanazawa1989
 visualization/        @Qiskit/terra-core @nonhermitian
 primitives/           @Qiskit/terra-core @Qiskit/qiskit-primitives
 # Override the release notes directories to have _no_ code owners, so any review


### PR DESCRIPTION
### Summary

Shelly and Sasha are both part of terra-core.  Rules that "specialise" a directory to terra-core are redundant, since the blanket rule catches that case.

Naoki is moved from being terra-core to instead being a specialised code-owner of the pulse and scheduling sections, which is more representative of the current reality.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

I also removed team members who have moved away from the core team from terra-core as well.
