### PR TITLE
Fix doc indents in parameter expression docs

### DIFF
--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -178,9 +178,9 @@ impl ParameterExpression {
     /// # Arguments
     ///
     /// * strict - If ``true``, only allow returning a value if all symbols are bound. If
-    ///     ``false``, allow casting expressions to values, even though symbols might still exist.
-    ///     For example, ``0 * x`` will return ``0`` for ``strict=false`` and otherwise return
-    ///     an error.
+    ///   ``false``, allow casting expressions to values, even though symbols might still exist.
+    ///   For example, ``0 * x`` will return ``0`` for ``strict=false`` and otherwise return
+    ///   an error.
     pub fn try_to_value(&self, strict: bool) -> Result<Value, ParameterError> {
         if strict && !self.name_map.is_empty() {
             let free_symbols = self.expr.parameters();
@@ -430,10 +430,10 @@ impl ParameterExpression {
     /// # Arguments
     ///
     /// * map - A hashmap with [Symbol] keys and [ParameterExpression]s to replace these
-    ///     symbols with.
+    ///   symbols with.
     /// * allow_unknown_parameters - If `false`, returns an error if any symbol in the
-    ///     hashmap is not present in the expression. If `true`, unknown symbols are ignored.
-    ///     Setting to `true` is slightly faster as it does not involve additional checks.
+    ///   hashmap is not present in the expression. If `true`, unknown symbols are ignored.
+    ///   Setting to `true` is slightly faster as it does not involve additional checks.
     ///
     /// # Returns
     ///
@@ -512,10 +512,10 @@ impl ParameterExpression {
     /// # Arguments
     ///
     /// * map - A hashmap with [Symbol] keys and [Value]s to replace these
-    ///     symbols with.
+    ///   symbols with.
     /// * allow_unknown_parameter - If `false`, returns an error if any symbol in the
-    ///     hashmap is not present in the expression. If `true`, unknown symbols are ignored.
-    ///     Setting to `true` is slightly faster as it does not involve additional checks.
+    ///   hashmap is not present in the expression. If `true`, unknown symbols are ignored.
+    ///   Setting to `true` is slightly faster as it does not involve additional checks.
     ///
     /// # Returns
     ///
@@ -768,7 +768,7 @@ impl PyParameterExpression {
     /// Get the parameters present in the expression.
     ///
     /// .. note::
-    ///     
+    ///
     ///     Qiskit guarantees equality (via ``==``) of parameters retrieved from an expression
     ///     with the original :class:`.Parameter` objects used to create this expression,
     ///     but does **not guarantee** ``is`` comparisons to succeed.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the recently merged #14757 a few docs lines were overindented. Newer versions of clippy detect this and raise a warning but the version we run in CI doesn't have this rule so this went uncaught. This commit fixes this small oversight so clippy is happy and the docs are properly formatted.

### Details and comments