### PR TITLE
Collapse Sabre nodes with no routing implications

### DIFF
--- a/crates/transpiler/src/passes/sabre/dag.rs
+++ b/crates/transpiler/src/passes/sabre/dag.rs
@@ -93,12 +93,17 @@ impl InteractionKind {
 /// Named access to the node elements in the [SabreDAG].
 #[derive(Clone, Debug)]
 pub struct SabreNode {
-    pub index: NodeIndex,
+    /// Indices into the original [DAGCircuit] in topological order that become routable once the
+    /// node as a whole is routable.
+    pub indices: Vec<NodeIndex>,
     pub kind: InteractionKind,
 }
 impl SabreNode {
-    fn new(index: NodeIndex, kind: InteractionKind) -> Self {
-        Self { index, kind }
+    fn new(initial: NodeIndex, kind: InteractionKind) -> Self {
+        Self {
+            indices: vec![initial],
+            kind,
+        }
     }
 }
 
@@ -116,6 +121,11 @@ impl From<SabreDAGError> for PyErr {
 }
 
 /// A DAG representation of the logical circuit to be routed.
+///
+/// This interaction representation retains only information about routing necessities; when
+/// possible, nodes in the input [DAGCircuit] are combined into a single node for routing purposes
+/// (for example, 1q gates are always folded into a preceding node and runs of 2q gates on the same
+/// qubits are combined).
 ///
 /// Note that all the qubit references here are to "virtual" qubits, that is, the qubits are those
 /// specified by the user.  This DAG does not need to be full-width on the hardware.
@@ -141,6 +151,31 @@ impl SabreDAG {
         let mut wire_pos: HashMap<Wire, NodeIndex> = HashMap::with_capacity(dag.width());
         let mut first_layer = Vec::<NodeIndex>::new();
 
+        enum Predecessors {
+            /// All the predecessors of a node are unmapped, so the node is an incoming external.
+            AllUnmapped,
+            /// All the predecessors of the node are the same concrete node.
+            Single(NodeIndex),
+            /// The node is not immediately dominated by a single concrete node (i.e. it's got more
+            /// than one in edge, or one but not all of its wires are unmapped).
+            Multiple,
+        }
+        let predecessors =
+            |dag_node: NodeIndex, sabre_pos: &HashMap<Wire, NodeIndex>| -> Predecessors {
+                let mut edges = dag.dag().edges_directed(dag_node, Direction::Incoming);
+                let Some(first) = edges.next() else {
+                    // 0-arity node, so it's always immediately eligible for routing.
+                    return Predecessors::AllUnmapped;
+                };
+                let single = sabre_pos.get(first.weight()).copied();
+                for edge in edges {
+                    if single != sabre_pos.get(edge.weight()).copied() {
+                        return Predecessors::Multiple;
+                    }
+                }
+                single.map_or(Predecessors::AllUnmapped, Predecessors::Single)
+            };
+
         for dag_node in dag
             .topological_op_nodes()
             .expect("infallible if DAG is in a valid state")
@@ -149,28 +184,54 @@ impl SabreDAG {
                 panic!("op nodes should always be of type `Operation`");
             };
             let kind = InteractionKind::from_op(&inst.op, dag.get_qargs(inst.qubits))?;
-            let sabre_node = sabre.add_node(SabreNode::new(dag_node, kind));
-            for edge in dag.dag().edges_directed(dag_node, Direction::Incoming) {
-                if let Some(parent) = wire_pos.insert(*edge.weight(), sabre_node) {
-                    sabre.add_edge(parent, sabre_node, ());
-                }
-            }
-            if sabre
-                .edges_directed(sabre_node, Direction::Incoming)
-                .next()
-                .is_none()
-            {
-                match &sabre[sabre_node].kind {
+            match predecessors(dag_node, &wire_pos) {
+                Predecessors::AllUnmapped => match kind {
                     InteractionKind::Synchronize => {
-                        for edge in dag.dag().edges_directed(dag_node, Direction::Incoming) {
-                            wire_pos.remove(edge.weight());
-                        }
-                        initial.push(sabre.remove_node(sabre_node).unwrap().index);
+                        initial.push(dag_node);
                     }
-                    _ => {
+                    kind => {
+                        let sabre_node = sabre.add_node(SabreNode::new(dag_node, kind));
                         first_layer.push(sabre_node);
+                        for edge in dag.dag().edges_directed(dag_node, Direction::Incoming) {
+                            wire_pos.insert(*edge.weight(), sabre_node);
+                        }
                     }
-                };
+                },
+                Predecessors::Multiple => {
+                    // It's possible that `kind` is `Synchronize` here and it only has a single
+                    // routing-enforced predecessor (and other wires that are automatically
+                    // satisfied). In that case, _technically_ we could fold it onto the single
+                    // constraining predecessor, but failing to do that doesn't cause correctness
+                    // issues, makes the logic easier, and will have next-to-no performance cost.
+                    let sabre_node = sabre.add_node(SabreNode::new(dag_node, kind));
+                    for edge in dag.dag().edges_directed(dag_node, Direction::Incoming) {
+                        if let Some(parent) = wire_pos.insert(*edge.weight(), sabre_node) {
+                            sabre.add_edge(parent, sabre_node, ());
+                        }
+                    }
+                }
+                Predecessors::Single(prev_sabre_node) => {
+                    let prev = sabre
+                        .node_weight_mut(prev_sabre_node)
+                        .expect("derived from 'edges_directed'");
+                    match (&prev.kind, kind) {
+                        // A "synchronise" that only has one predecessor isn't actually imposing any
+                        // synchronisation.  If a 2q gate depends only on another 2q gate, they've
+                        // got to be the same qubits, and therefore it's automatically routable.
+                        (_, InteractionKind::Synchronize)
+                        | (InteractionKind::TwoQ(_), InteractionKind::TwoQ(_)) => {
+                            prev.indices.push(dag_node);
+                        }
+                        // Otherwise we need the router to evaluate it.
+                        (_, kind) => {
+                            let sabre_node = sabre.add_node(SabreNode::new(dag_node, kind));
+                            sabre.add_edge(prev_sabre_node, sabre_node, ());
+                            for edge in dag.dag().edges_directed(dag_node, Direction::Incoming) {
+                                wire_pos.insert(*edge.weight(), sabre_node);
+                            }
+                        }
+                    }
+                }
             }
         }
         Ok(SabreDAG {
@@ -196,8 +257,10 @@ impl SabreDAG {
                 InteractionKind::Synchronize | InteractionKind::TwoQ(_) => node.kind.clone(),
                 InteractionKind::ControlFlow(_) => InteractionKind::Synchronize,
             };
+            // `NodeWeights` guarantees that the weights come out in index order, so the new indexes
+            // must match those in `self`.
             dag.add_node(SabreNode {
-                index: node.index,
+                indices: vec![],
                 kind,
             });
         }

--- a/crates/transpiler/src/passes/sabre/route.rs
+++ b/crates/transpiler/src/passes/sabre/route.rs
@@ -190,8 +190,15 @@ impl RoutingResult<'_> {
             for swap in item.initial_swaps() {
                 apply_swap(swap, &mut layout, &mut dag)?;
             }
-            let index = self.sabre.dag[item.node].index;
-            let NodeType::Operation(inst) = &self.dag[index] else {
+            let Some((head, rest)) = self.sabre.dag[item.node].indices.split_first() else {
+                // In theory this should never actually trigger: we're in a state where there was a
+                // Sabre routing-related interaction with no DAG node backing it.  That said, we do
+                // sometimes construct interaction graphs in this state (via
+                // [SabreDAG::only_interactions]), and either way, there's a meaningful way to
+                // handle it safely.
+                continue;
+            };
+            let NodeType::Operation(inst) = &self.dag[*head] else {
                 panic!("Sabre DAG should only contain op nodes");
             };
             match item.kind {
@@ -263,6 +270,12 @@ impl RoutingResult<'_> {
                     dag.push_back(new_inst)?
                 }
             };
+            for node in rest {
+                let NodeType::Operation(inst) = &self.dag[*node] else {
+                    panic!("sabre DAG should only contain op nodes");
+                };
+                apply_op(inst, &layout, &mut dag)?;
+            }
         }
         for swap in &self.final_swaps {
             apply_swap(swap, &mut layout, &mut dag)?;
@@ -439,7 +452,10 @@ impl<'a> RoutingState<'a> {
                     }
                 }
                 InteractionKind::ControlFlow(blocks) => {
-                    let NodeType::Operation(inst) = &self.dag[node.index] else {
+                    let dag_node_id = *node.indices.first().expect(
+                        "if control-flow interactions are included, so are original DAG indices",
+                    );
+                    let NodeType::Operation(inst) = &self.dag[dag_node_id] else {
                         panic!("Sabre DAG should only contain op nodes");
                     };
                     // The control-flow blocks aren't full width, so their "virtual" qubits aren't
@@ -545,35 +561,24 @@ impl<'a> RoutingState<'a> {
         let mut decremented: IndexMap<usize, u32, ahash::RandomState> =
             IndexMap::with_hasher(ahash::RandomState::default());
         let mut i = 0;
-        let mut visit_now: Vec<NodeIndex> = Vec::new();
-        let dag = self.sabre;
         while i < to_visit.len() && self.extended_set.len() < extended_set_size {
-            // Visit runs of non-2Q gates fully before moving on to children of 2Q gates. This way,
-            // traversal order is a BFS of 2Q gates rather than of all gates.
-            visit_now.push(to_visit[i]);
-            let mut j = 0;
-            while let Some(node) = visit_now.get(j) {
-                for edge in dag.dag.edges_directed(*node, Direction::Outgoing) {
-                    let successor_node = edge.target();
-                    let successor_index = successor_node.index();
-                    *decremented.entry(successor_index).or_insert(0) += 1;
-                    self.required_predecessors[successor_index] -= 1;
-                    if self.required_predecessors[successor_index] == 0 {
-                        // TODO: this looks "through" control-flow ops without seeing them, but we
-                        // actually eagerly route control-flow blocks as soon as they're eligible, so
-                        // they should be reflected in the extended set.
-                        if let InteractionKind::TwoQ([a, b]) = &dag.dag[successor_node].kind {
-                            self.extended_set
-                                .push([a.to_phys(&self.layout), b.to_phys(&self.layout)]);
-                            to_visit.push(successor_node);
-                            continue;
-                        }
-                        visit_now.push(successor_node);
+            let node = to_visit[i];
+            for edge in self.sabre.dag.edges_directed(node, Direction::Outgoing) {
+                let successor_node = edge.target();
+                let successor_index = successor_node.index();
+                *decremented.entry(successor_index).or_insert(0) += 1;
+                self.required_predecessors[successor_index] -= 1;
+                if self.required_predecessors[successor_index] == 0 {
+                    // TODO: this looks "through" control-flow ops without seeing them, but we
+                    // actually eagerly route control-flow blocks as soon as they're eligible, so
+                    // they should be reflected in the extended set.
+                    if let InteractionKind::TwoQ([a, b]) = &self.sabre.dag[successor_node].kind {
+                        self.extended_set
+                            .push([a.to_phys(&self.layout), b.to_phys(&self.layout)]);
                     }
+                    to_visit.push(successor_node);
                 }
-                j += 1;
             }
-            visit_now.clear();
             i += 1;
         }
         for (node, amount) in decremented.iter() {

--- a/releasenotes/notes/sabre-compress-c23c89e00ee96516.yaml
+++ b/releasenotes/notes/sabre-compress-c23c89e00ee96516.yaml
@@ -1,0 +1,8 @@
+---
+other:
+  - |
+    The implementation of Sabre routing used by :class:`.SabreLayout` and :class:`.SabreSwap` now
+    compresses runs of nodes that will automatically become eligible for routing at the same time
+    within its internal virtual-interaction representation.  This improves the efficiency of the
+    routing, reduces intermediate memory use, and avoids runs of 2q gates biasing the ``lookahead``
+    heuristic components.

--- a/test/python/transpiler/test_sabre_layout.py
+++ b/test/python/transpiler/test_sabre_layout.py
@@ -208,7 +208,7 @@ rz(0) q4835[1];
         self.assertIsInstance(res, QuantumCircuit)
         layout = res._layout.initial_layout
         self.assertEqual(
-            [layout[q] for q in qc.qubits], [14, 12, 5, 13, 26, 11, 19, 25, 18, 8, 17, 16, 9, 4]
+            [layout[q] for q in qc.qubits], [2, 0, 5, 1, 7, 3, 14, 6, 9, 8, 10, 11, 4, 12]
         )
 
     # pylint: disable=line-too-long
@@ -271,7 +271,7 @@ barrier q18585[5],q18585[2],q18585[8],q18585[3],q18585[6];
         self.assertIsInstance(res, QuantumCircuit)
         layout = res._layout.initial_layout
         self.assertEqual(
-            [layout[q] for q in qc.qubits], [0, 12, 7, 8, 6, 3, 1, 10, 4, 9, 2, 11, 13, 5]
+            [layout[q] for q in qc.qubits], [8, 21, 12, 16, 10, 4, 14, 23, 13, 9, 11, 19, 2, 20]
         )
 
     def test_support_var_with_rust_fastpath(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Not all nodes in the `SabreDAG` actually imply additional routing constraints.  For example, a 2q gate immediately following a prior 2q gate on the same qubits doesn't need to be routed; it's automatically valid as soon as its predecessor is.  Similarly, 1q gates (without additional classical wires) never impact routing and can be folded into previous instructions.

More formally, a `Synchronize` node whose incoming edges are all from the same predecessor (or are at the start of the circuit) does not actually synchronise anything, and can be folded into any preceding node.  A `TwoQ` node whose incoming edges are all from the same predecessor can be folded into that predecessor if it is another `TwoQ` node (even if there were already intermediate `Synchronize` nodes folded into that `TwoQ` node).  `ControlFlow` nodes always have to be considered by the router, because they need to be recursed into.

Collapsing these nodes as part of the `SabreDAG` construction has a few benefits:

- In layout, when we keep multiple versions of a `SabreDAG` around, we have to store less memory, especially because we can entirely throw away all tracking of the collapsed DAG nodes, since we never need to rebuild afterwards.

- In routing, when we look ahead to populate the extended set, we no longer need to have the separate `visit_now` queue because all the nodes (and more!) that we would "look through" to make a DFS over the 2q gates are now automatically folded into the preceding 2q gate already.  The behaviour is not entirely identical (the handling of wide `Synchronize` items can be slightly different), but the spirit is still there, and the handling is much easier.

- When populating the extended set, runs of 2q gates can no longer be multiply counted.  Previously, a run _could_ saturate the extended set, biasing the algorithm towards that particular pair, even though the routing constraint was no stronger than any other single gate.


### Details and comments

Based on #14317.