### PR TITLE
Allow qubit/clbit newtypes to be `petgraph` index-like

### DIFF
--- a/crates/circuit/src/nlayout.rs
+++ b/crates/circuit/src/nlayout.rs
@@ -25,7 +25,17 @@ use hashbrown::HashMap;
 macro_rules! qubit_newtype {
     ($id: ident) => {
         #[derive(
-            Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, IntoPyObject, IntoPyObjectRef,
+            Debug,
+            Clone,
+            Copy,
+            PartialEq,
+            Eq,
+            PartialOrd,
+            Ord,
+            Hash,
+            Default,
+            IntoPyObject,
+            IntoPyObjectRef,
         )]
         pub struct $id(pub u32);
 
@@ -55,6 +65,18 @@ macro_rules! qubit_newtype {
 
             fn clone_ref(&self, _py: Python<'_>) -> Self {
                 *self
+            }
+        }
+
+        unsafe impl ::rustworkx_core::petgraph::graph::IndexType for $id {
+            fn new(x: usize) -> Self {
+                Self::new(x as u32)
+            }
+            fn index(&self) -> usize {
+                self.0 as usize
+            }
+            fn max() -> Self {
+                Self(u32::MAX)
             }
         }
     };


### PR DESCRIPTION
This lets the newtypes behave like bounded integers (which is what they are) suitable for use as the `petgraph::visit::GraphBase::NodeId` type. This allows custom graph implementations to directly use these as the node identifiers, which is something we already _imply_ quite a lot throughout the library.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

No use added in this PR - it's a split out from #14317, which uses them in its `Neighbors` graph (though I won't promise I won't use them more in other graphs objects.