### PR TITLE
Add C API function to copy a circuit

### DIFF
--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -69,11 +69,11 @@ pub extern "C" fn qk_circuit_new(num_qubits: u32, num_clbits: u32) -> *mut Circu
 }
 
 /// @ingroup QkCircuit
-/// Create a copy of a QkCircuit.
+/// Create a copy of a ``QkCircuit``.
 ///
-/// @param circuit A pointer to the circuit to copy
+/// @param circuit A pointer to the circuit to copy.
 ///
-/// @return A new pointer to a copy of the input `circuit`.
+/// @return A new pointer to a copy of the input ``circuit``.
 ///
 /// # Example
 ///

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -69,6 +69,29 @@ pub extern "C" fn qk_circuit_new(num_qubits: u32, num_clbits: u32) -> *mut Circu
 }
 
 /// @ingroup QkCircuit
+/// Create a copy of a QkCircuit.
+///
+/// @param circuit A pointer to the circuit to copy
+///
+/// @return A new pointer to a copy of the input `circuit`.
+///
+/// # Example
+///
+///     QkCircuit *qc = qk_circuit_new(100, 100);
+///     QkCircuit *copy = qk_circuit_copy(qc);
+///
+/// # Safety
+///
+/// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
+#[no_mangle]
+#[cfg(feature = "cbinding")]
+pub unsafe extern "C" fn qk_circuit_copy(circuit: *const CircuitData) -> *mut CircuitData {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let circuit = unsafe { const_ptr_as_ref(circuit) };
+    Box::into_raw(Box::new(circuit.clone()))
+}
+
+/// @ingroup QkCircuit
 /// Get the number of qubits the circuit contains.
 ///
 /// @param circuit A pointer to the circuit.
@@ -77,7 +100,7 @@ pub extern "C" fn qk_circuit_new(num_qubits: u32, num_clbits: u32) -> *mut Circu
 ///
 /// # Example
 ///
-///     QkCircuit *qc = qk_circuit_new(100);
+///     QkCircuit *qc = qk_circuit_new(100, 100);
 ///     uint32_t num_qubits = qk_circuit_num_qubits(qc);  // num_qubits==100
 ///
 /// # Safety
