### PR TITLE
Update mergify to point to latest backport branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,4 +6,4 @@ pull_request_rules:
     actions:
       backport:
         branches:
-          - stable/1.3
+          - stable/1.4


### PR DESCRIPTION
With the release of 1.3.3 and the imminent release of 1.4.0, the regular backport branch is now `stable/1.4`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


