### PR TITLE
Restore HAS_TWEEDLEDUM optional checker

### DIFF
--- a/qiskit/utils/optionals.py
+++ b/qiskit/utils/optionals.py
@@ -183,6 +183,12 @@ External Python Libraries
     `testtools <https://pypi.org/project/testtools/>`__ library is installed.  This is generally
     only needed for Qiskit developers.
 
+.. py:data:: HAS_TWEEDLEDUM
+
+    `Tweedledum <https://github.com/boschmitt/tweedledum>`__ is an extension library for
+    synthesis and optimization of circuits that may involve classical oracles. In the past
+    Qiskit's :class:`.PhaseOracle` used this but it is no longer used by Qiskit.
+
 .. py:data:: HAS_Z3
 
     `Z3 <https://github.com/Z3Prover/z3>`__ is a theorem prover, used in the
@@ -318,6 +324,7 @@ HAS_SKQUANT = _LazyImportTester(
 HAS_SQSNOBFIT = _LazyImportTester("SQSnobFit", install="pip install SQSnobFit")
 HAS_SYMENGINE = _LazyImportTester("symengine", install="pip install symengine")
 HAS_TESTTOOLS = _LazyImportTester("testtools", install="pip install testtools")
+HAS_TWEEDLEDUM = _LazyImportTester("tweedledum", install="pip install tweedledum")
 HAS_Z3 = _LazyImportTester("z3", install="pip install z3-solver")
 
 HAS_GRAPHVIZ = _LazySubprocessTester(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #13815 the usage of the tweedledum library was removed from Qiskit. The classes that used this functionality was deprecated in 1.4.0, but the optional library checker was not deprecated. These optionals checkers are part of the public API and would have needed a deprecation before removal as there may be downstream users of the checker. This commit restores the checker, but alters the docstring to make it clear that tweedledum isn't used by Qiskit anymore. If we want to remove the checker in 3.0 we can deprecate it in 2.1.0 or another release in the 2.x series. Although, there is basically no real cost for keeping it around so it's probably not worth the effort.

### Details and comments


