### PR TITLE
Bump to ndarray 0.16 and vendor/fork ndarray_einsum_beta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,15 +43,6 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "approx"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
@@ -390,12 +381,12 @@ dependencies = [
 
 [[package]]
 name = "faer-ext"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf30f6ae73f372c0e0cf7556c44e50f1eee0a714d71396091613d68c43625c9"
+checksum = "fa0b66079aff3caae4e41177b37487914cbcb377651e86a838d6a2088fb4b666"
 dependencies = [
  "faer",
- "ndarray",
+ "ndarray 0.16.1",
  "num-complex",
 ]
 
@@ -404,6 +395,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "gemm"
@@ -594,6 +591,11 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -727,7 +729,7 @@ version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
@@ -824,8 +826,6 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
 dependencies = [
- "approx 0.4.0",
- "approx 0.5.1",
  "matrixmultiply",
  "num-complex",
  "num-integer",
@@ -835,14 +835,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "ndarray_einsum_beta"
-version = "0.7.0"
+name = "ndarray"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668b3abeae3e0637740340e0e32a9bf9308380e146ea6797950f9ff16e88d88a"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
 dependencies = [
- "lazy_static",
- "ndarray",
+ "approx",
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
  "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+ "rayon",
+]
+
+[[package]]
+name = "ndarray-rand"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f093b3db6fd194718dcdeea6bd8c829417deae904e3fcc7732dabcd4416d25d8"
+dependencies = [
+ "ndarray 0.16.1",
+ "rand 0.8.5",
+ "rand_distr 0.4.3",
+]
+
+[[package]]
+name = "ndarray_einsum"
+version = "2.0.0"
+dependencies = [
+ "approx",
+ "hashbrown 0.15.2",
+ "lazy_static",
+ "ndarray 0.16.1",
+ "ndarray-rand",
+ "num-traits",
+ "rand 0.8.5",
  "regex",
 ]
 
@@ -916,7 +946,7 @@ checksum = "b94caae805f998a07d33af06e6a3891e38556051b8045c615470a71590e13e78"
 dependencies = [
  "libc",
  "nalgebra",
- "ndarray",
+ "ndarray 0.16.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -1061,6 +1091,15 @@ name = "portable-atomic"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1239,7 +1278,7 @@ name = "qiskit-accelerate"
 version = "2.0.0"
 dependencies = [
  "ahash 0.8.11",
- "approx 0.5.1",
+ "approx",
  "bytemuck",
  "faer",
  "faer-ext",
@@ -1247,8 +1286,8 @@ dependencies = [
  "indexmap",
  "itertools 0.13.0",
  "nalgebra",
- "ndarray",
- "ndarray_einsum_beta",
+ "ndarray 0.16.1",
+ "ndarray_einsum",
  "num-bigint",
  "num-complex",
  "num-traits",
@@ -1272,14 +1311,14 @@ name = "qiskit-circuit"
 version = "2.0.0"
 dependencies = [
  "ahash 0.8.11",
- "approx 0.5.1",
+ "approx",
  "bitfield-struct",
  "bytemuck",
  "hashbrown 0.14.5",
  "indexmap",
  "itertools 0.13.0",
  "nalgebra",
- "ndarray",
+ "ndarray 0.16.1",
  "num-complex",
  "numpy",
  "pyo3",
@@ -1568,7 +1607,7 @@ dependencies = [
  "fixedbitset",
  "hashbrown 0.14.5",
  "indexmap",
- "ndarray",
+ "ndarray 0.15.6",
  "num-traits",
  "petgraph",
  "priority-queue",
@@ -1639,7 +1678,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "num-complex",
  "num-traits",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ hashbrown.version = "0.14.5"
 num-bigint = "0.4"
 num-complex = "0.4"
 nalgebra = "0.33"
-ndarray = "0.15"
 numpy = "0.23"
+ndarray = "0.16"
 smallvec = "1.13"
 thiserror = "2.0"
 rustworkx-core = "0.15"
@@ -43,6 +43,7 @@ qiskit-accelerate = { path = "crates/accelerate" }
 qiskit-circuit = { path = "crates/circuit" }
 qiskit-qasm2 = { path = "crates/qasm2" }
 qiskit-qasm3 = { path = "crates/qasm3" }
+ndarray_einsum = { path = "crates/ndarray_einsum" }
 
 [workspace.lints.clippy]
 # The lint forbids things like `if a < b {} else if a == b {}`, and suggests matching on `a.cmp(&b)`

--- a/crates/accelerate/Cargo.toml
+++ b/crates/accelerate/Cargo.toml
@@ -27,7 +27,7 @@ faer = "0.19.4"
 itertools.workspace = true
 qiskit-circuit.workspace = true
 thiserror.workspace = true
-ndarray_einsum_beta = "0.7"
+ndarray_einsum.workspace = true
 once_cell = "1.20.2"
 rustiq-core = "0.0.10"
 bytemuck.workspace = true
@@ -43,7 +43,7 @@ features = ["hashbrown", "indexmap", "num-complex", "num-bigint", "smallvec"]
 
 [dependencies.ndarray]
 workspace = true
-features = ["rayon", "approx-0_5"]
+features = ["rayon", "approx"]
 
 [dependencies.approx]
 workspace = true
@@ -58,7 +58,7 @@ workspace = true
 features = ["rayon"]
 
 [dependencies.faer-ext]
-version = "0.2.0"
+version = "0.3.0"
 features = ["ndarray"]
 
 [dependencies.pulp]

--- a/crates/accelerate/src/sparse_pauli_op.rs
+++ b/crates/accelerate/src/sparse_pauli_op.rs
@@ -1358,7 +1358,7 @@ mod tests {
     #[test]
     fn decompose_empty_operator_fails() {
         assert!(matches!(
-            decompose_dense_inner(aview2::<Complex64, [_; 0]>(&[]), 0.0),
+            decompose_dense_inner(aview2::<Complex64, 0>(&[]), 0.0),
             Err(DecomposeError::BadShape(_)),
         ));
     }
@@ -1408,7 +1408,7 @@ mod tests {
                 z_like,
             };
             let arr = Array1::from_vec(to_matrix_dense_inner(&paulis, false))
-                .into_shape((2, 2))
+                .into_shape_with_order((2, 2))
                 .unwrap();
             let expected: DecomposeMinimal = paulis.into();
             let actual: DecomposeMinimal = decompose_dense_inner(arr.view(), 0.0).unwrap().into();
@@ -1443,7 +1443,7 @@ mod tests {
                 z_like,
             };
             let arr = Array1::from_vec(to_matrix_dense_inner(&paulis, false))
-                .into_shape((8, 8))
+                .into_shape_with_order((8, 8))
                 .unwrap();
             let expected: DecomposeMinimal = paulis.into();
             let actual: DecomposeMinimal = decompose_dense_inner(arr.view(), 0.0).unwrap().into();

--- a/crates/accelerate/src/unitary_compose.rs
+++ b/crates/accelerate/src/unitary_compose.rs
@@ -11,7 +11,7 @@
 // that they have been altered from the originals.
 
 use ndarray::{Array, Array2, ArrayView, ArrayView2, IxDyn};
-use ndarray_einsum_beta::*;
+use ndarray_einsum::*;
 use num_complex::{Complex, Complex64, ComplexFloat};
 use num_traits::Zero;
 use qiskit_circuit::Qubit;
@@ -63,7 +63,7 @@ pub fn compose(
 
     let res = _einsum_matmul(&tensor, &mat, &indices, shift, right_mul)?
         .as_standard_layout()
-        .into_shape((num_rows, num_rows))
+        .into_shape_with_order((num_rows, num_rows))
         .unwrap()
         .into_dimensionality::<ndarray::Ix2>()
         .unwrap()
@@ -76,7 +76,7 @@ fn per_qubit_shaped<'a>(array: &ArrayView2<'a, Complex<f64>>) -> ArrayView<'a, C
     let overall_shape = (0..array.shape()[0].ilog2() as usize)
         .flat_map(|_| [2, 2])
         .collect::<Vec<usize>>();
-    array.into_shape(overall_shape).unwrap()
+    array.into_shape_with_order(overall_shape).unwrap()
 }
 
 // Determine einsum strings for perform a matrix multiplication on the input matrices

--- a/crates/ndarray_einsum/Cargo.toml
+++ b/crates/ndarray_einsum/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "ndarray_einsum"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+keywords = ["einsum", "einstein-summation", "tensor", "contraction", "ndarray"]
+categories = ["science"]
+description = "Implementation of the einsum function for the Rust ndarray crate. Fork of https://github.com/oracleofnj/einsum"
+
+[dependencies]
+regex = "1"
+lazy_static = "1"
+ndarray = { workspace = true, features = ["approx"] }
+num-traits = "0.2"
+hashbrown = "0.15"
+
+[dev-dependencies]
+approx = "0.5"
+ndarray-rand = "0.15.0"
+rand="0.8"

--- a/crates/ndarray_einsum/README.md
+++ b/crates/ndarray_einsum/README.md
@@ -1,0 +1,6 @@
+# ndarray einsum
+
+This crate is a fork of the upstream [ndarray_einsum_beta](https://github.com/oracleofnj/einsum) which is no longer
+active. This was bundled in qiskit's workspace to make necessary updates to it for use with modern versions of ndarray
+and the only changes from upstream are using the newer version of ndarray and
+then fitting the project into Qiskit's project requirements.

--- a/crates/ndarray_einsum/src/contractors/mod.rs
+++ b/crates/ndarray_einsum/src/contractors/mod.rs
@@ -1,0 +1,490 @@
+// Copyright 2019 Jared Samet
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Implementations of the base-case singleton and pair contractors for different types of contractions.
+//!
+//! This module defines the `SingletonViewer`, `SingletonContractor`, and `PairContractor` traits as well
+//! as the generic "container" objects `EinsumPath`, `SingletonContraction`, and `PairContraction` that
+//! hold `Box`ed trait objects of the specific cases determined at runtime to be most appropriate
+//! for the requested contraction.
+//!
+//! The specific singleton and pair contractors defined in the `singleton_contractors` and
+//! `pair_contractors` submodules implement the relevant traits defined here. The six specific singleton
+//! contractors defined in `singleton_contractors` perform some combination of permutation of the input
+//! axes (e.g. `ijk->jki`), diagonalization across repeated but un-summed axes (e.g. `ii->i`), and
+//! summation across axes not present in the output index list (e.g. `ijk->j`). Not all of the nine
+//! pair contractors defined in `pair_contractors` are currently used as some appear to be slower than others.
+//!
+//! Each struct implementing one of the `*Contractor` traits performs all the "setup work"
+//! required to perform the actual contraction. For example, `HadamardProductGeneral` permutes
+//! the input and output tensors and then computes the element-wise product of the two tensors.
+//! Given a `SizedContraction` (but no actual tensors), `HadamardProductGeneral::new()` figures out
+//! the permutation orders that will be needed so that `contract_pair` can simply execute the two
+//! permutations and then produce the element-wise product. This can be thought of as a way of
+//! compiling the `einsum` string into a set of instructions and the `EinsumPath` object
+//! can be thought of as an AST that is ready to compute a contraction when supplied with an
+//! actual set of operands to contract.
+
+use crate::optimizers::{
+    generate_optimized_order, ContractionOrder, OperandNumber, OptimizationMethod,
+};
+use crate::{ArrayLike, SizedContraction};
+use hashbrown::HashSet;
+use ndarray::prelude::*;
+use ndarray::LinalgScalar;
+use std::fmt::Debug;
+
+mod singleton_contractors;
+use singleton_contractors::{
+    Diagonalization, DiagonalizationAndSummation, Identity, Permutation, PermutationAndSummation,
+    Summation,
+};
+
+mod pair_contractors;
+pub use pair_contractors::TensordotGeneral;
+use pair_contractors::{
+    BroadcastProductGeneral, HadamardProduct, HadamardProductGeneral, MatrixScalarProduct,
+    MatrixScalarProductGeneral, ScalarMatrixProduct, ScalarMatrixProductGeneral,
+    StackedTensordotGeneral, TensordotFixedPosition,
+};
+
+mod strategies;
+use strategies::{PairMethod, PairSummary, SingletonMethod, SingletonSummary};
+
+/// `let new_view = obj.view_singleton(tensor_view);`
+///
+/// This trait represents contractions that can be performed by returning a view of the original
+/// tensor. The structs that currently implement this view are the ones that don't perform
+/// any summation over indices and hence return only a subset of the elements of the original tensor:
+/// `Identity`, `Permutation`, and `Diagonalization`. Note that whether `Diagonalization`
+/// can actually return a view is dependent on the memory layout of the input tensor; if the input
+/// tensor is not contiguous, `diag.view_singleton()` will `panic`.
+pub trait SingletonViewer<A>: Debug {
+    fn view_singleton<'a, 'b>(&self, tensor: &'b ArrayViewD<'a, A>) -> ArrayViewD<'b, A>
+    where
+        'a: 'b,
+        A: Clone + LinalgScalar;
+}
+
+/// `let new_array = obj.contract_singleton(tensor_view);`
+///
+/// All singleton contractions should implement this trait. It returns a new owned `ArrayD`.
+pub trait SingletonContractor<A>: Debug {
+    fn contract_singleton<'a, 'b>(&self, tensor: &'b ArrayViewD<'a, A>) -> ArrayD<A>
+    where
+        'a: 'b,
+        A: Clone + LinalgScalar;
+}
+
+/// `let new_array = obj.contract_pair(lhs_view, rhs_view);`
+///
+/// All pair contractions should implement this trait. It returns a new owned `ArrayD`. The trait
+/// also has a method with a default implementation, `obj.contract_and_assign_pair(lhs_view: &ArrayViewD,
+/// rhs_view: &ArrayViewD, out: &mut ArrayViewD) -> ()`.
+pub trait PairContractor<A>: Debug {
+    fn contract_pair<'a, 'b, 'c, 'd>(
+        &self,
+        lhs: &'b ArrayViewD<'a, A>,
+        rhs: &'d ArrayViewD<'c, A>,
+    ) -> ArrayD<A>
+    where
+        'a: 'b,
+        'c: 'd,
+        A: Clone + LinalgScalar;
+
+    fn contract_and_assign_pair<'a, 'b, 'c, 'd, 'e, 'f>(
+        &self,
+        lhs: &'b ArrayViewD<'a, A>,
+        rhs: &'d ArrayViewD<'c, A>,
+        out: &'f mut ArrayViewMutD<'e, A>,
+    ) where
+        'a: 'b,
+        'c: 'd,
+        'e: 'f,
+        A: Clone + LinalgScalar,
+    {
+        let result = self.contract_pair(lhs, rhs);
+        out.assign(&result);
+    }
+}
+
+/// Holds a `Box`ed `SingletonContractor` trait object.
+///
+/// Constructed at runtime based on the number of diagonalized, summed, and permuted axes
+/// in the input. Reimplements the `SingletonContractor` trait by delegating to the inner
+/// object.
+///
+/// For example, the contraction `iij->i` will be performed by assigning a `Box`ed
+/// `DiagonalizationAndSummation` to `op`. The contraction `ijk->kij` will be performed
+/// by assigning a `Box`ed `Permutation` to `op`.
+pub struct SingletonContraction<A> {
+    method: SingletonMethod,
+    op: Box<dyn SingletonContractor<A>>,
+}
+
+impl<A> SingletonContraction<A> {
+    pub fn new(sc: &SizedContraction) -> Self {
+        let singleton_summary = SingletonSummary::new(sc);
+        let method = singleton_summary.get_strategy();
+
+        SingletonContraction {
+            method,
+            op: match method {
+                SingletonMethod::Identity => Box::new(Identity::new(sc)),
+                SingletonMethod::Permutation => Box::new(Permutation::new(sc)),
+                SingletonMethod::Summation => Box::new(Summation::new(sc)),
+                SingletonMethod::Diagonalization => Box::new(Diagonalization::new(sc)),
+                SingletonMethod::PermutationAndSummation => {
+                    Box::new(PermutationAndSummation::new(sc))
+                }
+                SingletonMethod::DiagonalizationAndSummation => {
+                    Box::new(DiagonalizationAndSummation::new(sc))
+                }
+            },
+        }
+    }
+}
+
+impl<A> SingletonContractor<A> for SingletonContraction<A> {
+    fn contract_singleton<'a, 'b>(&self, tensor: &'b ArrayViewD<'a, A>) -> ArrayD<A>
+    where
+        'a: 'b,
+        A: Clone + LinalgScalar,
+    {
+        self.op.contract_singleton(tensor)
+    }
+}
+
+impl<A> Debug for SingletonContraction<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "SingletonContraction {{ method: {:?}, op: {:?} }}",
+            self.method, self.op
+        )
+    }
+}
+
+/// Holds an `Box<dyn SingletonContractor<A>>` and the resulting simplified indices.
+struct SimplificationMethodAndOutput<A> {
+    method: SingletonMethod,
+    op: Box<dyn SingletonContractor<A>>,
+    new_indices: Vec<char>,
+    einsum_string: String,
+}
+
+impl<A> SimplificationMethodAndOutput<A> {
+    /// Based on the number of diagonalized, permuted, and summed axes, chooses a struct implementing
+    /// `SingletonContractor` to simplify the tensor (or `None` if the tensor doesn't need simplification)
+    /// and computes the indices of the simplified tensor.
+    fn from_indices_and_sizes(
+        this_input_indices: &[char],
+        other_input_indices: &[char],
+        output_indices: &[char],
+        orig_contraction: &SizedContraction,
+    ) -> Option<Self> {
+        let this_input_uniques: HashSet<char> = this_input_indices.iter().cloned().collect();
+        let other_input_uniques: HashSet<char> = other_input_indices.iter().cloned().collect();
+        let output_uniques: HashSet<char> = output_indices.iter().cloned().collect();
+
+        let other_and_output: HashSet<char> = other_input_uniques
+            .union(&output_uniques)
+            .cloned()
+            .collect();
+        let desired_uniques: HashSet<char> = this_input_uniques
+            .intersection(&other_and_output)
+            .cloned()
+            .collect();
+        let new_indices: Vec<char> = desired_uniques.iter().cloned().collect();
+
+        let simplification_sc = orig_contraction
+            .subset(&[this_input_indices.to_vec()], &new_indices)
+            .unwrap();
+
+        let SingletonContraction { method, op } = SingletonContraction::new(&simplification_sc);
+
+        match method {
+            SingletonMethod::Identity | SingletonMethod::Permutation => None,
+            _ => Some(SimplificationMethodAndOutput {
+                method,
+                op,
+                new_indices,
+                einsum_string: simplification_sc.as_einsum_string(),
+            }),
+        }
+    }
+}
+
+impl<A> Debug for SimplificationMethodAndOutput<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "SingletonContraction {{ method: {:?}, op: {:?}, new_indices: {:?}, einsum_string: {:?} }}",
+            self.method, self.op, self.new_indices, self.einsum_string
+        )
+    }
+}
+
+/// Holds a `Box`ed `PairContractor` trait object and two `Option<Box>`ed simplifications for the LHS and RHS tensors.
+///
+/// For example, the contraction `ijk,kj->jk` will currently be performed as follows:
+///
+/// 1. Simplify the LHS with the contraction `ijk->jk`
+/// 2. Don't simplify the RHS
+/// 3. Use HadamardProductGeneral to compute `jk,kj->jk`
+///
+/// A second example is the contraction `iij,jkk->ik`:
+///
+/// 1. Simplify the LHS with the contraction `iij->ij`
+/// 2. Simplify the RHS with the contraction `jkk->jk`
+/// 3. Use TensordotGeneral to compute `ij,jk->ik`
+///
+/// Since the axis lengths aren't known until runtime, and the actual einsum string may not
+/// be either, it is generally not possible to know at compile time which specific PairContractor
+/// will be used to perform a given contraction, or even which contractions will be performed;
+/// the optimizer could choose a different order.
+pub struct PairContraction<A> {
+    lhs_simplification: Option<SimplificationMethodAndOutput<A>>,
+    rhs_simplification: Option<SimplificationMethodAndOutput<A>>,
+    method: PairMethod,
+    op: Box<dyn PairContractor<A>>,
+    simplified_einsum_string: String,
+}
+
+impl<A> PairContraction<A> {
+    pub fn new(sc: &SizedContraction) -> Self {
+        assert_eq!(sc.contraction.operand_indices.len(), 2);
+        let lhs_indices = &sc.contraction.operand_indices[0];
+        let rhs_indices = &sc.contraction.operand_indices[1];
+        let output_indices = &sc.contraction.output_indices;
+
+        let lhs_simplification = SimplificationMethodAndOutput::from_indices_and_sizes(
+            lhs_indices,
+            rhs_indices,
+            output_indices,
+            sc,
+        );
+        let rhs_simplification = SimplificationMethodAndOutput::from_indices_and_sizes(
+            rhs_indices,
+            lhs_indices,
+            output_indices,
+            sc,
+        );
+        let new_lhs_indices = match &lhs_simplification {
+            Some(ref s) => s.new_indices.clone(),
+            None => lhs_indices.clone(),
+        };
+        let new_rhs_indices = match &rhs_simplification {
+            Some(ref s) => s.new_indices.clone(),
+            None => rhs_indices.clone(),
+        };
+
+        let reduced_sc = sc
+            .subset(&[new_lhs_indices, new_rhs_indices], output_indices)
+            .unwrap();
+
+        let pair_summary = PairSummary::new(&reduced_sc);
+        let method = pair_summary.get_strategy();
+
+        let op: Box<dyn PairContractor<A>> = match method {
+            PairMethod::HadamardProduct => {
+                // Never gets returned in current implementation
+                Box::new(HadamardProduct::new(&reduced_sc))
+            }
+            PairMethod::HadamardProductGeneral => {
+                Box::new(HadamardProductGeneral::new(&reduced_sc))
+            }
+            PairMethod::ScalarMatrixProduct => {
+                // Never gets returned in current implementation
+                Box::new(ScalarMatrixProduct::new(&reduced_sc))
+            }
+            PairMethod::ScalarMatrixProductGeneral => {
+                Box::new(ScalarMatrixProductGeneral::new(&reduced_sc))
+            }
+            PairMethod::MatrixScalarProduct => {
+                // Never gets returned in current implementation
+                Box::new(MatrixScalarProduct::new(&reduced_sc))
+            }
+            PairMethod::MatrixScalarProductGeneral => {
+                Box::new(MatrixScalarProductGeneral::new(&reduced_sc))
+            }
+            PairMethod::TensordotFixedPosition => {
+                // Never gets returned in current implementation
+                Box::new(TensordotFixedPosition::new(&reduced_sc))
+            }
+            PairMethod::TensordotGeneral => Box::new(TensordotGeneral::new(&reduced_sc)),
+            PairMethod::StackedTensordotGeneral => {
+                Box::new(StackedTensordotGeneral::new(&reduced_sc))
+            }
+            PairMethod::BroadcastProductGeneral => {
+                // Never gets returned in current implementation
+                Box::new(BroadcastProductGeneral::new(&reduced_sc))
+            }
+        };
+        PairContraction {
+            lhs_simplification,
+            rhs_simplification,
+            method,
+            op,
+            simplified_einsum_string: reduced_sc.as_einsum_string(),
+        }
+    }
+}
+
+impl<A> PairContractor<A> for PairContraction<A> {
+    fn contract_pair<'a, 'b, 'c, 'd>(
+        &self,
+        lhs: &'b ArrayViewD<'a, A>,
+        rhs: &'d ArrayViewD<'c, A>,
+    ) -> ArrayD<A>
+    where
+        'a: 'b,
+        'c: 'd,
+        A: Clone + LinalgScalar,
+    {
+        match (&self.lhs_simplification, &self.rhs_simplification) {
+            (None, None) => self.op.contract_pair(lhs, rhs),
+            (Some(lhs_contraction), None) => self
+                .op
+                .contract_pair(&lhs_contraction.op.contract_singleton(lhs).view(), rhs),
+            (None, Some(rhs_contraction)) => self
+                .op
+                .contract_pair(lhs, &rhs_contraction.op.contract_singleton(rhs).view()),
+            (Some(lhs_contraction), Some(rhs_contraction)) => self.op.contract_pair(
+                &lhs_contraction.op.contract_singleton(lhs).view(),
+                &rhs_contraction.op.contract_singleton(rhs).view(),
+            ),
+        }
+    }
+}
+
+impl<A> Debug for PairContraction<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "PairContraction {{ \
+             lhs_simplification: {:?}, \
+             rhs_simplification: {:?}, \
+             method: {:?}, \
+             op: {:?}, \
+             simplified_einsum_string: {:?}",
+            self.lhs_simplification,
+            self.rhs_simplification,
+            self.method,
+            self.op,
+            self.simplified_einsum_string
+        )
+    }
+}
+
+/// Either a singleton contraction, in the case of a single input operand, or a list of pair contractions,
+/// given two or more input operands
+#[derive(Debug)]
+pub enum EinsumPathSteps<A> {
+    /// A `SingletonContraction` consists of some combination of permutation of the input axes,
+    /// diagonalization of repeated indices, and summation across axes not present in the output
+    SingletonContraction(SingletonContraction<A>),
+
+    /// Each `PairContraction` consists of a possible simplification of each of the two input tensors followed
+    /// by a contraction of the two simplified tensors. The two simplified tensors can be combined in a
+    /// number of fashions.
+    PairContractions(Vec<PairContraction<A>>),
+}
+
+/// An `EinsumPath`, returned by [`einsum_path`](fn.einsum_path.html), represents a fully-prepared plan to perform a tensor contraction.
+///
+/// It contains the order in which the input tensors should be contracted with one another or with one of the previous intermediate results,
+/// and for each step in the path, how to perform the pairwise contraction. For example, two tensors might be contracted
+/// with one another by computing the Hadamard (element-wise) product of the tensors, while a different pair might be contracted
+/// by performing a matrix multiplication. The contractions that will be performed are fully specified within the `EinsumPath`.
+pub struct EinsumPath<A> {
+    /// The order in which tensors should be paired off and contracted with one another
+    pub contraction_order: ContractionOrder,
+
+    /// The details of the contractions to be performed
+    pub steps: EinsumPathSteps<A>,
+}
+
+impl<A> EinsumPath<A> {
+    pub fn new(sc: &SizedContraction) -> Self {
+        let contraction_order = generate_optimized_order(sc, OptimizationMethod::Naive);
+
+        EinsumPath::from_path(&contraction_order)
+    }
+
+    pub fn from_path(contraction_order: &ContractionOrder) -> Self {
+        match contraction_order {
+            ContractionOrder::Singleton(sized_contraction) => EinsumPath {
+                contraction_order: contraction_order.clone(),
+                steps: EinsumPathSteps::SingletonContraction(SingletonContraction::new(
+                    sized_contraction,
+                )),
+            },
+            ContractionOrder::Pairs(order_steps) => {
+                let mut steps = Vec::new();
+
+                for step in order_steps.iter() {
+                    steps.push(PairContraction::new(&step.sized_contraction));
+                }
+
+                EinsumPath {
+                    contraction_order: contraction_order.clone(),
+                    steps: EinsumPathSteps::PairContractions(steps),
+                }
+            }
+        }
+    }
+}
+
+impl<A> EinsumPath<A> {
+    pub fn contract_operands(&self, operands: &[&dyn ArrayLike<A>]) -> ArrayD<A>
+    where
+        A: Clone + LinalgScalar,
+    {
+        // Uncomment for help debugging
+        // println!("{:?}", self);
+        match (&self.steps, &self.contraction_order) {
+            (EinsumPathSteps::SingletonContraction(c), ContractionOrder::Singleton(_)) => {
+                c.contract_singleton(&operands[0].into_dyn_view())
+            }
+            (EinsumPathSteps::PairContractions(steps), ContractionOrder::Pairs(order_steps)) => {
+                let mut intermediate_results: Vec<ArrayD<A>> = Vec::new();
+                for (step, order_step) in steps.iter().zip(order_steps.iter()) {
+                    let lhs = match order_step.operand_nums.lhs {
+                        OperandNumber::Input(pos) => operands[pos].into_dyn_view(),
+                        OperandNumber::IntermediateResult(pos) => intermediate_results[pos].view(),
+                    };
+                    let rhs = match order_step.operand_nums.rhs {
+                        OperandNumber::Input(pos) => operands[pos].into_dyn_view(),
+                        OperandNumber::IntermediateResult(pos) => intermediate_results[pos].view(),
+                    };
+                    let intermediate_result = step.contract_pair(&lhs, &rhs);
+                    // let lhs = match order_step.
+                    intermediate_results.push(intermediate_result);
+                }
+                intermediate_results.pop().unwrap()
+            }
+            _ => panic!(), // steps and contraction_order don't match
+        }
+    }
+}
+
+impl<A> Debug for EinsumPath<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match &self.steps {
+            EinsumPathSteps::SingletonContraction(step) => write!(f, "only_step: {:?}", step),
+            EinsumPathSteps::PairContractions(steps) => write!(f, "steps: {:?}", steps),
+        }
+    }
+}

