### PR TITLE
Add missing  `__getitem__` and other attributes to `BitLocations`

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -399,7 +399,7 @@ impl PyBitLocations {
             match index {
                 0 => self.index.into_py_any(py),
                 1 => Ok(self.registers.clone_ref(py).into_any()),
-                _ => Err(PyIndexError::new_err("tuple index out of range")),
+                _ => Err(PyIndexError::new_err("index out of range")),
             }
         };
         if let Ok(index) = index.with_len(2) {
@@ -409,7 +409,7 @@ impl PyBitLocations {
                     .map(|obj| obj.into_any().unbind()),
             }
         } else {
-            Err(PyIndexError::new_err("tuple index out of range"))
+            Err(PyIndexError::new_err("index out of range"))
         }
     }
 

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -34,6 +34,7 @@ use crate::operations::{ArrayType, Operation, OperationRef, Param, PyInstruction
 use crate::packed_instruction::{PackedInstruction, PackedOperation};
 use crate::register_data::RegisterData;
 use crate::rustworkx_core_vnext::isomorphism;
+use crate::slice::PySequenceIndex;
 use crate::{BitType, Clbit, Qubit, TupleLikeArg};
 
 use hashbrown::{HashMap, HashSet};
@@ -343,7 +344,7 @@ fn reject_new_register(reg: &Bound<PyAny>) -> PyResult<()> {
     )))
 }
 
-#[pyclass(name = "BitLocations", module = "qiskit._accelerate.circuit")]
+#[pyclass(name = "BitLocations", module = "qiskit._accelerate.circuit", sequence)]
 #[derive(Clone, Debug)]
 pub struct PyBitLocations {
     #[pyo3(get)]
@@ -391,6 +392,30 @@ impl PyBitLocations {
 
     fn __getnewargs__(slf: Bound<Self>) -> PyResult<(Bound<PyAny>, Bound<PyAny>)> {
         Ok((slf.getattr("index")?, slf.getattr("registers")?))
+    }
+
+    fn __getitem__<'py>(
+        slf: Bound<'py, Self>,
+        index: PySequenceIndex<'py>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let names = [intern!(slf.py(), "index"), intern!(slf.py(), "registers")];
+        if let Ok(index) = index.with_len(2) {
+            match index {
+                crate::slice::SequenceIndex::Int(index) => slf.getattr(names[index]),
+                _ => PyTuple::new(
+                    slf.py(),
+                    index.iter().map(|idx| slf.getattr(names[idx]).unwrap()),
+                )
+                .map(|obj| obj.into_any()),
+            }
+        } else {
+            Err(PyIndexError::new_err("tuple index out of range"))
+        }
+    }
+
+    #[staticmethod]
+    fn __len__() -> usize {
+        2
     }
 }
 

--- a/test/python/circuit/test_circuit_find_bit.py
+++ b/test/python/circuit/test_circuit_find_bit.py
@@ -188,9 +188,13 @@ class TestQuantumCircuitBitLocations(QiskitTestCase):
                 ],
             )
             self.assertEqual(location[0], index)
-            self.assertEqual(location[-1], [(reg, index),])
+            self.assertEqual(
+                location[-1],
+                [
+                    (reg, index),
+                ],
+            )
             self.assertEqual(location[-2], index)
-
 
             # Test index by slice positive range
             self.assertEqual(location[0:], tuple(location))

--- a/test/python/circuit/test_circuit_find_bit.py
+++ b/test/python/circuit/test_circuit_find_bit.py
@@ -167,7 +167,6 @@ class TestQuantumCircuitFindBit(QiskitTestCase):
                 )
 
 
-@ddt
 class TestQuantumCircuitBitLocations(QiskitTestCase):
     """Test cases for BitLocations in the QuantumCircuit."""
 

--- a/test/python/circuit/test_circuit_find_bit.py
+++ b/test/python/circuit/test_circuit_find_bit.py
@@ -172,6 +172,7 @@ class TestQuantumCircuitBitLocations(QiskitTestCase):
     """Test cases for BitLocations in the QuantumCircuit."""
 
     def test_bit_indexable(self):
+        """Tests whether a BitLocations instance can be indexed correctly"""
         qc = QuantumCircuit(5)
         # Retrieve the register this circuit contains
         reg = qc.qregs[0]
@@ -207,10 +208,10 @@ class TestQuantumCircuitBitLocations(QiskitTestCase):
 
             # Test invalid indices
             with self.assertRaisesRegex(IndexError, "out of range"):
-                location[2]
+                return location[2]
             with self.assertRaisesRegex(IndexError, "out of range"):
-                location[-3]
+                return location[-3]
             with self.assertRaisesRegex(IndexError, "out of range"):
-                location[-999999999]
+                return location[-999999999]
             with self.assertRaisesRegex(IndexError, "out of range"):
-                location[999999999]
+                return location[999999999]

--- a/test/python/circuit/test_circuit_find_bit.py
+++ b/test/python/circuit/test_circuit_find_bit.py
@@ -165,3 +165,48 @@ class TestQuantumCircuitFindBit(QiskitTestCase):
                 self.assertEqual(
                     qc.find_bit(bit), (circ_idx, [(reg2, idx), (even_reg, circ_idx // 2)])
                 )
+
+
+@ddt
+class TestQuantumCircuitBitLocations(QiskitTestCase):
+    """Test cases for BitLocations in the QuantumCircuit."""
+
+    def test_bit_indexable(self):
+        qc = QuantumCircuit(5)
+        # Retrieve the register this circuit contains
+        reg = qc.qregs[0]
+
+        # Check that all bits are localizable and that the `BitLocations` instance
+        # can be indexed.
+        for index, bit in enumerate(qc.qubits):
+            location = qc.find_bit(bit)
+            # Test index by integer
+            self.assertEqual(
+                location[1],
+                [
+                    (reg, index),
+                ],
+            )
+            self.assertEqual(location[0], index)
+            self.assertEqual(location[-1], [(reg, index),])
+            self.assertEqual(location[-2], index)
+
+
+            # Test index by slice positive range
+            self.assertEqual(location[0:], tuple(location))
+            self.assertEqual(location[0:9], tuple(location))
+
+            # Test index by slice negative range
+            self.assertEqual(location[::-1], tuple(reversed(location)))
+            self.assertEqual(location[-1::], (location[-1],))
+            self.assertEqual(location[-1:1], ())
+
+            # Test invalid indices
+            with self.assertRaisesRegex(IndexError, "out of range"):
+                location[2]
+            with self.assertRaisesRegex(IndexError, "out of range"):
+                location[-3]
+            with self.assertRaisesRegex(IndexError, "out of range"):
+                location[-999999999]
+            with self.assertRaisesRegex(IndexError, "out of range"):
+                location[999999999]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Fixes #13996

### Summary
We accidentaly removed the capability of indexing a `BitLocation` object. These commits add that functionality back!


### Details and comments
In an oversight after #13860, when switching to use the pyo3 friendly `BitLocations` which is not an instance of `namedtuple` we did not extend it to include sequence methods `__getitem__` and `__len__`, which results in breaking api changes.

The following commits add those methods to `BitLocations` and also labels the class correctly as a `sequence` in PyO3.
