### PR TITLE
Pin grcov version in CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-            cargo install grcov
+            cargo install grcov@0.8.24
             sudo apt-get install lcov
 
       # This is needed to support any requirements, particularly in the `optionals` set,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The coverage job has been failing the past day or two because the rust coverage data lcov file can't be found. There was a release of grcov (the tool used to generate this file) around that time. In an attempt to unblock CI this commit pins the version installed as part of the job to the previous release.

### Details and comments