### PR TITLE
Remove iter from `CircuitInstruction`.

### DIFF
--- a/releasenotes/notes/remove-circuit-inst-iter-3d1c87b721a08bea.yaml
+++ b/releasenotes/notes/remove-circuit-inst-iter-3d1c87b721a08bea.yaml
@@ -1,0 +1,8 @@
+---
+upgrade_circuits:
+  - |
+    :class:`~.circuit.CircuitInstruction` is no longer tuple-like nor iterable,
+    which was deprecated in Qiskit 1.2. Instead, use the
+    :class:`~.circuit.CircuitInstruction.operation`,
+    :class:`~.circuit.CircuitInstruction.qubits`, and
+    :class:`~.circuit.CircuitInstruction.clbits` named attributes.

--- a/test/python/circuit/test_circuit_data.py
+++ b/test/python/circuit/test_circuit_data.py
@@ -420,26 +420,6 @@ class TestQuantumCircuitInstructionData(QiskitTestCase):
     # but are included as tests to maintain compatability with the previous
     # list interface of circuit.data.
 
-    def test_iteration_of_data_entry(self):
-        """Verify that the base types of the legacy tuple iteration are correct, since they're
-        different to attribute access."""
-        qc = QuantumCircuit(3, 3)
-        qc.h(0)
-        qc.cx(0, 1)
-        qc.cx(1, 2)
-        qc.measure([0, 1, 2], [0, 1, 2])
-
-        def to_legacy(instruction):
-            return (instruction.operation, list(instruction.qubits), list(instruction.clbits))
-
-        expected = [to_legacy(instruction) for instruction in qc.data]
-
-        with self.assertWarnsRegex(
-            DeprecationWarning, "Treating CircuitInstruction as an iterable is deprecated"
-        ):
-            actual = [tuple(instruction) for instruction in qc.data]
-        self.assertEqual(actual, expected)
-
     def test_getitem_by_insertion_order(self):
         """Verify one can get circuit.data items in insertion order."""
         qr = QuantumRegister(2)


### PR DESCRIPTION
We already deprecated this, and it was slated for removal in 2.0, but since we missed the RC, let's do this in 3.0.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Treating `CircuitInstruction` as tuple-like was deprecated in 1.2 and slated for removal in 2.0.


