### PR TITLE
Bump PyO3 to 0.24.1 and numpy to 0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94caae805f998a07d33af06e6a3891e38556051b8045c615470a71590e13e78"
+checksum = "a7cfbf3f0feededcaa4d289fe3079b03659e85c5b5a177f4ba6fb01ab4fb3e39"
 dependencies = [
  "libc",
  "nalgebra",
@@ -1075,6 +1075,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pyo3",
+ "pyo3-build-config",
  "rustc-hash 2.1.1",
 ]
 
@@ -1341,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "17da310086b068fbdcefbba30aeb3721d5bb9af8db4987d6735b2183ca567229"
 dependencies = [
  "cfg-if",
  "hashbrown 0.15.2",
@@ -1355,7 +1356,7 @@ dependencies = [
  "num-complex",
  "once_cell",
  "portable-atomic",
- "pyo3-build-config 0.23.5",
+ "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
  "smallvec",
@@ -1364,39 +1365,29 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "e27165889bd793000a098bb966adc4300c312497ea25cf7a690a9f0ac5aa5fc1"
 dependencies = [
  "once_cell",
- "target-lexicon 0.12.16",
-]
-
-[[package]]
-name = "pyo3-build-config"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b6c2b34cf71427ea37c7001aefbaeb85886a074795e35f161f5aecc7620a7a"
-dependencies = [
- "once_cell",
- "target-lexicon 0.13.2",
+ "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "05280526e1dbf6b420062f3ef228b78c0c54ba94e157f5cb724a609d0f2faabc"
 dependencies = [
  "libc",
- "pyo3-build-config 0.23.5",
+ "pyo3-build-config",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "5c3ce5686aa4d3f63359a5100c62a127c9f15e8398e5fdeb5deef1fed5cd5f44"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1406,13 +1397,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "f4cf6faa0cbfb0ed08e89beb8103ae9724eb4750e3a78084ba4017cbe94f3855"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
- "pyo3-build-config 0.23.5",
+ "pyo3-build-config",
  "quote",
  "syn 2.0.99",
 ]
@@ -1456,7 +1447,7 @@ dependencies = [
  "cbindgen",
  "num-complex",
  "pyo3",
- "pyo3-build-config 0.24.0",
+ "pyo3-build-config",
  "qiskit-accelerate",
  "thiserror 2.0.12",
 ]
@@ -1936,12 +1927,6 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
 ]
-
-[[package]]
-name = "target-lexicon"
-version = "0.12.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "target-lexicon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ hashbrown.version = "0.15.2"
 num-bigint = "0.4"
 num-complex = "0.4"
 nalgebra = "0.33"
-numpy = "0.23"
+numpy = "0.24"
 ndarray = "0.16"
 smallvec = "1.14"
 thiserror = "2.0"
@@ -36,7 +36,7 @@ rayon = "1.10"
 # distributions).  We only activate that feature when building the C extension module; we still need
 # it disabled for Rust-only tests to avoid linker errors with it not being loaded.  See
 # https://pyo3.rs/main/features#extension-module for more.
-pyo3 = { version = "0.23", features = ["abi3-py39"] }
+pyo3 = { version = "0.24", features = ["abi3-py39"] }
 
 # These are our own crates.
 qiskit-accelerate = { path = "crates/accelerate" }

--- a/crates/cext/Cargo.toml
+++ b/crates/cext/Cargo.toml
@@ -23,7 +23,7 @@ pyo3 = { workspace = true, optional = true }
 
 [build-dependencies]
 cbindgen = "0.28"
-pyo3-build-config = { version = "0.24.0", features = ["resolve-config"] }
+pyo3-build-config = { version = "0.24", features = ["resolve-config"] }
 
 [features]
 default = ["cbinding"]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary


This commit bumps the PyO3 version we use in Qiskit to the latest pyo3 release 0.24.1. Luckily this time there don't seem to be any API changes required to upgrade so it's a straight version bump.

### Details and comments