### PR TITLE
Remove unused build dep pyo3-build-config on qiskit-cext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,7 +1447,6 @@ dependencies = [
  "cbindgen",
  "num-complex",
  "pyo3",
- "pyo3-build-config",
  "qiskit-accelerate",
  "qiskit-circuit",
  "thiserror 2.0.12",

--- a/crates/cext/Cargo.toml
+++ b/crates/cext/Cargo.toml
@@ -24,7 +24,6 @@ pyo3 = { workspace = true, optional = true }
 
 [build-dependencies]
 cbindgen = "0.28"
-pyo3-build-config = { version = "0.24", features = ["resolve-config"] }
 
 [features]
 default = ["cbinding"]


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #14239 the build.rs for qiskit-cext was updated to no longer write out the location where pyo3 found the installed python that it built against. This wasn't ever used correctly and the build system for the windows testing was updated to not depend on it anymore. However in that PR the build dependency on pyo3-build-config was never removed from the Cargo.toml for the cext crate so we were still installing that even though it wasn't used. This commit corrects that oversight and removes the unused build dependency.

### Details and comments