--- a/crates/ndarray_einsum/src/contractors/pair_contractors.rs
+++ b/crates/ndarray_einsum/src/contractors/pair_contractors.rs
@@ -1,0 +1,979 @@
+// Copyright 2019 Jared Samet
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Contains the specific implementations of `PairContractor` that represent the base-case ways
+//! to contract two simplified tensors.
+//!
+//! A tensor is simplified with respect to another tensor and a set of output indices
+//! if two conditions are met:
+//!
+//! 1. Each index in the tensor is present in either the other tensor or in the output indices.
+//! 2. Each index in the tensor appears only once.
+//!
+//! Examples of `einsum` strings with two simplified tensors:
+//!
+//! 1. `ijk,jkl->il`
+//! 2. `ijk,jkl->ijkl`
+//! 3. `ijk,ijk->`
+//!
+//! Examples of `einsum` strings with two tensors that are NOT simplified:
+//!
+//! 1. `iijk,jkl->il` Not simplified because `i` appears twice in the LHS tensor
+//! 2. `ijk,jkl->i` Not simplified because `l` only appears in the RHS tensor
+//!
+//! If the two input tensors are both simplified, all instances of tensor contraction
+//! can be expressed as one of a small number of cases. Note that there may be more than
+//! one way to express the same contraction; some preliminary benchmarking has been
+//! done to identify the faster choice.
+
+use hashbrown::HashSet;
+use ndarray::prelude::*;
+use ndarray::LinalgScalar;
+
+use super::{PairContractor, Permutation, SingletonContractor, SingletonViewer};
+use crate::SizedContraction;
+
+/// Helper function used throughout this module to find the positions of one set of indices
+/// in a second set of indices. The most common case is generating a permutation to
+/// be supplied to `permuted_axes`.
+fn maybe_find_outputs_in_inputs_unique(
+    output_indices: &[char],
+    input_indices: &[char],
+) -> Vec<Option<usize>> {
+    output_indices
+        .iter()
+        .map(|&output_char| {
+            let input_pos = input_indices
+                .iter()
+                .position(|&input_char| input_char == output_char);
+            if input_pos.is_some() {
+                assert!(!input_indices
+                    .iter()
+                    .skip(input_pos.unwrap() + 1)
+                    .any(|&input_char| input_char == output_char));
+            }
+            input_pos
+        })
+        .collect()
+}
+
+fn find_outputs_in_inputs_unique(output_indices: &[char], input_indices: &[char]) -> Vec<usize> {
+    maybe_find_outputs_in_inputs_unique(output_indices, input_indices)
+        .iter()
+        .map(|x| x.unwrap())
+        .collect()
+}
+
+/// Performs tensor dot product for two tensors where no permutation needs to be performed,
+/// e.g. `ijk,jkl->il` or `ijk,klm->ijlm`.
+///
+/// The axes to be contracted must be the last axes of the LHS tensor and the first axes
+/// of the RHS tensor, and the axis order for the output tensor must be all the uncontracted
+/// axes of the LHS tensor followed by all the uncontracted axes of the RHS tensor, in the
+/// orders those originally appear in the LHS and RHS tensors.
+///
+/// The contraction is performed by reshaping the LHS into a matrix (2-D tensor) of shape
+/// [len_uncontracted_lhs, len_contracted_axes], reshaping the RHS into shape
+/// [len_contracted_axes, len_contracted_rhs], matrix-multiplying the two reshaped tensor,
+/// and then reshaping the result into [...self.output_shape].
+#[derive(Clone, Debug)]
+pub struct TensordotFixedPosition {
+    /// The product of the lengths of all the uncontracted axes in the LHS (or 1 if all of the
+    /// LHS axes are contracted)
+    len_uncontracted_lhs: usize,
+
+    /// The product of the lengths of all the uncontracted axes in the RHS (or 1 if all of the
+    /// RHS axes are contracted)
+    len_uncontracted_rhs: usize,
+
+    /// The product of the lengths of all the contracted axes (or 1 if no axes are contracted,
+    /// i.e. the outer product is computed)
+    len_contracted_axes: usize,
+
+    /// The shape that the tensor dot product will be recast to
+    output_shape: Vec<usize>,
+}
+
+impl TensordotFixedPosition {
+    pub fn new(sc: &SizedContraction) -> Self {
+        assert_eq!(sc.contraction.operand_indices.len(), 2);
+        let lhs_indices = &sc.contraction.operand_indices[0];
+        let rhs_indices = &sc.contraction.operand_indices[1];
+        let output_indices = &sc.contraction.output_indices;
+        // Returns an n-dimensional array where n = |D| + |E| - 2 * last_n.
+        let twice_num_contracted_axes =
+            lhs_indices.len() + rhs_indices.len() - output_indices.len();
+        assert_eq!(twice_num_contracted_axes % 2, 0);
+        let num_contracted_axes = twice_num_contracted_axes / 2;
+        // TODO: Add an assert! that they have the same indices
+
+        let lhs_shape: Vec<usize> = lhs_indices.iter().map(|c| sc.output_size[c]).collect();
+        let rhs_shape: Vec<usize> = rhs_indices.iter().map(|c| sc.output_size[c]).collect();
+
+        TensordotFixedPosition::from_shapes_and_number_of_contracted_axes(
+            &lhs_shape,
+            &rhs_shape,
+            num_contracted_axes,
+        )
+    }
+
+    /// Compute the uncontracted and contracted axis lengths and the output shape based on the
+    /// input shapes and how many axes should be contracted from each tensor.
+    ///
+    /// TODO: The assert_eq! here could be tightened up by verifying that the
+    /// last `num_contracted_axes` of the LHS match the first `num_contracted_axes` of the
+    /// RHS axis-by-axis (as opposed to only checking the product as is done here.)
+    pub fn from_shapes_and_number_of_contracted_axes(
+        lhs_shape: &[usize],
+        rhs_shape: &[usize],
+        num_contracted_axes: usize,
+    ) -> Self {
+        let mut len_uncontracted_lhs = 1;
+        let mut len_uncontracted_rhs = 1;
+        let mut len_contracted_lhs = 1;
+        let mut len_contracted_rhs = 1;
+        let mut output_shape = Vec::new();
+
+        let num_axes_lhs = lhs_shape.len();
+        for (axis, &axis_length) in lhs_shape.iter().enumerate() {
+            if axis < (num_axes_lhs - num_contracted_axes) {
+                len_uncontracted_lhs *= axis_length;
+                output_shape.push(axis_length);
+            } else {
+                len_contracted_lhs *= axis_length;
+            }
+        }
+
+        for (axis, &axis_length) in rhs_shape.iter().enumerate() {
+            if axis < num_contracted_axes {
+                len_contracted_rhs *= axis_length;
+            } else {
+                len_uncontracted_rhs *= axis_length;
+                output_shape.push(axis_length);
+            }
+        }
+        assert_eq!(len_contracted_rhs, len_contracted_lhs);
+        let len_contracted_axes = len_contracted_lhs;
+
+        TensordotFixedPosition {
+            len_uncontracted_lhs,
+            len_uncontracted_rhs,
+            len_contracted_axes,
+            output_shape,
+        }
+    }
+}
+
+impl<A> PairContractor<A> for TensordotFixedPosition {
+    fn contract_pair<'a, 'b, 'c, 'd>(
+        &self,
+        lhs: &'b ArrayViewD<'a, A>,
+        rhs: &'d ArrayViewD<'c, A>,
+    ) -> ArrayD<A>
+    where
+        'a: 'b,
+        'c: 'd,
+        A: Clone + LinalgScalar,
+    {
+        let lhs_array;
+        let lhs_view = if lhs.is_standard_layout() {
+            lhs.view()
+                .into_shape_with_order((self.len_uncontracted_lhs, self.len_contracted_axes))
+                .unwrap()
+        } else {
+            lhs_array = Array::from_shape_vec(
+                [self.len_uncontracted_lhs, self.len_contracted_axes],
+                lhs.iter().cloned().collect(),
+            )
+            .unwrap();
+            lhs_array.view()
+        };
+
+        let rhs_array;
+        let rhs_view = if rhs.is_standard_layout() {
+            rhs.view()
+                .into_shape_with_order((self.len_contracted_axes, self.len_uncontracted_rhs))
+                .unwrap()
+        } else {
+            rhs_array = Array::from_shape_vec(
+                [self.len_contracted_axes, self.len_uncontracted_rhs],
+                rhs.iter().cloned().collect(),
+            )
+            .unwrap();
+            rhs_array.view()
+        };
+
+        lhs_view
+            .dot(&rhs_view)
+            .into_shape_with_order(IxDyn(&self.output_shape))
+            .unwrap()
+    }
+}
+
+// TODO: Micro-optimization possible: Have a version without the final permutation,
+// which clones the array
+/// Computes the tensor dot product of two tensors, with individual permutations of the
+/// LHS and RHS performed as necessary, as well as a final permutation of the output.
+///
+/// Examples that qualify for TensordotGeneral but not TensordotFixedPosition:
+///
+/// 1. `jik,jkl->il` LHS tensor needs to be permuted `jik->ijk`
+/// 2. `ijk,klm->imlj` Output tensor needs to be permuted `ijlm->imlj`
+#[derive(Clone, Debug)]
+pub struct TensordotGeneral {
+    lhs_permutation: Permutation,
+    rhs_permutation: Permutation,
+    tensordot_fixed_position: TensordotFixedPosition,
+    output_permutation: Permutation,
+}
+
+impl TensordotGeneral {
+    pub fn new(sc: &SizedContraction) -> Self {
+        assert_eq!(sc.contraction.operand_indices.len(), 2);
+        let lhs_indices = &sc.contraction.operand_indices[0];
+        let rhs_indices = &sc.contraction.operand_indices[1];
+        let contracted_indices = &sc.contraction.summation_indices;
+        let output_indices = &sc.contraction.output_indices;
+        let lhs_shape: Vec<usize> = lhs_indices.iter().map(|c| sc.output_size[c]).collect();
+        let rhs_shape: Vec<usize> = rhs_indices.iter().map(|c| sc.output_size[c]).collect();
+
+        TensordotGeneral::from_shapes_and_indices(
+            &lhs_shape,
+            &rhs_shape,
+            lhs_indices,
+            rhs_indices,
+            contracted_indices,
+            output_indices,
+        )
+    }
+
+    fn from_shapes_and_indices(
+        lhs_shape: &[usize],
+        rhs_shape: &[usize],
+        lhs_indices: &[char],
+        rhs_indices: &[char],
+        contracted_indices: &[char],
+        output_indices: &[char],
+    ) -> Self {
+        let lhs_contracted_axes = find_outputs_in_inputs_unique(contracted_indices, lhs_indices);
+        let rhs_contracted_axes = find_outputs_in_inputs_unique(contracted_indices, rhs_indices);
+        let mut uncontracted_chars: Vec<char> = lhs_indices
+            .iter()
+            .filter(|&&input_char| {
+                output_indices
+                    .iter()
+                    .any(|&output_char| input_char == output_char)
+            })
+            .cloned()
+            .collect();
+        let mut rhs_uncontracted_chars: Vec<char> = rhs_indices
+            .iter()
+            .filter(|&&input_char| {
+                output_indices
+                    .iter()
+                    .any(|&output_char| input_char == output_char)
+            })
+            .cloned()
+            .collect();
+        uncontracted_chars.append(&mut rhs_uncontracted_chars);
+        let output_order = find_outputs_in_inputs_unique(output_indices, &uncontracted_chars);
+
+        TensordotGeneral::from_shapes_and_axis_numbers(
+            lhs_shape,
+            rhs_shape,
+            &lhs_contracted_axes,
+            &rhs_contracted_axes,
+            &output_order,
+        )
+    }
+
+    /// Produces a `TensordotGeneral` from the shapes and list of axes to be contracted.
+    ///
+    /// Wrapped by the public `tensordot` function and used by `TensordotGeneral::new()`.
+    /// lhs_axes lists the axes from the lhs tensor to contract and rhs_axes lists the
+    /// axes from the rhs tensor to contract.
+    pub fn from_shapes_and_axis_numbers(
+        lhs_shape: &[usize],
+        rhs_shape: &[usize],
+        lhs_axes: &[usize],
+        rhs_axes: &[usize],
+        output_order: &[usize],
+    ) -> Self {
+        let num_contracted_axes = lhs_axes.len();
+        assert!(num_contracted_axes == rhs_axes.len());
+        let lhs_uniques: HashSet<_> = lhs_axes.iter().cloned().collect();
+        let rhs_uniques: HashSet<_> = rhs_axes.iter().cloned().collect();
+        assert!(num_contracted_axes == lhs_uniques.len());
+        assert!(num_contracted_axes == rhs_uniques.len());
+        let mut adjusted_lhs_shape = Vec::new();
+        let mut adjusted_rhs_shape = Vec::new();
+
+        // Rolls the axes specified in lhs and rhs to the back and front respectively,
+        // then calls tensordot_fixed_order(rolled_lhs, rolled_rhs, lhs_axes.len())
+        let mut permutation_lhs = Vec::new();
+        for (i, &axis_length) in lhs_shape.iter().enumerate() {
+            if !(lhs_uniques.contains(&i)) {
+                permutation_lhs.push(i);
+                adjusted_lhs_shape.push(axis_length);
+            }
+        }
+        for &axis in lhs_axes.iter() {
+            permutation_lhs.push(axis);
+            adjusted_lhs_shape.push(lhs_shape[axis]);
+        }
+
+        // Note: These two for loops are (intentionally!) in the reverse order
+        // as they are for LHS.
+        let mut permutation_rhs = Vec::new();
+        for &axis in rhs_axes.iter() {
+            permutation_rhs.push(axis);
+            adjusted_rhs_shape.push(rhs_shape[axis]);
+        }
+        for (i, &axis_length) in rhs_shape.iter().enumerate() {
+            if !(rhs_uniques.contains(&i)) {
+                permutation_rhs.push(i);
+                adjusted_rhs_shape.push(axis_length);
+            }
+        }
+
+        let lhs_permutation = Permutation::from_indices(&permutation_lhs);
+        let rhs_permutation = Permutation::from_indices(&permutation_rhs);
+        let tensordot_fixed_position =
+            TensordotFixedPosition::from_shapes_and_number_of_contracted_axes(
+                &adjusted_lhs_shape,
+                &adjusted_rhs_shape,
+                num_contracted_axes,
+            );
+
+        let output_permutation = Permutation::from_indices(output_order);
+
+        TensordotGeneral {
+            lhs_permutation,
+            rhs_permutation,
+            tensordot_fixed_position,
+            output_permutation,
+        }
+    }
+}
+
+impl<A> PairContractor<A> for TensordotGeneral {
+    fn contract_pair<'a, 'b, 'c, 'd>(
+        &self,
+        lhs: &'b ArrayViewD<'a, A>,
+        rhs: &'d ArrayViewD<'c, A>,
+    ) -> ArrayD<A>
+    where
+        'a: 'b,
+        'c: 'd,
+        A: Clone + LinalgScalar,
+    {
+        let permuted_lhs = self.lhs_permutation.view_singleton(lhs);
+        let permuted_rhs = self.rhs_permutation.view_singleton(rhs);
+        let tensordotted = self
+            .tensordot_fixed_position
+            .contract_pair(&permuted_lhs, &permuted_rhs);
+        self.output_permutation
+            .contract_singleton(&tensordotted.view())
+    }
+}
+
+/// Computes the Hadamard (element-wise) product of two tensors.
+///
+/// All instances of `SizedContraction` making use of this contractor must have the form
+/// `ij,ij->ij`.
+///
+/// Contractions of the form `ij,ji->ij` need to use `HadamardProductGeneral` instead.
+#[derive(Clone, Debug)]
+pub struct HadamardProduct {}
+
+impl HadamardProduct {
+    pub fn new(sc: &SizedContraction) -> Self {
+        assert_eq!(sc.contraction.operand_indices.len(), 2);
+        let lhs_indices = &sc.contraction.operand_indices[0];
+        let rhs_indices = &sc.contraction.operand_indices[1];
+        let output_indices = &sc.contraction.output_indices;
+        assert_eq!(lhs_indices, rhs_indices);
+        assert_eq!(lhs_indices, output_indices);
+
+        HadamardProduct {}
+    }
+
+    fn from_nothing() -> Self {
+        HadamardProduct {}
+    }
+}
+
+impl<A> PairContractor<A> for HadamardProduct {
+    fn contract_pair<'a, 'b, 'c, 'd>(
+        &self,
+        lhs: &'b ArrayViewD<'a, A>,
+        rhs: &'d ArrayViewD<'c, A>,
+    ) -> ArrayD<A>
+    where
+        'a: 'b,
+        'c: 'd,
+        A: Clone + LinalgScalar,
+    {
+        lhs * rhs
+    }
+}
+
+/// Permutes the axes of the LHS and RHS tensors to the order in which those axes appear in the
+/// output before computing the Hadamard (element-wise) product.
+///
+/// Examples of contractions that fit this category:
+///
+/// 1. `ij,ij->ij` (Can also can use `HadamardProduct`)
+/// 2. `ij,ji->ij` (Can only use `HadamardProductGeneral`)
+#[derive(Clone, Debug)]
+pub struct HadamardProductGeneral {
+    lhs_permutation: Permutation,
+    rhs_permutation: Permutation,
+    hadamard_product: HadamardProduct,
+}
+
+impl HadamardProductGeneral {
+    pub fn new(sc: &SizedContraction) -> Self {
+        assert_eq!(sc.contraction.operand_indices.len(), 2);
+        let lhs_indices = &sc.contraction.operand_indices[0];
+        let rhs_indices = &sc.contraction.operand_indices[1];
+        let output_indices = &sc.contraction.output_indices;
+        assert_eq!(lhs_indices.len(), rhs_indices.len());
+        assert_eq!(lhs_indices.len(), output_indices.len());
+
+        let lhs_permutation =
+            Permutation::from_indices(&find_outputs_in_inputs_unique(output_indices, lhs_indices));
+        let rhs_permutation =
+            Permutation::from_indices(&find_outputs_in_inputs_unique(output_indices, rhs_indices));
+        let hadamard_product = HadamardProduct::from_nothing();
+
+        HadamardProductGeneral {
+            lhs_permutation,
+            rhs_permutation,
+            hadamard_product,
+        }
+    }
+}
+
+impl<A> PairContractor<A> for HadamardProductGeneral {
+    fn contract_pair<'a, 'b, 'c, 'd>(
+        &self,
+        lhs: &'b ArrayViewD<'a, A>,
+        rhs: &'d ArrayViewD<'c, A>,
+    ) -> ArrayD<A>
+    where
+        'a: 'b,
+        'c: 'd,
+        A: Clone + LinalgScalar,
+    {
+        self.hadamard_product.contract_pair(
+            &self.lhs_permutation.view_singleton(lhs),
+            &self.rhs_permutation.view_singleton(rhs),
+        )
+    }
+}
+
+/// Multiplies every element of the RHS tensor by the single scalar in the 0-d LHS tensor.
+///
+/// This contraction can arise when the simplification of the LHS tensor results in all the
+/// axes being summed before the two tensors are contracted. For example, in the contraction
+/// `i,jk->jk`, every element of the RHS tensor is simply multiplied by the sum of the elements
+/// of the LHS tensor.
+#[derive(Clone, Debug)]
+pub struct ScalarMatrixProduct {}
+
+impl ScalarMatrixProduct {
+    pub fn new(sc: &SizedContraction) -> Self {
+        assert_eq!(sc.contraction.operand_indices.len(), 2);
+        let lhs_indices = &sc.contraction.operand_indices[0];
+        let rhs_indices = &sc.contraction.operand_indices[1];
+        let output_indices = &sc.contraction.output_indices;
+        assert_eq!(lhs_indices.len(), 0);
+        assert_eq!(output_indices, rhs_indices);
+
+        ScalarMatrixProduct {}
+    }
+
+    pub fn from_nothing() -> Self {
+        ScalarMatrixProduct {}
+    }
+}
+
+impl<A> PairContractor<A> for ScalarMatrixProduct {
+    fn contract_pair<'a, 'b, 'c, 'd>(
+        &self,
+        lhs: &'b ArrayViewD<'a, A>,
+        rhs: &'d ArrayViewD<'c, A>,
+    ) -> ArrayD<A>
+    where
+        'a: 'b,
+        'c: 'd,
+        A: Clone + LinalgScalar,
+    {
+        let lhs_0d: A = *lhs.first().unwrap();
+        rhs.mapv(|x| x * lhs_0d)
+    }
+}
+
+/// Permutes the axes of the RHS tensor to the output order and multiply all elements by the single
+/// scalar in the 0-d LHS tensor.
+///
+/// This contraction can arise when the simplification of the LHS tensor results in all the
+/// axes being summed before the two tensors are contracted. For example, in the contraction
+/// `i,jk->kj`, the output matrix is equal to the RHS matrix, transposed and then scalar-multiplied
+/// by the sum of the elements of the LHS tensor.
+#[derive(Clone, Debug)]
+pub struct ScalarMatrixProductGeneral {
+    rhs_permutation: Permutation,
+    scalar_matrix_product: ScalarMatrixProduct,
+}
+
+impl ScalarMatrixProductGeneral {
+    pub fn new(sc: &SizedContraction) -> Self {
+        assert_eq!(sc.contraction.operand_indices.len(), 2);
+        let lhs_indices = &sc.contraction.operand_indices[0];
+        let rhs_indices = &sc.contraction.operand_indices[1];
+        let output_indices = &sc.contraction.output_indices;
+        assert_eq!(lhs_indices.len(), 0);
+        assert_eq!(rhs_indices.len(), output_indices.len());
+
+        ScalarMatrixProductGeneral::from_indices(rhs_indices, output_indices)
+    }
+
+    pub fn from_indices(input_indices: &[char], output_indices: &[char]) -> Self {
+        let rhs_permutation = Permutation::from_indices(&find_outputs_in_inputs_unique(
+            output_indices,
+            input_indices,
+        ));
+        let scalar_matrix_product = ScalarMatrixProduct::from_nothing();
+
+        ScalarMatrixProductGeneral {
+            rhs_permutation,
+            scalar_matrix_product,
+        }
+    }
+}
+
+impl<A> PairContractor<A> for ScalarMatrixProductGeneral {
+    fn contract_pair<'a, 'b, 'c, 'd>(
+        &self,
+        lhs: &'b ArrayViewD<'a, A>,
+        rhs: &'d ArrayViewD<'c, A>,
+    ) -> ArrayD<A>
+    where
+        'a: 'b,
+        'c: 'd,
+        A: Clone + LinalgScalar,
+    {
+        self.scalar_matrix_product
+            .contract_pair(lhs, &self.rhs_permutation.view_singleton(rhs))
+    }
+}
+
+/// Multiplies every element of the LHS tensor by the single scalar in the 0-d RHS tensor.
+///
+/// This contraction can arise when the simplification of the LHS tensor results in all the
+/// axes being summed before the two tensors are contracted. For example, in the contraction
+/// `ij,k->ij`, every element of the LHS tensor is simply multiplied by the sum of the elements
+/// of the RHS tensor.
+#[derive(Clone, Debug)]
+pub struct MatrixScalarProduct {}
+
+impl MatrixScalarProduct {
+    pub fn new(sc: &SizedContraction) -> Self {
+        assert_eq!(sc.contraction.operand_indices.len(), 2);
+        let lhs_indices = &sc.contraction.operand_indices[0];
+        let rhs_indices = &sc.contraction.operand_indices[1];
+        let output_indices = &sc.contraction.output_indices;
+        assert_eq!(rhs_indices.len(), 0);
+        assert_eq!(output_indices, lhs_indices);
+
+        MatrixScalarProduct {}
+    }
+
+    pub fn from_nothing() -> Self {
+        MatrixScalarProduct {}
+    }
+}
+
+impl<A> PairContractor<A> for MatrixScalarProduct {
+    fn contract_pair<'a, 'b, 'c, 'd>(
+        &self,
+        lhs: &'b ArrayViewD<'a, A>,
+        rhs: &'d ArrayViewD<'c, A>,
+    ) -> ArrayD<A>
+    where
+        'a: 'b,
+        'c: 'd,
+        A: Clone + LinalgScalar,
+    {
+        let rhs_0d: A = *rhs.first().unwrap();
+        lhs.mapv(|x| x * rhs_0d)
+    }
+}
+
+/// Permutes the axes of the LHS tensor to the output order and multiply all elements by the single
+/// scalar in the 0-d RHS tensor.
+///
+/// This contraction can arise when the simplification of the RHS tensor results in all the
+/// axes being summed before the two tensors are contracted. For example, in the contraction
+/// `ij,k->ji`, the output matrix is equal to the LHS matrix, transposed and then scalar-multiplied
+/// by the sum of the elements of the RHS tensor.
+#[derive(Clone, Debug)]
+pub struct MatrixScalarProductGeneral {
+    lhs_permutation: Permutation,
+    matrix_scalar_product: MatrixScalarProduct,
+}
+
+impl MatrixScalarProductGeneral {
+    pub fn new(sc: &SizedContraction) -> Self {
+        assert_eq!(sc.contraction.operand_indices.len(), 2);
+        let lhs_indices = &sc.contraction.operand_indices[0];
+        let rhs_indices = &sc.contraction.operand_indices[1];
+        let output_indices = &sc.contraction.output_indices;
+        assert_eq!(rhs_indices.len(), 0);
+        assert_eq!(lhs_indices.len(), output_indices.len());
+
+        MatrixScalarProductGeneral::from_indices(lhs_indices, output_indices)
+    }
+
+    pub fn from_indices(input_indices: &[char], output_indices: &[char]) -> Self {
+        let lhs_permutation = Permutation::from_indices(&find_outputs_in_inputs_unique(
+            output_indices,
+            input_indices,
+        ));
+        let matrix_scalar_product = MatrixScalarProduct::from_nothing();
+
+        MatrixScalarProductGeneral {
+            lhs_permutation,
+            matrix_scalar_product,
+        }
+    }
+}
+
+impl<A> PairContractor<A> for MatrixScalarProductGeneral {
+    fn contract_pair<'a, 'b, 'c, 'd>(
+        &self,
+        lhs: &'b ArrayViewD<'a, A>,
+        rhs: &'d ArrayViewD<'c, A>,
+    ) -> ArrayD<A>
+    where
+        'a: 'b,
+        'c: 'd,
+        A: Clone + LinalgScalar,
+    {
+        self.matrix_scalar_product
+            .contract_pair(&self.lhs_permutation.view_singleton(lhs), rhs)
+    }
+}
+
+/// Permutes the axes of the LHS and RHS tensor, broadcasts into the output shape,
+/// and then computes the element-wise product of the two broadcast tensors.
+///
+/// Currently unused due to (limited) unfavorable benchmarking results compared to
+/// `StackedTensordotGeneral`. An example of a contraction that could theoretically
+/// be performed by this contraction is `ij,jk->ijk`: the LHS and RHS are both
+/// broadcast into output shape (|i|, |j|, |k|) and then multiplied elementwise.
+///
+/// However, the limited benchmarking performed so far favored iterating along the
+/// `j` axis and computing the outer products `i,k->ik` for each subview of the tensors.
+#[derive(Clone, Debug)]
+pub struct BroadcastProductGeneral {
+    lhs_permutation: Permutation,
+    rhs_permutation: Permutation,
+    lhs_insertions: Vec<usize>,
+    rhs_insertions: Vec<usize>,
+    output_sizes: Vec<usize>,
+    hadamard_product: HadamardProduct,
+}
+
+impl BroadcastProductGeneral {
+    pub fn new(sc: &SizedContraction) -> Self {
+        assert_eq!(sc.contraction.operand_indices.len(), 2);
+        let lhs_indices = &sc.contraction.operand_indices[0];
+        let rhs_indices = &sc.contraction.operand_indices[1];
+        let output_indices = &sc.contraction.output_indices;
+
+        let maybe_lhs_indices = maybe_find_outputs_in_inputs_unique(output_indices, lhs_indices);
+        let maybe_rhs_indices = maybe_find_outputs_in_inputs_unique(output_indices, rhs_indices);
+        let lhs_indices: Vec<usize> = maybe_lhs_indices.iter().copied().flatten().collect();
+        let rhs_indices: Vec<usize> = maybe_rhs_indices.iter().copied().flatten().collect();
+        let lhs_insertions: Vec<usize> = maybe_lhs_indices
+            .into_iter()
+            .enumerate()
+            .filter(|(_, x)| x.is_none())
+            .map(|(i, _)| i)
+            .collect();
+        let rhs_insertions: Vec<usize> = maybe_rhs_indices
+            .into_iter()
+            .enumerate()
+            .filter(|(_, x)| x.is_none())
+            .map(|(i, _)| i)
+            .collect();
+        let lhs_permutation = Permutation::from_indices(&lhs_indices);
+        let rhs_permutation = Permutation::from_indices(&rhs_indices);
+        let output_sizes: Vec<usize> = output_indices.iter().map(|c| sc.output_size[c]).collect();
+        let hadamard_product = HadamardProduct::from_nothing();
+
+        BroadcastProductGeneral {
+            lhs_permutation,
+            rhs_permutation,
+            lhs_insertions,
+            rhs_insertions,
+            output_sizes,
+            hadamard_product,
+        }
+    }
+}
+
+impl<A> PairContractor<A> for BroadcastProductGeneral {
+    fn contract_pair<'a, 'b, 'c, 'd>(
+        &self,
+        lhs: &'b ArrayViewD<'a, A>,
+        rhs: &'d ArrayViewD<'c, A>,
+    ) -> ArrayD<A>
+    where
+        'a: 'b,
+        'c: 'd,
+        A: Clone + LinalgScalar,
+    {
+        let mut adjusted_lhs = self.lhs_permutation.view_singleton(lhs);
+        let mut adjusted_rhs = self.rhs_permutation.view_singleton(rhs);
+        for &i in self.lhs_insertions.iter() {
+            adjusted_lhs = adjusted_lhs.insert_axis(Axis(i));
+        }
+        for &i in self.rhs_insertions.iter() {
+            adjusted_rhs = adjusted_rhs.insert_axis(Axis(i));
+        }
+        let output_shape = IxDyn(&self.output_sizes);
+        let broadcast_lhs = adjusted_lhs.broadcast(output_shape.clone()).unwrap();
+        let broadcast_rhs = adjusted_rhs.broadcast(output_shape).unwrap();
+        self.hadamard_product
+            .contract_pair(&broadcast_lhs, &broadcast_rhs)
+    }
+}
+
+// TODO: Micro-optimization: Have a version without the output permutation,
+// which clones the array
+//
+// TODO: Fix whatever bug prevents this from being used in all cases
+//
+// TODO: convert this to directly reshape into a 3-D matrix instead of delegating
+// that to TensordotGeneral
+
+/// Repeatedly computes the tensor dot of subviews of the two tensors, iterating over
+/// indices which appear in the LHS, RHS, and output.
+///
+/// The indices appearing in all three places are referred to here as the "stack" indices.
+/// For example, in the contraction `ijk,ikl->ijl`, `i` would be the (only) "stack" index.
+/// This contraction is an instance of batch matrix multiplication. The LHS and RHS are both
+/// 3-D tensors and the `i`th (2-D) subview of the output is the matrix product of the `i`th
+/// subview of the LHS matrix-multiplied by the `i`th subview of the RHS.
+///
+/// This is the most general contraction and in theory could handle all pairwise contractions,
+/// but is less performant than special-casing when there are no "stack" indices. It is also
+/// currently the only case that requires `.outer_iter_mut()` (which might make parallelizing
+/// operations more difficult).
+#[derive(Clone, Debug)]
+pub struct StackedTensordotGeneral {
+    lhs_permutation: Permutation,
+    rhs_permutation: Permutation,
+    lhs_output_shape: Vec<usize>,
+    rhs_output_shape: Vec<usize>,
+    intermediate_shape: Vec<usize>,
+    tensordot_fixed_position: TensordotFixedPosition,
+    output_shape: Vec<usize>,
+    output_permutation: Permutation,
+}
+
+impl StackedTensordotGeneral {
+    pub fn new(sc: &SizedContraction) -> Self {
+        let mut lhs_order = Vec::new();
+        let mut rhs_order = Vec::new();
+        let mut lhs_output_shape = Vec::new();
+        let mut rhs_output_shape = Vec::new();
+        let mut intermediate_shape = Vec::new();
+
+        assert_eq!(sc.contraction.operand_indices.len(), 2);
+        let lhs_indices = &sc.contraction.operand_indices[0];
+        let rhs_indices = &sc.contraction.operand_indices[1];
+        let output_indices = &sc.contraction.output_indices;
+
+        let maybe_lhs_axes = maybe_find_outputs_in_inputs_unique(output_indices, lhs_indices);
+        let maybe_rhs_axes = maybe_find_outputs_in_inputs_unique(output_indices, rhs_indices);
+        let mut lhs_stack_axes = Vec::new();
+        let mut rhs_stack_axes = Vec::new();
+        let mut stack_indices = Vec::new();
+        let mut lhs_outer_axes = Vec::new();
+        let mut lhs_outer_indices = Vec::new();
+        let mut rhs_outer_axes = Vec::new();
+        let mut rhs_outer_indices = Vec::new();
+        let mut lhs_contracted_axes = Vec::new();
+        let mut rhs_contracted_axes = Vec::new();
+        let mut intermediate_indices = Vec::new();
+        let mut lhs_uncontracted_shape = Vec::new();
+        let mut rhs_uncontracted_shape = Vec::new();
+        let mut contracted_shape = Vec::new();
+
+        lhs_output_shape.push(1);
+        rhs_output_shape.push(1);
+
+        for ((&maybe_lhs_pos, &maybe_rhs_pos), &output_char) in maybe_lhs_axes
+            .iter()
+            .zip(maybe_rhs_axes.iter())
+            .zip(output_indices.iter())
+        {
+            match (maybe_lhs_pos, maybe_rhs_pos) {
+                (Some(lhs_pos), Some(rhs_pos)) => {
+                    lhs_stack_axes.push(lhs_pos);
+                    rhs_stack_axes.push(rhs_pos);
+                    stack_indices.push(output_char);
+                    lhs_output_shape[0] *= sc.output_size[&output_char];
+                    rhs_output_shape[0] *= sc.output_size[&output_char];
+                }
+                (Some(lhs_pos), None) => {
+                    lhs_outer_axes.push(lhs_pos);
+                    lhs_outer_indices.push(output_char);
+                    lhs_uncontracted_shape.push(sc.output_size[&output_char]);
+                }
+                (None, Some(rhs_pos)) => {
+                    rhs_outer_axes.push(rhs_pos);
+                    rhs_outer_indices.push(output_char);
+                    rhs_uncontracted_shape.push(sc.output_size[&output_char]);
+                }
+                (None, None) => {
+                    panic!() // Output char must be either in lhs or rhs
+                }
+            }
+        }
+
+        for (lhs_pos, &lhs_char) in lhs_indices.iter().enumerate() {
+            if !output_indices
+                .iter()
+                .any(|&output_char| output_char == lhs_char)
+            {
+                // Contracted index
+                lhs_contracted_axes.push(lhs_pos);
+                // Must be in RHS if it's not in output
+                rhs_contracted_axes.push(
+                    rhs_indices
+                        .iter()
+                        .position(|&rhs_char| rhs_char == lhs_char)
+                        .unwrap(),
+                );
+                contracted_shape.push(sc.output_size[&lhs_char]);
+            }
+        }
+        // What order do we want the axes in?
+        //
+        // LHS: Stack axes, outer axes, contracted axes
+        // RHS: Stack axes, contracted axes, outer axes
+
+        lhs_order.append(&mut lhs_stack_axes.clone());
+        lhs_order.append(&mut lhs_outer_axes.clone());
+        lhs_output_shape.append(&mut lhs_uncontracted_shape);
+        lhs_order.append(&mut lhs_contracted_axes.clone());
+        lhs_output_shape.append(&mut contracted_shape.clone());
+
+        rhs_order.append(&mut rhs_stack_axes.clone());
+        rhs_order.append(&mut rhs_contracted_axes.clone());
+        rhs_output_shape.append(&mut contracted_shape);
+        rhs_order.append(&mut rhs_outer_axes.clone());
+        rhs_output_shape.append(&mut rhs_uncontracted_shape);
+
+        // What order will the intermediate output indices be in?
+        // Stack indices, lhs outer indices, rhs outer indices
+        intermediate_indices.append(&mut stack_indices.clone());
+        intermediate_indices.append(&mut lhs_outer_indices.clone());
+        intermediate_indices.append(&mut rhs_outer_indices.clone());
+
+        assert_eq!(lhs_output_shape[0], rhs_output_shape[0]);
+        intermediate_shape.push(lhs_output_shape[0]);
+        for lhs_char in lhs_outer_indices.iter() {
+            intermediate_shape.push(sc.output_size[lhs_char]);
+        }
+        for rhs_char in rhs_outer_indices.iter() {
+            intermediate_shape.push(sc.output_size[rhs_char]);
+        }
+
+        let output_order = find_outputs_in_inputs_unique(output_indices, &intermediate_indices);
+        let output_shape = intermediate_indices
+            .iter()
+            .map(|c| sc.output_size[c])
+            .collect();
+
+        let tensordot_fixed_position =
+            TensordotFixedPosition::from_shapes_and_number_of_contracted_axes(
+                &lhs_output_shape[1..],
+                &rhs_output_shape[1..],
+                lhs_contracted_axes.len(),
+            );
+        let lhs_permutation = Permutation::from_indices(&lhs_order);
+        let rhs_permutation = Permutation::from_indices(&rhs_order);
+        let output_permutation = Permutation::from_indices(&output_order);
+        StackedTensordotGeneral {
+            lhs_permutation,
+            rhs_permutation,
+            lhs_output_shape,
+            rhs_output_shape,
+            intermediate_shape,
+            tensordot_fixed_position,
+            output_shape,
+            output_permutation,
+        }
+    }
+}
+
+impl<A> PairContractor<A> for StackedTensordotGeneral {
+    fn contract_pair<'a, 'b, 'c, 'd>(
+        &self,
+        lhs: &'b ArrayViewD<'a, A>,
+        rhs: &'d ArrayViewD<'c, A>,
+    ) -> ArrayD<A>
+    where
+        'a: 'b,
+        'c: 'd,
+        A: Clone + LinalgScalar,
+    {
+        let lhs_permuted = self.lhs_permutation.view_singleton(lhs);
+        let lhs_reshaped = Array::from_shape_vec(
+            IxDyn(&self.lhs_output_shape),
+            lhs_permuted.iter().cloned().collect(),
+        )
+        .unwrap();
+        let rhs_permuted = self.rhs_permutation.view_singleton(rhs);
+        let rhs_reshaped = Array::from_shape_vec(
+            IxDyn(&self.rhs_output_shape),
+            rhs_permuted.iter().cloned().collect(),
+        )
+        .unwrap();
+        let mut intermediate_result: ArrayD<A> = Array::zeros(IxDyn(&self.intermediate_shape));
+        let mut lhs_iter = lhs_reshaped.outer_iter();
+        let mut rhs_iter = rhs_reshaped.outer_iter();
+        for mut output_subview in intermediate_result.outer_iter_mut() {
+            let lhs_subview = lhs_iter.next().unwrap();
+            let rhs_subview = rhs_iter.next().unwrap();
+            self.tensordot_fixed_position.contract_and_assign_pair(
+                &lhs_subview,
+                &rhs_subview,
+                &mut output_subview,
+            );
+        }
+        let intermediate_reshaped = intermediate_result
+            .into_shape_with_order(IxDyn(&self.output_shape))
+            .unwrap();
+        self.output_permutation
+            .contract_singleton(&intermediate_reshaped.view())
+    }
+}

