### PR TITLE
Remove mention of toffoli method in CCXGate documentation

### DIFF
--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -301,8 +301,7 @@ class CCXGate(SingletonControlledGate):
     r"""CCX gate, also known as Toffoli gate.
 
     Can be applied to a :class:`~qiskit.circuit.QuantumCircuit`
-    with the :meth:`~qiskit.circuit.QuantumCircuit.ccx` and
-    :meth:`~qiskit.circuit.QuantumCircuit.toffoli` methods.
+    with the :meth:`~qiskit.circuit.QuantumCircuit.ccx` method.
 
     **Circuit symbol:**
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes #14079 

In the current documentation for the [CCXGate](https://docs.quantum.ibm.com/api/qiskit/qiskit.circuit.library.CCXGate), there is a mention of the `toffoli` method which doesn't exist anymore for `QuantumCircuit`, see [release note](https://docs.quantum.ibm.com/api/qiskit/release-notes/1.0#circuits-upgrade-notes) for Qiskit 1.0. This PR removes it.


