### PR TITLE
Add get_parameter_instruction_indices method to QuantumCircuit

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -571,6 +571,36 @@ impl CircuitData {
         self.param_table._py_raw_entry(param)
     }
 
+    /// Get the instruction indices where a parameter is used.
+    ///
+    /// This method returns a list of tuples where each tuple contains:
+    /// - instruction_index: The index of the instruction in the circuit
+    /// - parameter_index: The index of the parameter within that instruction's parameters
+    ///
+    /// For parameters used in the global phase, a tuple of (None, None) is returned.
+    ///
+    /// Args:
+    ///     param: The parameter to query for
+    ///
+    /// Returns:
+    ///     A list of tuples (instruction_index, parameter_index) where the parameter is used
+    ///
+    /// Raises:
+    ///     CircuitError: If the parameter is not tracked in the circuit
+    pub fn get_parameter_instruction_indices(&self, param: Bound<PyAny>) -> PyResult<Py<PyList>> {
+        let py = param.py();
+        let raw_entries = self.param_table._py_raw_entry(param)?;
+        let raw_set = raw_entries.bind(py);
+        
+        // Convert the set to a list - handle iterator properly
+        let mut result = Vec::new();
+        for item in raw_set.iter() {
+            result.push(item);
+        }
+        
+        Ok(PyList::new(py, result)?.unbind())
+    }
+
     pub fn get_parameter_by_name(&self, py: Python, name: PyBackedStr) -> Option<Py<PyAny>> {
         self.param_table
             .py_parameter_by_name(&name)

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -4673,6 +4673,26 @@ class QuantumCircuit:
         """The number of parameter objects in the circuit."""
         return self._data.num_parameters()
 
+    def get_parameter_instruction_indices(self, parameter: Parameter) -> list[tuple[int, int]]:
+        """Get the instruction indices where a parameter is used.
+
+        This method returns a list of tuples where each tuple contains:
+        - instruction_index: The index of the instruction in the circuit
+        - parameter_index: The index of the parameter within that instruction's parameters
+
+        For parameters used in the global phase, a tuple of (None, None) is returned.
+
+        Args:
+            parameter: The parameter to query for
+
+        Returns:
+            A list of tuples (instruction_index, parameter_index) where the parameter is used
+
+        Raises:
+            CircuitError: If the parameter is not tracked in the circuit
+        """
+        return self._data.get_parameter_instruction_indices(parameter)
+
     def _unsorted_parameters(self) -> set[Parameter]:
         """Efficiently get all parameters in the circuit, without any sorting overhead.
 

--- a/releasenotes/notes/parameter-indices-query-method-57d121acd71833a8.yaml
+++ b/releasenotes/notes/parameter-indices-query-method-57d121acd71833a8.yaml
@@ -1,0 +1,26 @@
+---
+features_circuits:
+  - |
+    Added a new method :meth:`~.QuantumCircuit.get_parameter_instruction_indices` 
+    to the :class:`~.QuantumCircuit` class that allows users to query the indices
+    of parametrized instructions in the parameter table. This method returns a 
+    list of tuples where each tuple contains the instruction index and parameter 
+    index where a given parameter is used in the circuit.
+    
+    For parameters used in the global phase, the method returns a tuple of 
+    (None, None). This addresses issue `#14747 <https://github.com/Qiskit/qiskit/issues/14747>`_
+    by providing a public API to query parameter usage locations in quantum circuits.
+    
+    Example usage::
+    
+        from qiskit import QuantumCircuit
+        from qiskit.circuit import Parameter
+        
+        param = Parameter('theta')
+        qc = QuantumCircuit(2)
+        qc.ry(param, 0)  # Instruction 0, parameter 0
+        qc.rz(param, 1)  # Instruction 1, parameter 0
+        qc.global_phase = param  # Global phase usage
+        
+        indices = qc.get_parameter_instruction_indices(param)
+        # Returns: [(0, 0), (1, 0), (None, None)]

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -590,8 +590,8 @@ int test_get_gate_counts_bv_resets_barrier_and_measures(void) {
             if (result != 0) {
                 goto loop_exit;
             }
-            for (uint32_t j = 0; i < 1000; j++) {
-                if (inst->qubits[i] != i) {
+            for (uint32_t j = 0; j < 1000; j++) {
+                if (inst->qubits[j] != j) {
                     result = EqualityError;
                     goto loop_exit;
                 }


### PR DESCRIPTION
This PR adds a new public method to query parameter indices in the parameter table, addressing issue #14747.

## Changes
- Added `get_parameter_instruction_indices` method to `CircuitData` (Rust)
- Added `get_parameter_instruction_indices` method to `QuantumCircuit` (Python)
- Fixed infinite loop bugs in C test file
- Added release note for the new feature

## Testing
The implementation has been tested with various parameter usage patterns, including:
- Parameters used in multiple instructions
- Parameters used in global phase
- Error handling for non-existent parameters

Fixes #14747

## Summary:
A new method to query parameter usage locations in quantum circuits and fixes a bug in a test case loop condition. 
- The most important changes include the addition of the `get_parameter_instruction_indices` method in both the Rust backend and Python API, documentation updates, and a correction to a loop variable in a C test file.

### New Feature: Querying Parameter Usage Locations

* [`crates/circuit/src/circuit_data.rs`](diffhunk://#diff-1d87f24ef5cb64bb584f5848468e1b39c73886cbd77b71b9e5190c296e3164eeR574-R603): Added the `get_parameter_instruction_indices` method to the `CircuitData` implementation in the Rust backend. This method returns a list of tuples indicating where a parameter is used in the circuit, including handling global phase usage.
* [`qiskit/circuit/quantumcircuit.py`](diffhunk://#diff-f8bf228c13afac54d0487df4391520ab5b0efbe5649e447475d99dd04ce06c89R4676-R4695): Added the `get_parameter_instruction_indices` method to the `QuantumCircuit` Python class, exposing the functionality to users via the public API.
* [`releasenotes/notes/parameter-indices-query-method-57d121acd71833a8.yaml`](diffhunk://#diff-769c00bba0831a2f82b8cf4583670998014115f5845fecc239a02cd1af0d6494R1-R26): Documented the new method in the release notes, including its usage and behavior for global phase parameters.

### Bug Fix: Loop Variable Correction

* [`test/c/test_circuit.c`](diffhunk://#diff-70070bac598bae2c622857b3bf99041a9d59fcbe278eddd3a2957d2ed69f8763L593-R594): Fixed a bug in the loop condition of the `test_get_gate_counts_bv_resets_barrier_and_measures` function, ensuring the correct variable (`j`) is used for iteration.