### PR TITLE
Restore correct max_trials behaviour for VF2Layout pass

### DIFF
--- a/crates/transpiler/src/passes/vf2/vf2_layout.rs
+++ b/crates/transpiler/src/passes/vf2/vf2_layout.rs
@@ -369,7 +369,7 @@ pub fn vf2_layout_pass(
     strict_direction: bool,
     call_limit: Option<usize>,
     time_limit: Option<f64>,
-    max_trials: Option<usize>,
+    max_trials: Option<isize>,
     avg_error_map: Option<ErrorMap>,
 ) -> PyResult<Option<HashMap<VirtualQubit, PhysicalQubit>>> {
     if strict_direction {
@@ -389,6 +389,22 @@ pub fn vf2_layout_pass(
             false,
             call_limit,
         );
+        let max_trials: Option<usize> = match max_trials {
+            Some(max_trials) => {
+                if max_trials > 0 {
+                    Some(max_trials as usize)
+                } else {
+                    None
+                }
+            }
+            None => Some(
+                im_graph_data
+                    .im_graph
+                    .edge_count()
+                    .max(cm_graph.edge_count())
+                    + 15,
+            ),
+        };
         let mut trials: usize = 0;
         let start_time = Instant::now();
         let mut chosen_layout: Option<HashMap<VirtualQubit, PhysicalQubit>> = None;
@@ -415,6 +431,7 @@ pub fn vf2_layout_pass(
                     break;
                 }
             }
+
             if let Some(time_limit) = time_limit {
                 let elapsed_time = start_time.elapsed().as_secs_f64();
                 if elapsed_time >= time_limit {
@@ -443,6 +460,22 @@ pub fn vf2_layout_pass(
                 target,
             ));
         }
+        let max_trials: Option<usize> = match max_trials {
+            Some(max_trials) => {
+                if max_trials > 0 {
+                    Some(max_trials as usize)
+                } else {
+                    None
+                }
+            }
+            None => Some(
+                im_graph_data
+                    .im_graph
+                    .edge_count()
+                    .max(cm_graph.edge_count())
+                    + 15,
+            ),
+        };
         let mappings = vf2::Vf2Algorithm::new(
             &cm_graph,
             &im_graph_data.im_graph,

--- a/releasenotes/notes/fix-max-trials-vf2-1af00e09dd25a9a7.yaml
+++ b/releasenotes/notes/fix-max-trials-vf2-1af00e09dd25a9a7.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    Fixed the behavior of the ``max_trials`` argument for :class:`.VF2Layout`
+    when set to ``None`` or a negative number. The pass was documented as
+    limiting the search to being based on the size of the circuit or target
+    if the option was set to ``None`` and as accepting negative values to
+    specify an unbounded search. However in the 2.1.0 this behavior was
+    incorrectly changed so that ``None`` ran an unbounded search and trying
+    to use a negative number would raise an error. These oversights have
+    been corrected so that the pass behaves as documented and is consistent
+    with previous releases.

--- a/test/python/transpiler/test_vf2_layout.py
+++ b/test/python/transpiler/test_vf2_layout.py
@@ -316,6 +316,26 @@ class TestVF2LayoutLattice(LayoutTestCase):
         pass_.run(dag)
         self.assertLayout(dag, self.cmap25, pass_.property_set)
 
+    def test_hexagonal_lattice_graph_9_in_25_no_trial_limit(self):
+        """A 9x9 interaction map in 25x25 coupling map"""
+        graph_9_9 = rustworkx.generators.hexagonal_lattice_graph(9, 9)
+        circuit = self.graph_state_from_pygraph(graph_9_9)
+
+        dag = circuit_to_dag(circuit)
+        pass_ = VF2Layout(self.cmap25, seed=self.seed, max_trials=-1)
+        pass_.run(dag)
+        self.assertLayout(dag, self.cmap25, pass_.property_set)
+
+    def test_hexagonal_lattice_graph_9_in_25_default_trial_limit(self):
+        """A 9x9 interaction map in 25x25 coupling map"""
+        graph_9_9 = rustworkx.generators.hexagonal_lattice_graph(9, 9)
+        circuit = self.graph_state_from_pygraph(graph_9_9)
+
+        dag = circuit_to_dag(circuit)
+        pass_ = VF2Layout(self.cmap25, seed=self.seed, max_trials=None)
+        pass_.run(dag)
+        self.assertLayout(dag, self.cmap25, pass_.property_set)
+
 
 class TestVF2LayoutBackend(LayoutTestCase):
     """Tests VF2Layout against backends"""

--- a/test/python/transpiler/test_vf2_layout.py
+++ b/test/python/transpiler/test_vf2_layout.py
@@ -286,6 +286,7 @@ class TestVF2LayoutSimple(LayoutTestCase):
         self.assertLayout(dag, target.build_coupling_map(), vf2_pass.property_set)
 
 
+@ddt.ddt
 class TestVF2LayoutLattice(LayoutTestCase):
     """Fit in 25x25 hexagonal lattice coupling map"""
 
@@ -316,23 +317,25 @@ class TestVF2LayoutLattice(LayoutTestCase):
         pass_.run(dag)
         self.assertLayout(dag, self.cmap25, pass_.property_set)
 
-    def test_hexagonal_lattice_graph_9_in_25_no_trial_limit(self):
+    @ddt.data(True, False)
+    def test_hexagonal_lattice_graph_9_in_25_no_trial_limit(self, strict_direction):
         """A 9x9 interaction map in 25x25 coupling map"""
         graph_9_9 = rustworkx.generators.hexagonal_lattice_graph(9, 9)
         circuit = self.graph_state_from_pygraph(graph_9_9)
 
         dag = circuit_to_dag(circuit)
-        pass_ = VF2Layout(self.cmap25, seed=self.seed, max_trials=-1)
+        pass_ = VF2Layout(self.cmap25, seed=-1, max_trials=-1, strict_direction=strict_direction)
         pass_.run(dag)
         self.assertLayout(dag, self.cmap25, pass_.property_set)
 
-    def test_hexagonal_lattice_graph_9_in_25_default_trial_limit(self):
+    @ddt.data(True, False)
+    def test_hexagonal_lattice_graph_9_in_25_default_trial_limit(self, strict_direction):
         """A 9x9 interaction map in 25x25 coupling map"""
         graph_9_9 = rustworkx.generators.hexagonal_lattice_graph(9, 9)
         circuit = self.graph_state_from_pygraph(graph_9_9)
 
         dag = circuit_to_dag(circuit)
-        pass_ = VF2Layout(self.cmap25, seed=self.seed, max_trials=None)
+        pass_ = VF2Layout(self.cmap25, seed=-1, max_trials=None, strict_direction=strict_direction)
         pass_.run(dag)
         self.assertLayout(dag, self.cmap25, pass_.property_set)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The VF2Layout pass is documented as setting a trial limit equivalent to the being based on the number of edges of the interaction or connectivity graph. Additionally it supports being a negative value to run unbounded. However, when vf2 layout was ported to rust in #14056 this behavior was not preserved. It was not able to handle negative values and also a value of None was treated as unbounded. This commit corrects these oversights so the argument to the pass is handled correctly as documented.

### Details and comments