### PR TITLE
Fix: Disable pylint warnings for Qasm dump tests

### DIFF
--- a/test/python/circuit/test_circuit_qasm.py
+++ b/test/python/circuit/test_circuit_qasm.py
@@ -397,6 +397,7 @@ mcx q[0],q[1],q[2],q[3];"""
         self.assertEqual(dumps(qc), expected_qasm)
 
     def test_circuit_qasm_with_mcx_gate_variants(self):
+        # pylint: disable=line-too-long
         """Test circuit qasm() method with MCXGrayCode, MCXRecursive, MCXVChain"""
         import qiskit.circuit.library as cl
 

--- a/test/python/qasm2/test_export.py
+++ b/test/python/qasm2/test_export.py
@@ -376,6 +376,7 @@ custom q\[0\];""",
         self.assertEqual(Operator(qc), Operator(qasm2.loads(qasm_str)))
 
     def test_mcx_gate(self):
+        # pylint: disable=line-too-long
         qc = QuantumCircuit(4)
         qc.mcx([0, 1, 2], 3)
 
@@ -389,6 +390,7 @@ mcx q[0],q[1],q[2],q[3];"""
         self.assertEqual(qasm2.dumps(qc), expected_qasm)
 
     def test_mcx_gate_variants(self):
+        # pylint: disable=line-too-long
         n = 5
         qc = QuantumCircuit(2 * n - 1)
         qc.append(lib.MCXGrayCode(n), range(n + 1))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Some qasm tests were causing the `tox -e lint` workflow to fail locally. The following commits add the `# pylint: disable=line-too-long` to disable these warnings.


