### PR TITLE
Encapsulate VF2 configuration and return types

### DIFF
--- a/crates/cext/src/transpiler/passes/vf2.rs
+++ b/crates/cext/src/transpiler/passes/vf2.rs
@@ -280,7 +280,7 @@ pub unsafe extern "C" fn qk_vf2_layout_configuration_set_shuffle_seed(
 /// @param target A pointer to the target to run the VF2Layout pass on
 /// @param config A pointer to the ``QkVF2LayoutConfiguration`` configuration structure.  If this
 ///     pointer is null, the pass defaults are used.
-/// @param strict_direction If true, the pass will consider the edge direction in the
+/// @param strict_direction If ``true``, the pass will consider the edge direction in the
 ///     connectivity described in the ``target``. Typically, setting this to ``false``
 ///     is desireable as the error heuristic is already very approximate, and two-qubit gates can
 ///     almost invariably be synthesised to "flip" direction using only local one-qubit gates and

--- a/crates/cext/src/transpiler/passes/vf2.rs
+++ b/crates/cext/src/transpiler/passes/vf2.rs
@@ -10,25 +10,28 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use hashbrown::HashMap;
-
 use crate::pointers::const_ptr_as_ref;
 
+use qiskit_circuit::VirtualQubit;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::dag_circuit::DAGCircuit;
-use qiskit_circuit::{PhysicalQubit, VirtualQubit};
-use qiskit_transpiler::passes::vf2_layout_pass;
+use qiskit_transpiler::passes::vf2::{Vf2PassConfiguration, Vf2PassReturn, vf2_layout_pass};
 use qiskit_transpiler::target::Target;
 
 /// The result from ``qk_transpiler_pass_standalone_vf2_layout()``.
-pub struct VF2LayoutResult(Option<HashMap<VirtualQubit, PhysicalQubit>>);
+pub struct VF2LayoutResult(Vf2PassReturn);
 
 /// @ingroup QkVF2LayoutResult
 /// Check whether a result was found.
 ///
+/// A ``true`` value includes the situation where the configuration specified to try the "trivial"
+/// layout and it was found to be the best (and consequently no qubit relabelling is necessary,
+/// other than ancilla expansion if appropriate).  See ``qk_vf2_layout_result_has_improvement`` to
+/// distinguish whether an explicit remapping is stored.
+///
 /// @param layout a pointer to the layout
 ///
-/// @returns ``true`` if the ``qk_transpiler_pass_standalone_vf2_layout()`` run found a layout
+/// @returns ``true`` if the VF2-based layout pass found any match.
 ///
 /// # Safety
 ///
@@ -38,28 +41,27 @@ pub struct VF2LayoutResult(Option<HashMap<VirtualQubit, PhysicalQubit>>);
 #[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_vf2_layout_result_has_match(layout: *const VF2LayoutResult) -> bool {
     let layout = unsafe { const_ptr_as_ref(layout) };
-    layout.0.is_some()
+    layout.0 != Vf2PassReturn::NoSolution
 }
 
 /// @ingroup QkVF2LayoutResult
-/// Get the number of virtual qubits in the layout.
+/// Check whether the result is an improvement to the trivial layout.
 ///
 /// @param layout a pointer to the layout
 ///
-/// @returns The number of virtual qubits in the layout
+/// @returns ``true`` if the VF2-based layout pass found an improved match.
 ///
 /// # Safety
 ///
 /// Behavior is undefined if ``layout`` is not a valid, non-null pointer to a
-/// ``QkVF2LayoutResult``. The result must have a layout found.
+/// ``QkVF2LayoutResult``.
 #[unsafe(no_mangle)]
 #[cfg(feature = "cbinding")]
