### PR TITLE
Fix `ElidePermutations` pass in the presence of `PermutationGate`s

### DIFF
--- a/crates/transpiler/src/passes/elide_permutations.rs
+++ b/crates/transpiler/src/passes/elide_permutations.rs
@@ -63,17 +63,13 @@ pub fn run_elide_permutations(
                             .map(|q| q.index())
                             .collect();
 
-                        let remapped_qindices: Vec<usize> = (0..qindices.len())
-                            .map(|i| pattern[i])
-                            .map(|i| qindices[i as usize])
+                        let new_values: Vec<usize> = (0..qindices.len())
+                            .map(|i| mapping[qindices[pattern[i] as usize]])
                             .collect();
 
-                        qindices
-                            .iter()
-                            .zip(remapped_qindices.iter())
-                            .for_each(|(old, new)| {
-                                mapping[*old] = *new;
-                            });
+                        for i in 0..qindices.len() {
+                            mapping[qindices[i]] = new_values[i];
+                        }
                     } else {
                         unreachable!();
                     }

--- a/releasenotes/notes/fix-elide-permutation-gates-e4d2a718e1d50afa.yaml
+++ b/releasenotes/notes/fix-elide-permutation-gates-e4d2a718e1d50afa.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a bug in the :class:`.ElidePermutation` transpiler pass, where
+    the qubit mapping was not updated correctly in the presence of
+    :class:`.PermutationGate`\s, leading to incorrect circuits and
+    updates to the pass manager's property set.

--- a/test/python/transpiler/test_elide_permutations.py
+++ b/test/python/transpiler/test_elide_permutations.py
@@ -12,6 +12,7 @@
 
 """Test ElidePermutations pass"""
 
+import itertools
 import unittest
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -20,6 +21,7 @@ from qiskit.transpiler.passes.optimization.elide_permutations import ElidePermut
 from qiskit.transpiler.passes.routing import StarPreRouting
 from qiskit.circuit.controlflow import IfElseOp
 from qiskit.quantum_info import Operator
+from qiskit.transpiler.passmanager import PassManager
 from qiskit.transpiler.coupling import CouplingMap
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
@@ -365,6 +367,20 @@ class TestElidePermutationsInTranspileFlow(QiskitTestCase):
             spm.init += ElidePermutations()
             res = spm.run(qc)
             self.assertTrue(Operator.from_circuit(res).equiv(Operator(qc)))
+
+    def test_unitary_equivalence_permutation_gates(self):
+        """Test unitary equivalence of the original and transpiled circuits."""
+
+        for perm in itertools.permutations([0, 1, 2]):
+            qc = QuantumCircuit(5)
+            qc.h(1)
+            qc.swap(1, 2)
+            qc.swap(4, 3)
+            qc.append(PermutationGate(perm), [1, 2, 3])
+
+            pm = PassManager([ElidePermutations()])
+            res = pm.run(qc)
+            self.assertEqual(Operator.from_circuit(res), (Operator(qc)))
 
     def test_unitary_equivalence_routing_and_basis_translation(self):
         """Test on a larger example that includes routing and basis translation."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #14602.

### Details and comments

The `ElidePermutations` transpiler pass removes swap gates and permutation gates from the circuit, tracking the current permutation of the qubits using the internal variable ``mapping``. Previously, this mapping was not updated correctly in the presence of permutation gates, leading to incorrect output circuits and updates to the pass manager's property set (namely, to ``"virtual_permutation_layout"``).

The correct update rule should be $$M [ Q [i] ] \leftarrow M [Q [ P[i] ] ]$$ for $i=1,\dots,k$, where $M$ is the current mapping within the `ElidePermutations` pass, $Q$ is the set of qubits the permutation gate is defined on, and $P$ is the "permutation pattern" of the permutation gate (stating which qubits get mapped to positions $0$, $1$, etc. when the permutation gate is applied). 