### PR TITLE
Fix clippy issues in new MCX synthesis plugin

### DIFF
--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -674,7 +674,7 @@ fn increment_1_dirty(n: u32, flag_add: bool) -> PyResult<CircuitData> {
         ));
     }
 
-    let k = (n + 1) / 2;
+    let k = n.div_ceil(2);
 
     // This construction is described in Fig. 6 of [1].
     //
@@ -870,7 +870,7 @@ fn increment_2_dirty(n: u32, flag_add: bool) -> PyResult<CircuitData> {
 /// # References:
 ///
 /// 1. Huang and Palsberg, *Compiling Conditional Quantum Gates without Using Helper Qubits*, PLDI (2024),
-/// https://dl.acm.org/doi/10.1145/3656436.
+///    https://dl.acm.org/doi/10.1145/3656436.
 pub fn synth_mcx_noaux_hp24(num_controls: usize) -> PyResult<CircuitData> {
     let n = num_controls + 1;
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the recently merged #14666 two small clippy issues with latest stable slipped into the PR. We run clippy with our MSRV in CI for a stable CI as newer versions of Rust/clippy introduce new rules and/or change/improve existing rules so a new rust release would break CI which is disruptive. However, you can still use newer clippy for local development and when you do the issues it finds highlight real things that need to be fixed in the code. This commit fixes the two things that clippy flags in the mcx plugin code, one is just a code style change but the other is a small docs formatting issue which would have resulted in weird formatting for the rendered rustdoc.

### Details and comments


