### PR TITLE
Fixing problems in `CommutativeInverseCancellation` transpiler pass

### DIFF
--- a/qiskit/transpiler/passes/optimization/commutative_inverse_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/commutative_inverse_cancellation.py
@@ -81,9 +81,8 @@ class CommutativeInverseCancellation(TransformationPass):
         are equal up to a phase and that phase difference.
         """
         phase_difference = 0
-        if not matrix_based:
-            are_equal = op1 == op2
-        else:
+        are_equal = op1 == op2
+        if not are_equal and matrix_based:
             mat1 = Operator(op1).data
             mat2 = Operator(op2).data
             props = {}

--- a/qiskit/transpiler/passes/optimization/commutative_inverse_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/commutative_inverse_cancellation.py
@@ -51,7 +51,7 @@ class CommutativeInverseCancellation(TransformationPass):
             return True
         if getattr(node, "condition", None):
             return True
-        if node.op.is_parameterized():
+        if getattr(node.op, "is_parameterized", None) is not None and node.op.is_parameterized():
             return True
         return False
 

--- a/qiskit/transpiler/passes/optimization/commutative_inverse_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/commutative_inverse_cancellation.py
@@ -70,28 +70,28 @@ class CommutativeInverseCancellation(TransformationPass):
             inverse = None
         return inverse
 
-    def _check_inverse(self, node1, node2):
-        """Checks whether op1 and op2 are inverse up to a phase, that is whether
-        ``op2 = e^{i * d} op1^{-1})`` for some phase difference ``d``.
-        If this is the case, we can replace ``op2 * op1`` by `e^{i * d} I``.
-        The input to this function is a pair of DAG nodes.
-        The output is a tuple representing whether the two nodes
-        are inverse up to a phase and that phase difference.
+    def _check_equal_upto_phase(self, op1, op2, matrix_based):
+        """
+        Checks whether op1 and op2 are equal up to a phase, that is whether
+        ``op2 = e^{i * d} op1)`` for some phase difference ``d``.
+
+        If this is the case, we can replace ``op2 * op1^{-1}`` by `e^{i * d} I``.
+
+        The output is a tuple representing whether the two ops
+        are equal up to a phase and that phase difference.
         """
         phase_difference = 0
-        if not self._matrix_based:
-            is_inverse = node1.op.inverse() == node2.op
-        elif len(node2.qargs) > self._max_qubits:
-            is_inverse = False
+        if not matrix_based:
+            are_equal = op1 == op2
         else:
-            mat1 = Operator(node1.op.inverse()).data
-            mat2 = Operator(node2.op).data
+            mat1 = Operator(op1).data
+            mat2 = Operator(op2).data
             props = {}
-            is_inverse = matrix_equal(mat1, mat2, ignore_phase=True, props=props)
-            if is_inverse:
+            are_equal = matrix_equal(mat1, mat2, ignore_phase=True, props=props)
+            if are_equal:
                 # mat2 = e^{i * phase_difference} mat1
                 phase_difference = props["phase_difference"]
-        return is_inverse, phase_difference
+        return are_equal, phase_difference
 
     def run(self, dag: DAGCircuit):
         """
@@ -126,8 +126,14 @@ class CommutativeInverseCancellation(TransformationPass):
                     and topo_sorted_nodes[idx2].qargs == topo_sorted_nodes[idx1].qargs
                     and topo_sorted_nodes[idx2].cargs == topo_sorted_nodes[idx1].cargs
                 ):
