### PR TITLE
Fix classical bit mapping in HLS pass

### DIFF
--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -479,11 +479,7 @@ fn run_on_circuitdata(
             .iter()
             .map(|q| input_qubits[q.index()])
             .collect::<Vec<usize>>();
-        let op_clbits = input_circuit
-            .get_cargs(inst.clbits)
-            .iter()
-            .map(|c| c.index())
-            .collect::<Vec<usize>>();
+        let op_clbits = input_circuit.get_cargs(inst.clbits);
 
         // Start by handling special operations.
         // In the future, we can also consider other possible optimizations, e.g.:
@@ -638,7 +634,7 @@ fn run_on_circuitdata(
                         .collect();
                     let inst_outer_clbits: Vec<Clbit> = inst_inner_clbits
                         .iter()
-                        .map(|c| Clbit(op_clbits[c.0 as usize] as u32))
+                        .map(|c| op_clbits[c.0 as usize])
                         .collect();
 
                     output_circuit.push_packed_operation(

--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -479,6 +479,11 @@ fn run_on_circuitdata(
             .iter()
             .map(|q| input_qubits[q.index()])
             .collect::<Vec<usize>>();
+        let op_clbits = input_circuit
+            .get_cargs(inst.clbits)
+            .iter()
+            .map(|c| c.index())
+            .collect::<Vec<usize>>();
 
         // Start by handling special operations.
         // In the future, we can also consider other possible optimizations, e.g.:
@@ -631,8 +636,10 @@ fn run_on_circuitdata(
                         .iter()
                         .map(|q| Qubit::new(qubit_map[&q.index()]))
                         .collect();
-                    let inst_outer_clbits: Vec<Clbit> =
-                        inst_inner_clbits.iter().map(|c| Clbit(c.0)).collect();
+                    let inst_outer_clbits: Vec<Clbit> = inst_inner_clbits
+                        .iter()
+                        .map(|c| Clbit(op_clbits[c.0 as usize] as u32))
+                        .collect();
 
                     output_circuit.push_packed_operation(
                         inst_inner.op.clone(),

--- a/releasenotes/notes/fix-hls-clbits-6ddf1f8d1542eed2.yaml
+++ b/releasenotes/notes/fix-hls-clbits-6ddf1f8d1542eed2.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a bug in the :class:`.HighLevelSynthesis` pass where, if the circuit contained high level objects
+    with classical registers, these would get mapped to the relative index in the object instead of the
+    corresponding index in the outer circuit. The classical registers are now correctly mapped to the outer 
+    circuit index.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes a bug in HLS where classical registers were mapped to the indices in within the high level object they were defined on, instead of the corresponding index in the global circuit. 

Fixes #14569 . 


### Details and comments
The bug was introduced in 2.0, so the fix should be backported to the `stable/2.0` branch, but not `stable/1.4`.

