### PR TITLE
[Stretch] Don't reject non-const duration in constructors.

### DIFF
--- a/qiskit/circuit/classical/expr/constructors.py
+++ b/qiskit/circuit/classical/expr/constructors.py
@@ -683,16 +683,8 @@ Duration())
         left = _coerce_lossless(left, type)
         right = _coerce_lossless(right, type)
     elif left.type.kind is types.Duration and right.type.kind in {types.Uint, types.Float}:
-        if not right.const:
-            raise ValueError(
-                f"multiplying operands '{left}' and '{right}' would result in a non-const '{left.type}'"
-            )
         type = left.type
     elif right.type.kind is types.Duration and left.type.kind in {types.Uint, types.Float}:
-        if not left.const:
-            raise ValueError(
-                f"multiplying operands '{left}' and '{right}' would result in a non-const '{right.type}'"
-            )
         type = right.type
     else:
         raise TypeError(f"invalid types for '{Binary.Op.MUL}': '{left.type}' and '{right.type}'")
@@ -761,10 +753,6 @@ Duration())
             left = _coerce_lossless(left, type)
             right = _coerce_lossless(right, type)
     elif left.type.kind is types.Duration and right.type.kind in {types.Uint, types.Float}:
-        if not right.const:
-            raise ValueError(
-                f"division of '{left}' and '{right}' would result in a non-const '{left.type}'"
-            )
         type = left.type
     else:
         raise TypeError(f"invalid types for '{Binary.Op.DIV}': '{left.type}' and '{right.type}'")

--- a/test/python/circuit/classical/test_expr_constructors.py
+++ b/test/python/circuit/classical/test_expr_constructors.py
@@ -808,13 +808,6 @@ class TestExprConstructors(QiskitTestCase):
         with self.assertRaisesRegex(TypeError, "cannot multiply two durations"):
             expr.mul(Duration.dt(1000), Duration.dt(1000))
 
-        # Multiply timing expressions by non-const floats:
-        non_const_float = expr.Var.new("a", types.Float())
-        with self.assertRaisesRegex(ValueError, "would result in a non-const"):
-            expr.mul(Duration.dt(1000), non_const_float)
-        with self.assertRaisesRegex(ValueError, "would result in a non-const"):
-            expr.mul(non_const_float, Duration.dt(1000))
-
     def test_div_explicit(self):
         cr = ClassicalRegister(8, "c")
 
@@ -924,8 +917,3 @@ class TestExprConstructors(QiskitTestCase):
             expr.div(255.0, 1)
         with self.assertRaisesRegex(TypeError, "invalid types"):
             expr.div(255.0, Duration.dt(1000))
-
-        # Divide timing expressions by non-const floats:
-        non_const_float = expr.Var.new("a", types.Float())
-        with self.assertRaisesRegex(ValueError, "would result in a non-const"):
-            expr.div(Duration.dt(1000), non_const_float)


### PR DESCRIPTION




<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Originally, I thought it'd make the most sense to reject construction of operations that'd have a duration type but also be non-const expressions. But, a user can currently create a `Var` with a duration type, so this seems like an incomplete restriction.


### Details and comments

Consider this PR more of a suggestion—perhaps it makes more sense to also block construction of `Var` when the type is `Duration`. Either way, I think we should decide on this before 2.0.0.
