### PR TITLE
Adding BlockCollector classes to documentation

### DIFF
--- a/qiskit/dagcircuit/__init__.py
+++ b/qiskit/dagcircuit/__init__.py
@@ -36,7 +36,18 @@ Exceptions
 
 .. autoexception:: DAGCircuitError
 .. autoexception:: DAGDependencyError
+
+Utilities
+=========
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   BlockCollapser
+   BlockCollector
+   BlockSplitter
 """
+from .collect_blocks import BlockCollapser, BlockCollector, BlockSplitter
 from .dagcircuit import DAGCircuit
 from .dagnode import DAGNode, DAGOpNode, DAGInNode, DAGOutNode
 from .dagdepnode import DAGDepNode

--- a/qiskit/dagcircuit/collect_blocks.py
+++ b/qiskit/dagcircuit/collect_blocks.py
@@ -17,11 +17,12 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Callable
 
-from qiskit.dagcircuit import DAGDepNode
-
 from qiskit.circuit import QuantumCircuit, CircuitInstruction, ClassicalRegister, Bit
 from qiskit.circuit.controlflow import condition_resources
-from . import DAGOpNode, DAGCircuit, DAGDependency
+from qiskit.dagcircuit.dagcircuit import DAGCircuit
+from qiskit.dagcircuit.dagdependency import DAGDependency
+from qiskit.dagcircuit.dagnode import DAGOpNode
+from qiskit.dagcircuit.dagdepnode import DAGDepNode
 from .exceptions import DAGCircuitError
 
 
@@ -338,15 +339,18 @@ def split_block_into_layers(block: list[DAGOpNode | DAGDepNode]):
 
 class BlockCollapser:
     """This class implements various strategies of consolidating blocks of nodes
-     in a DAG (direct acyclic graph). It works both with the
-    :class:`~qiskit.dagcircuit.DAGCircuit` and
-    :class:`~qiskit.dagcircuit.DAGDependency` DAG representations.
+    in a DAG (direct acyclic graph). It works both with
+    the :class:`~qiskit.dagcircuit.DAGCircuit`
+    and :class:`~qiskit.dagcircuit.DAGDependency` DAG representations.
     """
 
     def __init__(self, dag):
         """
         Args:
             dag (Union[DAGCircuit, DAGDependency]): The input DAG.
+
+        Raises:
+            DAGCircuitError: the input object is not a DAG.
         """
 
         self.dag = dag


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Adds `BlockCollector` and friends to documentation, addressing #14141.

This was in fact already done as part of #10497, and hence  [older Qiskit documentation](https://docs.quantum.ibm.com/api/qiskit/0.44/dagcircuit) includes `BlockCollector`, but somehow did not make into the main branch.

### Details and comments

This PR adds `BlockCollector`, `BlockCollapser` and `BlockSplitter` to the documentation, as well as adapts some other minor relevant docstring improvements from #14141.

Fix #14141