### PR TITLE
Remove dateutil as a requirement

### DIFF
--- a/releasenotes/notes/no-dateutil-ca2ca5f5a75fbb22.yaml
+++ b/releasenotes/notes/no-dateutil-ca2ca5f5a75fbb22.yaml
@@ -2,7 +2,7 @@
 upgrade:
   - |
     The ``python-dateutil`` library is no longer a dependency of Qiskit. Since
-    Qiskit 2.0.0 nothing in the library wa actively using the library anymore
+    Qiskit 2.0.0 nothing in the library was actively using the library anymore
     and Qiskit didn't actually depend on the library anymore. This release
     removes it from the dependency list so it is not automatically installed
     as a prerequisite anymore. If you were relying on Qiskit to install

--- a/releasenotes/notes/no-dateutil-ca2ca5f5a75fbb22.yaml
+++ b/releasenotes/notes/no-dateutil-ca2ca5f5a75fbb22.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - |
+    The ``python-dateutil`` library is no longer a dependency of Qiskit. Since
+    Qiskit 2.0.0 nothing in the library wa actively using the library anymore
+    and Qiskit didn't actually depend on the library anymore. This release
+    removes it from the dependency list so it is not automatically installed
+    as a prerequisite anymore. If you were relying on Qiskit to install
+    dateutil for you as a dependency you will now need to ensure you're manually
+    installing it (which is best practice for direct dependencies).

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,10 @@ numpy>=1.17,<3
 scipy>=1.5
 sympy>=1.3
 dill>=0.3
-python-dateutil>=2.8.0
 stevedore>=3.0.0
 typing-extensions
 
-# If updating the version range here, consider updating the 
+# If updating the version range here, consider updating the
 # list of symengine dependencies used in the cross-version tests
 # in 'test/qpy_compat/run_tests.sh' and 'test/qpy_compat/qpy_test_constraints.txt'
 symengine>=0.11,<0.14


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The dateutil package was previously used by the BackendV1 models to parse datetime information that was passed into the from_dict() constructors for those objects. Since Qiskit 2.0.0 those objects haven't been part of Qiskit anymore as BackendV1 was removed in that release following it's deprecation period nothing is using the library anymore in Qiskit. However the dateutil library was not removed as a dependency at the time of removal. This commit corrects the oversight and removes the library as a dependency.

### Details and comments