### PR TITLE
Add fast-path parameter binding

### DIFF
--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -1061,6 +1061,9 @@ impl PyParameterExpression {
     /// checked, since this method is intended for performance-sensitive use.  Passing an incorrect
     /// dictionary may result in unexpected behavior.
     ///
+    /// Unlike :meth:`bind`, this method will not raise an exception if non-finite floating-point
+    /// values are encountered.
+    ///
     /// Args:
     ///     values: mapping of parameters to numeric values.
     #[pyo3(name = "bind_all")]

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -1065,7 +1065,7 @@ impl PyParameterExpression {
     ///     values: mapping of parameters to numeric values.
     #[pyo3(name = "bind_all")]
     #[pyo3(signature = (values, *))]
-    pub fn py_bind_all<'py>(&self, values: Bound<'py, PyAny>) -> PyResult<Value> {
+    pub fn py_bind_all(&self, values: Bound<PyAny>) -> PyResult<Value> {
         let mut partial_map = HashMap::with_capacity(self.inner.name_map.len());
         for symbol in self.inner.name_map.values() {
             let py_parameter = symbol.clone().into_pyobject(values.py())?;

--- a/crates/circuit/src/parameter/symbol_expr.rs
+++ b/crates/circuit/src/parameter/symbol_expr.rs
@@ -149,7 +149,7 @@ pub enum SymbolExpr {
 }
 
 /// Value type, can be integer, real or complex number
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, IntoPyObject, IntoPyObjectRef)]
 pub enum Value {
     Real(f64),
     Int(i64),

--- a/releasenotes/notes/parameter-bind-all-22337586429509f9.yaml
+++ b/releasenotes/notes/parameter-bind-all-22337586429509f9.yaml
@@ -1,0 +1,8 @@
+---
+features_circuits:
+  - |
+    A new fast-path method :meth:`.ParameterExpression.bind_all` is added to support the use-case of
+    binding many different :class:`.ParameterExpression` instances to numeric values using the same
+    mappings dictionary.  The existing :meth:`~.ParameterExpression.bind` method has a large amount
+    of overhead and unnecessary allocations, since it always returns a :class:`.ParameterExpression`
+    for typing consistency.

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -333,6 +333,24 @@ class TestParameters(QiskitTestCase):
         c = a.bind({a: 1, b: 1}, allow_unknown_parameters=True)
         self.assertEqual(c, a.bind({a: 1}))
 
+    def test_bind_all(self):
+        """Fast-path for binding numeric results."""
+        a, b, c = Parameter("a"), Parameter("b"), Parameter("c")
+        bindings = {a: -1.0, b: 2.5, c: 7}
+        self.assertEqual((a + b).bind_all(bindings), 1.5)
+        self.assertEqual(a.bind_all(bindings), -1.0)
+
+    def test_bind_all_failures(self):
+        """`bind_all` does not explicitly check failures for performance, but we want failure to not
+        pass completely silently."""
+        a, b = Parameter("a"), Parameter("b")
+        # Feel free to change the exact exceptions; it's only important that it's not silent.
+        expr = a + b
+        with self.assertRaises(KeyError):
+            expr.bind_all({a: -1.0})
+        with self.assertRaises(KeyError):
+            a.bind_all({b: 2.5})
+
     def test_assign_parameters_by_name(self):
         """Test that parameters can be assigned by name as well as value."""
         a = Parameter("a")


### PR DESCRIPTION
The new `ParameterExpresion.bind_all` is a fast path for producing a numeric result.  This has a couple of advantages over `ParameterExpression.bind`:

- we can allocate far fewer Python objects, since we do not need to allocate new versions of all the additional data that goes along with a complete `ParameterExpression` object; we know the output must be numeric.

- we have no historical API reasons to scan through the incoming mapping to search for invalid keys or values; this is a huge performance improvement for the case of using the same mapping to bind many different expressions (though there are ways that `ParameterExpression.bind` could be improved and its interface safely evolved to remove the worst cases of the scaling).

There is still a sizeable amount of performance gain to be had, because the interfaces in the Rust-space `ParameterExpression` and `SymbolExpr` require rather more heap allocations per binding call than are entirely necessary.  That said, this already provides a large performance improvement, and a complexity improvement for the case of a large values dictionary being used many times.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Fix #14471.

Currently in draft because there's no tests - I'm just putting it up so Sam and Ian from #14471 can test it out for their use case.  For the explicit example in that issue, a complete comparison on my machine:

<details><summary>Out of date timings</summary>
```python
In [1]: from qiskit.circuit import Parameter, ParameterExpression
   ...:
   ...: N: int = 100_000
   ...:
   ...: parameter_values = {Parameter(f"th_{i}"): 1 for i in range(N)}
   ...: parameter_values[param := Parameter("my_param")] = 1
   ...:
   ...: print("Using the specialised `Parameter` methods:")
   ...: %timeit param.bind(parameter_values, allow_unknown_parameters=True)
   ...: %timeit param.bind_all(parameter_values)
   ...:
   ...: print("Using the general `ParameterExpression` methods:")
   ...: %timeit ParameterExpression.bind(param, parameter_values, allow_unknown_parameters=True)
   ...: %timeit ParameterExpression.bind_all(param, parameter_values)
```
```text
Using the specialised `Parameter` methods:
32.8 ms ± 535 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)
68.5 ns ± 0.767 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
Using the general `ParameterExpression` methods:
34.2 ms ± 1.29 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
974 ns ± 8.14 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```
</details>