### PR TITLE
Remove deprecated QuantumCircuit.duration and DAGCircuit.duration

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -205,12 +205,6 @@ pub struct DAGCircuit {
     vars: BitData<Var>,
     /// Global phase.
     global_phase: Param,
-    /// Duration.
-    #[pyo3(set)]
-    duration: Option<PyObject>,
-    /// Unit of duration.
-    #[pyo3(set)]
-    unit: String,
 
     // Note: these are tracked separately from `qubits` and `clbits`
     // because it's not yet clear if the Rust concept of a native Qubit
@@ -376,8 +370,6 @@ impl DAGCircuit {
             clbits: BitData::new(py, "clbits".to_string()),
             vars: BitData::new(py, "vars".to_string()),
             global_phase: Param::Float(0.),
-            duration: None,
-            unit: "dt".to_string(),
             qubit_locations: PyDict::new(py).unbind(),
             clbit_locations: PyDict::new(py).unbind(),
             qubit_io_map: Vec::new(),
@@ -392,45 +384,6 @@ impl DAGCircuit {
                 PySet::empty(py)?.unbind(),
             ],
         })
-    }
-
-    /// The total duration of the circuit, set by a scheduling transpiler pass. Its unit is
-    /// specified by :attr:`.unit`
-    ///
-    /// DEPRECATED since Qiskit 1.3.0 and will be removed in Qiskit 2.0.0
-    #[getter]
-    fn get_duration(&self, py: Python) -> PyResult<Option<Py<PyAny>>> {
-        imports::WARNINGS_WARN.get_bound(py).call1((
-            intern!(
-                py,
-                concat!(
-                    "The property ``qiskit.dagcircuit.dagcircuit.DAGCircuit.duration`` is ",
-                    "deprecated as of Qiskit 1.3.0. It will be removed in Qiskit 2.0.0.",
-                )
-            ),
-            py.get_type::<PyDeprecationWarning>(),
-            2,
-        ))?;
-        Ok(self.duration.as_ref().map(|x| x.clone_ref(py)))
-    }
-
-    /// The unit that duration is specified in.
-    ///
-    /// DEPRECATED since Qiskit 1.3.0 and will be removed in Qiskit 2.0.0
-    #[getter]
-    fn get_unit(&self, py: Python) -> PyResult<String> {
-        imports::WARNINGS_WARN.get_bound(py).call1((
-            intern!(
-                py,
-                concat!(
-                    "The property ``qiskit.dagcircuit.dagcircuit.DAGCircuit.unit`` is ",
-                    "deprecated as of Qiskit 1.3.0. It will be removed in Qiskit 2.0.0.",
-                )
-            ),
-            py.get_type::<PyDeprecationWarning>(),
-            2,
-        ))?;
-        Ok(self.unit.clone())
     }
 
     #[getter]
