### PR TITLE
Avoid unecessary cloning in disjoint layout Python path

### DIFF
--- a/crates/transpiler/src/passes/disjoint_layout.rs
+++ b/crates/transpiler/src/passes/disjoint_layout.rs
@@ -10,6 +10,8 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use std::ops::DerefMut;
+
 use hashbrown::{HashMap, HashSet};
 
 use pyo3::create_exception;
@@ -87,11 +89,12 @@ fn subgraph(graph: &CouplingMap, node_set: &HashSet<NodeIndex>) -> CouplingMap {
 
 #[pyfunction(name = "run_pass_over_connected_components")]
 pub fn py_run_pass_over_connected_components(
-    dag: &mut DAGCircuit,
+    dag: Bound<DAGCircuit>,
     target: &Target,
     run_func: Bound<PyAny>,
 ) -> PyResult<Option<Vec<PyObject>>> {
-    let func = |dag: DAGCircuit, cmap: &CouplingMap| -> PyResult<PyObject> {
+    let py = dag.py();
+    let func = |dag: Bound<DAGCircuit>, cmap: &CouplingMap| -> PyResult<PyObject> {
         let py = run_func.py();
         let coupling_map_cls = COUPLING_MAP.get_bound(py);
         let endpoints: Vec<[usize; 2]> = cmap
@@ -117,13 +120,17 @@ pub fn py_run_pass_over_connected_components(
         }
         Ok(run_func.call1((dag, py_cmap))?.unbind())
     };
-    match distribute_components(dag, target)? {
+    let components = {
+        let mut borrowed = dag.borrow_mut();
+        distribute_components(borrowed.deref_mut(), target)?
+    };
+    match components {
         DisjointSplit::NoneNeeded => {
             let coupling_map: CouplingMap = match build_coupling_map(target) {
                 Some(map) => map,
                 None => return Ok(None),
             };
-            Ok(Some(vec![func(dag.clone(), &coupling_map)?]))
+            Ok(Some(vec![func(dag, &coupling_map)?]))
         }
         DisjointSplit::TargetSubset(qubits) => {
             let coupling_map = build_coupling_map(target).unwrap();
@@ -131,7 +138,7 @@ pub fn py_run_pass_over_connected_components(
                 &coupling_map,
                 &qubits.iter().map(|x| NodeIndex::new(x.index())).collect(),
             );
-            Ok(Some(vec![func(dag.clone(), &cmap)?]))
+            Ok(Some(vec![func(dag, &cmap)?]))
         }
         DisjointSplit::Arbitrary(components) => Some(
             components
@@ -146,7 +153,7 @@ pub fn py_run_pass_over_connected_components(
                             .map(|x| NodeIndex::new(x.index()))
                             .collect(),
                     );
-                    func(component.sub_dag, &cmap)
+                    func(component.sub_dag.into_pyobject(py)?, &cmap)
                 })
                 .collect::<PyResult<Vec<_>>>(),
         )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the recently merged #14177 the python path for running the disjoint components was unnecessarily copying the input dag before running the inner layout algorithm in the case there were no connected components to run. This was resulting in extra overhead in the nightly benchmarks for the `DenseLayout` pass when there were was no disjoint components in the connectivity graph. This is because the clone of the dag was relatively expensive relative to the overall cost of the pass. Since we can work by reference by handling borrowing the original input dag from Python by being a bit more explicit with the typing to make it explicit the Python entrypoint is working with Python and with some careful scoping to avoid runtime borrow checking issues. This commit applies these changes and removes the dag clone in the case when there is no disjoint handling needed.

### Details and comments