### PR TITLE
Add to_pauli and to_pauli_list conversion methods to qubit-sparse pauli classes

### DIFF
--- a/crates/quantum_info/src/lib.rs
+++ b/crates/quantum_info/src/lib.rs
@@ -25,4 +25,12 @@ mod test;
 
 use pyo3::import_exception;
 
+pub(crate) mod imports {
+    use qiskit_circuit::imports::ImportOnceCell;
+
+    pub static PAULI_TYPE: ImportOnceCell = ImportOnceCell::new("qiskit.quantum_info", "Pauli");
+    pub static PAULI_LIST_TYPE: ImportOnceCell =
+        ImportOnceCell::new("qiskit.quantum_info", "PauliList");
+}
+
 import_exception!(qiskit.exceptions, QiskitError);

--- a/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
@@ -852,6 +852,18 @@ impl PyPhasedQubitSparsePauli {
             .into_pyobject(py)
     }
 
+    /// Return a :class:`~.quantum_info.Pauli` representing the same Pauli.
+    fn to_pauli<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let quantum_info_module = py.import("qiskit.quantum_info")?;
+        let py_pauli = quantum_info_module.getattr("Pauli")?;
+        let pauli = py_pauli.call1((self.inner.qubit_sparse_pauli.to_dense_label(),))?;
+        pauli.setattr(
+            "phase",
+            self.inner.phase - self.inner.qubit_sparse_pauli.view().num_ys(),
+        )?;
+        pauli.extract()
+    }
+
     /// Get a copy of this term.
     fn copy(&self) -> Self {
         self.clone()
@@ -1408,6 +1420,29 @@ impl PyPhasedQubitSparsePauliList {
             out.append(to_py_tuple(view)?)?;
         }
         Ok(out.unbind())
+    }
+
+    /// Return a :class:`~.quantum_info.PauliList` representing the same list of Paulis.
+    fn to_pauli_list<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let quantum_info_module = py.import("qiskit.quantum_info")?;
+        let py_pauli_list = quantum_info_module.getattr("PauliList")?;
+        let inner = self.inner.read().map_err(|_| InnerReadError)?;
+        let pauli_list =
+            py_pauli_list.call1((inner.qubit_sparse_pauli_list.to_dense_label_list(),))?;
+
+        let mut phases = Vec::with_capacity(inner.num_terms());
+        for phased_qubit_sparse_pauli_view in inner.iter() {
+            phases.push(
+                phased_qubit_sparse_pauli_view.phase
+                    - phased_qubit_sparse_pauli_view
+                        .qubit_sparse_pauli_view
+                        .num_ys(),
+            );
+        }
+
+        pauli_list.setattr("phase", phases)?;
+
+        pauli_list.extract()
     }
 
     /// Apply a transpiler layout to this phased qubit sparse Pauli list.

--- a/releasenotes/notes/add-sparse-pauli-conversion-methods-0eee4738fd1ad5f0.yaml
+++ b/releasenotes/notes/add-sparse-pauli-conversion-methods-0eee4738fd1ad5f0.yaml
@@ -1,7 +1,6 @@
 ---
 features_quantum_info:
   - |
-    Adds methods :meth:`~.QubitSparsePauli.to_pauli`, :meth:`~.PhasedQubitSparsePauli.to_pauli`,
-    :meth:`~.QubitSparsePauliList.to_pauli_list`, and
-    :meth:`~.PhasedQubitSparsePauliList.to_pauli_list`. These methods convert the sparse objects
-    into the corresponding dense versions, :class:`Pauli` and :class:`PauliList` respectively.
+    Added methods :meth:`.QubitSparsePauli.to_pauli` and
+    :meth:`.QubitSparsePauliList.to_pauli_list`, which convert the sparse objects
+    into the corresponding dense versions, :class:`~.quantum_info.Pauli` and :class:`PauliList`, respectively.

--- a/releasenotes/notes/add-sparse-pauli-conversion-methods-0eee4738fd1ad5f0.yaml
+++ b/releasenotes/notes/add-sparse-pauli-conversion-methods-0eee4738fd1ad5f0.yaml
@@ -1,0 +1,7 @@
+---
+features_quantum_info:
+  - |
+    Adds methods :meth:`~.QubitSparsePauli.to_pauli`, :meth:`~.PhasedQubitSparsePauli.to_pauli`,
+    :meth:`~.QubitSparsePauliList.to_pauli_list`, and
+    :meth:`~.PhasedQubitSparsePauliList.to_pauli_list`. These methods convert the sparse objects
+    into the corresponding dense versions, :class:`Pauli` and :class:`PauliList` respectively.

--- a/test/python/quantum_info/test_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_qubit_sparse_pauli.py
@@ -22,11 +22,7 @@ import numpy as np
 
 from qiskit import transpile
 from qiskit.circuit import Measure, Parameter, library, QuantumCircuit
-from qiskit.quantum_info import (
-    QubitSparsePauli,
-    QubitSparsePauliList,
-    Pauli,
-)
+from qiskit.quantum_info import QubitSparsePauli, QubitSparsePauliList, Pauli, PauliList
 from qiskit.transpiler import Target
 
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
@@ -479,6 +475,22 @@ class TestQubitSparsePauli(QiskitTestCase):
             p0.commutes(p1)
         with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits: 3, 4"):
             p1.commutes(p0)
+
+    def test_to_pauli(self):
+        pauli = Pauli("XIZIY")
+        self.assertEqual(pauli, QubitSparsePauli(pauli).to_pauli())
+
+        # leading identities
+        pauli = Pauli("IIZIY")
+        self.assertEqual(pauli, QubitSparsePauli(pauli).to_pauli())
+
+        # trailing identities
+        pauli = Pauli("XIZIYII")
+        self.assertEqual(pauli, QubitSparsePauli(pauli).to_pauli())
+
+        # both
+        pauli = Pauli("IIXIZIYII")
+        self.assertEqual(pauli, QubitSparsePauli(pauli).to_pauli())
 
 
 @ddt.ddt
@@ -1188,6 +1200,16 @@ class TestQubitSparsePauliList(QiskitTestCase):
                 canonicalize_sparse_list(expected),
                 canonicalize_sparse_list(pauli_list.to_sparse_list()),
             )
+
+    def test_to_pauli_list(self):
+        pauli_strings = ["XIZIY", "IIZIY", "ZIYII", "IIZII"]
+        pauli_list = PauliList(pauli_strings)
+        self.assertEqual(pauli_list, QubitSparsePauliList.from_list(pauli_strings).to_pauli_list())
+
+        # single element
+        pauli_strings = ["XIZIY"]
+        pauli_list = PauliList(pauli_strings)
+        self.assertEqual(pauli_list, QubitSparsePauliList.from_list(pauli_strings).to_pauli_list())
 
     def test_to_dense_array(self):
         """Test converting to a dense array."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR depends on #14759 

Adds:
- `QubitSparsePauli.to_pauli` and `PhasedQubitSparsePauli.to_pauli` returning a `qiskit.quantum_info.Pauli` instance representing the same operator.
- `QubitSparsePauliList.to_pauli_list` and `PhasedQubitSparsePauliList.to_pauli_list` returning a `qiskit.quantum_info.PauliList` instance representing the same operator list.
