### PR TITLE
Run `VF2Layout` benchmarks without max-trials bounds

### DIFF
--- a/test/benchmarks/vf2.py
+++ b/test/benchmarks/vf2.py
@@ -106,17 +106,30 @@ class VF2LayoutSuite:
 
     # Heavy hex stuff.
 
-    def time_heavy_hex_line(self, state: State, num_physical_qubits, directional, line_qubits):
+    def time_heavy_hex_line(
+        self,
+        state: State,
+        num_physical_qubits,
+        directional,
+        line_qubits,
+        call_limit,
+    ):
         pass_ = VF2Layout(
             seed=-1,
             target=state.heavy_hex[num_physical_qubits],
             strict_direction=directional,
-            max_trials=-1,
+            max_trials=0,
+            call_limit=call_limit,
         )
         pass_.run(state.dag["line", line_qubits])
 
-    time_heavy_hex_line.params = ((115, 1081), (False, True), (10, 57))
-    time_heavy_hex_line.param_names = ("num_physical_qubits", "directional", "line_qubits")
+    time_heavy_hex_line.params = ((115, 1081), (False, True), (10, 57), (None, 1_000_000))
+    time_heavy_hex_line.param_names = (
+        "num_physical_qubits",
+        "directional",
+        "line_qubits",
+        "call_limit",
+    )
 
     def time_heavy_hex_trivial(self, state: State, num_physical_qubits):
         pass_ = VF2Layout(
@@ -130,35 +143,42 @@ class VF2LayoutSuite:
     time_heavy_hex_trivial.params = ((57,),)
     time_heavy_hex_trivial.param_names = ("num_physical_qubits",)
 
-    def time_heavy_hex_impossible(self, state: State, num_physical_qubits):
+    def time_heavy_hex_impossible(self, state: State, num_physical_qubits, call_limit):
         pass_ = VF2Layout(
             seed=-1,
             target=state.heavy_hex[num_physical_qubits],
             strict_direction=False,
             max_trials=0,
+            call_limit=call_limit,
         )
         pass_.run(state.dag["line", num_physical_qubits])
 
-    time_heavy_hex_impossible.params = ((57,),)
-    time_heavy_hex_impossible.param_names = ("num_physical_qubits",)
+    time_heavy_hex_impossible.params = ((57,), (None, 1_000_000))
+    time_heavy_hex_impossible.param_names = ("num_physical_qubits", "call_limit")
 
     # Grid stuff.
 
-    def time_grid_line(self, state: State, num_physical_qubits, directional, line_qubits):
+    def time_grid_line(
+        self, state: State, num_physical_qubits, directional, line_qubits, call_limit
+    ):
         pass_ = VF2Layout(
             seed=-1,
             target=state.grid[num_physical_qubits],
             strict_direction=directional,
             max_trials=0,
+            call_limit=call_limit,
         )
         pass_.run(state.dag["line", line_qubits])
 
-    time_grid_line.params = ((121, 256), (False, True), (10, 20))
-    time_grid_line.param_names = ("num_physical_qubits", "directional", "line_qubits")
+    time_grid_line.params = ((121, 256), (False, True), (10, 20), (None, 1_000_000))
+    time_grid_line.param_names = ("num_physical_qubits", "directional", "line_qubits", "call_limit")
 
     def time_grid_trivial(self, state: State, num_physical_qubits):
         pass_ = VF2Layout(
-            seed=-1, target=state.grid[num_physical_qubits], strict_direction=False, max_trials=0
+            seed=-1,
+            target=state.grid[num_physical_qubits],
+            strict_direction=False,
+            max_trials=0,
         )
         pass_.run(state.dag["grid", num_physical_qubits])
 

--- a/test/benchmarks/vf2.py
+++ b/test/benchmarks/vf2.py
@@ -108,7 +108,10 @@ class VF2LayoutSuite:
 
     def time_heavy_hex_line(self, state: State, num_physical_qubits, directional, line_qubits):
         pass_ = VF2Layout(
-            seed=-1, target=state.heavy_hex[num_physical_qubits], strict_direction=directional
+            seed=-1,
+            target=state.heavy_hex[num_physical_qubits],
+            strict_direction=directional,
+            max_trials=-1,
         )
         pass_.run(state.dag["line", line_qubits])
 
@@ -117,7 +120,10 @@ class VF2LayoutSuite:
 
     def time_heavy_hex_trivial(self, state: State, num_physical_qubits):
         pass_ = VF2Layout(
-            seed=-1, target=state.heavy_hex[num_physical_qubits], strict_direction=False
+            seed=-1,
+            target=state.heavy_hex[num_physical_qubits],
+            strict_direction=False,
+            max_trials=0,
         )
         pass_.run(state.dag["heavy hex", num_physical_qubits])
 
@@ -126,7 +132,10 @@ class VF2LayoutSuite:
 
     def time_heavy_hex_impossible(self, state: State, num_physical_qubits):
         pass_ = VF2Layout(
-            seed=-1, target=state.heavy_hex[num_physical_qubits], strict_direction=False
+            seed=-1,
+            target=state.heavy_hex[num_physical_qubits],
+            strict_direction=False,
+            max_trials=0,
         )
         pass_.run(state.dag["line", num_physical_qubits])
 
@@ -137,7 +146,10 @@ class VF2LayoutSuite:
 
     def time_grid_line(self, state: State, num_physical_qubits, directional, line_qubits):
         pass_ = VF2Layout(
-            seed=-1, target=state.grid[num_physical_qubits], strict_direction=directional
+            seed=-1,
+            target=state.grid[num_physical_qubits],
+            strict_direction=directional,
+            max_trials=0,
         )
         pass_.run(state.dag["line", line_qubits])
 
@@ -145,7 +157,9 @@ class VF2LayoutSuite:
     time_grid_line.param_names = ("num_physical_qubits", "directional", "line_qubits")
 
     def time_grid_trivial(self, state: State, num_physical_qubits):
-        pass_ = VF2Layout(seed=-1, target=state.grid[num_physical_qubits], strict_direction=False)
+        pass_ = VF2Layout(
+            seed=-1, target=state.grid[num_physical_qubits], strict_direction=False, max_trials=0
+        )
         pass_.run(state.dag["grid", num_physical_qubits])
 
     time_grid_trivial.params = ((49,),)


### PR DESCRIPTION
The benchmarks were supposed to run completely unbounded, to test the performance against huge minimisation problems.  At the time they were written, a bug was meaning that the default `max_trials=None` meant that the pass ran unbounded, even though that's actually documented as meaning a pretty low bound calculated relative to the input graphs.

Between the benchmarks being written and being merged, the bug was fixed, so on merge, they didn't have the intended effect any more.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

In #14235, Matt found the benchmarks ran really quickly on his machine.  This shouldn't have been possible; the largest test should have involved scoring hundreds of millions of 20q layouts.  The trouble is that I wrote the benchmarks after #14056 but before #14667.