### PR TITLE
Fix global phase update in `BasisTranslator` Pass

### DIFF
--- a/releasenotes/notes/fix-global-phase-in-basis-translator-d08d665198589828.yaml
+++ b/releasenotes/notes/fix-global-phase-in-basis-translator-d08d665198589828.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a problem in :class:`.BasisTranslator` transpiler pass, where the global
+    phase of the DAG was not updated correctly. 
+    Fixed `#14074 <https://github.com/Qiskit/qiskit/issues/14074>`__.

--- a/test/python/transpiler/test_basis_translator.py
+++ b/test/python/transpiler/test_basis_translator.py
@@ -1008,6 +1008,15 @@ class TestBasisExamples(QiskitTestCase):
         )
         self.assertEqual(Operator(dag_to_circuit(out_dag)), Operator(expected))
 
+    def test_rx_to_rz(self):
+        """Verify global phase is updated correctly in basis translation.
+        See https://github.com/Qiskit/qiskit/issues/14074."""
+        theta = 0.5 * pi
+        circ = QuantumCircuit(1)
+        circ.rx(theta, 0)
+        out_circ = BasisTranslator(std_eqlib, ["h", "rz"])(circ)
+        self.assertEqual(Operator(circ), Operator(out_circ))
+
     def test_skip_target_basis_equivalences_1(self):
         """Test that BasisTranslator skips gates in the target_basis - #6085"""
         circ = QuantumCircuit()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #14074. 

The `basis_translator` pass was not always updating the DAG's global phase as a part of  `replace_node`: this was only done when the target dag's global phase matched ``Param::ParameterExpression``. Updating the global phase in the case of ``Param::Float`` was missing, and this is fixed now. 

I am somewhat unsure if we also need to handle the ``Param::Obj`` case. I don't understand in what kind of a circuit we would see this, and I don't believe it's even supported, as per ``dag_circuit.rs.add_global_phase``, which throws an error in the case of ``Param::Obj``. Update: @jakelishman confirmed that ``Param::Obj`` is never permitted in ``global_phase``.

Update: added release notes.
