### PR TITLE
Add RemoveIdentityEquiv to the C API

### DIFF
--- a/crates/cext/src/transpiler/passes/mod.rs
+++ b/crates/cext/src/transpiler/passes/mod.rs
@@ -1,1 +1,2 @@
+pub mod remove_identity_equiv;
 pub mod vf2;

--- a/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
+++ b/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
@@ -28,12 +28,12 @@ use qiskit_transpiler::target::Target;
 /// gate fidelity with respect to the identity is below :math:`f`. Concretely,
 /// a gate :math:`G` is removed if :math:`\bar F < f` where
 ///
-/// $bar{F} = \frac{1 + d F_{\text{process}}}{1 + d},F_{\text{process}} =
-/// \frac{|\mathrm{Tr}(G)|^2}{d^2}$
+/// $bar{F} = \frac{1 + d F_{\text{process}}}{1 + d},F_{\text{process}} = \frac{|\mathrm{Tr}(G)|^2}{d^2}$
 ///
 /// where $d = 2^n$ is the dimension of the gate for $n$ qubits.
 ///
-/// @param circuit A pointer to the circuit to run RemoveIdentityEquivalent on
+/// @param circuit A pointer to the circuit to run RemoveIdentityEquivalent on. This circuit
+/// pointed to will be updated with the modified circuit if the pass is able to remove any gates.
 /// @param target The target for the RemoveIdentityEquivalent pass. If ``approximation_degree`` is set to
 /// ``NAN`` the tolerance for determining whether an operation is equivalent to
 /// identity will be set to the reported error rate in the target. Otherwise
@@ -43,8 +43,6 @@ use qiskit_transpiler::target::Target;
 /// approximate above the floating point precision. For a value < 1 this is used as a
 /// scaling factor for the cutoff fidelity. If the value is ``NAN`` this approximates up
 /// to the fidelity for the gate specified in ``target``.
-///
-/// @return QkCircuit A pointer to a new circuit which results from running the pass.
 ///
 /// # Example
 ///

