### PR TITLE
Correct documentation for methods in dag_circuit.rs

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -446,8 +446,8 @@ impl DAGCircuit {
         self.qregs.cached(py)
     }
 
-    /// Returns a dict mapping Clbit instances to tuple comprised of 0) the
-    /// corresponding index in circuit.clbits and 1) a list of
+    /// Returns a dict mapping Qubit instances to tuple comprised of 0) the
+    /// corresponding index in circuit.qubits and 1) a list of
     /// Register-int pairs for each Register containing the Bit and its index
     /// within that register.
     #[getter("_qubit_indices")]
@@ -455,7 +455,7 @@ impl DAGCircuit {
         self.qubit_locations.cached(py)
     }
 
-    /// Returns the dict containing the QuantumRegisters in the circuit
+    /// Returns the dict containing the ClassicalRegisters in the circuit
     #[getter]
     fn get_cregs(&self, py: Python) -> &Py<PyDict> {
         self.cregs.cached(py)
@@ -1031,7 +1031,7 @@ impl DAGCircuit {
         Ok(())
     }
 
-    /// Add individual qubit wires.
+    /// Add individual clbit wires.
     fn add_clbits(&mut self, clbits: Vec<Bound<'_, PyAny>>) -> PyResult<()> {
         for bit in clbits.into_iter() {
             let Ok(bit) = bit.extract::<ShareableClbit>() else {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This pull request corrects the duplication of documentation for the following methods in `dag_circuit.rs`:
- `get_qregs, get_cregs`
- `get_qubit_locations, get_clbit_locations`
- `add_qubits, add_clbits`

### Details and comments
--

