### PR TITLE
Remove unecessary nodes field in SabreDAG

### DIFF
--- a/crates/accelerate/src/sabre/layout.rs
+++ b/crates/accelerate/src/sabre/layout.rs
@@ -243,7 +243,6 @@ fn layout_trial(
         num_qubits: dag.num_qubits,
         num_clbits: dag.num_clbits,
         dag: dag.dag.clone(),
-        nodes: dag.nodes.clone(),
         first_layer: dag.first_layer.clone(),
         node_blocks: dag
             .node_blocks
@@ -251,13 +250,7 @@ fn layout_trial(
             .map(|index| (*index, Vec::new()))
             .collect(),
     };
-    let dag_no_control_reverse = SabreDAG::new(
-        dag_no_control_forward.num_qubits,
-        dag_no_control_forward.num_clbits,
-        dag_no_control_forward.nodes.iter().rev().cloned().collect(),
-        dag_no_control_forward.node_blocks.clone(),
-    )
-    .unwrap();
+    let dag_no_control_reverse = dag_no_control_forward.reverse_dag();
 
     for _iter in 0..max_iterations {
         for dag in [&dag_no_control_forward, &dag_no_control_reverse] {

--- a/crates/accelerate/src/sabre/sabre_dag.rs
+++ b/crates/accelerate/src/sabre/sabre_dag.rs
@@ -42,8 +42,26 @@ pub struct SabreDAG {
     pub num_clbits: usize,
     pub dag: DiGraph<DAGNode, ()>,
     pub first_layer: Vec<NodeIndex>,
-    pub nodes: Vec<(usize, Vec<VirtualQubit>, HashSet<usize>, bool)>,
     pub node_blocks: HashMap<usize, Vec<SabreDAG>>,
+}
+
+impl SabreDAG {
+    pub fn reverse_dag(&self) -> Self {
+        let mut out_dag = self.clone();
+        out_dag.dag.reverse();
+        out_dag.first_layer = out_dag
+            .dag
+            .node_indices()
+            .filter(|idx| {
+                out_dag
+                    .dag
+                    .neighbors_directed(*idx, Incoming)
+                    .next()
+                    .is_none()
+            })
+            .collect();
+        out_dag
+    }
 }
 
 #[pymethods]
@@ -105,7 +123,6 @@ impl SabreDAG {
             num_clbits,
             dag,
             first_layer,
-            nodes,
             node_blocks,
         })
     }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The SabreDAG struct was carrying a nodes field which was a Vec of the topologically sorted node descriptions used to create the inner graph object. The format of this field mirrors what Python passes to Rust when initially creating the DAG. The reason this was being kept around was for reversing the graph when working with control flow ops. However, in practice this isn't necessary because all the data contained in the vec is also contained in the graph and we can just reverse the graph directly and save having to carry around the entire object. Also removing this field simplifies the step of moving the sabre dag construction into Rust which is required for porting the remainder of the pass to Rust.

### Details and comments


