### PR TITLE
Update CS and CSdg in the equivalence library

### DIFF
--- a/qiskit/circuit/library/standard_gates/equivalence_library.py
+++ b/qiskit/circuit/library/standard_gates/equivalence_library.py
@@ -807,38 +807,6 @@ def_sdg = QuantumCircuit(q)
 def_sdg.append(U1Gate(-pi / 2), [q[0]], [])
 _sel.add_equivalence(SdgGate(), def_sdg)
 
-# CSGate
-#
-#                    ┌───┐
-# q_0: ──■──    q_0: ┤ T ├──■───────────■──
-#      ┌─┴─┐         ├───┤┌─┴─┐┌─────┐┌─┴─┐
-# q_1: ┤ S ├ =  q_1: ┤ T ├┤ X ├┤ Tdg ├┤ X ├
-#      └───┘         └───┘└───┘└─────┘└───┘
-q = QuantumRegister(2, "q")
-def_cs = QuantumCircuit(q)
-def_cs.append(TGate(), [q[0]], [])
-def_cs.append(TGate(), [q[1]], [])
-def_cs.append(CXGate(), [q[0], q[1]], [])
-def_cs.append(TdgGate(), [q[1]], [])
-def_cs.append(CXGate(), [q[0], q[1]], [])
-_sel.add_equivalence(CSGate(), def_cs)
-
-# CSdgGate
-#
-#                                     ┌─────┐
-# q_0: ───■───    q_0: ──■─────────■──┤ Tdg ├
-#      ┌──┴──┐         ┌─┴─┐┌───┐┌─┴─┐├─────┤
-# q_1: ┤ Sdg ├ =  q_1: ┤ X ├┤ T ├┤ X ├┤ Tdg ├
-#      └─────┘         └───┘└───┘└───┘└─────┘
-q = QuantumRegister(2, "q")
-def_csdg = QuantumCircuit(q)
-def_csdg.append(CXGate(), [q[0], q[1]], [])
-def_csdg.append(TGate(), [q[1]], [])
-def_csdg.append(CXGate(), [q[0], q[1]], [])
-def_csdg.append(TdgGate(), [q[0]], [])
-def_csdg.append(TdgGate(), [q[1]], [])
-_sel.add_equivalence(CSdgGate(), def_csdg)
-
 # SdgGate
 #
 #    ┌─────┐        ┌───┐┌───┐
@@ -881,6 +849,65 @@ for inst, qargs, cargs in [
 ]:
     def_sdg.append(inst, qargs, cargs)
 _sel.add_equivalence(SdgGate(), def_sdg)
