### PR TITLE
Multi-qubit fix for delay

### DIFF
--- a/qiskit/circuit/delay.py
+++ b/qiskit/circuit/delay.py
@@ -23,11 +23,7 @@ from qiskit._accelerate.circuit import StandardInstructionType
 
 
 class Delay(Instruction):
-    """Do nothing and just delay/wait/idle for a specified duration.
-
-    This version supports variadic qubits (multi-qubit delay) to match
-    OpenQASM 3 semantics. All specified qubits are delayed simultaneously.
-    """
+    """Do nothing and just delay/wait/idle for a specified duration."""
 
     _standard_instruction_type = StandardInstructionType.Delay
 

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -37,6 +37,7 @@ from typing import (
     Any,
     Literal,
     overload,
+    List
 )
 from math import pi
 import numpy as np
@@ -3555,6 +3556,39 @@ class QuantumCircuit:
             raise CircuitError(
                 f"Could not locate provided bit: {bit}. Has it been added to the QuantumCircuit?"
             ) from err
+        
+    def find_bits(self, bits: Union[Iterable[Bit], Instruction, Bit]) -> List[BitLocations]:
+        """Find locations in the circuit for multiple bits or an instruction.
+
+        Args:
+            bits (Iterable[Bit] | Instruction | Bit):
+                - An iterable of Bit objects (Qubit or Clbit)
+                - An instruction, from which qubits and clbits will be taken
+                - A single Bit
+
+        Returns:
+            list[BitLocations]: A list of BitLocations in the same order as the input bits.
+        """
+
+        if hasattr(bits, "qubits") or hasattr(bits, "clbits"):
+            bits = list(getattr(bits, "qubits", [])) + list(getattr(bits, "clbits", []))
+        elif isinstance(bits, Bit):
+            bits = [bits]  
+        else:
+            bits = list(bits)  
+
+
+        results = []
+        for b in bits:
+            try:
+                results.append(self.find_bit(b))
+            except CircuitError as err:
+                raise CircuitError(
+                    f"Could not locate provided bit: {b}. "
+                    f"Has it been added to the QuantumCircuit?"
+                ) from err
+
+        return results
 
     def _check_dups(self, qubits: Sequence[Qubit]) -> None:
         """Raise exception if list of qubits contains duplicates."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Reworks multi-qubit to synchronize instead of broadcasting to gate so the delay can be executed on the qubits at the same time. Attempted to add the feature requested in #14744.


### Details and comments
Only made changes to delay.py. Passes "test_circuit_operations.py" unit test but fails "test_delay" because the new multi-qubit version doesn't broadcast into several gates.

