### PR TITLE
Use Arc instead of Box for internal expression nodes in SymbolExpr

### DIFF
--- a/crates/circuit/src/parameter_expression.rs
+++ b/crates/circuit/src/parameter_expression.rs
@@ -21,6 +21,7 @@ use num_complex::Complex64;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt;
 use std::hash::{Hash, Hasher};
+use std::sync::Arc;
 
 use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
@@ -84,7 +85,7 @@ impl ParameterExpression {
             .replace("__end_sympy_replace__", "$");
 
         ParameterExpression {
-            expr: SymbolExpr::Symbol(Box::new(name)),
+            expr: SymbolExpr::Symbol(Arc::new(name)),
         }
     }
 

--- a/crates/circuit/src/symbol_expr.rs
+++ b/crates/circuit/src/symbol_expr.rs
@@ -10,15 +10,16 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-/// symbol_expr.rs
-/// symbolic expression engine for parameter expression
-use core::f64;
+//! symbol_expr.rs
+//! symbolic expression engine for parameter expression
+
 use hashbrown::{HashMap, HashSet};
 use std::cmp::Ordering;
 use std::cmp::PartialOrd;
 use std::convert::From;
 use std::fmt;
 use std::ops::{Add, Div, Mul, Neg, Sub};
+use std::sync::Arc;
 
 use num_complex::Complex64;
 
@@ -28,16 +29,16 @@ pub const SYMEXPR_EPSILON: f64 = f64::EPSILON * 8.0;
 /// node types of expression tree
 #[derive(Debug, Clone)]
 pub enum SymbolExpr {
-    Symbol(Box<String>),
+    Symbol(Arc<String>),
     Value(Value),
     Unary {
         op: UnaryOp,
-        expr: Box<SymbolExpr>,
+        expr: Arc<SymbolExpr>,
     },
     Binary {
         op: BinaryOp,
-        lhs: Box<SymbolExpr>,
-        rhs: Box<SymbolExpr>,
+        lhs: Arc<SymbolExpr>,
+        rhs: Arc<SymbolExpr>,
     },
 }
 
@@ -83,20 +84,20 @@ fn _add(lhs: SymbolExpr, rhs: SymbolExpr) -> SymbolExpr {
         match rhs.neg_opt() {
             Some(e) => SymbolExpr::Binary {
                 op: BinaryOp::Sub,
-                lhs: Box::new(lhs),
-                rhs: Box::new(e),
+                lhs: Arc::new(lhs),
+                rhs: Arc::new(e),
             },
             None => SymbolExpr::Binary {
                 op: BinaryOp::Sub,
-                lhs: Box::new(lhs),
-                rhs: Box::new(_neg(rhs)),
+                lhs: Arc::new(lhs),
+                rhs: Arc::new(_neg(rhs)),
             },
         }
     } else {
         SymbolExpr::Binary {
             op: BinaryOp::Add,
-            lhs: Box::new(lhs),
-            rhs: Box::new(rhs),
+            lhs: Arc::new(lhs),
+            rhs: Arc::new(rhs),
         }
     }
 }
@@ -108,20 +109,20 @@ fn _sub(lhs: SymbolExpr, rhs: SymbolExpr) -> SymbolExpr {
         match rhs.neg_opt() {
             Some(e) => SymbolExpr::Binary {
                 op: BinaryOp::Add,
-                lhs: Box::new(lhs),
-                rhs: Box::new(e),
+                lhs: Arc::new(lhs),
+                rhs: Arc::new(e),
             },
             None => SymbolExpr::Binary {
                 op: BinaryOp::Add,
-                lhs: Box::new(lhs),
-                rhs: Box::new(_neg(rhs)),
+                lhs: Arc::new(lhs),
+                rhs: Arc::new(_neg(rhs)),
             },
         }
     } else {
         SymbolExpr::Binary {
             op: BinaryOp::Sub,
-            lhs: Box::new(lhs),
-            rhs: Box::new(rhs),
+            lhs: Arc::new(lhs),
+            rhs: Arc::new(rhs),
         }
     }
 }
