### PR TITLE
Add NLayout::compose method

### DIFF
--- a/test/python/transpiler/test_layout.py
+++ b/test/python/transpiler/test_layout.py
@@ -428,7 +428,7 @@ class LayoutTest(QiskitTestCase):
         second = [2, 3, 1, 0]
         first_layout = Layout(dict(zip(qubits, first)))
         second_layout = Layout(dict(zip(qubits, second)))
-        self.assertEqual(second_layout.compose(first_layout, qubits), second_layout)
+        self.assertEqual(first_layout.compose(second_layout, qubits), second_layout)
 
     def test_compose_no_permutation_second(self):
         """Test compose where the second doesn't permute anything."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a method to compose two NLayout objects in rust, this is something that we'll need when we do a full path compilation in Rust as we'll be working directly with NLayout and we'll potentially need to compose layouts depending on the passes that run.

### Details and comments