### PR TITLE
Remove trailing function declaration in C tests

### DIFF
--- a/test/c/common.h
+++ b/test/c/common.h
@@ -14,8 +14,6 @@
 #include <qiskit.h>
 #include <stdio.h>
 
-QkComplex64 make_complex_double(double real, double imag);
-
 // An enumeration of test results. These should be returned by test functions to
 // indicate what kind of error occurred. This will be used to produce more
 // helpful messages for the developer running the test suite.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Remove trailing declaration of `make_complex_double` in `common.h`. This is an oversight from the recent #14340. I would've expected the compiler to complain about this, since in `test_complex.c` there is another definition of this function with a different signature...


