### PR TITLE
[Backport] Fix equality and pickling of DAGCircuit with stretches

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -4532,6 +4532,8 @@ impl DAGCircuit {
             .len()
     }
 
+    // These three stretch getter methods are for testing purposes, they'll be public
+    // APIs in Qiskit 2.1
     #[getter]
     fn _num_stretches(&self) -> usize {
         self._num_captured_stretches() + self._num_declared_stretches()

--- a/test/python/circuit/test_circuit_vars.py
+++ b/test/python/circuit/test_circuit_vars.py
@@ -189,10 +189,25 @@ class TestCircuitVars(QiskitTestCase):
         b = expr.Stretch.new("b")
         c = expr.Stretch.new("c")
 
+        # Capture order doesn't matter in circuit equality!
         qc1 = QuantumCircuit(captures=[a, b, c])
         self.assertEqual(qc1, QuantumCircuit(captures=[a, b, c]))
-        self.assertNotEqual(qc1, QuantumCircuit(captures=[c, b, a]))
+        self.assertEqual(qc1, QuantumCircuit(captures=[c, b, a]))
 
+        qc1 = QuantumCircuit()
+        qc1.add_stretch(a)
+        qc1.add_stretch(b)
+        qc1.add_stretch(c)
+
+        qc2 = QuantumCircuit()
+        qc2.add_stretch(c)
+        qc2.add_stretch(b)
+        qc2.add_stretch(a)
+
+        # But declaration order does!
+        self.assertNotEqual(qc1, qc2)
+
+        qc1 = QuantumCircuit(captures=[a, b, c])
         qc2 = QuantumCircuit(captures=[a])
         qc2.add_stretch(b)
         qc2.add_stretch(c)

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -10,6 +10,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+# pylint: disable=invalid-name
+
 """Test for the DAGCircuit object"""
 
 from __future__ import annotations
@@ -508,13 +510,16 @@ class TestDagWireRemoval(QiskitTestCase):
         dag.add_input_var(expr.Var.new("b", types.Uint(8)))
         dag.add_declared_var(expr.Var.new("c", types.Bool()))
         dag.add_declared_var(expr.Var.new("d", types.Uint(8)))
+        dag.add_declared_stretch(expr.Stretch.new("e"))
         self.assertEqual(dag, dag.copy_empty_like())
 
         dag = DAGCircuit()
         dag.add_captured_var(expr.Var.new("a", types.Bool()))
         dag.add_captured_var(expr.Var.new("b", types.Uint(8)))
-        dag.add_declared_var(expr.Var.new("c", types.Bool()))
-        dag.add_declared_var(expr.Var.new("d", types.Uint(8)))
+        dag.add_declared_stretch(expr.Stretch.new("c"))
+        dag.add_declared_var(expr.Var.new("d", types.Bool()))
+        dag.add_declared_var(expr.Var.new("e", types.Uint(8)))
+        dag.add_declared_stretch(expr.Stretch.new("f"))
         self.assertEqual(dag, dag.copy_empty_like())
 
     def test_copy_empty_like_vars_captures(self):
@@ -523,15 +528,18 @@ class TestDagWireRemoval(QiskitTestCase):
         b = expr.Var.new("b", types.Uint(8))
         c = expr.Var.new("c", types.Bool())
         d = expr.Var.new("d", types.Uint(8))
+        e = expr.Stretch.new("e")
         all_captures = DAGCircuit()
         for var in [a, b, c, d]:
             all_captures.add_captured_var(var)
+        all_captures.add_captured_stretch(e)
 
         dag = DAGCircuit()
         dag.add_input_var(a)
         dag.add_input_var(b)
         dag.add_declared_var(c)
         dag.add_declared_var(d)
+        dag.add_declared_stretch(e)
         self.assertEqual(all_captures, dag.copy_empty_like(vars_mode="captures"))
 
         dag = DAGCircuit()
@@ -539,6 +547,7 @@ class TestDagWireRemoval(QiskitTestCase):
         dag.add_captured_var(b)
         dag.add_declared_var(c)
         dag.add_declared_var(d)
+        dag.add_declared_stretch(e)
         self.assertEqual(all_captures, dag.copy_empty_like(vars_mode="captures"))
 
     def test_copy_empty_like_vars_drop(self):
@@ -547,12 +556,14 @@ class TestDagWireRemoval(QiskitTestCase):
         b = expr.Var.new("b", types.Uint(8))
         c = expr.Var.new("c", types.Bool())
         d = expr.Var.new("d", types.Uint(8))
+        e = expr.Stretch.new("e")
 
         dag = DAGCircuit()
         dag.add_input_var(a)
         dag.add_input_var(b)
         dag.add_declared_var(c)
         dag.add_declared_var(d)
+        dag.add_declared_stretch(e)
         self.assertEqual(DAGCircuit(), dag.copy_empty_like(vars_mode="drop"))
 
         dag = DAGCircuit()
@@ -560,6 +571,7 @@ class TestDagWireRemoval(QiskitTestCase):
         dag.add_captured_var(b)
         dag.add_declared_var(c)
         dag.add_declared_var(d)
+        dag.add_captured_stretch(e)
         self.assertEqual(DAGCircuit(), dag.copy_empty_like(vars_mode="drop"))
 
     def test_remove_busy_clbit(self):
@@ -1850,8 +1862,10 @@ class TestDagEquivalence(QiskitTestCase):
         """The vars should be compared whether or not they're used."""
         a_bool = expr.Var.new("a", types.Bool())
         a_u8 = expr.Var.new("a", types.Uint(8))
+        a_stretch = expr.Stretch.new("a")
         a_u8_other = expr.Var.new("a", types.Uint(8))
         b_bool = expr.Var.new("b", types.Bool())
+        b_stretch = expr.Stretch.new("b")
 
         left = DAGCircuit()
         left.add_input_var(a_bool)
@@ -1896,6 +1910,17 @@ class TestDagEquivalence(QiskitTestCase):
         self.assertNotEqual(left, right)
 
         right = DAGCircuit()
+        right.add_captured_stretch(a_stretch)
+        right.add_captured_stretch(b_stretch)
+        self.assertEqual(right.num_input_vars, 0)
+        self.assertEqual(right.num_captured_vars, 0)
+        self.assertEqual(right.num_declared_vars, 0)
+        self.assertEqual(right._num_captured_stretches, 2)
+        self.assertEqual(right._num_declared_stretches, 0)
+        self.assertEqual(right._num_stretches, 2)
+        self.assertNotEqual(left, right)
+
+        right = DAGCircuit()
         right.add_declared_var(a_bool)
         right.add_declared_var(b_bool)
         self.assertEqual(right.num_input_vars, 0)
@@ -1904,11 +1929,24 @@ class TestDagEquivalence(QiskitTestCase):
         self.assertEqual(right.num_vars, 2)
         self.assertNotEqual(left, right)
 
+        right = DAGCircuit()
+        right.add_declared_stretch(a_stretch)
+        right.add_declared_stretch(b_stretch)
+        self.assertEqual(right.num_input_vars, 0)
+        self.assertEqual(right.num_captured_vars, 0)
+        self.assertEqual(right.num_declared_vars, 0)
+        self.assertEqual(right._num_captured_stretches, 0)
+        self.assertEqual(right._num_declared_stretches, 2)
+        self.assertEqual(right._num_stretches, 2)
+        self.assertNotEqual(left, right)
+
         left = DAGCircuit()
         left.add_captured_var(a_u8)
+        left.add_captured_stretch(b_stretch)
 
         right = DAGCircuit()
         right.add_captured_var(a_u8)
+        right.add_captured_stretch(b_stretch)
         self.assertEqual(left, right)
 
         right = DAGCircuit()
@@ -2111,6 +2149,7 @@ class TestDagEquivalence(QiskitTestCase):
         """Test that a DAG can't have both captures and inputs."""
         a = expr.Var.new("a", types.Bool())
         b = expr.Var.new("b", types.Bool())
+        c = expr.Stretch.new("c")
 
         dag = DAGCircuit()
         dag.add_input_var(a)
@@ -2118,6 +2157,10 @@ class TestDagEquivalence(QiskitTestCase):
             DAGCircuitError, "cannot add captures to a circuit with inputs"
         ):
             dag.add_captured_var(b)
