### PR TITLE
Add support for Measure and Reset in Target's C API

### DIFF
--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -1014,6 +1014,18 @@ pub enum QkDelayUnit {
     PS = 4,
 }
 
+impl From<QkDelayUnit> for DelayUnit {
+    fn from(value: QkDelayUnit) -> Self {
+        match value {
+            QkDelayUnit::S => DelayUnit::S,
+            QkDelayUnit::MS => DelayUnit::MS,
+            QkDelayUnit::US => DelayUnit::US,
+            QkDelayUnit::NS => DelayUnit::NS,
+            QkDelayUnit::PS => DelayUnit::PS,
+        }
+    }
+}
+
 /// @ingroup QkCircuit
 /// Append a delay instruction to the circuit.
 ///
@@ -1043,13 +1055,7 @@ pub unsafe extern "C" fn qk_circuit_delay(
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { mut_ptr_as_ref(circuit) };
 
-    let delay_unit_variant = match unit {
-        QkDelayUnit::S => DelayUnit::S,
-        QkDelayUnit::MS => DelayUnit::MS,
-        QkDelayUnit::US => DelayUnit::US,
-        QkDelayUnit::NS => DelayUnit::NS,
-        QkDelayUnit::PS => DelayUnit::PS,
-    };
+    let delay_unit_variant = unit.into();
 
     let duration_param: Param = duration.into();
     let delay_instruction = StandardInstruction::Delay(delay_unit_variant);

--- a/crates/cext/src/transpiler/target.rs
+++ b/crates/cext/src/transpiler/target.rs
@@ -15,7 +15,6 @@ use crate::exit_codes::CInputError;
 use crate::exit_codes::ExitCode;
 use crate::pointers::{check_ptr, const_ptr_as_ref, mut_ptr_as_ref};
 use indexmap::IndexMap;
-use qiskit_circuit::operations::DelayUnit;
 use qiskit_circuit::operations::StandardInstruction;
 use qiskit_circuit::operations::{Operation, Param, StandardGate};
 use qiskit_circuit::packed_instruction::PackedOperation;
@@ -447,25 +446,9 @@ impl TargetEntry {
         }
     }
 
