### PR TITLE
Small improvement for multi-controlled 1-qubit gates

### DIFF
--- a/qiskit/circuit/add_control.py
+++ b/qiskit/circuit/add_control.py
@@ -266,8 +266,13 @@ def apply_basic_controlled_gate(circuit, gate, controls, target):
         circuit.s(target)
 
     elif gate.name == "h":
-        circuit.mcry(pi / 2, controls, target, use_basis_gates=False)
+        circuit.s(target)
+        circuit.h(target)
+        circuit.t(target)
         circuit.mcx(controls, target)
+        circuit.tdg(target)
+        circuit.h(target)
+        circuit.sdg(target)
 
     elif gate.name == "sx":
         circuit.h(target)

--- a/releasenotes/notes/improve-decomposition-controlled-one-qubit-unitaries-3ae333a106274b79.yaml
+++ b/releasenotes/notes/improve-decomposition-controlled-one-qubit-unitaries-3ae333a106274b79.yaml
@@ -5,6 +5,6 @@ features_circuits:
     single-qubit unitary gates. For example,
 
     * For multi-controlled :class:`.YGate` on 10 qubits, we reduce the :class:`.CXGate` count by 56%,
-    * For multi-controlled :class:`.HGate` on 10 qubits, we reduce the :class:`.CXGate` count by 44%,
+    * For multi-controlled :class:`.HGate` on 10 qubits, we reduce the :class:`.CXGate` count by 56%,
     * For multi-controlled :class:`.SXGate` and :class:`.SXdgGate` on 10 qubits, we reduce the :class:`.CXGate` count by 80%,
     * For multi-controlled :class:`.UGate` on 10 qubits, we reduce the :class:`.CXGate` count by 31%.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
As [ACE07-Sev](https://github.com/ACE07-Sev) pointed out in https://github.com/Qiskit/qiskit/pull/13801#issuecomment-2648721053, we could further improve the decomposition of multi-controlled `HGate`, based on the definition of the [`CHGate`](https://docs.quantum.ibm.com/api/qiskit/qiskit.circuit.library.CHGate):

```
        gate ch a,b {
            s b;
            h b;
            t b;
            cx a, b;
            tdg b;
            h b;
            sdg b;
        }
```

### Details and comments


