### PR TITLE
Fix: Relax `Interner` trait bounds for borrowed elements

### DIFF
--- a/crates/circuit/src/interner.rs
+++ b/crates/circuit/src/interner.rs
@@ -690,4 +690,39 @@ mod test {
             .collect::<HashSet<_>>();
         assert_eq!(expected, actual);
     }
+
+    #[test]
+    fn can_check_with_equivalent_element() {
+        // Check that borrowed equivalent elements can be used in queries.
+        let mut with_array: Interner<[u8]> = Interner::new();
+        let mut with_string: Interner<String> = Interner::new();
+
+        // Try to insert with slice
+        with_array.insert(&[1, 2]);
+        // Try to insert with vec ref
+        with_array.insert(&[0, 2]);
+
+        // Try to insert with str
+        with_string.insert("Foo");
+        // Try to insert with borrowed String
+        with_string.insert(&"Bar".to_string());
+
+        // Try checking with slice
+        assert!(with_array.contains(&[0, 2]));
+        // Try checking with vec
+        assert!(with_array.contains(&[1, 2]));
+        // Try checking with slice (fail)
+        assert!(!with_array.contains(&[0, 4]));
+        // Try checking with vec
+        assert!(!with_array.contains(&[1, 3]));
+
+        // Try checking with str
+        assert!(with_string.contains("Bar"));
+        // Try checking with String
+        assert!(with_string.contains(&"Foo".to_string()));
+        // Try checking with str (fail)
+        assert!(!with_string.contains("Fee"));
+        // Try checking with String (fail)
+        assert!(!with_string.contains(&"vec![1,3]".to_string()));
+    }
 }

--- a/crates/circuit/src/interner.rs
+++ b/crates/circuit/src/interner.rs
@@ -15,7 +15,7 @@ use std::fmt;
 use std::hash::Hash;
 use std::marker::PhantomData;
 
-use indexmap::IndexSet;
+use indexmap::{Equivalent, IndexSet};
 use smallvec::SmallVec;
 
 /// A key to retrieve a value (by reference) from an interner of the same type.  This is narrower
@@ -345,8 +345,8 @@ where
     /// This method does not store `value` if it is not present.
     pub fn try_key<Q>(&self, value: &Q) -> Option<Interned<T>>
     where
-        Q: ?Sized + Hash + Eq + ToOwned,
-        T: Borrow<Q> + ToOwned<Owned = <Q as ToOwned>::Owned>,
+        Q: ?Sized + Hash + Eq + Equivalent<T::Owned>,
+        T: Borrow<Q>,
     {
         self.0.get_index_of(value).map(|index| Interned {
             index: index as u32,
@@ -360,8 +360,8 @@ where
     /// stores the value if it wasn't already present.
     pub fn contains<Q>(&self, value: &Q) -> bool
     where
-        Q: ?Sized + Hash + Eq + ToOwned,
-        T: Borrow<Q> + ToOwned<Owned = <Q as ToOwned>::Owned>,
+        Q: ?Sized + Hash + Eq + Equivalent<T::Owned>,
+        T: Borrow<Q>,
     {
         self.try_key(value).is_some()
     }

--- a/crates/circuit/src/interner.rs
+++ b/crates/circuit/src/interner.rs
@@ -343,7 +343,11 @@ where
     /// stored.
     ///
     /// This method does not store `value` if it is not present.
-    pub fn try_key(&self, value: &T) -> Option<Interned<T>> {
+    pub fn try_key<Q>(&self, value: &Q) -> Option<Interned<T>>
+    where
+        Q: ?Sized + Hash + Eq + ToOwned,
+        T: Borrow<Q> + ToOwned<Owned = <Q as ToOwned>::Owned>,
+    {
         self.0.get_index_of(value).map(|index| Interned {
             index: index as u32,
             _type: PhantomData,
@@ -354,7 +358,11 @@ where
     ///
     /// Typically you want to use [try_key], which returns the key if present, or [insert], which
     /// stores the value if it wasn't already present.
-    pub fn contains(&self, value: &T) -> bool {
+    pub fn contains<Q>(&self, value: &Q) -> bool
+    where
+        Q: ?Sized + Hash + Eq + ToOwned,
+        T: Borrow<Q> + ToOwned<Owned = <Q as ToOwned>::Owned>,
+    {
         self.try_key(value).is_some()
     }
 }
@@ -403,7 +411,11 @@ where
     ///
     /// If you already have an owned value, use `insert_owned`, but in general this function will be
     /// more efficient *unless* you already had the value for other reasons.
-    pub fn insert(&mut self, value: &T) -> Interned<T> {
+    pub fn insert<Q>(&mut self, value: &Q) -> Interned<T>
+    where
+        Q: ?Sized + Hash + Eq + ToOwned,
+        T: Borrow<Q> + ToOwned<Owned = <Q as ToOwned>::Owned>,
+    {
         let index = match self.0.get_index_of(value) {
             Some(index) => index as u32,
             None => self.insert_new(value.to_owned()),


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Fix trait bounds in certain methods of `Interner` to allow for the use of elements that satisfy the trait bounds of `Equivalent<T>` in `IndexMap`.

### Details and comments
In a very special edge case for the `Interner` a user was not able to check if it contained an instance of `String` from an `&str`. The following commits relax the trait bounds on the `contains`, `try_key`, and `insert` methods, to allow for more flexibility by behaving similarly to the trait `Equivalent<T>` from `IndexMap`.

