### PR TITLE
Clarify error message in `qpy.dump`

### DIFF
--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -180,8 +180,8 @@ def dump(
         version = common.QPY_VERSION
     elif common.QPY_COMPATIBILITY_VERSION > version or version > common.QPY_VERSION:
         raise ValueError(
-            f"Dumping payloads with the specified QPY version ({version}) is not supported by the "
-            f"currently installed QPY version ({common.QPY_VERSION}). Try selecting a version between "
+            f"Dumping payloads with the specified QPY version ({version}) is not supported by "
+            f"this version of Qiskit. Try selecting a version between "
             f"{common.QPY_COMPATIBILITY_VERSION} and {common.QPY_VERSION} for `qpy.dump`."
         )
 

--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -180,9 +180,9 @@ def dump(
         version = common.QPY_VERSION
     elif common.QPY_COMPATIBILITY_VERSION > version or version > common.QPY_VERSION:
         raise ValueError(
-            f"The specified QPY version {version} is not support for dumping with this version, "
-            f"of Qiskit. The only supported versions between {common.QPY_COMPATIBILITY_VERSION} and "
-            f"{common.QPY_VERSION}"
+            f"Dumping payloads with the specified QPY version ({version}) is not supported by the "
+            f"currently installed QPY version ({common.QPY_VERSION}). Try selecting a version between "
+            f"{common.QPY_COMPATIBILITY_VERSION} and {common.QPY_VERSION} for `qpy.dump`."
         )
 
     version_match = VERSION_PATTERN_REGEX.search(__version__)

--- a/releasenotes/notes/fix-qpy-message-bf1a1b0c7b78a038.yaml
+++ b/releasenotes/notes/fix-qpy-message-bf1a1b0c7b78a038.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Clarified the error message for invalid specified versions in :meth:`.qpy.dump` to make it easier to act on.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
While testing out QPY version compatibility issues in downstream packages I realized that the error raised in `qpy.dump` is using strange language (and it took me a while to understand what "specified version" meant).

`ValueError: The specified QPY version 14 is not support for dumping with this version, of Qiskit. The only supported versions between 19 and 20`

This PR fixes the grammatical issues and proposes what I think would be a clearer message, but feel free to propose further adjustments:

`ValueError: Dumping payloads with the specified QPY version (14) is not supported this version of Qiskit. Try selecting a version between 19 and 20 for qpy.dump.`

### Details and comments
I was using fake QPY versions in case you were wondering how I got a 19 and a 20.

