### PR TITLE
Fix tests that assume a trivial layout from compilation

### DIFF
--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -1581,7 +1581,7 @@ class TestTranspile(QiskitTestCase):
 
         out = transpile(
             qc,
-            backend=GenericBackendV2(num_qubits=2, basis_gates=["cx", "h"]),
+            backend=GenericBackendV2(num_qubits=2, basis_gates=["cx", "h"], seed=0),
             optimization_level=optimization_level,
             seed_transpiler=42,
         )

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -970,12 +970,12 @@ class TestFinalLayouts(QiskitTestCase):
             result.layout.initial_index_layout(filter_ancillas=True), expected_layouts[level]
         )
 
-    @data(0, 1, 2, 3)
-    def test_all_levels_use_trivial_if_perfect(self, level):
-        """Test that we always use trivial if it's a perfect match.
+    @data(0, 1)
+    def test_low_levels_use_trivial_if_perfect(self, level):
+        """Test that we use trivial if it's a perfect match at levels 0 and 1.  Higher levels use
+        VF2 instead, which may not always return the trivial layout based on the scoring.
 
-        See: https://github.com/Qiskit/qiskit-terra/issues/5694 for more
-        details
+        See: https://github.com/Qiskit/qiskit-terra/issues/5694 for more details.
         """
         backend = GenericBackendV2(num_qubits=20, coupling_map=TOKYO_CMAP, seed=42)
 

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -851,7 +851,7 @@ class TestUnitarySynthesisTarget(QiskitTestCase):
         qc_transpiled = transpile(qc, backend, optimization_level=3, seed_transpiler=42)
         opcount = qc_transpiled.count_ops()
         self.assertTrue(set(opcount).issubset(basis_gates))
-        self.assertTrue(np.allclose(Operator(qc_transpiled), Operator(qc)))
+        self.assertTrue(np.allclose(Operator.from_circuit(qc_transpiled), Operator(qc)))
 
     @data(1, 2, 3)
     def test_qsd(self, opt):


### PR DESCRIPTION
These tests all have a built-in assumption that if the trivial layout produces a routed circuit, it will automatically be used at optimisation levels 2 and 3.  This is not formally the case; only optimization levels 0 and 1 set that by default.

An implementation detail of the current VF2Layout pass causes it to short-circuit out on the first possible solution without scoring, if the number of virtual qubits matches the number of physical qubits.  This allowed these tests to pass without any flakiness, even though some of them used unseeded randomness in `GenericBackendV2`.  This short-circuiting in VF2Layout is based on a false premise that all "complete" isomorphic layouts must have the same score, but this is not actually correct, and follow-on modifications to the VF2 pass might change this.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

This is preparing the test suite for a major rework of how we do `VF2Layout`.  It's a separate PR so the new patch series need not modify any tests, and these changes can be reviewed in isolation.