### PR TITLE
Fix ParameterExpression.gradient() to return numeric values for constant derivatives

### DIFF
--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -890,23 +890,14 @@ impl PyParameterExpression {
     pub fn gradient(&self, param: &Bound<'_, PyAny>) -> PyResult<PyObject> {
         let symbol = symbol_from_py_parameter(param)?;
         let d_expr = self.inner.derivative(&symbol)?;
-    
-        if d_expr.expr.parameters().is_empty() {
-            if let Some(val) = d_expr.expr.eval(true) {
-                match val {
-                    Value::Real(r) => Ok(r.into_py_any(param.py())?),
-                    Value::Int(i) => Ok(i.into_py_any(param.py())?),
-                    Value::Complex(c) => Ok(c.into_py_any(param.py())?),
-                }
-            } else {
-                Ok(Py::new(param.py(), PyParameterExpression::from(d_expr))?
-                    .into_any()
-                    .into())
-            }
-        } else {
-            Ok(Py::new(param.py(), PyParameterExpression::from(d_expr))?
-                .into_any()
-                .into())
+
+        match d_expr.try_to_value(true) {
+            Ok(val) => match val {
+                Value::Real(r) => Ok(r.into_py_any(param.py())?),
+                Value::Int(i) => Ok(i.into_py_any(param.py())?),
+                Value::Complex(c) => Ok(c.into_py_any(param.py())?),
+            },
+            Err(_) => Ok(Py::new(param.py(), PyParameterExpression::from(d_expr))?.into_any()),
         }
     }
 

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -891,13 +891,14 @@ impl PyParameterExpression {
         let symbol = symbol_from_py_parameter(param)?;
         let d_expr = self.inner.derivative(&symbol)?;
 
-        match d_expr.try_to_value(true) {
+        // try converting to value and return as built-in numeric type
+        match d_expr.try_to_value(false) {
             Ok(val) => match val {
-                Value::Real(r) => Ok(r.into_py_any(param.py())?),
-                Value::Int(i) => Ok(i.into_py_any(param.py())?),
-                Value::Complex(c) => Ok(c.into_py_any(param.py())?),
+                Value::Real(r) => r.into_py_any(param.py()),
+                Value::Int(i) => i.into_py_any(param.py()),
+                Value::Complex(c) => c.into_py_any(param.py()),
             },
-            Err(_) => Ok(Py::new(param.py(), PyParameterExpression::from(d_expr))?.into_any()),
+            Err(_) => PyParameterExpression::from(d_expr).into_py_any(param.py()),
         }
     }
 

--- a/test/python/circuit/test_parameter_expression.py
+++ b/test/python/circuit/test_parameter_expression.py
@@ -485,8 +485,6 @@ class TestParameterExpression(QiskitTestCase):
         for expr, param, expected in test_cases:
             with self.subTest(expr=str(expr), param=str(param)):
                 result = expr.gradient(param)
-                if isinstance(result, str):
-                    result = float(result)
                 self.assertIsInstance(result, (int, float, complex))
                 self.assertEqual(result, expected)
 

--- a/test/python/circuit/test_parameter_expression.py
+++ b/test/python/circuit/test_parameter_expression.py
@@ -467,6 +467,29 @@ class TestParameterExpression(QiskitTestCase):
         with self.assertRaises(RuntimeError):
             _ = expr.gradient(x)
 
+    def test_gradient_constant_derivatives(self):
+        """Test gradient method returns numeric values for constant derivatives."""
+        x = Parameter("x")
+        y = Parameter("y")
+
+        test_cases = [
+            (x, x, 1.0),
+            (x + 0, x, 1.0),
+            (0 * x, x, 0.0),
+            (x / 2, x, 0.5),
+            (x - x, x, 0.0),
+            (5 + x - x, x, 0.0),
+            (2 * x + y - x, x, 1.0),
+        ]
+
+        for expr, param, expected in test_cases:
+            with self.subTest(expr=str(expr), param=str(param)):
+                result = expr.gradient(param)
+                if isinstance(result, str):
+                    result = float(result)
+                self.assertIsInstance(result, (int, float, complex))
+                self.assertEqual(result, expected)
+
     @unittest.skipUnless(HAS_SYMPY, "Sympy is required for this test")
     def test_sympify_all_ops(self):
         """Test the sympify function works for all the supported operations."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.
- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

## Summary
Fixes #14845:
where `ParameterExpression.gradient()` returns a `ParameterExpression` object instead of the expected numeric value for constant derivatives.

## Details and comments

### Problem
After PR #14757, the behavior changed and `x.gradient(x)` started returning a `ParameterExpression` object instead of the expected `1.0` value.

**Before:**
```python
>>> x.gradient(x)
<qiskit._accelerate.circuit.ParameterExpression object at 0x...>
```

### Solution
Modified `gradient()` method to:
- Check if derivative is constant using `d_expr.expr.parameters().is_empty()`
- Return native Python types (float, int, complex) for constant derivatives
- Return `ParameterExpression` for symbolic derivatives

**After:**
```python
>>> x.gradient(x)
1.0
```
