### PR TITLE
Add 2q fractional gates to the `ConsolidateBlocks` transpiler pass

### DIFF
--- a/crates/accelerate/src/consolidate_blocks.rs
+++ b/crates/accelerate/src/consolidate_blocks.rs
@@ -67,7 +67,7 @@ const MAX_2Q_DEPTH: usize = 20;
 pub(crate) fn consolidate_blocks(
     py: Python,
     dag: &mut DAGCircuit,
-    decomposer: &DecomposerType,
+    decomposer: DecomposerType,
     basis_gate_name: &str,
     force_consolidate: bool,
     target: Option<&Target>,
@@ -218,10 +218,10 @@ pub(crate) fn consolidate_blocks(
             let matrix = blocks_to_matrix(py, dag, &block, block_index_map).ok();
             if let Some(matrix) = matrix {
                 let num_basis_gates = match decomposer {
-                    DecomposerType::TwoQubitBasis(decomp) => {
+                    DecomposerType::TwoQubitBasis(ref decomp) => {
                         decomp.num_basis_gates_inner(matrix.view())
                     }
-                    DecomposerType::TwoQubitControlledU(decomp) => {
+                    DecomposerType::TwoQubitControlledU(ref decomp) => {
                         decomp.num_basis_gates_inner(matrix.view())?
                     }
                 };

--- a/crates/accelerate/src/consolidate_blocks.rs
+++ b/crates/accelerate/src/consolidate_blocks.rs
@@ -17,9 +17,6 @@ use num_complex::Complex64;
 use numpy::PyReadonlyArray2;
 use pyo3::intern;
 use pyo3::prelude::*;
-use rustworkx_core::petgraph::stable_graph::NodeIndex;
-use smallvec::smallvec;
-
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::circuit_instruction::ExtraInstructionAttributes;
 use qiskit_circuit::dag_circuit::DAGCircuit;
@@ -28,12 +25,21 @@ use qiskit_circuit::imports::{QI_OPERATOR, QUANTUM_CIRCUIT};
 use qiskit_circuit::operations::{ArrayType, Operation, Param, UnitaryGate};
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::Qubit;
+use rustworkx_core::petgraph::stable_graph::NodeIndex;
+use smallvec::smallvec;
 
 use crate::convert_2q_block_matrix::{blocks_to_matrix, get_matrix_from_inst};
 use crate::euler_one_qubit_decomposer::matmul_1q;
 use crate::nlayout::PhysicalQubit;
 use crate::target_transpiler::Target;
-use crate::two_qubit_decompose::TwoQubitBasisDecomposer;
+use crate::two_qubit_decompose::{TwoQubitBasisDecomposer, TwoQubitControlledUDecomposer};
+
+#[derive(Clone, Debug)]
+#[pyclass]
+pub enum DecomposerType {
+    TwoQubitBasis(TwoQubitBasisDecomposer),
+    TwoQubitControlledU(TwoQubitControlledUDecomposer),
+}
 
 fn is_supported(
     target: Option<&Target>,
@@ -62,7 +68,7 @@ const MAX_2Q_DEPTH: usize = 20;
 pub(crate) fn consolidate_blocks(
     py: Python,
     dag: &mut DAGCircuit,
-    decomposer: &TwoQubitBasisDecomposer,
+    decomposer: &DecomposerType,
     basis_gate_name: &str,
     force_consolidate: bool,
     target: Option<&Target>,
@@ -212,8 +218,17 @@ pub(crate) fn consolidate_blocks(
             ];
             let matrix = blocks_to_matrix(py, dag, &block, block_index_map).ok();
             if let Some(matrix) = matrix {
+                let num_basis_gates = match decomposer {
+                    DecomposerType::TwoQubitBasis(decomp) => {
+                        decomp.num_basis_gates_inner(matrix.view())
+                    }
+                    DecomposerType::TwoQubitControlledU(decomp) => {
+                        decomp.num_basis_gates_inner(matrix.view())?
+                    }
+                };
+
                 if force_consolidate
-                    || decomposer.num_basis_gates_inner(matrix.view()) < basis_count
+                    || num_basis_gates < basis_count
                     || block.len() > MAX_2Q_DEPTH
                     || (basis_gates.is_some() && outside_basis)
                     || (target.is_some() && outside_basis)

--- a/crates/accelerate/src/consolidate_blocks.rs
+++ b/crates/accelerate/src/consolidate_blocks.rs
@@ -34,8 +34,7 @@ use crate::nlayout::PhysicalQubit;
 use crate::target_transpiler::Target;
 use crate::two_qubit_decompose::{TwoQubitBasisDecomposer, TwoQubitControlledUDecomposer};
 
-#[derive(Clone, Debug)]
-#[pyclass]
+#[derive(Clone, Debug, FromPyObject)]
 pub enum DecomposerType {
     TwoQubitBasis(TwoQubitBasisDecomposer),
     TwoQubitControlledU(TwoQubitControlledUDecomposer),

--- a/crates/accelerate/src/consolidate_blocks.rs
+++ b/crates/accelerate/src/consolidate_blocks.rs
@@ -34,6 +34,7 @@ use crate::nlayout::PhysicalQubit;
 use crate::target_transpiler::Target;
 use crate::two_qubit_decompose::{TwoQubitBasisDecomposer, TwoQubitControlledUDecomposer};
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, FromPyObject)]
 pub enum DecomposerType {
     TwoQubitBasis(TwoQubitBasisDecomposer),

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -2497,6 +2497,16 @@ type InverseReturn = (Option<StandardGate>, SmallVec<[f64; 3]>, SmallVec<[u8; 2]
 ///  :math:`U \sim U_d(\alpha, 0, 0) \sim \text{Ctrl-U}`
 ///  gate that is locally equivalent to an :class:`.RXXGate`.
 impl TwoQubitControlledUDecomposer {
+    /// Compute the number of basis gates needed for a given unitary
+    pub fn num_basis_gates_inner(&self, unitary: ArrayView2<Complex64>) -> PyResult<usize> {
+        let target_decomposed =
+            TwoQubitWeylDecomposition::new_inner(unitary, Some(DEFAULT_FIDELITY), None)?;
+        let num_basis_gates = (((target_decomposed.a).abs() > DEFAULT_ATOL) as usize)
+            + (((target_decomposed.b).abs() > DEFAULT_ATOL) as usize)
+            + (((target_decomposed.c).abs() > DEFAULT_ATOL) as usize);
+        Ok(num_basis_gates)
+    }
+
     /// invert 2q gate sequence
     fn invert_2q_gate(
         &self,

--- a/qiskit/synthesis/two_qubit/__init__.py
+++ b/qiskit/synthesis/two_qubit/__init__.py
@@ -16,4 +16,5 @@ from .two_qubit_decompose import (
     TwoQubitBasisDecomposer,
     two_qubit_cnot_decompose,
     TwoQubitWeylDecomposition,
+    TwoQubitControlledUDecomposer,
 )

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -288,15 +288,15 @@ class TwoQubitControlledUDecomposer:
             QiskitError: If the gate is not locally equivalent to an :class:`.RXXGate`.
         """
         if rxx_equivalent_gate._standard_gate is not None:
-            self._inner_decomposition = two_qubit_decompose.TwoQubitControlledUDecomposer(
+            self._inner_decomposer = two_qubit_decompose.TwoQubitControlledUDecomposer(
                 rxx_equivalent_gate._standard_gate, euler_basis
             )
         else:
-            self._inner_decomposition = two_qubit_decompose.TwoQubitControlledUDecomposer(
+            self._inner_decomposer = two_qubit_decompose.TwoQubitControlledUDecomposer(
                 rxx_equivalent_gate, euler_basis
             )
         self.rxx_equivalent_gate = rxx_equivalent_gate
-        self.scale = self._inner_decomposition.scale
+        self.scale = self._inner_decomposer.scale
         self.euler_basis = euler_basis
 
     def __call__(
@@ -312,7 +312,7 @@ class TwoQubitControlledUDecomposer:
 
         Note: atol is passed to OneQubitEulerDecomposer.
         """
-        circ_data = self._inner_decomposition(np.asarray(unitary, dtype=complex), atol)
+        circ_data = self._inner_decomposer(np.asarray(unitary, dtype=complex), atol)
         return QuantumCircuit._from_circuit_data(circ_data, add_regs=True)
 
 

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -291,6 +291,7 @@ class TwoQubitControlledUDecomposer:
             self._inner_decomposer = two_qubit_decompose.TwoQubitControlledUDecomposer(
                 rxx_equivalent_gate._standard_gate, euler_basis
             )
+            self.gate_name = rxx_equivalent_gate._standard_gate.name
         else:
             self._inner_decomposer = two_qubit_decompose.TwoQubitControlledUDecomposer(
                 rxx_equivalent_gate, euler_basis
@@ -353,6 +354,7 @@ class TwoQubitBasisDecomposer:
             gate_name = "cx"
         else:
             gate_name = "USER_GATE"
+        self.gate_name = gate_name
 
         self._inner_decomposer = two_qubit_decompose.TwoQubitBasisDecomposer(
             gate_name,

--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -12,10 +12,22 @@
 
 """Replace each block of consecutive gates by a single Unitary node."""
 from __future__ import annotations
-from math import pi
 
-from qiskit.synthesis.two_qubit import TwoQubitBasisDecomposer
-from qiskit.circuit.library.standard_gates import CXGate, CZGate, iSwapGate, ECRGate, RXXGate
+from qiskit.synthesis.two_qubit import TwoQubitBasisDecomposer, TwoQubitControlledUDecomposer
+from qiskit.circuit.library.standard_gates import (
+    CXGate,
+    CZGate,
+    iSwapGate,
+    ECRGate,
+    RXXGate,
+    RYYGate,
+    RZZGate,
+    RZXGate,
+    CRXGate,
+    CRYGate,
+    CRZGate,
+    CPhaseGate,
+)
 
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.passmanager import PassManager
@@ -29,7 +41,18 @@ KAK_GATE_NAMES = {
     "cz": CZGate(),
     "iswap": iSwapGate(),
     "ecr": ECRGate(),
-    "rxx": RXXGate(pi / 2),
+    # "rxx": RXXGate(pi / 2),
+}
+
+KAK_GATE_PARAM_NAMES = {
+    "rxx": RXXGate,
+    "rzz": RZZGate,
+    "ryy": RYYGate,
+    "rzx": RZXGate,
+    "cphase": CPhaseGate,
+    "crx": CRXGate,
+    "cry": CRYGate,
+    "crz": CRZGate,
 }
 
 
@@ -81,10 +104,10 @@ class ConsolidateBlocks(TransformationPass):
                 self.decomposer = TwoQubitBasisDecomposer(
                     KAK_GATE_NAMES[kak_gates.pop()], basis_fidelity=approximation_degree or 1.0
                 )
-            elif "rzx" in basis_gates:
-                self.decomposer = TwoQubitBasisDecomposer(
-                    CXGate(), basis_fidelity=approximation_degree or 1.0
-                )
+            # elif "rzx" in basis_gates:
+            #    self.decomposer = TwoQubitBasisDecomposer(
+            #        CXGate(), basis_fidelity=approximation_degree or 1.0
+            #    )
             else:
                 self.decomposer = None
         else:

--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -102,11 +102,11 @@ class ConsolidateBlocks(TransformationPass):
             kak_param_gates = KAK_GATE_PARAM_NAMES.keys() & (basis_gates or [])
             if kak_gates:
                 self.decomposer = TwoQubitBasisDecomposer(
-                    KAK_GATE_NAMES[kak_gates.pop()], basis_fidelity=approximation_degree or 1.0
+                    KAK_GATE_NAMES[list(kak_gates)[0]], basis_fidelity=approximation_degree or 1.0
                 )
             elif kak_param_gates:
                 self.decomposer = TwoQubitControlledUDecomposer(
-                    KAK_GATE_PARAM_NAMES[kak_param_gates.pop()]
+                    KAK_GATE_PARAM_NAMES[list(kak_param_gates)[0]]
                 )
             else:
                 self.decomposer = None

--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -100,9 +100,14 @@ class ConsolidateBlocks(TransformationPass):
             self.decomposer = TwoQubitBasisDecomposer(kak_basis_gate)
         elif basis_gates is not None:
             kak_gates = KAK_GATE_NAMES.keys() & (basis_gates or [])
+            kak_param_gates = KAK_GATE_PARAM_NAMES.keys() & (basis_gates or [])
             if kak_gates:
                 self.decomposer = TwoQubitBasisDecomposer(
                     KAK_GATE_NAMES[kak_gates.pop()], basis_fidelity=approximation_degree or 1.0
+                )
+            elif kak_param_gates:
+                self.decomposer = TwoQubitControlledUDecomposer(
+                    KAK_GATE_PARAM_NAMES[kak_param_gates.pop()]
                 )
             # elif "rzx" in basis_gates:
             #    self.decomposer = TwoQubitBasisDecomposer(

--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -109,10 +109,6 @@ class ConsolidateBlocks(TransformationPass):
                 self.decomposer = TwoQubitControlledUDecomposer(
                     KAK_GATE_PARAM_NAMES[kak_param_gates.pop()]
                 )
-            # elif "rzx" in basis_gates:
-            #    self.decomposer = TwoQubitBasisDecomposer(
-            #        CXGate(), basis_fidelity=approximation_degree or 1.0
-            #    )
             else:
                 self.decomposer = None
         else:
@@ -137,7 +133,7 @@ class ConsolidateBlocks(TransformationPass):
         consolidate_blocks(
             dag,
             self.decomposer._inner_decomposer,
-            self.decomposer.gate.name,
+            self.decomposer.gate_name,
             self.force_consolidate,
             target=self.target,
             basis_gates=self.basis_gates,

--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -41,7 +41,6 @@ KAK_GATE_NAMES = {
     "cz": CZGate(),
     "iswap": iSwapGate(),
     "ecr": ECRGate(),
-    # "rxx": RXXGate(pi / 2),
 }
 
 KAK_GATE_PARAM_NAMES = {

--- a/releasenotes/notes/add-2q-fractional-gates-to-consolidate-blocks-pass-65fadda8ba17c831.yaml
+++ b/releasenotes/notes/add-2q-fractional-gates-to-consolidate-blocks-pass-65fadda8ba17c831.yaml
@@ -1,0 +1,25 @@
+---
+features_transpiler:
+  - |
+    Added support for two-qubit fractional basis gates, such as :class:`.RZZGate`, to the
+    :class:`.ConsolidateBlocks` transpiler pass. The decomposition itself is done using the
+    :class:`.TwoQubitControlledUDecomposer`.
+
+    For example::
+
+      from qiskit import QuantumCircuit
+      from qiskit.transpiler import generate_preset_pass_manager
+      from qiskit.transpiler.passes import ConsolidateBlocks
+
+      qc = QuantumCircuit(2)
+      qc.rzz(0.1, 0, 1)
+      qc.rzz(0.2, 0, 1)
+      consolidate_pass = ConsolidateBlocks(basis_gates=["rz", "rzz", "sx", "x", "rx"])
+      block = consolidate_pass(qc)  # consolidate the circuit into a single unitary block
+      block.draw(output='mpl')
+
+      pm = generate_preset_pass_manager(
+          optimization_level=2, basis_gates=["rz", "rzz", "sx", "x", "rx"]
+      )
+      tqc = pm.run(qc)  # synthesizing the circuit into basis gates
+      tqc.draw(output='mpl')

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -671,10 +671,10 @@ class TestConsolidateBlocks(QiskitTestCase):
         qc = QuantumCircuit(2)
         qc.rzz(0.1, 0, 1)
         qc.rzz(0.2, 0, 1)
-        qc.rzz(0.3, 0, 1)
-        qc.rzz(0.4, 0, 1)
         consolidate_pass = ConsolidateBlocks(basis_gates=["rzz", "rx", "rz"])
-        qc2 = consolidate_pass(qc)
+        res = consolidate_pass(qc)
+        self.assertEqual({"unitary": 1}, res.count_ops())
+        self.assertEqual(Operator.from_circuit(qc), Operator(res.data[0].operation.params[0]))
 
 
 if __name__ == "__main__":

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -597,7 +597,11 @@ class TestConsolidateBlocks(QiskitTestCase):
             optimization_level=opt_level, basis_gates=["rz", "rzz", "sx", "x", "rx"]
         )
         tqc = pm.run(qc)
-        self.assertEqual(ref_tqc, tqc)
+        # it's enough to check that the number of 2-qubit gates does not change
+        count_rzz_ref = ref_tqc.count_ops()["rzz"]
+        count_rzz_tqc = tqc.count_ops()["rzz"]
+        self.assertEqual(Operator.from_circuit(qc), Operator.from_circuit(tqc))
+        self.assertEqual(count_rzz_ref, count_rzz_tqc)
 
     def test_non_cx_basis_gate(self):
         """Test a non-cx kak gate is consolidated correctly."""

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -666,6 +666,16 @@ class TestConsolidateBlocks(QiskitTestCase):
         self.assertEqual({"unitary": 1}, res.count_ops())
         self.assertEqual(Operator.from_circuit(qc), Operator(res.data[0].operation.params[0]))
 
+    def test_collect_rzz(self):
+        """Collect blocks with RZZ gates."""
+        qc = QuantumCircuit(2)
+        qc.rzz(0.1, 0, 1)
+        qc.rzz(0.2, 0, 1)
+        qc.rzz(0.3, 0, 1)
+        qc.rzz(0.4, 0, 1)
+        consolidate_pass = ConsolidateBlocks(basis_gates=["rzz", "rx", "rz"])
+        qc2 = consolidate_pass(qc)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
With the introduction of new 2q-fractional gates, such as `RZZGate` as part of the QPU, we add them to the `ConsolidateBlocks` transpiler pass.
https://www.ibm.com/quantum/blog/fractional-gates

This PR should close #13428

### Details and comments
Note that this PR may be eventually superseded by #13419 

