### PR TITLE
Handle VF2 coupling-map shuffling in Rust

### DIFF
--- a/crates/cext/src/transpiler/passes/vf2.rs
+++ b/crates/cext/src/transpiler/passes/vf2.rs
@@ -226,6 +226,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_vf2_layout(
         time_limit,
         max_trials,
         None,
+        None,
     ) {
         Ok(layout) => layout,
         Err(e) => panic!("{}", e),

--- a/crates/transpiler/src/passes/vf2/vf2_layout.rs
+++ b/crates/transpiler/src/passes/vf2/vf2_layout.rs
@@ -10,17 +10,21 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use std::convert::Infallible;
+use std::time::Instant;
+
 use hashbrown::HashMap;
 use indexmap::{IndexMap, IndexSet};
 use numpy::PyReadonlyArray1;
+use rand::prelude::*;
+use rand_pcg::Pcg64Mcg;
+use rayon::prelude::*;
+use rustworkx_core::petgraph::prelude::*;
+
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
 use pyo3::{create_exception, wrap_pyfunction};
-use rayon::prelude::*;
-use rustworkx_core::petgraph::prelude::*;
-use std::convert::Infallible;
-use std::time::Instant;
 
 use qiskit_circuit::converters::circuit_to_dag;
 use qiskit_circuit::dag_circuit::DAGCircuit;
@@ -364,8 +368,9 @@ fn map_free_qubits(
     Some(partial_layout)
 }
 
+#[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (dag, target, strict_direction=false, call_limit=None, time_limit=None, max_trials=None, avg_error_map=None))]
+#[pyo3(signature = (dag, target, strict_direction=false, call_limit=None, time_limit=None, max_trials=None, avg_error_map=None, shuffle_seed=None))]
 pub fn vf2_layout_pass(
     dag: &DAGCircuit,
     target: &Target,
@@ -374,6 +379,7 @@ pub fn vf2_layout_pass(
     time_limit: Option<f64>,
     max_trials: Option<isize>,
     avg_error_map: Option<ErrorMap>,
+    shuffle_seed: Option<u64>,
 ) -> PyResult<Option<HashMap<VirtualQubit, PhysicalQubit>>> {
     let add_interaction = |count: &mut usize, _: &PackedInstruction, repeats: usize| {
         *count += repeats;
@@ -386,8 +392,20 @@ pub fn vf2_layout_pass(
     let Some(mut coupling_graph) = build_coupling_map(target, &avg_error_map) else {
         return Ok(None);
     };
+    let num_physical_qubits = coupling_graph.node_count();
+    let mut coupling_qubits = (0..num_physical_qubits)
+        .map(|k| PhysicalQubit::new(k as u32))
+        .collect::<Vec<_>>();
     if !strict_direction {
         loosen_directionality(&mut coupling_graph);
+    }
+    if let Some(seed) = shuffle_seed {
+        coupling_qubits.shuffle(&mut Pcg64Mcg::seed_from_u64(seed));
+        let order = coupling_qubits
+            .iter()
+            .map(|qubit| NodeIndex::new(qubit.index()))
+            .collect::<Vec<_>>();
+        coupling_graph = vf2::reorder_nodes(&coupling_graph, &order);
     }
     let interactions = VirtualInteractions::from_dag(dag, add_interaction)?;
     let start_time = Instant::now();
@@ -427,15 +445,10 @@ pub fn vf2_layout_pass(
     // Remap node indices back to virtual/physical qubits.
     let mapping = mapping
         .iter()
-        .map(|(k, v)| {
-            (
-                interactions.nodes[k.index()],
-                PhysicalQubit::new(v.index() as u32),
-            )
-        })
+        .map(|(k, v)| (interactions.nodes[k.index()], coupling_qubits[v.index()]))
         .collect();
     Ok(map_free_qubits(
-        coupling_graph.node_count(),
+        num_physical_qubits,
         interactions,
         mapping,
         &avg_error_map,

--- a/crates/transpiler/src/transpiler.rs
+++ b/crates/transpiler/src/transpiler.rs
@@ -153,9 +153,16 @@ pub fn transpile(
                 target.num_qubits.unwrap(),
                 |x| PhysicalQubit(x.0),
             );
-        } else if let Some(vf2_result) =
-            vf2_layout_pass(&dag, target, false, Some(5_000_000), None, Some(2500), None)?
-        {
+        } else if let Some(vf2_result) = vf2_layout_pass(
+            &dag,
+            target,
+            false,
+            Some(5_000_000),
+            None,
+            Some(2500),
+            None,
+            None,
+        )? {
             apply_layout(
                 &mut dag,
                 &mut transpile_layout,
@@ -179,9 +186,16 @@ pub fn transpile(
                 layout_from_sabre_result(&dag, initial_layout, &final_layout, &transpile_layout);
         }
     } else if optimization_level == OptimizationLevel::Level2 {
-        if let Some(vf2_result) =
-            vf2_layout_pass(&dag, target, false, Some(5_000_000), None, Some(2500), None)?
-        {
+        if let Some(vf2_result) = vf2_layout_pass(
+            &dag,
+            target,
+            false,
+            Some(5_000_000),
+            None,
+            Some(2500),
+            None,
+            None,
+        )? {
             apply_layout(
                 &mut dag,
                 &mut transpile_layout,
@@ -211,6 +225,7 @@ pub fn transpile(
         Some(30_000_000),
         None,
         Some(250_000),
+        None,
         None,
     )? {
         apply_layout(

--- a/qiskit/transpiler/passes/layout/vf2_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_layout.py
@@ -12,21 +12,15 @@
 
 
 """VF2Layout pass to find a layout using subgraph isomorphism"""
-from enum import Enum
-import itertools
-import logging
-import time
 
-from rustworkx import vf2_mapping
+import random
+from enum import Enum
 
 from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.basepasses import AnalysisPass
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.passes.layout import vf2_utils
 from qiskit._accelerate.vf2_layout import vf2_layout_pass, MultiQEncountered
-
-
-logger = logging.getLogger(__name__)
 
 
 class VF2LayoutStopReason(Enum):
@@ -137,157 +131,36 @@ class VF2Layout(AnalysisPass):
             else:
                 target = self.target
         self.avg_error_map = self.property_set["vf2_avg_error_map"]
-        # Run rust fast path if we have no randomization
         if self.seed == -1:
-            try:
-                layout = vf2_layout_pass(
-                    dag,
-                    target,
-                    self.strict_direction,
-                    self.call_limit,
-                    self.time_limit,
-                    self.max_trials,
-                    self.avg_error_map,
-                )
-            except MultiQEncountered:
-                self.property_set["VF2Layout_stop_reason"] = VF2LayoutStopReason.MORE_THAN_2Q
-                return
-            if layout is None:
-                self.property_set["VF2Layout_stop_reason"] = VF2LayoutStopReason.NO_SOLUTION_FOUND
-                return
-
-            self.property_set["VF2Layout_stop_reason"] = VF2LayoutStopReason.SOLUTION_FOUND
-            mapping = {dag.qubits[virt]: phys for virt, phys in layout.items()}
-            chosen_layout = Layout(mapping)
-
-            self.property_set["layout"] = vf2_utils.allocate_idle_qubits(dag, target, chosen_layout)
-            for reg in dag.qregs.values():
-                self.property_set["layout"].add_register(reg)
-            return
-        # We can't use the rust fast path because we have a seed set, or no target so continue with
-        # the python path
-        if self.avg_error_map is None:
-            self.avg_error_map = vf2_utils.build_average_error_map(target, coupling_map)
-
-        result = vf2_utils.build_interaction_graph(dag, self.strict_direction)
-        if result is None:
+            # Happy path of no shuffling.
+            seed = None
+        elif self.seed is None or self.seed < -1:
+            # `seed is None` is OS entropy, `seed < -1` is a bad value (most pRNGs we're
+            # concerned with deal with `u64`), but the stdlib `random` handles it, so just use
+            # that to fix it up into something else.
+            seed = random.Random(self.seed).randrange((1 << 64) - 1)
+        else:
+            seed = self.seed
+        try:
+            layout = vf2_layout_pass(
+                dag,
+                target,
+                strict_direction=self.strict_direction,
+                call_limit=self.call_limit,
+                time_limit=self.time_limit,
+                max_trials=self.max_trials,
+                avg_error_map=self.avg_error_map,
+                shuffle_seed=seed,
+            )
+        except MultiQEncountered:
             self.property_set["VF2Layout_stop_reason"] = VF2LayoutStopReason.MORE_THAN_2Q
             return
-        im_graph, im_graph_node_map, reverse_im_graph_node_map, free_nodes = result
-        scoring_edge_list = vf2_utils.build_edge_list(im_graph)
-        scoring_bit_list = vf2_utils.build_bit_list(im_graph, im_graph_node_map)
-        cm_graph, cm_nodes = vf2_utils.shuffle_coupling_graph(
-            coupling_map, self.seed, self.strict_direction
-        )
-        # Filter qubits without any supported operations. If they don't support any operations
-        # They're not valid for layout selection
-        if target is not None and target.qargs is not None:
-            has_operations = set(itertools.chain.from_iterable(target.qargs))
-            to_remove = set(range(len(cm_nodes))).difference(has_operations)
-            if to_remove:
-                cm_graph.remove_nodes_from([cm_nodes[i] for i in to_remove])
+        if layout is None:
+            self.property_set["VF2Layout_stop_reason"] = VF2LayoutStopReason.NO_SOLUTION_FOUND
+            return
 
-        # To avoid trying to over optimize the result by default limit the number
-        # of trials based on the size of the graphs. For circuits with simple layouts
-        # like an all 1q circuit we don't want to sit forever trying every possible
-        # mapping in the search space if no other limits are set
-        if self.max_trials is None and self.call_limit is None and self.time_limit is None:
-            im_graph_edge_count = len(im_graph.edge_list())
-            cm_graph_edge_count = len(coupling_map.graph.edge_list())
-            self.max_trials = max(im_graph_edge_count, cm_graph_edge_count) + 15
-
-        logger.debug("Running VF2 to find mappings")
-        mappings = vf2_mapping(
-            cm_graph,
-            im_graph,
-            subgraph=True,
-            id_order=False,
-            induced=False,
-            call_limit=self.call_limit,
-        )
-        chosen_layout = None
-        chosen_layout_score = None
-        start_time = time.time()
-        trials = 0
-
-        def mapping_to_layout(layout_mapping):
-            return Layout({reverse_im_graph_node_map[k]: v for k, v in layout_mapping.items()})
-
-        for mapping in mappings:
-            trials += 1
-            logger.debug("Running trial: %s", trials)
-            stop_reason = VF2LayoutStopReason.SOLUTION_FOUND
-            layout_mapping = {im_i: cm_nodes[cm_i] for cm_i, im_i in mapping.items()}
-
-            # If the graphs have the same number of nodes we don't need to score or do multiple
-            # trials as the score heuristic currently doesn't weigh nodes based on gates on a
-            # qubit so the scores will always all be the same
-            if len(cm_graph) == len(im_graph):
-                chosen_layout = mapping_to_layout(layout_mapping)
-                break
-            # If there is no error map available we can just skip the scoring stage as there
-            # is nothing to score with, so any match is the best we can find.
-            if self.avg_error_map is None:
-                chosen_layout = mapping_to_layout(layout_mapping)
-                break
-            layout_score = vf2_utils.score_layout(
-                self.avg_error_map,
-                layout_mapping,
-                im_graph_node_map,
-                reverse_im_graph_node_map,
-                im_graph,
-                self.strict_direction,
-                edge_list=scoring_edge_list,
-                bit_list=scoring_bit_list,
-            )
-            # If the layout score is 0 we can't do any better and we'll just
-            # waste time finding additional mappings that will at best match
-            # the performance, so exit early in this case
-            if layout_score == 0.0:
-                chosen_layout = mapping_to_layout(layout_mapping)
-                break
-            logger.debug("Trial %s has score %s", trials, layout_score)
-            if chosen_layout is None:
-                chosen_layout = mapping_to_layout(layout_mapping)
-                chosen_layout_score = layout_score
-            elif layout_score < chosen_layout_score:
-                layout = mapping_to_layout(layout_mapping)
-                logger.debug(
-                    "Found layout %s has a lower score (%s) than previous best %s (%s)",
-                    layout,
-                    layout_score,
-                    chosen_layout,
-                    chosen_layout_score,
-                )
-                chosen_layout = layout
-                chosen_layout_score = layout_score
-            if self.max_trials is not None and self.max_trials > 0 and trials >= self.max_trials:
-                logger.debug("Trial %s is >= configured max trials %s", trials, self.max_trials)
-                break
-            elapsed_time = time.time() - start_time
-            if self.time_limit is not None and elapsed_time >= self.time_limit:
-                logger.debug(
-                    "VF2Layout has taken %s which exceeds configured max time: %s",
-                    elapsed_time,
-                    self.time_limit,
-                )
-                break
-        if chosen_layout is None:
-            stop_reason = VF2LayoutStopReason.NO_SOLUTION_FOUND
-        else:
-            chosen_layout = vf2_utils.map_free_qubits(
-                free_nodes,
-                chosen_layout,
-                cm_graph.num_nodes(),
-                reverse_im_graph_node_map,
-                self.avg_error_map,
-            )
-            # No free qubits for free qubit mapping
-            if chosen_layout is None:
-                self.property_set["VF2Layout_stop_reason"] = VF2LayoutStopReason.NO_SOLUTION_FOUND
-                return
-            self.property_set["layout"] = vf2_utils.allocate_idle_qubits(dag, target, chosen_layout)
-            for reg in dag.qregs.values():
-                self.property_set["layout"].add_register(reg)
-
-        self.property_set["VF2Layout_stop_reason"] = stop_reason
+        self.property_set["VF2Layout_stop_reason"] = VF2LayoutStopReason.SOLUTION_FOUND
+        layout = Layout({dag.qubits[virt]: phys for virt, phys in layout.items()})
+        for reg in dag.qregs.values():
+            layout.add_register(reg)
+        self.property_set["layout"] = layout

--- a/test/python/transpiler/test_vf2_layout.py
+++ b/test/python/transpiler/test_vf2_layout.py
@@ -117,7 +117,7 @@ class TestVF2LayoutSimple(LayoutTestCase):
         vf2_pass = VF2Layout(target=target, seed=self.seed)
         vf2_pass(qc)
         layout = vf2_pass.property_set["layout"]
-        self.assertEqual([1, 0], list(layout._p2v.keys()))
+        self.assertNotIn(2, layout.get_physical_bits())
 
     def test_2q_circuit_2q_coupling(self):
         """A simple example, without considering the direction
@@ -744,13 +744,8 @@ class TestMultipleTrials(QiskitTestCase):
         # Run without any limits set
         vf2_pass = VF2Layout(target=backend.target, seed=42)
         property_set = {}
-        with self.assertLogs("qiskit.transpiler.passes.layout.vf2_layout", level="DEBUG") as cm:
-            vf2_pass(qc, property_set)
-        self.assertIn(
-            "DEBUG:qiskit.transpiler.passes.layout.vf2_layout:Trial 717 is >= configured max trials 717",
-            cm.output,
-        )
-        self.assertEqual(set(property_set["layout"].get_physical_bits()), {16, 24, 6, 7, 0})
+        vf2_pass(qc, property_set)
+        self.assertEqual(set(property_set["layout"].get_physical_bits()), {26, 11, 14, 7, 10})
 
     def test_no_limits_with_negative(self):
         """Test that we're not enforcing a trial limit if set to negative."""
@@ -766,11 +761,8 @@ class TestMultipleTrials(QiskitTestCase):
             max_trials=0,
         )
         property_set = {}
-        with self.assertLogs("qiskit.transpiler.passes.layout.vf2_layout", level="DEBUG") as cm:
-            vf2_pass(qc, property_set)
-        for output in cm.output:
-            self.assertNotIn("is >= configured max trials", output)
-        self.assertEqual(set(property_set["layout"].get_physical_bits()), {3, 1, 0})
+        vf2_pass(qc, property_set)
+        self.assertEqual(set(property_set["layout"].get_physical_bits()), {3, 2, 0})
 
     def test_qregs_valid_layout_output(self):
         """Test that vf2 layout doesn't add extra qubits.


### PR DESCRIPTION
The shuffling is, in general, not a good idea.  Even so, moving it from Python down to Rust removes the last non-trivial Python-space code from `VF2Layout`, and moves us a step closer to completely removing all scoring-related logic from Python-space for VF2, once `VF2PostLayout` is ported.

