### PR TITLE
Fix binary value for `QkBitTerm_Left` in documentation

### DIFF
--- a/docs/cdoc/qk-bit-term.rst
+++ b/docs/cdoc/qk-bit-term.rst
@@ -48,7 +48,7 @@ Values
 * ``QkBitTerm_Left``
    The projector :math:`\lvert l\rangle\langle l\rvert` to the negative :math:`Y` eigenstate.
   
-   Value: 7 (``0b1011``)
+   Value: 7 (``0b0111``)
 
 * ``QkBitTerm_Zero``
    The projector :math:`\lvert 0\rangle\langle 0\rvert` to the positive :math:`Z` eigenstate.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This fixes a typo I noticed.  It was already correctly stated in `docs/cdoc/qk-obs.rst`. 

### Details and comments


