### PR TITLE
Add a new 'ps' variant to `Duration` for picoseconds.

### DIFF
--- a/crates/circuit/src/duration.rs
+++ b/crates/circuit/src/duration.rs
@@ -43,6 +43,7 @@ use pyo3::PyTypeInfo;
 #[allow(non_camel_case_types)]
 pub enum Duration {
     dt(i64),
+    ps(f64),
     ns(f64),
     us(f64),
     ms(f64),
@@ -55,6 +56,7 @@ impl Duration {
     fn unit(&self) -> &'static str {
         match self {
             Duration::dt(_) => "dt",
+            Duration::ps(_) => "ps",
             Duration::us(_) => "us",
             Duration::ns(_) => "ns",
             Duration::ms(_) => "ms",
@@ -70,14 +72,17 @@ impl Duration {
     fn py_value(&self, py: Python) -> PyResult<PyObject> {
         match self {
             Duration::dt(v) => v.into_py_any(py),
-            Duration::us(v) | Duration::ns(v) | Duration::ms(v) | Duration::s(v) => {
-                v.into_py_any(py)
-            }
+            Duration::ps(v)
+            | Duration::us(v)
+            | Duration::ns(v)
+            | Duration::ms(v)
+            | Duration::s(v) => v.into_py_any(py),
         }
     }
 
     fn __repr__(&self) -> String {
         match self {
+            Duration::ps(t) => format!("Duration::ps({t})"),
             Duration::ns(t) => format!("Duration.ns({t})"),
             Duration::us(t) => format!("Duration.us({t})"),
             Duration::ms(t) => format!("Duration.ms({t})"),

--- a/crates/circuit/src/duration.rs
+++ b/crates/circuit/src/duration.rs
@@ -82,7 +82,7 @@ impl Duration {
 
     fn __repr__(&self) -> String {
         match self {
-            Duration::ps(t) => format!("Duration::ps({t})"),
+            Duration::ps(t) => format!("Duration.ps({t})"),
             Duration::ns(t) => format!("Duration.ns({t})"),
             Duration::us(t) => format!("Duration.us({t})"),
             Duration::ms(t) => format!("Duration.ms({t})"),

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -209,6 +209,10 @@ pub fn circuit(m: &Bound<PyModule>) -> PyResult<()> {
     // to the module so that pickle can find them during deserialization.
     m.add_class::<duration::Duration>()?;
     m.add(
+        "Duration_ps",
+        duration::Duration::type_object(m.py()).getattr("ps")?,
+    )?;
+    m.add(
         "Duration_ns",
         duration::Duration::type_object(m.py()).getattr("ns")?,
     )?;

--- a/qiskit/qasm3/exporter.py
+++ b/qiskit/qasm3/exporter.py
@@ -1338,7 +1338,7 @@ class _ExprBuilder(expr.ExprVisitor[ast.Expression]):
                 return ast.DurationLiteral(node.value.value(), ast.DurationUnit.SAMPLE)
             if unit == "ps":
                 # QASM doesn't natively support picoseconds.
-                return ast.DurationLiteral(1000 * node.value.value(), ast.DurationUnit.NANOSECOND)
+                return ast.DurationLiteral(node.value.value() / 1000, ast.DurationUnit.NANOSECOND)
             if unit == "ns":
                 return ast.DurationLiteral(node.value.value(), ast.DurationUnit.NANOSECOND)
             if unit == "us":

--- a/qiskit/qasm3/exporter.py
+++ b/qiskit/qasm3/exporter.py
@@ -1336,6 +1336,9 @@ class _ExprBuilder(expr.ExprVisitor[ast.Expression]):
             unit = node.value.unit()
             if unit == "dt":
                 return ast.DurationLiteral(node.value.value(), ast.DurationUnit.SAMPLE)
+            if unit == "ps":
+                # QASM doesn't natively support picoseconds.
+                return ast.DurationLiteral(1000 * node.value.value(), ast.DurationUnit.NANOSECOND)
             if unit == "ns":
                 return ast.DurationLiteral(node.value.value(), ast.DurationUnit.NANOSECOND)
             if unit == "us":

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -444,6 +444,19 @@ byte offsets of each circuit payload in the file. The motivation for this change
 enable a more efficient loading of circuits using multi-threading in a future Rust
 implementation of the QPY deserializer.
 
+Changes to DURATION
+~~~~~~~~~~~~~~~~~~~
+
+A new variant has been added to the existing DURATION type encoding for picoseconds. This
+is encoded as follows, and is in addition to the previously supported variants.
+
+==============================  =========  =========================================================
+Qiskit class                    Type code  Payload
+==============================  =========  =========================================================
+:class:`~.circuit.Duration.ps`    ``p``    One ``double value``.
+
+==============================  =========  =========================================================
+
 .. _qpy_version_15:
 
 Version 15

--- a/qiskit/qpy/formats.py
+++ b/qiskit/qpy/formats.py
@@ -446,6 +446,10 @@ DURATION_DT = namedtuple("DURATION_DT", ["value"])
 DURATION_DT_PACK = "!Q"
 DURATION_DT_SIZE = struct.calcsize(DURATION_DT_PACK)
 
+DURATION_PS = namedtuple("DURATION_PS", ["value"])
+DURATION_PS_PACK = "!d"
+DURATION_PS_SIZE = struct.calcsize(DURATION_PS_PACK)
+
 DURATION_NS = namedtuple("DURATION_NS", ["value"])
 DURATION_NS_PACK = "!d"
 DURATION_NS_SIZE = struct.calcsize(DURATION_NS_PACK)

--- a/qiskit/qpy/type_keys.py
+++ b/qiskit/qpy/type_keys.py
@@ -369,6 +369,7 @@ class CircuitDuration(TypeKeyBase):
     """Type keys for the ``DURATION`` QPY item."""
 
     DT = b"t"
+    PS = b"p"
     NS = b"n"
     US = b"u"
     MS = b"m"
@@ -380,6 +381,8 @@ class CircuitDuration(TypeKeyBase):
             unit = obj.unit()
             if unit == "dt":
                 return cls.DT
+            if unit == "ps":
+                return cls.PS
             if unit == "ns":
                 return cls.NS
             if unit == "us":

--- a/releasenotes/notes/duration-ps-b6caf2f96e533f2a.yaml
+++ b/releasenotes/notes/duration-ps-b6caf2f96e533f2a.yaml
@@ -1,0 +1,5 @@
+---
+features_circuits:
+  - |
+    The :class:`~.circuit.Duration` class has gained a new ``ps`` variant, which can be
+    used to represent a duration in picoseconds.

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -2250,6 +2250,22 @@ class TestLoadFromQPY(QiskitTestCase):
         ):
             dump(qc, fptr, version=version)
 
+    @ddt.idata(range(14, 16))
+    def test_pre_v16_rejects_ps_duration(self, version):
+        """Test that dumping to older QPY versions rejects Duration.ps."""
+        from qiskit.circuit import Duration
+
+        qc = QuantumCircuit()
+        with qc.if_test(expr.less(Duration.ns(1000), Duration.ps(1))):
+            pass
+        with (
+            io.BytesIO() as fptr,
+            self.assertRaisesRegex(
+                UnsupportedFeatureForVersion, "version 16 is required.*Duration.ps"
+            ),
+        ):
+            dump(qc, fptr, version=version)
+
 
 class TestSymengineLoadFromQPY(QiskitTestCase):
     """Test use of symengine in qpy set of methods."""

--- a/test/python/circuit/test_delay.py
+++ b/test/python/circuit/test_delay.py
@@ -149,6 +149,7 @@ class TestDelayClass(QiskitTestCase):
         qc.delay(expr.lift(Duration.ms(3)), 0)
         qc.delay(expr.lift(Duration.s(4)), 0)
         qc.delay(expr.lift(Duration.dt(5)), 0)
+        qc.delay(expr.lift(Duration.ps(6)), 0)
         qc.delay(stretch, [0, 1])
         self.assertEqual(qc, pickle.loads(pickle.dumps(qc)))
         self.assertEqual(qc, copy.copy(qc))

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -2403,6 +2403,7 @@ class TestPostTranspileIntegration(QiskitTestCase):
         bits = [Qubit(), Qubit(), Clbit()]
         base = QuantumCircuit(*regs, bits)
         base.h(0)
+        base.delay(expr.lift(Duration.ps(1234)), 0)
         base.measure(0, 0)
         with base.if_test(expr.equal(base.cregs[0], 1)) as else_:
             base.cx(0, 1)
@@ -2553,7 +2554,7 @@ class TestPostTranspileIntegration(QiskitTestCase):
             control_flow=True,
         )
         transpiled = transpile(
-            self._control_flow_circuit(),
+            self._control_flow_expr_circuit(),
             backend=backend,
             optimization_level=optimization_level,
             seed_transpiler=2023_07_26,
@@ -2635,7 +2636,7 @@ class TestPostTranspileIntegration(QiskitTestCase):
         """Test that the output of a transpiled circuit with control flow and `Expr` nodes can be
         dumped into OpenQASM 3."""
         transpiled = transpile(
-            self._control_flow_circuit(),
+            self._control_flow_expr_circuit(),
             backend=GenericBackendV2(
                 num_qubits=27, coupling_map=MUMBAI_CMAP, control_flow=True, seed=2025_05_28
             ),

--- a/test/python/qasm3/test_export.py
+++ b/test/python/qasm3/test_export.py
@@ -739,6 +739,9 @@ c[1] = measure q[1];
         qc.delay(expr.div(s, 2.0), qreg[1])
         qc.delay(expr.add(expr.mul(s, expr.div(Duration.dt(1000), Duration.ns(200))), t), qreg[0])
 
+        # "ps" is not a valid unit in OQ3, so we need to convert.
+        qc.delay(expr.add(expr.mul(s, expr.div(Duration.dt(1000), Duration.ps(2))), t), qreg[0])
+
         expected_qasm = "\n".join(
             [
                 "OPENQASM 3.0;",
@@ -750,6 +753,7 @@ c[1] = measure q[1];
                 "delay[2000ns] qr[1];",
                 "delay[s / 2.0] qr[1];",
                 "delay[s * (1000dt / 200.0ns) + t] qr[0];",
+                "delay[s * (1000dt / 2000.0ns) + t] qr[0];",
                 "",
             ]
         )
@@ -1359,6 +1363,9 @@ c[1] = measure q[1];
         with qc.box(duration=a):
             with qc.box(duration=expr.mul(2, a)):
                 pass
+        with qc.box(duration=a):
+            with qc.box(duration=expr.add(expr.mul(2, a), Duration.ps(2))):
+                pass
 
         expected = """\
 OPENQASM 3.0;
@@ -1377,6 +1384,10 @@ box[200dt] {
 }
 box[a] {
   box[2 * a] {
+  }
+}
+box[a] {
+  box[2 * a + 2000.0ns] {
   }
 }
 """

--- a/test/python/qasm3/test_export.py
+++ b/test/python/qasm3/test_export.py
@@ -753,7 +753,7 @@ c[1] = measure q[1];
                 "delay[2000ns] qr[1];",
                 "delay[s / 2.0] qr[1];",
                 "delay[s * (1000dt / 200.0ns) + t] qr[0];",
-                "delay[s * (1000dt / 2000.0ns) + t] qr[0];",
+                "delay[s * (1000dt / 0.002ns) + t] qr[0];",
                 "",
             ]
         )
@@ -1387,7 +1387,7 @@ box[a] {
   }
 }
 box[a] {
-  box[2 * a + 2000.0ns] {
+  box[2 * a + 0.002ns] {
   }
 }
 """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Our `delay` and `box` instructions support picoseconds, so it's a gap that we can't use `Duration` to represent these. 

### Details and comments
The new variant requires support from QPY ~and thus bumps its version~. QASM3 does not have native support for picoseconds, so we convert to nanoseconds during export if they are encountered (this is what we currently do for the old-style duration and unit in a delay).

