### PR TITLE
Avoid all-to-all connectivity in slowest test

### DIFF
--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -3947,7 +3947,9 @@ class TestTranspileMultiChipTarget(QiskitTestCase):
         qc = QuantumCircuit(127)
         for i in range(1, 127):
             qc.ecr(0, i)
-        backend = GenericBackendV2(num_qubits=130)
+        backend = GenericBackendV2(
+            num_qubits=130, coupling_map=CouplingMap.from_line(130, bidirectional=False)
+        )
         original_map = copy.deepcopy(backend.coupling_map)
         transpile(qc, backend, optimization_level=opt_level, seed_transpiler=42)
         self.assertEqual(original_map, backend.coupling_map)


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The current slowest unit test in the suite is:
```
test_transpile_does_not_affect_backend_coupling_4_3
```
which is just sanity checking that a transpile() call doesn't mutate the CouplingMap by mistake. This is is a regression test for an old bug where that happened. However, in the move to use GenericBackendV2 it was creating a 130 qubit target with explicit all-to-all connectivity, which is the default behavior if you don't specify a coupling map argument. This ends up bogging the transpiler down in VF2PostLayout in optimization level 3 because there are a huge number of possible layouts, basically any permutation of 130 qubits. This isn't functionally part of the test because it's just trying to test if the coupling map is mutated by the transpiler. This commit updates the test to use a 130 qubit linear connectivity graph which still tests the circuit but takes a fraction of the time to execute because the target is much more constrained.

### Details and comments