### PR TITLE
Fix wheel builds for i686 Linux

### DIFF
--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -154,6 +154,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.3
         env:
+          CIBW_BEFORE_ALL_LINUX: 'yum install -y wget libatomic && {package}/tools/install_rust.sh'
           CIBW_SKIP: 'pp* cp36-* cp37-* cp38-* *musllinux* *amd64 *x86_64'
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the 1.4.1 release the i686 linux wheel builds failed because the recent release of rustup 1.28.0 and 1.28.1 added a runtime dependency on libatomic to download and install the rust compiler. The i686 manylinux container we run the wheel builds in didn't contain this library so rustup errored and crashed the build. This commit fixes this issue by installing libatomic prior to running rustup. This fix was used in a throwaway branch to push out the 1.4.1 release on PyPI, but this fixes it for real for when we publish 1.4.2.

### Details and comments