### PR TITLE
Add C API function to move a QkCircuit to Python

### DIFF
--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -21,6 +21,15 @@ use qiskit_circuit::operations::{Operation, Param, StandardGate, StandardInstruc
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::{Clbit, Qubit};
 
+#[cfg(feature = "python_binding")]
+use pyo3::ffi::PyObject;
+#[cfg(feature = "python_binding")]
+use pyo3::types::PyAnyMethods;
+#[cfg(feature = "python_binding")]
+use pyo3::{intern, Python};
+#[cfg(feature = "python_binding")]
+use qiskit_circuit::imports::QUANTUM_CIRCUIT;
+
 /// @ingroup QkCircuit
 /// Construct a new circuit with the given number of qubits and clbits.
 ///
@@ -559,5 +568,39 @@ pub unsafe extern "C" fn qk_opcounts_free(op_counts: OpCounts) {
     // SAFETY: Loading a box from the slice pointer created above
     unsafe {
         let _ = Box::from_raw(data);
+    }
+}
+
+/// @ingroup QkCircuit
+/// Convert to a Python-space ``QuantumCircuit``
+///
+/// @param circuit the C-space ``QkCircuit`` pointer
+///
+/// @return A Python ``QuantumCircuit`` object
+///
+/// # Safety
+///
+/// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to
+/// a ``QkCircuit``
+///
+/// It is assumed that the thread currently executing this function holds the
+/// Python GIL. This is required to create the Python object returned by this
+/// function.
+///
+/// This function takes ownership of the pointer and gives it to Python. Using
+/// the input ``circuit`` pointer after it's passed to this function is
+/// undefined behavior.
+#[no_mangle]
+#[cfg(feature = "python_binding")]
+#[cfg(feature = "cbinding")]
+pub unsafe extern "C" fn qk_circuit_to_python(circuit: *mut CircuitData) -> *mut PyObject {
+    unsafe {
+        let circuit = Box::from_raw(mut_ptr_as_ref(circuit));
+        let py = Python::assume_gil_acquired();
+        QUANTUM_CIRCUIT
+            .get_bound(py)
+            .call_method1(intern!(py, "_from_circuit_data"), (*circuit,))
+            .expect("Unabled to create a Python circuit")
+            .into_ptr()
     }
 }

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -572,11 +572,16 @@ pub unsafe extern "C" fn qk_opcounts_free(op_counts: OpCounts) {
 }
 
 /// @ingroup QkCircuit
-/// Convert to a Python-space ``QuantumCircuit``
+/// Convert to a Python-space ``QuantumCircuit``.
 ///
-/// @param circuit the C-space ``QkCircuit`` pointer
+/// This function takes ownership of the pointer and gives it to Python. Using
+/// the input ``circuit`` pointer after it's passed to this function is
+/// undefined behavior. In particular, ``qk_circuit_free`` should not be called
+/// on this pointer anymore.
 ///
-/// @return A Python ``QuantumCircuit`` object
+/// @param circuit The C-space ``QkCircuit`` pointer.
+///
+/// @return A Python ``QuantumCircuit`` object.
 ///
 /// # Safety
 ///
@@ -586,10 +591,6 @@ pub unsafe extern "C" fn qk_opcounts_free(op_counts: OpCounts) {
 /// It is assumed that the thread currently executing this function holds the
 /// Python GIL. This is required to create the Python object returned by this
 /// function.
-///
-/// This function takes ownership of the pointer and gives it to Python. Using
-/// the input ``circuit`` pointer after it's passed to this function is
-/// undefined behavior.
 #[no_mangle]
 #[cfg(feature = "python_binding")]
 #[cfg(feature = "cbinding")]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new function that can take a circuit built in C and passing it to Python. It takes in a QkCircuit pointer and converts that to a Python space QuantumCircuit.

### Details and comments