### PR TITLE
Make VF2 fully generic over index types and semantics

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -2249,10 +2249,10 @@ impl DAGCircuit {
             node_match(n1, n2).map(|ok| ok.then_some(()))
         };
 
-        vf2::is_isomorphic(
+        vf2::is_isomorphic_with_semantics(
             &self.dag,
             &other.dag,
-            (node_match, vf2::NoSemanticMatch),
+            (node_match, vf2::NoSemantics::new()),
             true,
             vf2::Problem::Exact,
             None,

--- a/crates/circuit/src/vf2.rs
+++ b/crates/circuit/src/vf2.rs
@@ -1018,6 +1018,9 @@ where
         }
     }
 
+    /// Find the mapping (in the graph) of the `target` of a local edge.
+    ///
+    /// If the edge is a self loop, return the mapping of `source`, if provided.
     pub fn map_target(
         &self,
         source: G::NodeId,

--- a/test/python/transpiler/test_sabre_layout.py
+++ b/test/python/transpiler/test_sabre_layout.py
@@ -564,7 +564,7 @@ class TestSabrePreLayout(QiskitTestCase):
         layout = pm.property_set["layout"]
         self.assertEqual(
             [layout[q] for q in self.circuit.qubits],
-            [80, 8, 79, 53, 85, 14, 21, 91, 22, 92, 58, 86, 16, 87, 54, 9],
+            [9, 81, 10, 82, 51, 76, 75, 2, 74, 1, 73, 0, 49, 7, 79, 80],
         )
 
     def test_integration_with_pass_manager(self):


### PR DESCRIPTION
This reworks several major parts of the generics structure of the VF2 implementation and is a substantial change to the interface.  In particular:

* The trait requirements on graphs that can be used with VF2 are wrapped into internal alias metatraits (with blanket implementations) to avoid needing to repeat the same bounds everywhere.  This matters more because of other changes, which require us to repeat the bounds in more places now.  The `for<'a>` bound on graph references (implying the underlying object must be `'static`) remains: we can either require borrowed objects (in which case we could avoid the `'static` but would struggle with the node reordering) or require owned objects (which we do).  If/when `petgraph` supplies GAT-based traits on references for `IntoEdgeReferences` etc, we could relax that bound, which in turn would allow input graphs that already implement `NodeCompactIndexable` to avoid being rewritten in default ordering.

* The `reorder` method was moved out of the `NodeSorter` trait, leaving only the `sort` method.  This lets the output graph type be controlled separately; sorting does not inherently affect impact the resulting graph structure that can be built with it, which lets us default the rewriting to using `Graph` even when given a `StableGraph`, letting us avoid `Option` unwrapping on `NodeIndex` lookups.

* The score/matching semantics impl on a 2-tuple is separated out into two separate implementations of `Semantics`, with scoring consistency now managed via a generic `NoSemantics`, and the `Vf2` struct itself ensuring scoring-consistency during its construction, via trait bounds on the generics.  There are now two wrapper structs, `Scorer` and `Matcher`, that disambiguate `Fn(&NeedleWeight, &HaystackWeight) -> Result<S, E>` inputs:

  - where `S: Vf2Score`, the function can be wrapped in `Scorer` to communciate that the scorer does not impose additional _matching_ semantics.
  - where `S = bool`, the function is lifted to one returning `Option<()>` (as `(): Vf2Score`), but allows natural matching functions.
  - where `S = Option<impl Vf2Score>`, a blanket implementation of `Semantics` works already.

The "semantics of the semantics" are specified as three-way logic, instead of just `ENABLED: bool`, allowing scores without matching to continue to use fast paths in consistency checks while the scoring is inactive.

* The old `Vf2Algorithm` structure is split into two components: the `Vf2` record type that constructs the problem, and `Vf2IntoIter` that is the actual iterator object.  This allows the `Vf2` object to become a pure builder object, without necessarily re-allocating the various state-tracking objects on edge modification, and allows delaying the rewriting of the graph to a stable form until only after the entire problem has been defined.  In theory, this allows the `Vf2` problem to spawn several iterators from it, potentially even from different points of the iteration (In the current form, this would still require cloning of the working graph, but this is plausibly relaxable with changes to the interface.)

The state tracking in `Vf2IntoIter` now tracks the score in a separate stack to the loop counters, in anticipation of allowing the score tracking to be temporarily suspended until the first match is found.

* The node identifiers used in the matching can now be arbitrary implementators of `IndexType`, and need not be the same.  In principle it's likely possible to relax even the bound on `IndexType`, since the graphs are already `NodeCompactIndexable`, but there's more book-keeping that would need to be done to choose a value to represent
  "not yet mapped" (`Option<NodeId>` is undesirable because of the extra memory use).

* `Vf2IntoIter` now formally requires the graphs it acts on to be `NodeCompactIndexable`.  This was already an actual requirement for correctness of the implementation, but couldn't be applied without making the implementation impossible to apply to `StableGraph` (which naturally _isn't_ compact-indexable).  It only worked previously because of the graph rewriting, which _in practice_ meant that the constructed graph would have compact indices, but there is no formal requirement that a graph that implements `NodeIndexable + Create` actually assigns ids consecutively from zero.

