### PR TITLE
Fix non-determinism VF2Layout with only 1q gates

### DIFF
--- a/crates/transpiler/src/passes/vf2/vf2_layout.rs
+++ b/crates/transpiler/src/passes/vf2/vf2_layout.rs
@@ -347,10 +347,14 @@ fn map_free_qubits(
             .get(&[PhysicalQubit::new(*qubit_b), PhysicalQubit::new(*qubit_b)])
             .unwrap_or(&0.);
         // Reverse comparison so lower error rates are at the end of the vec.
-        score_b.partial_cmp(&score_a).unwrap()
+        match score_b.partial_cmp(&score_a).unwrap() {
+            Ordering::Equal => qubit_b.cmp(qubit_a),
+            Ordering::Less => Ordering::Less,
+            Ordering::Greater => Ordering::Greater,
+        }
     });
     let mut free_indices: Vec<NodeIndex> = free_nodes.keys().copied().collect();
-    free_indices.par_sort_by_key(|index| free_nodes[index].values().sum::<usize>());
+    free_indices.par_sort_by_key(|index| (free_nodes[index].values().sum::<usize>(), *index));
     for im_index in free_indices {
         let selected_qubit = free_qubits.pop()?;
         partial_layout.insert(

--- a/releasenotes/notes/fix-1q-non-determinism-vf2-75490119547bf656.yaml
+++ b/releasenotes/notes/fix-1q-non-determinism-vf2-75490119547bf656.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed an issue in the :class:`.VF2Layout` transpiler pass where even with
+    a fixed seed set the output from the pass was potentially non-deterministic;
+    specifically if the input circuit had any active qubits that only contained
+    single qubit operations.
+    Fixed `#14729 <https://github.com/Qiskit/qiskit/issues/14729>`__


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue in the VF2Layout transpiler pass that would cause a non-deterministic output if the circuit had any qubit that only had single qubit operations. The dedicated internal function to deal with this special case sorts the qubits in the circuit by number of operations and the physical qubits on the target by error rate, to map the qubits with the lowest error rate. However this sorting wasn't fully stable as it was done on a hash set which doesn't have a stable iteration order. This commit fixes this by also sorting based on the qubit index so in the case of a tie the sort is stable.

### Details and comments

Fixes #14729