### PR TITLE
Add unit test for Python 3.9 deprecation warning

### DIFF
--- a/test/benchmarks/__init__.py
+++ b/test/benchmarks/__init__.py
@@ -1,3 +1,8 @@
+import sys
+import warnings
+import unittest
+from unittest import mock
+from qiskit import __init__ as qiskit_init
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2023
@@ -9,3 +14,12 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+
+class TestDeprecationWarnings(unittest.TestCase):
+    @mock.patch('sys.version_info', new=(3, 9))
+    def test_deprecation_warning_for_python_3_9(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            # Re-trigger the import to check for warnings after mocking
+            import qiskit.__init__ as qiskit_init
+            self.assertTrue(any(issubclass(warn.category, DeprecationWarning) for warn in w))


### PR DESCRIPTION
### Summary
This pull request introduces a new unit test that verifies the deprecation warning for Python 3.9 in the Qiskit framework, as outlined in PR #14543. The test checks that the appropriate warning is raised when Qiskit is imported with Python 3.9, enhancing coverage for the related functionality. This ensures users are adequately informed about the deprecation during the transition period. The newly added test covers previously uncovered lines in `qiskit/__init__.py`, improving overall test coverage.

### Details and comments
## Lines Incremented by this Test
| File | Block | Permalink |
| ---- | ----- | --------- |
| qiskit/__init__.py | 48-53 | [Here](https://github.com/mtreinish/qiskit-core/blob/c972f73125e30eee54fa936e8a4e0b502b572394/qiskit/__init__.py#L48-L53) |
## Lines Increment Visualization
```python
--------------------------------------------------------------------------------
# qiskit/__init__.py
--------------------------------------------------------------------------------
# This code is part of Qiskit.
#
# (C) Copyright IBM 2017.
#
# This code is licensed under the Apache License, Version 2.0. You may
# obtain a copy of this license in the LICENSE.txt file in the root directory
# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
#
# Any modifications or derivative works of this code must retain this
# copyright notice, and modified files need to carry a notice indicating
# that they have been altered from the originals.

# pylint: disable=wrong-import-position,wrong-import-order

"""Main Qiskit public functionality."""

import importlib.metadata
import importlib.util
import os
import sys
import warnings

try:
    importlib.metadata.version("qiskit-terra")
except importlib.metadata.PackageNotFoundError:
    # All good!
    pass
else:
    # 'qiskit.tools' is present in all 0.x series of Qiskit and not in Qiskit 1.0+.  If a dev has an
    # editable install and switches from 0.x branches to 1.0+ branches, they might have an empty
    # `qiskit/tools` folder in their path, which will appear as a "namespace package" with no valid
    # location.  We catch that case as "not actually having Qiskit 0.x" as a convenience to devs.
    _has_tools = getattr(importlib.util.find_spec("qiskit.tools"), "has_location", False)
    _suppress_error = os.environ.get("QISKIT_SUPPRESS_1_0_IMPORT_ERROR", False) == "1"
    if not _suppress_error and _has_tools:
        raise ImportError(
            "Qiskit is installed in an invalid environment that has both Qiskit >=1.0"
            " and an earlier version."
            " You should create a new virtual environment, and ensure that you do not mix"
            " dependencies between Qiskit <1.0 and >=1.0."
            " Any packages that depend on 'qiskit-terra' are not compatible with Qiskit 1.0 and"
            " will need to be updated."
            " Qiskit unfortunately cannot enforce this requirement during environment resolution."
            " See https://qisk.it/packaging-1-0 for more detail."
        )

if sys.version_info < (3, 10):
    warnings.warn( #✅ NOW COVERED
        "Using Qiskit with Python 3.9 is deprecated as of the 2.1.0 release. " #✅ NOW COVERED
        "Support for running Qiskit with Python 3.9 will be removed in the " #✅ NOW COVERED
        "2.3.0 release, which coincides with when Python 3.9 goes end of life.", #✅ NOW COVERED
        DeprecationWarning, #✅ NOW COVERED
    ) #✅ NOW COVERED

from . import _accelerate
import qiskit._numpy_compat

# Globally define compiled submodules. The normal import mechanism will not find compiled submodules
# in _accelerate because it relies on file paths, but PyO3 generates only one shared library file.
# We manually define them on import so people can directly import qiskit._accelerate.* submodules
# and not have to rely on attribute access.  No action needed for top-level extension packages.
sys.modules["qiskit._accelerate.circuit"] = _accelerate.circuit
sys.modules["qiskit._accelerate.circuit.classical"] = _accelerate.circuit.classical
sys.modules["qiskit._accelerate.circuit.classical.expr"] = _accelerate.circuit.classical.expr
sys.modules["qiskit._accelerate.circuit.classical.types"] = _accelerate.circuit.classical.types
sys.modules["qiskit._accelerate.circuit_library"] = _accelerate.circuit_library
sys.modules["qiskit._accelerate.basis_translator"] = _accelerate.basis_translator
sys.modules["qiskit._accelerate.converters"] = _accelerate.converters
sys.modules["qiskit._accelerate.dense_layout"] = _accelerate.dense_layout
sys.modules["qiskit._accelerate.disjoint_utils"] = _accelerate.disjoint_utils
sys.modules["qiskit._accelerate.equivalence"] = _accelerate.equivalence
sys.modules["qiskit._accelerate.error_map"] = _accelerate.error_map
sys.modules["qiskit._accelerate.gates_in_basis"] = _accelerate.gates_in_basis
sys.modules["qiskit._accelerate.isometry"] = _accelerate.isometry
sys.modules["qiskit._accelerate.uc_gate"] = _accelerate.uc_gate
sys.modules["qiskit._accelerate.euler_one_qubit_decomposer"] = (
    _accelerate.euler_one_qubit_decomposer
)
sys.modules["qiskit._accelerate.optimize_1q_gates_decomposition"] = (
    _accelerate.optimize_1q_gates_decomposition
)
sys.modules["qiskit._accelerate.nlayout"] = _accelerate.nlayout
sys.modules["qiskit._accelerate.optimize_1q_gates"] = _accelerate.optimize_1q_gates
sys.modules["qiskit._accelerate.pauli_expval"] = _accelerate.pauli_expval
sys.modules["qiskit._accelerate.pauli_lindblad_map"] = _accelerate.pauli_lindblad_map
sys.modules["qiskit._accelerate.qasm2"] = _accelerate.qasm2
sys.modules["qiskit._accelerate.qasm3"] = _accelerate.qasm3
sys.modules["qiskit._accelerate.remove_diagonal_gates_before_measure"] = (
    _accelerate.remove_diagonal_gates_before_measure
)
sys.modules["qiskit._accelerate.results"] = _accelerate.results
sys.modules["qiskit._accelerate.sabre"] = _accelerate.sabre
sys.modules["qiskit._accelerate.sampled_exp_val"] = _accelerate.sampled_exp_val
sys.modules["qiskit._accelerate.sparse_observable"] = _accelerate.sparse_observable
sys.modules["qiskit._accelerate.sparse_pauli_op"] = _accelerate.sparse_pauli_op
sys.modules["qiskit._accelerate.elide_permutations"] = _accelerate.elide_permutations
sys.modules["qiskit._accelerate.target"] = _accelerate.target
sys.modules["qiskit._accelerate.two_qubit_decompose"] = _accelerate.two_qubit_decompose
sys.modules["qiskit._accelerate.unitary_synthesis"] = _accelerate.unitary_synthesis
sys.modules["qiskit._accelerate.vf2_layout"] = _accelerate.vf2_layout
sys.modules["qiskit._accelerate.synthesis.permutation"] = _accelerate.synthesis.permutation
sys.modules["qiskit._accelerate.synthesis.linear"] = _accelerate.synthesis.linear
sys.modules["qiskit._accelerate.synthesis.clifford"] = _accelerate.synthesis.clifford

--------------------------------------------------------------------------------
```
## Test Patch
```diff
diff --git a/test/benchmarks/__init__.py b/test/benchmarks/__init__.py
index c7325a848..80f74da60 100644
--- a/test/benchmarks/__init__.py
+++ b/test/benchmarks/__init__.py
@@ -1,3 +1,8 @@
+import sys
+import warnings
+import unittest
+from unittest import mock
+from qiskit import __init__ as qiskit_init
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2023
@@ -9,3 +14,12 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+
+class TestDeprecationWarnings(unittest.TestCase):
+    @mock.patch('sys.version_info', new=(3, 9))
+    def test_deprecation_warning_for_python_3_9(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            # Re-trigger the import to check for warnings after mocking
+            import qiskit.__init__ as qiskit_init
+            self.assertTrue(any(issubclass(warn.category, DeprecationWarning) for warn in w))

```
## Fully Integrated Test
The new test is fully integrated into test file `test/benchmarks/__init__.py`.

To view the test file, navigate to `test.py`

To view the test file before new test is added on Github, click [here](https://github.com/mtreinish/qiskit-core/blob/c972f73125e30eee54fa936e8a4e0b502b572394/test/benchmarks/__init__.py)
## Test Runtime Log
```log
============================= test session starts ==============================
platform linux -- Python 3.11.13, pytest-8.4.0, pluggy-1.6.0
rootdir: /opt/qiskit
configfile: pyproject.toml
plugins: hypothesis-6.135.9, cov-6.1.1
collected 1 item

../opt/qiskit/test/test_2_integrated.py .                                [100%]

================================ tests coverage ================================
_______________ coverage: platform linux, python 3.11.13-final-0 _______________

Coverage XML written to file coverage.xml
============================== 1 passed in 26.78s ==============================

```

