### PR TITLE
Update Qiskit 1.4.0 release notes bad link

### DIFF
--- a/releasenotes/notes/1.4/prepare-1.4.0-aee22d10333374c8.yaml
+++ b/releasenotes/notes/1.4/prepare-1.4.0-aee22d10333374c8.yaml
@@ -11,7 +11,7 @@ prelude: |
     bugfixes  for 6 months and security fixes for 1 year after this
     release. The fixes will take place via patch releases.
     For more details on the release schedule and support cycle
-    see: https://docs.quantum.ibm.com/start/install#qiskit-versioning
+    see: https://docs.quantum.ibm.com/open-source/qiskit-sdk-version-strategy#qiskit-sdk-version-strategy
     which documents the release schedule in more detail.
 
 features_circuits:

--- a/releasenotes/notes/1.4/prepare-1.4.0-aee22d10333374c8.yaml
+++ b/releasenotes/notes/1.4/prepare-1.4.0-aee22d10333374c8.yaml
@@ -11,7 +11,7 @@ prelude: |
     bugfixes  for 6 months and security fixes for 1 year after this
     release. The fixes will take place via patch releases.
     For more details on the release schedule and support cycle
-    see: https://docs.quantum.ibm.com/open-source/qiskit-sdk-version-strategy#qiskit-sdk-version-strategy
+    see: https://docs.quantum.ibm.com/open-source/qiskit-sdk-version-strategy
     which documents the release schedule in more detail.
 
 features_circuits:


### PR DESCRIPTION
This PR replaces a link from the release notes of Qiskit 1.4.0. https://docs.quantum.ibm.com/start/install doesn't exist anymore and its redirection doesn't seem to take you to the desired page. A more appropriate alternative could be https://docs.quantum.ibm.com/open-source/qiskit-sdk-version-strategy