### PR TITLE
Configure reno for C API

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -6,7 +6,7 @@ pre_release_tag_re: (?P<pre_release>(?:[ab]|rc|pre)+\d*)$
 unreleased_version_title: Unreleased Notes Preview
 sections:
   - [features, New Features]
-  - [features_algorithms, Algorithms Features]
+  - [features_c, C API Features]
   - [features_circuits, Circuits Features]
   - [features_primitives, Primitives Features]
   - [features_providers, Providers Features]
@@ -22,6 +22,7 @@ sections:
   - [upgrade, Upgrade Notes]
   - [upgrade_algorithms, Algorithms Upgrade Notes]
   - [upgrade_circuits, Circuits Upgrade Notes]
+  - [upgrade_c, C API Upgrade Notes]
   - [upgrade_primitives, Primitives Upgrade Notes]
   - [upgrade_providers, Providers Upgrade Notes]
   - [upgrade_pulse, Pulse Upgrade Notes]
@@ -33,7 +34,6 @@ sections:
   - [upgrade_visualization, Visualization Upgrade Notes]
   - [upgrade_misc, Misc. Upgrade Notes]
   - [deprecations, Deprecation Notes]
-  - [deprecations_algorithms, Algorithms Deprecations]
   - [deprecations_circuits, Circuits Deprecations]
   - [deprecations_primitives, Primitives Deprecations]
   - [deprecations_providers, Providers Deprecations]
@@ -67,6 +67,9 @@ template: |
       available in another section, such as the prelude. This may mean repeating
       some details. If the feature note is contained within one of the modules
       listed below you should use the appropriate subsection instead.
+  features_c:
+    - |
+      New features related to the C API.
   features_circuits:
     - |
       New features related to the qiskit.circuit module.
@@ -116,6 +119,9 @@ template: |
       available in another section, such as the prelude. This may mean repeating
       some details. If the upgrade note is contained within one of the modules
       listed below you should use the appropriate subsection instead.
+  upgrade_c:
+    - |
+      Notes with upgrade impact related to the C API.
   upgrade_circuits:
     - |
       Notes with upgrade impact related to the qiskit.circuit module.

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -6,6 +6,7 @@ pre_release_tag_re: (?P<pre_release>(?:[ab]|rc|pre)+\d*)$
 unreleased_version_title: Unreleased Notes Preview
 sections:
   - [features, New Features]
+  - [features_algorithms, Algorithms Features]
   - [features_c, C API Features]
   - [features_circuits, Circuits Features]
   - [features_primitives, Primitives Features]
@@ -34,6 +35,8 @@ sections:
   - [upgrade_visualization, Visualization Upgrade Notes]
   - [upgrade_misc, Misc. Upgrade Notes]
   - [deprecations, Deprecation Notes]
+  - [deprecations_algorithms, Algorithms Deprecations]
+  - [deprecations_c, C API Deprecations]
   - [deprecations_circuits, Circuits Deprecations]
   - [deprecations_primitives, Primitives Deprecations]
   - [deprecations_providers, Providers Deprecations]
@@ -164,6 +167,9 @@ template: |
       the text needs to be worded so that it does not depend on any information
       only available in another section, such as the prelude. This may mean
       repeating some details.
+  deprecations_c:
+    - |
+      Deprecations related to the C API.
   deprecations_circuits:
     - |
       Deprecations related to the qiskit.circuit module.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This adds `features_c` and `upgrades_c` sections to the reno. There were also trailing `_algorithms` sections, which no longer exist (and were already removed from the template, but likely missed here).


