### PR TITLE
Disable cron on old stable branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ schedules:
   - cron: "20 6 * * *"
     displayName: "Complete matrix test"
     branches:
-      include: [ "main", "stable/*" ]
+      include: [ "main" ]
     always: false  # Only run if the code changed since the last cron sync.
 
 


### PR DESCRIPTION
Once the stable branch is superseded, we no longer need to run the nightly cronjob on it.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Once a branch reaches its end-of-life, like `stable/1.3` does today with the release of 1.4.0, we need to disable its nightly run of the full test matrix to avoid eating CI.  We may have forgotten this for quite some time - I just noticed this morning that we were still running cronjobs on `stable/1.0`, `stable/1.1` and `stable/1.2`, but the "comment on failure" item wasn't running, so we weren't being told.

I used admin powers to push this same patch to 1.0, 1.1 and 1.2 already, to avoid tying up CI further, but 1.3 is the current branch, so this is the proper procedure.
