### PR TITLE
Add `QuantumCircuit.ensure_physical`

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -365,9 +365,12 @@ impl CircuitData {
                         self.num_qubits()
                     )));
                 }
-                num_qubits as usize
+                num_qubits
             }
-            None => self.num_qubits(),
+            None => self
+                .num_qubits()
+                .try_into()
+                .expect("qubits are stored in 32-bit integers"),
         };
         self.make_physical(num_qubits);
         Ok(())
@@ -2087,15 +2090,12 @@ impl CircuitData {
     /// # Panics
     ///
     /// If `num_qubits` is less than the number of qubits in the circuit already.
-    pub fn make_physical(&mut self, num_qubits: usize) {
+    pub fn make_physical(&mut self, num_qubits: u32) {
         // If this method needs updating, `DAGCircuit::make_physical` probably does too.
         assert!(
-            num_qubits >= self.num_qubits(),
+            num_qubits as usize >= self.num_qubits(),
             "number of qubits {num_qubits} too small for circuit"
         );
-        let num_qubits: u32 = num_qubits
-            .try_into()
-            .expect("number of qubits must fit in a u32");
         // The strategy here is just to modify the qubit and quantum register objects entirely
         // inplace; we maintain all relative indices, so we don't need to modify any interner keys.
         let register = QuantumRegister::new_owning("q", num_qubits);

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -341,6 +341,40 @@ impl CircuitData {
         Ok(self_)
     }
 
+    /// Put ``self`` into the canonical physical form, with the given number of qubits.
+    ///
+    /// This acts in place, and does not need to traverse the circuit.  It is intended for use when
+    /// the circuit is known to already represent a physical circuit, and we just need to assert
+    /// that it is canonical physical form.
+    ///
+    /// This erases any information about virtual qubits in the :class:`CircuitData`; if using this
+    /// yourself, you may need to ensure you have created and stored a suitable :class:`.Layout`.
+    /// Effectively, this applies the "trivial" layout mapping virtual qubit 0 to physical qubit 0,
+    /// and so on.
+    ///
+    /// Args:
+    ///     num_qubits: if given, the total number of physical qubits in the output; it must be at
+    ///         least as large as the number of qubits in the circuit.  If not given, the number of
+    ///         qubits is unchanged.
+    #[pyo3(name = "make_physical", signature = (num_qubits=None))]
+    pub fn py_make_physical(&mut self, num_qubits: Option<u32>) -> PyResult<()> {
+        let num_qubits = match num_qubits {
+            Some(num_qubits) => {
+                if (num_qubits as usize) < self.num_qubits() {
+                    return Err(PyValueError::new_err(format!(
+                        "cannot have fewer physical qubits ({}) than virtual ({})",
+                        num_qubits,
+                        self.num_qubits()
+                    )));
+                }
+                num_qubits as usize
+            }
+            None => self.num_qubits(),
+        };
+        self.make_physical(num_qubits);
+        Ok(())
+    }
+
     pub fn __reduce__(self_: &Bound<CircuitData>, py: Python<'_>) -> PyResult<PyObject> {
         let ty: Bound<PyType> = self_.get_type();
         let args = {
@@ -2041,6 +2075,50 @@ impl CircuitData {
             }
         }
         Ok(res)
+    }
+
+    /// Modify `self` to mark its qubits as physical.
+    ///
+    /// This deletes the information about the virtual registers, and replaces it with the single
+    /// (implicitly) physical register.  This method does not need to traverse the circuit.
+    ///
+    /// The qubit indices all stay the same; effectively, this is the application of the "trivial"
+    /// layout.  If the incoming circuit is supposed to be considered physical, this method can be
+    /// used to ensure it is in the canonical physical form.
+    ///
+    /// # Panics
+    ///
+    /// If `num_qubits` is less than the number of qubits in the circuit already.
+    pub fn make_physical(&mut self, num_qubits: usize) {
+        // If this method needs updating, `DAGCircuit::make_physical` probably does too.
+        assert!(
+            num_qubits >= self.num_qubits(),
+            "number of qubits {num_qubits} too small for circuit"
+        );
+        let num_qubits: u32 = num_qubits
+            .try_into()
+            .expect("number of qubits must fit in a u32");
+        // The strategy here is just to modify the qubit and quantum register objects entirely
+        // inplace; we maintain all relative indices, so we don't need to modify any interner keys.
+        let register = QuantumRegister::new_owning("q", num_qubits);
+        let mut registry = ObjectRegistry::with_capacity(num_qubits as usize);
+        let mut locator = BitLocator::with_capacity(num_qubits as usize);
+        for (index, bit) in register.iter().enumerate() {
+            registry
+                .add(bit.clone(), false)
+                .expect("no duplicates, and in-bounds check already performed");
+            locator.insert(
+                bit,
+                BitLocations::new(index as u32, [(register.clone(), index)]),
+            );
+        }
+        let mut register_data = RegisterData::with_capacity(1);
+        register_data
+            .add_register(register, false)
+            .expect("infallible when 'strict=false'");
+        self.qubits = registry;
+        self.qregs = register_data;
+        self.qubit_indices = locator;
     }
 
     /// Append a standard gate to this CircuitData

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -347,10 +347,8 @@ impl CircuitData {
     /// the circuit is known to already represent a physical circuit, and we just need to assert
     /// that it is canonical physical form.
     ///
-    /// This erases any information about virtual qubits in the :class:`CircuitData`; if using this
-    /// yourself, you may need to ensure you have created and stored a suitable :class:`.Layout`.
-    /// Effectively, this applies the "trivial" layout mapping virtual qubit 0 to physical qubit 0,
-    /// and so on.
+    /// This erases any information about virtual qubits in the :class:`CircuitData`.  Effectively,
+    /// this applies the "trivial" layout mapping virtual qubit 0 to physical qubit 0, and so on.
     ///
     /// Args:
     ///     num_qubits: if given, the total number of physical qubits in the output; it must be at

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -4574,6 +4574,7 @@ impl DAGCircuit {
     ///
     /// If `num_qubits` is less than the number of qubits in the DAG already.
     pub fn make_physical(&mut self, num_qubits: usize) {
+        // If this method needs updating, `CircuitData::make_physical` probably does too.
         assert!(
             num_qubits >= self.num_qubits(),
             "number of qubits {num_qubits} too small for DAG"

--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -42,7 +42,7 @@ quantum computation <qiskit-primitives>`, which accumulate data from many shots 
 execution, along with advanced error-mitigation techniques and measurement optimizations, into
 well-typed classical data and error statistics.
 
-In Qiskit, circuits can be defined in one of two regimes:
+In Qiskit, circuits can be :ref:`defined in one of two regimes <circuit-abstract-physical>`:
 
 * an *abstract* circuit, which is defined in terms of *virtual qubits* and arbitrary high-level
   operations, like encapsulated algorithms and user-defined gates.
@@ -52,7 +52,11 @@ In Qiskit, circuits can be defined in one of two regimes:
   this concept referred to as an *ISA circuit*.
 
 You convert from an abstract circuit to a physical circuit by using :ref:`Qiskit's transpilation
-package <qiskit-transpiler>`, of which the top-level access point is :func:`.transpile`.
+package <qiskit-transpiler>`, of which the top-level access point is :func:`.transpile`.  If you
+define a circuit, where you intend the qubit indices to refer to physical qubits, you can use
+:meth:`.QuantumCircuit.ensure_physical` to rewrite the circuit's metadata to ensure that Qiskit
+recognizes the circuit as a physical circuit, though unlike transpilation, this does not enforce
+that the basis-gates and hardware-coupling constraints will be respected.
 
 In Qiskit, a quantum circuit is represented by the :class:`QuantumCircuit` class.  Below is an
 example of a quantum circuit that makes a three-qubit Greenberger–Horne–Zeilinger (GHZ) state

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -965,6 +965,45 @@ class QuantumCircuit:
     .. automethod:: qubit_start_time
     .. automethod:: qubit_stop_time
 
+
+    .. _circuit-abstract-physical:
+
+    Abstract and physical circuits
+    ==============================
+
+    Circuits are a fairly low-level abstraction of quantum algorithms.  However, even within this,
+    there are distinctions. Quantum programmers often want to use a wide arrange of gates and
+    instructions, and work in a regime where all qubits and interact with all others.  Quantum
+    hardware, however, typically has a restrictive set of native gates, and only certain pairs of
+    hardware qubits can interact.  We term these two regimes "abstract circuits" and "physical
+    circuits", respectively.
+
+    Qiskit has two ways of distinguishing a circuit that is intended to be physical.  This is a
+    fuzzy check, for historical reasons; originally, Qiskit never made the distinction at all (which
+    is why :func:`.transpile` is called that, and not called ``compile``!).  The most explicit way
+    is through the :attr:`layout` attribute of circuits; if this is set, the circuit is certainly
+    intended to be physical.  The older, more implicit, way is the metadata of the :class:`.Qubit`
+    objects and :class:`.QuantumRegister` instances in the circuit.  A circuit can only be
+    considered (as judged by several transpiler passes) as physical if it contains exactly one
+    quantum register, which is called ``q`` and owns all the circuit qubits in index order.  Again
+    for historical reasons, this is the default for the ``QuantumCircuit(int [, int])`` form of the
+    default constructor.
+
+    Normally, you create a :class:`QuantumCircuit` and build it in the abstract sense (regardless of
+    the qubit metadata).  You then call :func:`.transpile` to compile the circuit into a
+    hardware-supported circuit.  However, in cases where you want to write a hardware efficient
+    circuit from the beginning, you can short-circuit the full compilation infrastructure using the
+    :meth:`ensure_physical` method.  This will ensure that, no matter how you defined the initial
+    qubit metadata, all requirements for the circuit to be considered physical will be satisfied,
+    with the qubit indices mapped to the hardware qubits.
+
+    For more complete control over choosing a virtual-to-physical mapping and routing, see :ref:`the
+    layout <transpiler-preset-stage-layout>` and `routing <transpiler-preset-stage-routing>` stages
+    of the preset compilation pipelines.
+
+    .. automethod:: ensure_physical
+
+
     Instruction-like methods
     ========================
 
@@ -1607,6 +1646,82 @@ class QuantumCircuit:
         elif isinstance(register, ClassicalRegister) and register in self.cregs:
             has_reg = True
         return has_reg
+
+    def ensure_physical(self, num_qubits: int | None = None, *, apply_layout: bool = True) -> bool:
+        """Put this circuit into canonical physical form, with the given number of qubits, if it is
+        not already.
+
+        Several Qiskit transpiler passes only make sense when applied to circuits defined in terms
+        of physical qubits.  If you have manually constructed a circuit where the qubit indices
+        correspond to physical qubits, use this function to ensure that the metadata of the circuit
+        matches the canonical physical form.  This means replacing the qubit data with a single
+        owning register called ``"q"``, and (optionally) setting the :attr:`layout` field of the
+        circuit to link these physical qubits with the original virtual ones.
+
+        If the circuit does not already have a layout, this method (with ``apply_layout=True``) is
+        equivalent to applying the full :ref:`trivial layout method
+        <transpiler-preset-stage-layout-trivial>` of the preset compilation pipeline.
+
+        If the circuit is already canonically physical, nothing happens to it.  This method cannot
+        change the number of qubits in the circuit if it already has a :attr:`layout` set.
+
+        Args:
+            num_qubits: if given, expand the circuit with ancillas up to this size.  The ancillas
+                will always be the highest qubit indices of the circuit.  If not given (the
+                default), the circuit stays the same width.  This option cannot be set if the
+                circuit already as a :attr:`layout`.
+            apply_layout: if true (the default), set the :attr:`layout` attribute of the circuit
+                appropriately so that the circuit appears to have been laid out with the "trivial"
+                layout, including ancilla expansion, for a backend of width ``num_qubits``.  This
+                has no effect if the circuit already had a :attr:`layout`.
+
+        Returns:
+            whether the circuit was modified in order to make it physical.
+
+        Raises:
+            ValueError: if ``num_qubits`` is too small for the circuit.
+            CircuitError: if ``num_qubits`` is set to attempt to expand the circuit, but the circuit
+                already has a layout set.
+        """
+        from qiskit.transpiler import Layout, TranspileLayout  # pylint: disable=cyclic-import
+
+        original_num_qubits = self.num_qubits
+        if num_qubits is not None and num_qubits < original_num_qubits:
+            raise ValueError(
+                f"cannot have fewer physical qubits ({num_qubits})"
+                f" than virtual ({original_num_qubits})"
+            )
+        if self._layout is not None:
+            if num_qubits is not None and num_qubits != original_num_qubits:
+                raise CircuitError("cannot expand a circuit that already has a set layout")
+            expected = QuantumRegister(original_num_qubits, "q")
+            if self.qubits != list(expected) or self.qregs != [expected]:  # pragma: no cover
+                # This is mostly defensive; we _shouldn't_ get a circuit in this form, but it's
+                # possible for a badly formed transpiler pass to do it by accident.
+                raise CircuitError(
+                    "This circuit has a set layout, but its qubits are not in the canonical"
+                    " physical form.  This might indicate a faulty layout transpilation stage has"
+                    " been used."
+                )
+            return False
+
+        if apply_layout:
+            virtuals = self.qubits.copy()
+            if num_qubits is not None:
+                virtuals.extend(QuantumRegister(num_qubits - original_num_qubits, "ancilla"))
+            initial_layout = Layout(dict(enumerate(virtuals)))
+        else:
+            initial_layout = None
+        self._data.make_physical(num_qubits)
+        if initial_layout is not None:
+            self._layout = TranspileLayout(
+                initial_layout=initial_layout,
+                input_qubit_mapping=initial_layout.get_virtual_bits().copy(),
+                final_layout=None,
+                _input_qubit_count=original_num_qubits,
+                _output_qubit_list=self.qubits.copy(),
+            )
+        return True
 
     def reverse_ops(self) -> "QuantumCircuit":
         """Reverse the circuit by reversing the order of instructions.

--- a/releasenotes/notes/dag-make-physical-83c9ee2728528224.yaml
+++ b/releasenotes/notes/dag-make-physical-83c9ee2728528224.yaml
@@ -1,6 +1,15 @@
 ---
+features_circuits:
+  - |
+    A new method, :meth:`.QuantumCircuit.ensure_physical`, is provided to ensure that a circuit is
+    defined over physical qubits, with the qubit indices referring to physical qubits.  See the
+    :ref:`new discussion on abstract- and physical-circuit representations the documentation
+    <circuit-abstract-physical>` for more detail on the metadata concepts.  The concepts of
+    "abstract" and "physical" circuits are not at all new to Qiskit, just the explicit
+    documentation.
 features_transpiler:
   - |
-    A new method :meth:`.DAGCircuit.make_physical` is provided, which efficiently replaces the
+    A new method, :meth:`.DAGCircuit.make_physical`, is provided, which efficiently replaces the
     qubits in the :class:`.DAGCircuit` with the canonical physical-qubit register, potentially
-    including expansion.
+    including expansion.  A similar method, :meth:`.QuantumCircuit.ensure_physical` is also
+    available.

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -20,7 +20,7 @@ from itertools import combinations
 import numpy as np
 from ddt import data, ddt
 
-from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
+from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, transpile
 from qiskit.circuit import Gate, Instruction, Measure, Parameter, Barrier, AnnotatedOperation
 from qiskit.circuit.classical import expr, types
 from qiskit.circuit import Clbit
@@ -35,8 +35,10 @@ from qiskit.circuit.library.standard_gates import SGate
 from qiskit.circuit.quantumcircuit import BitLocations
 from qiskit.circuit.quantumcircuitdata import CircuitInstruction
 from qiskit.circuit import AncillaQubit, AncillaRegister, Qubit
+from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.providers.basic_provider import BasicSimulator
 from qiskit.quantum_info import Operator
+from qiskit.transpiler import Layout, CouplingMap
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
 
@@ -1629,6 +1631,118 @@ class TestCircuitOperations(QiskitTestCase):
                 circ.append(op, [0, 1], [1])
             # Check if circuit has any control flow operation
             self.assertTrue(circ.has_control_flow_op())
+
+    @data(True, False)
+    def test_ensure_physical_same_size(self, apply_layout):
+        """`num_qubits` need not be set."""
+        qr = QuantumRegister(10, "virtuals")
+        loose = [Qubit() for _ in range(5)]
+        num_qubits = len(qr) + len(loose)
+        qc = QuantumCircuit(qr, loose)
+        qc.h(0)
+        qc.cx(0, 1)
+        self.assertTrue(qc.ensure_physical(apply_layout=apply_layout))
+
+        physical_qreg = QuantumRegister(num_qubits, "q")
+        self.assertEqual(qc.qubits, list(physical_qreg))
+        self.assertEqual(qc.qregs, [physical_qreg])
+        if apply_layout:
+            self.assertEqual(
+                qc.layout.initial_virtual_layout(),
+                Layout(dict(enumerate(list(qr) + loose))),
+            )
+            self.assertEqual(qc.layout.final_index_layout(), list(range(num_qubits)))
+            self.assertEqual(qc.layout.routing_permutation(), list(range(num_qubits)))
+            # After all this, `ensure_physical` should be a no-op.
+            self.assertFalse(qc.ensure_physical())
+        else:
+            self.assertIsNone(qc.layout)
+
+    def test_ensure_physical_can_expand_circuit(self):
+        """`ensure_physical` can add ancillas."""
+        qr = QuantumRegister(10, "virtuals")
+        loose = [Qubit() for _ in range(5)]
+        num_virtual_qubits = len(qr) + len(loose)
+        num_physical_qubits = 20
+        qc = QuantumCircuit(qr, loose)
+        qc.h(0)
+        qc.cx(0, 1)
+        self.assertTrue(qc.ensure_physical(num_physical_qubits))
+
+        ancilla_qreg = QuantumRegister(num_physical_qubits - num_virtual_qubits, "ancilla")
+        physical_qreg = QuantumRegister(num_physical_qubits, "q")
+        self.assertEqual(qc.qubits, list(physical_qreg))
+        self.assertEqual(qc.qregs, [physical_qreg])
+        self.assertEqual(
+            qc.layout.initial_virtual_layout(filter_ancillas=True),
+            Layout(dict(enumerate(list(qr) + loose))),
+        )
+        self.assertEqual(
+            qc.layout.initial_virtual_layout(filter_ancillas=False),
+            Layout(dict(enumerate(list(qr) + loose + list(ancilla_qreg)))),
+        )
+        self.assertEqual(
+            qc.layout.final_index_layout(filter_ancillas=True), list(range(num_virtual_qubits))
+        )
+        self.assertEqual(qc.layout.routing_permutation(), list(range(num_physical_qubits)))
+
+        # After all this, `ensure_physical` should be a no-op.
+        self.assertFalse(qc.ensure_physical())
+
+    def test_ensure_physical_equivalence_to_trivial_layout(self):
+        """`ensure_physical` is equivalent to the `trivial` layout method in metadata."""
+        qr = QuantumRegister(5, "virtuals")
+        qc = QuantumCircuit(qr)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+
+        num_physical_qubits = 10
+        expected = transpile(
+            qc,
+            backend=GenericBackendV2(
+                num_qubits=num_physical_qubits,
+                coupling_map=CouplingMap.from_line(10),
+                basis_gates=["h", "rz", "sx", "cx"],
+                seed=2025_07_22,
+            ),
+            layout_method="trivial",
+            optimization_level=0,
+            seed_transpiler=2025_07_22,
+        )
+        self.assertTrue(qc.ensure_physical(num_physical_qubits))
+        self.assertEqual(qc.layout, expected.layout)
+        self.assertEqual(qc, expected)
+
+    def test_ensure_physical_no_op_if_physical(self):
+        """If the circuit is already physical, nothing should happen."""
+        qr = QuantumRegister(5, "virtuals")
+        qc = QuantumCircuit(qr)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+        initial = [4, 5, 6, 7, 8]
+        qc = transpile(
+            qc,
+            backend=GenericBackendV2(
+                num_qubits=10,
+                coupling_map=CouplingMap.from_line(10),
+                basis_gates=["h", "rz", "sx", "cx"],
+                seed=2025_07_22,
+            ),
+            initial_layout=initial,
+            optimization_level=0,
+            seed_transpiler=2025_07_22,
+        )
+        self.assertFalse(qc.ensure_physical())
+        # The layout shouldn't have changed.
+        self.assertEqual(qc.layout.initial_index_layout(filter_ancillas=True), initial)
+
+    def test_ensure_physical_cannot_shrink_circuit(self):
+        """It's an error to try and make a circuit narrower."""
+        qc = QuantumCircuit(10)
+        with self.assertRaisesRegex(ValueError, "cannot have fewer physical qubits"):
+            qc.ensure_physical(5)
 
 
 class TestCircuitPrivateOperations(QiskitTestCase):


### PR DESCRIPTION
This is similar but stronger to `DAGCircuit::make_physical`.  Since `QuantumCircuit` also has layout information available, this method safely handles this, and the case that the circuit has already been made physical.

The new documentation in the circuit module and the `QuantumCircuit` class is intended to help, since this is a common point of confusion among both users and developers; the documentation isn't supposed to be a strong personal endorsement of the current situation, just an explicit statement of what the current system _is_.

This commit was motivated by ad-hoc attempts to do this, such as in `QuantumCircuit._from_circuit_data(add_regs=True)` (which can be updated to use this in a follow-up).

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

The reason that the `QuantumCircuit` method is called `ensure_physical` and the `DAGCircuit` one is called `make_physical` is because the DAG one doesn't have the same information available to it about what (if anything) the current layout is (in the current Qiskit data flow, the layout, if any, is in the `PropertySet` while transpilation is ongoing), so it can't really do a proper verification; it's always an active modification.  The `QuantumCircuit` variant _can_ tell if a circuit is already laid out.