@@ -131,8 +132,8 @@ fn _sub(lhs: SymbolExpr, rhs: SymbolExpr) -> SymbolExpr {
 fn _mul(lhs: SymbolExpr, rhs: SymbolExpr) -> SymbolExpr {
     SymbolExpr::Binary {
         op: BinaryOp::Mul,
-        lhs: Box::new(lhs),
-        rhs: Box::new(rhs),
+        lhs: Arc::new(lhs),
+        rhs: Arc::new(rhs),
     }
 }
 
@@ -141,8 +142,8 @@ fn _mul(lhs: SymbolExpr, rhs: SymbolExpr) -> SymbolExpr {
 fn _div(lhs: SymbolExpr, rhs: SymbolExpr) -> SymbolExpr {
     SymbolExpr::Binary {
         op: BinaryOp::Div,
-        lhs: Box::new(lhs),
-        rhs: Box::new(rhs),
+        lhs: Arc::new(lhs),
+        rhs: Arc::new(rhs),
     }
 }
 
@@ -151,8 +152,8 @@ fn _div(lhs: SymbolExpr, rhs: SymbolExpr) -> SymbolExpr {
 fn _pow(lhs: SymbolExpr, rhs: SymbolExpr) -> SymbolExpr {
     SymbolExpr::Binary {
         op: BinaryOp::Pow,
-        lhs: Box::new(lhs),
-        rhs: Box::new(rhs),
+        lhs: Arc::new(lhs),
+        rhs: Arc::new(rhs),
     }
 }
 
@@ -163,7 +164,7 @@ fn _neg(expr: SymbolExpr) -> SymbolExpr {
         Some(e) => e,
         None => SymbolExpr::Unary {
             op: UnaryOp::Neg,
-            expr: Box::new(expr),
+            expr: Arc::new(expr),
         },
     }
 }
@@ -359,7 +360,7 @@ impl SymbolExpr {
             SymbolExpr::Value(e) => SymbolExpr::Value(*e),
             SymbolExpr::Unary { op, expr } => SymbolExpr::Unary {
                 op: op.clone(),
-                expr: Box::new(expr.bind(maps)),
+                expr: Arc::new(expr.bind(maps)),
             },
             SymbolExpr::Binary { op, lhs, rhs } => {
                 let new_lhs = lhs.bind(maps);
@@ -385,7 +386,7 @@ impl SymbolExpr {
             SymbolExpr::Value(e) => SymbolExpr::Value(*e),
             SymbolExpr::Unary { op, expr } => SymbolExpr::Unary {
                 op: op.clone(),
-                expr: Box::new(expr.subs(maps)),
+                expr: Arc::new(expr.subs(maps)),
             },
             SymbolExpr::Binary { op, lhs, rhs } => {
                 let new_lhs = lhs.subs(maps);
@@ -506,16 +507,16 @@ impl SymbolExpr {
                         UnaryOp::Abs => Ok(&(expr.as_ref() * &expr_d)
                             / &SymbolExpr::Unary {
                                 op: op.clone(),
-                                expr: Box::new(expr.as_ref().clone()),
+                                expr: Arc::new(expr.as_ref().clone()),
                             }),
                         UnaryOp::Neg => Ok(SymbolExpr::Unary {
                             op: UnaryOp::Neg,
-                            expr: Box::new(expr_d),
+                            expr: Arc::new(expr_d),
                         }),
                         UnaryOp::Sin => {
                             let lhs = SymbolExpr::Unary {
                                 op: UnaryOp::Cos,
-                                expr: Box::new(expr.as_ref().clone()),
+                                expr: Arc::new(expr.as_ref().clone()),
                             };
                             Ok(lhs * expr_d)
                         }
@@ -531,7 +532,7 @@ impl SymbolExpr {
                         UnaryOp::Cos => {
                             let lhs = SymbolExpr::Unary {
                                 op: UnaryOp::Sin,
-                                expr: Box::new(expr.as_ref().clone()),
+                                expr: Arc::new(expr.as_ref().clone()),
                             };
                             Ok(&-&lhs * &expr_d)
                         }
@@ -547,7 +548,7 @@ impl SymbolExpr {
                         UnaryOp::Tan => {
                             let d = SymbolExpr::Unary {
                                 op: UnaryOp::Cos,
-                                expr: Box::new(expr.as_ref().clone()),
+                                expr: Arc::new(expr.as_ref().clone()),
                             };
                             Ok(&(&expr_d / &d) / &d)
                         }
@@ -558,7 +559,7 @@ impl SymbolExpr {
                         }
                         UnaryOp::Exp => Ok(&SymbolExpr::Unary {
                             op: UnaryOp::Exp,
-                            expr: Box::new(expr.as_ref().clone()),
+                            expr: Arc::new(expr.as_ref().clone()),
                         } * &expr_d),
                         UnaryOp::Log => Ok(&expr_d / expr.as_ref()),
                         UnaryOp::Sign => {
@@ -588,12 +589,12 @@ impl SymbolExpr {
                                 Ok(_mul(
                                     SymbolExpr::Binary {
                                         op: BinaryOp::Pow,
-                                        lhs: Box::new(lhs.as_ref().clone()),
-                                        rhs: Box::new(rhs.as_ref().clone()),
+                                        lhs: Arc::new(lhs.as_ref().clone()),
+                                        rhs: Arc::new(rhs.as_ref().clone()),
                                     },
                                     SymbolExpr::Unary {
                                         op: UnaryOp::Log,
-                                        expr: Box::new(lhs.as_ref().clone()),
+                                        expr: Arc::new(lhs.as_ref().clone()),
                                     },
                                 ))
                             }
@@ -601,18 +602,18 @@ impl SymbolExpr {
                             Ok(rhs.as_ref()
                                 * &SymbolExpr::Binary {
                                     op: BinaryOp::Pow,
-                                    lhs: Box::new(lhs.as_ref().clone()),
-                                    rhs: Box::new(
+                                    lhs: Arc::new(lhs.as_ref().clone()),
+                                    rhs: Arc::new(
                                         rhs.as_ref() - &SymbolExpr::Value(Value::Real(1.0)),
                                     ),
                                 })
                         } else {
                             let new_expr = SymbolExpr::Unary {
                                 op: UnaryOp::Exp,
-                                expr: Box::new(_mul(
+                                expr: Arc::new(_mul(
                                     SymbolExpr::Unary {
                                         op: UnaryOp::Log,
-                                        expr: Box::new(lhs.as_ref().clone()),
+                                        expr: Arc::new(lhs.as_ref().clone()),
                                     },
                                     rhs.as_ref().clone(),
                                 )),
@@ -639,7 +640,7 @@ impl SymbolExpr {
                     },
                     _ => SymbolExpr::Unary {
                         op: op.clone(),
-                        expr: Box::new(ex),
+                        expr: Arc::new(ex),
                     },
                 }
             }
@@ -671,7 +672,7 @@ impl SymbolExpr {
     pub fn sign(&self) -> SymbolExpr {
         SymbolExpr::Unary {
             op: UnaryOp::Sign,
-            expr: Box::new(self.clone()),
+            expr: Arc::new(self.clone()),
         }
     }
 
@@ -778,8 +779,8 @@ impl SymbolExpr {
             SymbolExpr::Binary { op, lhs, rhs } => match op {
                 BinaryOp::Div => SymbolExpr::Binary {
                     op: op.clone(),
-                    lhs: Box::new(*rhs.clone()),
-                    rhs: Box::new(*lhs.clone()),
+                    lhs: rhs.clone(),
+                    rhs: lhs.clone(),
                 },
                 _ => _div(SymbolExpr::Value(Value::Real(1.0)), self.clone()),
             },
@@ -798,7 +799,7 @@ impl SymbolExpr {
         match self {
             SymbolExpr::Symbol(_) => SymbolExpr::Unary {
                 op: UnaryOp::Conj,
-                expr: Box::new(self.clone()),
+                expr: Arc::new(self.clone()),
             },
             SymbolExpr::Value(e) => match e {
                 Value::Complex(c) => SymbolExpr::Value(Value::Complex(c.conj())),
@@ -806,12 +807,12 @@ impl SymbolExpr {
             },
             SymbolExpr::Unary { op, expr } => SymbolExpr::Unary {
                 op: op.clone(),
-                expr: Box::new(expr.conjugate()),
+                expr: Arc::new(expr.conjugate()),
             },
             SymbolExpr::Binary { op, lhs, rhs } => SymbolExpr::Binary {
                 op: op.clone(),
-                lhs: Box::new(lhs.conjugate()),
-                rhs: Box::new(rhs.conjugate()),
+                lhs: Arc::new(lhs.conjugate()),
+                rhs: Arc::new(rhs.conjugate()),
             },
         }
     }
@@ -902,7 +903,7 @@ impl SymbolExpr {
             } => expr.abs(),
             _ => SymbolExpr::Unary {
                 op: UnaryOp::Abs,
-                expr: Box::new(self.clone()),
+                expr: Arc::new(self.clone()),
             },
         }
     }
@@ -911,7 +912,7 @@ impl SymbolExpr {
             SymbolExpr::Value(l) => SymbolExpr::Value(l.sin()),
             _ => SymbolExpr::Unary {
                 op: UnaryOp::Sin,
-                expr: Box::new(self.clone()),
+                expr: Arc::new(self.clone()),
             },
         }
     }
@@ -920,7 +921,7 @@ impl SymbolExpr {
             SymbolExpr::Value(l) => SymbolExpr::Value(l.asin()),
             _ => SymbolExpr::Unary {
                 op: UnaryOp::Asin,
-                expr: Box::new(self.clone()),
+                expr: Arc::new(self.clone()),
             },
         }
     }
@@ -929,7 +930,7 @@ impl SymbolExpr {
             SymbolExpr::Value(l) => SymbolExpr::Value(l.cos()),
             _ => SymbolExpr::Unary {
                 op: UnaryOp::Cos,
-                expr: Box::new(self.clone()),
+                expr: Arc::new(self.clone()),
             },
         }
     }
@@ -938,7 +939,7 @@ impl SymbolExpr {
             SymbolExpr::Value(l) => SymbolExpr::Value(l.acos()),
             _ => SymbolExpr::Unary {
                 op: UnaryOp::Acos,
-                expr: Box::new(self.clone()),
+                expr: Arc::new(self.clone()),
             },
         }
     }
@@ -947,7 +948,7 @@ impl SymbolExpr {
             SymbolExpr::Value(l) => SymbolExpr::Value(l.tan()),
             _ => SymbolExpr::Unary {
                 op: UnaryOp::Tan,
-                expr: Box::new(self.clone()),
+                expr: Arc::new(self.clone()),
             },
         }
     }
@@ -956,7 +957,7 @@ impl SymbolExpr {
             SymbolExpr::Value(l) => SymbolExpr::Value(l.atan()),
             _ => SymbolExpr::Unary {
                 op: UnaryOp::Atan,
-                expr: Box::new(self.clone()),
+                expr: Arc::new(self.clone()),
             },
         }
     }
@@ -965,7 +966,7 @@ impl SymbolExpr {
             SymbolExpr::Value(l) => SymbolExpr::Value(l.exp()),
             _ => SymbolExpr::Unary {
                 op: UnaryOp::Exp,
-                expr: Box::new(self.clone()),
+                expr: Arc::new(self.clone()),
             },
         }
     }
@@ -974,7 +975,7 @@ impl SymbolExpr {
             SymbolExpr::Value(l) => SymbolExpr::Value(l.log()),
             _ => SymbolExpr::Unary {
                 op: UnaryOp::Log,
-                expr: Box::new(self.clone()),
+                expr: Arc::new(self.clone()),
             },
         }
     }
@@ -984,14 +985,14 @@ impl SymbolExpr {
                 SymbolExpr::Value(r) => SymbolExpr::Value(l.pow(r)),
                 _ => SymbolExpr::Binary {
                     op: BinaryOp::Pow,
-                    lhs: Box::new(SymbolExpr::Value(*l)),
-                    rhs: Box::new(rhs.clone()),
+                    lhs: Arc::new(SymbolExpr::Value(*l)),
+                    rhs: Arc::new(rhs.clone()),
                 },
             },
             _ => SymbolExpr::Binary {
                 op: BinaryOp::Pow,
-                lhs: Box::new(self.clone()),
-                rhs: Box::new(rhs.clone()),
+                lhs: Arc::new(self.clone()),
+                rhs: Arc::new(rhs.clone()),
             },
         }
     }
@@ -1765,7 +1766,7 @@ impl SymbolExpr {
                         SymbolExpr::Value(v) => Some(_mul(SymbolExpr::Value(-v), self.clone())),
                         SymbolExpr::Symbol(s) => {
                             if s < e {
-                                Some(_neg(_mul(*expr.clone(), self.clone())))
+                                Some(_neg(_mul(expr.as_ref().clone(), self.clone())))
                             } else {
                                 Some(_neg(_mul(self.clone(), expr.as_ref().clone())))
                             }
@@ -1796,11 +1797,11 @@ impl SymbolExpr {
                         } => match expr.mul_opt(rexpr, recursive) {
                             Some(e) => Some(SymbolExpr::Unary {
                                 op: UnaryOp::Abs,
-                                expr: Box::new(e),
+                                expr: Arc::new(e),
                             }),
                             None => Some(SymbolExpr::Unary {
                                 op: UnaryOp::Abs,
-                                expr: Box::new(_mul(expr.as_ref().clone(), rexpr.as_ref().clone())),
+                                expr: Arc::new(_mul(expr.as_ref().clone(), rexpr.as_ref().clone())),
                             }),
                         },
                         _ => None,
@@ -2254,11 +2255,11 @@ impl SymbolExpr {
                         } => match expr.div_opt(rexpr, recursive) {
                             Some(e) => Some(SymbolExpr::Unary {
                                 op: UnaryOp::Abs,
-                                expr: Box::new(e),
+                                expr: Arc::new(e),
                             }),
                             None => Some(SymbolExpr::Unary {
                                 op: UnaryOp::Abs,
-                                expr: Box::new(_div(expr.as_ref().clone(), rexpr.as_ref().clone())),
+                                expr: Arc::new(_div(expr.as_ref().clone(), rexpr.as_ref().clone())),
                             }),
                         },
                         _ => None,
@@ -2515,7 +2516,7 @@ impl SymbolExpr {
                     },
                     _ => SymbolExpr::Unary {
                         op: op.clone(),
-                        expr: Box::new(opt),
+                        expr: Arc::new(opt),
                     },
                 }
             }
@@ -2552,12 +2553,12 @@ impl SymbolExpr {
             SymbolExpr::Value(e) => e.sympify(),
             SymbolExpr::Unary { op, expr } => SymbolExpr::Unary {
                 op: op.clone(),
-                expr: Box::new(expr.sympify()),
+                expr: Arc::new(expr.sympify()),
             },
             SymbolExpr::Binary { op, lhs, rhs } => SymbolExpr::Binary {
                 op: op.clone(),
-                lhs: Box::new(lhs.sympify()),
-                rhs: Box::new(rhs.sympify()),
+                lhs: Arc::new(lhs.sympify()),
+                rhs: Arc::new(rhs.sympify()),
             },
         }
     }
@@ -2786,7 +2787,7 @@ impl PartialOrd for SymbolExpr {
 
 impl From<&str> for SymbolExpr {
     fn from(v: &str) -> Self {
-        SymbolExpr::Symbol(Box::new(v.to_string()))
+        SymbolExpr::Symbol(Arc::new(v.to_string()))
     }
 }
 
@@ -3227,7 +3228,7 @@ impl Value {
                 SymbolExpr::Value(Value::Real(c.re)),
                 _mul(
                     SymbolExpr::Value(Value::Real(c.im)),
-                    SymbolExpr::Symbol(Box::new("I".to_string())),
+                    SymbolExpr::Symbol(Arc::new("I".to_string())),
                 ),
             ),
             _ => SymbolExpr::Value(*self),

--- a/crates/circuit/src/symbol_parser.rs
+++ b/crates/circuit/src/symbol_parser.rs
@@ -10,7 +10,9 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-/// Parser for equation strings to generate symbolic expression
+//! Parser for equation strings to generate symbolic expression
+use std::sync::Arc;
+
 use nom::branch::{alt, permutation};
 use nom::bytes::complete::tag;
 use nom::character::complete::{char, digit1, multispace0};
@@ -72,9 +74,9 @@ fn parse_symbol(s: &str) -> IResult<&str, SymbolExpr, VerboseError<&str>> {
                     // if array indexing is required in the future
                     // add indexing in Symbol struct
                     let s = format!("{}[{}]", v, i);
-                    Ok(SymbolExpr::Symbol(Box::new(s)))
+                    Ok(SymbolExpr::Symbol(Arc::new(s)))
                 }
-                None => Ok(SymbolExpr::Symbol(Box::new(v.to_string()))),
+                None => Ok(SymbolExpr::Symbol(Arc::new(v.to_string()))),
             }
         },
     )(s)
@@ -108,7 +110,7 @@ fn parse_unary(s: &str) -> IResult<&str, SymbolExpr, VerboseError<&str>> {
             };
             Ok(SymbolExpr::Unary {
                 op,
-                expr: Box::new(expr),
+                expr: Arc::new(expr),
             })
         },
     )(s)
