### PR TITLE
Fix is_parameterized() function of controlled gates

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -287,7 +287,7 @@ class Instruction(Operation):
         """Return whether the :class:`Instruction` contains :ref:`compile-time parameters
         <circuit-compile-time-parameters>`."""
         return any(
-            isinstance(param, ParameterExpression) and param.parameters for param in self._params
+            isinstance(param, ParameterExpression) and param.parameters for param in self.params
         )
 
     @property

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -1300,7 +1300,8 @@ class TestControlledGate(QiskitTestCase):
         """
         for gate_class in ControlledGate.__subclasses__():
             with self.subTest(i=repr(gate_class)):
-                # Singleton class isn't intended to be created directly, and its subclasses are not parameterized
+                # Singleton class isn't intended to be created directly, and its subclasses are not
+                # parameterized
                 if gate_class in {SingletonControlledGate, _SingletonControlledGateOverrides}:
                     continue
                 gate_params = _get_free_params(gate_class.__init__, ignore=["self"])

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -1275,7 +1275,11 @@ class TestControlledGate(QiskitTestCase):
         for gate_class in ControlledGate.__subclasses__():
             with self.subTest(i=repr(gate_class)):
                 # Singleton class isn't intended to be created directly
-                if gate_class in {SingletonControlledGate, _SingletonControlledGateOverrides}:
+                # Ignore classes from Aer, which has its own unit tests.
+                if gate_class in {
+                    SingletonControlledGate,
+                    _SingletonControlledGateOverrides,
+                } or gate_class.__module__.startswith("qiskit_aer"):
                     continue
                 gate_params = _get_free_params(gate_class.__init__, ignore=["self"])
                 num_free_params = len(gate_params)
@@ -1300,9 +1304,12 @@ class TestControlledGate(QiskitTestCase):
         """
         for gate_class in ControlledGate.__subclasses__():
             with self.subTest(i=repr(gate_class)):
-                # Singleton class isn't intended to be created directly, and its subclasses are not
-                # parameterized
-                if gate_class in {SingletonControlledGate, _SingletonControlledGateOverrides}:
+                # Singleton class isn't intended to be created directly, and its subclasses are not parameterized.
+                # Ignore classes from Aer, which has its own unit tests.
+                if gate_class in {
+                    SingletonControlledGate,
+                    _SingletonControlledGateOverrides,
+                } or gate_class.__module__.startswith("qiskit_aer"):
                     continue
                 gate_params = _get_free_params(gate_class.__init__, ignore=["self"])
                 num_free_params = len(gate_params)

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -1304,7 +1304,8 @@ class TestControlledGate(QiskitTestCase):
         """
         for gate_class in ControlledGate.__subclasses__():
             with self.subTest(i=repr(gate_class)):
-                # Singleton class isn't intended to be created directly, and its subclasses are not parameterized.
+                # Singleton class isn't intended to be created directly, and its subclasses are not
+                # parameterized.
                 # Ignore classes from Aer, which has its own unit tests.
                 if gate_class in {
                     SingletonControlledGate,


### PR DESCRIPTION
### Summary

Controlled gates are not recognised as parameterized by the `is_parameterized()` function. This causes issues in Aer and Algorithms when using circuits with controlled rotations: https://github.com/Qiskit/qiskit-aer/issues/2323, https://github.com/qiskit-community/qiskit-algorithms/issues/216

### Details and comments

The `is_parameterized()` function reads from the `_params` variable, which is not set by some classes that override the `params` property, such as `ControlledGate`, `CUGate`, `AnnotatedOperation` and `Initialize`.

This pull request fixes `is_parameterized()`, such that it reads the `params` variable instead, which corresponds to the parameters of the base gate for controlled gates.

This pull request also adds a unit test and fixes an existing one.