-pub unsafe extern "C" fn qk_vf2_layout_result_num_qubits(layout: *const VF2LayoutResult) -> u32 {
+pub unsafe extern "C" fn qk_vf2_layout_result_has_improvement(
+    layout: *const VF2LayoutResult,
+) -> bool {
     let layout = unsafe { const_ptr_as_ref(layout) };
-    let Some(ref layout) = layout.0 else {
-        panic!("Invalid call for empty layout result");
-    };
-    layout.len() as u32
+    matches!(layout.0, Vf2PassReturn::Solution(_))
 }
 
 /// @ingroup QkVF2LayoutResult
@@ -73,8 +75,8 @@ pub unsafe extern "C" fn qk_vf2_layout_result_num_qubits(layout: *const VF2Layou
 /// # Safety
 ///
 /// Behavior is undefined if ``layout`` is not a valid, non-null pointer to a
-/// ``QkVF2LayoutResult``. Also qubit must be a valid qubit for the circuit and
-/// there must be a result found.
+/// ``QkVF2LayoutResult`` containing a result, or if the qubit is out of range for the initial
+/// circuit.
 #[unsafe(no_mangle)]
 #[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_vf2_layout_result_map_virtual_qubit(
@@ -82,12 +84,12 @@ pub unsafe extern "C" fn qk_vf2_layout_result_map_virtual_qubit(
     qubit: u32,
 ) -> u32 {
     let layout = unsafe { const_ptr_as_ref(layout) };
-    let Some(ref layout) = layout.0 else {
-        panic!("There was no layout found");
-    };
-    match layout.get(&VirtualQubit(qubit)) {
-        Some(physical) => physical.0,
-        None => panic!("The specified qubit is not in the layout: {qubit}"),
+    match &layout.0 {
+        Vf2PassReturn::NoSolution => panic!("There was no layout found!"),
+        // It's undefined behaviour to pass a qubit that's out of range, so it's not our problem
+        // that we can't tell if this is valid.
+        Vf2PassReturn::NoImprovement => qubit,
+        Vf2PassReturn::Solution(mapping) => mapping[&VirtualQubit::new(qubit)].0,
     }
 }
 
@@ -118,40 +120,157 @@ pub unsafe extern "C" fn qk_vf2_layout_result_free(layout: *mut VF2LayoutResult)
     }
 }
 
-/// @ingroup QkTranspilerPasses
-/// Run the VF2Layout pass on a circuit.
+/// A set of configurations for the VF2 layout passes.
 ///
-/// VF2Layout is a pass for choosing a layout of a circuit onto a connectivity graph as
-/// a subgraph isomorphism problem solved by VF2.
+/// See the setter methods associated with this `struct` for the available configurations.
+pub struct VF2LayoutConfiguration(Vf2PassConfiguration);
+/// @ingroup QkVF2LayoutConfiguration
+/// Create a new configuration for the VF2 passes that runs everything completely unbounded.
+///
+/// Call ``qk_vf2_layout_configuration_free`` with the return value to free the memory when done.
+#[unsafe(no_mangle)]
+#[cfg(feature = "cbinding")]
+pub extern "C" fn qk_vf2_layout_configuration_new() -> *mut VF2LayoutConfiguration {
+    Box::into_raw(Box::new(VF2LayoutConfiguration(
+        Vf2PassConfiguration::default_unbounded(),
+    )))
+}
+/// @ingroup QkVF2LayoutConfiguration
+/// Create a new configuration for the VF2 passes that runs everything completely unbounded.
+///
+/// # Safety
+///
+/// Behavior is undefined if ``config`` is a non-null pointer, but does not point to a valid,
+/// aligned ``VF2LayoutConfiguration`` object.
+#[unsafe(no_mangle)]
+#[cfg(feature = "cbinding")]
+pub unsafe extern "C" fn qk_vf2_layout_configuration_free(config: *mut VF2LayoutConfiguration) {
+    if !config.is_null() {
+        if !config.is_aligned() {
+            panic!("Attempted to free a non-aligned pointer.");
+        }
+        let _ = unsafe { Box::from_raw(config) };
+    }
+}
+/// @ingroup QkVF2LayoutConfiguration
+/// Limit the numbers of times that the VF2 algorithm will attempt to extend its mapping.
+///
+/// @param config The configuration to update.
+/// @param limit The number of attempts to allow.  Set to a negative number to have no bound.
+///
+/// # Safety
+///
+/// Behavior is undefined if `config` is not a valid, aligned, non-null pointer to a
+/// `VF2LayoutConfiguration`.
+#[unsafe(no_mangle)]
+#[cfg(feature = "cbinding")]
+pub unsafe extern "C" fn qk_vf2_layout_configuration_call_limit(
+    config: *mut VF2LayoutConfiguration,
+    limit: i64,
+) {
+    let lift = |limit: i64| -> Option<usize> {
+        (limit > 0).then(|| limit.try_into().unwrap_or(usize::MAX))
+    };
+    unsafe { (*config).0.call_limit = lift(limit) };
+}
+/// @ingroup QkVF2LayoutConfiguration
+/// Limit the runtime of the VF2 search.
+///
+/// This is not a hard limit; it is only checked when an improved layout is encountered.  Using this
+/// option also makes the pass non-deterministic. It is generally recommended to use
+/// ``qk_vf2_layout_configuration_call_limit`` instead.
+///
+/// @param config The configuration to update.
+/// @param limit The time in seconds to allow.  Set to a non-positive value to run with no limit.
+///
+/// # Safety
+///
+/// Behavior is undefined if `config` is not a valid, aligned, non-null pointer to a
+/// `VF2LayoutConfiguration`.
+#[unsafe(no_mangle)]
+#[cfg(feature = "cbinding")]
+pub unsafe extern "C" fn qk_vf2_layout_configuration_time_limit(
+    config: *mut VF2LayoutConfiguration,
+    limit: f64,
+) {
+    unsafe { (*config).0.time_limit = (limit > 0.0).then_some(limit) };
+}
+/// @ingroup QkVF2LayoutConfiguration
+/// Limit the total number of complete improvements found.
+///
+/// Since the VF2 search tree is pruned on-the-fly based on scoring in the ``Target``, this limit
+/// is not especially powerful.  See ``qk_vf2_layout_configuration_call_limit`` for a tighter bound.
+///
+/// @param config The configuration to update.
+/// @param limit The number of complete layouts to allow before terminating.  Set to 0 to run
+///     unbounded.
+///
+/// # Safety
+///
+/// Behavior is undefined if `config` is not a valid, aligned, non-null pointer to a
+/// `VF2LayoutConfiguration`.
+#[unsafe(no_mangle)]
+#[cfg(feature = "cbinding")]
+pub unsafe extern "C" fn qk_vf2_layout_configuration_max_trials(
+    config: *mut VF2LayoutConfiguration,
+    limit: u64,
+) {
+    unsafe { (*config).0.max_trials = Some(limit.try_into().unwrap_or(usize::MAX)) };
+}
+/// @ingroup QkVF2LayoutConfiguration
+/// Activate node shuffling of the input graphs with a given seed.
+///
+/// This effectively drives a modification of the matching order of VF2, which in theory means that
+/// the space of a bounded search is not biased based on the node indices.  In practice, Qiskit uses
+/// the VF2++ ordering improvements when running in "average" mode (corresponding to initial layout
+/// search), and starts from the identity mapping in "exact" made.  Both of these ordering
+/// heuristics are typically far more likely to find results for the given problem than
+/// randomization.
+///
+/// If this function was not called, no node shuffling takes place.
+///
+/// @param config The configuration to update.
+/// @param seed The seed to use for the activated shuffling.
+///
+/// # Safety
+///
+/// Behavior is undefined if `config` is not a valid, aligned, non-null pointer to a
+/// `VF2LayoutConfiguration`.
+#[unsafe(no_mangle)]
+#[cfg(feature = "cbinding")]
+pub unsafe extern "C" fn qk_vf2_layout_configuration_shuffle_nodes(
+    config: *mut VF2LayoutConfiguration,
+    seed: u64,
+) {
+    unsafe { (*config).0.shuffle_seed = Some(seed) };
+}
+
+/// @ingroup QkTranspilerPasses
+/// Use the VF2 algorithm to choose a layout (if possible) for the input circuit, using a
+/// noise-aware scoring heuristic based only on hardware error rates, and not the specific gates in
+/// the circuit.
+///
+/// This function corresponds to the Python-space ``VF2Layout`` pass.
+///
+/// This function is suitable for use on circuits that have not yet been fully lowered to hardware.
+/// If your circuit has already been completely lowered to hardware and you are looking to _improve_
+/// the layout for an exact interaction graph, use ``qk_transpile_pass_standalone_vf2_layout_exact``
+/// instead.
 ///
 /// If this pass finds a solution that means there is a "perfect layout" and that no
 /// further swap mapping or routing is needed. However, there is not always a possible
 /// solution, or a solution might exist but it is not found within the limits specified
 /// when the pass is called.
 ///
-/// By default, this pass will construct a heuristic scoring map based on the error rates
-/// in the provided ``target`` argument. The function will continue searching for layouts
-/// and use the heuristic scoring to return the layout which will run with the best estimated
-/// fidelity.
-///
 /// @param circuit A pointer to the circuit to run VF2Layout on
 /// @param target A pointer to the target to run the VF2Layout pass on
-/// @param strict_direction If true the pass will consider the edge direction in the
-///     connectivity described in the ``target``. Typically setting this to ``false``
-///     is desirable as an undirected search has more degrees of freedom and is more likely
-///     to find a layout (or a better layout if there are multiple choices) and correcting
-///     directionality is a simple operation for later transpilation stages.
-/// @param call_limit The number of state visits to attempt in each execution of the VF2 algorithm.
-///     If the value is set to a negative value the VF2 algorithm will run without any limit.
-/// @param time_limit The total time in seconds to run for ``VF2Layout``. This is checked after
-///     each layout search so it is not a hard time limit, but a soft limit that when checked
-///     if the set time has elapsed the function will return the best layout it has found so
-///     far. Set this to a value less than or equal to 0.0 to run without any time limit.
-/// @param max_trials The maximum number of trials to run the VF2 algorithm to try and find
-///     layouts. If the value is negative this will be treated as unbounded which means the
-///     algorithm will run until all possible layouts are scored. If the value is 0 the number
-///     of trials will be limited based on the number of edges in the interaction or the coupling
-///     graph (whichever is larger).
+/// @param config A pointer to the ``QkVF2LayoutConfiguration`` configuration structure.  If this
+///     pointer is null, the pass defaults are used.
+/// @param strict_direction If true, the pass will consider the edge direction in the
+///     connectivity described in the ``target``. Typically, setting this to ``false``
+///     is desireable as the error heuristic is already very approximate, and two-qubit gates can
+///     almost invariably be synthesised to "flip" direction using only local one-qubit gates and
+///     the native-direction two-qubit gate.
 ///
 /// @return QkVF2LayoutResult A pointer to a result object that contains the
 /// results of the pass. This object is heap allocated and will need to be freed with the
@@ -177,22 +296,25 @@ pub unsafe extern "C" fn qk_vf2_layout_result_free(layout: *mut VF2LayoutResult)
 ///             qk_circuit_gate(qc, QkGate_CX, qargs, NULL);
 ///         }
 ///     }
-///     QkVF2LayoutResult *layout_result = qk_transpiler_pass_standalone_vf2_layout(qc, target, false, -1, NAN, -1);
+///     QkVF2LayoutConfiguration *config = qk_vf2_layout_configuration_new();
+///     qk_vf2_layout_configuration_call_limit(config, 10000);
+///     QkVF2LayoutResult *layout_result = qk_transpiler_pass_standalone_vf2_layout(qc, target, config, false);
 ///     qk_vf2_layout_result_free(layout_result);
+///     qk_vf2_layout_configuration_free(config);
 /// ```
 ///
 /// # Safety
 ///
-/// Behavior is undefined if ``circuit`` or ``target`` is not a valid, non-null pointer to a ``QkCircuit`` and ``QkTarget``.
+/// Behavior is undefined if ``circuit`` or ``target`` is not a valid, non-null pointer to a
+/// ``QkCircuit`` and ``QkTarget``.  Behavior is undefined if ``config`` is a non-null pointer that
+/// does not point to a valid ``QkVF2LayoutConfiguration`` object (but a null pointer is fine).
 #[unsafe(no_mangle)]
 #[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpiler_pass_standalone_vf2_layout(
     circuit: *const CircuitData,
     target: *const Target,
+    config: *const VF2LayoutConfiguration,
     strict_direction: bool,
-    call_limit: i64,
-    time_limit: f64,
-    max_trials: i64,
 ) -> *mut VF2LayoutResult {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { const_ptr_as_ref(circuit) };
@@ -201,35 +323,13 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_vf2_layout(
         Ok(dag) => dag,
         Err(e) => panic!("{}", e),
     };
-    let call_limit = if call_limit < 0 {
-        None
+    let config_default = Vf2PassConfiguration::default_abstract();
+    let config = if config.is_null() {
+        &config_default
     } else {
-        Some(call_limit as usize)
+        unsafe { &const_ptr_as_ref(config).0 }
     };
-    let time_limit = if time_limit <= 0.0 {
-        None
-    } else {
-        Some(time_limit)
-    };
-    let max_trials = if max_trials < 0 {
-        Some(0)
-    } else if max_trials == 0 {
-        None
-    } else {
-        Some(max_trials as isize)
-    };
-    let layout = match vf2_layout_pass(
-        &dag,
-        target,
-        strict_direction,
-        call_limit,
-        time_limit,
-        max_trials,
-        None,
-        None,
-    ) {
-        Ok(layout) => layout,
-        Err(e) => panic!("{}", e),
-    };
-    Box::into_raw(Box::new(VF2LayoutResult(layout)))
+    vf2_layout_pass(&dag, target, config, strict_direction, None)
+        .map(|result| Box::into_raw(Box::new(VF2LayoutResult(result))))
+        .unwrap()
 }

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -1726,6 +1726,11 @@ impl DAGCircuit {
         Ok(PyTuple::new(py, result)?.into_any().try_iter()?.unbind())
     }
 
+    /// Return `true` if there are no operation nodes in the graph.
+    fn is_empty(&self) -> bool {
+        self.dag.node_count() == 2 * (self.qubits.len() + self.clbits.len() + self.vars.len())
+    }
+
     /// Return the number of operations.  If there is control flow present, this count may only
     /// be an estimate, as the complete control-flow path cannot be statically known.
     ///

--- a/crates/circuit/src/vf2.rs
+++ b/crates/circuit/src/vf2.rs
@@ -39,7 +39,7 @@ use rustworkx_core::petgraph::visit::{
 };
 use rustworkx_core::petgraph::{Direction, Graph, Incoming, Outgoing};
 
-mod alias {
+pub mod alias {
     use std::hash::Hash;
 
     use rustworkx_core::petgraph::Direction;
@@ -805,6 +805,13 @@ where
     NS: Semantics<N::NodeWeight, H::NodeWeight>,
     ES: Semantics<N::EdgeWeight, H::EdgeWeight, Score = NS::Score>,
 {
+    pub fn needle(&self) -> &N {
+        &self.needle
+    }
+    pub fn haystack(&self) -> &H {
+        &self.haystack
+    }
+
     /// Add a limit to the number of candidate extensions the algorithm is allowed to attempt.
     ///
     /// This can be used to upper-bound the runtime of the algorithm while keeping it deterministic.

--- a/crates/transpiler/src/passes/mod.rs
+++ b/crates/transpiler/src/passes/mod.rs
@@ -47,7 +47,7 @@ pub mod sabre;
 mod split_2q_unitaries;
 mod unitary_synthesis;
 mod unroll_3q_or_more;
-mod vf2;
+pub mod vf2;
 mod wrap_angles;
 
 pub use alap_schedule_analysis::{alap_schedule_analysis_mod, run_alap_schedule_analysis};
@@ -88,5 +88,5 @@ pub use remove_identity_equiv::{remove_identity_equiv_mod, run_remove_identity_e
 pub use split_2q_unitaries::{run_split_2q_unitaries, split_2q_unitaries_mod};
 pub use unitary_synthesis::{run_unitary_synthesis, unitary_synthesis_mod};
 pub use unroll_3q_or_more::{run_unroll_3q_or_more, unroll_3q_or_more_mod};
-pub use vf2::{ErrorMap, error_map_mod, score_layout, vf2_layout_mod, vf2_layout_pass};
+pub use vf2::{ErrorMap, error_map_mod, vf2_layout_mod, vf2_layout_pass};
 pub use wrap_angles::{run_wrap_angles, wrap_angles_mod};

--- a/crates/transpiler/src/passes/vf2/mod.rs
+++ b/crates/transpiler/src/passes/vf2/mod.rs
@@ -14,4 +14,4 @@ mod error_map;
 mod vf2_layout;
 
 pub use error_map::{ErrorMap, error_map_mod};
-pub use vf2_layout::{score_layout, vf2_layout_mod, vf2_layout_pass};
+pub use vf2_layout::{Vf2PassConfiguration, Vf2PassReturn, vf2_layout_mod, vf2_layout_pass};

--- a/crates/transpiler/src/passes/vf2/vf2_layout.rs
+++ b/crates/transpiler/src/passes/vf2/vf2_layout.rs
@@ -19,23 +19,23 @@ use numpy::PyReadonlyArray1;
 use rand::prelude::*;
 use rand_pcg::Pcg64Mcg;
 use rayon::prelude::*;
+use rustworkx_core::petgraph::data::Create;
 use rustworkx_core::petgraph::prelude::*;
 
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
-use pyo3::{create_exception, wrap_pyfunction};
+use pyo3::{IntoPyObjectExt, create_exception, wrap_pyfunction};
 
 use qiskit_circuit::converters::circuit_to_dag;
 use qiskit_circuit::dag_circuit::DAGCircuit;
+use qiskit_circuit::nlayout::NLayout;
 use qiskit_circuit::operations::{Operation, OperationRef, Param};
 use qiskit_circuit::packed_instruction::PackedInstruction;
-use qiskit_circuit::vf2;
+use qiskit_circuit::{PhysicalQubit, VirtualQubit, vf2};
 
 use super::error_map::ErrorMap;
 use crate::target::{Qargs, QargsRef, Target};
-use qiskit_circuit::nlayout::NLayout;
-use qiskit_circuit::{PhysicalQubit, VirtualQubit};
 
 const PARALLEL_THRESHOLD: usize = 50;
 
@@ -43,7 +43,6 @@ const PARALLEL_THRESHOLD: usize = 50;
 pub struct EdgeList {
     pub edge_list: Vec<([VirtualQubit; 2], i32)>,
 }
-
 #[pymethods]
 impl EdgeList {
     #[new]
@@ -53,6 +52,155 @@ impl EdgeList {
 }
 
 create_exception!(qiskit, MultiQEncountered, pyo3::exceptions::PyException);
+
+#[pyclass(name = "VF2PassConfiguration")]
+#[derive(Clone, Debug)]
+pub struct Vf2PassConfiguration {
+    /// Number of times to allow extending the VF2 partial solution.  `None` means "no bound".
+    pub call_limit: Option<usize>,
+    /// Time in seconds to spend optimizing.  This is not a tight limit; control only returns to the
+    /// iterator to check for the time limit when a successful _improved_ match is found.
+    pub time_limit: Option<f64>,
+    /// In `max_trials`, `None` means "based on the number of graph edges" and `0` means
+    /// "unbounded".
+    pub max_trials: Option<usize>,
+    /// If set, shuffle the node indices of the input graphs using a specified random seed.  If
+    /// `None`, perform no shuffling.  You probably want this to be `None`.
+    pub shuffle_seed: Option<u64>,
+}
+impl Vf2PassConfiguration {
+    /// A set of defaults that just runs everything completely unbounded.
+    pub fn default_unbounded() -> Self {
+        Self {
+            call_limit: None,
+            time_limit: None,
+            max_trials: Some(0),
+            shuffle_seed: None,
+        }
+    }
+
+    /// A set of defaults suitable for calling the VF2 layout passes in "search" mode for a circuit
+    /// that has not been lowered to hardware instructions.
+    pub fn default_abstract() -> Self {
+        Self {
+            call_limit: None,
+            time_limit: None,
+            // There's no need to attempt to improve the layout, since everything's so approximate
+            // anyway.
+            max_trials: Some(1),
+            shuffle_seed: None,
+        }
+    }
+
+    /// A set of defaults for calling VF2 passes on circuits that are already lowered to hardware,
+    /// and we want to find the _best_ layout.
+    pub fn default_concrete() -> Self {
+        Self {
+            call_limit: None,
+            time_limit: None,
+            // Unbounded trials.
+            max_trials: Some(0),
+            shuffle_seed: None,
+        }
+    }
+}
+#[pymethods]
+impl Vf2PassConfiguration {
+    #[new]
+    #[pyo3(signature = (*, call_limit=None, time_limit=None, max_trials=None, shuffle_seed=None))]
+    fn py_new(
+        call_limit: Option<usize>,
+        time_limit: Option<f64>,
+        max_trials: Option<usize>,
+        shuffle_seed: Option<u64>,
+    ) -> Self {
+        Self {
+            call_limit,
+            time_limit,
+            max_trials,
+            shuffle_seed,
+        }
+    }
+
+    /// Construct the VF2 configuration from the legacy interface to the Python passes.
+    #[staticmethod]
+    #[pyo3(signature = (*, call_limit=None, time_limit=None, max_trials=None, shuffle_seed=None))]
+    fn from_legacy_api(
+        call_limit: Option<usize>,
+        time_limit: Option<f64>,
+        max_trials: Option<isize>,
+        shuffle_seed: Option<i64>,
+    ) -> PyResult<Self> {
+        // In the leagcy API, negative `max_trials` means unbounded (which we represent as 0) and
+        // `None` means "choose some values based on the size of the graph structures".
+        let max_trials = max_trials.map(|value| value.try_into().unwrap_or(0));
+        let shuffle_seed = match shuffle_seed {
+            None => {
+                // In Python space, `None` means "seed with OS entropy" because seeding was expected
+                // to be the default.
+                Some(Pcg64Mcg::from_os_rng().next_u64())
+            }
+            Some(-1) => None,
+            Some(seed) => {
+                // Python accepted negative seeds other than -1.  Since we're working with
+                // fixed-size integers, we'll just reinterpret the bits as a `u64`.
+                Some(u64::from_ne_bytes(seed.to_ne_bytes()))
+            }
+        };
+        Ok(Self {
+            call_limit,
+            time_limit,
+            max_trials,
+            shuffle_seed,
+        })
+    }
+}
+
+/// The possible success-path returns from a VF2-layout based path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Vf2PassReturn {
+    /// No solution could be found.
+    NoSolution,
+    /// The configuration asked us to score the identity layout, it resulted in a valid mapping, and
+    /// it was the best mapping seen (or at least tied for the best).
+    NoImprovement,
+    /// A solution was found (other than `NoImprovement`, if relevant).
+    Solution(HashMap<VirtualQubit, PhysicalQubit>),
+}
+impl<'py> IntoPyObject<'py> for Vf2PassReturn {
+    type Target = VF2PassReturn;
+    type Output = <Self::Target as IntoPyObject<'py>>::Output;
+    type Error = <Self::Target as IntoPyObject<'py>>::Error;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        VF2PassReturn(self).into_pyobject(py)
+    }
+}
+
+#[pyclass]
+pub struct VF2PassReturn(Vf2PassReturn);
+#[pymethods]
+impl VF2PassReturn {
+    /// True iff there exists a valid solution.  If ``True``, ``new_mapping`` can still be ``None``
+    /// if there was no improvement over the trivial mapping.
+    #[getter]
+    fn has_solution(&self) -> bool {
+        match &self.0 {
+            Vf2PassReturn::NoSolution => false,
+            Vf2PassReturn::NoImprovement | Vf2PassReturn::Solution(_) => true,
+        }
+    }
+    /// Get the improved mapping, if one exists.  Returns ``None`` if there was no solution or no
+    /// improvement.
+    fn new_mapping<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        match &self.0 {
+            Vf2PassReturn::NoSolution | Vf2PassReturn::NoImprovement => {
+                Ok(py.None().into_bound(py))
+            }
+            Vf2PassReturn::Solution(mapping) => mapping.into_bound_py_any(py),
+        }
+    }
+}
 
 /// Build an average error map for a given target.
 ///
@@ -161,37 +309,43 @@ struct VirtualInteractions<T> {
     idle: IndexSet<VirtualQubit>,
 }
 impl<T: Default> VirtualInteractions<T> {
-    fn from_dag<W>(dag: &DAGCircuit, weighter: W) -> PyResult<Self>
+    /// Create a set of virtual interactions from a DAG, and a weighter function for a single
+    /// interaction.  The weighter should return `true` on success, or `false` if no weight could be
+    /// created (indicating a necessary failure of the layout pass).
+    fn from_dag<W>(dag: &DAGCircuit, weighter: W) -> PyResult<Option<Self>>
     where
-        W: Fn(&mut T, &PackedInstruction, usize),
+        W: Fn(&mut T, &PackedInstruction, usize) -> bool,
     {
         let id_qubit_map = (0..dag.num_qubits())
             .map(|q| VirtualQubit(q as u32))
             .collect::<Vec<_>>();
         let mut out = Self::default();
-        out.add_interactions_from(dag, &id_qubit_map, 1, &weighter)?;
+        if !out.add_interactions_from(dag, &id_qubit_map, 1, &weighter)? {
+            return Ok(None);
+        }
         out.idle.extend(
             (0..dag.num_qubits() as u32)
                 .map(VirtualQubit)
                 .filter(|q| !(out.nodes.contains(q) || out.uncoupled.contains_key(q))),
         );
-        Ok(out)
+        Ok(Some(out))
     }
 
+    /// Add interactions from a given DAG.  Returns `false` if the weighter ever returned `false`.
     fn add_interactions_from<W>(
         &mut self,
         dag: &DAGCircuit,
         wire_map: &[VirtualQubit],
         repeats: usize,
         weighter: &W,
-    ) -> PyResult<()>
+    ) -> PyResult<bool>
     where
-        W: Fn(&mut T, &PackedInstruction, usize),
+        W: Fn(&mut T, &PackedInstruction, usize) -> bool,
     {
         for (_, inst) in dag.op_nodes(false) {
             let qubits = dag.get_qargs(inst.qubits);
             if inst.op.control_flow() {
-                Python::attach(|py| -> PyResult<()> {
+                let can_continue = Python::attach(|py| -> PyResult<bool> {
                     let OperationRef::Instruction(py_inst) = inst.op.view() else {
                         unreachable!("control-flow nodes are always PyInstructions");
                     };
@@ -208,15 +362,20 @@ impl<T: Default> VirtualInteractions<T> {
                     let wire_map: Vec<_> = qubits.iter().map(|i| wire_map[i.index()]).collect();
                     let blocks = py_inst.instruction.bind(py).getattr("blocks")?;
                     for block in blocks.downcast::<PyTuple>()?.iter() {
-                        self.add_interactions_from(
+                        if !self.add_interactions_from(
                             &circuit_to_dag(block.extract()?, false, None, None)?,
                             &wire_map,
                             repeats,
                             weighter,
-                        )?;
+                        )? {
+                            return Ok(false);
+                        };
                     }
-                    Ok(())
+                    Ok(true)
                 })?;
+                if !can_continue {
+                    return Ok(false);
+                };
                 continue;
             }
             match qubits {
@@ -228,7 +387,9 @@ impl<T: Default> VirtualInteractions<T> {
                             .graph
                             .node_weight_mut(NodeIndex::new(index))
                             .expect("node must be in graph if tracked in 'nodes'");
-                        weighter(weight, inst, repeats);
+                        if !weighter(weight, inst, repeats) {
+                            return Ok(false);
+                        };
                     } else {
                         let weight = self.uncoupled.entry(q).or_default();
                         weighter(weight, inst, repeats);
@@ -244,17 +405,21 @@ impl<T: Default> VirtualInteractions<T> {
                             .graph
                             .edge_weight_mut(edge)
                             .expect("this index came from a call to 'find_edge'");
-                        weighter(weight, inst, repeats);
+                        if !weighter(weight, inst, repeats) {
+                            return Ok(false);
+                        };
                     } else {
                         let mut weight = T::default();
-                        weighter(&mut weight, inst, repeats);
+                        if !weighter(&mut weight, inst, repeats) {
+                            return Ok(false);
+                        };
                         self.graph.add_edge(node0, node1, weight);
                     }
                 }
                 _ => return Err(MultiQEncountered::new_err("")),
             }
         }
-        Ok(())
+        Ok(true)
     }
 
     fn ensure_1q_in_graph(&mut self, q: VirtualQubit) -> NodeIndex {
@@ -267,16 +432,17 @@ impl<T: Default> VirtualInteractions<T> {
     }
 }
 
-fn build_coupling_map(target: &Target, errors: &ErrorMap) -> Option<Graph<f64, f64>> {
-    let neg_log_fidelity = |error: f64| {
-        if error.is_nan() || error <= 0. {
-            0.0
-        } else if error >= 1. {
-            f64::INFINITY
-        } else {
-            -((-error).ln_1p())
-        }
-    };
+fn neg_log_fidelity(error: f64) -> f64 {
+    if error.is_nan() || error <= 0. {
+        0.0
+    } else if error >= 1. {
+        f64::INFINITY
+    } else {
+        -((-error).ln_1p())
+    }
+}
+
+fn build_average_coupling_map(target: &Target, errors: &ErrorMap) -> Option<Graph<f64, f64>> {
     let num_qubits = target.num_qubits.unwrap_or_default() as usize;
     if target.num_qargs() == 0 {
         return None;
@@ -364,38 +530,87 @@ fn map_free_qubits(
     Some(partial_layout)
 }
 
-#[allow(clippy::too_many_arguments)]
+fn minimize_vf2<N, H, NG, HG, NO, HO, NS, ES>(
+    vf2: vf2::Vf2<N, H, NG, HG, NO, HO, NS, ES>,
+    config: &Vf2PassConfiguration,
+) -> Option<IndexMap<N::NodeId, H::NodeId, ::ahash::RandomState>>
+where
+    N: vf2::alias::IntoVf2Graph,
+    H: vf2::alias::IntoVf2Graph<EdgeType = N::EdgeType>,
+    NG: for<'a> vf2::alias::Vf2Graph<
+            'a,
+            NodeWeight = N::NodeWeight,
+            EdgeWeight = N::EdgeWeight,
+            EdgeType = N::EdgeType,
+        > + Create,
+    HG: for<'a> vf2::alias::Vf2Graph<
+            'a,
+            NodeWeight = H::NodeWeight,
+            EdgeWeight = H::EdgeWeight,
+            EdgeType = H::EdgeType,
+        > + Create,
+    NO: vf2::NodeSorter<N>,
+    HO: vf2::NodeSorter<H>,
+    NS: vf2::Semantics<N::NodeWeight, H::NodeWeight, Error = Infallible>,
+    ES: vf2::Semantics<N::EdgeWeight, H::EdgeWeight, Score = NS::Score, Error = Infallible>,
+{
+    let start_time = Instant::now();
+    let mut times_up = false;
+    let mut trials: usize = 0;
+    let max_trials = config
+        .max_trials
+        .unwrap_or_else(|| 15 + vf2.needle().edge_count().max(vf2.haystack().edge_count()));
+    let time_limit = config.time_limit.unwrap_or(f64::INFINITY);
+    let mut can_continue = || {
+        if times_up {
+            return false;
+        }
+        times_up = start_time.elapsed().as_secs_f64() >= time_limit;
+        trials += 1;
+        max_trials == 0 || trials <= max_trials
+    };
+    vf2.with_call_limit(config.call_limit)
+        .into_iter()
+        .take_while(|_| can_continue())
+        .last()
+        .map(|v| {
+            let (mapping, _score) = v.expect("error is infallible");
+            mapping
+        })
+}
+
 #[pyfunction]
-#[pyo3(signature = (dag, target, strict_direction=false, call_limit=None, time_limit=None, max_trials=None, avg_error_map=None, shuffle_seed=None))]
+#[pyo3(signature = (dag, target, config, *, strict_direction=false, avg_error_map=None))]
 pub fn vf2_layout_pass(
     dag: &DAGCircuit,
     target: &Target,
+    config: &Vf2PassConfiguration,
     strict_direction: bool,
-    call_limit: Option<usize>,
-    time_limit: Option<f64>,
-    max_trials: Option<isize>,
     avg_error_map: Option<ErrorMap>,
-    shuffle_seed: Option<u64>,
-) -> PyResult<Option<HashMap<VirtualQubit, PhysicalQubit>>> {
+) -> PyResult<Vf2PassReturn> {
     let add_interaction = |count: &mut usize, _: &PackedInstruction, repeats: usize| {
         *count += repeats;
+        true
     };
+    let interactions = VirtualInteractions::from_dag(dag, add_interaction)?
+        .expect("weighting function is infallible");
+
     let score =
         |count: &usize, err: &f64| -> Result<f64, Infallible> { Ok(*err * (*count as f64)) };
     let Some(avg_error_map) = avg_error_map.or_else(|| build_average_error_map(target)) else {
-        return Ok(None);
+        return Ok(Vf2PassReturn::NoSolution);
     };
-    let Some(mut coupling_graph) = build_coupling_map(target, &avg_error_map) else {
-        return Ok(None);
+    let Some(mut coupling_graph) = build_average_coupling_map(target, &avg_error_map) else {
+        return Ok(Vf2PassReturn::NoSolution);
     };
+    if !strict_direction {
+        loosen_directionality(&mut coupling_graph);
+    }
     let num_physical_qubits = coupling_graph.node_count();
     let mut coupling_qubits = (0..num_physical_qubits)
         .map(|k| PhysicalQubit::new(k as u32))
         .collect::<Vec<_>>();
-    if !strict_direction {
-        loosen_directionality(&mut coupling_graph);
-    }
-    if let Some(seed) = shuffle_seed {
+    if let Some(seed) = config.shuffle_seed {
         coupling_qubits.shuffle(&mut Pcg64Mcg::seed_from_u64(seed));
         let order = coupling_qubits
             .iter()
@@ -403,52 +618,23 @@ pub fn vf2_layout_pass(
             .collect::<Vec<_>>();
         coupling_graph = vf2::reorder_nodes(&coupling_graph, &order);
     }
-    let interactions = VirtualInteractions::from_dag(dag, add_interaction)?;
-    let start_time = Instant::now();
-    let mut times_up = false;
-    let mut trials: usize = 0;
-    let max_trials: usize = match max_trials {
-        Some(max_trials) => max_trials.try_into().unwrap_or(0),
-        None => {
-            15 + interactions
-                .graph
-                .edge_count()
-                .max(coupling_graph.edge_count())
-        }
-    };
-    let time_limit = time_limit.unwrap_or(f64::INFINITY);
-    let Some((mapping, _score)) =
-        vf2::Vf2::new(&interactions.graph, &coupling_graph, vf2::Problem::Subgraph)
-            .with_call_limit(call_limit)
-            .with_scoring(score, score)
-            .with_restriction(vf2::Restriction::Decreasing(None))
-            .with_vf2pp_ordering()
-            .into_iter()
-            .take_while(|_| {
-                if times_up {
-                    return false;
-                }
-                times_up = start_time.elapsed().as_secs_f64() >= time_limit;
-                trials += 1;
-                max_trials == 0 || trials <= max_trials
-            })
-            .map(|result| result.expect("error type is infallible"))
-            .last()
-    else {
-        return Ok(None);
-    };
 
+    let vf2 = vf2::Vf2::new(&interactions.graph, &coupling_graph, vf2::Problem::Subgraph)
+        .with_scoring(score, score)
+        .with_restriction(vf2::Restriction::Decreasing(None))
+        .with_vf2pp_ordering();
+    let Some(mapping) = minimize_vf2(vf2, config) else {
+        return Ok(Vf2PassReturn::NoSolution);
+    };
     // Remap node indices back to virtual/physical qubits.
     let mapping = mapping
         .iter()
         .map(|(k, v)| (interactions.nodes[k.index()], coupling_qubits[v.index()]))
         .collect();
-    Ok(map_free_qubits(
-        num_physical_qubits,
-        interactions,
-        mapping,
-        &avg_error_map,
-    ))
+    match map_free_qubits(num_physical_qubits, interactions, mapping, &avg_error_map) {
+        Some(mapping) => Ok(Vf2PassReturn::Solution(mapping)),
+        None => Ok(Vf2PassReturn::NoSolution),
+    }
 }
 
 /// Score a given circuit with a layout applied
@@ -494,7 +680,6 @@ pub fn score_layout(
             }
         })
     };
-
     let mut fidelity: f64 = if edge_list.edge_list.len() < PARALLEL_THRESHOLD || !run_in_parallel {
         edge_list
             .edge_list
@@ -529,5 +714,10 @@ pub fn vf2_layout_mod(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(vf2_layout_pass))?;
     m.add("MultiQEncountered", m.py().get_type::<MultiQEncountered>())?;
     m.add_class::<EdgeList>()?;
+    m.add(
+        "VF2PassConfiguration",
+        m.py().get_type::<Vf2PassConfiguration>(),
+    )?;
+    m.add("VF2PassReturn", m.py().get_type::<VF2PassReturn>())?;
     Ok(())
 }

--- a/crates/transpiler/src/transpiler.rs
+++ b/crates/transpiler/src/transpiler.rs
@@ -134,6 +134,22 @@ pub fn transpile(
     .with_lookahead(0.5, 20, sabre::SetScaling::Size)
     .with_decay(0.001, 5)?;
 
+    let vf2_config = match optimization_level {
+        OptimizationLevel::Level0 => vf2::Vf2PassConfiguration::default_abstract(), // Not used.
+        OptimizationLevel::Level1 | OptimizationLevel::Level2 => vf2::Vf2PassConfiguration {
+            call_limit: Some(5_000_000),
+            time_limit: None,
+            max_trials: Some(2_500),
+            shuffle_seed: None,
+        },
+        OptimizationLevel::Level3 => vf2::Vf2PassConfiguration {
+            call_limit: Some(30_000_000),
+            time_limit: None,
+            max_trials: Some(250_000),
+            shuffle_seed: None,
+        },
+    };
+
     if optimization_level == OptimizationLevel::Level0 {
         // Apply a trivial layout
         apply_layout(
@@ -153,21 +169,14 @@ pub fn transpile(
                 target.num_qubits.unwrap(),
                 |x| PhysicalQubit(x.0),
             );
-        } else if let Some(vf2_result) = vf2_layout_pass(
-            &dag,
-            target,
-            false,
-            Some(5_000_000),
-            None,
-            Some(2500),
-            None,
-            None,
-        )? {
+        } else if let vf2::Vf2PassReturn::Solution(layout) =
+            vf2_layout_pass(&dag, target, &vf2_config, false, None)?
+        {
             apply_layout(
                 &mut dag,
                 &mut transpile_layout,
                 target.num_qubits.unwrap(),
-                |x| vf2_result[&x],
+                |x| layout[&x],
             );
         } else {
             let (result, initial_layout, final_layout) = sabre::sabre_layout_and_routing(
@@ -186,21 +195,14 @@ pub fn transpile(
                 layout_from_sabre_result(&dag, initial_layout, &final_layout, &transpile_layout);
         }
     } else if optimization_level == OptimizationLevel::Level2 {
-        if let Some(vf2_result) = vf2_layout_pass(
-            &dag,
-            target,
-            false,
-            Some(5_000_000),
-            None,
-            Some(2500),
-            None,
-            None,
-        )? {
+        if let vf2::Vf2PassReturn::Solution(layout) =
+            vf2_layout_pass(&dag, target, &vf2_config, false, None)?
+        {
             apply_layout(
                 &mut dag,
                 &mut transpile_layout,
                 target.num_qubits.unwrap(),
-                |x| vf2_result[&x],
+                |x| layout[&x],
             );
         } else {
             let (result, initial_layout, final_layout) = sabre::sabre_layout_and_routing(
@@ -218,21 +220,14 @@ pub fn transpile(
             transpile_layout =
                 layout_from_sabre_result(&dag, initial_layout, &final_layout, &transpile_layout);
         }
-    } else if let Some(vf2_result) = vf2_layout_pass(
-        &dag,
-        target,
-        false,
-        Some(30_000_000),
-        None,
-        Some(250_000),
-        None,
-        None,
-    )? {
+    } else if let vf2::Vf2PassReturn::Solution(layout) =
+        vf2_layout_pass(&dag, target, &vf2_config, false, None)?
+    {
         apply_layout(
             &mut dag,
             &mut transpile_layout,
             target.num_qubits.unwrap(),
-            |x| vf2_result[&x],
+            |x| layout[&x],
         );
     } else {
         let (result, initial_layout, final_layout) = sabre::sabre_layout_and_routing(

--- a/docs/cdoc/index.h
+++ b/docs/cdoc/index.h
@@ -47,6 +47,10 @@
  */
 
 /**
+ * @defgroup QkVF2LayoutConfiguration QkVF2LayoutConfiguration
+ */
+
+/**
  * @defgroup QkTranspileLayout QkTranspileLayout
  */
 

--- a/docs/cdoc/index.rst
+++ b/docs/cdoc/index.rst
@@ -76,7 +76,7 @@ results transpiling circuits from Python via the C API.
    qk-target-entry
    qk-transpile-layout
    qk-transpiler-passes
-   qk-vf2-layout-result
+   qk-vf2-layout
    qk-sabre-layout-options
 
 

--- a/docs/cdoc/qk-vf2-layout.rst
+++ b/docs/cdoc/qk-vf2-layout.rst
@@ -1,4 +1,20 @@
-=================
+=========================
+VF2 compiler-pass objects
+=========================
+
+QkVF2LayoutConfiguration
+========================
+
+.. code-block:: c
+
+   typedef struct QkVF2LayoutConfiguration QkVF2LayoutConfiguration
+
+The :c:func:`qk_transpiler_pass_standalone_vf2_layout` function takes this object as its configuration.
+
+.. doxygengroup:: QkVF2LayoutConfiguration
+   :members:
+   :content-only:
+
 QkVF2LayoutResult
 =================
 
@@ -11,8 +27,9 @@ result as a ``QkVF2LayoutResult`` object. This object contains the outcome of th
 whether the pass was able to find a layout or not, and what the layout selected by the pass was.
 
 Functions
-=========
+~~~~~~~~~
 
 .. doxygengroup:: QkVF2LayoutResult
    :members:
    :content-only:
+

--- a/test/c/test_vf2_layout.c
+++ b/test/c/test_vf2_layout.c
@@ -56,26 +56,22 @@ static int test_vf2_layout_line(void) {
     int result = Ok;
     result = build_target(target, num_qubits);
     if (result != Ok) {
-        goto cleanup;
+        goto target_cleanup;
     }
     // Create a circuit with line connectivity.
-    QkCircuit *qc = qk_circuit_new(5, 0);
+    QkCircuit *qc = qk_circuit_new(num_qubits, 0);
     for (uint32_t i = 0; i < qk_circuit_num_qubits(qc) - 1; i++) {
         uint32_t qargs[2] = {i, i + 1};
         for (uint32_t j = 0; j < i + 1; j++) {
             qk_circuit_gate(qc, QkGate_CX, qargs, NULL);
         }
     }
+    QkVF2LayoutConfiguration *layout_config = qk_vf2_layout_configuration_new();
+    qk_vf2_layout_configuration_call_limit(layout_config, 10000);
     QkVF2LayoutResult *layout_result =
-        qk_transpiler_pass_standalone_vf2_layout(qc, target, false, -1, 0.0, -1);
+        qk_transpiler_pass_standalone_vf2_layout(qc, target, layout_config, false);
     if (!qk_vf2_layout_result_has_match(layout_result)) {
         printf("No layout was found");
-        result = EqualityError;
-        goto layout_cleanup;
-    }
-    if (qk_vf2_layout_result_num_qubits(layout_result) != qk_circuit_num_qubits(qc)) {
-        printf("Layout doesn't contain the same number of qubits as the circuit, %d != %d",
-               qk_vf2_layout_result_num_qubits(layout_result), qk_circuit_num_qubits(qc));
         result = EqualityError;
         goto layout_cleanup;
     }
@@ -84,7 +80,7 @@ static int test_vf2_layout_line(void) {
     // chose a trivial layout since it's the lowest error rate
     // in mapping these lines together.
     uint32_t expected[5] = {0, 1, 2, 3, 4};
-    for (uint32_t i = 0; i < qk_vf2_layout_result_num_qubits(layout_result); i++) {
+    for (uint32_t i = 0; i < num_qubits; i++) {
         uint32_t phys = qk_vf2_layout_result_map_virtual_qubit(layout_result, i);
         if (phys != expected[i]) {
             printf("Unexpected layout result virtual qubit %d mapped to %d", phys, expected[i]);
@@ -95,8 +91,9 @@ static int test_vf2_layout_line(void) {
 
 layout_cleanup:
     qk_vf2_layout_result_free(layout_result);
+    qk_vf2_layout_configuration_free(layout_config);
     qk_circuit_free(qc);
-cleanup:
+target_cleanup:
     qk_target_free(target);
     return result;
 }
@@ -110,7 +107,7 @@ static int test_vf2_no_layout_found(void) {
     int result = Ok;
     result = build_target(target, num_qubits);
     if (result != Ok) {
-        goto cleanup;
+        goto target_cleanup;
     }
     QkCircuit *qc = qk_circuit_new(5, 0);
     for (uint32_t i = 0; i < qk_circuit_num_qubits(qc); i++) {
@@ -123,7 +120,7 @@ static int test_vf2_no_layout_found(void) {
         }
     }
     QkVF2LayoutResult *layout_result =
-        qk_transpiler_pass_standalone_vf2_layout(qc, target, false, -1, 0.0, -1);
+        qk_transpiler_pass_standalone_vf2_layout(qc, target, NULL, false);
     if (qk_vf2_layout_result_has_match(layout_result)) {
         printf("Unexpected layout found when one shouldn't be possible");
         result = EqualityError;
@@ -132,7 +129,7 @@ static int test_vf2_no_layout_found(void) {
 layout_cleanup:
     qk_vf2_layout_result_free(layout_result);
     qk_circuit_free(qc);
-cleanup:
+target_cleanup:
     qk_target_free(target);
     return result;
 }

--- a/test/c/test_vf2_layout.c
+++ b/test/c/test_vf2_layout.c
@@ -67,7 +67,7 @@ static int test_vf2_layout_line(void) {
         }
     }
     QkVF2LayoutConfiguration *layout_config = qk_vf2_layout_configuration_new();
-    qk_vf2_layout_configuration_call_limit(layout_config, 10000);
+    qk_vf2_layout_configuration_set_call_limit(layout_config, 10000);
     QkVF2LayoutResult *layout_result =
         qk_transpiler_pass_standalone_vf2_layout(qc, target, layout_config, false);
     if (!qk_vf2_layout_result_has_match(layout_result)) {


### PR DESCRIPTION
The configuration of the Rust-space `vf2_layout_pass` is encapsulated into a single struct, and the C API updated to use this form.  This has benefits from C, in that we can modify the configuration, and C can more explicitly update it (since there's no named arguments in C), but also prospective benefits in our own internal Rust code, since it allows simpler configuration sharing between the current `VF2Layout` and the upcoming port of `VF2PostLayout` to Rust.

`strict_direction` and `avg_error_map` are not part of the new `Vf2PassConfiguration` object because they're additional configurations that apply only to the average-heuristic `VF2Layout`, and not `VF2PostLayout` running in strict mode (which is the most "complete" subgraph isomorphism checker).

The abstraction of the result return type is similarly in preparation for `VF2PostLayout`.

