### PR TITLE
Target: Improvements to `NullableIndexMap`

### DIFF
--- a/crates/accelerate/src/consolidate_blocks.rs
+++ b/crates/accelerate/src/consolidate_blocks.rs
@@ -26,6 +26,7 @@ use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::Qubit;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 use smallvec::smallvec;
+use smallvec::SmallVec;
 
 use crate::convert_2q_block_matrix::{blocks_to_matrix, get_matrix_from_inst};
 use crate::euler_one_qubit_decomposer::matmul_1q;
@@ -48,7 +49,8 @@ fn is_supported(
 ) -> bool {
     match target {
         Some(target) => {
-            let physical_qargs = qargs.iter().map(|bit| PhysicalQubit(bit.0)).collect();
+            let physical_qargs: SmallVec<[PhysicalQubit; 2]> =
+                qargs.iter().map(|bit| PhysicalQubit(bit.0)).collect();
             target.instruction_supported(name, Some(&physical_qargs))
         }
         None => match basis_gates {

--- a/crates/accelerate/src/euler_one_qubit_decomposer.rs
+++ b/crates/accelerate/src/euler_one_qubit_decomposer.rs
@@ -1091,11 +1091,7 @@ pub(crate) fn optimize_1q_gates_decomposition(
         };
         if basis_gates_per_qubit[qubit.index()].is_none() {
             let basis_gates = match target {
-                Some(target) => Some(
-                    target
-                        .operation_names_for_qargs(Some(&smallvec![qubit]))
-                        .unwrap(),
-                ),
+                Some(target) => Some(target.operation_names_for_qargs(Some(&[qubit])).unwrap()),
                 None => {
                     let basis = basis_gates.as_ref();
                     basis.map(|basis| basis.iter().map(|x| x.as_str()).collect())

--- a/crates/accelerate/src/gate_direction.rs
+++ b/crates/accelerate/src/gate_direction.rs
@@ -73,12 +73,12 @@ fn py_check_direction_coupling_map(
 #[pyo3(name = "check_gate_direction_target")]
 fn py_check_direction_target(py: Python, dag: &DAGCircuit, target: &Target) -> PyResult<bool> {
     let target_check = |inst: &PackedInstruction, op_args: &[Qubit]| -> bool {
-        let qargs = smallvec![
+        let qargs = &[
             PhysicalQubit::new(op_args[0].0),
-            PhysicalQubit::new(op_args[1].0)
+            PhysicalQubit::new(op_args[1].0),
         ];
 
-        target.instruction_supported(inst.op.name(), Some(&qargs))
+        target.instruction_supported(inst.op.name(), Some(qargs))
     };
 
     check_gate_direction(py, dag, &target_check, None)

--- a/crates/accelerate/src/gates_in_basis.rs
+++ b/crates/accelerate/src/gates_in_basis.rs
@@ -35,7 +35,8 @@ fn any_gate_missing_from_target(dag: &DAGCircuit, target: &Target) -> PyResult<b
         qargs: &[Qubit],
         wire_map: &HashMap<Qubit, PhysicalQubit>,
     ) -> PyResult<bool> {
-        let qargs_mapped = SmallVec::from_iter(qargs.iter().map(|q| wire_map[q]));
+        let qargs_mapped: SmallVec<[PhysicalQubit; 2]> =
+            qargs.iter().map(|q| wire_map[q]).collect();
         if !target.instruction_supported(gate.op.name(), Some(&qargs_mapped)) {
             return Ok(true);
         }

--- a/crates/accelerate/src/high_level_synthesis.rs
+++ b/crates/accelerate/src/high_level_synthesis.rs
@@ -371,7 +371,8 @@ fn instruction_supported(
             let target = target.borrow(py);
             if target.num_qubits.is_some() {
                 if borrowed_data.use_physical_indices {
-                    let physical_qubits = qubits.iter().map(|q| PhysicalQubit(q.0)).collect();
+                    let physical_qubits: SmallVec<[PhysicalQubit; 2]> =
+                        qubits.iter().map(|q| PhysicalQubit(q.0)).collect();
                     target.instruction_supported(name, Some(&physical_qubits))
                 } else {
                     target.instruction_supported(name, None)

--- a/crates/accelerate/src/target_transpiler/mod.rs
+++ b/crates/accelerate/src/target_transpiler/mod.rs
@@ -1192,10 +1192,8 @@ impl Target {
 
     /// Returns an iterator over all the qargs of a specific Target object
     pub fn qargs(&self) -> Option<impl Iterator<Item = Option<&[PhysicalQubit]>>> {
-        let mut qargs = self.qarg_gate_map.keys().peekable();
-        let next_entry = qargs.peek();
-        let is_none = next_entry.is_none() || next_entry.unwrap().is_none();
-        if qargs.len() == 1 && is_none {
+        let qargs = self.qarg_gate_map.keys();
+        if qargs.len() == 1 && self.qarg_gate_map.contains_key(None::<&[PhysicalQubit]>) {
             return None;
         }
         Some(qargs.map(|qargs| qargs.map(|qargs| qargs.as_slice())))

--- a/crates/accelerate/src/target_transpiler/nullable_index_map.rs
+++ b/crates/accelerate/src/target_transpiler/nullable_index_map.rs
@@ -296,7 +296,7 @@ where
             .filter_map(|(index, item)| match item {
                 (Some(key), value) => Some((key, value)),
                 (None, value) => {
-                    self.null_val = Some((len + index - 1, value));
+                    self.null_val = Some(((len + index).checked_sub(1).unwrap_or_default(), value));
                     None
                 }
             });

--- a/crates/accelerate/src/target_transpiler/nullable_index_map.rs
+++ b/crates/accelerate/src/target_transpiler/nullable_index_map.rs
@@ -121,6 +121,11 @@ impl<K, V> NullableIndexMap<K, V> {
     pub fn len(&self) -> usize {
         self.map.len() + self.null_val.is_some() as usize
     }
+
+    /// Returns whether the map is empty or not.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 impl<K, V> NullableIndexMap<K, V>
@@ -284,13 +289,14 @@ where
     K: Hash + Eq,
 {
     fn extend<T: IntoIterator<Item = (Option<K>, V)>>(&mut self, iter: T) {
+        let len = self.len();
         let filtered = iter
             .into_iter()
             .enumerate()
             .filter_map(|(index, item)| match item {
                 (Some(key), value) => Some((key, value)),
                 (None, value) => {
-                    self.null_val = Some((index, value));
+                    self.null_val = Some((len + index - 1, value));
                     None
                 }
             });
@@ -662,7 +668,8 @@ mod test {
         let mut ind_map: NullableIndexMap<i32, &str> = k_v_pairs.into_iter().collect();
 
         // Test extend
-        let k_v_pairs_extend: [(Option<i32>, &str); 2] = [(Some(3), "Whaddis"), (None, "Cat")];
+        let k_v_pairs_extend: [(Option<i32>, &str); 3] =
+            [(Some(3), "Whaddis"), (None, "Cat"), (Some(0), "Neko")];
         ind_map.extend(k_v_pairs_extend);
 
         for (key, value) in k_v_pairs_extend.iter() {
@@ -677,6 +684,7 @@ mod test {
             (Some(4), "Schrodinger"),
             (Some(3), "Whaddis"),
             (None, "Cat"),
+            (Some(0), "Neko"),
         ];
         assert_eq!(&ideal, ind_map.into_iter().collect::<Vec<_>>().as_slice());
     }

--- a/crates/accelerate/src/unitary_synthesis.rs
+++ b/crates/accelerate/src/unitary_synthesis.rs
@@ -23,7 +23,7 @@ use ndarray::prelude::*;
 use num_complex::{Complex, Complex64};
 use numpy::IntoPyArray;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
-use smallvec::{smallvec, SmallVec};
+use smallvec::SmallVec;
 
 use pyo3::intern;
 use pyo3::prelude::*;
@@ -114,7 +114,7 @@ fn get_euler_basis_set(basis_list: IndexSet<&str>) -> EulerBasisSet {
 /// This will determine the available 1q synthesis basis for different decomposers.
 fn get_target_basis_set(target: &Target, qubit: PhysicalQubit) -> EulerBasisSet {
     let mut target_basis_set: EulerBasisSet = EulerBasisSet::new();
-    let target_basis_list = target.operation_names_for_qargs(Some(&smallvec![qubit]));
+    let target_basis_list = target.operation_names_for_qargs(Some(&[qubit]));
     match target_basis_list {
         Ok(basis_list) => {
             target_basis_set = get_euler_basis_set(basis_list.into_iter().collect());


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
The following commits introduce essential improvements to `NullableIndexMap` which should also allow us to use `&[PhysicalQubit]` to query into the `Target`. This is a contingency plan in case #14156 falls through as either one of them is necessary for work on #14173 (a necessary step towards #13308).

Any input is accepted (including a better name for `NullableIndexMap`.) 🚀 

### Details and comments
The structure `NullableIndexMap` (renaming suggestions accepted), exists solely to solve an ownership issue that exists with `HashMap<K, V>` where if `K = Option<T>` you are unable to query into it by using `Option<&T>`.

The structure itself as of now has worked with limited capability. However, as we move towards #14173, we need to ensure that this structure works correctly in all use cases. The following commits introduce a couple of additions that enhance the capabilities of this struct, which are all necessary for #14173 to work:

- **Enable use of `Option<&Equivalent<T>>` when querying.** This will allow us to access attributes using, for example, `Option<&[T]>` when querying for `Option<[T]>`, or any collection struct compatible with `.as_slice()`.
- **Enable both swap and shift removals**: Previous implementations of this function were proven not to work.
- **Indexing by `usize`** to match the behavior of `IndexMap`.
- **Fix iterators to consider the index in which the `None` value resides.** Previously the `None` value, if existent, would always be in the back of the map.
- **Enable retrieving entry indices:** each entry's index can be retrieved (of use for #14173).

Many of the structures that made use of this class have been adapted to work with these additions.

