### PR TITLE
Make `Target` use interners to store gate names

### DIFF
--- a/crates/accelerate/src/target_transpiler/mod.rs
+++ b/crates/accelerate/src/target_transpiler/mod.rs
@@ -55,7 +55,7 @@ pub(crate) mod exceptions {
 
 // Custom types
 pub type Qargs = SmallVec<[PhysicalQubit; 2]>;
-type GateMap = IndexMap<Interned<String>, PropsMap, RandomState>;
+type GateMap = IndexMap<Interned<str>, PropsMap, RandomState>;
 type PropsMap = NullableIndexMap<Qargs, Option<InstructionProperties>>;
 type GateMapState = (String, Vec<(Option<Qargs>, Option<InstructionProperties>)>);
 
@@ -181,12 +181,12 @@ pub(crate) struct Target {
     #[pyo3(get, set)]
     pub concurrent_measurements: Option<Vec<Vec<PhysicalQubit>>>,
     gate_map: GateMap,
-    gate_name_interner: Interner<String>,
-    _gate_name_map: IndexMap<Interned<String>, TargetOperation, RandomState>,
-    global_operations: IndexMap<u32, HashSet<Interned<String>>, RandomState>,
-    qarg_gate_map: NullableIndexMap<Qargs, Option<HashSet<Interned<String>>>>,
-    non_global_strict_basis: Option<Vec<Interned<String>>>,
-    non_global_basis: Option<Vec<Interned<String>>>,
+    gate_name_interner: Interner<str>,
+    _gate_name_map: IndexMap<Interned<str>, TargetOperation, RandomState>,
+    global_operations: IndexMap<u32, HashSet<Interned<str>>, RandomState>,
+    qarg_gate_map: NullableIndexMap<Qargs, Option<HashSet<Interned<str>>>>,
+    non_global_strict_basis: Option<Vec<Interned<str>>>,
+    non_global_basis: Option<Vec<Interned<str>>>,
 }
 
 #[pymethods]
@@ -888,8 +888,7 @@ impl Target {
                         value
                             .clone()
                             .into_iter()
-                            .map(|key| self.gate_name_interner.get(key))
-                            .cloned()
+                            .map(|key| self.gate_name_interner.get(key).to_owned())
                             .collect::<HashSet<String>>(),
                     )
                 })
@@ -916,7 +915,7 @@ impl Target {
             "non_global_basis",
             self.non_global_basis.as_ref().map(|vec| {
                 vec.iter()
-                    .map(|key| self.gate_name_interner.get(*key).clone())
+                    .map(|key| self.gate_name_interner.get(*key))
                     .collect_vec()
             }),
         )?;
@@ -924,7 +923,7 @@ impl Target {
             "non_global_strict_basis",
             self.non_global_strict_basis.as_ref().map(|vec| {
                 vec.iter()
-                    .map(|key| self.gate_name_interner.get(*key).clone())
+                    .map(|key| self.gate_name_interner.get(*key))
                     .collect_vec()
             }),
         )?;
