### PR TITLE
CliffordT optimization

### DIFF
--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -225,6 +225,7 @@ from .optimization import OptimizeAnnotated
 from .optimization import RemoveIdentityEquivalent
 from .optimization import Split2QUnitaries
 from .optimization import ContractIdleWiresInControlFlow
+from .optimization import OptimizeCliffordT
 
 # circuit analysis
 from .analysis import ResourceEstimation

--- a/qiskit/transpiler/passes/optimization/__init__.py
+++ b/qiskit/transpiler/passes/optimization/__init__.py
@@ -39,3 +39,4 @@ from .remove_identity_equiv import RemoveIdentityEquivalent
 from .split_2q_unitaries import Split2QUnitaries
 from .collect_and_collapse import CollectAndCollapse
 from .contract_idle_wires_in_control_flow import ContractIdleWiresInControlFlow
+from .optimize_clifford_t import OptimizeCliffordT

--- a/qiskit/transpiler/passes/optimization/optimize_clifford_t.py
+++ b/qiskit/transpiler/passes/optimization/optimize_clifford_t.py
@@ -1,0 +1,68 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Combine consecutive T/Tdg gates in a Clifford+T circuit."""
+
+from qiskit.dagcircuit import DAGCircuit
+from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.circuit.library import SGate, SdgGate
+
+
+class OptimizeCliffordT(TransformationPass):
+    """An optimization pass for Clifford+T circuits.
+
+    Currently all the pass does is merging pairs of consecutive T-gates into
+    S-gates, and pair of consecutive Tdg-gates into Sdg-gates.
+    """
+
+    def run(self, dag: DAGCircuit):
+        """
+        Run the OptimizeCliffordT pass on `dag`.
+
+        Args:
+            dag: The directed acyclic graph to run on.
+
+        Returns:
+            DAGCircuit: Transformed DAG.
+        """
+
+        new_dag = dag.copy_empty_like()
+
+        nodes = list(dag.topological_op_nodes())
+        num_nodes = len(nodes)
+        idx = 0
+
+        while idx < num_nodes - 1:
+            cur_node = nodes[idx]
+            next_node = nodes[idx + 1]
+            if cur_node.name == "t" and next_node.name == "t" and cur_node.qargs == next_node.qargs:
+                # Combine two consecutive T-gates into an S-gate
+                new_dag.apply_operation_back(SGate(), cur_node.qargs, cur_node.cargs)
+                idx += 2
+            elif (
+                nodes[idx].name == "tdg"
+                and nodes[idx + 1].name == "tdg"
+                and nodes[idx].qargs == nodes[idx + 1].qargs
+            ):
+                # Combine two consecutive Tdg-gates into an Sdg-gate
+                new_dag.apply_operation_back(SdgGate(), cur_node.qargs, cur_node.cargs)
+                idx += 2
+            else:
+                new_dag.apply_operation_back(cur_node.op, cur_node.qargs, cur_node.cargs)
+                idx += 1
+
+        # Handle the last element (if any)
+        if idx == num_nodes - 1:
+            cur_node = nodes[idx]
+            new_dag.apply_operation_back(cur_node.op, cur_node.qargs, cur_node.cargs)
+
+        return new_dag

--- a/releasenotes/notes/clifford-t-optimization-cf60aad9b106820e.yaml
+++ b/releasenotes/notes/clifford-t-optimization-cf60aad9b106820e.yaml
@@ -3,4 +3,20 @@ features_transpiler:
   - |
     Added a new :class:`.OptimizeCliffordT` transpiler optimization pass that
     merges pairs of consecutive ``T``-gates into ``S``-gates and pairs of
-    consecutive ``Tdg``-gates into ``Sdg``-gates.
+    consecutive ``Tdg``-gates into ``Sdg``-gates. This optimization is particularly
+    effective for reducing T-count following Solovay-Kitaev decomposition, which
+    produces multiple consecutive ``T`` or ``Tdg`` gates. For example::
+
+      from qiskit.circuit import QuantumCircuit
+      from qiskit.transpiler.passes import SolovayKitaev, OptimizeCliffordT
+
+      qc = QuantumCircuit(1)
+      qc.rx(0.8, 0)
+
+      # Run Solovay-Kitaev pass on qc
+      transpiled = SolovayKitaev()(qc)
+      print(transpiled.count_ops().get("t", 0) + transpiled.count_ops().get("tdg", 0))
+
+      # Run Clifford+T optimization
+      optimized = OptimizeCliffordT()(transpiled)
+      print(optimized.count_ops().get("t", 0) + optimized.count_ops().get("tdg", 0))

--- a/releasenotes/notes/clifford-t-optimization-cf60aad9b106820e.yaml
+++ b/releasenotes/notes/clifford-t-optimization-cf60aad9b106820e.yaml
@@ -1,0 +1,6 @@
+---
+features_transpiler:
+  - |
+    Added a new :class:`.OptimizeCliffordT` transpiler optimization pass that
+    merges pairs of consecutive ``T``-gates into ``S``-gates and pairs of
+    consecutive ``Tdg``-gates into ``Sdg``-gates.

--- a/test/python/transpiler/test_optimize_clifford_t.py
+++ b/test/python/transpiler/test_optimize_clifford_t.py
@@ -1,0 +1,44 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test Clifford+T optimization pass"""
+
+import numpy as np
+
+from ddt import ddt, data
+
+from qiskit.circuit import QuantumCircuit
+from qiskit.transpiler.passes import SolovayKitaev, OptimizeCliffordT
+from qiskit.quantum_info import Operator
+from test import QiskitTestCase  # pylint: disable=wrong-import-order
+
+
+@ddt
+class TestOptimizeCliffordT(QiskitTestCase):
+    """Test the OptimizeCliffordT pass."""
+
+    angles = np.linspace(0, 2 * np.pi, 10)
+
+    @data(*angles)
+    def test_solovay_kitaev_rx(self, angle):
+        """Test optimization of circuits coming out of the Solovay-Kitaev pass."""
+        qc = QuantumCircuit(1)
+        qc.rx(angle, 0)
+
+        # Run Solovay-Kitaev pass on qc
+        transpiled = SolovayKitaev()(qc)
+        self.assertLessEqual(set(transpiled.count_ops()), {"h", "t", "tdg"})
+
+        # Run Clifford+T optimization pass on the transpiled circuit
+        optimized = OptimizeCliffordT()(transpiled)
+
+        self.assertTrue(Operator(transpiled), Operator(optimized))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This PR adds a Clifford+T optimization pass (see https://github.com/Qiskit/qiskit/pull/14225#pullrequestreview-2851008962). For now all it does is merging pairs of consecutive T-gates into S-gates, and pairs of consecutive Tdg-gates into Sdg-gates.

Despite its simplicity, it's already quite useful on circuits generated by the Solovay-Kitaev algorithm (which we call with ``["t", "tdg", "h"]`` basis set) reducing the overall T-count by approximately 5%-10%.

Longer-term the internals of this pass will be completely rewritten based on better algorithms available. 

### Details and comments

One can think of this as a placeholder for Clifford+T optimization algorithms that we are planning to implement.

I thought that ``CommutativeCancellation`` could merge consecutive ``Rz`` and ``T``-rotations (exploiting commutativity), however it does not do that. And I could not find any other Qiskit pass that can do this for us.

~ToDo: add this to the optimization stage of the Clifford+T pipeline.~
