### PR TITLE
Add `PackedInstruction::from_standard_gate`

### DIFF
--- a/crates/accelerate/src/twirling.rs
+++ b/crates/accelerate/src/twirling.rs
@@ -204,53 +204,21 @@ fn twirl_gate(
     let bit_one = out_circ.add_qargs(std::slice::from_ref(&qubits[1]));
     out_circ.push(
         py,
-        PackedInstruction {
-            op: PackedOperation::from_standard_gate(twirl[0]),
-            qubits: bit_zero,
-            clbits: circ.cargs_interner().get_default(),
-            params: None,
-            label: None,
-            #[cfg(feature = "cache_pygates")]
-            py_op: std::sync::OnceLock::new(),
-        },
+        PackedInstruction::from_standard_gate(twirl[0], None, bit_zero),
     )?;
     out_circ.push(
         py,
-        PackedInstruction {
-            op: PackedOperation::from_standard_gate(twirl[1]),
-            qubits: bit_one,
-            clbits: circ.cargs_interner().get_default(),
-            params: None,
-            label: None,
-            #[cfg(feature = "cache_pygates")]
-            py_op: std::sync::OnceLock::new(),
-        },
+        PackedInstruction::from_standard_gate(twirl[1], None, bit_one),
     )?;
 
     out_circ.push(py, inst.clone())?;
     out_circ.push(
         py,
-        PackedInstruction {
-            op: PackedOperation::from_standard_gate(twirl[2]),
-            qubits: bit_zero,
-            clbits: circ.cargs_interner().get_default(),
-            params: None,
-            label: None,
-            #[cfg(feature = "cache_pygates")]
-            py_op: std::sync::OnceLock::new(),
-        },
+        PackedInstruction::from_standard_gate(twirl[2], None, bit_zero),
     )?;
     out_circ.push(
         py,
-        PackedInstruction {
-            op: PackedOperation::from_standard_gate(twirl[3]),
-            qubits: bit_one,
-            clbits: circ.cargs_interner().get_default(),
-            params: None,
-            label: None,
-            #[cfg(feature = "cache_pygates")]
-            py_op: std::sync::OnceLock::new(),
-        },
+        PackedInstruction::from_standard_gate(twirl[3], None, bit_one),
     )?;
 
     if *twirl_phase != 0. {

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -1371,19 +1371,12 @@ impl CircuitData {
         let mut res =
             Self::with_capacity(num_qubits, 0, instruction_iter.size_hint().0, global_phase)?;
 
-        let no_clbit_index = res.cargs_interner.get_default();
         for (operation, params, qargs) in instruction_iter {
             let qubits = res.qargs_interner.insert(&qargs);
             let params = (!params.is_empty()).then(|| Box::new(params));
-            res.data.push(PackedInstruction {
-                op: operation.into(),
-                qubits,
-                clbits: no_clbit_index,
-                params,
-                label: None,
-                #[cfg(feature = "cache_pygates")]
-                py_op: OnceLock::new(),
-            });
+            res.data.push(PackedInstruction::from_standard_gate(
+                operation, params, qubits,
+            ));
             res.track_instruction_parameters(py, res.data.len() - 1)?;
         }
         Ok(res)
@@ -1436,18 +1429,11 @@ impl CircuitData {
         params: &[Param],
         qargs: &[Qubit],
     ) {
-        let no_clbit_index = self.cargs_interner.get_default();
         let params = (!params.is_empty()).then(|| Box::new(params.iter().cloned().collect()));
         let qubits = self.qargs_interner.insert(qargs);
-        self.data.push(PackedInstruction {
-            op: operation.into(),
-            qubits,
-            clbits: no_clbit_index,
-            params,
-            label: None,
-            #[cfg(feature = "cache_pygates")]
-            py_op: OnceLock::new(),
-        });
+        self.data.push(PackedInstruction::from_standard_gate(
+            operation, params, qubits,
+        ));
     }
 
     /// Append a packed operation to this CircuitData

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -7524,17 +7524,12 @@ mod test {
 
     macro_rules! cx_gate {
         ($dag:expr, $q0:expr, $q1:expr) => {
-            PackedInstruction {
-                op: PackedOperation::from_standard_gate(StandardGate::CX),
-                qubits: $dag
-                    .qargs_interner
+            PackedInstruction::from_standard_gate(
+                StandardGate::CX,
+                None,
+                $dag.qargs_interner
                     .insert_owned(vec![Qubit($q0), Qubit($q1)]),
-                clbits: $dag.cargs_interner.get_default(),
-                params: None,
-                label: None,
-                #[cfg(feature = "cache_pygates")]
-                py_op: Default::default(),
-            }
+            )
         };
     }
 

--- a/crates/circuit/src/interner.rs
+++ b/crates/circuit/src/interner.rs
@@ -41,6 +41,17 @@ impl<T: ?Sized> Clone for Interned<T> {
     }
 }
 impl<T: ?Sized> Copy for Interned<T> {}
+impl<T: ?Sized> Default for Interned<T>
+where
+    T: ToOwned<Owned: Default>,
+{
+    fn default() -> Self {
+        Self {
+            index: 0,
+            _type: PhantomData,
+        }
+    }
+}
 unsafe impl<T: ?Sized> Send for Interned<T> {}
 unsafe impl<T: ?Sized> Sync for Interned<T> {}
 

--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -706,6 +706,23 @@ pub struct PackedInstruction {
 }
 
 impl PackedInstruction {
+    /// Pack a [StandardGate] into a complete instruction.
+    pub fn from_standard_gate(
+        gate: StandardGate,
+        params: Option<Box<SmallVec<[Param; 3]>>>,
+        qubits: Interned<[Qubit]>,
+    ) -> Self {
+        Self {
+            op: gate.into(),
+            qubits,
+            clbits: Default::default(),
+            params,
+            label: None,
+            #[cfg(feature = "cache_pygates")]
+            py_op: OnceLock::new(),
+        }
+    }
+
     /// Access the standard gate in this `PackedInstruction`, if it is one.  If the instruction
     /// refers to a Python-space object, `None` is returned.
     #[inline]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This is a simple convenience interface to create gates from Rust space, for appending to a circuit, which is a pretty common occurrence.  This API implies access to an interner context, which was already implied by various `DAGCircuit` methods accepting a `PackedInstruction`.

### Details and comments

This is one of the small stand-alone changes split out from #14317 

cc @kevinhartman: I think you had opinions about whether `Interned` should implement `Default` at the time.  This PR adds that impl in service of the use case in the second commit, so I'm just making sure you see it.
