### PR TITLE
Create a secure internal path for custom prefixes in registers.

### DIFF
--- a/crates/circuit/src/bit.rs
+++ b/crates/circuit/src/bit.rs
@@ -771,6 +771,25 @@ macro_rules! create_bit_object {
                 })
             }
 
+            /// Allows for the creation of a new register with a provisional prefix and the
+            /// same instance counter.
+            #[pyo3(signature=(size=None, name=None, bits=None))]
+            #[staticmethod]
+            fn _new_with_prefix(
+                py: Python,
+                size: Option<isize>,
+                name: Option<String>,
+                bits: Option<Vec<$bit_struct>>,
+            ) -> PyResult<Py<Self>> {
+                let name =
+                    format!(
+                        "{}{}",
+                        name.unwrap_or(Self::prefix().to_string()),
+                        $reg_struct::anonymous_instance_count().fetch_add(1, Ordering::Relaxed)
+                    );
+                Py::new(py, Self::py_new(size, Some(name), bits)?)
+            }
+
             #[classattr]
             fn prefix() -> &'static str {
                 $pyreg_prefix

--- a/crates/circuit/src/bit.rs
+++ b/crates/circuit/src/bit.rs
@@ -771,7 +771,7 @@ macro_rules! create_bit_object {
                 })
             }
 
-            /// Allows for the creation of a new register with a provisional prefix and the
+            /// Allows for the creation of a new register with a temporary prefix and the
             /// same instance counter.
             #[pyo3(signature=(size=None, name=None, bits=None))]
             #[staticmethod]

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3889,7 +3889,7 @@ class QuantumCircuit:
     def _create_creg(self, length: int, name: str) -> ClassicalRegister:
         """Creates a creg, checking if ClassicalRegister with same name exists"""
         if name in [creg.name for creg in self.cregs]:
-            new_creg = ClassicalRegister(length, name=f"{name}{ClassicalRegister.instance_count}")
+            new_creg = ClassicalRegister._new_with_prefix(length, name)
         else:
             new_creg = ClassicalRegister(length, name)
         return new_creg
@@ -3897,7 +3897,7 @@ class QuantumCircuit:
     def _create_qreg(self, length: int, name: str) -> QuantumRegister:
         """Creates a qreg, checking if QuantumRegister with same name exists"""
         if name in [qreg.name for qreg in self.qregs]:
-            new_qreg = QuantumRegister(length, name=f"{name}{QuantumRegister.instance_count}")
+            new_qreg = QuantumRegister._new_with_prefix(length, name)
         else:
             new_qreg = QuantumRegister(length, name)
         return new_qreg

--- a/qiskit/transpiler/passes/layout/full_ancilla_allocation.py
+++ b/qiskit/transpiler/passes/layout/full_ancilla_allocation.py
@@ -92,9 +92,8 @@ class FullAncillaAllocation(AnalysisPass):
 
         if idle_physical_qubits:
             if self.ancilla_name in dag.qregs:
