### PR TITLE
Fixed a bug where nonequal boxes were considered equal

### DIFF
--- a/qiskit/dagcircuit/dagnode.py
+++ b/qiskit/dagcircuit/dagnode.py
@@ -174,6 +174,7 @@ def _for_loop_eq(node1, node2, bit_indices1, bit_indices2):
 def _box_eq(node1, node2, bit_indices1, bit_indices2):
     return (
         (node1.op.duration == node2.op.duration)
+        and (node1.op.unit == node2.op.unit)
         and (
             _circuit_to_dag(node1.op.blocks[0], node1.qargs, node1.cargs, bit_indices1)
             == _circuit_to_dag(node2.op.blocks[0], node2.qargs, node2.cargs, bit_indices2)

--- a/releasenotes/notes/fix-box-eq-check-1ff339fcc1db983f.yaml
+++ b/releasenotes/notes/fix-box-eq-check-1ff339fcc1db983f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a bug in the dagnode equality check, where for a box the `unit` field
+    was not being compared.

--- a/releasenotes/notes/fix-box-eq-check-1ff339fcc1db983f.yaml
+++ b/releasenotes/notes/fix-box-eq-check-1ff339fcc1db983f.yaml
@@ -1,5 +1,8 @@
 ---
 fixes:
   - |
-    Fixed a bug in the dagnode equality check, where for a box the `unit` field
+    Fixed a bug in the :class:`.DAGOpNode` equality check, where comparing two :class:`.DAGOpNode`
+    objects that contain a :class:`.BoxOp` instruction. Previously, the :attr:`.BoxOp.unit` attribute was not
+    considered as part of the equality check which could lead to a two unequal nodes be evaluated as
+    equal.
     was not being compared.

--- a/releasenotes/notes/fix-box-eq-check-1ff339fcc1db983f.yaml
+++ b/releasenotes/notes/fix-box-eq-check-1ff339fcc1db983f.yaml
@@ -5,4 +5,3 @@ fixes:
     objects that contain a :class:`.BoxOp` instruction. Previously, the :attr:`.BoxOp.unit` attribute was not
     considered as part of the equality check which could lead to a two unequal nodes be evaluated as
     equal.
-    was not being compared.

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -46,6 +46,7 @@ from qiskit.circuit import (
     WhileLoopOp,
     CASE_DEFAULT,
     Store,
+    BoxOp,
 )
 from qiskit.circuit.classical import expr, types
 from qiskit.circuit.library import (
@@ -1734,6 +1735,34 @@ class TestDagEquivalence(QiskitTestCase):
         node2 = DAGOpNode(op=instruction2, qargs=(qubit1, qubit2), cargs=())
 
         self.assertEqual(node1, node2)
+
+    def test_boxop_neq(self):
+        """Test non equality of nonequal DAGOpNodes and QuantumCircuits containing BoxOp gates."""
+        qc = QuantumCircuit()
+
+        box1 = BoxOp(body=qc, duration=300.0, unit="dt")
+        box2 = BoxOp(body=qc, duration=300.0, unit="ms")
+        node1 = DAGOpNode(op=box1, qargs=(), cargs=())
+        node2 = DAGOpNode(op=box2, qargs=(), cargs=())
+        self.assertNotEqual(node1, node2)
+
+        qc1 = QuantumCircuit()
+        qc2 = QuantumCircuit()
+        qc1.append(box1)
+        qc2.append(box2)
+        self.assertNotEqual(qc1, qc2)
+
+        box1 = BoxOp(body=qc, duration=300.0, unit="dt")
+        box2 = BoxOp(body=qc, duration=200.0, unit="dt")
+        node1 = DAGOpNode(op=box1, qargs=(), cargs=())
+        node2 = DAGOpNode(op=box2, qargs=(), cargs=())
+        self.assertNotEqual(node1, node2)
+
+        qc1 = QuantumCircuit()
+        qc2 = QuantumCircuit()
+        qc1.append(box1)
+        qc2.append(box2)
+        self.assertNotEqual(qc1, qc2)
 
     def test_dag_eq(self):
         """DAG equivalence check: True."""


### PR DESCRIPTION
### Summary
Fixes `_box_eq` to return non equality when the boxes have different `unit` fields.

### Details and comments
It seems `_box_eq` is invoked only when comparing circuits, not `DAGOpNode`s. There might be other cases we miss in other nodes due to the stricter check used by `DAGOpNode`.
