### PR TITLE
Limiting recursive BinaryOp optimization in SymbolExpr

### DIFF
--- a/crates/circuit/src/symbol_expr.rs
+++ b/crates/circuit/src/symbol_expr.rs
@@ -1016,8 +1016,13 @@ impl SymbolExpr {
                     rhs: r_rhs,
                 } = rhs
                 {
-                    if let SymbolExpr::Value(_) | SymbolExpr::Symbol(_) | SymbolExpr::Unary { .. } =
-                        self
+                    if let SymbolExpr::Value(_)
+                    | SymbolExpr::Symbol(_)
+                    | SymbolExpr::Unary { .. }
+                    | SymbolExpr::Binary {
+                        op: BinaryOp::Mul | BinaryOp::Div | BinaryOp::Pow,
+                        ..
+                    } = self
                     {
                         // recursive optimization for add and sub
                         if let BinaryOp::Add = &op {
@@ -1378,8 +1383,13 @@ impl SymbolExpr {
                     rhs: r_rhs,
                 } = rhs
                 {
-                    if let SymbolExpr::Value(_) | SymbolExpr::Symbol(_) | SymbolExpr::Unary { .. } =
-                        self
+                    if let SymbolExpr::Value(_)
+                    | SymbolExpr::Symbol(_)
+                    | SymbolExpr::Unary { .. }
+                    | SymbolExpr::Binary {
+                        op: BinaryOp::Mul | BinaryOp::Div | BinaryOp::Pow,
+                        ..
+                    } = self
                     {
                         // recursive optimization for add and sub
                         if let BinaryOp::Add = &op {

--- a/crates/circuit/src/symbol_expr.rs
+++ b/crates/circuit/src/symbol_expr.rs
@@ -1016,7 +1016,9 @@ impl SymbolExpr {
                     rhs: r_rhs,
                 } = rhs
                 {
-                    if let SymbolExpr::Value(_) | SymbolExpr::Symbol(_) | SymbolExpr::Unary { .. } = self {
+                    if let SymbolExpr::Value(_) | SymbolExpr::Symbol(_) | SymbolExpr::Unary { .. } =
+                        self
+                    {
                         // recursive optimization for add and sub
                         if let BinaryOp::Add = &op {
                             if let Some(e) = self.add_opt(r_lhs, true) {
@@ -1376,7 +1378,9 @@ impl SymbolExpr {
                     rhs: r_rhs,
                 } = rhs
                 {
-                    if let SymbolExpr::Value(_) | SymbolExpr::Symbol(_) | SymbolExpr::Unary { .. } = self {
+                    if let SymbolExpr::Value(_) | SymbolExpr::Symbol(_) | SymbolExpr::Unary { .. } =
+                        self
+                    {
                         // recursive optimization for add and sub
                         if let BinaryOp::Add = &op {
                             if let Some(e) = self.sub_opt(r_lhs, true) {

--- a/crates/circuit/src/symbol_expr.rs
+++ b/crates/circuit/src/symbol_expr.rs
@@ -1144,28 +1144,7 @@ impl SymbolExpr {
                             }
                         }
                     }
-
-                    // swap nodes by sorting rule
-                    match rhs {
-                        SymbolExpr::Binary { op: rop, .. } => {
-                            if let BinaryOp::Mul | BinaryOp::Div | BinaryOp::Pow = rop {
-                                if self > rhs {
-                                    Some(_add(rhs.clone(), self.clone()))
-                                } else {
-                                    None
-                                }
-                            } else {
-                                None
-                            }
-                        }
-                        _ => {
-                            if self > rhs {
-                                Some(_add(rhs.clone(), self.clone()))
-                            } else {
-                                None
-                            }
-                        }
-                    }
+                    None
                 }
                 SymbolExpr::Binary {
                     op,
@@ -1322,31 +1301,7 @@ impl SymbolExpr {
                             }
                         }
                     }
-                    // swap nodes by sorting rule
-                    if let BinaryOp::Mul | BinaryOp::Div | BinaryOp::Pow = op {
-                        match rhs {
-                            SymbolExpr::Binary { op: rop, .. } => {
-                                if let BinaryOp::Mul | BinaryOp::Div | BinaryOp::Pow = rop {
-                                    if self > rhs {
-                                        Some(_add(rhs.clone(), self.clone()))
-                                    } else {
-                                        None
-                                    }
-                                } else {
-                                    None
-                                }
-                            }
-                            _ => {
-                                if self > rhs {
-                                    Some(_add(rhs.clone(), self.clone()))
-                                } else {
-                                    None
-                                }
-                            }
-                        }
-                    } else {
-                        None
-                    }
+                    None
                 }
             }
         }
@@ -1503,34 +1458,7 @@ impl SymbolExpr {
                             }
                         }
                     }
-
-                    // swap nodes by sorting rule
-                    match rhs {
-                        SymbolExpr::Binary { op: rop, .. } => {
-                            if let BinaryOp::Mul | BinaryOp::Div | BinaryOp::Pow = rop {
-                                if self > rhs {
-                                    match rhs.neg_opt() {
-                                        Some(e) => Some(_add(e, self.clone())),
-                                        None => Some(_add(_neg(rhs.clone()), self.clone())),
-                                    }
-                                } else {
-                                    None
-                                }
-                            } else {
-                                None
-                            }
-                        }
-                        _ => {
-                            if self > rhs {
-                                match rhs.neg_opt() {
-                                    Some(e) => Some(_add(e, self.clone())),
-                                    None => Some(_add(_neg(rhs.clone()), self.clone())),
-                                }
-                            } else {
-                                None
-                            }
-                        }
-                    }
+                    None
                 }
                 SymbolExpr::Binary {
                     op,
@@ -1684,37 +1612,7 @@ impl SymbolExpr {
                             }
                         }
                     }
-                    // swap nodes by sorting rule
-                    if let BinaryOp::Mul | BinaryOp::Div | BinaryOp::Pow = op {
-                        match rhs {
-                            SymbolExpr::Binary { op: rop, .. } => {
-                                if let BinaryOp::Mul | BinaryOp::Div | BinaryOp::Pow = rop {
-                                    if self > rhs {
-                                        match rhs.neg_opt() {
-                                            Some(e) => Some(_add(e, self.clone())),
-                                            None => Some(_add(_neg(rhs.clone()), self.clone())),
-                                        }
-                                    } else {
-                                        None
-                                    }
-                                } else {
-                                    None
-                                }
-                            }
-                            _ => {
-                                if self > rhs {
-                                    match rhs.neg_opt() {
-                                        Some(e) => Some(_add(e, self.clone())),
-                                        None => Some(_add(_neg(rhs.clone()), self.clone())),
-                                    }
-                                } else {
-                                    None
-                                }
-                            }
-                        }
-                    } else {
-                        None
-                    }
+                    None
                 }
             }
         }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This is fix to issue #14786 

### Details and comments

This PR adds recursive call counter to `add_opt`, `sub_opt`, `mul_opt` and `div_opt` in `SymbolExpr` class to prevent falling into infinite loop.
