### PR TITLE
Fix Sabre rebuild with nested `Var` and `Stretch`

### DIFF
--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -374,6 +374,14 @@ def _apply_sabre_result(
         empty.add_clbits(block.clbits)
         for creg in block.cregs:
             empty.add_creg(creg)
+        for var_ in block.iter_declared_vars():
+            empty.add_declared_var(var_)
+        for var_ in block.iter_captured_vars():
+            empty.add_captured_var(var_)
+        for stretch in block.iter_declared_stretches():
+            empty.add_declared_stretch(stretch)
+        for stretch in block.iter_captured_stretches():
+            empty.add_captured_stretch(stretch)
         empty.global_phase = block.global_phase
         return empty
 

--- a/releasenotes/notes/fix-sabre-inner-vars-409448505fd56ca7.yaml
+++ b/releasenotes/notes/fix-sabre-inner-vars-409448505fd56ca7.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    :class:`.SabreLayout` and :class:`.SabreSwap` will no longer panic when applying the routing
+    result to a circuit that uses :class:`.expr.Var` or :class:`.Stretch` objects in a nested
+    control-flow scope.


### PR DESCRIPTION
The `empty_dag` helper, used to construct control-flow blocks, in the rebuilder failed to account for `Var` or `Stretch` nodes.  We have integration tests in `test/python/compiler/test_transpiler.py` that _in theory_ should have caught this, but in practice failed to because they are accidentally using all-to-all connectivity backends, so Sabre never runs in them.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

This fixes the test failures that #14484 turned up.
