### PR TITLE
Fixes for dimacs-related boolean expression code

### DIFF
--- a/qiskit/circuit/library/bit_flip_oracle.py
+++ b/qiskit/circuit/library/bit_flip_oracle.py
@@ -52,13 +52,13 @@ class BitFlipOracleGate(Gate):
 
     def __init__(
         self,
-        expression: str,
+        expression: str | BooleanExpression,
         var_order: list[str] | None = None,
         label: str | None = None,
     ) -> None:
         """
         Args:
-            expression: A Python-like boolean expression.
+            expression: A Python-like boolean expression string or a `BooleanExpression` object.
             var_order: A list with the order in which variables will be created.
                (default: by appearance)
             label: A label for the gate to display in visualizations. Per default, the label is

--- a/qiskit/circuit/library/bit_flip_oracle.py
+++ b/qiskit/circuit/library/bit_flip_oracle.py
@@ -64,11 +64,15 @@ class BitFlipOracleGate(Gate):
             label: A label for the gate to display in visualizations. Per default, the label is
                 set to display the textual represntation of the boolean expression (truncated if needed)
         """
-        self.boolean_expression = BooleanExpression(expression, var_order=var_order)
-
         if label is None:
-            short_expr_for_name = (expression[:15] + "...") if len(expression) > 15 else expression
-            label = short_expr_for_name
+            if isinstance(expression, str):
+                label = (expression[:15] + "...") if len(expression) > 15 else expression
+            else:
+                label = "Boolean Expression"
+
+        if isinstance(expression, str):
+            expression = BooleanExpression(expression, var_order=var_order)
+        self.boolean_expression = expression
 
         super().__init__(
             name="Bit-flip Oracle",

--- a/qiskit/circuit/library/phase_oracle.py
+++ b/qiskit/circuit/library/phase_oracle.py
@@ -57,7 +57,7 @@ class PhaseOracle(QuantumCircuit):
     )
     def __init__(
         self,
-        expression: str,
+        expression: str | BooleanExpression,
         var_order: list[str] | None = None,
     ) -> None:
         """
@@ -67,7 +67,9 @@ class PhaseOracle(QuantumCircuit):
                (default: by appearance)
         """
 
-        self.boolean_expression = BooleanExpression(expression, var_order=var_order)
+        if isinstance(expression, str):
+            expression = BooleanExpression(expression, var_order=var_order)
+        self.boolean_expression = expression
         oracle = self.boolean_expression.synth(circuit_type="phase")
 
         super().__init__(oracle.num_qubits, name="Phase Oracle")
@@ -168,7 +170,7 @@ class PhaseOracleGate(Gate):
 
     def __init__(
         self,
-        expression: str,
+        expression: str | BooleanExpression,
         var_order: list[str] | None = None,
         label: str | None = None,
     ) -> None:
@@ -180,11 +182,15 @@ class PhaseOracleGate(Gate):
             label: A label for the gate to display in visualizations. Per default, the label is
                 set to display the textual represntation of the boolean expression (truncated if needed)
         """
-        self.boolean_expression = BooleanExpression(expression, var_order=var_order)
-
         if label is None:
-            short_expr_for_name = (expression[:15] + "...") if len(expression) > 15 else expression
-            label = short_expr_for_name
+            if isinstance(expression, str):
+                label = (expression[:15] + "...") if len(expression) > 15 else expression
+            else:
+                label = "Boolean Expression"
+
+        if isinstance(expression, str):
+            expression = BooleanExpression(expression, var_order=var_order)
+        self.boolean_expression = expression
 
         super().__init__(
             name="Phase Oracle",

--- a/qiskit/circuit/library/phase_oracle.py
+++ b/qiskit/circuit/library/phase_oracle.py
@@ -62,7 +62,7 @@ class PhaseOracle(QuantumCircuit):
     ) -> None:
         """
         Args:
-            expression: A Python-like boolean expression.
+            expression: A Python-like boolean expression string or a `BooleanExpression` object.
             var_order: A list with the order in which variables will be created.
                (default: by appearance)
         """
@@ -176,7 +176,7 @@ class PhaseOracleGate(Gate):
     ) -> None:
         """
         Args:
-            expression: A Python-like boolean expression.
+            expression: A Python-like boolean expression string or a `BooleanExpression` object.
             var_order: A list with the order in which variables will be created.
                (default: by appearance)
             label: A label for the gate to display in visualizations. Per default, the label is

