### PR TITLE
The unused  parameter `dag` in `DAGNode` constructor is deprecated

### DIFF
--- a/crates/circuit/src/dag_node.rs
+++ b/crates/circuit/src/dag_node.rs
@@ -123,7 +123,7 @@ impl DAGOpNode {
         op: Bound<PyAny>,
         qargs: Option<TupleLikeArg>,
         cargs: Option<TupleLikeArg>,
-        #[allow(unused_variables)] dag: Option<Bound<PyAny>>,
+        dag: Option<Bound<PyAny>>,
     ) -> PyResult<Py<Self>> {
         let py_op = op.extract::<OperationFromPython>()?;
         let qargs = qargs.map_or_else(|| PyTuple::empty_bound(py), |q| q.value);
@@ -138,7 +138,19 @@ impl DAGOpNode {
             #[cfg(feature = "cache_pygates")]
             py_op: op.unbind().into(),
         };
-
+        if dag.is_some() {
+            imports::WARNINGS_WARN.get_bound(py).call1((
+                intern!(
+             py,
+             concat!(
+                 "The ``dag`` parameter in DAGNode subclass constructors "
+                 "is unused and it will be removed in Qiskit 2.0.",
+             )
+         ),
+                py.get_type::<PyDeprecationWarning>(),
+                2,
+            ))?;
+        }
         Py::new(
             py,
             (

--- a/crates/circuit/src/dag_node.rs
+++ b/crates/circuit/src/dag_node.rs
@@ -139,15 +139,14 @@ impl DAGOpNode {
             py_op: op.unbind().into(),
         };
         if dag.is_some() {
-            imports::WARNINGS_WARN.get_bound(py).call1((
+            WARNINGS_WARN.get_bound(py).call1((
                 intern!(
-             py,
-             concat!(
-                 "The ``dag`` parameter in DAGNode subclass constructors "
-                 "is unused and it will be removed in Qiskit 2.0.",
-             )
-         ),
-                py.get_type::<PyDeprecationWarning>(),
+                    py,
+                    concat!("The ``dag`` parameter in DAGNode subclass constructors ",
+                        "is unused and it will be removed in Qiskit 2.0.",
+                    )
+                ),
+                py.get_type_bound::<PyDeprecationWarning>(),
                 2,
             ))?;
         }

--- a/crates/circuit/src/dag_node.rs
+++ b/crates/circuit/src/dag_node.rs
@@ -142,7 +142,8 @@ impl DAGOpNode {
             WARNINGS_WARN.get_bound(py).call1((
                 intern!(
                     py,
-                    concat!("The ``dag`` parameter in DAGNode subclass constructors ",
+                    concat!(
+                        "The ``dag`` parameter in DAGNode subclass constructors ",
                         "is unused and it will be removed in Qiskit 2.0.",
                     )
                 ),

--- a/qiskit/dagcircuit/dagdependency_v2.py
+++ b/qiskit/dagcircuit/dagdependency_v2.py
@@ -345,7 +345,6 @@ class _DAGDependencyV2:
             op=operation,
             qargs=qargs,
             cargs=cargs,
-            dag=self,
         )
         new_node._node_id = self._multi_graph.add_node(new_node)
         self._update_edges()

--- a/qiskit/dagcircuit/dagnode.py
+++ b/qiskit/dagcircuit/dagnode.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import typing
 import uuid
-import warnings
 
 import qiskit._accelerate.circuit
 from qiskit.circuit import (
@@ -35,31 +34,10 @@ if typing.TYPE_CHECKING:
     from qiskit.dagcircuit import DAGCircuit
 
 
-def __init__wrapper__(cls):
-    old_init = cls.__init__
-
-    def new_init(self, *_, **kwargs):
-        if "dag" in kwargs:
-            warnings.warn(
-                f"The 'dag' parameter in {self.__class__.__qualname__} "
-                "constructor is unused and it will be removed in Qiskit 2.0.",
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
-        old_init(self)
-
-    return new_init
-
-
 DAGNode = qiskit._accelerate.circuit.DAGNode
 DAGOpNode = qiskit._accelerate.circuit.DAGOpNode
 DAGInNode = qiskit._accelerate.circuit.DAGInNode
 DAGOutNode = qiskit._accelerate.circuit.DAGOutNode
-
-DAGNode.__init__ = __init__wrapper__(qiskit._accelerate.circuit.DAGNode)
-DAGOpNode.__init__ = __init__wrapper__(qiskit._accelerate.circuit.DAGOpNode)
-DAGInNode.__init__ = __init__wrapper__(qiskit._accelerate.circuit.DAGInNode)
-DAGOutNode.__init__ = __init__wrapper__(qiskit._accelerate.circuit.DAGOutNode)
 
 
 def _legacy_condition_eq(cond1, cond2, bit_indices1, bit_indices2) -> bool:

--- a/qiskit/dagcircuit/dagnode.py
+++ b/qiskit/dagcircuit/dagnode.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import typing
 import uuid
+import warnings
 
 import qiskit._accelerate.circuit
 from qiskit.circuit import (
@@ -34,10 +35,25 @@ if typing.TYPE_CHECKING:
     from qiskit.dagcircuit import DAGCircuit
 
 
-DAGNode = qiskit._accelerate.circuit.DAGNode
-DAGOpNode = qiskit._accelerate.circuit.DAGOpNode
-DAGInNode = qiskit._accelerate.circuit.DAGInNode
-DAGOutNode = qiskit._accelerate.circuit.DAGOutNode
+def __init__wrapper__(func):
+    def wrapper(*args, **kwargs):
+        if "dag" in kwargs:
+            warnings.warn(
+                f"The 'dag' parameter in {func.__module__}.{func.__qualname__} "
+                "constructor is unused and it will be removed in Qiskit 2.0.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+        res = func(*args, **kwargs)
+        return res
+
+    return wrapper
+
+
+DAGNode = __init__wrapper__(qiskit._accelerate.circuit.DAGNode)
+DAGOpNode = __init__wrapper__(qiskit._accelerate.circuit.DAGOpNode)
+DAGInNode = __init__wrapper__(qiskit._accelerate.circuit.DAGInNode)
+DAGOutNode = __init__wrapper__(qiskit._accelerate.circuit.DAGOutNode)
 
 
 def _legacy_condition_eq(cond1, cond2, bit_indices1, bit_indices2) -> bool:

--- a/qiskit/dagcircuit/dagnode.py
+++ b/qiskit/dagcircuit/dagnode.py
@@ -35,25 +35,31 @@ if typing.TYPE_CHECKING:
     from qiskit.dagcircuit import DAGCircuit
 
 
-def __init__wrapper__(func):
-    def wrapper(*args, **kwargs):
+def __init__wrapper__(cls):
+    old_init = cls.__init__
+
+    def new_init(self, *_, **kwargs):
         if "dag" in kwargs:
             warnings.warn(
-                f"The 'dag' parameter in {func.__module__}.{func.__qualname__} "
+                f"The 'dag' parameter in {self.__class__.__qualname__} "
                 "constructor is unused and it will be removed in Qiskit 2.0.",
                 category=DeprecationWarning,
                 stacklevel=2,
             )
-        res = func(*args, **kwargs)
-        return res
+        old_init(self)
 
-    return wrapper
+    return new_init
 
 
-DAGNode = __init__wrapper__(qiskit._accelerate.circuit.DAGNode)
-DAGOpNode = __init__wrapper__(qiskit._accelerate.circuit.DAGOpNode)
-DAGInNode = __init__wrapper__(qiskit._accelerate.circuit.DAGInNode)
-DAGOutNode = __init__wrapper__(qiskit._accelerate.circuit.DAGOutNode)
+DAGNode = qiskit._accelerate.circuit.DAGNode
+DAGOpNode = qiskit._accelerate.circuit.DAGOpNode
+DAGInNode = qiskit._accelerate.circuit.DAGInNode
+DAGOutNode = qiskit._accelerate.circuit.DAGOutNode
+
+DAGNode.__init__ = __init__wrapper__(qiskit._accelerate.circuit.DAGNode)
+DAGOpNode.__init__ = __init__wrapper__(qiskit._accelerate.circuit.DAGOpNode)
+DAGInNode.__init__ = __init__wrapper__(qiskit._accelerate.circuit.DAGInNode)
+DAGOutNode.__init__ = __init__wrapper__(qiskit._accelerate.circuit.DAGOutNode)
 
 
 def _legacy_condition_eq(cond1, cond2, bit_indices1, bit_indices2) -> bool:

--- a/releasenotes/notes/deprecation_13022-9cf84f6c5ff13b29.yaml
+++ b/releasenotes/notes/deprecation_13022-9cf84f6c5ff13b29.yaml
@@ -1,0 +1,4 @@
+---
+deprecations_circuits:
+  - |
+    The ``DAGNode`` subclasses take a ``dag`` optional parameter when constructed that is currently unused and ignored. Now it is deprecated and will be removed in Qiskit 2.0


### PR DESCRIPTION
### Summary

Fixes #13022 

### Details and comments

Because `qiskit._accelerate.circuit.DAGNode` (and family) are rust implementations, I had to write a custom decorator wrapper for them.

