### PR TITLE
Fixed RemoveFinalMeasurement Pass

### DIFF
--- a/releasenotes/notes/fix-remove_final_measurements-pass-c01e16946bd039b5.yaml
+++ b/releasenotes/notes/fix-remove_final_measurements-pass-c01e16946bd039b5.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed an issue where measurements used in control flow operations were incorrectly removed by the `RemoveFinalMeasurements` pass.
+    Refer to `#14319 <https://github.com/Qiskit/qiskit/issues/14319>`for more details.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes the issue #14319 

The RemoveFinalMeasurements pass was incorrectly removing measurements whose results were consumed by subsequent control-flow operations (e.g., if, while_loop etc). These measurements are not truly "final" and are required for correct program execution. 

This fix updates the pass to skip removal of any measurement whose result is used as input to a control-flow gate.


### Details and comments


