### PR TITLE
Updated `SparsePauliOp.assign_parameters` to cast coefficients to complex once all parameters are bound

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -1181,9 +1181,8 @@ class SparsePauliOp(LinearOp):
                     coeff = complex(coeff)
                 bound.coeffs[i] = coeff
 
-        if (
-            bound.coeffs.dtype == object
-            and not any(isinstance(c, ParameterExpression) for c in bound.coeffs)
+        if bound.coeffs.dtype == object and not any(
+            isinstance(c, ParameterExpression) for c in bound.coeffs
         ):
             bound._coeffs = bound.coeffs.astype(complex)
 

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -1145,7 +1145,7 @@ class SparsePauliOp(LinearOp):
         r"""Bind the free ``Parameter``\s in the coefficients to provided values.
 
         .. note::
-            If all the parameters int he circuit are bound to numeric values, the coefficients array
+            If all the parameters in the circuit are bound to numeric values, the coefficients array
             will be returned with a :class:`complex` dtype.
 
         Args:

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -1152,6 +1152,10 @@ class SparsePauliOp(LinearOp):
         Returns:
             A copy of the operator with bound parameters, if ``inplace`` is ``False``, otherwise
             ``None``.
+
+        Notes:
+            When all parameters have been bound, the coefficients array will
+            automatically be converted to a ``complex`` dtype.
         """
         if inplace:
             bound = self
@@ -1176,6 +1180,9 @@ class SparsePauliOp(LinearOp):
                 if len(coeff.parameters) == 0:
                     coeff = complex(coeff)
                 bound.coeffs[i] = coeff
+
+        if bound.coeffs.dtype == object and not any(isinstance(c, ParameterExpression) for c in bound.coeffs):
+            bound._coeffs = bound.coeffs.astype(complex)
 
         return None if inplace else bound
 

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -1181,7 +1181,10 @@ class SparsePauliOp(LinearOp):
                     coeff = complex(coeff)
                 bound.coeffs[i] = coeff
 
-        if bound.coeffs.dtype == object and not any(isinstance(c, ParameterExpression) for c in bound.coeffs):
+        if (
+            bound.coeffs.dtype == object
+            and not any(isinstance(c, ParameterExpression) for c in bound.coeffs)
+        ):
             bound._coeffs = bound.coeffs.astype(complex)
 
         return None if inplace else bound

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -1144,6 +1144,10 @@ class SparsePauliOp(LinearOp):
     ) -> SparsePauliOp | None:
         r"""Bind the free ``Parameter``\s in the coefficients to provided values.
 
+        .. note::
+            If all the parameters int he circuit are bound to numeric values, the coefficients array
+            will be returned with a :class:`complex` dtype.
+
         Args:
             parameters: The values to bind the parameters to.
             inplace: If ``False``, a copy of the operator with the bound parameters is returned.
@@ -1152,10 +1156,6 @@ class SparsePauliOp(LinearOp):
         Returns:
             A copy of the operator with bound parameters, if ``inplace`` is ``False``, otherwise
             ``None``.
-
-        Notes:
-            When all parameters have been bound, the coefficients array will
-            automatically be converted to a ``complex`` dtype.
         """
         if inplace:
             bound = self

--- a/releasenotes/notes/sparsepauliop-assign_parameters-dtype-c0fef1f957beb1b2.yaml
+++ b/releasenotes/notes/sparsepauliop-assign_parameters-dtype-c0fef1f957beb1b2.yaml
@@ -1,0 +1,6 @@
+---
+upgrade_quantum_info:
+  - |
+    :meth:`.SparsePauliOp.assign_parameters` will now set the dtype of the output
+    :attr:`~.SparsePauliOp.coeffs` array to :class:`complex` if all parameters are fully bound to
+    numeric values.

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -1204,7 +1204,8 @@ class TestSparsePauliOpMethods(QiskitTestCase):
         # bind via array
         bound = op.assign_parameters([3])
         with self.subTest(msg="fully bound"):
-            self.assertTrue(np.allclose(bound.coeffs.astype(complex), [1, 3, 6]))
+            self.assertEqual(bound.coeffs.dtype, np.complex128)
+            self.assertTrue(np.allclose(bound.coeffs, [1, 3, 6]))
 
     def test_paulis_setter_rejects_bad_inputs(self):
         """Test that the setter for `paulis` rejects different-sized inputs."""


### PR DESCRIPTION
Changes:

- The `assign_parameters` method now checks if all parameters are resolved and converts the coefficient array to `complex` dtype when appropriate.
- The dtype expectation in the parameter-assignment test has been updated to verify automatic conversion to `np.complex128` and correct coefficient values.


Closes #14608