### PR TITLE
Remove py token from the dag_to_circuit signature

### DIFF
--- a/crates/accelerate/src/twirling.rs
+++ b/crates/accelerate/src/twirling.rs
@@ -344,7 +344,7 @@ fn generate_twirled_circuit(
     if optimizer_target.is_some() {
         let mut dag = DAGCircuit::from_circuit_data(out_circ, false)?;
         run_optimize_1q_gates_decomposition(&mut dag, optimizer_target, None, None)?;
-        dag_to_circuit(py, &dag, false)
+        dag_to_circuit(&dag, false)
     } else {
         Ok(out_circ)
     }

--- a/crates/circuit/src/converters.rs
+++ b/crates/circuit/src/converters.rs
@@ -55,11 +55,7 @@ pub fn circuit_to_dag(
 }
 
 #[pyfunction(signature = (dag, copy_operations = true))]
-pub fn dag_to_circuit(
-    py: Python,
-    dag: &DAGCircuit,
-    copy_operations: bool,
-) -> PyResult<CircuitData> {
+pub fn dag_to_circuit(dag: &DAGCircuit, copy_operations: bool) -> PyResult<CircuitData> {
     CircuitData::from_packed_instructions(
         dag.qubits().clone(),
         dag.clbits().clone(),
@@ -77,11 +73,15 @@ pub fn dag_to_circuit(
             };
             if copy_operations {
                 let op = match instr.op.view() {
-                    OperationRef::Gate(gate) => gate.py_deepcopy(py, None)?.into(),
-                    OperationRef::Instruction(instruction) => {
-                        instruction.py_deepcopy(py, None)?.into()
+                    OperationRef::Gate(gate) => {
+                        Python::with_gil(|py| gate.py_deepcopy(py, None))?.into()
                     }
-                    OperationRef::Operation(operation) => operation.py_deepcopy(py, None)?.into(),
+                    OperationRef::Instruction(instruction) => {
+                        Python::with_gil(|py| instruction.py_deepcopy(py, None))?.into()
+                    }
+                    OperationRef::Operation(operation) => {
+                        Python::with_gil(|py| operation.py_deepcopy(py, None))?.into()
+                    }
                     OperationRef::StandardGate(gate) => gate.into(),
                     OperationRef::StandardInstruction(instruction) => instruction.into(),
                     OperationRef::Unitary(unitary) => unitary.clone().into(),
@@ -90,13 +90,7 @@ pub fn dag_to_circuit(
                     op,
                     qubits: instr.qubits,
                     clbits: instr.clbits,
-                    params: Some(Box::new(
-                        instr
-                            .params_view()
-                            .iter()
-                            .map(|param| param.clone_ref(py))
-                            .collect(),
-                    )),
+                    params: Some(Box::new(instr.params_view().iter().cloned().collect())),
                     label: instr.label.clone(),
                     #[cfg(feature = "cache_pygates")]
                     py_op: OnceLock::new(),

--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -973,7 +973,7 @@ pub fn run_high_level_synthesis(
         // Regular-path: we synthesize the circuit recursively. Except for
         // this conversion from DAGCircuit to CircuitData and back, all
         // the recursive functions work with CircuitData objects only.
-        let circuit = dag_to_circuit(py, dag, false)?;
+        let circuit = dag_to_circuit(dag, false)?;
 
         let num_qubits = circuit.num_qubits();
         let input_qubits: Vec<usize> = (0..num_qubits).collect();


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit remove the py token from the dag_to_circuit signature. This enables calling this function from a standalone C context. The python usage in the function only comes into play if there are Python defined operations and we need to deepcopy them, or if there are any ParameterExpression for an instruction which needs to clone it. Since neither ParameterExpression or Python defined objects can exist in C we can avoid the py usage in those paths. For the ParameterExpression path since we have the py-clone feature enabled we can simply just replace the clone_ref() call with a clone() call. This has extra overhead equivalent to acquiring the gil explicitly but avoids the explicit python usage. When we have ParameterExpression in Rust this usage will continue to work because it will clone the rust object instead of dispatching to Python under the covers.

### Details and comments