### PR TITLE
Added support for using `SparseObservable` in `sampled_expectation_value`

### DIFF
--- a/qiskit/result/sampled_expval.py
+++ b/qiskit/result/sampled_expval.py
@@ -59,7 +59,7 @@ def sampled_expectation_value(dist, oper):
         oper_strs = []
         coeffs = []
         n = oper.num_qubits
-        for op, indxs, coeff in oper.to_sparse_list():
+        for op, indxs, coeff in oper.as_paulis().to_sparse_list():
             full_op = ["I"] * n
             for char, i in zip(op, indxs):
                 full_op[n - 1 - i] = char

--- a/qiskit/result/sampled_expval.py
+++ b/qiskit/result/sampled_expval.py
@@ -59,7 +59,7 @@ def sampled_expectation_value(dist, oper):
         oper_strs = []
         coeffs = []
         n = oper.num_qubits
-        for op, indxs, coeff in oper.as_paulis().to_sparse_list():
+        for op, indxs, coeff in oper.to_sparse_list():
             full_op = ["I"] * n
             for char, i in zip(op, indxs):
                 full_op[n - 1 - i] = char

--- a/qiskit/result/sampled_expval.py
+++ b/qiskit/result/sampled_expval.py
@@ -38,7 +38,7 @@ def sampled_expectation_value(dist, oper):
         QiskitError: if the input distribution or operator is an invalid type
     """
     from .counts import Counts
-    from qiskit.quantum_info import Pauli, SparsePauliOp
+    from qiskit.quantum_info import Pauli, SparsePauliOp, SparseObservable
 
     # This should be removed when these return bit-string keys
     if isinstance(dist, (QuasiDistribution, ProbDistribution)):
@@ -55,6 +55,17 @@ def sampled_expectation_value(dist, oper):
     elif isinstance(oper, SparsePauliOp):
         oper_strs = oper.paulis.to_labels()
         coeffs = np.asarray(oper.coeffs)
+    elif isinstance(oper, SparseObservable):
+        oper_strs = []
+        coeffs = []
+        n = oper.num_qubits
+        for op, indxs, coeff in oper.to_sparse_list():
+            full_op = ["I"] * n
+            for char, i in zip(op, indxs):
+                full_op[n - 1 - i] = char
+            oper_strs.append("".join(full_op))
+            coeffs.append(coeff)
+        coeffs = np.asarray(coeffs)
     else:
         raise QiskitError("Invalid operator type")
 

--- a/releasenotes/notes/fix-sparse-observable-exp-val-2e8c604d80e522d1.yaml
+++ b/releasenotes/notes/fix-sparse-observable-exp-val-2e8c604d80e522d1.yaml
@@ -1,5 +1,5 @@
 ---
 features:
   - |
-    Added ability to compute the expectation value of a `SparseObservable`
-    by using the `sampled_expectation_value` function.
+    Added ability to compute the expectation value of a :class:`.SparseObservable`
+    by using the :func:`.sampled_expectation_value` function.

--- a/releasenotes/notes/fix-sparse-observable-exp-val-2e8c604d80e522d1.yaml
+++ b/releasenotes/notes/fix-sparse-observable-exp-val-2e8c604d80e522d1.yaml
@@ -3,8 +3,3 @@ features:
   - |
     Added ability to compute the expectation value of a `SparseObservable`
     by using the `sampled_expectation_value` function.
-fixes:
-  - |
-    This fixes the issue where the `sampled_expectation_value` function does not
-    accept a `SparseObservable` as an argument. 
-    Refer to `#13446 <https://github.com/Qiskit/qiskit/issues/13446>` for more details.

--- a/releasenotes/notes/fix-sparse-observable-exp-val-2e8c604d80e522d1.yaml
+++ b/releasenotes/notes/fix-sparse-observable-exp-val-2e8c604d80e522d1.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Added ability to compute the expectation value of a `SparseObservable`
+    by using the `sampled_expectation_value` function.
+fixes:
+  - |
+    This fixes the issue where the `sampled_expectation_value` function does not
+    accept a `SparseObservable` as an argument. 
+    Refer to `#13446 <https://github.com/Qiskit/qiskit/issues/13446>` for more details.

--- a/test/python/result/test_sampled_expval.py
+++ b/test/python/result/test_sampled_expval.py
@@ -15,7 +15,7 @@
 import unittest
 
 from qiskit.result import Counts, QuasiDistribution, ProbDistribution, sampled_expectation_value
-from qiskit.quantum_info import Pauli, SparsePauliOp
+from qiskit.quantum_info import Pauli, SparsePauliOp, SparseObservable
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
 PROBS = {
@@ -84,6 +84,10 @@ class TestSampledExpval(QiskitTestCase):
         spo = SparsePauliOp([oper], coeffs=[1])
         exp3 = sampled_expectation_value(counts, spo)
         self.assertAlmostEqual(exp3, ans)
+
+        so = SparseObservable.from_label(oper)
+        exp4 = sampled_expectation_value(counts, so)
+        self.assertAlmostEqual(exp4, ans)
 
     def test_asym_ops(self):
         """Test that asymmetric exp values work"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

- Added the ability to pass `SparseObservable` objects to the `sampled_expectation_value` function.
- Fixes #13446

### Details and comments

- The following changes were made to enable this:
1. The `sampled_expectation_value` function (in `qiskit/result/sampled_expval.py`)was changed to allow `SparseObservable` objects by adding another `elif` clause.
2. This approach iterates through the returned tuples for each term by the `.to_sparse_list` method and initially populates all the single-qubit operators as `I`, followed by populating all non-identity operators (this is because the `SparseObservable` storage mechanism only stores the non-identity single-qubit operators).
3. These values are passed (in the same manner as the other types) to the rust routines for calculating the expectation value.

- The `test_sampled_expval.py` file (in `test/python/result`) was modified to also add a test for the `sampled_expectation_value` returned for `SparseObservable` objects.
