### PR TITLE
Remove: Unnecessary `py` tokens in `InstructionProperties`.

### DIFF
--- a/crates/accelerate/src/target_transpiler/instruction_properties.rs
+++ b/crates/accelerate/src/target_transpiler/instruction_properties.rs
@@ -39,7 +39,7 @@ impl InstructionProperties {
     ///         set of qubits.
     #[new]
     #[pyo3(signature = (duration=None, error=None))]
-    pub fn new(_py: Python<'_>, duration: Option<f64>, error: Option<f64>) -> Self {
+    pub fn new(duration: Option<f64>, error: Option<f64>) -> Self {
         Self { error, duration }
     }
 
@@ -47,13 +47,13 @@ impl InstructionProperties {
         Ok((self.duration, self.error))
     }
 
-    fn __setstate__(&mut self, _py: Python<'_>, state: (Option<f64>, Option<f64>)) -> PyResult<()> {
+    fn __setstate__(&mut self, state: (Option<f64>, Option<f64>)) -> PyResult<()> {
         self.duration = state.0;
         self.error = state.1;
         Ok(())
     }
 
-    fn __repr__(&self, _py: Python<'_>) -> String {
+    fn __repr__(&self) -> String {
         format!(
             "InstructionProperties(duration={}, error={})",
             if let Some(duration) = self.duration {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
The following PR removes some leftover `py` tokens from  a couple of `InstructionProperties` methods in Rust.


### Details and comments


