### PR TITLE
Fix SparsePauliOp.is_unitary() to respect input tolerance values

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -433,10 +433,14 @@ class SparsePauliOp(LinearOp):
     def is_unitary(self, atol: float | None = None, rtol: float | None = None) -> bool:
         """Return True if operator is a unitary matrix.
 
+        This method checks whether the operator composed with its adjoint equals
+        the identity, up to the provided tolerance. The tolerance is used when
+        simplifying the composed operator and checking if the result is the identity.
+
         Args:
             atol (float): Optional. Absolute tolerance for checking if
                           coefficients are zero (Default: 1e-8).
-            rtol (float): Optional. relative tolerance for checking if
+            rtol (float): Optional. Relative tolerance for checking if
                           coefficients are zero (Default: 1e-5).
 
         Returns:

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -449,7 +449,7 @@ class SparsePauliOp(LinearOp):
             rtol = self.rtol
 
         # Compose with adjoint
-        val = self.compose(self.adjoint()).simplify()
+        val = self.compose(self.adjoint()).simplify(atol=atol, rtol=rtol)
         # See if the result is an identity
         return (
             val.size == 1

--- a/releasenotes/notes/fix-sparse-pauli-op-is-unitary-tolerance-28249b2d55f38284.yaml
+++ b/releasenotes/notes/fix-sparse-pauli-op-is-unitary-tolerance-28249b2d55f38284.yaml
@@ -5,8 +5,3 @@ fixes:
     operator is unitary. The method now correctly uses the provided ``atol`` and
     ``rtol`` parameters when simplifying the operator and checking if it equals
     the identity. This fixes `#14107 <https://github.com/Qiskit/qiskit/issues/14107>`__.
-
-    This change ensures that the tolerance values passed to `is_unitary()` are
-    properly propagated to the internal simplification and comparison operations,
-    making the method more consistent with user expectations and other similar
-    methods in Qiskit.

--- a/releasenotes/notes/fix-sparse-pauli-op-is-unitary-tolerance-28249b2d55f38284.yaml
+++ b/releasenotes/notes/fix-sparse-pauli-op-is-unitary-tolerance-28249b2d55f38284.yaml
@@ -2,9 +2,9 @@ fixes:
   - |
     Fixed an issue where :meth:`~qiskit.quantum_info.SparsePauliOp.is_unitary`
     was not properly respecting the input tolerance values when checking if an
-    operator is unitary. The method now correctly uses the provided `atol` and
-    `rtol` parameters when simplifying the operator and checking if it equals
-    the identity. This fixes :issue:`14107`.
+    operator is unitary. The method now correctly uses the provided ``atol`` and
+    ``rtol`` parameters when simplifying the operator and checking if it equals
+    the identity. This fixes `#14107 <https://github.com/Qiskit/qiskit/issues/14107>`__.
 
     This change ensures that the tolerance values passed to `is_unitary()` are
     properly propagated to the internal simplification and comparison operations,

--- a/releasenotes/notes/fix-sparse-pauli-op-is-unitary-tolerance-28249b2d55f38284.yaml
+++ b/releasenotes/notes/fix-sparse-pauli-op-is-unitary-tolerance-28249b2d55f38284.yaml
@@ -1,0 +1,12 @@
+fixes:
+  - |
+    Fixed an issue where :meth:`~qiskit.quantum_info.SparsePauliOp.is_unitary`
+    was not properly respecting the input tolerance values when checking if an
+    operator is unitary. The method now correctly uses the provided `atol` and
+    `rtol` parameters when simplifying the operator and checking if it equals
+    the identity. This fixes :issue:`14107`.
+
+    This change ensures that the tolerance values passed to `is_unitary()` are
+    properly propagated to the internal simplification and comparison operations,
+    making the method more consistent with user expectations and other similar
+    methods in Qiskit.

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -1358,7 +1358,11 @@ class TestSparsePauliOpMethods(QiskitTestCase):
         self.assertEqual(SparsePauliOp(["II"], [0j]), res)
 
     def test_is_unitary_tolerance(self):
-        """Test that is_unitary respects the input tolerance values."""
+        """Test that is_unitary respects the input tolerance values.
+        
+        This test verifies that the tolerance parameters are properly passed through
+        to the internal operations. See issue #14107.
+        """
         # Create a matrix that's approximately unitary but not exactly
         a = np.array([
             [-9.9801135e-01 + 6.3036762e-02j, 5.6710692e-06 + 8.1099635e-05j],

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -1357,6 +1357,29 @@ class TestSparsePauliOpMethods(QiskitTestCase):
         res = op.simplify(atol=1e-7)
         self.assertEqual(SparsePauliOp(["II"], [0j]), res)
 
+    def test_is_unitary_tolerance(self):
+        """Test that is_unitary respects the input tolerance values."""
+        # Create a matrix that's approximately unitary but not exactly
+        a = np.array([
+            [-9.9801135e-01 + 6.3036762e-02j, 5.6710692e-06 + 8.1099635e-05j],
+            [5.6710610e-06 + 8.1099643e-05j, -9.9707150e-01 + 7.6473624e-02j]
+        ])
+        
+        # Verify the matrix is approximately unitary
+        identity = a @ a.conj().T
+        np.testing.assert_allclose(identity, np.eye(2), atol=1e-5, rtol=1e-3)
+        
+        # Create SparsePauliOp from the matrix
+        op = SparsePauliOp.from_operator(a)
+        
+        # Test with tolerance that should pass
+        self.assertTrue(op.is_unitary(atol=1e-5, rtol=1e-3),
+                       "Operator should be considered unitary with given tolerance")
+        
+        # Test with very small tolerance that should fail
+        self.assertFalse(op.is_unitary(atol=1e-10, rtol=1e-10),
+                        "Operator should not be considered unitary with very small tolerance")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -1359,30 +1359,36 @@ class TestSparsePauliOpMethods(QiskitTestCase):
 
     def test_is_unitary_tolerance(self):
         """Test that is_unitary respects the input tolerance values.