--- a/crates/ndarray_einsum/src/contractors/singleton_contractors.rs
+++ b/crates/ndarray_einsum/src/contractors/singleton_contractors.rs
@@ -1,0 +1,359 @@
+// Copyright 2019 Jared Samet
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Contains the specific implementations of `SingletonContractor` and `SingletonViewer` that
+//! represent the base-case ways to contract or simplify a single tensor.
+//!
+//! All the structs here perform perform some combination of
+//! permutation of the input axes (e.g. `ijk->jki`), diagonalization across repeated but
+//! un-summed axes (e.g. `ii->i`),
+//! and summation across axes not present in the output index list (e.g. `ijk->j`).
+
+use ndarray::prelude::*;
+use ndarray::LinalgScalar;
+
+use super::{SingletonContractor, SingletonViewer};
+use crate::{Contraction, SizedContraction};
+
+/// Returns a view or clone of the input tensor.
+///
+/// Example: `ij->ij`
+#[derive(Clone, Debug)]
+pub struct Identity {}
+
+impl Identity {
+    pub fn new(_sc: &SizedContraction) -> Self {
+        Identity {}
+    }
+}
+
+impl<A> SingletonViewer<A> for Identity {
+    fn view_singleton<'a, 'b>(&self, tensor: &'b ArrayViewD<'a, A>) -> ArrayViewD<'b, A>
+    where
+        'a: 'b,
+        A: Clone + LinalgScalar,
+    {
+        tensor.view()
+    }
+}
+
+impl<A> SingletonContractor<A> for Identity {
+    fn contract_singleton<'a, 'b>(&self, tensor: &'b ArrayViewD<'a, A>) -> ArrayD<A>
+    where
+        'a: 'b,
+        A: Clone + LinalgScalar,
+    {
+        tensor.to_owned()
+    }
+}
+
+/// Permutes the axes of the input tensor and returns a view or clones the elements.
+///
+/// Example: `ij->ji`
+#[derive(Clone, Debug)]
+pub struct Permutation {
+    permutation: Vec<usize>,
+}
+
+impl Permutation {
+    pub fn new(sc: &SizedContraction) -> Self {
+        let SizedContraction {
+            contraction:
+                Contraction {
+                    ref operand_indices,
+                    ref output_indices,
+                    ..
+                },
+            ..
+        } = sc;
+
+        assert_eq!(operand_indices.len(), 1);
+        assert_eq!(operand_indices[0].len(), output_indices.len());
+
+        let mut permutation = Vec::new();
+        for &c in output_indices.iter() {
+            permutation.push(operand_indices[0].iter().position(|&x| x == c).unwrap());
+        }
+
+        Permutation { permutation }
+    }
+
+    pub fn from_indices(permutation: &[usize]) -> Self {
+        Permutation {
+            permutation: permutation.to_vec(),
+        }
+    }
+}
+
+impl<A> SingletonViewer<A> for Permutation {
+    fn view_singleton<'a, 'b>(&self, tensor: &'b ArrayViewD<'a, A>) -> ArrayViewD<'b, A>
+    where
+        'a: 'b,
+        A: Clone + LinalgScalar,
+    {
+        tensor.view().permuted_axes(IxDyn(&self.permutation))
+    }
+}
+
+impl<A> SingletonContractor<A> for Permutation {
+    fn contract_singleton<'a, 'b>(&self, tensor: &'b ArrayViewD<'a, A>) -> ArrayD<A>
+    where
+        'a: 'b,
+        A: Clone + LinalgScalar,
+    {
+        tensor
+            .view()
+            .permuted_axes(IxDyn(&self.permutation))
+            .to_owned()
+    }
+}
+
+/// Sums across the elements of the input tensor that don't appear in the output tensor.
+///
+/// Example: `ij->i`
+#[derive(Clone, Debug)]
+pub struct Summation {
+    adjusted_axis_list: Vec<usize>,
+}
+
+impl Summation {
+    pub fn new(sc: &SizedContraction) -> Self {
+        let output_indices = &sc.contraction.output_indices;
+        let input_indices = &sc.contraction.operand_indices[0];
+
+        Summation::from_sizes(
+            output_indices.len(),
+            input_indices.len() - output_indices.len(),
+        )
+    }
+
+    fn from_sizes(start_index: usize, num_summed_axes: usize) -> Self {
+        assert!(num_summed_axes >= 1);
+        let adjusted_axis_list = (0..num_summed_axes).map(|_| start_index).collect();
+
+        Summation { adjusted_axis_list }
+    }
+}
+
+impl<A> SingletonContractor<A> for Summation {
+    fn contract_singleton<'a, 'b>(&self, tensor: &'b ArrayViewD<'a, A>) -> ArrayD<A>
+    where
+        'a: 'b,
+        A: Clone + LinalgScalar,
+    {
+        let mut result = tensor.sum_axis(Axis(self.adjusted_axis_list[0]));
+        for &axis in self.adjusted_axis_list[1..].iter() {
+            result = result.sum_axis(Axis(axis));
+        }
+        result
+    }
+}
+
+/// Returns the elements of the input tensor where all instances of the repeated indices are equal to one another.
+/// Optionally permutes the axes of the tensor as well.
+///
+/// Examples:
+///
+/// 1. `ii->i`
+/// 2. `iij->ji`
+#[derive(Clone, Debug)]
+pub struct Diagonalization {
+    input_to_output_mapping: Vec<usize>,
+    output_shape: Vec<usize>,
+}
+
+impl Diagonalization {
+    pub fn new(sc: &SizedContraction) -> Self {
+        let SizedContraction {
+            contraction:
+                Contraction {
+                    ref operand_indices,
+                    ref output_indices,
+                    ..
+                },
+            ref output_size,
+        } = sc;
+        assert_eq!(operand_indices.len(), 1);
+
+        let mut adjusted_output_indices = output_indices.clone();
+        let mut input_to_output_mapping = Vec::new();
+        for &c in operand_indices[0].iter() {
+            let current_length = adjusted_output_indices.len();
+            match adjusted_output_indices.iter().position(|&x| x == c) {
+                Some(pos) => {
+                    input_to_output_mapping.push(pos);
+                }
+                None => {
+                    adjusted_output_indices.push(c);
+                    input_to_output_mapping.push(current_length);
+                }
+            }
+        }
+        let output_shape = adjusted_output_indices
+            .iter()
+            .map(|c| output_size[c])
+            .collect();
+
+        Diagonalization {
+            input_to_output_mapping,
+            output_shape,
+        }
+    }
+}
+
+impl<A> SingletonViewer<A> for Diagonalization {
+    fn view_singleton<'a, 'b>(&self, tensor: &'b ArrayViewD<'a, A>) -> ArrayViewD<'b, A>
+    where
+        'a: 'b,
+        A: Clone + LinalgScalar,
+    {
+        // Construct the stride array on the fly by enumerating (idx, stride) from strides() and
+        // adding stride to self.which_index_is_this
+        let mut strides = vec![0; self.output_shape.len()];
+        for (idx, &stride) in tensor.strides().iter().enumerate() {
+            assert!(stride > 0);
+            strides[self.input_to_output_mapping[idx]] += stride as usize;
+        }
+
+        // Output shape we want is already stored in self.output_shape
+        // let t = ArrayView::from_shape(IxDyn(&[3]).strides(IxDyn(&[4])), &sl).unwrap();
+        let data_slice = tensor.as_slice_memory_order().unwrap();
+        ArrayView::from_shape(
+            IxDyn(&self.output_shape).strides(IxDyn(&strides)),
+            data_slice,
+        )
+        .unwrap()
+    }
+}
+
+impl<A> SingletonContractor<A> for Diagonalization {
+    fn contract_singleton<'a, 'b>(&self, tensor: &'b ArrayViewD<'a, A>) -> ArrayD<A>
+    where
+        'a: 'b,
+        A: Clone + LinalgScalar,
+    {
+        // We're only using this method if the tensor is not contiguous
+        // Clones twice as a result
+        let cloned_tensor: ArrayD<A> =
+            Array::from_shape_vec(tensor.raw_dim(), tensor.iter().cloned().collect()).unwrap();
+        self.view_singleton(&cloned_tensor.view()).into_owned()
+    }
+}
+
+/// Permutes the elements of the input tensor and sums across elements that don't appear in the output.
+///
+/// Example: `ijk->kj`
+#[derive(Clone, Debug)]
+pub struct PermutationAndSummation {
+    permutation: Permutation,
+    summation: Summation,
+}
+
+impl PermutationAndSummation {
+    pub fn new(sc: &SizedContraction) -> Self {
+        let mut output_order: Vec<usize> = Vec::new();
+
+        for &output_char in sc.contraction.output_indices.iter() {
+            let input_pos = sc.contraction.operand_indices[0]
+                .iter()
+                .position(|&input_char| input_char == output_char)
+                .unwrap();
+            output_order.push(input_pos);
+        }
+        for (i, &input_char) in sc.contraction.operand_indices[0].iter().enumerate() {
+            if !sc
+                .contraction
+                .output_indices
+                .iter()
+                .any(|&output_char| output_char == input_char)
+            {
+                output_order.push(i);
+            }
+        }
+
+        let permutation = Permutation::from_indices(&output_order);
+        let summation = Summation::new(sc);
+
+        PermutationAndSummation {
+            permutation,
+            summation,
+        }
+    }
+}
+
+impl<A> SingletonContractor<A> for PermutationAndSummation {
+    fn contract_singleton<'a, 'b>(&self, tensor: &'b ArrayViewD<'a, A>) -> ArrayD<A>
+    where
+        'a: 'b,
+        A: Clone + LinalgScalar,
+    {
+        let permuted_singleton = self.permutation.view_singleton(tensor);
+        self.summation.contract_singleton(&permuted_singleton)
+    }
+}
+
+/// Returns the elements of the input tensor where all instances of the repeated indices are equal
+/// to one another, optionally permuting the axes, and sums across indices that don't appear in the output.
+///
+/// Examples:
+///
+/// 1. `iijk->ik` (Diagonalizes the `i` axes and sums over `j`)
+/// 2. `jijik->ki` (Diagonalizes `i` and `j` and sums over `j` after diagonalization)
+#[derive(Clone, Debug)]
+pub struct DiagonalizationAndSummation {
+    diagonalization: Diagonalization,
+    summation: Summation,
+}
+
+impl DiagonalizationAndSummation {
+    pub fn new(sc: &SizedContraction) -> Self {
+        let diagonalization = Diagonalization::new(sc);
+        let summation = Summation::from_sizes(
+            sc.contraction.output_indices.len(),
+            diagonalization.output_shape.len() - sc.contraction.output_indices.len(),
+        );
+
+        DiagonalizationAndSummation {
+            diagonalization,
+            summation,
+        }
+    }
+}
+
+impl<A> SingletonContractor<A> for DiagonalizationAndSummation {
+    fn contract_singleton<'a, 'b>(&self, tensor: &'b ArrayViewD<'a, A>) -> ArrayD<A>
+    where
+        'a: 'b,
+        A: Clone + LinalgScalar,
+    {
+        // We can only do Diagonalization directly as a view if all the strides are
+        // positive and if the tensor is contiguous. We can't know this just from
+        // looking at the SizedContraction; we need the actual tensor that will
+        // be operated on. So this needs to get checked at "runtime".
+        //
+        // If either condition fails, we use the contract_singleton version to
+        // create a new tensor and view() that intermediate result.
+        let contracted_singleton;
+        let viewed_singleton = if tensor.as_slice_memory_order().is_some()
+            && tensor.strides().iter().all(|&stride| stride > 0)
+        {
+            self.diagonalization.view_singleton(tensor)
+        } else {
+            contracted_singleton = self.diagonalization.contract_singleton(tensor);
+            contracted_singleton.view()
+        };
+
+        self.summation.contract_singleton(&viewed_singleton)
+    }
+}

