### PR TITLE
Fix new clippy warning in Rust 1.87

### DIFF
--- a/crates/accelerate/src/sparse_observable/mod.rs
+++ b/crates/accelerate/src/sparse_observable/mod.rs
@@ -1398,9 +1398,11 @@ mod compose {
         /// [load_from] changes it).  If a 0 multiplier is encountered during the load, the
         /// iterator is empty.
         pub fn num_terms(&self) -> usize {
-            self.exhausted
-                .then_some(0)
-                .unwrap_or_else(|| self.multiples.iter().map(|item| item.slice.len()).product())
+            if self.exhausted {
+                0
+            } else {
+                self.multiples.iter().map(|item| item.slice.len()).product()
+            }
         }
         /// The length of each individual term in the iteration.
         pub fn term_len(&self) -> usize {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The recent release of Rust 1.87 has brought with it new clippy warnings from either now enabled rules or improved checks for existing rules. This commit applies the fixes recommended by clippy which in the case of this release was a single rule `obfuscated_if_else`. [1]

### Details and comments

[1] https://rust-lang.github.io/rust-clippy/master/index.html#obfuscated_if_else
