### PR TITLE
Add public, py-less, `substitute_node_with_dag` to DAGCircuit

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -5860,7 +5860,7 @@ impl DAGCircuit {
     ///
     /// # Arguments:
     /// * node_index: The node in the DAGCircuit to replace.
-    ///     other: The replacement DAGCircuit.
+    /// * other: The replacement DAGCircuit.
     /// * qubit_map: A mapping from the replacement DAGCircuit qubits to the replaced node's qargs.
     ///         If None, trivial mapping will be used.
     /// * clbit_map: A mapping from the replacement DAGCircuit clbits to the replaced node's clbits.

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -5858,7 +5858,8 @@ impl DAGCircuit {
 
     /// Substitutes a node by a given DAGCircuit and adds the replacement DAG's global phase to the current DAG.
     ///
-    /// # Arguments:
+    /// # Arguments
+    ///
     /// * node_index: The node in the DAGCircuit to replace.
     /// * other: The replacement DAGCircuit.
     /// * qubit_map: A mapping from the replacement DAGCircuit qubits to the replaced node's qargs.
@@ -5868,7 +5869,8 @@ impl DAGCircuit {
     /// * var_map: A mapping from the replacement DAGCircuit variables to the replaced node's variables.
     ///         Note: Inferring variable mapping automatically is currently not implemented.
     ///
-    /// # Returns:
+    /// # Returns
+    ///
     /// A mapping of the node indices in the replacement DAGCircuit to their corresponding node indices in the
     /// current DAGCircuit.
     pub fn substitute_node_with_dag(

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -2559,7 +2559,7 @@ impl DAGCircuit {
 
         let node_vars = if self.may_have_additional_wires(node.op.view()) {
             let (_additional_clbits, additional_vars) =
-                Python::with_gil(|py| self.additional_wires(py, node.op.view()))?;
+                self.additional_wires(py, node.op.view())?;
             let var_set: HashSet<&expr::Var> = additional_vars
                 .into_iter()
                 .map(|v| self.vars.get(v).unwrap())
@@ -2618,9 +2618,9 @@ impl DAGCircuit {
         let node_map = self.substitute_node_with_dag(
             node_index,
             input_dag,
-            Some(qubit_wire_map),
-            Some(clbit_wire_map),
-            Some(var_map),
+            Some(&qubit_wire_map),
+            Some(&clbit_wire_map),
+            Some(&var_map),
         )?;
 
         let out_dict = PyDict::new(py);
@@ -5869,15 +5869,15 @@ impl DAGCircuit {
     ///         Note: Inferring variable mapping automatically is currently not implemented.
     ///
     /// # Returns:
-    /// A mapping the indices of the nodes in the replacement DAGCircuit to their corresponding node indices in the
+    /// A mapping of the node indices in the replacement DAGCircuit to their corresponding node indices in the
     /// current DAGCircuit.
     pub fn substitute_node_with_dag(
         &mut self,
         node_index: NodeIndex,
         other: &DAGCircuit,
-        qubit_map: Option<HashMap<Qubit, Qubit>>,
-        clbit_map: Option<HashMap<Clbit, Clbit>>,
-        var_map: Option<HashMap<expr::Var, expr::Var>>,
+        qubit_map: Option<&HashMap<Qubit, Qubit>>,
+        clbit_map: Option<&HashMap<Clbit, Clbit>>,
+        var_map: Option<&HashMap<expr::Var, expr::Var>>,
     ) -> PyResult<IndexMap<NodeIndex, NodeIndex, RandomState>> {
         if self.dag.node_weight(node_index).is_none() {
             return Err(PyIndexError::new_err(format!(
@@ -5903,7 +5903,7 @@ impl DAGCircuit {
                         node_qubits.len()
                     )));
                 }
-                HashMap::<Qubit, Qubit>::from_iter(other_qubits.zip(node_qubits.iter().copied()))
+                &HashMap::<Qubit, Qubit>::from_iter(other_qubits.zip(node_qubits.iter().copied()))
             }
         };
 
@@ -5919,7 +5919,7 @@ impl DAGCircuit {
                         node_clbits.len()
                     )));
                 }
-                HashMap::<Clbit, Clbit>::from_iter(other_clbits.zip(node_clbits.iter().copied()))
+                &HashMap::<Clbit, Clbit>::from_iter(other_clbits.zip(node_clbits.iter().copied()))
             }
         };
 
@@ -5928,13 +5928,14 @@ impl DAGCircuit {
             None => {
                 if self.num_vars() > 0 || other.num_vars() > 0 {
                     unimplemented!("Inferring variable mapping in substitute_node_with_dag is not implemented yet. Consider using py_substitute_node instead.");
+                    // TODO: implement once additional_wires becomes Python-free
                 }
-                HashMap::<expr::Var, expr::Var>::new()
+                &HashMap::<expr::Var, expr::Var>::new()
             }
         };
 
         let out_map =
-            self.substitute_node_with_graph(node_index, other, &qubit_map, &clbit_map, &var_map)?;
+            self.substitute_node_with_graph(node_index, other, qubit_map, clbit_map, var_map)?;
         self.global_phase = add_global_phase(&self.global_phase, &other.global_phase)?;
 
         let mut wire_map_dict = HashMap::new();

--- a/crates/transpiler/src/passes/basis_translator/compose_transforms.rs
+++ b/crates/transpiler/src/passes/basis_translator/compose_transforms.rs
@@ -121,14 +121,7 @@ pub(super) fn compose_transforms<'a>(
                         None,
                         None,
                     )?;
-                    let op_node = dag.get_node(py, node)?;
-                    dag.py_substitute_node_with_dag(
-                        py,
-                        op_node.bind(py),
-                        &replace_dag,
-                        None,
-                        None,
-                    )?;
+                    dag.substitute_node_with_dag(node, &replace_dag, None, None, None)?;
                 }
             }
         }

