### PR TITLE
Use ahash for hashing everywhere with IndexMap

### DIFF
--- a/crates/accelerate/src/sparse_observable/mod.rs
+++ b/crates/accelerate/src/sparse_observable/mod.rs
@@ -3442,7 +3442,7 @@ impl PySparseObservable {
             let order = order
                 .try_iter()?
                 .map(|obj| obj.and_then(|obj| obj.extract::<u32>()))
-                .collect::<PyResult<IndexSet<u32>>>()?;
+                .collect::<PyResult<IndexSet<u32, ::ahash::RandomState>>>()?;
             if order.len() != in_length {
                 return Err(PyValueError::new_err("duplicate indices in qargs"));
             }

--- a/crates/accelerate/src/synthesis/clifford/greedy_synthesis.rs
+++ b/crates/accelerate/src/synthesis/clifford/greedy_synthesis.rs
@@ -194,10 +194,10 @@ impl GreedyCliffordSynthesis<'_> {
         gate_seq: &mut CliffordGatesVec,
         min_qubit: usize,
     ) -> Result<(), String> {
-        let mut a_qubits = IndexSet::new();
-        let mut b_qubits = IndexSet::new();
-        let mut c_qubits = IndexSet::new();
-        let mut d_qubits = IndexSet::new();
+        let mut a_qubits: IndexSet<_, ::ahash::RandomState> = IndexSet::default();
+        let mut b_qubits: IndexSet<_, ::ahash::RandomState> = IndexSet::default();
+        let mut c_qubits: IndexSet<_, ::ahash::RandomState> = IndexSet::default();
+        let mut d_qubits: IndexSet<_, ::ahash::RandomState> = IndexSet::default();
 
         for qubit in &self.unprocessed_qubits {
             let pauli_pair_index = pauli_pair_to_index(

--- a/crates/accelerate/src/target_transpiler/mod.rs
+++ b/crates/accelerate/src/target_transpiler/mod.rs
@@ -52,7 +52,7 @@ pub(crate) mod exceptions {
 
 // Custom types
 type GateMap = IndexMap<String, PropsMap, RandomState>;
-type PropsMap = IndexMap<Qargs, Option<InstructionProperties>>;
+type PropsMap = IndexMap<Qargs, Option<InstructionProperties>, RandomState>;
 
 /// Represents a Qiskit `Gate` object or a Variadic instruction.
 /// Keeps a reference to its Python instance for caching purposes.
@@ -222,7 +222,7 @@ pub struct Target {
     #[pyo3(get)]
     _gate_name_map: IndexMap<String, TargetOperation, RandomState>,
     global_operations: IndexMap<u32, HashSet<String>, RandomState>,
-    qarg_gate_map: IndexMap<Qargs, Option<HashSet<String>>>,
+    qarg_gate_map: IndexMap<Qargs, Option<HashSet<String>>, RandomState>,
     non_global_strict_basis: Option<Vec<String>>,
     non_global_basis: Option<Vec<String>>,
 }

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -877,18 +877,18 @@ impl DAGCircuit {
         let dict_state = state.downcast_bound::<PyDict>(py)?;
         self.name = dict_state.get_item("name")?.unwrap().extract()?;
         self.metadata = dict_state.get_item("metadata")?.unwrap().extract()?;
-        self.qregs = RegisterData::from_mapping(
-            dict_state
-                .get_item("qregs")?
-                .unwrap()
-                .extract::<IndexMap<String, QuantumRegister>>()?,
-        );
-        self.cregs = RegisterData::from_mapping(
-            dict_state
-                .get_item("cregs")?
-                .unwrap()
-                .extract::<IndexMap<String, ClassicalRegister>>()?,
-        );
+        self.qregs =
+            RegisterData::from_mapping(dict_state.get_item("qregs")?.unwrap().extract::<IndexMap<
+                String,
+                QuantumRegister,
+                ::ahash::RandomState,
+            >>()?);
+        self.cregs =
+            RegisterData::from_mapping(dict_state.get_item("cregs")?.unwrap().extract::<IndexMap<
+                String,
+                ClassicalRegister,
+                ::ahash::RandomState,
+            >>()?);
         self.global_phase = dict_state.get_item("global_phase")?.unwrap().extract()?;
         self.op_names = dict_state.get_item("op_name")?.unwrap().extract()?;
         self.vars_by_type =


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates all the IndexMap (and IndexSet) usage to ensure we're using ahash as our hasher implementation. By default IndexMap uses the default stdlib SipHash 1-3 hasher which is significantly slower than ahash. This is a large part of why we use Hashbrown for our default HashMap implementation, and usign it for IndexMap means the lookup performance is basically equivalent to hashbrown.

### Details and comments