### PR TITLE
New `atomic_evolution` signature in `ProductFormula` subclasses

### DIFF
--- a/qiskit/synthesis/evolution/lie_trotter.py
+++ b/qiskit/synthesis/evolution/lie_trotter.py
@@ -55,9 +55,7 @@ class LieTrotter(SuzukiTrotter):
         insert_barriers: bool = False,
         cx_structure: str = "chain",
         atomic_evolution: (
-            Callable[[Pauli | SparsePauliOp, float], QuantumCircuit]
-            | Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]
-            | None
+            Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None] | None
         ) = None,
         wrap: bool = False,
         preserve_order: bool = True,
@@ -75,9 +73,6 @@ class LieTrotter(SuzukiTrotter):
                 three arguments: the circuit to append the evolution to, the Pauli operator to
                 evolve, and the evolution time. By default, a single Pauli evolution is decomposed
                 into a chain of ``CX`` gates and a single ``RZ`` gate.
-                Alternatively, the function can also take Pauli operator and evolution time as
-                inputs and returns the circuit that will be appended to the overall circuit being
-                built.
             wrap: Whether to wrap the atomic evolutions into custom gate objects. This only takes
                 effect when ``atomic_evolution is None``.
             preserve_order: If ``False``, allows reordering the terms of the operator to

--- a/qiskit/synthesis/evolution/product_formula.py
+++ b/qiskit/synthesis/evolution/product_formula.py
@@ -25,7 +25,6 @@ import rustworkx as rx
 from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.circuit.quantumcircuit import QuantumCircuit, ParameterValueType
 from qiskit.quantum_info import SparsePauliOp, Pauli
-from qiskit.utils.deprecation import deprecate_arg
 from qiskit._accelerate.circuit_library import pauli_evolution
 
 from .evolution_synthesis import EvolutionSynthesis
@@ -42,21 +41,6 @@ class ProductFormula(EvolutionSynthesis):
     :obj:`.LieTrotter` and :obj:`.SuzukiTrotter` inherit from this class.
     """
 
-    @deprecate_arg(
-        name="atomic_evolution",
-        since="1.2",
-        predicate=lambda callable: callable is not None
-        and len(inspect.signature(callable).parameters) == 2,
-        deprecation_description=(
-            "The 'Callable[[Pauli | SparsePauliOp, float], QuantumCircuit]' signature of the "
-            "'atomic_evolution' argument"
-        ),
-        additional_msg=(
-            "Instead you should update your 'atomic_evolution' function to be of the following "
-            "type: 'Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]'."
-        ),
-        pending=True,
-    )
     def __init__(
         self,
         order: int,
@@ -64,9 +48,7 @@ class ProductFormula(EvolutionSynthesis):
         insert_barriers: bool = False,
         cx_structure: str = "chain",
         atomic_evolution: (
-            Callable[[Pauli | SparsePauliOp, float], QuantumCircuit]
-            | Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]
-            | None
+            Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None] | None
         ) = None,
         wrap: bool = False,
         preserve_order: bool = True,
@@ -85,9 +67,6 @@ class ProductFormula(EvolutionSynthesis):
                 three arguments: the circuit to append the evolution to, the Pauli operator to
                 evolve, and the evolution time. By default, a single Pauli evolution is decomposed
                 into a chain of ``CX`` gates and a single ``RZ`` gate.
-                Alternatively, the function can also take Pauli operator and evolution time as
-                inputs and returns the circuit that will be appended to the overall circuit being
-                built.
             wrap: Whether to wrap the atomic evolutions into custom gate objects. Note that setting
                 this to ``True`` is slower than ``False``. This only takes effect when
                 ``atomic_evolution is None``.

--- a/qiskit/synthesis/evolution/qdrift.py
+++ b/qiskit/synthesis/evolution/qdrift.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import inspect
 import math
 import typing
 from itertools import chain
@@ -22,7 +21,6 @@ from collections.abc import Callable
 import numpy as np
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.quantum_info.operators import SparsePauliOp, Pauli
-from qiskit.utils.deprecation import deprecate_arg
 from qiskit.exceptions import QiskitError
 
 from .product_formula import ProductFormula, reorder_paulis
@@ -41,30 +39,13 @@ class QDrift(ProductFormula):
         `arXiv:quant-ph/1811.08017 <https://arxiv.org/abs/1811.08017>`_
     """
 
