### PR TITLE
Rollback grcov version to 0.8.20

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-            cargo install grcov@0.8.24
+            cargo install grcov@0.8.20
             sudo apt-get install lcov
 
       # This is needed to support any requirements, particularly in the `optionals` set,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit rolls back the grcov version we use in the coverage CI job to the 0.8.20 release. We were previously pinning to the 0.8.24 version because of changes in 0.9.0 that were incompatible. However, the dependency of grcov zip recently yanked their 2.5 and 2.6 releases which are used by 0.8.24 and 0.9.0 respectively. This means cargo by default will not install those versions of grcov because it can't find a non-yanked zip version that matches the dependencies of grcov. The grcov 0.8.20 release depends on zip 2.4 which has not been yanked and can still be installed.

### Details and comments


