### PR TITLE
Deprecate NormalizeRXAngle and rzx_templates

### DIFF
--- a/qiskit/transpiler/passes/calibration/rzx_templates.py
+++ b/qiskit/transpiler/passes/calibration/rzx_templates.py
@@ -16,10 +16,17 @@ Convenience function to load RZXGate based templates.
 
 from enum import Enum
 from typing import List, Dict
+from qiskit.utils import deprecate_func
 
 from qiskit.circuit.library.templates import rzx
 
 
+@deprecate_func(
+    since="1.4",
+    removal_timeline="in Qiskit 2.0",
+    additional_msg="Use the functions in "
+    "qiskit.circuit.library.templates.rzx instead to generate rzx templates",
+)
 def rzx_templates(template_list: List[str] = None) -> Dict:
     """Convenience function to get the cost_dict and templates for template matching.
 

--- a/qiskit/transpiler/passes/optimization/normalize_rx_angle.py
+++ b/qiskit/transpiler/passes/optimization/normalize_rx_angle.py
@@ -20,6 +20,8 @@ that differ within a resolution provided by the user.
 
 import numpy as np
 
+from qiskit.utils import deprecate_func
+
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.circuit.library.standard_gates import RXGate, RZGate, SXGate, XGate
@@ -48,6 +50,12 @@ class NormalizeRXAngle(TransformationPass):
     Note that pulse calibration might be attached per each rotation angle.
     """
 
+    @deprecate_func(
+        since="1.4",
+        removal_timeline="in Qiskit 2.0",
+        additional_msg="This pass was used as pre-processing step of ``RXCalibrationBuilder``."
+        " With the removal of Pulse in Qiskit 2.0, this pass is no longer needed.",
+    )
     def __init__(self, target=None, resolution_in_radian=0):
         """NormalizeRXAngle initializer.
 

--- a/releasenotes/notes/deprecate-pulse-leftovers-b00c70f828d1a7fa.yaml
+++ b/releasenotes/notes/deprecate-pulse-leftovers-b00c70f828d1a7fa.yaml
@@ -1,0 +1,7 @@
+deprecations_transpiler:
+  - |
+    As part of Pulse deprecation in version 1.3, the calibration builder passes
+    were also deprecated and in particular :class:`.RXCalibrationBuilder`. The
+    :class:`.NormalizeRXAngle` pass is a requirement of :class:`.RXCalibrationBuilder`
+    hence it should also be deprecated. In addition, the :func:`.rzx_templates`
+    function in the calibration module is being deprecated as it is not used.

--- a/test/python/transpiler/test_normalize_rx_angle.py
+++ b/test/python/transpiler/test_normalize_rx_angle.py
@@ -34,7 +34,8 @@ class TestNormalizeRXAngle(QiskitTestCase):
         """Check that RX(pi) is NOT converted to X,
         if X calibration is not present in the target"""
         empty_target = Target()
-        tp = NormalizeRXAngle(target=empty_target)
+        with self.assertWarns(DeprecationWarning):
+            tp = NormalizeRXAngle(target=empty_target)
 
         qc = QuantumCircuit(1)
         qc.rx(90, 0)
@@ -47,7 +48,8 @@ class TestNormalizeRXAngle(QiskitTestCase):
         if SX calibration is present in the target"""
         target = Target()
         target.add_instruction(SXGate(), properties={(0,): None})
-        tp = NormalizeRXAngle(target=target)
+        with self.assertWarns(DeprecationWarning):
+            tp = NormalizeRXAngle(target=target)
 
         qc = QuantumCircuit(1)
         qc.rx(np.pi / 2, 0)
@@ -60,7 +62,8 @@ class TestNormalizeRXAngle(QiskitTestCase):
         if RX rotation angle is negative"""
 
         backend = GenericBackendV2(num_qubits=5)
-        tp = NormalizeRXAngle(target=backend.target)
+        with self.assertWarns(DeprecationWarning):
+            tp = NormalizeRXAngle(target=backend.target)
 
         # circuit to transpile and test
         qc = QuantumCircuit(1)
@@ -83,7 +86,8 @@ class TestNormalizeRXAngle(QiskitTestCase):
     def test_angle_wrapping_works(self, raw_theta, correct_wrapped_theta):
         """Check that RX rotation angles are correctly wrapped to [0, pi]"""
         backend = GenericBackendV2(num_qubits=5)
-        tp = NormalizeRXAngle(target=backend.target)
+        with self.assertWarns(DeprecationWarning):
+            tp = NormalizeRXAngle(target=backend.target)
 
         # circuit to transpile and test
         qc = QuantumCircuit(1)
@@ -118,7 +122,8 @@ class TestNormalizeRXAngle(QiskitTestCase):
         the requested angle is not in the vicinity of the already generated angles.
         """
         backend = GenericBackendV2(num_qubits=5)
-        tp = NormalizeRXAngle(backend.target, resolution_in_radian=resolution)
+        with self.assertWarns(DeprecationWarning):
+            tp = NormalizeRXAngle(backend.target, resolution_in_radian=resolution)
 
         qc = QuantumCircuit(1)
         for rx_angle in rx_angles:

--- a/test/python/transpiler/test_template_matching.py
+++ b/test/python/transpiler/test_template_matching.py
@@ -428,7 +428,8 @@ class TestTemplateMatching(QiskitTestCase):
         circuit_in.p(2 * theta, 1)
         circuit_in.cx(0, 1)
 
-        pass_ = TemplateOptimization(**rzx_templates(["zz2"]))
+        with self.assertWarns(DeprecationWarning):
+            pass_ = TemplateOptimization(**rzx_templates(["zz2"]))
         circuit_out = PassManager(pass_).run(circuit_in)
 
         # these are NOT equal if template optimization works


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
`NormalizeRXAngle` and `rzx_templates` should have been deprecated as well in 1.3 together with Pulse. They are not used anymore will be removed in Qiskit 2.0. 

This is an oversight of #13164 