### PR TITLE
Pre-import `qiskit` for PyO3 cargo tests.

### DIFF
--- a/tools/pyo3-tests/sitecustomize.py
+++ b/tools/pyo3-tests/sitecustomize.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import qiskit

--- a/tools/run_cargo_test.py
+++ b/tools/run_cargo_test.py
@@ -24,9 +24,20 @@ import subprocess
 import site
 import sysconfig
 
+from pathlib import Path
+
 # This allows the Python interpreter baked into our test executable to find the
 # Qiskit installed in the active environment.
-os.environ["PYTHONPATH"] = os.pathsep.join([os.getcwd()] + site.getsitepackages())
+os.environ["PYTHONPATH"] = os.pathsep.join(
+    [
+        os.getcwd(),
+        # This contains a sitecustomize.py which imports qiskit fully so that
+        # our Rust PyO3 tests (which run in parallel) don't attempt to import
+        # it at the same time!
+        f"{Path(__file__).resolve().parent}/pyo3-tests",
+    ]
+    + site.getsitepackages()
+)
 
 # Uncomment to debug PyO3's build / link against Python.
 # os.environ["PYO3_PRINT_CONFIG"] = "1"


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This is a workaround for the deadlock error issue caused by multiple PyO3 Rust tests attempting to import things from `qiskit` at the same time.


### Details and comments
The `sitecustomize.py` gets executed automatically since we add its directory to the Python path.

Originally discussed in #13776.
