### PR TITLE
Fix missing ``Qk`` prefix for C ``ExitCode``

### DIFF
--- a/crates/cext/cbindgen.toml
+++ b/crates/cext/cbindgen.toml
@@ -32,3 +32,4 @@ prefix_with_name = true
 "CSparseTerm" = "QkObsTerm"
 "BitTerm" = "QkBitTerm"
 "Complex64" = "QkComplex64"
+"ExitCode" = "QkExitCode"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Missed a ``Qk`` prefix for the ``ExitCode`` enum class, which should be called ``QkExitCode``. This sort of problem will likely keep popping up since we're manually adding this prefix, until we get a solution like https://github.com/mozilla/cbindgen/issues/1061.


