### PR TITLE
MSVC complex number support in `qiskit.h`

### DIFF
--- a/crates/cext/cbindgen.toml
+++ b/crates/cext/cbindgen.toml
@@ -7,9 +7,14 @@ after_includes = """
 #endif
 
 // Complex number typedefs -- note these are memory aligned but
-// not calling convention compatible.
+// not calling convention compatible. 
+#ifdef _MSC_VER
+typedef _Fcomplex QkComplex32;
+typedef _Dcomplex QkComplex64;
+#else
 typedef float complex QkComplex32;
 typedef double complex QkComplex64;
+#endif
 
 // Always expose [cfg(feature = "cbinding")] -- workaround for
 // https://github.com/mozilla/cbindgen/issues/995


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In MSVC complex numbers are structs called `_Dcomplex` (for `complex double`) and `_Fcomplex` (for `complex float`). This commit covers the MSVC compiler.

### Details and comments

Tested on @anedumla's 64-bit windows machine and MSVC version 19.34.31933. Maybe we can add this to #14030 in case this gets windows CI to pass? Though there might be some extra work required..
