### PR TITLE
Refactor `BitData` to `ObjectRegistry`.

### DIFF
--- a/crates/accelerate/src/commutation_checker.rs
+++ b/crates/accelerate/src/commutation_checker.rs
@@ -27,10 +27,10 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyDict, PySequence, PyTuple};
 use pyo3::BoundObject;
 
-use qiskit_circuit::object_registry::ObjectRegistry;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
 use qiskit_circuit::dag_node::DAGOpNode;
 use qiskit_circuit::imports::QI_OPERATOR;
+use qiskit_circuit::object_registry::ObjectRegistry;
 use qiskit_circuit::operations::OperationRef::{Gate as PyGateType, Operation as PyOperationType};
 use qiskit_circuit::operations::{
     get_standard_gate_names, Operation, OperationRef, Param, StandardGate,

--- a/crates/accelerate/src/commutation_checker.rs
+++ b/crates/accelerate/src/commutation_checker.rs
@@ -90,19 +90,19 @@ where
     T: From<BitType> + Copy,
     BitType: From<T>,
 {
-    // Using `VarAsKey` here is a total hack, but this is a short-term workaround before a
+    // Using `PyObjectAsKey` here is a total hack, but this is a short-term workaround before a
     // larger refactor of the commutation checker.
-    let mut bitdata: ObjectRegistry<T, PyObjectAsKey> = ObjectRegistry::new();
+    let mut registry: ObjectRegistry<T, PyObjectAsKey> = ObjectRegistry::new();
 
     for bit in bits1.iter().chain(bits2.iter()) {
-        bitdata.add(bit.into(), false)?;
+        registry.add(bit.into(), false)?;
     }
 
     Ok((
-        bitdata
+        registry
             .map_objects(bits1.iter().map(|bit| bit.into()))?
             .collect(),
-        bitdata
+        registry
             .map_objects(bits2.iter().map(|bit| bit.into()))?
             .collect(),
     ))

--- a/crates/accelerate/src/commutation_checker.rs
+++ b/crates/accelerate/src/commutation_checker.rs
@@ -16,7 +16,7 @@ use ndarray::Array2;
 use num_complex::Complex64;
 use num_complex::ComplexFloat;
 use once_cell::sync::Lazy;
-use qiskit_circuit::bit_data::VarAsKey;
+use qiskit_circuit::bit_data::PyObjectAsKey;
 use smallvec::SmallVec;
 use std::fmt::Debug;
 
@@ -92,7 +92,7 @@ where
 {
     // Using `VarAsKey` here is a total hack, but this is a short-term workaround before a
     // larger refactor of the commutation checker.
-    let mut bitdata: BitData<T, VarAsKey> = BitData::new();
+    let mut bitdata: BitData<T, PyObjectAsKey> = BitData::new();
 
     for bit in bits1.iter().chain(bits2.iter()) {
         bitdata.add(bit.into(), false)?;

--- a/crates/accelerate/src/commutation_checker.rs
+++ b/crates/accelerate/src/commutation_checker.rs
@@ -16,7 +16,7 @@ use ndarray::Array2;
 use num_complex::Complex64;
 use num_complex::ComplexFloat;
 use once_cell::sync::Lazy;
-use qiskit_circuit::bit_data::PyObjectAsKey;
+use qiskit_circuit::object_registry::PyObjectAsKey;
 use smallvec::SmallVec;
 use std::fmt::Debug;
 
@@ -27,7 +27,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyDict, PySequence, PyTuple};
 use pyo3::BoundObject;
 
-use qiskit_circuit::bit_data::BitData;
+use qiskit_circuit::object_registry::ObjectRegistry;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
 use qiskit_circuit::dag_node::DAGOpNode;
 use qiskit_circuit::imports::QI_OPERATOR;
@@ -92,7 +92,7 @@ where
 {
     // Using `VarAsKey` here is a total hack, but this is a short-term workaround before a
     // larger refactor of the commutation checker.
-    let mut bitdata: BitData<T, PyObjectAsKey> = BitData::new();
+    let mut bitdata: ObjectRegistry<T, PyObjectAsKey> = ObjectRegistry::new();
 
     for bit in bits1.iter().chain(bits2.iter()) {
         bitdata.add(bit.into(), false)?;
@@ -100,10 +100,10 @@ where
 
     Ok((
         bitdata
-            .map_bits(bits1.iter().map(|bit| bit.into()))?
+            .map_objects(bits1.iter().map(|bit| bit.into()))?
             .collect(),
         bitdata
-            .map_bits(bits2.iter().map(|bit| bit.into()))?
+            .map_objects(bits2.iter().map(|bit| bit.into()))?
             .collect(),
     ))
 }

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -19,12 +19,12 @@ use crate::bit::{
     BitLocations, ClassicalRegister, PyBit, QuantumRegister, Register, ShareableClbit,
     ShareableQubit,
 };
-use crate::object_registry::ObjectRegistry;
 use crate::bit_locator::BitLocator;
 use crate::circuit_instruction::{CircuitInstruction, OperationFromPython};
 use crate::dag_circuit::add_global_phase;
 use crate::imports::{ANNOTATED_OPERATION, QUANTUM_CIRCUIT};
 use crate::interner::{Interned, Interner};
+use crate::object_registry::ObjectRegistry;
 use crate::operations::{Operation, OperationRef, Param, StandardGate};
 use crate::packed_instruction::{PackedInstruction, PackedOperation};
 use crate::parameter_table::{ParameterTable, ParameterTableError, ParameterUse, ParameterUuid};

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -2279,10 +2279,6 @@ impl DAGCircuit {
             return Ok(false);
         }
 
-        // {
-        //     let our_stretches = PySet::new(py, self.captured_stretches.values())?;
-        //     let their_stretches = PySet::new(py, self.their_stretches.values())?;
-        // }
         for (our_stretch, their_stretch) in self
             .captured_stretches
             .values()

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -20,7 +20,7 @@ use crate::bit::{
     BitLocations, ClassicalRegister, PyClassicalRegister, PyClbit, PyQubit, QuantumRegister,
     Register, ShareableClbit, ShareableQubit,
 };
-use crate::bit_data::{BitData, PyObjectAsKey};
+use crate::object_registry::{ObjectRegistry, PyObjectAsKey};
 use crate::bit_locator::BitLocator;
 use crate::circuit_data::CircuitData;
 use crate::circuit_instruction::{CircuitInstruction, OperationFromPython};
@@ -202,11 +202,11 @@ pub struct DAGCircuit {
     /// The cache used to intern instruction cargs.
     pub cargs_interner: Interner<[Clbit]>,
     /// Qubits registered in the circuit.
-    qubits: BitData<Qubit, ShareableQubit>,
+    qubits: ObjectRegistry<Qubit, ShareableQubit>,
     /// Clbits registered in the circuit.
-    clbits: BitData<Clbit, ShareableClbit>,
+    clbits: ObjectRegistry<Clbit, ShareableClbit>,
     /// Variables registered in the circuit.
-    vars: BitData<Var, PyObjectAsKey>,
+    vars: ObjectRegistry<Var, PyObjectAsKey>,
     /// Global phase.
     global_phase: Param,
     /// Duration.
@@ -421,9 +421,9 @@ impl DAGCircuit {
             cregs: RegisterData::new(),
             qargs_interner: Interner::new(),
             cargs_interner: Interner::new(),
-            qubits: BitData::new(),
-            clbits: BitData::new(),
-            vars: BitData::new(),
+            qubits: ObjectRegistry::new(),
+            clbits: ObjectRegistry::new(),
+            vars: ObjectRegistry::new(),
             global_phase: Param::Float(0.),
             duration: None,
             unit: "dt".to_string(),
@@ -646,9 +646,9 @@ impl DAGCircuit {
                 .into_py_dict(py)?,
         )?;
         out_dict.set_item("vars_by_type", self.vars_by_type.clone())?;
-        out_dict.set_item("qubits", self.qubits.bits())?;
-        out_dict.set_item("clbits", self.clbits.bits())?;
-        out_dict.set_item("vars", self.vars.bits())?;
+        out_dict.set_item("qubits", self.qubits.objects())?;
+        out_dict.set_item("clbits", self.clbits.objects())?;
+        out_dict.set_item("vars", self.vars.objects())?;
         let mut nodes: Vec<PyObject> = Vec::with_capacity(self.dag.node_count());
         for node_idx in self.dag.node_indices() {
             let node_data = self.get_node(py, node_idx)?;
@@ -867,9 +867,9 @@ impl DAGCircuit {
     /// Return a list of the wires in order.
     #[getter]
     fn get_wires(&self, py: Python<'_>) -> PyResult<Py<PyList>> {
-        let wires: Bound<PyList> = PyList::new(py, self.qubits.bits().iter())?;
+        let wires: Bound<PyList> = PyList::new(py, self.qubits.objects().iter())?;
 
-        for clbit in self.clbits.bits().iter() {
+        for clbit in self.clbits.objects().iter() {
             wires.append(clbit)?
         }
 
@@ -1063,7 +1063,7 @@ impl DAGCircuit {
     ///         or is not idle.
     #[pyo3(signature = (*clbits))]
     fn remove_clbits(&mut self, py: Python, clbits: Vec<ShareableClbit>) -> PyResult<()> {
-        let bit_iter = match self.clbits.map_bits(clbits.iter().cloned()) {
+        let bit_iter = match self.clbits.map_objects(clbits.iter().cloned()) {
             Ok(bit_iter) => bit_iter,
             Err(_) => {
                 return Err(DAGCircuitError::new_err(format!(
@@ -1154,7 +1154,7 @@ impl DAGCircuit {
                     let carg_bits = old_clbits.map_indices(cargs).cloned();
                     op.clbits = self
                         .cargs_interner
-                        .insert_owned(self.clbits.map_bits(carg_bits)?.collect());
+                        .insert_owned(self.clbits.map_objects(carg_bits)?.collect());
                 }
                 NodeType::ClbitIn(c) | NodeType::ClbitOut(c) => {
                     *c = self.clbits.find(old_clbits.get(*c).unwrap()).unwrap();
@@ -1164,7 +1164,7 @@ impl DAGCircuit {
         }
 
         // Update bit locations.
-        for (i, bit) in self.clbits.bits().iter().enumerate() {
+        for (i, bit) in self.clbits.objects().iter().enumerate() {
             let raw_loc = self.clbit_locations.get_mut(bit).unwrap();
             raw_loc.index = i as u32;
         }
@@ -1232,7 +1232,7 @@ impl DAGCircuit {
     ///         or is not idle.
     #[pyo3(signature = (*qubits))]
     fn remove_qubits(&mut self, py: Python, qubits: Vec<ShareableQubit>) -> PyResult<()> {
-        let bit_iter = match self.qubits.map_bits(qubits.iter().cloned()) {
+        let bit_iter = match self.qubits.map_objects(qubits.iter().cloned()) {
             Ok(bit_iter) => bit_iter,
             Err(_) => {
                 return Err(DAGCircuitError::new_err(format!(
@@ -1319,7 +1319,7 @@ impl DAGCircuit {
                     let qarg_bits = old_qubits.map_indices(qargs).cloned();
                     op.qubits = self
                         .qargs_interner
-                        .insert_owned(self.qubits.map_bits(qarg_bits)?.collect());
+                        .insert_owned(self.qubits.map_objects(qarg_bits)?.collect());
                 }
                 NodeType::QubitIn(q) | NodeType::QubitOut(q) => {
                     *q = self.qubits.find(old_qubits.get(*q).unwrap()).unwrap();
@@ -1329,7 +1329,7 @@ impl DAGCircuit {
         }
 
         // Update bit locations.
-        for (i, bit) in self.qubits.bits().iter().enumerate() {
+        for (i, bit) in self.qubits.objects().iter().enumerate() {
             let raw_loc = self.qubit_locations.get_mut(bit).unwrap();
             raw_loc.index = i as u32;
         }
@@ -1449,10 +1449,10 @@ impl DAGCircuit {
         target_dag.qargs_interner = self.qargs_interner.clone();
         target_dag.cargs_interner = self.cargs_interner.clone();
 
-        for bit in self.qubits.bits() {
+        for bit in self.qubits.objects() {
             target_dag.add_qubit_unchecked(bit.clone())?;
         }
-        for bit in self.clbits.bits() {
+        for bit in self.clbits.objects() {
             target_dag.add_clbit_unchecked(bit.clone())?;
         }
         for reg in self.qregs.registers() {
@@ -1575,10 +1575,10 @@ impl DAGCircuit {
         let node = {
             let qubits_id = self
                 .qargs_interner
-                .insert_owned(self.qubits.map_bits(qargs.into_iter().flatten())?.collect());
+                .insert_owned(self.qubits.map_objects(qargs.into_iter().flatten())?.collect());
             let clbits_id = self
                 .cargs_interner
-                .insert_owned(self.clbits.map_bits(cargs.into_iter().flatten())?.collect());
+                .insert_owned(self.clbits.map_objects(cargs.into_iter().flatten())?.collect());
             let instr = PackedInstruction {
                 op: py_op.operation,
                 qubits: qubits_id,
@@ -1633,10 +1633,10 @@ impl DAGCircuit {
         let node = {
             let qubits_id = self
                 .qargs_interner
-                .insert_owned(self.qubits.map_bits(qargs.into_iter().flatten())?.collect());
+                .insert_owned(self.qubits.map_objects(qargs.into_iter().flatten())?.collect());
             let clbits_id = self
                 .cargs_interner
-                .insert_owned(self.clbits.map_bits(cargs.into_iter().flatten())?.collect());
+                .insert_owned(self.clbits.map_objects(cargs.into_iter().flatten())?.collect());
             let instr = PackedInstruction {
                 op: py_op.operation,
                 qubits: qubits_id,
@@ -1714,15 +1714,15 @@ impl DAGCircuit {
         // Number of qubits and clbits must match number in circuit or None
         let identity_qubit_map = other
             .qubits
-            .bits()
+            .objects()
             .iter()
-            .zip(slf.qubits.bits())
+            .zip(slf.qubits.objects())
             .into_py_dict(py)?;
         let identity_clbit_map = other
             .clbits
-            .bits()
+            .objects()
             .iter()
-            .zip(slf.clbits.bits())
+            .zip(slf.clbits.objects())
             .into_py_dict(py)?;
 
         let qubit_map: Bound<PyDict> = match qubits {
@@ -2306,10 +2306,10 @@ impl DAGCircuit {
         let self_bit_indices = {
             let indices = self
                 .qubits
-                .bits()
+                .objects()
                 .into_pyobject(py)?
                 .try_iter()?
-                .chain(self.clbits.bits().into_pyobject(py)?.try_iter()?)
+                .chain(self.clbits.objects().into_pyobject(py)?.try_iter()?)
                 .enumerate()
                 .map(|(idx, bit)| -> PyResult<_> { Ok((bit?, idx)) });
             indices.collect::<PyResult<Vec<_>>>()?.into_py_dict(py)?
@@ -2318,10 +2318,10 @@ impl DAGCircuit {
         let other_bit_indices = {
             let indices = other
                 .qubits
-                .bits()
+                .objects()
                 .into_pyobject(py)?
                 .try_iter()?
-                .chain(other.clbits.bits().clone().into_pyobject(py)?.try_iter()?)
+                .chain(other.clbits.objects().clone().into_pyobject(py)?.try_iter()?)
                 .enumerate()
                 .map(|(idx, bit)| -> PyResult<_> { Ok((bit?, idx)) });
             indices.collect::<PyResult<Vec<_>>>()?.into_py_dict(py)?
@@ -2341,8 +2341,8 @@ impl DAGCircuit {
             };
             if !self
                 .qubits
-                .map_bits(self_bits)?
-                .eq(other.qubits.map_bits(other_bits)?)
+                .map_objects(self_bits)?
+                .eq(other.qubits.map_objects(other_bits)?)
             {
                 return Ok(false);
             }
@@ -2363,8 +2363,8 @@ impl DAGCircuit {
             };
             if !self
                 .clbits
-                .map_bits(self_bits)?
-                .eq(other.clbits.map_bits(other_bits)?)
+                .map_objects(self_bits)?
+                .eq(other.clbits.map_objects(other_bits)?)
             {
                 return Ok(false);
             }
@@ -4799,19 +4799,19 @@ impl DAGCircuit {
 
     /// Returns an immutable view of the Qubits registered in the circuit
     #[inline(always)]
-    pub fn qubits(&self) -> &BitData<Qubit, ShareableQubit> {
+    pub fn qubits(&self) -> &ObjectRegistry<Qubit, ShareableQubit> {
         &self.qubits
     }
 
     /// Returns an immutable view of the Classical bits registered in the circuit
     #[inline(always)]
-    pub fn clbits(&self) -> &BitData<Clbit, ShareableClbit> {
+    pub fn clbits(&self) -> &ObjectRegistry<Clbit, ShareableClbit> {
         &self.clbits
     }
 
     /// Returns an immutable view of the Variable wires registered in the circuit
     #[inline(always)]
-    pub fn vars(&self) -> &BitData<Var, PyObjectAsKey> {
+    pub fn vars(&self) -> &ObjectRegistry<Var, PyObjectAsKey> {
         &self.vars
     }
 
@@ -5658,7 +5658,7 @@ impl DAGCircuit {
             let op_node = op_node.borrow();
             let qubits = self.qargs_interner.insert_owned(
                 self.qubits
-                    .map_bits(
+                    .map_objects(
                         op_node
                             .instruction
                             .qubits
@@ -5669,7 +5669,7 @@ impl DAGCircuit {
             );
             let clbits = self.cargs_interner.insert_owned(
                 self.clbits
-                    .map_bits(
+                    .map_objects(
                         op_node
                             .instruction
                             .clbits
@@ -6218,9 +6218,9 @@ impl DAGCircuit {
             cregs: RegisterData::new(),
             qargs_interner: Interner::with_capacity(num_qubits),
             cargs_interner: Interner::with_capacity(num_clbits),
-            qubits: BitData::with_capacity(num_qubits),
-            clbits: BitData::with_capacity(num_clbits),
-            vars: BitData::with_capacity(num_vars),
+            qubits: ObjectRegistry::with_capacity(num_qubits),
+            clbits: ObjectRegistry::with_capacity(num_clbits),
+            vars: ObjectRegistry::with_capacity(num_vars),
             global_phase: Param::Float(0.),
             duration: None,
             unit: "dt".to_string(),
@@ -6681,7 +6681,7 @@ impl DAGCircuit {
         } else {
             qc_data
                 .qubits()
-                .bits()
+                .objects()
                 .iter()
                 .try_for_each(|qubit| -> PyResult<_> {
                     new_dag.add_qubit_unchecked(qubit.clone())?;
@@ -6715,7 +6715,7 @@ impl DAGCircuit {
         } else {
             qc_data
                 .clbits()
-                .bits()
+                .objects()
                 .iter()
                 .try_for_each(|clbit| -> PyResult<()> {
                     new_dag.add_clbit_unchecked(clbit.clone())?;
@@ -6840,12 +6840,12 @@ impl DAGCircuit {
                                     let target_clbit: ShareableClbit = target.extract()?;
                                     block_cargs.insert(self.clbits.find(&target_clbit).unwrap());
                                 } else if target.is_instance_of::<PyClassicalRegister>() {
-                                    block_cargs.extend(self.clbits.map_bits(
+                                    block_cargs.extend(self.clbits.map_objects(
                                         target.extract::<Vec<ShareableClbit>>()?.into_iter(),
                                     )?);
                                 } else {
                                     block_cargs.extend(
-                                        self.clbits.map_bits(
+                                        self.clbits.map_objects(
                                             self.control_flow_module
                                                 .node_resources(&target)?
                                                 .clbits

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -11,7 +11,6 @@
 // that they have been altered from the originals.
 
 pub mod bit;
-pub mod object_registry;
 pub mod bit_locator;
 pub mod circuit_data;
 pub mod circuit_instruction;
@@ -24,6 +23,7 @@ pub mod error;
 pub mod gate_matrix;
 pub mod imports;
 pub mod interner;
+pub mod object_registry;
 pub mod operations;
 pub mod packed_instruction;
 pub mod parameter_table;

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -11,7 +11,7 @@
 // that they have been altered from the originals.
 
 pub mod bit;
-pub mod bit_data;
+pub mod object_registry;
 pub mod bit_locator;
 pub mod circuit_data;
 pub mod circuit_instruction;

--- a/crates/circuit/src/object_registry.rs
+++ b/crates/circuit/src/object_registry.rs
@@ -195,12 +195,18 @@ where
 
     /// Map the provided objects to their native indices.
     /// An error is returned if any object is not registered.
-    pub fn map_objects(&self, objects: impl IntoIterator<Item = B>) -> PyResult<impl Iterator<Item = T>> {
+    pub fn map_objects(
+        &self,
+        objects: impl IntoIterator<Item = B>,
+    ) -> PyResult<impl Iterator<Item = T>> {
         let v: Result<Vec<_>, _> = objects
             .into_iter()
             .map(|b| {
                 self.indices.get(&b).copied().ok_or_else(|| {
-                    PyKeyError::new_err(format!("Object {:?} has not been added to this circuit.", b))
+                    PyKeyError::new_err(format!(
+                        "Object {:?} has not been added to this circuit.",
+                        b
+                    ))
                 })
             })
             .collect();

--- a/crates/circuit/src/object_registry.rs
+++ b/crates/circuit/src/object_registry.rs
@@ -167,26 +167,6 @@ where
         &self.objects
     }
 
-    /// Gets a reference to the cached Python list, maintained by
-    /// this instance.
-    #[inline]
-    pub fn cached<'py>(&self, py: Python<'py>) -> &Py<PyList>
-    where
-        B: IntoPyObject<'py>,
-    {
-        self.cached
-            .get_or_init(|| PyList::new(py, self.objects.clone()).unwrap().into())
-    }
-
-    /// Gets a reference to the cached Python list, even if not initialized.
-    #[inline]
-    pub fn cached_raw(&self) -> Option<&Py<PyList>>
-    where
-        for<'a> B: IntoPyObject<'a>,
-    {
-        self.cached.get()
-    }
-
     /// Finds the native index of the given object.
     #[inline]
     pub fn find(&self, object: &B) -> Option<T> {
@@ -279,5 +259,28 @@ where
     pub fn dispose(&mut self) {
         self.indices.clear();
         self.objects.clear();
+    }
+}
+
+impl<'a, T, B> ObjectRegistry<T, B>
+where
+    B: Clone,
+    B: IntoPyObject<'a>,
+{
+    /// Gets a reference to the cached Python list, maintained by
+    /// this instance.
+    #[inline]
+    pub fn cached(&self, py: Python<'a>) -> &Py<PyList> {
+        self.cached.get_or_init(|| {
+            PyList::new(py, self.objects.iter().cloned())
+                .unwrap()
+                .into()
+        })
+    }
+
+    /// Gets a reference to the cached Python list, even if not initialized.
+    #[inline]
+    pub fn cached_raw(&self) -> Option<&Py<PyList>> {
+        self.cached.get()
     }
 }

--- a/test/python/circuit/test_circuit_data.py
+++ b/test/python/circuit/test_circuit_data.py
@@ -42,7 +42,7 @@ class TestQuantumCircuitData(QiskitTestCase):
         self.assertEqual(data.qubits, list(qr))
 
         # Test re-adding is disallowed by default.
-        with self.assertRaisesRegex(ValueError, "Existing bit"):
+        with self.assertRaisesRegex(ValueError, "Existing object"):
             data.add_qubit(qr[0])
 
         # Make sure re-adding is allowed in non-strict mode
@@ -58,7 +58,7 @@ class TestQuantumCircuitData(QiskitTestCase):
         self.assertEqual(data.qubits, qubits)
 
         # Test re-adding is disallowed by default.
-        with self.assertRaisesRegex(ValueError, "Existing bit"):
+        with self.assertRaisesRegex(ValueError, "Existing object"):
             data.add_qubit(qubits[0])
 
         # Make sure re-adding is allowed in non-strict mode
@@ -74,7 +74,7 @@ class TestQuantumCircuitData(QiskitTestCase):
         self.assertEqual(data.clbits, list(cr))
 
         # Test re-adding is disallowed by default.
-        with self.assertRaisesRegex(ValueError, "Existing bit"):
+        with self.assertRaisesRegex(ValueError, "Existing object"):
             data.add_clbit(cr[0])
 
         # Make sure re-adding is allowed in non-strict mode
@@ -90,7 +90,7 @@ class TestQuantumCircuitData(QiskitTestCase):
         self.assertEqual(data.clbits, clbits)
 
         # Test re-adding is disallowed by default.
-        with self.assertRaisesRegex(ValueError, "Existing bit"):
+        with self.assertRaisesRegex(ValueError, "Existing object"):
             data.add_clbit(clbits[0])
 
         # Make sure re-adding is allowed in non-strict mode


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This is a quick followup to address `BitData`'s name no longer being aligned with its function, esp. after #13860.

It's now called `ObjectRegistry` and functions the same way. The `VarAsKey` struct has been renamed to `PyObjectAsKey` since it was made public in #13860 and is thus now usable for other purposes. We will likely use it to track `stretch` variables as well.


### Details and comments
* I've removed the restriction that `BitData` (now `ObjectRegistry`) be used only with `ShareableBit`.
* I've moved the bound requirement `IntoPyObject` for `B` from the `ObjectRegistry` impl to its specific cache methods.
* I've also changed the `IntoPyObject` impl for `& PyObjectAsKey` to use `Borrowed` as its output type [as per the PyO3 migration guide](https://pyo3.rs/main/migration.html#intopyobject-manual-implementation).

