### PR TITLE
Allow passing custom label to special labels gates and fixed drawing

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -5171,18 +5171,19 @@ class QuantumCircuit:
             copy=False,
         )
 
-    def id(self, qubit: QubitSpecifier) -> InstructionSet:  # pylint: disable=invalid-name
+    def id(self, qubit: QubitSpecifier, label: str | None = None) -> InstructionSet:  # pylint: disable=invalid-name
         """Apply :class:`~qiskit.circuit.library.IGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
 
         Args:
             qubit: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.I, [qubit], ())
+        return self._append_standard_gate(StandardGate.I, [qubit], (), label=label)
 
     def ms(self, theta: ParameterValueType, qubits: Sequence[QubitSpecifier]) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.MSGate`.

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -6014,31 +6014,33 @@ class QuantumCircuit:
             copy=False,
         )
 
-    def sx(self, qubit: QubitSpecifier) -> InstructionSet:
+    def sx(self, qubit: QubitSpecifier, label: str | None = None) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.SXGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
 
         Args:
             qubit: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.SX, [qubit], ())
+        return self._append_standard_gate(StandardGate.SX, [qubit], (), label=label)
 
-    def sxdg(self, qubit: QubitSpecifier) -> InstructionSet:
+    def sxdg(self, qubit: QubitSpecifier, label: str | None = None) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.SXdgGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
 
         Args:
             qubit: The qubit(s) to apply the gate to.
+            label: The string label of the gate in the circuit.
 
         Returns:
             A handle to the instructions created.
         """
-        return self._append_standard_gate(StandardGate.SXdg, [qubit], ())
+        return self._append_standard_gate(StandardGate.SXdg, [qubit], (), label=label)
 
     def csx(
         self,

--- a/qiskit/visualization/circuit/text.py
+++ b/qiskit/visualization/circuit/text.py
@@ -1121,7 +1121,9 @@ class TextDrawing:
             params = get_param_str(op, "text", ndigits=5)
         if not isinstance(op, (SwapGate, Reset)) and not getattr(op, "_directive", False):
             gate_text, ctrl_text, _ = get_gate_ctrl_text(op, "text")
-            gate_text = TextDrawing.special_label(op) or gate_text
+            gate_text = (
+                op.label if op.label is not None else TextDrawing.special_label(op) or gate_text
+            )
             gate_text = gate_text + params
 
         if getattr(op, "condition", None) is not None:

--- a/releasenotes/notes/fix-overwrite-special-gates-drawn-names-0c0585e70fcdb5c6.yaml
+++ b/releasenotes/notes/fix-overwrite-special-gates-drawn-names-0c0585e70fcdb5c6.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed the QuantumCircuit.id method to allow the passing of a custom label.
+    In addition the TextDrawing has been update to take into account potential custom
+    labels for gates with "special labels": namely "I", "√X" and "√Xdg".

--- a/test/python/visualization/test_circuit_drawer.py
+++ b/test/python/visualization/test_circuit_drawer.py
@@ -289,3 +289,18 @@ class TestCircuitDrawer(QiskitTestCase):
         circuit.draw("latex_source")
         if optionals.HAS_MATPLOTLIB and optionals.HAS_PYLATEX:
             circuit.draw("mpl")
+
+    def test_identity_gate_with_custom_label(self):
+        """Test that when applied an identity gate (special case) with a custom label
+        the displayed name while drawn is indeed the one provided."""
+        circuit = QuantumCircuit(1)
+        circuit.id(0, label="foo")
+        expected = "\n".join(
+            [
+                "   ┌─────┐",
+                "q: ┤ foo ├",
+                "   └─────┘",
+            ]
+        )
+        result = circuit.draw("text")
+        self.assertEqual(result.__str__(), expected)


### PR DESCRIPTION
Fixes [#14335](https://github.com/Qiskit/qiskit/issues/14335)

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.

### Summary

Currently it's not possible to provide a label to the IDGate using  QuantumCircuit.id method. Even if it was, the label wouldn't still be displayed while drawing the circuit because of a special treatment reserved in the TextDrawing.special_label method.
This fixes it by giving priority to provided labels, if any.
