### PR TITLE
Add sanity check for all crates to CI

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -27,6 +27,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
+      - name: Standalone checks for all crates
+        run: |
+          set -e
+          for crate in `ls -d ./crates/*/` ; do
+              pushd "$crate"
+              cargo check
+              popd
+          done
       - name: Install Qiskit directly
         run: |
           set -e


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new step to the rust unit test CI job that runs cargo check on each of our crates in isolation to ensure that they all build on their own. This will prevent issues like what was fixed in #14526 from popping up again (which has happened before).

### Details and comments