--- a/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
+++ b/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
@@ -1,0 +1,101 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use crate::pointers::const_ptr_as_ref;
+
+use qiskit_circuit::circuit_data::CircuitData;
+use qiskit_circuit::converters::dag_to_circuit;
+use qiskit_circuit::dag_circuit::DAGCircuit;
+use qiskit_transpiler::passes::run_remove_identity_equiv;
+use qiskit_transpiler::target::Target;
+
+/// @ingroup QkTranspilerPasses
+/// Run the RemoveIdentityEquivalent transpiler pass on a circuit.
+///
+/// Removes gates whose effect is close to an identity operation up to a global phase
+/// and up to the specified tolerance. Parameterized gates are not considered by this pass.
+///
+/// For a cutoff fidelity :math:`f`, this pass removes gates whose average
+/// gate fidelity with respect to the identity is below :math:`f`. Concretely,
+/// a gate :math:`G` is removed if :math:`\bar F < f` where
+///
+/// $bar{F} = \frac{1 + d F_{\text{process}}}{1 + d},F_{\text{process}} =
+/// \frac{|\mathrm{Tr}(G)|^2}{d^2}$
+///
+/// where $d = 2^n$ is the dimension of the gate for $n$ qubits.
+///
+/// @param circuit A pointer to the circuit to run RemoveIdentityEquivalent on
+/// @param target The target for the RemoveIdentityEquivalent pass. If ``approximation_degree`` is set to
+/// ``NAN`` the tolerance for determining whether an operation is equivalent to
+/// identity will be set to the reported error rate in the target. Otherwise
+/// the ``target`` is not used as the tolerance is independent of the target.
+/// @param approximation_degree The degree to approximate for the equivalence check. This can be a
+/// floating point value between 0 and 1, or ``NAN``. If the value is 1 this does not
+/// approximate above the floating point precision. For a value < 1 this is used as a
+/// scaling factor for the cutoff fidelity. If the value is ``NAN`` this approximates up
+/// to the fidelity for the gate specified in ``target``.
+///
+/// @return QkCircuit A pointer to a new circuit which results from running the pass.
+///
+/// # Example
+///
+/// ```c
+///     QkTarget *target = qk_target_new(5)
+///     QkTargetEntry *cx_entry = qk_target_entry_new(QkGate_CX);
+///     for (uint32_t i = 0; i < current_num_qubits - 1; i++) {
+///         uint32_t qargs[2] = {i, i + 1};
+///         double inst_error = 0.0090393 * (current_num_qubits - i);
+///         double inst_duration = 0.020039;
+///         qk_target_entry_add_property(cx_entry, qargs, 2, inst_duration, inst_error);
+///     }
+///     QkExitCode result_cx = qk_target_add_instruction(target, cx_entry);
+///     QkCircuit *qc = qk_circuit_new(4, 0);
+///     for (uint32_t i = 0; i < qk_circuit_num_qubits(qc) - 1; i++) {
+///         uint32_t qargs[2] = {i, i + 1};
+///         for (uint32_t j = 0; j<i+1; j++) {
+///             qk_circuit_gate(qc, QkGate_CX, qargs, NULL);
+///         }
+///     }
+///     qk_circuit_gate(qc, QkGate_RZ, {1,}, {0.,});
+///     QkCircuit *output_circuit = qk_transpiler_pass_standalone_remove_identity_equivalent(qc, target, 1.0);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``circuit`` or ``target`` is not a valid, non-null pointer to a ``QkCircuit`` and ``QkTarget``.
+#[no_mangle]
+#[cfg(feature = "cbinding")]
+pub unsafe extern "C" fn qk_transpiler_pass_standalone_remove_identity_equivalent(
+    circuit: *const CircuitData,
+    target: *const Target,
+    approximation_degree: f64,
+) -> *mut CircuitData {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let circuit = unsafe { const_ptr_as_ref(circuit) };
+    let target = unsafe { const_ptr_as_ref(target) };
+    let mut dag = match DAGCircuit::from_circuit_data(circuit, false, None, None, None, None) {
+        Ok(dag) => dag,
+        Err(e) => panic!("{}", e),
+    };
+    let approximation_degree = if approximation_degree.is_nan() {
+        None
+    } else {
+        Some(approximation_degree)
+    };
+
+    run_remove_identity_equiv(&mut dag, approximation_degree, Some(target));
+    let out_circuit = match dag_to_circuit(&dag, false) {
+        Ok(qc) => qc,
+        Err(e) => panic!("{}", e),
+    };
+    Box::into_raw(Box::new(out_circuit))
+}

--- a/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
+++ b/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
@@ -24,7 +24,7 @@ use qiskit_transpiler::target::Target;
 /// Removes gates whose effect is close to an identity operation up to a global phase
 /// and up to the specified tolerance. Parameterized gates are not considered by this pass.
 ///
-/// For a cutoff fidelity \f$f\f, this pass removes gates whose average
+/// For a cutoff fidelity \f$f\f$, this pass removes gates whose average
 /// gate fidelity with respect to the identity is below \f$f\f$. Concretely,
 /// a gate \f$G\f$ is removed if \f$\bar F < f\f$ where
 ///

--- a/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
+++ b/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
@@ -65,8 +65,10 @@ use qiskit_transpiler::target::Target;
 ///             qk_circuit_gate(qc, QkGate_CX, qargs, NULL);
 ///         }
 ///     }
-///     qk_circuit_gate(qc, QkGate_RZ, {1,}, {0.,});
-///     QkCircuit *output_circuit = qk_transpiler_pass_standalone_remove_identity_equivalent(qc, target, 1.0);
+///     uint32_t rz_qargs[1] = {1,};
+///     double rz_params[1] = {0.,};
+///     qk_circuit_gate(qc, QkGate_RZ, rz_qargs, rz_params);
+///     qk_transpiler_pass_standalone_remove_identity_equivalent(qc, target, 1.0);
 /// ```
 ///
 /// # Safety

