### PR TITLE
Try removing restriction on MSRV for aarch64 PGO builds

### DIFF
--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -100,19 +100,13 @@ jobs:
         run: |
           set -e
           mkdir -p "$PGO_WORK_DIR"
-          if [[ `uname -m` == "aarch64" ]] ; then
-              INSTALL_RUST_PATH=tools/install_rust_msrv.sh
-              RUST_TOOLCHAIN=1.79
-          else
-              INSTALL_RUST_PATH=tools/install_rust.sh
-              RUST_TOOLCHAIN=stable
-          fi
+
           cat >>"$GITHUB_ENV" <<EOF
-          CIBW_BEFORE_ALL_LINUX=yum install -y wget && {package}/$INSTALL_RUST_PATH
+          CIBW_BEFORE_ALL_LINUX=yum install -y wget && {package}/tools/install_rust.sh
           CIBW_BEFORE_BUILD=bash ./tools/build_pgo.sh $PGO_WORK_DIR $PGO_OUT_PATH
           CIBW_ENVIRONMENT=RUSTUP_TOOLCHAIN=stable RUSTFLAGS='-Cprofile-use=$PGO_OUT_PATH -Cllvm-args=-pgo-warn-missing-function'
           CIBW_ENVIRONMENT_MACOS=MACOSX_DEPLOYMENT_TARGET='10.12' RUSTUP_TOOLCHAIN=stable RUSTFLAGS='-Cprofile-use=$PGO_OUT_PATH -Cllvm-args=-pgo-warn-missing-function'
-          CIBW_ENVIRONMENT_LINUX=RUSTUP_TOOLCHAIN=$RUST_TOOLCHAIN RUSTFLAGS='-Cprofile-use=$PGO_OUT_PATH -Cllvm-args=-pgo-warn-missing-function' PATH="\$PATH:\$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true"
+          CIBW_ENVIRONMENT_LINUX=RUSTUP_TOOLCHAIN=stable RUSTFLAGS='-Cprofile-use=$PGO_OUT_PATH -Cllvm-args=-pgo-warn-missing-function' PATH="\$PATH:\$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true"
           EOF
         env:
           PGO_WORK_DIR: ${{ github.workspace }}/pgo-data


### PR DESCRIPTION
With the recently identified manylinux image fixes around some of the gcc toolsets that were included in the latest cibuildwheel bugfix there is a chance that this could fix the issues we were facing on aarch64 PGO builds. This commit attempts to remove the restriction we have to build with MSRV for PGO in the wheel builds on aarch64 linux to validate whether this was actually fixed or not.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


