### PR TITLE
Applying a slight perturbation for ill-conditioned matrices

### DIFF
--- a/qiskit/quantum_info/operators/channel/transformations.py
+++ b/qiskit/quantum_info/operators/channel/transformations.py
@@ -234,13 +234,23 @@ def _choi_to_kraus(data, input_dim, output_dim, atol=ATOL_DEFAULT):
         #
         # So the eigenvalues are on the diagonal, therefore the basis-transformation matrix must be
         # a spanning set of the eigenspace.
+        #
+        # In addition, to prevent `numpy.linalg` errors when the matrix A is ill-conditioned,
+        # we apply a small perturbation, replacing A by A + eI. Since (A + eI)x = kx is
+        # equivalent to Ax = (k-e)x, it means that the eigenvectors of A + eI and A are the same,
+        # and we can perfectly recover the eigenvalues of A from the eigenvalues of A + eI by
+        # subtracting e.
+        apply_perturbation = np.linalg.cond(data) >= 1e10
 
-        if np.linalg.cond(data) >= 1e10:
-            # Regularization: applying a small perturbation for ill-conditioned matrices.
+        if apply_perturbation:
             data += 1e-10 * np.eye(data.shape[0])
 
         triangular, vecs = scipy.linalg.schur(data)
         values = triangular.diagonal().real
+
+        if apply_perturbation:
+            values = [v - 1e-10 for v in values]
+
         # If we're not a CP map, fall-through back to the generalization handling.  Since we needed
         # to get the eigenvalues anyway, we can do the CP check manually rather than deferring to a
         # separate re-calculation.

--- a/qiskit/quantum_info/operators/channel/transformations.py
+++ b/qiskit/quantum_info/operators/channel/transformations.py
@@ -234,6 +234,11 @@ def _choi_to_kraus(data, input_dim, output_dim, atol=ATOL_DEFAULT):
         #
         # So the eigenvalues are on the diagonal, therefore the basis-transformation matrix must be
         # a spanning set of the eigenspace.
+
+        if np.linalg.cond(data) >= 1e10:
+            # Regularization: applying a small perturbation for ill-conditioned matrices.
+            data += 1e-10 * np.eye(data.shape[0])
+
         triangular, vecs = scipy.linalg.schur(data)
         values = triangular.diagonal().real
         # If we're not a CP map, fall-through back to the generalization handling.  Since we needed

--- a/qiskit/quantum_info/operators/channel/transformations.py
+++ b/qiskit/quantum_info/operators/channel/transformations.py
@@ -249,7 +249,7 @@ def _choi_to_kraus(data, input_dim, output_dim, atol=ATOL_DEFAULT):
         values = triangular.diagonal().real
 
         if apply_perturbation:
-            values = [v - 1e-10 for v in values]
+            values = values - 1e-10
 
         # If we're not a CP map, fall-through back to the generalization handling.  Since we needed
         # to get the eigenvalues anyway, we can do the CP check manually rather than deferring to a

--- a/releasenotes/notes/choi-to-kraus-3ae7d49f0a27f639.yaml
+++ b/releasenotes/notes/choi-to-kraus-3ae7d49f0a27f639.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Applied a small regularisation factor against ill-conditioned Hermitian matrices
+    in super-operator representations.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fix two failing tests for the 1.3.3 release: 
`test.python.quantum_info.operators.channel.test_kraus.TestKraus.test_circuit_init` + one other very similar test.

The problem only occurs on aarch64 (arm linux), however the relevant matrix is ill-conditioned on my mac as well: the choi matrix has many eigenvalues that are negative and close to 0 (the "negative" is likely due to numerical imprecision errors), with the `numpy.linalg.cond` returning `np.inf`. 

By doing a search on the internet, one of the recommended techniques is to apply regularization, in this case adding a small perturbation to the matrix. Update: as per @jakelishman's suggestion, we can in fact perfectly recover the eigenvalues of the original matrix from the matrix with the perturbation.
