### PR TITLE
Fix pickle and repr for `Duration`.

### DIFF
--- a/crates/circuit/src/duration.rs
+++ b/crates/circuit/src/duration.rs
@@ -12,6 +12,7 @@
 
 use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
+use pyo3::PyTypeInfo;
 
 /// A length of time used to express circuit timing.
 ///
@@ -74,9 +75,7 @@ impl Duration {
             }
         }
     }
-}
 
-impl Duration {
     fn __repr__(&self) -> String {
         match self {
             Duration::ns(t) => format!("Duration.ns({})", t),
@@ -85,5 +84,13 @@ impl Duration {
             Duration::s(t) => format!("Duration.s({})", t),
             Duration::dt(t) => format!("Duration.dt({})", t),
         }
+    }
+
+    fn __reduce__(&self, py: Python) -> PyResult<Py<PyAny>> {
+        (
+            Duration::type_object(py).getattr(self.unit())?,
+            (self.py_value(py)?,),
+        )
+            .into_py_any(py)
     }
 }

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -35,6 +35,7 @@ mod rustworkx_core_vnext;
 
 use pyo3::prelude::*;
 use pyo3::types::{PySequence, PyTuple};
+use pyo3::PyTypeInfo;
 
 pub type BitType = u32;
 #[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq, FromPyObject)]
@@ -169,7 +170,31 @@ pub fn circuit(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<bit::PyClassicalRegister>()?;
     m.add_class::<bit::PyQuantumRegister>()?;
     m.add_class::<bit::PyAncillaRegister>()?;
+
+    // We need to explicitly add the auto-generated Python subclasses of Duration
+    // to the module so that pickle can find them during deserialization.
     m.add_class::<duration::Duration>()?;
+    m.add(
+        "Duration_ns",
+        duration::Duration::type_object(m.py()).getattr("ns")?,
+    )?;
+    m.add(
+        "Duration_us",
+        duration::Duration::type_object(m.py()).getattr("us")?,
+    )?;
+    m.add(
+        "Duration_ms",
+        duration::Duration::type_object(m.py()).getattr("ms")?,
+    )?;
+    m.add(
+        "Duration_s",
+        duration::Duration::type_object(m.py()).getattr("s")?,
+    )?;
+    m.add(
+        "Duration_dt",
+        duration::Duration::type_object(m.py()).getattr("dt")?,
+    )?;
+
     m.add_class::<circuit_data::CircuitData>()?;
     m.add_class::<circuit_instruction::CircuitInstruction>()?;
     m.add_class::<dag_circuit::DAGCircuit>()?;

--- a/releasenotes/notes/fix-duration-props-0543fe1d5e6e2820.yaml
+++ b/releasenotes/notes/fix-duration-props-0543fe1d5e6e2820.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Added missing ``repr`` support for :class:`~.Duration`.
+  - |
+    Added missing support for Python pickling of :class:`~.Duration`.
+    This was preventing parallel transpilation of circuits with 
+    :meth:`~.QuantumCircuit.delay` instructions that use duration
+    expressions.

--- a/test/python/circuit/test_delay.py
+++ b/test/python/circuit/test_delay.py
@@ -13,12 +13,15 @@
 # pylint: disable=missing-function-docstring
 
 """Test delay instruction for quantum circuits."""
+import copy
+import pickle
 
 import numpy as np
 
-from qiskit.circuit import Delay
+from qiskit.circuit import Delay, Duration
 from qiskit.circuit import Parameter, ParameterVector
 from qiskit.circuit import QuantumCircuit, CircuitInstruction
+from qiskit.circuit.classical import expr
 from qiskit.circuit.exceptions import CircuitError
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
@@ -135,6 +138,21 @@ class TestDelayClass(QiskitTestCase):
             self.assertNotEqual(circuit_from(Delay(2, "dt")), circuit_from(Delay(2, unit)))
             self.assertNotEqual(Delay(a, unit), Delay(a, "dt"))
             self.assertNotEqual(circuit_from(Delay(a, unit)), circuit_from(Delay(a, "dt")))
+
+    def test_delay_clone(self):
+        """Test that circuits with delays can be copied or pickled."""
+        qc = QuantumCircuit(3)
+        stretch = qc.add_stretch("a")
+        qc.delay(100, qc.qubits[0])
+        qc.delay(expr.lift(Duration.us(1)), 0)
+        qc.delay(expr.lift(Duration.ns(2)), 0)
+        qc.delay(expr.lift(Duration.ms(3)), 0)
+        qc.delay(expr.lift(Duration.s(4)), 0)
+        qc.delay(expr.lift(Duration.dt(5)), 0)
+        qc.delay(stretch, [0, 1])
+        self.assertEqual(qc, pickle.loads(pickle.dumps(qc)))
+        self.assertEqual(qc, copy.copy(qc))
+        self.assertEqual(qc, copy.deepcopy(qc))
 
 
 class TestParameterizedDelay(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Adds missing Python pickle support for the new `Duration` type added in Qiskit 2.0.


### Details and comments
To get this working, I needed to manually register the PyO3 generated `Duration_xx` Python classes at the module level, since `pickle` looks for them during deserialization. I'm not sure if there's a better way, but I'm open to suggestions if you can think of something cleaner. Pickle doesn't have explicit support in PyO3, so we're lucky to have any working solution here.

While fixing this, I also noticed that `__repr__` was defined inside an `impl` block that wasn't decorated with `#[pymethods]`, meaning it wasn't actually being used before. That's fixed here too.


Fixes #14169 