### PR TITLE
Fix clippy issues with latest clippy in parameter expression

### DIFF
--- a/crates/circuit/src/parameter_expression.rs
+++ b/crates/circuit/src/parameter_expression.rs
@@ -52,10 +52,8 @@ fn _extract_value(value: &Bound<PyAny>) -> Option<ParameterExpression> {
         } else {
             None
         }
-    } else if let Ok(e) = value.extract::<ParameterExpression>() {
-        Some(e)
     } else {
-        None
+        value.extract::<ParameterExpression>().ok()
     }
 }
 

--- a/crates/circuit/src/symbol_expr.rs
+++ b/crates/circuit/src/symbol_expr.rs
@@ -182,10 +182,10 @@ impl fmt::Display for SymbolExpr {
                         UnaryOp::Abs => format!("abs({})", s),
                         UnaryOp::Neg => match expr.as_ref() {
                             SymbolExpr::Value(e) => (-e).to_string(),
-                            SymbolExpr::Binary { op: eop, .. } => match eop {
-                                BinaryOp::Add | BinaryOp::Sub => format!("-({})", s),
-                                _ => format!("-{}", s),
-                            },
+                            SymbolExpr::Binary {
+                                op: BinaryOp::Add | BinaryOp::Sub,
+                                ..
+                            } => format!("-({})", s),
                             _ => format!("-{}", s),
                         },
                         UnaryOp::Sin => format!("sin({})", s),
@@ -880,13 +880,10 @@ impl SymbolExpr {
     pub fn abs(&self) -> SymbolExpr {
         match self {
             SymbolExpr::Value(l) => SymbolExpr::Value(l.abs()),
-            SymbolExpr::Unary { op, expr } => match op {
-                UnaryOp::Abs | UnaryOp::Neg => expr.abs(),
-                _ => SymbolExpr::Unary {
-                    op: UnaryOp::Abs,
-                    expr: Box::new(self.clone()),
-                },
-            },
+            SymbolExpr::Unary {
+                op: UnaryOp::Abs | UnaryOp::Neg,
+                expr,
+            } => expr.abs(),
             _ => SymbolExpr::Unary {
                 op: UnaryOp::Abs,
                 expr: Box::new(self.clone()),


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes some small clippy issues that are flagged in the recently merged symbol_expr.rs and parameter_expression.rs modules. This doesn't show up in CI because we run clippy with our MSRV to avoid spurious failure on new releases. But if you're running clippy locally with a newer release of Rust these issues will be flagged. They're mostly just code style where there is a more concise syntax available.

### Details and comments