--- a/crates/ndarray_einsum/src/contractors/strategies.rs
+++ b/crates/ndarray_einsum/src/contractors/strategies.rs
@@ -1,0 +1,163 @@
+// Copyright 2019 Jared Samet
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module contains the "strategy choice" logic for which specific contractor
+//! should be used for a given mini-contraction.
+//!
+//! In general, `DiagonalizationAndSummation` should be able to accomodate all singleton
+//! contractions and `StackedTensordotGeneral` should be able to handle all pairs; however,
+//! other trait implementations might be faster.
+//!
+//! The code here has some duplication and is probably not the most idiomatic way to accomplish this.
+
+use crate::SizedContraction;
+use hashbrown::{HashMap, HashSet};
+
+#[derive(Copy, Clone, Debug)]
+pub enum SingletonMethod {
+    Identity,
+    Permutation,
+    Summation,
+    Diagonalization,
+    PermutationAndSummation,
+    DiagonalizationAndSummation,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct SingletonSummary {
+    num_summed_axes: usize,
+    num_diagonalized_axes: usize,
+    num_reordered_axes: usize,
+}
+
+impl SingletonSummary {
+    pub fn new(sc: &SizedContraction) -> Self {
+        assert_eq!(sc.contraction.operand_indices.len(), 1);
+        let output_indices = &sc.contraction.output_indices;
+        let input_indices = &sc.contraction.operand_indices[0];
+
+        SingletonSummary::from_indices(input_indices, output_indices)
+    }
+
+    fn from_indices(input_indices: &[char], output_indices: &[char]) -> Self {
+        let mut input_counts = HashMap::new();
+        for &c in input_indices.iter() {
+            *input_counts.entry(c).or_insert(0) += 1;
+        }
+        let num_summed_axes = input_counts.len() - output_indices.len();
+        let num_diagonalized_axes = input_counts.iter().filter(|(_, &v)| v > 1).count();
+        let num_reordered_axes = output_indices
+            .iter()
+            .zip(input_indices.iter())
+            .filter(|(&output_char, &input_char)| output_char != input_char)
+            .count();
+
+        SingletonSummary {
+            num_summed_axes,
+            num_diagonalized_axes,
+            num_reordered_axes,
+        }
+    }
+
+    pub fn get_strategy(&self) -> SingletonMethod {
+        match (
+            self.num_summed_axes,
+            self.num_diagonalized_axes,
+            self.num_reordered_axes,
+        ) {
+            (0, 0, 0) => SingletonMethod::Identity,
+            (0, 0, _) => SingletonMethod::Permutation,
+            (_, 0, 0) => SingletonMethod::Summation,
+            (0, _, _) => SingletonMethod::Diagonalization,
+            (_, 0, _) => SingletonMethod::PermutationAndSummation,
+            (_, _, _) => SingletonMethod::DiagonalizationAndSummation,
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Copy, Clone)]
+pub enum PairMethod {
+    HadamardProduct,
+    HadamardProductGeneral,
+    TensordotFixedPosition,
+    TensordotGeneral,
+    ScalarMatrixProduct,
+    ScalarMatrixProductGeneral,
+    MatrixScalarProduct,
+    MatrixScalarProductGeneral,
+    BroadcastProductGeneral,
+    StackedTensordotGeneral,
+}
+
+#[derive(Debug, Clone)]
+pub struct PairSummary {
+    num_stacked_axes: usize,
+    num_lhs_outer_axes: usize,
+    num_rhs_outer_axes: usize,
+    num_contracted_axes: usize,
+}
+
+impl PairSummary {
+    pub fn new(sc: &SizedContraction) -> Self {
+        assert_eq!(sc.contraction.operand_indices.len(), 2);
+        let output_indices = &sc.contraction.output_indices;
+        let lhs_indices = &sc.contraction.operand_indices[0];
+        let rhs_indices = &sc.contraction.operand_indices[1];
+
+        PairSummary::from_indices(lhs_indices, rhs_indices, output_indices)
+    }
+
+    fn from_indices(lhs_indices: &[char], rhs_indices: &[char], output_indices: &[char]) -> Self {
+        let lhs_uniques: HashSet<char> = lhs_indices.iter().cloned().collect();
+        let rhs_uniques: HashSet<char> = rhs_indices.iter().cloned().collect();
+        let output_uniques: HashSet<char> = output_indices.iter().cloned().collect();
+        assert_eq!(lhs_indices.len(), lhs_uniques.len());
+        assert_eq!(rhs_indices.len(), rhs_uniques.len());
+        assert_eq!(output_indices.len(), output_uniques.len());
+
+        let lhs_and_rhs: HashSet<char> = lhs_uniques.intersection(&rhs_uniques).cloned().collect();
+        let stacked: HashSet<char> = lhs_and_rhs.intersection(&output_uniques).cloned().collect();
+
+        let num_stacked_axes = stacked.len();
+        let num_contracted_axes = lhs_and_rhs.len() - num_stacked_axes;
+        let num_lhs_outer_axes = lhs_uniques.len() - num_stacked_axes - num_contracted_axes;
+        let num_rhs_outer_axes = rhs_uniques.len() - num_stacked_axes - num_contracted_axes;
+
+        PairSummary {
+            num_stacked_axes,
+            num_lhs_outer_axes,
+            num_rhs_outer_axes,
+            num_contracted_axes,
+        }
+    }
+
+    pub fn get_strategy(&self) -> PairMethod {
+        match (
+            self.num_contracted_axes,
+            self.num_lhs_outer_axes,
+            self.num_rhs_outer_axes,
+            self.num_stacked_axes,
+        ) {
+            (0, 0, 0, _) => PairMethod::HadamardProductGeneral,
+            (0, 0, _, 0) => PairMethod::ScalarMatrixProductGeneral,
+            (0, _, 0, 0) => PairMethod::MatrixScalarProductGeneral,
+            // This contractor works, but appears to be slower
+            // than StackedTensordotGeneral
+            // (0, _, _, _) => PairMethod::BroadcastProductGeneral,
+            (_, _, _, 0) => PairMethod::TensordotGeneral,
+            (_, _, _, _) => PairMethod::StackedTensordotGeneral,
+        }
+    }
+}

--- a/crates/ndarray_einsum/src/iterators.rs
+++ b/crates/ndarray_einsum/src/iterators.rs
@@ -1,0 +1,92 @@
+// Copyright 2019 Jared Samet
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// struct MultiAxisIterator<'a, A> {
+//     carrying: bool,
+//     ndim: usize,
+//     // axes: Vec<usize>,
+//     renumbered_axes: Vec<usize>,
+//     shape: Vec<usize>,
+//     positions: Vec<usize>,
+//     underlying: &'a ArrayViewD<'a, A>,
+//     // subviews: Vec<ArrayViewD<'a, A>>,
+// }
+//
+// impl<'a, A> MultiAxisIterator<'a, A> {
+//     fn new(base: &'a ArrayViewD<'a, A>, axes: &[usize]) -> MultiAxisIterator<'a, A> {
+//         let ndim = axes.len();
+//         // let axes: Vec<usize> = axes.to_vec();
+//         let renumbered_axes: Vec<usize> = axes
+//             .iter()
+//             .enumerate()
+//             .map(|(i, &v)| v - axes[0..i].iter().filter(|&&x| x < v).count())
+//             .collect();
+//         let shape: Vec<usize> = axes
+//             .iter()
+//             .map(|&x| base.shape().get(x).unwrap())
+//             .cloned()
+//             .collect();
+//         let positions = vec![0; shape.len()];
+//
+//         // let mut subviews = Vec::new();
+//         // let mut axis_iters = Vec::new();
+//         //
+//         // for (ax_num, &ax) in axes.iter().enumerate() {
+//         //     let mut subview = base.view();
+//         //     for i in 0..ax_num {
+//         //         subview = subview.index_axis_move(Axis(0), 0);
+//         //     }
+//         //     subviews.push(subview);
+//         // }
+//
+//         MultiAxisIterator {
+//             underlying: base,
+//             carrying: false,
+//             ndim,
+//             // axes,
+//             renumbered_axes,
+//             shape,
+//             positions,
+//             // subviews,
+//         }
+//     }
+// }
+//
+// impl<'a, A> Iterator for MultiAxisIterator<'a, A> {
+//     type Item = ArrayViewD<'a, A>;
+//
+//     fn next(&mut self) -> Option<Self::Item> {
+//         if !self.carrying {
+//             let mut view = self.underlying.view();
+//             for (&ax, &pos) in self.renumbered_axes.iter().zip(&self.positions) {
+//                 view = view.index_axis_move(Axis(ax), pos);
+//             }
+//             self.carrying = true;
+//             for i in 0..self.ndim {
+//                 let axis = self.ndim - i - 1;
+//                 if self.positions[axis] == self.shape[axis] - 1 {
+//                     self.positions[axis] = 0;
+//                 } else {
+//                     self.positions[axis] += 1;
+//                     self.carrying = false;
+//                     break;
+//                 }
+//             }
+//             Some(view)
+//         } else {
+//             None
+//         }
+//     }
+// }
+//

--- a/crates/ndarray_einsum/src/lib.rs
+++ b/crates/ndarray_einsum/src/lib.rs
@@ -1,0 +1,295 @@
+// Copyright 2019 Jared Samet
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The `ndarray_einsum` crate implements the `einsum` function, originally
+//! implemented for numpy by Mark Wiebe and subsequently reimplemented for
+//! other tensor libraries such as Tensorflow and PyTorch. `einsum` (short for Einstein summation)
+//! implements general multidimensional tensor contraction. Many linear algebra operations
+//! and generalizations of those operations can be expressed as special cases of tensor
+//! contraction. Examples include matrix multiplication, matrix trace, vector dot product,
+//! tensor Hadamard [element-wise] product, axis permutation, outer product, batch
+//! matrix multiplication, bilinear transformations, and many more.
+//!
+//! Examples (deliberately similar to [numpy's documentation](https://docs.scipy.org/doc/numpy/reference/generated/numpy.einsum.html)):
+//!
+//! ```
+//! # use ndarray_einsum::*;
+//! # use ndarray::prelude::*;
+//! let a: Array2<f64> = Array::range(0., 25., 1.)
+//!     .into_shape((5,5,)).unwrap();
+//! let b: Array1<f64> = Array::range(0., 5., 1.);
+//! let c: Array2<f64> = Array::range(0., 6., 1.)
+//!     .into_shape((2,3,)).unwrap();
+//! let d: Array2<f64> = Array::range(0., 12., 1.)
+//!     .into_shape((3,4,)).unwrap();
+//! ```
+//!
+//! Trace of a matrix
+//! ```
+//! # use ndarray_einsum::*;
+//! # use ndarray::prelude::*;
+//! # let a: Array2<f64> = Array::range(0., 25., 1.)
+//! #     .into_shape((5,5,)).unwrap();
+//! # let b: Array1<f64> = Array::range(0., 5., 1.);
+//! # let c: Array2<f64> = Array::range(0., 6., 1.)
+//! #     .into_shape((2,3,)).unwrap();
+//! # let d: Array2<f64> = Array::range(0., 12., 1.)
+//! #     .into_shape((3,4,)).unwrap();
+//! assert_eq!(
+//!     einsum("ii", &[&a]).unwrap(),
+//!     arr0(60.).into_dyn()
+//! );
+//! assert_eq!(
+//!     einsum("ii", &[&a]).unwrap(),
+//!     arr0(a.diag().sum()).into_dyn()
+//! );
+//! ```
+//!
+//! Extract the diagonal
+//! ```
+//! # use ndarray_einsum::*;
+//! # use ndarray::prelude::*;
+//! # let a: Array2<f64> = Array::range(0., 25., 1.)
+//! #     .into_shape((5,5,)).unwrap();
+//! # let b: Array1<f64> = Array::range(0., 5., 1.);
+//! # let c: Array2<f64> = Array::range(0., 6., 1.)
+//! #     .into_shape((2,3,)).unwrap();
+//! # let d: Array2<f64> = Array::range(0., 12., 1.)
+//! #     .into_shape((3,4,)).unwrap();
+//! assert_eq!(
+//!     einsum("ii->i", &[&a]).unwrap(),
+//!     arr1(&[0., 6., 12., 18., 24.]).into_dyn()
+//! );
+//! assert_eq!(
+//!     einsum("ii->i", &[&a]).unwrap(),
+//!     a.diag().into_dyn()
+//! );
+//!
+//! ```
+//!
+//! Sum over an axis
+//! ```
+//! # use ndarray_einsum::*;
+//! # use ndarray::prelude::*;
+//! # let a: Array2<f64> = Array::range(0., 25., 1.)
+//! #     .into_shape((5,5,)).unwrap();
+//! # let b: Array1<f64> = Array::range(0., 5., 1.);
+//! # let c: Array2<f64> = Array::range(0., 6., 1.)
+//! #     .into_shape((2,3,)).unwrap();
+//! # let d: Array2<f64> = Array::range(0., 12., 1.)
+//! #     .into_shape((3,4,)).unwrap();
+//! assert_eq!(
+//!     einsum("ij->i", &[&a]).unwrap(),
+//!     arr1(&[10., 35., 60., 85., 110.]).into_dyn()
+//! );
+//! assert_eq!(
+//!     einsum("ij->i", &[&a]).unwrap(),
+//!     a.sum_axis(Axis(1)).into_dyn()
+//! );
+//!
+//! ```
+//!
+//! Compute matrix transpose
+//! ```
+//! # use ndarray_einsum::*;
+//! # use ndarray::prelude::*;
+//! # let a: Array2<f64> = Array::range(0., 25., 1.)
+//! #     .into_shape((5,5,)).unwrap();
+//! # let b: Array1<f64> = Array::range(0., 5., 1.);
+//! # let c: Array2<f64> = Array::range(0., 6., 1.)
+//! #     .into_shape((2,3,)).unwrap();
+//! # let d: Array2<f64> = Array::range(0., 12., 1.)
+//! #     .into_shape((3,4,)).unwrap();
+//! assert_eq!(
+//!     einsum("ji", &[&c]).unwrap(),
+//!     c.t().into_dyn()
+//! );
+//! assert_eq!(
+//!     einsum("ji", &[&c]).unwrap(),
+//!     arr2(&[[0., 3.], [1., 4.], [2., 5.]]).into_dyn()
+//! );
+//! assert_eq!(
+//!     einsum("ji", &[&c]).unwrap(),
+//!     einsum("ij->ji", &[&c]).unwrap()
+//! );
+//!
+//! ```
+//!
+//! Multiply two matrices
+//! ```
+//! # use ndarray_einsum::*;
+//! # use ndarray::prelude::*;
+//! # let a: Array2<f64> = Array::range(0., 25., 1.)
+//! #     .into_shape((5,5,)).unwrap();
+//! # let b: Array1<f64> = Array::range(0., 5., 1.);
+//! # let c: Array2<f64> = Array::range(0., 6., 1.)
+//! #     .into_shape((2,3,)).unwrap();
+//! # let d: Array2<f64> = Array::range(0., 12., 1.)
+//! #     .into_shape((3,4,)).unwrap();
+//! assert_eq!(
+//!     einsum("ij,jk->ik", &[&c, &d]).unwrap(),
+//!     c.dot(&d).into_dyn()
+//! );
+//! ```
+//!
+//! Compute the path separately from the result
+//! ```
+//! # use ndarray_einsum::*;
+//! # use ndarray::prelude::*;
+//! # let a: Array2<f64> = Array::range(0., 25., 1.)
+//! #     .into_shape((5,5,)).unwrap();
+//! # let b: Array1<f64> = Array::range(0., 5., 1.);
+//! # let c: Array2<f64> = Array::range(0., 6., 1.)
+//! #     .into_shape((2,3,)).unwrap();
+//! # let d: Array2<f64> = Array::range(0., 12., 1.)
+//! #     .into_shape((3,4,)).unwrap();
+//! let path = einsum_path(
+//!     "ij,jk->ik",
+//!     &[&c, &d],
+//!     OptimizationMethod::Naive
+//! ).unwrap();
+//! assert_eq!(
+//!     path.contract_operands(&[&c, &d]),
+//!     c.dot(&d).into_dyn()
+//! );
+//! ```
+use ndarray::prelude::*;
+use ndarray::{Data, IxDyn, LinalgScalar};
+
+mod validation;
+pub use validation::{
+    validate, validate_and_optimize_order, validate_and_size, Contraction, SizedContraction,
+};
+
+mod optimizers;
+pub use optimizers::{generate_optimized_order, ContractionOrder, OptimizationMethod};
+
+mod contractors;
+pub use contractors::{EinsumPath, EinsumPathSteps};
+use contractors::{PairContractor, TensordotGeneral};
+
+#[allow(clippy::wrong_self_convention)]
+/// This trait is implemented for all `ArrayBase` variants and is parameterized by the data type.
+///
+/// It's here so `einsum` and the other functions accepting a list of operands
+/// can take a slice `&[&dyn ArrayLike<A>]` where the elements of the slice can have
+/// different numbers of dimensions and can be a mixture of `Array` and `ArrayView`.
+pub trait ArrayLike<A> {
+    fn into_dyn_view(&self) -> ArrayView<A, IxDyn>;
+}
+
+impl<A, S, D> ArrayLike<A> for ArrayBase<S, D>
+where
+    S: Data<Elem = A>,
+    D: Dimension,
+{
+    fn into_dyn_view(&self) -> ArrayView<A, IxDyn> {
+        self.view().into_dyn()
+    }
+}
+
+/// Wrapper around [SizedContraction::contract_operands](struct.SizedContraction.html#method.contract_operands).
+pub fn einsum_sc<A: LinalgScalar>(
+    sized_contraction: &SizedContraction,
+    operands: &[&dyn ArrayLike<A>],
+) -> ArrayD<A> {
+    sized_contraction.contract_operands(operands)
+}
+
+/// Create a [SizedContraction](struct.SizedContraction.html), optimize the contraction order, and compile the result into an [EinsumPath](struct.EinsumPath.html).
+pub fn einsum_path<A>(
+    input_string: &str,
+    operands: &[&dyn ArrayLike<A>],
+    optimization_strategy: OptimizationMethod,
+) -> Result<EinsumPath<A>, &'static str> {
+    let contraction_order =
+        validate_and_optimize_order(input_string, operands, optimization_strategy)?;
+    Ok(EinsumPath::from_path(&contraction_order))
+}
+
+/// Performs all steps of the process in one function: parse the string, compile the execution plan, and execute the contraction.
+pub fn einsum<A: LinalgScalar>(
+    input_string: &str,
+    operands: &[&dyn ArrayLike<A>],
+) -> Result<ArrayD<A>, &'static str> {
+    let sized_contraction = validate_and_size(input_string, operands)?;
+    Ok(einsum_sc(&sized_contraction, operands))
+}
+
+/// Compute tensor dot product between two tensors.
+///
+/// Similar to [the numpy function of the same name](https://docs.scipy.org/doc/numpy/reference/generated/numpy.tensordot.html).
+/// Easiest to explain by showing the `einsum` equivalents:
+///
+/// ```
+/// # use ndarray::prelude::*;
+/// # use ndarray_einsum::*;
+/// let m1 = Array::range(0., (3*4*5*6) as f64, 1.)
+///             .into_shape((3,4,5,6,))
+///             .unwrap();
+/// let m2 = Array::range(0., (4*5*6*7) as f64, 1.)
+///             .into_shape((4,5,6,7))
+///             .unwrap();
+/// assert_eq!(
+///     einsum(
+///         "ijkl,jklm->im",
+///         &[&m1, &m2]
+///     ).unwrap(),
+///     tensordot(
+///         &m1,
+///         &m2,
+///         &[Axis(1), Axis(2), Axis(3)],
+///         &[Axis(0), Axis(1), Axis(2)]
+///     )
+/// );
+///
+/// assert_eq!(
+///     einsum(
+///         "abic,dief->abcdef",
+///         &[&m1, &m2]
+///     ).unwrap(),
+///     tensordot(
+///         &m1,
+///         &m2,
+///         &[Axis(2)],
+///         &[Axis(1)]
+///     )
+/// );
+/// ```
+pub fn tensordot<A, S, S2, D, E>(
+    lhs: &ArrayBase<S, D>,
+    rhs: &ArrayBase<S2, E>,
+    lhs_axes: &[Axis],
+    rhs_axes: &[Axis],
+) -> ArrayD<A>
+where
+    A: ndarray::LinalgScalar,
+    S: Data<Elem = A>,
+    S2: Data<Elem = A>,
+    D: Dimension,
+    E: Dimension,
+{
+    assert_eq!(lhs_axes.len(), rhs_axes.len());
+    let lhs_axes_copy: Vec<_> = lhs_axes.iter().map(|x| x.index()).collect();
+    let rhs_axes_copy: Vec<_> = rhs_axes.iter().map(|x| x.index()).collect();
+    let output_order: Vec<usize> = (0..(lhs.ndim() + rhs.ndim() - 2 * (lhs_axes.len()))).collect();
+    let tensordotter = TensordotGeneral::from_shapes_and_axis_numbers(
+        lhs.shape(),
+        rhs.shape(),
+        &lhs_axes_copy,
+        &rhs_axes_copy,
+        &output_order,
+    );
+    tensordotter.contract_pair(&lhs.view().into_dyn(), &rhs.view().into_dyn())
+}