+
+# CSGate
+#
+#                    ┌───┐
+# q_0: ──■──    q_0: ┤ T ├──■───────────■──
+#      ┌─┴─┐         ├───┤┌─┴─┐┌─────┐┌─┴─┐
+# q_1: ┤ S ├ =  q_1: ┤ T ├┤ X ├┤ Tdg ├┤ X ├
+#      └───┘         └───┘└───┘└─────┘└───┘
+q = QuantumRegister(2, "q")
+def_cs = QuantumCircuit(q)
+def_cs.append(TGate(), [q[0]], [])
+def_cs.append(TGate(), [q[1]], [])
+def_cs.append(CXGate(), [q[0], q[1]], [])
+def_cs.append(TdgGate(), [q[1]], [])
+def_cs.append(CXGate(), [q[0], q[1]], [])
+_sel.add_equivalence(CSGate(), def_cs)
+
+# CSGate
+#
+# q_0: ──■──   q_0: ───────■────────
+#      ┌─┴─┐        ┌───┐┌─┴──┐┌───┐
+# q_1: ┤ S ├ = q_1: ┤ H ├┤ Sx ├┤ H ├
+#      └───┘        └───┘└────┘└───┘
+q = QuantumRegister(2, "q")
+def_cs_csx = QuantumCircuit(q)
+def_cs_csx.append(HGate(), [q[1]], [])
+def_cs_csx.append(CSXGate(), [q[0], q[1]], [])
+def_cs_csx.append(HGate(), [q[1]], [])
+_sel.add_equivalence(CSGate(), def_cs_csx)
+
+# CSdgGate
+#
+#                                     ┌─────┐
+# q_0: ───■───    q_0: ──■─────────■──┤ Tdg ├
+#      ┌──┴──┐         ┌─┴─┐┌───┐┌─┴─┐├─────┤
+# q_1: ┤ Sdg ├ =  q_1: ┤ X ├┤ T ├┤ X ├┤ Tdg ├
+#      └─────┘         └───┘└───┘└───┘└─────┘
+q = QuantumRegister(2, "q")
+def_csdg = QuantumCircuit(q)
+def_csdg.append(CXGate(), [q[0], q[1]], [])
+def_csdg.append(TGate(), [q[1]], [])
+def_csdg.append(CXGate(), [q[0], q[1]], [])
+def_csdg.append(TdgGate(), [q[0]], [])
+def_csdg.append(TdgGate(), [q[1]], [])
+_sel.add_equivalence(CSdgGate(), def_csdg)
+
+# CSdgGate
+#
+# q_0: ───■───   q_0: ───────■────■────────
+#      ┌──┴──┐        ┌───┐┌─┴─┐┌─┴──┐┌───┐
+# q_1: ┤ Sdg ├ = q_1: ┤ H ├┤ X ├┤ Sx ├┤ H ├
+#      └─────┘        └───┘└───┘└────┘└───┘
+q = QuantumRegister(2, "q")
+def_csdg_csx = QuantumCircuit(q)
+def_csdg_csx.append(HGate(), [q[1]], [])
+def_csdg_csx.append(CXGate(), [q[0], q[1]], [])
+def_csdg_csx.append(CSXGate(), [q[0], q[1]], [])
+def_csdg_csx.append(HGate(), [q[1]], [])
+_sel.add_equivalence(CSdgGate(), def_csdg_csx)
 
 # SwapGate
 #                        ┌───┐

--- a/qiskit/circuit/library/standard_gates/equivalence_library.py
+++ b/qiskit/circuit/library/standard_gates/equivalence_library.py
@@ -809,29 +809,34 @@ _sel.add_equivalence(SdgGate(), def_sdg)
 
 # CSGate
 #
-# q_0: ──■──   q_0: ───────■────────
-#      ┌─┴─┐        ┌───┐┌─┴──┐┌───┐
-# q_1: ┤ S ├ = q_1: ┤ H ├┤ Sx ├┤ H ├
-#      └───┘        └───┘└────┘└───┘
+#                    ┌───┐
+# q_0: ──■──    q_0: ┤ T ├──■───────────■──
+#      ┌─┴─┐         ├───┤┌─┴─┐┌─────┐┌─┴─┐
+# q_1: ┤ S ├ =  q_1: ┤ T ├┤ X ├┤ Tdg ├┤ X ├
+#      └───┘         └───┘└───┘└─────┘└───┘
 q = QuantumRegister(2, "q")
 def_cs = QuantumCircuit(q)
-def_cs.append(HGate(), [q[1]], [])
-def_cs.append(CSXGate(), [q[0], q[1]], [])
-def_cs.append(HGate(), [q[1]], [])
+def_cs.append(TGate(), [q[0]], [])
+def_cs.append(TGate(), [q[1]], [])
+def_cs.append(CXGate(), [q[0], q[1]], [])
+def_cs.append(TdgGate(), [q[1]], [])
+def_cs.append(CXGate(), [q[0], q[1]], [])
 _sel.add_equivalence(CSGate(), def_cs)
 
 # CSdgGate
 #