--- a/crates/transpiler/src/passes/gate_direction.rs
+++ b/crates/transpiler/src/passes/gate_direction.rs
@@ -355,13 +355,7 @@ where
     }
 
     for (node, replacemanet_dag) in nodes_to_replace {
-        dag.py_substitute_node_with_dag(
-            py,
-            dag.get_node(py, node)?.bind(py),
-            &replacemanet_dag,
-            None,
-            None,
-        )?;
+        dag.substitute_node_with_dag(node, &replacemanet_dag, None, None, None)?;
     }
 
     Ok(dag)

--- a/crates/transpiler/src/passes/gate_direction.rs
+++ b/crates/transpiler/src/passes/gate_direction.rs
@@ -354,8 +354,8 @@ where
         dag.py_substitute_node(py, dag.get_node(py, node)?.bind(py), &new_op, false, None)?;
     }
 
-    for (node, replacemanet_dag) in nodes_to_replace {
-        dag.substitute_node_with_dag(node, &replacemanet_dag, None, None, None)?;
+    for (node, replacement_dag) in nodes_to_replace {
+        dag.substitute_node_with_dag(node, &replacement_dag, None, None, None)?;
     }
 
     Ok(dag)


### PR DESCRIPTION
This commit adds the `substitute_node_with_dag` function to `DAGCircuit` as a public function, which does not require a py token to call.

This PR supports #14452 

## Details
The current implementation of `substitute_node_with_dag` supports qubits, clbits and variable mapping (through `sustitute_node_with_subgraph`). If no qubits or clbits mapping is provided by the caller (i.e. by sending `None`), a trivial mapping - i.e. mapping the qubits/clbits of the replacement DAG by order to the qargs/cargs of the node to be replaced - is generated. However, inferring trivial mapping for a node with variables is currently not implemented in this PR. So, in case of replacing a node with variables, the caller would need to define the mapping upfront and pass it to the function. 



