### PR TITLE
Allow `Operator.__init__` to accept circuit with boxes

### DIFF
--- a/qiskit/converters/circuit_to_instruction.py
+++ b/qiskit/converters/circuit_to_instruction.py
@@ -84,7 +84,9 @@ def circuit_to_instruction(circuit, parameter_map=None, equivalence_library=None
             "Circuits with internal variables cannot yet be converted to instructions."
             " You may be able to use `QuantumCircuit.compose` to inline this circuit into another."
         )
-    if CONTROL_FLOW_OP_NAMES.intersection(op for op in circuit.count_ops() if op != "box"):
+    op_counts = circuit.count_ops()
+    op_counts.pop("box", None)
+    if CONTROL_FLOW_OP_NAMES.intersection(op_counts):
         raise QiskitError(
             "Circuits with control flow operations cannot be converted to an instruction."
         )

--- a/qiskit/converters/circuit_to_instruction.py
+++ b/qiskit/converters/circuit_to_instruction.py
@@ -84,7 +84,7 @@ def circuit_to_instruction(circuit, parameter_map=None, equivalence_library=None
             "Circuits with internal variables cannot yet be converted to instructions."
             " You may be able to use `QuantumCircuit.compose` to inline this circuit into another."
         )
-    if CONTROL_FLOW_OP_NAMES.intersection(circuit.count_ops()):
+    if CONTROL_FLOW_OP_NAMES.intersection(op for op in circuit.count_ops() if op != "box"):
         raise QiskitError(
             "Circuits with control flow operations cannot be converted to an instruction."
         )

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from qiskit import _numpy_compat
+from qiskit.circuit.controlflow import BoxOp
 from qiskit.circuit.instruction import Instruction
 from qiskit.circuit.library.standard_gates import HGate, IGate, SGate, TGate, XGate, YGate, ZGate
 from qiskit.circuit.operation import Operation
@@ -826,6 +827,8 @@ class Operator(LinearOp):
             self._data = op.data
         elif isinstance(obj, Barrier):
             return
+        elif isinstance(obj, BoxOp):
+            self._append_instruction(obj.body.to_instruction(), qargs)
         else:
             # If the instruction doesn't have a matrix defined we use its
             # circuit decomposition definition if it exists, otherwise we

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -181,6 +181,22 @@ class TestOperator(OperatorTestCase):
         target = np.kron(self.UI, np.diag([1, 0])) + np.kron(self.UH, np.diag([0, 1]))
         global_phase_equivalent = matrix_equal(op.data, target, ignore_phase=True)
         self.assertTrue(global_phase_equivalent)
+        
+        # Test when boxes present
+        circuit = QuantumCircuit(3)
+        with circuit.box():
+            circuit.h(0)
+        circuit.id(0)
+        with circuit.box():
+            with circuit.box():
+                circuit.x(1)
+            circuit.ry(np.pi / 2, 2)
+        op = Operator(circuit)
+        y90 = (1 / np.sqrt(2)) * np.array([[1, -1], [1, 1]])
+        target = np.kron(y90, np.kron(self.UX, self.UH))
+        global_phase_equivalent = matrix_equal(op.data, target, ignore_phase=True)
+        self.assertTrue(global_phase_equivalent)
+
 
     def test_instruction_init(self):
         """Test initialization from a circuit."""


### PR DESCRIPTION
### Summary

Closes #14291 by adding logic to `Operator` that recurses into `BoxOp` bodies while adding instructions.

### Details and comments

`BoxOp` is a subclass of `ControlFlowOp` and hence is not allowed by `Operator`. However, boxes don't actually have control flow, they execute a single body unconditionally, and once. So it is safe to recurse into them when considering Operators.