--- a/crates/ndarray_einsum/src/optimizers.rs
+++ b/crates/ndarray_einsum/src/optimizers.rs
@@ -1,0 +1,300 @@
+// Copyright 2019 Jared Samet
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Methods to produce a `ContractionOrder`, specifying what order in which to perform pairwise contractions between tensors
+//! in order to perform the full contraction.
+use crate::SizedContraction;
+use hashbrown::HashSet;
+
+/// Either an input operand or an intermediate result
+#[derive(Debug, Clone)]
+pub enum OperandNumber {
+    Input(usize),
+    IntermediateResult(usize),
+}
+
+/// Which two tensors to contract
+#[derive(Debug, Clone)]
+pub struct OperandNumPair {
+    pub lhs: OperandNumber,
+    pub rhs: OperandNumber,
+}
+
+/// A single pairwise contraction between two input operands, an input operand and an intermediate
+/// result, or two intermediate results.
+#[derive(Debug, Clone)]
+pub struct Pair {
+    /// The contraction to be performed
+    pub sized_contraction: SizedContraction,
+
+    /// Which two tensors to contract
+    pub operand_nums: OperandNumPair,
+}
+
+/// The order in which to contract pairs of tensors and the specific contractions to be performed between the pairs.
+///
+/// Either a singleton contraction, in the case of a single input operand, or a list of pair contractions,
+/// given two or more input operands
+#[derive(Debug, Clone)]
+pub enum ContractionOrder {
+    /// If there's only one input operand, this is simply a clone of the original SizedContraction
+    Singleton(SizedContraction),
+
+    /// If there are two or more input operands, this is a vector of pairwise contractions between
+    /// input operands and/or intermediate results from prior contractions.
+    Pairs(Vec<Pair>),
+}
+
+/// Strategy for optimizing the contraction. The only currently supported options are "Naive" and "Reverse".
+///
+/// TODO: Figure out whether this should be done with traits
+#[derive(Debug)]
+pub enum OptimizationMethod {
+    /// Contracts each pair of tensors in the order given in the input and uses the intermediate
+    /// result as the LHS of the next contraction.
+    Naive,
+
+    /// Contracts each pair of tensors in the reverse of the order given in the input and uses the
+    /// intermediate result as the LHS of the next contraction. Only implemented to help test
+    /// that this is actually functioning properly.
+    Reverse,
+
+    /// (Not yet supported) Something like [this](https://optimized-einsum.readthedocs.io/en/latest/greedy_path.html)
+    Greedy,
+
+    /// (Not yet supported) Something like [this](https://optimized-einsum.readthedocs.io/en/latest/optimal_path.html)
+    Optimal,
+
+    /// (Not yet supported) Something like [this](https://optimized-einsum.readthedocs.io/en/latest/branching_path.html)
+    Branch,
+}
+
+/// Returns a set of all the indices in any of the remaining operands or in the output
+fn get_remaining_indices(operand_indices: &[Vec<char>], output_indices: &[char]) -> HashSet<char> {
+    let mut result: HashSet<char> = HashSet::new();
+    for &c in operand_indices.iter().flat_map(|s| s.iter()) {
+        result.insert(c);
+    }
+    for &c in output_indices.iter() {
+        result.insert(c);
+    }
+    result
+}
+
+/// Returns a set of all the indices in the LHS or the RHS
+fn get_existing_indices(lhs_indices: &[char], rhs_indices: &[char]) -> HashSet<char> {
+    let mut result: HashSet<char> = lhs_indices.iter().cloned().collect();
+    for &c in rhs_indices.iter() {
+        result.insert(c);
+    }
+    result
+}
+
+/// Returns a permuted version of `sized_contraction`, specified by `tensor_order`
+fn generate_permuted_contraction(
+    sized_contraction: &SizedContraction,
+    tensor_order: &[usize],
+) -> SizedContraction {
+    // Reorder the operands of the SizedContraction and clone everything else
+    assert_eq!(
+        sized_contraction.contraction.operand_indices.len(),
+        tensor_order.len()
+    );
+    let mut new_operand_indices = Vec::new();
+    for &i in tensor_order {
+        new_operand_indices.push(sized_contraction.contraction.operand_indices[i].clone());
+    }
+    sized_contraction
+        .subset(
+            &new_operand_indices,
+            &sized_contraction.contraction.output_indices,
+        )
+        .unwrap()
+}
+
+/// Generates a mini-contraction corresponding to `lhs_operand_indices`,`rhs_operand_indices`->`output_indices`
+fn generate_sized_contraction_pair(
+    lhs_operand_indices: &[char],
+    rhs_operand_indices: &[char],
+    output_indices: &[char],
+    orig_contraction: &SizedContraction,
+) -> SizedContraction {
+    orig_contraction
+        .subset(
+            &[lhs_operand_indices.to_vec(), rhs_operand_indices.to_vec()],
+            output_indices,
+        )
+        .unwrap()
+}
+
+/// Generate the actual path consisting of all the mini-contractions. Currently always
+/// contracts two input operands and then repeatedly uses the result as the LHS of the
+/// next pairwise contraction.
+fn generate_path(sized_contraction: &SizedContraction, tensor_order: &[usize]) -> ContractionOrder {
+    // Generate the actual path consisting of all the mini-contractions.
+    //
+    // TODO: Take a &[OperandNumPair] instead of &[usize]
+    // and Keep track of the intermediate results
+
+    // Make a reordered full SizedContraction in the order specified by the called
+    let permuted_contraction = generate_permuted_contraction(sized_contraction, tensor_order);
+
+    match permuted_contraction.contraction.operand_indices.len() {
+        1 => {
+            // If there's only one input tensor, make a single-step path consisting of a
+            // singleton contraction (operand_nums = None).
+            ContractionOrder::Singleton(permuted_contraction.clone())
+        }
+        2 => {
+            // If there's exactly two input tensors, make a single-step path consisting
+            // of a pair contraction (operand_nums = Some(OperandNumPair)).
+            let sc = generate_sized_contraction_pair(
+                &permuted_contraction.contraction.operand_indices[0],
+                &permuted_contraction.contraction.operand_indices[1],
+                &permuted_contraction.contraction.output_indices,
+                &permuted_contraction,
+            );
+            let operand_num_pair = OperandNumPair {
+                lhs: OperandNumber::Input(tensor_order[0]),
+                rhs: OperandNumber::Input(tensor_order[1]),
+            };
+            let only_step = Pair {
+                sized_contraction: sc,
+                operand_nums: operand_num_pair,
+            };
+            ContractionOrder::Pairs(vec![only_step])
+        }
+        _ => {
+            // If there's three or more input tensors, we have some work to do.
+
+            let mut steps = Vec::new();
+            // In the main body of the loop, output_indices will contain the result of the prior pair
+            // contraction. Initialize it to the elements of the first LHS tensor so that we can
+            // clone it on the first go-around as well as all the later ones.
+            let mut output_indices = permuted_contraction.contraction.operand_indices[0].clone();
+
+            for idx_of_lhs in 0..(permuted_contraction.contraction.operand_indices.len() - 1) {
+                // lhs_indices is either the first tensor (on the first iteration of the loop)
+                // or the output from the previous step.
+                let lhs_indices = output_indices.clone();
+
+                // rhs_indices is always the next tensor.
+                let idx_of_rhs = idx_of_lhs + 1;
+                let rhs_indices = &permuted_contraction.contraction.operand_indices[idx_of_rhs];
+
+                // existing_indices and remaining_indices are only needed to figure out
+                // what output_indices will be for this step.
+                //
+                // existing_indices consists of the indices in either the LHS or the RHS tensor
+                // for this step.
+                //
+                // remaining_indices consists of the indices in all the elements after the RHS
+                // tensor or in the outputs.
+                //
+                // The output indices we want is the intersection of the two (unless this is
+                // the RHS is the last operand, in which case it's just the output indices).
+                //
+                // For example, say the string is "ij,jk,kl,lm->im".
+                // First iteration:
+                //      lhs = [i,j]
+                //      rhs = [j,k]
+                //      existing = {i,j,k}
+                //      remaining = {k,l,m,i} (the i is used in the final output so we need to
+                //      keep it around)
+                //      output = {i,k}
+                //      Mini-contraction: ij,jk->ik
+                // Second iteration:
+                //      lhs = [i,k]
+                //      rhs = [k,l]
+                //      existing = {i,k,l}
+                //      remaining = {l,m,i}
+                //      output = {i,l}
+                //      Mini-contraction: ik,kl->il
+                // Third (and final) iteration:
+                //      lhs = [i,l]
+                //      rhs = [l,m]
+                //      (Short-circuit) output = {i,m}
+                //      Mini-contraction: il,lm->im
+                output_indices =
+                    if idx_of_rhs == (permuted_contraction.contraction.operand_indices.len() - 1) {
+                        // Used up all the operands; just return output
+                        permuted_contraction.contraction.output_indices.clone()
+                    } else {
+                        let existing_indices = get_existing_indices(&lhs_indices, rhs_indices);
+                        let remaining_indices = get_remaining_indices(
+                            &permuted_contraction.contraction.operand_indices[(idx_of_rhs + 1)..],
+                            &permuted_contraction.contraction.output_indices,
+                        );
+                        existing_indices
+                            .intersection(&remaining_indices)
+                            .cloned()
+                            .collect()
+                    };
+
+                // Phew, now make the mini-contraction.
+                let sc = generate_sized_contraction_pair(
+                    &lhs_indices,
+                    rhs_indices,
+                    &output_indices,
+                    &permuted_contraction,
+                );
+
+                let operand_nums = if idx_of_lhs == 0 {
+                    OperandNumPair {
+                        lhs: OperandNumber::Input(tensor_order[idx_of_lhs]), // tensor_order[0]
+                        rhs: OperandNumber::Input(tensor_order[idx_of_rhs]), // tensor_order[1]
+                    }
+                } else {
+                    OperandNumPair {
+                        lhs: OperandNumber::IntermediateResult(idx_of_lhs - 1),
+                        rhs: OperandNumber::Input(tensor_order[idx_of_rhs]),
+                    }
+                };
+                steps.push(Pair {
+                    sized_contraction: sc,
+                    operand_nums,
+                });
+            }
+
+            ContractionOrder::Pairs(steps)
+        }
+    }
+}
+
+/// Contracts the first two operands, then contracts the result with the third operand, etc.
+fn naive_order(sized_contraction: &SizedContraction) -> Vec<usize> {
+    (0..sized_contraction.contraction.operand_indices.len()).collect()
+}
+
+/// Contracts the last two operands, then contracts the result with the third-to-last operand, etc.
+fn reverse_order(sized_contraction: &SizedContraction) -> Vec<usize> {
+    (0..sized_contraction.contraction.operand_indices.len())
+        .rev()
+        .collect()
+}
+
+// TODO: Maybe this should take a function pointer from &SizedContraction -> Vec<usize>?
+/// Given a `SizedContraction` and an optimization strategy, returns an order in which to
+/// perform pairwise contractions in order to produce the final result
+pub fn generate_optimized_order(
+    sized_contraction: &SizedContraction,
+    strategy: OptimizationMethod,
+) -> ContractionOrder {
+    let tensor_order = match strategy {
+        OptimizationMethod::Naive => naive_order(sized_contraction),
+        OptimizationMethod::Reverse => reverse_order(sized_contraction),
+        _ => panic!("Unsupported optimization method"),
+    };
+    generate_path(sized_contraction, &tensor_order)
+}

