### PR TITLE
Minor fix to consolidate blocks with RZZ and CZ gates

### DIFF
--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -100,13 +100,13 @@ class ConsolidateBlocks(TransformationPass):
         elif basis_gates is not None:
             kak_gates = KAK_GATE_NAMES.keys() & (basis_gates or [])
             kak_param_gates = KAK_GATE_PARAM_NAMES.keys() & (basis_gates or [])
-            if kak_gates:
-                self.decomposer = TwoQubitBasisDecomposer(
-                    KAK_GATE_NAMES[list(kak_gates)[0]], basis_fidelity=approximation_degree or 1.0
-                )
-            elif kak_param_gates:
+            if kak_param_gates:
                 self.decomposer = TwoQubitControlledUDecomposer(
                     KAK_GATE_PARAM_NAMES[list(kak_param_gates)[0]]
+                )
+            elif kak_gates:
+                self.decomposer = TwoQubitBasisDecomposer(
+                    KAK_GATE_NAMES[list(kak_gates)[0]], basis_fidelity=approximation_degree or 1.0
                 )
             else:
                 self.decomposer = None

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -654,12 +654,13 @@ class TestConsolidateBlocks(QiskitTestCase):
         self.assertEqual({"unitary": 1}, res.count_ops())
         self.assertEqual(Operator.from_circuit(qc), Operator(res.data[0].operation.params[0]))
 
-    def test_collect_rzz(self):
+    @data(["rzz", "rx", "rz"], ["rzz", "rx", "rz", "cz"])
+    def test_collect_rzz(self, basis_gates):
         """Collect blocks with RZZ gates."""
         qc = QuantumCircuit(2)
         qc.rzz(0.1, 0, 1)
         qc.rzz(0.2, 0, 1)
-        consolidate_pass = ConsolidateBlocks(basis_gates=["rzz", "rx", "rz"])
+        consolidate_pass = ConsolidateBlocks(basis_gates=basis_gates)
         res = consolidate_pass(qc)
         self.assertEqual({"unitary": 1}, res.count_ops())
         self.assertEqual(Operator.from_circuit(qc), Operator(res.data[0].operation.params[0]))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This is a minor fix to #13884 (so no release notes are needed, since it has not been released yet).

### Details and comments
A minor fix following https://github.com/Qiskit/qiskit/issues/13428#issuecomment-2699855434
when the backend has both CZ and RZZ gates

