### PR TITLE
Clifford unitary synthesis plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ Changelog = "https://docs.quantum.ibm.com/api/qiskit/release-notes"
 default = "qiskit.transpiler.passes.synthesis.default_unitary_synth_plugin:DefaultUnitarySynthesis"
 aqc = "qiskit.transpiler.passes.synthesis.aqc_plugin:AQCSynthesisPlugin"
 sk = "qiskit.transpiler.passes.synthesis.solovay_kitaev_synthesis:SolovayKitaevSynthesis"
+clifford = "qiskit.transpiler.passes.synthesis.clifford_unitary_synth_plugin:CliffordUnitarySynthesis"
 
 [project.entry-points."qiskit.synthesis"]
 "clifford.default" = "qiskit.transpiler.passes.synthesis.hls_plugins:DefaultSynthesisClifford"

--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -244,6 +244,7 @@ from .synthesis import HighLevelSynthesis
 from .synthesis import HLSConfig
 from .synthesis import SolovayKitaev
 from .synthesis import SolovayKitaevSynthesis
+from .synthesis import CliffordUnitarySynthesis
 from .synthesis import AQCSynthesisPlugin
 
 # circuit scheduling

--- a/qiskit/transpiler/passes/synthesis/__init__.py
+++ b/qiskit/transpiler/passes/synthesis/__init__.py
@@ -17,4 +17,5 @@ from .plugin import high_level_synthesis_plugin_names, unitary_synthesis_plugin_
 from .linear_functions_synthesis import LinearFunctionsToPermutations
 from .high_level_synthesis import HighLevelSynthesis, HLSConfig
 from .solovay_kitaev_synthesis import SolovayKitaev, SolovayKitaevSynthesis
+from .clifford_unitary_synth_plugin import CliffordUnitarySynthesis
 from .aqc_plugin import AQCSynthesisPlugin

--- a/qiskit/transpiler/passes/synthesis/clifford_unitary_synth_plugin.py
+++ b/qiskit/transpiler/passes/synthesis/clifford_unitary_synth_plugin.py
@@ -1,0 +1,123 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+=================================
+Clifford Unitary Synthesis Plugin
+=================================
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   CliffordUnitarySynthesis
+"""
+
+from __future__ import annotations
+
+import math
+
+from qiskit.exceptions import QiskitError
+from qiskit.converters import circuit_to_dag
+from qiskit.quantum_info import Operator, Clifford
+from qiskit.quantum_info.operators.predicates import matrix_equal
+
+from .plugin import UnitarySynthesisPlugin
+
+
+class CliffordUnitarySynthesis(UnitarySynthesisPlugin):
+    """A Clifford unitary synthesis plugin.
+
+    The plugin is invoked by the :class:`.UnitarySynthesis` transpiler pass
+    when the parameter ``method`` is set to ``"clifford"``.
+
+    The plugin checks if the given unitary can be represented by a Clifford,
+    in which case it returns a circuit implementing this unitary and
+    consisting only of Clifford gates.
+
+    In addition, the parameter ``plugin_config`` of :class:`.UnitarySynthesis`
+    can be used to pass the following plugin-specific parameters:
+
+    * min_qubits: the minumum number of qubits to consider (the default value is 1).
+
+    * max_qubits: the maximum number of qubits to consider (the defauly value is 3).
+
+    """
+
+    @property
+    def max_qubits(self):
+        return None
+
+    @property
+    def min_qubits(self):
+        return None
+
+    @property
+    def supports_basis_gates(self):
+        return False
+
+    @property
+    def supports_coupling_map(self):
+        return False
+
+    @property
+    def supports_natural_direction(self):
+        return False
+
+    @property
+    def supports_pulse_optimize(self):
+        return False
+
+    @property
+    def supports_gate_lengths(self):
+        return False
+
+    @property
+    def supports_gate_errors(self):
+        return False
+
+    @property
+    def supported_bases(self):
+        return None
+
+    def run(self, unitary, **options):
+        """Run the CliffordUnitarySynthesis plugin on the given unitary."""
+
+        config = options.get("config") or {}
+
+        min_qubits = config.get("min_qubits", 1)
+        max_qubits = config.get("max_qubits", 3)
+
+        num_qubits = int(math.log2(unitary.shape[0]))
+
+        dag = None
+        if min_qubits <= num_qubits <= max_qubits:
+            try:
+                # Attempts to construct a Clifford from a unitary
+                # (raises a QiskitError if this is not possible)
+                cliff = Clifford.from_matrix(unitary)
+
+                circuit = cliff.to_circuit()
+
+                # Constructing Clifford from a unitary discards the global phase,
+                # so we need to reconstruct it.
+                props = {}
+                if not matrix_equal(
+                    unitary, Operator(circuit)._data, ignore_phase=True, props=props
+                ):
+                    raise QiskitError("Clifford synthesis is incorrect")
+                circuit.global_phase -= props["phase_difference"]
+
+                dag = circuit_to_dag(circuit)
+            except QiskitError:
+                pass
+
+        return dag

--- a/qiskit/transpiler/passes/synthesis/clifford_unitary_synth_plugin.py
+++ b/qiskit/transpiler/passes/synthesis/clifford_unitary_synth_plugin.py
@@ -48,7 +48,7 @@ class CliffordUnitarySynthesis(UnitarySynthesisPlugin):
 
     * min_qubits: the minumum number of qubits to consider (the default value is 1).
 
-    * max_qubits: the maximum number of qubits to consider (the defauly value is 3).
+    * max_qubits: the maximum number of qubits to consider (the default value is 3).
 
     """
 

