### PR TITLE
Fix performance regression in circuit_to_instruction

### DIFF
--- a/qiskit/converters/circuit_to_instruction.py
+++ b/qiskit/converters/circuit_to_instruction.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 
 """Helper function for converting a circuit to an instruction."""
-from qiskit.circuit.controlflow.control_flow import ControlFlowOp
+from qiskit.circuit.controlflow import CONTROL_FLOW_OP_NAMES
 from qiskit.exceptions import QiskitError
 from qiskit.circuit.instruction import Instruction
 from qiskit.circuit.quantumregister import QuantumRegister
@@ -84,13 +84,10 @@ def circuit_to_instruction(circuit, parameter_map=None, equivalence_library=None
             "Circuits with internal variables cannot yet be converted to instructions."
             " You may be able to use `QuantumCircuit.compose` to inline this circuit into another."
         )
-
-    for inst in circuit.data:
-        if isinstance(inst.operation, ControlFlowOp):
-            raise QiskitError(
-                f"Circuits with control flow operations ({type(inst.operation)}) "
-                "cannot be converted to an instruction."
-            )
+    if CONTROL_FLOW_OP_NAMES.intersection(circuit.count_ops()):
+        raise QiskitError(
+            "Circuits with control flow operations cannot be converted to an instruction."
+        )
 
     if parameter_map is None:
         parameter_dict = {p: p for p in circuit.parameters}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #13921 a check was added to circuit_to_instruction() for determining if the circuit has a control flow op. This check was adding significant overhead to the function, nightly asv benchmarks are showing up to a ~9x slowdown. #13921 attempted to fix this regression but did so by adding a new API which isn't applicable at this point for 2.0. That PR could/should still be used in 2.1. In the meantime this commit seeks to solve the performance regression by adjusting how the check is performed to mitigate the runtime regression for 2.0.

### Details and comments