### PR TITLE
Add documentation examples on box annotations and stretches

### DIFF
--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -562,10 +562,14 @@ happen incoherently and to collapse any entanglement.
 
 Hardware can be instructed to apply a real-time idle period on a given qubit.  A scheduled circuit
 (see :mod:`qiskit.transpiler`) will include all the idle times on qubits explicitly in terms of this
-:class:`Delay`.
+:class:`Delay`.  :class:`.BoxOp` can also have an explicit delay attached.
 
 .. autoclass:: Delay
     :show-inheritance:
+
+Delay durations can be specified either with concrete, constant times, or with delayed-resolution
+"duration expressions" built out of :class:`.expr.Stretch` objects.  See :ref:`circuit-stretches`
+for more on this.
 
 The :class:`Barrier` instruction can span an arbitrary number of qubits and clbits, and is a no-op
 in hardware.  During transpilation and optimization, however, it blocks any optimizations from
@@ -715,9 +719,9 @@ classes associated to each name.
 .. autofunction:: get_control_flow_name_mapping
 
 These control-flow operations (:class:`IfElseOp`, :class:`WhileLoopOp`,
-:class:`SwitchCaseOp` and :class:`ForLoopOp`) all have specific state that defines the branching
-conditions and strategies, but contain all the different subcircuit blocks that might be entered in
-their :attr:`~ControlFlowOp.blocks` property.
+:class:`SwitchCaseOp`, :class:`ForLoopOp` and :class:`.BoxOp`) all have specific state that defines
+the branching conditions and strategies, but contain all the different subcircuit blocks that might
+be entered in their :attr:`~ControlFlowOp.blocks` property.
 
 .. autosummary::
     :toctree: ../stubs/
@@ -726,6 +730,7 @@ their :attr:`~ControlFlowOp.blocks` property.
     WhileLoopOp
     SwitchCaseOp
     ForLoopOp
+    BoxOp
 
 The :class:`.SwitchCaseOp` also understands a special value:
 
@@ -799,6 +804,28 @@ automatically.
 Consult :ref:`the control-flow construction documentation <circuit-control-flow-methods>` for more
 information on how to build circuits with control flow.
 
+
+Instruction-local annotations
+-----------------------------
+
+.. seealso::
+
+    :mod:`qiskit.circuit.annotation`
+        The module-level discussion of the annotation framework, including how to defined custom
+        annotations, and how the system interacts with the compiler and with serialization to other
+        formats.
+
+
+Certain circuit instructions can be "annotated" with instruction-local annotations.  As of Qiskit
+2.1.0, this is limited to :class:`.BoxOp`.  All annotations are subclasses of one base
+interface-defining object, but typically represent entirely custom analyses and commands.
+
+.. autosummary::
+    :toctree: ../stubs
+
+    Annotation
+
+
 Investigating commutation relations
 -----------------------------------
 
@@ -822,6 +849,70 @@ are available in the :class:`CommutationChecker`.
 
    CommutationChecker
 
+
+.. _circuit-stretches:
+
+Delayed-resolution scheduling
+-----------------------------
+
+Typically, the output of Qiskit's compiler cannot be directly executed on a QPU.  First, it is
+likely to pass through some vendor-specific pulse-level compiler, which converts the gates and
+measurements into signals to the controlling electronics of the QPU.  While Qiskit's
+:class:`.Target` can represent *some* of the timing constraints that these pulses will have, it is
+generally not entirely complete.  This is especially true when dynamic circuits (feed-forward
+operations) are involved; the delays induced by the classical components are often dependent on
+low-level post-optimization details of backend compilers, and cannot be known by Qiskit.
+
+In these situations, a user can still exert control over the relative scheduling of pulses, such as
+for dynamical decoupling, by using "stretch" durations.  These are constructed by
+:meth:`.QuantumCircuit.add_stretch`, and interact with the classical-expression system described in
+:mod:`qiskit.circuit.classical`, although they are not real-time mutable.
+
+For example, we can add stretches and boxes to set up a system where two separate dynamic-decoupling
+sequences are applied to the same qubit, while a pair of other qubits undergoes a delay of unknown
+duration.  The two sequences are constrained to have the same length, even though internally the
+concrete DD pulses have differing lengths.
+
+.. code-block:: python
+
+    from qiskit import QuantumCircuit
+    from qiskit.circuit.classical import expr
+
+    qc = QuantumCircuit(3, 3)
+    # This sets up three duration "degrees of freedom" that will
+    # be resolved later by a backend compiler.
+    a = qc.add_stretch("a")
+    b = qc.add_stretch("b")
+    c = qc.add_stretch("c")
+
+    # This set of operations involves feed-forward operations that
+    # Qiskit cannot know the length of.
+    with qc.box():
+        qc.h(1)
+        qc.cx(1, 2)
+        qc.measure([1, 2], [1, 2])
+        with qc.if_test(expr.equal(qc.clbits[1], qc.clbits[2])):
+            qc.h(1)
+
+    # While that stuff is happening to qubits (1, 2), we want
+    # qubit 0 to do two different DD sequences.  The two DD
+    # sequences are fixed to be the same length as each other,
+    # even though they're both internally stretchy.
+    with qc.box(duration=a):
+        # Textbook NMRish XX DD.
+        qc.delay(b, 0)
+        qc.x(0)
+        qc.delay(expr.mul(2, b), 0)
+        qc.x(0)
+        qc.delay(b, 0)
+    with qc.box(duration=a):
+        # XY4-like DD.
+        for _ in range(2):
+            qc.delay(c, 0)
+            qc.y(0)
+            qc.delay(expr.mul(2, c), 0)
+            qc.x(0)
+            qc.delay(c, 0)
 
 .. _circuit-custom-gates:
 

