### PR TITLE
(PoC) Allow QuantumCircuit as mixer_operator

### DIFF
--- a/qiskit/circuit/library/n_local/evolved_operator_ansatz.py
+++ b/qiskit/circuit/library/n_local/evolved_operator_ansatz.py
@@ -172,6 +172,9 @@ def evolved_operator_ansatz(
             elif isinstance(op, BaseOperator):
                 gate = PauliEvolutionGate(op, next(param_iter), synthesis=evolution)
                 flatten_operator = flatten is True or flatten is None
+            elif isinstance(op, QuantumCircuit):
+                gate = op.to_instruction()
+                flatten_operator = False
             else:
                 raise ValueError(f"Unsupported operator type: {type(op)}")
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

PoC to fix #14838 

- [ ] test
- [ ] docstring

### Details and comments

```python
from qiskit import QuantumCircuit, __version__
from qiskit.circuit.library import QAOAAnsatz, qaoa_ansatz
from qiskit.quantum_info import SparsePauliOp

print(f"qiskit_version={__version__}")

op = SparsePauliOp("Z")
qc = QuantumCircuit(1)
qaoa = QAOAAnsatz(op, mixer_operator=qc) 
print(qaoa)

qaoa = qaoa_ansatz(op, mixer_operator=qc)
print(qaoa)
```

```
qiskit_version=2.2.0.dev0+5846122
   ┌────────────┐
q: ┤ QAOA(γ[0]) ├
   └────────────┘
   ┌───┐┌────────────┐┌─────────────┐
q: ┤ H ├┤ Rz(2*γ[0]) ├┤ circuit-166 ├
   └───┘└────────────┘└─────────────┘
```
