### PR TITLE
Avoid using rustworkx 0.16.0 methods in vf2_utils

### DIFF
--- a/qiskit/transpiler/passes/layout/vf2_utils.py
+++ b/qiskit/transpiler/passes/layout/vf2_utils.py
@@ -189,7 +189,9 @@ def build_average_error_map(target, coupling_map):
         coupling_map = target.build_coupling_map()
     if not built and coupling_map is not None and num_qubits is not None:
         for qubit in range(num_qubits):
-            degree = len(set(coupling_map.graph.neighbors_undirected(qubit)))
+            degree = len(set(coupling_map.graph.successor_indices(qubit))) + len(
+                set(coupling_map.graph.predecessor_indices(qubit))
+            )
             avg_map.add_error((qubit, qubit), degree / num_qubits)
         for edge in coupling_map.graph.edge_list():
             avg_map.add_error(edge, (avg_map[edge[0], edge[0]] + avg_map[edge[1], edge[1]]) / 2)

--- a/qiskit/transpiler/passes/layout/vf2_utils.py
+++ b/qiskit/transpiler/passes/layout/vf2_utils.py
@@ -189,9 +189,9 @@ def build_average_error_map(target, coupling_map):
         coupling_map = target.build_coupling_map()
     if not built and coupling_map is not None and num_qubits is not None:
         for qubit in range(num_qubits):
-            degree = len(set(coupling_map.graph.successor_indices(qubit))) + len(
-                set(coupling_map.graph.predecessor_indices(qubit))
-            )
+            neighbor_set = set(coupling_map.graph.successor_indices(qubit))
+            neighbor_set.update(coupling_map.graph.predecessor_indices(qubit))
+            degree = len(neighbor_set)
             avg_map.add_error((qubit, qubit), degree / num_qubits)
         for edge in coupling_map.graph.edge_list():
             avg_map.add_error(edge, (avg_map[edge[0], edge[0]] + avg_map[edge[1], edge[1]]) / 2)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #14218 the vf2_utils module was updated to use the `PyDiGraph.neighbors_undirected()` method which was added in 0.16.0. However that PR neglected to bump the minimum required version of rustworkx to 0.16.0 from 0.15.0 which is the current minim version listed. While we could bump the minimum version (see #14507) to rustworkx 0.16.0 using this method isn't strictly necessary and #14218 was backported to stable branches and backporting a version bump is not desireable. This commit instead just updates the rustworkx usage to use APIs in 0.15.0.

This PR will need to be backported to stable/1.4 and stable/2.0 to fix compatibility with the listed rustworkx requirement. However, in the backport a fix note will be needed to document that the release fixes compatibility with the listed requirement.

### Details and comments