### PR TITLE
Unbias directionality in VF2 priority queue

### DIFF
--- a/test/python/transpiler/test_sabre_layout.py
+++ b/test/python/transpiler/test_sabre_layout.py
@@ -564,7 +564,7 @@ class TestSabrePreLayout(QiskitTestCase):
         layout = pm.property_set["layout"]
         self.assertEqual(
             [layout[q] for q in self.circuit.qubits],
-            [9, 81, 10, 82, 51, 76, 75, 2, 74, 1, 73, 0, 49, 7, 79, 80],
+            [9, 81, 54, 16, 86, 58, 92, 22, 91, 21, 57, 14, 85, 53, 79, 80],
         )
 
     def test_integration_with_pass_manager(self):
@@ -578,7 +578,7 @@ class TestSabrePreLayout(QiskitTestCase):
         qct_initial_layout = qct.layout.initial_layout
         self.assertEqual(
             [qct_initial_layout[q] for q in self.circuit.qubits],
-            [7, 12, 11, 10, 5, 16, 17, 18, 13, 14, 9, 8, 3, 2, 1, 6],
+            [12, 11, 10, 16, 17, 18, 13, 14, 9, 8, 3, 2, 1, 6, 5, 7],
         )
 
 


### PR DESCRIPTION
The previous implementation of the priority queue effective biased the VF2 search heavily in favour of nodes that had outgoing edges from the mapping.  The implementation of the VF2++ ordering heuristic was written to match this.  The likely reason was that it made it easier to completely compile out the cost for undirected searches, and to isolate the "additional" handling for directionality.

This new implementation now treats outgoing and incoming edges simultaneously, and chooses the next needle from the set of unmapped neighbours in any direction to the partial mapping.  This comes at a small unnecessary memory cost in the case of undirected graphs, but it feels unlikely that it fill have any significant effect on performance in those cases.  The VF2++ ordering heuristic is updated to treat outgoing and incoming edges equally; for now, it sums the two sides, though it's possible that there's a better metric of "difficulty to match" than the sum of the two degrees.

