### PR TITLE
Fix qiskit.qasm2.dumps produced not valid OpenQASM script

### DIFF
--- a/releasenotes/notes/fix-illegal-qasm-gates-75a492691257fdf8.yaml
+++ b/releasenotes/notes/fix-illegal-qasm-gates-75a492691257fdf8.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed a bug where :func:`qiskit.qasm2.dumps` could generate invalid
+    OpenQASM 2.0 output by placing illegal operations (such as ``reset``,
+    ``measure``, or ``barrier``) inside custom gate definitions.
+    The exporter now flattens such gates, ensuring the output is always
+    valid OpenQASM 2.0.
+    Fixes `#14814 <https://github.com/Qiskit/qiskit/issues/14814>`__.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes a bug where qiskit.qasm2.dumps could generate invalid OpenQASM 2.0 output by placing illegal operations (such as reset, measure, or barrier) inside custom gate definitions. OpenQASM 2.0 does not allow these operations inside gate definitions, which caused errors when importing the QASM back with QuantumCircuit.from_qasm_str.
Closes: #14814

### Details and comments

###What this PR changes:
The QASM exporter now detects if a custom gate definition contains illegal operations (reset, measure, barrier).
If such operations are present, the exporter flattens the gate: it inlines the operations directly into the main circuit, rather than creating a custom gate definition.
This ensures that all generated OpenQASM 2.0 is valid and can be parsed back into a circuit.

###Tests:
Added tests in test/python/qasm2/test_export.py:
test_initialize_gate_with_reset verifies that Initialize gates are exported correctly and can be parsed back.
test_custom_gate_with_barrier verifies that custom gates with barriers are flattened and not defined as gates.
All existing and new tests pass.
