### PR TITLE
Try building aarch64 wheels with Rust 1.83

### DIFF
--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -102,7 +102,7 @@ jobs:
           mkdir -p "$PGO_WORK_DIR"
           if [[ `uname -m` == "aarch64" ]] ; then
               INSTALL_RUST_PATH=tools/install_rust_msrv.sh
-              RUST_TOOLCHAIN=1.79
+              RUST_TOOLCHAIN=1.83
           else
               INSTALL_RUST_PATH=tools/install_rust.sh
               RUST_TOOLCHAIN=stable

--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -102,7 +102,7 @@ jobs:
           mkdir -p "$PGO_WORK_DIR"
           if [[ `uname -m` == "aarch64" ]] ; then
               INSTALL_RUST_PATH=tools/install_rust_msrv.sh
-              RUST_TOOLCHAIN=1.82
+              RUST_TOOLCHAIN=1.81
           else
               INSTALL_RUST_PATH=tools/install_rust.sh
               RUST_TOOLCHAIN=stable

--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -102,7 +102,7 @@ jobs:
           mkdir -p "$PGO_WORK_DIR"
           if [[ `uname -m` == "aarch64" ]] ; then
               INSTALL_RUST_PATH=tools/install_rust_msrv.sh
-              RUST_TOOLCHAIN=1.83
+              RUST_TOOLCHAIN=1.82
           else
               INSTALL_RUST_PATH=tools/install_rust.sh
               RUST_TOOLCHAIN=stable

--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -102,7 +102,7 @@ jobs:
           mkdir -p "$PGO_WORK_DIR"
           if [[ `uname -m` == "aarch64" ]] ; then
               INSTALL_RUST_PATH=tools/install_rust_msrv.sh
-              RUST_TOOLCHAIN=1.81
+              RUST_TOOLCHAIN=1.80
           else
               INSTALL_RUST_PATH=tools/install_rust.sh
               RUST_TOOLCHAIN=stable

--- a/tools/install_rust_msrv.sh
+++ b/tools/install_rust_msrv.sh
@@ -3,7 +3,7 @@ if [ ! -d rust-installer ]; then
     mkdir rust-installer
     wget https://sh.rustup.rs -O rust-installer/rustup.sh
     sh rust-installer/rustup.sh -y -c llvm-tools
-    rustup default 1.81
+    rustup default 1.80
     rustup component add llvm-tools
     rustup uninstall stable
 fi

--- a/tools/install_rust_msrv.sh
+++ b/tools/install_rust_msrv.sh
@@ -3,7 +3,7 @@ if [ ! -d rust-installer ]; then
     mkdir rust-installer
     wget https://sh.rustup.rs -O rust-installer/rustup.sh
     sh rust-installer/rustup.sh -y -c llvm-tools
-    rustup default 1.79
+    rustup default 1.83
     rustup component add llvm-tools
     rustup uninstall stable
 fi

--- a/tools/install_rust_msrv.sh
+++ b/tools/install_rust_msrv.sh
@@ -3,7 +3,7 @@ if [ ! -d rust-installer ]; then
     mkdir rust-installer
     wget https://sh.rustup.rs -O rust-installer/rustup.sh
     sh rust-installer/rustup.sh -y -c llvm-tools
-    rustup default 1.83
+    rustup default 1.82
     rustup component add llvm-tools
     rustup uninstall stable
 fi

--- a/tools/install_rust_msrv.sh
+++ b/tools/install_rust_msrv.sh
@@ -3,7 +3,7 @@ if [ ! -d rust-installer ]; then
     mkdir rust-installer
     wget https://sh.rustup.rs -O rust-installer/rustup.sh
     sh rust-installer/rustup.sh -y -c llvm-tools
-    rustup default 1.82
+    rustup default 1.81
     rustup component add llvm-tools
     rustup uninstall stable
 fi


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit attempts to build the aarch64 linux wheels with rust 1.83. When we made aarch64 linux a tier 1 supported platform #13737 there were packaging issues with the official distrubtions for Rust 1.85 and 1.84 on the platform which were preventing PGO builds from succeeding. At the time we we determined that our MSRV of 1.79 was able to build successfully. However, during the 2.0.0rc1 pre-release the wheel build job failed because of reported LLVM bug when combining LTO and PGO which we do for the release jobs. Local debugging determined these errors should be been fixed if built with Rust 1.85. Since we know we're not able to build with Rust 1.85 or 1.84 this commit tries building with 1.83 to see if this can work. If this does not work, follow up commits will walk backwards to see if 1.82, 1.81, or 1.80 can build successfully with LTO+PGO.

### Details and comments

Related to: #13983