### PR TITLE
Add support for parameterized gates to the Target C API

### DIFF
--- a/crates/cext/src/transpiler/target.rs
+++ b/crates/cext/src/transpiler/target.rs
@@ -475,7 +475,7 @@ impl TargetEntry {
 /// Creates an entry to the ``QkTarget`` based on a ``QkGate`` instance.
 ///
 /// @param operation The ``QkGate`` whose properties this target entry defines. If the ``QkGate``
-/// takes parameters (which can be checked with ``qk_gate_num_params``) this will be added as a
+/// takes parameters (which can be checked with ``qk_gate_num_params``) it will be added as a
 /// an instruction on the target which accepts any parameter value. If the gate only accepts a
 /// fixed parameter value you can use ``qk_target_entry_new_fixed`` instead.
 ///

--- a/releasenotes/notes/parameterized_target_c-9c9a4ad2915c2348.yaml
+++ b/releasenotes/notes/parameterized_target_c-9c9a4ad2915c2348.yaml
@@ -17,8 +17,12 @@ features_c:
         QkTargetEntry *rz_entry = qk_target_entry_new(QkGate_RZ);
         for (uint32_t i = 0; i < 5; i++) {
             uint32_t qargs[1] = {i};
-            result_prop = qk_target_entry_add_property(rz_entry, qargs, 1, 1.2e-6, 1.3e-9);
+            qk_target_entry_add_property(rz_entry, qargs, 1, 1.2e-6, 1.3e-9);
         }
+        qk_target_add_instruction(target, rz_entry);
+
+        // Clean up after using target
+        qk_target_free(target);
 
     This creates a 5 qubit target that will accept an RZ gate on any qubit with any parameter
     value being supported by that gate.

--- a/releasenotes/notes/parameterized_target_c-9c9a4ad2915c2348.yaml
+++ b/releasenotes/notes/parameterized_target_c-9c9a4ad2915c2348.yaml
@@ -1,0 +1,24 @@
+---
+features_c:
+  - |
+    The ``QkTarget`` type is now able to represent targets that support
+    parameterized ``QkGate`` types that accept any parameter value. Previously,
+    these gates could only be added to the target with a fixed angle value
+    supported by using ``qk_target_entry_new_fixed`` to create the ``QkTargetEntry``.
+    Now, the ``qk_target_entry_new`` function can be used with parameterized gates
+    and when it is this indicates the gate in the target will support any value for
+    all of the gate's parameters. For example:
+
+    .. code-block:: c
+
+        #include <qiskit.h>
+
+        QkTarget *target = qk_target_new(5);
+        QkTargetEntry *rz_entry = qk_target_entry_new(QkGate_RZ);
+        for (uint32_t i = 0; i < 5; i++) {
+            uint32_t qargs[1] = {i};
+            result_prop = qk_target_entry_add_property(rz_entry, qargs, 1, 1.2e-6, 1.3e-9);
+        }
+
+    This creates a 5 qubit target that will accept an RZ gate on any qubit with any parameter
+    value being supported by that gate.

--- a/test/c/test_target.c
+++ b/test/c/test_target.c
@@ -140,6 +140,129 @@ cleanup:
     return result;
 }
 
