### PR TITLE
Bug fix in HighLevelSynthesis fast-return mechanism

### DIFF
--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -333,7 +333,7 @@ fn all_instructions_supported(
     data: &Bound<HighLevelSynthesisData>,
     dag: &DAGCircuit,
 ) -> PyResult<bool> {
-    let ops = dag.count_ops(py, false)?;
+    let ops = dag.count_ops(py, true)?;
     let mut op_keys = ops.keys();
 
     let borrowed_data = data.borrow();

--- a/releasenotes/notes/fix-hls-fast-return-6daff39a5eba40ce.yaml
+++ b/releasenotes/notes/fix-hls-fast-return-6daff39a5eba40ce.yaml
@@ -2,6 +2,6 @@
 fixes:
   - |
     Fixed a problem in :class:`.HighLevelSynthesis` transpiler pass that caused
-    it to erroneously terminate early on certain circuits with control flow 
+    it to erroneously terminate early on certain circuits with control flow
     operations.
     Fixed `#14338 <https://github.com/Qiskit/qiskit-terra/issues/14338>`__

--- a/releasenotes/notes/fix-hls-fast-return-6daff39a5eba40ce.yaml
+++ b/releasenotes/notes/fix-hls-fast-return-6daff39a5eba40ce.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a problem in :class:`.HighLevelSynthesis` transpiler pass that caused
+    it to erroneously terminate early on certain circuits with control flow 
+    operations.
+    Fixed `#14338 <https://github.com/Qiskit/qiskit-terra/issues/14338>`__

--- a/test/python/transpiler/test_high_level_synthesis.py
+++ b/test/python/transpiler/test_high_level_synthesis.py
@@ -742,6 +742,21 @@ class TestHighLevelSynthesisInterface(QiskitTestCase):
             expected_block.cx(0, 1)
             self.assertEqual(transpiled_block, expected_block)
 
+    def test_control_flow(self):
+        """Test that the pass recurses into control-flow ops."""
+        clifford_circuit = QuantumCircuit(3)
+        clifford_circuit.cx(1, 0)
+        clifford_circuit.cz(0, 2)
+        cliff = Clifford(clifford_circuit)
+
+        qc = QuantumCircuit(5, 5)
+        with qc.for_loop(range(3)):
+            qc.append(cliff, [0, 1, 4])
+
+        transpiled = HighLevelSynthesis(basis_gates=["cx", "u", "for_loop"])(qc)
+        transpiled_block = transpiled[0].operation.blocks[0]
+        self.assertNotIn("clifford", transpiled_block.count_ops())
+
 
 class TestHighLevelSynthesisQuality(QiskitTestCase):
     """Test the "quality" of circuits produced by HighLevelSynthesis."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

The `HighLevelSynthesis` transpiler pass checks whether all of the circuit instructions are already natively supported, in which case the pass terminates early. Previously this check called `dag.count_ops(py, recurse=false`), which however is not correct on circuits with control-flow operations when operations within the blocks that are not natively supported. The PR simply changes `recurse=false` to `recurse=true`.

### Details and comments

This should fix #14338 and #14254.