### PR TITLE
Add ElidePermutations standalone function to the C API

### DIFF
--- a/crates/cext/cbindgen.toml
+++ b/crates/cext/cbindgen.toml
@@ -53,3 +53,4 @@ prefix_with_name = true
 "Target" = "QkTarget"
 "TargetEntry" = "QkTargetEntry"
 "VF2LayoutResult" = "QkVF2LayoutResult"
+"ElidePermutationsResult" = "QkElidePermutationsResult"

--- a/crates/cext/src/transpiler/passes/elide_permutations.rs
+++ b/crates/cext/src/transpiler/passes/elide_permutations.rs
@@ -109,10 +109,6 @@ pub unsafe extern "C" fn qk_elide_permutations_result_permutation(
 ///
 /// @param result a pointer to the result object to free
 ///
-/// # Example
-///
-///     QkCircuit *qc = qk_circuit_new(1, 0);
-///
 /// # Safety
 ///
 /// Behavior is undefined if ``layout`` is not a valid, non-null pointer to a

--- a/crates/cext/src/transpiler/passes/elide_permutations.rs
+++ b/crates/cext/src/transpiler/passes/elide_permutations.rs
@@ -1,0 +1,195 @@
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use crate::pointers::const_ptr_as_ref;
+
+use qiskit_circuit::circuit_data::CircuitData;
+use qiskit_circuit::converters::dag_to_circuit;
+use qiskit_circuit::dag_circuit::DAGCircuit;
+use qiskit_transpiler::passes::run_elide_permutations;
+
+/// The result from ``qk_transpiler_pass_standalone_elide_permutations()``.
+pub struct ElidePermutationsResult {
+    elided: bool,
+    circuit: Option<CircuitData>,
+    permutation: Option<Vec<usize>>,
+}
+
+/// @ingroup QkElidePermutationsResult
+/// Check whether the elide permutations was able to elide anything
+///
+/// @param result a pointer to the result
+///
+/// @returns ``true`` if the ``qk_transpiler_pass_standalone_elide_permutations()`` run elided any gates
+///
+/// # Safety
+///
+/// Behavior is undefined if ``result`` is not a valid, non-null pointer to a
+/// ``QkVF2LayoutResult``.
+#[no_mangle]
+#[cfg(feature = "cbinding")]
+pub unsafe extern "C" fn qk_elide_permutations_result_elided_gates(
+    result: *const ElidePermutationsResult,
+) -> bool {
+    let result = unsafe { const_ptr_as_ref(result) };
+    result.elided
+}
+
+/// @ingroup QkElidePermutationsResult
+/// Get the circuit from the elide permutations result
+///
+/// @param result a pointer to the result of the pass. It must have elided gates as checked by
+/// ``qk_elide_permutations_result_elided_gates()``
+///
+/// @returns A pointer to a circuit with the elide
+///
+/// # Safety
+///
+/// Behavior is undefined if ``result`` is not a valid, non-null pointer to a
+/// ``QkVF2LayoutResult``. The pointer to the returned circuit is owned by the
+/// result object, it should not be passed to ``qk_circuit_free()`` as it will
+/// be freed by ``qk_elide_permutations_result_free()``.
+#[no_mangle]
+#[cfg(feature = "cbinding")]
+pub unsafe extern "C" fn qk_elide_permutations_result_circuit(
+    result: *const ElidePermutationsResult,
+) -> *const CircuitData {
+    let result = unsafe { const_ptr_as_ref(result) };
+    result
+        .circuit
+        .as_ref()
+        .map(|x| x as *const _)
+        .expect("Result didn't elide any gates")
+}
+
+/// @ingroup QkElidePermutationsResult
+/// Get the permutation array for the elided gates
+///
+/// @param result a pointer to the result of the pass. It must have elided gates as checked by
+/// ``qk_elide_permutations_result_elided_gates()``
+///
+/// @returns A pointer to the permutation array caused by the swap elision performed by the
+/// pass. This array has a length equal to the number of qubits of the circuit returned by
+/// ``qk_elide_permutations_result_elided_gates()`` (or the circuit passed into
+/// ``qk_transpiler_pass_standalone_elide_permutations()``). The permutation array maps the
+/// virtual qubit in the original circuit at each index to its new output position after all
+/// the elision performed by the pass. For example, and array of ``[2, 1, 0]`` means that
+/// qubit 0 is now in qubit 2 on the output of the circuit and qubit 2's is now at 0 (qubit 1
+/// remains unchanged)
+///
+/// # Safety
+///
+/// Behavior is undefined if ``layout`` is not a valid, non-null pointer to a
+/// ``QkVF2LayoutResult``. Also qubit must be a valid qubit for the circuit and
+/// there must be a result found. The pointer to the permutation array is owned by the
+/// result object, it should not be passed to ``free()`` as it will be freed by
+/// ``qk_elide_permutations_result_free()`` when that is called.
+#[no_mangle]
+#[cfg(feature = "cbinding")]
+pub unsafe extern "C" fn qk_elide_permutations_result_permutation(
+    result: *const ElidePermutationsResult,
+) -> *const usize {
+    let result = unsafe { const_ptr_as_ref(result) };
+    result
+        .permutation
+        .as_ref()
+        .map(|x| x.as_ptr())
+        .expect("Result didn't elide any gates")
+}
+
+/// @ingroup QkVF2LayoutResult
+/// Free a ``QkVF2LayoutResult`` object
+///
+/// @param layout a pointer to the layout to free
+///
+/// # Example
+///
+///     QkCircuit *qc = qk_circuit_new(1, 0);
+///
+/// # Safety
+///
+/// Behavior is undefined if ``layout`` is not a valid, non-null pointer to a
+/// ``QkElidePermutationsResult``.
+#[no_mangle]
+#[cfg(feature = "cbinding")]
+pub unsafe extern "C" fn qk_elide_permutations_result_free(result: *mut ElidePermutationsResult) {
+    if !result.is_null() {
+        if !result.is_aligned() {
+            panic!("Attempted to free a non-aligned pointer.")
+        }
+        // SAFETY: We have verified the pointer is non-null and aligned, so
+        // it should be readable by Box.
+        unsafe {
+            let _ = Box::from_raw(result);
+        }
+    }
+}
+
+/// @ingroup QkTranspilerPasses
+/// Run the ElidePermutations transpiler pass on a circuit.
+///
+/// The ElidePermutations transpiler pass removes any permutation operations from a pre-layout
+/// circuit.
+///
+/// This pass is intended to be run before a layout (mapping virtual qubits to physical qubits) is
+/// set during the transpilation pipeline. This pass iterates over the circuit
+/// and when a Swap gate is encountered it permutes the virtual qubits in
+/// the circuit and removes the swap gate. This will effectivelyt remove any
+/// swap gates in the cirucit prior to running layout. This optimization is
+/// not valid after a layout has been set and should not be run in this case.
+///
+/// @param circuit A pointer to the circuit to run ElidePermutations on
+///
+/// @return QkElidePermutationsResult object that contains the results of the pass
+///
+/// # Example
+///
+/// ```c
+///     QkCircuit *qc = qk_circuit_new(4, 0);
+///     for (uint32_t i = 0; i < qk_circuit_num_qubits(qc) - 1; i++) {
+///         uint32_t qargs[2] = {i, i + 1};
+///         for (uint32_t j = 0; j<i+1; j++) {
+///             qk_circuit_gate(qc, QkGate_CX, qargs, NULL);
+///         }
+///     }
+///     QkElidePermutationsResult *elide_result = qk_transpiler_pass_standalone_elide_permutations(qc);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``circuit`` or ``target`` is not a valid, non-null pointer to a ``QkCircuit`` and ``QkTarget``.
+#[no_mangle]
+#[cfg(feature = "cbinding")]
+pub unsafe extern "C" fn qk_transpiler_pass_standalone_elide_permutations(
+    circuit: *const CircuitData,
+) -> *mut ElidePermutationsResult {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let circuit = unsafe { const_ptr_as_ref(circuit) };
+    let dag = match DAGCircuit::from_circuit_data(circuit, false, None, None, None, None) {
+        Ok(dag) => dag,
+        Err(e) => panic!("{}", e),
+    };
+    let res = match run_elide_permutations(&dag) {
+        Ok(res) => res,
+        Err(e) => panic!("{}", e),
+    };
+    match res {
+        Some(res) => Box::into_raw(Box::new(ElidePermutationsResult {
+            elided: true,
+            circuit: Some(dag_to_circuit(&res.0, false).expect("DAG to Circuit conversion failed")),
+            permutation: Some(res.1),
+        })),
+        None => Box::into_raw(Box::new(ElidePermutationsResult {
+            elided: false,
+            circuit: None,
+            permutation: None,
+        })),
+    }
+}

--- a/crates/cext/src/transpiler/passes/elide_permutations.rs
+++ b/crates/cext/src/transpiler/passes/elide_permutations.rs
@@ -32,7 +32,7 @@ pub struct ElidePermutationsResult {
 /// # Safety
 ///
 /// Behavior is undefined if ``result`` is not a valid, non-null pointer to a
-/// ``QkVF2LayoutResult``.
+/// ``QkElidePermutationsResult``.
 #[no_mangle]
 #[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_elide_permutations_result_elided_gates(
@@ -48,12 +48,12 @@ pub unsafe extern "C" fn qk_elide_permutations_result_elided_gates(
 /// @param result a pointer to the result of the pass. It must have elided gates as checked by
 /// ``qk_elide_permutations_result_elided_gates()``
 ///
-/// @returns A pointer to a circuit with the elide
+/// @returns A pointer to the circuit with the permutation gates elided
 ///
 /// # Safety
 ///
 /// Behavior is undefined if ``result`` is not a valid, non-null pointer to a
-/// ``QkVF2LayoutResult``. The pointer to the returned circuit is owned by the
+/// ``QkElidePermutationsResult``. The pointer to the returned circuit is owned by the
 /// result object, it should not be passed to ``qk_circuit_free()`` as it will
 /// be freed by ``qk_elide_permutations_result_free()``.
 #[no_mangle]
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn qk_elide_permutations_result_circuit(
 /// # Safety
 ///
 /// Behavior is undefined if ``layout`` is not a valid, non-null pointer to a
-/// ``QkVF2LayoutResult``. Also qubit must be a valid qubit for the circuit and
+/// ``QkElidePermutationsResult``. Also qubit must be a valid qubit for the circuit and
 /// there must be a result found. The pointer to the permutation array is owned by the
 /// result object, it should not be passed to ``free()`` as it will be freed by
 /// ``qk_elide_permutations_result_free()`` when that is called.
@@ -104,10 +104,10 @@ pub unsafe extern "C" fn qk_elide_permutations_result_permutation(
         .expect("Result didn't elide any gates")
 }
 
-/// @ingroup QkVF2LayoutResult
-/// Free a ``QkVF2LayoutResult`` object
+/// @ingroup QkElidePermutationsResult
+/// Free a ``QkElidePermutationsResult`` object
 ///
-/// @param layout a pointer to the layout to free
+/// @param result a pointer to the result object to free
 ///
 /// # Example
 ///
@@ -141,7 +141,7 @@ pub unsafe extern "C" fn qk_elide_permutations_result_free(result: *mut ElidePer
 /// This pass is intended to be run before a layout (mapping virtual qubits to physical qubits) is
 /// set during the transpilation pipeline. This pass iterates over the circuit
 /// and when a Swap gate is encountered it permutes the virtual qubits in
-/// the circuit and removes the swap gate. This will effectivelyt remove any
+/// the circuit and removes the swap gate. This will effectively remove any
 /// swap gates in the cirucit prior to running layout. This optimization is
 /// not valid after a layout has been set and should not be run in this case.
 ///
@@ -164,7 +164,7 @@ pub unsafe extern "C" fn qk_elide_permutations_result_free(result: *mut ElidePer
 ///
 /// # Safety
 ///
-/// Behavior is undefined if ``circuit`` or ``target`` is not a valid, non-null pointer to a ``QkCircuit`` and ``QkTarget``.
+/// Behavior is undefined if ``circuit``  is not a valid, non-null pointer to a ``QkCircuit``.
 #[no_mangle]
 #[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpiler_pass_standalone_elide_permutations(

--- a/crates/cext/src/transpiler/passes/mod.rs
+++ b/crates/cext/src/transpiler/passes/mod.rs
@@ -1,1 +1,2 @@
+pub mod elide_permutations;
 pub mod vf2;

--- a/docs/cdoc/index.h
+++ b/docs/cdoc/index.h
@@ -41,3 +41,7 @@
 /**
  * @defgroup QkVF2LayoutResult QkVF2LayoutResult
  */
+
+/**
+ * @defgroup QkElidePermutationsResult QkElidePermutationsResult
+ */

--- a/docs/cdoc/index.rst
+++ b/docs/cdoc/index.rst
@@ -61,7 +61,8 @@ results transpiling circuits from Python via the C API.
 .. toctree::
    :maxdepth: 1
 
-   qk-transpiler-passes
-   qk-vf2-layout-result
    qk-target
    qk-target-entry
+   qk-transpiler-passes
+   qk-vf2-layout-result
+   qk-elide-permutations-result

--- a/docs/cdoc/qk-elide-permutations-result.rst
+++ b/docs/cdoc/qk-elide-permutations-result.rst
@@ -1,0 +1,19 @@
+=========================
+QkElidePermutationsResult
+=========================
+
+.. code-block:: c
+
+   typedef struct QkElidePermutationsResult QkElidePermutationsResult
+
+When running the ``qk_transpiler_pass_standalone_elide_permutations`` function it returns a
+modified circuit and a permutation array as a QkElidePermutationsResult object. This object
+contains the outcome of the transpiler pass, whether the pass was able to elide any gates or not,
+and what the results of that elision were.
+
+Functions
+=========
+
+.. doxygengroup:: QkElidePermutationsResult
+   :members:
+   :content-only:

--- a/test/c/test_elide_permutations.c
+++ b/test/c/test_elide_permutations.c
@@ -26,7 +26,7 @@
 int test_elide_permutations_no_result(void) {
     const uint32_t num_qubits = 5;
 
-    QkCircuit *qc = qk_circuit_new(5, 0);
+    QkCircuit *qc = qk_circuit_new(num_qubits, 0);
     for (uint32_t i = 0; i < qk_circuit_num_qubits(qc) - 1; i++) {
         uint32_t qargs[2] = {i, i + 1};
         for (uint32_t j = 0; j < i + 1; j++) {

--- a/test/c/test_elide_permutations.c
+++ b/test/c/test_elide_permutations.c
@@ -36,7 +36,7 @@ int test_elide_permutations_no_result(void) {
     int result = Ok;
     QkElidePermutationsResult *pass_result = qk_transpiler_pass_standalone_elide_permutations(qc);
     if (qk_elide_permutations_result_elided_gates(pass_result)) {
-        printf("A gate was elideed when one shouldn't have been");
+        printf("A gate was elided when one shouldn't have been");
         result = EqualityError;
         goto result_cleanup;
     }
@@ -67,7 +67,7 @@ int test_elide_permutations_swap_result(void) {
     int result = Ok;
     QkElidePermutationsResult *pass_result = qk_transpiler_pass_standalone_elide_permutations(qc);
     if (!qk_elide_permutations_result_elided_gates(pass_result)) {
-        printf("A gate wasn't elideed when one should have been");
+        printf("A gate wasn't elided when one should have been");
         result = EqualityError;
         goto result_cleanup;
     }
@@ -83,7 +83,7 @@ int test_elide_permutations_swap_result(void) {
     }
     QkOpCounts op_counts = qk_circuit_count_ops(modified_circuit);
     if (op_counts.len != 1) {
-        printf("more than 1 type of gates in circuit");
+        printf("More than 1 type of gates in circuit");
         result = EqualityError;
         goto result_cleanup;
     }

--- a/test/c/test_elide_permutations.c
+++ b/test/c/test_elide_permutations.c
@@ -1,0 +1,115 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+#include "common.h"
+#include <complex.h>
+#include <math.h>
+#include <qiskit.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/**
+ * Test running the path with no elision.
+ */
+int test_elide_permutations_no_result(void) {
+    const uint32_t num_qubits = 5;
+
+    QkCircuit *qc = qk_circuit_new(5, 0);
+    for (uint32_t i = 0; i < qk_circuit_num_qubits(qc) - 1; i++) {
+        uint32_t qargs[2] = {i, i + 1};
+        for (uint32_t j = 0; j < i + 1; j++) {
+            qk_circuit_gate(qc, QkGate_CX, qargs, NULL);
+        }
+    }
+    int result = Ok;
+    QkElidePermutationsResult *pass_result = qk_transpiler_pass_standalone_elide_permutations(qc);
+    if (qk_elide_permutations_result_elided_gates(pass_result)) {
+        printf("A gate was elideed when one shouldn't have been");
+        result = EqualityError;
+        goto result_cleanup;
+    }
+result_cleanup:
+    qk_elide_permutations_result_free(pass_result);
+cleanup:
+    qk_circuit_free(qc);
+    return result;
+}
+
+/**
+ * Test running the path with no elision.
+ */
+int test_elide_permutations_swap_result(void) {
+    const uint32_t num_qubits = 5;
+
+    QkCircuit *qc = qk_circuit_new(5, 0);
+    uint32_t swap_qargs[2] = {1, 3};
+    for (uint32_t i = 0; i < qk_circuit_num_qubits(qc) - 1; i++) {
+        uint32_t qargs[2] = {i, i + 1};
+        for (uint32_t j = 0; j < i + 1; j++) {
+            qk_circuit_gate(qc, QkGate_CX, qargs, NULL);
+        }
+        if (i == 2) {
+            qk_circuit_gate(qc, QkGate_Swap, swap_qargs, NULL);
+        }
+    }
+    int result = Ok;
+    QkElidePermutationsResult *pass_result = qk_transpiler_pass_standalone_elide_permutations(qc);
+    if (!qk_elide_permutations_result_elided_gates(pass_result)) {
+        printf("A gate wasn't elideed when one should have been");
+        result = EqualityError;
+        goto result_cleanup;
+    }
+    QkCircuit *modified_circuit = qk_elide_permutations_result_circuit(pass_result);
+    size_t *permutation = qk_elide_permutations_result_permutation(pass_result);
+    size_t expected_permutation[5] = {0, 3, 2, 1, 4};
+    for (int i = 0; i < 5; i++) {
+        if (permutation[i] != expected_permutation[i]) {
+            printf("Permutation doesn't match expected");
+            result = EqualityError;
+            goto result_cleanup;
+        }
+    }
+    QkOpCounts op_counts = qk_circuit_count_ops(modified_circuit);
+    if (op_counts.len != 1) {
+        printf("more than 1 type of gates in circuit");
+        result = EqualityError;
+        goto result_cleanup;
+    }
+    for (int i = 0; i < op_counts.len; i++) {
+        int swap_gate = strcmp(op_counts.data[i].name, "swap");
+        if (swap_gate == 0) {
+            printf("Swap gate in circuit which should have been elided");
+            result = EqualityError;
+            goto result_cleanup;
+        }
+    }
+
+result_cleanup:
+    qk_elide_permutations_result_free(pass_result);
+cleanup:
+    qk_circuit_free(qc);
+    return result;
+}
+
+int test_elide_permutations(void) {
+    int num_failed = 0;
+    num_failed += RUN_TEST(test_elide_permutations_no_result);
+    num_failed += RUN_TEST(test_elide_permutations_swap_result);
+
+    fflush(stderr);
+    fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);
+
+    return num_failed;
+}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a standalone transpiler pass function to the C API for
running the ElidePermutations transpiler pass. This function returns a
new result type QkElidePermutationsResult that tracks whether there was
any elision performed, and in addition to containing the circuit it also
returns an output permutation array that is induced by any elision
performed by the pass.

### Details and comments

Fixes #14442

~This PR is based on top of #14699, #14707, and #14668 and will need to be rebased once all 3 merge. In the meantime you can review just the contents of this PR by looking at the HEAD commit on the PR: a5d30cf~ This has been rebased and is unblocked now.