### PR TITLE
Introduce PauliLindbladMap

### DIFF
--- a/crates/quantum_info/src/pauli_lindblad_map/mod.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/mod.rs
@@ -10,12 +10,15 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use pauli_lindblad_map_class::PyPauliLindbladMap;
 use pyo3::prelude::*;
 use qubit_sparse_pauli::{PyQubitSparsePauli, PyQubitSparsePauliList};
 
+pub mod pauli_lindblad_map_class;
 pub mod qubit_sparse_pauli;
 
 pub fn pauli_lindblad_map(m: &Bound<PyModule>) -> PyResult<()> {
+    m.add_class::<PyPauliLindbladMap>()?;
     m.add_class::<PyQubitSparsePauli>()?;
     m.add_class::<PyQubitSparsePauliList>()?;
     Ok(())

--- a/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -345,7 +345,7 @@ impl PyGeneratorTerm {
     fn py_new(rate: f64, qubit_sparse_pauli: &PyQubitSparsePauli) -> PyResult<Self> {
         let inner = GeneratorTerm {
             rate,
-            qubit_sparse_pauli: qubit_sparse_pauli.inner.clone(),
+            qubit_sparse_pauli: qubit_sparse_pauli.get_inner().clone(),
         };
         Ok(PyGeneratorTerm { inner })
     }

--- a/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -613,12 +613,12 @@ impl PyGeneratorTerm {
 ///
 /// An existing :class:`PauliLindbladMap` can be converted into other formats.
 ///
-/// .. table:: Conversion methods to other observable forms.
+/// .. table:: Conversion methods to other forms.
 ///
 ///   ===========================  =================================================================
 ///   Method                       Summary
 ///   ===========================  =================================================================
-///   :meth:`to_sparse_list`       Express the observable in a sparse list format with elements
+///   :meth:`to_sparse_list`       Express the map in a sparse list format with elements
 ///                                ``(paulis, indices, rate)``.
 ///   ===========================  =================================================================
 #[pyclass(name = "PauliLindbladMap", module = "qiskit.quantum_info", sequence)]

--- a/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -1,0 +1,1177 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use numpy::{PyArray1, PyArrayMethods};
+use pyo3::{
+    exceptions::{PyTypeError, PyValueError},
+    intern,
+    prelude::*,
+    types::{PyList, PyString, PyTuple, PyType},
+    IntoPyObjectExt, PyErr,
+};
+use std::sync::{Arc, RwLock};
+
+use qiskit_circuit::slice::{PySequenceIndex, SequenceIndex};
+
+use super::qubit_sparse_pauli::{
+    raw_parts_from_sparse_list, ArithmeticError, CoherenceError, InnerReadError, InnerWriteError,
+    LabelError, Pauli, PyQubitSparsePauli, PyQubitSparsePauliList, QubitSparsePauli,
+    QubitSparsePauliList, QubitSparsePauliView,
+};
+
+/// A Pauli Lindblad map that stores its data in a qubit-sparse format. Note that gamma,
+/// probabilities, and non_negative_rates is
+///
+/// See [PyPauliLindbladMap] for detailed docs.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PauliLindbladMap {
+    /// The rates of each abstract term in the generator sum.  This has as many elements as
+    /// terms in the sum.
+    rates: Vec<f64>,
+    /// A list of qubit sparse Paulis corresponding to the rates
+    qubit_sparse_pauli_list: QubitSparsePauliList,
+    /// The gamma parameter.
+    gamma: f64,
+    /// Probability of application of a given Pauli operator in product form. Note that if the
+    /// corresponding rate is less than 0, this is a quasi-probability.
+    probabilities: Vec<f64>,
+    /// List of boolean values for the statement rate >= 0 for each rate in rates.
+    non_negative_rates: Vec<bool>,
+}
+
+impl PauliLindbladMap {
+    pub fn new(
+        rates: Vec<f64>,
+        qubit_sparse_pauli_list: QubitSparsePauliList,
+    ) -> Result<Self, CoherenceError> {
+        if rates.len() + 1 != qubit_sparse_pauli_list.boundaries().len() {
+            return Err(CoherenceError::MismatchedTermCount {
+                rates: rates.len(),
+                qspl: qubit_sparse_pauli_list.boundaries().len() - 1,
+            });
+        }
+
+        let (gamma, probabilities, non_negative_rates) = derived_values_from_rates(&rates);
+
+        Ok(Self {
+            rates,
+            qubit_sparse_pauli_list,
+            gamma,
+            probabilities,
+            non_negative_rates,
+        })
+    }
+
+    /// Create a new Pauli Lindblad map from the raw components that make it up.
+    pub fn new_from_raw_parts(
+        num_qubits: u32,
+        rates: Vec<f64>,
+        paulis: Vec<Pauli>,
+        indices: Vec<u32>,
+        boundaries: Vec<usize>,
+    ) -> Result<Self, CoherenceError> {
+        if rates.len() + 1 != boundaries.len() {
+            return Err(CoherenceError::MismatchedTermCount {
+                rates: rates.len(),
+                qspl: boundaries.len() - 1,
+            });
+        }
+        let qubit_sparse_pauli_list: QubitSparsePauliList =
+            QubitSparsePauliList::new(num_qubits, paulis, indices, boundaries)?;
+        Self::new(rates, qubit_sparse_pauli_list)
+    }
+
+    /// Create a new [PauliLindbladMap] without checking data coherence.
+    ///
+    /// # Safety
+    ///
+    /// It is up to the caller to ensure that the data-coherence requirements, as enumerated in the
+    /// struct-level documentation, have been upheld.
+    #[inline(always)]
+    pub unsafe fn new_unchecked(
+        rates: Vec<f64>,
+        qubit_sparse_pauli_list: QubitSparsePauliList,
+    ) -> Self {
+        let (gamma, probabilities, non_negative_rates) = derived_values_from_rates(&rates);
+        Self {
+            rates,
+            qubit_sparse_pauli_list,
+            gamma,
+            probabilities,
+            non_negative_rates,
+        }
+    }
+
+    /// Get an iterator over the individual generator terms of the map.
+    ///
+    /// Recall that two [PauliLindbladMap]s that have different term orders can still represent the
+    /// same object.  Use [canonicalize] to apply a canonical ordering to the terms.
+    pub fn iter(&'_ self) -> impl ExactSizeIterator<Item = GeneratorTermView<'_>> + '_ {
+        self.rates
+            .iter()
+            .enumerate()
+            .map(|(i, rate)| GeneratorTermView {
+                rate: *rate,
+                qubit_sparse_pauli: self.qubit_sparse_pauli_list.term(i),
+            })
+    }
+
+    /// Get the number of qubits the map is defined on.
+    #[inline]
+    pub fn num_qubits(&self) -> u32 {
+        self.qubit_sparse_pauli_list.num_qubits()
+    }
+
+    /// Get the number of generator terms in the map.
+    #[inline]
+    pub fn num_terms(&self) -> usize {
+        self.rates.len()
+    }
+
+    /// Get the rates of the generator terms.
+    #[inline]
+    pub fn rates(&self) -> &[f64] {
+        &self.rates
+    }
+
+    /// Get the probabilities associated with each generator term.
+    #[inline]
+    pub fn probabilities(&self) -> &[f64] {
+        &self.probabilities
+    }
+
+    /// Get the list of booleans for which rates are non-negative.
+    #[inline]
+    pub fn non_negative_rates(&self) -> &[bool] {
+        &self.non_negative_rates
+    }
+
+    /// Get the indices of each [Pauli].
+    #[inline]
+    pub fn indices(&self) -> &[u32] {
+        self.qubit_sparse_pauli_list.indices()
+    }
+
+    /// Get the boundaries of each term.
+    #[inline]
+    pub fn boundaries(&self) -> &[usize] {
+        self.qubit_sparse_pauli_list.boundaries()
+    }
+
+    /// Get the [Pauli]s in the map.
+    #[inline]
+    pub fn paulis(&self) -> &[Pauli] {
+        self.qubit_sparse_pauli_list.paulis()
+    }
+
+    /// Create a [PauliLindbladMap] representing the identity map on ``num_qubits`` qubits.
+    pub fn identity(num_qubits: u32) -> Self {
+        Self::with_capacity(num_qubits, 0, 0)
+    }
+
+    /// Add the generator term implied by a dense string label onto this map.
+    pub fn add_dense_label<L: AsRef<[u8]>>(
+        &mut self,
+        label: L,
+        rate: f64,
+    ) -> Result<(), LabelError> {
+        self.qubit_sparse_pauli_list.add_dense_label(label)?;
+
+        let (g, p, pr) = derived_values_from_rate(&rate);
+        self.rates.push(rate);
+        self.gamma *= g;
+        self.probabilities.push(p);
+        self.non_negative_rates.push(pr);
+        Ok(())
+    }
+
+    /// Create a new identity map (with zero generator) with pre-allocated space for the given
+    /// number of summands and single-qubit bit terms.
+    #[inline]
+    pub fn with_capacity(num_qubits: u32, num_terms: usize, num_paulis: usize) -> Self {
+        let qubit_sparse_pauli_list =
+            QubitSparsePauliList::with_capacity(num_qubits, num_terms, num_paulis);
+        Self {
+            rates: Vec::with_capacity(num_terms),
+            qubit_sparse_pauli_list,
+            gamma: 1.0,
+            probabilities: Vec::with_capacity(num_terms),
+            non_negative_rates: Vec::with_capacity(num_terms),
+        }
+    }
+
+    /// Clear all the generator terms from this map, making it equal to the identity map again.
+    ///
+    /// This does not change the capacity of the internal allocations, so subsequent addition or
+    /// substraction of generator terms may not need to reallocate.
+    pub fn clear(&mut self) {
+        self.rates.clear();
+        self.gamma = 1.0;
+        self.probabilities.clear();
+        self.non_negative_rates.clear();
+        self.qubit_sparse_pauli_list.clear();
+    }
+
+    /// Add a single generator term to this map.
+    pub fn add_term(&mut self, term: GeneratorTermView) -> Result<(), ArithmeticError> {
+        let term = term.to_term();
+        if self.num_qubits() != term.num_qubits() {
+            return Err(ArithmeticError::MismatchedQubits {
+                left: self.num_qubits(),
+                right: term.num_qubits(),
+            });
+        }
+        let (g, p, pr) = derived_values_from_rate(&term.rate);
+        self.rates.push(term.rate);
+        self.gamma *= g;
+        self.probabilities.push(p);
+        self.non_negative_rates.push(pr);
+        unsafe {
+            // at this point we already know the term needs to be valid
+            let new_pauli = QubitSparsePauli::new_unchecked(
+                self.num_qubits(),
+                term.qubit_sparse_pauli.paulis().to_vec().into_boxed_slice(),
+                term.indices().to_vec().into_boxed_slice(),
+            );
+            self.qubit_sparse_pauli_list
+                .add_qubit_sparse_pauli(new_pauli.view())?;
+            Ok(())
+        }
+    }
+
+    /// Get a view onto a representation of a single sparse term.
+    ///
+    /// This is effectively an indexing operation into the [PauliLindbladMap].  Recall that two
+    /// [PauliLindbladMap]s that have different generator term orders can still represent the same
+    /// object. Use [canonicalize] to apply a canonical ordering to the terms.
+    ///
+    /// # Panics
+    ///
+    /// If the index is out of bounds.
+    pub fn term(&self, index: usize) -> GeneratorTermView {
+        debug_assert!(index < self.num_terms(), "index {index} out of bounds");
+        GeneratorTermView {
+            rate: self.rates[index],
+            qubit_sparse_pauli: self.qubit_sparse_pauli_list.term(index),
+        }
+    }
+}
+
+/// Given a rate, return the corresponding gamma, probability, and boolean for whether the rate is
+/// non-negative.
+fn derived_values_from_rate(rate: &f64) -> (f64, f64, bool) {
+    let rate = *rate;
+    let w: f64 = 0.5 * (1.0 + (-2.0 * rate).exp());
+    let g: f64 = w.abs() + (1.0 - w).abs();
+    let p: f64 = w / g;
+    let nnr: bool = rate >= 0.0;
+    (g, p, nnr)
+}
+
+/// Return the gamma, probabilities, and non-negative rates bools for a vector of rates.
+fn derived_values_from_rates(rates: &Vec<f64>) -> (f64, Vec<f64>, Vec<bool>) {
+    let mut gamma = 1.0;
+    let mut probabilities = Vec::new();
+    let mut non_negative_rates = Vec::new();
+
+    for rate in rates {
+        let (g, p, nnr) = derived_values_from_rate(rate);
+        gamma *= g;
+        probabilities.push(p);
+        non_negative_rates.push(nnr);
+    }
+    (gamma, probabilities, non_negative_rates)
+}
+
+/// A view object onto a single generator term of a `PauliLindbladMap`.
+///
+/// The lengths of `paulis` and `indices` are guaranteed to be created equal, but might be zero
+/// (in the case that the term is proportional to the identity).
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct GeneratorTermView<'a> {
+    pub rate: f64,
+    pub qubit_sparse_pauli: QubitSparsePauliView<'a>,
+}
+impl GeneratorTermView<'_> {
+    /// Convert this `GeneratorTermView` into an owning [GeneratorTerm] of the same data.
+    pub fn to_term(&self) -> GeneratorTerm {
+        GeneratorTerm {
+            rate: self.rate,
+            qubit_sparse_pauli: self.qubit_sparse_pauli.to_term(),
+        }
+    }
+
+    pub fn to_sparse_str(self) -> String {
+        let rate = format!("{}", self.rate).replace('i', "j");
+        let paulis = self
+            .qubit_sparse_pauli
+            .indices
+            .iter()
+            .zip(self.qubit_sparse_pauli.paulis)
+            .rev()
+            .map(|(i, op)| format!("{}_{}", op.py_label(), i))
+            .collect::<Vec<String>>()
+            .join(" ");
+        format!("({})L({})", rate, paulis)
+    }
+}
+
+/// A single term from a complete :class:`PauliLindbladMap`.
+///
+/// These are typically created by indexing into or iterating through a :class:`PauliLindbladMap`.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GeneratorTerm {
+    /// The real rate of the term.
+    rate: f64,
+    qubit_sparse_pauli: QubitSparsePauli,
+}
+impl GeneratorTerm {
+    pub fn new(rate: f64, qubit_sparse_pauli: QubitSparsePauli) -> Self {
+        Self {
+            rate,
+            qubit_sparse_pauli,
+        }
+    }
+
+    pub fn num_qubits(&self) -> u32 {
+        self.qubit_sparse_pauli.num_qubits()
+    }
+
+    pub fn rate(&self) -> f64 {
+        self.rate
+    }
+
+    pub fn indices(&self) -> &[u32] {
+        self.qubit_sparse_pauli.indices()
+    }
+
+    pub fn paulis(&self) -> &[Pauli] {
+        self.qubit_sparse_pauli.paulis()
+    }
+
+    pub fn view(&self) -> GeneratorTermView {
+        GeneratorTermView {
+            rate: self.rate,
+            qubit_sparse_pauli: self.qubit_sparse_pauli.view(),
+        }
+    }
+
+    /// Convert this term to a complete :class:`PauliLindbladMap`.
+    pub fn to_pauli_lindblad_map(&self) -> Result<PauliLindbladMap, CoherenceError> {
+        let qubit_sparse_pauli_list = QubitSparsePauliList::new(
+            self.num_qubits(),
+            self.paulis().to_vec(),
+            self.indices().to_vec(),
+            vec![0, self.paulis().len()],
+        )?;
+        PauliLindbladMap::new(vec![self.rate], qubit_sparse_pauli_list)
+    }
+}
+
+/// A single term from a complete :class:`PauliLindbladMap`.
+///
+/// These are typically created by indexing into or iterating through a :class:`PauliLindbladMap`.
+#[pyclass(name = "GeneratorTerm", frozen, module = "qiskit.quantum_info")]
+#[derive(Clone, Debug)]
+struct PyGeneratorTerm {
+    inner: GeneratorTerm,
+}
+#[pymethods]
+impl PyGeneratorTerm {
+    // Mark the Python class as being defined "within" the `PauliLindbladMap` class namespace.
+    #[classattr]
+    #[pyo3(name = "__qualname__")]
+    fn type_qualname() -> &'static str {
+        "PauliLindbladMap.GeneratorTerm"
+    }
+
+    #[new]
+    #[pyo3(signature = (/, rate, qubit_sparse_pauli))]
+    fn py_new(rate: f64, qubit_sparse_pauli: &PyQubitSparsePauli) -> PyResult<Self> {
+        let inner = GeneratorTerm::new(rate, qubit_sparse_pauli.inner.clone());
+        Ok(PyGeneratorTerm { inner })
+    }
+
+    /// Convert this term to a complete :class:`PauliLindbladMap`.
+    fn to_pauli_lindblad_map(&self) -> PyResult<PyPauliLindbladMap> {
+        let pauli_lindblad_map = PauliLindbladMap::new_from_raw_parts(
+            self.inner.num_qubits(),
+            vec![self.inner.rate()],
+            self.inner.paulis().to_vec(),
+            self.inner.indices().to_vec(),
+            vec![0, self.inner.paulis().len()],
+        )?;
+        Ok(pauli_lindblad_map.into())
+    }
+
+    fn to_label(&self) -> PyResult<String> {
+        Ok(self.inner.view().to_sparse_str())
+    }
+
+    fn __eq__(slf: Bound<Self>, other: Bound<PyAny>) -> PyResult<bool> {
+        if slf.is(&other) {
+            return Ok(true);
+        }
+        let Ok(other) = other.downcast_into::<Self>() else {
+            return Ok(false);
+        };
+        let slf = slf.borrow();
+        let other = other.borrow();
+        Ok(slf.inner.eq(&other.inner))
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!(
+            "<{} on {} qubit{}: {}>",
+            Self::type_qualname(),
+            self.inner.num_qubits(),
+            if self.inner.num_qubits() == 1 {
+                ""
+            } else {
+                "s"
+            },
+            self.inner.view().to_sparse_str(),
+        ))
+    }
+
+    /// Get a copy of this term.
+    fn copy(&self) -> Self {
+        self.clone()
+    }
+
+    /// Read-only view onto the individual single-qubit terms.
+    ///
+    /// The only valid values in the array are those with a corresponding
+    /// :class:`~PauliLindbladMap.Pauli`.
+    #[getter]
+    fn get_paulis(slf_: Bound<Self>) -> Bound<PyArray1<u8>> {
+        let borrowed = slf_.borrow();
+        let paulis = borrowed.inner.paulis();
+        let arr = ::ndarray::aview1(::bytemuck::cast_slice::<_, u8>(paulis));
+        // SAFETY: in order to call this function, the lifetime of `self` must be managed by Python.
+        // We tie the lifetime of the array to `slf_`, and there are no public ways to modify the
+        // `Box<[Pauli]>` allocation (including dropping or reallocating it) other than the entire
+        // object getting dropped, which Python will keep safe.
+        let out = unsafe { PyArray1::borrow_from_array(&arr, slf_.into_any()) };
+        out.readwrite().make_nonwriteable();
+        out
+    }
+
+    /// The number of qubits the term is defined on.
+    #[getter]
+    fn get_num_qubits(&self) -> u32 {
+        self.inner.num_qubits()
+    }
+
+    /// The term's rate.
+    #[getter]
+    fn get_rate(&self) -> f64 {
+        self.inner.rate()
+    }
+
+    /// The term's qubit_sparse_pauli.
+    #[getter]
+    fn get_qubit_sparse_pauli(&self) -> PyQubitSparsePauli {
+        self.inner.qubit_sparse_pauli.clone().into()
+    }
+
+    /// Read-only view onto the indices of each non-identity single-qubit term.
+    ///
+    /// The indices will always be in sorted order.
+    #[getter]
+    fn get_indices(slf_: Bound<Self>) -> Bound<PyArray1<u32>> {
+        let borrowed = slf_.borrow();
+        let indices = borrowed.inner.indices();
+        let arr = ::ndarray::aview1(indices);
+        // SAFETY: in order to call this function, the lifetime of `self` must be managed by Python.
+        // We tie the lifetime of the array to `slf_`, and there are no public ways to modify the
+        // `Box<[u32]>` allocation (including dropping or reallocating it) other than the entire
+        // object getting dropped, which Python will keep safe.
+        let out = unsafe { PyArray1::borrow_from_array(&arr, slf_.into_any()) };
+        out.readwrite().make_nonwriteable();
+        out
+    }
+
+    /// Return the pauli labels of the term as string.
+    ///
+    /// The pauli labels will match the order of :attr:`.GeneratorTerm.indices`, such that the
+    /// i-th character in the string is applied to the qubit index at ``term.indices[i]``.
+    ///
+    /// Returns:
+    ///     The non-identity bit terms as concatenated string.
+    fn pauli_labels<'py>(&self, py: Python<'py>) -> Bound<'py, PyString> {
+        let string: String = self
+            .inner
+            .paulis()
+            .iter()
+            .map(|bit| bit.py_label())
+            .collect();
+        PyString::new(py, string.as_str())
+    }
+
+    fn __getnewargs__(slf_: Bound<Self>) -> PyResult<Bound<PyTuple>> {
+        let py = slf_.py();
+        let borrowed = slf_.borrow();
+        (
+            borrowed.inner.rate,
+            borrowed.inner.qubit_sparse_pauli.clone(),
+        )
+            .into_pyobject(py)
+    }
+}
+
+/// A Pauli Lindblad map stored in a qubit-sparse format.
+///
+/// Mathematics
+/// ===========
+///
+/// A Pauli-Lindblad map is a linear map acting on density matrices on :math:`n`-qubits of the form:
+///
+/// .. math::
+///
+///     \Lambda = \exp\left(\sum_{P \in K} \lambda_P (P \cdot P - \cdot)\right)
+///
+/// where :math:`K` is a subset of :math:`n`-qubit Pauli operators, and the rates, or coefficients,
+/// :math:`\lambda_P` are real numbers. When all the rates :math:`\lambda_P` are
+/// non-negative, this corresponds to a completely positive and trace preserving map. The sum in the
+/// exponential is called the generator, and each individual term the generators. To simplify
+/// notation in the rest of the documention, we denote :math:`L(P) = P \cdot P - \cdot`.
+///
+/// Quasi-probability representation
+/// ================================
+///
+/// The map :math:`\Lambda` can be written as a product:
+///
+/// .. math::
+///
+///     \Lambda = \prod_{P \in K}\exp\left(\lambda_P(P \cdot P - \cdot)\right).
+///
+/// For each :math:`P`, it holds that
+///
+/// .. math::
+///
+///     \exp\left(\lambda_P(P \cdot P - \cdot)\right) = \omega(\lambda_P) \cdot + (1 - \omega(\lambda_P)) P \cdot P,
+///
+/// where :math:`\omega(x) = \frac{1}{2}(1 + e^{-2 x})`. Observe that if :math:`\lambda_P \geq 0`,
+/// then :math:`\omega(\lambda_P) \in (\frac{1}{2}, 1]`, and this term is a completely-positive and
+/// trace-preserving map. However, if :math:`\lambda_P < 0`, then :math:`\omega(\lambda_P) > 1` and
+/// the map is not completely positive or trace preserving. Letting
+/// :math:`\gamma_P = \omega(\lambda_P) + |1 - \omega(\lambda_P)|`,
+/// :math:`p_P = \omega(\lambda_P) / \gamma_P` and :math:`b_P \in \{0, 1\}` be :math:`1` if
+/// :math:`\lambda_P < 0` and :math:`0` otherwise, we rewrite the map as:
+///
+/// .. math::
+///
+///     \omega(\lambda_P) \cdot + (1 - \omega(\lambda_P)) P \cdot P = \gamma_P \left(p_P \cdot + (-1)^{b_P}(1 - p_P) P \cdot P\right).
+///
+/// If :math:`\lambda_P \geq 0`, :math:`\gamma_P = 1` and the expression reduces to the standard
+/// mixture of the identity map and conjugation by :math:`P`. If :math:`\lambda_P < 0`,
+/// :math:`\gamma_P > 1`, and the map is a scaled difference of the identity map and conjugation by
+/// :math:`P`, with probability weights (hence "quasi-probability"). Note that this is a slightly
+/// different presentation than in the literature, but this notation allows us to handle both
+/// non-negative and negative rates simultaneously. The overall :math:`\gamma` of the channel is the
+/// product :math:`\gamma = \prod_{P \in K} \gamma_P`.
+///
+/// Representation
+/// ==============
+///
+/// Each individual Pauli operator in the generator is a tensor product of single-qubit Pauli
+/// operators of the form :math:`P = \bigotimes_n A^{(n)}_i`, for :math:`A^{(n)}_i \in \{I, X, Y,
+/// Z\}`. The internal representation of a :class:`PauliLindbladMap` stores only the non-identity
+/// single-qubit Pauli operators.  This makes it significantly more efficient to represent
+/// generators such as :math:`\sum_{n\in \text{qubits}} c_n L(Z^{(n)})`; for which
+/// :class:`PauliLindbladMap` requires an amount of memory linear in the total number of qubits.
+///
+/// Internally, :class:`.PauliLindbladMap` stores an array of rates and a
+/// :class:`.QubitSparsePauliList` containing the corresponding sparse Pauli operators.
+/// Additionally, :class:`.PauliLindbladMap` stores the overall channel :math:`\gamma` in the
+/// :attr:`gamma` attribute, as well as probabilities corresponding probabilities (or
+/// quasi-probabilities) in the :attr:`probabilities` attribute.
+///
+/// Indexing
+/// --------
+///
+/// :class:`PauliLindbladMap` behaves as `a Python sequence
+/// <https://docs.python.org/3/glossary.html#term-sequence>`__ (the standard form, not the expanded
+/// :class:`collections.abc.Sequence`).  The generators of the map can be indexed by integers, and
+/// iterated through to yield individual generator terms.
+///
+/// Each generator term appears as an instance a self-contained class.  The individual terms are
+/// copied out of the base map; mutations to them will not affect the original map from which they
+/// are indexed.
+///
+/// .. autoclass:: qiskit.quantum_info::PauliLindbladMap.GeneratorTerm
+///     :members:
+///
+/// Construction
+/// ============
+///
+/// :class:`PauliLindbladMap` defines several constructors.  The default constructor will attempt to
+/// delegate to one of the more specific constructors, based on the type of the input.  You can
+/// always use the specific constructors to have more control over the construction.
+///
+/// .. _pauli-lindblad-map-convert-constructors:
+/// .. table:: Construction from other objects
+///
+///   ============================  ================================================================
+///   Method                        Summary
+///   ============================  ================================================================
+///   :meth:`from_list`             Generators given as a list of tuples of dense string labels and
+///                                 the associated rates.
+///
+///   :meth:`from_sparse_list`      Generators given as a list of tuples of sparse string labels,
+///                                 the qubits they apply to, and their rates.
+///
+///   :meth:`from_terms`            Sum explicit single :class:`GeneratorTerm` instances.
+///
+///   :meth:`from_components`       Build from an array of rates and a
+///                                 :class:`.QubitSparsePauliList` instance.
+///   ============================  ================================================================
+///
+/// .. py:function:: PauliLindbladMap.__new__(data, /, num_qubits=None)
+///
+///     The default constructor of :class:`PauliLindbladMap`.
+///
+///     This delegates to one of :ref:`the explicit conversion-constructor methods
+///     <pauli-lindblad-map-convert-constructors>`, based on the type of the ``data`` argument.  If
+///     ``num_qubits`` is supplied and constructor implied by the type of ``data`` does not accept a
+///     number, the given integer must match the input.
+///
+///     :param data: The data type of the input.  This can be another :class:`PauliLindbladMap`, in
+///         which case the input is copied, or it can be a list in a valid format for either
+///         :meth:`from_list` or :meth:`from_sparse_list`.
+///     :param int|None num_qubits: Optional number of qubits for the map.  For most data
+///         inputs, this can be inferred and need not be passed.  It is only necessary for empty
+///         lists or the sparse-list format.  If given unnecessarily, it must match the data input.
+///
+/// In addition to the conversion-based constructors, there are also helper methods that construct
+/// special forms of maps.
+///
+/// .. table:: Construction of special maps
+///
+///   ============================  ================================================================
+///   Method                        Summary
+///   ============================  ================================================================
+///   :meth:`identity`              The identity map on a given number of qubits.
+///   ============================  ================================================================
+///
+/// Conversions
+/// ===========
+///
+/// An existing :class:`PauliLindbladMap` can be converted into other formats.
+///
+/// .. table:: Conversion methods to other observable forms.
+///
+///   ===========================  =================================================================
+///   Method                       Summary
+///   ===========================  =================================================================
+///   :meth:`to_sparse_list`       Express the observable in a sparse list format with elements
+///                                ``(paulis, indices, rate)``.
+///   ===========================  =================================================================
+#[pyclass(name = "PauliLindbladMap", module = "qiskit.quantum_info", sequence)]
+#[derive(Debug)]
+pub struct PyPauliLindbladMap {
+    // This class keeps a pointer to a pure Rust-GeneratorTerm and serves as interface from Python.
+    inner: Arc<RwLock<PauliLindbladMap>>,
+}
+
+#[pymethods]
+impl PyPauliLindbladMap {
+    #[pyo3(signature = (data, /, num_qubits=None))]
+    #[new]
+    fn py_new(data: &Bound<PyAny>, num_qubits: Option<u32>) -> PyResult<Self> {
+        let py = data.py();
+        let check_num_qubits = |data: &Bound<PyAny>| -> PyResult<()> {
+            let Some(num_qubits) = num_qubits else {
+                return Ok(());
+            };
+            let other_qubits = data.getattr(intern!(py, "num_qubits"))?.extract::<u32>()?;
+            if num_qubits == other_qubits {
+                return Ok(());
+            }
+            Err(PyValueError::new_err(format!(
+                "explicitly given 'num_qubits' ({num_qubits}) does not match operator ({other_qubits})"
+            )))
+        };
+        if let Ok(pauli_lindblad_map) = data.downcast_exact::<Self>() {
+            check_num_qubits(data)?;
+            let borrowed = pauli_lindblad_map.borrow();
+            let inner = borrowed.inner.read().map_err(|_| InnerReadError)?;
+            return Ok(inner.clone().into());
+        }
+        // The type of `vec` is inferred from the subsequent calls to `Self::from_list` or
+        // `Self::from_sparse_list` to be either the two-tuple or the three-tuple form during the
+        // `extract`.  The empty list will pass either, but it means the same to both functions.
+        if let Ok(vec) = data.extract() {
+            return Self::from_list(vec, num_qubits);
+        }
+        if let Ok(vec) = data.extract() {
+            let Some(num_qubits) = num_qubits else {
+                return Err(PyValueError::new_err(
+                    "if using the sparse-list form, 'num_qubits' must be provided",
+                ));
+            };
+            return Self::from_sparse_list(vec, num_qubits);
+        }
+        if let Ok(term) = data.downcast_exact::<PyGeneratorTerm>() {
+            return term.borrow().to_pauli_lindblad_map();
+        };
+        if let Ok(pauli_lindblad_map) = Self::from_terms(data, num_qubits) {
+            return Ok(pauli_lindblad_map);
+        }
+        Err(PyTypeError::new_err(format!(
+            "unknown input format for 'PauliLindbladMap': {}",
+            data.get_type().repr()?,
+        )))
+    }
+
+    #[staticmethod]
+    fn from_components(
+        rates: Vec<f64>,
+        qubit_sparse_pauli_list: &PyQubitSparsePauliList,
+    ) -> PyResult<Self> {
+        let qubit_sparse_pauli_list = qubit_sparse_pauli_list
+            .inner
+            .read()
+            .map_err(|_| InnerReadError)?;
+        let inner = PauliLindbladMap::new(rates.clone(), qubit_sparse_pauli_list.clone())?;
+
+        Ok(inner.into())
+    }
+
+    /// Construct a Pauli Lindblad map from a list of dense generator labels and rates.
+    ///
+    /// This is analogous to :meth:`.SparsePauliOp.from_list`. In this dense form, you must supply
+    /// all identities explicitly in each label.
+    ///
+    /// The label must be a sequence of the alphabet ``'IXYZ'``.  The label is interpreted
+    /// analogously to a bitstring.  In other words, the right-most letter is associated with qubit
+    /// 0, and so on.  This is the same as the labels for :class:`.Pauli` and
+    /// :class:`.SparsePauliOp`.
+    ///
+    /// Args:
+    ///     iter (list[tuple[str, float]]): Pairs of labels and their associated rates in the
+    ///         generator sum.
+    ///     num_qubits (int | None): It is not necessary to specify this if you are sure that
+    ///         ``iter`` is not an empty sequence, since it can be inferred from the label lengths.
+    ///         If ``iter`` may be empty, you must specify this argument to disambiguate how many
+    ///         qubits the map acts on.  If this is given and ``iter`` is not empty, the value
+    ///         must match the label lengths.
+    ///
+    /// Examples:
+    ///
+    ///     Construct a Pauli Lindblad map from a list of labels::
+    ///
+    ///         >>> PauliLindbladMap.from_list([
+    ///         ...     ("IIIXX", 1.0),
+    ///         ...     ("IIYYI", 1.0),
+    ///         ...     ("IXXII", -0.5),
+    ///         ...     ("ZZIII", -0.25),
+    ///         ... ])
+    ///         <PauliLindbladMap with 4 terms on 5 qubits:
+    ///             (1)L(X_1 X_0) + (1)L(Y_2 Y_1) + (-0.5)L(X_3 X_2) + (-0.25)L(Z_4 Z_3)>
+    ///
+    ///     Use ``num_qubits`` to disambiguate potentially empty inputs::
+    ///
+    ///         >>> PauliLindbladMap.from_list([], num_qubits=10)
+    ///         <PauliLindbladMap with 0 terms on 10 qubits: 0.0>
+    ///
+    ///     This method is equivalent to calls to :meth:`from_sparse_list` with the explicit
+    ///     qubit-arguments field set to decreasing integers::
+    ///
+    ///         >>> labels = ["XYXZ", "YYZZ", "XYXZ"]
+    ///         >>> rates = [1.5, 2.0, -0.5]
+    ///         >>> from_list = PauliLindbladMap.from_list(list(zip(labels, rates)))
+    ///         >>> from_sparse_list = PauliLindbladMap.from_sparse_list([
+    ///         ...     (label, (3, 2, 1, 0), rate)
+    ///         ...     for label, rate in zip(labels, rates)
+    ///         ... ])
+    ///         >>> assert from_list == from_sparse_list
+    ///
+    /// See also:
+    ///     :meth:`from_sparse_list`
+    ///         Construct the map from a list of labels without explicit identities, but with
+    ///         the qubits each single-qubit generator term applies to listed explicitly.
+    #[staticmethod]
+    #[pyo3(signature = (iter, /, *, num_qubits=None))]
+    fn from_list(iter: Vec<(String, f64)>, num_qubits: Option<u32>) -> PyResult<Self> {
+        if iter.is_empty() && num_qubits.is_none() {
+            return Err(PyValueError::new_err(
+                "cannot construct a PauliLindbladMap from an empty list without knowing `num_qubits`",
+            ));
+        }
+        let num_qubits = match num_qubits {
+            Some(num_qubits) => num_qubits,
+            None => iter[0].0.len() as u32,
+        };
+        let mut inner = PauliLindbladMap::with_capacity(num_qubits, iter.len(), 0);
+        for (label, rate) in iter {
+            inner.add_dense_label(&label, rate)?;
+        }
+        Ok(inner.into())
+    }
+
+    /// Get the identity map on the given number of qubits.
+    ///
+    /// The identity map contains no generator terms, and is the identity element for composition of
+    /// two :class:`PauliLindbladMap` instances; anything composed with the identity map is equal to
+    /// itself.
+    ///
+    /// Examples:
+    ///
+    ///     Get the identity map on 100 qubits::
+    ///
+    ///         >>> PauliLindbladMap.identity(100)
+    ///         <PauliLindbladMap with 0 terms on 100 qubits: 0.0>
+    #[pyo3(signature = (/, num_qubits))]
+    #[staticmethod]
+    pub fn identity(num_qubits: u32) -> Self {
+        PauliLindbladMap::identity(num_qubits).into()
+    }
+
+    /// Construct a :class:`PauliLindbladMap` out of individual terms.
+    ///
+    /// All the terms must have the same number of qubits.  If supplied, the ``num_qubits`` argument
+    /// must match the terms.
+    ///
+    /// No simplification is done as part of the map creation.
+    ///
+    /// Args:
+    ///     obj (Iterable[Term]): Iterable of individual terms to build the map generator from.
+    ///     num_qubits (int | None): The number of qubits the map should act on.  This is
+    ///         usually inferred from the input, but can be explicitly given to handle the case
+    ///         of an empty iterable.
+    ///
+    /// Returns:
+    ///     The corresponding map.
+    #[staticmethod]
+    #[pyo3(signature = (obj, /, num_qubits=None))]
+    fn from_terms(obj: &Bound<PyAny>, num_qubits: Option<u32>) -> PyResult<Self> {
+        let mut iter = obj.try_iter()?;
+        let mut inner = match num_qubits {
+            Some(num_qubits) => PauliLindbladMap::identity(num_qubits),
+            None => {
+                let Some(first) = iter.next() else {
+                    return Err(PyValueError::new_err(
+                        "cannot construct a PauliLindbladMap from an empty list without knowing `num_qubits`",
+                    ));
+                };
+                let py_term = first?.downcast::<PyGeneratorTerm>()?.borrow();
+                py_term.inner.to_pauli_lindblad_map()?
+            }
+        };
+        for bound_py_term in iter {
+            let py_term = bound_py_term?.downcast::<PyGeneratorTerm>()?.borrow();
+            inner.add_term(py_term.inner.view())?;
+        }
+        Ok(inner.into())
+    }
+
+    /// Clear all the generator terms from this map, making it equal to the identity map again.
+    ///
+    /// This does not change the capacity of the internal allocations, so subsequent addition or
+    /// substraction operations resulting from composition may not need to reallocate.
+    ///
+    /// Examples:
+    ///
+    ///     .. code-block:: python
+    ///
+    ///         >>> pauli_lindblad_map = PauliLindbladMap.from_list([("IXXXYY", 2.0), ("ZZYZII", -1)])
+    ///         >>> pauli_lindblad_map.clear()
+    ///         >>> assert pauli_lindblad_map == PauliLindbladMap.identity(pauli_lindblad_map.py_num_qubits())
+    pub fn clear(&mut self) -> PyResult<()> {
+        let mut inner = self.inner.write().map_err(|_| InnerWriteError)?;
+        inner.clear();
+        Ok(())
+    }
+
+    /// Construct a Pauli Lindblad map from a list of labels, the qubits each item applies to, and
+    /// the rate of the whole term.
+    ///
+    /// This is analogous to :meth:`.SparsePauliOp.from_sparse_list`.
+    ///
+    /// The "labels" and "indices" fields of the triples are associated by zipping them together.
+    /// For example, this means that a call to :meth:`from_list` can be converted to the form used
+    /// by this method by setting the "indices" field of each triple to ``(num_qubits-1, ..., 1,
+    /// 0)``.
+    ///
+    /// Args:
+    ///     iter (list[tuple[str, Sequence[int], float]]): triples of labels, the qubits
+    ///         each single-qubit term applies to, and the rate of the entire term.
+    ///
+    ///     num_qubits (int): the number of qubits the map acts on.
+    ///
+    /// Examples:
+    ///
+    ///     Construct a simple map::
+    ///
+    ///         >>> PauliLindbladMap.from_sparse_list(
+    ///         ...     [("ZX", (1, 4), 1.0), ("YY", (0, 3), 2)],
+    ///         ...     num_qubits=5,
+    ///         ... )
+    ///         <PauliLindbladMap with 2 terms on 5 qubits: (1)L(X_4 Z_1) + (2)L(Y_3 Y_0)>
+    ///
+    ///     This method can replicate the behavior of :meth:`from_list`, if the qubit-arguments
+    ///     field of the triple is set to decreasing integers::
+    ///
+    ///         >>> labels = ["XYXZ", "YYZZ", "XYXZ"]
+    ///         >>> rates = [1.5, 2.0, -0.5]
+    ///         >>> from_list = PauliLindbladMap.from_list(list(zip(labels, rates)))
+    ///         >>> from_sparse_list = PauliLindbladMap.from_sparse_list([
+    ///         ...     (label, (3, 2, 1, 0), rate)
+    ///         ...     for label, rate in zip(labels, rates)
+    ///         ... ])
+    ///         >>> assert from_list == from_sparse_list
+    ///
+    /// See also:
+    ///     :meth:`to_sparse_list`
+    ///         The reverse of this method.
+    #[staticmethod]
+    #[pyo3(signature = (iter, /, num_qubits))]
+    fn from_sparse_list(iter: Vec<(String, Vec<u32>, f64)>, num_qubits: u32) -> PyResult<Self> {
+        let rates = iter.iter().map(|(_, _, rate)| *rate).collect();
+        let op_iter = iter
+            .iter()
+            .map(|(label, indices, _)| (label.clone(), indices.clone()))
+            .collect();
+        let (paulis, indices, boundaries) = raw_parts_from_sparse_list(op_iter, num_qubits)?;
+        let qubit_sparse_pauli_list =
+            QubitSparsePauliList::new(num_qubits, paulis, indices, boundaries)?;
+        let inner: PauliLindbladMap = PauliLindbladMap::new(rates, qubit_sparse_pauli_list)?;
+        Ok(inner.into())
+    }
+
+    /// Get a copy of this Pauli Lindblad map.
+    ///
+    /// Examples:
+    ///
+    ///     .. code-block:: python
+    ///
+    ///         >>> pauli_lindblad_map = PauliLindbladMap.from_list([("IXZXYYZZ", 2.5), ("ZXIXYYZZ", 0.5)])
+    ///         >>> assert pauli_lindblad_map == pauli_lindblad_map.copy()
+    ///         >>> assert pauli_lindblad_map is not pauli_lindblad_map.copy()
+    fn copy(&self) -> PyResult<Self> {
+        let inner = self.inner.read().map_err(|_| InnerReadError)?;
+        Ok(inner.clone().into())
+    }
+
+    /// The number of qubits the map acts on.
+    ///
+    /// This is not inferable from any other shape or values, since identities are not stored
+    /// explicitly.
+    #[getter]
+    #[inline]
+    pub fn num_qubits(&self) -> PyResult<u32> {
+        let inner = self.inner.read().map_err(|_| InnerReadError)?;
+        Ok(inner.num_qubits())
+    }
+
+    /// The number of generator terms in the exponent for this map.
+    #[getter]
+    #[inline]
+    pub fn num_terms(&self) -> PyResult<usize> {
+        let inner = self.inner.read().map_err(|_| InnerReadError)?;
+        Ok(inner.num_terms())
+    }
+
+    /// The gamma for the map.
+    #[getter]
+    #[inline]
+    fn get_gamma(&self) -> PyResult<f64> {
+        let inner = self.inner.read().map_err(|_| InnerReadError)?;
+        Ok(inner.gamma)
+    }
+
+    /// The rates for the map.
+    #[getter]
+    fn get_rates(slf_: Bound<Self>) -> Bound<PyArray1<f64>> {
+        let borrowed = &slf_.borrow();
+        let inner = borrowed.inner.read().unwrap();
+        let rates = inner.rates();
+        let arr = ::ndarray::aview1(rates);
+        // SAFETY: in order to call this function, the lifetime of `self` must be managed by Python.
+        // We tie the lifetime of the array to `slf_`, and there are no public ways to modify the
+        // `Box<[u32]>` allocation (including dropping or reallocating it) other than the entire
+        // object getting dropped, which Python will keep safe.
+        let out = unsafe { PyArray1::borrow_from_array(&arr, slf_.into_any()) };
+        out.readwrite().make_nonwriteable();
+        out
+    }
+
+    /// The probabilities for the map.
+    #[getter]
+    fn get_probabilities(slf_: Bound<Self>) -> Bound<PyArray1<f64>> {
+        let borrowed = &slf_.borrow();
+        let inner = borrowed.inner.read().unwrap();
+        let probabilities = inner.probabilities();
+        let arr = ::ndarray::aview1(probabilities);
+        // SAFETY: in order to call this function, the lifetime of `self` must be managed by Python.
+        // We tie the lifetime of the array to `slf_`, and there are no public ways to modify the
+        // `Box<[u32]>` allocation (including dropping or reallocating it) other than the entire
+        // object getting dropped, which Python will keep safe.
+        let out = unsafe { PyArray1::borrow_from_array(&arr, slf_.into_any()) };
+        out.readwrite().make_nonwriteable();
+        out
+    }
+
+    /// The map's qubit sparse pauli list.
+    #[getter]
+    fn get_qubit_sparse_pauli_list(&self) -> PyQubitSparsePauliList {
+        let inner = self.inner.read().unwrap();
+        inner.qubit_sparse_pauli_list.clone().into()
+    }
+
+    /// Express the map in terms of a sparse list format.
+    ///
+    /// This can be seen as counter-operation of :meth:`.PauliLindbladMap.from_sparse_list`, however
+    /// the order of terms is not guaranteed to be the same at after a roundtrip to a sparse
+    /// list and back.
+    ///
+    /// Examples:
+    ///
+    ///     >>> pauli_lindblad_map = PauliLindbladMap.from_list([("IIXIZ", 2), ("IIZIX", 3)])
+    ///     >>> reconstructed = PauliLindbladMap.from_sparse_list(pauli_lindblad_map.to_sparse_list(), pauli_lindblad_map.num_qubits)
+    ///
+    /// See also:
+    ///     :meth:`from_sparse_list`
+    ///         The constructor that can interpret these lists.
+    #[pyo3(signature = ())]
+    fn to_sparse_list(&self, py: Python) -> PyResult<Py<PyList>> {
+        let inner = self.inner.read().map_err(|_| InnerReadError)?;
+
+        // turn a SparseView into a Python tuple of (bit terms, indices, rate)
+        let to_py_tuple = |view: GeneratorTermView| {
+            let mut pauli_string = String::with_capacity(view.qubit_sparse_pauli.paulis.len());
+
+            for bit in view.qubit_sparse_pauli.paulis.iter() {
+                pauli_string.push_str(bit.py_label());
+            }
+            let py_string = PyString::new(py, &pauli_string).unbind();
+            let py_indices = PyList::new(py, view.qubit_sparse_pauli.indices.iter())?.unbind();
+            let py_rate = view.rate.into_py_any(py)?;
+
+            PyTuple::new(py, vec![py_string.as_any(), py_indices.as_any(), &py_rate])
+        };
+
+        let out = PyList::empty(py);
+        for view in inner.iter() {
+            out.append(to_py_tuple(view)?)?;
+        }
+        Ok(out.unbind())
+    }
+
+    fn __len__(&self) -> PyResult<usize> {
+        self.num_terms()
+    }
+
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyTuple>> {
+        let inner = self.inner.read().map_err(|_| InnerReadError)?;
+        (
+            py.get_type::<Self>().getattr("from_sparse_list")?,
+            (self.to_sparse_list(py)?, inner.num_qubits()),
+        )
+            .into_pyobject(py)
+    }
+
+    fn __getitem__<'py>(
+        &self,
+        py: Python<'py>,
+        index: PySequenceIndex<'py>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let inner = self.inner.read().map_err(|_| InnerReadError)?;
+        let indices = match index.with_len(inner.num_terms())? {
+            SequenceIndex::Int(index) => {
+                return PyGeneratorTerm {
+                    inner: inner.term(index).to_term(),
+                }
+                .into_bound_py_any(py)
+            }
+            indices => indices,
+        };
+        let mut out = PauliLindbladMap::identity(inner.num_qubits());
+        for index in indices.iter() {
+            out.add_term(inner.term(index))?;
+        }
+        out.into_bound_py_any(py)
+    }
+
+    fn __eq__(slf: Bound<Self>, other: Bound<PyAny>) -> PyResult<bool> {
+        // this is also important to check before trying to read both slf and other
+        if slf.is(&other) {
+            return Ok(true);
+        }
+        let Ok(other) = other.downcast_into::<Self>() else {
+            return Ok(false);
+        };
+        let slf_borrowed = slf.borrow();
+        let other_borrowed = other.borrow();
+        let slf_inner = slf_borrowed.inner.read().map_err(|_| InnerReadError)?;
+        let other_inner = other_borrowed.inner.read().map_err(|_| InnerReadError)?;
+        Ok(slf_inner.eq(&other_inner))
+    }
+
+    // The documentation for this is inlined into the class-level documentation of
+    // `PauliLindbladMap`.
+    #[allow(non_snake_case)]
+    #[classattr]
+    fn GeneratorTerm(py: Python) -> Bound<PyType> {
+        py.get_type::<PyGeneratorTerm>()
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        let num_terms = self.num_terms()?;
+        let num_qubits = self.num_qubits()?;
+
+        let str_num_terms = format!(
+            "{} term{}",
+            num_terms,
+            if num_terms == 1 { "" } else { "s" }
+        );
+        let str_num_qubits = format!(
+            "{} qubit{}",
+            num_qubits,
+            if num_qubits == 1 { "" } else { "s" }
+        );
+
+        let inner = self.inner.read().map_err(|_| InnerReadError)?;
+        let str_terms = if num_terms == 0 {
+            "0.0".to_owned()
+        } else {
+            inner
+                .iter()
+                .map(GeneratorTermView::to_sparse_str)
+                .collect::<Vec<_>>()
+                .join(" + ")
+        };
+        Ok(format!(
+            "<PauliLindbladMap with {} on {}: {}>",
+            str_num_terms, str_num_qubits, str_terms
+        ))
+    }
+}
+
+impl From<PauliLindbladMap> for PyPauliLindbladMap {
+    fn from(val: PauliLindbladMap) -> PyPauliLindbladMap {
+        PyPauliLindbladMap {
+            inner: Arc::new(RwLock::new(val)),
+        }
+    }
+}
+impl<'py> IntoPyObject<'py> for PauliLindbladMap {
+    type Target = PyPauliLindbladMap;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> PyResult<Self::Output> {
+        PyPauliLindbladMap::from(self).into_pyobject(py)
+    }
+}

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -907,8 +907,15 @@ impl<'py> FromPyObject<'py> for Pauli {
 #[pyclass(name = "QubitSparsePauli", frozen, module = "qiskit.quantum_info")]
 #[derive(Clone, Debug)]
 pub struct PyQubitSparsePauli {
-    pub inner: QubitSparsePauli,
+    inner: QubitSparsePauli,
 }
+
+impl PyQubitSparsePauli {
+    pub fn get_inner(&self) -> &QubitSparsePauli {
+        &self.inner
+    }
+}
+
 #[pymethods]
 impl PyQubitSparsePauli {
     #[new]

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -947,7 +947,7 @@ impl PyQubitSparsePauli {
                     label.len(),
                 )));
             }
