### PR TITLE
Compute dense-layout Sabre trial only over virtual qubits

### DIFF
--- a/crates/transpiler/src/passes/sabre/layout.rs
+++ b/crates/transpiler/src/passes/sabre/layout.rs
@@ -444,11 +444,7 @@ fn add_heuristic_layouts(
     let num_physical_qubits = problem.target.neighbors.num_qubits();
     // Run a dense layout trial
     starting_layouts.push(compute_dense_starting_layout(
-        // TODO: This actually should be `dag.num_qubits()`, but a side-effect of the previous
-        // Python-space disjoint coupling handling meant that DAGs were being expanded to full
-        // hardware width (of the relevant component) before Sabre was called, so were running in
-        // this configuration instead.  This behaviour is initially kept for RNG compatibility.
-        num_physical_qubits,
+        problem.dag.num_qubits(),
         problem.target,
         run_in_parallel,
     ));

--- a/releasenotes/notes/sabre-dense-layout-d9db50ba46811e09.yaml
+++ b/releasenotes/notes/sabre-dense-layout-d9db50ba46811e09.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    :class:`.SabreLayout` uses a "dense subset" layout as one of its trials, following the same
+    algorithm as :class:`.DenseLayout`.  Previously, however, the version used by Sabre was assigning
+    all virtual qubits, including dummy ancillas, to a physical qubit, compromising the effectiveness
+    of the algorithm, but not its correctness.  Sabre will now only use the virtual qubits defined by
+    the user for this initial trial, which may result in small improvements in layout selection
+    when averaged over large classes of circuit.

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -960,7 +960,7 @@ class TestFinalLayouts(QiskitTestCase):
                     qc.cx(qubit_control, qubit_target)
         expected_layouts = [
             [0, 1, 2, 3, 4],
-            [6, 5, 11, 10, 2],
+            [6, 5, 10, 11, 2],
             [6, 5, 2, 11, 10],
             [6, 5, 2, 11, 10],
         ]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The previous Sabre implementation, when it used the Python-space disjoint handling, would always see incoming `DAGCircuit` objects as being already full-width on the chip subset.  This meant that the dense-layout subset choice would never be a subset, just a re-ordering, and would assign arbitrary and unimportant values to ancillas.

The new Rust-space disjoint handling sees the true sizes of the incoming `DAGCircuit`s, so can handle the dense-layout choice in the intended manner.  This has an effect on the randomisation, so was deferred to this separate commit.



### Details and comments

Depends on #14317.

Technically we _could_ backport this logical change to 2.1.  It doesn't impact correctness at all, though, so it can just be considered a quality improvement.  It's most likely not worth the risk of backport.