### PR TITLE
delete erroneous note in XXMinusYY documentation

### DIFF
--- a/qiskit/circuit/library/standard_gates/xx_minus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_minus_yy.py
@@ -63,36 +63,6 @@ class XXMinusYYGate(Gate):
                 0 & 0 & 1 & 0 \\
                 -i\sin\left(\rotationangle\right)e^{i\beta} & 0 & 0 & \cos\left(\rotationangle\right)
             \end{pmatrix}
-
-    .. note::
-
-        In Qiskit's convention, higher qubit indices are more significant
-        (little endian convention). In the above example we apply the gate
-        on (q_0, q_1) which results in adding the (optional) phase defined
-        by :math:`\beta` on q_1. Instead, if we apply it on (q_1, q_0), the
-        phase is added on q_0. If :math:`\beta` is set to its default value
-        of :math:`0`, the gate is equivalent in big and little endian.
-
-        .. code-block:: text
-
-                 ┌───────────────┐
-            q_0: ┤1              ├
-                 │  (XX-YY)(θ,β) │
-            q_1: ┤0              ├
-                 └───────────────┘
-
-        .. math::
-
-            \newcommand{\rotationangle}{\frac{\theta}{2}}
-
-            R_{XX-YY}(\theta, \beta) q_1, q_0 =
-            RZ_0(\beta) \cdot \exp\left(-i \frac{\theta}{2} \frac{XX-YY}{2}\right) \cdot RZ_0(-\beta) =
-            \begin{pmatrix}
-                \cos\left(\rotationangle\right) & 0 & 0 & -i\sin\left(\rotationangle\right)e^{i\beta} \\
-                0 & 1 & 0 & 0 \\
-                0 & 0 & 1 & 0 \\
-                -i\sin\left(\rotationangle\right)e^{-i\beta} & 0 & 0 & \cos\left(\rotationangle\right)
-            \end{pmatrix}
     """
 
     _standard_gate = StandardGate.XXMinusYYGate


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Actually, it doesn't matter which qubit the phase is applied to because the gate only affects the symmetric subspace containing the 00 and 11 states.

### Details and comments


