### PR TITLE
Support stretchy delays in `box`

### DIFF
--- a/qiskit/circuit/controlflow/box.py
+++ b/qiskit/circuit/controlflow/box.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import typing
 
+from qiskit.circuit.delay import Delay
 from qiskit.circuit.exceptions import CircuitError
 from .control_flow import ControlFlowOp
 
@@ -43,7 +44,7 @@ class BoxOp(ControlFlowOp):
         self,
         body: QuantumCircuit,
         duration: None = None,
-        unit: typing.Literal["dt", "s", "ms", "us", "ns", "ps"] = "dt",
+        unit: typing.Literal["dt", "s", "ms", "us", "ns", "ps", "expr"] | None = None,
         label: str | None = None,
         annotations: typing.Iterable[Annotation] = (),
     ):
@@ -63,9 +64,8 @@ class BoxOp(ControlFlowOp):
                 the iterable.
         """
         super().__init__("box", body.num_qubits, body.num_clbits, [body], label=label)
-        self.duration = duration
-        self.unit = unit
         self.annotations = list(annotations)
+        self.duration, self.unit = Delay._validate_arguments(duration, unit)
 
     @property
     def params(self):

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2724,6 +2724,8 @@ class QuantumCircuit:
             if copy and is_parameter:
                 operation = _copy.deepcopy(operation)
         if isinstance(operation, ControlFlowOp):
+            if operation.name == "box" and operation.unit == "expr":
+                _validate_expr(circuit_scope, operation.duration)
             # Verify that any variable bindings are valid.  Control-flow ops are already enforced
             # by the class not to contain 'input' variables.
             if bad_captures := {
@@ -6721,7 +6723,7 @@ class QuantumCircuit:
         *,
         label: str | None = None,
         duration: None = None,
-        unit: Literal["dt", "s", "ms", "us", "ns", "ps"] = "dt",
+        unit: Literal["dt", "s", "ms", "us", "ns", "ps", "expr"] | None = None,
         annotations: typing.Iterable[Annotation] = ...,
     ):
         """Create a ``box`` of operations on this circuit that are treated atomically in the greater

--- a/releasenotes/notes/stretchy-boxes-f031618cf17b4c09.yaml
+++ b/releasenotes/notes/stretchy-boxes-f031618cf17b4c09.yaml
@@ -1,0 +1,5 @@
+---
+features_circuits:
+  - |
+    The :attr:`.BoxOp.duration` field can now be an :class:`.expr.Expr` node with type
+    :class:`~.classical.types.Duration`, just like :attr:`.Delay.duration`.  This includes stretches.

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -1903,6 +1903,28 @@ class TestLoadFromQPY(QiskitTestCase):
         self.assertEqual(box_1_0.unit, "s")
         self.assertEqual(box_1_0.label, "world")
 
+    def test_box_with_stretch(self):
+        """Test that box's duration and unit round-trip with stretches."""
+        qc = QuantumCircuit(2)
+        a = qc.add_stretch("a")
+        b = qc.add_stretch("b")
+        with qc.box(duration=a):
+            with qc.box(duration=expr.mul(2, b)):
+                pass
+
+        with io.BytesIO() as fptr:
+            dump(qc, fptr)
+            fptr.seek(0)
+            out = load(fptr)[0]
+
+        box_outer = out.data[0].operation
+        self.assertEqual(box_outer.duration, a)
+        self.assertEqual(box_outer.unit, "expr")
+        box_inner = box_outer.blocks[0].data[0].operation
+        self.assertEqual(box_inner.duration, expr.mul(2, b))
+        self.assertEqual(box_inner.unit, "expr")
+        self.assertEqual(qc, out)
+
     def test_multiple_nested_control_custom_definitions(self):
         """Test that circuits with multiple controlled custom gates that in turn depend on custom
         gates can be exported successfully when there are several such gates in the outer circuit.

--- a/test/python/circuit/test_control_flow.py
+++ b/test/python/circuit/test_control_flow.py
@@ -580,6 +580,15 @@ class TestCreatingControlFlowOperations(QiskitTestCase):
         self.assertEqual(op.unit, "ms")
         self.assertEqual(op.label, "hello, world")
 
+        a = expr.Stretch.new("a")
+        op = BoxOp(body, duration=a)
+        self.assertEqual(op.duration, a)
+        self.assertEqual(op.unit, "expr")
+
+        op = BoxOp(body, duration=expr.mul(2, a))
+        self.assertEqual(op.duration, expr.mul(2, a))
+        self.assertEqual(op.unit, "expr")
+
     def test_box_valid_params_setter(self):
         """Verify that valid sets to `params` function."""
         a = Parameter("a")

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -1546,10 +1546,14 @@ class TestTranspile(QiskitTestCase):
         qc.h(0)
         qc.delay(a, 1)
         qc.cx(0, 1)
+        with qc.box(duration=a):
+            pass
 
         out = transpile(
             qc,
-            backend=GenericBackendV2(num_qubits=2, basis_gates=["cx", "h"], seed=0),
+            backend=GenericBackendV2(
+                num_qubits=2, basis_gates=["cx", "h"], control_flow=True, seed=0
+            ),
             optimization_level=optimization_level,
             seed_transpiler=42,
         )

--- a/test/python/qasm3/test_export.py
+++ b/test/python/qasm3/test_export.py
@@ -1348,6 +1348,7 @@ c[1] = measure q[1];
     def test_box(self):
         """Test that 'box' statements can be exported'"""
         qc = QuantumCircuit(2)
+        a = qc.add_stretch("a")
         with qc.box():
             qc.x(0)
         with qc.box(duration=50.0, unit="ms"):
@@ -1355,11 +1356,15 @@ c[1] = measure q[1];
         with qc.box(duration=200, unit="dt"):
             with qc.box(duration=10, unit="dt"):
                 pass
+        with qc.box(duration=a):
+            with qc.box(duration=expr.mul(2, a)):
+                pass
 
         expected = """\
 OPENQASM 3.0;
 include "stdgates.inc";
 qubit[2] q;
+stretch a;
 box {
   x q[0];
 }
@@ -1368,6 +1373,10 @@ box[50.0ms] {
 }
 box[200dt] {
   box[10dt] {
+  }
+}
+box[a] {
+  box[2 * a] {
   }
 }
 """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Mostly this just needed to re-use the existing handling from within `Delay`, and to teach the control-flow builders to look in another special place (`BoxOp.duration`) for potential `Expr` instances to close over.

<details><summary>Old PR message</summary>
This is currently built on top of a roll-up merge of Kevin's `stretchy-delay` branch, and just unifies the handling between `Delay` and `Box` so that they both support the `Expr` stuff.  There's no need for Rust-space handling for `box`, because the entirety of the control-flow system isn't handled in Python-space yet.

This might need further modification based on Kevin's work on transpiler support.

This commit will be rebased and amended along with the rest of the `stretch` patch series.
</details>

### Details and comments

Built on top of both #13869 and #13853.
