### PR TITLE
Fix incorrect error estimation in VF2 fallback

### DIFF
--- a/qiskit/transpiler/passes/layout/vf2_utils.py
+++ b/qiskit/transpiler/passes/layout/vf2_utils.py
@@ -189,11 +189,8 @@ def build_average_error_map(target, coupling_map):
         coupling_map = target.build_coupling_map()
     if not built and coupling_map is not None and num_qubits is not None:
         for qubit in range(num_qubits):
-            avg_map.add_error(
-                (qubit, qubit),
-                (coupling_map.graph.out_degree(qubit) + coupling_map.graph.in_degree(qubit))
-                / num_qubits,
-            )
+            degree = len(set(coupling_map.graph.neighbors_undirected(qubit)))
+            avg_map.add_error((qubit, qubit), degree / num_qubits)
         for edge in coupling_map.graph.edge_list():
             avg_map.add_error(edge, (avg_map[edge[0], edge[0]] + avg_map[edge[1], edge[1]]) / 2)
             built = True

--- a/releasenotes/notes/vf2-fallback-98550f601432a37b.yaml
+++ b/releasenotes/notes/vf2-fallback-98550f601432a37b.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The fallback error heuristic in :class:`.VF2Layout` and :class:`.VF2PostLayout`, used when there
+    were no reported error rates, could previously assign errors greater than one, and have
+    unpredictable effects on the resulting layout scores.


### PR DESCRIPTION
### Summary

The VF2 passes include a fall-back error heuristic if the `Target` specifies no error rates: a number proportional to the node degree is used.  This was a proxy metric, used historically becasue IBM bowtie devices (amongst others) were unreliable at reporting error rates but had significantly degraded performance on higher-degree nodes.

The calculation of the node degree, however, could double count qubits in a directional backend, and since the scaling factor is the total number of qubits, this could cause error rates greater than one, which then cause unpredictable behaviour on the scoring.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


