### PR TITLE
Add `DAGCircuit.make_physical`

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -1345,8 +1345,9 @@ impl DAGCircuit {
 
     /// Put ``self`` into the canonical physical form, with the given number of qubits.
     ///
-    /// This acts in place and is cheap.  It is intended for use when the DAG is known to already
-    /// represent a physical circuit, and we just need to assert that it is canonical physical form.
+    /// This acts in place, and does not need to traverse the DAG.  It is intended for use when the
+    /// DAG is known to already represent a physical circuit, and we just need to assert that it is
+    /// canonical physical form.
     ///
     /// This erases any information about virtual qubits in the :class:`DAGCircuit`; if using this
     /// yourself, you may need to ensure you have created and stored a suitable :class:`.Layout`.

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -1343,6 +1343,36 @@ impl DAGCircuit {
         self.copy_empty_like_with_capacity(0, 0, vars_mode)
     }
 
+    /// Put ``self`` into the canonical physical form, with the given number of qubits.
+    ///
+    /// This acts in place and is cheap.  It is intended for use when the DAG is known to already
+    /// represent a physical circuit, and we just need to assert that it is canonical physical form.
+    ///
+    /// This erases any information about virtual qubits in the :class:`DAGCircuit`; if using this
+    /// yourself, you may need to ensure you have created and stored a suitable :class:`.Layout`.
+    /// Effectively, this applies the "trivial" layout mapping virtual qubit 0 to physical qubit 0,
+    /// and so on.
+    ///
+    /// Args:
+    ///     num_qubits: if given, the total number of physical qubits in the output; it must be at
+    ///         least as large as the number of qubits in the DAG.  If not given, the number of
+    ///         qubits is unchanged.
+    #[pyo3(name = "make_physical", signature = (num_qubits=None))]
+    pub fn py_make_physical(&mut self, num_qubits: Option<u32>) -> PyResult<()> {
+        let ancillas = match num_qubits {
+            Some(total) => total.checked_sub(self.num_qubits() as u32).ok_or_else(|| {
+                PyValueError::new_err(format!(
+                    "cannot have fewer physical qubits ({}) than virtual ({})",
+                    total,
+                    self.num_qubits()
+                ))
+            })?,
+            None => 0,
+        };
+        self.make_physical(ancillas as usize);
+        Ok(())
+    }
+
     #[pyo3(signature=(node, check=false))]
     fn _apply_op_node_back(
         &mut self,
@@ -4594,6 +4624,51 @@ impl DAGCircuit {
         }
 
         Ok(target_dag)
+    }
+
+    /// Modify `self` to mark its qubits as physical.
+    ///
+    /// This deletes the information about the virtual registers, and replaces it with the single
+    /// (implicitly) physical register.  This method does not need to traverse the DAG, other than
+    /// to add any ancilla in/out nodes.
+    ///
+    /// The qubit indices all stay the same; effectively, this is the application of the "trivial"
+    /// layout.  If the incoming DAG is supposed to be considered physical, this method can be used
+    /// to ensure it is in the canonical physical form.
+    pub fn make_physical(&mut self, ancillas: usize) {
+        let virtuals = self.num_qubits() as u32;
+        // The strategy here is just to modify the qubit and quantum register objects entirely
+        // inplace; we maintain all relative indices, so we don't need to modify any interner keys.
+        let num_qubits = virtuals
+            .checked_add(
+                ancillas
+                    .try_into()
+                    .expect("number of ancillas should fit in a u32"),
+            )
+            .expect("total number of qubits should fit in a u32");
+        let register = QuantumRegister::new_owning("q", num_qubits);
+        let mut registry = ObjectRegistry::with_capacity(num_qubits as usize);
+        let mut locator = BitLocator::with_capacity(num_qubits as usize);
+        for (index, bit) in register.iter().enumerate() {
+            registry
+                .add(bit.clone(), false)
+                .expect("no duplicates, and in-bounds check already performed");
+            locator.insert(
+                bit,
+                BitLocations::new(index as u32, [(register.clone(), index)]),
+            );
+        }
+        let mut register_data = RegisterData::with_capacity(1);
+        register_data
+            .add_register(register, false)
+            .expect("infallible when 'strict=false'");
+        for qubit in virtuals..num_qubits {
+            self.add_wire(Wire::Qubit(Qubit(qubit)))
+                .expect("this qubit has the next sequential index");
+        }
+        self.qubits = registry;
+        self.qregs = register_data;
+        self.qubit_locations = locator;
     }
 
     /// Returns an immutable view of the [QuantumRegister] instances in the circuit.

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -1360,7 +1360,6 @@ impl DAGCircuit {
     ///         qubits is unchanged.
     #[pyo3(name = "make_physical", signature = (num_qubits=None))]
     pub fn py_make_physical(&mut self, num_qubits: Option<u32>) -> PyResult<()> {
-        //let num_qubits = num_qubits.map(|x| x as usize).unwrap_or(self.num_qubits());
         let num_qubits = match num_qubits {
             Some(num_qubits) => {
                 if (num_qubits as usize) < self.num_qubits() {

--- a/releasenotes/notes/dag-make-physical-83c9ee2728528224.yaml
+++ b/releasenotes/notes/dag-make-physical-83c9ee2728528224.yaml
@@ -1,0 +1,6 @@
+---
+features_transpiler:
+  - |
+    A new method :meth:`.DAGCircuit.make_physical` is provided, which efficiently replaces the
+    qubits in the :class:`.DAGCircuit` with the canonical physical-qubit register, potentially
+    including expansion.

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from collections import Counter
+import math
 import pickle
 import copy
 import io
@@ -3415,6 +3416,98 @@ class TestDagCausalCone(QiskitTestCase):
         result = dag.quantum_causal_cone(dag.qubits[1])
         expected = {qreg[0], qreg[1], qreg[2], qreg[3]}
         self.assertEqual(result, expected)
+
+
+class TestDAGMakePhysical(QiskitTestCase):
+    """Tests of `make_physical`."""
+
+    def test_basic(self):
+        """Test basic usage of `make_physical`."""
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+
+        def from_qubit_circuit(qc: QuantumCircuit):
+            qc.add_register(ClassicalRegister(5, "c"))
+            qc.add_input(a)
+            qc.add_var(b, expr.lift(False))
+            qc.h(0)
+            qc.cx(0, 1)
+            qc.measure([0, 1], [0, 1])
+            return circuit_to_dag(qc, copy_operations=False)
+
+        base = from_qubit_circuit(QuantumCircuit(QuantumRegister(5, "virtuals")))
+        base.make_physical()
+        self.assertEqual(base, from_qubit_circuit(QuantumCircuit(QuantumRegister(5, "q"))))
+
+        expanded = from_qubit_circuit(QuantumCircuit([Qubit() for _ in range(3)]))
+        expanded.make_physical(10)
+        self.assertEqual(expanded, from_qubit_circuit(QuantumCircuit(QuantumRegister(10, "q"))))
+
+    def test_after_substitution(self):
+        """Make sure that having a nonsequential node ordering in the graph doesn't matter."""
+        base = DAGCircuit()
+        base.add_qreg(QuantumRegister(1, "virtuals"))
+        base.apply_operation_back(XGate(), [base.qubits[0]], [])
+        mid = base.apply_operation_back(HGate(), [base.qubits[0]], [])
+        base.apply_operation_back(XGate(), [base.qubits[0]], [])
+
+        replacement = QuantumCircuit(1, global_phase=-math.pi / 4)
+        replacement.s(0)
+        replacement.sx(0)
+        replacement.s(0)
+
+        base.substitute_node_with_dag(mid, circuit_to_dag(replacement))
+        base.make_physical(5)
+
+        expected = QuantumCircuit(QuantumRegister(5, "q"), global_phase=-math.pi / 4)
+        expected.x(0)
+        expected.s(0)
+        expected.sx(0)
+        expected.s(0)
+        expected.x(0)
+
+        raise_if_dagcircuit_invalid(base)
+        self.assertEqual(base, circuit_to_dag(expected))
+
+    def test_empty(self):
+        """An empty DAGCircuit."""
+        empty_0q = DAGCircuit()
+        empty_0q.make_physical()
+        expected = DAGCircuit()
+        expected.add_qreg(QuantumRegister(0, "q"))
+        self.assertEqual(empty_0q, expected)
+
+        empty_8q = DAGCircuit()
+        empty_8q.make_physical(8)
+        expanded = DAGCircuit()
+        expanded.add_qreg(QuantumRegister(8, "q"))
+        self.assertEqual(empty_8q, expanded)
+
+    def test_0q_with_classical(self):
+        """Classical data should still work fine even if there are no qubits."""
+        cr = ClassicalRegister(3, "cr")
+        qc = QuantumCircuit(cr)
+        a = qc.add_input("a", types.Bool())
+        b = qc.add_var("b", expr.lift(False))
+        qc.store(b, a)
+
+        def expected(num_qubits):
+            dag = DAGCircuit()
+            dag.add_qreg(QuantumRegister(num_qubits, "q"))
+            dag.add_creg(cr)
+            dag.add_input_var(a)
+            dag.add_declared_var(b)
+            dag.apply_operation_back(Store(b, expr.lift(False)), [], [])
+            dag.apply_operation_back(Store(b, a), [], [])
+            return dag
+
+        dag = circuit_to_dag(qc)
+        dag.make_physical()
+        self.assertEqual(dag, expected(0))
+
+        dag = circuit_to_dag(qc)
+        dag.make_physical(156)
+        self.assertEqual(dag, expected(156))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This method replaces the qubits on the `DAGCircuit` with the "canonical" physical register.  This does a similar job to running `TrivialLayout`, ancilla-allocation/expansion and `ApplyLayout`, and in fact this method can be used as one half of action of `ApplyLayout` in general.

This commit is a stepping stone to having `ApplyLayout` in pure Rust space.  The `TrivialLayout` pass could also, in a follow-up, be upgraded to be similar to `SabreLayout` and perform its layout action inline too. That can follow in a separate patch, however, since it has additional API considerations, as it would change the behaviour of the pass.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Sabre (#14317) will use this in a fast-return case for all-to-all connectivity.  I can also follow up with a patch that builds off this to do all of `ApplyLayout` in Rust.