-# q_0: ───■───   q_0: ───────■────■────────
-#      ┌──┴──┐        ┌───┐┌─┴─┐┌─┴──┐┌───┐
-# q_1: ┤ Sdg ├ = q_1: ┤ H ├┤ X ├┤ Sx ├┤ H ├
-#      └─────┘        └───┘└───┘└────┘└───┘
+#                                     ┌─────┐
+# q_0: ───■───    q_0: ──■─────────■──┤ Tdg ├
+#      ┌──┴──┐         ┌─┴─┐┌───┐┌─┴─┐├─────┤
+# q_1: ┤ Sdg ├ =  q_1: ┤ X ├┤ T ├┤ X ├┤ Tdg ├
+#      └─────┘         └───┘└───┘└───┘└─────┘
 q = QuantumRegister(2, "q")
 def_csdg = QuantumCircuit(q)
-def_csdg.append(HGate(), [q[1]], [])
 def_csdg.append(CXGate(), [q[0], q[1]], [])
-def_csdg.append(CSXGate(), [q[0], q[1]], [])
-def_csdg.append(HGate(), [q[1]], [])
+def_csdg.append(TGate(), [q[1]], [])
+def_csdg.append(CXGate(), [q[0], q[1]], [])
+def_csdg.append(TdgGate(), [q[0]], [])
+def_csdg.append(TdgGate(), [q[1]], [])
 _sel.add_equivalence(CSdgGate(), def_csdg)
 
 # SdgGate

--- a/releasenotes/notes/update-cs-csdg-in-equivalence-library-c1e70d3246f4aa6d.yaml
+++ b/releasenotes/notes/update-cs-csdg-in-equivalence-library-c1e70d3246f4aa6d.yaml
@@ -1,7 +1,7 @@
 ---
 features_synthesis:
   - |
-    Add more equivalences to :class:`.CSGate` and :class:`.CSdgGate` in the equivalence library.
-    Previously, the basis translator used 3 :class:`.CXGate` gates for the synthesis of
-    :class:`.CSdgGate` and now it uses only two :class:`.CXGate`.
-    For both gates we reduce the number of single-qubit gates in their basis translation.
+    The standard equivalence library has additional equivalences for :class:`.CSGate` and :class:`.CSdgGate`.
+    When transpiling to the `["cx", "u"]` basis set, the :class:`.BasisTranslator` transpiler pass now uses
+    2  :class:`.CXGate` gates instead of 3 for :class:`.CSdgGate`, and in addition reduces the number of single-qubit
+    gates in both cases.

--- a/releasenotes/notes/update-cs-csdg-in-equivalence-library-c1e70d3246f4aa6d.yaml
+++ b/releasenotes/notes/update-cs-csdg-in-equivalence-library-c1e70d3246f4aa6d.yaml
@@ -1,5 +1,5 @@
 ---
-upgrades_synthesis:
+upgrade_synthesis:
   - |
     Update the synthesis of :class:`.CSGate` and :class:`.CSdgGate` in the equivalence library.
     Previously, the basis translator used 3 :class:`.CXGate` gates for the synthesis of

--- a/releasenotes/notes/update-cs-csdg-in-equivalence-library-c1e70d3246f4aa6d.yaml
+++ b/releasenotes/notes/update-cs-csdg-in-equivalence-library-c1e70d3246f4aa6d.yaml
@@ -1,7 +1,7 @@
 ---
-upgrade_synthesis:
+features_synthesis:
   - |
-    Update the synthesis of :class:`.CSGate` and :class:`.CSdgGate` in the equivalence library.
+    Add more equivalences to :class:`.CSGate` and :class:`.CSdgGate` in the equivalence library.
     Previously, the basis translator used 3 :class:`.CXGate` gates for the synthesis of
     :class:`.CSdgGate` and now it uses only two :class:`.CXGate`.
     For both gates we reduce the number of single-qubit gates in their basis translation.

--- a/releasenotes/notes/update-cs-csdg-in-equivalence-library-c1e70d3246f4aa6d.yaml
+++ b/releasenotes/notes/update-cs-csdg-in-equivalence-library-c1e70d3246f4aa6d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Update the synthesis of :class:`.CSGate` and :class:`.CSdgGate` in the equivalence library
+    so that the basis translator will use only two :class:`.CXGate`s for their synthesis and not 3.

