### PR TITLE
Expose `Target::operation_from_name` with native types

### DIFF
--- a/crates/accelerate/src/target_transpiler/mod.rs
+++ b/crates/accelerate/src/target_transpiler/mod.rs
@@ -429,10 +429,7 @@ impl Target {
         instruction: &str,
     ) -> PyResult<Bound<'py, PyAny>> {
         match self.operation_from_name(instruction) {
-            Some(TargetOperation::Normal(operation)) => {
-                operation.into_pyobject(py).map(|x| x.to_owned())
-            }
-            Some(TargetOperation::Variadic(ob)) => Ok(ob.bind(py).clone()),
+            Some(op) => op.into_bound_py_any(py),
             None => Err(PyKeyError::new_err(format!(
                 "Instruction {instruction} not in target"
             ))),


### PR DESCRIPTION
### Summary

The previous version of `operation_from_name` made assumptions about what the Rust-space caller needed, and hid some of the information with two different paths ending up in a `TargetKeyError` (not present and present but variadic).  Some callers need to know if the instruction was variadic (as the Python-space version does), and the more typical error return for "not present" in lookups is `Option`, to avoid constructing potentially costly error objects.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

This clashes a bit with some of the work Ray's currently doing, so it's plausible to subsume it.  Also, this replaces _one_ use of `Result<T, TargetKeyError>` with `Option<T>`, but a more complete patch might replace all such occurrences - I can update this if we want to do it in one go.

I need this for some VF2-based work I've got in the fire at the moment, and separated out this patch because it also touches other `accelerate` code.