### PR TITLE
Port `ConstrainedReschedule` to Rust

### DIFF
--- a/crates/pyext/src/lib.rs
+++ b/crates/pyext/src/lib.rs
@@ -45,6 +45,7 @@ fn _accelerate(m: &Bound<PyModule>) -> PyResult<()> {
     add_submodule(m, ::qiskit_transpiler::commutation_checker::commutation_checker, "commutation_checker")?;
     add_submodule(m, ::qiskit_transpiler::passes::commutative_optimization_mod, "commutative_optimization")?;
     add_submodule(m, ::qiskit_transpiler::passes::consolidate_blocks_mod, "consolidate_blocks")?;
+    add_submodule(m, ::qiskit_transpiler::passes::constrained_reschedule_mod, "constrained_reschedule")?;
     add_submodule(m, ::qiskit_synthesis::linalg::cos_sin_decomp::cos_sin_decomp, "cos_sin_decomp")?;
     add_submodule(m, ::qiskit_transpiler::passes::dense_layout_mod, "dense_layout")?;
     add_submodule(m, ::qiskit_transpiler::equivalence::equivalence, "equivalence")?;

--- a/crates/transpiler/src/passes/constrained_reschedule.rs
+++ b/crates/transpiler/src/passes/constrained_reschedule.rs
@@ -1,0 +1,112 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use hashbrown::{HashMap, HashSet};
+use crate::TranspilerError;
+use pyo3::prelude::*;
+use pyo3::{pyfunction, wrap_pyfunction, Bound, PyResult, Python};
+use pyo3::types::PyDict;
+use rustworkx_core::petgraph::stable_graph::NodeIndex;
+use qiskit_circuit::dag_circuit::{DAGCircuit,NodeType, Wire};
+use qiskit_circuit::dag_node::DAGOpNode;
+use qiskit_circuit::operations::{Operation, OperationRef, StandardInstruction};
+use qiskit_circuit::Qubit;
+
+fn push_node_back(py: Python, dag: &DAGCircuit, node_index: NodeIndex, node_start_time: &Bound<PyDict>, clbit_write_latency: u64, pulse_align: u64, acquire_align: u64){
+    let op = match dag.dag().node_weight(node_index) {
+             Some(NodeType::Operation(op)) => op,
+             _ => panic!("topological_op_nodes() should only return instances of DagOpNode."),
+         };
+    
+    let op_view=op.op.view();
+    let alignment = match op_view {
+        OperationRef::Gate(_) | OperationRef::StandardGate(_) => Some(pulse_align),
+        OperationRef::StandardInstruction(StandardInstruction::Reset) |
+        OperationRef::StandardInstruction(StandardInstruction::Measure) => Some(acquire_align),
+        OperationRef::StandardInstruction(StandardInstruction::Delay(_)) | _ => None,
+    };
+    let obj = node_start_time.get_item(node_index.index()).unwrap();
+    let mut this_t0: f64 = obj
+        .as_ref()
+        .expect("Expected value in node_start_time for node_index")
+        .extract()
+        .unwrap();
+
+    if let Some(alignment) = alignment {
+        let misalignment = this_t0 % alignment as f64;
+        let shift = if misalignment != 0.0 {
+        (alignment as f64 - misalignment).max(0.0)
+        } else {
+        0.0
+        };
+        this_t0 += shift;
+        node_start_time.set_item(node_index.index(), this_t0).unwrap();
+    }
+
+    //need to continue from here
+    
+
+
+    
+}
+
+#[pyfunction]
+#[pyo3(name="constrained_reschedule", signature=(dag, node_start_time, clbit_write_latency, acquire_align, pulse_align))]
+pub fn run_constrained_reschedule(
+    py: Python,
+    dag: &DAGCircuit,
+    node_start_time: &Bound<PyDict>,
+    clbit_write_latency: u64,
+    acquire_align: u64,
+    pulse_align: u64
+) -> PyResult<Py<PyDict>> {
+    for node_index in dag.topological_op_nodes()? {
+        // Use node_index.index() (usize) as the key for PyDict lookup
+        let start_time= node_start_time.get_item(node_index.index());
+        match start_time {
+            Ok(Some(obj)) => {
+                let val: f64 = obj.extract().map_err(|e| {
+                    TranspilerError::new_err(format!(
+                        "Failed to extract start time for node index {}: {}", node_index.index(), e
+                    ))
+                })?;
+                if val == 0.0 {
+                    continue;
+                }
+                val
+            },
+            Ok(None) => {
+                return Err(TranspilerError::new_err(format!(
+                    "Start time of node at node index {} is not found. This node is likely added after this circuit is scheduled. Run scheduler again.",
+                    node_index.index()
+                )));
+            },
+            Err(e) => {
+                return Err(TranspilerError::new_err(format!(
+                    "PyDict get_item error for node index {}: {}",
+                    node_index.index(), e
+                )));
+            }
+        };
+
+        push_node_back(py, dag, node_index, node_start_time, clbit_write_latency, acquire_align, pulse_align);
+
+
+    }
+    // Return an empty dict for now (replace with actual result as needed)
+    Ok(PyDict::new(py).into())
+}
+
+pub fn constrained_reschedule_mod(m: &Bound<PyModule>) -> PyResult<()> {
+    m.add_wrapped(wrap_pyfunction!(run_constrained_reschedule))?;
+    Ok(())
+}

--- a/crates/transpiler/src/passes/constrained_reschedule.rs
+++ b/crates/transpiler/src/passes/constrained_reschedule.rs
@@ -88,7 +88,7 @@ fn push_node_back(
     if let Some(alignment) = alignment {
         let misalignment = this_t0 % alignment;
         let shift = if misalignment != 0 {
-            (alignment - misalignment).max(0)
+            alignment - misalignment
         } else {
             0
         };

--- a/crates/transpiler/src/passes/constrained_reschedule.rs
+++ b/crates/transpiler/src/passes/constrained_reschedule.rs
@@ -85,7 +85,8 @@ fn push_node_back(
         OperationRef::Gate(_) | OperationRef::StandardGate(_) => Some(pulse_align),
         OperationRef::StandardInstruction(StandardInstruction::Reset)
         | OperationRef::StandardInstruction(StandardInstruction::Measure) => Some(acquire_align),
-        OperationRef::StandardInstruction(StandardInstruction::Delay(_)) | _ => None,
+        OperationRef::StandardInstruction(StandardInstruction::Delay(_)) => None,
+        _ => None,
     };
 
     let obj = node_start_time.get_item(node_index.index())?;

--- a/crates/transpiler/src/passes/constrained_reschedule.rs
+++ b/crates/transpiler/src/passes/constrained_reschedule.rs
@@ -198,7 +198,7 @@ fn push_node_back(
 
         // Compute overlap if there is qubits overlap
         let qreg_overlap = if !this_qubits.is_disjoint(&next_qubits) {
-            (new_t1q - next_t0q).max(0)
+            new_t1q - next_t0q
         } else {
             0
         };
@@ -209,7 +209,7 @@ fn push_node_back(
             && !this_clbits.is_disjoint(&next_clbits)
         {
             if let (Some(t1c), Some(t0c)) = (new_t1c, next_t0c) {
-                (t1c - t0c).max(0)
+                t1c - t0c
             } else {
                 0
             }

--- a/crates/transpiler/src/passes/constrained_reschedule.rs
+++ b/crates/transpiler/src/passes/constrained_reschedule.rs
@@ -4,7 +4,7 @@
 //
 // This code is licensed under the Apache License, Version 2.0. You may
 // obtain a copy of this license in the LICENSE.txt file in the root directory
-// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
 //
 // Any modifications or derivative works of this code must retain this
 // copyright notice, and modified files need to carry a notice indicating

--- a/crates/transpiler/src/passes/constrained_reschedule.rs
+++ b/crates/transpiler/src/passes/constrained_reschedule.rs
@@ -1,6 +1,6 @@
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2025
+// (C) Copyright IBM 2025.
 //
 // This code is licensed under the Apache License, Version 2.0. You may
 // obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -10,100 +10,291 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use hashbrown::{HashMap, HashSet};
 use crate::TranspilerError;
+use crate::target::Target;
+use ::hashbrown::HashSet;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::{pyfunction, wrap_pyfunction, Bound, PyResult, Python};
 use pyo3::types::PyDict;
-use rustworkx_core::petgraph::stable_graph::NodeIndex;
-use qiskit_circuit::dag_circuit::{DAGCircuit,NodeType, Wire};
-use qiskit_circuit::dag_node::DAGOpNode;
+use pyo3::{Bound, PyResult, pyfunction, wrap_pyfunction};
+use qiskit_circuit::PhysicalQubit;
+use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType};
+use qiskit_circuit::operations::Param;
 use qiskit_circuit::operations::{Operation, OperationRef, StandardInstruction};
-use qiskit_circuit::Qubit;
+use rustworkx_core::petgraph::Direction::Outgoing;
+use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
-fn push_node_back(py: Python, dag: &DAGCircuit, node_index: NodeIndex, node_start_time: &Bound<PyDict>, clbit_write_latency: u64, pulse_align: u64, acquire_align: u64){
+/// Returns the immediate successor operation nodes of a given node in the DAG.
+///
+/// This function traverses the DAG to find all nodes that are direct successors
+/// of the given node and filters them to return only operation nodes.
+///
+/// # Arguments
+///
+/// * `dag` - Reference to the DAGCircuit containing the quantum circuit
+/// * `node_index` - Index of the node whose successors we want to find
+///
+/// # Returns
+///
+/// A vector of `NodeIndex` values representing the immediate successor operation nodes.
+fn get_next_gate(dag: &DAGCircuit, node_index: NodeIndex) -> Vec<NodeIndex> {
+    dag.dag()
+        .neighbors_directed(node_index, Outgoing)
+        .filter(|&succ_idx| {
+            matches!(
+                dag.dag().node_weight(succ_idx),
+                Some(NodeType::Operation(_))
+            )
+        })
+        .collect()
+}
+
+/// Update the start time of the current node to satisfy alignment constraints.
+/// Immediate successors are pushed back to avoid overlap and will be processed later.
+///
+/// Note:
+/// This logic assumes that all bits in the qregs and cregs synchronously start and end,
+/// i.e. occupy the same time slot, but qregs and cregs can take different time slots
+/// due to classical I/O latencies.
+///
+/// # Args:
+/// * `py` - Python interpreter reference for PyO3 operations
+/// * `dag` - Reference to the DAGCircuit to be rescheduled with constraints
+/// * `node_index` - Index of the current node to be processed
+/// * `node_start_time` - Mutable Python dictionary mapping node indices to start times
+/// * `clbit_write_latency` - Additional latency for classical bit write operations
+/// * `pulse_align` - Alignment constraint for gate operations (in dt units)
+/// * `acquire_align` - Alignment constraint for measurement/reset operations (in dt units)
+/// * `target` - Optional target backend for duration information
+fn push_node_back(
+    dag: &DAGCircuit,
+    node_index: NodeIndex,
+    node_start_time: &Bound<PyDict>,
+    clbit_write_latency: u64,
+    pulse_align: u64,
+    acquire_align: u64,
+    target: Option<&Target>,
+) -> PyResult<()> {
     let op = match dag.dag().node_weight(node_index) {
-             Some(NodeType::Operation(op)) => op,
-             _ => panic!("topological_op_nodes() should only return instances of DagOpNode."),
-         };
-    
-    let op_view=op.op.view();
+        Some(NodeType::Operation(op)) => op,
+        _ => panic!("topological_op_nodes() should only return instances of DagOpNode."),
+    };
+
+    let op_view = op.op.view();
     let alignment = match op_view {
         OperationRef::Gate(_) | OperationRef::StandardGate(_) => Some(pulse_align),
-        OperationRef::StandardInstruction(StandardInstruction::Reset) |
-        OperationRef::StandardInstruction(StandardInstruction::Measure) => Some(acquire_align),
+        OperationRef::StandardInstruction(StandardInstruction::Reset)
+        | OperationRef::StandardInstruction(StandardInstruction::Measure) => Some(acquire_align),
         OperationRef::StandardInstruction(StandardInstruction::Delay(_)) | _ => None,
     };
-    let obj = node_start_time.get_item(node_index.index()).unwrap();
+
+    let obj = node_start_time.get_item(node_index.index())?;
     let mut this_t0: f64 = obj
         .as_ref()
-        .expect("Expected value in node_start_time for node_index")
-        .extract()
-        .unwrap();
+        .ok_or_else(|| PyValueError::new_err("Missing value in node_start_time"))?
+        .extract()?;
 
     if let Some(alignment) = alignment {
         let misalignment = this_t0 % alignment as f64;
         let shift = if misalignment != 0.0 {
-        (alignment as f64 - misalignment).max(0.0)
+            (alignment as f64 - misalignment).max(0.0)
         } else {
-        0.0
+            0.0
         };
         this_t0 += shift;
-        node_start_time.set_item(node_index.index(), this_t0).unwrap();
+        node_start_time
+            .set_item(node_index.index(), this_t0)
+            .unwrap();
     }
 
-    //need to continue from here
-    
+    let new_t1q = if let Some(target) = target {
+        let qargs: Vec<PhysicalQubit> = dag
+            .qargs_interner()
+            .get(op.qubits)
+            .iter()
+            .map(|q| PhysicalQubit(q.index() as u32))
+            .collect();
+        let duration = target.get_duration(op.op.name(), &qargs).unwrap_or(0.0);
+        this_t0 + duration
+    } else if matches!(
+        op_view,
+        OperationRef::StandardInstruction(StandardInstruction::Delay(_))
+    ) {
+        let duration = if let Some(param) = op.params_view().first() {
+            match param {
+                Param::Obj(val) => {
+                    // Try to extract as different numeric types
+                    val.bind(node_start_time.py())
+                        .extract::<f64>()
+                        .or_else(|_| {
+                            val.bind(node_start_time.py())
+                                .extract::<u32>()
+                                .map(|v| v as f64)
+                        })
+                        .unwrap_or(0.0)
+                }
+                Param::Float(f) => *f,
+                _ => 0.0,
+            }
+        } else {
+            return Err(PyValueError::new_err(format!(
+                "Delay instruction for node {} missing duration parameter",
+                node_index.index()
+            )));
+        };
+        this_t0 + duration
+    } else {
+        this_t0
+    };
 
+    let this_qubits: HashSet<_> = dag
+        .qargs_interner()
+        .get(op.qubits)
+        .iter()
+        .map(|q| q.index())
+        .collect();
 
-    
+    // Handle classical bits based on operation type
+    let (new_t1c, this_clbits) = if matches!(
+        op_view,
+        OperationRef::StandardInstruction(StandardInstruction::Measure)
+            | OperationRef::StandardInstruction(StandardInstruction::Reset)
+    ) {
+        // creg access ends at the end of instruction
+        let new_t1c = Some(new_t1q);
+        let this_clbits: HashSet<_> = dag
+            .cargs_interner()
+            .get(op.clbits)
+            .iter()
+            .map(|c| c.index())
+            .collect();
+        (new_t1c, this_clbits)
+    } else {
+        (None, HashSet::new())
+    };
+    // Check immediate successors for overlap
+    for next_node_index in get_next_gate(dag, node_index) {
+        // Get the next node
+        let next_node = match dag.dag().node_weight(next_node_index) {
+            Some(NodeType::Operation(op)) => op,
+            _ => continue, // Skip non-operation nodes
+        };
+
+        // Compute next node start time separately for qreg and creg
+        let next_t0q_obj = node_start_time.get_item(next_node_index.index())?;
+        let next_t0q: f64 = next_t0q_obj
+            .as_ref()
+            .expect("Expected value in node_start_time for next_node_index")
+            .extract()?;
+
+        let next_qubits: HashSet<_> = dag
+            .qargs_interner()
+            .get(next_node.qubits)
+            .iter()
+            .map(|q| q.index())
+            .collect();
+
+        let next_op_view = next_node.op.view();
+        let (next_t0c, next_clbits) = if matches!(
+            next_op_view,
+            OperationRef::StandardInstruction(StandardInstruction::Measure)
+                | OperationRef::StandardInstruction(StandardInstruction::Reset)
+        ) {
+            // creg access starts after write latency
+            let next_t0c = Some(next_t0q + clbit_write_latency as f64);
+            let next_clbits: HashSet<_> = dag
+                .cargs_interner()
+                .get(next_node.clbits)
+                .iter()
+                .map(|c| c.index())
+                .collect();
+            (next_t0c, next_clbits)
+        } else {
+            (None, HashSet::new())
+        };
+
+        // Compute overlap if there is qubits overlap
+        let qreg_overlap = if !this_qubits.is_disjoint(&next_qubits) {
+            (new_t1q - next_t0q).max(0.0)
+        } else {
+            0.0
+        };
+
+        // Compute overlap if there is clbits overlap
+        let creg_overlap = if !this_clbits.is_empty()
+            && !next_clbits.is_empty()
+            && !this_clbits.is_disjoint(&next_clbits)
+        {
+            if let (Some(t1c), Some(t0c)) = (new_t1c, next_t0c) {
+                (t1c - t0c).max(0.0)
+            } else {
+                0.0
+            }
+        } else {
+            0.0
+        };
+
+        // Shift next node if there is finite overlap in either qubits or clbits
+        let overlap = qreg_overlap.max(creg_overlap);
+        if overlap > 0.0 {
+            let new_start_time = next_t0q + overlap;
+            node_start_time.set_item(next_node_index.index(), new_start_time)?;
+        }
+    }
+    Ok(())
 }
 
 #[pyfunction]
-#[pyo3(name="constrained_reschedule", signature=(dag, node_start_time, clbit_write_latency, acquire_align, pulse_align))]
+#[pyo3(name="constrained_reschedule", signature=(dag, node_start_time, clbit_write_latency, acquire_align, pulse_align, target))]
 pub fn run_constrained_reschedule(
-    py: Python,
     dag: &DAGCircuit,
     node_start_time: &Bound<PyDict>,
     clbit_write_latency: u64,
     acquire_align: u64,
-    pulse_align: u64
+    pulse_align: u64,
+    target: Option<&Target>,
 ) -> PyResult<Py<PyDict>> {
-    for node_index in dag.topological_op_nodes()? {
-        // Use node_index.index() (usize) as the key for PyDict lookup
-        let start_time= node_start_time.get_item(node_index.index());
-        match start_time {
-            Ok(Some(obj)) => {
-                let val: f64 = obj.extract().map_err(|e| {
-                    TranspilerError::new_err(format!(
-                        "Failed to extract start time for node index {}: {}", node_index.index(), e
-                    ))
-                })?;
-                if val == 0.0 {
-                    continue;
-                }
-                val
-            },
-            Ok(None) => {
-                return Err(TranspilerError::new_err(format!(
-                    "Start time of node at node index {} is not found. This node is likely added after this circuit is scheduled. Run scheduler again.",
+    for node_index in dag.topological_op_nodes(false) {
+        let start_time = node_start_time.get_item(node_index.index());
+        let val = start_time
+            .map_err(|e| {
+                TranspilerError::new_err(format!(
+                    "PyDict error for node {}: {}",
+                    node_index.index(),
+                    e
+                ))
+            })?
+            .ok_or_else(|| {
+                TranspilerError::new_err(format!(
+                    "Missing start time for node {}. Run scheduler again.",
                     node_index.index()
-                )));
-            },
-            Err(e) => {
-                return Err(TranspilerError::new_err(format!(
-                    "PyDict get_item error for node index {}: {}",
-                    node_index.index(), e
-                )));
-            }
-        };
+                ))
+            })?
+            .extract::<f64>()
+            .map_err(|e| {
+                TranspilerError::new_err(format!(
+                    "Extract error for node {}: {}",
+                    node_index.index(),
+                    e
+                ))
+            })?;
 
-        push_node_back(py, dag, node_index, node_start_time, clbit_write_latency, acquire_align, pulse_align);
+        if val == 0.0 {
+            continue;
+        }
 
-
+        push_node_back(
+            dag,
+            node_index,
+            node_start_time,
+            clbit_write_latency,
+            acquire_align,
+            pulse_align,
+            target,
+        )?;
     }
-    // Return an empty dict for now (replace with actual result as needed)
-    Ok(PyDict::new(py).into())
+
+    Ok(node_start_time.clone().into())
 }
 
 pub fn constrained_reschedule_mod(m: &Bound<PyModule>) -> PyResult<()> {

--- a/crates/transpiler/src/passes/constrained_reschedule.rs
+++ b/crates/transpiler/src/passes/constrained_reschedule.rs
@@ -11,11 +11,13 @@
 // that they have been altered from the originals.
 
 use crate::TranspilerError;
+use crate::passes::schedule_analysis::{NodeDurations, PyNodeDurations};
 use crate::target::Target;
 use ::hashbrown::HashSet;
+use ahash::RandomState;
+use indexmap::IndexMap;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
 use pyo3::{Bound, PyResult, pyfunction, wrap_pyfunction};
 use qiskit_circuit::PhysicalQubit;
 use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType};
@@ -61,7 +63,7 @@ fn get_next_gate(dag: &DAGCircuit, node_index: NodeIndex) -> impl Iterator<Item 
 fn push_node_back(
     dag: &DAGCircuit,
     node_index: NodeIndex,
-    node_start_time: &Bound<PyDict>,
+    node_start_time: &mut IndexMap<NodeIndex<u32>, u64, RandomState>,
     clbit_write_latency: u32,
     pulse_align: u32,
     acquire_align: u32,
@@ -79,23 +81,22 @@ fn push_node_back(
         _ => None,
     };
 
-    let obj = node_start_time.get_item(node_index.index())?;
-    let mut this_t0: u32 = obj
-        .as_ref()
-        .ok_or_else(|| PyValueError::new_err("Missing value in node_start_time"))?
-        .extract()?;
+    let mut this_t0: u64 = *node_start_time
+        .get(&node_index)
+        .ok_or_else(|| PyValueError::new_err("Missing value in node_start_time"))?;
 
     if let Some(alignment) = alignment {
-        let misalignment = this_t0 % alignment;
+        let misalignment = this_t0 % alignment as u64;
         let shift = if misalignment != 0 {
-            alignment - misalignment
+            alignment as u64 - misalignment
         } else {
             0
         };
-        this_t0 += shift;
+        this_t0 += shift as u64;
         node_start_time
-            .set_item(node_index.index(), this_t0)
-            .unwrap();
+            .entry(node_index)
+            .and_modify(|old_t0| *old_t0 = this_t0)
+            .or_insert(this_t0);
     }
 
     let new_t1q = if let Some(target) = target {
@@ -106,7 +107,7 @@ fn push_node_back(
             .map(|q| PhysicalQubit(q.index() as u32))
             .collect();
         let duration = target.get_duration(op.op.name(), &qargs).unwrap_or(0.0);
-        this_t0 + duration as u32
+        this_t0 + duration as u64
     } else if matches!(
         op_view,
         OperationRef::StandardInstruction(StandardInstruction::Delay(_))
@@ -118,9 +119,9 @@ fn push_node_back(
         let duration = match param {
             Param::Obj(val) => {
                 // Try to extract as different numeric types
-                val.bind(node_start_time.py()).extract::<u32>()
+                Python::attach(|py| val.bind(py).extract::<u64>())
             }
-            Param::Float(f) => Ok(*f as u32),
+            Param::Float(f) => Ok(*f as u64),
             _ => Err(TranspilerError::new_err(
                 "The provided Delay duration is not in terms of dt.",
             )),
@@ -164,11 +165,10 @@ fn push_node_back(
         };
 
         // Compute next node start time separately for qreg and creg
-        let next_t0q_obj = node_start_time.get_item(next_node_index.index())?;
-        let next_t0q: u32 = next_t0q_obj
-            .as_ref()
-            .expect("Expected value in node_start_time for next_node_index")
-            .extract()?;
+        let next_t0q: u64 = node_start_time
+            .get(&next_node_index)
+            .copied()
+            .expect("Expected value in node_start_time for next_node_index");
 
         let next_qubits: HashSet<_> = dag
             .qargs_interner()
@@ -184,7 +184,7 @@ fn push_node_back(
                 | OperationRef::StandardInstruction(StandardInstruction::Reset)
         ) {
             // creg access starts after write latency
-            let next_t0c = Some(next_t0q + clbit_write_latency);
+            let next_t0c = Some(next_t0q + clbit_write_latency as u64);
             let next_clbits: HashSet<_> = dag
                 .cargs_interner()
                 .get(next_node.clbits)
@@ -221,7 +221,10 @@ fn push_node_back(
         let overlap = qreg_overlap.max(creg_overlap);
         if overlap > 0 {
             let new_start_time = next_t0q + overlap;
-            node_start_time.set_item(next_node_index.index(), new_start_time)?;
+            node_start_time
+                .entry(next_node_index)
+                .and_modify(|old_start| *old_start = new_start_time)
+                .or_insert(new_start_time);
         }
     }
     Ok(())
@@ -229,38 +232,46 @@ fn push_node_back(
 
 #[pyfunction]
 #[pyo3(name="constrained_reschedule", signature=(dag, node_start_time, clbit_write_latency, acquire_align, pulse_align, target))]
-pub fn run_constrained_reschedule(
+pub fn py_run_constrained_reschedule(
     dag: &DAGCircuit,
-    node_start_time: &Bound<PyDict>,
+    mut node_start_time: PyNodeDurations,
     clbit_write_latency: u32,
     acquire_align: u32,
     pulse_align: u32,
     target: Option<&Target>,
-) -> PyResult<Py<PyDict>> {
+) -> PyResult<PyNodeDurations> {
+    let NodeDurations::Dt(durations) = &mut *node_start_time else {
+        return Err(TranspilerError::new_err(
+            "The durations provided have not been properly converted to 'dt' units.",
+        ));
+    };
+    run_constrained_reschedule(
+        dag,
+        durations,
+        clbit_write_latency,
+        acquire_align,
+        pulse_align,
+        target,
+    )?;
+    Ok(node_start_time)
+}
+
+pub fn run_constrained_reschedule(
+    dag: &DAGCircuit,
+    node_start_time: &mut IndexMap<NodeIndex<u32>, u64, RandomState>,
+    clbit_write_latency: u32,
+    acquire_align: u32,
+    pulse_align: u32,
+    target: Option<&Target>,
+) -> PyResult<()> {
     for node_index in dag.topological_op_nodes(false) {
-        let start_time = node_start_time.get_item(node_index.index());
-        let val = start_time
-            .map_err(|e| {
-                TranspilerError::new_err(format!(
-                    "PyDict error for node {}: {}",
-                    node_index.index(),
-                    e
-                ))
-            })?
-            .ok_or_else(|| {
-                TranspilerError::new_err(format!(
-                    "Missing start time for node {}. Run scheduler again.",
-                    node_index.index()
-                ))
-            })?
-            .extract::<u32>()
-            .map_err(|e| {
-                TranspilerError::new_err(format!(
-                    "Extract error for node {}: {}",
-                    node_index.index(),
-                    e
-                ))
-            })?;
+        let start_time = node_start_time.get(&node_index);
+        let val = *start_time.ok_or_else(|| {
+            TranspilerError::new_err(format!(
+                "Missing start time for node {}. Run scheduler again.",
+                node_index.index()
+            ))
+        })?;
 
         if val == 0 {
             continue;
@@ -277,10 +288,10 @@ pub fn run_constrained_reschedule(
         )?;
     }
 
-    Ok(node_start_time.clone().into())
+    Ok(())
 }
 
 pub fn constrained_reschedule_mod(m: &Bound<PyModule>) -> PyResult<()> {
-    m.add_wrapped(wrap_pyfunction!(run_constrained_reschedule))?;
+    m.add_wrapped(wrap_pyfunction!(py_run_constrained_reschedule))?;
     Ok(())
 }

--- a/crates/transpiler/src/passes/constrained_reschedule.rs
+++ b/crates/transpiler/src/passes/constrained_reschedule.rs
@@ -78,7 +78,17 @@ fn push_node_back(
         OperationRef::Gate(_) | OperationRef::StandardGate(_) => Some(pulse_align),
         OperationRef::StandardInstruction(StandardInstruction::Reset)
         | OperationRef::StandardInstruction(StandardInstruction::Measure) => Some(acquire_align),
-        _ => None,
+        OperationRef::StandardInstruction(StandardInstruction::Delay(_)) => None,
+        _ => {
+            if !op_view.directive() {
+                None
+            } else {
+                return Err(TranspilerError::new_err(format!(
+                    "Unknown operation type for '{}'.",
+                    op_view.name()
+                )));
+            }
+        }
     };
 
     let mut this_t0: u64 = *node_start_time
@@ -88,7 +98,7 @@ fn push_node_back(
     if let Some(alignment) = alignment {
         let misalignment = this_t0 % alignment as u64;
         let shift = if misalignment != 0 {
-            alignment as u64 - misalignment
+            (alignment as u64).saturating_sub(misalignment)
         } else {
             0
         };

--- a/crates/transpiler/src/passes/constrained_reschedule.rs
+++ b/crates/transpiler/src/passes/constrained_reschedule.rs
@@ -21,7 +21,6 @@ use qiskit_circuit::PhysicalQubit;
 use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType};
 use qiskit_circuit::operations::Param;
 use qiskit_circuit::operations::{Operation, OperationRef, StandardInstruction};
-use rustworkx_core::petgraph::Direction::Outgoing;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
 /// Returns the immediate successor operation nodes of a given node in the DAG.
@@ -36,17 +35,10 @@ use rustworkx_core::petgraph::stable_graph::NodeIndex;
 ///
 /// # Returns
 ///
-/// A vector of `NodeIndex` values representing the immediate successor operation nodes.
-fn get_next_gate(dag: &DAGCircuit, node_index: NodeIndex) -> Vec<NodeIndex> {
-    dag.dag()
-        .neighbors_directed(node_index, Outgoing)
-        .filter(|&succ_idx| {
-            matches!(
-                dag.dag().node_weight(succ_idx),
-                Some(NodeType::Operation(_))
-            )
-        })
-        .collect()
+/// An iterator of `NodeIndex` values representing the immediate successor operation nodes.
+fn get_next_gate(dag: &DAGCircuit, node_index: NodeIndex) -> impl Iterator<Item = NodeIndex> + '_ {
+    dag.quantum_successors(node_index)
+        .filter(|&idx| matches!(dag[idx], NodeType::Operation(_)))
 }
 
 /// Update the start time of the current node to satisfy alignment constraints.
@@ -70,14 +62,13 @@ fn push_node_back(
     dag: &DAGCircuit,
     node_index: NodeIndex,
     node_start_time: &Bound<PyDict>,
-    clbit_write_latency: u64,
-    pulse_align: u64,
-    acquire_align: u64,
+    clbit_write_latency: u32,
+    pulse_align: u32,
+    acquire_align: u32,
     target: Option<&Target>,
 ) -> PyResult<()> {
-    let op = match dag.dag().node_weight(node_index) {
-        Some(NodeType::Operation(op)) => op,
-        _ => panic!("topological_op_nodes() should only return instances of DagOpNode."),
+    let NodeType::Operation(op) = &dag[node_index] else {
+        unreachable!("topological_op_nodes() should only return operations.")
     };
 
     let op_view = op.op.view();
@@ -85,22 +76,21 @@ fn push_node_back(
         OperationRef::Gate(_) | OperationRef::StandardGate(_) => Some(pulse_align),
         OperationRef::StandardInstruction(StandardInstruction::Reset)
         | OperationRef::StandardInstruction(StandardInstruction::Measure) => Some(acquire_align),
-        OperationRef::StandardInstruction(StandardInstruction::Delay(_)) => None,
         _ => None,
     };
 
     let obj = node_start_time.get_item(node_index.index())?;
-    let mut this_t0: f64 = obj
+    let mut this_t0: u32 = obj
         .as_ref()
         .ok_or_else(|| PyValueError::new_err("Missing value in node_start_time"))?
         .extract()?;
 
     if let Some(alignment) = alignment {
-        let misalignment = this_t0 % alignment as f64;
-        let shift = if misalignment != 0.0 {
-            (alignment as f64 - misalignment).max(0.0)
+        let misalignment = this_t0 % alignment;
+        let shift = if misalignment != 0 {
+            (alignment - misalignment).max(0)
         } else {
-            0.0
+            0
         };
         this_t0 += shift;
         node_start_time
@@ -116,33 +106,26 @@ fn push_node_back(
             .map(|q| PhysicalQubit(q.index() as u32))
             .collect();
         let duration = target.get_duration(op.op.name(), &qargs).unwrap_or(0.0);
-        this_t0 + duration
+        this_t0 + duration as u32
     } else if matches!(
         op_view,
         OperationRef::StandardInstruction(StandardInstruction::Delay(_))
     ) {
-        let duration = if let Some(param) = op.params_view().first() {
-            match param {
-                Param::Obj(val) => {
-                    // Try to extract as different numeric types
-                    val.bind(node_start_time.py())
-                        .extract::<f64>()
-                        .or_else(|_| {
-                            val.bind(node_start_time.py())
-                                .extract::<u32>()
-                                .map(|v| v as f64)
-                        })
-                        .unwrap_or(0.0)
-                }
-                Param::Float(f) => *f,
-                _ => 0.0,
+        let params = op.params_view();
+        let param = params
+            .first()
+            .ok_or_else(|| PyValueError::new_err("Delay instruction missing duration parameter"))?;
+        let duration = match param {
+            Param::Obj(val) => {
+                // Try to extract as different numeric types
+                val.bind(node_start_time.py()).extract::<u32>()
             }
-        } else {
-            return Err(PyValueError::new_err(format!(
-                "Delay instruction for node {} missing duration parameter",
-                node_index.index()
-            )));
-        };
+            Param::Float(f) => Ok(*f as u32),
+            _ => Err(TranspilerError::new_err(
+                "The provided Delay duration is not in terms of dt.",
+            )),
+        }?;
+
         this_t0 + duration
     } else {
         this_t0
@@ -176,14 +159,13 @@ fn push_node_back(
     // Check immediate successors for overlap
     for next_node_index in get_next_gate(dag, node_index) {
         // Get the next node
-        let next_node = match dag.dag().node_weight(next_node_index) {
-            Some(NodeType::Operation(op)) => op,
-            _ => continue, // Skip non-operation nodes
+        let NodeType::Operation(next_node) = &dag[next_node_index] else {
+            unreachable!("topological_op_nodes() should only return operations.")
         };
 
         // Compute next node start time separately for qreg and creg
         let next_t0q_obj = node_start_time.get_item(next_node_index.index())?;
-        let next_t0q: f64 = next_t0q_obj
+        let next_t0q: u32 = next_t0q_obj
             .as_ref()
             .expect("Expected value in node_start_time for next_node_index")
             .extract()?;
@@ -202,7 +184,7 @@ fn push_node_back(
                 | OperationRef::StandardInstruction(StandardInstruction::Reset)
         ) {
             // creg access starts after write latency
-            let next_t0c = Some(next_t0q + clbit_write_latency as f64);
+            let next_t0c = Some(next_t0q + clbit_write_latency);
             let next_clbits: HashSet<_> = dag
                 .cargs_interner()
                 .get(next_node.clbits)
@@ -216,9 +198,9 @@ fn push_node_back(
 
         // Compute overlap if there is qubits overlap
         let qreg_overlap = if !this_qubits.is_disjoint(&next_qubits) {
-            (new_t1q - next_t0q).max(0.0)
+            (new_t1q - next_t0q).max(0)
         } else {
-            0.0
+            0
         };
 
         // Compute overlap if there is clbits overlap
@@ -227,17 +209,17 @@ fn push_node_back(
             && !this_clbits.is_disjoint(&next_clbits)
         {
             if let (Some(t1c), Some(t0c)) = (new_t1c, next_t0c) {
-                (t1c - t0c).max(0.0)
+                (t1c - t0c).max(0)
             } else {
-                0.0
+                0
             }
         } else {
-            0.0
+            0
         };
 
         // Shift next node if there is finite overlap in either qubits or clbits
         let overlap = qreg_overlap.max(creg_overlap);
-        if overlap > 0.0 {
+        if overlap > 0 {
             let new_start_time = next_t0q + overlap;
             node_start_time.set_item(next_node_index.index(), new_start_time)?;
         }
@@ -250,9 +232,9 @@ fn push_node_back(
 pub fn run_constrained_reschedule(
     dag: &DAGCircuit,
     node_start_time: &Bound<PyDict>,
-    clbit_write_latency: u64,
-    acquire_align: u64,
-    pulse_align: u64,
+    clbit_write_latency: u32,
+    acquire_align: u32,
+    pulse_align: u32,
     target: Option<&Target>,
 ) -> PyResult<Py<PyDict>> {
     for node_index in dag.topological_op_nodes(false) {
@@ -271,7 +253,7 @@ pub fn run_constrained_reschedule(
                     node_index.index()
                 ))
             })?
-            .extract::<f64>()
+            .extract::<u32>()
             .map_err(|e| {
                 TranspilerError::new_err(format!(
                     "Extract error for node {}: {}",
@@ -280,7 +262,7 @@ pub fn run_constrained_reschedule(
                 ))
             })?;
 
-        if val == 0.0 {
+        if val == 0 {
             continue;
         }
 

--- a/crates/transpiler/src/passes/constrained_reschedule.rs
+++ b/crates/transpiler/src/passes/constrained_reschedule.rs
@@ -92,7 +92,7 @@ fn push_node_back(
         } else {
             0
         };
-        this_t0 += shift as u64;
+        this_t0 += shift;
         node_start_time
             .entry(node_index)
             .and_modify(|old_t0| *old_t0 = this_t0)

--- a/crates/transpiler/src/passes/mod.rs
+++ b/crates/transpiler/src/passes/mod.rs
@@ -29,6 +29,7 @@ mod commutation_analysis;
 mod commutation_cancellation;
 mod commutative_optimization;
 mod consolidate_blocks;
+mod constrained_reschedule;
 mod convert_to_pauli_rotations;
 mod dense_layout;
 mod disjoint_layout;
@@ -64,6 +65,7 @@ pub use commutation_analysis::{analyze_commutations, commutation_analysis_mod};
 pub use commutation_cancellation::{cancel_commutations, commutation_cancellation_mod};
 pub use commutative_optimization::{commutative_optimization_mod, run_commutative_optimization};
 pub use consolidate_blocks::{DecomposerType, consolidate_blocks_mod, run_consolidate_blocks};
+pub use constrained_reschedule::{constrained_reschedule_mod, run_constrained_reschedule};
 pub use convert_to_pauli_rotations::{
     convert_to_pauli_rotations_mod, py_convert_to_pauli_rotations,
 };

--- a/crates/transpiler/src/passes/schedule_analysis/mod.rs
+++ b/crates/transpiler/src/passes/schedule_analysis/mod.rs
@@ -13,7 +13,9 @@
 pub mod alap_schedule_analysis;
 pub mod asap_schedule_analysis;
 
-use std::ops::{Add, Deref, Sub};
+use std::ops::{
+    Add, AddAssign, Deref, DerefMut, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Sub, SubAssign,
+};
 
 use ahash::RandomState;
 use hashbrown::HashMap;
@@ -32,7 +34,38 @@ use rustworkx_core::petgraph::graph::NodeIndex;
 
 use crate::TranspilerError;
 
-pub trait TimeOps: Copy + PartialOrd + Add<Output = Self> + Sub<Output = Self> {
+pub trait Number:
+    Copy
+    + Add<Output = Self>
+    + Sub<Output = Self>
+    + Mul<Output = Self>
+    + Div<Output = Self>
+    + Rem<Output = Self>
+    + AddAssign
+    + SubAssign
+    + MulAssign
+    + DivAssign
+    + RemAssign
+{
+}
+
+impl<
+    T: Copy
+        + Add<Output = Self>
+        + Sub<Output = Self>
+        + Mul<Output = Self>
+        + Div<Output = Self>
+        + Rem<Output = Self>
+        + AddAssign
+        + SubAssign
+        + MulAssign
+        + DivAssign
+        + RemAssign,
+> Number for T
+{
+}
+
+pub trait TimeOps: Copy + PartialOrd + Number {
     fn zero() -> Self;
     fn max<'a>(a: &'a Self, b: &'a Self) -> &'a Self;
 }
@@ -74,6 +107,12 @@ impl Deref for PyNodeDurations {
 
     fn deref(&self) -> &Self::Target {
         &self.inner
+    }
+}
+
+impl DerefMut for PyNodeDurations {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
     }
 }
 

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -110,6 +110,7 @@ sys.modules["qiskit._accelerate.commutation_analysis"] = _accelerate.commutation
 sys.modules["qiskit._accelerate.commutation_cancellation"] = _accelerate.commutation_cancellation
 sys.modules["qiskit._accelerate.commutative_optimization"] = _accelerate.commutative_optimization
 sys.modules["qiskit._accelerate.consolidate_blocks"] = _accelerate.consolidate_blocks
+sys.modules["qiskit._accelerate.constrained_reschedule"] = _accelerate.constrained_reschedule
 sys.modules["qiskit._accelerate.synthesis.linear_phase"] = _accelerate.synthesis.linear_phase
 sys.modules["qiskit._accelerate.synthesis.evolution"] = _accelerate.synthesis.evolution
 sys.modules["qiskit._accelerate.synthesis.discrete_basis"] = _accelerate.synthesis.discrete_basis

--- a/qiskit/transpiler/passes/scheduling/alignments/reschedule.py
+++ b/qiskit/transpiler/passes/scheduling/alignments/reschedule.py
@@ -22,6 +22,7 @@ from qiskit.dagcircuit import DAGCircuit, DAGOpNode, DAGOutNode
 from qiskit.transpiler.basepasses import AnalysisPass
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.target import Target
+from qiskit._accelerate import constrained_reschedule
 
 
 class ConstrainedReschedule(AnalysisPass):
@@ -233,19 +234,8 @@ class ConstrainedReschedule(AnalysisPass):
             )
 
         node_start_time = self.property_set["node_start_time"]
+        clbit_write_latency = self.property_set.get("clbit_write_latency", 0)
 
-        for node in dag.topological_op_nodes():
+        constrained_reschedule(dag, node_start_time, clbit_write_latency, self.acquire_align, self.pulse_align)
 
-            start_time = node_start_time.get(node)
-
-            if start_time is None:
-                raise TranspilerError(
-                    f"Start time of {node!r} is not found. This node is likely added after "
-                    "this circuit is scheduled. Run scheduler again."
-                )
-
-            if start_time == 0:
-                # Every instruction can start at t=0.
-                continue
-
-            self._push_node_back(dag, node)
+        

--- a/qiskit/transpiler/passes/scheduling/alignments/reschedule.py
+++ b/qiskit/transpiler/passes/scheduling/alignments/reschedule.py
@@ -12,13 +12,7 @@
 
 """Rescheduler pass to adjust node start times."""
 from __future__ import annotations
-from collections.abc import Generator
-
-from qiskit.circuit.gate import Gate
-from qiskit.circuit.delay import Delay
-from qiskit.circuit.measure import Measure
-from qiskit.circuit.reset import Reset
-from qiskit.dagcircuit import DAGCircuit, DAGOpNode, DAGOutNode
+from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import AnalysisPass
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.target import Target
@@ -90,107 +84,6 @@ class ConstrainedReschedule(AnalysisPass):
             self.acquire_align = target.acquire_alignment
             self.pulse_align = target.pulse_alignment
 
-    @classmethod
-    def _get_next_gate(cls, dag: DAGCircuit, node: DAGOpNode) -> Generator[DAGOpNode, None, None]:
-        """Get next non-delay nodes.
-
-        Args:
-            dag: DAG circuit to be rescheduled with constraints.
-            node: Current node.
-
-        Returns:
-            A list of non-delay successors.
-        """
-        for next_node in dag.successors(node):
-            if not isinstance(next_node, DAGOutNode):
-                yield next_node
-
-    def _push_node_back(self, dag: DAGCircuit, node: DAGOpNode):
-        """Update the start time of the current node to satisfy alignment constraints.
-        Immediate successors are pushed back to avoid overlap and will be processed later.
-
-        .. note::
-
-            This logic assumes the all bits in the qregs and cregs synchronously start and end,
-            i.e. occupy the same time slot, but qregs and cregs can take
-            different time slot due to classical I/O latencies.
-
-        Args:
-            dag: DAG circuit to be rescheduled with constraints.
-            node: Current node.
-        """
-        node_start_time = self.property_set["node_start_time"]
-        clbit_write_latency = self.property_set.get("clbit_write_latency", 0)
-
-        if isinstance(node.op, Gate):
-            alignment = self.pulse_align
-        elif isinstance(node.op, (Measure, Reset)):
-            alignment = self.acquire_align
-        elif isinstance(node.op, Delay) or getattr(node.op, "_directive", False):
-            # Directive or delay. These can start at arbitrary time.
-            alignment = None
-        else:
-            raise TranspilerError(f"Unknown operation type for {node!r}.")
-
-        this_t0 = node_start_time[node]
-
-        if alignment is not None:
-            misalignment = node_start_time[node] % alignment
-            if misalignment != 0:
-                shift = max(0, alignment - misalignment)
-            else:
-                shift = 0
-            this_t0 += shift
-            node_start_time[node] = this_t0
-
-        # Compute shifted t1 of this node separately for qreg and creg
-        if self.target is not None:
-            try:
-                duration = self.durations.get(node.op, [dag.find_bit(x).index for x in node.qargs])
-            except TranspilerError:
-                duration = 0
-            new_t1q = this_t0 + duration
-
-        elif node.name == "delay":
-            new_t1q = this_t0 + node.op.duration
-        else:
-            new_t1q = this_t0
-        this_qubits = set(node.qargs)
-        if isinstance(node.op, (Measure, Reset)):
-            # creg access ends at the end of instruction
-            new_t1c = new_t1q
-            this_clbits = set(node.cargs)
-        else:
-            new_t1c = None
-            this_clbits = set()
-
-        # Check immediate successors for overlap
-        for next_node in self._get_next_gate(dag, node):
-            # Compute next node start time separately for qreg and creg
-            next_t0q = node_start_time[next_node]
-            next_qubits = set(next_node.qargs)
-            if isinstance(next_node.op, (Measure, Reset)):
-                # creg access starts after write latency
-                next_t0c = next_t0q + clbit_write_latency
-                next_clbits = set(next_node.cargs)
-            else:
-                next_t0c = None
-                next_clbits = set()
-            # Compute overlap if there is qubits overlap
-            if any(this_qubits & next_qubits):
-                qreg_overlap = new_t1q - next_t0q
-            else:
-                qreg_overlap = 0
-            # Compute overlap if there is clbits overlap
-            if any(this_clbits & next_clbits):
-                creg_overlap = new_t1c - next_t0c
-            else:
-                creg_overlap = 0
-
-            # Shift next node if there is finite overlap in either in qubits or clbits
-            overlap = max(qreg_overlap, creg_overlap)
-            node_start_time[next_node] = node_start_time[next_node] + overlap
-
     def run(self, dag: DAGCircuit):
         """Run rescheduler.
 
@@ -235,7 +128,11 @@ class ConstrainedReschedule(AnalysisPass):
 
         node_start_time = self.property_set["node_start_time"]
         clbit_write_latency = self.property_set.get("clbit_write_latency", 0)
-
-        constrained_reschedule(dag, node_start_time, clbit_write_latency, self.acquire_align, self.pulse_align)
-
-        
+        constrained_reschedule(
+            dag,
+            node_start_time,
+            clbit_write_latency,
+            self.acquire_align,
+            self.pulse_align,
+            self.target,
+        )

--- a/qiskit/transpiler/passes/scheduling/alignments/reschedule.py
+++ b/qiskit/transpiler/passes/scheduling/alignments/reschedule.py
@@ -16,7 +16,7 @@ from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import AnalysisPass
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.target import Target
-from qiskit._accelerate import constrained_reschedule
+from qiskit._accelerate.constrained_reschedule import constrained_reschedule
 
 
 class ConstrainedReschedule(AnalysisPass):
@@ -125,10 +125,9 @@ class ConstrainedReschedule(AnalysisPass):
                 f"The input circuit {dag.name} is not scheduled. Call one of scheduling passes "
                 f"before running the {self.__class__.__name__} pass."
             )
-
         node_start_time = self.property_set["node_start_time"]
         clbit_write_latency = self.property_set.get("clbit_write_latency", 0)
-        constrained_reschedule(
+        self.property_set["node_start_time"] = constrained_reschedule(
             dag,
             node_start_time,
             clbit_write_latency,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Rebased on top of #15276

This PR ports the `ConstrainedReschedule` pass to Rust, preserving the original logic and maintaining identical user-facing behavior.

Since the pass assumes it is receiving its durations in terms of `dt`, it will now print an error back to Python asking to provide the durations in the correct terms.

### Details and comments
Fixes #12268 


