### PR TITLE
multi_control_rotation improve CX count by using action_only=True

### DIFF
--- a/qiskit/synthesis/multi_controlled/multi_control_rotation_gates.py
+++ b/qiskit/synthesis/multi_controlled/multi_control_rotation_gates.py
@@ -182,19 +182,16 @@ def _mcsu2_real_diagonal(
     circuit.compose(mcx_1, controls[:k_1] + [target] + controls[k_1 : 2 * k_1 - 2], inplace=True)
     circuit.append(s_gate, [target])
 
-    # TODO: improve CX count by using action_only=True (based on #9687)
-    mcx_2 = synth_mcx_n_dirty_i15(num_ctrl_qubits=k_2).to_gate()
+    mcx_2 = synth_mcx_n_dirty_i15(num_ctrl_qubits=k_2, action_only=True).to_gate()
     circuit.compose(
         mcx_2.inverse(), controls[k_1:] + [target] + controls[k_1 - k_2 + 2 : k_1], inplace=True
     )
     circuit.append(s_gate.inverse(), [target])
 
-    mcx_3 = synth_mcx_n_dirty_i15(num_ctrl_qubits=k_1).to_gate()
-    circuit.compose(mcx_3, controls[:k_1] + [target] + controls[k_1 : 2 * k_1 - 2], inplace=True)
+    circuit.compose(mcx_1, controls[:k_1] + [target] + controls[k_1 : 2 * k_1 - 2], inplace=True)
     circuit.append(s_gate, [target])
 
-    mcx_4 = synth_mcx_n_dirty_i15(num_ctrl_qubits=k_2).to_gate()
-    circuit.compose(mcx_4, controls[k_1:] + [target] + controls[k_1 - k_2 + 2 : k_1], inplace=True)
+    circuit.compose(mcx_2, controls[k_1:] + [target] + controls[k_1 - k_2 + 2 : k_1], inplace=True)
     circuit.append(s_gate.inverse(), [target])
 
     if not is_secondary_diag_real:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Improve improve CX count by using action_only=True in multi_control_rotation_gates.py

### Details and comments


