### PR TITLE
Unitary simulator in Rust

### DIFF
--- a/crates/pyext/src/lib.rs
+++ b/crates/pyext/src/lib.rs
@@ -63,6 +63,7 @@ fn _accelerate(m: &Bound<PyModule>) -> PyResult<()> {
     add_submodule(m, ::qiskit_accelerate::sampled_exp_val::sampled_exp_val, "sampled_exp_val")?;
     add_submodule(m, ::qiskit_quantum_info::sparse_observable::sparse_observable, "sparse_observable")?;
     add_submodule(m, ::qiskit_quantum_info::sparse_pauli_op::sparse_pauli_op, "sparse_pauli_op")?;
+    add_submodule(m, ::qiskit_quantum_info::unitary_sim::unitary_sim, "unitary_sim")?;
     add_submodule(m, ::qiskit_transpiler::passes::split_2q_unitaries_mod, "split_2q_unitaries")?;
     add_submodule(m, ::qiskit_synthesis::synthesis, "synthesis")?;
     add_submodule(m, ::qiskit_transpiler::target::target, "target")?;

--- a/crates/quantum_info/src/lib.rs
+++ b/crates/quantum_info/src/lib.rs
@@ -15,6 +15,7 @@ pub mod pauli_lindblad_map;
 pub mod sparse_observable;
 pub mod sparse_pauli_op;
 pub mod unitary_compose;
+pub mod unitary_sim;
 pub mod versor_u2;
 
 mod rayon_ext;

--- a/crates/quantum_info/src/unitary_sim.rs
+++ b/crates/quantum_info/src/unitary_sim.rs
@@ -1,0 +1,72 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use ndarray::Array2;
+use num_complex::Complex64;
+use numpy::IntoPyArray;
+use pyo3::prelude::*;
+use qiskit_circuit::circuit_data::{CircuitData, CircuitError};
+use qiskit_circuit::operations::Operation;
+
+use crate::unitary_compose;
+
+// The code is based on top of unitary_compose. For circuits with 13 or more qubits, einsum
+// throws an "index out of bounds" error.
+const MAX_NUM_QUBITS: usize = 12;
+
+/// Create a unitary matrix for a circuit.
+#[pyfunction]
+pub fn sim_unitary_circuit(py: Python, circuit: &CircuitData) -> PyResult<PyObject> {
+    if circuit.num_clbits() > 0 {
+        return Err(CircuitError::new_err(
+            "Cannot simulate circuit involving classical bits.".to_string(),
+        ));
+    }
+
+    let num_qubits = circuit.num_qubits();
+
+    if num_qubits > MAX_NUM_QUBITS {
+        return Err(CircuitError::new_err(format!(
+            "The number of circuit qubits ({num_qubits}) exceeds the maximum allowed number of qubits allowed for simulation ({MAX_NUM_QUBITS})."  
+        )));
+    }
+
+    // Product matrix holding the result
+    let mut product_mat = Array2::<Complex64>::eye(2_usize.pow(num_qubits as u32));
+
+    for inst in circuit.data() {
+        if !circuit.get_cargs(inst.clbits).is_empty() {
+            return Err(CircuitError::new_err(
+                "Cannot simulate circuit with instructions involving classical bits".to_string(),
+            ));
+        }
+
+        let qubits = circuit.get_qargs(inst.qubits);
+
+        let mat = inst.op.matrix(inst.params_view()).ok_or_else(|| {
+            CircuitError::new_err(format!(
+                "Cannot extract matrix for operation {:?}.",
+                inst.op
+            ))
+        })?;
+
+        product_mat = unitary_compose::compose(&product_mat.view(), &mat.view(), qubits, false)
+            .map_err(CircuitError::new_err)?;
+    }
+
+    Ok(product_mat.into_pyarray(py).into_any().unbind())
+}
+
+pub fn unitary_sim(m: &Bound<PyModule>) -> PyResult<()> {
+    m.add_wrapped(wrap_pyfunction!(sim_unitary_circuit))?;
+    Ok(())
+}

--- a/crates/quantum_info/src/unitary_sim.rs
+++ b/crates/quantum_info/src/unitary_sim.rs
@@ -15,7 +15,7 @@ use num_complex::Complex64;
 use numpy::IntoPyArray;
 use pyo3::prelude::*;
 use qiskit_circuit::circuit_data::{CircuitData, CircuitError};
-use qiskit_circuit::operations::Operation;
+use qiskit_circuit::operations::{Operation, OperationRef, StandardInstruction};
 
 use crate::unitary_compose;
 
@@ -50,12 +50,17 @@ pub fn sim_unitary_circuit(py: Python, circuit: &CircuitData) -> PyResult<PyObje
             ));
         }
 
