### PR TITLE
Reenforcing all observables in an observables array to have the same number of qubits

### DIFF
--- a/qiskit/primitives/containers/observables_array.py
+++ b/qiskit/primitives/containers/observables_array.py
@@ -78,7 +78,7 @@ class ObservablesArray(ShapedMixin):
 
         self._array = object_array(observables, copy=copy, list_types=(PauliList,))
         self._shape = self._array.shape
-        self._num_qubits = num_qubits 
+        self._num_qubits = num_qubits
 
         if validate:
             for ndi, obs in np.ndenumerate(self._array):

--- a/qiskit/primitives/containers/observables_array.py
+++ b/qiskit/primitives/containers/observables_array.py
@@ -200,6 +200,7 @@ class ObservablesArray(ShapedMixin):
 
     @property
     def num_qubits(self) -> int:
+        """Return the observable array's number of qubits"""
         return self._num_qubits
 
     @classmethod

--- a/qiskit/primitives/containers/observables_array.py
+++ b/qiskit/primitives/containers/observables_array.py
@@ -91,7 +91,7 @@ class ObservablesArray(ShapedMixin):
                         "observables array."
                     )
                 self._array[ndi] = basis_obs
-        elif self._num_qubits is None and len(self._array) > 0:
+        elif self._num_qubits is None and self._array.size > 0:
             self._num_qubits = self._array.reshape(-1)[0].num_qubits
 
     @staticmethod

--- a/qiskit/primitives/containers/observables_array.py
+++ b/qiskit/primitives/containers/observables_array.py
@@ -94,6 +94,10 @@ class ObservablesArray(ShapedMixin):
         elif self._num_qubits is None and self._array.size > 0:
             self._num_qubits = self._array.reshape(-1)[0].num_qubits
 
+        # can happen for empty arrays
+        if self._num_qubits is None:
+            self._num_qubits = 0
+
     @staticmethod
     def _obs_to_dict(obs: SparseObservable) -> Mapping[str, float]:
         """Convert a sparse observable to a mapping from Pauli strings to coefficients"""

--- a/qiskit/primitives/containers/observables_array.py
+++ b/qiskit/primitives/containers/observables_array.py
@@ -63,10 +63,9 @@ class ObservablesArray(ShapedMixin):
             observables: An array-like of basis observable compatible objects.
             copy: Specify the ``copy`` kwarg of the :func:`.object_array` function
                 when initializing observables.
-            num_qubits: The number of qubits of the observables. If not specified, and `validate`
-                is ``True``, the number of qubits will be inferred from the observables. If specified,
-                and `validate` is ``True``, then the specified number of qubits must match the number
-                of qubits in the observables.
+            num_qubits: The number of qubits of the observables. If not specified, the number of
+                qubits will be inferred from the observables. If specified, then the specified
+                number of qubits must match the number of qubits in the observables.
             validate: If true, coerce entries into the internal format and validate them. If false,
                 the input should already be an array-like.
 
@@ -76,9 +75,11 @@ class ObservablesArray(ShapedMixin):
         super().__init__()
         if isinstance(observables, ObservablesArray):
             observables = observables._array
+
         self._array = object_array(observables, copy=copy, list_types=(PauliList,))
         self._shape = self._array.shape
-        self._num_qubits = num_qubits
+        self._num_qubits = num_qubits 
+
         if validate:
             for ndi, obs in np.ndenumerate(self._array):
                 basis_obs = self.coerce_observable(obs)
@@ -90,6 +91,8 @@ class ObservablesArray(ShapedMixin):
                         "observables array."
                     )
                 self._array[ndi] = basis_obs
+        elif self._num_qubits is None and len(self._array) > 0:
+            self._num_qubits = self._array.reshape(-1)[0].num_qubits
 
     @staticmethod
     def _obs_to_dict(obs: SparseObservable) -> Mapping[str, float]:
@@ -267,14 +270,11 @@ class ObservablesArray(ShapedMixin):
 
     def validate(self):
         """Validate the consistency in observables array."""
-        num_qubits = None
         for obs in self._array.reshape(-1):
-            if num_qubits is None:
-                num_qubits = obs.num_qubits
-            elif obs.num_qubits != num_qubits:
+            if obs.num_qubits != self.num_qubits:
                 raise ValueError(
-                    "The number of qubits must be the same for all observables in the "
-                    "observables array."
+                    "An observable was detected, whose number of qubits"
+                    " does not match the array's number of qubits"
                 )
 
 

--- a/qiskit/primitives/containers/observables_array.py
+++ b/qiskit/primitives/containers/observables_array.py
@@ -53,7 +53,7 @@ class ObservablesArray(ShapedMixin):
     def __init__(
         self,
         observables: ObservablesArrayLike,
-        num_qubits=None,
+        num_qubits: int | None = None,
         copy: bool = True,
         validate: bool = True,
     ):

