### PR TITLE
Address C API documentation issues

### DIFF
--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -706,7 +706,7 @@ fn is_unitary(matrix: &ArrayType, tol: f64) -> bool {
 ///
 ///   QkCircuit *circuit = qk_circuit_new(1, 0);  // 1 qubit circuit
 ///   uint32_t qubit[1] = {0};  // qubit to apply the unitary on
-///   qk_circuit_unitary(circuit, unitary, qubit, num_qubits, true
+///   qk_circuit_unitary(circuit, unitary, qubit, num_qubits, true);
 /// ```
 ///
 /// # Safety

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -85,8 +85,9 @@ pub extern "C" fn qk_circuit_new(num_qubits: u32, num_clbits: u32) -> *mut Circu
 /// @return A pointer to the created register
 ///
 /// # Example
-///
+/// ```c
 ///     QkQuantumRegister *qr = qk_quantum_register_new(5, "five_qubits");
+/// ```
 ///
 /// # Safety
 ///
@@ -116,9 +117,10 @@ pub unsafe extern "C" fn qk_quantum_register_new(
 /// @param reg A pointer to the register to free.
 ///
 /// # Example
-///
+/// ```c
 ///     QkQuantumRegister *qr = qk_quantum_register_new(1024, "qreg");
 ///     qk_quantum_register_free(qr);
+/// ```
 ///
 /// # Safety
 ///
@@ -146,9 +148,10 @@ pub unsafe extern "C" fn qk_quantum_register_free(reg: *mut QuantumRegister) {
 /// @param reg A pointer to the register to free.
 ///
 /// # Example
-///
+/// ```c
 ///     QkClassicalRegister *cr = qk_classical_register_new(1024, "creg");
 ///     qk_classical_register_free(cr);
+/// ```
 ///
 /// # Safety
 ///
@@ -180,8 +183,9 @@ pub unsafe extern "C" fn qk_classical_register_free(reg: *mut ClassicalRegister)
 /// @return A pointer to the created register
 ///
 /// # Example
-///
+/// ```c
 ///     QkClassicalRegister *cr = qk_classical_register_new(5, "five_qubits");
+/// ```
 ///
 /// # Safety
 ///
@@ -212,12 +216,13 @@ pub unsafe extern "C" fn qk_classical_register_new(
 /// @param reg A pointer to the quantum register
 ///
 /// # Example
-///
+/// ```c
 ///     QkCircuit *qc = qk_circuit_new(0, 0);
 ///     QkQuantumRegister *qr = qk_quantum_register_new(1024, "my_little_register");
 ///     qk_circuit_add_quantum_register(qc, qr);
 ///     qk_quantum_register_free(qr);
-///     qk_circuit_free(qc)
+///     qk_circuit_free(qc);
+/// ```
 ///
 /// # Safety
 ///
@@ -245,12 +250,13 @@ pub unsafe extern "C" fn qk_circuit_add_quantum_register(
 /// @param reg A pointer to the classical register
 ///
 /// # Example
-///
+/// ```c
 ///     QkCircuit *qc = qk_circuit_new(0, 0);
 ///     QkClassicalRegister *cr = qk_classical_register_new(24, "my_big_register");
 ///     qk_circuit_add_classical_register(qc, cr);
 ///     qk_classical_register_free(cr);
-///     qk_circuit_free(qc)
+///     qk_circuit_free(qc);
+/// ```
 ///
 /// # Safety
 ///
@@ -279,9 +285,10 @@ pub unsafe extern "C" fn qk_circuit_add_classical_register(
 /// @return A new pointer to a copy of the input ``circuit``.
 ///
 /// # Example
-///
+/// ```c
 ///     QkCircuit *qc = qk_circuit_new(100, 100);
 ///     QkCircuit *copy = qk_circuit_copy(qc);
+/// ```
 ///
 /// # Safety
 ///
@@ -302,9 +309,10 @@ pub unsafe extern "C" fn qk_circuit_copy(circuit: *const CircuitData) -> *mut Ci
 /// @return The number of qubits the circuit is defined on.
 ///
 /// # Example
-///
+/// ```c
 ///     QkCircuit *qc = qk_circuit_new(100, 100);
 ///     uint32_t num_qubits = qk_circuit_num_qubits(qc);  // num_qubits==100
+/// ```
 ///
 /// # Safety
 ///
@@ -326,9 +334,10 @@ pub unsafe extern "C" fn qk_circuit_num_qubits(circuit: *const CircuitData) -> u
 /// @return The number of qubits the circuit is defined on.
 ///
 /// # Example
-///
+/// ```c
 ///     QkCircuit *qc = qk_circuit_new(100, 50);
 ///     uint32_t num_clbits = qk_circuit_num_clbits(qc);  // num_clbits==50
+/// ```
 ///
 /// # Safety
 ///
@@ -348,9 +357,10 @@ pub unsafe extern "C" fn qk_circuit_num_clbits(circuit: *const CircuitData) -> u
 /// @param circuit A pointer to the circuit to free.
 ///
 /// # Example
-///
+/// ```c
 ///     QkCircuit *qc = qk_circuit_new(100, 100);
 ///     qk_circuit_free(qc);
+/// ```
 ///
 /// # Safety
 ///
@@ -385,16 +395,17 @@ pub unsafe extern "C" fn qk_circuit_free(circuit: *mut CircuitData) {
 /// @return An exit code.
 ///
 /// # Example
-///
+/// ```c
 ///     QkCircuit *qc = qk_circuit_new(100, 0);
 ///     uint32_t qubit[1] = {0};
 ///     qk_circuit_gate(qc, QkGate_H, qubit, NULL);
+/// ```
 ///
 /// # Safety
 ///
 /// The ``qubits`` and ``params`` types are expected to be a pointer to an array of ``uint32_t``
 /// and ``double`` respectively where the length is matching the expectations for the standard
-/// gate. If the array is insufficently long the behavior of this function is undefined as this
+/// gate. If the array is insufficiently long the behavior of this function is undefined as this
 /// will read outside the bounds of the array. It can be a null pointer if there are no qubits
 /// or params for a given gate. You can check ``qk_gate_num_qubits`` and ``qk_gate_num_params`` to
 /// determine how many qubits and params are required for a given gate.
@@ -468,8 +479,9 @@ pub unsafe extern "C" fn qk_circuit_gate(
 /// @return The number of qubits the gate acts on.
 ///
 /// # Example
-///
+/// ```c
 ///     uint32_t num_qubits = qk_gate_num_qubits(QkGate_CCX);
+/// ```
 ///
 #[no_mangle]
 #[cfg(feature = "cbinding")]
@@ -485,8 +497,9 @@ pub extern "C" fn qk_gate_num_qubits(gate: StandardGate) -> u32 {
 /// @return The number of parameters the gate has.
 ///
 /// # Example
-///
+/// ```c
 ///     uint32_t num_params = qk_gate_num_params(QkGate_R);
+/// ```
 ///
 #[no_mangle]
 #[cfg(feature = "cbinding")]
@@ -504,9 +517,10 @@ pub extern "C" fn qk_gate_num_params(gate: StandardGate) -> u32 {
 /// @return An exit code.
 ///
 /// # Example
-///
+/// ```c
 ///     QkCircuit *qc = qk_circuit_new(100, 1);
 ///     qk_circuit_measure(qc, 0, 0);
+/// ```
 ///
 /// # Safety
 ///
@@ -540,9 +554,10 @@ pub unsafe extern "C" fn qk_circuit_measure(
 /// @return An exit code.
 ///
 /// # Example
-///
+/// ```c
 ///     QkCircuit *qc = qk_circuit_new(100, 0);
 ///     qk_circuit_reset(qc, 0);
+/// ```
 ///
 /// # Safety
 ///
@@ -573,10 +588,11 @@ pub unsafe extern "C" fn qk_circuit_reset(circuit: *mut CircuitData, qubit: u32)
 /// @return An exit code.
 ///
 /// # Example
-///
+/// ```c
 ///     QkCircuit *qc = qk_circuit_new(100, 1);
 ///     uint32_t qubits[5] = {0, 1, 2, 3, 4};
 ///     qk_circuit_barrier(qc, qubits, 5);
+/// ```
 ///
 /// # Safety
 ///
@@ -680,18 +696,18 @@ fn is_unitary(matrix: &ArrayType, tol: f64) -> bool {
 ///     the matrix is not unitary this is undefined behavior and will result in a corrupt
 ///     circuit.
 /// # Example
+/// ```c
+///   QkComplex64 c0 = {0, 0};  // 0+0i
+///   QkComplex64 c1 = {1, 0};  // 1+0i
 ///
-///     QkComplex64 c0 = qk_complex64_from_native(0);  // 0+0i
-///     QkComplex64 c1 = qk_complex64_from_native(1);  // 1+0i
+///   const uint32_t num_qubits = 1;
+///   QkComplex64 unitary[2*2] = {c0, c1,  // row 0
+///                                     c1, c0}; // row 1
 ///
-///     const uint32_t num_qubits = 1;
-///     const uint32_t dim = 2;
-///     QkComplex64[dim * dim] unitary = {c0, c1,  // row 0
-///                                       c1, c0}; // row 1
-///
-///     QkCircuit *circuit = qk_circuit_new(1, 0);  // 1 qubit circuit
-///     uint32_t qubit = {0};  // qubit to apply the unitary on
-///     qk_circuit_unitary(circuit, unitary, qubit, num_qubits);
+///   QkCircuit *circuit = qk_circuit_new(1, 0);  // 1 qubit circuit
+///   uint32_t qubit[1] = {0};  // qubit to apply the unitary on
+///   qk_circuit_unitary(circuit, unitary, qubit, num_qubits, true
+/// ```
 ///
 /// # Safety
 ///
@@ -750,11 +766,12 @@ pub unsafe extern "C" fn qk_circuit_unitary(
 /// @return An ``OpCounts`` struct containing the circuit operation counts.
 ///
 /// # Example
-///
+/// ```c
 ///     QkCircuit *qc = qk_circuit_new(100, 0);
-///     uint32_t qubit[1] = {0};
+///     uint32_t qubits[1] = {0};
 ///     qk_circuit_gate(qc, QkGate_H, qubits, NULL);
 ///     QkOpCounts counts = qk_circuit_count_ops(qc);
+/// ```
 ///
 /// # Safety
 ///
@@ -786,11 +803,12 @@ pub unsafe extern "C" fn qk_circuit_count_ops(circuit: *const CircuitData) -> Op
 /// @return The total number of instructions in the circuit.
 ///
 /// # Example
-///
+/// ```c
 ///     QkCircuit *qc = qk_circuit_new(100, 0);
 ///     uint32_t qubit[1] = {0};
 ///     qk_circuit_gate(qc, QkGate_H, qubit, NULL);
 ///     size_t num = qk_circuit_num_instructions(qc); // 1
+/// ```
 ///
 /// # Safety
 ///
@@ -838,12 +856,13 @@ pub struct CInstruction {
 ///
 ///
 /// # Example
-///
+/// ```c
 ///     QkCircuitInstruction inst;
-///     QkCircuit *qc = qk_circuit_new(100);
+///     QkCircuit *qc = qk_circuit_new(100, 0);
 ///     uint32_t qubit[1] = {0};
 ///     qk_circuit_gate(qc, QkGate_H, qubit, NULL);
 ///     qk_circuit_get_instruction(qc, 0, &inst);
+/// ```
 ///
 /// # Safety
 ///
@@ -912,15 +931,16 @@ pub unsafe extern "C" fn qk_circuit_get_instruction(
 /// @param inst A pointer to the instruction to free.
 ///
 /// # Example
-///
+/// ```c
 ///     QkCircuitInstruction *inst = malloc(sizeof(QkCircuitInstruction));
-///     QkCircuit *qc = qk_circuit_new(100);
-///     uint32_t q0 = {0};
+///     QkCircuit *qc = qk_circuit_new(100, 0);
+///     uint32_t q0[1] = {0};
 ///     qk_circuit_gate(qc, QkGate_H, q0, NULL);
 ///     qk_circuit_get_instruction(qc, 0, inst);
 ///     qk_circuit_instruction_clear(inst); // free the data
 ///     free(inst); // free the pointer
 ///     qk_circuit_free(qc); // free the circuit
+/// ```
 ///
 /// # Safety
 ///
@@ -1043,9 +1063,10 @@ impl From<QkDelayUnit> for DelayUnit {
 /// @return An exit code.
 ///
 /// # Example
-///
+/// ```c
 ///     QkCircuit *qc = qk_circuit_new(1, 0);
 ///     qk_circuit_delay(qc, 0, 100.0, QkDelayUnit_NS);
+/// ```
 ///
 /// # Safety
 ///

--- a/crates/cext/src/sparse_observable.rs
+++ b/crates/cext/src/sparse_observable.rs
@@ -80,8 +80,9 @@ impl TryFrom<&CSparseTerm> for SparseTermView<'_> {
 /// @return A pointer to the created observable.
 ///
 /// # Example
-///
+/// ```c
 ///     QkObs *zero = qk_obs_zero(100);
+/// ```
 ///
 #[no_mangle]
 #[cfg(feature = "cbinding")]
@@ -98,8 +99,9 @@ pub extern "C" fn qk_obs_zero(num_qubits: u32) -> *mut SparseObservable {
 /// @return A pointer to the created observable.
 ///
 /// # Example
-///
+/// ```c
 ///     QkObs *identity = qk_obs_identity(100);
+/// ```
 ///
 #[no_mangle]
 #[cfg(feature = "cbinding")]
@@ -127,26 +129,26 @@ pub extern "C" fn qk_obs_identity(num_qubits: u32) -> *mut SparseObservable {
 ///     to the observable. Otherwise a null pointer is returned.
 ///
 /// # Example
+/// ```c
+///    // define the raw data for the 100-qubit observable |01><01|_{0, 1} - |+-><+-|_{98, 99}
+///    uint32_t num_qubits = 100;
+///    uint64_t num_terms = 2;  // we have 2 terms: |01><01|, -1 * |+-><+-|
+///    uint64_t num_bits = 4; // we have 4 non-identity bits: 0, 1, +, -
+///    QkComplex64 coeffs = {1, -1};
+///    QkBitTerm bits[4] = {QkBitTerm_Zero, QkBitTerm_One, QkBitTerm_Plus, QkBitTerm_Minus};
 ///
-///     // define the raw data for the 100-qubit observable |01><01|_{0, 1} - |+-><+-|_{98, 99}
-///     uint32_t num_qubits = 100;
-///     uint64_t num_terms = 2;  // we have 2 terms: |01><01|, -1 * |+-><+-|
-///     uint64_t num_bits = 4; // we have 4 non-identity bits: 0, 1, +, -
-///
-///     complex double coeffs[2] = {1, -1};
-///     QkBitTerm bits[4] = {QkBitTerm_Zero, QkBitTerm_One, QkBitTerm_Plus, QkBitTerm_Minus};
-///     uint32_t indices[4] = {0, 1, 98, 99};  // <-- e.g. {1, 0, 99, 98} would be invalid
-///     size_t boundaries[3] = {0, 2, 4};
-///
-///     QkObs *obs = qk_obs_new(
-///         num_qubits, num_terms, num_bits, coeffs, bits, indices, boundaries
-///     );
+///    uint32_t indices[4] = {0, 1, 98, 99};  // <-- e.g. {1, 0, 99, 98} would be invalid
+///    size_t boundaries[3] = {0, 2, 4};
+///    QkObs *obs = qk_obs_new(
+///        num_qubits, num_terms, num_bits, &coeffs, bits, indices, boundaries
+///    );
+/// ```
 ///
 /// # Safety
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-///   * ``coeffs`` is a pointer to a ``complex double`` array of length ``num_terms``
+///   * ``coeffs`` is a pointer to a ``QkComplex64`` array of length ``num_terms``
 ///   * ``bit_terms`` is a pointer to an array of valid ``QkBitTerm`` elements of length ``num_bits``
 ///   * ``indices`` is a pointer to a ``uint32_t`` array of length ``num_bits``, which is
 ///     term-wise sorted in strict ascending order, and every element is smaller than ``num_qubits``
@@ -192,9 +194,10 @@ pub unsafe extern "C" fn qk_obs_new(
 /// @param obs A pointer to the observable to free.
 ///
 /// # Example
-///
+/// ```c
 ///     QkObs *obs = qk_obs_zero(100);
 ///     qk_obs_free(obs);
+/// ```
 ///
 /// # Safety
 ///
@@ -224,16 +227,17 @@ pub unsafe extern "C" fn qk_obs_free(obs: *mut SparseObservable) {
 /// @return An exit code. This is ``>0`` if the term is incoherent or adding the term fails.
 ///
 /// # Example
-///
+/// ```c
 ///     uint32_t num_qubits = 100;
 ///     QkObs *obs = qk_obs_zero(num_qubits);
 ///
-///     complex double coeff = 1;
+///     QkComplex64 coeff = {1, 0};
 ///     QkBitTerm bit_terms[3] = {QkBitTerm_X, QkBitTerm_Y, QkBitTerm_Z};
 ///     uint32_t indices[3] = {0, 1, 2};
-///     QkObsTerm term = {&coeff, 3, bit_terms, indices, num_qubits};
+///     QkObsTerm term = {coeff, 3, bit_terms, indices, num_qubits};
 ///
 ///     int exit_code = qk_obs_add_term(obs, &term);
+/// ```
 ///
 /// # Safety
 ///
@@ -277,12 +281,13 @@ pub unsafe extern "C" fn qk_obs_add_term(
 /// @return An exit code.
 ///
 /// # Example
-///
+/// ```c
 ///     QkObs *obs = qk_obs_identity(100);
 ///     QkObsTerm term;
 ///     int exit_code = qk_obs_term(obs, 0, &term);
 ///     // out-of-bounds indices return an error code
 ///     // int error = qk_obs_term(obs, 12, &term);
+/// ```
 ///
 /// # Safety
 ///
@@ -325,9 +330,10 @@ pub unsafe extern "C" fn qk_obs_term(
 /// @return The number of terms in the observable.
 ///
 /// # Example
-///
+/// ```c
 ///     QkObs *obs = qk_obs_identity(100);
 ///     size_t num_terms = qk_obs_num_terms(obs);  // num_terms==1
+/// ```
 ///
 /// # Safety
 ///
@@ -349,9 +355,10 @@ pub unsafe extern "C" fn qk_obs_num_terms(obs: *const SparseObservable) -> usize
 /// @return The number of qubits the observable is defined on.
 ///
 /// # Example
-///
+/// ```c
 ///     QkObs *obs = qk_obs_identity(100);
 ///     uint32_t num_qubits = qk_obs_num_qubits(obs);  // num_qubits==100
+/// ```
 ///
 /// # Safety
 ///
@@ -373,9 +380,10 @@ pub unsafe extern "C" fn qk_obs_num_qubits(obs: *const SparseObservable) -> u32 
 /// @return The number of terms in the observable.
 ///
 /// # Example
-///
+/// ```c
 ///     QkObs *obs = qk_obs_identity(100);
 ///     size_t len = qk_obs_len(obs);  // len==0, as there are no non-trivial bit terms
+/// ```
 ///
 /// # Safety
 ///
@@ -393,21 +401,22 @@ pub unsafe extern "C" fn qk_obs_len(obs: *const SparseObservable) -> usize {
 /// Get a pointer to the coefficients.
 ///
 /// This can be used to read and modify the observable's coefficients. The resulting
-/// pointer is valid to read for ``qk_obs_num_terms(obs)`` elements of ``complex double``.
+/// pointer is valid to read for ``qk_obs_num_terms(obs)`` elements of ``QkComplex64``.
 ///
 /// @param obs A pointer to the observable.
 ///
 /// @return A pointer to the coefficients.
 ///
 /// # Example
+/// ```c
+///    QkObs *obs = qk_obs_identity(100);
+///    size_t num_terms = qk_obs_num_terms(obs);
+///    QkComplex64 *coeffs = qk_obs_coeffs(obs);
 ///
-///     QkObs *obs = qk_obs_identity(100);
-///     size_t num_terms = qk_obs_num_terms(obs);
-///     complex double *coeffs = qk_obs_coeffs(obs);
-///
-///     for (size_t i = 0; i < num_terms; i++) {
-///         printf("%f + i%f\n", creal(coeffs[i]), cimag(coeffs[i]));
-///     }
+///    for (size_t i = 0; i < num_terms; i++) {
+///        printf("%f + i%f\n", coeffs[i].re, coeffs[i].im);
+///    }
+/// ```
 ///
 /// # Safety
 ///
@@ -432,14 +441,14 @@ pub unsafe extern "C" fn qk_obs_coeffs(obs: *mut SparseObservable) -> *mut Compl
 /// @return A pointer to the indices.
 ///
 /// # Example
-///
+/// ```c
 ///     uint32_t num_qubits = 100;
 ///     QkObs *obs = qk_obs_zero(num_qubits);
 ///
-///     complex double coeff = 1;
+///     QkComplex64 coeff = {1, 0};
 ///     QkBitTerm bit_terms[3] = {QkBitTerm_X, QkBitTerm_Y, QkBitTerm_Z};
-///     uint32_t indices[3] = {0, 1, 2};
-///     QkObsTerm term = {&coeff, 3, bit_terms, indices, num_qubits};
+///     uint32_t term_indices[3] = {0, 1, 2};
+///     QkObsTerm term = {coeff, 3, bit_terms, term_indices, num_qubits};
 ///     qk_obs_add_term(obs, &term);
 ///
 ///     size_t len = qk_obs_len(obs);
@@ -448,6 +457,7 @@ pub unsafe extern "C" fn qk_obs_coeffs(obs: *mut SparseObservable) -> *mut Compl
 ///     for (size_t i = 0; i < len; i++) {
 ///         printf("index %i: %i\n", i, indices[i]);
 ///     }
+/// ```
 ///
 ///     qk_obs_free(obs);
 ///
@@ -475,22 +485,23 @@ pub unsafe extern "C" fn qk_obs_indices(obs: *mut SparseObservable) -> *mut u32 
 /// @return A pointer to the boundaries.
 ///
 /// # Example
+/// ```c
+///    uint32_t num_qubits = 100;
+///    QkObs *obs = qk_obs_zero(num_qubits);
 ///
-///     uint32_t num_qubits = 100;
-///     QkObs *obs = qk_obs_zero(num_qubits);
+///    QkComplex64 coeff = {1, 0};
+///    QkBitTerm bit_terms[3] = {QkBitTerm_X, QkBitTerm_Y, QkBitTerm_Z};
+///    uint32_t indices[3] = {0, 1, 2};
+///    QkObsTerm term = {coeff, 3, bit_terms, indices, num_qubits};
+///    qk_obs_add_term(obs, &term);
 ///
-///     complex double coeff = 1;
-///     QkBitTerm bit_terms[3] = {QkBitTerm_X, QkBitTerm_Y, QkBitTerm_Z};
-///     uint32_t indices[3] = {0, 1, 2};
-///     QkObsTerm term = {&coeff, 3, bit_terms, indices, num_qubits};
-///     qk_obs_add_term(obs, &term);
+///    size_t num_terms = qk_obs_num_terms(obs);
+///    uintptr_t *boundaries = qk_obs_boundaries(obs);
 ///
-///     size_t num_terms = qk_obs_num_terms(obs);
-///     uint32_t *boundaries = qk_obs_boundaries(obs);
-///
-///     for (size_t i = 0; i < num_terms + 1; i++) {
-///         printf("boundary %i: %i\n", i, boundaries[i]);
-///     }
+///    for (size_t i = 0; i < num_terms + 1; i++) {
+///        printf("boundary %i: %i\n", i, boundaries[i]);
+///    }
+/// ```
 ///
 /// # Safety
 ///
@@ -517,14 +528,14 @@ pub unsafe extern "C" fn qk_obs_boundaries(obs: *mut SparseObservable) -> *mut u
 /// @return A pointer to the bit terms.
 ///
 /// # Example
-///
+/// ```c
 ///     uint32_t num_qubits = 100;
 ///     QkObs *obs = qk_obs_zero(num_qubits);
 ///
-///     complex double coeff = 1;
+///     QkComplex64 coeff = {1, 0};
 ///     QkBitTerm bit_terms[3] = {QkBitTerm_X, QkBitTerm_Y, QkBitTerm_Z};
 ///     uint32_t indices[3] = {0, 1, 2};
-///     QkObsTerm term = {&coeff, 3, bit_terms, indices, num_qubits};
+///     QkObsTerm term = {coeff, 3, bit_terms, indices, num_qubits};
 ///     qk_obs_add_term(obs, &term);
 ///
 ///     size_t len = qk_obs_len(obs);
@@ -535,6 +546,7 @@ pub unsafe extern "C" fn qk_obs_boundaries(obs: *mut SparseObservable) -> *mut u
 ///     }
 ///
 ///     qk_obs_free(obs);
+/// ```
 ///
 /// # Safety
 ///
@@ -556,16 +568,17 @@ pub unsafe extern "C" fn qk_obs_bit_terms(obs: *mut SparseObservable) -> *mut Bi
 /// @param coeff The coefficient to multiply the observable with.
 ///
 /// # Example
-///
+/// ```c
 ///     QkObs *obs = qk_obs_identity(100);
-///     complex double coeff = 2;
+///     QkComplex64 coeff = {2, 0};
 ///     QkObs *result = qk_obs_multiply(obs, &coeff);
+/// ```
 ///
 /// # Safety
 ///
 /// Behavior is undefined if any of the following is violated
 /// * ``obs`` is a valid, non-null pointer to a ``QkObs``
-/// * ``coeff`` is a valid, non-null pointer to a ``complex double``
+/// * ``coeff`` is a valid, non-null pointer to a ``QkComplex64``
 #[no_mangle]
 #[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_multiply(
@@ -589,10 +602,11 @@ pub unsafe extern "C" fn qk_obs_multiply(
 /// @return A pointer to the result ``left + right``.
 ///
 /// # Example
-///
+/// ```c
 ///     QkObs *left = qk_obs_identity(100);
 ///     QkObs *right = qk_obs_zero(100);
 ///     QkObs *result = qk_obs_add(left, right);
+/// ```
 ///
 /// # Safety
 ///
@@ -622,10 +636,11 @@ pub unsafe extern "C" fn qk_obs_add(
 ///     in terms of the matrix multiplication ``@``.
 ///
 /// # Example
-///
+/// ```c
 ///     QkObs *first = qk_obs_zero(100);
 ///     QkObs *second = qk_obs_identity(100);
 ///     QkObs *result = qk_obs_compose(first, second);
+/// ```
 ///
 /// # Safety
 ///
@@ -659,10 +674,11 @@ pub unsafe extern "C" fn qk_obs_compose(
 ///     in terms of the matrix multiplication ``@``.
 ///
 /// # Example
-///
+/// ```c
 ///     QkObs *first = qk_obs_zero(100);
 ///     QkObs *second = qk_obs_identity(100);
 ///     QkObs *result = qk_obs_compose(first, second);
+/// ```
 ///
 /// # Safety
 ///
@@ -711,12 +727,13 @@ pub unsafe extern "C" fn qk_obs_compose_map(
 /// @return The canonical representation of the observable.
 ///
 /// # Example
+/// ```c
+///    QkObs *iden = qk_obs_identity(100);
+///    QkObs *two = qk_obs_add(iden, iden);
 ///
-///     QkObs *iden = qk_obs_identity(100);
-///     QkObs *two = qk_obs_add(iden, iden);
-///
-///     double tol = 1e-6;
-///     QkObs *canonical = qk_obs_canonicalize(two);
+///    double tol = 1e-6;
+///    QkObs *canonical = qk_obs_canonicalize(two, tol);
+/// ```
 ///
 /// # Safety
 ///
@@ -742,9 +759,10 @@ pub unsafe extern "C" fn qk_obs_canonicalize(
 /// @return A pointer to a copy of the observable.
 ///
 /// # Example
-///
+/// ```c
 ///     QkObs *original = qk_obs_identity(100);
 ///     QkObs *copied = qk_obs_copy(original);
+/// ```
 ///
 /// # Safety
 ///
@@ -771,10 +789,11 @@ pub unsafe extern "C" fn qk_obs_copy(obs: *const SparseObservable) -> *mut Spars
 /// @return ``true`` if the observables are equal, ``false`` otherwise.
 ///
 /// # Example
-///
+/// ```c
 ///     QkObs *observable = qk_obs_identity(100);
 ///     QkObs *other = qk_obs_identity(100);
 ///     bool are_equal = qk_obs_equal(observable, other);
+/// ```
 ///
 /// # Safety
 ///
@@ -801,10 +820,11 @@ pub unsafe extern "C" fn qk_obs_equal(
 /// @return A pointer to a nul-terminated char array of the string representation for ``obs``
 ///
 /// # Example
-///
+/// ```c
 ///     QkObs *obs = qk_obs_identity(100);
 ///     char *string = qk_obs_str(obs);
 ///     qk_str_free(string);
+/// ```
 ///
 /// # Safety
 ///
@@ -851,12 +871,13 @@ pub unsafe extern "C" fn qk_str_free(string: *mut c_char) {
 /// @return The function exit code. This is ``>0`` if reading the term failed.
 ///
 /// # Example
-///
+/// ```c
 ///     QkObs *obs = qk_obs_identity(100);
 ///     QkObsTerm term;
 ///     qk_obs_term(obs, 0, &term);
 ///     char *string = qk_obsterm_str(&term);
 ///     qk_str_free(string);
+/// ```
 ///
 /// # Safety
 ///
@@ -886,10 +907,11 @@ pub unsafe extern "C" fn qk_obsterm_str(term: *const CSparseTerm) -> *mut c_char
 /// @return The label as ``uint8_t``, which can be cast to ``char`` to obtain the character.
 ///
 /// # Example
-///
+/// ```c
 ///     QkBitTerm bit_term = QkBitTerm_Y;
 ///     // cast the uint8_t to char
 ///     char label = qk_bitterm_label(bit_term);
+/// ```
 ///
 /// # Safety
 ///

--- a/crates/cext/src/transpiler/passes/elide_permutations.rs
+++ b/crates/cext/src/transpiler/passes/elide_permutations.rs
@@ -138,7 +138,7 @@ pub unsafe extern "C" fn qk_elide_permutations_result_free(result: *mut ElidePer
 /// set during the transpilation pipeline. This pass iterates over the circuit
 /// and when a Swap gate is encountered it permutes the virtual qubits in
 /// the circuit and removes the swap gate. This will effectively remove any
-/// swap gates in the cirucit prior to running layout. This optimization is
+/// swap gates in the circuit prior to running layout. This optimization is
 /// not valid after a layout has been set and should not be run in this case.
 ///
 /// @param circuit A pointer to the circuit to run ElidePermutations on

--- a/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
+++ b/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
@@ -51,7 +51,8 @@ use qiskit_transpiler::target::Target;
 /// # Example
 ///
 /// ```c
-///     QkTarget *target = qk_target_new(5)
+///     QkTarget *target = qk_target_new(5);
+///     uint32_t current_num_qubits = qk_target_num_qubits(target);
 ///     QkTargetEntry *cx_entry = qk_target_entry_new(QkGate_CX);
 ///     for (uint32_t i = 0; i < current_num_qubits - 1; i++) {
 ///         uint32_t qargs[2] = {i, i + 1};

--- a/crates/cext/src/transpiler/passes/vf2.rs
+++ b/crates/cext/src/transpiler/passes/vf2.rs
@@ -138,7 +138,7 @@ pub unsafe extern "C" fn qk_vf2_layout_result_free(layout: *mut VF2LayoutResult)
 /// @param target A pointer to the target to run the VF2Layout pass on
 /// @param strict_direction If true the pass will consider the edge direction in the
 ///     connectivity described in the ``target``. Typically setting this to ``false``
-///     is desireable as an undirected search has more degrees of freedom and is more likely
+///     is desirable as an undirected search has more degrees of freedom and is more likely
 ///     to find a layout (or a better layout if there are multiple choices) and correcting
 ///     directionality is a simple operation for later transpilation stages.
 /// @param call_limit The number of state visits to attempt in each execution of the VF2 algorithm.
@@ -160,7 +160,8 @@ pub unsafe extern "C" fn qk_vf2_layout_result_free(layout: *mut VF2LayoutResult)
 /// # Example
 ///
 /// ```c
-///     QkTarget *target = qk_target_new(5)
+///     QkTarget *target = qk_target_new(5);
+///     uint32_t current_num_qubits = qk_target_num_qubits(target);
 ///     QkTargetEntry *cx_entry = qk_target_entry_new(QkGate_CX);
 ///     for (uint32_t i = 0; i < current_num_qubits - 1; i++) {
 ///         uint32_t qargs[2] = {i, i + 1};

--- a/crates/cext/src/transpiler/target.rs
+++ b/crates/cext/src/transpiler/target.rs
@@ -35,8 +35,9 @@ use smallvec::{smallvec, SmallVec};
 /// @return A pointer to the new ``QkTarget``
 ///
 /// # Example
-///
+/// ```c
 ///     QkTarget *target = qk_target_new(5);
+/// ```
 ///
 #[no_mangle]
 #[cfg(feature = "cbinding")]
@@ -64,9 +65,10 @@ pub extern "C" fn qk_target_new(num_qubits: u32) -> *mut Target {
 /// @return The number of qubits this target can use.
 ///
 /// # Example
-///
+/// ```c
 ///     QkTarget *target = qk_target_new(5);
 ///     uint32_t num_qubits = qk_target_num_qubits(target);
+/// ```
 ///
 /// # Safety
 ///
@@ -84,13 +86,14 @@ pub unsafe extern "C" fn qk_target_num_qubits(target: *const Target) -> u32 {
 ///
 /// @param target A pointer to the ``QkTarget``.
 ///
-/// @return The dt value of this ``QkTarget`` or ``NaN`` if not assigned.
+/// @return The dt value of this ``QkTarget`` or ``NAN`` if not assigned.
 ///
 /// # Example
-///
+/// ```c
 ///     QkTarget *target = qk_target_new(5);
 ///     qk_target_set_dt(target, 10e-9);
 ///     double dt = qk_target_dt(target);
+/// ```
 ///
 /// # Safety
 ///
@@ -111,10 +114,11 @@ pub unsafe extern "C" fn qk_target_dt(target: *const Target) -> f64 {
 /// @return The ``granularity`` value of this ``QkTarget``.
 ///
 /// # Example
-///
+/// ```c
 ///     QkTarget *target = qk_target_new(5);
 ///     // The value defaults to 1
 ///     uint32_t granularity = qk_target_granularity(target);
+/// ```
 ///
 /// # Safety
 ///
@@ -135,10 +139,11 @@ pub unsafe extern "C" fn qk_target_granularity(target: *const Target) -> u32 {
 /// @return The ``min_length`` value of this ``QkTarget``.
 ///
 /// # Example
-///
+/// ```c
 ///     QkTarget *target = qk_target_new(5);
 ///     // The value defaults to 1
 ///     size_t min_length = qk_target_min_length(target);
+/// ```
 ///
 /// # Safety
 ///
@@ -159,10 +164,11 @@ pub unsafe extern "C" fn qk_target_min_length(target: *const Target) -> u32 {
 /// @return The ``pulse_alignment`` value of this ``QkTarget``.
 ///
 /// # Example
-///
+/// ```c
 ///     QkTarget *target = qk_target_new(5);
 ///     // The value defaults to 1
 ///     uint32_t pulse_alignment = qk_target_pulse_alignment(target);
+/// ```
 ///
 /// # Safety
 ///
@@ -183,10 +189,11 @@ pub unsafe extern "C" fn qk_target_pulse_alignment(target: *const Target) -> u32
 /// @return The ``acquire_alignment`` value of this ``QkTarget``.
 ///
 /// # Example
-///
+/// ```c
 ///     QkTarget *target = qk_target_new(5);
 ///     // The value defaults to 0
 ///     uint32_t acquire_alignment = qk_target_pulse_alignment(target);
+/// ```
 ///
 /// # Safety
 ///
@@ -209,8 +216,10 @@ pub unsafe extern "C" fn qk_target_acquire_alignment(target: *const Target) -> u
 ///
 /// # Example
 ///
+/// ```c
 ///     QkTarget *target = qk_target_new(5);
 ///     double dt = qk_target_set_dt(target, 10e-9);
+/// ```
 ///
 /// # Safety
 ///
@@ -234,10 +243,11 @@ pub unsafe extern "C" fn qk_target_set_dt(target: *mut Target, dt: f64) -> ExitC
 /// @return ``QkExitCode`` specifying if the operation was successful.
 ///
 /// # Example
-///
+/// ```c
 ///     QkTarget *target = qk_target_new(5);
 ///     // The value defaults to 1
 ///     qk_target_set_granularity(target, 2);
+/// ```
 ///
 /// # Safety
 ///
@@ -264,9 +274,11 @@ pub unsafe extern "C" fn qk_target_set_granularity(
 ///
 /// # Example
 ///
+/// ```c
 ///     QkTarget *target = qk_target_new(5);
 ///     // The value defaults to 1
 ///     qk_target_set_min_length(target, 3);
+/// ```
 ///
 /// # Safety
 ///
@@ -292,10 +304,11 @@ pub unsafe extern "C" fn qk_target_set_min_length(
 /// @return ``QkExitCode`` specifying if the operation was successful.
 ///
 /// # Example
-///
+/// ```c
 ///     QkTarget *target = qk_target_new(5);
 ///     // The value defaults to 1
 ///     qk_target_set_pulse_alignment(target, 4);
+/// ```
 ///
 /// # Safety
 ///
@@ -322,9 +335,11 @@ pub unsafe extern "C" fn qk_target_set_pulse_alignment(
 /// @return ``QkExitCode`` specifying if the operation was successful.
 ///
 /// # Example
+/// ```c
 ///     QkTarget *target = qk_target_new(5);
 ///     // The value defaults to 0
 ///     qk_target_set_acquire_alignment(target, 5);
+/// ```
 ///
 /// # Safety
 ///
@@ -349,7 +364,7 @@ pub unsafe extern "C" fn qk_target_set_acquire_alignment(
 /// @return A pointer to the new copy of the ``QkTarget``.
 ///
 /// # Example
-///
+/// ```c
 ///     QkTarget *target = qk_target_new(5);
 ///     QkTargetEntry *entry = qk_target_entry_new(QkGate_CX);
 ///     uint32_t qargs[2] = {0, 1};
@@ -357,6 +372,7 @@ pub unsafe extern "C" fn qk_target_set_acquire_alignment(
 ///     QkExitCode result = qk_target_add_instruction(target, entry);
 ///
 ///     QkTarget *copied = qk_target_copy(target);
+/// ```
 ///
 /// # Safety
 ///
@@ -376,9 +392,10 @@ pub unsafe extern "C" fn qk_target_copy(target: *mut Target) -> *mut Target {
 /// @param target A pointer to the ``QkTarget`` to free.
 ///
 /// # Example
-///
+/// ```c
 ///     QkTarget *target = qk_target_new(5);
 ///     qk_target_free(target);
+/// ```
 ///
 /// # Safety
 ///
@@ -482,8 +499,9 @@ impl TargetEntry {
 /// @return A pointer to the new ``QkTargetEntry``.
 ///
 /// # Example
-///
+/// ```c
 ///     QkTargetEntry *entry = qk_target_entry_new(QkGate_H);
+/// ```
 #[no_mangle]
 #[cfg(feature = "cbinding")]
 pub extern "C" fn qk_target_entry_new(operation: StandardGate) -> *mut TargetEntry {
@@ -496,7 +514,7 @@ pub extern "C" fn qk_target_entry_new(operation: StandardGate) -> *mut TargetEnt
 /// @return A pointer to the new ``QkTargetEntry`` for a measurement instruction.
 ///
 /// # Example
-///
+/// ```c
 ///     QkTargetEntry *entry = qk_target_entry_new_measure();
 ///     // Add fixed duration and error rates from qubits at index 0 to 4.
 ///     for (uint32_t i = 0; i < 5; i++) {
@@ -508,6 +526,7 @@ pub extern "C" fn qk_target_entry_new(operation: StandardGate) -> *mut TargetEnt
 ///     // Add the entry to a target with 5 qubits
 ///     QkTarget *measure_target = qk_target_new(5);
 ///     qk_target_add_instruction(measure_target, entry);
+/// ```
 #[no_mangle]
 #[cfg(feature = "cbinding")]
 pub extern "C" fn qk_target_entry_new_measure() -> *mut TargetEntry {
@@ -522,7 +541,7 @@ pub extern "C" fn qk_target_entry_new_measure() -> *mut TargetEntry {
 /// @return A pointer to the new ``QkTargetEntry`` for a reset instruction.
 ///
 /// # Example
-///
+/// ```c
 ///     QkTargetEntry *entry = qk_target_entry_new_reset();
 ///     // Add fixed duration and error rates from qubits at index 0 to 2.
 ///     for (uint32_t i = 0; i < 3; i++) {
@@ -534,6 +553,7 @@ pub extern "C" fn qk_target_entry_new_measure() -> *mut TargetEntry {
 ///     // Add the entry to a target with 3 qubits
 ///     QkTarget *reset_target = qk_target_new(3);
 ///     qk_target_add_instruction(reset_target, entry);
+/// ```
 #[no_mangle]
 #[cfg(feature = "cbinding")]
 pub extern "C" fn qk_target_entry_new_reset() -> *mut TargetEntry {
@@ -543,7 +563,7 @@ pub extern "C" fn qk_target_entry_new_reset() -> *mut TargetEntry {
 }
 
 /// @ingroup QkTargetEntry
-/// Creates an entry to the ``QkTarget`` based on a ``QkGate`` instance with
+/// Creates an entry in the ``QkTarget`` based on a ``QkGate`` instance with
 /// no parameters.
 ///
 /// @note Adding a ``QkGate`` with regular parameters is not currently supported.
@@ -554,14 +574,15 @@ pub extern "C" fn qk_target_entry_new_reset() -> *mut TargetEntry {
 /// @return A pointer to the new ``QkTargetEntry``.
 ///
 /// # Example
-///
+/// ```c
 ///     double crx_params[1] = {3.14};
-///     QkTargetEntry *entry = qk_target_entry_new(QkGate_CRX, crx_params);
+///     QkTargetEntry *entry = qk_target_entry_new_fixed(QkGate_CRX, crx_params);
+/// ```
 ///
 /// # Safety
 ///
 /// The ``params`` type is expected to be a pointer to an array of ``double`` where the length
-/// matches the the expectations of the ``QkGate``. If the array is insufficently long the
+/// matches the expectations of the ``QkGate``. If the array is insufficiently long the
 /// behavior of this function is undefined as this will read outside the bounds of the array.
 /// It can be a null pointer if there are no params for a given gate. You can check
 /// ``qk_gate_num_params`` to determine how many qubits are required for a given gate.
@@ -587,10 +608,11 @@ pub unsafe extern "C" fn qk_target_entry_new_fixed(
 /// @return The number of properties in the ``QkTargetEntry``.
 ///
 /// # Example
-///
+/// ```c
 ///     // Create an entry for an H gate
 ///     QkTargetEntry *entry = qk_target_entry_new(QkGate_H);
 ///     size_t props_size = qk_target_entry_num_properties(entry);
+/// ```
 ///
 /// # Safety
 ///
@@ -614,9 +636,10 @@ pub unsafe extern "C" fn qk_target_entry_num_properties(entry: *const TargetEntr
 /// @param entry The pointer to the mapping object to be freed.
 ///
 /// # Example
-///
+/// ```c
 ///     QkTargetEntry *entry = qk_target_entry_new(QkGate_H);
 ///     qk_target_entry_free(entry);
+/// ```
 ///
 /// # Safety
 ///
@@ -650,10 +673,11 @@ pub unsafe extern "C" fn qk_target_entry_free(entry: *mut TargetEntry) {
 /// @param error The instruction's average error rate on the specific set of qubits.
 ///
 /// # Example
-///
+/// ```c
 ///     QkTargetEntry *entry = qk_target_entry_new(QkGate_CX);
 ///     uint32_t qargs[2] = {0, 1};
 ///     qk_target_entry_add_property(entry, qargs, 2, 0.0, 0.1);
+/// ```
 ///
 /// # Safety
 ///
@@ -698,12 +722,13 @@ pub unsafe extern "C" fn qk_target_entry_add_property(
 /// @return ``QkExitCode`` specifying if the operation was successful.
 ///
 /// # Example
-///
+/// ```c
 ///     QkTarget *target = qk_target_new(5);
 ///     QkTargetEntry *entry = qk_target_entry_new(QkGate_CX);
 ///     uint32_t qargs[2] = {0, 1};
 ///     qk_target_entry_add_property(entry, qargs, 2, 0.0, 0.1);
 ///     QkExitCode result = qk_target_add_instruction(target, entry);
+/// ```
 ///
 /// # Safety
 ///
@@ -763,7 +788,7 @@ pub unsafe extern "C" fn qk_target_add_instruction(
 /// @return ``QkExitCode`` specifying if the operation was successful.
 ///
 /// # Example
-///
+/// ```c
 ///     QkTarget *target = qk_target_new(5);
 ///     double params[1] = {3.1415};
 ///     QkTargetEntry *entry = qk_target_entry_new_fixed(QkGate_CRX, params);
@@ -771,7 +796,8 @@ pub unsafe extern "C" fn qk_target_add_instruction(
 ///     qk_target_entry_add_property(entry, qargs, 2, 0.0, 0.1);
 ///     qk_target_add_instruction(target, entry);
 ///
-///     qk_target_update_property(target, QkGate_CRX, qargs, 2, 0.0012, 1.1)
+///     qk_target_update_property(target, QkGate_CRX, qargs, 2, 0.0012, 1.1);
+/// ```
 ///
 /// # Safety
 ///
@@ -779,7 +805,7 @@ pub unsafe extern "C" fn qk_target_add_instruction(
 ///
 /// The ``qargs`` type is expected to be a pointer to an array of ``uint32_t`` where the length
 /// matches is specified by ``num_qubits`` and has to match the expectation of the gate. If the
-/// array is insufficently long the behavior of this function is undefined as this will read
+/// array is insufficiently long the behavior of this function is undefined as this will read
 /// outside the bounds of the array. It can be a null pointer if there are no qubits for
 /// a given gate. You can check ``qk_gate_num_qubits`` to determine how many qubits are required
 /// for a given gate.
@@ -823,12 +849,13 @@ pub unsafe extern "C" fn qk_target_update_property(
 /// @return The length of the target.
 ///
 /// # Example
-///
+/// ```c
 ///     QkTarget *target = qk_target_new(5);
-///     QkTargetEntry *target_enty = qk_target_entry_new(QkGate_H);
+///     QkTargetEntry *target_entry = qk_target_entry_new(QkGate_H);
 ///     qk_target_add_instruction(target, target_entry);
 ///
 ///     size_t num_instructions = qk_target_num_instructions(target);
+/// ```
 ///
 /// # Safety
 ///
@@ -871,7 +898,7 @@ unsafe fn parse_qargs(qargs: *const u32, num_qubits: u32) -> Qargs {
     }
 }
 
-/// Parse params based on a standarg gate and a pointer to a float.
+/// Parse params based on a standard gate and a pointer to a float.
 ///
 /// # Arguments
 ///
@@ -885,7 +912,7 @@ unsafe fn parse_qargs(qargs: *const u32, num_qubits: u32) -> Qargs {
 /// # Safety
 ///
 /// The ``params`` type is expected to be a pointer to an array of ``double`` where the length
-/// matches the the expectations of the ``QkGate``. If the array is insufficently long the
+/// matches the expectations of the ``QkGate``. If the array is insufficiently long the
 /// behavior of this function is undefined as this will read outside the bounds of the array.
 /// It can be a null pointer if there are no params for a given gate. You can check
 /// ``qk_gate_num_params`` to determine how many qubits are required for a given gate.

--- a/docs/cdoc/qk-circuit.rst
+++ b/docs/cdoc/qk-circuit.rst
@@ -31,11 +31,11 @@ state defined as:
     // Create a circuit with three qubits and 3 classical bits
     QkCircuit *qc = qk_circuit_new(3, 0);
     // H gate on qubit 0, putting this qubit in a superposition of |0> + |1>.
-    qk_circuit_gate(qc, QkGate_H, {0}, NULL);
+    qk_circuit_gate(qc, QkGate_H, (uint32_t[]){0}, NULL);
     // A CX (CNOT) gate on control qubit 0 and target qubit 1 generating a Bell state.
-    qk_circuit_gate(qc, QkGate_CX, {0, 1}, NULL);
+    qk_circuit_gate(qc, QkGate_CX, (uint32_t[]){0, 1}, NULL);
     // A CX (CNOT) gate on control qubit 0 and target qubit 2 generating a GHZ state.
-    qk_circuit_gate(qc, QkGate_CX, {0, 2}, NULL);
+    qk_circuit_gate(qc, QkGate_CX, (uint32_t[]){0, 2}, NULL);
     // Free the created circuit.
     qk_circuit_free(qc);
 

--- a/docs/cdoc/qk-classical-register.rst
+++ b/docs/cdoc/qk-classical-register.rst
@@ -9,13 +9,13 @@ QkClassicalRegister
 A common way to instantiate several bits at once is to create a register. A
 register is a named collection of bits. Creating a register enables giving a
 collection of bits a name which can be use as metadata around specific bits
-in a circuit. This name will also typically be preseserved when exporting the
+in a circuit. This name will also typically be preserved when exporting the
 circuit to interchange languages.
 
 You can create a register by calling ``qk_classical_register_new()``, for
 example:
 
-.. code-block: c
+.. code-block:: c
 
     #include <qiskit.h>
 
@@ -26,7 +26,7 @@ Which creates a new 5 classical bit register named ``"my_creg"``.
 Then to add the register to a circuit you use the
 ``qk_circuit_add_classical_register()`` function:
 
-.. code-block: c
+.. code-block:: c
 
     QkCircuit *qc = qk_circuit_new(0, 0);
     qk_circuit_add_classical_register(qc, creg);

--- a/docs/cdoc/qk-complex64.rst
+++ b/docs/cdoc/qk-complex64.rst
@@ -2,15 +2,15 @@
 QkComplex64
 ===========
 
-A complex, double-precision number representation. This data type is used to safely 
+A complex, double-precision number representation. This data type is used to safely
 use complex numbers within Qiskit, but is not necessarily designed for easy manipulation
 on user-side. Instead, we provide functions to convert from compiler-native representation
-(e.g. ``double complex`` for GNU or Clang compilers), which allow for ergonomic handling,
-to Qiskit's ``QkComplex64`` representation, which is meant for passing into Qiskit functions 
+(e.g. ``complex double`` for GNU or Clang compilers), which allow for ergonomic handling,
+to Qiskit's ``QkComplex64`` representation, which is meant for passing into Qiskit functions
 and structs.
 
-Explicitly, Qiskit assumes the compiler-native complex number type in C to be 
-``_Dcomplex`` for Windows MSVC (if ``_MSC_VER`` is defined) and ``double _Complex`` otherwise. 
+Explicitly, Qiskit assumes the compiler-native complex number type in C to be
+``_Dcomplex`` for Windows MSVC (if ``_MSC_VER`` is defined) and ``double _Complex`` otherwise.
 In C++ (if ``__cplusplus`` is defined), the complex number type is always ``std::complex<double>``.
 
 
@@ -36,12 +36,12 @@ Functions
 Example
 -------
 
-Assuming a GNU/clang compiler with ``double complex`` as native complex number, we have
+Assuming a GNU/clang compiler with ``complex double`` as native complex number, we have
 
 .. code-block:: c
 
    QkComplex64 qk_value = {1, 1}; // represents 1 + i
-   double complex value = qk_complex64_to_native(&qk_value);
+   complex double value = qk_complex64_to_native(&qk_value);
 
 Safety
 ------
@@ -64,11 +64,11 @@ Behavior is undefined if ``value`` is not a valid, non-null pointer to a ``QkCom
 Example
 -------
 
-Assuming a GNU/clang compiler with ``double complex`` as native complex number, we have
+Assuming a GNU/clang compiler with ``complex double`` as native complex number, we have
 
 .. code-block:: c
 
-   double complex value = 1 + I; 
+   complex double value = 1 + I;
    QkComplex64 qk_value = qk_complex64_from_native(&value);
 
 Safety

--- a/docs/cdoc/qk-obs.rst
+++ b/docs/cdoc/qk-obs.rst
@@ -149,7 +149,7 @@ can be in any order while representing the same observable, since addition is co
 the summation order).
 
 These two categories of representation degeneracy can cause the operator equality,
-``qk_obs_equal``, to claim that two observables are not equal, despite representating the same
+``qk_obs_equal``, to claim that two observables are not equal, despite representing the same
 object.  In these cases, it can be convenient to define some *canonical form*, which allows
 observables to be compared structurally.
 You can put a ``QkObs`` in canonical form by using the ``qk_obs_canonicalize`` function.
@@ -165,19 +165,19 @@ structurally by comparing their simplified forms.
     .. code-block:: c
 
         bool equivalent(QkObs *left, QkObs *right, double tol) {
-            // compare a canonicalized version of left - right to the zero observable
-            QkObs *neg_right = qk_obs_mul(right, -1);
-            QkObs *diff = qk_obs_add(left, neg_right);
-            QkObs *canonical = qk_obs_canonicalize(diff, tol);
+          // compare a canonicalized version of left - right to the zero observable
+          QkObs *neg_right = qk_obs_multiply(right, &(QkComplex64){-1, 0});
+          QkObs *diff = qk_obs_add(left, neg_right);
+          QkObs *canonical = qk_obs_canonicalize(diff, tol);
 
-            QkObs *zero = qk_obs_zero(qk_obs_num_qubits(left));
-            bool equiv = qk_obs_equal(diff, zero);
-            // free all temporary variables
-            qk_obs_free(neg_right);
-            qk_obs_free(diff);
-            qk_obs_free(canonical);
-            qk_obs_free(zero);
-            return equiv;
+          QkObs *zero = qk_obs_zero(qk_obs_num_qubits(left));
+          bool equiv = qk_obs_equal(diff, zero);
+          // free all temporary variables
+          qk_obs_free(neg_right);
+          qk_obs_free(diff);
+          qk_obs_free(canonical);
+          qk_obs_free(zero);
+          return equiv;
         }
 
 .. note::

--- a/docs/cdoc/qk-quantum-register.rst
+++ b/docs/cdoc/qk-quantum-register.rst
@@ -14,7 +14,7 @@ circuit to interchange languages.
 
 You can create a register by calling ``qk_quantum_register_new()``, for example:
 
-.. code-block: c
+.. code-block:: c
 
     #include <qiskit.h>
 
@@ -25,7 +25,7 @@ Which creates a new 5 qubit register named ``"my_qreg"``.
 Then to add the register to a circuit you use the
 ``qk_circuit_add_quantum_register()`` function:
 
-.. code-block: c
+.. code-block:: c
 
     QkCircuit *qc = qk_circuit_new(0, 0);
     qk_circuit_add_quantum_register(qc, qreg);

--- a/docs/cdoc/qk-target-entry.rst
+++ b/docs/cdoc/qk-target-entry.rst
@@ -7,7 +7,7 @@ QkTargetEntry
 
     typedef struct QkTargetEntry QkTargetEntry
 
-A mapping of qubit arguments and properties representing gate map of the 
+A mapping of qubit arguments and properties representing gate map of the
 Target. This feature is used due to not having valid native mappings available
 from C.
 
@@ -23,10 +23,10 @@ Here's an example of how this structure works:
 
     // Add mapping between (0,1) and properties duration of 10e-9 and unknown error.
     uint32_t qargs[2] = {0, 1};
-    qk_target_entry_add(entry, qargs, 2, 10e-9, NAN);
+    qk_target_entry_add_property(entry, qargs, 2, 10e-9, NAN);
 
     // Add mapping between Global, and no set duration NAN and error of 0.003)
-    qk_target_entry_add(entry, NULL, 0, NAN, 0.003);
+    qk_target_entry_add_property(entry, NULL, 0, NAN, 0.003);
 
 
 Functions

--- a/docs/cdoc/qk-target.rst
+++ b/docs/cdoc/qk-target.rst
@@ -6,7 +6,7 @@ QkTarget
 
     typedef struct QkTarget QkTarget
 
-A mapping of instructions and properties representing the partiucular constraints
+A mapping of instructions and properties representing the particular constraints
 of a backend. Its purpose is to provide the compiler with information that allows it
 to compile an input circuit into another that is optimized taking in consideration the
 ``QkTarget``'s specifications. This structure represents a low level interface to the main
@@ -27,8 +27,8 @@ Here's an example of how this structure works:
     // error = NaN
     uint32_t qargs[2] = {0, 1};
     QkTargetEntry *entry = qk_target_entry_new(QkGate_CX);
-    qk_target_entry_add(entry, qargs, 2, 0.0123, NAN);
-    
+    qk_target_entry_add_property(entry, qargs, 2, 0.0123, NAN);
+
     // Add a CX Gate to the target
     qk_target_add_instruction(target, entry);
 


### PR DESCRIPTION
### Summary
This commit addresses several issues in the C API documentation.

### Details and comments
The issues being addressed in this PR include:
- Code examples which do not compile
- Usages of non-existent functions
- Sporadic typos
- Outdated examples or comments, updated to reflect recent APIs (e.g., replacing `complex double` with `QkComplex64`)
It also standardizes all code examples to use the ```c markdown tag, so that C syntax highlighting is properly applied in all examples.