+        with self.assertRaisesRegex(
+            DAGCircuitError, "cannot add captures to a circuit with inputs"
+        ):
+            dag.add_captured_stretch(c)
 
         dag = DAGCircuit()
         dag.add_captured_var(a)
@@ -2125,6 +2168,13 @@ class TestDagEquivalence(QiskitTestCase):
             DAGCircuitError, "cannot add inputs to a circuit with captures"
         ):
             dag.add_input_var(b)
+
+        dag = DAGCircuit()
+        dag.add_captured_stretch(c)
+        with self.assertRaisesRegex(
+            DAGCircuitError, "cannot add inputs to a circuit with captures"
+        ):
+            dag.add_input_var(a)
 
     def test_forbid_adding_nonstandalone_var(self):
         """Temporary "wrapping" vars aren't standalone and can't be tracked separately."""
@@ -2138,12 +2188,69 @@ class TestDagEquivalence(QiskitTestCase):
         """Can't re-add a variable that exists, nor a shadowing variable in the same scope."""
         a1 = expr.Var.new("a", types.Bool())
         a2 = expr.Var.new("a", types.Bool())
+        a3 = expr.Stretch.new("a")
         dag = DAGCircuit()
         dag.add_declared_var(a1)
         with self.assertRaisesRegex(DAGCircuitError, "already present in the circuit"):
             dag.add_declared_var(a1)
         with self.assertRaisesRegex(DAGCircuitError, "cannot add .* as its name shadows"):
             dag.add_declared_var(a2)
