### PR TITLE
Add missing stacklevel to deprecation warning for 3.9

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -50,6 +50,7 @@ if sys.version_info < (3, 10):
         "Support for running Qiskit with Python 3.9 will be removed in the "
         "2.3.0 release, which coincides with when Python 3.9 goes end of life.",
         DeprecationWarning,
+        stacklevel=2,
     )
 
 from . import _accelerate

--- a/releasenotes/notes/fix-deprecation-warning-e512acab95844e36.yaml
+++ b/releasenotes/notes/fix-deprecation-warning-e512acab95844e36.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed the deprecation warning for Python 3.9 so that it correctly is identified
+    as being caused by user code when importing Qiskit. Previously, it would not
+    be identified as being caused by user code and this meant that Python's default
+    warning filters would not display the warning to the user.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In Qiskit 2.1.0 we deprecated Python 3.9 support since it will not be supported in the 2.3.0 release. However, the warnings.warn call to emit the deprecation warning was missing the stacklevel argument. This means that the default Python warning filters will not display the warning to end users because it's not user code that's triggering the warn() call. This commit fixes this oversight so that Python 3.9 users will see the warning by default.

### Details and comments