### PR TITLE
Port `InstructionDurationCheck` to Rust

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -4084,7 +4084,7 @@ impl DAGCircuit {
 
     /// Total number of stretches tracked by the circuit.
     #[getter]
-    fn num_stretches(&self) -> usize {
+    pub fn num_stretches(&self) -> usize {
         self.num_captured_stretches() + self.num_declared_stretches()
     }
 

--- a/crates/pyext/src/lib.rs
+++ b/crates/pyext/src/lib.rs
@@ -48,6 +48,7 @@ fn _accelerate(m: &Bound<PyModule>) -> PyResult<()> {
     add_submodule(m, ::qiskit_transpiler::passes::filter_op_nodes_mod, "filter_op_nodes")?;
     add_submodule(m, ::qiskit_transpiler::passes::gate_direction_mod, "gate_direction")?;
     add_submodule(m, ::qiskit_transpiler::passes::gates_in_basis_mod, "gates_in_basis")?;
+    add_submodule(m, ::qiskit_transpiler::passes::instruction_duration_check_mod, "instruction_duration_check")?;
     add_submodule(m, ::qiskit_transpiler::passes::inverse_cancellation_mod, "inverse_cancellation")?;
     add_submodule(m, ::qiskit_accelerate::isometry::isometry, "isometry")?;
     add_submodule(m, ::qiskit_circuit::nlayout::nlayout, "nlayout")?;

--- a/crates/transpiler/src/passes/instruction_duration_check.rs
+++ b/crates/transpiler/src/passes/instruction_duration_check.rs
@@ -60,15 +60,14 @@ pub fn run_instruction_duration_check(
                 ));
             }
             let duration = match param {
-                Param::Float(val) => Some(*val as u32),
-                Param::Obj(val) | Param::ParameterExpression(val) => {
-                    val.bind(py).extract::<u32>().ok()
-                }
-            };
-            if let Some(duration) = duration {
-                if !(duration % acquire_align == 0 || duration % pulse_align == 0) {
-                    return Ok(true);
-                }
+                Param::Obj(val) => val.bind(py).extract::<u32>(),
+                _ => Err(TranspilerError::new_err(
+                    "Delay instruction parameter is not an object.",
+                )),
+            }?;
+
+            if !(duration % acquire_align == 0 || duration % pulse_align == 0) {
+                return Ok(true);
             }
         }
     }

--- a/crates/transpiler/src/passes/instruction_duration_check.rs
+++ b/crates/transpiler/src/passes/instruction_duration_check.rs
@@ -1,0 +1,66 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use pyo3::prelude::*;
+use pyo3::wrap_pyfunction;
+use qiskit_circuit::dag_circuit::DAGCircuit;
+use qiskit_circuit::operations::Operation;
+use qiskit_circuit::operations::Param;
+
+/// Run duration validation passes.
+///
+/// Args:
+///     dag: DAG circuit to check instruction durations.
+///     acquire_align: Integer number representing the minimum time resolution to
+///         trigger acquisition instruction in units of dt.
+///     pulse_align: Integer number representing the minimum time resolution to
+///         trigger gate instruction in units of ``dt``.
+/// Returns:
+///     True if rescheduling is required, False otherwise.
+
+#[pyfunction]
+#[pyo3(signature=(dag, acquire_align, pulse_align))]
+pub fn run_instruction_duration_check(
+    dag: &DAGCircuit,
+    acquire_align: u32,
+    pulse_align: u32,
+) -> PyResult<bool> {
+    let num_stretches = dag.num_stretches();
+
+    //Rescheduling is not necessary
+    if (acquire_align == 1 && pulse_align == 1) || num_stretches != 0 {
+        return Ok(false);
+    }
+
+    //Check delay durations
+    for (_, packed_op) in dag.op_nodes(false) {
+        if packed_op.op.name() == "delay" {
+            let params = packed_op.params_view();
+            if let Some(param) = params.first() {
+                let duration = match param {
+                    Param::Float(val) => *val as u32,
+                    _ => continue,
+                };
+
+                if !(duration % acquire_align == 0 || duration % pulse_align == 0) {
+                    return Ok(true);
+                }
+            }
+        }
+    }
+    Ok(false)
+}
+
+pub fn instruction_duration_check_mod(m: &Bound<PyModule>) -> PyResult<()> {
+    m.add_wrapped(wrap_pyfunction!(run_instruction_duration_check))?;
+    Ok(())
+}

