### PR TITLE
Update security policy for 1.x and 2.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ and one year of security fixes.
 
 For example, if the most recent release is 1.0.1, then the current major release series is 1.x and the current minor release is 1.0.x.
 The 1.0.x series will be supported with bug fixes, until the release of 1.1.0, which will include new features.
-The last version of the previous major release, 0.46.x, is supported with bugfixes only until six months after the final release of 1.0.0,
+The last version of the previous major release, 0.46.x, is supported with bug fixes until six months after the final release of 1.0.0,
 and for one year with any security fixes.
 
 We provide more detail on [the release and support schedule of Qiskit in our documentation](https://docs.quantum.ibm.com/open-source/qiskit-sdk-version-strategy).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,13 @@
 
 Qiskit supports the most recent major release with new features, which will only appear in minor releases of that series.
 The most recent minor release in the current major release series is also supported with bug fixes.
-In addition, the last minor release of the *previous* major release series is supported with bug fixes for six months after a new major release.
+In addition, the last minor release of the *previous* major release series is supported with bug fixes for six months after a new major release,
+and one year of security fixes.
 
 For example, if the most recent release is 1.0.1, then the current major release series is 1.x and the current minor release is 1.0.x.
 The 1.0.x series will be supported with bug fixes, until the release of 1.1.0, which will include new features.
-The last version of the previous major release, 0.46.x, is supported with bugfixes only until six months after the final release of 1.0.0.
+The last version of the previous major release, 0.46.x, is supported with bugfixes only until six months after the final release of 1.0.0,
+and for one year with any security fixes.
 
 We provide more detail on [the release and support schedule of Qiskit in our documentation](https://docs.quantum.ibm.com/open-source/qiskit-sdk-version-strategy).
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

With the 1.x release we're extending security support for Qiskit to 1 yr. We still only support 1.x for general bugfixes for 6 months after the 2.0.0 release. But for 1.x if any security vulnerabilities are identified we will provide fixes for that up to 1 yr after the release of 2.0.0. This was reflected in the 1.4.0 release notes and is on the version strategy docs:

https://docs.quantum.ibm.com/open-source/qiskit-sdk-version-strategy

but we forgot to update the security policy document in the Qiskit repo. This commit fixes this oversight.

### Details and comments


