### PR TITLE
Fix: Incorrect initialization of `BackendV2` for `transpiler_level` ASV Test

### DIFF
--- a/test/benchmarks/transpiler_levels.py
+++ b/test/benchmarks/transpiler_levels.py
@@ -154,7 +154,7 @@ class TranspilerLevelBenchmarks:
         self.qasm_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "qasm"))
         large_qasm_path = os.path.join(self.qasm_path, "test_eoh_qasm.qasm")
         self.large_qasm = QuantumCircuit.from_qasm_file(large_qasm_path)
-        self.melbourne = GenericBackendV2(num_qubits=20, coupling_map=MELBOURNE_CMAP, seed=0)
+        self.melbourne = GenericBackendV2(num_qubits=14, coupling_map=MELBOURNE_CMAP, seed=0)
 
         self.durations = InstructionDurations(
             [


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
After the removal of `BackendV1` in #13793, and the prospective updates done by #13805, the `transpiler_level` tests are no longer working due to an erroneous initialization of a `GenericBackendV2` in which the number of qubits on the backend did not match the number of qubits in the coupling map. The following commits fix said issue by ensuring both of these parameters match.


