### PR TITLE
Fix docs typo in ``qk_obsterm_str`` 

### DIFF
--- a/crates/cext/src/sparse_observable.rs
+++ b/crates/cext/src/sparse_observable.rs
@@ -874,7 +874,7 @@ pub unsafe extern "C" fn qk_str_free(string: *mut c_char) {
 ///     QkObs *obs = qk_obs_identity(100);
 ///     QkObsTerm term;
 ///     qk_obs_term(obs, 0, &term);
-///     char *string = qk_obsterm_print(&term);
+///     char *string = qk_obsterm_str(&term);
 ///     qk_str_free(string);
 ///
 /// # Safety


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

We missed a `print` -> `str` rename in the docs. The function is now called `qk_obsterm_str`, not `qk_obsterm_print` anymore.


