### PR TITLE
Fixed indentation of docstrings.

### DIFF
--- a/qiskit/circuit/library/arithmetic/piecewise_polynomial_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/piecewise_polynomial_pauli_rotations.py
@@ -101,9 +101,9 @@ class PiecewisePolynomialPauliRotations(FunctionalPauliRotations):
             breakpoints: The breakpoints to define the piecewise-linear function.
                 Defaults to ``[0]``.
             coeffs: The coefficients of the polynomials for different segments of the
-            piecewise-linear function. ``coeffs[j][i]`` is the coefficient of the i-th power of x
-            for the j-th polynomial.
-                Defaults to linear: ``[[1]]``.
+                piecewise-linear function. ``coeffs[j][i]`` is the coefficient of the i-th power of x
+                for the j-th polynomial.
+                    Defaults to linear: ``[[1]]``.
             basis: The type of Pauli rotation (``'X'``, ``'Y'``, ``'Z'``).
             name: The name of the circuit.
         """

--- a/qiskit/circuit/library/arithmetic/piecewise_polynomial_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/piecewise_polynomial_pauli_rotations.py
@@ -103,7 +103,7 @@ class PiecewisePolynomialPauliRotations(FunctionalPauliRotations):
             coeffs: The coefficients of the polynomials for different segments of the
                 piecewise-linear function. ``coeffs[j][i]`` is the coefficient of the i-th power of x
                 for the j-th polynomial.
-                    Defaults to linear: ``[[1]]``.
+                Defaults to linear: ``[[1]]``.
             basis: The type of Pauli rotation (``'X'``, ``'Y'``, ``'Z'``).
             name: The name of the circuit.
         """

--- a/qiskit/circuit/random/utils.py
+++ b/qiskit/circuit/random/utils.py
@@ -54,9 +54,9 @@ def random_circuit(
         reset (bool): if True, insert middle resets
         seed (int): sets random seed (optional)
         num_operand_distribution (dict): a distribution of gates that specifies the ratio
-        of 1-qubit, 2-qubit, 3-qubit, ..., n-qubit gates in the random circuit. Expect a
-        deviation from the specified ratios that depends on the size of the requested
-        random circuit. (optional)
+            of 1-qubit, 2-qubit, 3-qubit, ..., n-qubit gates in the random circuit. Expect a
+            deviation from the specified ratios that depends on the size of the requested
+            random circuit. (optional)
 
     Returns:
         QuantumCircuit: constructed circuit

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -585,7 +585,7 @@ class Pauli(BasePauli):
             other (Pauli or Clifford or QuantumCircuit): The Clifford operator to evolve by.
             qargs (list): a list of qubits to apply the Clifford to.
             frame (string): ``'h'`` for Heisenberg (default) or ``'s'`` for
-            Schrödinger framework.
+                Schrödinger framework.
 
         Returns:
             Pauli: the Pauli :math:`C^\dagger.P.C` (Heisenberg picture)

--- a/releasenotes/notes/fix-docstrings-indentation-e1eb23d0019cbdaf.yaml
+++ b/releasenotes/notes/fix-docstrings-indentation-e1eb23d0019cbdaf.yaml
@@ -1,6 +1,0 @@
-fixes:
-  - |
-    Fixes doctrings indentation in ``PiecewisePolynomialPauliRotations.init()``,
-    ``qiskit.circuit.random.random_circuit()`` ,``Pauli.evolve()``. Refer to
-    `#13839 <https://github.com/Qiskit/qiskit/issues/13839>` for more
-    details.

--- a/releasenotes/notes/fix-docstrings-indentation-e1eb23d0019cbdaf.yaml
+++ b/releasenotes/notes/fix-docstrings-indentation-e1eb23d0019cbdaf.yaml
@@ -1,0 +1,6 @@
+fixes:
+  - |
+    Fixes doctrings indentation in ``PiecewisePolynomialPauliRotations.init()``,
+    ``qiskit.circuit.random.random_circuit()`` ,``Pauli.evolve()``. Refer to
+    `#13839 <https://github.com/Qiskit/qiskit/issues/13839>` for more
+    details.


### PR DESCRIPTION
### Summary

It fixes #13839 

### Details and comments
Some docstrings are not correctly idented causing documentation or mdx incorrect generation. I fixed the identation of reported methods.

