### PR TITLE
Set base-circuit properties on entry to `PassManager.run`

### DIFF
--- a/qiskit/passmanager/passmanager.py
+++ b/qiskit/passmanager/passmanager.py
@@ -302,16 +302,19 @@ def _run_workflow(
     flow_controller = pass_manager.to_flow_controller()
     initial_status = WorkflowStatus()
 
+    property_set = (
+        PropertySet() if initial_property_set is None else PropertySet(initial_property_set)
+    )
+    pass_manager.property_set = property_set
     passmanager_ir = pass_manager._passmanager_frontend(
         input_program=program,
         **kwargs,
     )
-    property_set = (
-        PropertySet() if initial_property_set is None else PropertySet(initial_property_set)
-    )
     passmanager_ir, final_state = flow_controller.execute(
         passmanager_ir=passmanager_ir,
-        state=PassManagerState(workflow_status=initial_status, property_set=property_set),
+        state=PassManagerState(
+            workflow_status=initial_status, property_set=pass_manager.property_set
+        ),
         callback=kwargs.get("callback", None),
     )
     # The `property_set` has historically been returned as a mutable attribute on `PassManager`

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -59,6 +59,10 @@ class PassManager(BasePassManager):
         input_program: QuantumCircuit,
         **kwargs,
     ) -> DAGCircuit:
+        self.property_set["original_qubit_indices"] = {
+            bit: i for i, bit in enumerate(input_program.qubits)
+        }
+        self.property_set["num_input_qubits"] = input_program.num_qubits
         return circuit_to_dag(input_program, copy_operations=True)
 
     def _passmanager_backend(

--- a/releasenotes/notes/default-transpile-properties-610c0f16ec967f34.yaml
+++ b/releasenotes/notes/default-transpile-properties-610c0f16ec967f34.yaml
@@ -1,0 +1,13 @@
+---
+features_transpiler:
+  - |
+    Custom subclasses of :class:`.BasePassManager` can now modify their
+    :attr:`~.BasePassManager.property_set` attribute during their :meth:`~.BasePassManager._passmanager_frontend`
+    method, to seed initial properties.  This provides symmetry, as it was previously only possible
+    to read the final properties during :meth:`~.BasePassManager._passmanager_backend`.
+upgrade_transpiler:
+  - |
+    The circuit :class:`.PassManager` now always sets the properties ``original_circuit_indices``
+    and ``num_input_qubits`` before execution starts on individual passes.  These are properties of
+    the input circuit, which it was previously up to individual passes to set, often as a side
+    effect of their primary purpose.

--- a/test/python/transpiler/test_pass_call.py
+++ b/test/python/transpiler/test_pass_call.py
@@ -18,6 +18,14 @@ from ._dummy_passes import PassD_TP_NR_NP, PassE_AP_NR_NP, PassN_AP_NR_NP
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
 
+def initial_properties(circuit):
+    """The properties that are inherent to the start of pass-manager execution."""
+    return {
+        "original_qubit_indices": {bit: i for i, bit in enumerate(circuit.qubits)},
+        "num_input_qubits": circuit.num_qubits,
+    }
+
+
 class TestPassCall(QiskitTestCase):
     """Test calling passes (passmanager-less)."""
 
@@ -48,7 +56,14 @@ class TestPassCall(QiskitTestCase):
             result = pass_e(circuit, property_set)
 
         self.assertMessageLog(cm, ["run analysis pass PassE_AP_NR_NP", "set property as value"])
-        self.assertEqual(property_set, {"another_property": "another_value", "property": "value"})
+        self.assertEqual(
+            property_set,
+            {
+                "another_property": "another_value",
+                "property": "value",
+                **initial_properties(circuit),
+            },
+        )
         self.assertIsInstance(property_set, dict)
         self.assertEqual(circuit, result)
 
@@ -64,7 +79,14 @@ class TestPassCall(QiskitTestCase):
 
         self.assertMessageLog(cm, ["run analysis pass PassE_AP_NR_NP", "set property as value"])
         self.assertEqual(
-            property_set, PropertySet({"another_property": "another_value", "property": "value"})
+            property_set,
+            PropertySet(
+                {
+                    "another_property": "another_value",
+                    "property": "value",
+                    **initial_properties(circuit),
+                }
+            ),
         )
         self.assertIsInstance(property_set, PropertySet)
         self.assertEqual(circuit, result)
@@ -87,7 +109,9 @@ class TestPassCall(QiskitTestCase):
                 "property to none noned",
             ],
         )
-        self.assertEqual(property_set, PropertySet({"to none": None}))
+        self.assertEqual(
+            property_set, PropertySet({"to none": None, **initial_properties(circuit)})
+        )
         self.assertIsInstance(property_set, dict)
         self.assertEqual(circuit, result)
 

--- a/test/python/transpiler/test_passmanager.py
+++ b/test/python/transpiler/test_passmanager.py
@@ -50,6 +50,13 @@ class TestPassManager(QiskitTestCase):
         expected_start.append(U2Gate(0, np.pi), [qr[0]])
         expected_start_dag = circuit_to_dag(expected_start)
 
+        base_property_set = PropertySet(
+            {
+                "original_qubit_indices": {bit: i for i, bit in enumerate(circuit.qubits)},
+                "num_input_qubits": circuit.num_qubits,
+            }
+        )
+
         expected_end = QuantumCircuit(qr)
         expected_end.append(U2Gate(0, np.pi), [qr[0]])
         expected_end_dag = circuit_to_dag(expected_end)
@@ -71,14 +78,14 @@ class TestPassManager(QiskitTestCase):
         self.assertEqual(calls[0]["pass_"].name(), "BasisTranslator")
         self.assertEqual(expected_start_dag, calls[0]["dag"])
         self.assertIsInstance(calls[0]["time"], float)
-        self.assertEqual(calls[0]["property_set"], PropertySet())
+        self.assertEqual(calls[0]["property_set"], base_property_set)
         self.assertEqual("MyCircuit", calls[0]["dag"].name)
         self.assertEqual(len(calls[1]), 5)
         self.assertEqual(calls[1]["count"], 1)
         self.assertEqual(calls[1]["pass_"].name(), "Optimize1qGates")
         self.assertEqual(expected_end_dag, calls[1]["dag"])
-        self.assertIsInstance(calls[0]["time"], float)
-        self.assertEqual(calls[0]["property_set"], PropertySet())
+        self.assertIsInstance(calls[1]["time"], float)
+        self.assertEqual(calls[1]["property_set"], base_property_set)
         self.assertEqual("MyCircuit", calls[1]["dag"].name)
 
     def test_callback_with_pass_requires(self):


### PR DESCRIPTION
Previously, we relied on `original_qubit_indices` being set by `ApplyLayout` (and some other passes), even though it really is a function of the input circuit, and knowable immediately.  This commit first makes it possible to set initial properties (just as pass-manager finalisation could already read final properties), then uses the new behaviour to ensure `original_qubit_indices`, and a new property `num_input_qubits`, is always set.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


