### PR TITLE
Fix ``code-block:: c`` with lowercase ``c`` for docs

### DIFF
--- a/docs/cdoc/qk-target-entry.rst
+++ b/docs/cdoc/qk-target-entry.rst
@@ -3,7 +3,7 @@
 QkTargetEntry
 =============
 
-.. code-block:: C
+.. code-block:: c
 
     typedef struct QkTargetEntry QkTargetEntry
 
@@ -13,7 +13,7 @@ from C.
 
 Here's an example of how this structure works:
 
-.. code-block:: C
+.. code-block:: c
 
     #include <qiskit.h>
     #include <math.h>

--- a/docs/cdoc/qk-target.rst
+++ b/docs/cdoc/qk-target.rst
@@ -2,7 +2,7 @@
 QkTarget
 ========
 
-.. code-block:: C
+.. code-block:: c
 
     typedef struct QkTarget QkTarget
 
@@ -15,7 +15,7 @@ counterpart, :class:`.Target`.
 
 Here's an example of how this structure works:
 
-.. code-block:: C
+.. code-block:: c
 
     #include <qiskit.h>
     #include <math.h>


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The code snippets on the `QkTarget(Entry)` pages are not properly syntax-highlighted, likely due to our setup not accepting an upper case `C` as identifier for the C language. Other snippets with lowercase `c` work. (Local docs builds also accept uppercase `C` so I'm assuming some part of our custom build process or style causes this.)

### Details and comments

See https://docs.quantum.ibm.com/api/qiskit-c/dev/qk-target

![image](https://github.com/user-attachments/assets/d30fa6cf-ef43-44a1-9e6d-c68f1e886f64)



