### PR TITLE
The unused parameter dag in DAGNode constructor is removed

### DIFF
--- a/crates/circuit/src/dag_node.rs
+++ b/crates/circuit/src/dag_node.rs
@@ -119,13 +119,12 @@ pub struct DAGOpNode {
 #[pymethods]
 impl DAGOpNode {
     #[new]
-    #[pyo3(signature = (op, qargs=None, cargs=None, *, dag=None))]
+    #[pyo3(signature = (op, qargs=None, cargs=None, *))]
     pub fn py_new(
         py: Python,
         op: Bound<PyAny>,
         qargs: Option<TupleLikeArg>,
         cargs: Option<TupleLikeArg>,
-        #[allow(unused_variables)] dag: Option<Bound<PyAny>>,
     ) -> PyResult<Py<Self>> {
         let py_op = op.extract::<OperationFromPython>()?;
         let qargs = qargs.map_or_else(|| PyTuple::empty(py), |q| q.value);

--- a/crates/circuit/src/dag_node.rs
+++ b/crates/circuit/src/dag_node.rs
@@ -119,7 +119,7 @@ pub struct DAGOpNode {
 #[pymethods]
 impl DAGOpNode {
     #[new]
-    #[pyo3(signature = (op, qargs=None, cargs=None, *))]
+    #[pyo3(signature = (op, qargs=None, cargs=None))]
     pub fn py_new(
         py: Python,
         op: Bound<PyAny>,

--- a/qiskit/dagcircuit/dagdependency_v2.py
+++ b/qiskit/dagcircuit/dagdependency_v2.py
@@ -345,7 +345,6 @@ class _DAGDependencyV2:
             op=operation,
             qargs=qargs,
             cargs=cargs,
-            dag=self,
         )
         new_node._node_id = self._multi_graph.add_node(new_node)
         self._update_edges()

--- a/releasenotes/notes/removal_13022-13f237b337e3d5fb.yaml
+++ b/releasenotes/notes/removal_13022-13f237b337e3d5fb.yaml
@@ -1,4 +1,7 @@
 ---
 upgrade_circuits:
   - |
-    The ``DAGNode`` subclasses take a ``dag`` optional parameter when constructed that it was unused and ignored. The parameter was deprecated in 1.4 and now it is removed.
+    The deprecated argument ``.dag`` for :class:`.DAGNode` and its subclasses :class:`.DAGOpNode`,
+    :class:`.DAGOutNode`, and :class:`.DAGInNode`.  ``dag`` was optional parameter when constructing
+    these objects that was unused and ignored since the 1.3.0 release. The parameter was deprecated
+    in 1.4 and has now been is removed.

--- a/releasenotes/notes/removal_13022-13f237b337e3d5fb.yaml
+++ b/releasenotes/notes/removal_13022-13f237b337e3d5fb.yaml
@@ -1,0 +1,4 @@
+---
+upgrade_circuits:
+  - |
+    The ``DAGNode`` subclasses take a ``dag`` optional parameter when constructed that it was unused and ignored. The parameter was deprecated in 1.4 and now it is removed.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Removal of the deprecation from #13862 . Therefore, `on hold` until the deprecation is merged in 1.4


