### PR TITLE
Fix ConsolidateBlocks pass for collecting non-CX KAK gate

### DIFF
--- a/releasenotes/notes/fix-consolidate-blocks-e2421dd2408403eb.yaml
+++ b/releasenotes/notes/fix-consolidate-blocks-e2421dd2408403eb.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed an issue in the :class:`.ConsolidateBlocks` transpiler pass where it
+    would fail to consolidate some blocks if the KAK gate selected (either
+    directly or via the target) is supercontrolled and not :class:`.CXGate`.
+    Fixed `#14413 <https://github.com/Qiskit/qiskit/issues/14413>`__


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

A bug was introduced into the ConsolidateBlocks pass in #13884 around how the KAK gate name was passed to rust from the Python pass. The consolidate blocks internal logic around whether to consolidate a pass or not is based on the estimate from the selected decomposer of whether the estimated number of gates used to synthesis the unitary would exceed the number of basis gates in the block. To do this the pass counts the gate with the synthesis target name in the block. However, in the case of the decomposer being the TwoQubitBasisDecomposer the name being used for this look wasn't the name of the gate, but instead was an internal sentinel value string "USER_GATE" which is used to handle arbitrary user gate definitions in the decomposer. This led to the consolidate blocks pass missing opportunities for consolidation. This commit fixes the oversight so that the name we use for making this determination is the actual basis gate name and the pass functions correctly.

### Details and comments

Fixes #14413