@@ -158,7 +181,7 @@ pub unsafe extern "C" fn qk_circuit_free(circuit: *mut CircuitData) {
 ///
 /// # Example
 ///
-///     QkCircuit *qc = qk_circuit_new(100);
+///     QkCircuit *qc = qk_circuit_new(100, 0);
 ///     qk_circuit_gate(qc, QkGate_H, *[0], *[]);
 ///
 /// # Safety
@@ -302,9 +325,8 @@ pub unsafe extern "C" fn qk_circuit_measure(
 ///
 /// # Example
 ///
-///     QkCircuit *qc = qk_circuit_new(100);
+///     QkCircuit *qc = qk_circuit_new(100, 0);
 ///     qk_circuit_reset(qc, 0);
-///
 ///
 /// # Safety
 ///
@@ -332,7 +354,7 @@ pub unsafe extern "C" fn qk_circuit_reset(circuit: *mut CircuitData, qubit: u32)
 ///
 /// # Example
 ///
-///     QkCircuit *qc = qk_circuit_new(100);
+///     QkCircuit *qc = qk_circuit_new(100, 1);
 ///     uint32_t qubits[5] = {0, 1, 2, 3, 4};
 ///     qk_circuit_barrier(qc, 5, qubits);
 ///
@@ -394,9 +416,9 @@ pub struct OpCounts {
 ///
 /// # Example
 ///
-///     QkCircuit *qc = qk_circuit_new(100);
+///     QkCircuit *qc = qk_circuit_new(100, 0);
 ///     qk_circuit_gate(qc, HGate, *[0], *[]);
-///     qk_circuit_count_ops(qc);
+///     QkOpCounts *counts = qk_circuit_count_ops(qc);
 ///
 /// # Safety
 ///
@@ -429,7 +451,7 @@ pub unsafe extern "C" fn qk_circuit_count_ops(circuit: *const CircuitData) -> Op
 ///
 ///     QkCircuit *qc = qk_circuit_new(100);
 ///     qk_circuit_gate(qc, QkGate_H, *[0], *[]);
-///     qk_circuit_num_instructions(qc); // 1
+///     uintptr_t num_instructions = qk_circuit_num_instructions(qc); // 1
 ///
 /// # Safety
 ///
@@ -646,7 +668,7 @@ pub enum QkDelayUnit {
 ///
 ///     QkCircuit *qc = qk_circuit_new(1, 0);
 ///     qk_circuit_delay(qc, 0, 100.0, QkDelayUnit_NS);
-///     
+///
 /// # Safety
 ///
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -44,6 +44,30 @@ int test_empty(void) {
     return Ok;
 }
 
+int test_circuit_copy(void) {
+    QkCircuit *qc = qk_circuit_new(10, 10);
+    QkCircuit *copy = qk_circuit_copy(qc);
+    for (int i = 0; i < 10; i++) {
+        qk_circuit_measure(qc, i, i);
+        int qubits[1] = {
+            i,
+        };
+        if (i % 2 == 0) {
+            qk_circuit_gate(copy, QkGate_H, qubits, NULL);
+        }
+    }
+    size_t num_instructions = qk_circuit_num_instructions(qc);
+    size_t num_copy_instructions = qk_circuit_num_instructions(copy);
+    qk_circuit_free(qc);
+    qk_circuit_free(copy);
+    if (num_instructions == num_copy_instructions) {
+        printf("The number of instructions %lu is equal to the copied %lu", num_instructions,
+               num_copy_instructions);
+        return EqualityError;
+    }
+    return Ok;
+}
+
 int test_no_gate_1000_bits(void) {
     QkCircuit *qc = qk_circuit_new(1000, 1000);
     uint32_t num_qubits = qk_circuit_num_qubits(qc);
@@ -585,6 +609,7 @@ cleanup:
 int test_circuit(void) {
     int num_failed = 0;
     num_failed += RUN_TEST(test_empty);
+    num_failed += RUN_TEST(test_circuit_copy);
     num_failed += RUN_TEST(test_no_gate_1000_bits);
     num_failed += RUN_TEST(test_get_gate_counts_bv_no_measure);
     num_failed += RUN_TEST(test_get_gate_counts_bv_measures);

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -68,6 +68,51 @@ int test_circuit_copy(void) {
     return Ok;
 }
 
+int test_circuit_copy_with_instructions(void) {
+    QkCircuit *qc = qk_circuit_new(10, 10);
+    for (int i = 0; i < 10; i++) {
+        qk_circuit_measure(qc, i, i);
+        int qubits[1] = {
+            i,
+        };
+        qk_circuit_gate(qc, QkGate_H, qubits, NULL);
+    }
+    QkCircuit *copy = qk_circuit_copy(qc);
+    size_t num_instructions = qk_circuit_num_instructions(qc);
+    size_t num_copy_instructions = qk_circuit_num_instructions(copy);
+    if (num_instructions != num_copy_instructions) {
+        printf("The number of instructions %lu does not equal the copied %lu", num_instructions,
+               num_copy_instructions);
+        return EqualityError;
+    }
+
+    for (int i = 0; i < 10; i++) {
+        qk_circuit_measure(qc, i, i);
+        int qubits[1] = {
+            i,
+        };
+        qk_circuit_gate(qc, QkGate_Z, qubits, NULL);
+    }
+    for (int i = 0; i < 15; i++) {
+        qk_circuit_measure(qc, i, i);
+        int qubits[1] = {
+            i,
+        };
+        qk_circuit_gate(copy, QkGate_X, qubits, NULL);
+    }
+
+    num_instructions = qk_circuit_num_instructions(qc);
+    num_copy_instructions = qk_circuit_num_instructions(copy);
+    qk_circuit_free(qc);
+    qk_circuit_free(copy);
+    if (num_instructions == num_copy_instructions) {
+        printf("The number of instructions %lu is equal to the copied %lu", num_instructions,
+               num_copy_instructions);
+        return EqualityError;
+    }
+    return Ok;
+}
+
 int test_no_gate_1000_bits(void) {
     QkCircuit *qc = qk_circuit_new(1000, 1000);
     uint32_t num_qubits = qk_circuit_num_qubits(qc);
@@ -610,6 +655,7 @@ int test_circuit(void) {
     int num_failed = 0;
     num_failed += RUN_TEST(test_empty);
     num_failed += RUN_TEST(test_circuit_copy);
+    num_failed += RUN_TEST(test_circuit_copy_with_instructions);
     num_failed += RUN_TEST(test_no_gate_1000_bits);
     num_failed += RUN_TEST(test_get_gate_counts_bv_no_measure);
     num_failed += RUN_TEST(test_get_gate_counts_bv_measures);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new function to the circuits C API that enables copying a circuit. It takes in a pointer to a circuit and returns a pointer to a new clone of that circuit.

### Details and comments