-            return Self::from_label(&label).map_err(PyErr::from);
+            return Self::from_label(&label);
         }
         if let Ok(sparse_label) = data.extract() {
             let Some(num_qubits) = num_qubits else {

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -911,7 +911,7 @@ pub struct PyQubitSparsePauli {
 }
 
 impl PyQubitSparsePauli {
-    pub fn get_inner(&self) -> &QubitSparsePauli {
+    pub fn inner(&self) -> &QubitSparsePauli {
         &self.inner
     }
 }

--- a/qiskit/quantum_info/__init__.py
+++ b/qiskit/quantum_info/__init__.py
@@ -30,6 +30,7 @@ Operators
    ScalarOp
    SparseObservable
    SparsePauliOp
+   PauliLindbladMap
    QubitSparsePauli
    QubitSparsePauliList
    CNOTDihedral
@@ -118,7 +119,11 @@ Analysis
 
 from __future__ import annotations
 
-from qiskit._accelerate.pauli_lindblad_map import QubitSparsePauliList, QubitSparsePauli
+from qiskit._accelerate.pauli_lindblad_map import (
+    QubitSparsePauliList,
+    QubitSparsePauli,
+    PauliLindbladMap,
+)
 from qiskit._accelerate.sparse_observable import SparseObservable
 
 from .analysis import hellinger_distance, hellinger_fidelity, Z2Symmetries

--- a/releasenotes/notes/pauli-lindblad-map-a51b2b577c24aa95.yaml
+++ b/releasenotes/notes/pauli-lindblad-map-a51b2b577c24aa95.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Introduces the :class:`.QubitSparsePauli`, :class:`.QubitSparsePauliList`, and
+    :class:`.PauliLindbladMap` classes. These classes represent, respectively, a single phase-less
+    Pauli operator, a list of phase-less Pauli operators, and a Pauli Lindblad map, all stored
+    in qubit-sparse format. 

--- a/test/python/quantum_info/test_pauli_lindblad_map.py
+++ b/test/python/quantum_info/test_pauli_lindblad_map.py
@@ -343,17 +343,17 @@ class TestPauliLindbladMap(QiskitTestCase):
     def test_identity(self):
         identity_5 = PauliLindbladMap.identity(5)
         self.assertEqual(identity_5.num_qubits, 5)
-        self.assertEqual(identity_5.get_gamma(), 1.0)
+        self.assertEqual(identity_5.gamma(), 1.0)
         self.assertEqual(identity_5.num_terms, 0.0)
         np.testing.assert_equal(identity_5.rates, np.array([], dtype=float))
-        np.testing.assert_equal(identity_5.get_probabilities(), np.array([], dtype=float))
+        np.testing.assert_equal(identity_5.probabilities(), np.array([], dtype=float))
 
         identity_0 = PauliLindbladMap.identity(0)
         self.assertEqual(identity_0.num_qubits, 0)
-        self.assertEqual(identity_0.get_gamma(), 1.0)
+        self.assertEqual(identity_0.gamma(), 1.0)
         self.assertEqual(identity_0.num_terms, 0.0)
         np.testing.assert_equal(identity_0.rates, np.array([], dtype=float))
-        np.testing.assert_equal(identity_0.get_probabilities(), np.array([], dtype=float))
+        np.testing.assert_equal(identity_0.probabilities(), np.array([], dtype=float))
 
     def test_len(self):
         self.assertEqual(len(PauliLindbladMap.identity(0)), 0)
@@ -453,8 +453,6 @@ class TestPauliLindbladMap(QiskitTestCase):
             pauli_lindblad_map.rates = 1.0
         with self.assertRaisesRegex(ValueError, "assignment destination is read-only"):
             pauli_lindblad_map.rates[0] = 1.0
-        with self.assertRaisesRegex(ValueError, "assignment destination is read-only"):
-            pauli_lindblad_map.get_probabilities()[0] = 1.0
 
     @ddt.idata(single_cases())
     def test_clear(self, pauli_lindblad_map):
@@ -673,22 +671,22 @@ class TestPauliLindbladMap(QiskitTestCase):
 
         pauli_lindblad_map = PauliLindbladMap([("IXYZXYZXYZ", 1.0)])
         w = 0.5 * (1 + np.exp(-2 * 1.0))
-        self.assertTrue(np.allclose(w, pauli_lindblad_map.get_probabilities()[0]))
-        self.assertTrue(np.allclose(1.0, pauli_lindblad_map.get_gamma()))
+        self.assertTrue(np.allclose(w, pauli_lindblad_map.probabilities()[0]))
+        self.assertTrue(np.allclose(1.0, pauli_lindblad_map.gamma()))
 
         pauli_lindblad_map = PauliLindbladMap([("IXYZXYZXYZ", -1.0)])
         w = 0.5 * (1 + np.exp(-2 * -1.0))
         gamma = w + np.abs(1 - w)
         prob = w / gamma
-        self.assertTrue(np.allclose(prob, pauli_lindblad_map.get_probabilities()[0]))
-        self.assertTrue(np.allclose(gamma, pauli_lindblad_map.get_gamma()))
+        self.assertTrue(np.allclose(prob, pauli_lindblad_map.probabilities()[0]))
+        self.assertTrue(np.allclose(gamma, pauli_lindblad_map.gamma()))
 
         pauli_lindblad_map = PauliLindbladMap([("IXYZXYZXYZ", -0.5)])
         w = 0.5 * (1 + np.exp(-2 * -0.5))
         gamma = w + np.abs(1 - w)
         prob = w / gamma
-        self.assertTrue(np.allclose(prob, pauli_lindblad_map.get_probabilities()[0]))
-        self.assertTrue(np.allclose(gamma, pauli_lindblad_map.get_gamma()))
+        self.assertTrue(np.allclose(prob, pauli_lindblad_map.probabilities()[0]))
+        self.assertTrue(np.allclose(gamma, pauli_lindblad_map.gamma()))
 
         pauli_lindblad_map = PauliLindbladMap(
             [("IXYZXYZXYZ", -1.0), ("IXYZXYZXYZ", 1.0), ("IXYZXYZXYZ", -0.5)]
@@ -698,8 +696,8 @@ class TestPauliLindbladMap(QiskitTestCase):
         gammas = w + np.abs(1 - w)
         probs = w / gammas
         gamma = np.prod(gammas)
-        self.assertTrue(np.allclose(probs, pauli_lindblad_map.get_probabilities()))
-        self.assertTrue(np.allclose(gamma, pauli_lindblad_map.get_gamma()))
+        self.assertTrue(np.allclose(probs, pauli_lindblad_map.probabilities()))
+        self.assertTrue(np.allclose(gamma, pauli_lindblad_map.gamma()))
 
 
 def canonicalize_term(pauli, indices, rate):

--- a/test/python/quantum_info/test_pauli_lindblad_map.py
+++ b/test/python/quantum_info/test_pauli_lindblad_map.py
@@ -664,7 +664,8 @@ class TestPauliLindbladMap(QiskitTestCase):
             [1.0, 2.0], QubitSparsePauliList(["II", "XX"])
         )
         self.assertEqual(
-            pauli_lindblad_map.get_qubit_sparse_pauli_list_copy(), QubitSparsePauliList.from_list(["II", "XX"])
+            pauli_lindblad_map.get_qubit_sparse_pauli_list_copy(),
+            QubitSparsePauliList.from_list(["II", "XX"]),
         )
 
     def test_derived_properties(self):

--- a/test/python/quantum_info/test_pauli_lindblad_map.py
+++ b/test/python/quantum_info/test_pauli_lindblad_map.py
@@ -1,0 +1,720 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2025
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
+
+import copy
+import pickle
+
+import ddt
+import numpy as np
+
+from qiskit.quantum_info import QubitSparsePauli, QubitSparsePauliList, PauliLindbladMap
+
+from test import QiskitTestCase  # pylint: disable=wrong-import-order
+
+
+def single_cases():
+    return [
+        PauliLindbladMap.identity(0),
+        PauliLindbladMap.identity(10),
+        PauliLindbladMap.from_list([("YIXZII", -0.25), ("ZZYYXX", 0.25)]),
+        # Includes a duplicate entry.
+        PauliLindbladMap.from_list([("IXZ", -0.25), ("ZZI", 0.25), ("IXZ", 0.75)]),
+    ]
+
+
+@ddt.ddt
+class TestPauliLindbladMap(QiskitTestCase):
+
+    def test_default_constructor_list(self):
+        data = [("IXIIZ", 0.5), ("XIXII", 1.0), ("IIXYI", -0.75)]
+        self.assertEqual(PauliLindbladMap(data), PauliLindbladMap.from_list(data))
+        self.assertEqual(PauliLindbladMap(data, num_qubits=5), PauliLindbladMap.from_list(data))
+        with self.assertRaisesRegex(ValueError, "label with length 5 cannot be added"):
+            PauliLindbladMap(data, num_qubits=4)
+        with self.assertRaisesRegex(ValueError, "label with length 5 cannot be added"):
+            PauliLindbladMap(data, num_qubits=6)
+        self.assertEqual(
+            PauliLindbladMap([], num_qubits=5), PauliLindbladMap.from_list([], num_qubits=5)
+        )
+
+    def test_default_constructor_sparse_list(self):
+        data = [("ZX", (0, 3), 0.5), ("XY", (2, 4), 1.0), ("ZY", (2, 1), -0.75)]
+        self.assertEqual(
+            PauliLindbladMap(data, num_qubits=5),
+            PauliLindbladMap.from_sparse_list(data, num_qubits=5),
+        )
+        self.assertEqual(
+            PauliLindbladMap(data, num_qubits=10),
+            PauliLindbladMap.from_sparse_list(data, num_qubits=10),
+        )
+        with self.assertRaisesRegex(ValueError, "'num_qubits' must be provided"):
+            PauliLindbladMap(data)
+        self.assertEqual(
+            PauliLindbladMap([], num_qubits=5), PauliLindbladMap.from_sparse_list([], num_qubits=5)
+        )
+
+    def test_default_constructor_copy(self):
+        base = PauliLindbladMap.from_list([("IXIZIY", 1.0), ("XYZIII", -1.0)])
+        copied = PauliLindbladMap(base)
+        self.assertEqual(base, copied)
+        self.assertIsNot(base, copied)
+
+        with self.assertRaisesRegex(ValueError, "explicitly given 'num_qubits'"):
+            PauliLindbladMap(base, num_qubits=base.num_qubits + 1)
+
+    def test_default_constructor_term(self):
+        expected = PauliLindbladMap.from_list([("IIZXII", 2)])
+        self.assertEqual(PauliLindbladMap(expected[0]), expected)
+
+    def test_default_constructor_term_iterable(self):
+        expected = PauliLindbladMap.from_list([("IIZXII", 2), ("IIIIII", 0.5)])
+        terms = [expected[0], expected[1]]
+        self.assertEqual(PauliLindbladMap(list(terms)), expected)
+        self.assertEqual(PauliLindbladMap(tuple(terms)), expected)
+        self.assertEqual(PauliLindbladMap(term for term in terms), expected)
+
+    def test_from_list(self):
+        label = "IXYIZZY"
+        self.assertEqual(
+            PauliLindbladMap.from_list([(label, 1.0)]),
+            PauliLindbladMap.from_components([1.0], QubitSparsePauliList.from_label(label)),
+        )
+        self.assertEqual(
+            PauliLindbladMap.from_list([(label, 1.0)], num_qubits=len(label)),
+            PauliLindbladMap.from_components([1.0], QubitSparsePauliList.from_label(label)),
+        )
+
+        self.assertEqual(
+            PauliLindbladMap.from_list([("IIIXZI", 1.0), ("XXIIII", -0.5)]),
+            PauliLindbladMap.from_components(
+                [1.0, -0.5], QubitSparsePauliList.from_list(["IIIXZI", "XXIIII"])
+            ),
+        )
+
+        self.assertEqual(PauliLindbladMap.from_list([], num_qubits=5), PauliLindbladMap.identity(5))
+        self.assertEqual(PauliLindbladMap.from_list([], num_qubits=0), PauliLindbladMap.identity(0))
+
+    def test_from_list_failures(self):
+        with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
+            # Bad letters that are still ASCII.
+            PauliLindbladMap.from_list([("XZIIZY", 0.5), ("I+-$%I", 1.0)])
+        with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
+            # Unicode shenangigans.
+            PauliLindbladMap.from_list([("🐍", 0.5)])
+        with self.assertRaisesRegex(ValueError, "label with length 4 cannot be added"):
+            PauliLindbladMap.from_list([("IIZ", 0.5), ("IIXI", 1.0)])
+        with self.assertRaisesRegex(ValueError, "label with length 2 cannot be added"):
+            PauliLindbladMap.from_list([("IIZ", 0.5), ("II", 1.0)])
+        with self.assertRaisesRegex(ValueError, "label with length 3 cannot be added"):
+            PauliLindbladMap.from_list([("IIZ", 0.5), ("IXI", 1.0)], num_qubits=2)
+        with self.assertRaisesRegex(ValueError, "label with length 3 cannot be added"):
+            PauliLindbladMap.from_list([("IIZ", 0.5), ("IXI", 1.0)], num_qubits=4)
+        with self.assertRaisesRegex(ValueError, "cannot construct.*without knowing `num_qubits`"):
+            PauliLindbladMap.from_list([])
+
+    def test_from_components(self):
+        self.assertEqual(
+            PauliLindbladMap.from_components(
+                [0.5, -0.25, 1.0],
+                QubitSparsePauliList.from_sparse_list(
+                    [
+                        (
+                            "XY",
+                            (0, 1),
+                        ),
+                        (
+                            "XX",
+                            (1, 3),
+                        ),
+                        ("YYZ", (0, 2, 4)),
+                    ],
+                    num_qubits=5,
+                ),
+            ),
+            PauliLindbladMap.from_list([("IIIYX", 0.5), ("IXIXI", -0.25), ("ZIYIY", 1.0)]),
+        )
+
+        # The indices should be allowed to be given in unsorted order, but they should be term-wise
+        # sorted in the output.
+        from_unsorted = PauliLindbladMap.from_components(
+            [1.5, -0.5],
+            QubitSparsePauliList.from_sparse_list(
+                [
+                    ("XYZ", (2, 1, 0)),
+                    ("XYY", (2, 0, 1)),
+                ],
+                num_qubits=3,
+            ),
+        )
+        self.assertEqual(from_unsorted, PauliLindbladMap.from_list([("XYZ", 1.5), ("XYY", -0.5)]))
+        np.testing.assert_equal(from_unsorted[0].indices, np.array([0, 1, 2], dtype=np.uint32))
+        np.testing.assert_equal(from_unsorted[1].indices, np.array([0, 1, 2], dtype=np.uint32))
+
+        # Explicit identities should still work, just be skipped over.
+        explicit_identity = PauliLindbladMap.from_components(
+            [1.0, -0.5],
+            QubitSparsePauliList.from_sparse_list(
+                [
+                    ("ZXI", (0, 1, 2)),
+                    ("XYIII", (0, 1, 2, 3, 8)),
+                ],
+                num_qubits=10,
+            ),
+        )
+        self.assertEqual(
+            explicit_identity,
+            PauliLindbladMap.from_sparse_list(
+                [("XZ", (1, 0), 1.0), ("YX", (1, 0), -0.5)], num_qubits=10
+            ),
+        )
+        np.testing.assert_equal(explicit_identity[0].indices, np.array([0, 1], dtype=np.uint32))
+        np.testing.assert_equal(explicit_identity[1].indices, np.array([0, 1], dtype=np.uint32))
+
+        self.assertEqual(
+            PauliLindbladMap.from_components([], QubitSparsePauliList.empty(1_000_000)),
+            PauliLindbladMap.identity(1_000_000),
+        )
+        self.assertEqual(
+            PauliLindbladMap.from_components([], QubitSparsePauliList.empty(0)),
+            PauliLindbladMap.identity(0),
+        )
+
+    def test_from_components_failures(self):
+        with self.assertRaisesRegex(
+            ValueError, r"`rates` \(1\) must be the same length as `qubit_sparse_pauli_list` \(2\)"
+        ):
+            PauliLindbladMap.from_components([1.0], QubitSparsePauliList(["II", "XX"]))
+
+    def test_from_sparse_list(self):
+        self.assertEqual(
+            PauliLindbladMap.from_sparse_list(
+                [
+                    ("XY", (0, 1), 0.5),
+                    ("XX", (1, 3), -0.25),
+                    ("YYZ", (0, 2, 4), 1.0),
+                ],
+                num_qubits=5,
+            ),
+            PauliLindbladMap.from_list([("IIIYX", 0.5), ("IXIXI", -0.25), ("ZIYIY", 1.0)]),
+        )
+
+        # The indices should be allowed to be given in unsorted order, but they should be term-wise
+        # sorted in the output.
+        from_unsorted = PauliLindbladMap.from_sparse_list(
+            [
+                ("XYZ", (2, 1, 0), 1.5),
+                ("XYY", (2, 0, 1), -0.5),
+            ],
+            num_qubits=3,
+        )
+        self.assertEqual(from_unsorted, PauliLindbladMap.from_list([("XYZ", 1.5), ("XYY", -0.5)]))
+        np.testing.assert_equal(from_unsorted[0].indices, np.array([0, 1, 2], dtype=np.uint32))
+        np.testing.assert_equal(from_unsorted[1].indices, np.array([0, 1, 2], dtype=np.uint32))
+
+        # Explicit identities should still work, just be skipped over.
+        explicit_identity = PauliLindbladMap.from_sparse_list(
+            [
+                ("ZXI", (0, 1, 2), 1.0),
+                ("XYIII", (0, 1, 2, 3, 8), -0.5),
+            ],
+            num_qubits=10,
+        )
+        self.assertEqual(
+            explicit_identity,
+            PauliLindbladMap.from_sparse_list(
+                [("XZ", (1, 0), 1.0), ("YX", (1, 0), -0.5)], num_qubits=10
+            ),
+        )
+        np.testing.assert_equal(explicit_identity[0].indices, np.array([0, 1], dtype=np.uint32))
+        np.testing.assert_equal(explicit_identity[1].indices, np.array([0, 1], dtype=np.uint32))
+
+        self.assertEqual(
+            PauliLindbladMap.from_sparse_list([], num_qubits=1_000_000),
+            PauliLindbladMap.identity(1_000_000),
+        )
+        self.assertEqual(
+            PauliLindbladMap.from_sparse_list([], num_qubits=0),
+            PauliLindbladMap.identity(0),
+        )
+
+    def test_from_sparse_list_failures(self):
+        with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
+            # Bad letters that are still ASCII.
+            PauliLindbladMap.from_sparse_list(
+                [("XZZY", (5, 3, 1, 0), 0.5), ("+$", (2, 1), 1.0)], num_qubits=8
+            )
+        # Unicode shenangigans.  These two should fail with a `ValueError`, but the exact message
+        # isn't important.  "\xff" is "ÿ", which is two bytes in UTF-8 (so has a length of 2 in
+        # Rust), but has a length of 1 in Python, so try with both a length-1 and length-2 index
+        # sequence, and both should still raise `ValueError`.
+        with self.assertRaises(ValueError):
+            PauliLindbladMap.from_sparse_list([("\xff", (1,), 0.5)], num_qubits=5)
+        with self.assertRaises(ValueError):
+            PauliLindbladMap.from_sparse_list([("\xff", (1, 2), 0.5)], num_qubits=5)
+
+        with self.assertRaisesRegex(ValueError, "label with length 2 does not match indices"):
+            PauliLindbladMap.from_sparse_list([("XZ", (0,), 1.0)], num_qubits=5)
+        with self.assertRaisesRegex(ValueError, "label with length 2 does not match indices"):
+            PauliLindbladMap.from_sparse_list([("XZ", (0, 1, 2), 1.0)], num_qubits=5)
+
+        with self.assertRaisesRegex(ValueError, "index 3 is out of range for a 3-qubit operator"):
+            PauliLindbladMap.from_sparse_list([("XZY", (0, 1, 3), 1.0)], num_qubits=3)
+        with self.assertRaisesRegex(ValueError, "index 4 is out of range for a 3-qubit operator"):
+            PauliLindbladMap.from_sparse_list([("XZY", (0, 1, 4), 1.0)], num_qubits=3)
+        with self.assertRaisesRegex(ValueError, "index 3 is out of range for a 3-qubit operator"):
+            # ... even if it's for an explicit identity.
+            PauliLindbladMap.from_sparse_list([("XXI", (0, 1, 3), 1.0)], num_qubits=3)
+
+        with self.assertRaisesRegex(ValueError, "index 3 is duplicated"):
+            PauliLindbladMap.from_sparse_list([("XZ", (3, 3), 1.0)], num_qubits=5)
+        with self.assertRaisesRegex(ValueError, "index 3 is duplicated"):
+            PauliLindbladMap.from_sparse_list([("XYZXZ", (3, 0, 1, 2, 3), 1.0)], num_qubits=5)
+
+    def test_from_terms(self):
+        self.assertEqual(
+            PauliLindbladMap.from_terms([], num_qubits=5), PauliLindbladMap.identity(5)
+        )
+        self.assertEqual(
+            PauliLindbladMap.from_terms((), num_qubits=0), PauliLindbladMap.identity(0)
+        )
+        self.assertEqual(
+            PauliLindbladMap.from_terms((None for _ in []), num_qubits=3),
+            PauliLindbladMap.identity(3),
+        )
+
+        expected = PauliLindbladMap.from_sparse_list(
+            [
+                ("XYZ", (4, 2, 1), 1),
+                ("XXYY", (8, 5, 3, 2), 0.5),
+                ("ZZ", (5, 0), 2.0),
+            ],
+            num_qubits=10,
+        )
+        self.assertEqual(PauliLindbladMap.from_terms(list(expected)), expected)
+        self.assertEqual(PauliLindbladMap.from_terms(tuple(expected)), expected)
+        self.assertEqual(PauliLindbladMap.from_terms(term for term in expected), expected)
+        self.assertEqual(
+            PauliLindbladMap.from_terms(
+                (term for term in expected), num_qubits=expected.num_qubits
+            ),
+            expected,
+        )
+
+    def test_from_terms_failures(self):
+        with self.assertRaisesRegex(ValueError, "cannot construct.*without knowing `num_qubits`"):
+            PauliLindbladMap.from_terms([])
+
+        left, right = (
+            PauliLindbladMap([("IIXYI", 1.0)])[0],
+            PauliLindbladMap([("IIIIIIIIX", 1.0)])[0],
+        )
+        with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits"):
+            PauliLindbladMap.from_terms([left, right])
+        with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits"):
+            PauliLindbladMap.from_terms([left], num_qubits=100)
+
+    def test_default_constructor_failed_inference(self):
+        with self.assertRaises(TypeError):
+            # Mixed dense/sparse list.
+            PauliLindbladMap([("IIXIZ", 1.0), ("IZ", (2, 3), -1.0)], num_qubits=5)
+
+    def test_num_qubits(self):
+        self.assertEqual(PauliLindbladMap.identity(0).num_qubits, 0)
+        self.assertEqual(PauliLindbladMap.identity(10).num_qubits, 10)
+
+    def test_num_terms(self):
+        self.assertEqual(PauliLindbladMap.identity(0).num_terms, 0)
+        self.assertEqual(PauliLindbladMap.identity(10).num_terms, 0)
+        self.assertEqual(
+            PauliLindbladMap.from_list([("IIIXIZ", 1.0), ("YYXXII", 0.5)]).num_terms, 2
+        )
+
+    def test_identity(self):
+        identity_5 = PauliLindbladMap.identity(5)
+        self.assertEqual(identity_5.num_qubits, 5)
+        self.assertEqual(identity_5.gamma, 1.0)
+        self.assertEqual(identity_5.num_terms, 0.0)
+        np.testing.assert_equal(identity_5.rates, np.array([], dtype=float))
+        np.testing.assert_equal(identity_5.probabilities, np.array([], dtype=float))
+
+        identity_0 = PauliLindbladMap.identity(0)
+        self.assertEqual(identity_0.num_qubits, 0)
+        self.assertEqual(identity_0.gamma, 1.0)
+        self.assertEqual(identity_0.num_terms, 0.0)
+        np.testing.assert_equal(identity_0.rates, np.array([], dtype=float))
+        np.testing.assert_equal(identity_0.probabilities, np.array([], dtype=float))
+
+    def test_len(self):
+        self.assertEqual(len(PauliLindbladMap.identity(0)), 0)
+        self.assertEqual(len(PauliLindbladMap.identity(10)), 0)
+        self.assertEqual(len(PauliLindbladMap.from_list([("IIIXIZ", 1.0), ("YYXXII", 0.5)])), 2)
+
+    @ddt.idata(single_cases())
+    def test_pickle(self, pauli_lindblad_map):
+        self.assertEqual(pauli_lindblad_map, copy.copy(pauli_lindblad_map))
+        self.assertIsNot(pauli_lindblad_map, copy.copy(pauli_lindblad_map))
+        self.assertEqual(pauli_lindblad_map, copy.deepcopy(pauli_lindblad_map))
+        self.assertEqual(pauli_lindblad_map, pickle.loads(pickle.dumps(pauli_lindblad_map)))
+
+    @ddt.data(
+        # This is every combination of (0, 1, many) for (terms, qubits, non-identites per term).
+        PauliLindbladMap.identity(0),
+        PauliLindbladMap.identity(1),
+        PauliLindbladMap.identity(10),
+        PauliLindbladMap.from_list([("YIXZII", -0.25)]),
+        PauliLindbladMap.from_list([("YIXZII", -0.25), ("ZZYYXX", 0.25)]),
+    )
+    def test_repr(self, data):
+        # The purpose of this is just to test that the `repr` doesn't crash, rather than asserting
+        # that it has any particular form.
+        self.assertIsInstance(repr(data), str)
+        self.assertIn("PauliLindbladMap", repr(data))
+
+    @ddt.idata(single_cases())
+    def test_copy(self, pauli_lindblad_map):
+        self.assertEqual(pauli_lindblad_map, pauli_lindblad_map.copy())
+        self.assertIsNot(pauli_lindblad_map, pauli_lindblad_map.copy())
+
+    def test_equality(self):
+        sparse_data = [("XZ", (1, 0), 0.5), ("XYY", (3, 1, 0), -0.25)]
+        op = PauliLindbladMap.from_sparse_list(sparse_data, num_qubits=5)
+        self.assertEqual(op, op.copy())
+        # Take care that Rust space allows multiple views onto the same object.
+        self.assertEqual(op, op)
+
+        # Comparison to some other object shouldn't fail.
+        self.assertNotEqual(op, None)
+
+        # No costly automatic simplification (mathematically, these operators _are_ the same).
+        self.assertNotEqual(
+            PauliLindbladMap.from_list([("X", 2.0), ("X", -1.0)]), PauliLindbladMap([("X", 1.0)])
+        )
+
+        # Difference in qubit count.
+        self.assertNotEqual(
+            op, PauliLindbladMap.from_sparse_list(sparse_data, num_qubits=op.num_qubits + 1)
+        )
+        self.assertNotEqual(PauliLindbladMap.identity(2), PauliLindbladMap.identity(3))
+
+        # Difference in rates.
+        self.assertNotEqual(
+            PauliLindbladMap.from_list([("IIXZI", 1.0), ("XXYYZ", -0.5)]),
+            PauliLindbladMap.from_list([("IIXZI", 1.0), ("XXYYZ", 0.5)]),
+        )
+        self.assertNotEqual(
+            PauliLindbladMap.from_list([("IIXZI", 1.0), ("XXYYZ", -0.5)]),
+            PauliLindbladMap.from_list([("IIXZI", -1.0), ("XXYYZ", -0.5)]),
+        )
+
+        # Difference in bit terms.
+        self.assertNotEqual(
+            PauliLindbladMap.from_list([("IIXZI", 1.0), ("XXYYZ", -0.5)]),
+            PauliLindbladMap.from_list([("IIYZI", 1.0), ("XXYYZ", -0.5)]),
+        )
+        self.assertNotEqual(
+            PauliLindbladMap.from_list([("IIXZI", 1.0), ("XXYYZ", -0.5)]),
+            PauliLindbladMap.from_list([("IIXZI", 1.0), ("XXYYY", -0.5)]),
+        )
+
+        # Difference in indices.
+        self.assertNotEqual(
+            PauliLindbladMap.from_list([("IIXZI", 1.0), ("XXYYZ", -0.5)]),
+            PauliLindbladMap.from_list([("IXIZI", 1.0), ("XXYYZ", -0.5)]),
+        )
+        self.assertNotEqual(
+            PauliLindbladMap.from_list([("IIXZI", 1.0), ("XIYYZ", -0.5)]),
+            PauliLindbladMap.from_list([("IIXZI", 1.0), ("IXYYZ", -0.5)]),
+        )
+
+        # Difference in boundaries.
+        self.assertNotEqual(
+            PauliLindbladMap.from_sparse_list(
+                [("XZ", (0, 1), 1.5), ("XX", (2, 3), -0.5)], num_qubits=5
+            ),
+            PauliLindbladMap.from_sparse_list(
+                [("XZX", (0, 1, 2), 1.5), ("X", (3,), -0.5)], num_qubits=5
+            ),
+        )
+
+    def test_attributes_immutable(self):
+        pauli_lindblad_map = PauliLindbladMap.from_list([("XZY", 1.5), ("XXY", -0.5)])
+        with self.assertRaisesRegex(AttributeError, "attribute 'rates'"):
+            pauli_lindblad_map.rates = 1.0
+        with self.assertRaisesRegex(AttributeError, "attribute 'gamma'"):
+            pauli_lindblad_map.gamma = 1.0
+        with self.assertRaisesRegex(AttributeError, "attribute 'probabilities'"):
+            pauli_lindblad_map.probabilities = 1.0
+        with self.assertRaisesRegex(ValueError, "assignment destination is read-only"):
+            pauli_lindblad_map.rates[0] = 1.0
+        with self.assertRaisesRegex(ValueError, "assignment destination is read-only"):
+            pauli_lindblad_map.probabilities[0] = 1.0
+
+    @ddt.idata(single_cases())
+    def test_clear(self, pauli_lindblad_map):
+        num_qubits = pauli_lindblad_map.num_qubits
+        pauli_lindblad_map.clear()
+        self.assertEqual(pauli_lindblad_map, PauliLindbladMap.identity(num_qubits))
+
+    def test_iteration(self):
+        self.assertEqual(list(PauliLindbladMap.identity(5)), [])
+        self.assertEqual(tuple(PauliLindbladMap.identity(0)), ())
+
+        pauli_lindblad_map = PauliLindbladMap.from_sparse_list(
+            [
+                ("XYY", (4, 2, 1), 2),
+                ("", (), 0.5),
+                ("ZZ", (3, 0), -0.25),
+                ("XX", (2, 1), 1.0),
+                ("YZ", (4, 1), 1),
+            ],
+            num_qubits=5,
+        )
+        expected = [
+            PauliLindbladMap.GeneratorTerm(2, QubitSparsePauli(("YYX", [1, 2, 4]), 5)),
+            PauliLindbladMap.GeneratorTerm(0.5, QubitSparsePauli(("", []), 5)),
+            PauliLindbladMap.GeneratorTerm(-0.25, QubitSparsePauli(("ZZ", [0, 3]), 5)),
+            PauliLindbladMap.GeneratorTerm(1.0, QubitSparsePauli(("XX", [1, 2]), 5)),
+            PauliLindbladMap.GeneratorTerm(1, QubitSparsePauli(("ZY", [1, 4]), 5)),
+        ]
+        self.assertEqual(list(pauli_lindblad_map), expected)
+
+    def test_indexing(self):
+        pauli_lindblad_map = PauliLindbladMap.from_sparse_list(
+            [
+                ("XYY", (4, 2, 1), 2),
+                ("", (), 0.5),
+                ("ZZ", (3, 0), -0.25),
+                ("XX", (2, 1), 1.0),
+                ("YZ", (4, 1), 1),
+            ],
+            num_qubits=5,
+        )
+        expected = [
+            PauliLindbladMap.GeneratorTerm(2, QubitSparsePauli(("YYX", [1, 2, 4]), 5)),
+            PauliLindbladMap.GeneratorTerm(0.5, QubitSparsePauli(("", []), 5)),
+            PauliLindbladMap.GeneratorTerm(-0.25, QubitSparsePauli(("ZZ", [0, 3]), 5)),
+            PauliLindbladMap.GeneratorTerm(1.0, QubitSparsePauli(("XX", [1, 2]), 5)),
+            PauliLindbladMap.GeneratorTerm(1, QubitSparsePauli(("ZY", [1, 4]), 5)),
+        ]
+        self.assertEqual(pauli_lindblad_map[0], expected[0])
+        self.assertEqual(pauli_lindblad_map[-2], expected[-2])
+        self.assertEqual(pauli_lindblad_map[2:4], PauliLindbladMap(expected[2:4]))
+        self.assertEqual(pauli_lindblad_map[1::2], PauliLindbladMap(expected[1::2]))
+        self.assertEqual(pauli_lindblad_map[:], PauliLindbladMap(expected))
+        self.assertEqual(pauli_lindblad_map[-1:-4:-1], PauliLindbladMap(expected[-1:-4:-1]))
+
+    @ddt.data(
+        PauliLindbladMap.from_sparse_list([("YXZ", [2, 3, 5], -0.25)], num_qubits=6),
+        PauliLindbladMap.from_list([("YIXZII", -0.25)]),
+    )
+    def test_term_repr(self, pauli_lindblad_map):
+        # The purpose of this is just to test that the `repr` doesn't crash, rather than asserting
+        # that it has any particular form.
+        term = pauli_lindblad_map[0]
+        self.assertIsInstance(repr(term), str)
+        self.assertIn("PauliLindbladMap.GeneratorTerm", repr(term))
+
+    @ddt.data(
+        PauliLindbladMap.from_sparse_list([("YXZ", [2, 3, 5], -0.25)], num_qubits=6),
+        PauliLindbladMap.from_list([("YIXZII", -0.25)]),
+    )
+    def test_term_to_pauli_lindblad_map(self, pauli_lindblad_map):
+        self.assertEqual(pauli_lindblad_map[0].to_pauli_lindblad_map(), pauli_lindblad_map)
+        self.assertIsNot(pauli_lindblad_map[0].to_pauli_lindblad_map(), pauli_lindblad_map)
+
+    def test_term_equality(self):
+        self.assertEqual(
+            PauliLindbladMap.GeneratorTerm(1.0, QubitSparsePauli(("", []), 5)),
+            PauliLindbladMap.GeneratorTerm(1.0, QubitSparsePauli(("", []), 5)),
+        )
+        self.assertNotEqual(
+            PauliLindbladMap.GeneratorTerm(1.0, QubitSparsePauli(("", []), 5)),
+            PauliLindbladMap.GeneratorTerm(1.0, QubitSparsePauli(("", []), 8)),
+        )
+        self.assertNotEqual(
+            PauliLindbladMap.GeneratorTerm(1.0, QubitSparsePauli(("", []), 5)),
+            PauliLindbladMap.GeneratorTerm(2.0, QubitSparsePauli(("", []), 5)),
+        )
+        self.assertNotEqual(
+            PauliLindbladMap.GeneratorTerm(1.0, QubitSparsePauli(("", []), 5)),
+            PauliLindbladMap.GeneratorTerm(-1, QubitSparsePauli(("", []), 8)),
+        )
+
+        pauli_lindblad_map = PauliLindbladMap.from_list(
+            [
+                ("IIXIZ", 2),
+                ("IIZIX", 2),
+                ("XXIII", -1.5),
+                ("XYIII", -1.5),
+                ("IYIYI", 0.5),
+                ("IIYIY", 0.5),
+            ]
+        )
+        self.assertEqual(pauli_lindblad_map[0], pauli_lindblad_map[0])
+        self.assertEqual(pauli_lindblad_map[1], pauli_lindblad_map[1])
+        self.assertNotEqual(pauli_lindblad_map[0], pauli_lindblad_map[1])
+        self.assertEqual(pauli_lindblad_map[2], pauli_lindblad_map[2])
+        self.assertEqual(pauli_lindblad_map[3], pauli_lindblad_map[3])
+        self.assertNotEqual(pauli_lindblad_map[2], pauli_lindblad_map[3])
+        self.assertEqual(pauli_lindblad_map[4], pauli_lindblad_map[4])
+        self.assertEqual(pauli_lindblad_map[5], pauli_lindblad_map[5])
+        self.assertNotEqual(pauli_lindblad_map[4], pauli_lindblad_map[5])
+
+    @ddt.data(
+        PauliLindbladMap.from_sparse_list([("YXZ", [2, 3, 5], -0.25)], num_qubits=6),
+        PauliLindbladMap.from_list([("YIXZII", -0.25)]),
+    )
+    def test_term_pickle(self, pauli_lindblad_map):
+        term = pauli_lindblad_map[0]
+        self.assertEqual(pickle.loads(pickle.dumps(term)), term)
+        self.assertEqual(copy.copy(term), term)
+        self.assertEqual(copy.deepcopy(term), term)
+
+    def test_term_attributes(self):
+        term = PauliLindbladMap([("IIXIIXZ", 5.0)])[0]
+        self.assertEqual(term.num_qubits, 7)
+        self.assertEqual(term.rate, 5.0)
+        np.testing.assert_equal(
+            term.paulis,
+            np.array(
+                [
+                    QubitSparsePauli.Pauli.Z,
+                    QubitSparsePauli.Pauli.X,
+                    QubitSparsePauli.Pauli.X,
+                ],
+                dtype=np.uint8,
+            ),
+        )
+        np.testing.assert_equal(term.indices, np.array([0, 1, 4], dtype=np.uintp))
+
+        term = PauliLindbladMap.from_list([("IIXYZ", 0.5)])[0]
+        self.assertEqual(term.num_qubits, 5)
+        self.assertEqual(term.rate, 0.5)
+        self.assertEqual(
+            list(term.paulis),
+            [
+                QubitSparsePauli.Pauli.Z,
+                QubitSparsePauli.Pauli.Y,
+                QubitSparsePauli.Pauli.X,
+            ],
+        )
+        self.assertEqual(list(term.indices), [0, 1, 2])
+
+        self.assertEqual(term.qubit_sparse_pauli, QubitSparsePauli.from_label("IIXYZ"))
+
+    def test_term_new(self):
+        expected = PauliLindbladMap([("IIIXXZIII", 1.0)])[0]
+
+        self.assertEqual(
+            PauliLindbladMap.GeneratorTerm(1.0, QubitSparsePauli(("ZXX", [3, 4, 5]), 9)),
+            expected,
+        )
+
+    def test_to_sparse_list(self):
+        """Test converting to a sparse list."""
+        with self.subTest(msg="identity"):
+            pauli_lindblad_map = PauliLindbladMap.identity(100)
+            expected = []
+            self.assertEqual(expected, pauli_lindblad_map.to_sparse_list())
+
+        with self.subTest(msg="IXYZ"):
+            pauli_lindblad_map = PauliLindbladMap([("IXYZ", 1.0)])
+            expected = [("ZYX", [0, 1, 2], 1)]
+            self.assertEqual(
+                canonicalize_sparse_list(expected),
+                canonicalize_sparse_list(pauli_lindblad_map.to_sparse_list()),
+            )
+
+        with self.subTest(msg="multiple"):
+            pauli_lindblad_map = PauliLindbladMap.from_list([("XXIZ", 0.5), ("YYIZ", -1)])
+            expected = [("XXZ", [3, 2, 0], 0.5), ("ZYY", [0, 2, 3], -1)]
+            self.assertEqual(
+                canonicalize_sparse_list(expected),
+                canonicalize_sparse_list(pauli_lindblad_map.to_sparse_list()),
+            )
+
+    def test_sparse_term_pauli_labels(self):
+        """Test getting the bit labels of a SparseTerm."""
+
+        pauli_lindblad_map = PauliLindbladMap([("IXYZXYZXYZ", 1.0)])
+        term = pauli_lindblad_map[0]
+        indices = term.indices
+        labels = term.pauli_labels()
+
+        label_dict = dict(zip(indices, labels))
+        expected = dict(enumerate("ZYXZYXZYX"))
+
+        for i, label in expected.items():
+            self.assertEqual(label, label_dict[i])
+
+        reconstructed = PauliLindbladMap.from_sparse_list(
+            [(labels, indices, 1)], pauli_lindblad_map.num_qubits
+        )
+        self.assertEqual(pauli_lindblad_map, reconstructed)
+
+    def test_attributes(self):
+        pauli_lindblad_map = PauliLindbladMap.from_components(
+            [1.0, 2.0], QubitSparsePauliList(["II", "XX"])
+        )
+        self.assertEqual(
+            pauli_lindblad_map.qubit_sparse_pauli_list, QubitSparsePauliList.from_list(["II", "XX"])
+        )
+
+    def test_derived_properties(self):
+        """Test whether gamma and probabilities are correctly calculated."""
+
+        pauli_lindblad_map = PauliLindbladMap([("IXYZXYZXYZ", 1.0)])
+        w = 0.5 * (1 + np.exp(-2 * 1.0))
+        self.assertTrue(np.allclose(w, pauli_lindblad_map.probabilities[0]))
+        self.assertTrue(np.allclose(1.0, pauli_lindblad_map.gamma))
+
+        pauli_lindblad_map = PauliLindbladMap([("IXYZXYZXYZ", -1.0)])
+        w = 0.5 * (1 + np.exp(-2 * -1.0))
+        gamma = w + np.abs(1 - w)
+        prob = w / gamma
+        self.assertTrue(np.allclose(prob, pauli_lindblad_map.probabilities[0]))
+        self.assertTrue(np.allclose(gamma, pauli_lindblad_map.gamma))
+
+        pauli_lindblad_map = PauliLindbladMap([("IXYZXYZXYZ", -0.5)])
+        w = 0.5 * (1 + np.exp(-2 * -0.5))
+        gamma = w + np.abs(1 - w)
+        prob = w / gamma
+        self.assertTrue(np.allclose(prob, pauli_lindblad_map.probabilities[0]))
+        self.assertTrue(np.allclose(gamma, pauli_lindblad_map.gamma))
+
+        pauli_lindblad_map = PauliLindbladMap(
+            [("IXYZXYZXYZ", -1.0), ("IXYZXYZXYZ", 1.0), ("IXYZXYZXYZ", -0.5)]
+        )
+        rates = np.array([-1.0, 1.0, -0.5])
+        w = 0.5 * (1 + np.exp(-2 * rates))
+        gammas = w + np.abs(1 - w)
+        probs = w / gammas
+        gamma = np.prod(gammas)
+        self.assertTrue(np.allclose(probs, pauli_lindblad_map.probabilities))
+        self.assertTrue(np.allclose(gamma, pauli_lindblad_map.gamma))
+
+
+def canonicalize_term(pauli, indices, rate):
+    # canonicalize a sparse list term by sorting by indices (which is unique as
+    # indices cannot be repeated)
+    idcs = np.argsort(indices)
+    sorted_paulis = "".join(pauli[i] for i in idcs)
+    return (sorted_paulis, np.asarray(indices)[idcs].tolist(), float(rate))
+
+
+def canonicalize_sparse_list(sparse_list):
+    # sort a sparse list representation by canonicalizing the terms and then applying
+    # Python's built-in sort
+    canonicalized_terms = [canonicalize_term(*term) for term in sparse_list]
+    return sorted(canonicalized_terms)

--- a/test/python/quantum_info/test_pauli_lindblad_map.py
+++ b/test/python/quantum_info/test_pauli_lindblad_map.py
@@ -343,17 +343,17 @@ class TestPauliLindbladMap(QiskitTestCase):
     def test_identity(self):
         identity_5 = PauliLindbladMap.identity(5)
         self.assertEqual(identity_5.num_qubits, 5)
-        self.assertEqual(identity_5.gamma, 1.0)
+        self.assertEqual(identity_5.get_gamma(), 1.0)
         self.assertEqual(identity_5.num_terms, 0.0)
         np.testing.assert_equal(identity_5.rates, np.array([], dtype=float))
-        np.testing.assert_equal(identity_5.probabilities, np.array([], dtype=float))
+        np.testing.assert_equal(identity_5.get_probabilities(), np.array([], dtype=float))
 
         identity_0 = PauliLindbladMap.identity(0)
         self.assertEqual(identity_0.num_qubits, 0)
-        self.assertEqual(identity_0.gamma, 1.0)
+        self.assertEqual(identity_0.get_gamma(), 1.0)
         self.assertEqual(identity_0.num_terms, 0.0)
         np.testing.assert_equal(identity_0.rates, np.array([], dtype=float))
-        np.testing.assert_equal(identity_0.probabilities, np.array([], dtype=float))
+        np.testing.assert_equal(identity_0.get_probabilities(), np.array([], dtype=float))
 
     def test_len(self):
         self.assertEqual(len(PauliLindbladMap.identity(0)), 0)
@@ -451,14 +451,10 @@ class TestPauliLindbladMap(QiskitTestCase):
         pauli_lindblad_map = PauliLindbladMap.from_list([("XZY", 1.5), ("XXY", -0.5)])
         with self.assertRaisesRegex(AttributeError, "attribute 'rates'"):
             pauli_lindblad_map.rates = 1.0
-        with self.assertRaisesRegex(AttributeError, "attribute 'gamma'"):
-            pauli_lindblad_map.gamma = 1.0
-        with self.assertRaisesRegex(AttributeError, "attribute 'probabilities'"):
-            pauli_lindblad_map.probabilities = 1.0
         with self.assertRaisesRegex(ValueError, "assignment destination is read-only"):
             pauli_lindblad_map.rates[0] = 1.0
         with self.assertRaisesRegex(ValueError, "assignment destination is read-only"):
-            pauli_lindblad_map.probabilities[0] = 1.0
+            pauli_lindblad_map.get_probabilities()[0] = 1.0
 
     @ddt.idata(single_cases())
     def test_clear(self, pauli_lindblad_map):
@@ -668,7 +664,7 @@ class TestPauliLindbladMap(QiskitTestCase):
             [1.0, 2.0], QubitSparsePauliList(["II", "XX"])
         )
         self.assertEqual(
-            pauli_lindblad_map.qubit_sparse_pauli_list, QubitSparsePauliList.from_list(["II", "XX"])
+            pauli_lindblad_map.get_qubit_sparse_pauli_list_copy(), QubitSparsePauliList.from_list(["II", "XX"])
         )
 
     def test_derived_properties(self):
@@ -676,22 +672,22 @@ class TestPauliLindbladMap(QiskitTestCase):
 
         pauli_lindblad_map = PauliLindbladMap([("IXYZXYZXYZ", 1.0)])
         w = 0.5 * (1 + np.exp(-2 * 1.0))
-        self.assertTrue(np.allclose(w, pauli_lindblad_map.probabilities[0]))
-        self.assertTrue(np.allclose(1.0, pauli_lindblad_map.gamma))
+        self.assertTrue(np.allclose(w, pauli_lindblad_map.get_probabilities()[0]))
+        self.assertTrue(np.allclose(1.0, pauli_lindblad_map.get_gamma()))
 
         pauli_lindblad_map = PauliLindbladMap([("IXYZXYZXYZ", -1.0)])
         w = 0.5 * (1 + np.exp(-2 * -1.0))
         gamma = w + np.abs(1 - w)
         prob = w / gamma
-        self.assertTrue(np.allclose(prob, pauli_lindblad_map.probabilities[0]))
-        self.assertTrue(np.allclose(gamma, pauli_lindblad_map.gamma))
+        self.assertTrue(np.allclose(prob, pauli_lindblad_map.get_probabilities()[0]))
+        self.assertTrue(np.allclose(gamma, pauli_lindblad_map.get_gamma()))
 
         pauli_lindblad_map = PauliLindbladMap([("IXYZXYZXYZ", -0.5)])
         w = 0.5 * (1 + np.exp(-2 * -0.5))
         gamma = w + np.abs(1 - w)
         prob = w / gamma
-        self.assertTrue(np.allclose(prob, pauli_lindblad_map.probabilities[0]))
-        self.assertTrue(np.allclose(gamma, pauli_lindblad_map.gamma))
+        self.assertTrue(np.allclose(prob, pauli_lindblad_map.get_probabilities()[0]))
+        self.assertTrue(np.allclose(gamma, pauli_lindblad_map.get_gamma()))
 
         pauli_lindblad_map = PauliLindbladMap(
             [("IXYZXYZXYZ", -1.0), ("IXYZXYZXYZ", 1.0), ("IXYZXYZXYZ", -0.5)]
@@ -701,8 +697,8 @@ class TestPauliLindbladMap(QiskitTestCase):
         gammas = w + np.abs(1 - w)
         probs = w / gammas
         gamma = np.prod(gammas)
-        self.assertTrue(np.allclose(probs, pauli_lindblad_map.probabilities))
-        self.assertTrue(np.allclose(gamma, pauli_lindblad_map.gamma))
+        self.assertTrue(np.allclose(probs, pauli_lindblad_map.get_probabilities()))
+        self.assertTrue(np.allclose(gamma, pauli_lindblad_map.get_gamma()))
 
 
 def canonicalize_term(pauli, indices, rate):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This is the second PR in a series of 3 introducing `QubitSparsePauli`, `QubitSparsePauliList`, and `PauliLindbladMap`. The first PR, which this PR depends on, is #14283 .

This introduces the data structure of the class `PauliLindladMap`, building on `QubitSparsePauliList`.

### Details and comments

This depends on #14283 
