### PR TITLE
[broken] Fix indentation of bit array docs

### DIFF
--- a/qiskit/primitives/containers/bit_array.py
+++ b/qiskit/primitives/containers/bit_array.py
@@ -601,9 +601,9 @@ class BitArray(ShapedMixin):
 
         Args:
             observables: The observable(s) to take the expectation value of.
-            Must have a shape broadcastable with with this bit array and
-            the same number of qubits as the number of bits of this bit array.
-            The observables must be diagonal (I, Z, 0 or 1) too.
+                Must have a shape broadcastable with with this bit array and
+                the same number of qubits as the number of bits of this bit array.
+                The observables must be diagonal (I, Z, 0 or 1) too.
 
         Returns:
             An array of expectation values whose shape is the broadcast shape of ``observables``


### PR DESCRIPTION
Spotted by @samanthavbarron.

![image_720](https://github.com/user-attachments/assets/d89a5e20-d525-4eff-bd18-b183b51d08ef)
