### PR TITLE
Simple fix typo in docstring

### DIFF
--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -100,7 +100,7 @@ class BaseOperator(GroupMixin, ABC):
 
     @property
     def _output_dim(self):
-        """Return the total input dimension."""
+        """Return the total output dimension."""
         return self._op_shape._dim_l
 
     def reshape(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Simply fix the typo on the docstring under `qiskit/quantum_info/operators/base_operator.py`

Docstring typo in property `_output_dim`: 
“Return the total input dimension.” → “Return the total output dimension.”



