### PR TITLE
Port Unroll3qOrMore to Rust

### DIFF
--- a/crates/pyext/src/lib.rs
+++ b/crates/pyext/src/lib.rs
@@ -73,6 +73,7 @@ fn _accelerate(m: &Bound<PyModule>) -> PyResult<()> {
     add_submodule(m, ::qiskit_synthesis::two_qubit_decompose::two_qubit_decompose, "two_qubit_decompose")?;
     add_submodule(m, ::qiskit_transpiler::passes::unitary_synthesis_mod, "unitary_synthesis")?;
     add_submodule(m, ::qiskit_accelerate::uc_gate::uc_gate, "uc_gate")?;
+    add_submodule(m, ::qiskit_transpiler::passes::unroll_3q_or_more_mod, "unroll_3q_or_more")?;
     add_submodule(m, ::qiskit_transpiler::passes::vf2_layout_mod, "vf2_layout")?;
     add_submodule(m, ::qiskit_circuit::circuit, "circuit")?;
     add_submodule(m, ::qiskit_circuit::converters::converters, "converters")?;

--- a/crates/transpiler/src/passes/mod.rs
+++ b/crates/transpiler/src/passes/mod.rs
@@ -43,6 +43,7 @@ mod remove_identity_equiv;
 pub mod sabre;
 mod split_2q_unitaries;
 mod unitary_synthesis;
+mod unroll_3q_or_more;
 mod vf2;
 
 pub use alap_schedule_analysis::{alap_schedule_analysis_mod, run_alap_schedule_analysis};
@@ -79,4 +80,5 @@ pub use remove_diagonal_gates_before_measure::{
 pub use remove_identity_equiv::{remove_identity_equiv_mod, run_remove_identity_equiv};
 pub use split_2q_unitaries::{run_split_2q_unitaries, split_2q_unitaries_mod};
 pub use unitary_synthesis::{run_unitary_synthesis, unitary_synthesis_mod};
+pub use unroll_3q_or_more::{run_unroll_3q_or_more, unroll_3q_or_more_mod};
 pub use vf2::{error_map_mod, score_layout, vf2_layout_mod, vf2_layout_pass, ErrorMap};

--- a/crates/transpiler/src/passes/unroll_3q_or_more.rs
+++ b/crates/transpiler/src/passes/unroll_3q_or_more.rs
@@ -1,0 +1,88 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use pyo3::prelude::*;
+use pyo3::wrap_pyfunction;
+use rustworkx_core::petgraph::stable_graph::NodeIndex;
+
+use crate::target::Target;
+use crate::QiskitError;
+use qiskit_circuit::dag_circuit::DAGCircuit;
+use qiskit_circuit::operations::Operation;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Unroll3qError {
+    #[error("Cannot unroll all 3q or more gates. No rule to expand {0}")]
+    NoDefinition(String),
+    #[error("Failed to substitute the definition")]
+    SubstitutionError(PyErr),
+}
+
+#[pyfunction]
+#[pyo3(name = "unroll_3q_or_more")]
+pub fn py_unroll_3q_or_more(dag: &mut DAGCircuit, target: Option<&Target>) -> PyResult<()> {
+    run_unroll_3q_or_more(dag, target).map_err(|err| match err {
+        Unroll3qError::NoDefinition(e) => QiskitError::new_err(format!(
+            "Cannot unroll all 3q or more gates. No rule to expand {}",
+            e
+        )),
+        Unroll3qError::SubstitutionError(e) => e,
+    })
+}
+
+pub fn run_unroll_3q_or_more(
+    dag: &mut DAGCircuit,
+    target: Option<&Target>,
+) -> Result<(), Unroll3qError> {
+    let remove_list: Result<Vec<(NodeIndex, DAGCircuit)>, Unroll3qError> = dag
+        .op_nodes(false)
+        .filter_map(
+            |(idx, inst)| -> Option<Result<(NodeIndex, DAGCircuit), Unroll3qError>> {
+                if inst.op.num_qubits() < 3 || inst.op.control_flow() {
+                    return None;
+                }
+                if let Some(target) = target {
+                    if target.contains_key(inst.op.name()) {
+                        return None;
+                    }
+                }
+                let definition = match inst.op.definition(inst.params_view()) {
+                    Some(def) => def,
+                    None => {
+                        return Some(Err(Unroll3qError::NoDefinition(inst.op.name().to_string())))
+                    }
+                };
+                let mut decomp_dag =
+                    match DAGCircuit::from_circuit_data(&definition, false, None, None, None, None)
+                    {
+                        Ok(dag) => dag,
+                        Err(e) => return Some(Err(Unroll3qError::SubstitutionError(e))),
+                    };
+                if let Err(e) = run_unroll_3q_or_more(&mut decomp_dag, target) {
+                    return Some(Err(e));
+                }
+                Some(Ok((idx, decomp_dag)))
+            },
+        )
+        .collect();
+    for (idx, decomp_dag) in remove_list? {
+        dag.substitute_node_with_dag(idx, &decomp_dag, None, None, None)
+            .map_err(Unroll3qError::SubstitutionError)?;
+    }
+    Ok(())
+}
+
+pub fn unroll_3q_or_more_mod(m: &Bound<PyModule>) -> PyResult<()> {
+    m.add_wrapped(wrap_pyfunction!(py_unroll_3q_or_more))?;
+    Ok(())
+}

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -131,6 +131,7 @@ sys.modules["qiskit._accelerate.high_level_synthesis"] = _accelerate.high_level_
 sys.modules["qiskit._accelerate.remove_identity_equiv"] = _accelerate.remove_identity_equiv
 sys.modules["qiskit._accelerate.circuit_duration"] = _accelerate.circuit_duration
 sys.modules["qiskit._accelerate.cos_sin_decomp"] = _accelerate.cos_sin_decomp
+sys.modules["qiskit._accelerate.unroll_3q_or_more"] = _accelerate.unroll_3q_or_more
 
 from qiskit.exceptions import QiskitError, MissingOptionalLibraryError
 

--- a/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
+++ b/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
@@ -13,10 +13,11 @@
 """Recursively expands 3q+ gates until the circuit only contains 2q or 1q gates."""
 
 from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.transpiler.target import Target
 from qiskit.transpiler.passes.utils import control_flow
-from qiskit.exceptions import QiskitError
-from qiskit.circuit import ControlFlowOp
-from qiskit.converters.circuit_to_dag import circuit_to_dag
+from qiskit._accelerate.unroll_3q_or_more import unroll_3q_or_more
+from qiskit.transpiler.passes.synthesis import UnitarySynthesis
+from qiskit.circuit.controlflow import CONTROL_FLOW_OP_NAMES
 
 
 class Unroll3qOrMore(TransformationPass):
@@ -42,7 +43,12 @@ class Unroll3qOrMore(TransformationPass):
         self.basis_gates = None
         if basis_gates is not None:
             self.basis_gates = set(basis_gates)
+            if target is None:
+                self.target = Target.from_configuration(
+                    [x for x in basis_gates if x not in CONTROL_FLOW_OP_NAMES]
+                )
 
+    @control_flow.trivial_recurse
     def run(self, dag):
         """Run the Unroll3qOrMore pass on `dag`.
 
@@ -53,32 +59,15 @@ class Unroll3qOrMore(TransformationPass):
         Raises:
             QiskitError: if a 3q+ gate is not decomposable
         """
-        for node in dag.multi_qubit_ops():
+        # In Rust unitary gates don't have a definition and we always
+        # run UnitarySynthesis first in a pass manager. But for backwards
+        # compatibility we need to unroll any unitary gates in the circuit.
+        # The simplest way to do this is to just run UnitarySynthesis with
+        # the default universal basis of U-CX
+        if "unitary" in dag.count_ops(recurse=False) and (
+            not self.target or "unitary" not in self.target
+        ):
+            dag = UnitarySynthesis(["cx", "u"], min_qubits=3).run(dag)
 
-            if isinstance(node.op, ControlFlowOp):
-                dag.substitute_node(node, control_flow.map_blocks(self.run, node.op))
-                continue
-
-            if self.target is not None:
-                # Treat target instructions as global since this pass can be run
-                # prior to layout and routing we don't have physical qubits from
-                # the circuit yet
-                if node.name in self.target:
-                    continue
-            elif self.basis_gates is not None and node.name in self.basis_gates:
-                continue
-
-            # TODO: allow choosing other possible decompositions
-            rule = node.op.definition.data
-            if not rule:
-                if rule == []:  # empty node
-                    dag.remove_op_node(node)
-                    continue
-                raise QiskitError(
-                    "Cannot unroll all 3q or more gates. "
-                    f"No rule to expand instruction {node.op.name}."
-                )
-            decomposition = circuit_to_dag(node.op.definition, copy_operations=False)
-            decomposition = self.run(decomposition)  # recursively unroll
-            dag.substitute_node_with_dag(node, decomposition)
+        unroll_3q_or_more(dag, self.target)
         return dag


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit ports the implementation of the Unroll3qOrMore transpiler
pass to Rust. Functionally in Python we don't use this pass by default
anymore by default because it's been superseded by HighLevelSynthesis
which does unrolling of custom operations for us. However, in the C
transpilation API we don't expose high level synthesis because we don't
expose custom operations to C yet. So to handle multiqubit gates in the
circuit we need the unroll 3q or more pass to serve the purpose it did
before high level synthesis. The first step for that is porting the
implementation of the pass to rust which will then let us call it from C
without Python.

### Details and comments

Fixes #12247

~This PR is based on #14766 and it will need to be rebased after #14766 merges this will need to be rebased. In the meantime you can view the contents of just this PR by looking at the HEAD commit: https://github.com/Qiskit/qiskit/commit/b5b94bd732b281b4e5be9f276e42ebec9b95445d~ This has been rebased now.