### PR TITLE
Update comment about PackedOperation for StandardGate

### DIFF
--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -83,10 +83,10 @@ unsafe impl ::bytemuck::NoUninit for PackedOperationType {}
 ///
 /// ```text
 /// StandardGate:
-/// 0b_xxxxxxxx_xxxxxxxx_xxxxxxxx_xxxxxxxx_xxxxxxxx_xxxxxxxx_SSSSSSSS_xxxxx000
-///                                                          |------|      |-|
-///                                                              |          |
-///                      Standard gate, stored inline as a u8. --+          +-- Discriminant.
+/// 0b_xxxxxxxx_xxxxxxxx_xxxxxxxx_xxxxxxxx_xxxxxxxx_xxxxxxxx_xxxxxSSS_SSSSS000
+///                                                               |-------||-|
+///                                                                   |     |
+///                      Standard gate, stored inline as a u8. -------+     +-- Discriminant.
 ///
 /// StandardInstruction:
 /// 0b_DDDDDDDD_DDDDDDDD_DDDDDDDD_DDDDDDDD_xxxxxxxx_xxxxxxxx_SSSSSSSS_xxxxx001


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The PackedOperation representation for StandardGate doesn't have any padding between the discriminant and the StandardGate u8. The comment incorrectly showed 5 bits of padding making the u8 byte aligned in the word. This commit corrects this oversight so the comment text describes what is actually stored.

### Details and comments