### PR TITLE
Make Rust-space `VarsMode` strongly, not stringly, typed

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -1338,8 +1338,8 @@ impl DAGCircuit {
     ///
     /// Returns:
     ///     DAGCircuit: An empty copy of self.
-    #[pyo3(signature = (*, vars_mode="alike"))]
-    pub fn copy_empty_like(&self, vars_mode: &str) -> PyResult<Self> {
+    #[pyo3(signature = (*, vars_mode=VarsMode::Alike))]
+    pub fn copy_empty_like(&self, vars_mode: VarsMode) -> PyResult<Self> {
         self.copy_empty_like_with_capacity(0, 0, vars_mode)
     }
 
@@ -2820,12 +2820,12 @@ impl DAGCircuit {
     /// Each :class:`~.DAGCircuit` instance returned by this method will contain the same number of
     /// clbits as ``self``. The global phase information in ``self`` will not be maintained
     /// in the subcircuits returned by this method.
-    #[pyo3(signature = (remove_idle_qubits=false, *, vars_mode="alike"))]
+    #[pyo3(signature = (remove_idle_qubits=false, *, vars_mode=VarsMode::Alike))]
     fn separable_circuits(
         &self,
         py: Python,
         remove_idle_qubits: bool,
-        vars_mode: &str,
+        vars_mode: VarsMode,
     ) -> PyResult<Py<PyList>> {
         let connected_components = rustworkx_core::connectivity::connected_components(&self.dag);
         let dags = PyList::empty(py);
@@ -3561,8 +3561,8 @@ impl DAGCircuit {
     /// TODO: Gates that use the same cbits will end up in different
     /// layers as this is currently implemented. This may not be
     /// the desired behavior.
-    #[pyo3(signature = (*, vars_mode="captures"))]
-    fn layers(&self, py: Python, vars_mode: &str) -> PyResult<Py<PyIterator>> {
+    #[pyo3(signature = (*, vars_mode=VarsMode::Captures))]
+    fn layers(&self, py: Python, vars_mode: VarsMode) -> PyResult<Py<PyIterator>> {
         let layer_list = PyList::empty(py);
         let mut graph_layers = self.multigraph_layers();
         if graph_layers.next().is_none() {
@@ -3619,8 +3619,8 @@ impl DAGCircuit {
     ///
     /// A serial layer is a circuit with one gate. The layers have the
     /// same structure as in layers().
-    #[pyo3(signature = (*, vars_mode="captures"))]
-    fn serial_layers(&self, py: Python, vars_mode: &str) -> PyResult<Py<PyIterator>> {
+    #[pyo3(signature = (*, vars_mode=VarsMode::Captures))]
+    fn serial_layers(&self, py: Python, vars_mode: VarsMode) -> PyResult<Py<PyIterator>> {
         let layer_list = PyList::empty(py);
         for next_node in self.topological_op_nodes()? {
             let retrieved_node: &PackedInstruction = match self.dag.node_weight(next_node) {
@@ -4447,7 +4447,7 @@ impl DAGCircuit {
     ///
     /// This method clones both the `qargs_interner` and `cargs_interner` of `self`;
     /// `Interned<[Qubit]>` and `Interned<[Clbit]>` keys from `self` are valid in the output DAG.
-    pub fn copy_empty_like_with_same_capacity(&self, vars_mode: &str) -> PyResult<Self> {
+    pub fn copy_empty_like_with_same_capacity(&self, vars_mode: VarsMode) -> PyResult<Self> {
         self.copy_empty_like_with_capacity(
             self.dag.node_count().saturating_sub(2 * self.width()),
             self.dag.edge_count(),
@@ -4464,7 +4464,7 @@ impl DAGCircuit {
         &self,
         num_ops: usize,
         num_edges: usize,
-        vars_mode: &str,
+        vars_mode: VarsMode,
     ) -> PyResult<Self> {
         let mut out = self.qubitless_empty_like_with_capacity(
             self.num_qubits(),
@@ -4487,7 +4487,7 @@ impl DAGCircuit {
     /// Create an empty DAG with the canonical "physical" register of the correct length, with all
     /// classical data and metadata retained.
     ///
-    /// This is similar to [copy_empty_like_with_capacity] with `vars_mode="alike"`, and copies the
+    /// This is similar to [copy_empty_like_with_capacity] with [VarsMode::Alike], and copies the
     /// same things over (global phase, metadata, etc) it does, except for replacing the qubits.
     ///
     /// This method clones the `cargs_interner` of `self`; `Interned<[Clbit]>` keys from `self` are
@@ -4501,8 +4501,12 @@ impl DAGCircuit {
         num_ops: usize,
         num_edges: usize,
     ) -> PyResult<Self> {
-        let mut out =
-            self.qubitless_empty_like_with_capacity(num_qubits, num_ops, num_edges, "alike")?;
+        let mut out = self.qubitless_empty_like_with_capacity(
+            num_qubits,
+            num_ops,
+            num_edges,
+            VarsMode::Alike,
+        )?;
         out.add_qreg(QuantumRegister::new_owning("q", num_qubits as u32))?;
         Ok(out)
     }
@@ -4528,15 +4532,19 @@ impl DAGCircuit {
         num_qubits: usize,
         num_ops: usize,
         num_edges: usize,
-        vars_mode: &str,
+        vars_mode: VarsMode,
     ) -> PyResult<Self> {
+        let (num_vars, num_stretches) = match vars_mode {
+            VarsMode::Drop => (0, 0),
+            _ => (self.num_vars(), self.num_stretches()),
+        };
         let mut target_dag = Self::with_capacity(
             num_qubits,
             self.num_clbits(),
-            (vars_mode != "drop").then_some(self.num_vars()),
+            Some(num_vars),
             Some(num_ops),
             Some(num_edges),
-            (vars_mode != "drop").then_some(self.num_stretches()),
+            Some(num_stretches),
         )?;
         target_dag.name.clone_from(&self.name);
         target_dag.global_phase = self.global_phase.clone();
@@ -4553,46 +4561,44 @@ impl DAGCircuit {
         for reg in self.cregs.registers() {
             target_dag.add_creg(reg.clone())?;
         }
-        if vars_mode == "alike" {
-            for info in self.identifier_info.values() {
-                match info {
-                    DAGIdentifierInfo::Stretch(DAGStretchInfo { stretch, type_ }) => {
-                        let stretch = self.stretches.get(*stretch).unwrap().clone();
-                        match type_ {
-                            DAGStretchType::Capture => {
-                                target_dag.add_captured_stretch(stretch)?;
-                            }
-                            DAGStretchType::Declare => {
-                                target_dag.add_declared_stretch(stretch)?;
+        match vars_mode {
+            VarsMode::Alike => {
+                for info in self.identifier_info.values() {
+                    match info {
+                        DAGIdentifierInfo::Stretch(DAGStretchInfo { stretch, type_ }) => {
+                            let stretch = self.stretches.get(*stretch).unwrap().clone();
+                            match type_ {
+                                DAGStretchType::Capture => {
+                                    target_dag.add_captured_stretch(stretch)?;
+                                }
+                                DAGStretchType::Declare => {
+                                    target_dag.add_declared_stretch(stretch)?;
+                                }
                             }
                         }
-                    }
-                    DAGIdentifierInfo::Var(DAGVarInfo { var, type_, .. }) => {
-                        let var = self.vars.get(*var).unwrap().clone();
-                        target_dag.add_var(var, *type_)?;
-                    }
-                }
-            }
-        } else if vars_mode == "captures" {
-            for info in self.identifier_info.values() {
-                match info {
-                    DAGIdentifierInfo::Stretch(DAGStretchInfo { stretch, .. }) => {
-                        let stretch = self.stretches.get(*stretch).unwrap().clone();
-                        target_dag.add_captured_stretch(stretch)?;
-                    }
-                    DAGIdentifierInfo::Var(DAGVarInfo { var, .. }) => {
-                        let var = self.vars.get(*var).unwrap().clone();
-                        target_dag.add_var(var, DAGVarType::Capture)?;
+                        DAGIdentifierInfo::Var(DAGVarInfo { var, type_, .. }) => {
+                            let var = self.vars.get(*var).unwrap().clone();
+                            target_dag.add_var(var, *type_)?;
+                        }
                     }
                 }
             }
-        } else if vars_mode != "drop" {
-            return Err(PyValueError::new_err(format!(
-                "unknown vars_mode: '{}'",
-                vars_mode
-            )));
-        }
-
+            VarsMode::Captures => {
+                for info in self.identifier_info.values() {
+                    match info {
+                        DAGIdentifierInfo::Stretch(DAGStretchInfo { stretch, .. }) => {
+                            let stretch = self.stretches.get(*stretch).unwrap().clone();
+                            target_dag.add_captured_stretch(stretch)?;
+                        }
+                        DAGIdentifierInfo::Var(DAGVarInfo { var, .. }) => {
+                            let var = self.vars.get(*var).unwrap().clone();
+                            target_dag.add_var(var, DAGVarType::Capture)?;
+                        }
+                    }
+                }
+            }
+            VarsMode::Drop => (),
+        };
         Ok(target_dag)
     }
 
@@ -7580,6 +7586,31 @@ pub(crate) fn add_global_phase(phase: &Param, other: &Param) -> PyResult<Param> 
 }
 
 type SortKeyType<'a> = (&'a [Qubit], &'a [Clbit]);
+
+/// The mode to copy the classical [Var]s in, for operations that create a new [DAGCircuit] based on
+/// an existing one.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum VarsMode {
+    /// Each [Var] has the same type it had in the input.
+    Alike,
+    /// Each [Var] becomes a "capture".  This is useful when building a [DAGCircuit] to compose back
+    /// onto the original base.
+    Captures,
+    /// Do not copy the [Var] data over.
+    Drop,
+}
+impl<'py> FromPyObject<'py> for VarsMode {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        match &*ob.downcast::<PyString>()?.to_string_lossy() {
+            "alike" => Ok(VarsMode::Alike),
+            "captures" => Ok(VarsMode::Captures),
+            "drop" => Ok(VarsMode::Drop),
+            mode => Err(PyValueError::new_err(format!(
+                "unknown vars_mode: '{mode}'"
+            ))),
+        }
+    }
+}
 
 #[cfg(all(test, not(miri)))]
 mod test {

--- a/crates/transpiler/src/passes/basis_translator/mod.rs
+++ b/crates/transpiler/src/passes/basis_translator/mod.rs
@@ -29,7 +29,7 @@ use pyo3::types::{IntoPyDict, PyComplex, PyDict, PyTuple};
 use pyo3::PyTypeInfo;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
 use qiskit_circuit::converters::circuit_to_dag;
-use qiskit_circuit::dag_circuit::DAGCircuitBuilder;
+use qiskit_circuit::dag_circuit::{DAGCircuitBuilder, VarsMode};
 use qiskit_circuit::imports::DAG_TO_CIRCUIT;
 use qiskit_circuit::imports::PARAMETER_EXPRESSION;
 use qiskit_circuit::operations::Param;
@@ -478,7 +478,7 @@ fn apply_translation(
     >,
 ) -> PyResult<(DAGCircuit, bool)> {
     let mut is_updated = false;
-    let out_dag = dag.copy_empty_like("alike")?;
+    let out_dag = dag.copy_empty_like(VarsMode::Alike)?;
     let mut out_dag_builder = out_dag.into_builder();
     for node in dag.topological_op_nodes()? {
         let node_obj = dag[node].unwrap_operation();

--- a/crates/transpiler/src/passes/disjoint_layout.rs
+++ b/crates/transpiler/src/passes/disjoint_layout.rs
@@ -28,7 +28,7 @@ use uuid::Uuid;
 
 use qiskit_circuit::bit::ShareableQubit;
 use qiskit_circuit::converters::circuit_to_dag;
-use qiskit_circuit::dag_circuit::DAGCircuit;
+use qiskit_circuit::dag_circuit::{DAGCircuit, VarsMode};
 use qiskit_circuit::imports::ImportOnceCell;
 use qiskit_circuit::operations::{Operation, OperationRef, Param, StandardInstruction};
 use qiskit_circuit::packed_instruction::PackedOperation;
@@ -446,7 +446,7 @@ fn separate_dag(dag: &mut DAGCircuit) -> PyResult<Vec<DAGCircuit>> {
     let decomposed_dags: PyResult<Vec<DAGCircuit>> = component_qubits
         .into_iter()
         .map(|dag_qubits| -> PyResult<DAGCircuit> {
-            let mut new_dag = dag.copy_empty_like("alike")?;
+            let mut new_dag = dag.copy_empty_like(VarsMode::Alike)?;
             let qubits_to_revmove: Vec<Qubit> = qubits.difference(&dag_qubits).copied().collect();
 
             new_dag.remove_qubits(qubits_to_revmove)?;

--- a/crates/transpiler/src/passes/elide_permutations.rs
+++ b/crates/transpiler/src/passes/elide_permutations.rs
@@ -13,7 +13,7 @@
 use numpy::PyReadonlyArray1;
 use pyo3::prelude::*;
 
-use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType};
+use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType, VarsMode};
 use qiskit_circuit::operations::{Operation, Param};
 use qiskit_circuit::Qubit;
 
@@ -42,7 +42,7 @@ pub fn run_elide_permutations(
     let mut mapping: Vec<usize> = (0..dag.num_qubits()).collect();
 
     // note that DAGCircuit::copy_empty_like clones the interners
-    let mut new_dag = dag.copy_empty_like("alike")?;
+    let mut new_dag = dag.copy_empty_like(VarsMode::Alike)?;
     for node_index in dag.topological_op_nodes()? {
         if let NodeType::Operation(inst) = &dag[node_index] {
             match inst.op.name() {

--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -26,7 +26,7 @@ use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
 use qiskit_circuit::converters::dag_to_circuit;
 use qiskit_circuit::converters::QuantumCircuitData;
-use qiskit_circuit::dag_circuit::DAGCircuit;
+use qiskit_circuit::dag_circuit::{DAGCircuit, VarsMode};
 use qiskit_circuit::gate_matrix::CX_GATE;
 use qiskit_circuit::imports::{HLS_SYNTHESIZE_OP_USING_PLUGINS, QS_DECOMPOSITION, QUANTUM_CIRCUIT};
 use qiskit_circuit::operations::Operation;
@@ -993,7 +993,7 @@ fn convert_circuit_to_dag_with_data(
 ) -> PyResult<DAGCircuit> {
     // Calling copy_empty_like makes sure that all the python-space information (qregs, cregs, input variables)
     // get copied correctly.
-    let mut new_dag = dag.copy_empty_like("alike")?;
+    let mut new_dag = dag.copy_empty_like(VarsMode::Alike)?;
     new_dag.set_global_phase(circuit.global_phase().clone())?;
     let qarg_map = new_dag.merge_qargs(circuit.qargs_interner(), |bit| Some(*bit));
     let carg_map = new_dag.merge_cargs(circuit.cargs_interner(), |bit: &Clbit| Some(*bit));

--- a/crates/transpiler/src/passes/split_2q_unitaries.rs
+++ b/crates/transpiler/src/passes/split_2q_unitaries.rs
@@ -18,7 +18,7 @@ use pyo3::prelude::*;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 use smallvec::{smallvec, SmallVec};
 
-use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType, Wire};
+use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType, VarsMode, Wire};
 use qiskit_circuit::operations::{ArrayType, Operation, OperationRef, Param, UnitaryGate};
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::Qubit;
@@ -100,7 +100,7 @@ pub fn run_split_2q_unitaries(
     // We have swap-like unitaries, so we create a new DAG in a manner similar to
     // The Elide Permutations pass, while also splitting the unitaries to 1-qubit gates
     let mut mapping: Vec<usize> = (0..dag.num_qubits()).collect();
-    let new_dag = dag.copy_empty_like("alike")?;
+    let new_dag = dag.copy_empty_like(VarsMode::Alike)?;
     let mut new_dag = new_dag.into_builder();
     for node in dag.topological_op_nodes()? {
         let NodeType::Operation(inst) = &dag.dag()[node] else {

--- a/crates/transpiler/src/passes/unitary_synthesis.rs
+++ b/crates/transpiler/src/passes/unitary_synthesis.rs
@@ -21,7 +21,6 @@ use ndarray::prelude::*;
 use num_complex::Complex64;
 use numpy::{IntoPyArray, ToPyArray};
 use qiskit_circuit::circuit_instruction::OperationFromPython;
-use qiskit_circuit::dag_circuit::DAGCircuitBuilder;
 use smallvec::SmallVec;
 
 use pyo3::intern;
@@ -31,7 +30,7 @@ use pyo3::wrap_pyfunction;
 use pyo3::Python;
 
 use qiskit_circuit::converters::{circuit_to_dag, QuantumCircuitData};
-use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType};
+use qiskit_circuit::dag_circuit::{DAGCircuit, DAGCircuitBuilder, NodeType, VarsMode};
 use qiskit_circuit::imports;
 use qiskit_circuit::operations::{Operation, OperationRef, Param, PyGate, StandardGate};
 use qiskit_circuit::packed_instruction::{PackedInstruction, PackedOperation};
@@ -250,7 +249,7 @@ pub fn run_unitary_synthesis(
     // is lossy. We need `QuantumCircuit` instances to be used in `replace_blocks`.
     let dag_to_circuit = imports::DAG_TO_CIRCUIT.get_bound(py);
 
-    let out_dag = dag.copy_empty_like("alike")?;
+    let out_dag = dag.copy_empty_like(VarsMode::Alike)?;
     let mut out_dag = out_dag.into_builder();
 
     // Iterate over dag nodes and determine unitary synthesis approach
@@ -1119,7 +1118,7 @@ fn reversed_synth_su4_dag(
         unreachable!("reversed_synth_su4_dag should only be called for XXDecomposer")
     };
 
-    let target_dag = synth_dag.copy_empty_like("alike")?;
+    let target_dag = synth_dag.copy_empty_like(VarsMode::Alike)?;
     let flip_bits: [Qubit; 2] = [Qubit(1), Qubit(0)];
     let mut target_dag_builder = target_dag.into_builder();
     for node in synth_dag.topological_op_nodes()? {


### PR DESCRIPTION
### Summary

In Python-space, enums are relatively heavy and annoying, because you can still just pass an incorrect type.  In Rust, they help clarity, come for free, and make it impossible to ask for an invalid mode.

We manage the conversion from the Python-space string API to the Rust-space strong type at the Python/Rust boundary.


### Details and comments

Built on top of #14496.  This is mostly fixing a nitpick I have with the Rust interface, which I touched a few times in that PR.