-                    is_inverse, phase = self._check_inverse(
-                        topo_sorted_nodes[idx1], topo_sorted_nodes[idx2]
+                    matrix_based = (
+                        self._matrix_based
+                        and len(topo_sorted_nodes[idx2].qargs) <= self._max_qubits
+                    )
+                    is_inverse, phase = self._check_equal_upto_phase(
+                        topo_sorted_nodes[idx1].op.inverse(),
+                        topo_sorted_nodes[idx2].op,
+                        matrix_based,
                     )
                     if is_inverse:
                         phase_update += phase

--- a/qiskit/transpiler/passes/optimization/commutative_inverse_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/commutative_inverse_cancellation.py
@@ -73,9 +73,9 @@ class CommutativeInverseCancellation(TransformationPass):
     def _check_equal_upto_phase(self, op1, op2, matrix_based):
         """
         Checks whether op1 and op2 are equal up to a phase, that is whether
-        ``op2 = e^{i * d} op1)`` for some phase difference ``d``.
+        ``op2 = e^{i * d} op1`` for some phase difference ``d``.
 
-        If this is the case, we can replace ``op2 * op1^{-1}`` by `e^{i * d} I``.
+        If this is the case, we can replace ``op2 * op1^{-1}`` by ``e^{i * d} I``.
 
         The output is a tuple representing whether the two ops
         are equal up to a phase and that phase difference.
@@ -119,7 +119,7 @@ class CommutativeInverseCancellation(TransformationPass):
                 continue
 
             matrix_based = (
-                self._matrix_based and len(topo_sorted_nodes[idx1].qargs) <= self._max_qubits
+                self._matrix_based and topo_sorted_nodes[idx1].num_qubits <= self._max_qubits
             )
 
             matched_idx2 = -1

--- a/releasenotes/notes/fix-cic-e53e6a3eb78b72bf.yaml
+++ b/releasenotes/notes/fix-cic-e53e6a3eb78b72bf.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixed several problems in the :class:`.CommutativeInverseCancellation`
+    transpiler pass: the pass now works correctly on circuits containing
+    :class:`.Clifford` operations, control-flow operations, and non-invertible
+    operations such as :class:`.Initialize`.
+
+    Fixed `#14407 <https://github.com/Qiskit/qiskit-terra/issues/14407>`__
+    Fixed `#14645 <https://github.com/Qiskit/qiskit-terra/issues/14645>`__
+    Fixed `#14645 <https://github.com/Qiskit/qiskit-terra/issues/14645>`__

--- a/releasenotes/notes/fix-cic-e53e6a3eb78b72bf.yaml
+++ b/releasenotes/notes/fix-cic-e53e6a3eb78b72bf.yaml
@@ -7,7 +7,7 @@ fixes:
     operations such as :class:`.Initialize`.
 
     In addition, the pass now always first performs a syntactic (non-matrix-based)
-    check when identidying inverse gate pairs. If the gates are not syntactically
+    check when identifying inverse gate pairs. If the gates are not syntactically
     equal, the argument ``matrix_based`` is set to ``True``, and the operation
     does not act on more than ``max_qubits`` qubits, then a matrix-based check
     is also performed. This slightly improves the reduction potential of the pass.

--- a/releasenotes/notes/fix-cic-e53e6a3eb78b72bf.yaml
+++ b/releasenotes/notes/fix-cic-e53e6a3eb78b72bf.yaml
@@ -7,5 +7,5 @@ fixes:
     operations such as :class:`.Initialize`.
 
     Fixed `#14407 <https://github.com/Qiskit/qiskit-terra/issues/14407>`__
-    Fixed `#14645 <https://github.com/Qiskit/qiskit-terra/issues/14645>`__
+    Fixed `#14635 <https://github.com/Qiskit/qiskit-terra/issues/14635>`__
     Fixed `#14645 <https://github.com/Qiskit/qiskit-terra/issues/14645>`__

--- a/releasenotes/notes/fix-cic-e53e6a3eb78b72bf.yaml
+++ b/releasenotes/notes/fix-cic-e53e6a3eb78b72bf.yaml
@@ -6,6 +6,12 @@ fixes:
     :class:`.Clifford` operations, control-flow operations, and non-invertible
     operations such as :class:`.Initialize`.
 
+    In addition, the pass now always first performs a syntactic (non-matrix-based)
+    check when identidying inverse gate pairs. If the gates are not syntactically
+    equal, the argument ``matrix_based`` is set to ``True``, and the operation
+    does not act on more than ``max_qubits`` qubits, then a matrix-based check
+    is also performed. This slightly improves the reduction potential of the pass.
+
     Fixed `#14407 <https://github.com/Qiskit/qiskit-terra/issues/14407>`__
     Fixed `#14635 <https://github.com/Qiskit/qiskit-terra/issues/14635>`__
     Fixed `#14645 <https://github.com/Qiskit/qiskit-terra/issues/14645>`__

--- a/test/python/transpiler/test_commutative_inverse_cancellation.py
+++ b/test/python/transpiler/test_commutative_inverse_cancellation.py
@@ -20,7 +20,7 @@ from ddt import data, ddt
 
 from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.circuit.library import RZGate, UnitaryGate, U2Gate
-from qiskit.quantum_info import Operator
+from qiskit.quantum_info import Operator, Clifford
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.passes import CommutativeInverseCancellation
 
@@ -877,6 +877,23 @@ class TestCommutativeInverseCancellation(QiskitTestCase):
 
         self.assertEqual(tqc.count_ops().get("u2", 0), 1)
         self.assertEqual(tqc.count_ops().get("rxx", 0), 1)
+
+    def test_clifford(self):
+        """Test a circuit that contains a Clifford."""
+        cliff_circuit = QuantumCircuit(2)
+        cliff_circuit.cx(0, 1)
+        cliff = Clifford(cliff_circuit)
+
+        circuit = QuantumCircuit(2)
+        circuit.s(0)
+        circuit.append(cliff, [0, 1])
+        circuit.sdg(0)
+
+        pm = PassManager(CommutativeInverseCancellation())
+        tqc = pm.run(circuit)
+
+        # The S and Sdg gates should cancel.
+        self.assertEqual(tqc.count_ops(), {"clifford": 1})
 
 
 if __name__ == "__main__":

--- a/test/python/transpiler/test_commutative_inverse_cancellation.py
+++ b/test/python/transpiler/test_commutative_inverse_cancellation.py
@@ -19,7 +19,7 @@ import numpy as np
 from ddt import data, ddt
 
 from qiskit.circuit import Parameter, QuantumCircuit
-from qiskit.circuit.library import RZGate, UnitaryGate, U2Gate
+from qiskit.circuit.library import RZGate, UnitaryGate, U2Gate, Initialize
 from qiskit.quantum_info import Operator, Clifford
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.passes import CommutativeInverseCancellation
@@ -903,6 +903,21 @@ class TestCommutativeInverseCancellation(QiskitTestCase):
 
         with circuit.for_loop(range(3)):
             circuit.cx(1, 0)
+
+        pm = PassManager(CommutativeInverseCancellation())
+        tqc = pm.run(circuit)
+
+        # The pass should run successfully but not reduce anything
+        self.assertEqual(circuit, tqc)
+
+    def test_initialize(self):
+        """Test a circuit with Initialize instruction."""
+        desired_vector = [0.5, 0.5, 0.5, 0.5]
+        initialize = Initialize(desired_vector)
+
+        circuit = QuantumCircuit(2)
+        circuit.append(initialize, [0, 1])
+        circuit.x(1)
 
         pm = PassManager(CommutativeInverseCancellation())
         tqc = pm.run(circuit)

--- a/test/python/transpiler/test_commutative_inverse_cancellation.py
+++ b/test/python/transpiler/test_commutative_inverse_cancellation.py
@@ -892,8 +892,23 @@ class TestCommutativeInverseCancellation(QiskitTestCase):
         pm = PassManager(CommutativeInverseCancellation())
         tqc = pm.run(circuit)
 
-        # The S and Sdg gates should cancel.
+        # The S and Sdg gates should cancel
         self.assertEqual(tqc.count_ops(), {"clifford": 1})
+
+    def test_control_flow(self):
+        """Test a circuit that contains a control-flow operation."""
+
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+
+        with circuit.for_loop(range(3)):
+            circuit.cx(1, 0)
+
+        pm = PassManager(CommutativeInverseCancellation())
+        tqc = pm.run(circuit)
+
+        # The pass should run successfully but not reduce anything
+        self.assertEqual(circuit, tqc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes multiple issues in the `CommutativeInverseCancellation` pass: #14407, #14635, #14645. Thanks to @YaegakiY for discovering these.

Previously the pass failed on circuits containing control-flow operations (as these do not have the `inverse` method), cliffords (as these do not have `is_parameterized` and `inverse` methods) and instructions such as `Initialize` (which are not invertible). Moreover, the code was slightly refactored as to compute an inverse of a given operation at most once.

### Details and comments

While making the above changes, I have noticed two additional possibilities for improvement. First, the pass does not recurse (which can be easily supported using `@control_flow.trivial_recurse`). Second, the pass could probably be extended to handling inverse parameterized gates (such as `Rz(theta)` and `Rz(-theta)`).
