### PR TITLE
Pin symengine in backwards compatibility tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ python-dateutil>=2.8.0
 stevedore>=3.0.0
 typing-extensions
 
-# If updating the version range here, consider updating 'test/qpy_compat/run_tests.sh' to update the
-# list of symengine dependencies used in the cross-version tests.
+# If updating the version range here, consider updating the 
+# list of symengine dependencies used in the cross-version tests
+# in 'test/qpy_compat/run_tests.sh' and 'test/qpy_compat/qpy_test_constraints.txt'
 symengine>=0.11,<0.14

--- a/test/qpy_compat/qpy_test_constraints.txt
+++ b/test/qpy_compat/qpy_test_constraints.txt
@@ -1,2 +1,3 @@
 numpy===1.24.4
 scipy===1.10.1
+symengine>=0.11,<0.14

--- a/test/qpy_compat/qpy_test_constraints.txt
+++ b/test/qpy_compat/qpy_test_constraints.txt
@@ -1,8 +1,7 @@
 numpy===1.24.4
 scipy===1.10.1
 
-# Note that these are looses constraints in the range of symengine versions 
-# because the logic that selects the versions for the tests is distributed 
-# between this file and `test/qpy_compat/run_tests.sh` and we don't want to
-# interfere with that.
+# This is a loose constraint because we want to test different versions,
+# as defined in 'test/qpy_compat/run_tests.sh', but any symengine version 
+# above (and including) 0.14 will be incompatible with qpy.
 symengine<0.14

--- a/test/qpy_compat/qpy_test_constraints.txt
+++ b/test/qpy_compat/qpy_test_constraints.txt
@@ -1,3 +1,8 @@
 numpy===1.24.4
 scipy===1.10.1
+
+# Note that these are looses constraints in the range of symengine versions 
+# because the logic that selects the versions for the tests is distributed 
+# between this file and `test/qpy_compat/run_tests.sh` and we don't want to
+# interfere with that.
 symengine>=0.11,<0.14

--- a/test/qpy_compat/qpy_test_constraints.txt
+++ b/test/qpy_compat/qpy_test_constraints.txt
@@ -5,4 +5,4 @@ scipy===1.10.1
 # because the logic that selects the versions for the tests is distributed 
 # between this file and `test/qpy_compat/run_tests.sh` and we don't want to
 # interfere with that.
-symengine>=0.11,<0.14
+symengine<0.14

--- a/test/qpy_compat/run_tests.sh
+++ b/test/qpy_compat/run_tests.sh
@@ -57,6 +57,8 @@ popd
 # This will likely duplicate the base dev-compatibility test, but the tests are fairly fast, and
 # it's better safe than sorry with the serialisation tests.
 
+# Note that the constraint in the range of symengine versions is logically duplicated 
+# in `qpy_test_constraints.txt`
 symengine_versions=(
     '>=0.11,<0.12'
     '>=0.13,<0.14'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The recent symengine 1.14 release breaks the qpy backwards compatibility tests in the `stable/1.4` branch with a `qiskit.qpy.exceptions.QpyError: 'Incompatible symengine version 0.14 used to generate the QPY payload'` error.

The symengine version was already pinned to <1.14 in the following locations:

- `requirements.txt`
- `test/qpy_compat/run_tests.sh`

The symengine version is not directly modified in `test/qpy_compat/process_version.sh`, but seems to pull the version constraints from `test/qpy_compat/qpy_test_constraints.txt`, which didn't include symengine. 

For this reason, this PR pins symengine to <1.14 in `test/qpy_compat/qpy_test_constraints.txt`. 

### Details and comments
The `main` branch doesn't seem to share this issue even though the inspected files look the same. There might be an additional constraint in `main` that I am missing, but for the moment decided to open this PR directly against 1.4. [Edit: I think that the tests in main are used the cached qpy files and not generating them from scratch. The bugfix should still probably be ported to 2.0 and 1.3]

