### PR TITLE
Add a Python free path to the commutation checker module

### DIFF
--- a/crates/transpiler/src/passes/commutation_analysis.rs
+++ b/crates/transpiler/src/passes/commutation_analysis.rs
@@ -51,7 +51,6 @@ const MAX_NUM_QUBITS: u32 = 3;
 ///     node_indices = {(0, 0): 0, (1, 0): 3, (2, 0): 1, (3, 0): 1, (4, 0): 2}
 ///
 pub fn analyze_commutations(
-    py: Python,
     dag: &mut DAGCircuit,
     commutation_checker: &mut CommutationChecker,
     approximation_degree: f64,
@@ -93,7 +92,6 @@ pub fn analyze_commutations(
                         let cargs2 = dag.get_cargs(packed_inst1.clbits);
 
                         all_commute = commutation_checker.commute_inner(
-                            py,
                             &op1,
                             params1,
                             qargs1,
@@ -143,7 +141,7 @@ pub fn py_analyze_commutations(
     //   * The index in which commutation set a given node is located on a wire: {(node, wire): index}
     // The Python dict will store both of these dictionaries in one.
     let (commutation_set, node_indices) =
-        analyze_commutations(py, dag, commutation_checker, approximation_degree)?;
+        analyze_commutations(dag, commutation_checker, approximation_degree)?;
 
     let out_dict = PyDict::new(py);
 

--- a/crates/transpiler/src/passes/commutation_cancellation.rs
+++ b/crates/transpiler/src/passes/commutation_cancellation.rs
@@ -15,7 +15,7 @@ use std::f64::consts::PI;
 use hashbrown::{HashMap, HashSet};
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
-use pyo3::{pyfunction, wrap_pyfunction, Bound, PyResult, Python};
+use pyo3::{pyfunction, wrap_pyfunction, Bound, PyResult};
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 use smallvec::{smallvec, SmallVec};
 
@@ -72,7 +72,6 @@ struct CancellationSetKey {
 #[pyfunction]
 #[pyo3(signature = (dag, commutation_checker, basis_gates=None, approximation_degree=1.))]
 pub fn cancel_commutations(
-    py: Python,
     dag: &mut DAGCircuit,
     commutation_checker: &mut CommutationChecker,
     basis_gates: Option<HashSet<String>>,
@@ -112,7 +111,7 @@ pub fn cancel_commutations(
         qubits and commutation sets.
     */
     let (commutation_set, node_indices) =
-        analyze_commutations(py, dag, commutation_checker, approximation_degree)?;
+        analyze_commutations(dag, commutation_checker, approximation_degree)?;
     let mut cancellation_sets: HashMap<CancellationSetKey, Vec<NodeIndex>> = HashMap::new();
 
     (0..dag.num_qubits() as u32).for_each(|qubit| {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the commutation analysis and cancellation pass Rust functions to no longer require the Python token. Python was only ever used if checking the commutation with the gate matrices of custom Python defined operations that didn't have a matrix defined but did have a definition. Since this is not in the common path and also is not possible in a C context we can remove the Python token from the function signature and use Python::with_gil() in the specific conditions where Python is needed. This frees up the pass to be able to be called from a standalone C context, the only blocker right now is having the standard commutation library construction in Rust, as right now the library is only defined in Python.

### Details and comments

Related to: #14446