-    @deprecate_arg(
-        name="atomic_evolution",
-        since="1.2",
-        predicate=lambda callable: callable is not None
-        and len(inspect.signature(callable).parameters) == 2,
-        deprecation_description=(
-            "The 'Callable[[Pauli | SparsePauliOp, float], QuantumCircuit]' signature of the "
-            "'atomic_evolution' argument"
-        ),
-        additional_msg=(
-            "Instead you should update your 'atomic_evolution' function to be of the following "
-            "type: 'Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]'."
-        ),
-        pending=True,
-    )
     def __init__(
         self,
         reps: int = 1,
         insert_barriers: bool = False,
         cx_structure: str = "chain",
         atomic_evolution: (
-            Callable[[Pauli | SparsePauliOp, float], QuantumCircuit]
-            | Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]
-            | None
+            Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None] | None
         ) = None,
         seed: int | None = None,
         wrap: bool = False,
@@ -83,9 +64,6 @@ class QDrift(ProductFormula):
                 three arguments: the circuit to append the evolution to, the Pauli operator to
                 evolve, and the evolution time. By default, a single Pauli evolution is decomposed
                 into a chain of ``CX`` gates and a single ``RZ`` gate.
-                Alternatively, the function can also take Pauli operator and evolution time as
-                inputs and returns the circuit that will be appended to the overall circuit being
-                built.
             seed: An optional seed for reproducibility of the random sampling process.
             wrap: Whether to wrap the atomic evolutions into custom gate objects. This only takes
                 effect when ``atomic_evolution is None``.

--- a/qiskit/synthesis/evolution/suzuki_trotter.py
+++ b/qiskit/synthesis/evolution/suzuki_trotter.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import inspect
 import typing
 from collections.abc import Callable
 from itertools import chain
@@ -23,7 +22,6 @@ import numpy as np
 from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.quantum_info.operators import SparsePauliOp, Pauli
-from qiskit.utils.deprecation import deprecate_arg
 
 from .product_formula import ProductFormula, reorder_paulis
 
