### PR TITLE
Add test for `ConsolidateBlocks` with `kak_basis_gate`

### DIFF
--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -36,6 +36,11 @@ from qiskit.quantum_info.operators.measures import process_fidelity
 from qiskit.transpiler import PassManager, Target, generate_preset_pass_manager
 from qiskit.transpiler.passes import ConsolidateBlocks, Collect1qRuns, Collect2qBlocks
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
+import unittest
+from qiskit import QuantumCircuit
+from qiskit.transpiler import PassManager
+from qiskit.transpiler.passes import ConsolidateBlocks
+from qiskit.circuit.library import CXGate
 
 
 @ddt
@@ -691,3 +696,14 @@ class TestConsolidateBlocks(QiskitTestCase):
             expected = QuantumCircuit(2)
             expected.unitary(np.asarray(RZZGate(angle)), [0, 1])
             self.assertEqual(res, expected)
+
+    def test_consolidate_with_kak_basis_gate(self):
+        """Test that ConsolidateBlocks works with a kak_basis_gate."""
+
+        kak_basis_gate = CXGate()
+        consolidate_pass = ConsolidateBlocks(kak_basis_gate=kak_basis_gate)
+        qc = QuantumCircuit(2)
+        qc.cx(0, 1)
+        dag = circuit_to_dag(qc)
+        res = consolidate_pass.run(dag)
+        self.assertEqual(res.count_ops().get('cx', 0), 1)

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -36,11 +36,6 @@ from qiskit.quantum_info.operators.measures import process_fidelity
 from qiskit.transpiler import PassManager, Target, generate_preset_pass_manager
 from qiskit.transpiler.passes import ConsolidateBlocks, Collect1qRuns, Collect2qBlocks
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
-import unittest
-from qiskit import QuantumCircuit
-from qiskit.transpiler import PassManager
-from qiskit.transpiler.passes import ConsolidateBlocks
-from qiskit.circuit.library import CXGate
 
 
 @ddt


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR adds a test to check the behavior of `ConsolidateBlocks` when gives a `kak_basis_gate` parameter. The newly tested corner case was edited in PR https://github.com/Qiskit/qiskit/pull/14417 and missed some test coverage. 

### Details and comments
This new test adds coverage to the following lines:

```python
--------------------------------------------------------------------------------
# qiskit/transpiler/passes/optimization/consolidate_blocks.py
--------------------------------------------------------------------------------
class ConsolidateBlocks(TransformationPass):
    # omitted
    def __init__(
        self,
        kak_basis_gate=None,
        force_consolidate=False,
        basis_gates=None,
        approximation_degree=1.0,
        target=None,
    ):
        """ConsolidateBlocks initializer.

        If ``kak_basis_gate`` is not ``None`` it will be used as the basis gate for KAK decomposition.
        Otherwise, if ``basis_gates`` is not ``None`` a basis gate will be chosen from this list.
        Otherwise, the basis gate will be :class:`.CXGate`.

        Args:
            kak_basis_gate (Gate): Basis gate for KAK decomposition.
            force_consolidate (bool): Force block consolidation.
            basis_gates (List(str)): Basis gates from which to choose a KAK gate.
            approximation_degree (float): a float between :math:`[0.0, 1.0]`. Lower approximates more.
            target (Target): The target object for the compilation target backend.
        """
        super().__init__()
        self.basis_gates = None
        self.basis_gate_name = None
        # Bypass target if it doesn't contain any basis gates (i.e. it's a _FakeTarget), as this
        # not part of the official target model.
        self.target = target if target is not None and len(target.operation_names) > 0 else None
        if basis_gates is not None:
            self.basis_gates = set(basis_gates)
        self.force_consolidate = force_consolidate
        if kak_basis_gate is not None:
            self.decomposer = TwoQubitBasisDecomposer(kak_basis_gate)
            self.basis_gate_name = kak_basis_gate.name #✅ NOW COVERED
        elif basis_gates is not None:
            kak_gates = KAK_GATE_NAMES.keys() & (basis_gates or [])
            kak_param_gates = KAK_GATE_PARAM_NAMES.keys() & (basis_gates or [])
            if kak_param_gates:
                self.decomposer = TwoQubitControlledUDecomposer(
                    KAK_GATE_PARAM_NAMES[list(kak_param_gates)[0]]
                )
                self.basis_gate_name = list(kak_param_gates)[0]
            elif kak_gates:
                self.decomposer = TwoQubitBasisDecomposer(
                    KAK_GATE_NAMES[list(kak_gates)[0]], basis_fidelity=approximation_degree or 1.0
                )
                self.basis_gate_name = list(kak_gates)[0]
            else:
                self.decomposer = None
        else:
            self.decomposer = TwoQubitBasisDecomposer(CXGate())
            self.basis_gate_name = "cx"
     # omitted
--------------------------------------------------------------------------------
```

Note: Parts of this test have been automatically generated by a novel technique that we're currently developing as part of an academic research project aiming at improving test coverage. *To not waste developer time, two researchers manually checked the test before submitting it.* We appreciate the developers' time and any feedback is welcomed. 

