### PR TITLE
Fix UnitarySynthesis to respect synth_gates

### DIFF
--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -294,7 +294,7 @@ class UnitarySynthesis(TransformationPass):
 
         out_dag = dag.copy_empty_like()
         for node in dag.topological_op_nodes():
-            if node.name == "unitary" and len(node.qargs) >= self._min_qubits:
+            if node.name in self._synth_gates and len(node.qargs) >= self._min_qubits:
                 synth_dag = None
                 unitary = node.matrix
                 n_qubits = len(node.qargs)

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -223,6 +223,7 @@ class UnitarySynthesis(TransformationPass):
                 self._min_qubits,
                 self._target,
                 self._basis_gates,
+                self._synth_gates,
                 _coupling_edges,
                 self._approximation_degree,
                 self._natural_direction,

--- a/releasenotes/notes/fix-UnitarySynthesis-synth_gates-4e084db18ece8bfe.yaml
+++ b/releasenotes/notes/fix-UnitarySynthesis-synth_gates-4e084db18ece8bfe.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a bug in the :class:`.UnitarySynthesis` transpiler pass, where the pass ignored the
+    ``synth_gates`` parameter and only synthesized the ``unitary`` gates. The pass now correctly
+    synthesizes all gates specified in the ``synth_gates`` parameter.
+    Fixed `#14343 <https://github.com/Qiskit/qiskit/issues/14343>`__.

--- a/test/python/transpiler/test_solovay_kitaev.py
+++ b/test/python/transpiler/test_solovay_kitaev.py
@@ -320,6 +320,24 @@ class TestSolovayKitaev(QiskitTestCase):
         diff = _trace_distance(circuit, transpiled)
         self.assertLess(diff, 1e-6)
 
+    @data(["unitary"], ["rz"])
+    def test_sk_synth_gates_to_basis(self, synth_gates):
+        """Verify two qubit unitaries are synthesized to match basis gates."""
+        unitary = QuantumCircuit(1)
+        unitary.h(0)
+        unitary_op = Operator(unitary)
+
+        qc = QuantumCircuit(1)
+        qc.unitary(unitary_op, 0)
+        qc.rz(0.1, 0)
+        dag = circuit_to_dag(qc)
+
+        basis_gates = ["h", "t", "tdg"]
+        out = UnitarySynthesis(basis_gates=basis_gates, synth_gates=synth_gates, method="sk").run(
+            dag
+        )
+        self.assertTrue(set(out.count_ops()).isdisjoint(synth_gates))
+
 
 @ddt
 class TestGateSequence(QiskitTestCase):

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -445,6 +445,22 @@ class TestUnitarySynthesisBasisGates(QiskitTestCase):
         pass_ = UnitarySynthesis(["unknown", "gates"])
         self.assertEqual(qc, pass_(qc))
 
+    @data(["unitary"], ["rz"])
+    def test_synth_gates_to_basis(self, synth_gates):
+        """Verify two qubit unitaries are synthesized to match basis gates."""
+        unitary = QuantumCircuit(1)
+        unitary.h(0)
+        unitary_op = Operator(unitary)
+
+        qc = QuantumCircuit(1)
+        qc.unitary(unitary_op, 0)
+        qc.rz(0.1, 0)
+        dag = circuit_to_dag(qc)
+
+        basis_gates = ["u3"]
+        out = UnitarySynthesis(basis_gates=basis_gates, synth_gates=synth_gates).run(dag)
+        self.assertTrue(set(out.count_ops()).isdisjoint(synth_gates))
+
 
 @ddt
 class TestUnitarySynthesisTarget(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Fixes #14343 

### Summary

This commit fixes UnitarySynthesis. It has a parameter `synth_gates`, which is meant to be a list of gates that are synthesized. However, the previous implementation did not respect this parameter, and only synthesized the gates named `unitary`. This commit fixes this issue by checking if gate's name is in `synth_gates`.

### Details and comments

When a non-default method is specified, the DAG nodes are traversed in `UnitarySynthesis._run_main_loop`. There, the name of the node is checked, and in the original implementation, the operation is synthesized if the name is `unitary`. This PR fixes this condition so that the synthesis takes place if the name is in `synth_gates`.

When the method argument is not given, UnitarySynthesis invokes the rust version of `run_main_loop`, which basically has the same structure. The PR also fixes it.