### PR TITLE
Integrate C API tests into new GHA workflow structure

### DIFF
--- a/.github/workflows/ctests.yml
+++ b/.github/workflows/ctests.yml
@@ -1,11 +1,7 @@
 ---
-name: Tests
+name: C API Tests
 on:
-  push:
-    branches: [ main, 'stable/*' ]
-  pull_request:
-    branches: [ main, 'stable/*' ]
-  merge_group:
+  workflow_call:
 
 jobs:
   tests:

--- a/.github/workflows/on-merge-queue.yml
+++ b/.github/workflows/on-merge-queue.yml
@@ -81,6 +81,6 @@ jobs:
       install-optionals: false
       runner: ${{ matrix.runner }}
   c-tests:
-+   if: github.repository_owner == 'Qiskit'
-+   name: C API Unit Tests
-+   uses: ./.github/workflows/ctests.yml
+    if: github.repository_owner == 'Qiskit'
+    name: C API Unit Tests
+    uses: ./.github/workflows/ctests.yml

--- a/.github/workflows/on-merge-queue.yml
+++ b/.github/workflows/on-merge-queue.yml
@@ -80,3 +80,7 @@ jobs:
       python-version: ${{ matrix.python-version }}
       install-optionals: false
       runner: ${{ matrix.runner }}
+  c-tests:
++   if: github.repository_owner == 'Qiskit'
++   name: C API Unit Tests
++   uses: ./.github/workflows/ctests.yml

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -80,3 +80,7 @@ jobs:
       python-version: ${{ matrix.python_version }}
       install-optionals: ${{ matrix.python_version == '3.9'}}
       runner: ${{ matrix.runner }}
+  c-tests:
+    if: github.repository_owner == 'Qiskit'
+    name: C API Unit Tests
+    uses: ./.github/workflows/ctests.yml


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #13474 we restructured our CI to be based solely on github actions. As part of that change a new workflow structure was introduced where there were `on-*.yml` files that enumerate the jobs run for each job trigger. For example, `on-pull-request.yml` lists all the jobs that run when a pull request is opened or updated. However, the C API tests were not integrated into this new structure as part of #13474 as they were already running and that PR didn't want to change github actions usage that was already working. This commit is the follow up that updates the C API tests so they fit into the new structure and the jobs that are run are listed in the specific trigger sections.

### Details and comments


