### PR TITLE
Remove DT from C API for adding delays

### DIFF
--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -628,8 +628,6 @@ pub enum QkDelayUnit {
     NS = 3,
     /// Picoseconds.
     PS = 4,
-    /// Device-native time unit ``dt``.
-    DT = 5,
 }
 
 /// @ingroup QkCircuit
@@ -646,7 +644,7 @@ pub enum QkDelayUnit {
 ///
 ///     QkCircuit *qc = qk_circuit_new(1, 0);
 ///     qk_circuit_delay(qc, 0, 100.0, QkDelayUnit_NS);
-///     
+///
 /// # Safety
 ///
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
@@ -667,7 +665,6 @@ pub unsafe extern "C" fn qk_circuit_delay(
         QkDelayUnit::US => DelayUnit::US,
         QkDelayUnit::NS => DelayUnit::NS,
         QkDelayUnit::PS => DelayUnit::PS,
-        QkDelayUnit::DT => DelayUnit::DT,
     };
 
     let duration_param: Param = duration.into();

--- a/releasenotes/notes/add-delay-c-api-d040c3f8b60b295b.yaml
+++ b/releasenotes/notes/add-delay-c-api-d040c3f8b60b295b.yaml
@@ -1,9 +1,0 @@
----
-features_circuits:
-  - |
-    There is a now a C API function, ``qk_circuit_delay`` for adding a delay to a circuit.
-
-    .. code-block:: c
-
-      QkCircuit *qc = qk_circuit_new(1, 0);
-      qk_circuit_delay(qc, 0, 100.0, QkDelayUnit_NS);

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -562,14 +562,7 @@ int test_delay_instruction(void) {
     QkCircuit *qc = qk_circuit_new(2, 0);
     int result = Ok;
 
-    QkExitCode delay_dt_code;
     QkExitCode delay_s_code;
-
-    delay_dt_code = qk_circuit_delay(qc, 1, 10, QkDelayUnit_DT);
-    if (delay_dt_code != QkExitCode_Success) {
-        result = RuntimeError;
-        goto cleanup;
-    }
 
     delay_s_code = qk_circuit_delay(qc, 0, 0.001, QkDelayUnit_S);
     if (delay_s_code != QkExitCode_Success) {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The C API for adding delay only handled the case of floating point values for the delay. However one of the available units was dt. This isn't actually correct usage because dt is represented by an integer value not a floating point. While this is expressible in the data model it violates the expectations of the delay operation and likely would have caused unexpected behavior when the circuit is used elsewhere. Right now the rust data model doesn't natively model the integer duration because it's not a valid variant on the Param enum, so the delay instruction is modeling it by wrapping it in a PyObject. To express dt unit delays from the C API we will need to store ints in Rust before we can add this to the API. After we do this then we'll probably want to add a new function qk_circuit_delay_dt() to represent the different typing. This is similar to what will need to happen for representing stretch durations from C as well.

Also since we haven't released the C API for circuits we didn't need a dedicated release note because this is all part of the new feature for exposing circuits to the C API. Having individual release notes for each new function is a bit redundant. The new function is definitely very important but we just didn't need a dedicated release note entry for it.

### Details and comments


