### PR TITLE
Make DAG `Wire`s `Copy`

### DIFF
--- a/crates/accelerate/src/commutation_analysis.rs
+++ b/crates/accelerate/src/commutation_analysis.rs
@@ -62,11 +62,11 @@ pub(crate) fn analyze_commutations_inner(
     for qubit in 0..dag.num_qubits() {
         let wire = Wire::Qubit(Qubit(qubit as u32));
 
-        for current_gate_idx in dag.nodes_on_wire(&wire, false) {
+        for current_gate_idx in dag.nodes_on_wire(wire, false) {
             // get the commutation set associated with the current wire, or create a new
             // index set containing the current gate
             let commutation_entry = commutation_set
-                .entry(wire.clone())
+                .entry(wire)
                 .or_insert_with(|| vec![vec![current_gate_idx]]);
 
             // we can unwrap as we know the commutation entry has at least one element
@@ -123,10 +123,7 @@ pub(crate) fn analyze_commutations_inner(
                 }
             }
 
-            node_indices.insert(
-                (current_gate_idx, wire.clone()),
-                commutation_entry.len() - 1,
-            );
+            node_indices.insert((current_gate_idx, wire), commutation_entry.len() - 1);
         }
     }
 

--- a/crates/accelerate/src/split_2q_unitaries.rs
+++ b/crates/accelerate/src/split_2q_unitaries.rs
@@ -62,33 +62,32 @@ pub fn split_2q_unitaries(
                 let k1r_arr = decomp.k1r_view();
                 let k1l_arr = decomp.k1l_view();
 
-                let insert_fn = |edge: &Wire| -> (PackedOperation, SmallVec<[Param; 3]>) {
-                    if let Wire::Qubit(qubit) = edge {
-                        if *qubit == qubits[0] {
-                            let mat: Matrix2<Complex64> = [
-                                [k1r_arr[[0, 0]], k1r_arr[[1, 0]]],
-                                [k1r_arr[[0, 1]], k1r_arr[[1, 1]]],
-                            ]
-                            .into();
-                            let k1r_gate = Box::new(UnitaryGate {
-                                array: ArrayType::OneQ(mat),
-                            });
-                            (PackedOperation::from_unitary(k1r_gate), smallvec![])
-                        } else {
-                            let mat: Matrix2<Complex64> = [
-                                [k1l_arr[[0, 0]], k1l_arr[[1, 0]]],
-                                [k1l_arr[[0, 1]], k1l_arr[[1, 1]]],
-                            ]
-                            .into();
-
-                            let k1l_gate = Box::new(UnitaryGate {
-                                array: ArrayType::OneQ(mat),
-                            });
-
-                            (PackedOperation::from_unitary(k1l_gate), smallvec![])
-                        }
+                let insert_fn = |edge: Wire| -> (PackedOperation, SmallVec<[Param; 3]>) {
+                    let Wire::Qubit(qubit) = edge else {
+                        panic!("must only be called on ops with no classical wires");
+                    };
+                    if qubit == qubits[0] {
+                        let mat: Matrix2<Complex64> = [
+                            [k1r_arr[[0, 0]], k1r_arr[[1, 0]]],
+                            [k1r_arr[[0, 1]], k1r_arr[[1, 1]]],
+                        ]
+                        .into();
+                        let k1r_gate = Box::new(UnitaryGate {
+                            array: ArrayType::OneQ(mat),
+                        });
+                        (PackedOperation::from_unitary(k1r_gate), smallvec![])
                     } else {
-                        unreachable!("This will only be called on ops with no classical wires.");
+                        let mat: Matrix2<Complex64> = [
+                            [k1l_arr[[0, 0]], k1l_arr[[1, 0]]],
+                            [k1l_arr[[0, 1]], k1l_arr[[1, 1]]],
+                        ]
+                        .into();
+
+                        let k1l_gate = Box::new(UnitaryGate {
+                            array: ArrayType::OneQ(mat),
+                        });
+
+                        (PackedOperation::from_unitary(k1l_gate), smallvec![])
                     }
                 };
                 dag.replace_node_with_1q_ops(py, node, insert_fn)?;


### PR DESCRIPTION
The inner types are all simple integers; it's logically a `Copy` type.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