--- a/crates/ndarray_einsum/src/validation.rs
+++ b/crates/ndarray_einsum/src/validation.rs
@@ -1,0 +1,447 @@
+// Copyright 2019 Jared Samet
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Contains functions and structs related to parsing an `einsum`-formatted string
+//!
+//! This module has the implementation of `Contraction` and `SizedContraction`. `SizedContraction`
+//! is used throughout the library to store the details of a full contraction (corresponding
+//! to a string supplied by the caller) or a mini-contraction (corresponding to a simplification of
+//! a single tensor or a pairwise contraction between two tensors) produced by the optimizer in order
+//! to perform the full contraction.
+//!
+//!
+use crate::{
+    generate_optimized_order, ArrayLike, ContractionOrder, EinsumPath, OptimizationMethod,
+};
+use hashbrown::{HashMap, HashSet};
+use lazy_static::lazy_static;
+use ndarray::prelude::*;
+use ndarray::LinalgScalar;
+use regex::Regex;
+
+/// The result of running an `einsum`-formatted string through the regex.
+#[derive(Debug)]
+struct EinsumParse {
+    operand_indices: Vec<String>,
+    output_indices: Option<String>,
+}
+
+/// A `Contraction` contains the result of parsing an `einsum`-formatted string.
+///
+/// ```
+/// # use ndarray_einsum::*;
+/// let contraction = Contraction::new("ij,jk->ik").unwrap();
+/// assert_eq!(contraction.operand_indices, vec![vec!['i', 'j'], vec!['j', 'k']]);
+/// assert_eq!(contraction.output_indices, vec!['i', 'k']);
+/// assert_eq!(contraction.summation_indices, vec!['j']);
+///
+/// let contraction = Contraction::new("ij,jk").unwrap();
+/// assert_eq!(contraction.operand_indices, vec![vec!['i', 'j'], vec!['j', 'k']]);
+/// assert_eq!(contraction.output_indices, vec!['i', 'k']);
+/// assert_eq!(contraction.summation_indices, vec!['j']);
+/// ```
+#[derive(Debug, Clone)]
+pub struct Contraction {
+    /// A vector with as many elements as input operands, where each
+    /// member of the vector is a `Vec<char>` with each char representing the label for
+    /// each axis of the operand.
+    pub operand_indices: Vec<Vec<char>>,
+
+    /// Specifies which axes the resulting tensor will contain
+    // (corresponding to axes in one or more of the input operands).
+    pub output_indices: Vec<char>,
+
+    /// Contains the axes that will be summed over (a.k.a contracted) by the operation.
+    pub summation_indices: Vec<char>,
+}
+
+impl Contraction {
+    /// Validates and creates a `Contraction` from an `einsum`-formatted string.
+    pub fn new(input_string: &str) -> Result<Self, &'static str> {
+        let p = parse_einsum_string(input_string).ok_or("Invalid string")?;
+        Contraction::from_parse(&p)
+    }
+
+    /// If output_indices has been specified in the parse (i.e. explicit case),
+    /// e.g. "ij,jk->ik", simply converts the strings to `Vec<char>`s and passes
+    /// them to Contraction::from_indices. If the output indices haven't been specified,
+    /// e.g. "ij,jk", figures out which ones aren't duplicated and hence summed over,
+    /// sorts them alphabetically, and uses those as the output indices.
+    fn from_parse(parse: &EinsumParse) -> Result<Self, &'static str> {
+        let requested_output_indices: Vec<char> = match &parse.output_indices {
+            Some(s) => s.chars().collect(),
+            _ => {
+                // Handle implicit case, e.g. nothing to the right of the arrow
+                let mut input_indices = HashMap::new();
+                for c in parse.operand_indices.iter().flat_map(|s| s.chars()) {
+                    *input_indices.entry(c).or_insert(0) += 1;
+                }
+
+                let mut unique_indices: Vec<char> = input_indices
+                    .iter()
+                    .filter(|(_, &v)| v == 1)
+                    .map(|(&k, _)| k)
+                    .collect();
+                unique_indices.sort();
+                unique_indices
+            }
+        };
+
+        let operand_indices: Vec<Vec<char>> = parse
+            .operand_indices
+            .iter()
+            .map(|x| x.chars().collect::<Vec<char>>())
+            .collect();
+        Contraction::from_indices(&operand_indices, &requested_output_indices)
+    }
+
+    /// Validates and creates a `Contraction` from a slice of `Vec<char>`s containing
+    /// the operand indices, and a slice of `char` containing the desired output indices.
+    fn from_indices(
+        operand_indices: &[Vec<char>],
+        output_indices: &[char],
+    ) -> Result<Self, &'static str> {
+        let mut input_char_counts = HashMap::new();
+        for &c in operand_indices.iter().flat_map(|operand| operand.iter()) {
+            *input_char_counts.entry(c).or_insert(0) += 1;
+        }
+
+        let mut distinct_output_indices = HashMap::new();
+        for &c in output_indices.iter() {
+            *distinct_output_indices.entry(c).or_insert(0) += 1;
+        }
+        for (&c, &n) in distinct_output_indices.iter() {
+            // No duplicates
+            if n > 1 {
+                return Err("Requested output has duplicate index");
+            }
+
+            // Must be in inputs
+            if !input_char_counts.contains_key(&c) {
+                return Err("Requested output contains an index not found in inputs");
+            }
+        }
+
+        let mut summation_indices: Vec<char> = input_char_counts
+            .keys()
+            .filter(|&c| !distinct_output_indices.contains_key(c))
+            .cloned()
+            .collect();
+        summation_indices.sort();
+
+        let cloned_operand_indices: Vec<Vec<char>> = operand_indices.to_vec();
+
+        Ok(Contraction {
+            operand_indices: cloned_operand_indices,
+            output_indices: output_indices.to_vec(),
+            summation_indices,
+        })
+    }
+}
+
+/// Alias for `HashMap<char, usize>`. Contains the axis lengths for all indices in the contraction.
+/// Contrary to the name, does not only hold the sizes for output indices.
+pub type OutputSize = HashMap<char, usize>;
+
+/// Enables `OutputSize::from_contraction_and_shapes()`
+trait OutputSizeMethods {
+    fn from_contraction_and_shapes(
+        contraction: &Contraction,
+        operand_shapes: &[Vec<usize>],
+    ) -> Result<OutputSize, &'static str>;
+}
+impl OutputSizeMethods for OutputSize {
+    /// Build the HashMap containing the axis lengths
+    fn from_contraction_and_shapes(
+        contraction: &Contraction,
+        operand_shapes: &[Vec<usize>],
+    ) -> Result<Self, &'static str> {
+        // Check that len(operand_indices) == len(operands)
+        if contraction.operand_indices.len() != operand_shapes.len() {
+            return Err(
+                "number of operands in contraction does not match number of operands supplied",
+            );
+        }
+
+        let mut index_lengths: OutputSize = HashMap::new();
+
+        for (indices, operand_shape) in contraction.operand_indices.iter().zip(operand_shapes) {
+            // Check that len(operand_indices[i]) == len(operands[i].shape())
+            if indices.len() != operand_shape.len() {
+                return Err(
+                    "number of indices in one or more operands does not match dimensions of operand",
+                );
+            }
+
+            // Check that whenever there are multiple copies of an index,
+            // operands[i].shape()[m] == operands[j].shape()[n]
+            for (&c, &n) in indices.iter().zip(operand_shape) {
+                let existing_n = index_lengths.entry(c).or_insert(n);
+                if *existing_n != n {
+                    return Err("repeated index with different size");
+                }
+            }
+        }
+
+        Ok(index_lengths)
+    }
+}
+
+/// A `SizedContraction` contains a `Contraction` as well as a `HashMap<char, usize>`
+/// specifying the axis lengths for each index in the contraction.
+///
+/// Note that output_size is a misnomer (to be changed); it contains all the axis lengths,
+/// including the ones that will be contracted (i.e. not just the ones in
+/// contraction.output_indices).
+#[derive(Debug, Clone)]
+pub struct SizedContraction {
+    pub contraction: Contraction,
+    pub output_size: OutputSize,
+}
+
+impl SizedContraction {
+    /// Creates a new SizedContraction based on a subset of the operand indices and/or output
+    /// indices. Not intended for general use; used internally in the crate when compiling
+    /// a multi-tensor contraction into a set of tensor simplifications (a.k.a. singleton
+    /// contractions) and pairwise contractions.
+    ///
+    /// ```
+    /// # use ndarray_einsum::*;
+    /// # use ndarray::prelude::*;
+    /// let m1: Array3<f64> = Array::zeros((2, 2, 3));
+    /// let m2: Array2<f64> = Array::zeros((3, 4));
+    /// let sc = SizedContraction::new("iij,jk->ik", &[&m1, &m2]).unwrap();
+    /// let lhs_simplification = sc.subset(&[vec!['i','i','j']], &['i','j']).unwrap();
+    /// let diagonalized_m1 = lhs_simplification.contract_operands(&[&m1]);
+    /// assert_eq!(diagonalized_m1.shape(), &[2, 3]);
+    /// ```
+    pub fn subset(
+        &self,
+        new_operand_indices: &[Vec<char>],
+        new_output_indices: &[char],
+    ) -> Result<Self, &'static str> {
+        // Make sure all chars in new_operand_indices are in self
+        let all_operand_indices: HashSet<char> = new_operand_indices
+            .iter()
+            .flat_map(|operand| operand.iter())
+            .cloned()
+            .collect();
+        if all_operand_indices
+            .iter()
+            .any(|c| !self.output_size.contains_key(c))
+        {
+            return Err("Character found in new_operand_indices but not in self.output_size");
+        }
+
+        // Validate what they asked for and compute summation_indices
+        let new_contraction = Contraction::from_indices(new_operand_indices, new_output_indices)?;
+
+        // Clone output_size, omitting unused characters
+        let new_output_size: OutputSize = self
+            .output_size
+            .iter()
+            .filter(|(&k, _)| all_operand_indices.contains(&k))
+            .map(|(&k, &v)| (k, v))
+            .collect();
+
+        Ok(SizedContraction {
+            contraction: new_contraction,
+            output_size: new_output_size,
+        })
+    }
+
+    fn from_contraction_and_shapes(
+        contraction: &Contraction,
+        operand_shapes: &[Vec<usize>],
+    ) -> Result<Self, &'static str> {
+        let output_size = OutputSize::from_contraction_and_shapes(contraction, operand_shapes)?;
+
+        Ok(SizedContraction {
+            contraction: contraction.clone(),
+            output_size,
+        })
+    }
+
+    /// Create a SizedContraction from an already-created Contraction and a list
+    /// of operands.
+    /// ```
+    /// # use ndarray_einsum::*;
+    /// # use ndarray::prelude::*;
+    /// let m1: Array2<f64> = Array::zeros((2, 3));
+    /// let m2: Array2<f64> = Array::zeros((3, 4));
+    /// let c = Contraction::new("ij,jk->ik").unwrap();
+    /// let sc = SizedContraction::from_contraction_and_operands(&c, &[&m1, &m2]).unwrap();
+    /// assert_eq!(sc.output_size[&'i'], 2);
+    /// assert_eq!(sc.output_size[&'k'], 4);
+    /// assert_eq!(sc.output_size[&'j'], 3);
+    /// ```
+    pub fn from_contraction_and_operands<A>(
+        contraction: &Contraction,
+        operands: &[&dyn ArrayLike<A>],
+    ) -> Result<Self, &'static str> {
+        let operand_shapes = get_operand_shapes(operands);
+
+        SizedContraction::from_contraction_and_shapes(contraction, &operand_shapes)
+    }
+
+    /// Create a SizedContraction from an `einsum`-formatted input string and a slice
+    /// of `Vec<usize>`s containing the shapes of each operand.
+    /// ```
+    /// # use ndarray_einsum::*;
+    /// # use ndarray::prelude::*;
+    /// let sc = SizedContraction::from_string_and_shapes(
+    ///     "ij,jk->ik",
+    ///     &[vec![2, 3], vec![3, 4]]
+    /// ).unwrap();
+    /// assert_eq!(sc.output_size[&'i'], 2);
+    /// assert_eq!(sc.output_size[&'k'], 4);
+    /// assert_eq!(sc.output_size[&'j'], 3);
+    /// ```
+    pub fn from_string_and_shapes(
+        input_string: &str,
+        operand_shapes: &[Vec<usize>],
+    ) -> Result<Self, &'static str> {
+        let contraction = validate(input_string)?;
+        SizedContraction::from_contraction_and_shapes(&contraction, operand_shapes)
+    }
+
+    /// Create a SizedContraction from an `einsum`-formatted input string and a list
+    /// of operands.
+    ///
+    /// ```
+    /// # use ndarray_einsum::*;
+    /// # use ndarray::prelude::*;
+    /// let m1: Array2<f64> = Array::zeros((2, 3));
+    /// let m2: Array2<f64> = Array::zeros((3, 4));
+    /// let sc = SizedContraction::new("ij,jk->ik", &[&m1, &m2]).unwrap();
+    /// assert_eq!(sc.output_size[&'i'], 2);
+    /// assert_eq!(sc.output_size[&'k'], 4);
+    /// assert_eq!(sc.output_size[&'j'], 3);
+    /// ```
+    pub fn new<A>(
+        input_string: &str,
+        operands: &[&dyn ArrayLike<A>],
+    ) -> Result<Self, &'static str> {
+        let operand_shapes = get_operand_shapes(operands);
+
+        SizedContraction::from_string_and_shapes(input_string, &operand_shapes)
+    }
+
+    /// Perform the contraction on a set of operands.
+    ///
+    /// ```
+    /// # use ndarray_einsum::*;
+    /// # use ndarray::prelude::*;
+    /// let m1: Array2<f64> = Array::zeros((2, 3));
+    /// let m2: Array2<f64> = Array::zeros((3, 4));
+    /// let out: ArrayD<f64> = Array::zeros((2, 4)).into_dyn();
+    /// let sc = validate_and_size("ij,jk->ik", &[&m1, &m2]).unwrap();
+    /// assert_eq!(sc.contract_operands(&[&m1, &m2]), out);
+    /// ```
+    pub fn contract_operands<A: Clone + LinalgScalar>(
+        &self,
+        operands: &[&dyn ArrayLike<A>],
+    ) -> ArrayD<A> {
+        let cpc = EinsumPath::new(self);
+        cpc.contract_operands(operands)
+    }
+
+    /// Show as an `einsum`-formatted string.
+    ///
+    /// ```
+    /// # use ndarray_einsum::*;
+    /// # use ndarray::prelude::*;
+    /// let m1: Array2<f64> = Array::zeros((2, 3));
+    /// let m2: Array2<f64> = Array::zeros((3, 4));
+    /// let sc = validate_and_size("ij,jk", &[&m1, &m2]).unwrap();
+    /// assert_eq!(sc.as_einsum_string(), "ij,jk->ik");
+    /// ```
+    pub fn as_einsum_string(&self) -> String {
+        assert!(!self.contraction.operand_indices.is_empty());
+        let mut s: String = self.contraction.operand_indices[0]
+            .iter()
+            .cloned()
+            .collect();
+        for op in self.contraction.operand_indices[1..].iter() {
+            s.push(',');
+            for &c in op.iter() {
+                s.push(c);
+            }
+        }
+        s.push_str("->");
+        for &c in self.contraction.output_indices.iter() {
+            s.push(c);
+        }
+        s
+    }
+}
+
+/// Runs an input string through a regex and convert it to an EinsumParse.
+fn parse_einsum_string(input_string: &str) -> Option<EinsumParse> {
+    lazy_static! {
+        // Unwhitespaced version:
+        // ^([a-z]+)((?:,[a-z]+)*)(?:->([a-z]*))?$
+        static ref RE: Regex = Regex::new(r"(?x)
+            ^
+            (?P<first_operand>[a-z]+)
+            (?P<more_operands>(?:,[a-z]+)*)
+            (?:->(?P<output>[a-z]*))?
+            $
+            ").unwrap();
+    }
+    let captures = RE.captures(input_string)?;
+    let mut operand_indices = Vec::new();
+    let output_indices = captures.name("output").map(|s| String::from(s.as_str()));
+
+    operand_indices.push(String::from(&captures["first_operand"]));
+    for s in captures["more_operands"].split(',').skip(1) {
+        operand_indices.push(String::from(s));
+    }
+
+    Some(EinsumParse {
+        operand_indices,
+        output_indices,
+    })
+}
+
+/// Wrapper around [Contraction::new()](struct.Contraction.html#method.new).
+pub fn validate(input_string: &str) -> Result<Contraction, &'static str> {
+    Contraction::new(input_string)
+}
+
+/// Returns a vector holding one `Vec<usize>` for each operand.
+fn get_operand_shapes<A>(operands: &[&dyn ArrayLike<A>]) -> Vec<Vec<usize>> {
+    operands
+        .iter()
+        .map(|operand| Vec::from(operand.into_dyn_view().shape()))
+        .collect()
+}
+
+/// Wrapper around [SizedContraction::new()](struct.SizedContraction.html#method.new).
+pub fn validate_and_size<A>(
+    input_string: &str,
+    operands: &[&dyn ArrayLike<A>],
+) -> Result<SizedContraction, &'static str> {
+    SizedContraction::new(input_string, operands)
+}
+
+/// Create a [SizedContraction](struct.SizedContraction.html) and then optimize the order in which pairs of inputs will be contracted.
+pub fn validate_and_optimize_order<A>(
+    input_string: &str,
+    operands: &[&dyn ArrayLike<A>],
+    optimization_strategy: OptimizationMethod,
+) -> Result<ContractionOrder, &'static str> {
+    let sc = validate_and_size(input_string, operands)?;
+    Ok(generate_optimized_order(&sc, optimization_strategy))
+}