+        with self.assertRaisesRegex(DAGCircuitError, "cannot add .* as its name shadows"):
+            dag.add_declared_stretch(a3)
+
+        dag = DAGCircuit()
+        dag.add_declared_stretch(a3)
+        with self.assertRaisesRegex(DAGCircuitError, "already present in the circuit"):
+            dag.add_captured_stretch(a3)
+        with self.assertRaisesRegex(DAGCircuitError, "cannot add .* as its name shadows"):
+            dag.add_declared_var(a1)
+        with self.assertRaisesRegex(DAGCircuitError, "cannot add .* as its name shadows"):
+            dag.add_declared_var(a2)
+
+    def test_pickle_stretches(self):
+        """Test stretches preserved through pickle."""
+        a = expr.Stretch.new("a")
+        b = expr.Stretch.new("b")
+
+        # Check captures and declarations.
+        dag = DAGCircuit()
+        dag.add_declared_stretch(a)
+        dag.add_captured_stretch(b)
+
+        self.assertEqual(dag._num_stretches, 2)
+        self.assertEqual(dag._num_captured_stretches, 1)
+        self.assertEqual(dag._num_declared_stretches, 1)
+
+        with io.BytesIO() as buf:
+            pickle.dump(dag, buf)
+            buf.seek(0)
+            output = pickle.load(buf)
+
+        self.assertEqual(output._num_stretches, 2)
+        self.assertEqual(output._num_captured_stretches, 1)
+        self.assertEqual(output._num_declared_stretches, 1)
+        self.assertEqual(output, dag)
+
+    def test_deepcopy_stretches(self):
+        """Test stretches preserved through deepcopy."""
+        a = expr.Stretch.new("a")
+        b = expr.Stretch.new("b")
+
+        # Check captures and declarations.
+        dag = DAGCircuit()
+        dag.add_declared_stretch(a)
+        dag.add_captured_stretch(b)
+
+        self.assertEqual(dag._num_stretches, 2)
+        self.assertEqual(dag._num_captured_stretches, 1)
+        self.assertEqual(dag._num_declared_stretches, 1)
+
+        output = copy.deepcopy(dag)
+
+        self.assertEqual(output._num_stretches, 2)
+        self.assertEqual(output._num_captured_stretches, 1)
+        self.assertEqual(output._num_declared_stretches, 1)
+        self.assertEqual(output, dag)
 
 
 class TestDagSubstitute(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

Backport of #14000

### Summary
During testing, I've found two bugs with `DAGCircuit`'s handling of stretches:

1. #13998 
2. #13999 

They are fixed here.