### PR TITLE
fixed unescaped quotes in README.md example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ from qiskit.primitives import StatevectorSampler
 sampler = StatevectorSampler()
 job = sampler.run([qc_measured], shots=1000)
 result = job.result()
-print(f" > Counts: {result[0].data["meas"].get_counts()}")
+print(f" > Counts: {result[0].data['meas'].get_counts()}")
 ```
 Running this will give an outcome similar to `{'000': 497, '111': 503}` which is `000` 50% of the time and `111` 50% of the time up to statistical fluctuations.
 To illustrate the power of the Estimator, we now use the quantum information toolbox to create the operator $XXY+XYX+YXX-YYY$ and pass it to the `run()` function, along with our quantum circuit. Note that the Estimator requires a circuit _**without**_ measurements, so we use the `qc` circuit we created earlier.


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.


-->

### Summary
prior, quotes around `"meas"` in the README.md file were not escaped properly, leading to the following error when running the code

```shell
...
    print(f" > Counts: {result[0].data["meas"].get_counts()}")
                                        ^^^^
SyntaxError: f-string: unmatched '['
```

changed quotes to single quotes (that don't need to be escaped)

### Details and comments
versions:
* python 3.10
* qiskit 2.0.0