### PR TITLE
Pre-allocate bits storage in CircuitData::new

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -145,18 +145,35 @@ impl CircuitData {
         reserve: usize,
         global_phase: Param,
     ) -> PyResult<Self> {
+        let qubits_registry = match qubits {
+            Some(ref bits) => ObjectRegistry::with_capacity(bits.len()),
+            None => ObjectRegistry::new(),
+        };
+        let clbits_registry = match clbits {
+            Some(ref bits) => ObjectRegistry::with_capacity(bits.len()),
+            None => ObjectRegistry::new(),
+        };
+        let qubit_indices = match qubits {
+            Some(ref bits) => BitLocator::with_capacity(bits.len()),
+            None => BitLocator::new(),
+        };
+        let clbit_indices = match qubits {
+            Some(ref bits) => BitLocator::with_capacity(bits.len()),
+            None => BitLocator::new(),
+        };
+
         let mut self_ = CircuitData {
             data: Vec::new(),
             qargs_interner: Interner::new(),
             cargs_interner: Interner::new(),
-            qubits: ObjectRegistry::new(),
-            clbits: ObjectRegistry::new(),
+            qubits: qubits_registry,
+            clbits: clbits_registry,
             param_table: ParameterTable::new(),
             global_phase: Param::Float(0.),
             qregs: RegisterData::new(),
             cregs: RegisterData::new(),
-            qubit_indices: BitLocator::new(),
-            clbit_indices: BitLocator::new(),
+            qubit_indices,
+            clbit_indices,
         };
         self_.set_global_phase(global_phase)?;
         if let Some(qubits) = qubits {

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -145,22 +145,12 @@ impl CircuitData {
         reserve: usize,
         global_phase: Param,
     ) -> PyResult<Self> {
-        let qubits_registry = match qubits {
-            Some(ref bits) => ObjectRegistry::with_capacity(bits.len()),
-            None => ObjectRegistry::new(),
-        };
-        let clbits_registry = match clbits {
-            Some(ref bits) => ObjectRegistry::with_capacity(bits.len()),
-            None => ObjectRegistry::new(),
-        };
-        let qubit_indices = match qubits {
-            Some(ref bits) => BitLocator::with_capacity(bits.len()),
-            None => BitLocator::new(),
-        };
-        let clbit_indices = match qubits {
-            Some(ref bits) => BitLocator::with_capacity(bits.len()),
-            None => BitLocator::new(),
-        };
+        let qubit_size = qubits.as_ref().map_or(0, |bits| bits.len());
+        let clbit_size = clbits.as_ref().map_or(0, |bits| bits.len());
+        let qubits_registry = ObjectRegistry::with_capacity(qubit_size);
+        let clbits_registry = ObjectRegistry::with_capacity(clbit_size);
+        let qubit_indices = BitLocator::with_capacity(qubit_size);
+        let clbit_indices = BitLocator::with_capacity(clbit_size);
 
         let mut self_ = CircuitData {
             data: Vec::new(),


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

When calling `CircuitData::new()` if the qubits or clbits arguments are passed in as Some we know how large the allocation for the ObjectRegistry and BitLocations objects are going to be. Right now we don't preallocate this space and rely on the internal `HashMap`s and `Vec`s to grow as we populate the mappings. This ends up being wasted time as we reallocate the underlying storage. For very wide circuits with a large number of qubits or clbits the extra allocation time can be quite substantial relative to the other operations `new()` performs. This commit fixes this issue by calling the `with_capacity()` methods if qubits or clbits is set to preallocate the ObjectRegistry and BitLocations.

### Details and comments