### PR TITLE
Decomposer extraction for Rust native `ConsolidateBlocks`

### DIFF
--- a/crates/transpiler/src/passes/consolidate_blocks.rs
+++ b/crates/transpiler/src/passes/consolidate_blocks.rs
@@ -77,11 +77,11 @@ fn get_decomposer_and_basis_gate(
 ) -> (DecomposerType, StandardGate) {
     if let Some(target) = target {
         // Targets from C should only support Standard gates.
-        if let Some(gate) = KAK_GATES_PARAM
-            .iter()
-            .find(|gate| target.contains_key(gate.name()))
-            .copied()
-        {
+        if let Some(gate) = target.operations().find_map(|op| {
+            op.operation
+                .try_standard_gate()
+                .and_then(|gate| KAK_GATES_PARAM.contains(&gate).then_some(gate))
+        }) {
             return (
                 DecomposerType::TwoQubitControlledU(
                     TwoQubitControlledUDecomposer::new(RXXEquivalent::Standard(gate), "ZXZ")
@@ -95,11 +95,11 @@ fn get_decomposer_and_basis_gate(
                 gate,
             );
         }
-        if let Some(gate) = KAK_GATES
-            .iter()
-            .find(|gate| target.contains_key(gate.name()))
-            .copied()
-        {
+        if let Some(gate) = target.operations().find_map(|op| {
+            op.operation
+                .try_standard_gate()
+                .and_then(|gate| KAK_GATES.contains(&gate).then_some(gate))
+        }) {
             return (DecomposerType::TwoQubitBasis(
                 TwoQubitBasisDecomposer::new_inner(
                     gate.into(),

--- a/crates/transpiler/src/passes/consolidate_blocks.rs
+++ b/crates/transpiler/src/passes/consolidate_blocks.rs
@@ -442,10 +442,11 @@ fn py_run_consolidate_blocks(
 
 /// Replaces each block of consecutive gates by a single unitary node.
 ///
-/// This is the main function of the `ConsolidateBlocks` transpiler pass
-/// which replaces uninterrupted sequences of gates acting on the same qubits
-/// into a Unitary node, which will consecutively be resynthesized into a
-/// more optimal subcircuit.
+/// This is function is the Rust entry point for the `ConsolidateBlocks` transpiler pass
+/// which replaces uninterrupted sequences of gates acting on the same pair of qubits
+/// into a [`UnitaryGate`] representing the unitary of that two qubit block if it estimated to
+/// to optimize the circuit. This [`UnitaryGate`] subsequently will be synthesized by the
+/// unitary synthesis pass into a more optimal subcircuit to replace that block.
 ///
 /// # Arguments
 /// * `dag` - The circuit for which we will consolidate gates.

--- a/crates/transpiler/src/passes/consolidate_blocks.rs
+++ b/crates/transpiler/src/passes/consolidate_blocks.rs
@@ -450,15 +450,16 @@ fn py_run_consolidate_blocks(
 ///
 /// # Arguments
 /// * `dag` - The circuit for which we will consolidate gates.
-/// * `approximation_degree` - A float between `[0.0, 1.0]`. Lower approximates more.
 /// * `force_consolidate` - Decides whether to force all consolidations or not.
+/// * `approximation_degree` - A float between `[0.0, 1.0]`. Lower approximates more.
 /// * `target` - The target representing the backend for which the pass is consolidating.
 pub fn run_consolidate_blocks(
     dag: &mut DAGCircuit,
-    approximation_degree: f64,
     force_consolidate: bool,
+    approximation_degree: Option<f64>,
     target: Option<&Target>,
 ) -> PyResult<()> {
+    let approximation_degree = approximation_degree.unwrap_or(1.0);
     let (decomposer, basis_gate) = get_decomposer_and_basis_gate(target, approximation_degree);
     py_run_consolidate_blocks(
         dag,

--- a/crates/transpiler/src/passes/consolidate_blocks.rs
+++ b/crates/transpiler/src/passes/consolidate_blocks.rs
@@ -480,7 +480,7 @@ pub fn consolidate_blocks_mod(m: &Bound<PyModule>) -> PyResult<()> {
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(miri)))]
 mod test_consolidate_blocks {
     use std::sync::Arc;
 

--- a/crates/transpiler/src/passes/consolidate_blocks.rs
+++ b/crates/transpiler/src/passes/consolidate_blocks.rs
@@ -35,7 +35,6 @@ use smallvec::smallvec;
 use smallvec::SmallVec;
 
 use super::optimize_1q_gates_decomposition::matmul_1q;
-use super::unitary_synthesis::{PARAM_SET_BASIS_GATES, TWO_QUBIT_BASIS_SET_GATES};
 use qiskit_quantum_info::convert_2q_block_matrix::{blocks_to_matrix, get_matrix_from_inst};
 use qiskit_synthesis::two_qubit_decompose::{
     TwoQubitBasisDecomposer, TwoQubitControlledUDecomposer,
@@ -43,6 +42,7 @@ use qiskit_synthesis::two_qubit_decompose::{
 
 use crate::target::Qargs;
 use crate::target::Target;
+use crate::{PARAM_SET, TWO_QUBIT_BASIS_SET};
 use qiskit_circuit::PhysicalQubit;
 
 #[allow(clippy::large_enum_variant)]
@@ -76,7 +76,7 @@ fn get_decomposer_and_basis_gate(
         if let Some(gate) = target.operations().find_map(|op| {
             op.operation
                 .try_standard_gate()
-                .and_then(|gate| PARAM_SET_BASIS_GATES.contains(&gate).then_some(gate))
+                .and_then(|gate| matches!(gate, PARAM_SET!()).then_some(gate))
         }) {
             return (
                 DecomposerType::TwoQubitControlledU(
@@ -94,7 +94,7 @@ fn get_decomposer_and_basis_gate(
         if let Some(gate) = target.operations().find_map(|op| {
             op.operation
                 .try_standard_gate()
-                .and_then(|gate| TWO_QUBIT_BASIS_SET_GATES.contains(&gate).then_some(gate))
+                .and_then(|gate| matches!(gate, TWO_QUBIT_BASIS_SET!()).then_some(gate))
         }) {
             return (
                 DecomposerType::TwoQubitBasis(

--- a/crates/transpiler/src/passes/consolidate_blocks.rs
+++ b/crates/transpiler/src/passes/consolidate_blocks.rs
@@ -480,8 +480,7 @@ pub fn consolidate_blocks_mod(m: &Bound<PyModule>) -> PyResult<()> {
     Ok(())
 }
 
-#[cfg(test)]
-// #[cfg(all(test, not(miri)))]
+#[cfg(all(test, not(miri)))]
 mod test_consolidate_blocks {
 
     use indexmap::IndexMap;

--- a/crates/transpiler/src/passes/consolidate_blocks.rs
+++ b/crates/transpiler/src/passes/consolidate_blocks.rs
@@ -40,9 +40,9 @@ use qiskit_synthesis::two_qubit_decompose::{
     TwoQubitBasisDecomposer, TwoQubitControlledUDecomposer,
 };
 
+use crate::passes::unitary_synthesis::{PARAM_SET, TWO_QUBIT_BASIS_SET};
 use crate::target::Qargs;
 use crate::target::Target;
-use crate::{PARAM_SET, TWO_QUBIT_BASIS_SET};
 use qiskit_circuit::PhysicalQubit;
 
 #[allow(clippy::large_enum_variant)]

--- a/crates/transpiler/src/passes/unitary_synthesis.rs
+++ b/crates/transpiler/src/passes/unitary_synthesis.rs
@@ -71,7 +71,7 @@ macro_rules! PARAM_SET {
 }
 
 // Make sure that this is kept in sync with the macro PARAM_SET above
-static PARAM_SET_BASIS_GATES: [StandardGate; 8] = [
+pub static PARAM_SET_BASIS_GATES: [StandardGate; 8] = [
     StandardGate::RXX,
     StandardGate::RYY,
     StandardGate::RZZ,
@@ -98,7 +98,7 @@ macro_rules! TWO_QUBIT_BASIS_SET {
 }
 
 // Make sure this is kept in sync with the macro TWO_QUBIT_BASIS_SET above
-static TWO_QUBIT_BASIS_SET_GATES: [StandardGate; 7] = [
+pub static TWO_QUBIT_BASIS_SET_GATES: [StandardGate; 7] = [
     StandardGate::CX,
     StandardGate::CY,
     StandardGate::CZ,

--- a/crates/transpiler/src/passes/unitary_synthesis.rs
+++ b/crates/transpiler/src/passes/unitary_synthesis.rs
@@ -56,7 +56,6 @@ const PI4: f64 = PI / 4.;
 
 /// The matcher for the set of standard gates that the TwoQubitControlledUDecomposer
 /// supports
-#[macro_export]
 macro_rules! PARAM_SET {
     // Make sure that this is kept in sync with the static array PARAM_GATES below
     () => {
@@ -85,7 +84,6 @@ static PARAM_SET_BASIS_GATES: [StandardGate; 8] = [
 
 /// The matcher for the set of standard gates that the TwoQubitBasisDecomposer
 /// supports
-#[macro_export]
 macro_rules! TWO_QUBIT_BASIS_SET {
     // Make sure that this is kept in sync with the static array TWO_QUBIT_BASIS_SET_GATES below
     () => {
@@ -109,6 +107,8 @@ static TWO_QUBIT_BASIS_SET_GATES: [StandardGate; 7] = [
     StandardGate::ISwap,
     StandardGate::ECR,
 ];
+
+pub(crate) use {PARAM_SET, TWO_QUBIT_BASIS_SET};
 
 #[derive(Clone, Debug)]
 enum DecomposerType {

--- a/crates/transpiler/src/passes/unitary_synthesis.rs
+++ b/crates/transpiler/src/passes/unitary_synthesis.rs
@@ -56,6 +56,7 @@ const PI4: f64 = PI / 4.;
 
 /// The matcher for the set of standard gates that the TwoQubitControlledUDecomposer
 /// supports
+#[macro_export]
 macro_rules! PARAM_SET {
     // Make sure that this is kept in sync with the static array PARAM_GATES below
     () => {
@@ -71,7 +72,7 @@ macro_rules! PARAM_SET {
 }
 
 // Make sure that this is kept in sync with the macro PARAM_SET above
-pub static PARAM_SET_BASIS_GATES: [StandardGate; 8] = [
+static PARAM_SET_BASIS_GATES: [StandardGate; 8] = [
     StandardGate::RXX,
     StandardGate::RYY,
     StandardGate::RZZ,
@@ -84,6 +85,7 @@ pub static PARAM_SET_BASIS_GATES: [StandardGate; 8] = [
 
 /// The matcher for the set of standard gates that the TwoQubitBasisDecomposer
 /// supports
+#[macro_export]
 macro_rules! TWO_QUBIT_BASIS_SET {
     // Make sure that this is kept in sync with the static array TWO_QUBIT_BASIS_SET_GATES below
     () => {
@@ -98,7 +100,7 @@ macro_rules! TWO_QUBIT_BASIS_SET {
 }
 
 // Make sure this is kept in sync with the macro TWO_QUBIT_BASIS_SET above
-pub static TWO_QUBIT_BASIS_SET_GATES: [StandardGate; 7] = [
+static TWO_QUBIT_BASIS_SET_GATES: [StandardGate; 7] = [
     StandardGate::CX,
     StandardGate::CY,
     StandardGate::CZ,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
The following commit adds the ability for the `ConsolidateBlocks` pass to instantiate decomposers and choose a basis gate based on the provided `Target`. In the case that a `Target` is not provided, it will default to a `TwoBasisDecomposer` with a `CX` gate.


### Details and comments
Built on top of #14748. Will rebase after it merges.
Prerequisite for #14751.