--- a/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
+++ b/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
@@ -91,6 +91,9 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_remove_identity_equivalen
     let approximation_degree = if approximation_degree.is_nan() {
         None
     } else {
+        if !(0.0..=1.0).contains(&approximation_degree) {
+            panic!("Invalid value provided for approximation degree, only NAN or values between 0.0 and 1.0 inclusive are valid");
+        }
         Some(approximation_degree)
     };
 

--- a/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
+++ b/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
@@ -10,7 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::pointers::const_ptr_as_ref;
+use crate::pointers::{const_ptr_as_ref, mut_ptr_as_ref};
 
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::converters::dag_to_circuit;
@@ -75,12 +75,12 @@ use qiskit_transpiler::target::Target;
 #[no_mangle]
 #[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpiler_pass_standalone_remove_identity_equivalent(
-    circuit: *const CircuitData,
+    circuit: *mut CircuitData,
     target: *const Target,
     approximation_degree: f64,
-) -> *mut CircuitData {
+) {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
-    let circuit = unsafe { const_ptr_as_ref(circuit) };
+    let circuit = unsafe { mut_ptr_as_ref(circuit) };
     let target = unsafe { const_ptr_as_ref(target) };
     let mut dag = match DAGCircuit::from_circuit_data(circuit, false, None, None, None, None) {
         Ok(dag) => dag,
@@ -97,5 +97,5 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_remove_identity_equivalen
         Ok(qc) => qc,
         Err(e) => panic!("{}", e),
     };
-    Box::into_raw(Box::new(out_circuit))
+    *circuit = out_circuit;
 }

--- a/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
+++ b/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
@@ -24,13 +24,17 @@ use qiskit_transpiler::target::Target;
 /// Removes gates whose effect is close to an identity operation up to a global phase
 /// and up to the specified tolerance. Parameterized gates are not considered by this pass.
 ///
-/// For a cutoff fidelity :math:`f`, this pass removes gates whose average
-/// gate fidelity with respect to the identity is below :math:`f`. Concretely,
-/// a gate :math:`G` is removed if :math:`\bar F < f` where
+/// For a cutoff fidelity \f$f\f, this pass removes gates whose average
+/// gate fidelity with respect to the identity is below \f$f\f$. Concretely,
+/// a gate \f$G\f$ is removed if \f$\bar F < f\f$ where
 ///
-/// $bar{F} = \frac{1 + d F_{\text{process}}}{1 + d},F_{\text{process}} = \frac{|\mathrm{Tr}(G)|^2}{d^2}$
+/// \f[
+/// bar{F} = \frac{1 + d F_{\text{process}}}{1 + d},\
 ///
-/// where $d = 2^n$ is the dimension of the gate for $n$ qubits.
+/// F_{\text{process}} = \frac{|\mathrm{Tr}(G)|^2}{d^2}
+/// \f]
+///
+/// where \f$d = 2^n\f$ is the dimension of the gate for \f$n\f$ qubits.
 ///
 /// @param circuit A pointer to the circuit to run RemoveIdentityEquivalent on. This circuit
 /// pointed to will be updated with the modified circuit if the pass is able to remove any gates.

--- a/releasenotes/notes/add-remove-identity-equiv-c-4bc4354c54531156.yaml
+++ b/releasenotes/notes/add-remove-identity-equiv-c-4bc4354c54531156.yaml
@@ -1,0 +1,7 @@
+---
+features_c:
+  - |
+    Added a new transpiler pass standalone function to the C API,
+    :cpp:func:`qk_transpiler_pass_standalone_remove_identity_equivalent`
+    which is equivalent to calling the :class:`.RemoveIdentityEquivalent`
+    pass.

