### PR TITLE
Fix doc example for `qk_circuit_get_instruction`

### DIFF
--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -837,7 +837,7 @@ pub struct CInstruction {
 ///     QkCircuit *qc = qk_circuit_new(100);
 ///     uint32_t qubit[1] = {0};
 ///     qk_circuit_gate(qc, QkGate_H, qubit, NULL);
-///     QkCircuitInstruction inst = qk_circuit_get_instruction(qc, 0);
+///     qk_circuit_get_instruction(qc, 0, inst);
 ///
 /// # Safety
 ///

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -833,11 +833,11 @@ pub struct CInstruction {
 ///
 /// # Example
 ///
-///     QkCircuitInstruction *inst = malloc(sizeof(QkCircuitInstruction));
+///     QkCircuitInstruction inst;
 ///     QkCircuit *qc = qk_circuit_new(100);
 ///     uint32_t qubit[1] = {0};
 ///     qk_circuit_gate(qc, QkGate_H, qubit, NULL);
-///     qk_circuit_get_instruction(qc, 0, inst);
+///     qk_circuit_get_instruction(qc, 0, &inst);
 ///
 /// # Safety
 ///

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -542,135 +542,134 @@ int test_get_gate_counts_bv_resets_barrier_and_measures(void) {
         result = EqualityError;
         goto cleanup;
     }
-    QkCircuitInstruction *inst = malloc(sizeof(QkCircuitInstruction));
+    QkCircuitInstruction inst;
     for (size_t i = 0; i < num_instructions; i++) {
 
-        qk_circuit_get_instruction(qc, i, inst);
+        qk_circuit_get_instruction(qc, i, &inst);
         if (i < 1000) {
-            result = strcmp(inst->name, "reset");
+            result = strcmp(inst.name, "reset");
             if (result != 0) {
                 goto loop_exit;
             }
-            if (inst->qubits[0] != i || inst->num_qubits != 1) {
+            if (inst.qubits[0] != i || inst.num_qubits != 1) {
                 result = EqualityError;
                 goto loop_exit;
             }
-            if (inst->num_clbits > 0 || inst->num_params > 0) {
+            if (inst.num_clbits > 0 || inst.num_params > 0) {
                 result = EqualityError;
                 goto loop_exit;
             }
         } else if (i == 1000) {
-            result = strcmp(inst->name, "x");
+            result = strcmp(inst.name, "x");
             if (result != 0) {
                 goto loop_exit;
             }
-            if (inst->qubits[0] != 999 || inst->num_qubits != 1) {
+            if (inst.qubits[0] != 999 || inst.num_qubits != 1) {
                 result = EqualityError;
                 goto loop_exit;
             }
-            if (inst->num_clbits > 0 || inst->num_params > 0) {
+            if (inst.num_clbits > 0 || inst.num_params > 0) {
                 result = EqualityError;
                 goto loop_exit;
             }
         } else if (i < 2001) {
-            result = strcmp(inst->name, "h");
+            result = strcmp(inst.name, "h");
             if (result != 0) {
                 goto loop_exit;
             }
-            if (inst->qubits[0] != i - 1001 || inst->num_qubits != 1) {
+            if (inst.qubits[0] != i - 1001 || inst.num_qubits != 1) {
                 result = EqualityError;
                 goto loop_exit;
             }
-            if (inst->num_clbits > 0 || inst->num_params > 0 || inst->num_qubits != 1) {
+            if (inst.num_clbits > 0 || inst.num_params > 0 || inst.num_qubits != 1) {
                 result = EqualityError;
                 goto loop_exit;
             }
         } else if (i == 2001) {
-            result = strcmp(inst->name, "barrier");
+            result = strcmp(inst.name, "barrier");
             if (result != 0) {
                 goto loop_exit;
             }
             for (uint32_t j = 0; i < 1000; j++) {
-                if (inst->qubits[i] != i) {
+                if (inst.qubits[i] != i) {
                     result = EqualityError;
                     goto loop_exit;
                 }
             }
-            if (inst->num_clbits > 0 || inst->num_params > 0 || inst->num_qubits != 1000) {
+            if (inst.num_clbits > 0 || inst.num_params > 0 || inst.num_qubits != 1000) {
                 result = EqualityError;
                 goto loop_exit;
             }
         } else if (i <= 2501) {
-            result = strcmp(inst->name, "cx");
+            result = strcmp(inst.name, "cx");
             if (result != 0) {
                 goto loop_exit;
             }
-            if (inst->qubits[0] != (i - 2002) * 2) {
+            if (inst.qubits[0] != (i - 2002) * 2) {
                 result = EqualityError;
                 goto loop_exit;
             }
-            if (inst->qubits[1] != 999 || inst->num_qubits != 2) {
+            if (inst.qubits[1] != 999 || inst.num_qubits != 2) {
                 result = EqualityError;
                 goto loop_exit;
             }
-            if (inst->num_clbits > 0 || inst->num_params > 0) {
+            if (inst.num_clbits > 0 || inst.num_params > 0) {
                 result = EqualityError;
                 goto loop_exit;
             }
         } else if (i == 2502) {
-            result = strcmp(inst->name, "barrier");
+            result = strcmp(inst.name, "barrier");
             if (result != 0) {
                 goto loop_exit;
             }
             for (uint32_t j = 0; i < 1000; j++) {
-                if (inst->qubits[i] != i) {
+                if (inst.qubits[i] != i) {
                     result = EqualityError;
                     goto loop_exit;
                 }
             }
-            if (inst->num_clbits > 0 || inst->num_params > 0 || inst->num_qubits != 1000) {
+            if (inst.num_clbits > 0 || inst.num_params > 0 || inst.num_qubits != 1000) {
                 result = EqualityError;
                 goto loop_exit;
             }
         } else if (i <= 3501) {
-            result = strcmp(inst->name, "h");
+            result = strcmp(inst.name, "h");
             if (result != 0) {
                 goto loop_exit;
             }
-            if (inst->qubits[0] != i - 2503 || inst->num_qubits != 1) {
+            if (inst.qubits[0] != i - 2503 || inst.num_qubits != 1) {
                 result = EqualityError;
                 goto loop_exit;
             }
-            if (inst->num_clbits > 0 || inst->num_params > 0) {
+            if (inst.num_clbits > 0 || inst.num_params > 0) {
                 result = EqualityError;
                 goto loop_exit;
             }
         } else if (i <= 4500) {
-            result = strcmp(inst->name, "measure");
+            result = strcmp(inst.name, "measure");
             if (result != 0) {
                 goto loop_exit;
             }
-            if (inst->qubits[0] != i - 3502 || inst->num_qubits != 1) {
+            if (inst.qubits[0] != i - 3502 || inst.num_qubits != 1) {
                 result = EqualityError;
                 goto loop_exit;
             }
-            if (inst->clbits[0] != i - 3502 || inst->num_clbits != 1) {
+            if (inst.clbits[0] != i - 3502 || inst.num_clbits != 1) {
                 result = EqualityError;
                 goto loop_exit;
             }
-            if (inst->num_params > 0) {
+            if (inst.num_params > 0) {
                 result = EqualityError;
                 goto loop_exit;
             }
         }
     loop_exit:
-        qk_circuit_instruction_clear(inst);
+        qk_circuit_instruction_clear(&inst);
         if (result != 0) {
             break;
         }
     }
 cleanup:
-    free(inst);
     qk_circuit_free(qc);
     qk_opcounts_free(op_counts);
     return result;
@@ -713,14 +712,13 @@ int test_unitary_gate(void) {
     }
     qk_opcounts_free(op_counts);
 
-    QkCircuitInstruction *inst = malloc(sizeof(QkCircuitInstruction));
-    qk_circuit_get_instruction(qc, 0, inst);
-    if (strcmp(inst->name, "unitary") != 0 || inst->num_clbits != 0 || inst->num_params != 0 ||
-        inst->num_qubits != 2) {
+    QkCircuitInstruction inst;
+    qk_circuit_get_instruction(qc, 0, &inst);
+    if (strcmp(inst.name, "unitary") != 0 || inst.num_clbits != 0 || inst.num_params != 0 ||
+        inst.num_qubits != 2) {
         result = EqualityError;
     }
-    qk_circuit_instruction_clear(inst);
-    free(inst);
+    qk_circuit_instruction_clear(&inst);
 
 cleanup:
     qk_circuit_free(qc);
@@ -762,14 +760,13 @@ int test_unitary_gate_1q(void) {
     }
     qk_opcounts_free(op_counts);
 
-    QkCircuitInstruction *inst = malloc(sizeof(QkCircuitInstruction));
-    qk_circuit_get_instruction(qc, 0, inst);
-    if (strcmp(inst->name, "unitary") != 0 || inst->num_clbits != 0 || inst->num_params != 0 ||
-        inst->num_qubits != 1) {
+    QkCircuitInstruction inst;
+    qk_circuit_get_instruction(qc, 0, &inst);
+    if (strcmp(inst.name, "unitary") != 0 || inst.num_clbits != 0 || inst.num_params != 0 ||
+        inst.num_qubits != 1) {
         result = EqualityError;
     }
-    qk_circuit_instruction_clear(inst);
-    free(inst);
+    qk_circuit_instruction_clear(&inst);
 
 cleanup:
     qk_circuit_free(qc);
@@ -816,14 +813,13 @@ int test_unitary_gate_3q(void) {
         goto cleanup;
     }
     qk_opcounts_free(op_counts);
-    QkCircuitInstruction *inst = malloc(sizeof(QkCircuitInstruction));
-    qk_circuit_get_instruction(qc, 0, inst);
-    if (strcmp(inst->name, "unitary") != 0 || inst->num_clbits != 0 || inst->num_params != 0 ||
-        inst->num_qubits != 3) {
+    QkCircuitInstruction inst;
+    qk_circuit_get_instruction(qc, 0, &inst);
+    if (strcmp(inst.name, "unitary") != 0 || inst.num_clbits != 0 || inst.num_params != 0 ||
+        inst.num_qubits != 3) {
         result = EqualityError;
     }
-    qk_circuit_instruction_clear(inst);
-    free(inst);
+    qk_circuit_instruction_clear(&inst);
 
 cleanup:
     qk_circuit_free(qc);


### PR DESCRIPTION




<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This example now passes the newly allocated `inst` to `qk_circuit_get_instruction`, matching the signature expected by the function and the examples in `test_circuit.c`.

### Details and comments


Alternatively, I believe the whole thing could be simplified (and have slightly better performance) by using stack allocation:

```c
QkCircuitInstruction inst;
QkCircuit *qc = qk_circuit_new(100);
uint32_t qubit[1] = {0};
qk_circuit_gate(qc, QkGate_H, qubit, NULL);
qk_circuit_get_instruction(qc, 0, &inst);
```

Then one would access its members using `inst.` instead of `inst->`.