### PR TITLE
Added support for querying version information in the Qiskit C API.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,6 +1473,7 @@ dependencies = [
  "pyo3",
  "qiskit-accelerate",
  "qiskit-circuit",
+ "regex",
  "thiserror 2.0.12",
 ]
 

--- a/crates/cext/Cargo.toml
+++ b/crates/cext/Cargo.toml
@@ -24,6 +24,7 @@ pyo3 = { workspace = true, optional = true }
 
 [build-dependencies]
 cbindgen = "0.28"
+regex = "1"
 
 [features]
 default = ["cbinding"]

--- a/crates/cext/build.rs
+++ b/crates/cext/build.rs
@@ -10,9 +10,58 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use std::fs;
 use std::str::FromStr;
 
 extern crate cbindgen;
+
+/// This function generates the version.h file from the VERSION.txt file information.
+fn generate_version_header() {
+    //Reading the version string from the VERSION.txt file.
+    let version_file_path = "../../qiskit/VERSION.txt";
+    let version_h_file_path = "../../dist/c/include/version.h";
+    let qiskit_version = fs::read_to_string(version_file_path)
+        .expect("Failed to read VERSION.txt file!")
+        .trim()
+        .to_string();
+
+    // Obtain the major, minor and patch version numbers.
+    let mut part = qiskit_version.split('.');
+    let major = part.next().unwrap_or("0");
+    let minor = part.next().unwrap_or("0");
+    let patch = part.next().unwrap_or("0");
+
+    // Read the existing version.h content
+    let mut version_h_content = fs::read_to_string(version_h_file_path).unwrap();
+
+    // Define the regex patterns to match the version lines in version.h
+    use regex::Regex;
+    let re_major = Regex::new(r#"#define QISKIT_VERSION_MAJOR.*"#).unwrap();
+    let re_minor = Regex::new(r#"#define QISKIT_VERSION_MINOR.*"#).unwrap();
+    let re_patch = Regex::new(r#"#define QISKIT_VERSION_PATCH.*"#).unwrap();
+
+    // Replace the version lines with the new version numbers and write to version.h
+    version_h_content = re_major
+        .replace_all(
+            &version_h_content,
+            format!("#define QISKIT_VERSION_MAJOR {}", major),
+        )
+        .to_string();
+    version_h_content = re_minor
+        .replace_all(
+            &version_h_content,
+            format!("#define QISKIT_VERSION_MINOR {}", minor),
+        )
+        .to_string();
+    version_h_content = re_patch
+        .replace_all(
+            &version_h_content,
+            format!("#define QISKIT_VERSION_PATCH {}", patch),
+        )
+        .to_string();
+
+    fs::write(version_h_file_path, version_h_content).expect("Failed to write version.h file!");
+}
 
 /// This function generates the C header for Qiskit from the qiskit-cext crate.
 fn generate_qiskit_header() {
@@ -38,5 +87,6 @@ fn generate_qiskit_header() {
 }
 
 fn main() {
+    generate_version_header();
     generate_qiskit_header();
 }

--- a/crates/cext/cbindgen.toml
+++ b/crates/cext/cbindgen.toml
@@ -10,6 +10,9 @@ after_includes = """
     #include <Python.h>
 #endif
 
+// Qiskit version information
+#include "version.h"
+
 // Complex number typedefs -- note these are memory aligned but
 // not calling convention compatible.
 #ifdef __cplusplus

--- a/test/c/test_version_info.c
+++ b/test/c/test_version_info.c
@@ -1,0 +1,22 @@
+#include "common.h"
+
+// Test that QISKIT_VERSION_MAJOR, _MINOR, _PATCH are defined and print them
+int test_version_macros()
+{
+    printf("Qiskit version: %d.%d.%d\n", QISKIT_VERSION_MAJOR, QISKIT_VERSION_MINOR, QISKIT_VERSION_PATCH);
+    if (QISKIT_VERSION_MAJOR < 0 || QISKIT_VERSION_MINOR < 0 || QISKIT_VERSION_PATCH < 0) {
+        return EqualityError;
+    }
+    return Ok;
+}
+
+// Main test function
+int test_version_info()
+{
+    int num_failed = 0;
+    num_failed += RUN_TEST(test_version_macros);
+
+    fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);
+    fflush(stderr);
+    return num_failed;
+}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

- Updated the Qiskit C extension to enable querying the Qiskit major, minor and patch version information.
- This fixes the following open issue: https://github.com/Qiskit/qiskit/issues/14280

### Details and comments

The approach used includes the following changes:
1) Adds a file called `version.h` in the directory `dist/c/include` having macros for the version information.
2) Includes the `version.h` macros in the `qiskit.h` file generated for the C API calls (added through the `cbindgen.toml` file within `crates/cext`).
3) The version information is populated into the `version.h` file by reading the `VERSION.txt` file within the `qiskit` subdirectory by the `build.rs` code via regex matching and replacement at compile time (for this an additional build dependency `regex = "1"` was added to the `Cargo.toml` file in the `cext` crate). The removes the need to update the header for every new release.

- All code was formatted via `cargo fmt` and passed the `tox -elint` 
- The modified branch was tested and validated via the `test_version_info.c` file in the `test/c` directory.