### PR TITLE
Optimize Matplotlib Circuit Drawing: Auto-Close Figures to Prevent Memory Leak

### DIFF
--- a/qiskit/visualization/circuit/matplotlib.py
+++ b/qiskit/visualization/circuit/matplotlib.py
@@ -54,6 +54,9 @@ from qiskit.qasm3.printer import BasicPrinter
 from qiskit.circuit.tools.pi_check import pi_check
 from qiskit.utils import optionals as _optionals
 
+from matplotlib import pyplot as plt
+
+
 from .qcstyle import load_style
 from ._utils import (
     get_gate_ctrl_text,
@@ -83,6 +86,28 @@ PORDER_GATE_PLUS = 11
 PORDER_TEXT = 13
 
 INFINITE_FOLD = 10000000
+
+
+def autodel(figure: plt.Figure = None) -> plt.Figure:
+    """Autodeleter for matplotlib figures.
+    The mechanism is used to delete the previous figure when a new figure is created.
+
+    Args:
+        figure: The figure to delete.
+        
+    Yields:
+        The figure to delete.
+    
+    res : plt.Figure
+        The figure to delete.
+    """
+    while True:
+        res = yield figure
+        plt.close(figure)
+        figure = res
+    
+autodeleter = autodel()
+next(autodeleter)
 
 
 @_optionals.HAS_MATPLOTLIB.require_in_instance
@@ -257,7 +282,6 @@ class MatplotlibDrawer:
 
         # Import matplotlib and load all the figure, window, and style info
         from matplotlib import patches
-        from matplotlib import pyplot as plt
 
         # glob_data contains global values used throughout, "n_lines", "x_offset", "next_x_index",
         # "patches_mod", "subfont_factor"
@@ -393,7 +417,7 @@ class MatplotlibDrawer:
             )
         if not is_user_ax:
             matplotlib_close_if_inline(mpl_figure)
-            return mpl_figure
+            return autodeleter.send(mpl_figure)
 
     def _get_layer_widths(self, node_data, wire_map, outer_circuit, glob_data):
         """Compute the layer_widths for the layers"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

**Description**  
When drawing quantum circuits using Matplotlib (`circ.draw(output='mpl')`), the figures are not automatically closed after being created. This leads to a memory leak and results in the following warning when creating many circuits:

```
RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (matplotlib.pyplot.figure) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam figure.max_open_warning). Consider using matplotlib.pyplot.close().
mpl_figure = plt.figure()
```

**Steps to Reproduce**  
1. Create and draw a quantum circuit in a loop: 
```python 
from qiskit.circuit.random import random_circuit
for i in range(101):
    circ = random_circuit(2, 2, max_operands=2)
    circ.draw(output='mpl')
```

2. Run the code via `python xxx.py`.

**Expected Behaviour**  
- Figures should be automatically closed after being drawn to avoid excessive memory usage.
- No warnings should be raised about too many open figures.



### Details and comments

To solve this problem, we could either add a generator **autodeleter** to fix this problem