--- a/crates/ndarray_einsum/tests/einsum_test.rs
+++ b/crates/ndarray_einsum/tests/einsum_test.rs
@@ -1,0 +1,1166 @@
+use ndarray::prelude::*;
+use ndarray::Data;
+use ndarray_einsum::*;
+use ndarray_rand::RandomExt;
+use rand::distributions::Uniform;
+const TOL: f64 = 1e-10;
+
+trait AllClose {
+    fn my_all_close<S2, E>(&self, rhs: &ArrayBase<S2, E>, tol: f64) -> bool
+    where
+        S2: Data<Elem = f64>,
+        E: Dimension;
+}
+
+impl<S, D> AllClose for ArrayBase<S, D>
+where
+    D: Dimension,
+    S: Data<Elem = f64>,
+{
+    fn my_all_close<S2, E>(&self, rhs: &ArrayBase<S2, E>, tol: f64) -> bool
+    where
+        S2: Data<Elem = f64>,
+        E: Dimension,
+    {
+        let self_dyn_view = self.view().into_dyn();
+        let rhs_dyn_view = rhs.view().into_dyn();
+
+        self_dyn_view.abs_diff_eq(&rhs_dyn_view, tol)
+    }
+}
+
+#[test]
+fn tp1() {
+    let contraction = Contraction::new("i->").unwrap();
+    assert_eq!(contraction.operand_indices, &[vec!['i']]);
+    assert_eq!(contraction.output_indices.len(), 0);
+    assert_eq!(contraction.summation_indices, &['i']);
+}
+
+#[test]
+fn tp2() {
+    let contraction = Contraction::new("ij->").unwrap();
+    assert_eq!(contraction.operand_indices, &[vec!['i', 'j']]);
+    assert_eq!(contraction.output_indices.len(), 0);
+    assert_eq!(contraction.summation_indices, &['i', 'j']);
+}
+
+#[test]
+fn tp3() {
+    let contraction = Contraction::new("i->i").unwrap();
+    assert_eq!(contraction.operand_indices, &[vec!['i']]);
+    assert_eq!(contraction.output_indices, &['i']);
+    assert_eq!(contraction.summation_indices.len(), 0);
+}
+
+#[test]
+fn tp4() {
+    let contraction = Contraction::new("ij,ij->ij").unwrap();
+    assert_eq!(
+        contraction.operand_indices,
+        &[vec!['i', 'j'], vec!['i', 'j']]
+    );
+    assert_eq!(contraction.output_indices, &['i', 'j']);
+    assert_eq!(contraction.summation_indices.len(), 0);
+}
+
+#[test]
+fn tp5() {
+    let contraction = Contraction::new("ij,ij->").unwrap();
+    assert_eq!(
+        contraction.operand_indices,
+        &[vec!['i', 'j'], vec!['i', 'j']]
+    );
+    assert_eq!(contraction.output_indices.len(), 0);
+    assert_eq!(contraction.summation_indices, &['i', 'j']);
+}
+
+#[test]
+fn tp6() {
+    let contraction = Contraction::new("ij,kl->").unwrap();
+    assert_eq!(
+        contraction.operand_indices,
+        &[vec!['i', 'j'], vec!['k', 'l']]
+    );
+    assert_eq!(contraction.output_indices.len(), 0);
+    assert_eq!(contraction.summation_indices, &['i', 'j', 'k', 'l']);
+}
+
+#[test]
+fn tp7() {
+    let contraction = Contraction::new("ij,jk->ik").unwrap();
+    assert_eq!(
+        contraction.operand_indices,
+        &[vec!['i', 'j'], vec!['j', 'k']]
+    );
+    assert_eq!(contraction.output_indices, &['i', 'k']);
+    assert_eq!(contraction.summation_indices, &['j']);
+}
+
+#[test]
+fn tp8() {
+    let contraction = Contraction::new("ijk,jkl,klm->im").unwrap();
+    assert_eq!(
+        contraction.operand_indices,
+        &[
+            vec!['i', 'j', 'k'],
+            vec!['j', 'k', 'l'],
+            vec!['k', 'l', 'm']
+        ]
+    );
+    assert_eq!(contraction.output_indices, &['i', 'm']);
+    assert_eq!(contraction.summation_indices, &['j', 'k', 'l']);
+}
+
+#[test]
+fn tp9() {
+    let contraction = Contraction::new("ij,jk->ki").unwrap();
+    assert_eq!(
+        contraction.operand_indices,
+        &[vec!['i', 'j'], vec!['j', 'k']]
+    );
+    assert_eq!(contraction.output_indices, &['k', 'i']);
+    assert_eq!(contraction.summation_indices, &['j']);
+}
+
+#[test]
+fn tp10() {
+    let contraction = Contraction::new("ij,ja->ai").unwrap();
+    assert_eq!(
+        contraction.operand_indices,
+        &[vec!['i', 'j'], vec!['j', 'a']]
+    );
+    assert_eq!(contraction.output_indices, &['a', 'i']);
+    assert_eq!(contraction.summation_indices, &['j']);
+}
+
+#[test]
+fn tp11() {
+    let contraction = Contraction::new("ii->i").unwrap();
+    assert_eq!(contraction.operand_indices, &[vec!['i', 'i']]);
+    assert_eq!(contraction.output_indices, &['i']);
+    assert_eq!(contraction.summation_indices.len(), 0);
+}
+
+#[test]
+fn tp12() {
+    let contraction = Contraction::new("ij,k").unwrap();
+    assert_eq!(contraction.operand_indices, &[vec!['i', 'j'], vec!['k']]);
+    assert_eq!(contraction.output_indices, &['i', 'j', 'k']);
+    assert_eq!(contraction.summation_indices.len(), 0);
+}
+
+#[test]
+fn tp13() {
+    let contraction = Contraction::new("i").unwrap();
+    assert_eq!(contraction.operand_indices, &[vec!['i']]);
+    assert_eq!(contraction.output_indices, &['i']);
+    assert_eq!(contraction.summation_indices.len(), 0);
+}
+
+#[test]
+fn tp14() {
+    let contraction = Contraction::new("ii").unwrap();
+    assert_eq!(contraction.operand_indices, &[vec!['i', 'i']]);
+    assert_eq!(contraction.output_indices.len(), 0);
+    assert_eq!(contraction.summation_indices, &['i']);
+}
+
+#[test]
+fn tp15() {
+    let contraction = Contraction::new("ijj").unwrap();
+    assert_eq!(contraction.operand_indices, &[vec!['i', 'j', 'j']]);
+    assert_eq!(contraction.output_indices, &['i']);
+    assert_eq!(contraction.summation_indices, &['j']);
+}
+
+#[test]
+fn tp16() {
+    let contraction = Contraction::new("i,j,klm,nop").unwrap();
+    assert_eq!(
+        contraction.operand_indices,
+        &[
+            vec!['i'],
+            vec!['j'],
+            vec!['k', 'l', 'm'],
+            vec!['n', 'o', 'p']
+        ]
+    );
+    assert_eq!(
+        contraction.output_indices,
+        &['i', 'j', 'k', 'l', 'm', 'n', 'o', 'p',]
+    );
+    assert_eq!(contraction.summation_indices.len(), 0);
+}
+
+#[test]
+fn tp17() {
+    let contraction = Contraction::new("ij,jk").unwrap();
+    assert_eq!(
+        contraction.operand_indices,
+        &[vec!['i', 'j'], vec!['j', 'k']]
+    );
+    assert_eq!(contraction.output_indices, &['i', 'k']);
+    assert_eq!(contraction.summation_indices, &['j']);
+}
+
+#[test]
+fn tp18() {
+    let contraction = Contraction::new("ij,ja").unwrap();
+    assert_eq!(
+        contraction.operand_indices,
+        &[vec!['i', 'j'], vec!['j', 'a']]
+    );
+    assert_eq!(contraction.output_indices, &['a', 'i']);
+    assert_eq!(contraction.summation_indices, &['j']);
+}
+
+#[test]
+fn bad_parses_1() {
+    for s in vec!["->i", "i,", "->", "i,,,j->k"].iter() {
+        let contraction_result = Contraction::new(s);
+        assert!(contraction_result.is_err());
+    }
+}
+
+#[test]
+fn bad_outputs_1() {
+    for s in vec!["i,j,k,l,m->p", "i,j->ijj"].iter() {
+        let contraction_result = Contraction::new(s);
+        assert!(contraction_result.is_err());
+    }
+}
+
+fn rand_array<Sh, D: Dimension>(shape: Sh) -> ArrayBase<ndarray::OwnedRepr<f64>, D>
+where
+    Sh: ShapeBuilder<Dim = D>,
+{
+    Array::random(shape, Uniform::new(-5., 5.))
+}
+
+#[test]
+fn it_multiplies_two_matrices() {
+    let a = rand_array((3, 4));
+    let b = rand_array((4, 5));
+
+    let correct_answer = a.dot(&b).into_dyn();
+    let lib_output = einsum("ij,jk->ik", &[&a, &b]).unwrap();
+
+    assert!(correct_answer.my_all_close(&lib_output, TOL));
+}
+
+#[test]
+fn it_computes_the_trace() {
+    let square_matrix = rand_array((5, 5));
+
+    let diag: Vec<_> = (0..square_matrix.shape()[0])
+        .map(|i| square_matrix[[i, i]])
+        .collect();
+    let correct_answer = arr1(&diag).into_dyn();
+
+    let lib_output = einsum("ii->i", &[&square_matrix]).unwrap();
+
+    assert!(correct_answer.my_all_close(&lib_output, TOL));
+}
+
+#[test]
+fn it_transposes_a_matrix() {
+    let rect_matrix = rand_array((2, 5));
+
+    let correct_answer = rect_matrix.t();
+
+    let tr1 = einsum("ji", &[&rect_matrix]).unwrap();
+    let tr2 = einsum("ij->ji", &[&rect_matrix]).unwrap();
+    let tr3 = einsum("ji->ij", &[&rect_matrix]).unwrap();
+
+    assert!(correct_answer.my_all_close(&tr1, TOL));
+    assert!(correct_answer.my_all_close(&tr2, TOL));
+    assert!(correct_answer.my_all_close(&tr3, TOL));
+}
+
+#[test]
+fn it_clones_a_matrix() {
+    let rect_matrix = rand_array((2, 5));
+
+    let correct_answer = rect_matrix.view().into_dyn();
+
+    let cloned = einsum("ij->ij", &[&rect_matrix]).unwrap();
+    assert!(correct_answer.my_all_close(&cloned, TOL));
+}
+
+#[test]
+fn it_collapses_a_singleton_with_noncontiguous_strides() {
+    // [?] -> ii -> <empty>
+    let cube = rand_array((4, 4, 4));
+
+    let data_slice = cube.as_slice_memory_order().unwrap();
+    let output_shape = vec![4, 4];
+    let strides = vec![17, 4];
+    let square =
+        ArrayView::from_shape(IxDyn(&output_shape).strides(IxDyn(&strides)), &data_slice).unwrap();
+
+    let correct_answer = arr0(square.diag().sum());
+
+    let ep = einsum_path("ii->", &[&square], OptimizationMethod::Naive).unwrap();
+    let collapsed = ep.contract_operands(&[&square]);
+
+    assert!(correct_answer.into_dyn().my_all_close(&collapsed, TOL));
+}
+
+#[test]
+fn it_collapses_a_singleton_without_repeats() {
+    // ijkl->lij
+    let s = rand_array((4, 2, 3, 5));
+
+    let mut correct_answer: Array3<f64> = Array::zeros((5, 4, 2));
+    for l in 0..5 {
+        for i in 0..4 {
+            for j in 0..2 {
+                let mut r = 0.;
+                for k in 0..3 {
+                    r += s[[i, j, k, l]];
+                }
+                correct_answer[[l, i, j]] = r;
+            }
+        }
+    }
+
+    let ep = einsum_path("ijkl->lij", &[&s], OptimizationMethod::Naive).unwrap();
+    let collapsed = ep.contract_operands(&[&s]);
+
+    assert!(correct_answer.into_dyn().my_all_close(&collapsed, TOL));
+}
+
+#[test]
+fn it_diagonalizes_a_singleton() {
+    // jkiii
+    let s = rand_array((2, 3, 4, 4, 4));
+
+    let mut correct_answer: Array3<f64> = Array::zeros((2, 4, 3));
+    for i in 0..4 {
+        for j in 0..2 {
+            for k in 0..3 {
+                correct_answer[[j, i, k]] = s[[j, k, i, i, i]];
+            }
+        }
+    }
+
+    let ep = einsum_path("jkiii->jik", &[&s], OptimizationMethod::Naive).unwrap();
+    let collapsed = ep.contract_operands(&[&s]);
+
+    assert!(correct_answer.into_dyn().my_all_close(&collapsed, TOL));
+}
+
+#[test]
+fn it_collapses_a_singleton_with_multiple_repeats() {
+    // kjiji->ijk
+    let s = rand_array((4, 3, 2, 3, 2));
+
+    let mut correct_answer: Array3<f64> = Array::zeros((2, 3, 4));
+    for i in 0..2 {
+        for j in 0..3 {
+            for k in 0..4 {
+                correct_answer[[i, j, k]] = s[[k, j, i, j, i]];
+            }
+        }
+    }
+
+    let ep = einsum_path("kjiji->ijk", &[&s], OptimizationMethod::Naive).unwrap();
+    let collapsed = ep.contract_operands(&[&s]);
+
+    assert!(correct_answer.into_dyn().my_all_close(&collapsed, TOL));
+}
+
+#[test]
+fn it_collapses_a_singleton_with_a_repeat_that_gets_summed() {
+    // iij->j
+    let s = rand_array((2, 2, 3));
+
+    let mut correct_answer: Array1<f64> = Array::zeros((3,));
+    for j in 0..3 {
+        let mut res = 0.;
+        for i in 0..2 {
+            res += s[[i, i, j]];
+        }
+        correct_answer[j] = res;
+    }
+
+    let ep = einsum_path("iij->j", &[&s], OptimizationMethod::Naive).unwrap();
+    let collapsed = ep.contract_operands(&[&s]);
+    assert!(correct_answer.into_dyn().my_all_close(&collapsed, TOL));
+}
+
+#[test]
+fn it_collapses_a_singleton_with_multiple_repeats_that_get_summed() {
+    // iijkk->j
+    let s = rand_array((2, 2, 3, 4, 4));
+
+    let mut correct_answer: Array1<f64> = Array::zeros((3,));
+    for j in 0..3 {
+        let mut res = 0.;
+        for i in 0..2 {
+            for k in 0..4 {
+                res += s[[i, i, j, k, k]];
+            }
+        }
+        correct_answer[j] = res;
+    }
+
+    let ep = einsum_path("iijkk->j", &[&s], OptimizationMethod::Naive).unwrap();
+    let collapsed = ep.contract_operands(&[&s]);
+    assert!(correct_answer.into_dyn().my_all_close(&collapsed, TOL));
+}
+
+#[test]
+fn it_sums_a_singleton() {
+    // ijk->
+    let s = rand_array((2, 3, 4));
+
+    let correct_answer = arr0(s.sum());
+
+    let ep = einsum_path("ijk->", &[&s], OptimizationMethod::Naive).unwrap();
+    let collapsed = ep.contract_operands(&[&s]);
+    assert!(correct_answer.into_dyn().my_all_close(&collapsed, TOL));
+}
+
+#[test]
+fn it_collapses_a_singleton_with_multiple_sums() {
+    // ijk->k
+    let s = rand_array((2, 3, 4));
+
+    let mut correct_answer: Array1<f64> = Array::zeros((4,));
+    for k in 0..4 {
+        let mut res = 0.;
+        for i in 0..2 {
+            for j in 0..3 {
+                res += s[[i, j, k]];
+            }
+        }
+        correct_answer[k] = res;
+    }
+
+    let ep = einsum_path("ijk->k", &[&s], OptimizationMethod::Naive).unwrap();
+    let collapsed = ep.contract_operands(&[&s]);
+    assert!(correct_answer.into_dyn().my_all_close(&collapsed, TOL));
+}
+
+#[test]
+fn it_collapses_a_singleton() {
+    // iijkl->lij
+    let s = rand_array((4, 4, 2, 3, 5));
+
+    let mut correct_answer: Array3<f64> = Array::zeros((5, 4, 2));
+    for l in 0..5 {
+        for i in 0..4 {
+            for j in 0..2 {
+                let mut r = 0.;
+                for k in 0..3 {
+                    r += s[[i, i, j, k, l]];
+                }
+                correct_answer[[l, i, j]] = r;
+            }
+        }
+    }
+
+    let ep = einsum_path("iijkl->lij", &[&s], OptimizationMethod::Naive).unwrap();
+    let collapsed = ep.contract_operands(&[&s]);
+
+    assert!(correct_answer.into_dyn().my_all_close(&collapsed, TOL));
+}
+
+#[test]
+fn tensordot_handles_degenerate_lhs() {
+    let lhs = arr0(1.);
+    let rhs = rand_array((2, 3));
+
+    let dotted = tensordot(&lhs, &rhs, &[], &[]);
+    assert!(rhs.into_dyn().my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn tensordot_handles_degenerate_rhs() {
+    let lhs = rand_array((2, 3));
+    let rhs = arr0(1.);
+
+    let dotted = tensordot(&lhs, &rhs, &[], &[]);
+    assert!(lhs.into_dyn().my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn tensordot_handles_degenerate_both() {
+    let lhs = arr0(1.);
+    let rhs = arr0(1.);
+
+    let dotted = tensordot(&lhs, &rhs, &[], &[]);
+    assert!(dotted[[]] == 1.);
+}
+
+#[test]
+fn deduped_handles_dot_product() {
+    let lhs = rand_array((3,));
+    let rhs = rand_array((3,));
+
+    let correct_answer = arr0(lhs.dot(&rhs));
+    let ep = einsum_path("i,i->", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn deduped_handles_hadamard_product() {
+    let lhs = rand_array((3,));
+    let rhs = rand_array((3,));
+
+    let correct_answer = (&lhs * &rhs).into_dyn();
+    let ep = einsum_path("i,i->i", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn deduped_handles_outer_product_vec_vec() {
+    let lhs = rand_array((3,));
+    let rhs = rand_array((4,));
+
+    let mut correct_answer: Array2<f64> = Array::zeros((3, 4));
+    for i in 0..3 {
+        for j in 0..4 {
+            correct_answer[[i, j]] = lhs[[i]] * rhs[[j]];
+        }
+    }
+
+    let ep = einsum_path("i,j->ij", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn deduped_handles_matrix_vector_1() {
+    let lhs = rand_array((3, 4));
+    let rhs = rand_array((4,));
+
+    let mut correct_answer: Array1<f64> = Array::zeros((3,));
+    for i in 0..3 {
+        let mut res = 0.;
+        for j in 0..4 {
+            res += lhs[[i, j]] * rhs[[j]];
+        }
+        correct_answer[i] = res;
+    }
+
+    let ep = einsum_path("ij,j->i", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+    assert!(correct_answer.my_all_close(&(lhs.dot(&rhs)), TOL));
+}
+
+#[test]
+fn deduped_handles_matrix_vector_2() {
+    let lhs = rand_array((3,));
+    let rhs = rand_array((3, 4));
+
+    let mut correct_answer: Array1<f64> = Array::zeros((4,));
+    for j in 0..4 {
+        let mut res = 0.;
+        for i in 0..3 {
+            res += lhs[[i]] * rhs[[i, j]];
+        }
+        correct_answer[j] = res;
+    }
+
+    let ep = einsum_path("i,ij->j", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+    assert!(correct_answer.my_all_close(&(lhs.dot(&rhs)), TOL));
+}
+
+#[test]
+fn deduped_handles_matrix_vector_3() {
+    let lhs = rand_array((3, 4));
+    let rhs = rand_array((3,));
+
+    let mut correct_answer: Array1<f64> = Array::zeros((4,));
+    for j in 0..4 {
+        let mut res = 0.;
+        for i in 0..3 {
+            res += lhs[[i, j]] * rhs[[i]];
+        }
+        correct_answer[j] = res;
+    }
+
+    let ep = einsum_path("ij,i->j", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+    assert!(correct_answer.my_all_close(&(rhs.dot(&lhs)), TOL));
+}
+
+#[test]
+fn deduped_handles_matrix_vector_4() {
+    let lhs = rand_array((4,));
+    let rhs = rand_array((3, 4));
+
+    let mut correct_answer: Array1<f64> = Array::zeros((3,));
+    for i in 0..3 {
+        let mut res = 0.;
+        for j in 0..4 {
+            res += lhs[[j]] * rhs[[i, j]];
+        }
+        correct_answer[i] = res;
+    }
+
+    let ep = einsum_path("j,ij->i", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+    assert!(correct_answer.my_all_close(&(rhs.dot(&lhs)), TOL));
+}
+
+#[test]
+fn deduped_handles_stacked_scalar_vector_product_1() {
+    let lhs = rand_array((3, 4));
+    let rhs = rand_array((3,));
+
+    let mut correct_answer: Array2<f64> = Array::zeros((3, 4));
+    for i in 0..3 {
+        for j in 0..4 {
+            correct_answer[[i, j]] = lhs[[i, j]] * rhs[[i]];
+        }
+    }
+
+    let ep = einsum_path("ij,i->ij", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn deduped_handles_stacked_scalar_vector_product_2() {
+    let lhs = rand_array((3, 4));
+    let rhs = rand_array((3,));
+
+    let mut correct_answer: Array2<f64> = Array::zeros((4, 3));
+    for i in 0..3 {
+        for j in 0..4 {
+            correct_answer[[j, i]] = lhs[[i, j]] * rhs[[i]];
+        }
+    }
+
+    let ep = einsum_path("ij,i->ji", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn deduped_handles_stacked_scalar_vector_product_3() {
+    let lhs = rand_array((3,));
+    let rhs = rand_array((4, 3));
+
+    let mut correct_answer: Array2<f64> = Array::zeros((3, 4));
+    for i in 0..3 {
+        for j in 0..4 {
+            correct_answer[[i, j]] = lhs[[i]] * rhs[[j, i]];
+        }
+    }
+
+    let ep = einsum_path("i,ji->ij", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn deduped_handles_summed_hadamard_product_aka_stacked_1d_tensordot_1() {
+    let lhs = rand_array((3, 4));
+    let rhs = rand_array((3, 4));
+
+    let correct_answer = (&lhs * &rhs).sum_axis(Axis(1));
+
+    let ep = einsum_path("ij,ij->i", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn deduped_handles_summed_hadamard_product_aka_stacked_1d_tensordot_2() {
+    let lhs = rand_array((3, 4));
+    let rhs = rand_array((4, 3));
+
+    let correct_answer = (&lhs * &rhs.t()).sum_axis(Axis(1));
+
+    let ep = einsum_path("ij,ji->i", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn deduped_handles_summed_hadamard_product_aka_stacked_1d_tensordot_3() {
+    let lhs = rand_array((3, 4));
+    let rhs = rand_array((4, 3));
+
+    let correct_answer = (&lhs * &rhs.t()).sum_axis(Axis(0));
+
+    let ep = einsum_path("ji,ij->i", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn deduped_handles_summed_hadamard_product_multiple_stacked_axes() {
+    let lhs = rand_array((2, 3, 4, 5));
+    let rhs = rand_array((3, 5, 4, 2));
+
+    let mut correct_answer: Array3<f64> = Array::zeros((4, 3, 2));
+    for i in 0..2 {
+        for j in 0..3 {
+            for k in 0..4 {
+                for l in 0..5 {
+                    correct_answer[[k, j, i]] += lhs[[i, j, k, l]] * rhs[[j, l, k, i]];
+                }
+            }
+        }
+    }
+
+    let ep = einsum_path("ijkl,jlki->kji", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn deduped_handles_2d_hadamard_product() {
+    let lhs = rand_array((2, 3));
+    let rhs = rand_array((2, 3));
+
+    let correct_answer = (&lhs * &rhs).into_dyn();
+
+    let ep = einsum_path("ij,ij->ij", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn deduped_handles_2d_hadamard_product_2() {
+    let lhs = rand_array((2, 3));
+    let rhs = rand_array((2, 3));
+
+    let correct_answer_t = (&lhs * &rhs).into_dyn();
+    let correct_answer = correct_answer_t.t();
+
+    let ep = einsum_path("ij,ij->ji", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn deduped_handles_2d_hadamard_product_3() {
+    let lhs = rand_array((3, 2));
+    let rhs = rand_array((2, 3));
+
+    let correct_answer = (&lhs.t() * &rhs).into_dyn();
+
+    let ep = einsum_path("ji,ij->ij", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn deduped_handles_double_dot_product_mat_mat() {
+    let lhs = rand_array((2, 3));
+    let rhs = rand_array((2, 3));
+
+    let correct_answer = arr0((&lhs * &rhs).sum());
+    let ep = einsum_path("ij,ij->", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn deduped_handles_outer_product_vect_mat_1() {
+    let lhs = rand_array((2, 3));
+    let rhs = rand_array((4,));
+
+    let mut correct_answer: Array3<f64> = Array::zeros((4, 2, 3));
+    for i in 0..2 {
+        for j in 0..3 {
+            for k in 0..4 {
+                correct_answer[[k, i, j]] = lhs[[i, j]] * rhs[[k]];
+            }
+        }
+    }
+    let ep = einsum_path("ij,k->kij", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn deduped_handles_outer_product_vect_mat_2() {
+    let lhs = rand_array((4,));
+    let rhs = rand_array((2, 3));
+
+    let mut correct_answer: Array3<f64> = Array::zeros((4, 2, 3));
+    for i in 0..2 {
+        for j in 0..3 {
+            for k in 0..4 {
+                correct_answer[[k, i, j]] = rhs[[i, j]] * lhs[[k]];
+            }
+        }
+    }
+    let ep = einsum_path("k,ij->kij", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn deduped_handles_outer_product_mat_mat() {
+    let lhs = rand_array((5, 4));
+    let rhs = rand_array((2, 3));
+
+    let mut correct_answer: Array4<f64> = Array::zeros((4, 2, 5, 3));
+    for i in 0..2 {
+        for j in 0..3 {
+            for k in 0..4 {
+                for l in 0..5 {
+                    correct_answer[[k, i, l, j]] = lhs[[l, k]] * rhs[[i, j]];
+                }
+            }
+        }
+    }
+    let ep = einsum_path("lk,ij->kilj", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn deduped_handles_matrix_product_1() {
+    let lhs = rand_array((2, 3));
+    let rhs = rand_array((3, 4));
+
+    let correct_answer = lhs.dot(&rhs);
+    let ep = einsum_path("ij,jk", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn it_handles_stacked_matrix_product_1() {
+    let lhs = rand_array((4, 2, 5));
+    let rhs = rand_array((4, 5, 3));
+
+    let mut correct_answer: Array3<f64> = Array::zeros((4, 2, 3));
+    for n in 0..4 {
+        for i in 0..2 {
+            for j in 0..5 {
+                for k in 0..3 {
+                    correct_answer[[n, i, k]] += lhs[[n, i, j]] * rhs[[n, j, k]];
+                }
+            }
+        }
+    }
+    let ep = einsum_path("nij,njk->nik", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn it_handles_stacked_matrix_product_2() {
+    let lhs = rand_array((4, 5, 2));
+    let rhs = rand_array((4, 5, 3));
+
+    let mut correct_answer: Array3<f64> = Array::zeros((4, 2, 3));
+    for n in 0..4 {
+        for i in 0..2 {
+            for j in 0..5 {
+                for k in 0..3 {
+                    correct_answer[[n, i, k]] += lhs[[n, j, i]] * rhs[[n, j, k]];
+                }
+            }
+        }
+    }
+    let ep = einsum_path("nji,njk->nik", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn it_handles_stacked_matrix_product_3() {
+    let lhs = rand_array((5, 2, 4));
+    let rhs = rand_array((4, 5, 3));
+
+    let mut correct_answer: Array3<f64> = Array::zeros((4, 2, 3));
+    for n in 0..4 {
+        for i in 0..2 {
+            for j in 0..5 {
+                for k in 0..3 {
+                    correct_answer[[n, i, k]] += lhs[[j, i, n]] * rhs[[n, j, k]];
+                }
+            }
+        }
+    }
+    let ep = einsum_path("jin,njk->nik", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn deduped_handles_matrix_product_2() {
+    let lhs = rand_array((2, 3));
+    let rhs = rand_array((4, 3));
+
+    let correct_answer = lhs.dot(&rhs.t());
+    let ep = einsum_path("ij,kj", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn deduped_handles_stacked_outer_product_1() {
+    let lhs = rand_array((2, 3));
+    let rhs = rand_array((4, 2));
+
+    let mut correct_answer: Array3<f64> = Array::zeros((2, 3, 4));
+    for i in 0..2 {
+        for j in 0..3 {
+            for k in 0..4 {
+                correct_answer[[i, j, k]] = lhs[[i, j]] * rhs[[k, i]];
+            }
+        }
+    }
+
+    let ep = einsum_path("ij,ki->ijk", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn diagonals_product() {
+    let lhs = rand_array((2, 2));
+    let rhs = rand_array((2, 2));
+
+    let mut correct_answer: Array1<f64> = Array::zeros((2,));
+    for i in 0..2 {
+        correct_answer[[i]] = lhs[[i, i]] * rhs[[i, i]];
+    }
+
+    let ep = einsum_path("ii,ii->i", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn diagonals_product_lhs() {
+    let lhs = rand_array((2, 2));
+    let rhs = rand_array((2,));
+
+    let mut correct_answer: Array1<f64> = Array::zeros((2,));
+    for i in 0..2 {
+        correct_answer[[i]] = lhs[[i, i]] * rhs[[i]];
+    }
+
+    let ep = einsum_path("ii,i->i", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn diagonals_product_rhs() {
+    let lhs = rand_array((2,));
+    let rhs = rand_array((2, 2));
+
+    let mut correct_answer: Array1<f64> = Array::zeros((2,));
+    for i in 0..2 {
+        correct_answer[[i]] = lhs[[i]] * rhs[[i, i]];
+    }
+
+    let ep = einsum_path("i,ii->i", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn presum_lhs() {
+    let lhs = rand_array((2, 3));
+    let rhs = rand_array((2, 2));
+
+    let mut correct_answer: Array1<f64> = Array::zeros((2,));
+    for i in 0..2 {
+        for j in 0..3 {
+            correct_answer[[i]] += lhs[[i, j]] * rhs[[i, i]];
+        }
+    }
+
+    let ep = einsum_path("ij,ii->i", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn it_tolerates_permuted_axes() {
+    let lhs = rand_array((2, 3, 4));
+    let mut rhs = rand_array((5, 3, 4));
+    rhs = rhs.permuted_axes([1, 2, 0]);
+
+    let mut correct_answer: Array2<f64> = Array::zeros((2, 5));
+    for i in 0..2 {
+        for l in 0..5 {
+            for j in 0..3 {
+                for k in 0..4 {
+                    correct_answer[[i, l]] += lhs[[i, j, k]] * rhs[[j, k, l]];
+                }
+            }
+        }
+    }
+
+    let ep = einsum_path("ijk,jkl->il", &[&lhs, &rhs], OptimizationMethod::Naive).unwrap();
+    let dotted = ep.contract_operands(&[&lhs, &rhs]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn it_contracts_three_matrices() {
+    let op1 = rand_array((2, 3));
+    let op2 = rand_array((3, 4));
+    let op3 = rand_array((4, 5));
+
+    let mut correct_answer: Array2<f64> = Array::zeros((2, 5));
+    for i in 0..2 {
+        for l in 0..5 {
+            for j in 0..3 {
+                for k in 0..4 {
+                    correct_answer[[i, l]] += op1[[i, j]] * op2[[j, k]] * op3[[k, l]];
+                }
+            }
+        }
+    }
+
+    let ep = einsum_path(
+        "ij,jk,kl->il",
+        &[&op1, &op2, &op3],
+        OptimizationMethod::Naive,
+    )
+    .unwrap();
+    let dotted = ep.contract_operands(&[&op1, &op2, &op3]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn it_contracts_three_matrices_with_repeats_1() {
+    let op1 = rand_array((2, 3));
+    let op2 = rand_array((3, 6, 6, 7, 4));
+    let op3 = rand_array((4, 5));
+
+    let mut correct_answer: Array2<f64> = Array::zeros((2, 5));
+    for i in 0..2 {
+        for l in 0..5 {
+            for j in 0..3 {
+                for k in 0..4 {
+                    for m in 0..6 {
+                        for n in 0..7 {
+                            correct_answer[[i, l]] +=
+                                op1[[i, j]] * op2[[j, m, m, n, k]] * op3[[k, l]];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let ep = einsum_path(
+        "ij,jmmnk,kl->il",
+        &[&op1, &op2, &op3],
+        OptimizationMethod::Naive,
+    )
+    .unwrap();
+    let dotted = ep.contract_operands(&[&op1, &op2, &op3]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn it_contracts_three_matrices_with_repeats_2() {
+    let op1 = rand_array((2, 6, 6, 7, 3));
+    let op2 = rand_array((3, 4));
+    let op3 = rand_array((4, 6, 5));
+
+    let mut correct_answer: Array2<f64> = Array::zeros((2, 5));
+    for i in 0..2 {
+        for l in 0..5 {
+            for j in 0..3 {
+                for k in 0..4 {
+                    for m in 0..6 {
+                        for n in 0..7 {
+                            correct_answer[[i, l]] +=
+                                op1[[i, m, m, n, j]] * op2[[j, k]] * op3[[k, m, l]];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let ep = einsum_path(
+        "immnj,jk,kml->il",
+        &[&op1, &op2, &op3],
+        OptimizationMethod::Naive,
+    )
+    .unwrap();
+    let dotted = ep.contract_operands(&[&op1, &op2, &op3]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn it_contracts_three_matrices_with_repeats_3() {
+    let op1 = rand_array((2, 6, 6, 7, 3));
+    let op2 = rand_array((3, 4));
+    let op3 = rand_array((4, 5));
+
+    let mut correct_answer: Array3<f64> = Array::zeros((6, 2, 5));
+    for i in 0..2 {
+        for l in 0..5 {
+            for j in 0..3 {
+                for k in 0..4 {
+                    for m in 0..6 {
+                        for n in 0..7 {
+                            correct_answer[[m, i, l]] +=
+                                op1[[i, m, m, n, j]] * op2[[j, k]] * op3[[k, l]];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let ep = einsum_path(
+        "immnj,jk,kl->mil",
+        &[&op1, &op2, &op3],
+        OptimizationMethod::Naive,
+    )
+    .unwrap();
+    let dotted = ep.contract_operands(&[&op1, &op2, &op3]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}
+
+#[test]
+fn it_contracts_four_matrices() {
+    let op1 = rand_array((2, 3));
+    let op2 = rand_array((3, 4));
+    let op3 = rand_array((4, 5));
+    let op4 = rand_array((5, 6));
+
+    let mut correct_answer: Array2<f64> = Array::zeros((2, 5));
+    for i in 0..2 {
+        for j in 0..3 {
+            for k in 0..4 {
+                for l in 0..5 {
+                    for m in 0..6 {
+                        correct_answer[[i, l]] +=
+                            op1[[i, j]] * op2[[j, k]] * op3[[k, l]] * op4[[l, m]];
+                    }
+                }
+            }
+        }
+    }
+
+    let ep = einsum_path(
+        "ij,jk,kl,lm->il",
+        &[&op1, &op2, &op3, &op4],
+        OptimizationMethod::Naive,
+    )
+    .unwrap();
+    let dotted = ep.contract_operands(&[&op1, &op2, &op3, &op4]);
+    assert!(correct_answer.my_all_close(&dotted, TOL));
+}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit bumps the ndarray version to ndarray 0.16 which was released some time ago. We have been blocked from upgrading this because of our use of ndarray_einsum_beta, which is functionally inactive at this point with no development activity in > 4 years. To facilitate the upgrade this commit forks ndarray einsum and vendors it as an internal crate in Qiskit. It's not a very large library only ~1k lines and this is the fastest path to getting us on a new version of ndarray. If it's preferred I can create an fork as a separate repository outside the qiskit workspace and update the dependency that way instead.

### Details and comments