### PR TITLE
Hide Python dependency in `ConsolidateBlocks`

### DIFF
--- a/crates/quantum_info/src/convert_2q_block_matrix.rs
+++ b/crates/quantum_info/src/convert_2q_block_matrix.rs
@@ -30,7 +30,7 @@ use crate::versor_u2::{VersorSU2, VersorU2, VersorU2Error};
 use crate::QiskitError;
 
 #[inline]
-pub fn get_matrix_from_inst(py: Python, inst: &PackedInstruction) -> PyResult<Array2<Complex64>> {
+pub fn get_matrix_from_inst(inst: &PackedInstruction) -> PyResult<Array2<Complex64>> {
     if let Some(mat) = inst.op.matrix(inst.params_view()) {
         Ok(mat)
     } else if inst.op.try_standard_gate().is_some() {
@@ -38,13 +38,19 @@ pub fn get_matrix_from_inst(py: Python, inst: &PackedInstruction) -> PyResult<Ar
             "Parameterized gates can't be consolidated",
         ))
     } else if let OperationRef::Gate(gate) = inst.op.view() {
-        Ok(QI_OPERATOR
-            .get_bound(py)
-            .call1((gate.gate.clone_ref(py),))?
-            .getattr(intern!(py, "data"))?
-            .extract::<PyReadonlyArray2<Complex64>>()?
-            .as_array()
-            .to_owned())
+        // If the operation is a custom python gate, we will acquire the gil
+        // and use an Operator. Otherwise, using op.matrix() should work.
+        // A user should not be able to reach this condition in Rust standalone
+        // mode.
+        Python::with_gil(|py| -> PyResult<_> {
+            Ok(QI_OPERATOR
+                .get_bound(py)
+                .call1((gate.gate.clone_ref(py),))?
+                .getattr(intern!(py, "data"))?
+                .extract::<PyReadonlyArray2<Complex64>>()?
+                .as_array()
+                .to_owned())
+        })
     } else {
         Err(QiskitError::new_err(
             "Can't compute matrix of non-unitary op",
@@ -106,7 +112,7 @@ impl Separable1q {
 }
 
 /// Extract a versor representation of an arbitrary 1q DAG instruction.
-fn versor_from_1q_gate(py: Python, inst: &PackedInstruction) -> PyResult<VersorU2> {
+fn versor_from_1q_gate(inst: &PackedInstruction) -> PyResult<VersorU2> {
     let tol = 1e-12;
     match inst.op.view() {
         OperationRef::StandardGate(gate) => VersorU2::from_standard(gate, inst.params_view()),
@@ -115,7 +121,7 @@ fn versor_from_1q_gate(py: Python, inst: &PackedInstruction) -> PyResult<VersorU
             ArrayType::OneQ(arr) => Ok(VersorU2::from_nalgebra_unchecked(arr)),
             ArrayType::TwoQ(_) => Err(VersorU2Error::MultiQubit),
         },
-        _ => VersorU2::from_ndarray(&get_matrix_from_inst(py, inst)?.view(), tol),
+        _ => VersorU2::from_ndarray(&get_matrix_from_inst(inst)?.view(), tol),
     }
     .map_err(|err| QiskitError::new_err(err.to_string()))
 }
@@ -126,7 +132,6 @@ fn versor_from_1q_gate(py: Python, inst: &PackedInstruction) -> PyResult<VersorU
 ///
 /// If any node in `op_list` is not a 1q or 2q gate.
 pub fn blocks_to_matrix(
-    py: Python,
     dag: &DAGCircuit,
     op_list: &[NodeIndex],
     block_index_map: [Qubit; 2],
@@ -166,14 +171,14 @@ pub fn blocks_to_matrix(
         let qarg = qarg_lookup(inst.qubits);
         match qarg {
             Qarg::Q0 | Qarg::Q1 => {
-                let versor = versor_from_1q_gate(py, inst)?;
+                let versor = versor_from_1q_gate(inst)?;
                 match qubits_1q.as_mut() {
                     Some(sep) => sep.apply_on_qubit(qarg as usize, &versor),
                     None => qubits_1q = Some(Separable1q::from_qubit(qarg as usize, versor)),
                 };
             }
             Qarg::Q01 | Qarg::Q10 => {
-                let mut matrix = get_matrix_from_inst(py, inst)?;
+                let mut matrix = get_matrix_from_inst(inst)?;
                 if qarg == Qarg::Q10 {
                     change_basis_inplace(matrix.view_mut());
                 }

--- a/crates/transpiler/src/passes/consolidate_blocks.rs
+++ b/crates/transpiler/src/passes/consolidate_blocks.rs
@@ -354,10 +354,11 @@ fn py_run_consolidate_blocks(
 
 /// Replaces each block of consecutive gates by a single unitary node.
 ///
-/// This is the main function of the `ConsolidateBlocks` transpiler pass
-/// which replaces uninterrupted sequences of gates acting on the same qubits
-/// into a Unitary node, which will consecutively be resynthesized into a
-/// more optimal subcircuit.
+/// This is function is the Rust entry point for the `ConsolidateBlocks` transpiler pass
+/// which replaces uninterrupted sequences of gates acting on the same pair of qubits
+/// into a [`UnitaryGate`] representing the unitary of that two qubit block if it estimated to
+/// to optimize the circuit. This [`UnitaryGate`] subsequently will be synthesized by the
+/// unitary synthesis pass into a more optimal subcircuit to replace that block.
 ///
 /// # Arguments
 /// * `dag` - The circuit for which we will consolidate gates.

--- a/crates/transpiler/src/passes/consolidate_blocks.rs
+++ b/crates/transpiler/src/passes/consolidate_blocks.rs
@@ -65,6 +65,28 @@ fn is_supported(
 // If depth > 20, there will be 1q gates to consolidate.
 const MAX_2Q_DEPTH: usize = 20;
 
+/// Replaces each block of consecutive gates by a single unitary node.
+///
+/// This is the main function of the `ConsolidateBlocks` transpiler pass
+/// which replaces uninterrupted sequences of gates acting on the same qubits
+/// into a Unitary node, which will consecutively be resynthesized into a
+/// more optimal subcircuit.
+///
+/// If blocks are provided in standalone mode (Rust or C only) the blocks must not be
+/// operations with more than 2 qubits. Any consolidation with more than 2 qubits will use
+/// the Python class `Operator` which is not yet available through standalone mode and
+/// may lead to a panic.
+///
+/// # Arguments
+/// * `dag` - The circuit for which we will consolidate gates.
+/// * `decomposer` - The type of decomposer to be used, could be of types
+///   [TwoQubitBasisDecomposer] or [TwoQubitControlledUDecomposer].
+/// * `basis_gate_name` - The basis gate selected for the decomposition.
+/// * `force_consolidate` - Decides whether to force all consolidations or not.
+/// * `target` - The target representing the backend for which the pass is consolidating.
+/// * `basis_gates` - The basis gates from which the decomposer will choose.
+/// * `blocks` - The pre-collected blocks from the dag.
+/// * `runs` - The pre-collected runs from the dag.
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
 #[pyo3(name = "consolidate_blocks", signature = (dag, decomposer, basis_gate_name, force_consolidate, target=None, basis_gates=None, blocks=None, runs=None))]

--- a/crates/transpiler/src/passes/consolidate_blocks.rs
+++ b/crates/transpiler/src/passes/consolidate_blocks.rs
@@ -68,7 +68,7 @@ const MAX_2Q_DEPTH: usize = 20;
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
 #[pyo3(name = "consolidate_blocks", signature = (dag, decomposer, basis_gate_name, force_consolidate, target=None, basis_gates=None, blocks=None, runs=None))]
-fn py_run_consolidate_blocks(
+pub fn run_consolidate_blocks(
     dag: &mut DAGCircuit,
     decomposer: DecomposerType,
     basis_gate_name: &str,
@@ -352,43 +352,7 @@ fn py_run_consolidate_blocks(
     Ok(())
 }
 
-/// Replaces each block of consecutive gates by a single unitary node.
-///
-/// This is function is the Rust entry point for the `ConsolidateBlocks` transpiler pass
-/// which replaces uninterrupted sequences of gates acting on the same pair of qubits
-/// into a [`UnitaryGate`] representing the unitary of that two qubit block if it estimated to
-/// to optimize the circuit. This [`UnitaryGate`] subsequently will be synthesized by the
-/// unitary synthesis pass into a more optimal subcircuit to replace that block.
-///
-/// # Arguments
-/// * `dag` - The circuit for which we will consolidate gates.
-/// * `decomposer` - The type of decomposer to be used, could be of types
-///   [TwoQubitBasisDecomposer] or [TwoQubitControlledUDecomposer].
-/// * `basis_gate_name` - The basis gate selected for the decomposition.
-/// * `force_consolidate` - Decides whether to force all consolidations or not.
-/// * `target` - The target representing the backend for which the pass is consolidating.
-/// * `basis_gates` - The basis gates from which the decomposer will choose.
-pub fn run_consolidate_blocks(
-    dag: &mut DAGCircuit,
-    decomposer: DecomposerType,
-    basis_gate_name: &str,
-    force_consolidate: bool,
-    target: Option<&Target>,
-    basis_gates: Option<HashSet<String>>,
-) -> PyResult<()> {
-    py_run_consolidate_blocks(
-        dag,
-        decomposer,
-        basis_gate_name,
-        force_consolidate,
-        target,
-        basis_gates,
-        None,
-        None,
-    )
-}
-
 pub fn consolidate_blocks_mod(m: &Bound<PyModule>) -> PyResult<()> {
-    m.add_wrapped(wrap_pyfunction!(py_run_consolidate_blocks))?;
+    m.add_wrapped(wrap_pyfunction!(run_consolidate_blocks))?;
     Ok(())
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
The following commits "hide" the Python dependency in the `run_consolidate_blocks` function as well as the `get_matrix_from_instruction` function from the `quantum_info` crate.

### Details and comments

The reason why I'm referring to this as "hiding" the python dependency instead of removing it, is that this workaround just limits the places where a `py` token is needed to only when Python is in use.

For example, in the both methods, we usually don't need a Py token to obtain the matrix of a `StandardGate` from Rust, since the definition is already in rust-space. However we will need one for any `PyGate` (which mostly represent custom defined gates), and to do so we require the usage of the `Operator` class. Since the need for `py` is only to call the `Operator` class in the case of a `PyGate` and `PyGate` can never be created from standalone mode, we assume that python is already in use and we manually obtain access to the `GIL`.

The one part that I'm not very satisfied with is the way we are hiding the `py` from the case when a block has more than 2 qubits. Since you can technically provide the nodes from Rust directly, there might be a case where a user might provide a block with more than 2 qubits. A warning has been added in the docstring of the `run_consolidate_blocks` method. However, I have an idea for a workaround by creating a wrapper around the function that accepts the same arguments, except for the ``blocks`` and ``runs``, which should be public to Rust users and might be the one to be used for the C API.

Feel free to comment with your thoughts.
