### PR TITLE
Fix Y-eigenstate convention in `SparsePauliOp.as_paulis`

### DIFF
--- a/crates/accelerate/src/sparse_observable.rs
+++ b/crates/accelerate/src/sparse_observable.rs
@@ -198,8 +198,8 @@ fn bit_term_as_pauli(bit: &BitTerm) -> &'static [(bool, Option<BitTerm>)] {
         BitTerm::Z => &[(true, Some(BitTerm::Z))],
         BitTerm::Plus => &[(true, None), (true, Some(BitTerm::X))],
         BitTerm::Minus => &[(true, None), (false, Some(BitTerm::X))],
-        BitTerm::Left => &[(true, None), (true, Some(BitTerm::Y))],
-        BitTerm::Right => &[(true, None), (false, Some(BitTerm::Y))],
+        BitTerm::Right => &[(true, None), (true, Some(BitTerm::Y))],
+        BitTerm::Left => &[(true, None), (false, Some(BitTerm::Y))],
         BitTerm::Zero => &[(true, None), (true, Some(BitTerm::Z))],
         BitTerm::One => &[(true, None), (false, Some(BitTerm::Z))],
     }

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -392,7 +392,7 @@ class TestSparsePauliOpConversions(QiskitTestCase):
         with self.subTest("XrZ"):
             obs = SparseObservable("XrZ")
             spo = SparsePauliOp.from_sparse_observable(obs)
-            expected = SparsePauliOp(["XIZ", "XYZ"], coeffs=[0.5, -0.5])
+            expected = SparsePauliOp(["XIZ", "XYZ"], coeffs=[0.5, 0.5])
 
             # we don't guarantee the order of Paulis, so check equality by comparing
             # the matrix representation and that all Pauli strings are present

--- a/test/python/quantum_info/test_sparse_observable.py
+++ b/test/python/quantum_info/test_sparse_observable.py
@@ -2126,13 +2126,13 @@ class TestSparseObservable(QiskitTestCase):
             expected = SparseObservable.from_sparse_list(
                 [
                     ("", [], 1 / 8),
-                    ("Y", [2], -1 / 8),
+                    ("Y", [2], 1 / 8),
                     ("YY", [3, 2], -1 / 8),
                     ("Z", [0], 1 / 8),
-                    ("YZ", [2, 0], -1 / 8),
+                    ("YZ", [2, 0], 1 / 8),
                     ("YYZ", [3, 2, 0], -1 / 8),
-                    ("Y", [3], 1 / 8),
-                    ("YZ", [3, 0], 1 / 8),
+                    ("Y", [3], -1 / 8),
+                    ("YZ", [3, 0], -1 / 8),
                 ],
                 4,
             )
@@ -2140,7 +2140,7 @@ class TestSparseObservable(QiskitTestCase):
 
         # test multiple terms
         with self.subTest(msg="+X + lY - ZI"):
-            obs = SparseObservable.from_list([("+X", 1), ("rY", 1), ("ZI", -1)])
+            obs = SparseObservable.from_list([("+X", 1), ("lY", 1), ("ZI", -1)])
             obs_paulis = obs.as_paulis()
 
             expected = SparseObservable.from_list(


### PR DESCRIPTION
`|r>` is the positive eigenstate of Y, not the negative one.  The tests also asserted this backwards.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

No reno because the bug isn't released yet.
