### PR TITLE
Add Rust tests to the coverage collection

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -70,6 +70,14 @@ jobs:
           ctest -V --test-dir test/c/build
         env:
           LLVM_PROFILE_FILE: "qiskit-%p-%m.profraw"
+
+      - name: Generate rust test coverage report
+        run: |
+          python tools/run_cargo_test.py
+        env:
+          RUSTFLAGS: "-Cinstrument-coverage -Cincremental=false"
+          LLVM_PROFILE_FILE: "qiskit-%p-%m.profraw"
+
       - name: Generate lcov with grcov
         run: |
           # Copy ctest coverage to cwd


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Right now we're not including the coverage collected from the rust
tests in our collected coverage data for the coverage report. While
we don't have a huge amount of rust testing, since it's not our public
interface we do have some which is often used to test negative paths to
ensure we're handling error edge cases correctly which are not normally
triggered by using the Python or C APIs. This commit expands the
coverage job to run the rust tests with coverage collection enabled and
to include that in the collected coverage data.

### Details and comments

~This commit is built on top of #14046 and will need to be rebased after
that PR merges. You can look at: https://github.com/Qiskit/qiskit/pull/14246/commits/c09145ca0614816f946baa6ad8d86d5fb730ee0f to view the contents of just this PR.~

 #14046 has merged and this  has been rebased

