### PR TITLE
Handle global target overridden by coupling map in Rust VF2

### DIFF
--- a/crates/accelerate/src/vf2_layout.rs
+++ b/crates/accelerate/src/vf2_layout.rs
@@ -254,7 +254,8 @@ fn build_coupling_map<Ty: EdgeType>(
     if target.num_qargs() == 0 {
         return None;
     }
-    let mut cm_graph = StableGraph::with_capacity(num_qubits, target.num_qargs() - num_qubits);
+    let mut cm_graph =
+        StableGraph::with_capacity(num_qubits, target.num_qargs().saturating_sub(num_qubits));
     for _ in 0..num_qubits {
         cm_graph.add_node(HashSet::new());
     }

--- a/qiskit/transpiler/passes/layout/vf2_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_layout.py
@@ -111,13 +111,7 @@ class VF2Layout(AnalysisPass):
         """
         super().__init__()
         self.target = target
-        if (
-            target is not None
-            and (target_coupling_map := self.target.build_coupling_map()) is not None
-        ):
-            self.coupling_map = target_coupling_map
-        else:
-            self.coupling_map = coupling_map
+        self.coupling_map = coupling_map
         self.strict_direction = strict_direction
         self.seed = seed
         self.call_limit = call_limit
@@ -127,15 +121,28 @@ class VF2Layout(AnalysisPass):
 
     def run(self, dag):
         """run the layout method"""
-        if self.coupling_map is None:
+        if self.target is None and self.coupling_map is None:
             raise TranspilerError("coupling_map or target must be specified.")
+        if self.coupling_map is None:
+            target, coupling_map = self.target, self.target.build_coupling_map()
+        elif self.target is None:
+            coupling_map = self.coupling_map
+            target = vf2_utils.build_dummy_target(coupling_map)
+        else:
+            # We have both, but may need to override the target if it has no connectivity.
+            coupling_map = self.target.build_coupling_map()
+            if coupling_map is None:
+                target = vf2_utils.build_dummy_target(self.coupling_map)
+                coupling_map = self.coupling_map
+            else:
+                target = self.target
         self.avg_error_map = self.property_set["vf2_avg_error_map"]
-        # Run rust fast path if we have a target and no randomization
-        if self.seed == -1 and self.target is not None:
+        # Run rust fast path if we have no randomization
+        if self.seed == -1:
             try:
                 layout = vf2_layout_pass(
                     dag,
-                    self.target,
+                    target,
                     self.strict_direction,
                     self.call_limit,
                     self.time_limit,
@@ -159,7 +166,7 @@ class VF2Layout(AnalysisPass):
         # We can't use the rust fast path because we have a seed set, or no target so continue with
         # the python path
         if self.avg_error_map is None:
-            self.avg_error_map = vf2_utils.build_average_error_map(self.target, self.coupling_map)
+            self.avg_error_map = vf2_utils.build_average_error_map(target, coupling_map)
 
         result = vf2_utils.build_interaction_graph(dag, self.strict_direction)
         if result is None:
@@ -169,12 +176,12 @@ class VF2Layout(AnalysisPass):
         scoring_edge_list = vf2_utils.build_edge_list(im_graph)
         scoring_bit_list = vf2_utils.build_bit_list(im_graph, im_graph_node_map)
         cm_graph, cm_nodes = vf2_utils.shuffle_coupling_graph(
-            self.coupling_map, self.seed, self.strict_direction
+            coupling_map, self.seed, self.strict_direction
         )
         # Filter qubits without any supported operations. If they don't support any operations
         # They're not valid for layout selection
-        if self.target is not None and self.target.qargs is not None:
-            has_operations = set(itertools.chain.from_iterable(self.target.qargs))
+        if target is not None and target.qargs is not None:
+            has_operations = set(itertools.chain.from_iterable(target.qargs))
             to_remove = set(range(len(cm_nodes))).difference(has_operations)
             if to_remove:
                 cm_graph.remove_nodes_from([cm_nodes[i] for i in to_remove])
@@ -185,7 +192,7 @@ class VF2Layout(AnalysisPass):
         # mapping in the search space if no other limits are set
         if self.max_trials is None and self.call_limit is None and self.time_limit is None:
             im_graph_edge_count = len(im_graph.edge_list())
-            cm_graph_edge_count = len(self.coupling_map.graph.edge_list())
+            cm_graph_edge_count = len(coupling_map.graph.edge_list())
             self.max_trials = max(im_graph_edge_count, cm_graph_edge_count) + 15
 
         logger.debug("Running VF2 to find mappings")

--- a/qiskit/transpiler/passes/layout/vf2_utils.py
+++ b/qiskit/transpiler/passes/layout/vf2_utils.py
@@ -20,6 +20,7 @@ from rustworkx import PyDiGraph, PyGraph, connected_components
 
 from qiskit.circuit import ForLoopOp
 from qiskit.converters import circuit_to_dag
+from qiskit.transpiler.target import Target
 from qiskit._accelerate import vf2_layout
 from qiskit._accelerate.nlayout import NLayout
 from qiskit._accelerate.error_map import ErrorMap
@@ -138,6 +139,15 @@ def score_layout(
         edge_list = build_edge_list(im_graph)
     return vf2_layout.score_layout(
         bit_list, edge_list, avg_error_map, nlayout, strict_direction, run_in_parallel
+    )
+
+
+def build_dummy_target(coupling_map) -> Target:
+    """Build a dummy target with no error rates that represents the coupling in ``coupling_map``."""
+    # The choice of basis gates is completely arbitrary, and we have no source of error rates.
+    # We just want _something_ to represent the coupling constraints.
+    return Target.from_configuration(
+        basis_gates=["u", "cx"], num_qubits=coupling_map.size(), coupling_map=coupling_map
     )
 
 

--- a/test/python/transpiler/test_vf2_layout.py
+++ b/test/python/transpiler/test_vf2_layout.py
@@ -583,7 +583,7 @@ class TestVF2LayoutOther(LayoutTestCase):
         target.add_instruction(CXGate())
 
         vf2_pass = VF2Layout(
-            coupling_map=CouplingMap([[0, 2], [1, 2]]), target=target, seed=42, max_trials=1
+            coupling_map=CouplingMap([[0, 2], [1, 2]]), target=target, seed=-1, max_trials=1
         )
         vf2_pass.run(dag)
 


### PR DESCRIPTION
### Summary

The move to Rust-space `VF2Layout` didn't handle this case, which is a documented part of the interface of the pass.  We didn't catch it because the test of it happens to set a `seed`, which is one of the conditions for skipping the Rust-space version of the pass.

As a side-effect of this fix, the Rust fast-path can now handle the case of no `Target` given at all.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

No reno because it's fixing a bug in #14056 that isn't released yet.
