### PR TITLE
Fix warnings in circuit tests

### DIFF
--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -38,7 +38,7 @@ int test_empty(void) {
         return EqualityError;
     }
     if (num_instructions != 0) {
-        printf("The number of instructions %lu is not 0", num_instructions);
+        printf("The number of instructions %zu is not 0", num_instructions);
         return EqualityError;
     }
     return Ok;
@@ -62,7 +62,7 @@ int test_circuit_with_quantum_reg(void) {
         return EqualityError;
     }
     if (num_instructions != 0) {
-        printf("The number of instructions %lu is not 0", num_instructions);
+        printf("The number of instructions %zu is not 0", num_instructions);
         return EqualityError;
     }
     return Ok;
@@ -85,7 +85,7 @@ int test_circuit_copy(void) {
     qk_circuit_free(qc);
     qk_circuit_free(copy);
     if (num_instructions == num_copy_instructions) {
-        printf("The number of instructions %lu is equal to the copied %lu", num_instructions,
+        printf("The number of instructions %zu is equal to the copied %zu", num_instructions,
                num_copy_instructions);
         return EqualityError;
     }
@@ -110,7 +110,7 @@ int test_circuit_with_classical_reg(void) {
         return EqualityError;
     }
     if (num_instructions != 0) {
-        printf("The number of instructions %lu is not 0", num_instructions);
+        printf("The number of instructions %zu is not 0", num_instructions);
         return EqualityError;
     }
     return Ok;
@@ -129,7 +129,7 @@ int test_circuit_copy_with_instructions(void) {
     size_t num_instructions = qk_circuit_num_instructions(qc);
     size_t num_copy_instructions = qk_circuit_num_instructions(copy);
     if (num_instructions != num_copy_instructions) {
-        printf("The number of instructions %lu does not equal the copied %lu", num_instructions,
+        printf("The number of instructions %zu does not equal the copied %zu", num_instructions,
                num_copy_instructions);
         return EqualityError;
     }
@@ -154,7 +154,7 @@ int test_circuit_copy_with_instructions(void) {
     qk_circuit_free(qc);
     qk_circuit_free(copy);
     if (num_instructions == num_copy_instructions) {
-        printf("The number of instructions %lu is equal to the copied %lu", num_instructions,
+        printf("The number of instructions %zu is equal to the copied %zu", num_instructions,
                num_copy_instructions);
         return EqualityError;
     }
@@ -177,7 +177,7 @@ int test_no_gate_1000_bits(void) {
         return EqualityError;
     }
     if (num_instructions != 0) {
-        printf("The number of instructions %lu is not 0", num_instructions);
+        printf("The number of instructions %zu is not 0", num_instructions);
         return EqualityError;
     }
 
@@ -373,7 +373,7 @@ cleanup:
     return result;
 }
 
-int test_get_gate_counts_bv_barrier_and_measures() {
+int test_get_gate_counts_bv_barrier_and_measures(void) {
     QkCircuit *qc = qk_circuit_new(1000, 1000);
     double *params = NULL;
     uint32_t i = 0;

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -73,7 +73,7 @@ int test_circuit_copy(void) {
     QkCircuit *copy = qk_circuit_copy(qc);
     for (int i = 0; i < 10; i++) {
         qk_circuit_measure(qc, i, i);
-        int qubits[1] = {
+        uint32_t qubits[1] = {
             i,
         };
         if (i % 2 == 0) {
@@ -120,7 +120,7 @@ int test_circuit_copy_with_instructions(void) {
     QkCircuit *qc = qk_circuit_new(10, 10);
     for (int i = 0; i < 10; i++) {
         qk_circuit_measure(qc, i, i);
-        int qubits[1] = {
+        uint32_t qubits[1] = {
             i,
         };
         qk_circuit_gate(qc, QkGate_H, qubits, NULL);
@@ -136,14 +136,14 @@ int test_circuit_copy_with_instructions(void) {
 
     for (int i = 0; i < 10; i++) {
         qk_circuit_measure(qc, i, i);
-        int qubits[1] = {
+        uint32_t qubits[1] = {
             i,
         };
         qk_circuit_gate(qc, QkGate_Z, qubits, NULL);
     }
     for (int i = 0; i < 15; i++) {
         qk_circuit_measure(qc, i, i);
-        int qubits[1] = {
+        uint32_t qubits[1] = {
             i,
         };
         qk_circuit_gate(copy, QkGate_X, qubits, NULL);
@@ -459,7 +459,6 @@ int test_get_gate_counts_bv_resets_barrier_and_measures(void) {
     uint32_t i = 0;
     uint32_t qubits[1] = {999};
     for (i = 0; i < 1000; i++) {
-        uint32_t qubits[1] = {i};
         qk_circuit_reset(qc, i);
     }
     qk_circuit_gate(qc, QkGate_X, qubits, params);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

When building the C unit tests with clang it warns about some mismatched types in the circuit tests which are potential bugs. While in practice this isn't like to cause an issue the clang warning is still correct and there is no reason to use a signed integer when the function expects a uin32_t and it's just a counter. This commit fixes the typing to match and that fixes the warning. In the future we can look at adding a clang tidy CI job for the C tests or denying warnings in the C compiler in CI to prevent these kinds of issues from slipping in.

### Details and comments


