### PR TITLE
Avoid clone on entry to `BasisTranslator`

### DIFF
--- a/crates/transpiler/src/passes/basis_translator/mod.rs
+++ b/crates/transpiler/src/passes/basis_translator/mod.rs
@@ -56,16 +56,16 @@ type PhysicalQargs = SmallVec<[PhysicalQubit; 2]>;
 #[pyfunction(name = "base_run", signature = (dag, equiv_lib, qargs_with_non_global_operation, min_qubits, target_basis=None, target=None, non_global_operations=None))]
 pub fn run_basis_translator(
     py: Python<'_>,
-    dag: DAGCircuit,
+    dag: &DAGCircuit,
     equiv_lib: &mut EquivalenceLibrary,
     qargs_with_non_global_operation: HashMap<Qargs, HashSet<String>>,
     min_qubits: usize,
     target_basis: Option<HashSet<String>>,
     target: Option<&Target>,
     non_global_operations: Option<HashSet<String>>,
-) -> PyResult<DAGCircuit> {
+) -> PyResult<Option<DAGCircuit>> {
     if target_basis.is_none() && target.is_none() {
-        return Ok(dag);
+        return Ok(None);
     }
 
     let qargs_with_non_global_operation: IndexMap<
@@ -108,7 +108,7 @@ pub fn run_basis_translator(
             .collect();
         extract_basis_target(
             py,
-            &dag,
+            dag,
             &mut source_basis,
             &mut qargs_local_source_basis,
             min_qubits,
@@ -119,7 +119,7 @@ pub fn run_basis_translator(
             .into_iter()
             .map(|x| x.to_string())
             .collect();
-        source_basis = extract_basis(py, &dag, min_qubits)?;
+        source_basis = extract_basis(py, dag, min_qubits)?;
         new_target_basis = target_basis.unwrap().into_iter().collect();
     }
     new_target_basis = new_target_basis
@@ -131,7 +131,7 @@ pub fn run_basis_translator(
     // translate and we can exit early.
     let source_basis_names: IndexSet<String> = source_basis.iter().map(|x| x.0.clone()).collect();
     if source_basis_names.is_subset(&new_target_basis) && qargs_local_source_basis.is_empty() {
-        return Ok(dag);
+        return Ok(None);
     }
     let basis_transforms = basis_search(equiv_lib, &source_basis, &new_target_basis);
     let mut qarg_local_basis_transforms: IndexMap<
@@ -198,27 +198,27 @@ pub fn run_basis_translator(
         )));
     };
 
-    let instr_map: InstMap = compose_transforms(py, &basis_transforms, &source_basis, &dag)?;
+    let instr_map: InstMap = compose_transforms(py, &basis_transforms, &source_basis, dag)?;
     let extra_inst_map: ExtraInstructionMap = qarg_local_basis_transforms
         .iter()
         .map(|(qarg, transform)| -> PyResult<_> {
             Ok((
                 *qarg,
-                compose_transforms(py, transform, &qargs_local_source_basis[*qarg], &dag)?,
+                compose_transforms(py, transform, &qargs_local_source_basis[*qarg], dag)?,
             ))
         })
         .collect::<PyResult<_>>()?;
 
     let (out_dag, _) = apply_translation(
         py,
-        &dag,
+        dag,
         &new_target_basis,
         &instr_map,
         &extra_inst_map,
         min_qubits,
         &qargs_with_non_global_operation,
     )?;
-    Ok(out_dag)
+    Ok(Some(out_dag))
 }
 
 /// Method that extracts all gate instances identifiers from a DAGCircuit.

--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -127,7 +127,7 @@ class BasisTranslator(TransformationPass):
             DAGCircuit: translated circuit.
         """
 
-        return base_run(
+        out = base_run(
             dag,
             self._equiv_lib,
             self._qargs_with_non_global_operation,
@@ -136,3 +136,6 @@ class BasisTranslator(TransformationPass):
             self._target,
             None if self._non_global_operations is None else set(self._non_global_operations),
         )
+        # If Rust-space basis translation returns `None`, it's because the input DAG is already
+        # suitable and it didn't need to modify anything.
+        return dag if out is None else out


### PR DESCRIPTION
The Rust-space method takes ownership of the `DAGCircuit` so that the return type can be a unified `PyResult<DAGCircuit>`, even though in the majority case, the pass actually builds a completely new DAG.  This unfortunately requires an implicit clone on entry from Python space, even though there is no situation where the clone is actually _necessary_; the rebuild form never mutates the input, and in the fast-return paths, Python space can simply continue using the reference to a `DAGCircuit` it already holds.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


