### PR TITLE
Fix sympify() for expressions with vector element .subs()

### DIFF
--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -683,8 +683,8 @@ class ParameterExpression:
                 sympy_binds = {}
                 for old, new in inst.binds.items():
                     if isinstance(new, ParameterExpression):
-                        new = new.name
-                    sympy_binds[old.name] = new
+                        new = new.sympify()
+                    sympy_binds[old.sympify()] = new
                 output = output.subs(sympy_binds, simultaneous=True)
                 continue
 

--- a/test/python/circuit/test_parameter_expression.py
+++ b/test/python/circuit/test_parameter_expression.py
@@ -505,3 +505,17 @@ class TestParameterExpression(QiskitTestCase):
         expected = sympy.Abs(expected)
         expected = expected.subs({c: a})
         self.assertEqual(result, expected)
+
+    @unittest.skipUnless(HAS_SYMPY, "Sympy is required for this test")
+    def test_sympify_subs_vector(self):
+        """Test an expression with subbed ParameterVectorElements is sympifiable"""
+        import sympy
+
+        p_vec = ParameterVector("p", length=2)
+        theta = Parameter("theta")
+
+        expression = theta + 1
+        expression = expression.subs({theta: p_vec[0]})
+        result = expression.sympify()
+        expected = sympy.Symbol("p[0]") + 1
+        self.assertEqual(expected, result)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue in the .sympify() method when building the Sympy expression for a `ParameterExpression` that was constructed by calling `ParameterExpression.subs()` with a ParameterVectorElement type. The previous implementation of this method was passing the symbols for substitution by string which required sympy to "parse" the input. The square brackets for indexing the vector element in it's string representation was not valid for sympy to parse and this caused the error. To avoid this problem this commit adjusts the usage to pass a sypy expression object instead of a string. This is the intent of the function as string parsing has other issues in sympy and this was an oversight in the implementation that was doing this. By passing a sympy object to sympy it is able to handle the vector's name with square brackets.

### Details and comments

Fixes #14640

