### PR TITLE
Reapply "Add ``qk_circuit_unitary``  (#14334)" (#14492)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,6 +1455,8 @@ name = "qiskit-cext"
 version = "2.1.0"
 dependencies = [
  "cbindgen",
+ "nalgebra",
+ "ndarray",
  "num-complex",
  "pyo3",
  "qiskit-circuit",

--- a/crates/cext/Cargo.toml
+++ b/crates/cext/Cargo.toml
@@ -21,6 +21,8 @@ num-complex.workspace = true
 qiskit-quantum-info.workspace = true
 qiskit-circuit.workspace = true
 pyo3 = { workspace = true, optional = true }
+ndarray.workspace = true
+nalgebra.workspace = true
 
 [build-dependencies]
 cbindgen = "0.29"

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -15,10 +15,16 @@ use std::ffi::{c_char, CStr, CString};
 use crate::exit_codes::ExitCode;
 use crate::pointers::{const_ptr_as_ref, mut_ptr_as_ref};
 
+use nalgebra::{Matrix2, Matrix4};
+use ndarray::{Array2, ArrayView2};
+use num_complex::{Complex64, ComplexFloat};
+
 use qiskit_circuit::bit::{ClassicalRegister, QuantumRegister};
 use qiskit_circuit::bit::{ShareableClbit, ShareableQubit};
 use qiskit_circuit::circuit_data::CircuitData;
-use qiskit_circuit::operations::{DelayUnit, Operation, Param, StandardGate, StandardInstruction};
+use qiskit_circuit::operations::{
+    ArrayType, DelayUnit, Operation, Param, StandardGate, StandardInstruction, UnitaryGate,
+};
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::{Clbit, Qubit};
 
@@ -617,6 +623,117 @@ pub struct OpCounts {
     data: *mut OpCount,
     /// The number of elements in ``data``
     len: usize,
+}
+
+#[inline]
+fn conjugate(matrix: ArrayView2<Complex64>) -> Array2<Complex64> {
+    Array2::from_shape_fn((matrix.nrows(), matrix.ncols()), |(i, j)| {
+        matrix[(j, i)].conj()
+    })
+}
+
+/// Check an [ArrayType] represents a unitary matrix. Uses an element-wise check; if
+/// any element in ``conjugate(matrix) * matrix`` differs from the identity by more than ``tol``
+/// (in magnitude), the matrix is not considered unitary.
+fn is_unitary(matrix: &ArrayType, tol: f64) -> bool {
+    let not_unitary = match matrix {
+        ArrayType::OneQ(mat) => (mat.adjoint() * mat - Matrix2::identity())
+            .iter()
+            .any(|val| val.abs() > tol),
+        ArrayType::TwoQ(mat) => (mat.adjoint() * mat - Matrix4::identity())
+            .iter()
+            .any(|val| val.abs() > tol),
+        ArrayType::NDArray(mat) => {
+            let product = mat.dot(&conjugate(mat.view()));
+            product.indexed_iter().any(|((row, col), value)| {
+                if row == col {
+                    (value - Complex64::ONE).abs() > tol
+                } else {
+                    value.abs() > tol
+                }
+            })
+        }
+    };
+    !not_unitary // using double negation to use ``any`` (faster) instead of ``all``
+}
+
+/// @ingroup QkCircuit
+/// Append an arbitrary unitary matrix to the circuit.
+///
+/// @param circuit A pointer to the circuit to append the unitary to.
+/// @param matrix A pointer to the ``QkComplex64`` array representing the unitary matrix.
+///     This must be a row-major, unitary matrix of dimension ``2 ^ num_qubits x 2 ^ num_qubits``.
+///     More explicitly: the ``(i, j)``-th element is given by ``matrix[i * 2^n + j]``.
+///     The contents of ``matrix`` are copied inside this function before being added to the circuit,
+///     so caller keeps ownership of the original memory that ``matrix`` points to and can reuse it
+///     after the call and the caller is responsible for freeing it.
+/// @param qubits A pointer to array of qubit indices, of length ``num_qubits``.
+/// @param num_qubits The number of qubits the unitary acts on.
+/// @param check_input When true, the function verifies that the matrix is unitary.
+///     If set to False the caller is responsible for ensuring the matrix is unitary, if
+///     the matrix is not unitary this is undefined behavior and will result in a corrupt
+///     circuit.
+/// # Example
+///
+///     QkComplex64 c0 = qk_complex64_from_native(0);  // 0+0i
+///     QkComplex64 c1 = qk_complex64_from_native(1);  // 1+0i
+///
+///     const uint32_t num_qubits = 1;
+///     const uint32_t dim = 2;
+///     QkComplex64[dim * dim] unitary = {c0, c1,  // row 0
+///                                       c1, c0}; // row 1
+///
+///     QkCircuit *circuit = qk_circuit_new(1, 0);  // 1 qubit circuit
+///     uint32_t qubit = {0};  // qubit to apply the unitary on
+///     qk_circuit_unitary(circuit, unitary, qubit, num_qubits);
+///
+/// # Safety
+///
+/// Behavior is undefined if any of the following is violated:
+///
+///   * ``circuit`` is a valid, non-null pointer to a ``QkCircuit``
+///   * ``matrix`` is a pointer to a nested array of ``QkComplex64`` of dimension
+///     ``2 ^ num_qubits x 2 ^ num_qubits``
+///   * ``qubits`` is a pointer to ``num_qubits`` readable element of type ``uint32_t``
+///
+#[no_mangle]
+#[cfg(feature = "cbinding")]
+pub unsafe extern "C" fn qk_circuit_unitary(
+    circuit: *mut CircuitData,
+    matrix: *const Complex64,
+    qubits: *const u32,
+    num_qubits: u32,
+    check_input: bool,
+) -> ExitCode {
+    // SAFETY: Caller quarantees pointer validation, alignment
+    let circuit = unsafe { mut_ptr_as_ref(circuit) };
+
+    // Dimension of the unitart: 2^n
+    let dim = 1 << num_qubits;
+
+    // Build ndarray::Array2
+    let raw = unsafe { std::slice::from_raw_parts(matrix, dim * dim * 2) };
+    let mat = match num_qubits {
+        1 => ArrayType::OneQ(Matrix2::from_fn(|i, j| raw[i * dim + j])),
+        2 => ArrayType::TwoQ(Matrix4::from_fn(|i, j| raw[i * dim + j])),
+        _ => ArrayType::NDArray(Array2::from_shape_fn((dim, dim), |(i, j)| raw[i * dim + j])),
+    };
+
+    // verify the matrix is unitary
+    if check_input && !is_unitary(&mat, 1e-12) {
+        return ExitCode::ExpectedUnitary;
+    }
+
+    // Build qubit slice
+    let qargs: &[Qubit] =
+        unsafe { std::slice::from_raw_parts(qubits as *const Qubit, num_qubits as usize) };
+
+    // Create PackedOperation -> push to circuit_data
+    let u_gate = Box::new(UnitaryGate { array: mat });
+    let op = PackedOperation::from_unitary(u_gate);
+    circuit.push_packed_operation(op, &[], qargs, &[]);
+    // Return success
+    ExitCode::Success
 }
 
 /// @ingroup QkCircuit

--- a/crates/cext/src/exit_codes.rs
+++ b/crates/cext/src/exit_codes.rs
@@ -41,6 +41,8 @@ pub enum ExitCode {
     ArithmeticError = 200,
     /// Mismatching number of qubits.
     MismatchedQubits = 201,
+    /// Matrix is not unitary.
+    ExpectedUnitary = 202,
 }
 
 impl From<ArithmeticError> for ExitCode {

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -38,7 +38,7 @@ int test_empty(void) {
         return EqualityError;
     }
     if (num_instructions != 0) {
-        printf("The number of instructions %lu is not 0", num_instructions);
+        printf("The number of instructions %zu is not 0", num_instructions);
         return EqualityError;
     }
     return Ok;
@@ -675,6 +675,90 @@ cleanup:
     return result;
 }
 
+/**
+ * Test appending a unitary gate.
+ */
+int test_unitary_gate(void) {
+    QkCircuit *qc = qk_circuit_new(2, 0);
+    uint32_t qubits[2] = {0, 1};
+
+    QkComplex64 c0 = {0.0, 0.0};
+    QkComplex64 c1 = {1.0, 0.0};
+    QkComplex64 matrix[16] = {c1, c0, c0, c0,  // this
+                              c0, c1, c0, c0,  // is
+                              c0, c0, c1, c0,  // for
+                              c0, c0, c0, c1}; // formatting
+
+    int ec = qk_circuit_unitary(qc, matrix, qubits, 2, false);
+    if (ec != QkExitCode_Success) {
+        qk_circuit_free(qc);
+        return ec;
+    }
+
+    int result = Ok;
+
+    size_t num_inst = qk_circuit_num_instructions(qc);
+    if (num_inst != 1) {
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    QkOpCounts op_counts = qk_circuit_count_ops(qc);
+    if (op_counts.len != 1 || strcmp(op_counts.data[0].name, "unitary") != 0 ||
+        op_counts.data[0].count != 1) {
+        result = EqualityError;
+        qk_opcounts_free(op_counts);
+        goto cleanup;
+    }
+    qk_opcounts_free(op_counts);
+
+    QkCircuitInstruction inst = qk_circuit_get_instruction(qc, 0);
+    if (strcmp(inst.name, "unitary") != 0 || inst.num_clbits != 0 || inst.num_params != 0 ||
+        inst.num_qubits != 2) {
+        result = EqualityError;
+    }
+    qk_circuit_instruction_free(inst);
+
+cleanup:
+    qk_circuit_free(qc);
+    return result;
+}
+
+/**
+ * Test passing a non-unitary gate returns the correct exit code.
+ */
+int test_not_unitary_gate(void) {
+    QkCircuit *qc = qk_circuit_new(2, 0);
+    uint32_t qubits[2] = {0, 1};
+
+    QkComplex64 c0 = {0.0, 0.0};
+    QkComplex64 c1 = {1.0, 0.0};
+    QkComplex64 matrix[16] = {c1, c1, c0, c0,  // this
+                              c1, c1, c0, c0,  // is
+                              c0, c0, c1, c0,  // for
+                              c0, c0, c0, c1}; // formatting
+
+    int exit_code = qk_circuit_unitary(qc, matrix, qubits, 2, true);
+
+    int result = Ok;
+    if (exit_code != QkExitCode_ExpectedUnitary) {
+        printf("Got exit code %i but expected %i", exit_code, QkExitCode_ExpectedUnitary);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    size_t num_inst = qk_circuit_num_instructions(qc);
+    if (num_inst != 0) { // we expect no gate was added
+        printf("Found gate when none should be added");
+        result = EqualityError;
+        goto cleanup;
+    }
+
+cleanup:
+    qk_circuit_free(qc);
+    return result;
+}
+
 int test_delay_instruction(void) {
     QkCircuit *qc = qk_circuit_new(2, 0);
     int result = Ok;
@@ -707,6 +791,8 @@ int test_circuit(void) {
     num_failed += RUN_TEST(test_gate_num_qubits);
     num_failed += RUN_TEST(test_gate_num_params);
     num_failed += RUN_TEST(test_delay_instruction);
+    num_failed += RUN_TEST(test_unitary_gate);
+    num_failed += RUN_TEST(test_not_unitary_gate);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

We originally merged this C API function in #14334 but it had to be reverted in #14492 because the C API tests conflicted with #14340 and failed the tests. It was only able to merge because of a brief configuration issue with CI. This commit reapplies the originally PR and fixes the test conflict.

### Details and comments

This reverts commit 49874c6a826666fa65e12aecfb16c4586981176e.