--- a/qiskit/transpiler/preset_passmanagers/common.py
+++ b/qiskit/transpiler/preset_passmanagers/common.py
@@ -532,6 +532,9 @@ def generate_translation_passmanager(
                 approximation_degree=approximation_degree,
                 force_consolidate=True,
             ),
+            # We use the "clifford" unitary synthesis plugin to replace single-qubit
+            # unitary gates that can be represented as Cliffords by Clifford gates.
+            UnitarySynthesis(method="clifford", plugin_config={"max_qubits": 1}),
             # We use the Solovay-Kitaev decomposition via the plugin mechanism for "sk"
             # UnitarySynthesisPlugin.
             UnitarySynthesis(

--- a/releasenotes/notes/qiskit-unitary-synthesis-plugin-8ae54f82a65a09a3.yaml
+++ b/releasenotes/notes/qiskit-unitary-synthesis-plugin-8ae54f82a65a09a3.yaml
@@ -1,0 +1,57 @@
+---
+features_transpiler:
+  - |
+    Added a new unitary synthesis plugin :class:`.CliffordUnitarySynthesis` that
+    attempts to syntesize a given unitary gate by checking if it can be represented
+    by a Clifford, in which case it returns a circuit implementing this unitary and
+    consisting only of Clifford gates.
+    
+    The plugin is invoked by the :class:`.UnitarySynthesis` transpiler pass
+    when the parameter ``method`` is set to ``"clifford"``.
+
+    In addition, the parameter ``plugin_config`` of :class:`.UnitarySynthesis`
+    can be used to pass the following plugin-specific parameters:
+
+    * min_qubits: the minumum number of qubits to consider (the default value is 1).
+    * max_qubits: the maximum number of qubits to consider (the defauly value is 3).
+
+    For example::
+
+      import math
+
+      from qiskit.circuit import QuantumCircuit
+      from qiskit.circuit.library import UnitaryGate
+      from qiskit.quantum_info import Operator
+      from qiskit.transpiler.passes import UnitarySynthesis
+
+      # clifford unitary over 2 qubits
+      c2 = QuantumCircuit(2)
+      c2.h(0)
+      c2.rz(math.pi / 4, 1)
+      c2.rz(math.pi / 4, 1)
+      c2.sdg(1)
+      uc2 = UnitaryGate(Operator(c2).data)
+
+      # non-clifford unitary over 2 qubits
+      n2 = QuantumCircuit(2)
+      n2.h(0)
+      n2.rz(math.pi / 4, 1)
+      n2.sdg(1)
+      un2 = UnitaryGate(Operator(n2).data)
+
+      # quantum circuit with two unitary gates
+      qc = QuantumCircuit(3)
+      qc.append(uc2, [2, 1])
+      qc.append(un2, [0, 2])
+
+      transpiled = UnitarySynthesis(method="clifford")(qc)
+
+    Executing the code above resynthesized the first unitary gate into 
+    Clifford gates, while the second gate remains unchanged.
+
+    If we modify the example above as follows::
+
+      config = {"min_qubits": 3}
+      transpiled = UnitarySynthesis(method="clifford", plugin_config=config)(qc)
+
+    then both unitary gates remain unchanged.

--- a/releasenotes/notes/qiskit-unitary-synthesis-plugin-8ae54f82a65a09a3.yaml
+++ b/releasenotes/notes/qiskit-unitary-synthesis-plugin-8ae54f82a65a09a3.yaml
@@ -13,7 +13,7 @@ features_transpiler:
     can be used to pass the following plugin-specific parameters:
 
     * min_qubits: the minumum number of qubits to consider (the default value is 1).
-    * max_qubits: the maximum number of qubits to consider (the defauly value is 3).
+    * max_qubits: the maximum number of qubits to consider (the default value is 3).
 
     For example::
 

--- a/test/python/transpiler/test_clifford_synthesis_plugin.py
+++ b/test/python/transpiler/test_clifford_synthesis_plugin.py
@@ -1,0 +1,204 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test the 'clifford' unitary synthesis plugin."""
+
+import math
+
+from qiskit.circuit import QuantumCircuit
+from qiskit.circuit.library import UnitaryGate
+from qiskit.converters import dag_to_circuit
+from qiskit.quantum_info import Operator, get_clifford_gate_names
+from qiskit.transpiler.passes import UnitarySynthesis, CliffordUnitarySynthesis
+from test import QiskitTestCase  # pylint: disable=wrong-import-order
+
+
+class TestCliffordSynthesis(QiskitTestCase):
+    """Test the 'clifford' unitary synthesis plugin."""
+
+    def setUp(self):
+        super().setUp()
+        self._create_unitaries()
+
+    def _create_unitaries(self):
+        """
+        Creates unitary gates of varying sizes, some of which can be represented
+        as Cliffords and some of which cannot.
+        """
+
+        # clifford unitary over 1 qubit
+        c1 = QuantumCircuit(1)
+        c1.h(0)
+        c1.s(0)
+        self.uc1 = UnitaryGate(Operator(c1).data)
+
+        # clifford unitary over 2 qubits
+        c2 = QuantumCircuit(2)
+        c2.h(0)
+        c2.rz(math.pi / 4, 1)
+        c2.rz(math.pi / 4, 1)
+        c2.sdg(1)
+        self.uc2 = UnitaryGate(Operator(c2).data)
+
+        # clifford unitary over 3 qubits
+        c3 = QuantumCircuit(3)
+        c3.h(0)
+        c3.cx(0, 1)
+        c3.cx(1, 2)
+        c3.rx(math.pi / 2, 2)
+        self.uc3 = UnitaryGate(Operator(c3).data)
+
+        # non-clifford unitary over 1 qubit
+        n1 = QuantumCircuit(1)
+        n1.h(0)
+        n1.rz(0.8, 0)
+        self.un1 = UnitaryGate(Operator(n1).data)
+
+        # non-clifford unitary over 2 qubits
+        n2 = QuantumCircuit(2)
+        n2.h(0)
+        n2.rz(math.pi / 4, 1)
+        n2.sdg(1)
+        self.un2 = UnitaryGate(Operator(n2).data)
+
+        # non-clifford unitary over 3 qubits
+        n3 = QuantumCircuit(3)
+        n3.h(0)
+        n3.cx(0, 1)
+        n3.cx(1, 2)
+        n3.rx(0.8, 2)
+        self.un3 = UnitaryGate(Operator(n3).data)
+
+    def test_plugin(self):
+        """Test running CliffordUnitarySynthesis plugin directly."""
+
+        plugin = CliffordUnitarySynthesis()
+        clifford_gate_names = set(get_clifford_gate_names())
+
+        with self.subTest(msg="uc1"):
+            mat = self.uc1.to_matrix()
+            out = plugin.run(mat)
+            self.assertLessEqual(set(out.count_ops()), clifford_gate_names)
+            self.assertEqual(Operator(dag_to_circuit(out)), Operator(mat))
+
+        with self.subTest(msg="uc2"):
+            mat = self.uc2.to_matrix()
+            out = plugin.run(mat)
+            self.assertLessEqual(set(out.count_ops()), clifford_gate_names)
+            self.assertEqual(Operator(dag_to_circuit(out)), Operator(mat))
+
+        with self.subTest(msg="uc3"):
+            mat = self.uc3.to_matrix()
+            out = plugin.run(mat)
+            self.assertLessEqual(set(out.count_ops()), clifford_gate_names)
+            self.assertEqual(Operator(dag_to_circuit(out)), Operator(mat))
+
+        with self.subTest(msg="un1"):
+            out = plugin.run(self.un1.to_matrix())
+            self.assertIsNone(out)
+
+        with self.subTest(msg="un2"):
+            out = plugin.run(self.un2.to_matrix())
+            self.assertIsNone(out)
+
+        with self.subTest(msg="un3"):
+            out = plugin.run(self.un3.to_matrix())
+            self.assertIsNone(out)
+
+    def test_plugin_with_parameters(self):
+        """Test that we can pass parameters to the plugin."""
+
+        plugin = CliffordUnitarySynthesis()
+
+        with self.subTest(msg="min_qubits=2"):
+            config = {"min_qubits": 2}
+            mat = self.uc1.to_matrix()
+            out = plugin.run(mat, config=config)
+            self.assertIsNone(out)
+
+        with self.subTest(msg="max_qubits=2"):
+            config = {"max_qubits": 2}
+            mat = self.uc3.to_matrix()
+            out = plugin.run(mat, config=config)
+            self.assertIsNone(out)
+
+    def test_unitary_synthesis(self):
+        """Test running the plugin from the unitary synthesis transpiler pass."""
+
+        clifford_gate_names = set(get_clifford_gate_names())
+
+        with self.subTest(msg="uc1"):
+            qc = QuantumCircuit(3)
+            qc.append(self.uc1, [1])
+            transpiled = UnitarySynthesis(method="clifford")(qc)
+            transpiled_ops = transpiled.count_ops()
+            self.assertEqual(transpiled_ops.get("unitary", 0), 0)
+            self.assertLessEqual(set(transpiled_ops), clifford_gate_names)
+            self.assertEqual(Operator(transpiled), Operator(qc))
+
+        with self.subTest(msg="uc2"):
+            qc = QuantumCircuit(3)
+            qc.append(self.uc2, [1, 2])
+            transpiled = UnitarySynthesis(method="clifford")(qc)
+            transpiled_ops = transpiled.count_ops()
+            self.assertEqual(transpiled_ops.get("unitary", 0), 0)
+            self.assertLessEqual(set(transpiled_ops), clifford_gate_names)
+            self.assertEqual(Operator(transpiled), Operator(qc))
+
+        with self.subTest(msg="uc3"):
+            qc = QuantumCircuit(3)
+            qc.append(self.uc3, [2, 0, 1])
+            transpiled = UnitarySynthesis(method="clifford")(qc)
+            transpiled_ops = transpiled.count_ops()
+            self.assertEqual(transpiled_ops.get("unitary", 0), 0)
+            self.assertLessEqual(set(transpiled_ops), clifford_gate_names)
+            self.assertEqual(Operator(transpiled), Operator(qc))
+
+        with self.subTest(msg="un1"):
+            qc = QuantumCircuit(3)
+            qc.append(self.un1, [1])
+            # the circuit should be unchanged
+            transpiled = UnitarySynthesis(method="clifford")(qc)
+            self.assertEqual(qc, transpiled)
+
+        with self.subTest(msg="un2"):
+            qc = QuantumCircuit(3)
+            qc.append(self.un2, [1, 2])
+            # the circuit should be unchanged
+            transpiled = UnitarySynthesis(method="clifford")(qc)
+            self.assertEqual(qc, transpiled)
+
+        with self.subTest(msg="un3"):
+            qc = QuantumCircuit(3)
+            qc.append(self.un3, [2, 0, 1])
+            # the circuit should be unchanged
+            transpiled = UnitarySynthesis(method="clifford")(qc)
+            self.assertEqual(qc, transpiled)
+
+    def test_unitary_synthesis_with_parameters(self):
+        """Test that we can pass parameters to the plugin via unitary synthesis."""
+
+        with self.subTest(msg="min_qubits=2"):
+            config = {"min_qubits": 2}
+            qc = QuantumCircuit(3)
+            qc.append(self.uc1, [1])
+            transpiled = UnitarySynthesis(method="clifford", plugin_config=config)(qc)
+            # the circuit should be unchanged
+            self.assertEqual(qc, transpiled)
+
+        with self.subTest(msg="max_qubits=2"):
+            config = {"max_qubits": 2}
+            qc = QuantumCircuit(3)
+            qc.append(self.uc3, [2, 0, 1])
+            transpiled = UnitarySynthesis(method="clifford", plugin_config=config)(qc)
+            # the circuit should be unchanged
+            self.assertEqual(qc, transpiled)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This PR implements a new unitary synthesis plugin that checks whether a given unitary gate secretly happens to be a Clifford (such as, for example, an Rx-rotation by $\pi/2$). If so, a circuit implementing this unitary and consisting of only Clifford gates is returned. Otherwise, the unitary gate remains unchanged.

The new plugin is also integrated into the translation stage of the Clifford+T pipeline (see #14225): after collecting runs of single-qubit gates into single-qubit unitaries, we now first run the plugin (attempting to find a sequence of Clifford gates that exactly implement this unitary) and only then run the Solovay-Kitaev approximation algorithm.

### Details and comments

In particular, this avoids running the Solovay-Kitaev algorithm on "secretly Clifford" gates (which, for example, includes both S and RX($\pi/2$)). This also allows to strengthen the Clifford tests from #14225: each "secretly Clifford" gate should be synthesized to only Clifford basic gates, which BasisTranslator should then translate to the target basis set. (Note that when the target basis set includes both H and S, the rules in our equivalence library enable to do the translation without introducing T-gates).

In principle we already have a somewhat related `CollectCliffords` pass in Qiskit, which could replace unitary gates by Clifford objects, which we could then synthesize using HighLevelSynthesis. However, this approach has a fundamental problem: replacing unitary gates by ``Clifford``s discards global phase, thus changing the circuit. The current approach avoids this because the plugin returns an actual circuit (consisting of clifford gates) and explicitly takes care of the global phase to make sure the unitary operator does not change.