### PR TITLE
Port cosine-sine decomposition to Rust.

### DIFF
--- a/crates/accelerate/src/cos_sin_decomp.rs
+++ b/crates/accelerate/src/cos_sin_decomp.rs
@@ -64,6 +64,18 @@ fn reverse_vec(vec: &mut DVector<f64>) {
     }
 }
 
+/// Given a matrix that is "close" to unitary, returns the closest
+/// unitary matrix.
+/// See https://michaelgoerz.net/notes/finding-the-closest-unitary-for-a-given-matrix/,
+fn closest_unitary(mat: DMatrix<Complex64>) -> DMatrix<Complex64> {
+    // This implementation consumes the original mat but avoids calling
+    // an unnecessary clone.
+    let svd = mat.svd(true, true);
+    let u = svd.u.unwrap();
+    let v_t = svd.v_t.unwrap();
+    &u * &v_t
+}
+
 /// Computes the cosine-sin decomposition (CSD) of a unitary matrix.
 ///
 /// # Args
@@ -196,6 +208,11 @@ pub fn cos_sin_decomposition(u: DMatrix<Complex64>) -> CosSinDecompReturn {
             }
         }
     }
+
+    // While in theory r1 is unitary, in practice (due to numerical errors)
+    // it might be a tiny bit away from a unitary. We "fix" this by finding
+    // the closest unitary.
+    let r1 = closest_unitary(r1);
 
     (l0, l1, r0, r1, thetas)
 }

