### PR TITLE
Add `ContractIdleWiresInControlFlow` to default pipelines

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -42,6 +42,7 @@ from qiskit.transpiler.passes.optimization import (
     ConsolidateBlocks,
     InverseCancellation,
     RemoveIdentityEquivalent,
+    ContractIdleWiresInControlFlow,
 )
 from qiskit.transpiler.passes import Depth, Size, FixedPoint, MinimumPoint
 from qiskit.transpiler.passes.utils.gates_basis import GatesInBasis
@@ -125,22 +126,25 @@ class DefaultInitPassManager(PassManagerStagePlugin):
                     pass_manager_config.qubits_initially_zero,
                 )
             init.append(
-                InverseCancellation(
-                    [
-                        CXGate(),
-                        ECRGate(),
-                        CZGate(),
-                        CYGate(),
-                        XGate(),
-                        YGate(),
-                        ZGate(),
-                        HGate(),
-                        SwapGate(),
-                        (TGate(), TdgGate()),
-                        (SGate(), SdgGate()),
-                        (SXGate(), SXdgGate()),
-                    ]
-                )
+                [
+                    InverseCancellation(
+                        [
+                            CXGate(),
+                            ECRGate(),
+                            CZGate(),
+                            CYGate(),
+                            XGate(),
+                            YGate(),
+                            ZGate(),
+                            HGate(),
+                            SwapGate(),
+                            (TGate(), TdgGate()),
+                            (SGate(), SdgGate()),
+                            (SXGate(), SXdgGate()),
+                        ]
+                    ),
+                    ContractIdleWiresInControlFlow(),
+                ]
             )
 
         elif optimization_level in {2, 3}:
@@ -155,31 +159,32 @@ class DefaultInitPassManager(PassManagerStagePlugin):
             )
             if pass_manager_config.routing_method != "none":
                 init.append(ElidePermutations())
-            init.append(RemoveDiagonalGatesBeforeMeasure())
-            # Target not set on RemoveIdentityEquivalent because we haven't applied a Layout
-            # yet so doing anything relative to an error rate in the target is not valid.
             init.append(
-                RemoveIdentityEquivalent(
-                    approximation_degree=pass_manager_config.approximation_degree
-                )
-            )
-            init.append(
-                InverseCancellation(
-                    [
-                        CXGate(),
-                        ECRGate(),
-                        CZGate(),
-                        CYGate(),
-                        XGate(),
-                        YGate(),
-                        ZGate(),
-                        HGate(),
-                        SwapGate(),
-                        (TGate(), TdgGate()),
-                        (SGate(), SdgGate()),
-                        (SXGate(), SXdgGate()),
-                    ]
-                )
+                [
+                    RemoveDiagonalGatesBeforeMeasure(),
+                    # Target not set on RemoveIdentityEquivalent because we haven't applied a Layout
+                    # yet so doing anything relative to an error rate in the target is not valid.
+                    RemoveIdentityEquivalent(
+                        approximation_degree=pass_manager_config.approximation_degree
+                    ),
+                    InverseCancellation(
+                        [
+                            CXGate(),
+                            ECRGate(),
+                            CZGate(),
+                            CYGate(),
+                            XGate(),
+                            YGate(),
+                            ZGate(),
+                            HGate(),
+                            SwapGate(),
+                            (TGate(), TdgGate()),
+                            (SGate(), SdgGate()),
+                            (SXGate(), SXdgGate()),
+                        ]
+                    ),
+                    ContractIdleWiresInControlFlow(),
+                ]
             )
             init.append(CommutativeCancellation())
             init.append(ConsolidateBlocks())
@@ -539,6 +544,7 @@ class OptimizationPassManager(PassManagerStagePlugin):
                             (SXGate(), SXdgGate()),
                         ]
                     ),
+                    ContractIdleWiresInControlFlow(),
                 ]
 
             elif optimization_level == 2:
@@ -551,6 +557,7 @@ class OptimizationPassManager(PassManagerStagePlugin):
                         basis=pass_manager_config.basis_gates, target=pass_manager_config.target
                     ),
                     CommutativeCancellation(target=pass_manager_config.target),
+                    ContractIdleWiresInControlFlow(),
                 ]
             elif optimization_level == 3:
                 # Steps for optimization level 3
@@ -576,6 +583,7 @@ class OptimizationPassManager(PassManagerStagePlugin):
                         basis=pass_manager_config.basis_gates, target=pass_manager_config.target
                     ),
                     CommutativeCancellation(target=pass_manager_config.target),
+                    ContractIdleWiresInControlFlow(),
                 ]
 
                 def _opt_control(property_set):

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -2090,6 +2090,45 @@ class TestTranspile(QiskitTestCase):
         )
         self.assertLessEqual(set(transpiled.count_ops().keys()), {"u1", "u2", "u3", "cx"})
 
+    @data(1, 2, 3)
+    def test_optimize_decomposition_around_control_flow(self, level):
+        """Test that we successfully optimise away idle wires from control flow."""
+        qc = QuantumCircuit(5, 1)
+        # This cz(0, 1) can't cancel with its friend on the other side until the data dependency is
+        # removed from the `if` block.  Similarly, the sx(2) needs the two x(2) in the `if` to go.
+        qc.cz(0, 1)
+        qc.sx(2)
+        qc.cz(3, 4)
+        with qc.if_test((qc.clbits[0], False)):
+            # The `(0, 4)` data dependencies should be removed before routing, so we don't see any
+            # swaps in here.
+            qc.cz(0, 4)
+            qc.x(2)
+            qc.x(2)
+            qc.x(3)
+            qc.cz(0, 4)
+        qc.cz(0, 1)
+        qc.sxdg(2)
+        qc.cz(3, 4)
+
+        expected = qc.copy_empty_like()
+        expected.cz(3, 4)
+        with expected.if_test((expected.clbits[0], False)):
+            expected.x(3)
+        expected.cz(3, 4)
+
+        target = Target(5)
+        target.add_instruction(XGate(), {(i,): None for i in range(5)})
+        target.add_instruction(SXGate(), {(i,): None for i in range(5)})
+        target.add_instruction(RZGate(Parameter("a")), {(i,): None for i in range(5)})
+        target.add_instruction(CZGate(), {pair: None for pair in CouplingMap.from_line(5)})
+        target.add_instruction(IfElseOp, name="if_else")
+
+        self.assertEqual(
+            transpile(qc, target=target, optimization_level=level, initial_layout=[0, 1, 2, 3, 4]),
+            expected,
+        )
+
 
 @ddt
 class TestPostTranspileIntegration(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This is cheap, and can be done both in the `init` stage (where it may help routing) and the the general optimisation loop (where it may allow chains of optimisations to collapse).

### Details and comments

Built on top of #13779.