### PR TITLE
[PoC] Add symbolic optimization pass for consecutive gates of the same type

### DIFF
--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -91,6 +91,7 @@ Optimizations
    Split2QUnitaries
    RemoveIdentityEquivalent
    ContractIdleWiresInControlFlow
+   OptimizeConsecutive
 
 Scheduling
 =============
@@ -227,6 +228,7 @@ from .optimization import RemoveIdentityEquivalent
 from .optimization import Split2QUnitaries
 from .optimization import ContractIdleWiresInControlFlow
 from .optimization import OptimizeCliffordT
+from .optimization import OptimizeConsecutive
 
 # circuit analysis
 from .analysis import ResourceEstimation

--- a/qiskit/transpiler/passes/optimization/__init__.py
+++ b/qiskit/transpiler/passes/optimization/__init__.py
@@ -40,3 +40,4 @@ from .split_2q_unitaries import Split2QUnitaries
 from .collect_and_collapse import CollectAndCollapse
 from .contract_idle_wires_in_control_flow import ContractIdleWiresInControlFlow
 from .optimize_clifford_t import OptimizeCliffordT
+from .optimize_consecutive import OptimizeConsecutive

--- a/qiskit/transpiler/passes/optimization/optimize_consecutive.py
+++ b/qiskit/transpiler/passes/optimization/optimize_consecutive.py
@@ -1,0 +1,101 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Optimize consecutive gates of identical gate type by combining them into a single gate."""
+
+from typing import Optional
+
+from qiskit.circuit.library.standard_gates.p import PhaseGate
+from qiskit.circuit.library.standard_gates.rx import RXGate
+from qiskit.circuit.library.standard_gates.rxx import RXXGate
+from qiskit.circuit.library.standard_gates.ry import RYGate
+from qiskit.circuit.library.standard_gates.ryy import RYYGate
+from qiskit.circuit.library.standard_gates.rz import RZGate
+from qiskit.circuit.library.standard_gates.rzx import RZXGate
+from qiskit.circuit.library.standard_gates.rzz import RZZGate
+from qiskit.circuit.parameterexpression import ParameterExpression
+from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.transpiler.exceptions import TranspilerError
+
+_SUPPORTED_GATES = {
+    "p": PhaseGate,
+    "rx": RXGate,
+    "ry": RYGate,
+    "rz": RZGate,
+    "rxx": RXXGate,
+    "ryy": RYYGate,
+    "rzz": RZZGate,
+    "rzx": RZXGate,
+}
+
+
+class OptimizeConsecutive(TransformationPass):
+    """Optimize chains of rotation gates of the same type by combining them into a single gate."""
+
+    def __init__(self, basis: Optional[list[str]] = None, eps: float = 1e-15):
+        """Optimize1qGates initializer.
+
+        Args:
+            basis (list[str]): Basis gates to consider, e.g. `['rz', 'rx']`. For the effects
+                of this pass, the basis is the set intersection between the `basis` parameter and
+                the set `{'rx','rz','rzz'}`.
+            eps (float): EPS to check against
+
+        Raises:
+            ValueError: if `basis` contain any basis gate that is not supported.
+        """
+        super().__init__()
+        if basis:
+            for gate_type in basis:
+                if gate_type not in _SUPPORTED_GATES:
+                    raise ValueError(f"Gate type ({gate_type}) is not supported")
+            self.basis = set(basis)
+        else:
+            self.basis = set(_SUPPORTED_GATES)
+        self.eps = eps
+
+    def run(self, dag):
+        """Run the OptimizeConsecutive pass on `dag`.
+
+        Args:
+            dag (DAGCircuit): the DAG to be optimized.
+
+        Returns:
+            DAGCircuit: the optimized DAG.
+        """
+
+        for gate_type in self.basis:
+            runs = dag.collect_runs([gate_type])
+            for run in runs:
+                if len(run) == 1:
+                    continue
+                name = run[0].op.name
+                if len(run[0].params) != 1:
+                    raise TranspilerError("internal error")
+
+                parameter = run[0].op.params[0]
+                for current_node in run[1:]:
+                    if len(current_node.params) != 1:
+                        raise TranspilerError("internal error")
+                    parameter += current_node.op.params[0]
+                if isinstance(parameter, ParameterExpression) and parameter.is_real():
+                    parameter = float(parameter)
+
+                if not isinstance(parameter, ParameterExpression) and abs(parameter) <= self.eps:
+                    for current_node in run:
+                        dag.remove_op_node(current_node)
+                else:
+                    new_op = _SUPPORTED_GATES[name](parameter)
+                    dag.substitute_node(run[0], new_op, inplace=True)
+                    for current_node in run[1:]:
+                        dag.remove_op_node(current_node)
+        return dag

--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -33,6 +33,7 @@ from qiskit.transpiler.passes import ElidePermutations
 from qiskit.transpiler.passes import RemoveDiagonalGatesBeforeMeasure
 from qiskit.transpiler.passes import OptimizeCliffordT
 from qiskit.transpiler.passes import BasisTranslator
+from qiskit.transpiler.passes import OptimizeConsecutive
 from qiskit.transpiler.preset_passmanagers import common
 from qiskit.transpiler.preset_passmanagers.plugin import (
     PassManagerStagePlugin,
@@ -171,6 +172,7 @@ class DefaultInitPassManager(PassManagerStagePlugin):
                     RemoveIdentityEquivalent(
                         approximation_degree=pass_manager_config.approximation_degree
                     ),
+                    OptimizeConsecutive(),
                     InverseCancellation(
                         [
                             CXGate(),
@@ -593,8 +595,9 @@ class OptimizationPassManager(PassManagerStagePlugin):
             # 1. ConsolidateBlocks
             # 2. UnitarySynthesis
             # 3. RemoveIdentityEquivalent
-            # 4. Optimize1qGatesDecomposition
-            # 5. CommutativeCancellation
+            # 4. OptimizeConsecutive
+            # 5. Optimize1qGatesDecomposition
+            # 6. CommutativeCancellation
             elif optimization_level == 3:
                 _opt = [
                     ConsolidateBlocks(
@@ -614,6 +617,7 @@ class OptimizationPassManager(PassManagerStagePlugin):
                         approximation_degree=pass_manager_config.approximation_degree,
                         target=pass_manager_config.target,
                     ),
+                    OptimizeConsecutive(),
                     Optimize1qGatesDecomposition(
                         basis=pass_manager_config.basis_gates, target=pass_manager_config.target
                     ),


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Symbolic gate optimization is generally challenging.
However, it becomes feasible when dealing with consecutive gates of the same type.
To explore this, I introduce `OptimizeConsecutive` pass.
I also added this pass to `init` and `optimization` stages of the preset pass manager to handle cases such as the following examples.

I'm not sure this pass provides sufficient benefit, as it introduces some overhead and the examples may not be representative of typical use cases.
Therefore, I submit this PR primarily for discussion and feedback.

### Details and comments

#### Example 1
`OptimizeConsecutive` in `optimization` stage works for Example 1

```python
from qiskit import __version__, generate_preset_pass_manager
from qiskit.circuit.library import unitary_overlap, zz_feature_map

print(__version__)
qc = zz_feature_map(2, reps=1)
params = qc.parameters
qc = unitary_overlap(qc, qc)
qc = qc.assign_parameters(list(params) * 2)
print(qc)
pm = generate_preset_pass_manager(optimization_level=3)
t_qc = pm.run(qc)
print(t_qc)
```

release version
```
2.0.2
     ┌───┐┌─────────────┐                                                                                     ┌──────────────┐┌───┐
q_0: ┤ H ├┤ P(2.0*x[0]) ├──■────────────────────────────────────■────■─────────────────────────────────────■──┤ P(-2.0*x[0]) ├┤ H ├
     ├───┤├─────────────┤┌─┴─┐┌──────────────────────────────┐┌─┴─┐┌─┴─┐┌───────────────────────────────┐┌─┴─┐├──────────────┤├───┤
q_1: ┤ H ├┤ P(2.0*x[1]) ├┤ X ├┤ P(2.0*(x[0] - π)*(x[1] - π)) ├┤ X ├┤ X ├┤ P(-2.0*(x[0] - π)*(x[1] - π)) ├┤ X ├┤ P(-2.0*x[1]) ├┤ H ├
     └───┘└─────────────┘└───┘└──────────────────────────────┘└───┘└───┘└───────────────────────────────┘└───┘└──────────────┘└───┘
     ┌───┐┌─────────────┐                                                                           ┌──────────────┐┌───┐
q_0: ┤ H ├┤ P(2.0*x[0]) ├──■─────────────────────────────────────────────────────────────────────■──┤ P(-2.0*x[0]) ├┤ H ├
     ├───┤├─────────────┤┌─┴─┐┌──────────────────────────────┐┌───────────────────────────────┐┌─┴─┐├──────────────┤├───┤
q_1: ┤ H ├┤ P(2.0*x[1]) ├┤ X ├┤ P(2.0*(x[0] - π)*(x[1] - π)) ├┤ P(-2.0*(x[0] - π)*(x[1] - π)) ├┤ X ├┤ P(-2.0*x[1]) ├┤ H ├
     └───┘└─────────────┘└───┘└──────────────────────────────┘└───────────────────────────────┘└───┘└──────────────┘└───┘
```

this PR
```
2.2.0.dev0+5175b35
     ┌───┐┌───────────┐                                                                                       ┌──────────────┐┌───┐
q_0: ┤ H ├┤ P(2*x[0]) ├──■────────────────────────────────────■────■───────────────────────────────────────■──┤ P((-2)*x[0]) ├┤ H ├
     ├───┤├───────────┤┌─┴─┐┌──────────────────────────────┐┌─┴─┐┌─┴─┐┌─────────────────────────────────┐┌─┴─┐├──────────────┤├───┤
q_1: ┤ H ├┤ P(2*x[1]) ├┤ X ├┤ P(2*(-π + x[1])*(-π + x[0])) ├┤ X ├┤ X ├┤ P((-2)*(-π + x[1])*(-π + x[0])) ├┤ X ├┤ P((-2)*x[1]) ├┤ H ├
     └───┘└───────────┘└───┘└──────────────────────────────┘└───┘└───┘└─────────────────────────────────┘└───┘└──────────────┘└───┘

q_0:

q_1:
```

-----
#### Example 2

`OptimizeConsecutive` in `init` stage works for Example 2

```python
from qiskit import QuantumCircuit, __version__, generate_preset_pass_manager
from qiskit.circuit import ParameterVector

print(__version__)
qc = QuantumCircuit(1)
x = ParameterVector("x", 3)
qc.rx(x[0], 0)
qc.rx(-x[0], 0)
qc.ry(x[1], 0)
qc.ry(-x[1], 0)
qc.rz(x[2], 0)
qc.rz(-x[2], 0)
print(qc)
pm = generate_preset_pass_manager(optimization_level=3)
t_qc = pm.run(qc)
print(t_qc)
```

release version
```
2.0.2
   ┌──────────┐┌───────────┐┌──────────┐┌───────────┐┌──────────┐┌───────────┐
q: ┤ Rx(x[0]) ├┤ Rx(-x[0]) ├┤ Ry(x[1]) ├┤ Ry(-x[1]) ├┤ Rz(x[2]) ├┤ Rz(-x[2]) ├
   └──────────┘└───────────┘└──────────┘└───────────┘└──────────┘└───────────┘
   ┌──────────┐┌───────────┐┌──────────┐┌───────────┐┌──────────┐┌───────────┐
q: ┤ Rx(x[0]) ├┤ Rx(-x[0]) ├┤ Ry(x[1]) ├┤ Ry(-x[1]) ├┤ Rz(x[2]) ├┤ Rz(-x[2]) ├
   └──────────┘└───────────┘└──────────┘└───────────┘└──────────┘└───────────┘
```

this PR
```
2.2.0.dev0+5175b35
   ┌──────────┐┌───────────┐┌──────────┐┌───────────┐┌──────────┐┌───────────┐
q: ┤ Rx(x[0]) ├┤ Rx(-x[0]) ├┤ Ry(x[1]) ├┤ Ry(-x[1]) ├┤ Rz(x[2]) ├┤ Rz(-x[2]) ├
   └──────────┘└───────────┘└──────────┘└───────────┘└──────────┘└───────────┘

q:

```