@@ -977,7 +976,7 @@ impl Target {
             .downcast_into::<PyDict>()?
             .items()
             .iter()
-            .map(|item| -> PyResult<(Interned<String>, TargetOperation)> {
+            .map(|item| -> PyResult<(Interned<str>, TargetOperation)> {
                 let (name, op): (String, TargetOperation) = item.extract()?;
                 Ok((self.gate_name_interner.try_key(&name).unwrap(), op))
             })
@@ -1078,7 +1077,7 @@ impl Target {
     pub fn operation_names(&self) -> impl ExactSizeIterator<Item = &str> {
         self.gate_map
             .keys()
-            .map(|x| self.gate_name_interner.get(*x).as_str())
+            .map(|x| self.gate_name_interner.get(*x))
     }
 
     /// Get the `OperationType` objects present in the target.
@@ -1137,7 +1136,7 @@ impl Target {
                 }
             }
         }
-        let mut incomplete_basis_gates: Vec<Interned<String>> = vec![];
+        let mut incomplete_basis_gates: Vec<Interned<str>> = vec![];
         let mut size_dict: IndexMap<usize, usize, RandomState> = IndexMap::default();
         *size_dict
             .entry(1)
@@ -1184,7 +1183,7 @@ impl Target {
     pub fn get_non_global_operation_names<'a>(
         &'a mut self,
         strict_direction: bool,
-    ) -> Option<Box<dyn ExactSizeIterator<Item = &'a String> + 'a>> {
+    ) -> Option<Box<dyn ExactSizeIterator<Item = &'a str> + 'a>> {
         if strict_direction {
             if self.non_global_strict_basis.is_some() {
                 return Some(Box::new(
@@ -1256,7 +1255,7 @@ impl Target {
             res.extend(
                 qarg_gate_map_arg
                     .iter()
-                    .map(|key| self.gate_name_interner.get(*key).as_str()),
+                    .map(|key| self.gate_name_interner.get(*key)),
             );
         }
         for (name, obj) in self._gate_name_map.iter() {
@@ -1269,7 +1268,7 @@ impl Target {
                 res.extend(
                     global_gates
                         .iter()
-                        .map(|key| self.gate_name_interner.get(*key).as_str()),
+                        .map(|key| self.gate_name_interner.get(*key)),
                 );
             }
         }
@@ -1435,7 +1434,7 @@ impl Target {
     pub fn keys(&self) -> impl Iterator<Item = &str> {
         self.gate_map
             .keys()
-            .map(|x| self.gate_name_interner.get(*x).as_str())
+            .map(|x| self.gate_name_interner.get(*x))
     }
 
     /// Retrieves an iterator over the property maps stored within the Target

--- a/crates/accelerate/src/target_transpiler/nullable_index_map.rs
+++ b/crates/accelerate/src/target_transpiler/nullable_index_map.rs
@@ -94,26 +94,6 @@ where
         }
     }
 
-    /// Creates an instance of `NullableIndexMap<K, V>` from an iterator over instances of
-    /// `(Option<K>, V)`.
-    pub fn from_iter<'a, I>(iter: I) -> Self
-    where
-        I: IntoIterator<Item = (Option<K>, V)> + 'a,
-    {
-        let mut null_val = None;
-        let filtered = iter.into_iter().filter_map(|item| match item {
-            (Some(key), value) => Some((key, value)),
-            (None, value) => {
-                null_val = Some(value);
-                None
-            }
-        });
-        Self {
-            map: IndexMap::from_iter(filtered),
-            null_val,
-        }
-    }
-
     /// Returns `true` if the map contains a slot indexed by `key`, otherwise `false`.
     pub fn contains_key(&self, key: Option<&K>) -> bool {
         match key {
@@ -386,6 +366,48 @@ where
         Self {
             map: IndexMap::default(),
             null_val: None,
+        }
+    }
+}
+
+impl<K, V, const N: usize> From<[(Option<K>, V); N]> for NullableIndexMap<K, V>
+where
+    K: Eq + Hash + Clone,
+    V: Clone,
+{
+    fn from(value: [(Option<K>, V); N]) -> Self {
+        let mut null_val = None;
+        let filtered = value.into_iter().filter_map(|item| match item {
+            (Some(key), value) => Some((key, value)),
+            (None, value) => {
+                null_val = Some(value);
+                None
+            }
+        });
+        Self {
+            map: IndexMap::from_iter(filtered),
+            null_val,
+        }
+    }
+}
+
+impl<K, V> FromIterator<(Option<K>, V)> for NullableIndexMap<K, V>
+where
+    K: Eq + Hash + Clone,
+    V: Clone,
+{
+    fn from_iter<T: IntoIterator<Item = (Option<K>, V)>>(iter: T) -> Self {
+        let mut null_val = None;
+        let filtered = iter.into_iter().filter_map(|item| match item {
+            (Some(key), value) => Some((key, value)),
+            (None, value) => {
+                null_val = Some(value);
+                None
+            }
+        });
+        Self {
+            map: IndexMap::from_iter(filtered),
+            null_val,
         }
     }
 }

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -430,7 +430,7 @@ class Target(BaseTarget):
         is globally defined.
         """
         return [
-            (self._gate_name_map[op], qarg)
+            (self.operation_from_name(op), qarg)
             for op, qargs in self._gate_map.items()
             for qarg in qargs
         ]
@@ -481,7 +481,7 @@ class Target(BaseTarget):
             self._coupling_graph.add_nodes_from([{} for _ in range(self.num_qubits)])
         for gate, qarg_map in self._gate_map.items():
             if qarg_map is None:
-                if self._gate_name_map[gate].num_qubits == 2:
+                if self.operation_from_name(gate).num_qubits == 2:
                     self._coupling_graph = None  # pylint: disable=attribute-defined-outside-init
                     return
                 continue


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
~This PR is built on top of #14039, and should not be merged before it.~ The following commits aim to add usage of interners for the gate names in the `Target`.


### Details and comments
~This PR is built on top of #14039, and should not be merged before it.~  The `Target` currently keeps up to 5 copies of the names of every gate instance, this is due to the many mappings present within that still need to keep a connection between the gate name and some other relation or attribute. By using interners, we ensure that we only keep one instance of each gate's name and we use indices to satisfy the correlation later on.

These changes are internal and should not affect how the target is used throughout our infrastructure.