### PR TITLE
Resolve the merge conflict in #14351

### DIFF
--- a/crates/accelerate/src/unitary_synthesis.rs
+++ b/crates/accelerate/src/unitary_synthesis.rs
@@ -237,13 +237,8 @@ fn apply_synth_sequence(
 /// This function is currently used in the Python `UnitarySynthesis`` transpiler pass as a replacement for the `_run_main_loop` method.
 /// It returns a new `DAGCircuit` with the different synthesized gates.
 #[pyfunction]
-<<<<<<< HEAD:crates/accelerate/src/unitary_synthesis.rs
-#[pyo3(name = "run_main_loop", signature=(dag, qubit_indices, min_qubits, target, basis_gates, coupling_edges, approximation_degree=None, natural_direction=None, pulse_optimize=None))]
-fn py_run_main_loop(
-=======
 #[pyo3(name = "run_main_loop", signature=(dag, qubit_indices, min_qubits, target, basis_gates, synth_gates, coupling_edges, approximation_degree=None, natural_direction=None, pulse_optimize=None))]
-pub fn run_unitary_synthesis(
->>>>>>> 0c2ce6488 (Fix UnitarySynthesis to respect synth_gates (#14345)):crates/transpiler/src/passes/unitary_synthesis.rs
+fn py_run_main_loop(
     py: Python,
     dag: &mut DAGCircuit,
     qubit_indices: Vec<usize>,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR resolves the merge conflict in #14351, which is the backport PR of #14345. I opened this PR, as per the [comment](https://github.com/Qiskit/qiskit/pull/14351#issuecomment-2876711466), because I didn't have permission to push to the PR.

### Details and comments

In the main branch, from which the commit in [the backport PR](https://github.com/Qiskit/qiskit/tree/mergify/bp/stable/2.0/pr-14345) was cherry-picked, `py_run_main_loop` has been renamed to [`run_unitary_synthesis`](https://github.com/Qiskit/qiskit/blob/main/crates/transpiler/src/passes/unitary_synthesis.rs#L236) and made public during the process of reorganizing the crates. This change seems irrelevant to `stable/2.0`, so I have undone the name change.
