### PR TITLE
Update BackendV1 to BackendV2 release notes link

### DIFF
--- a/releasenotes/notes/1.3/deprecate-basic-simulator-configuration-9d782925196993e9.yaml
+++ b/releasenotes/notes/1.3/deprecate-basic-simulator-configuration-9d782925196993e9.yaml
@@ -28,5 +28,5 @@ deprecations_providers:
     (*) Note that ``backend.target.operation_names`` includes ``basis_gates`` and additional 
     non-gate instructions, in some implementations it might be necessary to filter the output.
 
-    See `this guide <https://docs.quantum.ibm.com/api/qiskit/providers#migrating-from-backendv1-to-backendv2>`__
+    See `this guide <https://docs.quantum.ibm.com/migration-guides/qiskit-backendv1-to-v2>`__
     for more information on migrating to the ``BackendV2`` model.


### PR DESCRIPTION
This PR updates the v1.3 releases notes to use the new migration guide introduced by @ElePT in https://github.com/Qiskit/documentation/pull/2705 rather than linking to the provider's section