### PR TITLE
Deprecate Python 3.9 support

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -44,6 +44,14 @@ else:
             " See https://qisk.it/packaging-1-0 for more detail."
         )
 
+if sys.version_info < (3, 10):
+    warnings.warn(
+        "Using Qiskit with Python 3.9 is deprecated as of the 2.1.0 release. "
+        "Support for running Qiskit with Python 3.9 will be removed in the "
+        "2.3.0 release, which coincides with when Python 3.9 goes end of life.",
+        DeprecationWarning,
+    )
+
 from . import _accelerate
 import qiskit._numpy_compat
 

--- a/releasenotes/notes/2.1/deprecate-3.9-b0c1d363a38cafbd.yaml
+++ b/releasenotes/notes/2.1/deprecate-3.9-b0c1d363a38cafbd.yaml
@@ -1,0 +1,10 @@
+---
+deprecations:
+  - |
+    Support for running Qiskit with Python 3.9 has been deprecated and will
+    be removed in the Qiskit 2.3.0 release. The 2.3.0 is the first release after
+    Python 3.9 goes end of life and is no longer supported. [1] This means that
+    starting in the 2.3.0 release you will need to upgrade the Python version
+    you're using to Python 3.9 or above.
+
+    [1] https://devguide.python.org/versions/


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit deprecates Python 3.9 support. During the deprecation window we will continue to fully support Python 3.9 and test it in CI, but it will emit a warning that we will be removing support for 3.9 in the future to inform users to upgrade to Python 3.10 or newer. The removal will occur during the Qiskit 2.3.0 release as it is the first release scheduled to occur after the upstream Python EoL date in October 2025. [1]

On the development side once we create the stable/2.2 branch on the 2.2.0rc1 release, then we can drop Python 3.9 support and raise the minimum Python version to 3.10 (including in CI).

### Details and comments

[1] https://devguide.python.org/versions/
