### PR TITLE
Fix MCXSynthesis1DirtyKG24 and MCXSynthesis2DirtyKG24 plugins

### DIFF
--- a/qiskit/transpiler/passes/synthesis/hls_plugins.py
+++ b/qiskit/transpiler/passes/synthesis/hls_plugins.py
@@ -1254,7 +1254,9 @@ class MCXSynthesis2DirtyKG24(HighLevelSynthesisPlugin):
             return None
 
         num_ctrl_qubits = high_level_object.num_ctrl_qubits
-        num_dirty_ancillas = options.get("num_dirty_ancillas", 0)
+        num_dirty_ancillas = options.get("num_dirty_ancillas", 0) + options.get(
+            "num_clean_ancillas", 0
+        )
 
         if num_dirty_ancillas < 2:
             return None
@@ -1338,7 +1340,9 @@ class MCXSynthesis1DirtyKG24(HighLevelSynthesisPlugin):
             return None
 
         num_ctrl_qubits = high_level_object.num_ctrl_qubits
-        num_dirty_ancillas = options.get("num_dirty_ancillas", 0)
+        num_dirty_ancillas = options.get("num_dirty_ancillas", 0) + options.get(
+            "num_clean_ancillas", 0
+        )
 
         if num_dirty_ancillas < 1:
             return None

--- a/releasenotes/notes/fix-mcx-kg-plugins-e5bfd7e8114d8e52.yaml
+++ b/releasenotes/notes/fix-mcx-kg-plugins-e5bfd7e8114d8e52.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a problem in high-level synthesis plugins :class:`.MCXSynthesis1DirtyKG24`
+    and :class:`.MCXSynthesis2DirtyKG24` for :class:`.MCXGate`, where the plugins
+    did not consider available clean auxiliary qubits as available dirty auxiliary
+    qubits. In particular, the plugin :class:`.MCXSynthesis2DirtyKG24` did not apply
+    when one clean and one dirty auxiliary qubits were available.

--- a/test/python/transpiler/test_high_level_synthesis.py
+++ b/test/python/transpiler/test_high_level_synthesis.py
@@ -2745,12 +2745,15 @@ class TestMCXSynthesisPlugins(QiskitTestCase):
             )
             self.assertIsNotNone(decomposition)
 
-        with self.subTest(method="2_clean_kg24", num_clean_ancillas=1, num_dirty_ancillas=0):
+        with self.subTest(method="2_clean_kg24", num_clean_ancillas=1, num_dirty_ancillas=1):
             # should not have a decomposition
             decomposition = MCXSynthesis2CleanKG24().run(
-                gate, num_clean_ancillas=1, num_dirty_ancillas=0
+                gate, num_clean_ancillas=1, num_dirty_ancillas=1
             )
             self.assertIsNone(decomposition)
+
+        with self.subTest(method="2_clean_kg24", num_clean_ancillas=0, num_dirty_ancillas=0):
+            # should not have a decomposition
             decomposition = MCXSynthesis2CleanKG24().run(
                 gate, num_clean_ancillas=0, num_dirty_ancillas=0
             )
@@ -2763,12 +2766,22 @@ class TestMCXSynthesisPlugins(QiskitTestCase):
             )
             self.assertIsNotNone(decomposition)
 
+        with self.subTest(method="2_dirty_kg24", num_clean_ancillas=1, num_dirty_ancillas=1):
+            # should have a decomposition
+            decomposition = MCXSynthesis2DirtyKG24().run(
+                gate, num_clean_ancillas=1, num_dirty_ancillas=1
+            )
+            self.assertIsNotNone(decomposition)
+
         with self.subTest(method="2_dirty_kg24", num_clean_ancillas=0, num_dirty_ancillas=1):
             # should not have a decomposition
             decomposition = MCXSynthesis2DirtyKG24().run(
                 gate, num_clean_ancillas=0, num_dirty_ancillas=1
             )
             self.assertIsNone(decomposition)
+
+        with self.subTest(method="2_dirty_kg24", num_clean_ancillas=0, num_dirty_ancillas=0):
+            # should not have a decomposition
             decomposition = MCXSynthesis2DirtyKG24().run(
                 gate, num_clean_ancillas=0, num_dirty_ancillas=0
             )
@@ -2794,6 +2807,14 @@ class TestMCXSynthesisPlugins(QiskitTestCase):
                 gate, num_clean_ancillas=0, num_dirty_ancillas=1
             )
             self.assertIsNotNone(decomposition)
+
+        with self.subTest(method="1_dirty_kg24", num_clean_ancillas=1, num_dirty_ancillas=0):
+            # should have a decomposition
+            decomposition = MCXSynthesis1DirtyKG24().run(
+                gate, num_clean_ancillas=1, num_dirty_ancillas=0
+            )
+            self.assertIsNotNone(decomposition)
+
         with self.subTest(method="1_dirty_kg24", num_clean_ancillas=0, num_dirty_ancillas=0):
             # should not have a decomposition
             decomposition = MCXSynthesis1DirtyKG24().run(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

In #14143 we have introduced new `MCXGate` synthesis plugins `MCXSynthesis2CleanKG24`, `MCXSynthesis2DirtyKG24`, `MCXSynthesis1CleanKG24`, `MCXSynthesis1DirtyKG24`. In particular, the plugin `MCXSynthesis1DirtyKG24` should apply when there is (at least) one available dirty auxiliary qubit, and the plugin `MCXSynthesis2DirtyKG24` should apply when there are (at least) two available dirty auxiliary qubits. However, the number of dirty qubits available failed to include the number of clean qubits available, and in particular `MCXSynthesis2DirtyKG24` failed to apply with one clean and one dirty auxiliary qubits.
