### PR TITLE
Implement `From<f64>` for `Param`

### DIFF
--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -130,6 +130,13 @@ impl AsRef<Param> for Param {
     }
 }
 
+// Conveniently converts an f64 into a `Param`.
+impl From<f64> for Param {
+    fn from(value: f64) -> Self {
+        Param::Float(value)
+    }
+}
+
 /// Struct to provide iteration over Python-space `Parameter` instances within a `Param`.
 pub struct ParamParameterIter<'py>(Option<Bound<'py, PyIterator>>);
 impl<'py> Iterator for ParamParameterIter<'py> {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Add a convenient way of converting an `f64` into a `Param` by implementing the `From` trait. This would enable us to simply call `f64::into<Param>()` (or more simply `0.0.into()`) to turn a float into an instance of `Param` in Rust. As used in #13686 


