### PR TITLE
13911 | Add ignoring of RuntimeWarning of aer in GenericBackendV2 test

### DIFF
--- a/test/python/providers/fake_provider/test_generic_backend_v2.py
+++ b/test/python/providers/fake_provider/test_generic_backend_v2.py
@@ -13,7 +13,6 @@
 """ Test of GenericBackendV2 backend"""
 
 import math
-import warnings
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, transpile
 from qiskit.providers.fake_provider import GenericBackendV2
@@ -169,11 +168,7 @@ class TestGenericBackendV2(QiskitTestCase):
 
         backend = GenericBackendV2(num_qubits=5, basis_gates=["cx", "id", "rz", "sx", "x"], seed=42)
         tqc = transpile(qc, backend=backend, optimization_level=3, seed_transpiler=42)
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=RuntimeWarning)
-            result = backend.run(tqc, seed_simulator=42, shots=1000).result()
-
+        result = backend.run(tqc, seed_simulator=42, shots=1000).result()
         counts = result.get_counts()
 
         self.assertTrue(math.isclose(counts["00000"], 500, rel_tol=0.1))

--- a/test/python/providers/fake_provider/test_generic_backend_v2.py
+++ b/test/python/providers/fake_provider/test_generic_backend_v2.py
@@ -13,6 +13,7 @@
 """ Test of GenericBackendV2 backend"""
 
 import math
+import warnings
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, transpile
 from qiskit.providers.fake_provider import GenericBackendV2
@@ -168,7 +169,11 @@ class TestGenericBackendV2(QiskitTestCase):
 
         backend = GenericBackendV2(num_qubits=5, basis_gates=["cx", "id", "rz", "sx", "x"], seed=42)
         tqc = transpile(qc, backend=backend, optimization_level=3, seed_transpiler=42)
-        result = backend.run(tqc, seed_simulator=42, shots=1000).result()
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=RuntimeWarning)
+            result = backend.run(tqc, seed_simulator=42, shots=1000).result()
+
         counts = result.get_counts()
 
         self.assertTrue(math.isclose(counts["00000"], 500, rel_tol=0.1))

--- a/test/utils/base.py
+++ b/test/utils/base.py
@@ -95,6 +95,13 @@ class QiskitTestCase(BaseTestCase):
         warnings.filterwarnings("error", category=DeprecationWarning)
         warnings.filterwarnings("error", category=QiskitWarning)
 
+        warnings.filterwarnings(
+            "ignore",
+            category=RuntimeWarning,
+            message="Aer not found using BasicSimulator and no noise",
+            module="qiskit.providers.fake_provider.generic_backend_v2",
+        )
+
         # Numpy 2 made a few new modules private, and have warnings that trigger if you try to
         # access attributes that _would_ have existed.  Unfortunately, Python's `warnings` module
         # adds a field called `__warningregistry__` to any module that triggers a warning, and


### PR DESCRIPTION
### Summary
Because the `aer` isn't available on all envs, the test logs get flooded with sometimes meaningless `DeprecationWarnings`.

This PR adds that the affected class's error gets ignored in the tests.

Fixes #13911