### PR TITLE
Fix QPY test of `use_symengine` if Symengine is available

### DIFF
--- a/test/python/qpy/test_circuit_load_from_qpy.py
+++ b/test/python/qpy/test_circuit_load_from_qpy.py
@@ -24,7 +24,6 @@ from qiskit.qpy import dump, load, formats, QPY_COMPATIBILITY_VERSION
 from qiskit.qpy.common import QPY_VERSION
 from qiskit.transpiler import TranspileLayout
 from qiskit.compiler import transpile
-from qiskit.utils import optionals
 from qiskit.qpy.formats import FILE_HEADER_V10_PACK, FILE_HEADER_V10, FILE_HEADER_V10_SIZE
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 

--- a/test/python/qpy/test_circuit_load_from_qpy.py
+++ b/test/python/qpy/test_circuit_load_from_qpy.py
@@ -14,7 +14,6 @@
 
 import io
 import struct
-import unittest
 
 from ddt import ddt, data
 
@@ -297,8 +296,6 @@ class TestUseSymengineFlag(QpyCircuitTestCase):
     @data(True, False)
     def test_use_symengine_with_bool_like(self, use_symengine):
         """Test that the use_symengine flag is set correctly with a bool-like input."""
-        if use_symengine and not optionals.HAS_SYMENGINE:
-            raise unittest.SkipTest("we can't force 'use_symengine' if we don't have it")
 
         class Booly:  # pylint: disable=missing-class-docstring,missing-function-docstring
             def __init__(self, value):
@@ -313,6 +310,9 @@ class TestUseSymengineFlag(QpyCircuitTestCase):
         qc.rx(two_theta, 0)
         qc.measure_all()
         # Assert Roundtrip works
+        # `use_symengine` is near-completely ignored with QPY versions 13+; it doesn't actually
+        # matter if we _have_ symengine installed or not, because those QPYs don't ever use it
+        # (except for setting a single byte in the header, which is promptly ignored).
         self.assert_roundtrip_equal(qc, use_symengine=Booly(use_symengine), version=13)
         # Also check the qpy symbolic expression encoding is correct in the
         # payload


### PR DESCRIPTION
Since symengine was dropped as a requirement, and the default for QPY serialisation of parameter expressions was set to use our internal replay format, this test has been broken if Symengine _was_ available, because we'd be forcibly setting `use_symengine` but then asserting that the expression format was ours.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


