### PR TITLE
Add test for `coerce_observable` method of `ObservablesArray` (invalid keys of the mapping)

### DIFF
--- a/test/python/primitives/containers/test_observables_array.py
+++ b/test/python/primitives/containers/test_observables_array.py
@@ -22,6 +22,8 @@ from qiskit.providers.basic_provider import BasicSimulator
 from qiskit.primitives import BackendEstimatorV2
 from qiskit.primitives.containers.observables_array import ObservablesArray, object_array
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
+import unittest
+from qiskit.primitives.containers.observables_array import ObservablesArray, SparseObservable
 
 
 @ddt.ddt
@@ -622,3 +624,9 @@ class ObservablesArrayTestCase(QiskitTestCase):
         arr2 = obsarray.sparse_observables_array(copy=False)
         self.assertEqual(arr2, arr)
         self.assertEqual(id(arr2), id(arr))
+
+    def test_invalid_basis_type_raises_type_error(self):
+        """Test that invalid basis type raises TypeError"""
+        invalid_basis = {1: 'value', 2: 'another_value'}  # Invalid keys (integers)
+        with self.assertRaises(TypeError):
+            ObservablesArray.coerce_observable(invalid_basis)

--- a/test/python/primitives/containers/test_observables_array.py
+++ b/test/python/primitives/containers/test_observables_array.py
@@ -20,10 +20,11 @@ import qiskit.quantum_info as qi
 from qiskit import QuantumCircuit
 from qiskit.providers.basic_provider import BasicSimulator
 from qiskit.primitives import BackendEstimatorV2
-from qiskit.primitives.containers.observables_array import ObservablesArray, object_array
+from qiskit.primitives.containers.observables_array import (
+    ObservablesArray,
+    object_array,
+)
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
-import unittest
-from qiskit.primitives.containers.observables_array import ObservablesArray, SparseObservable
 
 
 @ddt.ddt

--- a/test/python/primitives/containers/test_observables_array.py
+++ b/test/python/primitives/containers/test_observables_array.py
@@ -628,6 +628,6 @@ class ObservablesArrayTestCase(QiskitTestCase):
 
     def test_invalid_basis_type_raises_type_error(self):
         """Test that invalid basis type raises TypeError"""
-        invalid_basis = {1: 'value', 2: 'another_value'}  # Invalid keys (integers)
+        invalid_basis = {1: "value", 2: "another_value"}  # Invalid keys (integers)
         with self.assertRaises(TypeError):
             ObservablesArray.coerce_observable(invalid_basis)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR adds a test for the `coerce_observable` method in the `ObservablesArray` class. The test checks that a `TypeError` is raised when an invalid basis type (integers as keys in a dictionary) is provided. The test covers a corner case introduced in [PR #14132](https://github.com/Qiskit/qiskit/pull/14132) that previously lacked test coverage.

### Details and comments
This new test adds coverage to the following lines:
```python
--------------------------------------------------------------------------------
# qiskit/primitives/containers/observables_array.py
--------------------------------------------------------------------------------
    # omitted

    @classmethod
    def coerce_observable(cls, observable: ObservableLike) -> SparseObservable:
        """Format an observable-like object into the internal format.

        Args:
            observable: The observable-like to format.

        Returns:
            The coerced observable.

        Raises:
            TypeError: If the input cannot be formatted because its type is not valid.
            ValueError: If the input observable is invalid.
        """
        # Pauli-type conversions
        if isinstance(observable, SparsePauliOp):
            observable = SparseObservable.from_sparse_pauli_op(observable)
        elif isinstance(observable, Pauli):
            observable = SparseObservable.from_pauli(observable)
        elif isinstance(observable, str):
            observable = SparseObservable.from_label(observable)
        elif isinstance(observable, _Mapping):
            term_list = []
            for basis, coeff in observable.items():
                if isinstance(basis, str):
                    term_list.append((basis, coeff))
                elif isinstance(basis, Pauli):
                    unphased_basis, phase = basis[:].to_label(), basis.phase
                    term_list.append((unphased_basis, complex(0, 1) ** phase * coeff))
                else:
                    raise TypeError(f"Invalid observable basis type: {type(basis)}") #✅ NOW COVERED
            observable = SparseObservable.from_list(term_list)
    # omitted

--------------------------------------------------------------------------------
```

Note: Parts of this test have been automatically generated by a novel technique that we're currently developing as part of an academic research project aiming at improving test coverage. *To not waste developer time, two researchers manually checked the test before submitting it.* We appreciate the developers' time and any feedback is welcomed. 
