### PR TITLE
Fix IQFT drawing 

### DIFF
--- a/qiskit/synthesis/qft/qft_decompose_full.py
+++ b/qiskit/synthesis/qft/qft_decompose_full.py
@@ -56,7 +56,7 @@ def synth_qft_full(
 
     """
     _warn_if_precision_loss(num_qubits - approximation_degree - 1)
-    circuit = QuantumCircuit(num_qubits, name=name)
+    circuit = QuantumCircuit(num_qubits)
 
     for j in reversed(range(num_qubits)):
         circuit.h(j)
@@ -76,6 +76,11 @@ def synth_qft_full(
 
     if inverse:
         circuit = circuit.inverse()
+
+    # It is important to set the name afte the circuit's generic "inverse" is called,
+    # since that will add ``_dg`` to the name.
+    if name is not None:
+        circuit.name = name
 
     return circuit
 

--- a/releasenotes/notes/fix-qft-draw-47d95d1bb620005a.yaml
+++ b/releasenotes/notes/fix-qft-draw-47d95d1bb620005a.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed an edge case in the display of the :class:`.QFT` circuit.
+    Previously, when :meth:`.QFT.inverse` was called and then the attributes of the QFT circuit
+    were modified, the QFT was displayed as ``"IQFT_dg"``. This was incorrect, and now
+    it correctly shows ``"IQFT"``.
+    Fixed `#14758 <https://github.com/Qiskit/qiskit/issues/14758>`__.

--- a/test/python/circuit/library/test_qft.py
+++ b/test/python/circuit/library/test_qft.py
@@ -219,6 +219,27 @@ class TestQFT(QiskitTestCase):
                 with self.assertRaises(SentinelException):
                     qft._build()
 
+    def test_name_after_inverse_rebuild(self):
+        """Test the inverse QFT is correctly labeled, even after triggering rebuilds.
+
+        Regression test of #14758.
+        """
+        with self.assertWarns(DeprecationWarning):
+            qft = QFT(2)
+
+        iqft = qft.inverse()  # name is IQFT
+        iqft.num_qubits = 1  # name should still be IQFT, and not display IQFT_dg
+
+        expect = "\n".join(
+            [
+                "   ┌──────┐",
+                "q: ┤ IQFT ├",
+                "   └──────┘",
+            ]
+        )
+        out = str(iqft.draw())
+        self.assertEqual(expect, out)
+
 
 @ddt
 class TestQFTGate(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #14758.

### Details and comments

Fixed an edge case, when calling `QFT(...).inverse()` and _then_ modifying the circuit would result in a displayed label of `IQFT_dg`. The issue came from using the `QuantumCircuit`'s default `inverse` method, which automatically adds the `_dg` postfix. This PR resolves the issue by properly setting the circuit's name _after_ inversion instead of before.

