### PR TITLE
Fix behavior of HLS plugins after `preserve_order=False`

### DIFF
--- a/qiskit/transpiler/passes/synthesis/hls_plugins.py
+++ b/qiskit/transpiler/passes/synthesis/hls_plugins.py
@@ -1917,13 +1917,15 @@ class PauliEvolutionSynthesisDefault(HighLevelSynthesisPlugin):
             # Don't do anything if a gate is called "evolution" but is not an
             # actual PauliEvolutionGate
             return None
-
         algo = high_level_object.synthesis
 
+        original_preserve_order = algo.preserve_order
         if "preserve_order" in options and isinstance(algo, ProductFormula):
             algo.preserve_order = options["preserve_order"]
 
-        return algo.synthesize(high_level_object)
+        synth_object = algo.synthesize(high_level_object)
+        algo.preserve_order = original_preserve_order
+        return synth_object
 
 
 class PauliEvolutionSynthesisRustiq(HighLevelSynthesisPlugin):
@@ -1974,6 +1976,7 @@ class PauliEvolutionSynthesisRustiq(HighLevelSynthesisPlugin):
             )
             return None
 
+        original_preserve_order = algo.preserve_order
         if "preserve_order" in options:
             algo.preserve_order = options["preserve_order"]
 
@@ -1986,7 +1989,7 @@ class PauliEvolutionSynthesisRustiq(HighLevelSynthesisPlugin):
         upto_phase = options.get("upto_phase", False)
         resynth_clifford_method = options.get("resynth_clifford_method", 1)
 
-        return synth_pauli_network_rustiq(
+        synth_object = synth_pauli_network_rustiq(
             num_qubits=num_qubits,
             pauli_network=pauli_network,
             optimize_count=optimize_count,
@@ -1995,6 +1998,8 @@ class PauliEvolutionSynthesisRustiq(HighLevelSynthesisPlugin):
             upto_phase=upto_phase,
             resynth_clifford_method=resynth_clifford_method,
         )
+        algo.preserve_order = original_preserve_order
+        return synth_object
 
 
 class AnnotatedSynthesisDefault(HighLevelSynthesisPlugin):

--- a/releasenotes/notes/fix-preserve-order-0b8c1bf383f42297.yaml
+++ b/releasenotes/notes/fix-preserve-order-0b8c1bf383f42297.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug in the :class:`.PauliEvolutionSynthesisDefault` and :class:`.PauliEvolutionSynthesisRustiq` plugins that 
+    modified the `.synthesis` attribute of the original circuit when setting ``preserve_order=False``. The behavior of the
+    plugins has been restored and the original circuit is now preserved throughout the transpilation pipeline.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The HLS plugins for `PauliEvolutionGates` were modifying the original circuit's `gate.synthesis.preserve_order` attribute, which would result in an unexpected behavior of the pass manager when run multiple times. The bug can be fixed by restoring the property in the plugin after it being used in `.synthesize`.

### Details and comments


