### PR TITLE
Implement `CircuitData::copy_empty_like()`

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -284,18 +284,8 @@ impl CircuitData {
     ///     CircuitData: The shallow copy.
     #[pyo3(signature = (copy_instructions=true, deepcopy=false))]
     pub fn copy(&self, py: Python<'_>, copy_instructions: bool, deepcopy: bool) -> PyResult<Self> {
-        let mut res = CircuitData::new(
-            py,
-            Some(self.qubits.cached().bind(py)),
-            Some(self.clbits.cached().bind(py)),
-            None,
-            self.data.len(),
-            self.global_phase.clone(),
-        )?;
-        res.qargs_interner = self.qargs_interner.clone();
-        res.cargs_interner = self.cargs_interner.clone();
+        let mut res = self.copy_empty_like(py, Some(self.data().len()))?;
         res.param_table.clone_from(&self.param_table);
-
         if deepcopy {
             let memo = PyDict::new(py);
             for inst in &self.data {
@@ -327,6 +317,25 @@ impl CircuitData {
         Ok(res)
     }
 
+    /// Performs an empty-like shallow copy.
+    ///
+    /// Returns:
+    ///     CircuitData: The shallow copy.
+    #[pyo3(signature = (reserve = None,))]
+    pub fn copy_empty_like(&self, py: Python<'_>, reserve: Option<usize>) -> PyResult<Self> {
+        let mut res = CircuitData::new(
+            py,
+            Some(self.qubits.cached().bind(py)),
+            Some(self.clbits.cached().bind(py)),
+            None,
+            reserve.unwrap_or_default(),
+            self.global_phase.clone(),
+        )?;
+        res.qargs_interner = self.qargs_interner.clone();
+        res.cargs_interner = self.cargs_interner.clone();
+
+        Ok(res)
+    }
     /// Reserves capacity for at least ``additional`` more
     /// :class:`.CircuitInstruction` instances to be added to this container.
     ///

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3698,7 +3698,14 @@ class QuantumCircuit:
         Returns:
           QuantumCircuit: a deepcopy of the current circuit, with the specified name
         """
-        cpy = self.copy_empty_like(name)
+        if not (name is None or isinstance(name, str)):
+            raise TypeError(
+                f"invalid name for a circuit: '{name}'. The name must be a string or 'None'."
+            )
+        cpy = _copy.copy(self)
+
+        _copy_metadata(self, cpy, "alike")
+
         cpy._data = self._data.copy()
         return cpy
 
@@ -3755,9 +3762,7 @@ class QuantumCircuit:
 
         _copy_metadata(self, cpy, vars_mode)
 
-        cpy._data = CircuitData(
-            self._data.qubits, self._data.clbits, global_phase=self._data.global_phase
-        )
+        cpy._data = self._data.copy_empty_like()
 
         if name:
             cpy.name = name

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3698,14 +3698,7 @@ class QuantumCircuit:
         Returns:
           QuantumCircuit: a deepcopy of the current circuit, with the specified name
         """
-        if not (name is None or isinstance(name, str)):
-            raise TypeError(
-                f"invalid name for a circuit: '{name}'. The name must be a string or 'None'."
-            )
-        cpy = _copy.copy(self)
-
-        _copy_metadata(self, cpy, "alike")
-
+        cpy = self.copy_empty_like(name)
         cpy._data = self._data.copy()
         return cpy
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
The following commits add some quality-of-life changes to `CircuitData` and `QuantumCircuit` discovered while working on #13686:
- Implement a separate `copy_empty_like()` method for `CircuitData`.
- Separate use of `copy()` and `copy_empty_like()` for `QuantumCircuit` to avoid creating repeated instances of `CircuitData`.


### Comments
Feel free to ask any questions down below or on a review.


