### PR TITLE
Fix Sabre extended-set tracking

### DIFF
--- a/crates/transpiler/src/passes/sabre/layer.rs
+++ b/crates/transpiler/src/passes/sabre/layer.rs
@@ -236,14 +236,14 @@ impl ExtendedSet {
     /// Apply a physical swap to the current layout data structure.
     pub fn apply_swap(&mut self, swap: [PhysicalQubit; 2]) {
         let [a, b] = swap;
-        for other in self.qubits[a.index()].iter_mut() {
-            if *other == b {
-                *other = a
-            }
-        }
-        for other in self.qubits[b.index()].iter_mut() {
+        // This effectively iterates twice through each element of the extended set, which is a
+        // complexity bottleneck if the extended set scales with the size of the circuit.  We should
+        // find a new structure that makes these updates more efficient.
+        for other in self.qubits.iter_mut().flat_map(|others| others.iter_mut()) {
             if *other == a {
-                *other = b
+                *other = b;
+            } else if *other == b {
+                *other = a;
             }
         }
         self.qubits.swap(a.index(), b.index());

--- a/releasenotes/notes/sabre-extended-set-fix-0b168b2e643a77af.yaml
+++ b/releasenotes/notes/sabre-extended-set-fix-0b168b2e643a77af.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    A logic bug in the extended-set tracking for the ``lookahead`` heuristic in Sabre routing
+    previously causing its tracking to become self-inconsistent has been fixed.  This did not affect
+    the correctness of the compiler, but caused the heuristic to not measure what it was intended to
+    measure.  See `#14244 <https://github.com/Qiskit/qiskit/issues/14244>`__ for more detail.

--- a/test/python/transpiler/test_sabre_layout.py
+++ b/test/python/transpiler/test_sabre_layout.py
@@ -270,7 +270,7 @@ barrier q18585[5],q18585[2],q18585[8],q18585[3],q18585[6];
         self.assertIsInstance(res, QuantumCircuit)
         layout = res._layout.initial_layout
         self.assertEqual(
-            [layout[q] for q in qc.qubits], [0, 12, 7, 8, 6, 3, 1, 10, 4, 9, 2, 11, 13, 5]
+            [layout[q] for q in qc.qubits], [26, 19, 16, 23, 14, 15, 25, 20, 22, 17, 24, 21, 13, 18]
         )
 
     def test_support_var_with_rust_fastpath(self):
@@ -519,7 +519,7 @@ class TestSabrePreLayout(QiskitTestCase):
         qct_initial_layout = qct.layout.initial_layout
         self.assertEqual(
             [qct_initial_layout[q] for q in self.circuit.qubits],
-            [8, 7, 12, 13, 18, 19, 17, 16, 11, 10, 5, 6, 1, 2, 3, 9],
+            [2, 3, 8, 7, 12, 13, 14, 18, 17, 16, 15, 11, 10, 5, 6, 1],
         )
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This fixes the logic bug in extended-set tracking where the "other" qubit of a gate touched by a swap would not have its tracking data updated during an `apply_swap` operation.

This change has the effect of making the extended-set update operation now linear in the size of the extended set in all cases, whereas previously it was only worst-case linear and average-case constant. This can be offset in the future by modifications to how the "lookahead" gates are tracked at all, if it is needed.



### Details and comments

Fix #14244.  I'm tagging for 2.2.0 because it's not a correctness bug, so imo it's not worth the risk of changing behaviour in the backport, and it _does_ have performance implications.

This does make it more costly to update a swap in the `ExtendedSet`, and we probably should revisit the struct to make it cheaper.  The ASV benchmarks below (with options `-b UtilityScale -b sabre` and `--only-changed`) show that it doesn't seem to have a critical impact on runtime performance, though, at the scale of fixed 20-gate size:

```text
| Change   | Before [3e19a7ad]    | After [801295b5]    |   Ratio | Benchmark (Parameter)                                                                        |
|----------|----------------------|---------------------|---------|----------------------------------------------------------------------------------------------|
| -        | 148497               | 122160              |    0.82 | qft.LargeQFTMappingTrackBench.track_depth_sabre_swap(1081, 'lookahead')                      |
| -        | 3358                 | 2827                |    0.84 | qft.LargeQFTMappingTrackBench.track_depth_sabre_swap(115, 'lookahead')                       |
| -        | 31891                | 27395               |    0.86 | qft.LargeQFTMappingTrackBench.track_depth_sabre_swap(409, 'lookahead')                       |
| -        | 6360                 | 5337                |    0.84 | quantum_volume.LargeQuantumVolumeMappingTrackBench.track_depth_sabre_swap(1081, 10, 'decay') |
| -        | 203±10ms             | 157±7ms             |    0.77 | queko.QUEKOTranspilerBench.time_transpile_bss(3, 'sabre')                                    |
| -        | 666                  | 592                 |    0.89 | queko.QUEKOTranspilerBench.track_depth_bntf_optimal_depth_25(0, 'sabre')                     |
| -        | 230                  | 198                 |    0.86 | queko.QUEKOTranspilerBench.track_depth_bntf_optimal_depth_25(2, 'sabre')                     |
| -        | 197                  | 165                 |    0.84 | queko.QUEKOTranspilerBench.track_depth_bntf_optimal_depth_25(3, 'sabre')                     |
| -        | 765                  | 671                 |    0.88 | queko.QUEKOTranspilerBench.track_depth_bss_optimal_depth_100(0, 'sabre')                     |
| -        | 505                  | 392                 |    0.78 | queko.QUEKOTranspilerBench.track_depth_bss_optimal_depth_100(1, 'sabre')                     |
| Change   | Before [3e19a7ad]    | After [801295b5]    |   Ratio | Benchmark (Parameter)                                                                       |
|----------|----------------------|---------------------|---------|---------------------------------------------------------------------------------------------|
| +        | 428±4ms              | 479±3ms             |    1.12 | mapping_passes.PassBenchmarks.time_sabre_layout(5, 1024)                                    |
| +        | 3239                 | 3807                |    1.18 | qft.LargeQFTMappingTrackBench.track_depth_sabre_swap(115, 'decay')                          |
| +        | 1.35±0.01s           | 1.61±0.01s          |    1.19 | quantum_volume.LargeQuantumVolumeMappingTimeBench.time_sabre_swap(1081, 10, 'decay')        |
| +        | 1396                 | 1667                |    1.19 | quantum_volume.LargeQuantumVolumeMappingTrackBench.track_depth_sabre_swap(409, 10, 'decay') |
| +        | 262                  | 330                 |    1.26 | queko.QUEKOTranspilerBench.track_depth_bss_optimal_depth_100(2, 'sabre')                    |
| +        | 2053                 | 2321                |    1.13 | utility_scale.UtilityScaleBenchmarks.track_qft_depth('cx')                                  |
| +        | 2053                 | 2321                |    1.13 | utility_scale.UtilityScaleBenchmarks.track_qft_depth('cz')                                  |
| +        | 2053                 | 2320                |    1.13 | utility_scale.UtilityScaleBenchmarks.track_qft_depth('ecr')                                 |
```