### PR TITLE
Fix: Updated commentfor statevector_estimator.py (#14150)

### DIFF
--- a/qiskit/primitives/statevector_estimator.py
+++ b/qiskit/primitives/statevector_estimator.py
@@ -33,7 +33,7 @@ class StatevectorEstimator(BaseEstimatorV2):
     Simple implementation of :class:`BaseEstimatorV2` with full state vector simulation.
 
     This class is implemented via :class:`~.Statevector` which turns provided circuits into
-    pure state vectors. These states are subsequently acted on by :class:~.SparsePauliOp`,
+    pure state vectors. These states are subsequently acted on by :class:`~.SparsePauliOp`,
     which implies that, at present, this implementation is only compatible with Pauli-based
     observables.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the CONTRIBUTING document.
-->

### Summary
Added missing " ` " to reference docstring in StatevectorEtimator.py.
Checked that reference is loaded correctly when selecting StatevectorEstimator class.

### Details and comments