@@ -60,21 +58,6 @@ class SuzukiTrotter(ProductFormula):
         `arXiv:math-ph/0506007 <https://arxiv.org/pdf/math-ph/0506007.pdf>`_
     """
 
-    @deprecate_arg(
-        name="atomic_evolution",
-        since="1.2",
-        predicate=lambda callable: callable is not None
-        and len(inspect.signature(callable).parameters) == 2,
-        deprecation_description=(
-            "The 'Callable[[Pauli | SparsePauliOp, float], QuantumCircuit]' signature of the "
-            "'atomic_evolution' argument"
-        ),
-        additional_msg=(
-            "Instead you should update your 'atomic_evolution' function to be of the following "
-            "type: 'Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]'."
-        ),
-        pending=True,
-    )
     def __init__(
         self,
         order: int = 2,
@@ -82,9 +65,7 @@ class SuzukiTrotter(ProductFormula):
         insert_barriers: bool = False,
         cx_structure: str = "chain",
         atomic_evolution: (
-            Callable[[Pauli | SparsePauliOp, float], QuantumCircuit]
-            | Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None]
-            | None
+            Callable[[QuantumCircuit, Pauli | SparsePauliOp, float], None] | None
         ) = None,
         wrap: bool = False,
         preserve_order: bool = True,
@@ -102,9 +83,6 @@ class SuzukiTrotter(ProductFormula):
                 three arguments: the circuit to append the evolution to, the Pauli operator to
                 evolve, and the evolution time. By default, a single Pauli evolution is decomposed
                 into a chain of ``CX`` gates and a single ``RZ`` gate.
-                Alternatively, the function can also take Pauli operator and evolution time as
-                inputs and returns the circuit that will be appended to the overall circuit being
-                built.
             wrap: Whether to wrap the atomic evolutions into custom gate objects. This only takes
                 effect when ``atomic_evolution is None``.
             preserve_order: If ``False``, allows reordering the terms of the operator to

--- a/releasenotes/notes/fixes_13858-2dacfc0431c1a6ea.yaml
+++ b/releasenotes/notes/fixes_13858-2dacfc0431c1a6ea.yaml
@@ -2,7 +2,8 @@
 upgrade_synthesis:
   - |
     The ``atomic_evolution`` argument to :class:`.ProductFormula` (and its
-    subclasses :class:`.QDrift` and :class:`SuzukiTrotter` ) has a new function signature. Rather than taking some Pauli
+    subclasses :class:`.QDrift`, :class:`.LieTrotter` and :class:`SuzukiTrotter` ) 
+    has a new function signature. Rather than taking some Pauli
     operator and time coefficient and returning the evolution circuit, the new
     function takes in an existing circuit and should append the evolution of the
     provided Pauli and given time to this circuit. This new implementation

--- a/releasenotes/notes/fixes_13858-2dacfc0431c1a6ea.yaml
+++ b/releasenotes/notes/fixes_13858-2dacfc0431c1a6ea.yaml
@@ -1,0 +1,9 @@
+---
+upgrade_synthesis:
+  - |
+    The ``atomic_evolution`` argument to :class:`.ProductFormula` (and its
+    subclasses :class:`.QDrift` and :class:`SuzukiTrotter` ) has a new function signature. Rather than taking some Pauli
+    operator and time coefficient and returning the evolution circuit, the new
+    function takes in an existing circuit and should append the evolution of the
+    provided Pauli and given time to this circuit. This new implementation
+    benefits from significantly better performance.

--- a/test/python/circuit/library/test_evolution_gate.py
+++ b/test/python/circuit/library/test_evolution_gate.py
@@ -442,7 +442,7 @@ class TestEvolutionGate(QiskitTestCase):
     def test_atomic_evolution(self):
         """Test a custom atomic_evolution."""
 
-        def atomic_evolution(pauli, time):
+        def atomic_evolution(circuit, pauli, time):
             if isinstance(pauli, SparsePauliOp):
                 if len(pauli.paulis) != 1:
                     raise ValueError("Unsupported input.")
@@ -458,24 +458,20 @@ class TestEvolutionGate(QiskitTestCase):
                     target = i
                     break
 
-            definition = QuantumCircuit(pauli.num_qubits)
-            definition.compose(cliff, inplace=True)
-            definition.compose(chain, inplace=True)
-            definition.rz(2 * time, target)
-            definition.compose(chain.inverse(), inplace=True)
-            definition.compose(cliff.inverse(), inplace=True)
-
-            return definition
+            circuit.compose(cliff, inplace=True)
+            circuit.compose(chain, inplace=True)
+            circuit.rz(2 * time, target)
+            circuit.compose(chain.inverse(), inplace=True)
+            circuit.compose(cliff.inverse(), inplace=True)
 
         op = (X ^ X ^ X) + (Y ^ Y ^ Y) + (Z ^ Z ^ Z)
         time = 0.123
         reps = 4
-        with self.assertWarns(PendingDeprecationWarning):
-            evo_gate = PauliEvolutionGate(
-                op,
-                time,
-                synthesis=LieTrotter(reps=reps, atomic_evolution=atomic_evolution),
-            )
+        evo_gate = PauliEvolutionGate(
+            op,
+            time,
+            synthesis=LieTrotter(reps=reps, atomic_evolution=atomic_evolution),
+        )
         decomposed = evo_gate.definition.decompose()
         self.assertEqual(decomposed.count_ops()["cx"], reps * 3 * 4)
 


### PR DESCRIPTION
Fixes #13858 

### Summary

Removes the types, the deprecations, and readjust the test.

### Details and comments

Probably makes sense that @mrossinek takes a look to this.