### PR TITLE
Improve MCMT synthesis for `XGate` base gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ clifford = "qiskit.transpiler.passes.synthesis.clifford_unitary_synth_plugin:Cli
 "mcmt.default" = "qiskit.transpiler.passes.synthesis.hls_plugins:MCMTSynthesisDefault"
 "mcmt.noaux" = "qiskit.transpiler.passes.synthesis.hls_plugins:MCMTSynthesisNoAux"
 "mcmt.vchain" = "qiskit.transpiler.passes.synthesis.hls_plugins:MCMTSynthesisVChain"
+"mcmt.xgate" = "qiskit.transpiler.passes.synthesis.hls_plugins:MCMTSynthesisXGate"
 "permutation.default" = "qiskit.transpiler.passes.synthesis.hls_plugins:BasicSynthesisPermutation"
 "permutation.kms" = "qiskit.transpiler.passes.synthesis.hls_plugins:KMSSynthesisPermutation"
 "permutation.basic" = "qiskit.transpiler.passes.synthesis.hls_plugins:BasicSynthesisPermutation"

--- a/qiskit/synthesis/__init__.py
+++ b/qiskit/synthesis/__init__.py
@@ -127,6 +127,7 @@ Multi Controlled Synthesis
 ==========================
 
 .. autofunction:: synth_mcmt_vchain
+.. autofunction:: synth_mcmt_xgate
 .. autofunction:: synth_mcx_1_clean_kg24
 .. autofunction:: synth_mcx_1_dirty_kg24
 .. autofunction:: synth_mcx_2_clean_kg24
