### PR TITLE
Fix dagger symbol in `RGate` API documentation

### DIFF
--- a/qiskit/circuit/library/standard_gates/r.py
+++ b/qiskit/circuit/library/standard_gates/r.py
@@ -79,7 +79,7 @@ class RGate(Gate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Invert this gate as: :math:`R(θ, φ)^{\dagger} = R(-θ, φ)`
+        r"""Invert this gate as: :math:`R(θ, φ)^{\dagger} = R(-θ, φ)`
 
         Args:
             annotated: when set to ``True``, this is typically used to return an

--- a/qiskit/circuit/library/standard_gates/r.py
+++ b/qiskit/circuit/library/standard_gates/r.py
@@ -79,7 +79,7 @@ class RGate(Gate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Invert this gate as: :math:`r(θ, φ)^dagger = r(-θ, φ)`
+        """Invert this gate as: :math:`r(θ, φ)^{\dagger} = r(-θ, φ)`
 
         Args:
             annotated: when set to ``True``, this is typically used to return an

--- a/qiskit/circuit/library/standard_gates/r.py
+++ b/qiskit/circuit/library/standard_gates/r.py
@@ -79,7 +79,7 @@ class RGate(Gate):
         self.definition = qc
 
     def inverse(self, annotated: bool = False):
-        """Invert this gate as: :math:`r(θ, φ)^{\dagger} = r(-θ, φ)`
+        """Invert this gate as: :math:`R(θ, φ)^{\dagger} = R(-θ, φ)`
 
         Args:
             annotated: when set to ``True``, this is typically used to return an


### PR DESCRIPTION
### Summary

The dagger symbol in the equation at `inverse()` is displayed as a "dagger" text with a superscript "d", because of a missing backslash.

### Details and comments

Screenshot showing the problem:
![grafik](https://github.com/user-attachments/assets/1706aad9-8993-4d0c-aac3-976b8bf589ea)
