### PR TITLE
Add minimum QPY version to user config

### DIFF
--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -288,7 +288,9 @@ def load(
     config = user_config.get_config()
     
     min_qpy_version = config.get("min_qpy_version")
-    if min_qpy_version is not None and common.QPY_VERSION < int(min_qpy_version):
+    
+    if min_qpy_version is not None and data.qpy_version < min_qpy_version:
+        
         raise QiskitError(
             f"QPY version {data.qpy_version} is lower than the configured minimum "
             f"version {min_qpy_version}. Aborting load for security reasons."

--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -25,6 +25,7 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.exceptions import QiskitError
 from qiskit.qpy import formats, common, binary_io, type_keys
 from qiskit.qpy.exceptions import QpyError
+from qiskit import user_config
 from qiskit.version import __version__
 
 
@@ -282,6 +283,15 @@ def load(
                 formats.FILE_HEADER_V10_PACK,
                 file_obj.read(formats.FILE_HEADER_V10_SIZE),
             )
+        )
+
+    config = user_config.get_config()
+    
+    min_qpy_version = config.get("min_qpy_version")
+    if min_qpy_version is not None and common.QPY_VERSION < int(min_qpy_version):
+        raise QiskitError(
+            f"QPY version {data.qpy_version} is lower than the configured minimum "
+            f"version {min_qpy_version}. Aborting load for security reasons."
         )
 
     if data.preface.decode(common.ENCODE) != "QISKIT":

--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -286,11 +286,11 @@ def load(
         )
 
     config = user_config.get_config()
-    
+
     min_qpy_version = config.get("min_qpy_version")
-    
+
     if min_qpy_version is not None and data.qpy_version < min_qpy_version:
-        
+
         raise QiskitError(
             f"QPY version {data.qpy_version} is lower than the configured minimum "
             f"version {min_qpy_version}. Aborting load for security reasons."

--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -288,12 +288,10 @@ def load(
     config = user_config.get_config()
 
     min_qpy_version = config.get("min_qpy_version")
-
     if min_qpy_version is not None and data.qpy_version < min_qpy_version:
-
-        raise QiskitError(
+        raise QpyError(
             f"QPY version {data.qpy_version} is lower than the configured minimum "
-            f"version {min_qpy_version}. Aborting load for security reasons."
+            f"version {min_qpy_version}."
         )
 
     if data.preface.decode(common.ENCODE) != "QISKIT":

--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -286,7 +286,6 @@ def load(
         )
 
     config = user_config.get_config()
-
     min_qpy_version = config.get("min_qpy_version")
     if min_qpy_version is not None and data.qpy_version < min_qpy_version:
         raise QpyError(

--- a/qiskit/user_config.py
+++ b/qiskit/user_config.py
@@ -36,6 +36,7 @@ class UserConfig:
     parallel = False
     num_processes = 4
     sabre_all_threads = true
+    min_qpy_version = 13
 
     """
 
@@ -176,6 +177,10 @@ class UserConfig:
             if sabre_all_threads is not None:
                 self.settings["sabre_all_threads"] = sabre_all_threads
 
+        # Parse min_qpy_version
+        min_qpy_version = self.config_parser.get("default", "min_qpy_version", fallback=None)
+        if min_qpy_version:
+            self.settings["min_qpy_version"] = min_qpy_version
 
 def set_config(key, value, section=None, file_path=None):
     """Adds or modifies a user configuration
@@ -217,6 +222,7 @@ def set_config(key, value, section=None, file_path=None):
         "parallel",
         "num_processes",
         "sabre_all_threads",
+        "min_qpy_version",
     }
 
     if section in [None, "default"]:

--- a/qiskit/user_config.py
+++ b/qiskit/user_config.py
@@ -176,15 +176,16 @@ class UserConfig:
             )
             if sabre_all_threads is not None:
                 self.settings["sabre_all_threads"] = sabre_all_threads
-            
+
             # Parse min_qpy_version
             min_qpy_version = self.config_parser.getint("default", "min_qpy_version", fallback=None)
             if min_qpy_version:
                 if min_qpy_version < 0:
                     raise exceptions.QiskitUserConfigError(
-                        f"{min_qpy_version} is not a valid QPY version. Must be greater than or equal to 0."
+                        f"{min_qpy_version} is not a valid QPY version."
                     )
                 self.settings["min_qpy_version"] = min_qpy_version
+
 
 def set_config(key, value, section=None, file_path=None):
     """Adds or modifies a user configuration

--- a/qiskit/user_config.py
+++ b/qiskit/user_config.py
@@ -176,11 +176,15 @@ class UserConfig:
             )
             if sabre_all_threads is not None:
                 self.settings["sabre_all_threads"] = sabre_all_threads
-
-        # Parse min_qpy_version
-        min_qpy_version = self.config_parser.get("default", "min_qpy_version", fallback=None)
-        if min_qpy_version:
-            self.settings["min_qpy_version"] = min_qpy_version
+            
+            # Parse min_qpy_version
+            min_qpy_version = self.config_parser.getint("default", "min_qpy_version", fallback=None)
+            if min_qpy_version:
+                if min_qpy_version < 0:
+                    raise exceptions.QiskitUserConfigError(
+                        f"{min_qpy_version} is not a valid QPY version. Must be greater than or equal to 0."
+                    )
+                self.settings["min_qpy_version"] = min_qpy_version
 
 def set_config(key, value, section=None, file_path=None):
     """Adds or modifies a user configuration

--- a/releasenotes/notes/min-qpy-version-363a36dda39553b6.yaml
+++ b/releasenotes/notes/min-qpy-version-363a36dda39553b6.yaml
@@ -1,6 +1,6 @@
 ---
 features_qpy:
   - |
-    Added a setting named ``min_qpy_version`` in ``qiskit/user_config.py``. This setting defines the minimum required QPY version, 
-    which will be checked against the version currently in use in ``qiskit/qpy/interface.py``. If the active version is lower than 
-    the configured minimum, the system will raise a ``QiskitError``.
+    Added a setting named ``min_qpy_version`` in the user config file. When set, it defines the minimum allowed QPY version
+    For :func:`.qpy.load`. If the format version of a QPY file s lower than the ``minimum_qpy_version``
+    setting it will raise an exception.

--- a/releasenotes/notes/min-qpy-version-363a36dda39553b6.yaml
+++ b/releasenotes/notes/min-qpy-version-363a36dda39553b6.yaml
@@ -1,0 +1,6 @@
+---
+features_qpy:
+  - |
+    Added a setting named ``min_qpy_version`` in ``qiskit/user_config.py``. This setting defines the minimum required QPY version, 
+    which will be checked against the version currently in use in ``qiskit/qpy/interface.py``. If the active version is lower than 
+    the configured minimum, the system will raise a ``QiskitError``.

--- a/test/python/test_user_config.py
+++ b/test/python/test_user_config.py
@@ -157,6 +157,31 @@ class TestUserConfig(QiskitTestCase):
             config.read_config_file()
             self.assertEqual({"num_processes": 31}, config.settings)
 
+    def test_invalid_min_qpy_version(self):
+        test_config = """
+        [default]
+        min_qpy_version = -1
+        """
+        self.addCleanup(os.remove, self.file_path)
+        with open(self.file_path, "w") as file:
+            file.write(test_config)
+            file.flush()
+            config = user_config.UserConfig(self.file_path)
+            self.assertRaises(exceptions.QiskitUserConfigError, config.read_config_file)
+
+    def test_valid_min_qpy_version(self):
+        test_config = """
+        [default]
+        min_qpy_version = 13
+        """
+        self.addCleanup(os.remove, self.file_path)
+        with open(self.file_path, "w") as file:
+            file.write(test_config)
+            file.flush()
+            config = user_config.UserConfig(self.file_path)
+            config.read_config_file()
+            self.assertEqual({"min_qpy_version": 13}, config.settings)
+
     def test_valid_parallel(self):
         test_config = """
         [default]


### PR DESCRIPTION
Recently, several CVEs were published regarding vulnerabilities in older versions of **QPY**.  
To mitigate security risks and ensure the system runs on a secure version, a new configuration option has been introduced in `user_config.py`: **`min_qpy_version`**.

This setting defines the **minimum required QPY version**, which will be checked against the version currently in use.  
If the active version is lower than the configured minimum, the system will raise a error.
This change improves overall security and enforces compatibility with up-to-date QPY versions.

This will close #14034

### Summary

- Added a new configuration option **`min_qpy_version`** to the **`settings.conf`** file to enforce a minimum required QPY version.
- Changes were made in the **`user_config.py`** and **`interface.py`** files.


### Details and comments