### PR TITLE
Fix: Add `legacy_cmaps` to `python.benchmarks`

### DIFF
--- a/test/benchmarks/legacy_cmaps.py
+++ b/test/benchmarks/legacy_cmaps.py
@@ -1,0 +1,96 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Coupling maps for fake backend generation and transpiler testing."""
+
+# directional
+# 16 qubits
+MELBOURNE_CMAP = [
+    [1, 0],
+    [1, 2],
+    [2, 3],
+    [4, 3],
+    [4, 10],
+    [5, 4],
+    [5, 6],
+    [5, 9],
+    [6, 8],
+    [7, 8],
+    [9, 8],
+    [9, 10],
+    [11, 3],
+    [11, 10],
+    [11, 12],
+    [12, 2],
+    [13, 1],
+    [13, 12],
+]
+
+# 27 qubits
+MUMBAI_CMAP = [
+    [0, 1],
+    [1, 0],
+    [1, 2],
+    [1, 4],
+    [2, 1],
+    [2, 3],
+    [3, 2],
+    [3, 5],
+    [4, 1],
+    [4, 7],
+    [5, 3],
+    [5, 8],
+    [6, 7],
+    [7, 4],
+    [7, 6],
+    [7, 10],
+    [8, 5],
+    [8, 9],
+    [8, 11],
+    [9, 8],
+    [10, 7],
+    [10, 12],
+    [11, 8],
+    [11, 14],
+    [12, 10],
+    [12, 13],
+    [12, 15],
+    [13, 12],
+    [13, 14],
+    [14, 11],
+    [14, 13],
+    [14, 16],
+    [15, 12],
+    [15, 18],
+    [16, 14],
+    [16, 19],
+    [17, 18],
+    [18, 15],
+    [18, 17],
+    [18, 21],
+    [19, 16],
+    [19, 20],
+    [19, 22],
+    [20, 19],
+    [21, 18],
+    [21, 23],
+    [22, 19],
+    [22, 25],
+    [23, 21],
+    [23, 24],
+    [24, 23],
+    [24, 25],
+    [25, 22],
+    [25, 24],
+    [25, 26],
+    [26, 25],
+]

--- a/test/benchmarks/transpiler_levels.py
+++ b/test/benchmarks/transpiler_levels.py
@@ -21,7 +21,7 @@ from qiskit.transpiler import InstructionDurations
 from qiskit.providers.fake_provider import GenericBackendV2
 
 from .utils import build_qv_model_circuit
-from ..python.legacy_cmaps import MELBOURNE_CMAP
+from .legacy_cmaps import MELBOURNE_CMAP
 
 
 class TranspilerLevelBenchmarks:

--- a/test/benchmarks/transpiler_qualitative.py
+++ b/test/benchmarks/transpiler_qualitative.py
@@ -19,7 +19,7 @@ from qiskit import QuantumCircuit
 from qiskit.compiler import transpile
 from qiskit.providers.fake_provider import GenericBackendV2
 
-from ..python.legacy_cmaps import MUMBAI_CMAP
+from .legacy_cmaps import MUMBAI_CMAP
 
 
 class TranspilerQualitativeBench:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
In a previous oversight, a beyond-local-level relative import was preventing us from running the asv suite locally. Due to the nature of asv, we cannot import these coupling maps from where the file is located. The following commits add a file into the local level of ASV benchmarks which contains the necessary legacy coupling maps.


### Details and comments


