### PR TITLE
Fix bad math expression in pauli_lindblad_map_class.rs

### DIFF
--- a/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -1548,7 +1548,7 @@ impl PyPauliLindbladMap {
     ///
     /// .. math::
     ///     
-    ///     f(Q) = \exp\left(-2 \sum_{P \in K} \lambda(P) \langle P, Q\rangle_{sp}),
+    ///     f(Q) = \exp\left(-2 \sum_{P \in K} \lambda(P) \langle P, Q\rangle_{sp}\right),
     ///
     /// where :math:`\langle P, Q\rangle_{sp}` is :math:`0` if :math:`P` and :math:`Q` commute, and
     /// :math:`1` if they anti-commute.


### PR DESCRIPTION
This PR fixes a math expression that wasn't rendering properly

```
[ParseError]: KaTeX parse error: Expected '\right', got 'EOF' at end of input: …Q\rangle_{sp}),
```

The error was caught by [CI](https://github.com/Qiskit/documentation/actions/runs/15490518404/job/43614758818?pr=3272#step:21:9) in Qiskit/documentation