### PR TITLE
Do not construct layout passes with no coupling map

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -736,13 +736,18 @@ class DefaultLayoutPassManager(PassManagerStagePlugin):
         layout = PassManager()
         layout.append(_given_layout)
         if optimization_level == 0:
-            layout.append(
-                ConditionalController(
-                    TrivialLayout(coupling_map), condition=_choose_layout_condition
+            if coupling_map is not None:
+                layout.append(
+                    ConditionalController(
+                        TrivialLayout(coupling_map), condition=_choose_layout_condition
+                    )
                 )
-            )
             layout += common.generate_embed_passmanager(coupling_map)
             return layout
+
+        if coupling_map is None:
+            # There's nothing to lay out onto.  We only need to embed the initial layout, if given.
+            pass
         elif optimization_level == 1:
             layout.append(
                 ConditionalController(
@@ -870,9 +875,12 @@ class TrivialLayoutPassManager(PassManagerStagePlugin):
 
         layout = PassManager()
         layout.append(_given_layout)
-        layout.append(
-            ConditionalController(TrivialLayout(coupling_map), condition=_choose_layout_condition)
-        )
+        if coupling_map is not None:
+            layout.append(
+                ConditionalController(
+                    TrivialLayout(coupling_map), condition=_choose_layout_condition
+                )
+            )
         layout += common.generate_embed_passmanager(coupling_map)
         return layout
 
@@ -893,15 +901,16 @@ class DenseLayoutPassManager(PassManagerStagePlugin):
 
         layout = PassManager()
         layout.append(_given_layout)
-        layout.append(
-            ConditionalController(
-                DenseLayout(
-                    coupling_map=pass_manager_config.coupling_map,
-                    target=pass_manager_config.target,
-                ),
-                condition=_choose_layout_condition,
+        if coupling_map is not None:
+            layout.append(
+                ConditionalController(
+                    DenseLayout(
+                        coupling_map=pass_manager_config.coupling_map,
+                        target=pass_manager_config.target,
+                    ),
+                    condition=_choose_layout_condition,
+                )
             )
-        )
         layout += common.generate_embed_passmanager(coupling_map)
         return layout
 
@@ -925,7 +934,9 @@ class SabreLayoutPassManager(PassManagerStagePlugin):
 
         layout = PassManager()
         layout.append(_given_layout)
-        if optimization_level == 0:
+        if coupling_map is None:
+            layout_pass = None
+        elif optimization_level == 0:
             trial_count = _get_trial_count(5)
 
             layout_pass = SabreLayout(
@@ -971,17 +982,18 @@ class SabreLayoutPassManager(PassManagerStagePlugin):
             )
         else:
             raise TranspilerError(f"Invalid optimization level: {optimization_level}")
-        layout.append(
-            ConditionalController(
-                [
-                    BarrierBeforeFinalMeasurements(
-                        "qiskit.transpiler.internal.routing.protection.barrier"
-                    ),
-                    layout_pass,
-                ],
-                condition=_choose_layout_condition,
+        if layout_pass is not None:
+            layout.append(
+                ConditionalController(
+                    [
+                        BarrierBeforeFinalMeasurements(
+                            "qiskit.transpiler.internal.routing.protection.barrier"
+                        ),
+                        layout_pass,
+                    ],
+                    condition=_choose_layout_condition,
+                )
             )
-        )
         embed = common.generate_embed_passmanager(coupling_map)
         layout.append(ConditionalController(embed.to_flow_controller(), condition=_swap_mapped))
         return layout

--- a/releasenotes/notes/no-layout-presets-87e0bcde698f002e.yaml
+++ b/releasenotes/notes/no-layout-presets-87e0bcde698f002e.yaml
@@ -1,0 +1,12 @@
+---
+upgrade_transpiler:
+  - |
+    :ref:`The built-in layout plugins <transpiler-preset-stage-layout>` for the present pass
+    managers will no longer contain their principal component (e.g. a :class:`.SabreLayout` instance
+    for :ref:`the "sabre" stage <transpiler-preset-stage-layout-sabre>`) if no coupling constraints
+    are provided.  Previously, the plugins would construct invalid instances of their layout passes,
+    under an assumption that separate logic would prevent the passes from executing and raising
+    exceptions.
+
+    This should have no meaningful effect on the use of the preset pass managers or the plugins,
+    since it was already never valid to call the passes in an invalid state .


### PR DESCRIPTION
### Summary

The builtin plugins fairly frequently construct instances of the layout passes with `coupling_map=None` (or similar), even when this is against the documentation of the passes.  A couple of passes, but not all, have defensive code in their `run` methods to raise a better error in this case, but even so, there is an assumption that passes will not be _run_ with `coupling_map=None`.

The preset pass managers do follow this assumption; conditional code prevents those passes from ever being called.  However, we know that there's no coupling map ahead of time, so we can simply not even construct the layout passes, let alone add them to the `PassManager`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Input normalisation typically wants to be done in pass initialisation, not deferred to runtime (though expensive properties can still be computed only on first run and cached).  The current strategy of silently ignoring invalid inputs until runtime makes it harder to do this; it's clearer to have the pass-manager construction logic never produce objects in invalid states in the first place.