### PR TITLE
Minor fix to UnitarySynthesis with RZZ and CZ gates

### DIFF
--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -656,7 +656,8 @@ class TestConsolidateBlocks(QiskitTestCase):
 
     @data(["rzz", "rx", "rz"], ["rzz", "rx", "rz", "cz"])
     def test_collect_and_synthesize_rzz(self, basis_gates):
-        """Collect blocks with RZZ gates, and re-synthesizing it."""
+        """Collect blocks with RZZ gates, and re-synthesizing it.
+        Regression test for https://github.com/Qiskit/qiskit/issues/13428"""
         qc = QuantumCircuit(2)
         qc.rzz(0.1, 0, 1)
         qc.rzz(0.2, 0, 1)

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -664,9 +664,7 @@ class TestConsolidateBlocks(QiskitTestCase):
         res = consolidate_pass(qc)
         self.assertEqual({"unitary": 1}, res.count_ops())
         self.assertEqual(Operator.from_circuit(qc), Operator(res.data[0].operation.params[0]))
-        pm = generate_preset_pass_manager(
-            optimization_level=2, basis_gates=["rz", "rzz", "sx", "x", "rx"]
-        )
+        pm = generate_preset_pass_manager(optimization_level=2, basis_gates=basis_gates)
         tqc = pm.run(qc)
         self.assertEqual(tqc.count_ops()["rzz"], 1)
 

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -655,8 +655,8 @@ class TestConsolidateBlocks(QiskitTestCase):
         self.assertEqual(Operator.from_circuit(qc), Operator(res.data[0].operation.params[0]))
 
     @data(["rzz", "rx", "rz"], ["rzz", "rx", "rz", "cz"])
-    def test_collect_rzz(self, basis_gates):
-        """Collect blocks with RZZ gates."""
+    def test_collect_and_synthesize_rzz(self, basis_gates):
+        """Collect blocks with RZZ gates, and re-synthesizing it."""
         qc = QuantumCircuit(2)
         qc.rzz(0.1, 0, 1)
         qc.rzz(0.2, 0, 1)
@@ -664,6 +664,11 @@ class TestConsolidateBlocks(QiskitTestCase):
         res = consolidate_pass(qc)
         self.assertEqual({"unitary": 1}, res.count_ops())
         self.assertEqual(Operator.from_circuit(qc), Operator(res.data[0].operation.params[0]))
+        pm = generate_preset_pass_manager(
+            optimization_level=2, basis_gates=["rz", "rzz", "sx", "x", "rx"]
+        )
+        tqc = pm.run(qc)
+        self.assertEqual(tqc.count_ops()["rzz"], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This is a minor fix to https://github.com/Qiskit/qiskit/issues/13428#issuecomment-2712715129.
(so no release notes are needed, since it has not been released yet).

### Details and comments

A minor fix following https://github.com/Qiskit/qiskit/issues/13428#issuecomment-2699855434
when the backend has both CZ and RZZ gates, we need to handle first the parametric KAK gate (RZZ) and not the KAK gate (CZ).
