### PR TITLE
Add `--slowest` flag to stestr run in CI

### DIFF
--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -22,7 +22,7 @@ jobs:
           python -m pip install -c constraints.txt -e .
           python -m pip install "qiskit-aer" "z3-solver" "cplex" -c constraints.txt
       - name: Run all tests including slow
-        run: stestr run
+        run: stestr run --slowest
         env:
           RUST_BACKTRACE: 1
           QISKIT_TESTS: "run_slow"

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -97,7 +97,7 @@ jobs:
           python tools/report_numpy_state.py
           export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))")
           echo "PYTHONHASHSEED=$PYTHONHASHSEED"
-          stestr run
+          stestr run --slowest
         env:
           QISKIT_PARALLEL: FALSE
           QISKIT_IGNORE_USER_SETTINGS: TRUE
@@ -122,7 +122,7 @@ jobs:
           pushd /tmp/terra-tests
           export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))")
           echo "PYTHONHASHSEED=$PYTHONHASHSEED"
-          stestr run
+          stestr run --slowest
           popd
         env:
           QISKIT_PARALLEL: FALSE

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -72,7 +72,7 @@ jobs:
           python tools/report_numpy_state.py
           export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))")
           echo "PYTHONHASHSEED=$PYTHONHASHSEED"
-          stestr run
+          stestr run --slowest
         env:
           QISKIT_PARALLEL: FALSE
           QISKIT_IGNORE_USER_SETTINGS: TRUE

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -70,7 +70,7 @@ jobs:
           python tools/report_numpy_state.py
           $Env:PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 1024))")
           echo "PYTHONHASHSEED=$PYTHONHASHSEED"
-          stestr run
+          stestr run --slowest
       - name: Filter stestr history
         run: |
           pushd .stestr


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds the --slowest flag to the stestr run command for all the CI jobs that are running stestr (except for coverage which runs in debug mode). This flag adds the top 10 slowest tests to the end of the output. When we were on azure pipelines the built-in analytics would let us track this and aggregate it across runs. But after the migration to github actions we don't have the analytics functionality anymore. So reporting the slowest tests for each individual job run is the next best option. This will let us see which tests are the slowest and prioritize either speeding up that functionality or catching test bugs.


### Details and comments