### PR TITLE
Use correct minimum rustworkx requirement version

### DIFF
--- a/releasenotes/notes/bump-minimum-rx-93fc954877c1c6c1.yaml
+++ b/releasenotes/notes/bump-minimum-rx-93fc954877c1c6c1.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    The minimum required version of `rustworkx <https://www.rustworkx.org/>`__
+    in Qiskit's dependencies has been raised from 0.15.0 to 0.16.0. This was
+    done as functionality added in 0.16.0 is now being used in Qiskit.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-rustworkx>=0.15.0
+rustworkx>=0.16.0
 numpy>=1.17,<3
 scipy>=1.5
 sympy>=1.3


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The rustworkx version we have previously had set as the minimum requirement is not correct. It was listed as 0.15.0 but we are using `PyDiGraph.neighbors_undirected()` since #14218 merged which was added in rustworkx 0.16.0. [1] This means the requirement is incorrect and if you try to run Qiskit with rustworkx 0.15.0 it will not work when this method is run. This commit corrects this issue and bumps the minimum supported rustworkx version in the requirements list to 0.16.0.

### Details and comments

[1] https://www.rustworkx.org/release_notes.html#relnotes-0-16-0