### PR TITLE
Fix non-determinism in `CommutativeCancellation`

### DIFF
--- a/crates/transpiler/src/passes/commutation_analysis.rs
+++ b/crates/transpiler/src/passes/commutation_analysis.rs
@@ -12,21 +12,21 @@
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::PyModule;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
 use pyo3::{pyfunction, wrap_pyfunction, Bound, PyResult, Python};
-use qiskit_circuit::Qubit;
+
+use indexmap::IndexMap;
+use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
 use crate::commutation_checker::CommutationChecker;
-use hashbrown::HashMap;
-use pyo3::prelude::*;
-
-use pyo3::types::{PyDict, PyList};
 use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType, Wire};
-use rustworkx_core::petgraph::stable_graph::NodeIndex;
+use qiskit_circuit::Qubit;
 
 // Custom types to store the commutation sets and node indices,
 // see the docstring below for more information.
-type CommutationSet = HashMap<Wire, Vec<Vec<NodeIndex>>>;
-type NodeIndices = HashMap<(NodeIndex, Wire), usize>;
+type CommutationSet = IndexMap<Wire, Vec<Vec<NodeIndex>>, ::ahash::RandomState>;
+type NodeIndices = IndexMap<(NodeIndex, Wire), usize, ::ahash::RandomState>;
 
 // the maximum number of qubits we check commutativity for
 const MAX_NUM_QUBITS: u32 = 3;
@@ -55,8 +55,8 @@ pub fn analyze_commutations(
     commutation_checker: &mut CommutationChecker,
     approximation_degree: f64,
 ) -> PyResult<(CommutationSet, NodeIndices)> {
-    let mut commutation_set: CommutationSet = HashMap::new();
-    let mut node_indices: NodeIndices = HashMap::new();
+    let mut commutation_set: CommutationSet = Default::default();
+    let mut node_indices: NodeIndices = Default::default();
 
     for qubit in 0..dag.num_qubits() {
         let wire = Wire::Qubit(Qubit(qubit as u32));

--- a/qiskit/transpiler/passes/optimization/commutative_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/commutative_cancellation.py
@@ -78,5 +78,7 @@ class CommutativeCancellation(TransformationPass):
         Returns:
             DAGCircuit: the optimized DAG.
         """
-        commutation_cancellation.cancel_commutations(dag, self._commutation_checker, self.basis)
+        commutation_cancellation.cancel_commutations(
+            dag, self._commutation_checker, sorted(self.basis)
+        )
         return dag

--- a/releasenotes/notes/fix-commutation-nondeterminism-51b545db6f2f1e18.yaml
+++ b/releasenotes/notes/fix-commutation-nondeterminism-51b545db6f2f1e18.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed a non-determinism in :class:`.CommutativeCancellation`.  This did not affect the order
+    returned by :meth:`.DAGCircuit.topological_nodes` or :meth:`~.DAGCircuit.topological_op_nodes`,
+    which typically should be used when node-order determinism is important, due to their built-in
+    canonical sorting function.  However, if inspecting the nodes by arbitrary order
+    (:meth:`.DAGCircuit.op_nodes`) or the edge structure (:meth:`.DAGCircuit.edges`), the iteration
+    order would be non-deterministic after a call to :class:`.CommutativeCancellation`.


### PR DESCRIPTION
The use of `HashMap` and `HashSet` for internal tracking structures in the pass, which were subsequently iterated over, caused node removals to happen in a non-deterministic order, which in turn could cause the edge structure of the `DAGCircuit` to be non-deterministic.  This did not affect a topological iteration over the nodes when canonicalised by the `qargs` and `cargs`, but passes (such as Rust-space Sabre) that iterate over the edge structure themselves can observe the non-determinism.

Sabre wants to iterate over the edges itself because, as a routing algorithm, it is implementing its own coroutine variant of topological ordering on a related graph.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

No test currently, because how I write it depends on whether we take #14762 or not.  I manually verified that this PR fixes the current determinism issue in the ASV benchmark `QUEKOTranspilerBench.track_depth_bss_optimal_depth_100`.