### PR TITLE
Drop unused import in HighLevelSynthesis

### DIFF
--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -47,9 +47,6 @@ use qiskit_synthesis::euler_one_qubit_decomposer::angles_from_unitary;
 use qiskit_synthesis::euler_one_qubit_decomposer::EulerBasis;
 use qiskit_synthesis::two_qubit_decompose::TwoQubitBasisDecomposer;
 
-#[cfg(feature = "cache_pygates")]
-use std::sync::OnceLock;
-
 /// Track global qubits by their state.
 /// The global qubits are numbered by consecutive integers starting at `0`,
 /// and the states are distinguished into clean (:math:`|0\rangle`)


### PR DESCRIPTION
This is protected by a feature guard, but the only place `OnceLock` is actually used (also feature-guard protected), it's used fully qualified.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

There's a compiler warning for me when building Qiskit with the feature enabled.  I guess we presumably run the clippy check in CI _without_ features enabled; perhaps we should change that?