@@ -1443,7 +1396,6 @@ impl DAGCircuit {
     /// That structure includes:
     ///     * name and other metadata
     ///     * global phase
-    ///     * duration
     ///     * all the qubits and clbits, including the registers.
     ///
     /// Returns:
@@ -1460,8 +1412,6 @@ impl DAGCircuit {
         )?;
         target_dag.name = self.name.as_ref().map(|n| n.clone_ref(py));
         target_dag.global_phase = self.global_phase.clone();
-        target_dag.duration = self.duration.as_ref().map(|d| d.clone_ref(py));
-        target_dag.unit.clone_from(&self.unit);
         target_dag.metadata = self.metadata.as_ref().map(|m| m.clone_ref(py));
         target_dag.qargs_interner = self.qargs_interner.clone();
         target_dag.cargs_interner = self.cargs_interner.clone();
@@ -5895,8 +5845,6 @@ impl DAGCircuit {
             clbits: BitData::with_capacity(py, "clbits".to_string(), num_clbits),
             vars: BitData::with_capacity(py, "vars".to_string(), num_vars),
             global_phase: Param::Float(0.),
-            duration: None,
-            unit: "dt".to_string(),
             qubit_locations: PyDict::new(py).unbind(),
             clbit_locations: PyDict::new(py).unbind(),
             qubit_io_map: Vec::with_capacity(num_qubits),

--- a/qiskit/converters/circuit_to_dag.py
+++ b/qiskit/converters/circuit_to_dag.py
@@ -75,6 +75,4 @@ def circuit_to_dag(circuit, copy_operations=True, *, qubit_order=None, clbit_ord
 
     dagcircuit = core_circuit_to_dag(circuit, copy_operations, qubit_order, clbit_order)
 
-    dagcircuit.duration = circuit._duration
-    dagcircuit.unit = circuit._unit
     return dagcircuit

--- a/qiskit/converters/dag_to_circuit.py
+++ b/qiskit/converters/dag_to_circuit.py
@@ -73,6 +73,4 @@ def dag_to_circuit(dag, copy_operations=True):
     circuit.metadata = dag.metadata or {}
     circuit._data = circuit_data
 
-    circuit._duration = dag.duration
-    circuit._unit = dag.unit
     return circuit

--- a/qiskit/transpiler/passes/scheduling/padding/base_padding.py
+++ b/qiskit/transpiler/passes/scheduling/padding/base_padding.py
@@ -124,7 +124,6 @@ class BasePadding(TransformationPass):
 
         new_dag.name = dag.name
         new_dag.metadata = dag.metadata
-        new_dag.unit = self.property_set["time_unit"]
         new_dag.global_phase = dag.global_phase
 
         idle_after = {bit: 0 for bit in dag.qubits}
@@ -185,8 +184,6 @@ class BasePadding(TransformationPass):
                     next_node=node,
                     prev_node=prev_node,
                 )
-
-        new_dag.duration = circuit_duration
 
         return new_dag
 

--- a/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
@@ -180,15 +180,20 @@ class PadDynamicalDecoupling(BasePadding):
         self._no_dd_qubits: set[int] = set()
         self._dd_sequence_lengths: dict[Qubit, list[int]] = {}
         self._sequence_phase = 0
+        self._unit = "s"
         if target is not None:
             # The priority order for instruction durations is: target > standalone.
             self._durations = target.durations()
             self._alignment = target.pulse_alignment
+            if target.dt is not None:
+                self._unit = "dt"
             for gate in dd_sequence:
                 if gate.name not in target.operation_names:
                     raise TranspilerError(
                         f"{gate.name} in dd_sequence is not supported in the target"
                     )
+        if self._unit == "s" and durations is not None and durations.dt is not None:
+            self._unit = "dt"
 
     def _pre_runhook(self, dag: DAGCircuit):
         super()._pre_runhook(dag)
@@ -310,14 +315,14 @@ class PadDynamicalDecoupling(BasePadding):
 
         if not self.__is_dd_qubit(dag.qubits.index(qubit)):
             # Target physical qubit is not the target of this DD sequence.
-            self._apply_scheduled_op(dag, t_start, Delay(time_interval, dag.unit), qubit)
+            self._apply_scheduled_op(dag, t_start, Delay(time_interval, self._unit), qubit)
             return
 
         if self._skip_reset_qubits and (
             isinstance(prev_node, DAGInNode) or isinstance(prev_node.op, Reset)
         ):
             # Previous node is the start edge or reset, i.e. qubit is ground state.
-            self._apply_scheduled_op(dag, t_start, Delay(time_interval, dag.unit), qubit)
+            self._apply_scheduled_op(dag, t_start, Delay(time_interval, self._unit), qubit)
             return
 
         slack = time_interval - np.sum(self._dd_sequence_lengths[qubit])
@@ -325,7 +330,7 @@ class PadDynamicalDecoupling(BasePadding):
 
         if slack <= 0:
             # Interval too short.
-            self._apply_scheduled_op(dag, t_start, Delay(time_interval, dag.unit), qubit)
+            self._apply_scheduled_op(dag, t_start, Delay(time_interval, self._unit), qubit)
             return
 
         if len(self._dd_sequence) == 1:
@@ -351,7 +356,7 @@ class PadDynamicalDecoupling(BasePadding):
                 sequence_gphase += phase
             else:
                 # Don't do anything if there's no single-qubit gate to absorb the inverse
-                self._apply_scheduled_op(dag, t_start, Delay(time_interval, dag.unit), qubit)
+                self._apply_scheduled_op(dag, t_start, Delay(time_interval, self._unit), qubit)
                 return
 
         def _constrained_length(values):
@@ -387,7 +392,7 @@ class PadDynamicalDecoupling(BasePadding):
             if dd_ind < len(taus):
                 tau = taus[dd_ind]
                 if tau > 0:
-                    self._apply_scheduled_op(dag, idle_after, Delay(tau, dag.unit), qubit)
+                    self._apply_scheduled_op(dag, idle_after, Delay(tau, self._unit), qubit)
                     idle_after += tau
             if dd_ind < len(self._dd_sequence):
                 gate = self._dd_sequence[dd_ind]

--- a/qiskit/transpiler/passes/scheduling/padding/pad_delay.py
+++ b/qiskit/transpiler/passes/scheduling/padding/pad_delay.py
@@ -87,4 +87,9 @@ class PadDelay(BasePadding):
             return
 
         time_interval = t_end - t_start
-        self._apply_scheduled_op(dag, t_start, Delay(time_interval, dag.unit), qubit)
+        unit = "s"
+        if (self.target and self.target.dt is not None) or (
+            self.durations and self.durations.dt is not None
+        ):
+            unit = "dt"
+        self._apply_scheduled_op(dag, t_start, Delay(time_interval, unit), qubit)

--- a/qiskit/visualization/timeline/core.py
+++ b/qiskit/visualization/timeline/core.py
@@ -260,7 +260,9 @@ class DrawerCanvas:
                     self.add_data(datum)
 
         # update time range
-        t_end = max(program.duration, self.formatter["margin.minimum_duration"])
+        t_end = max(
+            program.estimate_duration(target, "dt"), self.formatter["margin.minimum_duration"]
+        )
         self.set_time_range(t_start=0, t_end=t_end)
 
     def set_time_range(self, t_start: int, t_end: int):

--- a/releasenotes/notes/remove-deprecated-duration-attr-f51af44809ea4e8c.yaml
+++ b/releasenotes/notes/remove-deprecated-duration-attr-f51af44809ea4e8c.yaml
@@ -1,0 +1,29 @@
+---
+upgrade_circuits:
+  - |
+    The deprecated ``.duration`` and ``.unit`` attributes for the
+    :class:`.QuantumCircuit` class have been removed. These attributes
+    were used to track the estimated duration and unit of that duration
+    to execute on the circuit. However, the values of these attributes
+    were always limited, as they would only be properly populated if the
+    transpiler were run with the correct settings. The duration was also
+    only a guess based on the longest path on the sum of instruction
+    durations and wouldn’t ever correctly account for control flow or
+    conditionals in the circuit. If you need to compute an estimate of
+    the duration of a circuit you can use the
+    :meth:`.QuantumCircuit.estimate_duration` method which does a similar
+    calculation but makes the fact that it's an estimate explicit.
+upgrade_transpiler:
+  - |
+    The deprecated ``.duration`` and ``.unit`` attributes for the
+    :class:`.DAGCircuit` class have been removed. These attributes
+    were used to track the estimated duration and unit of that duration
+    to execute on the circuit. However, the values of these attributes
+    were always limited, as they would only be properly populated if the
+    transpiler were run with the correct settings. The duration was also
+    only a guess based on the longest path on the sum of instruction
+    durations and wouldn’t ever correctly account for control flow or
+    conditionals in the circuit. If you need to compute an estimate of
+    the duration of a circuit you can use the
+    :meth:`.QuantumCircuit.estimate_duration` method which does a similar
+    calculation but makes the fact that it's an estimate explicit.

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -410,8 +410,6 @@ class TestDagWireRemoval(QiskitTestCase):
         self.assertEqual(self.dag.qubits, result_dag.qubits)
         self.assertEqual(self.dag.cregs, result_dag.cregs)
         self.assertEqual(self.dag.qregs, result_dag.qregs)
-        self.assertEqual(self.dag.duration, result_dag.duration)
-        self.assertEqual(self.dag.unit, result_dag.unit)
 
     def test_copy_empty_like_vars(self):
         """Variables should be part of the empty copy."""

--- a/test/python/transpiler/_dummy_passes.py
+++ b/test/python/transpiler/_dummy_passes.py
@@ -122,10 +122,11 @@ class PassF_reduce_dag_property(DummyTP):
 
     def run(self, dag):
         super().run(dag)
-        if dag.duration is None:
-            dag.duration = 8
-        dag.duration = round(dag.duration * 0.8)
-        logging.getLogger(logger).info("dag property = %i", dag.duration)
+        if not dag.global_phase:
+            dag.global_phase = 8
+        else:
+            dag.global_phase = round(dag.global_phase * 0.8)
+        logging.getLogger(logger).info("dag property = %i", dag.global_phase)
         return dag
 
 
@@ -138,10 +139,10 @@ class PassG_calculates_dag_property(DummyAP):
 
     def run(self, dag):
         super().run(dag)
-        if dag.duration is not None:
-            self.property_set["property"] = dag.duration
-        else:
+        if not dag.global_phase:
             self.property_set["property"] = 8
+        else:
+            self.property_set["property"] = dag.global_phase
         logging.getLogger(logger).info(
             "set property as %s (from dag.property)", self.property_set["property"]
         )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit removes the deprecated duration attributes for circuits.
This was deprecated in the 1.3.0 release and replaced by the
QuantumCircuit.estimate_duration() method in 1.4.0.

### Details and comments

This commit is based on top of #13506 and is blocked on #13708 and #13662
(as many tests using this functionality are of these deprecated
components)