### PR TITLE
Use Luciano's new email as the canonical one

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -162,10 +162,9 @@ Kevin J. Sung <kevinsung@users.noreply.github.com> <kevjsung@umich.edu>
 Kevin Krsulich <kevin.krsulich@ibm.com> <kevin@krsulich.net>
 Lauren Capelluto <lcapelluto@users.noreply.github.com> <laurencapelluto@gmail.com>
 Lev S. Bishop <18673315+levbishop@users.noreply.github.com>
-Luciano Bello <luciano.bello@ibm.com> <bel@zurich.ibm.com>
-Luciano Bello <luciano.bello@ibm.com> <lbello@gmail.com>
-Luciano Bello <luciano.bello@ibm.com> <luciano.bello@ibm.com>
-Luciano Bello <luciano.bello@ibm.com> <luciano@debian.org>
+Luciano Bello <bel@zurich.ibm.com> <lbello@gmail.com>
+Luciano Bello <bel@zurich.ibm.com> <luciano.bello@ibm.com>
+Luciano Bello <bel@zurich.ibm.com> <luciano@debian.org>
 M. Chandler Bennett <mchandlerbennett@gmail.com> <mcbennet@ncsu.edu>
 Manoel Marques <manoel@us.ibm.com> <manoel.marques@ibm.com>
 Manoel Marques <manoel@us.ibm.com> <manoelmrqs@gmail.com>


### PR DESCRIPTION
Luciano had an old IBM email address that is no longer active.  We were previously canonicalising to that email, rather than his current one.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


This (might) fix the giant gap in commit history that GitHub assigns to Luciano in the early years of him being an IBMer.