### PR TITLE
Change the register name for `measure_active` to `meas`

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3953,7 +3953,7 @@ class QuantumCircuit:
             circ = self.copy()
         dag = circuit_to_dag(circ)
         qubits_to_measure = [qubit for qubit in circ.qubits if qubit not in dag.idle_wires()]
-        new_creg = circ._create_creg(len(qubits_to_measure), "measure")
+        new_creg = circ._create_creg(len(qubits_to_measure), "meas")
         circ.add_register(new_creg)
         circ.barrier()
         circ.measure(qubits_to_measure, new_creg)

--- a/releasenotes/notes/closes_12345-2356fd2d919e3f4a.yaml
+++ b/releasenotes/notes/closes_12345-2356fd2d919e3f4a.yaml
@@ -1,6 +1,6 @@
 ---
 upgrade_circuits:
   - |
-    The method :meth:`QuantumCircuit.measure_active` has changed the name of the classical register it creates,
+    The method :meth:`.QuantumCircuit.measure_active` has changed the name of the classical register it creates,
     as the previous name conflicted with an OpenQASM reserved word. Instead of ``measure``, it is now called ``meas``,
-    aligning with the register name used by :meth:`QuantumCircuit.measure_all`.
+    aligning with the register name used by :meth:`~.QuantumCircuit.measure_all`.

--- a/releasenotes/notes/closes_12345-2356fd2d919e3f4a.yaml
+++ b/releasenotes/notes/closes_12345-2356fd2d919e3f4a.yaml
@@ -1,0 +1,6 @@
+---
+upgrade_circuits:
+  - |
+    The method :meth:`QuantumCircuit.measure_active` has changed the name of the classical register it creates,
+    as the previous name conflicted with an OpenQASM reserved word. Instead of ``measure``, it is now called ``meas``,
+    aligning with the register name used by :meth:`QuantumCircuit.measure_all`.

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -636,7 +636,7 @@ class TestCircuitOperations(QiskitTestCase):
         the amount of non-idle qubits to store the measured values.
         """
         qr = QuantumRegister(4)
-        cr = ClassicalRegister(2, "measure")
+        cr = ClassicalRegister(2, "meas")
 
         circuit = QuantumCircuit(qr)
         circuit.h(qr[0])
@@ -658,7 +658,7 @@ class TestCircuitOperations(QiskitTestCase):
         the amount of non-idle qubits to store the measured values.
         """
         qr = QuantumRegister(4)
-        cr = ClassicalRegister(2, "measure")
+        cr = ClassicalRegister(2, "meas")
 
         circuit = QuantumCircuit(qr)
         circuit.h(qr[0])


### PR DESCRIPTION
### Summary

Closes #12345 

### Details and comments

The method `QuantumCircuit.measure_active()` has changed the name of the classical register it creates, as the previous name conflicted with an OpenQASM reserved word. Instead of `measure`, it is now called `meas`, aligning with the register name used by `QuantumCircuit.measure_all()`.