### PR TITLE
Add missing release note for ElidePermutations C API

### DIFF
--- a/releasenotes/notes/elide_permutations_c-e2c66e8cd42a1afd.yaml
+++ b/releasenotes/notes/elide_permutations_c-e2c66e8cd42a1afd.yaml
@@ -1,0 +1,9 @@
+---
+features_c:
+  - |
+    Added a new standalone transpiler pass function
+    ``qk_transpiler_pass_standalone_elide_permutations`` which is for running the
+    :class:`.ElidePermutations` transpiler pass. Calling this function in C is equivalent
+    to running the pass in Python like::
+
+      ElidePermutations(..)(circuit)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the recently merged #14708 a C API was added for calling ElidePermutations in standalone mode. However that PR neglected to include a release note. This commit corrects this oversight and adds the missing release note.

### Details and comments