### PR TITLE
Add `dt` to `GenericBackendV2`

### DIFF
--- a/qiskit/providers/fake_provider/generic_backend_v2.py
+++ b/qiskit/providers/fake_provider/generic_backend_v2.py
@@ -530,6 +530,7 @@ class GenericBackendV2(BackendV2):
         control_flow: bool = False,
         calibrate_instructions: bool | InstructionScheduleMap | None = None,
         dtm: float | None = None,
+        dt: float | None = None,
         seed: int | None = None,
         pulse_channels: bool = True,
         noise_info: bool = True,
@@ -579,6 +580,9 @@ class GenericBackendV2(BackendV2):
             dtm: System time resolution of output signals in nanoseconds.
                 None by default.
 
+            dt: System time resolution of input signals in nanoseconds.
+                None by default.
+
             seed: Optional seed for generation of default values.
 
             pulse_channels: DEPRECATED. If true, sets default pulse channel information on the backend.
@@ -596,6 +600,7 @@ class GenericBackendV2(BackendV2):
         self._sim = None
         self._rng = np.random.default_rng(seed=seed)
         self._dtm = dtm
+        self._dt = dt
         self._num_qubits = num_qubits
         self._control_flow = control_flow
         self._calibrate_instructions = calibrate_instructions
@@ -788,7 +793,7 @@ class GenericBackendV2(BackendV2):
             self._target = Target(
                 description=f"Generic Target with {self._num_qubits} qubits",
                 num_qubits=self._num_qubits,
-                dt=properties["dt"],
+                dt=properties["dt"] if self._dt is None else self._dt,
                 qubit_properties=None,
                 concurrent_measurements=[list(range(self._num_qubits))],
             )
@@ -796,7 +801,7 @@ class GenericBackendV2(BackendV2):
             self._target = Target(
                 description=f"Generic Target with {self._num_qubits} qubits",
                 num_qubits=self._num_qubits,
-                dt=properties["dt"],
+                dt=properties["dt"] if self._dt is None else self._dt,
                 qubit_properties=[
                     QubitProperties(
                         t1=self._rng.uniform(properties["t1"][0], properties["t1"][1]),

--- a/releasenotes/notes/add-dt-generic-backend-v2-822f8806517e5dd1.yaml
+++ b/releasenotes/notes/add-dt-generic-backend-v2-822f8806517e5dd1.yaml
@@ -1,0 +1,12 @@
+---
+features_providers:
+  - |
+    Added the ability to set the ``dt`` property of :class:`.GenericBackendV2` in the class initializer
+    with a new ``dt`` argument. Example usage::
+
+      from qiskit.providers.fake_provider import GenericBackendV2
+      backend = GenericBackendV2(
+        num_qubits=5, 
+        basis_gates=["cx", "id", "rz", "sx", "x"],
+        dt= 2.22*e-10, 
+        seed=42)

--- a/test/python/providers/fake_provider/test_generic_backend_v2.py
+++ b/test/python/providers/fake_provider/test_generic_backend_v2.py
@@ -227,3 +227,12 @@ class TestGenericBackendV2(QiskitTestCase):
                     if inst not in ["delay", "reset"]:
                         self.assertGreaterEqual(duration, expected_durations[inst][0])
                         self.assertLessEqual(duration, expected_durations[inst][1])
+
+    def test_custom_dt(self):
+        """Test that the custom dt is respected."""
+
+        ref_backend = GenericBackendV2(num_qubits=2, basis_gates=["cx", "id"], seed=42)
+        double_dt_backend = GenericBackendV2(
+            num_qubits=2, basis_gates=["cx", "id"], dt=ref_backend.dt * 2, seed=42
+        )
+        self.assertEqual(ref_backend.dt * 2, double_dt_backend.dt)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR allows to configure `dt` from the `GenericBackendV2` init, a useful feature for some scheduling tests. This should have been added from the start but was likely left out as an oversight.


### Details and comments


