### PR TITLE
Fix construction of IQP circuits

### DIFF
--- a/crates/accelerate/src/circuit_library/iqp.rs
+++ b/crates/accelerate/src/circuit_library/iqp.rs
@@ -27,7 +27,7 @@ use smallvec::{smallvec, SmallVec};
 use crate::CircuitError;
 
 const PI2: f64 = PI / 2.0;
-const PI8: f64 = PI / 8.0;
+const PI4: f64 = PI / 4.0;
 
 fn iqp(
     interactions: ArrayView2<i64>,
@@ -54,7 +54,7 @@ fn iqp(
             })
     });
 
-    // The layer of T gates. Again we use the Phase gate, now with powers of Pi/8. The powers
+    // The layer of T gates. Again we use the Phase gate, now with powers of Pi/4. The powers
     // are given by the diagonal of the ``interactions`` matrix.
     let shifts = (0..num_qubits)
         .map(move |i| interactions[(i, i)])
@@ -63,7 +63,7 @@ fn iqp(
         .map(|(i, value)| {
             (
                 StandardGate::Phase,
-                smallvec![Param::Float(PI8 * value as f64)],
+                smallvec![Param::Float(PI4 * value as f64)],
                 smallvec![Qubit(i as u32)],
             )
         });

--- a/releasenotes/notes/fix-iqp-203557797d0d448e.yaml
+++ b/releasenotes/notes/fix-iqp-203557797d0d448e.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed the construction of Instantaneous Quantum Polynomial time (IQP) circuits
+    in :class:`~qiskit.circuit.library.IQP` and by :func:`~qiskit.circuit.library.iqp`:
+    a T-gate is equivalent to P(pi/4) and not to P(pi/2).

--- a/releasenotes/notes/fix-iqp-203557797d0d448e.yaml
+++ b/releasenotes/notes/fix-iqp-203557797d0d448e.yaml
@@ -2,5 +2,6 @@
 fixes:
   - |
     Fixed the construction of Instantaneous Quantum Polynomial time (IQP) circuits
-    in :class:`~qiskit.circuit.library.IQP` and by :func:`~qiskit.circuit.library.iqp`:
-    T-gate is equivalent to P(pi/4) and not to P(pi/8).
+    in :class:`~qiskit.circuit.library.IQP` and by :func:`~qiskit.circuit.library.iqp`.
+    The previous implementation incorrectly used powers of the :math:`\sqrt{T}` gate
+    instead of powers of the :math:`T` gate.

--- a/releasenotes/notes/fix-iqp-203557797d0d448e.yaml
+++ b/releasenotes/notes/fix-iqp-203557797d0d448e.yaml
@@ -3,4 +3,4 @@ fixes:
   - |
     Fixed the construction of Instantaneous Quantum Polynomial time (IQP) circuits
     in :class:`~qiskit.circuit.library.IQP` and by :func:`~qiskit.circuit.library.iqp`:
-    a T-gate is equivalent to P(pi/4) and not to P(pi/2).
+    T-gate is equivalent to P(pi/4) and not to P(pi/8).

--- a/test/python/circuit/library/test_iqp.py
+++ b/test/python/circuit/library/test_iqp.py
@@ -31,12 +31,12 @@ class TestIQPLibrary(QiskitTestCase):
     def test_iqp(self, use_function):
         """Test iqp circuit.
 
-             ┌───┐                             ┌─────────┐┌───┐
-        q_0: ┤ H ├─■───────────────────■───────┤ P(3π/4) ├┤ H ├
-             ├───┤ │P(5π/2)            │       └┬────────┤├───┤
-        q_1: ┤ H ├─■─────────■─────────┼────────┤ P(π/2) ├┤ H ├
-             ├───┤           │P(3π/2)  │P(π/2)  ├────────┤├───┤
-        q_2: ┤ H ├───────────■─────────■────────┤ P(π/4) ├┤ H ├
+             ┌───┐                   ┌─────────┐  ┌───┐
+        q_0: ┤ H ├─■─────────■───────┤ P(3π/2) ├──┤ H ├────────
+             ├───┤ │P(5π/2)  │       └─────────┘ ┌┴───┴─┐ ┌───┐
+        q_1: ┤ H ├─■─────────┼─────────■─────────┤ P(π) ├─┤ H ├
+             ├───┤           │P(π/2)   │P(3π/2) ┌┴──────┴┐├───┤
+        q_2: ┤ H ├───────────■─────────■────────┤ P(π/2) ├┤ H ├
              └───┘                              └────────┘└───┘
         """
 
@@ -52,9 +52,9 @@ class TestIQPLibrary(QiskitTestCase):
         expected.cp(5 * np.pi / 2, 0, 1)
         expected.cp(3 * np.pi / 2, 1, 2)
         expected.cp(1 * np.pi / 2, 0, 2)
-        expected.p(6 * np.pi / 8, 0)
-        expected.p(4 * np.pi / 8, 1)
-        expected.p(2 * np.pi / 8, 2)
+        expected.p(6 * np.pi / 4, 0)
+        expected.p(4 * np.pi / 4, 1)
+        expected.p(2 * np.pi / 4, 2)
         expected.h([0, 1, 2])
         expected = Operator(expected)
         simulated = Operator(circuit)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

As documented in https://docs.quantum.ibm.com/api/qiskit/qiskit.circuit.library.iqp_function, an _Instantaneous quantum polynomial time (IQP) circuit_ consists of Hadamard gates, powers of T-gate, powers of CS-gate, and more Hadamard gates. However, a T-gate is P($\pi$/4), not P($\pi$/8), see https://docs.quantum.ibm.com/api/qiskit/qiskit.circuit.library.PhaseGate. This PR fixes the construction as used both within ``iqp_function`` and ``IQP``.


### Trivia

The bug was introduced in the original commit #4266 and survived porting to Rust #13241. Incidentally, the original commit pertains to one of the questions from (the internal) Qiskit 2.0 quiz.