### PR TITLE
Warn on use of `property_set` kwarg to `BasePassManger.run`

### DIFF
--- a/qiskit/passmanager/passmanager.py
+++ b/qiskit/passmanager/passmanager.py
@@ -30,7 +30,7 @@ from .compilation_status import PropertySet, WorkflowStatus, PassManagerState
 
 logger = logging.getLogger(__name__)
 
-_NOT_PRESENT = object()
+_MISSING = object()
 
 
 class BasePassManager(ABC):
@@ -178,7 +178,7 @@ class BasePassManager(ABC):
         callback: Callable = None,
         num_processes: int = None,
         *,
-        property_set: object = _NOT_PRESENT,
+        property_set: object = _MISSING,
         **kwargs,
     ) -> Any:
         """Run all the passes on the specified ``in_programs``.
@@ -224,7 +224,7 @@ class BasePassManager(ABC):
         Returns:
             The transformed program(s).
         """
-        if property_set is not _NOT_PRESENT:
+        if property_set is not _MISSING:
             warnings.warn(
                 "From Qiskit 2.0, 'property_set' will be a reserved keyword argument of"
                 " 'BasePassManager.run', and not passed on to the conversion functions."

--- a/qiskit/passmanager/passmanager.py
+++ b/qiskit/passmanager/passmanager.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from itertools import chain
@@ -28,6 +29,8 @@ from .flow_controllers import FlowControllerLinear
 from .compilation_status import PropertySet, WorkflowStatus, PassManagerState
 
 logger = logging.getLogger(__name__)
+
+_NOT_PRESENT = object()
 
 
 class BasePassManager(ABC):
@@ -174,6 +177,8 @@ class BasePassManager(ABC):
         in_programs: Any | list[Any],
         callback: Callable = None,
         num_processes: int = None,
+        *,
+        property_set: object = _NOT_PRESENT,
         **kwargs,
     ) -> Any:
         """Run all the passes on the specified ``in_programs``.
@@ -211,12 +216,25 @@ class BasePassManager(ABC):
                 execution is enabled. This argument overrides ``num_processes`` in the user
                 configuration file, and the ``QISKIT_NUM_PROCS`` environment variable. If set
                 to ``None`` the system default or local user configuration will be used.
-
+            property_set: Currently a key that will be interpreted as all other arbitrary
+                ``kwargs``.  In Qiskit 2.0, this will instead seed the :class:`.PropertySet` of the
+                compilation (but does not do so in this version).
             kwargs: Arbitrary arguments passed to the compiler frontend and backend.
 
         Returns:
             The transformed program(s).
         """
+        if property_set is not _NOT_PRESENT:
+            warnings.warn(
+                "From Qiskit 2.0, 'property_set' will be a reserved keyword argument of"
+                " 'BasePassManager.run', and not passed on to the conversion functions."
+                " This subclass of 'BasePassManager' needs to use a different keyword argument"
+                " for passing on this data.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            kwargs["property_set"] = property_set
+
         if not self._tasks and not kwargs and callback is None:
             return in_programs
 

--- a/releasenotes/notes/passmanager-run-property_set-cb19ce448ab1e93a.yaml
+++ b/releasenotes/notes/passmanager-run-property_set-cb19ce448ab1e93a.yaml
@@ -1,0 +1,13 @@
+---
+upgrade_transpiler:
+  - |
+    Passing ``property_set`` as an arbitrary keyword argument to the :meth:`~.BasePassManager.run`
+    method of a subclass of :class:`.BasePassManager` will change behavior in Qiskit 2.0.  It is
+    currently forwarded to the internal representation converting functions of the pass maanger, as
+    is any arbitrary keyword argument to that method.  Starting from Qiskit 2.0, the option will
+    instead be used to set the seed of the :class:`.PropertySet` for the pipeline run, and the
+    argument will not be passed to the conversion functions.
+
+    This note only concerns implementers of subclasses of :class:`.BasePassManager` who have chosen
+    their ``_passmanager_frontend`` and ``_passmanager_backend`` implementations to accept a keyword
+    argument called ``property_set``.

--- a/releasenotes/notes/passmanager-run-property_set-cb19ce448ab1e93a.yaml
+++ b/releasenotes/notes/passmanager-run-property_set-cb19ce448ab1e93a.yaml
@@ -3,7 +3,7 @@ upgrade_transpiler:
   - |
     Passing ``property_set`` as an arbitrary keyword argument to the :meth:`~.BasePassManager.run`
     method of a subclass of :class:`.BasePassManager` will change behavior in Qiskit 2.0.  It is
-    currently forwarded to the internal representation converting functions of the pass maanger, as
+    currently forwarded to the internal representation converting functions of the pass manager, as
     is any arbitrary keyword argument to that method.  Starting from Qiskit 2.0, the option will
     instead be used to set the seed of the :class:`.PropertySet` for the pipeline run, and the
     argument will not be passed to the conversion functions.


### PR DESCRIPTION
The transpiler's `BasePass.__call__` implementation accepts a `property_set` kwarg that can be used to seed the property set for the run of that pass.  Starting in Qiskit 2.0, `PassManager.run` will also have that behaviour, so this commit begins emitting a warning on the potential change.

The impact of this is expected to be minimal, as we are not aware of much use of the subclassing of the generic `BasePassManager`, and even less of passing arbitrary keyword arguments to the conversion functions.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

This is the warning to enable to API change of #13820.