### PR TITLE
Deprecate backend_props arg in generate_translation_pass_manager

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/common.py
+++ b/qiskit/transpiler/preset_passmanagers/common.py
@@ -15,6 +15,7 @@
 
 import collections
 from typing import Optional
+import warnings
 
 from qiskit.circuit.equivalence_library import SessionEquivalenceLibrary as sel
 from qiskit.circuit.controlflow import CONTROL_FLOW_OP_NAMES
@@ -454,6 +455,18 @@ def generate_translation_passmanager(
     Raises:
         TranspilerError: If the ``method`` kwarg is not a valid value
     """
+    if backend_props is not None:
+        warnings.warn(
+            "The backend_props argument for this function has been deprecated. "
+            "The BackendProperties data structure has been deprecated and will be "
+            "removed in Qiskit 2.0, instead you should use a Target object with the "
+            "required target argument. You can use Target.from_configuration() "
+            "to build the target from the properties object, but in 2.0 you will need "
+            "to generate a target directly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     if method == "translator":
         unroll = [
             # Use unitary synthesis for basis aware decomposition of

--- a/releasenotes/notes/deprecate-bp-args-gtpm-4023a5f86668d96d.yaml
+++ b/releasenotes/notes/deprecate-bp-args-gtpm-4023a5f86668d96d.yaml
@@ -1,0 +1,10 @@
+---
+deprecations_transpiler:
+  - |
+    The ``backend_props`` argument of the
+    :func:`.generate_translation_pass_manager` function is deprecated and
+    will be removed in Qiskit 2.0. This argument is optional and is superseded
+    if the required ``target`` argument is populated. As the
+    :class:`.BackendProperties` is deprecated and will be removed in Qiskit
+    2.0 specifying this option will also no longer work. Usage of the argument
+    can safely be removed in 1.x as long as you were passing in a target.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit deprecates the backend_props argument for the generate translation pass manager helper function. This argument was removed as part of cleaning up the transpiler interface in 2.0 to remove loose constraints and any tie to the BackendV1 models objects. However, the fact that this function was public was overlooked and a deprecation was not added ahead of time.

### Details and comments

Fixes #13831