### PR TITLE
Fix `ApplyLayout` with empty layout

### DIFF
--- a/qiskit/transpiler/passes/layout/apply_layout.py
+++ b/qiskit/transpiler/passes/layout/apply_layout.py
@@ -48,11 +48,11 @@ class ApplyLayout(TransformationPass):
             TranspilerError: if no layout is found in ``property_set`` or no full physical qubits.
         """
         layout = self.property_set["layout"]
-        if not layout:
+        if layout is None:
             raise TranspilerError(
                 "No 'layout' is found in property_set. Please run a Layout pass in advance."
             )
-        if len(layout) != (1 + max(layout.get_physical_bits())):
+        if len(layout) != (1 + max(layout.get_physical_bits(), default=-1)):
             raise TranspilerError("The 'layout' must be full (with ancilla).")
 
         post_layout = self.property_set["post_layout"]

--- a/releasenotes/notes/apply-empty-layout-711f2d1359f329e1.yaml
+++ b/releasenotes/notes/apply-empty-layout-711f2d1359f329e1.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    :class:`.ApplyLayout` will now correctly handle the case of applying a zero-qubit :class:`.Layout`.
+    Previously, it would claim that no layout had been set, even if the ``"layout"`` field of the
+    :class:`.PropertySet` was equal to ``Layout()``.

--- a/test/python/transpiler/test_apply_layout.py
+++ b/test/python/transpiler/test_apply_layout.py
@@ -51,6 +51,18 @@ class TestApplyLayout(QiskitTestCase):
 
         self.assertEqual(circuit_to_dag(expected), after)
 
+    def test_empty_layout(self):
+        """If the layout and the backend are empty, the pass should still be well behaved."""
+        qc = QuantumCircuit()
+        out = ApplyLayout()(qc, property_set={"layout": Layout()})
+        self.assertEqual(out.layout.initial_virtual_layout(), Layout())
+
+    def test_empty_post_layout(self):
+        """If the layout and the backend are empty, the pass should still be well behaved."""
+        qc = QuantumCircuit()
+        out = ApplyLayout()(qc, property_set={"layout": Layout(), "post_layout": Layout()})
+        self.assertEqual(out.layout.initial_virtual_layout(), Layout())
+
     def test_raise_when_no_layout_is_supplied(self):
         """Test error is raised if no layout is found in property_set."""
         v = QuantumRegister(2, "v")


### PR DESCRIPTION
### Summary

It's unlikely to ever be useful, but strictly there still is a well-defined behaviour for `ApplyLayout` on a zero-qubit circuit and backend.  Previously, the pass errored out falsely asserting user error.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments


