### PR TITLE
Add structural equality check for `DAGCircuit`

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -2245,10 +2245,6 @@ impl DAGCircuit {
     /// but does consider many low-level implementation details of the internal representation, many
     /// of which do not change the semantics of the circuit.
     ///
-    /// ..
-    ///
-    ///     Note to devs: the internal details referred to are things like the interners.
-    ///
     /// This method should, in general, be much faster than graph-equivalence checks, but will
     /// return ``False`` in many more situations.  This method should never return ``True`` when a
     /// graph-equivalence check would return ``False``.
@@ -2258,6 +2254,15 @@ impl DAGCircuit {
     ///     This currently does not handle control flow, because of technical limitations in the
     ///     internal representation of control flow, and will return `false` if any control-flow
     ///     operation is present, even if they are individually equal.
+    ///
+    /// .. seealso::
+    ///     The ``==`` operator
+    ///         :class:`DAGCircuit` implements :func:`~object.__eq__` between itself and other
+    ///         :class:`DAGCircuit` instances (this same method also powers
+    ///         :class:`.QuantumCircuit`'s equality check).  This implements a basic semantic
+    ///         data-flow equality check, which is less sensitive to the order operations were
+    ///         defined.  This is more usually what a circuit user cares about with respect to
+    ///         equality.
     fn structurally_equal(&self, other: &DAGCircuit) -> PyResult<bool> {
         if self.qubits != other.qubits {
             return Ok(false);
@@ -2277,8 +2282,8 @@ impl DAGCircuit {
         if self.cregs != other.cregs {
             return Ok(false);
         }
-        // Checking the identfiier information should handle all different methods of declaration
-        // for all identfiiers, whether var or stretch.  We do a manual iteration-based check here
+        // Checking the identifier information should handle all different methods of declaration
+        // for all identifiers, whether var or stretch.  We do a manual iteration-based check here
         // because `IndexMap`'s default is order-insensitive, but we actually do care about order
         // for the structural check.
         if self.identifier_info.len() != other.identifier_info.len() {

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -2259,10 +2259,9 @@ impl DAGCircuit {
     ///     The ``==`` operator
     ///         :class:`DAGCircuit` implements :func:`~object.__eq__` between itself and other
     ///         :class:`DAGCircuit` instances (this same method also powers
-    ///         :class:`.QuantumCircuit`'s equality check).  This implements a basic semantic
+    ///         :class:`.QuantumCircuit`'s equality check).  This implements a semantic
     ///         data-flow equality check, which is less sensitive to the order operations were
-    ///         defined.  This is more usually what a circuit user cares about with respect to
-    ///         equality.
+    ///         defined.  This is typically what a user cares about with respect to equality.
     fn structurally_equal(&self, other: &DAGCircuit) -> PyResult<bool> {
         if self.qubits != other.qubits {
             return Ok(false);

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -44,7 +44,7 @@ use crate::{imports, Clbit, Qubit, Stretch, TupleLikeArg, Var, VarsMode};
 
 use hashbrown::{HashMap, HashSet};
 use indexmap::IndexMap;
-use itertools::Itertools;
+use itertools::{EitherOrBoth, Itertools};
 
 use pyo3::exceptions::{
     PyDeprecationWarning, PyIndexError, PyRuntimeError, PyTypeError, PyValueError,
@@ -104,6 +104,23 @@ impl NodeType {
         match self {
             NodeType::Operation(instr) => instr,
             _ => panic!("Node is not an operation!"),
+        }
+    }
+
+    /// Are these two nodes equal, using the given closure to compare [PackedInstruction] variants.
+    pub fn equal_with<F, E>(&self, other: &Self, cmp: F) -> Result<bool, E>
+    where
+        F: FnOnce(&PackedInstruction, &PackedInstruction) -> Result<bool, E>,
+    {
+        match (self, other) {
+            (Self::QubitIn(left), Self::QubitIn(right)) => Ok(left == right),
+            (Self::QubitOut(left), Self::QubitOut(right)) => Ok(left == right),
+            (Self::ClbitIn(left), Self::ClbitIn(right)) => Ok(left == right),
+            (Self::ClbitOut(left), Self::ClbitOut(right)) => Ok(left == right),
+            (Self::VarIn(left), Self::VarIn(right)) => Ok(left == right),
+            (Self::VarOut(left), Self::VarOut(right)) => Ok(left == right),
+            (Self::Operation(left), Self::Operation(right)) => cmp(left, right),
+            _ => Ok(false),
         }
     }
 }
@@ -335,7 +352,7 @@ impl PyBitLocations {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum DAGVarType {
     Input = 0,
     Capture = 1,
@@ -352,7 +369,7 @@ impl From<CircuitVarType> for DAGVarType {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DAGVarInfo {
     var: Var,
     type_: DAGVarType,
@@ -397,7 +414,7 @@ impl DAGVarInfo {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum DAGStretchType {
     Capture = 0,
     Declare = 1,
@@ -412,7 +429,7 @@ impl From<CircuitStretchType> for DAGStretchType {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DAGStretchInfo {
     stretch: Stretch,
     type_: DAGStretchType,
@@ -446,7 +463,7 @@ impl DAGStretchInfo {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DAGIdentifierInfo {
     Stretch(DAGStretchInfo),
     Var(DAGVarInfo),
@@ -2214,6 +2231,182 @@ impl DAGCircuit {
                 unreachable!()
             }
         })
+    }
+
+    /// Are these two DAGs structurally equal?
+    ///
+    /// This function returns true iff the graph structures are precisely the same as each other,
+    /// including the valid node indices, edge orders, and so on.  This is a much stricter check
+    /// than graph equivalence, and is mostly useful for testing if two :class:`DAGCircuit`
+    /// instances have been constructed and manipulated in the exact same ways.  For example, this
+    /// method can be used to test whether a sequence of manipulations of a DAG is deterministic.
+    ///
+    /// This method does not consider tracking metadata such as :attr:`metadata` or :attr:`name`,
+    /// but does consider many low-level implementation details of the internal representation, many
+    /// of which do not change the semantics of the circuit.
+    ///
+    /// ..
+    ///
+    ///     Note to devs: the internal details referred to are things like the interners.
+    ///
+    /// This method should, in general, be much faster than graph-equivalence checks, but will
+    /// return ``False`` in many more situations.  This method should never return ``True`` when a
+    /// graph-equivalence check would return ``False``.
+    ///
+    /// .. note::
+    ///
+    ///     This currently does not handle control flow, because of technical limitations in the
+    ///     internal representation of control flow, and will return `false` if any control-flow
+    ///     operation is present, even if they are individually equal.
+    fn structurally_equal(&self, other: &DAGCircuit) -> PyResult<bool> {
+        if self.qubits != other.qubits {
+            return Ok(false);
+        }
+        if self.clbits != other.clbits {
+            return Ok(false);
+        }
+        if self.vars != other.vars {
+            return Ok(false);
+        }
+        if self.stretches != other.stretches {
+            return Ok(false);
+        }
+        if self.qregs != other.qregs {
+            return Ok(false);
+        }
+        if self.cregs != other.cregs {
+            return Ok(false);
+        }
+        // Checking the identfiier information should handle all different methods of declaration
+        // for all identfiiers, whether var or stretch.  We do a manual iteration-based check here
+        // because `IndexMap`'s default is order-insensitive, but we actually do care about order
+        // for the structural check.
+        if self.identifier_info.len() != other.identifier_info.len() {
+            return Ok(false);
+        }
+        if self
+            .identifier_info
+            .iter()
+            .zip(other.identifier_info.iter())
+            .any(|(a, b)| a != b)
+        {
+            return Ok(false);
+        }
+        // This is a stricter check than `Param::eq`, since we don't allow equality between explicit
+        // floats and Python-object representations of the same float.
+        let param_eq = |left: &Param, right: &Param| -> PyResult<bool> {
+            match (left, right) {
+                (Param::Float(a), Param::Float(b)) => Ok(a.total_cmp(b) == Ordering::Equal),
+                (Param::ParameterExpression(a), Param::ParameterExpression(b)) => Ok(a.eq(b)),
+                (Param::Obj(a), Param::Obj(b)) => Python::with_gil(|py| a.bind(py).eq(b.bind(py))),
+                _ => Ok(false),
+            }
+        };
+        if !param_eq(&self.global_phase, &other.global_phase)? {
+            return Ok(false);
+        }
+        // This is stricter than `PackedInstruction::py_op_eq` because it doesn't allow equality
+        // between `StandardGate` and Python versions of that.  Additionally, it short-circuits out
+        // of control-flow, rather than recursing through while we currently don't have a clean
+        // representation of DAG-like structured control flow.
+        let inst_eq = |from_self: &PackedInstruction,
+                       from_other: &PackedInstruction|
+         -> PyResult<bool> {
+            if self.qargs_interner.get(from_self.qubits)
+                != other.qargs_interner.get(from_other.qubits)
+            {
+                return Ok(false);
+            }
+            if self.cargs_interner.get(from_self.clbits)
+                != other.cargs_interner.get(from_other.clbits)
+            {
+                return Ok(false);
+            }
+            match (from_self.params.as_ref(), from_other.params.as_ref()) {
+                (None, None) => (),
+                (Some(_), None) | (None, Some(_)) => return Ok(false),
+                (Some(left), Some(right)) => {
+                    if left.len() != right.len() {
+                        return Ok(false);
+                    }
+                    for (left, right) in left.iter().zip(right.iter()) {
+                        if !param_eq(left, right)? {
+                            return Ok(false);
+                        }
+                    }
+                }
+            }
+            match (from_self.op.view(), from_other.op.view()) {
+                (OperationRef::StandardGate(left), OperationRef::StandardGate(right)) => {
+                    Ok(left == right)
+                }
+                (
+                    OperationRef::StandardInstruction(left),
+                    OperationRef::StandardInstruction(right),
+                ) => Ok(left == right),
+                (OperationRef::Unitary(left), OperationRef::Unitary(right)) => Ok(left == right),
+                (OperationRef::Gate(left), OperationRef::Gate(right)) => {
+                    Python::with_gil(|py| left.gate.bind(py).eq(&right.gate))
+                }
+                (OperationRef::Instruction(left), OperationRef::Instruction(right)) => {
+                    Python::with_gil(|py| left.instruction.bind(py).eq(&right.instruction))
+                }
+                (OperationRef::Operation(left), OperationRef::Operation(right)) => {
+                    Python::with_gil(|py| left.operation.bind(py).eq(&right.operation))
+                }
+                _ => Ok(false),
+            }
+        };
+        // We use this helper because the default impl of `PartialEq` doesn't check the source and
+        // target, since it usually doesn't make sense to compare references between graphs.  It
+        // makes sense for us, because we're checking that the graphs are structurally identical.
+        let edgeref_eq = |left: EdgeReference<'_, Wire>, right: EdgeReference<'_, Wire>| -> bool {
+            left.source() == right.source()
+                && left.target() == right.target()
+                && left.id() == right.id()
+                && left.weight() == right.weight()
+        };
+
+        // Now the meat of the actual comparison.  This is deliberately non-topological and
+        // index-sensitive - that's exactly what we're testing for.
+        if self.dag.node_count() != other.dag.node_count()
+            || self.dag.edge_count() != other.dag.edge_count()
+        {
+            return Ok(false);
+        }
+        for (self_index, other_index) in self.dag.node_indices().zip(other.dag.node_indices()) {
+            // The `NodeIndex` values should be the same for both; for the example of two DAGs that
+            // have undergone a deterministic compilation pipeline, this means that they've seen the
+            // same sequence of additions, removals and substitutions (or at least a comparable
+            // sequence), which they should have.
+            if self_index != other_index {
+                return Ok(false);
+            }
+            if !self.dag[self_index].equal_with(&other.dag[other_index], inst_eq)? {
+                return Ok(false);
+            }
+            for pair in self
+                .dag
+                .edges_directed(self_index, Direction::Incoming)
+                .zip_longest(other.dag.edges_directed(other_index, Direction::Incoming))
+            {
+                match pair {
+                    EitherOrBoth::Both(left, right) if edgeref_eq(left, right) => (),
+                    _ => return Ok(false),
+                }
+            }
+            for pair in self
+                .dag
+                .edges_directed(self_index, Direction::Outgoing)
+                .zip_longest(other.dag.edges_directed(other_index, Direction::Outgoing))
+            {
+                match pair {
+                    EitherOrBoth::Both(left, right) if edgeref_eq(left, right) => (),
+                    _ => return Ok(false),
+                }
+            }
+        }
+        Ok(true)
     }
 
     /// Yield nodes in topological order.

--- a/crates/circuit/src/object_registry.rs
+++ b/crates/circuit/src/object_registry.rs
@@ -134,6 +134,15 @@ where
         Self::new()
     }
 }
+// The stronger `Eq` restriction here on `B` (not `PartialEq`) is because it's necessary for the
+// hashmap to function correctly and consequently to implement `PartialEq`.
+impl<T: PartialEq, B: Eq + Hash> PartialEq for ObjectRegistry<T, B> {
+    fn eq(&self, other: &Self) -> bool {
+        (self.objects == other.objects) && (self.indices == other.indices)
+    }
+}
+impl<T: Eq, B: Eq + Hash> Eq for ObjectRegistry<T, B> {}
+
 impl<T, B> ObjectRegistry<T, B>
 where
     T: From<u32> + Copy,

--- a/crates/circuit/src/register_data.rs
+++ b/crates/circuit/src/register_data.rs
@@ -69,6 +69,12 @@ where
         Self::new()
     }
 }
+impl<R: Register + PartialEq> PartialEq for RegisterData<R> {
+    fn eq(&self, other: &Self) -> bool {
+        (self.registers == other.registers) && (self.reg_index == other.reg_index)
+    }
+}
+impl<R: Register + Eq> Eq for RegisterData<R> {}
 
 impl<R> RegisterData<R>
 where

--- a/releasenotes/notes/dag-structural-equality-2618b4a2cb6486f1.yaml
+++ b/releasenotes/notes/dag-structural-equality-2618b4a2cb6486f1.yaml
@@ -1,0 +1,7 @@
+---
+features_transpiler:
+  - |
+    A new method, :meth:`.DAGCircuit.structurally_equal`, can be used to if two :class:`.DAGCircuit`
+    instances have been created and modified in the exact same order.  This is a much stronger test
+    than the standard semantic equivalence check of the ``==`` overload, and can be used by
+    transpiler-pass authors to verify that their modification orders are deterministic.


### PR DESCRIPTION
The current implementation of equality (the Python-facing `DAGCircuit.__eq__`) is a semantic-equality checker.  This is typically what users care about.  Transpiler-pass authors, however, need to care about determinism in the order of modifications of a DAG, including normally internal details such as the precise set of `NodeIndex`es that are populated, or the order the edges are traversed for any given node.

This commit adds a new method, `DAGCircuit::structurally_equal`, which checks the node and edge lists of the graph structure for exact equality (slightly indirectly, since `petgraph` doesn't let us access the internal details of the `StableGraph` struct directly), to help verify whether two DAGs have gone through the same order of modifications.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

This needs tests but I wanted to push it for comment before I spend the time writing them, since it's implying strong requirements on determinism for passes.  Currently, Rust-space Sabre (since #14317) appears non-deterministic on some ASV benchmarks, but this is because it directly iterates over the internal graph structure (the node and edge lists), which are modified in a non-deterministic order by `CommutativeCancellation`.  The check function in this PR is how I tracked down the non-determinism, using a pretty hacky recipe such as:

```python
import queue
import threading
from qiskit import transpile, QuantumCircuit

cm = [
    [0, 5], [0, 1], [1, 2], [1, 0], [2, 3], [2, 1], [3, 4], [3, 2], [4, 6], [4, 3], [5, 9], [5, 0], [6, 13], [6, 4], [7, 16],
    [7, 8], [8, 9], [8, 7], [9, 10], [9, 8], [9, 5], [10, 11], [10, 9], [11, 17], [11, 12], [11, 10], [12, 13], [12, 11], [13, 14],
    [13, 12], [13, 6], [14, 15], [14, 13], [15, 18], [15, 14], [16, 19], [16, 7], [17, 23], [17, 11], [18, 27], [18, 15], [19, 20],
    [19, 16], [20, 21], [20, 19], [21, 28], [21, 22], [21, 20], [22, 23], [22, 21], [23, 24], [23, 22], [23, 17], [24, 25], [24, 23],
    [25, 29], [25, 26], [25, 24], [26, 27], [26, 25], [27, 26], [27, 18], [28, 32], [28, 21], [29, 36], [29, 25], [30, 39], [30, 31],
    [31, 32], [31, 30], [32, 33], [32, 31], [32, 28], [33, 34], [33, 32], [34, 40], [34, 35], [34, 33], [35, 36], [35, 34], [36, 37],
    [36, 35], [36, 29], [37, 38], [37, 36], [38, 41], [38, 37], [39, 42], [39, 30], [40, 46], [40, 34], [41, 50], [41, 38], [42, 43],
    [42, 39], [43, 44], [43, 42], [44, 51], [44, 45], [44, 43], [45, 46], [45, 44], [46, 47], [46, 45], [46, 40], [47, 48], [47, 46],
    [48, 52], [48, 49], [48, 47], [49, 50], [49, 48], [50, 49], [50, 41], [51, 44], [52, 48],
]
# (assuming we're in the repo root)
qc = QuantumCircuit.from_qasm_file("test/benchmarks/qasm/53QBT_100CYC_QSE_3.qasm")

kwargs = dict(
    coupling_map=cm,
    basis_gates=["id", "rz", "sx", "x", "cx"],
    layout_method="sabre",
    optimization_level=2,
    seed_transpiler=0,
)

def per_pass_iter(qc, kwargs):
    worker = queue.Queue(1)
    driver = queue.Queue(1)
    done = object()
    keep_going = object()

    def run_transpile():
        def push(pass_, dag, **_):
            driver.put((pass_, dag))
            if worker.get() is done:
                raise SystemExit

        if worker.get() is done:
            return
        transpile(qc, **kwargs, callback=push)
        driver.put(done)

    thread = threading.Thread(target=run_transpile)
    thread.start()

    try:
        while True:
            worker.put(keep_going)
            if (msg := driver.get()) is done:
                return
            yield msg
    finally:
        worker.put(done)

for (left_pass, left), (right_pass, right) in zip(per_pass_iter(qc, kwargs), per_pass_iter(qc, kwargs)):
    assert left_pass.name() == right_pass.name()
    print(left_pass.name(), left.structurally_equal(right))
```