@@ -137,7 +139,7 @@ fn parse_sign(s: &str) -> IResult<&str, SymbolExpr, VerboseError<&str>> {
             } else {
                 Ok(SymbolExpr::Unary {
                     op: UnaryOp::Neg,
-                    expr: Box::new(expr),
+                    expr: Arc::new(expr),
                 })
             }
         },

--- a/releasenotes/notes/fix-performance-of-large-expression-351afeb1a7ebf4d6.yaml
+++ b/releasenotes/notes/fix-performance-of-large-expression-351afeb1a7ebf4d6.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a performance regression when incrementally building :class:`.ParameterExpression`
+    from combining a large number of sub-expressions.
+    Fixed `#14653 <https://github.com/Qiskit/qiskit/issues/14653>`__


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the internal construction of the SymbolExpr struct use a reference counting pointer instead of a regular pointer to a heap allocated object. The way the binary tree gets constructed internally using a normal pointer results in a lot of a copies of elements on the tree. This creates a large performance overhead for the symbol expr as we end up copying and freeing elements on the binary tree a large amount. This was the root cause of the regression reported in #14653 as the expression that gets generated by the transpiler internally ends up adding a lot of elements to global phase expression and that results in a lot of memory allocation and deallocation overhead. By using a reference counting pointer instead of creating and freeing copies of the expressions on the tree we instead only keep a single copy and just increment or decrement the reference count.

### Details and comments

Fixes #14653