### PR TITLE
Improving numerical errors in cossin decomposition

### DIFF
--- a/crates/accelerate/src/cos_sin_decomp.rs
+++ b/crates/accelerate/src/cos_sin_decomp.rs
@@ -220,7 +220,7 @@ pub fn cos_sin_decomposition(u: DMatrix<Complex64>) -> CosSinDecompReturn {
     let thetas: Vec<f64> = c
         .iter()
         .zip(s.iter())
-        .map(|(&ci, &si)| if ci < 0.5 { ci.acos() } else { si.asin() })
+        .map(|(&ci, &si)| si.atan2(ci))
         .collect();
 
     (l0, l1, r0, r1, thetas)

--- a/crates/accelerate/src/cos_sin_decomp.rs
+++ b/crates/accelerate/src/cos_sin_decomp.rs
@@ -126,19 +126,16 @@ pub fn cos_sin_decomposition(u: DMatrix<Complex64>) -> CosSinDecompReturn {
     let mut c: DVector<f64> = svd.singular_values.column(0).into_owned();
 
     // We have u00 = l0 c r0, where l0 and r0 are unitary, and c is a diagonal matrix
-    // with positive entries in the descending order. However, we want the entries of c
-    // to be in the ascending order instead (otherwise, we will not be able to guarantee
-    // that s is a diagonal matrix too). Fortunately, it is easy to modify l0, c, and r0,
-    // so that this becomes true.
+    // with positive entries in the descending order. Also note that u00 is a submatrix
+    // of a unitary matrix, and hence its singular values (the entries of c) are all <= 1
+    // (well, due to floating-point precision errors, it is possible that some of
+    // the c-values are just a tiny bit larger than 1, so we have to be careful about that).
+    // However, we want the entries of c to be in the ascending order instead (otherwise,
+    // we will not be able to guarantee that s is a diagonal matrix too). Fortunately,
+    // it is easy to modify l0, c, and r0, so that this becomes true.
     reverse_rows(&mut r0);
     reverse_columns(&mut l0);
     reverse_vec(&mut c);
-
-    // Compute the angles theta. Because u00 is a submatrix of a unitary matrix, its
-    // singular values (the entries of c) are all <= 1. Due to floating-point precision
-    // errors, it is possible that some of the c-values are just a tiny bit larger than 1,
-    // so we correct for that.
-    let thetas: Vec<f64> = c.iter().map(|f| f.min(1.0).acos()).collect();
 
     // Apply QR to u10 r0*.
     // We have u10 r0* = l1 s, where l1 is unitary and s is upper-triangular.
@@ -213,6 +210,18 @@ pub fn cos_sin_decomposition(u: DMatrix<Complex64>) -> CosSinDecompReturn {
     // it might be a tiny bit away from a unitary. We "fix" this by finding
     // the closest unitary.
     let r1 = closest_unitary(r1);
+
+    // Compute the angles theta given approximate values of their cosines (entries of c)
+    // and their sines (entries of s).
+    // We can compute theta either as c.acos() or as s.asin(), however the first formula
+    // is not very accurate when c is close to 1 (an epsilon error in c leads to a
+    // sqrt(epsilon) error in theta), while the second formula is not very accurate when
+    // c is close to 0.
+    let thetas: Vec<f64> = c
+        .iter()
+        .zip(s.iter())
+        .map(|(&ci, &si)| if ci < 0.5 { ci.acos() } else { si.asin() })
+        .collect();
 
     (l0, l1, r0, r1, thetas)
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

In #14233, we have added the ``cossin`` decomposition. However, in an ongoing work (#13688) on using QSD to synthesize controlled unitaries, we have observed that in certain cases the ``cossin`` decomposition can significantly amplify numerical errors.

After a bit of investigation, we traced the issue to the following riddle: suppose we have values $c$ and $s$, where $c$ approximates $\cos(\theta)$ and $s$ approximates $\sin(\theta)$, how do we recover $\theta$?

Previously we computed $\theta$ as $\arccos(c)$, however this computation is not accurate when $c$ is close to $1$: an $\epsilon$-error in $c$ may lead to a $\epsilon^{1/2}$-error in $\theta$, amplifying the error. However, in this case we can compute $\theta$ as $\arcsin(s)$ instead, and an $\epsilon$-error in $s$ leads to only an $\epsilon$-error in $\theta$.

All this PR does is to choose the better of the two ways to compute $\theta$, either as $\arccos(c)$ or as $\arcsin(s)$, depending on which gives better numerical accuracy. UPDATE: apparently there is a direct method for that already, thanks to @jakelishman for pointing this out.

This should help #13688.

