### PR TITLE
Update version in deprecation message for `CircuitInstruction` iteration.

### DIFF
--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -698,7 +698,7 @@ fn warn_on_legacy_circuit_instruction_iteration(py: Python) -> PyResult<()> {
                 py,
                 concat!(
                     "Treating CircuitInstruction as an iterable is deprecated legacy behavior",
-                    " since Qiskit 1.2, and will be removed in Qiskit 2.0.",
+                    " since Qiskit 1.2, and will be removed in Qiskit 3.0.",
                     " Instead, use the `operation`, `qubits` and `clbits` named attributes."
                 )
             ),

--- a/releasenotes/notes/extend-deprecation-tuple-inst-f24ab7a5632191e3.yaml
+++ b/releasenotes/notes/extend-deprecation-tuple-inst-f24ab7a5632191e3.yaml
@@ -1,0 +1,9 @@
+---
+deprecations_circuits:
+  - |
+    The deprecated tuple-like interface for :class:`~.circuit.CircuitInstruction` was not
+    removed in this release as originally planned. It will be removed in Qiskit 3.0.0
+    instead. Instead, use the
+    :class:`~.circuit.CircuitInstruction.operation`,
+    :class:`~.circuit.CircuitInstruction.qubits`, and
+    :class:`~.circuit.CircuitInstruction.clbits` named attributes.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
We'd planned to remove the ability to treat `CircuitInstruction` as a tuple in Qiskit 2.0, but we forgot. 


### Details and comments
This PR just updates the version in the deprecation warning since we can't remove this now until 3.0.