-                qreg = QuantumRegister(
-                    len(idle_physical_qubits),
-                    name=f"{self.ancilla_name}{QuantumRegister.instances_count + 1}",
+                qreg = QuantumRegister._new_with_prefix(
+                    len(idle_physical_qubits), self.ancilla_name
                 )
             else:
                 qreg = QuantumRegister(len(idle_physical_qubits), name=self.ancilla_name)

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -867,7 +867,7 @@ class TestCircuitOperations(QiskitTestCase):
         # Second call should also create a new register
         circuit.measure_all()
         self.assertEqual(len(circuit.cregs), 2)  # Now two cregs
-        self.assertTrue(all(circuit.cregs), lambda reg: len(reg) == 1)  # All of length 1
+        self.assertTrue(all(len(reg) == 1 for reg in circuit.cregs))  # All of length 1
         # Check that no name is the same
         self.assertEqual(len(set([reg.name for reg in circuit.cregs])), 2)
 

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -869,14 +869,14 @@ class TestCircuitOperations(QiskitTestCase):
         self.assertEqual(len(circuit.cregs), 2)  # Now two cregs
         self.assertTrue(all(len(reg) == 1 for reg in circuit.cregs))  # All of length 1
         # Check that no name is the same
-        self.assertEqual(len(set(reg.name for reg in circuit.cregs)), 2)
+        self.assertEqual(len({reg.name for reg in circuit.cregs}), 2)
 
         # Third call should also create a new register
         circuit.measure_all()
         self.assertEqual(len(circuit.cregs), 3)  # Now two cregs
         self.assertTrue(all(len(reg) == 1 for reg in circuit.cregs))  # All of length 1
         # Check that no name is the same
-        self.assertEqual(len(set(reg.name for reg in circuit.cregs)), 3)
+        self.assertEqual(len({reg.name for reg in circuit.cregs}), 3)
 
     def test_remove_final_measurements(self):
         """Test remove_final_measurements

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -873,7 +873,7 @@ class TestCircuitOperations(QiskitTestCase):
 
         # Third call should also create a new register
         circuit.measure_all()
-        self.assertEqual(len(circuit.cregs), 3)  # Now two cregs
+        self.assertEqual(len(circuit.cregs), 3)  # Now three cregs
         self.assertTrue(all(len(reg) == 1 for reg in circuit.cregs))  # All of length 1
         # Check that no name is the same
         self.assertEqual(len({reg.name for reg in circuit.cregs}), 3)

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -852,6 +852,32 @@ class TestCircuitOperations(QiskitTestCase):
         self.assertEqual(len(circuit.cregs[0]), 2)  # Both length 2
         self.assertEqual(len(circuit.cregs[1]), 2)
 
+    def test_measure_all_with_multiple_regs_creation(self):
+        """Test measure_all in a circuit where the method is called
+        multiple times consecutively, and checks that a register of
+        a different name is created on each call."""
+
+        circuit = QuantumCircuit(1)
+
+        # First call should create a new register
+        circuit.measure_all()
+        self.assertEqual(len(circuit.cregs), 1)  # One creg
+        self.assertEqual(len(circuit.cregs[0]), 1)  # Of length 1
+
+        # Second call should also create a new register
+        circuit.measure_all()
+        self.assertEqual(len(circuit.cregs), 2)  # Now two cregs
+        self.assertTrue(all(circuit.cregs), lambda reg: len(reg) == 1)  # All of length 1
+        # Check that no name is the same
+        self.assertEqual(len(set([reg.name for reg in circuit.cregs])), 2)
+
+        # Third call should also create a new register
+        circuit.measure_all()
+        self.assertEqual(len(circuit.cregs), 3)  # Now two cregs
+        self.assertTrue(all(circuit.cregs), lambda reg: len(reg) == 1)  # All of length 1
+        # Check that no name is the same
+        self.assertEqual(len(set([reg.name for reg in circuit.cregs])), 3)
+
     def test_remove_final_measurements(self):
         """Test remove_final_measurements
         Removes all measurements at end of circuit.

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -854,7 +854,7 @@ class TestCircuitOperations(QiskitTestCase):
 
     def test_measure_all_with_multiple_regs_creation(self):
         """Test measure_all in a circuit where the method is called
-        multiple times consecutively, and checks that a register of
+        multiple times consecutively and checks that a register of
         a different name is created on each call."""
 
         circuit = QuantumCircuit(1)
@@ -869,14 +869,14 @@ class TestCircuitOperations(QiskitTestCase):
         self.assertEqual(len(circuit.cregs), 2)  # Now two cregs
         self.assertTrue(all(len(reg) == 1 for reg in circuit.cregs))  # All of length 1
         # Check that no name is the same
-        self.assertEqual(len(set([reg.name for reg in circuit.cregs])), 2)
+        self.assertEqual(len(set(reg.name for reg in circuit.cregs)), 2)
 
         # Third call should also create a new register
         circuit.measure_all()
         self.assertEqual(len(circuit.cregs), 3)  # Now two cregs
-        self.assertTrue(all(circuit.cregs), lambda reg: len(reg) == 1)  # All of length 1
+        self.assertTrue(all(len(reg) == 1 for reg in circuit.cregs))  # All of length 1
         # Check that no name is the same
-        self.assertEqual(len(set([reg.name for reg in circuit.cregs])), 3)
+        self.assertEqual(len(set(reg.name for reg in circuit.cregs)), 3)
 
     def test_remove_final_measurements(self):
         """Test remove_final_measurements


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
The following commits add the internal method `_new_with_prefix`, which allows for the one-time replacement of the set prefix name and use of the same instance counter.

### Details and comments
Prior implementations would replace the `Register`'s prefix attribute in place which is an unsafe operation. The following commits add a secure path for a provisional replacement of a register's prefix name to fix changed unsafe behavior from #13860 and attempts to fix #14003.