### PR TITLE
Bump ahash to 0.8.12 on `qiskit_transpiler`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,7 +1514,7 @@ dependencies = [
 name = "qiskit-transpiler"
 version = "2.1.0"
 dependencies = [
- "ahash 0.8.11",
+ "ahash 0.8.12",
  "approx",
  "hashbrown 0.15.2",
  "indexmap",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
After splitting off `qiskit_transpiler` into its own crate, we forgot to upgrade ahash to the latest version. The following commits bump up this dependency to the most current version.


