### PR TITLE
Implement `Copy` for `InstructionProperties`.

### DIFF
--- a/crates/accelerate/src/target_transpiler/instruction_properties.rs
+++ b/crates/accelerate/src/target_transpiler/instruction_properties.rs
@@ -20,7 +20,7 @@ use pyo3::{prelude::*, pyclass};
     name = "BaseInstructionProperties",
     module = "qiskit._accelerate.target"
 )]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct InstructionProperties {
     #[pyo3(get, set)]
     pub duration: Option<f64>,

--- a/crates/accelerate/src/target_transpiler/mod.rs
+++ b/crates/accelerate/src/target_transpiler/mod.rs
@@ -674,7 +674,7 @@ impl Target {
             let gate_map_oper = props_map.values();
             for inst_props in gate_map_oper {
                 if index_counter == index {
-                    return Ok(inst_props.clone());
+                    return Ok(*inst_props);
                 }
                 index_counter += 1;
             }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
The following commits make `InstructionProperties` implement the `Copy` trait, since the structure itself already contains copyable attributes.


