### PR TITLE
Fix random number generator seed argument for quantum_volume

### DIFF
--- a/qiskit/circuit/library/quantum_volume.py
+++ b/qiskit/circuit/library/quantum_volume.py
@@ -180,6 +180,7 @@ def quantum_volume(
     `arXiv:1811.12926 <https://arxiv.org/abs/1811.12926>`__
     """
     if isinstance(seed, np.random.Generator):
-        seed = seed.integers(0, dtype=np.uint64)
+        max_value = np.iinfo(np.int64).max
+        seed = seed.integers(max_value, dtype=np.int64)
     depth = depth or num_qubits
     return QuantumCircuit._from_circuit_data(qv_rs(num_qubits, depth, seed))

--- a/releasenotes/notes/qv-rng-4bc9572d2df93671.yaml
+++ b/releasenotes/notes/qv-rng-4bc9572d2df93671.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    :func:`qiskit.circuit.library.quantum_volume` was updated to handle a
+    :class:`numpy.random.Generator` as input for its ``seed`` argument.
+    Previously, such a generator argument would result in a ``TypeError``.

--- a/test/python/circuit/library/test_quantum_volume.py
+++ b/test/python/circuit/library/test_quantum_volume.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import numpy as np
+
 from test.utils.base import QiskitTestCase
 from qiskit.circuit.library import QuantumVolume
 from qiskit.circuit.library.quantum_volume import quantum_volume
@@ -51,6 +53,12 @@ class TestQuantumVolumeLibrary(QiskitTestCase):
 
         left = quantum_volume(10, 10, seed=4196)
         right = quantum_volume(10, 10, seed=4196)
+        self.assertEqual(left, right)
+
+        rng = np.random.default_rng(256)
+        left = quantum_volume(10, 10, seed=rng)
+        rng = np.random.default_rng(256)
+        right = quantum_volume(10, 10, seed=rng)
         self.assertEqual(left, right)
 
 

--- a/test/python/circuit/library/test_quantum_volume.py
+++ b/test/python/circuit/library/test_quantum_volume.py
@@ -14,9 +14,10 @@
 
 import unittest
 
+from test.utils.base import QiskitTestCase
+
 import numpy as np
 
-from test.utils.base import QiskitTestCase
 from qiskit.circuit.library import QuantumVolume
 from qiskit.circuit.library.quantum_volume import quantum_volume
 


### PR DESCRIPTION
The `seed` argument to `quantum_volume` being a `numpy.random.Generator` resulted in `integers` being called with 0 for the `low` argument. When called with only a `low` argument like this, this value is taken as one more than the maximum and 0 is treated as the minimum. This resulted in a `TypeError` because the range is from 0 to -1. Here the handling of `Generator` was updated to match how the deprecated `QuantumVolume` class handled `seed` (which was slightly odd -- it caps the range at the int64 limit even though the argument is a `u64` in the Rust function -- but probably fine; keeping the range helps keep the behavior consistent between `QuantumVolume` and `quantum_volume` for a generator with the same seed).
