### PR TITLE
Fix default optimization level in comment

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -249,7 +249,7 @@ def transpile(  # pylint: disable=too-many-return-statements
     start_time = time()
 
     if optimization_level is None:
-        # Take optimization level from the configuration or 1 as default.
+        # Take optimization level from the configuration or 2 as default.
         config = user_config.get_config()
         optimization_level = config.get("transpile_optimization_level", 2)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [NA ] I have added the tests to cover my changes.
- [X ] I have updated the documentation accordingly.
- [ X] I have read the CONTRIBUTING document.
-->

### Summary

Change default optimization level in comment from 1 to 2.

### Details and comments

The comment on line 252 of transpiler.py said "Take optimization level from the configuration or 1 as default." This is incorrect - the default is 2. I have corrected the comment.

https://github.com/Qiskit/qiskit/blob/219dec70451a42f905054d6b9f96bf9893117896/qiskit/compiler/transpiler.py#L252

This fixes issue 14036:

https://github.com/Qiskit/qiskit/issues/14036