-        
+
         This test verifies that the tolerance parameters are properly passed through
         to the internal operations. See issue #14107.
         """
         # Create a matrix that's approximately unitary but not exactly
-        a = np.array([
-            [-9.9801135e-01 + 6.3036762e-02j, 5.6710692e-06 + 8.1099635e-05j],
-            [5.6710610e-06 + 8.1099643e-05j, -9.9707150e-01 + 7.6473624e-02j]
-        ])
-        
+        a = np.array(
+            [
+                [-9.9801135e-01 + 6.3036762e-02j, 5.6710692e-06 + 8.1099635e-05j],
+                [5.6710610e-06 + 8.1099643e-05j, -9.9707150e-01 + 7.6473624e-02j],
+            ]
+        )
+
         # Verify the matrix is approximately unitary
         identity = a @ a.conj().T
         np.testing.assert_allclose(identity, np.eye(2), atol=1e-5, rtol=1e-3)
-        
+
         # Create SparsePauliOp from the matrix
         op = SparsePauliOp.from_operator(a)
-        
+
         # Test with tolerance that should pass
-        self.assertTrue(op.is_unitary(atol=1e-5, rtol=1e-3),
-                       "Operator should be considered unitary with given tolerance")
-        
+        self.assertTrue(
+            op.is_unitary(atol=1e-5, rtol=1e-3),
+            "Operator should be considered unitary with given tolerance",
+        )
+
         # Test with very small tolerance that should fail
-        self.assertFalse(op.is_unitary(atol=1e-10, rtol=1e-10),
-                        "Operator should not be considered unitary with very small tolerance")
+        self.assertFalse(
+            op.is_unitary(atol=1e-10, rtol=1e-10),
+            "Operator should not be considered unitary with very small tolerance",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #14107

### Summary

This PR fixes an issue where `SparsePauliOp.is_unitary()` was not properly respecting the input tolerance values when checking if an operator is unitary. The method was not passing the tolerance parameters to the internal [simplify()] call.

### Details and comments

The main changes in this PR are:

1. Modified `SparsePauliOp.is_unitary()` to pass the atol and rtol parameters to the [simplify()] method
2. Added a test case that verifies the fix works as expected by:
   - Creating a matrix that's approximately unitary but not exactly
   - Verifying it's considered unitary with appropriate tolerances
   - Verifying it's not considered unitary with very tight tolerances

### Testing
- [x] I have added the tests to cover my changes.
- [x] All tests pass locally with my changes
- [x] I have read the CONTRIBUTING document.

### Release Notes

Fixed an issue where `SparsePauliOp.is_unitary()` was not respecting the input tolerance values when checking if an operator is unitary. 