### PR TITLE
Fix more spurious complex parts in circuit functions

### DIFF
--- a/qiskit/circuit/library/n_local/evolved_operator_ansatz.py
+++ b/qiskit/circuit/library/n_local/evolved_operator_ansatz.py
@@ -27,6 +27,7 @@ from qiskit.circuit import QuantumRegister
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.quantum_info import Operator, Pauli, SparsePauliOp
 from qiskit.quantum_info.operators.base_operator import BaseOperator
+from qiskit.synthesis.evolution.product_formula import real_or_fail
 
 from qiskit._accelerate.circuit_library import pauli_evolution
 
@@ -136,7 +137,8 @@ def evolved_operator_ansatz(
             for term in sparse_labels:
                 param = next(param_iter)
                 expanded_paulis += [
-                    (pauli, indices, 2 * coeff * param) for pauli, indices, coeff in term
+                    (pauli, indices, 2 * real_or_fail(coeff) * param)
+                    for pauli, indices, coeff in term
                 ]
 
         data = pauli_evolution(num_qubits, expanded_paulis, insert_barriers, False)

--- a/releasenotes/notes/spurious-complex-b926da41d051e63a.yaml
+++ b/releasenotes/notes/spurious-complex-b926da41d051e63a.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a bug in the circuit functions :func:`.evolved_operator_ansatz`,
+    :func:`.qaoa_ansatz` and :func:`.hamiltonian_variational_ansatz`, where the
+    parameters had a zero complex component.  This mostly was no issue, unless
+    translated to SymPy using the :meth:`.ParameterExpression.sympify` method,
+    which would then raise an error.

--- a/releasenotes/notes/spurious-complex-b926da41d051e63a.yaml
+++ b/releasenotes/notes/spurious-complex-b926da41d051e63a.yaml
@@ -1,8 +1,8 @@
 ---
 fixes:
   - |
-    Fixed a bug in the circuit functions :func:`.evolved_operator_ansatz`,
-    :func:`.qaoa_ansatz` and :func:`.hamiltonian_variational_ansatz`, where the
+    Fixed a bug in the circuit functions :func:`~.evolved_operator_ansatz.evolved_operator_ansatz`,
+    :func:`~.qaoa_ansatz.qaoa_ansatz` and :func:`.hamiltonian_variational_ansatz`, where the
     parameters had a zero complex component.  This mostly was no issue, unless
     translated to SymPy using the :meth:`.ParameterExpression.sympify` method,
     which would then raise an error.

--- a/test/python/circuit/library/test_evolved_op_ansatz.py
+++ b/test/python/circuit/library/test_evolved_op_ansatz.py
@@ -183,6 +183,15 @@ class TestEvolvedOperatorAnsatz(QiskitTestCase):
             self.assertIn("hamiltonian", ops)
             self.assertIn("PauliEvolution", ops)
 
+    def test_sympify_is_real(self):
+        """Test converting the parameters to sympy is real."""
+        evo = evolved_operator_ansatz(SparsePauliOp(["Z"], coeffs=[1 + 0j]))
+        param = evo.parameters[0]  # get the gamma parameter
+
+        angle = evo.data[0].operation.params[0]
+        expected = (2.0 * param).sympify()
+        self.assertEqual(expected, angle.sympify())
+
 
 class TestHamiltonianVariationalAnsatz(QiskitTestCase):
     """Test the hamiltonian_variational_ansatz function.

--- a/test/python/circuit/library/test_qaoa_ansatz.py
+++ b/test/python/circuit/library/test_qaoa_ansatz.py
@@ -220,3 +220,12 @@ class TestQAOAAnsatz(QiskitTestCase):
                         circuit = QAOAAnsatz(cost_operator=cost, mixer_operator=mixer, reps=reps)
                     target = reps if mixer is None else 0
                     self.assertEqual(circuit.num_parameters, target)
+
+    def test_sympify_is_real(self):
+        """Test converting the parameters to sympy is real."""
+        qaoa = qaoa_ansatz(SparsePauliOp(["Z"], coeffs=[1 + 0j]))
+        param = qaoa.parameters[1]  # get the gamma parameter
+
+        angle = qaoa.data[1].operation.params[0]
+        expected = (2.0 * param).sympify()
+        self.assertEqual(expected, angle.sympify())


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

@ElePT reported that #13643 came back for other circuits, too. This essentially affects circuits that use operators as inputs, which have coefficients of complex types. This problem does not appear on `main`, I assume #13278 removes the 0 complex component. We could still consider to add this safetyguard to `main`, but there's no way to break it right now that I'm aware of.


