### PR TITLE
Extending rustiq synthesis plugin to work SparseObservables

### DIFF
--- a/crates/synthesis/src/evolution/pauli_network.rs
+++ b/crates/synthesis/src/evolution/pauli_network.rs
@@ -11,6 +11,7 @@
 // that they have been altered from the originals.
 
 use crate::clifford::greedy_synthesis::resynthesize_clifford_circuit;
+use crate::QiskitError;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyList, PyString, PyTuple};
@@ -310,6 +311,8 @@ pub fn pauli_network_synthesis_inner(
     let mut paulis: Vec<String> = Vec::with_capacity(pauli_network.len());
     let mut angles: Vec<Param> = Vec::with_capacity(pauli_network.len());
 
+    let allowed_chars = ['I', 'X', 'Y', 'Z'];
+
     // go over the input pauli network and extract a list of pauli rotations and
     // the corresponding rotation angles
     for item in pauli_network {
@@ -318,6 +321,12 @@ pub fn pauli_network_synthesis_inner(
         let sparse_pauli: String = tuple.get_item(0)?.downcast::<PyString>()?.extract()?;
         let qubits: Vec<u32> = tuple.get_item(1)?.extract()?;
         let angle: Param = tuple.get_item(2)?.extract()?;
+
+        if sparse_pauli.chars().any(|c| !allowed_chars.contains(&c)) {
+            return Err(QiskitError::new_err(format!(
+                "Pauli network contains invalid Pauli string {sparse_pauli}"
+            )));
+        }
 
         paulis.push(expand_pauli(sparse_pauli, &qubits, num_qubits));
         angles.push(angle);

--- a/qiskit/transpiler/passes/synthesis/hls_plugins.py
+++ b/qiskit/transpiler/passes/synthesis/hls_plugins.py
@@ -1966,7 +1966,29 @@ class PauliEvolutionSynthesisRustiq(HighLevelSynthesisPlugin):
             # actual PauliEvolutionGate
             return None
 
-        algo = high_level_object.synthesis
+        from qiskit.quantum_info import SparsePauliOp, SparseObservable
+
+        # The synthesis function synth_pauli_network_rustiq does not support SparseObservables,
+        # so we need to convert them to SparsePauliOps.
+        if isinstance(high_level_object.operator, SparsePauliOp):
+            pauli_op = high_level_object.operator
+
+        elif isinstance(high_level_object.operator, SparseObservable):
+            pauli_op = SparsePauliOp.from_sparse_observable(high_level_object.operator)
+
+        elif isinstance(high_level_object.operator, list):
+            pauli_op = []
+            for op in high_level_object.operator:
+                if isinstance(op, SparseObservable):
+                    pauli_op.append(SparsePauliOp.from_sparse_observable(op))
+                else:
+                    pauli_op.append(op)
+
+        else:
+            raise TranspilerError("Invalid PauliEvolutionGate.")
+
+        evo = PauliEvolutionGate(pauli_op, high_level_object.time)
+        algo = evo.synthesis
 
         if not isinstance(algo, ProductFormula):
             warnings.warn(
@@ -1980,9 +2002,8 @@ class PauliEvolutionSynthesisRustiq(HighLevelSynthesisPlugin):
         if "preserve_order" in options:
             algo.preserve_order = options["preserve_order"]
 
-        num_qubits = high_level_object.num_qubits
-        pauli_network = algo.expand(high_level_object)
-
+        num_qubits = evo.num_qubits
+        pauli_network = algo.expand(evo)
         optimize_count = options.get("optimize_count", True)
         preserve_order = options.get("preserve_order", True)
         upto_clifford = options.get("upto_clifford", False)

--- a/qiskit/transpiler/passes/synthesis/hls_plugins.py
+++ b/qiskit/transpiler/passes/synthesis/hls_plugins.py
@@ -1987,7 +1987,12 @@ class PauliEvolutionSynthesisRustiq(HighLevelSynthesisPlugin):
         else:
             raise TranspilerError("Invalid PauliEvolutionGate.")
 
-        evo = PauliEvolutionGate(pauli_op, high_level_object.time)
+        evo = PauliEvolutionGate(
+            pauli_op,
+            time=high_level_object.time,
+            label=high_level_object.label,
+            synthesis=high_level_object.synthesis,
+        )
         algo = evo.synthesis
 
         if not isinstance(algo, ProductFormula):

--- a/releasenotes/notes/fix-rustiq-on-sparse-observable-5aac72f014ac2b6d.yaml
+++ b/releasenotes/notes/fix-rustiq-on-sparse-observable-5aac72f014ac2b6d.yaml
@@ -1,0 +1,17 @@
+---
+fixes:
+  - |
+    Fixed a bug in the :class:`.PauliEvolutionSynthesisRustiq` plugin that produced
+    incorrect circuits in the case that the operator of a :class:`.PauliEvolutionGate` 
+    contains objects of type :class:`.SparseObservable`.
+
+    For example::
+
+      from qiskit.circuit.library import PauliEvolutionGate
+      from qiskit.quantum_info import SparseObservable, Operator
+      from qiskit.transpiler.passes.synthesis.hls_plugins import PauliEvolutionSynthesisRustiq
+
+      obs = SparseObservable.from_sparse_list([("1+XY", (0, 1, 2, 3), 1.5)], num_qubits=4)
+      evo = PauliEvolutionGate(obs, 1)
+      qct = PauliEvolutionSynthesisRustiq().run(evo)
+      assert Operator(qct) == Operator(evo)

--- a/test/python/transpiler/test_high_level_synthesis.py
+++ b/test/python/transpiler/test_high_level_synthesis.py
@@ -55,7 +55,14 @@ from qiskit.circuit.library import (
     GlobalPhaseGate,
 )
 from qiskit.circuit.library import LinearFunction, PauliEvolutionGate
-from qiskit.quantum_info import Clifford, Operator, Statevector, SparsePauliOp
+from qiskit.quantum_info import (
+    Pauli,
+    Clifford,
+    Operator,
+    Statevector,
+    SparsePauliOp,
+    SparseObservable,
+)
 from qiskit.synthesis.evolution import synth_pauli_network_rustiq
 from qiskit.synthesis.linear import random_invertible_binary_matrix
 from qiskit.synthesis.arithmetic import adder_qft_d00
@@ -3031,6 +3038,41 @@ class TestPauliEvolutionSynthesisPlugins(QiskitTestCase):
         )
         self.assertEqual(count_rotation_gates(qct), 2)
         self.assertEqual(set(qct.parameters), {alpha, beta})
+
+    def test_rustiq_raises_on_invalid_input(self):
+        """Test that we get an error on invalid input."""
+        # The Pauli string "1Y" is invalid
+        pauli_network = [("XXX", [0, 1, 2], 0.5), ("1Y", [1, 2], -0.5)]
+        with self.assertRaises(QiskitError):
+            synth_pauli_network_rustiq(num_qubits=4, pauli_network=pauli_network)
+
+    def test_on_sparse_observable(self):
+        """Test that plugins handle operators with SparseObservables."""
+        obs = SparseObservable.from_sparse_list([("1+XY", (0, 1, 2, 3), 1.5)], num_qubits=4)
+        evo = PauliEvolutionGate(obs, time=1)
+        qc = QuantumCircuit(4)
+        qc.append(evo, [0, 1, 2, 3])
+        default_config = HLSConfig(PauliEvolution=["default"])
+        qct_default = HighLevelSynthesis(hls_config=default_config)(qc)
+        rustiq_config = HLSConfig(PauliEvolution=[("rustiq")])
+        qct_rustiq = HighLevelSynthesis(hls_config=rustiq_config)(qc)
+        self.assertEqual(Operator(qct_default), Operator(qc))
+        self.assertEqual(Operator(qct_rustiq), Operator(qc))
+
+    def test_on_list_with_sparse_observable(self):
+        """Test that plugins handle operators with SparseObservables."""
+        pauli = Pauli("-XYZI")
+        op = SparsePauliOp(["IZXY"], 1)
+        obs = SparseObservable.from_sparse_list([("1+XY", (0, 1, 2, 3), 1.5)], num_qubits=4)
+        evo = PauliEvolutionGate([pauli, op, obs], time=1)
+        qc = QuantumCircuit(4)
+        qc.append(evo, [0, 1, 2, 3])
+        default_config = HLSConfig(PauliEvolution=["default"])
+        qct_default = HighLevelSynthesis(hls_config=default_config)(qc)
+        rustiq_config = HLSConfig(PauliEvolution=[("rustiq")])
+        qct_rustiq = HighLevelSynthesis(hls_config=rustiq_config)(qc)
+        self.assertEqual(Operator(qct_default), Operator(qc))
+        self.assertEqual(Operator(qct_rustiq), Operator(qc))
 
 
 class TestAnnotatedSynthesisPlugins(QiskitTestCase):


### PR DESCRIPTION
### Summary

In #13301, we introduced a synthesis plugin `PauliEvolutionSynthesisRustiq` for objects of type `PauliEvolutionGate`. At the time, the ``operator`` of a PauliEvolutionGate could be either a ``Pauli`` or a ``SparsePauliOp`` (or a list of such objects). Later, in #13836, we extended PauliEvolutionGate to also support operators of type ``SparseObservable``, leading to impressive gains for the default synthesis plugin for PauliEvolutionGate. However, we forgot to extend `PauliEvolutionSynthesisRustiq` as well. As the result, the following code could run without raising any errors, but produced incorrect output circuits:

```
from qiskit.circuit.library import PauliEvolutionGate
from qiskit.quantum_info import SparseObservable, Operator
from qiskit.transpiler.passes.synthesis.hls_plugins import PauliEvolutionSynthesisRustiq

obs = SparseObservable.from_sparse_list([("1+XY", (0, 1, 2, 3), 1.5)], num_qubits=4)
evo = PauliEvolutionGate(obs, 1)
qct = PauliEvolutionSynthesisRustiq().run(evo)
assert Operator(qct) == Operator(evo)
```

This PR fixes the above problem by converting within the rustiq plugin ``SparseObservables`` to ``SparsePauliOps`` (note that this might exponentially increase the number of terms). In addition, the Qiskit Rust interface to rustiq has been extended to raise an error when the pauli input strings are invalid.