--- a/test/python/primitives/containers/test_observables_array.py
+++ b/test/python/primitives/containers/test_observables_array.py
@@ -361,6 +361,24 @@ class ObservablesArrayTestCase(QiskitTestCase):
         obs = ObservablesArray([{"XXY": 1, "YZI": 2}, {"IYX": 3}])
         self.assertEqual(obs.num_qubits, 3)
 
+        with self.assertRaisesRegex(ValueError, "number of qubits"):
+            obs = ObservablesArray([{"XXY": 1, "YZI": 2}, {"IYX": 3}], num_qubits=20)
+
+        with self.assertRaisesRegex(ValueError, "number of qubits"):
+            obs = ObservablesArray([{"XXY": 1, "YZI": 2}, {"YX": 3}], num_qubits=20)
+
+        obs = ObservablesArray([{"XX": 1}] * 15).reshape((3, 5))
+        self.assertEqual(obs.num_qubits, 2)
+
+        obs = ObservablesArray([{"XX": 1}] * 15)[4:6]
+        self.assertEqual(obs.num_qubits, 2)
+
+        obs = ObservablesArray(
+            [ObservablesArray.coerce({"XX": 1}), ObservablesArray.coerce({"XYZ": 1})],
+            validate=False,
+        )
+        self.assertEqual(obs.num_qubits, 2)
+
     def test_validate(self):
         """Test the validate method"""
         ObservablesArray({"XX": 1}).validate()

--- a/test/python/primitives/containers/test_observables_array.py
+++ b/test/python/primitives/containers/test_observables_array.py
@@ -360,3 +360,16 @@ class ObservablesArrayTestCase(QiskitTestCase):
         """Test num_qubits method"""
         obs = ObservablesArray([{"XXY": 1, "YZI": 2}, {"IYX": 3}])
         self.assertEqual(obs.num_qubits, 3)
+
+    def test_validate(self):
+        """Test the validate method"""
+        ObservablesArray({"XX": 1}).validate()
+        ObservablesArray([{"XX": 1}] * 5).validate()
+        ObservablesArray([{"XX": 1}] * 15).reshape((3, 5)).validate()
+
+        obs = ObservablesArray(
+            [ObservablesArray.coerce({"XX": 1}), ObservablesArray.coerce({"XYZ": 1})],
+            validate=False,
+        )
+        with self.assertRaisesRegex(ValueError, "number of qubits"):
+            obs.validate()

--- a/test/python/primitives/containers/test_observables_array.py
+++ b/test/python/primitives/containers/test_observables_array.py
@@ -204,7 +204,7 @@ class ObservablesArrayTestCase(QiskitTestCase):
     def test_init_validate_false(self):
         """Test init validate kwarg"""
         obj = [["X", "Y", "Z"], ["I", "0", "1"]]
-        obs = ObservablesArray(obj, validate=False)
+        obs = ObservablesArray(obj, validate=False, num_qubits=1)
         self.assertEqual(obs.shape, (2, 3))
         self.assertEqual(obs.size, 6)
         for i in range(2):

--- a/test/python/primitives/containers/test_observables_array.py
+++ b/test/python/primitives/containers/test_observables_array.py
@@ -355,3 +355,8 @@ class ObservablesArrayTestCase(QiskitTestCase):
                             {labels_rs[idx]: 1},
                             msg=f"failed for shape {shape} with input format {input_shape}",
                         )
+
+    def test_num_qubits(self):
+        """Test num_qubits method"""
+        obs = ObservablesArray([{"XXY": 1, "YZI": 2}, {"IYX": 3}])
+        self.assertEqual(obs.num_qubits, 3)


### PR DESCRIPTION
### Summary

- Reenforcing all observables in an observables array to have the same number of qubits, after this constraint was removed in #14132.
- Adding a new property `ObservableArray.num_qubits`.

### Details and comments

In #14132 I intentionally removed the constraint, because I didn't see a reason for it. I actually still don't, however:
- I identified current usages of `ObservablesArray` which assume and rely on the number of qubits being equal in all the observables. Specifically, these usages deduce the global number of qubits by looking only at the first observable. Therefore, reenforcing the constraint is necessary in order to prevent breaking changes.
- Although I deleted the validation from the constructor, the constraint is checked also elsewhere, in a `validate` method, which survived #14132. So either we delete this method (and places where it is called), or, again, we return the validation also to the constructor.

A couple of comments:
- An alternative can be to expand all the observables to the maximum number of qubits (among the observables).
- The addition of a data member `_num_qubits` and a method `num_qubits` is for convenience and is of use of the API. It does add a bit of extra work and risk of introducing bugs when maintaining `ObservablesArray`.

