### PR TITLE
Cleanup python submodules in rust code

### DIFF
--- a/crates/accelerate/src/basis/basis_translator/mod.rs
+++ b/crates/accelerate/src/basis/basis_translator/mod.rs
@@ -800,7 +800,6 @@ fn replace_node(
     Ok(())
 }
 
-#[pymodule]
 pub fn basis_translator(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(run))?;
     Ok(())

--- a/crates/accelerate/src/basis/mod.rs
+++ b/crates/accelerate/src/basis/mod.rs
@@ -10,12 +10,4 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use pyo3::{prelude::*, wrap_pymodule};
-
 pub mod basis_translator;
-
-#[pymodule]
-pub fn basis(m: &Bound<PyModule>) -> PyResult<()> {
-    m.add_wrapped(wrap_pymodule!(basis_translator::basis_translator))?;
-    Ok(())
-}

--- a/crates/accelerate/src/equivalence.rs
+++ b/crates/accelerate/src/equivalence.rs
@@ -817,7 +817,6 @@ where
     Ok(graph.unbind())
 }
 
-#[pymodule]
 pub fn equivalence(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<EquivalenceLibrary>()?;
     m.add_class::<NodeData>()?;

--- a/crates/accelerate/src/gate_direction.rs
+++ b/crates/accelerate/src/gate_direction.rs
@@ -555,7 +555,6 @@ fn rzx_replacement_dag(py: Python, param: &[Param]) -> PyResult<DAGCircuit> {
     Ok(new_dag.clone())
 }
 
-#[pymodule]
 pub fn gate_direction(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(py_check_direction_coupling_map))?;
     m.add_wrapped(wrap_pyfunction!(py_check_direction_target))?;

--- a/crates/accelerate/src/unitary_synthesis.rs
+++ b/crates/accelerate/src/unitary_synthesis.rs
@@ -1346,7 +1346,6 @@ fn run_2q_unitary_synthesis(
     Ok(())
 }
 
-#[pymodule]
 pub fn unitary_synthesis(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(py_run_main_loop))?;
     Ok(())

--- a/crates/pyext/src/lib.rs
+++ b/crates/pyext/src/lib.rs
@@ -30,7 +30,7 @@ where
 #[pymodule]
 fn _accelerate(m: &Bound<PyModule>) -> PyResult<()> {
     add_submodule(m, ::qiskit_accelerate::barrier_before_final_measurement::barrier_before_final_measurements_mod, "barrier_before_final_measurement")?;
-    add_submodule(m, ::qiskit_accelerate::basis::basis, "basis")?;
+    add_submodule(m, ::qiskit_accelerate::basis::basis_translator::basis_translator, "basis_translator")?;
     add_submodule(m, ::qiskit_accelerate::check_map::check_map_mod, "check_map")?;
     add_submodule(m, ::qiskit_accelerate::circuit_duration::compute_duration, "circuit_duration")?;
     add_submodule(m, ::qiskit_accelerate::circuit_library::circuit_library, "circuit_library")?;

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -53,11 +53,8 @@ import qiskit._numpy_compat
 # and not have to rely on attribute access.  No action needed for top-level extension packages.
 sys.modules["qiskit._accelerate.circuit"] = _accelerate.circuit
 sys.modules["qiskit._accelerate.circuit_library"] = _accelerate.circuit_library
-sys.modules["qiskit._accelerate.basis"] = _accelerate.basis
-sys.modules["qiskit._accelerate.basis.basis_translator"] = _accelerate.basis.basis_translator
+sys.modules["qiskit._accelerate.basis_translator"] = _accelerate.basis_translator
 sys.modules["qiskit._accelerate.converters"] = _accelerate.converters
-sys.modules["qiskit._accelerate.basis"] = _accelerate.basis
-sys.modules["qiskit._accelerate.basis.basis_translator"] = _accelerate.basis.basis_translator
 sys.modules["qiskit._accelerate.dense_layout"] = _accelerate.dense_layout
 sys.modules["qiskit._accelerate.equivalence"] = _accelerate.equivalence
 sys.modules["qiskit._accelerate.error_map"] = _accelerate.error_map

--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -18,7 +18,7 @@ import logging
 from collections import defaultdict
 
 from qiskit.transpiler.basepasses import TransformationPass
-from qiskit._accelerate.basis.basis_translator import base_run
+from qiskit._accelerate.basis_translator import base_run
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit cleans up the submodule usage in our rust extension. We shouldn't be using the pymodule attribute for submodules. This also cleans up the submodule in the basis translator which was unnecessarily two layers deep and also duplicated in the init file.

### Details and comments