### PR TITLE
adding missing equality between unitary gates

### DIFF
--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -2700,7 +2700,13 @@ pub struct UnitaryGate {
 
 impl PartialEq for UnitaryGate {
     fn eq(&self, other: &Self) -> bool {
-        self.matrix(&[]) == other.matrix(&[])
+        match (&self.array, &other.array) {
+            (ArrayType::OneQ(mat1), ArrayType::OneQ(mat2)) => mat1 == mat2,
+            (ArrayType::TwoQ(mat1), ArrayType::TwoQ(mat2)) => mat1 == mat2,
+            // we could also slightly optimize comparisons between NDArray and OneQ/TwoQ if
+            // this becomes performance critical
+            _ => self.matrix(&[]) == other.matrix(&[]),
+        }
     }
 }
 

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -2683,7 +2683,7 @@ impl Operation for PyOperation {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ArrayType {
     NDArray(Array2<Complex64>),
     OneQ(Matrix2<Complex64>),

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -2683,7 +2683,7 @@ impl Operation for PyOperation {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub enum ArrayType {
     NDArray(Array2<Complex64>),
     OneQ(Matrix2<Complex64>),
@@ -2696,6 +2696,12 @@ pub enum ArrayType {
 #[repr(align(8))]
 pub struct UnitaryGate {
     pub array: ArrayType,
+}
+
+impl PartialEq for UnitaryGate {
+    fn eq(&self, other: &Self) -> bool {
+        self.matrix(&[]) == other.matrix(&[])
+    }
 }
 
 impl Operation for UnitaryGate {

--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -446,6 +446,9 @@ impl PackedOperation {
             (OperationRef::Operation(left), OperationRef::Operation(right)) => {
                 left.operation.bind(py).eq(&right.operation)
             }
+            (OperationRef::Unitary(left), OperationRef::Unitary(right)) => {
+                Ok(left.array == right.array)
+            }    
             _ => Ok(false),
         }
     }

--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -446,9 +446,7 @@ impl PackedOperation {
             (OperationRef::Operation(left), OperationRef::Operation(right)) => {
                 left.operation.bind(py).eq(&right.operation)
             }
-            (OperationRef::Unitary(left), OperationRef::Unitary(right)) => {
-                Ok(left.array == right.array)
-            }
+            (OperationRef::Unitary(left), OperationRef::Unitary(right)) => Ok(left == right),
             _ => Ok(false),
         }
     }

--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -448,7 +448,7 @@ impl PackedOperation {
             }
             (OperationRef::Unitary(left), OperationRef::Unitary(right)) => {
                 Ok(left.array == right.array)
-            }    
+            }
             _ => Ok(false),
         }
     }

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -21,6 +21,7 @@ import io
 import unittest
 
 from ddt import ddt, data
+import numpy as np
 from numpy import pi
 
 from qiskit.dagcircuit import DAGCircuit, DAGOpNode, DAGInNode, DAGOutNode, DAGCircuitError
@@ -1656,6 +1657,38 @@ class TestDagEquivalence(QiskitTestCase):
         circ1.u(0.0, 0.1, 0.2, self.qr1[3])
         circ1.ccx(self.qr2[0], self.qr2[1], self.qr1[0])
         self.dag1 = circuit_to_dag(circ1)
+
+    def test_unitary_gate_eq(self):
+        """Test equality of equal DAGOpNodes containing unitary gates.
+        See: https://github.com/Qiskit/qiskit-terra/issues/14047
+        """
+        # Create the unitary matrix
+        unitary_matrix = np.array(
+            [
+                [0.65328148 - 0.27059805j, 0.0 + 0.0j, 0.0 + 0.0j, 0.65328148 - 0.27059805j],
+                [0.0 + 0.0j, 0.65328148 - 0.27059805j, -0.65328148 + 0.27059805j, 0.0 + 0.0j],
+                [0.27059805 - 0.65328148j, 0.0 + 0.0j, 0.0 + 0.0j, -0.27059805 + 0.65328148j],
+                [0.0 + 0.0j, 0.27059805 - 0.65328148j, 0.27059805 - 0.65328148j, 0.0 + 0.0j],
+            ]
+        )
+
+        # Create the instruction
+        instruction = Instruction(
+            name="unitary", num_qubits=2, num_clbits=0, params=[unitary_matrix]
+        )
+
+        # Create the quantum register and qubits
+        qreg = QuantumRegister(9, "q")
+        qubit1 = Qubit(qreg, 7)
+        qubit2 = Qubit(qreg, 5)
+
+        # Create the DAGOpNode
+        dag_op_node = DAGOpNode(op=instruction, qargs=(qubit1, qubit2), cargs=())
+
+        # Create the DAGOpNode2
+        dag_op_node_2 = DAGOpNode(op=instruction, qargs=(qubit1, qubit2), cargs=())
+
+        self.assertEqual(dag_op_node, dag_op_node_2)
 
     def test_dag_eq(self):
         """DAG equivalence check: True."""

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -45,7 +45,17 @@ from qiskit.circuit import (
     Store,
 )
 from qiskit.circuit.classical import expr, types
-from qiskit.circuit.library import IGate, HGate, CXGate, CZGate, XGate, YGate, U1Gate, RXGate
+from qiskit.circuit.library import (
+    IGate,
+    HGate,
+    CXGate,
+    CZGate,
+    XGate,
+    YGate,
+    U1Gate,
+    RXGate,
+    CSGate,
+)
 from qiskit.converters import circuit_to_dag
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
@@ -1689,6 +1699,27 @@ class TestDagEquivalence(QiskitTestCase):
         dag_op_node_2 = DAGOpNode(op=instruction, qargs=(qubit1, qubit2), cargs=())
 
         self.assertEqual(dag_op_node, dag_op_node_2)
+
+    def test_unitary_gate_variants_eq(self):
+        """Test equality of equal DAGOpNodes containing unitary gates."""
+        # Create the instructions.
+        # Note that our rust code will interpret mat1 as ArrayType::NDArray and
+        # mat2 as ArrayType::TwoQ.
+        mat1 = np.asarray(CSGate().to_matrix(), dtype=complex)
+        mat2 = np.asarray(CSGate().to_matrix(), dtype=complex, order="f")
+        instruction1 = Instruction(name="unitary", num_qubits=2, num_clbits=0, params=[mat1])
+        instruction2 = Instruction(name="unitary", num_qubits=2, num_clbits=0, params=[mat2])
+
+        # Create the quantum register and qubits
+        qreg = QuantumRegister(9, "q")
+        qubit1 = Qubit(qreg, 7)
+        qubit2 = Qubit(qreg, 5)
+
+        # Create DAGOpNodes
+        node1 = DAGOpNode(op=instruction1, qargs=(qubit1, qubit2), cargs=())
+        node2 = DAGOpNode(op=instruction2, qargs=(qubit1, qubit2), cargs=())
+
+        self.assertEqual(node1, node2)
 
     def test_dag_eq(self):
         """DAG equivalence check: True."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #14047.

### Details and comments

The function ``pub fn py_eq(&self, py: Python, other: &PackedOperation) -> PyResult<bool>`` was missing the branch to check the equality between two ``OperationRef::Unitary``s and defaulted to ``false``.

