### PR TITLE
Fix accidentally disjoint test

### DIFF
--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -2996,10 +2996,11 @@ class TestTranspileParallel(QiskitTestCase):
         qc.cz(0, 3)
         qc.cz(0, 4)
         qc.measure_all()
-        cmap = CouplingMap.from_line(5, bidirectional=False)
+        num_qubits = 5
+        cmap = CouplingMap.from_line(num_qubits, bidirectional=False)
         tqc = transpile(
             qc,
-            backend=GenericBackendV2(num_qubits=6),
+            backend=GenericBackendV2(num_qubits=num_qubits),
             coupling_map=cmap,
             optimization_level=opt_level,
             seed_transpiler=12345678942,


### PR DESCRIPTION
This test accidentally invokes disjoint handling because it isolates qubit 5 while overriding the coupling map.  That's not intended behaviour, it just seems to be a typo.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


While working on Sabre, I needed to temporarily disable disjoint-handling tests as I built it up incrementally.  This one is a non-obvious disjoint test that just seems to be a mistake.