### PR TITLE
Fix a bug in `Target::py_instruction_supported` and remove the `py` token parameter

### DIFF
--- a/crates/transpiler/src/passes/gate_direction.rs
+++ b/crates/transpiler/src/passes/gate_direction.rs
@@ -23,6 +23,7 @@ use qiskit_circuit::{
     converters::{circuit_to_dag, QuantumCircuitData},
     dag_circuit::DAGCircuit,
     imports,
+    imports::get_std_gate_class,
     operations::Operation,
     operations::Param,
     operations::StandardGate,
@@ -209,9 +210,13 @@ pub fn fix_direction_target(
                 StandardGate::RXX | StandardGate::RYY | StandardGate::RZZ | StandardGate::RZX => {
                     return target
                         .py_instruction_supported(
-                            Some(std_gate.get_name().to_string()),
-                            qargs.into(),
                             None,
+                            qargs.into(),
+                            Some(
+                                get_std_gate_class(py, std_gate)
+                                    .expect("These gates should have Python classes")
+                                    .bind(py),
+                            ),
                             Some(inst.params_view().to_vec()),
                         )
                         .unwrap_or(false)

--- a/crates/transpiler/src/passes/gate_direction.rs
+++ b/crates/transpiler/src/passes/gate_direction.rs
@@ -23,7 +23,6 @@ use qiskit_circuit::{
     converters::{circuit_to_dag, QuantumCircuitData},
     dag_circuit::DAGCircuit,
     imports,
-    imports::get_std_gate_class,
     operations::Operation,
     operations::Param,
     operations::StandardGate,
@@ -210,14 +209,9 @@ pub fn fix_direction_target(
                 StandardGate::RXX | StandardGate::RYY | StandardGate::RZZ | StandardGate::RZX => {
                     return target
                         .py_instruction_supported(
-                            py,
-                            None,
+                            Some(std_gate.get_name().to_string()),
                             qargs.into(),
-                            Some(
-                                get_std_gate_class(py, std_gate)
-                                    .expect("These gates should have Python classes")
-                                    .bind(py),
-                            ),
+                            None,
                             Some(inst.params_view().to_vec()),
                         )
                         .unwrap_or(false)

--- a/crates/transpiler/src/target/mod.rs
+++ b/crates/transpiler/src/target/mod.rs
@@ -551,9 +551,8 @@ impl Target {
                         }
                     }
                     TargetOperation::Normal(normal) => {
-                        if Python::with_gil(|py| {
-                            normal.into_pyobject(py)?.is_instance(_operation_class)
-                        })? {
+                        let py = _operation_class.py();
+                        if normal.into_pyobject(py)?.is_instance(_operation_class)? {
                             if let Some(parameters) = &parameters {
                                 if parameters.len() != normal.params.len() {
                                     continue;

--- a/releasenotes/notes/fix-instruction-supported-qargs-3e7b03210fa23a65.yaml
+++ b/releasenotes/notes/fix-instruction-supported-qargs-3e7b03210fa23a65.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug in :meth:`.Target.instruction_supported` where the check of instruction's qubit order
+    was skipped when the method was called with ``operation_name`` and ``parameters`` arguments
+    that matched an existing instruction.

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -1090,6 +1090,9 @@ Instructions:
         self.assertTrue(
             mumbai.target.instruction_supported("rzx_45", qargs=(0, 1), parameters=[math.pi / 4])
         )
+        self.assertFalse(
+            mumbai.target.instruction_supported("rzx_45", qargs=(1, 0), parameters=[math.pi / 4])
+        )
         self.assertTrue(mumbai.target.instruction_supported("rzx_45", qargs=(0, 1)))
         self.assertTrue(mumbai.target.instruction_supported("rzx_45", parameters=[math.pi / 4]))
         self.assertFalse(mumbai.target.instruction_supported("rzx_45", parameters=[math.pi / 6]))


### PR DESCRIPTION
This commit removes the py token from `Target::py_instruction_supported()` function.  `python::with_gil` is still used when the function is called ~~with `operation_class` or~~ with `operation_name` and `parameters` arguments and Python side checking of parameters is required.

Also fixed a bug where qargs checking was skipped when the function was called with an operation name and a parameters list that matched an existing instruction, resulting with the function returning `true` even if the order of qargs differed from the stored instruction. 

This PR supports #14452.

