### PR TITLE
Remove Python dependency from `EquivalenceLibrary`

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -2182,6 +2182,11 @@ impl CircuitData {
         self.param_table.symbols()
     }
 
+    /// Get the unsorted symbols in this circuit.
+    pub fn iter_parameters(&self) -> impl Iterator<Item = &Symbol> {
+        self.param_table.iter_symbols()
+    }
+
     /// Assigns parameters to circuit data based on a slice of `Param`.
     pub fn assign_parameters_from_slice(&mut self, slice: &[Param]) -> PyResult<()> {
         if slice.len() != self.param_table.num_parameters() {

--- a/crates/transpiler/src/equivalence.rs
+++ b/crates/transpiler/src/equivalence.rs
@@ -154,8 +154,8 @@ impl Equivalence {
     }
 
     #[getter]
-    fn get_circuit<'py>(slf: &'py Bound<'py, Self>) -> CircuitFromPython {
-        CircuitFromPython(slf.borrow().circuit.clone())
+    fn get_circuit(&self) -> CircuitFromPython {
+        CircuitFromPython(self.circuit.clone())
     }
 
     fn __getnewargs__<'py>(

--- a/crates/transpiler/src/equivalence.rs
+++ b/crates/transpiler/src/equivalence.rs
@@ -362,7 +362,7 @@ impl EquivalenceLibrary {
     ///         be referenced if an entry is not found in this library.
     #[new]
     #[pyo3(signature= (base=None))]
-    fn new(base: Option<&EquivalenceLibrary>) -> Self {
+    pub fn new(base: Option<&EquivalenceLibrary>) -> Self {
         if let Some(base) = base {
             Self {
                 graph: base.graph.clone(),

--- a/crates/transpiler/src/passes/basis_translator/basis_search.rs
+++ b/crates/transpiler/src/passes/basis_translator/basis_search.rs
@@ -103,7 +103,7 @@ pub(crate) fn basis_search(
         let edge_data = edge.weight().as_ref().unwrap();
         let mut cost_tot = 0;
         let borrowed_cost = opt_cost_map.borrow();
-        for instruction in edge_data.rule.circuit.0.iter() {
+        for instruction in edge_data.rule.circuit.iter() {
             let instruction_op = instruction.op.view();
             cost_tot += borrowed_cost[&(
                 instruction_op.name().to_string(),

--- a/crates/transpiler/src/passes/basis_translator/compose_transforms.rs
+++ b/crates/transpiler/src/passes/basis_translator/compose_transforms.rs
@@ -24,11 +24,9 @@ use qiskit_circuit::{
 };
 use smallvec::SmallVec;
 
-use crate::equivalence::CircuitFromPython;
-
 // Custom types
 pub type GateIdentifier = (String, u32);
-pub type BasisTransformIn = (SmallVec<[Param; 3]>, CircuitFromPython);
+pub type BasisTransformIn = (SmallVec<[Param; 3]>, CircuitData);
 pub type BasisTransformOut = (SmallVec<[Param; 3]>, DAGCircuit);
 
 pub(super) fn compose_transforms<'a>(
@@ -120,17 +118,9 @@ pub(super) fn compose_transforms<'a>(
                             .map(|(uuid, param)| (uuid, param.clone_ref(py)))
                             .collect();
                     let mut replacement = equiv.clone();
-                    replacement
-                        .0
-                        .assign_parameters_from_mapping(param_mapping)?;
-                    let replace_dag: DAGCircuit = DAGCircuit::from_circuit_data(
-                        &replacement.0,
-                        true,
-                        None,
-                        None,
-                        None,
-                        None,
-                    )?;
+                    replacement.assign_parameters_from_mapping(param_mapping)?;
+                    let replace_dag: DAGCircuit =
+                        DAGCircuit::from_circuit_data(&replacement, true, None, None, None, None)?;
                     dag.substitute_node_with_dag(node, &replace_dag, None, None, None)?;
                 }
             }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
The following commits remove the Python dependency from `EquivalenceLibrary` mainly from the following things:
- The `raise_if_param_mismatch` function uses rust native parameters and will filter out from the parameters included by the gate.
- Use `CircuitData` when using Rust native methods.
- Exposes the `new()` method to the rest of the crates.

### Details and comments
~~This is built on top of #14799 and should be rebased once it merges.~~ Rebased!

