### PR TITLE
Fix cargo clippy warnings in Rust 1.86

### DIFF
--- a/crates/accelerate/src/circuit_library/multi_local.rs
+++ b/crates/accelerate/src/circuit_library/multi_local.rs
@@ -40,11 +40,11 @@ type Instruction = (
 ///
 /// - `num_qubits`: The number of qubits in the circuit.
 /// - `rotation_blocks`: A reference to a vector containing the instructions to insert.
-///     This is a vector (sind we can have multiple rotations  operations per layer), with
-///     3-tuple elements containing (packed_operation, num_qubits, num_params).
+///   This is a vector (sind we can have multiple rotations  operations per layer), with
+///   3-tuple elements containing (packed_operation, num_qubits, num_params).
 /// - `parameters`: The set of parameter objects to use for the operations. This is a 3x nested
-///     vector, organized as operation -> block -> param. That means that for operation `i`
-///     and block `j`, the parameters are given by `parameters[i][j]`.
+///   vector, organized as operation -> block -> param. That means that for operation `i`
+///   and block `j`, the parameters are given by `parameters[i][j]`.
 /// - skipped_qubits: A hash-set containing which qubits are skipped in the rotation layer.
 ///
 /// # Returns
@@ -91,14 +91,14 @@ fn rotation_layer<'a>(
 /// # Arguments
 ///
 /// - `entanglement`: The entanglement structure in this layer. Given as 3x nested vector, which
-///     for each entanglement block contains a vector of connections, where each connection
-///     is a vector of indices.
+///   for each entanglement block contains a vector of connections, where each connection
+///   is a vector of indices.
 /// - `entanglement_blocks`: A reference to a vector containing the instructions to insert.
-///     This is a vector (sind we can have multiple entanglement operations per layer), with
-///     3-tuple elements containing (packed_operation, num_qubits, num_params).
+///   This is a vector (sind we can have multiple entanglement operations per layer), with
+///   3-tuple elements containing (packed_operation, num_qubits, num_params).
 /// - `parameters`: The set of parameter objects to use for the operations. This is a 3x nested
-///     vector, organized as operation -> block -> param. That means that for operation `i`
-///     and block `j`, the parameters are given by `parameters[i][j]`.
+///   vector, organized as operation -> block -> param. That means that for operation `i`
+///   and block `j`, the parameters are given by `parameters[i][j]`.
 ///
 /// # Returns
 ///
@@ -133,24 +133,24 @@ fn entanglement_layer<'a>(
 ///
 /// - `num_qubits`: The number of qubits of the circuit.
 /// - `rotation_blocks`: The blocks used in the rotation layers. If multiple are passed,
-///     these will be applied one after another (like new sub-layers).
+///   these will be applied one after another (like new sub-layers).
 /// - `entanglement_blocks`: The blocks used in the entanglement layers. If multiple are passed,
-///     these will be applied one after another.
+///   these will be applied one after another.
 /// - `entanglement`: The indices specifying on which qubits the input blocks act. This is
-///     specified by string describing an entanglement strategy (see the additional info)
-///     or a list of qubit connections.
-///     If a list of entanglement blocks is passed, different entanglement for each block can
-///     be specified by passing a list of entanglements. To specify varying entanglement for
-///     each repetition, pass a callable that takes as input the layer and returns the
-///     entanglement for that layer.
-///     Defaults to ``"full"``, meaning an all-to-all entanglement structure.
+///   specified by string describing an entanglement strategy (see the additional info)
+///   or a list of qubit connections.
+///   If a list of entanglement blocks is passed, different entanglement for each block can
+///   be specified by passing a list of entanglements. To specify varying entanglement for
+///   each repetition, pass a callable that takes as input the layer and returns the
+///   entanglement for that layer.
+///   Defaults to ``"full"``, meaning an all-to-all entanglement structure.
 /// - `reps`: Specifies how often the rotation blocks and entanglement blocks are repeated.
 /// - `insert_barriers`: If ``True``, barriers are inserted in between each layer. If ``False``,
-///     no barriers are inserted.
+///   no barriers are inserted.
 /// - `parameter_prefix`: The prefix used if default parameters are generated.
 /// - `skip_final_rotation_layer`: Whether a final rotation layer is added to the circuit.
 /// - `skip_unentangled_qubits`: If ``True``, the rotation gates act only on qubits that
-///     are entangled. If ``False``, the rotation gates act on all qubits.
+///   are entangled. If ``False``, the rotation gates act on all qubits.
 ///
 /// # Returns
 ///

--- a/crates/accelerate/src/circuit_library/multi_local.rs
+++ b/crates/accelerate/src/circuit_library/multi_local.rs
@@ -40,7 +40,7 @@ type Instruction = (
 ///
 /// - `num_qubits`: The number of qubits in the circuit.
 /// - `rotation_blocks`: A reference to a vector containing the instructions to insert.
-///   This is a vector (sind we can have multiple rotations  operations per layer), with
+///   This is a vector (since we can have multiple operations per layer), with
 ///   3-tuple elements containing (packed_operation, num_qubits, num_params).
 /// - `parameters`: The set of parameter objects to use for the operations. This is a 3x nested
 ///   vector, organized as operation -> block -> param. That means that for operation `i`
@@ -94,7 +94,7 @@ fn rotation_layer<'a>(
 ///   for each entanglement block contains a vector of connections, where each connection
 ///   is a vector of indices.
 /// - `entanglement_blocks`: A reference to a vector containing the instructions to insert.
-///   This is a vector (sind we can have multiple entanglement operations per layer), with
+///   This is a vector (since we can have multiple entanglement operations per layer), with
 ///   3-tuple elements containing (packed_operation, num_qubits, num_params).
 /// - `parameters`: The set of parameter objects to use for the operations. This is a 3x nested
 ///   vector, organized as operation -> block -> param. That means that for operation `i`

--- a/crates/accelerate/src/commutation_analysis.rs
+++ b/crates/accelerate/src/commutation_analysis.rs
@@ -35,10 +35,10 @@ const MAX_NUM_QUBITS: u32 = 3;
 ///
 /// We return two HashMaps:
 ///  * {wire: commutation_sets}: For each wire, we keep a vector of index sets, where each index
-///     set contains mutually commuting nodes. Note that these include the input and output nodes
-///     which do not commute with anything.
+///    set contains mutually commuting nodes. Note that these include the input and output nodes
+///    which do not commute with anything.
 ///  * {(node, wire): index}: For each (node, wire) pair we store the index indicating in which
-///     commutation set the node appears on a given wire.
+///    commutation set the node appears on a given wire.
 ///
 /// For example, if we have a circuit
 ///

--- a/crates/accelerate/src/sparse_observable/mod.rs
+++ b/crates/accelerate/src/sparse_observable/mod.rs
@@ -4130,7 +4130,7 @@ fn cast_array_type<'py, T>(
 ///
 /// * `Ok(Some(obs))` if the coercion was completely successful.
 /// * `Ok(None)` if the input value was just completely the wrong type and no coercion could be
-///    attempted.
+///   attempted.
 /// * `Err` if the input was a valid type for coercion, but the coercion failed with a Python
 ///   exception.
 ///

--- a/crates/accelerate/src/synthesis/evolution/pauli_network.rs
+++ b/crates/accelerate/src/synthesis/evolution/pauli_network.rs
@@ -165,11 +165,11 @@ impl CommutativityDag {
 ///
 /// * py: a GIL handle, needed to negate rotation parameters in Python space.
 /// * gates: the sequence of Rustiq's Clifford gates returned by Rustiq's
-///     pauli network synthesis algorithm.
+///   pauli network synthesis algorithm.
 /// * paulis: Rustiq's data structure storing the pauli rotations.
 /// * angles: Qiskit's rotation angles corresponding to the pauli rotations.
 /// * preserve_order: specifies whether the order of paulis should be preserved,
-///     up to commutativity.
+///   up to commutativity.
 fn inject_rotations(
     py: Python,
     gates: &[CliffordGate],
@@ -275,24 +275,24 @@ fn synthesize_final_clifford(
 /// * py: a GIL handle, needed to add and negate rotation parameters in Python space.
 /// * num_qubits: total number of qubits.
 /// * pauli_network: pauli network represented in sparse format. It's a list
-///     of triples such as `[("XX", [0, 3], theta), ("ZZ", [0, 1], 0.1)]`.
+///   of triples such as `[("XX", [0, 3], theta), ("ZZ", [0, 1], 0.1)]`.
 /// * optimize_count: if `true`, Rustiq's synthesis algorithms aims to optimize
-///     the 2-qubit gate count; and if `false`, then the 2-qubit depth.
+///   the 2-qubit gate count; and if `false`, then the 2-qubit depth.
 /// * preserve_order: whether the order of paulis should be preserved, up to
-///     commutativity. If the order is not preserved, the returned circuit will
-///     generally not be equivalent to the given pauli network.
+///   commutativity. If the order is not preserved, the returned circuit will
+///   generally not be equivalent to the given pauli network.
 /// * upto_clifford: if `true`, the final Clifford operator is not synthesized
-///     and the returned circuit will generally not be equivalent to the given
-///     pauli network. In addition, the argument `upto_phase` would be ignored.
+///   and the returned circuit will generally not be equivalent to the given
+///   pauli network. In addition, the argument `upto_phase` would be ignored.
 /// * upto_phase: if `true`, the global phase of the returned circuit may differ
-///     from the global phase of the given pauli network. The argument is considered
-///     to be `true` when `upto_clifford` is `true`.
+///   from the global phase of the given pauli network. The argument is considered
+///   to be `true` when `upto_clifford` is `true`.
 /// * resynth_clifford_method: describes the strategy to synthesize the final
-///     Clifford operator. If `0` a naive approach is used, which doubles the number
-///     of gates but preserves the global phase of the circuit. If `1`, the Clifford is
-///     resynthesized using Qiskit's greedy Clifford synthesis algorithm. If `2`, it
-///     is resynthesized by Rustiq itself. If `upto_phase` is `false`, the naive
-///     approach is used, as neither synthesis method preserves the global phase.
+///   Clifford operator. If `0` a naive approach is used, which doubles the number
+///   of gates but preserves the global phase of the circuit. If `1`, the Clifford is
+///   resynthesized using Qiskit's greedy Clifford synthesis algorithm. If `2`, it
+///   is resynthesized by Rustiq itself. If `upto_phase` is `false`, the naive
+///   approach is used, as neither synthesis method preserves the global phase.
 ///
 /// If `preserve_order` is `true` and both `upto_clifford` and `upto_phase` are `false`,
 /// the returned circuit is equivalent to the given pauli network.

--- a/crates/accelerate/src/synthesis/linear_phase/cz_depth_lnn.rs
+++ b/crates/accelerate/src/synthesis/linear_phase/cz_depth_lnn.rs
@@ -132,7 +132,7 @@ pub(super) fn synth_cz_depth_line_mr_inner(matrix: ArrayView2<bool>) -> (usize, 
         }
     }
 
-    for i in 0..((num_qubits + 1) / 2) {
+    for i in 0..num_qubits.div_ceil(2) {
         for j in 0..num_qubits {
             let pat_val = pats[&(i, j)];
             if patlist.contains(&pat_val) {

--- a/crates/accelerate/src/synthesis/permutation/mod.rs
+++ b/crates/accelerate/src/synthesis/permutation/mod.rs
@@ -126,7 +126,7 @@ pub(crate) fn _append_cx_stage1(gates: &mut LnnGatesVec, n: usize) {
         ))
     }
 
-    for i in 0..((n + 1) / 2 - 1) {
+    for i in 0..(n.div_ceil(2) - 1) {
         gates.push((
             StandardGate::CX,
             smallvec![],
@@ -145,7 +145,7 @@ pub(crate) fn _append_cx_stage2(gates: &mut LnnGatesVec, n: usize) {
         ))
     }
 
-    for i in 0..((n + 1) / 2 - 1) {
+    for i in 0..(n.div_ceil(2) - 1) {
         gates.push((
             StandardGate::CX,
             smallvec![],
@@ -157,7 +157,7 @@ pub(crate) fn _append_cx_stage2(gates: &mut LnnGatesVec, n: usize) {
 /// Append reverse permutation to a QuantumCircuit for linear nearest-neighbor architectures
 /// using Kutin, Moulton, Smithline method.
 fn _append_reverse_permutation_lnn_kms(gates: &mut LnnGatesVec, num_qubits: usize) {
-    (0..(num_qubits + 1) / 2).for_each(|_| {
+    (0..num_qubits.div_ceil(2)).for_each(|_| {
         _append_cx_stage1(gates, num_qubits);
         _append_cx_stage2(gates, num_qubits);
     });

--- a/crates/circuit/src/bit.rs
+++ b/crates/circuit/src/bit.rs
@@ -297,20 +297,20 @@ pub trait Register {
 ///
 /// * `bit_struct` - Identifier for new bit struct, for example, `ShareableQubit`.
 /// * `subclass_ty` - Subclass type used for determining parent bit type, typically an enum to
-///     select between different bit types (for qubit this is Qubit vs AncillaQubit). See
-///     [QubitSubclass] and [ClbitSubclass] for typical types used here.
+///   select between different bit types (for qubit this is Qubit vs AncillaQubit). See
+///   [QubitSubclass] and [ClbitSubclass] for typical types used here.
 /// * `pybit_struct` - Identifier for python bit struct name, for example `PyQubit`.
 /// * `pybit_name` - Python space class name for `pybit_struct`, for example `"Qubit"`.
 /// * `bit_desc` - &'static str used as a name for describing bits, typically only used in error
-///     messages to describe the bit. For example,   "qubit",
+///   messages to describe the bit. For example,   "qubit",
 /// * `reg_struct` - Identifier for rust register struct name, for example `QuantumRegister`
 /// * `pyreg_struct` - Identifier for python register struct, for example `PyQuantumRegister`
 /// * `pyreg_name` - Python space class name for `pyreg_struct. For example, `"QuantumRegister"`.
 /// * `pyreg_prefix` - String prefix for python space registers. Normally only `"q"` or `"c"`.
 /// * `bit_counter_name` - Identifier to use for global static atomic counter of anonymous bits
-///     created. For example, `QUBIT_INSTANCES`.
+///   created. For example, `QUBIT_INSTANCES`.
 /// * `reg_counter_name` - Identifier to use for global static atomic counter of anonymous
-///     registers create. For example, `QUANTUM_REGISTER_INSTANCES`.
+///   registers create. For example, `QUANTUM_REGISTER_INSTANCES`.
 macro_rules! create_bit_object {
     (
         $bit_struct:ident,

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -1208,11 +1208,11 @@ impl CircuitData {
     ///
     /// * py: A GIL handle this is needed to instantiate Qubits in Python space
     /// * num_qubits: The number of qubits in the circuit. These will be created
-    ///     in Python as loose bits without a register.
+    ///   in Python as loose bits without a register.
     /// * num_clbits: The number of classical bits in the circuit. These will be created
-    ///     in Python as loose bits without a register.
+    ///   in Python as loose bits without a register.
     /// * instructions: An iterator of the (packed operation, params, qubits, clbits) to
-    ///     add to the circuit
+    ///   add to the circuit
     /// * global_phase: The global phase to use for the circuit
     pub fn from_packed_operations<I>(
         py: Python,
@@ -1273,23 +1273,23 @@ impl CircuitData {
     /// * qubits: The BitData to use for the new circuit's qubits
     /// * clbits: The BitData to use for the new circuit's clbits
     /// * qargs_interner: The interner for Qubit objects in the circuit. This must
-    ///     contain all the Interned<Qubit> indices stored in the
-    ///     PackedInstructions from `instructions`
+    ///   contain all the Interned<Qubit> indices stored in the
+    ///   PackedInstructions from `instructions`
     /// * cargs_interner: The interner for Clbit objects in the circuit. This must
-    ///     contain all the Interned<Clbit> indices stored in the
-    ///     PackedInstructions from `instructions`
+    ///   contain all the Interned<Clbit> indices stored in the
+    ///   PackedInstructions from `instructions`
     /// * qregs: The internal QuantumRegister data stored within the circuit.
     /// * cregs: The internal ClassicalRegister data stored within the circuit.
     /// * qubit_indices: The Mapping between qubit instances and their locations within
-    ///     registers in the circuit.
+    ///   registers in the circuit.
     /// * clbit_indices: The Mapping between clbit instances and their locations within
-    ///     registers in the circuit.
+    ///   registers in the circuit.
     /// * Instructions: An iterator with items of type: `PyResult<PackedInstruction>`
-    ///     that contais the instructions to insert in iterator order to the new
-    ///     CircuitData. This returns a `PyResult` to facilitate the case where
-    ///     you need to make a python copy (such as with `PackedOperation::py_deepcopy()`)
-    ///     of the operation while iterating for constructing the new `CircuitData`. An
-    ///     example of this use case is in `qiskit_circuit::converters::dag_to_circuit`.
+    ///   that contais the instructions to insert in iterator order to the new
+    ///   CircuitData. This returns a `PyResult` to facilitate the case where
+    ///   you need to make a python copy (such as with `PackedOperation::py_deepcopy()`)
+    ///   of the operation while iterating for constructing the new `CircuitData`. An
+    ///   example of this use case is in `qiskit_circuit::converters::dag_to_circuit`.
     /// * global_phase: The global phase value to use for the new circuit.
     #[allow(clippy::too_many_arguments)]
     pub fn from_packed_instructions<I>(
@@ -1347,9 +1347,9 @@ impl CircuitData {
     ///
     /// * py: A GIL handle this is needed to instantiate Qubits in Python space
     /// * num_qubits: The number of qubits in the circuit. These will be created
-    ///     in Python as loose bits without a register.
+    ///   in Python as loose bits without a register.
     /// * instructions: An iterator of the standard gate params and qubits to
-    ///     add to the circuit
+    ///   add to the circuit
     /// * global_phase: The global phase to use for the circuit
     pub fn from_standard_gates<I>(
         py: Python,
@@ -1918,8 +1918,8 @@ impl CircuitData {
     ///
     /// * other - The other `CircuitData` to clone an empty `CircuitData` from.
     /// * capacity - The capacity for instructions to use in the output `CircuitData`
-    ///     If `None` the length of `other` will be used, if `Some` the integer
-    ///     value will be used as the capacity.
+    ///   If `None` the length of `other` will be used, if `Some` the integer
+    ///   value will be used as the capacity.
     pub fn clone_empty_like(other: &Self, capacity: Option<usize>) -> PyResult<Self> {
         let mut empty = CircuitData {
             data: Vec::with_capacity(capacity.unwrap_or(other.data.len())),
@@ -1943,8 +1943,8 @@ impl CircuitData {
     /// # Arguments
     ///
     /// * packed: The new packed instruction to insert to the end of the CircuitData
-    ///     The qubits and clbits **must** already be present in the interner for this
-    ///     function to work. If they are not this will corrupt the circuit.
+    ///   The qubits and clbits **must** already be present in the interner for this
+    ///   function to work. If they are not this will corrupt the circuit.
     pub fn push(&mut self, py: Python, packed: PackedInstruction) -> PyResult<()> {
         let new_index = self.data.len();
         self.data.push(packed);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the recently released Rust 1.86 new clippy rules were added/enabled by default which were causing warnings when using it to run clippy locally. WHile we run clippy with the msrv in CI to avoid disruptions on every release these clippy rules typically flag real issues in the code that would be good to address even if there isn't a CI failure associated with it. This commit makes the updates flagged by clippy.

### Details and comments