--- a/test/c/test_remove_identity_equiv.c
+++ b/test/c/test_remove_identity_equiv.c
@@ -28,22 +28,23 @@ int test_remove_identity_equiv_removes_gates(void) {
     uint32_t qargs[1] = {
         0,
     };
-    double params[1] = {
+    double params_zero[1] = {
         0.,
     };
+    double params[1] = {
+        1.23,
+    };
     qk_circuit_gate(qc, QkGate_I, qargs, NULL);
-    qk_circuit_gate(qc, QkGate_RZ, qargs, params);
+    qk_circuit_gate(qc, QkGate_RZ, qargs, params_zero);
     qk_circuit_gate(qc, QkGate_RX, qargs, params);
 
     qk_transpiler_pass_standalone_remove_identity_equivalent(qc, target, 1.0);
-    if (qk_circuit_num_instructions(qc) != 0) {
+    if (qk_circuit_num_instructions(qc) != 1) {
         result = EqualityError;
         printf("The gates weren't removed by this circuit");
     }
 
-circuit_cleanup:
     qk_circuit_free(qc);
-cleanup:
     qk_target_free(target);
     return result;
 }

--- a/test/c/test_remove_identity_equiv.c
+++ b/test/c/test_remove_identity_equiv.c
@@ -35,13 +35,11 @@ int test_remove_identity_equiv_removes_gates(void) {
     qk_circuit_gate(qc, QkGate_RZ, qargs, params);
     qk_circuit_gate(qc, QkGate_RX, qargs, params);
 
-    QkCircuit *result_circ =
-        qk_transpiler_pass_standalone_remove_identity_equivalent(qc, target, 1.0);
-    if (qk_circuit_num_instructions(result_circ) != 0) {
+    qk_transpiler_pass_standalone_remove_identity_equivalent(qc, target, 1.0);
+    if (qk_circuit_num_instructions(qc) != 0) {
         result = EqualityError;
         printf("The gates weren't removed by this circuit");
     }
-    qk_circuit_free(result_circ);
 
 circuit_cleanup:
     qk_circuit_free(qc);

--- a/test/c/test_remove_identity_equiv.c
+++ b/test/c/test_remove_identity_equiv.c
@@ -1,0 +1,61 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+#include "common.h"
+#include <complex.h>
+#include <qiskit.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+int test_remove_identity_equiv_removes_gates(void) {
+    const uint32_t num_qubits = 5;
+    QkTarget *target = qk_target_new(num_qubits);
+    int result = Ok;
+
+    QkCircuit *qc = qk_circuit_new(1, 0);
+    uint32_t qargs[1] = {
+        0,
+    };
+    double params[1] = {
+        0.,
+    };
+    qk_circuit_gate(qc, QkGate_I, qargs, NULL);
+    qk_circuit_gate(qc, QkGate_RZ, qargs, params);
+    qk_circuit_gate(qc, QkGate_RX, qargs, params);
+
+    QkCircuit *result_circ =
+        qk_transpiler_pass_standalone_remove_identity_equivalent(qc, target, 1.0);
+    if (qk_circuit_num_instructions(result_circ) != 0) {
+        result = EqualityError;
+        printf("The gates weren't removed by this circuit");
+    }
+    qk_circuit_free(result_circ);
+
+circuit_cleanup:
+    qk_circuit_free(qc);
+cleanup:
+    qk_target_free(target);
+    return result;
+}
+
+int test_remove_identity_equiv(void) {
+    int num_failed = 0;
+    num_failed += RUN_TEST(test_remove_identity_equiv_removes_gates);
+
+    fflush(stderr);
+    fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);
+
+    return num_failed;
+}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a standalone transpiler pass function to the C API for
running the RemoveIdentityEquiv transpiler pass. This pass mutates a DAG
in place so there isn't a custom result type needed, it instead just
returns a new circuit object.

### Details and comments

Fixes #14445

~This PR is based on top of #14668 will need to be rebased once #14668 merges. In the meantime you can review just the contents of this PR by looking at the HEAD commit on the PR: https://github.com/Qiskit/qiskit/commit/c013b5d608f9f3c75861d5e12e25c896b293782d~ This has been rebased now