### PR TITLE
Fix result.to_dict() following new 2.0 typing

### DIFF
--- a/qiskit/result/models.py
+++ b/qiskit/result/models.py
@@ -145,8 +145,7 @@ class ExperimentResult:
             status (str): The status of the experiment
             seed (int): The seed used for simulation (if run on a simulator)
             meas_return (str): The type of measurement returned
-            header (dict): A free form dictionary
-                header for the experiment
+            header (dict): A free form dictionary header for the experiment
             kwargs: Arbitrary extra fields
 
         Raises:

--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -88,7 +88,7 @@ class Result:
             "backend_name": self.backend_name,
             "backend_version": self.backend_version,
             "date": self.date,
-            "header": None if self.header is None else self.header.to_dict(),
+            "header": None if self.header is None else self.header,
             "job_id": self.job_id,
             "status": self.status,
             "success": self.success,

--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -88,7 +88,7 @@ class Result:
             "backend_name": self.backend_name,
             "backend_version": self.backend_version,
             "date": self.date,
-            "header": None if self.header is None else self.header,
+            "header": self.header,
             "job_id": self.job_id,
             "status": self.status,
             "success": self.success,

--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -34,6 +34,9 @@ class Result:
             each experiment success)
         results (list[ExperimentResult]): corresponding results for array of
             experiments of the input
+        date (str): optional date field
+        status (str): optional status field
+        header (dict): an optional free form dictionary header
     """
 
     _metadata = {}
@@ -128,11 +131,10 @@ class Result:
         the get_xxx method, and the data will be post-processed for the data type.
 
         Args:
-            experiment (str or QuantumCircuit or Schedule or int or None): the index of the
+            experiment (str or QuantumCircuit or int or None): the index of the
                 experiment. Several types are accepted for convenience::
                 * str: the name of the experiment.
                 * QuantumCircuit: the name of the circuit instance will be used.
-                * Schedule: the name of the schedule instance will be used.
                 * int: the position of the experiment.
                 * None: if there is only one experiment, returns it.
 
@@ -179,7 +181,7 @@ class Result:
         ['00000', '01000', '10100', '10100', '11101', '11100', '00101', ..., '01010']
 
         Args:
-            experiment (str or QuantumCircuit or Schedule or int or None): the index of the
+            experiment (str or QuantumCircuit or int or None): the index of the
                 experiment, as specified by ``data()``.
 
         Returns:
@@ -231,7 +233,7 @@ class Result:
         """Get the histogram data of an experiment.
 
         Args:
-            experiment (str or QuantumCircuit or Schedule or int or None): the index of the
+            experiment (str or QuantumCircuit or int or None): the index of the
                 experiment, as specified by ``data([experiment])``.
 
         Returns:
@@ -283,7 +285,7 @@ class Result:
         """Get the final statevector of an experiment.
 
         Args:
-            experiment (str or QuantumCircuit or Schedule or int or None): the index of the
+            experiment (str or QuantumCircuit or int or None): the index of the
                 experiment, as specified by ``data()``.
             decimals (int): the number of decimals in the statevector.
                 If None, does not round.
@@ -305,7 +307,7 @@ class Result:
         """Get the final unitary of an experiment.
 
         Args:
-            experiment (str or QuantumCircuit or Schedule or int or None): the index of the
+            experiment (str or QuantumCircuit or int or None): the index of the
                 experiment, as specified by ``data()``.
             decimals (int): the number of decimals in the unitary.
                 If None, does not round.
@@ -326,7 +328,7 @@ class Result:
         """Return a single experiment result from a given key.
 
         Args:
-            key (str or QuantumCircuit or Schedule or int or None): the index of the
+            key (str or QuantumCircuit or int or None): the index of the
                 experiment, as specified by ``data()``.
 
         Returns:

--- a/releasenotes/notes/fix-result-to-dict-c970e9e9340962d7.yaml
+++ b/releasenotes/notes/fix-result-to-dict-c970e9e9340962d7.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fix Result unable to generate a dictionary via to_dict()

--- a/releasenotes/notes/fix-result-to-dict-c970e9e9340962d7.yaml
+++ b/releasenotes/notes/fix-result-to-dict-c970e9e9340962d7.yaml
@@ -1,3 +1,0 @@
-fixes:
-  - |
-    Fix Result unable to generate a dictionary via to_dict()

--- a/test/python/result/test_result.py
+++ b/test/python/result/test_result.py
@@ -121,6 +121,38 @@ class TestResultOperations(QiskitTestCase):
         )
         self.assertEqual(expected, repr(result))
 
+    def test_result_to_dict(self):
+        """Test that dictionary is constructed correctly for a results object."""
+        raw_counts = {"0x0": 4, "0x2": 10}
+        data = models.ExperimentResultData(counts=raw_counts)
+        exp_result_header = {"creg_sizes": [["c0", 2], ["c0", 1], ["c1", 1]], "memory_slots": 4}
+        exp_result = models.ExperimentResult(
+            shots=14, success=True, meas_level=2, data=data, header=exp_result_header
+        )
+        header = {"header-property": 1}
+        result = Result(results=[exp_result], header=header, **self.base_result_args)
+
+        expected = {
+            "backend_name": "test_backend",
+            "backend_version": "1.0.0",
+            "header": {"header-property": 1},
+            "date": None,
+            "job_id": "job-123",
+            "status": None,
+            "success": True,
+            "results": [
+                {
+                    "shots": 14,
+                    "success": True,
+                    "data": {"counts": {"0x0": 4, "0x2": 10}},
+                    "meas_level": 2,
+                    "header": {"creg_sizes": [["c0", 2], ["c0", 1], ["c1", 1]], "memory_slots": 4},
+                }
+            ],
+        }
+
+        self.assertEqual(expected, result.to_dict())
+
     def test_multiple_circuits_counts(self):
         """Test that counts are returned either as a list or a single item.
 


### PR DESCRIPTION
Following on the changes in https://github.com/Qiskit/qiskit/pull/13793, I think we should also stop trying to serialize into a dictionary since the header should already be a dictionary.

Currently we face the following issue when doing `result.to_dict()`

```
  File "/opt/app-root/lib64/python3.11/site-packages/qiskit/result/result.py", line 91, in to_dict
    "header": None if self.header is None else self.header.to_dict(),
                                               ^^^^^^^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'to_dict'
```

Added corresponding regression test based on existing to_repr test