### PR TITLE
Simplify argument typing on new dag builder

### DIFF
--- a/crates/accelerate/src/basis/basis_translator/mod.rs
+++ b/crates/accelerate/src/basis/basis_translator/mod.rs
@@ -509,8 +509,8 @@ fn apply_translation(
                 out_dag_builder.apply_operation_back(
                     py,
                     new_op.operation,
-                    Some(node_qarg),
-                    Some(node_carg),
+                    node_qarg,
+                    node_carg,
                     if new_op.params.is_empty() {
                         None
                     } else {
@@ -524,8 +524,8 @@ fn apply_translation(
                 out_dag_builder.apply_operation_back(
                     py,
                     node_obj.op.clone(),
-                    Some(node_qarg),
-                    Some(node_carg),
+                    node_qarg,
+                    node_carg,
                     node_obj.params.as_ref().map(|x| *x.clone()),
                     node_obj.label.as_deref().cloned(),
                     #[cfg(feature = "cache_pygates")]
@@ -542,8 +542,8 @@ fn apply_translation(
             out_dag_builder.apply_operation_back(
                 py,
                 node_obj.op.clone(),
-                Some(node_qarg),
-                Some(node_carg),
+                node_qarg,
+                node_carg,
                 node_obj.params.as_ref().map(|x| *x.clone()),
                 node_obj.label.as_deref().cloned(),
                 #[cfg(feature = "cache_pygates")]
@@ -625,8 +625,8 @@ fn replace_node(
             dag.apply_operation_back(
                 py,
                 new_op,
-                Some(&new_qubits),
-                Some(&new_clbits),
+                &new_qubits,
+                &new_clbits,
                 if new_params.is_empty() {
                     None
                 } else {
@@ -729,8 +729,8 @@ fn replace_node(
             dag.apply_operation_back(
                 py,
                 new_op,
-                Some(&new_qubits),
-                Some(&new_clbits),
+                &new_qubits,
+                &new_clbits,
                 if new_params.is_empty() {
                     None
                 } else {

--- a/crates/accelerate/src/basis/basis_translator/mod.rs
+++ b/crates/accelerate/src/basis/basis_translator/mod.rs
@@ -509,12 +509,12 @@ fn apply_translation(
                 out_dag_builder.apply_operation_back(
                     py,
                     new_op.operation,
-                    Some(node_qarg.into()),
-                    Some(node_carg.into()),
+                    Some(node_qarg),
+                    Some(node_carg),
                     if new_op.params.is_empty() {
                         None
                     } else {
-                        Some(Box::new(new_op.params))
+                        Some(new_op.params)
                     },
                     new_op.label.as_deref().cloned(),
                     #[cfg(feature = "cache_pygates")]
@@ -524,9 +524,9 @@ fn apply_translation(
                 out_dag_builder.apply_operation_back(
                     py,
                     node_obj.op.clone(),
-                    Some(node_qarg.into()),
-                    Some(node_carg.into()),
-                    node_obj.params.clone(),
+                    Some(node_qarg),
+                    Some(node_carg),
+                    node_obj.params.as_ref().map(|x| *x.clone()),
                     node_obj.label.as_deref().cloned(),
                     #[cfg(feature = "cache_pygates")]
                     None,
@@ -542,9 +542,9 @@ fn apply_translation(
             out_dag_builder.apply_operation_back(
                 py,
                 node_obj.op.clone(),
-                Some(node_qarg.into()),
-                Some(node_carg.into()),
-                node_obj.params.clone(),
+                Some(node_qarg),
+                Some(node_carg),
+                node_obj.params.as_ref().map(|x| *x.clone()),
                 node_obj.label.as_deref().cloned(),
                 #[cfg(feature = "cache_pygates")]
                 None,
@@ -625,12 +625,12 @@ fn replace_node(
             dag.apply_operation_back(
                 py,
                 new_op,
-                Some(new_qubits.into()),
-                Some(new_clbits.into()),
+                Some(&new_qubits),
+                Some(&new_clbits),
                 if new_params.is_empty() {
                     None
                 } else {
-                    Some(Box::new(new_params))
+                    Some(new_params)
                 },
                 node.label.as_deref().cloned(),
                 #[cfg(feature = "cache_pygates")]
@@ -729,12 +729,12 @@ fn replace_node(
             dag.apply_operation_back(
                 py,
                 new_op,
-                Some(new_qubits.into()),
-                Some(new_clbits.into()),
+                Some(&new_qubits),
+                Some(&new_clbits),
                 if new_params.is_empty() {
                     None
                 } else {
-                    Some(Box::new(new_params))
+                    Some(new_params)
                 },
                 inner_node.label.as_deref().cloned(),
                 #[cfg(feature = "cache_pygates")]

--- a/crates/accelerate/src/unitary_synthesis.rs
+++ b/crates/accelerate/src/unitary_synthesis.rs
@@ -212,8 +212,8 @@ fn apply_synth_sequence(
         out_dag.apply_operation_back(
             py,
             new_op,
-            Some(&mapped_qargs),
-            None,
+            &mapped_qargs,
+            &[],
             new_params,
             None,
             #[cfg(feature = "cache_pygates")]

--- a/crates/accelerate/src/unitary_synthesis.rs
+++ b/crates/accelerate/src/unitary_synthesis.rs
@@ -144,7 +144,7 @@ fn apply_synth_dag(
             .iter()
             .map(|qarg| out_qargs[qarg.0 as usize])
             .collect();
-        out_packed_instr.qubits = out_dag.insert_qargs(mapped_qargs.into());
+        out_packed_instr.qubits = out_dag.insert_qargs(&mapped_qargs);
         out_dag.push_back(py, out_packed_instr)?;
     }
     out_dag.add_global_phase(&synth_dag.get_global_phase())?;
@@ -167,15 +167,15 @@ fn apply_synth_sequence(
             Some(gate) => &PackedOperation::from_standard_gate(*gate),
         };
         let mapped_qargs: Vec<Qubit> = qubit_ids.iter().map(|id| out_qargs[*id as usize]).collect();
-        let new_params: Option<Box<SmallVec<[Param; 3]>>> = match gate {
-            Some(_) => Some(Box::new(params.iter().map(|p| Param::Float(*p)).collect())),
+        let new_params: Option<SmallVec<[Param; 3]>> = match gate {
+            Some(_) => Some(params.iter().map(|p| Param::Float(*p)).collect()),
             None => {
                 if !sequence.decomp_params.is_empty()
                     && matches!(sequence.decomp_params[0], Param::Float(_))
                 {
-                    Some(Box::new(sequence.decomp_params.clone()))
+                    Some(sequence.decomp_params.clone())
                 } else {
-                    Some(Box::new(params.iter().map(|p| Param::Float(*p)).collect()))
+                    Some(params.iter().map(|p| Param::Float(*p)).collect())
                 }
             }
         };
@@ -187,7 +187,6 @@ fn apply_synth_sequence(
                     "params",
                     new_params
                         .as_deref()
-                        .map(SmallVec::as_slice)
                         .unwrap_or(&[])
                         .iter()
                         .map(|param| param.clone_ref(py))
@@ -213,7 +212,7 @@ fn apply_synth_sequence(
         out_dag.apply_operation_back(
             py,
             new_op,
-            Some(mapped_qargs.into()),
+            Some(&mapped_qargs),
             None,
             new_params,
             None,
@@ -1083,7 +1082,7 @@ fn reversed_synth_su4_dag(
             .iter()
             .map(|x| flip_bits[x.0 as usize])
             .collect();
-        inst.qubits = target_dag_builder.insert_qargs(qubits.into());
+        inst.qubits = target_dag_builder.insert_qargs(&qubits);
         target_dag_builder.push_back(py, inst)?;
     }
     Ok(target_dag_builder.build())

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -10,7 +10,6 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use std::borrow::Cow;
 use std::hash::Hash;
 use std::sync::OnceLock;
 
@@ -7278,9 +7277,9 @@ impl DAGCircuitBuilder {
         &mut self,
         py: Python,
         op: PackedOperation,
-        qubits: Option<Cow<[Qubit]>>,
-        clbits: Option<Cow<[Clbit]>>,
-        params: Option<Box<SmallVec<[Param; 3]>>>,
+        qubits: Option<&[Qubit]>,
+        clbits: Option<&[Clbit]>,
+        params: Option<SmallVec<[Param; 3]>>,
         label: Option<String>,
         #[cfg(feature = "cache_pygates")] py_op: Option<PyObject>,
     ) -> PyResult<NodeIndex> {
@@ -7386,9 +7385,9 @@ impl DAGCircuitBuilder {
     pub fn pack_instruction(
         &mut self,
         op: PackedOperation,
-        qubits: Option<Cow<[Qubit]>>,
-        clbits: Option<Cow<[Clbit]>>,
-        params: Option<Box<SmallVec<[Param; 3]>>>,
+        qubits: Option<&[Qubit]>,
+        clbits: Option<&[Clbit]>,
+        params: Option<SmallVec<[Param; 3]>>,
         label: Option<String>,
         #[cfg(feature = "cache_pygates")] py_op: Option<PyObject>,
     ) -> PackedInstruction {
@@ -7412,7 +7411,7 @@ impl DAGCircuitBuilder {
             op,
             qubits,
             clbits,
-            params,
+            params: params.map(Box::new),
             label: label.map(|label| label.into()),
             #[cfg(feature = "cache_pygates")]
             py_op,
@@ -7430,13 +7429,13 @@ impl DAGCircuitBuilder {
     }
 
     /// Packs qargs into the circuit.
-    pub fn insert_qargs(&mut self, qargs: Cow<[Qubit]>) -> Interned<[Qubit]> {
-        self.dag.qargs_interner.insert_cow(qargs)
+    pub fn insert_qargs(&mut self, qargs: &[Qubit]) -> Interned<[Qubit]> {
+        self.dag.qargs_interner.insert(qargs)
     }
 
     /// Packs qargs into the circuit.
-    pub fn insert_cargs(&mut self, cargs: Cow<[Clbit]>) -> Interned<[Clbit]> {
-        self.dag.cargs_interner.insert_cow(cargs)
+    pub fn insert_cargs(&mut self, cargs: &[Clbit]) -> Interned<[Clbit]> {
+        self.dag.cargs_interner.insert(cargs)
     }
 
     /// Adds a new value to the global phase of the inner [DAGCircuit].

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -7277,8 +7277,8 @@ impl DAGCircuitBuilder {
         &mut self,
         py: Python,
         op: PackedOperation,
-        qubits: Option<&[Qubit]>,
-        clbits: Option<&[Clbit]>,
+        qubits: &[Qubit],
+        clbits: &[Clbit],
         params: Option<SmallVec<[Param; 3]>>,
         label: Option<String>,
         #[cfg(feature = "cache_pygates")] py_op: Option<PyObject>,
@@ -7385,8 +7385,8 @@ impl DAGCircuitBuilder {
     pub fn pack_instruction(
         &mut self,
         op: PackedOperation,
-        qubits: Option<&[Qubit]>,
-        clbits: Option<&[Clbit]>,
+        qubits: &[Qubit],
+        clbits: &[Clbit],
         params: Option<SmallVec<[Param; 3]>>,
         label: Option<String>,
         #[cfg(feature = "cache_pygates")] py_op: Option<PyObject>,
@@ -7397,12 +7397,12 @@ impl DAGCircuitBuilder {
         } else {
             OnceLock::new()
         };
-        let qubits = if let Some(qubits) = qubits {
+        let qubits = if !qubits.is_empty() {
             self.insert_qargs(qubits)
         } else {
             self.dag.qargs_interner.get_default()
         };
-        let clbits = if let Some(clbits) = clbits {
+        let clbits = if !clbits.is_empty() {
             self.insert_cargs(clbits)
         } else {
             self.dag.cargs_interner.get_default()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The typing for some of the new methods on the DAGCircuitBuilder where a bit too strict and required the caller to do more work than was necessary. This commit loosens the typing to make it a bit more ergonomic and straightforward to use. It also more closely matches the DAGCircuit methods the builder struct is mirroring.

### Details and comments


