### PR TITLE
Remove QPY generation venvs more eagerly

### DIFF
--- a/test/qpy_compat/process_version.sh
+++ b/test/qpy_compat/process_version.sh
@@ -52,7 +52,9 @@ if [[ ! -d $cache_dir ]] ; then
     mkdir -p "$cache_dir"
     pushd "$cache_dir"
     echo "Generating QPY files with $package==$version"
-    "$venv_dir/bin/python" "${our_dir}/test_qpy.py" generate --version="$version"
+    # If the generation script fails, we still want to tidy up before exiting.
+    "$venv_dir/bin/python" "${our_dir}/test_qpy.py" generate --version="$version" || { rm -rf "$venv_dir"; exit 1; }
+    rm -rf "$venv_dir"
 else
     echo "Using cached QPY files for $version"
     pushd "${cache_dir}"
@@ -60,4 +62,3 @@ fi
 echo "Loading qpy files from $version with dev Qiskit"
 "$python" "${our_dir}/test_qpy.py" load --version="$version"
 popd
-rm -rf "$venv_dir"


### PR DESCRIPTION
Previously, the venv was only tidied up at the end of the script.  We now have enough published versions of Qiskit that if a script fails its QPY runs (and so exited before cleaning up its venv), we could overflow the disk space allocated to the VM, and get no output from the job.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


