### PR TITLE
[PoC] Reduce the number of reshapes to improve Statevector performance

### DIFF
--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -875,22 +875,16 @@ class Statevector(QuantumState, TolerancesMixin):
         axes = indices + [i for i in range(num_qargs) if i not in indices]
         axes_inv = np.argsort(axes).tolist()
 
-        # Calculate contraction dimensions
-        contract_dim = oper._op_shape.shape[1]
-        contract_shape = (contract_dim, statevec._op_shape.shape[0] // contract_dim)
-
         # Reshape and transpose input array for contraction
         tensor = np.transpose(
             np.reshape(statevec.data, statevec._op_shape.tensor_shape),
             axes,
         )
-        tensor_shape = tensor.shape
 
         # Perform contraction
-        tensor = np.reshape(
-            np.dot(oper.data, np.reshape(tensor, contract_shape)),
-            tensor_shape,
-        )
+        oper_tensor = oper.data.reshape(oper._op_shape.tensor_shape)
+        axes = oper_tensor.ndim // 2
+        tensor = np.tensordot(oper_tensor, tensor, axes=axes)
 
         # Transpose back to  original subsystem spec and flatten
         statevec._data = np.reshape(np.transpose(tensor, axes_inv), new_shape.shape[0])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

This PR is a PoC to study the performance issue to resolve #14028.
This is made for discussion.

- Added `flatten` option to control the flatten operation in `Statevector. _evolve_operator `
  - Changed to apply flatten only at the beginning and the end of `Statevector._evolve_instruction`
- Simplified the contraction with `np.tensordot`
  - It does not have any performance improvement though


### Details and comments

```python
import timeit

import numpy as np
from qiskit import __version__ as qiskit_vesrion
from qiskit.circuit.library import EfficientSU2
from qiskit.quantum_info import Statevector

print(f"{qiskit_vesrion=}")

n_qubits = 18

qiskit_circuit = EfficientSU2(n_qubits, entanglement="pairwise", reps=n_qubits)
qiskit_circuit.assign_parameters(np.ones(qiskit_circuit.num_parameters), inplace=True)

number = 1
execution_time = timeit.timeit(lambda: Statevector(qiskit_circuit), number=number)
print(f"Average execution time: {execution_time / number:.6f} seconds")
```

main branch a6d6584
```
qiskit_vesrion='2.1.0.dev0+a6d6584'
Average execution time: 1.764300 seconds
```

this PR
```
qiskit_vesrion='2.1.0.dev0+313d92d'
Average execution time: 1.373686 seconds
```