--- a/qiskit/synthesis/boolean/boolean_expression.py
+++ b/qiskit/synthesis/boolean/boolean_expression.py
@@ -191,8 +191,9 @@ class BooleanExpression:
         """
         header_regex = re.compile(r"p\s+cnf\s+(\d+)\s+(\d+)")
         clause_regex = re.compile(r"(-?\d+)")
+        lines = [line.strip() for line in dimacs.split("\n")]
         lines = [
-            line for line in dimacs.split("\n") if not line.startswith("c") and line != ""
+            line for line in lines if not line.startswith("c") and line != ""
         ]  # DIMACS comment line start with c
         header_match = header_regex.match(lines[0])
         if not header_match:

--- a/releasenotes/notes/fix-dimacs-load-c48f4d08062ade74.yaml
+++ b/releasenotes/notes/fix-dimacs-load-c48f4d08062ade74.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.PhaseOracle`, :class:`.PhaseOracleGate` and :class:`.BitFlipOracleGate`
+    where trying to load from dimacs file raised a TypeError.

--- a/test/python/circuit/library/test_phase_and_bitflip_oracles.py
+++ b/test/python/circuit/library/test_phase_and_bitflip_oracles.py
@@ -13,6 +13,7 @@
 """Test the phase and bit-flip oracle circuits."""
 
 import unittest
+import tempfile
 from ddt import ddt, data, unpack
 from numpy import sqrt, isclose
 
@@ -109,6 +110,28 @@ class TestPhaseOracleAndGate(QiskitTestCase):
                 self.assertListEqual(expected_valid, result_valid)
                 self.assertListEqual(expected_invalid, result_invalid)
 
+    def test_from_dimacs_file(self):
+        """Initializing from DIMACS file"""
+        input_3sat_instance = """
+        c DIMACS CNF file with 3 satisfying assignments: 1 -2 3, -1 -2 -3, 1 2 -3.
+        p cnf 3 5
+        -1 -2 -3 0
+        1 -2 3 0
+        1 2 -3 0
+        1 -2 -3 0
+        -1 2 3 0
+        """
+        filename = tempfile.mkstemp(suffix=".dimacs")[1]
+        with open(filename, "w") as file:
+            file.write(input_3sat_instance)
+        for use_gate in [True, False]:
+            if use_gate:
+                oracle = PhaseOracleGate.from_dimacs_file(filename)
+            else:
+                with self.assertWarns(DeprecationWarning):
+                    oracle = PhaseOracle.from_dimacs_file(filename)
+            self.assertEqual(oracle.num_qubits, 3)
+
 
 @ddt
 class TestBitFlipOracleGate(QiskitTestCase):
@@ -179,6 +202,23 @@ class TestBitFlipOracleGate(QiskitTestCase):
         result_invalid = [isclose(statevector.data[state], invalid_state) for state in states]
         self.assertListEqual(expected_valid, result_valid)
         self.assertListEqual(expected_invalid, result_invalid)
+
+    def test_from_dimacs_file(self):
+        """Initializing from DIMACS file"""
+        input_3sat_instance = """
+        c DIMACS CNF file with 3 satisfying assignments: 1 -2 3, -1 -2 -3, 1 2 -3.
+        p cnf 3 5
+        -1 -2 -3 0
+        1 -2 3 0
+        1 2 -3 0
+        1 -2 -3 0
+        -1 2 3 0
+        """
+        filename = tempfile.mkstemp(suffix=".dimacs")[1]
+        with open(filename, "w") as file:
+            file.write(input_3sat_instance)
+        oracle = BitFlipOracleGate.from_dimacs_file(filename)
+        self.assertEqual(oracle.num_qubits, 4)
 
 
 if __name__ == "__main__":

--- a/test/python/synthesis/test_boolean.py
+++ b/test/python/synthesis/test_boolean.py
@@ -169,10 +169,6 @@ class TestBooleanExpressionDIMACS(QiskitTestCase):
     def test_bad_formatting(self):
         """Tests DIMACS parsing on edge cases"""
         # pylint: disable=trailing-whitespace
-        dimacs = """ 
-p cnf 10 5"""  # first line is not p cnf nor empty nor comment (it has whitespace)
-        with self.assertRaisesRegex(ValueError, "First line must start with 'p cnf'"):
-            exp = BooleanExpression.from_dimacs(dimacs)
         dimacs = """p cnf 2 1
          
         1 2 0"""  # has empty line with whitespace - should ignore it


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes a bug in the code for creating phase and bit-flip oracles from DIMACS files.

Fixes #14634


### Details and comments
Currently, oracles are generated from DIMACS files by using `BooleanExpression.from_dimacs` to generate an expression and pass it to the init of the oracle. However, the init currently expects a string representing a boolean expression, not the expression itself.

This PR changes the behavior such that the oracles can be initialized from a `BooleanExpression` object, and slightly improves DIMACS parsing.

