### PR TITLE
Fix qiskit-synthesis crate standalone builds

### DIFF
--- a/crates/synthesis/Cargo.toml
+++ b/crates/synthesis/Cargo.toml
@@ -56,7 +56,7 @@ features = ["num-complex"]
 
 [dependencies.hashbrown]
 workspace = true
-features = ["rayon"]
+features = ["rayon", "serde"]
 
 [dependencies.indexmap]
 workspace = true

--- a/crates/synthesis/src/discrete_basis/basic_approximations.rs
+++ b/crates/synthesis/src/discrete_basis/basic_approximations.rs
@@ -377,7 +377,7 @@ impl BasicApproximations {
     /// - ``basis_gates`` - A slice of [StandardGate]s to use in basic approximation.
     /// - ``depth`` - The maximum gate depth of the basic approximations.
     /// - ``tol`` - Control the granularity of the tree; new sequences are accepted if they
-    ///     are further than ``sqrt(tol)`` from an existing element.
+    ///   are further than ``sqrt(tol)`` from an existing element.
     pub fn generate_from(
         basis_gates: &[StandardGate],
         depth: usize,
@@ -469,8 +469,7 @@ impl BasicApproximations {
 
         // store the now serializable HashMap
         let file = ::std::fs::File::create(filename)?;
-        bincode::serialize_into(file, &serializable_approx)
-            .map_err(|e| ::std::io::Error::new(::std::io::ErrorKind::Other, e))?;
+        bincode::serialize_into(file, &serializable_approx).map_err(::std::io::Error::other)?;
         Ok(())
     }
 
@@ -479,8 +478,7 @@ impl BasicApproximations {
         // store the now serializable HashMap
         let file = ::std::fs::File::open(filename)?;
         let serializable_approx: HashMap<usize, SerializableGateSequence> =
-            bincode::deserialize_from(file)
-                .map_err(|e| ::std::io::Error::new(::std::io::ErrorKind::Other, e))?;
+            bincode::deserialize_from(file).map_err(::std::io::Error::other)?;
 
         // construct the GateSequence from it's serializable version
         let approximations = serializable_approx

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -289,7 +289,7 @@ fn add_reset_gadget(circuit: &mut CircuitData, q0: u32, q1: u32, q2: u32) {
 /// # References
 ///
 /// 1. Iten et al., *Quantum Circuits for Isometries*, Phys. Rev. A 93, 032318 (2016),
-/// [arXiv:1501.06911] (http://arxiv.org/abs/1501.06911).
+///    [arXiv:1501.06911] (http://arxiv.org/abs/1501.06911).
 pub fn synth_mcx_n_dirty_i15(
     num_controls: usize,
     relative_phase: bool,
@@ -377,8 +377,8 @@ pub fn synth_mcx_n_dirty_i15(
 /// # References
 ///
 /// 1. Vale et. al., *Circuit Decomposition of Multicontrolled Special Unitary
-/// Single-Qubit Gates*, IEEE TCAD 43(3) (2024),
-/// [arXiv:2302.06377] (https://arxiv.org/abs/2302.06377).
+///    Single-Qubit Gates*, IEEE TCAD 43(3) (2024),
+///    [arXiv:2302.06377] (https://arxiv.org/abs/2302.06377).
 pub fn synth_mcx_noaux_v24(py: Python, num_controls: usize) -> PyResult<CircuitData> {
     if num_controls == 3 {
         c3x()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the recently merged #14203 the bincode dependency was added to the qiskit-synthesis crate to provide a binary serialization of the computed basic approximations. However, under the covers this library is using serde and it depends on having anything passed to it be serde serializable. When building the qiskit-synthesis crate by itself the hashbrown crate does not enable the serde feature meaning it doesn't derive the necessary serialization traits for serde. This didn't show up in a full build because other libraries pulled in as part of the build cause serde to be enabled for hashbrown. This commit fixes this by adding the serde feature to the Cargo.toml for hashbrown to ensure we're building with the feature required in the crate using it.

This also takes the opportunity to fix some small clippy lint issues identified by the latest stable version of clippy in the synthesis crate which were introduced in #14203 and #13929.

### Details and comments


