### PR TITLE
Add `RemoveDiagonalGatesBeforeMeasure` to the C API

### DIFF
--- a/crates/cext/src/transpiler/passes/mod.rs
+++ b/crates/cext/src/transpiler/passes/mod.rs
@@ -1,3 +1,4 @@
 pub mod elide_permutations;
+pub mod remove_diagonal_gates_before_measure;
 pub mod remove_identity_equiv;
 pub mod vf2;

--- a/crates/cext/src/transpiler/passes/remove_diagonal_gates_before_measure.rs
+++ b/crates/cext/src/transpiler/passes/remove_diagonal_gates_before_measure.rs
@@ -1,0 +1,55 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use crate::pointers::mut_ptr_as_ref;
+use qiskit_circuit::circuit_data::CircuitData;
+use qiskit_circuit::converters::dag_to_circuit;
+use qiskit_circuit::dag_circuit::DAGCircuit;
+use qiskit_transpiler::passes::run_remove_diagonal_before_measure;
+
+/// @ingroup QkTranspilerPasses
+/// Run the ``RemoveDiagonalGatesBeforeMeasure`` pass on a circuit.
+///
+/// Transpiler pass to remove diagonal gates (like RZ, T, Z, etc) before
+/// a measurement. Including diagonal 2Q gates.
+///
+/// @param circuit A pointer to the circuit to run this pass on
+///
+/// # Example
+///
+/// ```c
+///     QkCircuit *qc = qk_circuit_new(1, 1);
+///     qk_circuit_gate(qc, QkGate_Z, {0}, NULL);
+///     qk_circuit_measure(qc, 0, 0);
+///     qk_transpiler_pass_standalone_remove_diagonal_gates_before_measure(qc);
+///     // ...
+///     qk_circuit_free(qc);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
+#[no_mangle]
+#[cfg(feature = "cbinding")]
+pub unsafe extern "C" fn qk_transpiler_pass_standalone_remove_diagonal_gates_before_measure(
+    circuit: *mut CircuitData,
+) {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let circuit = unsafe { mut_ptr_as_ref(circuit) };
+    let mut dag = match DAGCircuit::from_circuit_data(circuit, false, None, None, None, None) {
+        Ok(dag) => dag,
+        Err(e) => panic!("{}", e),
+    };
+    run_remove_diagonal_before_measure(&mut dag);
+    let result = dag_to_circuit(&dag, false).expect("DAG to Circuit conversion failed");
+    *circuit = result;
+}

--- a/crates/cext/src/transpiler/passes/remove_diagonal_gates_before_measure.rs
+++ b/crates/cext/src/transpiler/passes/remove_diagonal_gates_before_measure.rs
@@ -46,7 +46,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_remove_diagonal_gates_bef
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { mut_ptr_as_ref(circuit) };
     let mut dag = DAGCircuit::from_circuit_data(circuit, false, None, None, None, None)
-        .expect("DAG to Circuit conversion failed");
+        .expect("Circuit to DAG conversion failed");
     run_remove_diagonal_before_measure(&mut dag);
     let result = dag_to_circuit(&dag, false).expect("DAG to Circuit conversion failed");
     *circuit = result;

