### PR TITLE
Updated TwoQubitBasisDecomposer to use actual gate names instead of a sentinel string

### DIFF
--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -833,6 +833,15 @@ impl StandardGate {
             Self::RC3X => None, // the inverse in not a StandardGate
         }
     }
+
+    pub fn standard_gate_from_name(name: &str) -> Option<StandardGate> {
+        for (index, &gate_name) in STANDARD_GATE_NAME.iter().enumerate() {
+            if gate_name == name {
+                return Some(bytemuck::checked::cast::<u8, StandardGate>(index as u8));
+            }
+        }
+        None
+    }
 }
 
 #[pymethods]

--- a/crates/synthesis/src/two_qubit_decompose.rs
+++ b/crates/synthesis/src/two_qubit_decompose.rs
@@ -2124,60 +2124,60 @@ impl TwoQubitBasisDecomposer {
             .collect()
     }
 
-    fn get_basis_gate_params(&self) -> SmallVec<[f64; 3]> {  
-        match self.basis_gate {   
-            // Single-parameter gates  
-            Some(StandardGate::GlobalPhase) => smallvec![self.basis_decomposer.global_phase],  
-            Some(StandardGate::Phase) => smallvec![self.basis_decomposer.a * 2.0],  
-            Some(StandardGate::RX) => smallvec![self.basis_decomposer.a * 2.0],  
-            Some(StandardGate::RY) => smallvec![self.basis_decomposer.b * 2.0],  
-            Some(StandardGate::RZ) => smallvec![self.basis_decomposer.c * 2.0],  
-            Some(StandardGate::U1) => smallvec![self.basis_decomposer.c * 2.0],  
-            Some(StandardGate::CPhase) => smallvec![self.basis_decomposer.a * 2.0],  
-            Some(StandardGate::CRX) => smallvec![self.basis_decomposer.a * 2.0],  
-            Some(StandardGate::CRY) => smallvec![self.basis_decomposer.b * 2.0],  
-            Some(StandardGate::CRZ) => smallvec![self.basis_decomposer.c * 2.0],  
-            Some(StandardGate::CU1) => smallvec![self.basis_decomposer.c * 2.0],  
-            Some(StandardGate::RXX) => smallvec![self.basis_decomposer.a * 2.0],  
-            Some(StandardGate::RYY) => smallvec![self.basis_decomposer.b * 2.0],  
-            Some(StandardGate::RZZ) => smallvec![self.basis_decomposer.c * 2.0],  
-            Some(StandardGate::RZX) => smallvec![self.basis_decomposer.a * 2.0],  
-    
-            // Two-parameter gates  
-            Some(StandardGate::R) => smallvec![  
-                self.basis_decomposer.a * 2.0,  
-                self.basis_decomposer.global_phase  
-            ],  
-            Some(StandardGate::U2) => smallvec![  
-                self.basis_decomposer.b * 2.0,  
-                self.basis_decomposer.c * 2.0  
-            ],  
-            Some(StandardGate::XXMinusYY) => smallvec![  
-                self.basis_decomposer.a * 2.0,  
-                self.basis_decomposer.global_phase  
-            ],  
-            Some(StandardGate::XXPlusYY) => smallvec![  
-                self.basis_decomposer.a * 2.0,  
-                self.basis_decomposer.global_phase  
-            ],  
-    
-            // Three-parameter gates  
-            Some(StandardGate::U) => smallvec![  
-                self.basis_decomposer.a * 2.0,  
-                self.basis_decomposer.b * 2.0,  
-                self.basis_decomposer.c * 2.0  
-            ],  
-            Some(StandardGate::U3) => smallvec![  
-                self.basis_decomposer.a * 2.0,  
-                self.basis_decomposer.b * 2.0,  
-                self.basis_decomposer.c * 2.0  
-            ],  
-            Some(StandardGate::CU3) => smallvec![  
-                self.basis_decomposer.a * 2.0,  
-                self.basis_decomposer.b * 2.0,  
-                self.basis_decomposer.c * 2.0  
-            ],  
-    
+    fn get_basis_gate_params(&self) -> SmallVec<[f64; 3]> {
+        match self.basis_gate {
+            // Single-parameter gates
+            Some(StandardGate::GlobalPhase) => smallvec![self.basis_decomposer.global_phase],
+            Some(StandardGate::Phase) => smallvec![self.basis_decomposer.a * 2.0],
+            Some(StandardGate::RX) => smallvec![self.basis_decomposer.a * 2.0],
+            Some(StandardGate::RY) => smallvec![self.basis_decomposer.b * 2.0],
+            Some(StandardGate::RZ) => smallvec![self.basis_decomposer.c * 2.0],
+            Some(StandardGate::U1) => smallvec![self.basis_decomposer.c * 2.0],
+            Some(StandardGate::CPhase) => smallvec![self.basis_decomposer.a * 2.0],
+            Some(StandardGate::CRX) => smallvec![self.basis_decomposer.a * 2.0],
+            Some(StandardGate::CRY) => smallvec![self.basis_decomposer.b * 2.0],
+            Some(StandardGate::CRZ) => smallvec![self.basis_decomposer.c * 2.0],
+            Some(StandardGate::CU1) => smallvec![self.basis_decomposer.c * 2.0],
+            Some(StandardGate::RXX) => smallvec![self.basis_decomposer.a * 2.0],
+            Some(StandardGate::RYY) => smallvec![self.basis_decomposer.b * 2.0],
+            Some(StandardGate::RZZ) => smallvec![self.basis_decomposer.c * 2.0],
+            Some(StandardGate::RZX) => smallvec![self.basis_decomposer.a * 2.0],
+
+            // Two-parameter gates
+            Some(StandardGate::R) => smallvec![
+                self.basis_decomposer.a * 2.0,
+                self.basis_decomposer.global_phase
+            ],
+            Some(StandardGate::U2) => smallvec![
+                self.basis_decomposer.b * 2.0,
+                self.basis_decomposer.c * 2.0
+            ],
+            Some(StandardGate::XXMinusYY) => smallvec![
+                self.basis_decomposer.a * 2.0,
+                self.basis_decomposer.global_phase
+            ],
+            Some(StandardGate::XXPlusYY) => smallvec![
+                self.basis_decomposer.a * 2.0,
+                self.basis_decomposer.global_phase
+            ],
+
+            // Three-parameter gates
+            Some(StandardGate::U) => smallvec![
+                self.basis_decomposer.a * 2.0,
+                self.basis_decomposer.b * 2.0,
+                self.basis_decomposer.c * 2.0
+            ],
+            Some(StandardGate::U3) => smallvec![
+                self.basis_decomposer.a * 2.0,
+                self.basis_decomposer.b * 2.0,
+                self.basis_decomposer.c * 2.0
+            ],
+            Some(StandardGate::CU3) => smallvec![
+                self.basis_decomposer.a * 2.0,
+                self.basis_decomposer.b * 2.0,
+                self.basis_decomposer.c * 2.0
+            ],
+
             // Skip four-parameter gates for now due to SmallVec size limit
 
             // Non-parameterized gates

--- a/crates/synthesis/src/two_qubit_decompose.rs
+++ b/crates/synthesis/src/two_qubit_decompose.rs
@@ -2148,10 +2148,9 @@ impl TwoQubitBasisDecomposer {
                 self.basis_decomposer.a * 2.0,
                 self.basis_decomposer.global_phase
             ],
-            Some(StandardGate::U2) => smallvec![
-                self.basis_decomposer.b * 2.0,
-                self.basis_decomposer.c * 2.0
-            ],
+            Some(StandardGate::U2) => {
+                smallvec![self.basis_decomposer.b * 2.0, self.basis_decomposer.c * 2.0]
+            }
             Some(StandardGate::XXMinusYY) => smallvec![
                 self.basis_decomposer.a * 2.0,
                 self.basis_decomposer.global_phase

--- a/crates/synthesis/src/two_qubit_decompose.rs
+++ b/crates/synthesis/src/two_qubit_decompose.rs
@@ -2181,8 +2181,8 @@ impl TwoQubitBasisDecomposer {
             // Skip four-parameter gates for now due to SmallVec size limit
 
             // Non-parameterized gates
-            _ => smallvec![],  
-        }  
+            _ => smallvec![],
+        }
     }
 
     /// Decompose a two-qubit ``unitary`` over fixed basis and :math:`SU(2)` using the best

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -347,17 +347,10 @@ class TwoQubitBasisDecomposer:
         self.gate = gate
         self.basis_fidelity = basis_fidelity
         self.pulse_optimize = pulse_optimize
-        # Use cx as gate name for pulse optimal decomposition detection
-        # otherwise use USER_GATE as a unique key to support custom gates
-        # including parameterized gates like UnitaryGate.
-        if isinstance(gate, CXGate):
-            gate_name = "cx"
-        else:
-            gate_name = "USER_GATE"
-        self.gate_name = gate_name
+        self.gate_name = gate.name
 
         self._inner_decomposer = two_qubit_decompose.TwoQubitBasisDecomposer(
-            gate_name,
+            gate.name,
             Operator(gate).data,
             basis_fidelity=basis_fidelity,
             euler_basis=euler_basis,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

- Updated the logic in the `TwoQubitBasisDecomposer` Python object (in `qiskit/synthesis/two_qubit/two_qubit_decompose.py`) to pass the actual gate names (rather than the `USER_GATE` sentinel) for all non-CX gates to the `TwoQubitBasisDecomposer` rust struct.
- Fixes #14418.


### Details and comments

- Replaces the `if-else` clause within the `__init__` method of the Python class `TwoQubitDecomposer` with a statement to directly pass the `gate.name` attribute to the rust struct instead.