### PR TITLE
Consider `unit` in `Delay` comparisons

### DIFF
--- a/qiskit/circuit/delay.py
+++ b/qiskit/circuit/delay.py
@@ -84,6 +84,11 @@ class Delay(Instruction):
         """
         return self.__array__(dtype=complex)
 
+    def __eq__(self, other):
+        return (
+            isinstance(other, Delay) and self.unit == other.unit and self._compare_parameters(other)
+        )
+
     def __repr__(self):
         """Return the official string representing the delay."""
         return f"{self.__class__.__name__}(duration={self.params[0]}[unit={self.unit}])"

--- a/releasenotes/notes/delay-compare-b7ecb26b94ff0cd3.yaml
+++ b/releasenotes/notes/delay-compare-b7ecb26b94ff0cd3.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Comparisons of :class:`~.circuit.Delay` instructions, including within circuits, now require the
+    units to be equal as well as the duration value.


### PR DESCRIPTION
The `unit` field was previously ignored, allowing delays in `dt` units to compare equal to those in `s`. This commit does not add additional on-the-fly unit conversion to the comparison: if the user specified durations in different time multiples, they may have had a reason to consider them non-equal.  This could be revisiting after the new system for duration handling lands (i.e. the new functionality for `stretch` and other delayed scheduling).

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


Fix #13812.