### PR TITLE
Add gitattributes file to adjust linguist settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Exclude benchmark qasm and reference text:
+test/benchmarks/qasm/** linguist-generated
+test/python/visualization/references/*.tex linguist-generated
+test/python/visualization/references/*.txt linguist-generated
+# Mark qasm libs as qasm not c++
+*.inc linguist-language=OpenQASM


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Github uses a ruby library linguist [1] for detecting the languages used in a github repository. The detection this library does is not perfect as it relies on file extensions and obviously it doesn't know about context around certain files. Linguist provides tools for correcting these issues so the reported split of languages in a repository is more accurate. This commit adds a .gitattributes file to Qiskit to adjust how linguist interprets some files to provide a better measurement of the languages used in the repository. This involves three main changes:

1. Marking the qasm files in test/benchmarks/qasm as generated code as they're all generated output for measuring qasm parsing time or to have a deterministic circuit definition. These aren't source files that should be counted as part of the language breakdown.
2. Marking the visualization text references in LaTeX and txt files as generated, as they're generated from the visualization output to serve as a comparison for testing.
3. Marking the qasm libraries using the *inc extension as OpenQASM not C++.

With these three changes the languages used by qiskit is a better reflection of the current state of the repository.

### Details and comments

[1] https://github.com/github-linguist/linguist