### PR TITLE
Expose `DAGCircuit.bfs_predecessors`

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -3769,6 +3769,28 @@ impl DAGCircuit {
             .unbind())
     }
 
+    /// Returns an iterator of tuples of (DAGNode, [DAGNodes]) where the DAGNode is the current node
+    /// and [DAGNode] is its precessors in  BFS order.
+    #[pyo3(name = "bfs_predecessors")]
+    fn py_bfs_predecessors(&self, py: Python, node: &DAGNode) -> PyResult<Py<PyIterator>> {
+        let predecessor_index: PyResult<Vec<(PyObject, Vec<PyObject>)>> = self
+            .bfs_predecessors(node.node.unwrap())
+            .map(|(node, nodes)| -> PyResult<(PyObject, Vec<PyObject>)> {
+                Ok((
+                    self.get_node(py, node)?,
+                    nodes
+                        .iter()
+                        .map(|sub_node| self.get_node(py, *sub_node))
+                        .collect::<PyResult<Vec<_>>>()?,
+                ))
+            })
+            .collect();
+        Ok(PyList::new(py, predecessor_index?)?
+            .into_any()
+            .try_iter()?
+            .unbind())
+    }
+
     /// Returns iterator of the successors of a node that are
     /// connected by a classical edge as DAGOpNodes and DAGOutNodes.
     fn classical_successors(&self, py: Python, node: &DAGNode) -> PyResult<Py<PyIterator>> {

--- a/releasenotes/notes/dag-bfs-15f4882db4c0a63f.yaml
+++ b/releasenotes/notes/dag-bfs-15f4882db4c0a63f.yaml
@@ -1,0 +1,5 @@
+---
+features_transpiler:
+  - |
+    :meth:`.DAGCircuit.bfs_predecessors`, a counterpart to the existing
+    :meth:`.DAGCircuit.bfs_successors` is now exposed as a Python-space method on :class:`.DAGCircuit`.


### PR DESCRIPTION
Ever since the introduction of `DAGCircuit.bfs_successors` in Python space, we have have no corresponding Python-space predecessors version. The move to Rust added an exposed Rust version of `bfs_predecessors`, but it wasn't exposed to Python.  Neither method was previously tested.

The implementation detail here produces eager lists that are then type-erased into iterators, erasing the memory and/or performance benefits of lazy iterators. This problem is endemic to `DAGCircuit` methods, and probably something we should fix in the future; it is often easier to write an accidentally quadratic (or worse) algorithm with `DAGCircuit` than it is to write the correct form.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

From an offline conversation with Hoss, though it transpired that `predecessors` was suitable for the use there.