@@ -225,6 +226,7 @@ from .two_qubit.two_qubit_decompose import (
 )
 from .multi_controlled import (
     synth_mcmt_vchain,
+    synth_mcmt_xgate,
     synth_mcx_1_clean_kg24,
     synth_mcx_1_dirty_kg24,
     synth_mcx_2_clean_kg24,

--- a/qiskit/synthesis/multi_controlled/__init__.py
+++ b/qiskit/synthesis/multi_controlled/__init__.py
@@ -13,7 +13,7 @@
 """Module containing multi-controlled circuits synthesis"""
 
 from .mcmt_vchain import synth_mcmt_vchain
-from .mcmt_x import synth_mcmt_x
+from .mcmt_xgate import synth_mcmt_xgate
 from .mcx_synthesis import (
     synth_mcx_1_clean_kg24,
     synth_mcx_1_dirty_kg24,

--- a/qiskit/synthesis/multi_controlled/__init__.py
+++ b/qiskit/synthesis/multi_controlled/__init__.py
@@ -13,6 +13,7 @@
 """Module containing multi-controlled circuits synthesis"""
 
 from .mcmt_vchain import synth_mcmt_vchain
+from .mcmt_x import synth_mcmt_x
 from .mcx_synthesis import (
     synth_mcx_1_clean_kg24,
     synth_mcx_1_dirty_kg24,

--- a/qiskit/synthesis/multi_controlled/mcmt_vchain.py
+++ b/qiskit/synthesis/multi_controlled/mcmt_vchain.py
@@ -49,7 +49,7 @@ def synth_mcmt_vchain(
         ctrl_state: Optional control state as an integer.
 
     Returns:
-        QuantumCircuit: The synthesized circuit for the MCMT gate.
+        The synthesized circuit for the MCMT gate.
 
     """
     if gate.num_qubits != 1:

--- a/qiskit/synthesis/multi_controlled/mcmt_vchain.py
+++ b/qiskit/synthesis/multi_controlled/mcmt_vchain.py
@@ -42,6 +42,15 @@ def synth_mcmt_vchain(
         q_6: ─────┤ X ├──■────■──┤ X ├─────
                   └───┘          └───┘
 
+    Args:
+        gate: base gate to be applied to the targets.
+        num_ctrl_qubits: Number of control qubits.
+        num_target_qubits: Number of target qubits.
+        ctrl_state: Optional control state as an integer.
+
+    Returns:
+        QuantumCircuit: The synthesized circuit for the MCMT gate.
+
     """
     if gate.num_qubits != 1:
         raise ValueError("Only single qubit gates are supported as input.")

--- a/qiskit/synthesis/multi_controlled/mcmt_vchain.py
+++ b/qiskit/synthesis/multi_controlled/mcmt_vchain.py
@@ -43,7 +43,7 @@ def synth_mcmt_vchain(
                   └───┘          └───┘
 
     Args:
-        gate: base gate to be applied to the targets.
+        gate: Base gate to be applied to the targets.
         num_ctrl_qubits: Number of control qubits.
         num_target_qubits: Number of target qubits.
         ctrl_state: Optional control state as an integer.

--- a/qiskit/synthesis/multi_controlled/mcmt_x.py
+++ b/qiskit/synthesis/multi_controlled/mcmt_x.py
@@ -46,7 +46,7 @@ def synth_mcmt_x(
         ctrl_state: Optional control state as an integer.
 
     Returns:
-        QuantumCircuit: The synthesized circuit for the MCMT X gate.
+        The synthesized circuit for the MCMT X gate.
 
     """
 

--- a/qiskit/synthesis/multi_controlled/mcmt_x.py
+++ b/qiskit/synthesis/multi_controlled/mcmt_x.py
@@ -26,6 +26,7 @@ def synth_mcmt_x(
     any ancillary qubits and benefits from efficient MCX decompositions.
 
     E.g. a 3-control, 3-target X gate will be synthesized as::
+
         q_0: ─────────────■────────────
                           |
         q_1: ─────────────■────────────
@@ -39,9 +40,15 @@ def synth_mcmt_x(
         q_5: ─┤ X ├───────────────┤ X ├
               └───┘               └───┘
 
+    Args:
+        num_ctrl_qubits: Number of control qubits.
+        num_target_qubits: Number of target qubits.
+        ctrl_state: Optional control state as an integer.
+
+    Returns:
+        QuantumCircuit: The synthesized circuit for the MCMT X gate.
+
     """
-    if ctrl_state is not None:
-        assert len(ctrl_state) == num_ctrl_qubits, "ctrl_state must match num_ctrl length"
 
     qr_c = QuantumRegister(num_ctrl_qubits, "ctrl")
     qr_t = QuantumRegister(num_target_qubits, "targ")

--- a/qiskit/synthesis/multi_controlled/mcmt_x.py
+++ b/qiskit/synthesis/multi_controlled/mcmt_x.py
@@ -19,6 +19,26 @@ from qiskit.circuit import QuantumCircuit, QuantumRegister
 def synth_mcmt_x(
     num_ctrl_qubits: int, num_target_qubits: int, ctrl_state: int | None = None
 ) -> QuantumCircuit:
+    """Synthesize MCMT X gate.
+
+    This uses a special circuit structure that is efficient for MCMT X gates. It does not require
+    any ancillary qubits and benefits from efficient MCX decompositions.
+
+    E.g. a 3-control, 3-target X gate will be synthesized as::
+        q_0: ─────────────■────────────
+                          |
+        q_1: ─────────────■────────────
+                          |
+        q_2: ─────────────■────────────
+                        ┌─┴─┐
+        q_3: ────────■──┤ X ├──■───────
+                   ┌─┴─┐└───┘┌─┴─┐
+        q_4: ───■──┤ X ├─────┤ X ├──■──
+              ┌─┴─┐└───┘     └───┘┌─┴─┐
+        q_5: ─┤ X ├───────────────┤ X ├
+              └───┘               └───┘
+
+    """
     if ctrl_state is not None:
         assert len(ctrl_state) == num_ctrl_qubits, "ctrl_state must match num_ctrl length"
 

--- a/qiskit/synthesis/multi_controlled/mcmt_x.py
+++ b/qiskit/synthesis/multi_controlled/mcmt_x.py
@@ -17,9 +17,9 @@ from qiskit.circuit import QuantumCircuit, QuantumRegister
 
 
 def synth_mcmt_x(
-        num_ctrl_qubits: int, num_target_qubits: int, ctrl_state: int | None = None
+    num_ctrl_qubits: int, num_target_qubits: int, ctrl_state: int | None = None
 ) -> QuantumCircuit:
-    if len(ctrl_state) > 0:
+    if ctrl_state is not None:
         assert len(ctrl_state) == num_ctrl_qubits, "ctrl_state must match num_ctrl length"
 
     qr_c = QuantumRegister(num_ctrl_qubits, "ctrl")
@@ -27,7 +27,7 @@ def synth_mcmt_x(
     qc = QuantumCircuit(qr_c, qr_t)
 
     if num_ctrl_qubits == 1:
-        qc.cx([qr_c[0]]* num_target_qubits, qr_t, ctrl_state=ctrl_state)
+        qc.cx([qr_c[0]] * num_target_qubits, qr_t, ctrl_state=ctrl_state)
         return qc
 
     # Linear nearest-neighbor style CX ladder before and after MCX

--- a/qiskit/synthesis/multi_controlled/mcmt_x.py
+++ b/qiskit/synthesis/multi_controlled/mcmt_x.py
@@ -1,0 +1,42 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Synthesis for multiple-control, multiple-target X Gate."""
+from __future__ import annotations
+
+from qiskit.circuit import QuantumCircuit, QuantumRegister
+
+
+def synth_mcmt_x(
+        num_ctrl_qubits: int, num_target_qubits: int, ctrl_state: int | None = None
+) -> QuantumCircuit:
+    if len(ctrl_state) > 0:
+        assert len(ctrl_state) == num_ctrl_qubits, "ctrl_state must match num_ctrl length"
+
+    qr_c = QuantumRegister(num_ctrl_qubits, "ctrl")
+    qr_t = QuantumRegister(num_target_qubits, "targ")
+    qc = QuantumCircuit(qr_c, qr_t)
+
+    if num_ctrl_qubits == 1:
+        qc.cx([qr_c[0]]* num_target_qubits, qr_t, ctrl_state=ctrl_state)
+        return qc
+
+    # Linear nearest-neighbor style CX ladder before and after MCX
+    for i in range(num_target_qubits - 1, 0, -1):
+        qc.cx(qr_t[i - 1], qr_t[i])
+
+    qc.mcx(qr_c, qr_t[0], ctrl_state=ctrl_state)
+
+    for i in range(1, num_target_qubits):
+        qc.cx(qr_t[i - 1], qr_t[i])
+
+    return qc

--- a/qiskit/synthesis/multi_controlled/mcmt_x.py
+++ b/qiskit/synthesis/multi_controlled/mcmt_x.py
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Synthesis for multiple-control, multiple-target X Gate."""
+
 from __future__ import annotations
 
 from qiskit.circuit import QuantumCircuit, QuantumRegister

--- a/qiskit/synthesis/multi_controlled/mcmt_xgate.py
+++ b/qiskit/synthesis/multi_controlled/mcmt_xgate.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from qiskit.circuit import QuantumCircuit, QuantumRegister
 
 
-def synth_mcmt_x(
+def synth_mcmt_xgate(
     num_ctrl_qubits: int, num_target_qubits: int, ctrl_state: int | None = None
 ) -> QuantumCircuit:
     """Synthesize MCMT X gate.

--- a/qiskit/transpiler/passes/synthesis/hls_plugins.py
+++ b/qiskit/transpiler/passes/synthesis/hls_plugins.py
@@ -567,7 +567,7 @@ from qiskit.synthesis.multi_controlled import (
     synth_mcx_gray_code,
     synth_mcx_noaux_v24,
     synth_mcmt_vchain,
-    synth_mcmt_x,
+    synth_mcmt_xgate,
 )
 from qiskit.synthesis.evolution import ProductFormula, synth_pauli_network_rustiq
 from qiskit.synthesis.arithmetic import (
@@ -1543,7 +1543,7 @@ class MCMTSynthesisXGate(HighLevelSynthesisPlugin):
             return None  # this plugin only supports X gates
 
         ctrl_state = options.get("ctrl_state", None)
-        return synth_mcmt_x(
+        return synth_mcmt_xgate(
             high_level_object.num_ctrl_qubits, high_level_object.num_target_qubits, ctrl_state
         )
 

--- a/qiskit/transpiler/passes/synthesis/hls_plugins.py
+++ b/qiskit/transpiler/passes/synthesis/hls_plugins.py
@@ -277,7 +277,7 @@ MCMT Synthesis
 
    MCMTSynthesisVChain
    MCMTSynthesisNoAux
-    MCMTSynthesisXGate
+   MCMTSynthesisXGate
    MCMTSynthesisDefault
 
    
@@ -1474,7 +1474,6 @@ class MCMTSynthesisDefault(HighLevelSynthesisPlugin):
         for synthesis_method in [
             MCMTSynthesisXGate,
             MCMTSynthesisVChain,
-            MCMTSynthesisNoAux,
         ]:
             if (
                 decomposition := synthesis_method().run(
@@ -1482,6 +1481,8 @@ class MCMTSynthesisDefault(HighLevelSynthesisPlugin):
                 )
             ) is not None:
                 return decomposition
+
+        return MCMTSynthesisNoAux().run(high_level_object, coupling_map, target, qubits, **options)
 
 
 class MCMTSynthesisNoAux(HighLevelSynthesisPlugin):

--- a/qiskit/transpiler/passes/synthesis/hls_plugins.py
+++ b/qiskit/transpiler/passes/synthesis/hls_plugins.py
@@ -498,6 +498,7 @@ from qiskit.circuit.operation import Operation
 from qiskit.circuit.library import (
     LinearFunction,
     QFTGate,
+    XGate,
     MCXGate,
     C3XGate,
     C4XGate,
@@ -560,6 +561,7 @@ from qiskit.synthesis.multi_controlled import (
     synth_mcx_gray_code,
     synth_mcx_noaux_v24,
     synth_mcmt_vchain,
+    synth_mcmt_x,
 )
 from qiskit.synthesis.evolution import ProductFormula, synth_pauli_network_rustiq
 from qiskit.synthesis.arithmetic import (
@@ -1463,6 +1465,13 @@ class MCMTSynthesisDefault(HighLevelSynthesisPlugin):
         # first try to use the V-chain synthesis if enough auxiliary qubits are available
         if not isinstance(high_level_object, MCMTGate):
             return None
+
+        if isinstance(high_level_object.base_gate, XGate):
+            # If the base gate is an X gate, we can use the specialised synthesis
+            ctrl_state = options.get("ctrl_state", None)
+            return synth_mcmt_x(
+                high_level_object.num_ctrl_qubits, high_level_object.num_target_qubits, ctrl_state
+            )
 
         if (
             decomposition := MCMTSynthesisVChain().run(

--- a/releasenotes/notes/mcmtx_synthesis-da7f9c822d73e4e1.yaml
+++ b/releasenotes/notes/mcmtx_synthesis-da7f9c822d73e4e1.yaml
@@ -1,6 +1,6 @@
 ---
 features_synthesis:
   - |
-    Added :func:`.synth_mcmt_xgate` to synthesize the multi-control multi-target gate when base gate
-    is :class:`XGate()`. It has decomposition in linear number of CX gates and `0` ancilla qubits 
-    along with the high-level synthesis plugin :class:`.MCMTSynthesisXGate`.
+    Added :func:`.synth_mcmt_xgate` to synthesize the multi-control multi-target gate when 
+    the base gate is :class:`XGate()`. It has a decomposition in linear number of CX gates and `0`
+    ancilla qubits along with the high-level synthesis plugin :class:`.MCMTSynthesisXGate`.

--- a/releasenotes/notes/mcmtx_synthesis-da7f9c822d73e4e1.yaml
+++ b/releasenotes/notes/mcmtx_synthesis-da7f9c822d73e4e1.yaml
@@ -1,0 +1,6 @@
+---
+features_synthesis:
+  - |
+    Added :func:`.synth_mcmt_xgate` to synthesize the multi-control multi-target gate when base gate
+    is :class:`XGate()`. It has decomposition in linear number of CX gates and `0` ancilla qubits 
+    along with the high-level synthesis plugin :class:`.MCMTSynthesisXGate`.

--- a/releasenotes/notes/mcmtx_synthesis-da7f9c822d73e4e1.yaml
+++ b/releasenotes/notes/mcmtx_synthesis-da7f9c822d73e4e1.yaml
@@ -2,5 +2,5 @@
 features_synthesis:
   - |
     Added :func:`.synth_mcmt_xgate` to synthesize the multi-control multi-target gate when 
-    the base gate is :class:`XGate()`. It has a decomposition in linear number of CX gates and `0`
+    the base gate is :class:`.XGate`. It has a decomposition in linear number of CX gates and `0`
     ancilla qubits along with the high-level synthesis plugin :class:`.MCMTSynthesisXGate`.

--- a/test/python/circuit/library/test_mcmt.py
+++ b/test/python/circuit/library/test_mcmt.py
@@ -273,7 +273,7 @@ class TestMCMT(QiskitTestCase):
         """Test MCMT gate uses `synth_mcmt_x` for X gate synthesis."""
         mcmt_x_gate = MCMTGate(XGate(), num_ctrl_qubits=num_ctrl, num_target_qubits=num_targ)
         qc = QuantumCircuit(num_ctrl + num_targ)
-        qc.compose(mcmt_x_gate, range(num_ctrl + num_targ), inplace=True)
+        qc.append(mcmt_x_gate, range(num_ctrl + num_targ))
 
         qc_transpiled = transpile(qc, basis_gates=["u", "cx"], qubits_initially_zero=False)
         expected_cx_count = 12 * num_ctrl + 2 * (

--- a/test/python/circuit/library/test_mcmt.py
+++ b/test/python/circuit/library/test_mcmt.py
@@ -20,6 +20,7 @@ from qiskit.exceptions import QiskitError
 from qiskit.compiler import transpile
 from qiskit.circuit import QuantumCircuit, QuantumRegister, Parameter
 from qiskit.circuit.library import (
+    ZGate,
     MCMT,
     MCMTVChain,
     CHGate,
@@ -184,7 +185,7 @@ class TestMCMT(QiskitTestCase):
         num_target = 2
         num_vchain_ancillas = num_controls - 1
 
-        gate = XGate()
+        gate = ZGate()  # Anything other than XGate as XGate has special handling
         mcmt = MCMTGate(gate, num_controls, num_target)
 
         # make sure MCX-synthesis does not use ancilla qubits

--- a/test/python/circuit/library/test_mcmt.py
+++ b/test/python/circuit/library/test_mcmt.py
@@ -13,7 +13,8 @@
 """Test library of multi-controlled multi-target circuits."""
 
 import unittest
-from itertools import product
+from functools import reduce
+from itertools import repeat
 from ddt import ddt, data, unpack
 import numpy as np
 
@@ -39,7 +40,7 @@ from qiskit.quantum_info import Statevector
 from qiskit.quantum_info.states import state_fidelity
 from qiskit.quantum_info.operators.operator_utils import _equal_with_ancillas
 from qiskit.transpiler.passes import HighLevelSynthesis, HLSConfig
-from qiskit.synthesis.multi_controlled import synth_mcmt_vchain
+from qiskit.synthesis.multi_controlled import synth_mcmt_vchain, synth_mcmt_xgate
 from qiskit.quantum_info import Operator
 from test import QiskitTestCase, combine  # pylint: disable=wrong-import-order
 
@@ -270,15 +271,27 @@ class TestMCMT(QiskitTestCase):
 
     @combine(num_ctrl=range(1, 6), num_targ=range(2, 6))
     def test_mcmt_x_gate(self, num_ctrl, num_targ):
+        """Test the MCMT X gate synthesis."""
+        ctrl_state = None
+
+        synthesized = synth_mcmt_xgate(num_ctrl, num_targ, ctrl_state)
+        result = Operator(synthesized).data
+
+        x_gate_matrix = XGate().to_matrix()
+        target_gate_matrix = reduce(np.kron, repeat(x_gate_matrix, num_targ))
+
+        expected = _compute_control_matrix(target_gate_matrix, num_ctrl, ctrl_state)
+        self.assertTrue(np.allclose(result, expected))
+
+    @combine(num_ctrl=range(1, 6), num_targ=range(2, 6))
+    def test_mcmt_x_gate_counts(self, num_ctrl, num_targ):
         """Test MCMT gate uses `synth_mcmt_x` for X gate synthesis."""
         mcmt_x_gate = MCMTGate(XGate(), num_ctrl_qubits=num_ctrl, num_target_qubits=num_targ)
         qc = QuantumCircuit(num_ctrl + num_targ)
         qc.append(mcmt_x_gate, range(num_ctrl + num_targ))
 
         qc_transpiled = transpile(qc, basis_gates=["u", "cx"], qubits_initially_zero=False)
-        expected_cx_count = 12 * num_ctrl + 2 * (
-            num_targ - 1
-        )  # 1 MCX + 2(num_targ - 1) CX gates
+        expected_cx_count = 12 * num_ctrl + 2 * (num_targ - 1)  # 1 MCX + 2(num_targ - 1) CX gates
         self.assertLessEqual(qc_transpiled.count_ops().get("cx", 0), expected_cx_count)
 
     def test_invalid_base_gate_width(self):

--- a/test/python/circuit/library/test_mcmt.py
+++ b/test/python/circuit/library/test_mcmt.py
@@ -20,7 +20,6 @@ from qiskit.exceptions import QiskitError
 from qiskit.compiler import transpile
 from qiskit.circuit import QuantumCircuit, QuantumRegister, Parameter
 from qiskit.circuit.library import (
-    ZGate,
     MCMT,
     MCMTVChain,
     CHGate,

--- a/test/python/circuit/library/test_mcmt.py
+++ b/test/python/circuit/library/test_mcmt.py
@@ -269,7 +269,7 @@ class TestMCMT(QiskitTestCase):
             )
         )
 
-    @combine(num_ctrl=range(1, 6), num_targ=range(2, 6))
+    @combine(num_ctrl=range(1, 3), num_targ=range(2, 4))
     def test_mcmt_x_gate(self, num_ctrl, num_targ):
         """Test the MCMT X gate synthesis."""
         ctrl_state = None


### PR DESCRIPTION
This PR optimises the synthesis of multi-controlled multi-target (MCMT) gates when the `base_gate` is `XGate()`. The current implementation uses a generic V-chain construction, which is suboptimal for this case. We replace it with a more efficient decomposition:

* For `n_target = 1`, it reduces to a standard `MCX` gate.
* For `n_target > 1`, it uses a single `MCX` gate and `2*(t-1)` CX gates, with at least one dirty ancilla available.
* This enables the use of optimized MCX decompositions (e.g., #14394).

A comparison plot is included below, showing that the proposed method achieves savings of hundreds to thousands of CX gates, depending on the circuit size. Here, `MCMTX` is the proposed decomposition.

<img width="921" height="590" alt="image" src="https://github.com/user-attachments/assets/1626dade-37d7-4d12-a2e2-87878b6682e8" />

Tagging @ShellyGarion and @alexanderivrii based on past discussions around MCX gates.