### PR TITLE
Consitency of azimuthal angle name in `RZ` docstring

### DIFF
--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -37,17 +37,17 @@ class RZGate(Gate):
     .. code-block:: text
 
              ┌───────┐
-        q_0: ┤ Rz(λ) ├
+        q_0: ┤ Rz(φ) ├
              └───────┘
 
     **Matrix Representation:**
 
     .. math::
 
-        RZ(\lambda) = \exp\left(-i\frac{\lambda}{2}Z\right) =
+        RZ(\phi) = \exp\left(-i\frac{\phi}{2}Z\right) =
             \begin{pmatrix}
-                e^{-i\frac{\lambda}{2}} & 0 \\
-                0 & e^{i\frac{\lambda}{2}}
+                e^{-i\frac{\phi}{2}} & 0 \\
+                0 & e^{i\frac{\phi}{2}}
             \end{pmatrix}
 
     .. seealso::
@@ -57,7 +57,7 @@ class RZGate(Gate):
 
             .. math::
 
-                U1(\lambda) = e^{i{\lambda}/2}RZ(\lambda)
+                U1(\theta=\phi) = e^{i{\phi}/2}RZ(\phi)
 
         Reference for virtual Z gate implementation:
         `1612.00858 <https://arxiv.org/abs/1612.00858>`_
@@ -181,10 +181,10 @@ class CRZGate(ControlledGate):
     .. math::
 
         CRZ(\theta)\ q_0, q_1 =
-            I \otimes |0\rangle\langle 0| + RZ(\theta) \otimes |1\rangle\langle 1| =
+            I \otimes |0\rangle\langle 0| + RZ(\phi=\theta) \otimes |1\rangle\langle 1| =
             \begin{pmatrix}
                 1 & 0 & 0 & 0 \\
-                0 & e^{-i\frac{\lambda}{2}} & 0 & 0 \\
+                0 & e^{-i\frac{\theta}{2}} & 0 & 0 \\
                 0 & 0 & 1 & 0 \\
                 0 & 0 & 0 & e^{i\frac{\theta}{2}}
             \end{pmatrix}


### PR DESCRIPTION
- [x] I have added the tests to cover my changes. (Doesn't apply :x:)
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
---

## Summary:

### Solves the 2nd part of Issue: https://github.com/Qiskit/qiskit/issues/13871

> But at least, what should 100% be done quickly, is make sure their documentation is consistent, for each gate, since there are cases where `lambdas` appear instead of `thetas` or `phis`... [check attached images]:
> 
> <img width="387" alt="Image" src="https://github.com/user-attachments/assets/e96cf780-0dab-4fe5-8422-7b436540b448" />
> <img width="294" alt="Image" src="https://github.com/user-attachments/assets/fc1860b9-7862-4fce-85cb-7227eac8d3df" />
> 