--- a/crates/cext/src/transpiler/passes/remove_diagonal_gates_before_measure.rs
+++ b/crates/cext/src/transpiler/passes/remove_diagonal_gates_before_measure.rs
@@ -45,10 +45,8 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_remove_diagonal_gates_bef
 ) {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { mut_ptr_as_ref(circuit) };
-    let mut dag = match DAGCircuit::from_circuit_data(circuit, false, None, None, None, None) {
-        Ok(dag) => dag,
-        Err(e) => panic!("{}", e),
-    };
+    let mut dag = DAGCircuit::from_circuit_data(circuit, false, None, None, None, None)
+        .expect("DAG to Circuit conversion failed");
     run_remove_diagonal_before_measure(&mut dag);
     let result = dag_to_circuit(&dag, false).expect("DAG to Circuit conversion failed");
     *circuit = result;

--- a/crates/transpiler/src/passes/remove_diagonal_gates_before_measure.rs
+++ b/crates/transpiler/src/passes/remove_diagonal_gates_before_measure.rs
@@ -24,7 +24,7 @@ use qiskit_circuit::operations::StandardGate;
 ///     DAGCircuit: the optimized DAG.
 #[pyfunction]
 #[pyo3(name = "remove_diagonal_gates_before_measure")]
-pub fn run_remove_diagonal_before_measure(dag: &mut DAGCircuit) -> PyResult<()> {
+pub fn run_remove_diagonal_before_measure(dag: &mut DAGCircuit) {
     static DIAGONAL_1Q_GATES: [StandardGate; 8] = [
         StandardGate::RZ,
         StandardGate::Z,
@@ -90,8 +90,6 @@ pub fn run_remove_diagonal_before_measure(dag: &mut DAGCircuit) -> PyResult<()> 
             dag.remove_op_node(node_to_remove);
         }
     }
-
-    Ok(())
 }
 
 pub fn remove_diagonal_gates_before_measure_mod(m: &Bound<PyModule>) -> PyResult<()> {

--- a/releasenotes/notes/rm-diag-gates-before-meas-c-9bb9f2b5490cf0a2.yaml
+++ b/releasenotes/notes/rm-diag-gates-before-meas-c-9bb9f2b5490cf0a2.yaml
@@ -1,0 +1,8 @@
+---
+features_c:
+  - |
+    Added a new standalone transpiler pass function
+    ``qk_transpiler_pass_standalone_remove_diagonal_gates_before_measure`` which is for running the
+    :class:`.RemoveDiagonalGatesBeforeMeasure` transpiler pass. Calling this function in C is equivalent
+    to running the pass in Python like::
+      RemoveDiagonalGatesBeforeMeasure(..)(circuit)

--- a/releasenotes/notes/rm-diag-gates-before-meas-c-9bb9f2b5490cf0a2.yaml
+++ b/releasenotes/notes/rm-diag-gates-before-meas-c-9bb9f2b5490cf0a2.yaml
@@ -5,4 +5,5 @@ features_c:
     ``qk_transpiler_pass_standalone_remove_diagonal_gates_before_measure`` which is for running the
     :class:`.RemoveDiagonalGatesBeforeMeasure` transpiler pass. Calling this function in C is equivalent
     to running the pass in Python like::
+      
       RemoveDiagonalGatesBeforeMeasure(..)(circuit)

--- a/test/c/test_remove_diagonal_gates_before_measure.c
+++ b/test/c/test_remove_diagonal_gates_before_measure.c
@@ -1,0 +1,71 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025.
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+#include "common.h"
+#include <complex.h>
+#include <math.h>
+#include <qiskit.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/**
+ * Test removing a Z gate before a measure.
+ */
+int test_remove_z_gate(void) {
+    int result = Ok;
+    QkCircuit *qc = qk_circuit_new(1, 1);
+    qk_circuit_gate(qc, QkGate_Z, (int[]){0}, NULL);
+    qk_circuit_measure(qc, 0, 0);
+
+    if (2 != qk_circuit_num_instructions(qc)) {
+        printf("Circuit build failure");
+        result = RuntimeError;
+        goto cleanup;
+    }
+
+    qk_transpiler_pass_standalone_remove_diagonal_gates_before_measure(qc);
+
+    if (1 != qk_circuit_num_instructions(qc)) {
+        printf("Circuit should only have a single instruction");
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    QkCircuitInstruction inst;
+    qk_circuit_get_instruction(qc, 0, &inst);
+
+    if (0 != strcmp("measure", inst.name)) {
+        printf("Circuit should contain a single 'measure' instruction. Instead, it has one: '%s'.",
+               inst.name);
+        result = EqualityError;
+        goto cleanup_inst;
+    }
+
+cleanup_inst:
+    qk_circuit_instruction_clear(&inst);
+cleanup:
+    qk_circuit_free(qc);
+    return result;
+}
+
+int test_remove_diagonal_gates_before_measure(void) {
+    int num_failed = 0;
+    num_failed += RUN_TEST(test_remove_z_gate);
+
+    fflush(stderr);
+    fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);
+
+    return num_failed;
+}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Adds a new function to the C API to invoke a standalone pass run of `RemoveDiagonalGatesBeforeMeasure`.


### Details and comments
Currently, I've chosen to modify the input `QkCircuit` in place instead of allocating a new one. If we'd rather always allocate a copy for standalone passes, I'm happy to change this.

Based on #14668 which should be merged first.

#### To-do
- [x] Make the test(s) a little...better.
- [x] Rebase on #14668 
- [x] Write release note.