### PR TITLE
Fix index.rst to have alphabetical order

### DIFF
--- a/docs/apidoc/index.rst
+++ b/docs/apidoc/index.rst
@@ -14,11 +14,11 @@ Circuit construction:
 
    circuit
    qiskit.circuit.QuantumCircuit
+   circuit_annotation
    circuit_classical
    circuit_library
    circuit_random
    circuit_singleton
-   circuit_annotation
 
 Quantum information:
 


### PR DESCRIPTION
This PR sorts the entries in the circuit section alphabetically (excluding manually created pages like `qiskit.circuit.QuantumCircuit`).

The change is needed because the MDX conversion pipeline generates the left TOC in that order and expects that the entries in the index match it for consistency. [Here](https://github.com/Qiskit/documentation/actions/runs/15485914400/job/43600457379?pr=3272#step:17:25) you can see the test failing when generating qiskit 2.1.0rc1
