### PR TITLE
Avoid coupling-graph randomisation in `SabrePreLayout`

### DIFF
--- a/qiskit/transpiler/passes/layout/sabre_pre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_pre_layout.py
@@ -116,7 +116,7 @@ class SabrePreLayout(AnalysisPass):
             augmented_map, augmented_error_map = self._add_extra_edges(cur_distance)
             pass_ = VF2Layout(
                 augmented_map,
-                seed=0,
+                seed=-1,
                 max_trials=self.max_trials_vf2,
                 call_limit=self.call_limit_vf2,
             )

--- a/test/python/transpiler/test_sabre_layout.py
+++ b/test/python/transpiler/test_sabre_layout.py
@@ -505,7 +505,7 @@ class TestSabrePreLayout(QiskitTestCase):
         layout = pm.property_set["layout"]
         self.assertEqual(
             [layout[q] for q in self.circuit.qubits],
-            [30, 98, 104, 36, 103, 35, 65, 28, 61, 91, 22, 92, 23, 93, 62, 99],
+            [8, 80, 9, 81, 10, 82, 76, 3, 75, 2, 74, 1, 73, 0, 49, 79],
         )
 
     def test_integration_with_pass_manager(self):
@@ -519,7 +519,7 @@ class TestSabrePreLayout(QiskitTestCase):
         qct_initial_layout = qct.layout.initial_layout
         self.assertEqual(
             [qct_initial_layout[q] for q in self.circuit.qubits],
-            [17, 16, 11, 12, 7, 6, 5, 1, 2, 3, 8, 9, 14, 13, 19, 18],
+            [8, 7, 12, 13, 18, 19, 17, 16, 11, 10, 5, 6, 1, 2, 3, 9],
         )
 
 

--- a/test/python/transpiler/test_sabre_pre_layout.py
+++ b/test/python/transpiler/test_sabre_pre_layout.py
@@ -46,7 +46,7 @@ class TestSabrePreLayout(QiskitTestCase):
         layouts = pm.property_set["sabre_starting_layouts"]
         self.assertEqual(len(layouts), 1)
         layout = layouts[0]
-        self.assertEqual([layout[q] for q in qc.qubits], [2, 1, 0, 4])
+        self.assertEqual([layout[q] for q in qc.qubits], [0, 1, 2, 3])
 
     def test_perfect_layout_exists(self):
         """Test the case that a perfect layout exists."""


### PR DESCRIPTION
### Summary

The `seed` input to `VF2Layout` is supposed to be set to `-1` to disable randomisation.  Setting it to `0` is still deterministic, but not what was intended by the pass, and inconsistent with how we handle `VF2Layout` normally, which is to avoid the randomisation.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

No changelog because it's just a randomisation change, which is allowed (and frequently expected) within API stability guarantees.
