### PR TITLE
Raising an error when an invalid PauliEvolutionGate is constructed

### DIFF
--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -129,7 +129,8 @@ class PauliEvolutionGate(Gate):
             for op in operator[1:]:
                 if op.num_qubits != num_qubits:
                     raise ValueError(
-                        "When represented as a list of operators, all of these operators must have the same number of qubits."
+                        "When represented as a list of operators, all of these operators "
+                        "must have the same number of qubits."
                     )
         else:
             num_qubits = operator.num_qubits

--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -122,7 +122,18 @@ class PauliEvolutionGate(Gate):
         if label is None:
             label = _get_default_label(operator)
 
-        num_qubits = operator[0].num_qubits if isinstance(operator, list) else operator.num_qubits
+        if isinstance(operator, list):
+            if len(operator) == 0:
+                raise ValueError("Operator cannot be represented using an empty list.")
+            num_qubits = operator[0].num_qubits
+            for op in operator[1:]:
+                if op.num_qubits != num_qubits:
+                    raise ValueError(
+                        "When represented as a list of operators, all of these operators must have the same number of qubits."
+                    )
+        else:
+            num_qubits = operator.num_qubits
+
         super().__init__(name="PauliEvolution", num_qubits=num_qubits, params=[time], label=label)
         self.operator = operator
 

--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -124,7 +124,7 @@ class PauliEvolutionGate(Gate):
 
         if isinstance(operator, list):
             if len(operator) == 0:
-                raise ValueError("Operator cannot be represented using an empty list.")
+                raise ValueError("The argument 'operator' cannot be an empty list.")
             num_qubits = operator[0].num_qubits
             for op in operator[1:]:
                 if op.num_qubits != num_qubits:

--- a/releasenotes/notes/evogate-error-on-bad-list-b0b2c64f541f9dbd.yaml
+++ b/releasenotes/notes/evogate-error-on-bad-list-b0b2c64f541f9dbd.yaml
@@ -1,0 +1,14 @@
+---
+fixes:
+  - |
+    Previously one could define an invalid :class:`.PauliEvolutionGate`
+    from a list of operators, where the operators were not all defined on
+    the same number of qubits. This is now fixed, and we now raise an error
+    when the gate is defined::
+
+      from qiskit.quantum_info import Pauli, SparsePauliOp
+      from qiskit.circuit.library import PauliEvolutionGate
+
+      pauli = Pauli("XYZ")  # 3 qubits
+      op = SparsePauliOp(["XYIZ"], [1])  # 4 qubits
+      evo = PauliEvolutionGate([pauli, op], time=1)

--- a/test/python/circuit/library/test_evolution_gate.py
+++ b/test/python/circuit/library/test_evolution_gate.py
@@ -726,6 +726,21 @@ class TestEvolutionGate(QiskitTestCase):
         # we should also be less (or equal) to this
         self.assertLessEqual(cx_count, num_cx)
 
+    def test_raises_on_empty_list(self):
+        """Test that an error gets raised when a Pauli evolution gate is created from an empty list."""
+        with self.assertRaises(ValueError):
+            PauliEvolutionGate([], time=1)
+
+    def test_raises_on_list_with_different_num_qubits(self):
+        """Test that an error gets raised when a Pauli evolution gate is created from a list,
+        where not all of the operators have the same number of qubits.
+        """
+
+        with self.assertRaises(ValueError):
+            pauli = Pauli("XYZ")  # 3 qubits
+            op = SparsePauliOp(["XYIZ"], [1])  # 4 qubits
+            PauliEvolutionGate([pauli, op], time=1)
+
 
 def exact_atomic_evolution(circuit, pauli, time):
     """An exact atomic evolution for Suzuki-Trotter.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

We can construct a `PauliEvolutionGate` from a list of operators, however previously we did not check that all of these operators are defined on the same number of qubits.

For example, the following code
```
pauli = Pauli('-XY')  # 2 qubits
op = SparsePauliOp(['IZXYX', "XXXXX"], [1, 2])  # 5 qubits 
obs = SparseObservable.from_sparse_list([("1+XY", (0, 1, 2, 3), 1.5)], num_qubits=4)  # 4 qubits

evo = PauliEvolutionGate([pauli, op, obs], time=1)
```
did not raise errors, and the problems typically manifested much later, when a circuit containing such an invalid evolution gate was synthesized.

This (tiny) PR raises an error when such an invalid gate is defined. Once at that, it also raises a slightly more meaningful error when a PauliEvolutionGate is defined from an empty list. I am not sure whether this should be considered as a bug fix or a small usability feature. I am also completely fine not targeting this for 2.1 release.