--- a/crates/transpiler/src/passes/instruction_duration_check.rs
+++ b/crates/transpiler/src/passes/instruction_duration_check.rs
@@ -62,7 +62,7 @@ pub fn run_instruction_duration_check(
             let duration = match param {
                 Param::Obj(val) => val.bind(py).extract::<u32>(),
                 _ => Err(TranspilerError::new_err(
-                    "Delay instruction parameter is not an object.",
+                    "The provided Delay duration is not in terms of dt.",
                 )),
             }?;
 

--- a/crates/transpiler/src/passes/instruction_duration_check.rs
+++ b/crates/transpiler/src/passes/instruction_duration_check.rs
@@ -10,10 +10,11 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use qiskit_circuit::dag_circuit::DAGCircuit;
-use qiskit_circuit::operations::Operation;
+use qiskit_circuit::operations::{DelayUnit, OperationRef, StandardInstruction};
 use qiskit_circuit::operations::Param;
 
 /// Run duration validation passes.
@@ -30,29 +31,35 @@ use qiskit_circuit::operations::Param;
 #[pyfunction]
 #[pyo3(signature=(dag, acquire_align, pulse_align))]
 pub fn run_instruction_duration_check(
+    py: Python,
     dag: &DAGCircuit,
-    acquire_align: u32,
-    pulse_align: u32,
+    acquire_align: i32,
+    pulse_align: i32,
 ) -> PyResult<bool> {
     let num_stretches = dag.num_stretches();
 
-    //Rescheduling is not necessary
+    // Rescheduling is not necessary
     if (acquire_align == 1 && pulse_align == 1) || num_stretches != 0 {
         return Ok(false);
     }
 
-    //Check delay durations
+    // Check delay durations
     for (_, packed_op) in dag.op_nodes(false) {
-        if packed_op.op.name() == "delay" {
+        if let OperationRef::StandardInstruction(StandardInstruction::Delay(unit)) = packed_op.op.view() {
             let params = packed_op.params_view();
-            if let Some(param) = params.first() {
-                let duration = match param {
-                    Param::Float(val) => *val as u32,
-                    _ => continue,
-                };
+            let param = params.first().ok_or_else(|| {
+                PyValueError::new_err("Delay instruction missing duration parameter")
+            })?;
 
-                if !(duration % acquire_align == 0 || duration % pulse_align == 0) {
-                    return Ok(true);
+            if unit == DelayUnit::DT {
+                let duration = match param {
+                    Param::Float(val) => Some(*val as i32),
+                    Param::Obj(val) | Param::ParameterExpression(val) => val.bind(py).extract::<i32>().ok(),
+                };
+                if let Some(duration) = duration {
+                    if !(duration.rem_euclid(acquire_align) == 0 || duration.rem_euclid(pulse_align) == 0) {
+                        return Ok(true);
+                    }
                 }
             }
         }

--- a/crates/transpiler/src/passes/mod.rs
+++ b/crates/transpiler/src/passes/mod.rs
@@ -34,6 +34,7 @@ mod filter_op_nodes;
 mod gate_direction;
 mod gates_in_basis;
 mod high_level_synthesis;
+mod instruction_duration_check;
 mod inverse_cancellation;
 mod optimize_1q_gates_decomposition;
 mod remove_diagonal_gates_before_measure;
@@ -62,6 +63,9 @@ pub use gate_direction::{
 pub use gates_in_basis::{gates_in_basis_mod, gates_missing_from_basis, gates_missing_from_target};
 pub use high_level_synthesis::{
     high_level_synthesis_mod, run_high_level_synthesis, HighLevelSynthesisData,
+};
+pub use instruction_duration_check::{
+    instruction_duration_check_mod, run_instruction_duration_check,
 };
 pub use inverse_cancellation::{inverse_cancellation_mod, run_inverse_cancellation};
 pub use optimize_1q_gates_decomposition::{

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -118,6 +118,9 @@ sys.modules["qiskit._accelerate.synthesis.multi_controlled"] = (
 sys.modules["qiskit._accelerate.synthesis.qft"] = _accelerate.synthesis.qft
 sys.modules["qiskit._accelerate.split_2q_unitaries"] = _accelerate.split_2q_unitaries
 sys.modules["qiskit._accelerate.gate_direction"] = _accelerate.gate_direction
+sys.modules["qiskit._accelerate.instruction_duration_check"] = (
+    _accelerate.instruction_duration_check
+)
 sys.modules["qiskit._accelerate.inverse_cancellation"] = _accelerate.inverse_cancellation
 sys.modules["qiskit._accelerate.check_map"] = _accelerate.check_map
 sys.modules["qiskit._accelerate.filter_op_nodes"] = _accelerate.filter_op_nodes

--- a/qiskit/transpiler/passes/scheduling/alignments/check_durations.py
+++ b/qiskit/transpiler/passes/scheduling/alignments/check_durations.py
@@ -11,10 +11,10 @@
 # that they have been altered from the originals.
 """A pass to check if input circuit requires reschedule."""
 
-from qiskit.circuit.delay import Delay
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import AnalysisPass
 from qiskit.transpiler.target import Target
+from qiskit._accelerate.instruction_duration_check import run_instruction_duration_check
 
 
 class InstructionDurationCheck(AnalysisPass):
@@ -56,15 +56,6 @@ class InstructionDurationCheck(AnalysisPass):
         Args:
             dag: DAG circuit to check instruction durations.
         """
-        self.property_set["reschedule_required"] = False
-
-        # Rescheduling is not necessary
-        if (self.acquire_align == 1 and self.pulse_align == 1) or dag.num_stretches != 0:
-            return
-
-        # Check delay durations
-        for delay_node in dag.op_nodes(Delay):
-            dur = delay_node.op.duration
-            if not (dur % self.acquire_align == 0 and dur % self.pulse_align == 0):
-                self.property_set["reschedule_required"] = True
-                return
+        self.property_set["reschedule_required"] = run_instruction_duration_check(
+            dag, self.acquire_align, self.pulse_align
+        )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR ports the `InstructionDurationCheck` analysis pass from Python to Rust for improved performance and integration with the Qiskit transpiler. No changes to pass logic or user-facing behavior are introduced.

### Details and comments

- Fixes #12267 
- As part of this port, I had to make the `num_stretches` method in `DAGCircuit` public to allow access from the new Rust pass.