+/*
+ * Test target construction with a parameterized gate
+ */
+int test_target_construction_ibm_like_target(void) {
+    int result = Ok;
+    QkTarget *target = qk_target_new(5);
+    QkTargetEntry *cx_entry = qk_target_entry_new(QkGate_CX);
+    uint32_t cx_qargs[2] = {0, 1};
+    QkExitCode result_prop = qk_target_entry_add_property(cx_entry, cx_qargs, 2, 2.2e-4, 6.2e-9);
+    if (result_prop != QkExitCode_Success) {
+        printf("Unexpected error occurred when adding entry.");
+        qk_target_entry_free(cx_entry);
+        result = EqualityError;
+        goto cleanup;
+    }
+    cx_qargs[0] = 2;
+    result_prop = qk_target_entry_add_property(cx_entry, cx_qargs, 2, 3.2e-4, 4.2e-9);
+    if (result_prop != QkExitCode_Success) {
+        printf("Unexpected error occurred when adding entry.");
+        qk_target_entry_free(cx_entry);
+        result = EqualityError;
+        goto cleanup;
+    }
+    cx_qargs[1] = 3;
+    result_prop = qk_target_entry_add_property(cx_entry, cx_qargs, 2, 1.2e-4, 4.2e-8);
+    if (result_prop != QkExitCode_Success) {
+        printf("Unexpected error occurred when adding entry.");
+        qk_target_entry_free(cx_entry);
+        result = EqualityError;
+        goto cleanup;
+    }
+    cx_qargs[0] = 4;
+    result_prop = qk_target_entry_add_property(cx_entry, cx_qargs, 2, 1.2e-3, 2.2e-8);
+    if (result_prop != QkExitCode_Success) {
+        printf("Unexpected error occurred when adding entry.");
+        qk_target_entry_free(cx_entry);
+        result = EqualityError;
+        goto cleanup;
+    }
+    QkExitCode result_cx = qk_target_add_instruction(target, cx_entry);
+    if (result_cx != QkExitCode_Success) {
+        printf("Unexpected error occurred when adding a CX gate.");
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    QkTargetEntry *rz_entry = qk_target_entry_new(QkGate_RZ);
+    for (uint32_t i = 0; i < 5; i++) {
+        uint32_t qargs[1] = {i};
+        result_prop = qk_target_entry_add_property(rz_entry, qargs, 1, 0, 0);
+        if (result_prop != QkExitCode_Success) {
+            printf("Unexpected error occurred when adding entry.");
+            result = EqualityError;
+            qk_target_entry_free(rz_entry);
+            goto cleanup;
+        }
+    }
+    QkExitCode result_rz = qk_target_add_instruction(target, rz_entry);
+    if (result_rz != QkExitCode_Success) {
+        printf("Unexpected error occurred when adding a parameterized RZ gate.");
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    QkTargetEntry *sx_entry = qk_target_entry_new(QkGate_SX);
+    for (uint32_t i = 0; i < 5; i++) {
+        uint32_t qargs[1] = {i};
+        result_prop = qk_target_entry_add_property(sx_entry, qargs, 1, 1.928e-10, 7.9829e-11);
+        if (result_prop != QkExitCode_Success) {
+            printf("Unexpected error occurred when adding entry.");
+            result = EqualityError;
+            qk_target_entry_free(sx_entry);
+            goto cleanup;
+        }
+    }
+    QkExitCode result_sx = qk_target_add_instruction(target, sx_entry);
+    if (result_sx != QkExitCode_Success) {
+        printf("Unexpected error occurred when adding a parameterized RZ gate.");
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    QkTargetEntry *x_entry = qk_target_entry_new(QkGate_X);
+    for (uint32_t i = 0; i < 5; i++) {
+        uint32_t qargs[1] = {i};
+        result_prop = qk_target_entry_add_property(x_entry, qargs, 1, 1.928e-10, 7.9829e-11);
+        if (result_prop != QkExitCode_Success) {
+            printf("Unexpected error occurred when adding entry.");
+            result = EqualityError;
+            qk_target_entry_free(x_entry);
+            goto cleanup;
+        }
+    }
+    QkExitCode result_x = qk_target_add_instruction(target, x_entry);
+    if (result_x != QkExitCode_Success) {
+        printf("Unexpected error occurred when adding a parameterized RZ gate.");
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    QkTargetEntry *measure_entry = qk_target_entry_new_measure();
+    for (uint32_t i = 0; i < 5; i++) {
+        uint32_t qargs[1] = {i};
+        result_prop = qk_target_entry_add_property(measure_entry, qargs, 1, 1.928e-10, 7.9829e-11);
+        if (result_prop != QkExitCode_Success) {
+            printf("Unexpected error occurred when adding entry.");
+            result = EqualityError;
+            qk_target_entry_free(measure_entry);
+            goto cleanup;
+        }
+    }
+    QkExitCode result_measure = qk_target_add_instruction(target, measure_entry);
+    if (result_measure != QkExitCode_Success) {
+        printf("Unexpected error occurred when adding a parameterized RZ gate.");
+        result = EqualityError;
+        goto cleanup;
+    }
+
+cleanup:
+    qk_target_free(target);
+    return result;
+}
+
 /**
  * Test construction of a QkTargetEntry
  */
@@ -423,6 +546,7 @@ int test_target(void) {
     num_failed += RUN_TEST(test_target_entry_construction);
     num_failed += RUN_TEST(test_target_add_instruction);
     num_failed += RUN_TEST(test_target_update_instruction);
+    num_failed += RUN_TEST(test_target_construction_ibm_like_target);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit expands the QkTarget API to support taking parameterized
gates that accept any angle value. Previously, this was not possible
because representing these gates internally in the target depended on
Python. That restriction has been removed with #14799 and we can now
expose this functionality to C. This is a necessary component for being
able to build targets for current devices since they all typically
expose at least one gate that takes an arbitrary angle.

### Details and comments

Fixes #14704

~This commit is based on #14799 and will need to be rebased when that merges. In the meantime you can look at the HEAD commit on the PR branch to see the contents of just this PR: https://github.com/Qiskit/qiskit/commit/00d71df7d173f59d1da41fe24aa6aeb51aa62321~ #14799 has merged and this has been rebased now.