--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -562,7 +562,8 @@ happen incoherently and to collapse any entanglement.
 
 Hardware can be instructed to apply a real-time idle period on a given qubit.  A scheduled circuit
 (see :mod:`qiskit.transpiler`) will include all the idle times on qubits explicitly in terms of this
-:class:`Delay`.  :class:`.BoxOp` can also have an explicit delay attached.
+:class:`Delay`.  :class:`.BoxOp` can also have an explicit duration attached, in its
+:attr:`.BoxOp.duration` field.
 
 .. autoclass:: Delay
     :show-inheritance:

--- a/qiskit/circuit/annotation.py
+++ b/qiskit/circuit/annotation.py
@@ -162,7 +162,7 @@ Finally, this can be put together, showing the output OpenQASM 3.
     dumped = qasm3.dumps(collected, annotation_handlers=handlers)
     print(dumped)
 
-,. code-block:: openqasm3
+.. code-block:: openqasm3
 
     OPENQASM 3.0;
     include "stdgates.inc";

--- a/qiskit/circuit/annotation.py
+++ b/qiskit/circuit/annotation.py
@@ -84,6 +84,106 @@ used to pass serializers.
 .. autoclass:: QPYSerializer
 .. autoclass:: QPYFromOpenQASM3Serializer
 .. autoclass:: OpenQASM3Serializer
+
+
+Examples
+========
+
+A toy block-collection transpiler pass
+--------------------------------------
+
+A principal goal of the annotation framework is to allow custom analyses and commands to be stored
+on circuits in an instruction-local manner, either by the user on entry to the compiler, or for one
+compiler pass to store information for later consumption.
+
+For example, we can write a simple transpiler pass that collects runs of single-qubit operations,
+and puts each run into a :class:`.BoxOp`, the calculates the total unitary action and attaches it as
+a custom annotation, so the same analysis does not need to be repeated later, even if the internals
+of each block are optimized.
+
+.. code-block:: python
+
+    from qiskit.circuit import annotation, QuantumCircuit, BoxOp
+    from qiskit.quantum_info import Operator
+    from qiskit.transpiler import TransformationPass
+
+    class PerformsUnitary(annotation.Annotation):
+        namespace = "unitary"
+        def __init__(self, matrix):
+            self.matrix = matrix
+
+    class Collect1qRuns(TransformationPass):
+        def run(self, dag):
+            for run in dag.collect_1q_runs():
+                block = QuantumCircuit(1)
+                for node in run:
+                    block.append(node.op, [0], [])
+                box = BoxOp(block, annotations=[PerformsUnitary(Operator(block).data)])
+                dag.replace_block_with_op(run, box, {run[0].qargs[0]: 0})
+            return dag
+
+In order to serialize the annotation to OpenQASM 3, we must define custom logic, since the analysis
+itself is entirely custom.  The serialization is separate to the annotation; there may be
+circumstances in which serialization should be done differently.
+
+.. code-block:: python
+
+    import ast
+    import numpy as np
+
+    class Serializer(annotation.OpenQASM3Serializer):
+        def dump(self, annotation):
+            if annotation.namespace != "unitary":
+                return NotImplemented
+            line = lambda row: "[" + ", ".join(repr(x) for x in row) + "]"
+            return "[" + ", ".join(line(row) for row in annotation.matrix.tolist()) + "]"
+
+        def load(self, namespace, payload):
+            if namespace != "unitary":
+                return NotImplemented
+            return PerformsUnitary(np.array(ast.literal_eval(payload), dtype=complex))
+
+Finally, this can be put together, showing the output OpenQASM 3.
+
+.. code-block:: python
+
+    from qiskit import qasm3
+
+    qc = QuantumCircuit(3)
+    qc.s(0)
+    qc.t(0)
+    qc.y(1)
+    qc.x(1)
+    qc.h(2)
+    qc.s(2)
+    collected = Collect1qRuns()(qc)
+
+    handlers = {"unitary": Serializer()}
+    dumped = qasm3.dumps(collected, annotation_handlers=handlers)
+    print(dumped)
+
+,. code-block:: openqasm3
+
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[3] q;
+    @unitary [[(1+0j), 0j], [0j, (-0.7071067811865475+0.7071067811865475j)]]
+    box {
+      s q[0];
+      t q[0];
+    }
+    @unitary [[1j, 0j], [0j, -1j]]
+    box {
+      y q[1];
+      x q[1];
+    }
+    @unitary [[(0.7071067811865475+0j), (0.7071067811865475+0j)], [0.7071067811865475j, \
+-0.7071067811865475j]]
+    box {
+      h q[2];
+      s q[2];
+    }
+
 """
 
 from __future__ import annotations

--- a/qiskit/circuit/annotation.py
+++ b/qiskit/circuit/annotation.py
@@ -89,8 +89,8 @@ used to pass serializers.
 Examples
 ========
 
-A toy block-collection transpiler pass
---------------------------------------
+A block-collection transpiler pass
+----------------------------------
 
 A principal goal of the annotation framework is to allow custom analyses and commands to be stored
 on circuits in an instruction-local manner, either by the user on entry to the compiler, or for one

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -45,6 +45,7 @@ threadpoolctl
 # like `sphinx-design` to make sure that `Qiskit/documentation` will be able to
 # consume it properly.
 Sphinx>=6.0,<7.2
+openqasm-pygments
 reno >= 4.1.0
 sphinxcontrib-katex==0.9.9
 breathe>=4.35.0


### PR DESCRIPTION
This uses examples that were used to demonstrate new features in Qiskit 2.1.

The `openqasm-pygments` packages gives us syntax highlighting for OpenQASM 2 and 3 code blocks.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


