### PR TITLE
Fix new clippy warnings from Rust 1.85

### DIFF
--- a/crates/accelerate/src/sparse_observable/mod.rs
+++ b/crates/accelerate/src/sparse_observable/mod.rs
@@ -2467,7 +2467,7 @@ impl PySparseObservable {
                     "if using the sparse-list form, 'num_qubits' must be provided",
                 ));
             };
-            return Self::from_sparse_list(vec, num_qubits).map_err(PyErr::from);
+            return Self::from_sparse_list(vec, num_qubits);
         }
         if let Ok(term) = data.downcast_exact::<PySparseTerm>() {
             return term.borrow().to_observable();
@@ -2638,7 +2638,7 @@ impl PySparseObservable {
         for (i, (x, z)) in x.as_array().iter().zip(z.as_array().iter()).enumerate() {
             // The only failure case possible here is the identity, because of how we're
             // constructing the value to convert.
-            let Ok(term) = ::bytemuck::checked::try_cast((*x as u8) << 1 | (*z as u8)) else {
+            let Ok(term) = ::bytemuck::checked::try_cast(((*x as u8) << 1) | (*z as u8)) else {
                 continue;
             };
             num_ys += (term == BitTerm::Y) as isize;
@@ -3018,7 +3018,7 @@ impl PySparseObservable {
             for (i, (x, z)) in term_x.iter().zip(term_z.iter()).enumerate() {
                 // The only failure case possible here is the identity, because of how we're
                 // constructing the value to convert.
-                let Ok(term) = ::bytemuck::checked::try_cast((*x as u8) << 1 | (*z as u8)) else {
+                let Ok(term) = ::bytemuck::checked::try_cast(((*x as u8) << 1) | (*z as u8)) else {
                     continue;
                 };
                 indices.push(i as u32);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The recently release Rust 1.85 introduced some new clippy rules that are triggering warnings in the Qiskit Rust code. This commit fixes the warnings flagged by these new rules.

### Details and comments