### PR TITLE
Add random_clifford_circuit to API docs

### DIFF
--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -1058,6 +1058,7 @@ Generating random circuits
 
 .. currentmodule:: qiskit.circuit.random
 .. autofunction:: random_circuit
+.. autofunction:: random_clifford_circuit
 .. currentmodule:: qiskit.circuit
 
 Apply Pauli twirling to a circuit

--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -303,9 +303,10 @@ assist compilation workflows.  These include:
 * :data:`SessionEquivalenceLibrary`, a mutable instance of :class:`EquivalenceLibrary` which is used
   by default by the compiler's :class:`.BasisTranslator`.
 
-There is also a utility for generating random circuits:
+There are also utilities for generating random circuits:
 
 * :func:`random.random_circuit`
+* :func:`random.random_clifford_circuit`
 
 Finally, the circuit module has its own exception class, to indicate when things went wrong in
 circuit-specific manners:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR adds the `random_clifford_circuit` function to API docs. The function was added in https://github.com/Qiskit/qiskit/pull/12347 and was mentioned in previous release notes. 


### Details and comments