--- a/releasenotes/notes/update-cs-csdg-in-equivalence-library-c1e70d3246f4aa6d.yaml
+++ b/releasenotes/notes/update-cs-csdg-in-equivalence-library-c1e70d3246f4aa6d.yaml
@@ -1,5 +1,7 @@
 ---
-fixes:
+upgrades_synthesis:
   - |
-    Update the synthesis of :class:`.CSGate` and :class:`.CSdgGate` in the equivalence library
-    so that the basis translator will use only two :class:`.CXGate`s for their synthesis and not 3.
+    Update the synthesis of :class:`.CSGate` and :class:`.CSdgGate` in the equivalence library.
+    Previously, the basis translator used 3 :class:`.CXGate` gates for the synthesis of
+    :class:`.CSdgGate` and now it uses only two :class:`.CXGate`.
+    For both gates we reduce the number of single-qubit gates in their basis translation.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Update the synthesis of `CS` and `CSdg` in the equivalence library, so that the basis translator will use 2 CX gates for their synthesis and not 3 (a relevant test with `CX` counts should be updated as part of #13961 )


### Details and comments
The current translation (optimization_level=0) of `CS` looks like:
```
     ┌────────────┐                                                     »
q_0: ┤ U(0,0,π/4) ├────────────────■───────────────────■────────────────»
     ├────────────┤┌────────────┐┌─┴─┐┌─────────────┐┌─┴─┐┌────────────┐»
q_1: ┤ U(π/2,0,π) ├┤ U(π/2,0,π) ├┤ X ├┤ U(0,0,-π/4) ├┤ X ├┤ U(0,0,π/4) ├»
     └────────────┘└────────────┘└───┘└─────────────┘└───┘└────────────┘»
«                                 
«q_0: ────────────────────────────
«     ┌────────────┐┌────────────┐
«q_1: ┤ U(π/2,0,π) ├┤ U(π/2,0,π) ├
«     └────────────┘└────────────┘
```

and for `CSdg` it looks like (with 3 `CX` gates):
```
                        ┌────────────┐                                       »
q_0: ────────────────■──┤ U(0,0,π/4) ├──■───────────────────■────────────────»
     ┌────────────┐┌─┴─┐├────────────┤┌─┴─┐┌─────────────┐┌─┴─┐┌────────────┐»
q_1: ┤ U(π/2,0,π) ├┤ X ├┤ U(π/2,0,π) ├┤ X ├┤ U(0,0,-π/4) ├┤ X ├┤ U(0,0,π/4) ├»
     └────────────┘└───┘└────────────┘└───┘└─────────────┘└───┘└────────────┘»
«                                 
«q_0: ────────────────────────────
«     ┌────────────┐┌────────────┐
«q_1: ┤ U(π/2,0,π) ├┤ U(π/2,0,π) ├
«     └────────────┘└────────────┘
```

After this PR, the translation (optimization_level=0) of `CS` should look like:
```
     ┌────────────┐                         
q_0: ┤ U(0,0,π/4) ├──■───────────────────■──
     ├────────────┤┌─┴─┐┌─────────────┐┌─┴─┐
q_1: ┤ U(0,0,π/4) ├┤ X ├┤ U(0,0,-π/4) ├┤ X ├
     └────────────┘└───┘└─────────────┘└───┘
```
and for `CSdg` it should look like (with only 2 `CX` gates):
 ```
                              ┌─────────────┐
q_0: ──■──────────────────■──┤ U(0,0,-π/4) ├
      ┌─┴─┐┌────────────┐┌─┴─┐├─────────────┤
q_1: ┤ X ├┤ U(0,0,π/4) ├┤ X ├┤ U(0,0,-π/4) ├
      └───┘└────────────┘└───┘└─────────────┘
```