+        // Ignore barriers
+        if let OperationRef::StandardInstruction(StandardInstruction::Barrier(_)) = inst.op.view() {
+            continue;
+        }
+
         let qubits = circuit.get_qargs(inst.qubits);
 
         let mat = inst.op.matrix(inst.params_view()).ok_or_else(|| {
             CircuitError::new_err(format!(
                 "Cannot extract matrix for operation {:?}.",
-                inst.op
+                inst.op.name()
             ))
         })?;
 

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -1357,6 +1357,25 @@ class TestUnitarySim(QiskitTestCase):
         rust_mat = unitary_sim.sim_unitary_circuit(qc._data)
         assert_allclose(python_mat, rust_mat)
 
+    def test_equivalence_with_barriers(self):
+        """Test equivalence of Python and Rust code where the
+        circuit includes barriers"""
+        qc = QuantumCircuit(5)
+        qc.h(0)
+        qc.barrier()
+        qc.cx(0, 1)
+        qc.swap(1, 2)
+        qc.s(1)
+        qc.cx(3, 1)
+        qc.rz(0.1, 2)
+        qc.barrier()
+        qc.ccx(3, 4, 0)
+        qc.s(4)
+        qc.barrier()
+
+        python_mat = Operator(qc).data
+        rust_mat = unitary_sim.sim_unitary_circuit(qc._data)
+        assert_allclose(python_mat, rust_mat)
 
 
 if __name__ == "__main__":

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -38,6 +38,9 @@ from qiskit.compiler.transpiler import transpile
 from qiskit.circuit import Qubit
 from qiskit.circuit.library import PermutationGate
 from qiskit.utils import optionals
+
+from qiskit._accelerate import unitary_sim
+
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
 logger = logging.getLogger(__name__)
@@ -1334,6 +1337,26 @@ class TestOperator(OperatorTestCase):
         self.assertTrue(_equal_with_ancillas(op1, op2, [1]))
         self.assertFalse(_equal_with_ancillas(op1, op2, [2]))
         self.assertTrue(_equal_with_ancillas(op1, op2, [2, 1]))
+
+
+class TestUnitarySim(QiskitTestCase):
+    """Tests simulation of unitary circuits in Rust."""
+
+    def test_equivalence(self):
+        """Test equivalence of Python and Rust code"""
+        qc = QuantumCircuit(5)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.swap(1, 2)
+        qc.s(1)
+        qc.cx(3, 1)
+        qc.rz(0.1, 2)
+        qc.ccx(3, 4, 0)
+        qc.s(4)
+        python_mat = Operator(qc).data
+        rust_mat = unitary_sim.sim_unitary_circuit(qc._data)
+        assert_allclose(python_mat, rust_mat)
+
 
 
 if __name__ == "__main__":

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -1340,7 +1340,7 @@ class TestOperator(OperatorTestCase):
 
 
 class TestUnitarySim(QiskitTestCase):
-    """Tests simulation of unitary circuits in Rust."""
+    """Test simulation of unitary circuits in Rust."""
 
     def test_equivalence(self):
         """Test equivalence of Python and Rust code"""
@@ -1376,6 +1376,16 @@ class TestUnitarySim(QiskitTestCase):
         python_mat = Operator(qc).data
         rust_mat = unitary_sim.sim_unitary_circuit(qc._data)
         assert_allclose(python_mat, rust_mat)
+
+    def test_raises_on_classical_bits(self):
+        """Test that simulating circuits with classical bits
+        raises an error."""
+        qc = QuantumCircuit(5, 1)
+        qc.h(0)
+        qc.cx(0, 1)
+
+        with self.assertRaises(QiskitError):
+            _ = unitary_sim.sim_unitary_circuit(qc._data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This PR adds a Rust-space method ``sim_unitary_circuit`` that constructs a unitary matrix (represented as ``Array2<Complex64>``) from a ``CircuitData`` with only unitary operations (or barriers). Functionality-wise, this is equivalent to ``Operator(circuit)`` in Python-space.

This is needed to enable better in-Rust testing of Rust-space synthesis methods, for example as requested in #14666.

### Details and comments

This is a simple wrapper on top of the existing `unitary_compose`. One caveat, that while both Python and Rust implementations of `unitary_compose` use `einsum` tricks for composing smaller-sized matrices onto larger-sized matrices as subsystems, _the Python's implementation works for more qubits and is quite a bit faster_. On circuits with 13 or more qubits, the Rust implementation throws the "index out of bounds" error, while the Python implementation works up to at least 16 qubits. (Personally, I don't think this is such a huge restriction, since at this point the Python code is quite slow and we will not likely use it in practice.) In the future, we should possibly revisit our implementation of `unitary_compose` to see if we can speed it up a bit.

I have not added release notes since this is not planned to be user-facing.
