### PR TITLE
Fix typo in release notes

### DIFF
--- a/releasenotes/notes/2.0/add-bit-register-rust-979dd113aefb3563.yaml
+++ b/releasenotes/notes/2.0/add-bit-register-rust-979dd113aefb3563.yaml
@@ -14,5 +14,5 @@ upgrade_circuits:
     :class:`.Register` classes is no longer possible. Directly instantiating
     these classes was clearly documented as something that was **not** supported
     and being able to do it was was just an implementation artifact of how the
-    class heirarchy in previous releases. Starting in this release it is no longer
+    class hierarchy in previous releases. Starting in this release it is no longer
     possible to do this.


### PR DESCRIPTION
### Summary

heirarchy -> hierarchy

### Details and comments

This line is edited again to insert a version number in #14021 but I don't have the right to comment there.