### PR TITLE
Remove some unnecessary DAG 'Python' tokens

### DIFF
--- a/crates/accelerate/src/basis/basis_translator/mod.rs
+++ b/crates/accelerate/src/basis/basis_translator/mod.rs
@@ -479,7 +479,7 @@ fn apply_translation(
 ) -> PyResult<(DAGCircuit, bool)> {
     let mut is_updated = false;
     let out_dag = dag.copy_empty_like(py, "alike")?;
-    let mut out_dag_builder = out_dag.into_builder(py);
+    let mut out_dag_builder = out_dag.into_builder();
     for node in dag.topological_op_nodes()? {
         let node_obj = dag[node].unwrap_operation();
         let node_qarg = dag.get_qargs(node_obj.qubits);

--- a/crates/accelerate/src/unitary_synthesis.rs
+++ b/crates/accelerate/src/unitary_synthesis.rs
@@ -375,7 +375,7 @@ fn py_run_main_loop(
                     out_dag.push_back(py, packed_instr.clone())?;
                     Ok(())
                 };
-                let mut builder = out_dag.into_builder(py);
+                let mut builder = out_dag.into_builder();
                 run_2q_unitary_synthesis(
                     py,
                     unitary,
@@ -408,7 +408,7 @@ fn py_run_main_loop(
                         None,
                     )?;
                     let out_qargs = dag.get_qargs(packed_instr.qubits);
-                    let mut dag_builder = out_dag.into_builder(py);
+                    let mut dag_builder = out_dag.into_builder();
                     apply_synth_dag(py, &mut dag_builder, out_qargs, &synth_dag)?;
                     out_dag = dag_builder.build();
                 }
@@ -1072,7 +1072,7 @@ fn reversed_synth_su4_dag(
 
     let target_dag = synth_dag.copy_empty_like(py, "alike")?;
     let flip_bits: [Qubit; 2] = [Qubit(1), Qubit(0)];
-    let mut target_dag_builder = target_dag.into_builder(py);
+    let mut target_dag_builder = target_dag.into_builder();
     for node in synth_dag.topological_op_nodes()? {
         let mut inst = synth_dag[node].unwrap_operation().clone();
         let qubits: Vec<Qubit> = synth_dag


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In particular, we don't need the Python GIL to work out how many `Var`s the circuit contains, and the `DAGCircuitBuilder` doesn't need the `py` token to take ownership of a `DAGCircuit`.

### Details and comments


