### PR TITLE
Deprecate subclassing of `Register` and `Bit`

### DIFF
--- a/qiskit/circuit/bit.py
+++ b/qiskit/circuit/bit.py
@@ -14,6 +14,7 @@
 Quantum bit and Classical bit objects.
 """
 import copy
+import warnings
 
 from qiskit.circuit.exceptions import CircuitError
 
@@ -56,6 +57,17 @@ class Bit:
             self._index = index
             self._hash = hash((self._register, self._index))
             self._repr = f"{self.__class__.__name__}({self._register}, {self._index})"
+
+    def __init_subclass__(cls):
+        # In Qiskit 2.0, `Bit` and `Register` will move to Rust space, and the allowable types of
+        # them will be fixed, similar to if the classes had been marked as `final`.
+        if cls.__module__.split(".", 2)[0] != __name__.split(".", 2)[0]:
+            warnings.warn(
+                "subclassing 'Bit' is not supported, and may not be possible in Qiskit 2.0",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+        return cls
 
     def __repr__(self):
         """Return the official string representing the bit."""

--- a/qiskit/circuit/register.py
+++ b/qiskit/circuit/register.py
@@ -17,7 +17,9 @@ Base register reference object.
 """
 
 from __future__ import annotations
+
 import itertools
+import warnings
 import numpy as np
 
 from qiskit.circuit.exceptions import CircuitError
@@ -124,6 +126,17 @@ class Register:
             # first on deep-copying or on pickling, so defer populating _bit_indices
             # until first access.
             self._bit_indices = None
+
+    def __init_subclass__(cls):
+        # In Qiskit 2.0, `Bit` and `Register` will move to Rust space, and the allowable types of
+        # them will be fixed, similar to if the classes had been marked as `final`.
+        if cls.__module__.split(".", 2)[0] != __name__.split(".", 2)[0]:
+            warnings.warn(
+                "subclassing 'Register' is not supported, and may not be possible in Qiskit 2.0",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+        return cls
 
     @property
     def name(self):

--- a/releasenotes/notes/deprecate-subclass-register-0ee4ab0b71c4bb4f.yaml
+++ b/releasenotes/notes/deprecate-subclass-register-0ee4ab0b71c4bb4f.yaml
@@ -1,0 +1,9 @@
+---
+deprecations_circuits:
+  - |
+    It is now deprecated to subclass :class:`.Register` or :class:`.Bit`, or any subclass of them
+    (for example, :class:`.QuantumRegister` or :class:`~.circuit.Qubit`).  Subclassing these types
+    was never explicitly supported by Qiskit, and it is not clear precisely what the meaning would
+    be.  In Qiskit 2.0, the subclassing may become impossible due to technical limitations, and will
+    certainly not be stored in a circuit.  This is because of the move of the data model to Rust
+    space to improve performance.

--- a/test/python/circuit/test_bit.py
+++ b/test/python/circuit/test_bit.py
@@ -16,7 +16,7 @@
 import copy
 from unittest import mock
 
-from qiskit.circuit import bit
+from qiskit.circuit import bit, Qubit
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
 
@@ -75,6 +75,18 @@ class TestBitClass(QiskitTestCase):
         bit2 = copy.copy(bit1)
 
         self.assertIs(bit1, bit2)
+
+    def test_deprecation_of_subclass(self):
+        """It's not permitted to subclass the objects."""
+        with self.assertWarnsRegex(DeprecationWarning, "subclassing 'Bit' is not supported"):
+
+            class _MyBit(bit.Bit):
+                """Direct subclass."""
+
+        with self.assertWarnsRegex(DeprecationWarning, "subclassing 'Bit' is not supported"):
+
+            class _MyQubit(Qubit):
+                """Indirect subclass."""
 
 
 class TestNewStyleBit(QiskitTestCase):

--- a/test/python/circuit/test_register.py
+++ b/test/python/circuit/test_register.py
@@ -16,10 +16,7 @@
 
 from ddt import data, ddt
 
-from qiskit.circuit import bit
-from qiskit.circuit import QuantumRegister
-from qiskit.circuit import AncillaRegister
-from qiskit.circuit import ClassicalRegister
+from qiskit.circuit import bit, QuantumRegister, Register, AncillaRegister, ClassicalRegister
 from qiskit.circuit.exceptions import CircuitError
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
@@ -119,3 +116,15 @@ class TestRegisterClass(QiskitTestCase):
         bits_difftype = [difftype.bit_type() for _ in range(3)]
         reg_difftype = difftype(name="foo", bits=bits_difftype)
         self.assertNotEqual(reg_difftype, test_reg)
+
+    def test_deprecation_of_subclass(self):
+        """It's not permitted to subclass the objects."""
+        with self.assertWarnsRegex(DeprecationWarning, "subclassing 'Register' is not supported"):
+
+            class _MyRegister(Register):
+                """Direct subclass."""
+
+        with self.assertWarnsRegex(DeprecationWarning, "subclassing 'Register' is not supported"):
+
+            class _MyQuantumRegister(QuantumRegister):
+                """Indirect subclass."""


### PR DESCRIPTION
The data represented by these classes will move to Rust space in Qiskit 2.0, and the remaining Python objects will be thin wrappers around the Rust-space objects.  Rust space will not support additional bits beyond the existing triple `Qubit/AncillaQubit/Clbit`, and so Python-space will be unable to represent anything beyond this in the circuit data model.

It's not clear what, if any, meaning was intended by subclassing these objects already, and Qiskit did not consider them subclass safe.  We don't expect that anybody will have been doing this, so the impact should be minimal.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

This is prep work for #13686, or an in-the-works PR by Ray that will supersede that one.