--- a/crates/accelerate/src/cos_sin_decomp.rs
+++ b/crates/accelerate/src/cos_sin_decomp.rs
@@ -104,7 +104,7 @@ pub fn cos_sin_decomposition(u: DMatrix<Complex64>) -> CosSinDecompReturn {
     //   u00 = l0 c r0
     //   u01 = -l0 s r1
     //   u10 = l1 s r0
-    //   u11 = l1 s r1
+    //   u11 = l1 c r1
     // We will first find l0, c, and r0, then s and l1, and finally r1.
 
     // Apply SVD to u00

--- a/crates/accelerate/src/cos_sin_decomp.rs
+++ b/crates/accelerate/src/cos_sin_decomp.rs
@@ -1,0 +1,182 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+// Based on the Cosine Sine decomposition TKET uses for unitary matrices:
+//
+// https://github.com/CQCL/tket/blob/a61bbac1c07487521acd8da463023f3c85c799e8/tket/src/Utils/CosSinDecomposition.cpp
+
+use numpy::PyReadonlyArray2;
+use numpy::ToPyArray;
+use pyo3::prelude::*;
+
+use nalgebra::{DMatrix, DVector};
+use num_complex::{Complex64, ComplexFloat};
+
+const EPS: f64 = 1e-11;
+
+type CosSinDecompReturn = (
+    DMatrix<Complex64>,
+    DMatrix<Complex64>,
+    DMatrix<Complex64>,
+    DMatrix<Complex64>,
+    DMatrix<f64>,
+    DMatrix<f64>,
+);
+
+/// Comute the cosine-sin decomposition of a Unitary matrix
+///
+/// # Args
+///
+/// - `u`: The input unitary to decompose
+///
+/// # Returns
+///
+/// The tuple (l0, l1, r0, r1, c, s) which represents the decomposition
+///
+/// [l0   ] [c -s] [r0   ]
+/// [   l1] [s  c] [   r1]
+///
+/// where l0, l1, r0 and r1 are unitaries of equal size, c and s are diagonal
+/// matrices with non-negative entries, the diagonal entries of c are in
+/// non-decreasimg order, and
+///
+/// c^2 + s^2 = I
+pub fn cos_sin_decomposition(u: DMatrix<Complex64>) -> CosSinDecompReturn {
+    let shape = u.shape();
+    let n = shape.0 / 2;
+    // Upper left corner
+    let u00 = u.view((0, 0), (n, n));
+    // Upper right corner
+    let u01 = u.view((0, n), (n, n));
+    // Lower left corner
+    let u10 = u.view((n, 0), (n, n)).to_owned();
+    // Lower right corner
+    let u11 = u.view((n, n), (n, n));
+
+    let svd = u00.svd(true, true);
+    let mut l0 = svd.u.unwrap();
+    // Row-wise reverse u
+    let mut start = 0;
+    let mut end = n - 1;
+    while start < end {
+        l0.swap_rows(start, end);
+        start += 1;
+        end -= 1;
+    }
+    let mut r0_dag = svd.v_t.unwrap();
+    // Row-wise reverse v
+    start = 0;
+    end = 0;
+    while start < end {
+        r0_dag.swap_rows(start, end);
+        start += 1;
+        end -= 1;
+    }
+    let singular_values = svd.singular_values;
+    let values_diag: DVector<f64> =
+        DVector::from_iterator(singular_values.len(), singular_values.iter().rev().copied());
+    let c = DMatrix::from_diagonal(&values_diag);
+    let r0 = r0_dag.adjoint();
+
+    // Now u00 = l0 c r0; l0 and r0 are unitary, and c is diagonal with positive
+    // non-decreasing entries. Because u00 is a submatrix of a unitary matrix, its
+    // singular values (the entries of c) are all <= 1.
+
+    let u10_r0_dag = u10 * r0_dag;
+    let qr = u10_r0_dag.qr();
+    let mut l1 = qr.q();
+    let mut s = qr.unpack_r();
+    // Now u10 r0* = l1 S; l1 is unitary, and S is upper triangular.
+    //
+    // Claim: S is diagonal.
+    // Proof: Since u is unitary, we have
+    //     I = u00* u00 + u10* u10
+    //       = (l0 c r0)* (l0 c r0) + (l1 S r0)* (l1 S r0)
+    //       = r0* c l0* l0 c r0 + r0* S* l1* l1 S r0
+    //       = r0* c^2 r0 + r0* S* S r0
+    //       = r0* (c^2 + S* S) r0
+    // So I = c^2 + (S* S), so (S* S) = I - c^2 is a diagonal matrix with non-
+    // increasing entries in the range [0,1). As S is upper triangular, this
+    // implies that S must be diagonal. (Proof by induction over the dimension n
+    // of S: consider the two cases S_00 = 0 and S_00 != 0 and reduce to the n-1
+    // case.)
+    //
+    // We want S to be real. This is not guaranteed, though since it is diagonal
+    // it can be made so by adjusting l1.
+    if s.iter().any(|x| x.im != 0.) {
+        for j in 0..n {
+            let z = s[(j, j)];
+            let r = z.abs();
+            if r > EPS {
+                let w = z.conj() / r;
+                s[(j, j)] *= w;
+                l1.column_mut(j).iter_mut().for_each(|x| *x /= w);
+            }
+        }
+    }
+
+    // Now s is real and diagonal, and c^2 + S^2 = I
+    let mut s_real: DMatrix<f64> = s.map(|x| x.re);
+    // Make all entries in s_real non-negative.
+    for j in 0..n {
+        let val = s_real[(j, j)];
+        if val < 0. {
+            s_real[(j, j)] = -val;
+            l1.column_mut(j).iter_mut().for_each(|x| *x = -(*x));
+        }
+    }
+    // Finally compute r1, being careful not to divide by small things.
+    let mut r1: DMatrix<Complex64> = DMatrix::zeros(n, n);
+    let l0_adjoint = l0.adjoint();
+    let l1_adjoint = l1.adjoint();
+    for i in 0..n {
+        let mut row = r1.row_mut(i);
+        if s_real[(i, i)] > c[(i, i)] {
+            let mut new_mat = &l0_adjoint * u01;
+            let mut new_row = new_mat.row_mut(i);
+            new_row.iter_mut().for_each(|x| *x = -(*x) / s[(i, i)]);
+            row.iter_mut()
+                .zip(new_row.into_iter())
+                .for_each(|(x, y)| *x = *y);
+        } else {
+            let mut new_mat = &l1_adjoint * u11;
+            let mut new_row = new_mat.row_mut(i);
+            new_row.iter_mut().for_each(|x| *x /= c[(i, i)]);
+            row.iter_mut()
+                .zip(new_row.into_iter())
+                .for_each(|(x, y)| *x = *y);
+        }
+    }
+
+    (l0.to_owned(), l1, r0.to_owned(), r1, c, s_real)
+}
+
+// TODO: Remove this function and all the python interface when QSD is ported to rust
+#[pyfunction]
+pub fn cossin<'py>(py: Python<'py>, u: PyReadonlyArray2<Complex64>) -> PyResult<Bound<'py, PyAny>> {
+    let array = u.as_array();
+    let shape = array.shape();
+    let mat: DMatrix<Complex64> = DMatrix::from_fn(shape[0], shape[1], |i, j| array[[i, j]]);
+    let res = cos_sin_decomposition(mat);
+    Ok((
+        (res.0.to_pyarray(py), res.1.to_pyarray(py)),
+        res.5.to_pyarray(py),
+        (res.2.to_pyarray(py), res.3.to_pyarray(py)),
+    )
+        .into_pyobject(py)?
+        .into_any())
+}
+
+pub fn cos_sin_decomp(m: &Bound<PyModule>) -> PyResult<()> {
+    m.add_wrapped(wrap_pyfunction!(cossin))?;
+    Ok(())
+}

