### PR TITLE
Fix circuit-metadata propagation in `SabreLayout`

### DIFF
--- a/qiskit/transpiler/passes/layout/sabre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_layout.py
@@ -305,6 +305,9 @@ class SabreLayout(TransformationPass):
         # the layout and routing together as part of resolving the Sabre result.
         physical_qubits = QuantumRegister(self.coupling_map.size(), "q")
         mapped_dag = DAGCircuit()
+        mapped_dag.name = dag.name
+        mapped_dag.metadata = dag.metadata
+        mapped_dag.global_phase = dag.global_phase
         mapped_dag.add_qreg(physical_qubits)
         mapped_dag.add_clbits(dag.clbits)
         for creg in dag.cregs.values():
@@ -319,7 +322,6 @@ class SabreLayout(TransformationPass):
             mapped_dag.add_captured_stretch(stretch)
         for stretch in dag.iter_declared_stretches():
             mapped_dag.add_declared_stretch(stretch)
-        mapped_dag.global_phase = dag.global_phase
         self.property_set["original_qubit_indices"] = {
             bit: index for index, bit in enumerate(dag.qubits)
         }

--- a/releasenotes/notes/fix-sabre-metadata-88e2a63c02810e61.yaml
+++ b/releasenotes/notes/fix-sabre-metadata-88e2a63c02810e61.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    :class:`.SabreLayout` will now correctly propagate a circuit's :attr:`~.DAGCircuit.name` and
+    :attr:`~.DAGCircuit.metadata` fields when performing as a joint layout and routing pass.

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -1465,8 +1465,15 @@ class TestGeneratePresetPassManagers(QiskitTestCase):
         ):
             generate_preset_pass_manager(seed_transpiler=0.1)
 
-    @data(0, 1, 2, 3)
-    def test_preserves_circuit_metadata(self, optimization_level):
+    @combine(
+        optimization_level=[0, 1, 2, 3],
+        layout_method=["default", "dense", "sabre"],
+        routing_method=["default", "sabre"],
+        translation_method=["default", "translator"],
+    )
+    def test_preserves_circuit_metadata(
+        self, optimization_level, layout_method, routing_method, translation_method
+    ):
         """Test that basic metadata is preserved."""
         metadata = {"experiment_id": "1234", "execution_number": 4}
         name = "my circuit"
@@ -1481,7 +1488,12 @@ class TestGeneratePresetPassManagers(QiskitTestCase):
         target.add_instruction(CXGate(), {pair: None for pair in CouplingMap.from_line(num_qubits)})
 
         pm = generate_preset_pass_manager(
-            optimization_level=optimization_level, target=target, seed_transpiler=42
+            optimization_level=optimization_level,
+            target=target,
+            seed_transpiler=42,
+            layout_method=layout_method,
+            routing_method=routing_method,
+            translation_method=translation_method,
         )
         res = pm.run(circuit)
         self.assertEqual(res.metadata, metadata)


### PR DESCRIPTION
### Summary

This has been a bug since gh-10712, but wasn't caught by the integration test in the test suite because that constructs a because the circuit has a perfect layout, so the layout stage was short-circuiting out after VF2.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments


I caught this by making a buggy version of VF2 that doesn't recognise `Target` 2q links without a defined error.