### PR TITLE
Missing release note in #13890

### DIFF
--- a/releasenotes/notes/fix_qpy_serialization_13890-00b08354fe991921.yaml
+++ b/releasenotes/notes/fix_qpy_serialization_13890-00b08354fe991921.yaml
@@ -3,3 +3,4 @@ fixes:
   - |
     The serialization of :class:`ParameterExpression` now does not raise an ``AttributeError`` exception
     when serializing with QPY 13.
+    Fixed `#7742 <https://github.com/Qiskit/qiskit-terra/issues/7742>`__.

--- a/releasenotes/notes/fix_qpy_serialization_13890-00b08354fe991921.yaml
+++ b/releasenotes/notes/fix_qpy_serialization_13890-00b08354fe991921.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The serialization of :class:`ParameterExpression` now does not raise an ``AttributeError`` exception
+    when serializing with QPY 13.


### PR DESCRIPTION
### Summary

While working in 1.4.1, I noticed that the PR #13890 was missing a release note.


