### PR TITLE
Fix ignored errors/durations  in `generate_preset_pass_manager` if `dt` is set

### DIFF
--- a/crates/accelerate/src/target_transpiler/mod.rs
+++ b/crates/accelerate/src/target_transpiler/mod.rs
@@ -150,7 +150,6 @@ pub(crate) struct Target {
     pub description: Option<String>,
     #[pyo3(get)]
     pub num_qubits: Option<usize>,
-    #[pyo3(get, set)]
     pub dt: Option<f64>,
     #[pyo3(get, set)]
     pub granularity: u32,
@@ -740,6 +739,17 @@ impl Target {
     }
 
     // Instance attributes
+
+    /// The dt attribute.
+    #[getter(_dt)]
+    fn get_dt(&self) -> Option<f64> {
+        self.dt
+    }
+
+    #[setter(_dt)]
+    fn set_dt(&mut self, dt: Option<f64>) {
+        self.dt = dt
+    }
 
     /// The set of qargs in the target.
     #[getter]

--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -200,6 +200,9 @@ def generate_preset_pass_manager(
     # If there are no loose constraints => use backend target if available
     _no_loose_constraints = basis_gates is None and coupling_map is None and dt is None
 
+    # If the only loose constraint is dt => use backend target and modify dt
+    _adjust_dt = backend is not None and dt is not None
+
     # Warn about inconsistencies in backend + loose constraints path (dt shouldn't be a problem)
     if backend is not None and (coupling_map is not None or basis_gates is not None):
         warnings.warn(
@@ -233,6 +236,10 @@ def generate_preset_pass_manager(
         if backend is not None and _no_loose_constraints:
             # If a backend is specified without loose constraints, use its target directly.
             target = backend.target
+        elif _adjust_dt:
+            # If a backend is specified with loose dt, use its target and andjust the dt value.
+            target = backend.target
+            target.dt = dt
         else:
             if basis_gates is not None:
                 # Build target from constraints.

--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -241,10 +241,11 @@ def generate_preset_pass_manager(
             target.dt = dt
             # we must update the instruction properties to internally clear the value of
             # _instruction_durations in the target so that the new dt is saved
-            for inst_name in target.operation_names:
-                props_map = target[inst_name]
-                for qargs, props in props_map.items():
-                    target.update_instruction_properties(inst_name, qargs, props)
+            inst_name = list(target.operation_names)[0]
+            props_map = target[inst_name]
+            for qargs, props in props_map.items():
+                target.update_instruction_properties(inst_name, qargs, props)
+                break
         else:
             if basis_gates is not None:
                 # Build target from constraints.

--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -207,8 +207,7 @@ def generate_preset_pass_manager(
     if backend is not None and (coupling_map is not None or basis_gates is not None):
         warnings.warn(
             "Providing `coupling_map` and/or `basis_gates` along with `backend` is not "
-            "recommended. This may introduce inconsistencies in the transpilation target, "
-            "leading to potential errors.",
+            "recommended, as this will invalidate the backend's gate durations and error rates.",
             category=UserWarning,
             stacklevel=2,
         )
@@ -229,7 +228,7 @@ def generate_preset_pass_manager(
                 raise ValueError(
                     f"Gates with 3 or more qubits ({gate}) in `basis_gates` or `backend` are "
                     "incompatible with a custom `coupling_map`. To include 3-qubit or larger "
-                    " gates in the transpilation basis, use a custom `target` instance instead."
+                    " gates in the transpilation basis, provide a custom `target` instead."
                 )
 
     if target is None:
@@ -237,7 +236,7 @@ def generate_preset_pass_manager(
             # If a backend is specified without loose constraints, use its target directly.
             target = backend.target
         elif _adjust_dt:
-            # If a backend is specified with loose dt, use its target and andjust the dt value.
+            # If a backend is specified with loose dt, use its target and adjust the dt value.
             target = backend.target
             target.dt = dt
         else:

--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -241,11 +241,7 @@ def generate_preset_pass_manager(
             target.dt = dt
             # we must update the instruction properties to internally clear the value of
             # _instruction_durations in the target so that the new dt is saved
-            inst_name = list(target.operation_names)[0]
-            props_map = target[inst_name]
-            for qargs, props in props_map.items():
-                target.update_instruction_properties(inst_name, qargs, props)
-                break
+            target._instruction_durations = None
         else:
             if basis_gates is not None:
                 # Build target from constraints.

--- a/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
+++ b/qiskit/transpiler/preset_passmanagers/generate_preset_pass_manager.py
@@ -239,9 +239,6 @@ def generate_preset_pass_manager(
             # If a backend is specified with loose dt, use its target and adjust the dt value.
             target = copy.deepcopy(backend.target)
             target.dt = dt
-            # we must update the instruction properties to internally clear the value of
-            # _instruction_durations in the target so that the new dt is saved
-            target._instruction_durations = None
         else:
             if basis_gates is not None:
                 # Build target from constraints.

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -270,6 +270,17 @@ class Target(BaseTarget):
         self._instruction_durations = None
         self._instruction_schedule_map = None
 
+    @property
+    def dt(self):
+        """Return dt."""
+        return self._dt
+
+    @dt.setter
+    def dt(self, dt):
+        """Set dt and invalidate instruction duration cache"""
+        self._dt = dt
+        self._instruction_durations = None
+
     def add_instruction(self, instruction, properties=None, name=None):
         """Add a new instruction to the :class:`~qiskit.transpiler.Target`
 

--- a/releasenotes/notes/fix-dt-oversight-be7e9b00f9c7b7a8.yaml
+++ b/releasenotes/notes/fix-dt-oversight-be7e9b00f9c7b7a8.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed an oversight in the :class:`.Target` class where setting a new value for the ``dt`` attribute
+    and subsequently calling ``target.durations()`` would not show the updated ``dt`` value in the returned
+    :class:`.InstructionDurations` object. This is now fixed through an invalidation of the internal target
+    instruction durations cache in the ``dt`` setter.

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -1677,12 +1677,13 @@ class TestTranspile(QiskitTestCase):
         """Test that scheduling-related loose transpile constraints
         work with BackendV2."""
 
-        backend_v2 = GenericBackendV2(num_qubits=2, seed=1)
+        original_dt = 2.2222222222222221e-10
+        backend_v2 = GenericBackendV2(num_qubits=2, dt=original_dt, seed=3)
         qc = QuantumCircuit(1, 1)
         qc.x(0)
         qc.measure(0, 0)
-        original_dt = 2.2222222222222221e-10
-        original_duration = 5059
+        scheduled = transpile(qc, backend=backend_v2, scheduling_method="asap")
+        original_duration = scheduled.duration
 
         # halve dt in sec = double duration in dt
         scheduled = transpile(qc, backend=backend_v2, scheduling_method="asap", dt=original_dt / 2)

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -2296,12 +2296,12 @@ class TestTranspile(QiskitTestCase):
         tqc_no_dt = transpile(qc, backend=backend, seed_transpiler=4242)
         # confirm that the output layouts are different
         self.assertNotEqual(
-            tqc_no_dt.layout.final_index_layout, tqc_no_error.layout.final_index_layout
+            tqc_no_dt.layout.final_index_layout(), tqc_no_error.layout.final_index_layout()
         )
         # now modify dt with gate errors
         tqc_dt = transpile(qc, backend=backend, seed_transpiler=4242, dt=backend.dt * 2)
         # confirm that dt doesn't affect layout
-        self.assertEqual(tqc_no_dt.layout.final_index_layout, tqc_dt.layout.final_index_layout)
+        self.assertEqual(tqc_no_dt.layout.final_index_layout(), tqc_dt.layout.final_index_layout())
 
 
 @ddt

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -2278,29 +2278,6 @@ class TestTranspile(QiskitTestCase):
         and vf2 runs as expected.
         """
 
-        def _get_index_layout(transpiled_circuit: QuantumCircuit, num_source_qubits: int):
-            """Return the index layout of a transpiled circuit"""
-            layout = transpiled_circuit.layout
-            if layout is None:
-                return list(range(num_source_qubits))
-
-            pos_to_virt = {v: k for k, v in layout.input_qubit_mapping.items()}
-            qubit_indices = []
-            for index in range(num_source_qubits):
-                qubit_idx = layout.initial_layout[pos_to_virt[index]]
-                if layout.final_layout is not None:
-                    qubit_idx = layout.final_layout[transpiled_circuit.qubits[qubit_idx]]
-                qubit_indices.append(qubit_idx)
-            return qubit_indices
-
-        vf2_post_layout_called = False
-
-        def callback(**kwargs):
-            nonlocal vf2_post_layout_called
-            if isinstance(kwargs["pass_"], VF2PostLayout):
-                vf2_post_layout_called = True
-                self.assertIsNotNone(kwargs["property_set"]["post_layout"])
-
         coupling_map = [[0, 1], [1, 0], [1, 2], [1, 3], [2, 1], [3, 1], [3, 4], [4, 3]]
         backend = GenericBackendV2(
             num_qubits=5,
@@ -2313,11 +2290,18 @@ class TestTranspile(QiskitTestCase):
         for i in range(5):
             qc.cx(i % qubits, int(i + qubits / 2) % qubits)
 
-        tqc = transpile(
-            qc, backend=backend, seed_transpiler=4242, callback=callback, dt=backend.dt * 2
+        # transpile with no gate errors
+        tqc_no_error = transpile(qc, coupling_map=coupling_map, seed_transpiler=4242)
+        # transpile with gate errors
+        tqc_no_dt = transpile(qc, backend=backend, seed_transpiler=4242)
+        # confirm that the output layouts are different
+        self.assertNotEqual(
+            tqc_no_dt.layout.final_index_layout, tqc_no_error.layout.final_index_layout
         )
-        self.assertTrue(vf2_post_layout_called)
-        self.assertEqual([2, 1, 0], _get_index_layout(tqc, qubits))
+        # now modify dt with gate errors
+        tqc_dt = transpile(qc, backend=backend, seed_transpiler=4242, dt=backend.dt * 2)
+        # confirm that dt doesn't affect layout
+        self.assertEqual(tqc_no_dt.layout.final_index_layout, tqc_dt.layout.final_index_layout)
 
 
 @ddt


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
https://github.com/Qiskit/qiskit/pull/14056#issuecomment-2742155706 reported an unexpected behavior of `generate_preset_pass_manager` where setting a custom `dt` would invalidate the backend's gate durations and error rates. This was due to an oversight in [#9256 ](https://github.com/Qiskit/qiskit/pull/12850), where a custom target would be built from scratch using `Target.from_configuration` whenever any loose constraint was set, and any information regarding instruction properties would be lost. This was intentional for `coupling_map` and `basis_gates`, as they modify the target gate map, but not necessary for `dt`, where the target could be kept and simply updated. 

This PR fixes this use case, adds a test with vf2 + dt, and modifies the user warning to explicitly communicate what will happen with gate durations and errors if `coupling_map` or `basis_gates` are set with a `backend`.


### Details and comments
The changelog is None as [#9256 ](https://github.com/Qiskit/qiskit/pull/12850) has not been released yet.

