### PR TITLE
Remove unused python config output file

### DIFF
--- a/crates/cext/build.rs
+++ b/crates/cext/build.rs
@@ -37,28 +37,6 @@ fn generate_qiskit_header() {
         .write_to_file(path);
 }
 
-// Get the Python library directory and library name that PyO3 is using, and store it into a
-// configuration file.
-fn write_python_config() {
-    let interpreter_config = pyo3_build_config::get();
-    let pyo3_lib_config = format!(
-        "PYO3_PYTHON_LIB_DIR={}\nPYO3_PYTHON_LIB_NAME={}\n",
-        interpreter_config.lib_dir.clone().unwrap_or("".to_string()),
-        interpreter_config
-            .lib_name
-            .clone()
-            .unwrap_or("".to_string())
-    );
-
-    // This path is relative to the current file, i.e. we write into the root's target dir.
-    let pyo3_config_file = "../../target/pyo3_python.config";
-    match ::std::fs::write(pyo3_config_file, pyo3_lib_config) {
-        Ok(_) => (),
-        Err(_) => println!("cargo:warning=Failed to write Python config."),
-    };
-}
-
 fn main() {
     generate_qiskit_header();
-    write_python_config();
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The C api's build.rs was generating a config file that pointed to where the Python that pyo3 links against was located. This was previously used by the c test's cmake file to add to the search path on windows to enable the windows ctest runner to find the python lib it needs to load to run the tests. However, in practice this wasn't pointing to the correct location to point windows at libpython and PR #14006 stopped using this file when it updated the path set to be found using cmake's FindPython module. This commit is just a follow up to remove this part of the build.rs as it's not longer actively used for anything.

### Details and comments