### PR TITLE
Add missing argument list to quantum_volume() docs

### DIFF
--- a/qiskit/circuit/library/quantum_volume.py
+++ b/qiskit/circuit/library/quantum_volume.py
@@ -149,6 +149,15 @@ def quantum_volume(
     environment variable. For example, setting ``RAYON_NUM_THREADS=4`` would limit the thread pool
     to 4 threads.
 
+    Args:
+        num_qubits: The number qubits to use for the generated circuit.
+        depth: The number of layers for the generated circuit. If this
+            is not specified it will default to ``num_qubits`` layers.
+        seed: An optional RNG seed used for generating the random SU(4)
+            matrices used in the output circuit. This can be either an
+            integer or a numpy generator. If an integer is specfied it must
+            be an value between 0 and 2**64 - 1.
+
     **Reference Circuit:**
 
     .. plot::


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds the missing description of the function's arguments to the quantum_volume(). The docstring was largely copied from the QuantumVolume class's docstring, but because it was a class the arguments were documented in the `__init__()` method and were missed in the function's docstring. This commit corrects that oversight.

### Details and comments