-    pub fn measure() -> Self {
+    pub fn new_instruction(instruction: StandardInstruction) -> Self {
         Self {
-            operation: StandardOperation::Instruction(StandardInstruction::Measure),
-            params: None,
-            map: Default::default(),
-        }
-    }
-
-    pub fn reset() -> Self {
-        Self {
-            operation: StandardOperation::Instruction(StandardInstruction::Reset),
-            params: None,
-            map: Default::default(),
-        }
-    }
-
-    pub fn delay(unit: DelayUnit) -> Self {
-        Self {
-            operation: StandardOperation::Instruction(StandardInstruction::Delay(unit)),
+            operation: StandardOperation::Instruction(instruction),
             params: None,
             map: Default::default(),
         }
@@ -506,8 +489,10 @@ pub extern "C" fn qk_target_entry_new(operation: StandardGate) -> *mut TargetEnt
 ///     QkTargetEntry *entry = qk_target_entry_measure();
 #[no_mangle]
 #[cfg(feature = "cbinding")]
-pub extern "C" fn qk_target_entry_measure() -> *mut TargetEntry {
-    Box::into_raw(Box::new(TargetEntry::measure()))
+pub extern "C" fn qk_target_entry_new_measure() -> *mut TargetEntry {
+    Box::into_raw(Box::new(TargetEntry::new_instruction(
+        StandardInstruction::Measure,
+    )))
 }
 
 /// @ingroup QkTargetEntry
@@ -521,7 +506,9 @@ pub extern "C" fn qk_target_entry_measure() -> *mut TargetEntry {
 #[no_mangle]
 #[cfg(feature = "cbinding")]
 pub extern "C" fn qk_target_entry_reset() -> *mut TargetEntry {
-    Box::into_raw(Box::new(TargetEntry::reset()))
+    Box::into_raw(Box::new(TargetEntry::new_instruction(
+        StandardInstruction::Reset,
+    )))
 }
 
 /// @ingroup QkTargetEntry
@@ -536,7 +523,9 @@ pub extern "C" fn qk_target_entry_reset() -> *mut TargetEntry {
 #[no_mangle]
 #[cfg(feature = "cbinding")]
 pub extern "C" fn qk_target_entry_delay(unit: QkDelayUnit) -> *mut TargetEntry {
-    Box::into_raw(Box::new(TargetEntry::delay(unit.into())))
+    Box::into_raw(Box::new(TargetEntry::new_instruction(
+        StandardInstruction::Delay(unit.into()),
+    )))
 }
 
 /// @ingroup QkTargetEntry

--- a/crates/cext/src/transpiler/target.rs
+++ b/crates/cext/src/transpiler/target.rs
@@ -485,6 +485,16 @@ pub extern "C" fn qk_target_entry_new(operation: StandardGate) -> *mut TargetEnt
 /// # Example
 ///
 ///     QkTargetEntry *entry = qk_target_entry_new_measure();
+///     // Add fixed duration and error rates from qubits at index 0 to 4.
+///     for (uint32_t i = 0; i < 5; i++) {
+///         // Measure is a single qubit instruction
+///         uint32_t qargs[1] = {i};
+///         qk_target_entry_add_property(entry, qargs, 1, 1.928e-10, 7.9829e-11);
+///     }
+///     
+///     // Add the entry to a target with 5 qubits
+///     QkTarget *measure_target = qk_target_new(5);
+///     qk_target_add_instruction(measure_target, entry);
 #[no_mangle]
 #[cfg(feature = "cbinding")]
 pub extern "C" fn qk_target_entry_new_measure() -> *mut TargetEntry {
@@ -501,6 +511,16 @@ pub extern "C" fn qk_target_entry_new_measure() -> *mut TargetEntry {
 /// # Example
 ///
 ///     QkTargetEntry *entry = qk_target_entry_new_reset();
+///     // Add fixed duration and error rates from qubits at index 0 to 2.
+///     for (uint32_t i = 0; i < 3; i++) {
+///         // Reset is a single qubit instruction
+///         uint32_t qargs[1] = {i};
+///         qk_target_entry_add_property(entry, qargs, 1, 1.2e-11, 5.9e-13);
+///     }
+///     
+///     // Add the entry to a target with 3 qubits
+///     QkTarget *reset_target = qk_target_new(3);
+///     qk_target_add_instruction(reset_target, entry);
 #[no_mangle]
 #[cfg(feature = "cbinding")]
 pub extern "C" fn qk_target_entry_new_reset() -> *mut TargetEntry {

--- a/crates/cext/src/transpiler/target.rs
+++ b/crates/cext/src/transpiler/target.rs
@@ -478,13 +478,13 @@ pub extern "C" fn qk_target_entry_new(operation: StandardGate) -> *mut TargetEnt
 }
 
 /// @ingroup QkTargetEntry
-/// Creates a measurement entry for a ``QkTarget``.
+/// Creates a new entry for adding a measurement instruction to a ``QkTarget``.
 ///
 /// @return A pointer to the new ``QkTargetEntry`` for a measurement instruction.
 ///
 /// # Example
 ///
-///     QkTargetEntry *entry = qk_target_entry_new_measure()();
+///     QkTargetEntry *entry = qk_target_entry_new_measure();
 #[no_mangle]
 #[cfg(feature = "cbinding")]
 pub extern "C" fn qk_target_entry_new_measure() -> *mut TargetEntry {
@@ -494,7 +494,7 @@ pub extern "C" fn qk_target_entry_new_measure() -> *mut TargetEntry {
 }
 
 /// @ingroup QkTargetEntry
-/// Creates a reset entry for a ``QkTarget``.
+/// Creates a new entry for adding a reset instruction to a ``QkTarget``.
 ///
 /// @return A pointer to the new ``QkTargetEntry`` for a reset instruction.
 ///

--- a/crates/cext/src/transpiler/target.rs
+++ b/crates/cext/src/transpiler/target.rs
@@ -10,9 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::circuit::QkDelayUnit;
-use crate::exit_codes::CInputError;
-use crate::exit_codes::ExitCode;
+use crate::exit_codes::{CInputError, ExitCode};
 use crate::pointers::{check_ptr, const_ptr_as_ref, mut_ptr_as_ref};
 use indexmap::IndexMap;
 use qiskit_circuit::operations::StandardInstruction;
@@ -486,7 +484,7 @@ pub extern "C" fn qk_target_entry_new(operation: StandardGate) -> *mut TargetEnt
 ///
 /// # Example
 ///
-///     QkTargetEntry *entry = qk_target_entry_measure();
+///     QkTargetEntry *entry = qk_target_entry_new_measure()();
 #[no_mangle]
 #[cfg(feature = "cbinding")]
 pub extern "C" fn qk_target_entry_new_measure() -> *mut TargetEntry {
@@ -502,29 +500,12 @@ pub extern "C" fn qk_target_entry_new_measure() -> *mut TargetEntry {
 ///
 /// # Example
 ///
-///     QkTargetEntry *entry = qk_target_entry_reset();
+///     QkTargetEntry *entry = qk_target_entry_new_reset();
 #[no_mangle]
 #[cfg(feature = "cbinding")]
-pub extern "C" fn qk_target_entry_reset() -> *mut TargetEntry {
+pub extern "C" fn qk_target_entry_new_reset() -> *mut TargetEntry {
     Box::into_raw(Box::new(TargetEntry::new_instruction(
         StandardInstruction::Reset,
-    )))
-}
-
-/// @ingroup QkTargetEntry
-/// Creates a delay entry for a ``QkTarget``.
-///
-/// @param unit The delay unit.
-/// @return A pointer to the new ``QkTargetEntry`` for a delay instruction.
-///
-/// # Example
-///
-///     QkTargetEntry *entry = qk_target_entry_delay(QkDelayUnit::NS);
-#[no_mangle]
-#[cfg(feature = "cbinding")]
-pub extern "C" fn qk_target_entry_delay(unit: QkDelayUnit) -> *mut TargetEntry {
-    Box::into_raw(Box::new(TargetEntry::new_instruction(
-        StandardInstruction::Delay(unit.into()),
     )))
 }
 

--- a/crates/transpiler/src/target/mod.rs
+++ b/crates/transpiler/src/target/mod.rs
@@ -305,7 +305,7 @@ impl Target {
             granularity: granularity.unwrap_or(1),
             min_length: min_length.unwrap_or(1),
             pulse_alignment: pulse_alignment.unwrap_or(1),
-            acquire_alignment: acquire_alignment.unwrap_or(0),
+            acquire_alignment: acquire_alignment.unwrap_or(1),
             qubit_properties,
             concurrent_measurements,
             gate_map: GateMap::default(),

--- a/test/c/test_target.c
+++ b/test/c/test_target.c
@@ -311,7 +311,7 @@ int test_target_add_instruction(void) {
     }
     uint32_t num_meas = qk_target_entry_num_properties(meas);
     if (num_meas != 3) {
-        printf("Expected 3 measurement entries but got: %lu", num_meas);
+        printf("Expected 3 measurement entries but got: %u", num_meas);
         result = EqualityError;
         qk_target_entry_free(meas);
         goto cleanup;
@@ -330,6 +330,50 @@ int test_target_add_instruction(void) {
     current_size = qk_target_num_instructions(target);
     if (current_size != 4) {
         printf("The size of this target is not correct: Expected 4, got %zu", current_size);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    // Add a reset
+    QkTargetEntry *reset = qk_target_entry_reset();
+    for (uint32_t i = 0; i < 3; i++) {
+        uint32_t q[1] = {i};
+        qk_target_entry_add_property(meas, q, 1, 2e-6, 2e-4);
+    }
+    uint32_t num_reset = qk_target_entry_num_properties(reset);
+    if (num_meas != 3) {
+        printf("Expected 3 reset entries but got: %u", num_reset);
+        result = EqualityError;
+        qk_target_entry_free(reset);
+        goto cleanup;
+    }
+
+    qk_target_add_instruction(target, reset);
+    current_size = qk_target_num_instructions(target);
+    if (current_size != 5) {
+        printf("The size of this target is not correct: Expected 5, got %zu", current_size);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    // Add a delay
+    QkTargetEntry *delay = qk_target_entry_delay(QkDelayUnit_NS);
+    for (uint32_t i = 0; i < 3; i++) {
+        uint32_t q[1] = {i};
+        qk_target_entry_add_property(meas, q, 1, NAN, 0.0);
+    }
+    uint32_t num_delays = qk_target_entry_num_properties(delay);
+    if (num_delays != 3) {
+        printf("Expected 3 reset entries but got: %u", num_delays);
+        result = EqualityError;
+        qk_target_entry_free(delay);
+        goto cleanup;
+    }
+
+    qk_target_add_instruction(target, delay);
+    current_size = qk_target_num_instructions(target);
+    if (current_size != 6) {
+        printf("The size of this target is not correct: Expected 6, got %zu", current_size);
         result = EqualityError;
         goto cleanup;
     }

--- a/test/c/test_target.c
+++ b/test/c/test_target.c
@@ -304,7 +304,7 @@ int test_target_add_instruction(void) {
     }
 
     // Add a measurement
-    QkTargetEntry *meas = qk_target_entry_measure();
+    QkTargetEntry *meas = qk_target_entry_new_measure();
     for (uint32_t i = 0; i < 3; i++) {
         uint32_t q[1] = {i};
         qk_target_entry_add_property(meas, q, 1, 1e-6, 1e-4);
@@ -335,7 +335,7 @@ int test_target_add_instruction(void) {
     }
 
     // Add a reset
-    QkTargetEntry *reset = qk_target_entry_reset();
+    QkTargetEntry *reset = qk_target_entry_new_reset();
     for (uint32_t i = 0; i < 3; i++) {
         uint32_t q[1] = {i};
         qk_target_entry_add_property(meas, q, 1, 2e-6, 2e-4);
@@ -352,28 +352,6 @@ int test_target_add_instruction(void) {
     current_size = qk_target_num_instructions(target);
     if (current_size != 5) {
         printf("The size of this target is not correct: Expected 5, got %zu", current_size);
-        result = EqualityError;
-        goto cleanup;
-    }
-
-    // Add a delay
-    QkTargetEntry *delay = qk_target_entry_delay(QkDelayUnit_NS);
-    for (uint32_t i = 0; i < 3; i++) {
-        uint32_t q[1] = {i};
-        qk_target_entry_add_property(meas, q, 1, NAN, 0.0);
-    }
-    uint32_t num_delays = qk_target_entry_num_properties(delay);
-    if (num_delays != 3) {
-        printf("Expected 3 reset entries but got: %u", num_delays);
-        result = EqualityError;
-        qk_target_entry_free(delay);
-        goto cleanup;
-    }
-
-    qk_target_add_instruction(target, delay);
-    current_size = qk_target_num_instructions(target);
-    if (current_size != 6) {
-        printf("The size of this target is not correct: Expected 6, got %zu", current_size);
         result = EqualityError;
         goto cleanup;
     }

--- a/test/c/test_target.c
+++ b/test/c/test_target.c
@@ -63,8 +63,8 @@ int test_empty_target(void) {
     }
 
     uint32_t acquire_alignment = qk_target_acquire_alignment(target);
-    if (acquire_alignment != 0) {
-        printf("The acquire_alignment values %u is not 0.", acquire_alignment);
+    if (acquire_alignment != 1) {
+        printf("The acquire_alignment values %u is not 1.", acquire_alignment);
         result = EqualityError;
         goto cleanup;
     }

--- a/test/c/test_target.c
+++ b/test/c/test_target.c
@@ -194,8 +194,8 @@ int test_target_add_instruction(void) {
     // Let's create a target with one qubit for now
     QkTarget *target = qk_target_new(num_qubits);
     int result = Ok;
-    // Add an X Gate.
 
+    // Add an X Gate.
     // This operation is global, no property map is provided
     QkExitCode result_x = qk_target_add_instruction(target, qk_target_entry_new(QkGate_X));
     if (result_x != QkExitCode_Success) {
@@ -299,6 +299,37 @@ int test_target_add_instruction(void) {
     current_size = qk_target_num_instructions(target);
     if (current_size != 3) {
         printf("The size of this target is not correct: Expected 3, got %zu", current_size);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    // Add a measurement
+    QkTargetEntry *meas = qk_target_entry_measure();
+    for (uint32_t i = 0; i < 3; i++) {
+        uint32_t q[1] = {i};
+        qk_target_entry_add_property(meas, q, 1, 1e-6, 1e-4);
+    }
+    uint32_t num_meas = qk_target_entry_num_properties(meas);
+    if (num_meas != 3) {
+        printf("Expected 3 measurement entries but got: %lu", num_meas);
+        result = EqualityError;
+        qk_target_entry_free(meas);
+        goto cleanup;
+    }
+
+    QkExitCode result_meas_props = qk_target_add_instruction(target, meas);
+    // Number of qubits of the target should remain 3.
+    current_num_qubits = qk_target_num_qubits(target);
+    if (current_num_qubits != 3) {
+        printf("The number of qubits this target is compatible with is not 3: %d",
+               current_num_qubits);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    current_size = qk_target_num_instructions(target);
+    if (current_size != 4) {
+        printf("The size of this target is not correct: Expected 4, got %zu", current_size);
         result = EqualityError;
         goto cleanup;
     }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Follow up on the Target C API: Add support for directives.

### Details and comments

This keeps the existing interface in place and simply extends the target entries to not only hold a `StandardGate`, but a
```rust
enum StandardOperation {
    Gate(StandardGate),
    Directive(StandardInstruction),
}
```
instead. This could potentially also be upgraded to `OperationRef` if we wanted to add support for custom gates in the target.

Docs and other constructors than measure to follow.