--- a/crates/accelerate/src/cos_sin_decomp.rs
+++ b/crates/accelerate/src/cos_sin_decomp.rs
@@ -115,7 +115,8 @@ pub fn cos_sin_decomposition(u: DMatrix<Complex64>) -> CosSinDecompReturn {
 
     // We have u00 = l0 c r0, where l0 and r0 are unitary, and c is a diagonal matrix
     // with positive non-decreasing entries. However, we want the entries of c to be
-    // in the ascending order instead. Fortunately, it is easy to modify l0, c, and r0,
+    // in the ascending order instead (otherwise, we will not be able to guarantee that
+    // s is a digonal matrix). Fortunately, it is easy to modify l0, c, and r0,
     // so that this becomes true.
     reverse_rows(&mut r0);
     reverse_columns(&mut l0);
@@ -132,7 +133,7 @@ pub fn cos_sin_decomposition(u: DMatrix<Complex64>) -> CosSinDecompReturn {
     // Equivalently, u10 = l1 s r0.
     let r0_dag = r0.adjoint();
     let u10_r0_dag = u10 * r0_dag;
-    let qr = u10_r0_dag.clone().qr();
+    let qr = u10_r0_dag.qr();
     let mut l1 = qr.q();
     let mut s = qr.unpack_r();
 
@@ -140,14 +141,15 @@ pub fn cos_sin_decomposition(u: DMatrix<Complex64>) -> CosSinDecompReturn {
     // Proof: Since u is unitary, we have
     //     I = u00* u00 + u10* u10
     //       = (l0 c r0)* (l0 c r0) + (l1 s r0)* (l1 s r0)
-    //       = r0* c* l0* l0 c r0 + r0* S* l1* l1 s r0
+    //       = r0* c* l0* l0 c r0 + r0* s* l1* l1 s r0
     //       = r0* c* c r0 + r0* s* s r0
     //       = r0* (c^2 + s* s) r0
-    // So I = c^2 + (S* S), so (S* S) = I - c^2 is a diagonal matrix with non-
+    // So I = c^2 + (s* s), so (s* s) = I - c^2 is a diagonal matrix with non-
     // increasing entries in the range [0,1). As s is upper triangular, this
     // implies that s must be diagonal. (Proof by induction over the dimension n
-    // of S: consider the two cases s_00 = 0 and s_00 != 0 and reduce to the n-1
-    // case. Note: it is important that the entries of s are in descending order).
+    // of s: consider the two cases s_00 = 0 and s_00 != 0 and reduce to the n-1
+    // case. Note: it is important that the entries of s are in descending order
+    // for this proof to work.)
 
     // We want s to be real. This is not guaranteed, though it seems to be always
     // true in practice. In either case, it can be made possible by suitable adjusting

--- a/crates/accelerate/src/cos_sin_decomp.rs
+++ b/crates/accelerate/src/cos_sin_decomp.rs
@@ -28,11 +28,45 @@ type CosSinDecompReturn = (
     DMatrix<Complex64>,
     DMatrix<Complex64>,
     DMatrix<Complex64>,
-    DMatrix<f64>,
-    DMatrix<f64>,
+    Vec<f64>,
 );
 
-/// Comute the cosine-sin decomposition of a Unitary matrix
+/// Reverses rows in-place.
+fn reverse_rows(mat: &mut DMatrix<Complex64>) {
+    // Row-wise reverse u
+    let mut start = 0;
+    let mut end = mat.nrows() - 1;
+    while start < end {
+        mat.swap_rows(start, end);
+        start += 1;
+        end -= 1;
+    }
+}
+
+/// Reverses columns in-place.
+fn reverse_columns(mat: &mut DMatrix<Complex64>) {
+    // Row-wise reverse u
+    let mut start = 0;
+    let mut end = mat.ncols() - 1;
+    while start < end {
+        mat.swap_columns(start, end);
+        start += 1;
+        end -= 1;
+    }
+}
+
+/// Reverses elements in-place.
+fn reverse_vec(vec: &mut DVector<f64>) {
+    let mut start = 0;
+    let mut end = vec.len() - 1;
+    while start < end {
+        vec.swap_rows(start, end);
+        start += 1;
+        end -= 1;
+    }
+}
+
+/// Computes the cosine-sin decomposition (CSD) of a unitary matrix.
 ///
 /// # Args
 ///
@@ -40,16 +74,22 @@ type CosSinDecompReturn = (
 ///
 /// # Returns
 ///
-/// The tuple (l0, l1, r0, r1, c, s) which represents the decomposition
+/// The tuple `(l0, l1, r0, r1, theta)` representing the CSD:
 ///
+/// ```text
 /// [l0   ] [c -s] [r0   ]
 /// [   l1] [s  c] [   r1]
+/// ```
 ///
-/// where l0, l1, r0 and r1 are unitaries of equal size, c and s are diagonal
-/// matrices with non-negative entries, the diagonal entries of c are in
-/// non-decreasimg order, and
+/// - `l0`, `l1`, `r0`, and `r1` are unitaries of equal size,
+/// - `theta` is the array of angles, with each angle in in the interval :math:`[0, \pi/2]`.
 ///
-/// c^2 + s^2 = I
+/// The diagonal matrices `c` and `s` contain the cosines and sines of angles in `theta`,
+/// respectively. In particular, `c^2 + s^2 = I`.
+///
+/// Furthermore, the angles in `theta` are sorted in descending order, so:
+/// - cosines are in ascending order,
+/// - sines are in descending order.
 pub fn cos_sin_decomposition(u: DMatrix<Complex64>) -> CosSinDecompReturn {
     let shape = u.shape();
     let n = shape.0 / 2;
@@ -58,61 +98,56 @@ pub fn cos_sin_decomposition(u: DMatrix<Complex64>) -> CosSinDecompReturn {
     // Upper right corner
     let u01 = u.view((0, n), (n, n));
     // Lower left corner
-    let u10 = u.view((n, 0), (n, n)).to_owned();
+    let u10 = u.view((n, 0), (n, n));
     // Lower right corner
     let u11 = u.view((n, n), (n, n));
 
+    // Apply SVD to u00
     let svd = u00.svd(true, true);
     let mut l0 = svd.u.unwrap();
-    // Row-wise reverse u
-    let mut start = 0;
-    let mut end = n - 1;
-    while start < end {
-        l0.swap_rows(start, end);
-        start += 1;
-        end -= 1;
-    }
-    let mut r0_dag = svd.v_t.unwrap();
-    // Row-wise reverse v
-    start = 0;
-    end = 0;
-    while start < end {
-        r0_dag.swap_rows(start, end);
-        start += 1;
-        end -= 1;
-    }
-    let singular_values = svd.singular_values;
-    let values_diag: DVector<f64> =
-        DVector::from_iterator(singular_values.len(), singular_values.iter().rev().copied());
-    let c = DMatrix::from_diagonal(&values_diag);
-    let r0 = r0_dag.adjoint();
+    let mut r0 = svd.v_t.unwrap();
+    let mut c: DVector<f64> = svd.singular_values.column(0).into_owned();
 
-    // Now u00 = l0 c r0; l0 and r0 are unitary, and c is diagonal with positive
-    // non-decreasing entries. Because u00 is a submatrix of a unitary matrix, its
-    // singular values (the entries of c) are all <= 1.
+    // We have u00 = l0 c r0, where l0 and r0 are unitary, and c is a diagonal matrix
+    // with positive non-decreasing entries. However, we want the entries of c to be
+    // in the ascending order instead. Fortunately, it is easy to modify l0, c, and r0,
+    // so that this becomes true.
+    reverse_rows(&mut r0);
+    reverse_columns(&mut l0);
+    reverse_vec(&mut c);
 
+    // Compute the angles theta. Because u00 is a submatrix of a unitary matrix, its
+    // singular values (the entries of c) are all <= 1. Due to floating-point precision
+    // errors, it is possible that some of the c-values are just a tiny bit larger than 1,
+    // so we correct for that.
+    let thetas: Vec<f64> = c.iter().map(|f| f.min(1.0).acos()).collect();
+
+    // Apply QR to u10_r0_dag.
+    // We have u10 r0* = l1 s, where l1 is unitary and S is upper-triangular.
+    // Equivalently, u10 = l1 s r0.
+    let r0_dag = r0.adjoint();
     let u10_r0_dag = u10 * r0_dag;
-    let qr = u10_r0_dag.qr();
+    let qr = u10_r0_dag.clone().qr();
     let mut l1 = qr.q();
     let mut s = qr.unpack_r();
-    // Now u10 r0* = l1 S; l1 is unitary, and S is upper triangular.
-    //
-    // Claim: S is diagonal.
+
+    // Claim: s is diagonal.
     // Proof: Since u is unitary, we have
     //     I = u00* u00 + u10* u10
-    //       = (l0 c r0)* (l0 c r0) + (l1 S r0)* (l1 S r0)
-    //       = r0* c l0* l0 c r0 + r0* S* l1* l1 S r0
-    //       = r0* c^2 r0 + r0* S* S r0
-    //       = r0* (c^2 + S* S) r0
+    //       = (l0 c r0)* (l0 c r0) + (l1 s r0)* (l1 s r0)
+    //       = r0* c* l0* l0 c r0 + r0* S* l1* l1 s r0
+    //       = r0* c* c r0 + r0* s* s r0
+    //       = r0* (c^2 + s* s) r0
     // So I = c^2 + (S* S), so (S* S) = I - c^2 is a diagonal matrix with non-
-    // increasing entries in the range [0,1). As S is upper triangular, this
-    // implies that S must be diagonal. (Proof by induction over the dimension n
-    // of S: consider the two cases S_00 = 0 and S_00 != 0 and reduce to the n-1
-    // case.)
-    //
-    // We want S to be real. This is not guaranteed, though since it is diagonal
-    // it can be made so by adjusting l1.
-    if s.iter().any(|x| x.im != 0.) {
+    // increasing entries in the range [0,1). As s is upper triangular, this
+    // implies that s must be diagonal. (Proof by induction over the dimension n
+    // of S: consider the two cases s_00 = 0 and s_00 != 0 and reduce to the n-1
+    // case. Note: it is important that the entries of s are in descending order).
+
+    // We want s to be real. This is not guaranteed, though it seems to be always
+    // true in practice. In either case, it can be made possible by suitable adjusting
+    // both S and l1 together.
+    if s.diagonal().iter().any(|x| x.im != 0.) {
         for j in 0..n {
             let z = s[(j, j)];
             let r = z.abs();
@@ -124,40 +159,38 @@ pub fn cos_sin_decomposition(u: DMatrix<Complex64>) -> CosSinDecompReturn {
         }
     }
 
-    // Now s is real and diagonal, and c^2 + S^2 = I
-    let mut s_real: DMatrix<f64> = s.map(|x| x.re);
-    // Make all entries in s_real non-negative.
+    // Now s is real and diagonal, and c^2 + s^2 = I.
+    let mut s: DVector<f64> = s.diagonal().map(|x| x.re);
+
+    // Additionally, adjust l1 and s so that all entries in s are non-negative.
+    // Again, this seems to be never needed in practice.
     for j in 0..n {
-        let val = s_real[(j, j)];
+        let val = s[j];
         if val < 0. {
-            s_real[(j, j)] = -val;
+            s[j] = -s[j];
             l1.column_mut(j).iter_mut().for_each(|x| *x = -(*x));
         }
     }
+
     // Finally compute r1, being careful not to divide by small things.
+    // r1 should satisfy u01 = -l0 s r1 and u11 = l1 c r1, with these two
+    // conditions being equivalent due to u being unitary.
     let mut r1: DMatrix<Complex64> = DMatrix::zeros(n, n);
-    let l0_adjoint = l0.adjoint();
-    let l1_adjoint = l1.adjoint();
+    let l0_dag_u01 = l0.adjoint() * u01;
+    let l1_dag_u11 = l1.adjoint() * u11;
     for i in 0..n {
-        let mut row = r1.row_mut(i);
-        if s_real[(i, i)] > c[(i, i)] {
-            let mut new_mat = &l0_adjoint * u01;
-            let mut new_row = new_mat.row_mut(i);
-            new_row.iter_mut().for_each(|x| *x = -(*x) / s[(i, i)]);
-            row.iter_mut()
-                .zip(new_row.into_iter())
-                .for_each(|(x, y)| *x = *y);
+        if s[i] > c[i] {
+            for j in 0..n {
+                r1[(i, j)] = -l0_dag_u01[(i, j)] / s[i];
+            }
         } else {
-            let mut new_mat = &l1_adjoint * u11;
-            let mut new_row = new_mat.row_mut(i);
-            new_row.iter_mut().for_each(|x| *x /= c[(i, i)]);
-            row.iter_mut()
-                .zip(new_row.into_iter())
-                .for_each(|(x, y)| *x = *y);
+            for j in 0..n {
+                r1[(i, j)] = l1_dag_u11[(i, j)] / c[i];
+            }
         }
     }
 
-    (l0.to_owned(), l1, r0.to_owned(), r1, c, s_real)
+    (l0, l1, r0, r1, thetas)
 }
 
 // TODO: Remove this function and all the python interface when QSD is ported to rust
@@ -169,7 +202,7 @@ pub fn cossin<'py>(py: Python<'py>, u: PyReadonlyArray2<Complex64>) -> PyResult<
     let res = cos_sin_decomposition(mat);
     Ok((
         (res.0.to_pyarray(py), res.1.to_pyarray(py)),
-        res.5.to_pyarray(py),
+        res.4.to_pyarray(py),
         (res.2.to_pyarray(py), res.3.to_pyarray(py)),
     )
         .into_pyobject(py)?

--- a/crates/accelerate/src/cos_sin_decomp.rs
+++ b/crates/accelerate/src/cos_sin_decomp.rs
@@ -114,9 +114,9 @@ pub fn cos_sin_decomposition(u: DMatrix<Complex64>) -> CosSinDecompReturn {
     let mut c: DVector<f64> = svd.singular_values.column(0).into_owned();
 
     // We have u00 = l0 c r0, where l0 and r0 are unitary, and c is a diagonal matrix
-    // with positive non-decreasing entries. However, we want the entries of c to be
-    // in the ascending order instead (otherwise, we will not be able to guarantee that
-    // s is a digonal matrix). Fortunately, it is easy to modify l0, c, and r0,
+    // with positive entries in the descending order. However, we want the entries of c
+    // to be in the ascending order instead (otherwise, we will not be able to guarantee
+    // that s is a diagonal matrix too). Fortunately, it is easy to modify l0, c, and r0,
     // so that this becomes true.
     reverse_rows(&mut r0);
     reverse_columns(&mut l0);

--- a/crates/accelerate/src/lib.rs
+++ b/crates/accelerate/src/lib.rs
@@ -24,6 +24,7 @@ pub mod commutation_cancellation;
 pub mod commutation_checker;
 pub mod consolidate_blocks;
 pub mod convert_2q_block_matrix;
+pub mod cos_sin_decomp;
 pub mod dense_layout;
 pub mod elide_permutations;
 pub mod equivalence;

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -668,7 +668,7 @@ impl TwoQubitWeylDecomposition {
                 .for_each(|(index, x)| *x = d_inner[index]);
 
             let compare = p_inner.dot(&diag_d).dot(&p_inner.t());
-            found = abs_diff_eq!(compare.view(), m2, epsilon = 1.0e-11);
+            found = abs_diff_eq!(compare.view(), m2, epsilon = 1.0e-13);
             if found {
                 p = p_inner;
                 d = d_inner;

--- a/crates/accelerate/src/two_qubit_decompose.rs
+++ b/crates/accelerate/src/two_qubit_decompose.rs
@@ -668,7 +668,7 @@ impl TwoQubitWeylDecomposition {
                 .for_each(|(index, x)| *x = d_inner[index]);
 
             let compare = p_inner.dot(&diag_d).dot(&p_inner.t());
-            found = abs_diff_eq!(compare.view(), m2, epsilon = 1.0e-13);
+            found = abs_diff_eq!(compare.view(), m2, epsilon = 1.0e-11);
             if found {
                 p = p_inner;
                 d = d_inner;

--- a/crates/pyext/src/lib.rs
+++ b/crates/pyext/src/lib.rs
@@ -38,6 +38,7 @@ fn _accelerate(m: &Bound<PyModule>) -> PyResult<()> {
     add_submodule(m, ::qiskit_accelerate::commutation_cancellation::commutation_cancellation, "commutation_cancellation")?;
     add_submodule(m, ::qiskit_accelerate::commutation_checker::commutation_checker, "commutation_checker")?;
     add_submodule(m, ::qiskit_accelerate::consolidate_blocks::consolidate_blocks_mod, "consolidate_blocks")?;
+    add_submodule(m, ::qiskit_accelerate::cos_sin_decomp::cos_sin_decomp, "cos_sin_decomp")?;
     add_submodule(m, ::qiskit_accelerate::dense_layout::dense_layout, "dense_layout")?;
     add_submodule(m, ::qiskit_accelerate::equivalence::equivalence, "equivalence")?;
     add_submodule(m, ::qiskit_accelerate::error_map::error_map, "error_map")?;

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -107,6 +107,7 @@ sys.modules["qiskit._accelerate.twirling"] = _accelerate.twirling
 sys.modules["qiskit._accelerate.high_level_synthesis"] = _accelerate.high_level_synthesis
 sys.modules["qiskit._accelerate.remove_identity_equiv"] = _accelerate.remove_identity_equiv
 sys.modules["qiskit._accelerate.circuit_duration"] = _accelerate.circuit_duration
+sys.modules["qiskit._accelerate.cos_sin_decomp"] = _accelerate.cos_sin_decomp
 
 from qiskit.exceptions import QiskitError, MissingOptionalLibraryError
 

--- a/qiskit/synthesis/unitary/qsd.py
+++ b/qiskit/synthesis/unitary/qsd.py
@@ -124,7 +124,6 @@ def qs_decomposition(
     else:
         qr = QuantumRegister(nqubits)
         circ = QuantumCircuit(qr)
-        dim_o2 = dim // 2
         # perform cosine-sine decomposition
         (u1, u2), vtheta, (v1h, v2h) = cossin(np.asarray(mat, dtype=complex))
         # left circ

--- a/qiskit/synthesis/unitary/qsd.py
+++ b/qiskit/synthesis/unitary/qsd.py
@@ -31,6 +31,7 @@ from qiskit.circuit.library.generalized_gates.uc_pauli_rot import UCPauliRotGate
 from qiskit.circuit.library.generalized_gates.ucry import UCRYGate
 from qiskit.circuit.library.generalized_gates.ucrz import UCRZGate
 from qiskit._accelerate.two_qubit_decompose import two_qubit_decompose_up_to_diagonal
+from qiskit._accelerate.cos_sin_decomp import cossin
 
 
 def qs_decomposition(
@@ -125,7 +126,7 @@ def qs_decomposition(
         circ = QuantumCircuit(qr)
         dim_o2 = dim // 2
         # perform cosine-sine decomposition
-        (u1, u2), vtheta, (v1h, v2h) = scipy.linalg.cossin(mat, separate=True, p=dim_o2, q=dim_o2)
+        (u1, u2), vtheta, (v1h, v2h) = cossin(mat)
         # left circ
         left_circ = _demultiplex(v1h, v2h, opt_a1=opt_a1, opt_a2=opt_a2, _depth=_depth)
         circ.append(left_circ.to_instruction(), qr)

--- a/qiskit/synthesis/unitary/qsd.py
+++ b/qiskit/synthesis/unitary/qsd.py
@@ -126,7 +126,7 @@ def qs_decomposition(
         circ = QuantumCircuit(qr)
         dim_o2 = dim // 2
         # perform cosine-sine decomposition
-        (u1, u2), vtheta, (v1h, v2h) = cossin(mat)
+        (u1, u2), vtheta, (v1h, v2h) = cossin(np.asarray(mat, dtype=complex))
         # left circ
         left_circ = _demultiplex(v1h, v2h, opt_a1=opt_a1, opt_a2=opt_a2, _depth=_depth)
         circ.append(left_circ.to_instruction(), qr)

--- a/test/python/synthesis/test_cos_sin_decomp.py
+++ b/test/python/synthesis/test_cos_sin_decomp.py
@@ -18,6 +18,7 @@ from ddt import ddt
 import numpy as np
 
 from qiskit.quantum_info.random import random_unitary
+from qiskit.quantum_info.operators.predicates import is_unitary_matrix
 from qiskit.circuit._utils import _compute_control_matrix
 from qiskit._accelerate.cos_sin_decomp import cossin
 
@@ -35,6 +36,12 @@ class TestCSD(QiskitTestCase):
 
         # Run QSD: u = [u1, u2], v = [v1, v2]
         csd_u, csd_thetas, csd_v = cossin(mat)
+
+        # Check that the computed matrices are unitary
+        self.assertTrue(is_unitary_matrix(csd_u[0], atol=1e-13))
+        self.assertTrue(is_unitary_matrix(csd_u[1], atol=1e-13))
+        self.assertTrue(is_unitary_matrix(csd_v[0], atol=1e-13))
+        self.assertTrue(is_unitary_matrix(csd_v[1], atol=1e-13))
 
         # Create appropriate 2n x 2n matrices and multiply
         zero_mat = np.zeros((n, n), dtype=complex)

--- a/test/python/synthesis/test_cos_sin_decomp.py
+++ b/test/python/synthesis/test_cos_sin_decomp.py
@@ -1,0 +1,67 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for cosine-sine decomposition."""
+
+import math
+
+from ddt import ddt
+import numpy as np
+
+from qiskit.quantum_info.random import random_unitary
+from qiskit.circuit._utils import _compute_control_matrix
+from qiskit._accelerate.cos_sin_decomp import cossin
+
+from test import combine  # pylint: disable=wrong-import-order
+from test import QiskitTestCase  # pylint: disable=wrong-import-order
+
+
+@ddt
+class TestCSD(QiskitTestCase):
+    """Test the cosine-sine decomposition."""
+
+    def assertCossinDecompositionIsCorrect(self, mat):
+        """Run QSD on mat and verify that it is correct."""
+        n = mat.shape[0] // 2
+
+        # Run QSD: u = [u1, u2], v = [v1, v2]
+        csd_u, csd_thetas, csd_v = cossin(mat)
+
+        # Create appropriate 2n x 2n matrices and multiply
+        zero_mat = np.zeros((n, n), dtype=complex)
+        c_mat = np.diag([math.cos(theta) for theta in csd_thetas])
+        s_mat = np.diag([math.sin(theta) for theta in csd_thetas])
+        cs_mat = np.vstack([np.hstack([c_mat, -1 * s_mat]), np.hstack([s_mat, c_mat])])
+        u_mat = np.vstack([np.hstack([csd_u[0], zero_mat]), np.hstack([zero_mat, csd_u[1]])])
+        v_mat = np.vstack([np.hstack([csd_v[0], zero_mat]), np.hstack([zero_mat, csd_v[1]])])
+        recomputed_mat = u_mat @ cs_mat @ v_mat
+
+        np.testing.assert_allclose(
+            mat,
+            recomputed_mat,
+            atol=1e-7,
+        )
+
+    @combine(num_qubits=[1, 2, 3, 4], seed=list(range(100)))
+    def test_random_unitary(self, num_qubits, seed):
+        """Test CSD for random unitary matricies."""
+        mat = random_unitary(2**num_qubits, seed=seed).data
+        self.assertCossinDecompositionIsCorrect(mat)
+
+    @combine(num_controls=[1, 2, 3], num_targets=[1, 2, 3], seed=list(range(50)))
+    def test_controlled_test_random_unitary(self, num_controls, num_targets, seed):
+        """Test CSD for controlled random unitary matricies."""
+        # Note that scipy has numerical stability problems on cotrolled
+        # random unitary matrices.
+        base_mat = random_unitary(2**num_targets, seed=seed).data
+        mat = _compute_control_matrix(base_mat, num_controls)
+        self.assertCossinDecompositionIsCorrect(mat)

--- a/test/python/synthesis/test_cos_sin_decomp.py
+++ b/test/python/synthesis/test_cos_sin_decomp.py
@@ -60,15 +60,31 @@ class TestCSD(QiskitTestCase):
 
     @combine(num_qubits=[1, 2, 3, 4], seed=list(range(100)))
     def test_random_unitary(self, num_qubits, seed):
-        """Test CSD for random unitary matricies."""
+        """Test CSD for random unitary matrices."""
         mat = random_unitary(2**num_qubits, seed=seed).data
         self.assertCossinDecompositionIsCorrect(mat)
 
     @combine(num_controls=[1, 2, 3], num_targets=[1, 2, 3], seed=list(range(50)))
-    def test_controlled_test_random_unitary(self, num_controls, num_targets, seed):
-        """Test CSD for controlled random unitary matricies."""
-        # Note that scipy has numerical stability problems on cotrolled
+    def test_controlled_random_unitary(self, num_controls, num_targets, seed):
+        """Test CSD for controlled random unitary matrices."""
+        # Note that scipy has numerical stability problems on controlled
         # random unitary matrices.
         base_mat = random_unitary(2**num_targets, seed=seed).data
         mat = _compute_control_matrix(base_mat, num_controls)
         self.assertCossinDecompositionIsCorrect(mat)
+
+    @combine(num_qubits=[1, 2, 3, 4], seed=list(range(20)))
+    def test_random_hermitian(self, num_qubits, seed):
+        """Test CSD for random Hermitian matrices."""
+        umat = random_unitary(2**num_qubits, seed=seed).data
+        np.random.seed(seed)
+        dmat = np.diag(np.exp(1j * np.random.normal(size=2**num_qubits)))
+        mat = umat.T.conjugate() @ dmat @ umat
+        self.assertCossinDecompositionIsCorrect(mat)
+
+    @combine(num_qubits=[1, 2, 3, 4], seed=list(range(20)))
+    def test_random_diagonal(self, num_qubits, seed):
+        """Test CSD for random diagonal matrices."""
+        np.random.seed(seed)
+        dmat = np.diag(np.exp(1j * np.random.normal(size=2**num_qubits)))
+        self.assertCossinDecompositionIsCorrect(dmat)

--- a/test/python/synthesis/test_synthesis.py
+++ b/test/python/synthesis/test_synthesis.py
@@ -1686,7 +1686,7 @@ class TestQuantumShannonDecomposer(QiskitTestCase):
         mat = np.diag(np.exp(1j * np.random.normal(size=dim)))
         circ = self.qsd(mat, opt_a1=True, opt_a2=False)
         ccirc = transpile(circ, basis_gates=["u", "cx"], optimization_level=0)
-        self.assertTrue(np.allclose(mat, Operator(ccirc).data))
+        np.testing.assert_allclose(mat, Operator(ccirc).data, atol=1e-7)
         if nqubits > 1:
             expected_cx = self._qsd_l2_cx_count(nqubits) - self._qsd_l2_a1_mod(nqubits)
             self.assertLessEqual(ccirc.count_ops().get("cx"), expected_cx)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This PR ports the cosine-sine decomposition to Rust, based on [Tket's implementation](https://github.com/CQCL/tket/blob/a61bbac1c07487521acd8da463023f3c85c799e8/tket/src/Utils/CosSinDecomposition.cpp).

In particular, this seems to fully avoid problems for computing CSDs for controlled unitary matrices described in #14157. 

 
### Details and comments

Tket has a specialized implementation in their code using eigen for the same problem space we need in qiskit for the qsd. This commit attempts to port their implementation into Rust for qiskit so we can have a native decomposition in rust. To start this just calls the function via python. But this is just a short term step to validate the implementation is correct. The eventual goal is to just replace the python implemenation of qsd and never expose this function to Python. This is just an intermediate steps towards working for that.

**Acknowledgements**: Tket developers, obviously. Matthew did the heavy lifting of porting the code to Rust and I have finalized the implementation. Thanks to Gadi and Shelly for helping me understand some of the technical details behind Tket's implementation.

**Note**: experimentally, it seems that the diagonal matrix `s` obtained using the QR-decomposition already satisfies that its entries are real and positive. If we could prove that this is always true, we could further simplify the algorithm.