### PR TITLE
Fix memory leaks in `qk_circuit_get_instruction`.

### DIFF
--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -909,6 +909,10 @@ pub unsafe extern "C" fn qk_circuit_get_instruction(
             .collect();
         params_vec.into_boxed_slice()
     };
+    // These lists (e.g. 'qargs') are Box<[T]>, so we use .as_mut_ptr()
+    // to get a mutable pointer to the underlying slice/array on
+    // the heap and Box::into_raw() to consume the Box without freeing
+    // it (so the underlying array doesn't get freed when we return)
     let out_qargs = qargs.as_mut_ptr();
     let out_qargs_len = qargs.len() as u32;
     let _ = Box::into_raw(qargs);
@@ -965,10 +969,6 @@ pub unsafe extern "C" fn qk_circuit_get_instruction(
 #[no_mangle]
 #[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_instruction_clear(inst: *mut CInstruction) {
-    if inst.is_null() {
-        return;
-    }
-
     // SAFETY: Loading the data from pointers contained in a CInstruction. These should only be
     // created by rust code and are constructed from Vecs internally or CStrings.
     unsafe {

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -829,7 +829,7 @@ pub unsafe extern "C" fn qk_circuit_num_instructions(circuit: *const CircuitData
 #[repr(C)]
 pub struct CInstruction {
     /// The instruction name
-    name: *const c_char,
+    name: *mut c_char,
     /// A pointer to an array of qubit indices this instruction operates on.
     qubits: *mut u32,
     /// A pointer to an array of clbit indices this instruction operates on.
@@ -850,6 +850,10 @@ pub struct CInstruction {
 /// This function is used to get the instruction details for a given instruction in
 /// the circuit.
 ///
+/// This function allocates memory internally for the provided ``QkCircuitInstruction``
+/// and thus you are responsible for calling ``qk_circuit_instruction_clear`` to
+/// free it.
+///
 /// @param circuit A pointer to the circuit to get the instruction details for.
 /// @param index The instruction index to get the instruction details of.
 /// @param instruction A pointer to where to write out the ``QkCircuitInstruction``
@@ -862,6 +866,7 @@ pub struct CInstruction {
 ///     uint32_t qubit[1] = {0};
 ///     qk_circuit_gate(qc, QkGate_H, qubit, NULL);
 ///     qk_circuit_get_instruction(qc, 0, &inst);
+///     qk_circuit_instruction_clear(&inst);
 /// ```
 ///
 /// # Safety
@@ -883,24 +888,36 @@ pub unsafe extern "C" fn qk_circuit_get_instruction(
         panic!("Invalid index")
     }
     let packed_inst = &circuit.data()[index];
-    let qargs = circuit.get_qargs(packed_inst.qubits);
-    let mut qargs_vec: Vec<u32> = qargs.iter().map(|x| x.0).collect();
-    let cargs = circuit.get_cargs(packed_inst.clbits);
-    let mut cargs_vec: Vec<u32> = cargs.iter().map(|x| x.0).collect();
-    let params = packed_inst.params_view();
-    let mut params_vec: Vec<f64> = params
-        .iter()
-        .map(|x| match x {
-            Param::Float(val) => *val,
-            _ => unreachable!("Invalid parameter on instruction"),
-        })
-        .collect();
-    let out_qargs = qargs_vec.as_mut_ptr();
-    std::mem::forget(qargs_vec);
-    let out_cargs = cargs_vec.as_mut_ptr();
-    std::mem::forget(cargs_vec);
-    let out_params = params_vec.as_mut_ptr();
-    std::mem::forget(params_vec);
+    let mut qargs = {
+        let qargs = circuit.get_qargs(packed_inst.qubits);
+        let qargs_vec: Vec<u32> = qargs.iter().map(|x| x.0).collect();
+        qargs_vec.into_boxed_slice()
+    };
+    let mut cargs = {
+        let cargs = circuit.get_cargs(packed_inst.clbits);
+        let cargs_vec: Vec<u32> = cargs.iter().map(|x| x.0).collect();
+        cargs_vec.into_boxed_slice()
+    };
+    let mut params = {
+        let params = packed_inst.params_view();
+        let params_vec: Vec<f64> = params
+            .iter()
+            .map(|x| match x {
+                Param::Float(val) => *val,
+                _ => panic!("Invalid parameter on instruction"),
+            })
+            .collect();
+        params_vec.into_boxed_slice()
+    };
+    let out_qargs = qargs.as_mut_ptr();
+    let out_qargs_len = qargs.len() as u32;
+    let _ = Box::into_raw(qargs);
+    let out_cargs = cargs.as_mut_ptr();
+    let out_cargs_len = cargs.len() as u32;
+    let _ = Box::into_raw(cargs);
+    let out_params = params.as_mut_ptr();
+    let out_params_len = params.len() as u32;
+    let _ = Box::into_raw(params);
 
     // SAFETY: The pointer must point to a CInstruction size allocation
     // per the docstring.
@@ -909,11 +926,11 @@ pub unsafe extern "C" fn qk_circuit_get_instruction(
             instruction,
             CInstruction {
                 name: CString::new(packed_inst.op.name()).unwrap().into_raw(),
-                num_qubits: qargs.len() as u32,
+                num_qubits: out_qargs_len,
                 qubits: out_qargs,
-                num_clbits: cargs.len() as u32,
+                num_clbits: out_cargs_len,
                 clbits: out_cargs,
-                num_params: params.len() as u32,
+                num_params: out_params_len,
                 params: out_params,
             },
         );
@@ -937,8 +954,8 @@ pub unsafe extern "C" fn qk_circuit_get_instruction(
 ///     uint32_t q0[1] = {0};
 ///     qk_circuit_gate(qc, QkGate_H, q0, NULL);
 ///     qk_circuit_get_instruction(qc, 0, inst);
-///     qk_circuit_instruction_clear(inst); // free the data
-///     free(inst); // free the pointer
+///     qk_circuit_instruction_clear(inst); // clear internal allocations
+///     free(inst); // free struct
 ///     qk_circuit_free(qc); // free the circuit
 /// ```
 ///
@@ -947,24 +964,37 @@ pub unsafe extern "C" fn qk_circuit_get_instruction(
 /// Behavior is undefined if ``inst`` is not a valid, non-null pointer to a ``QkCircuitInstruction``.
 #[no_mangle]
 #[cfg(feature = "cbinding")]
-pub unsafe extern "C" fn qk_circuit_instruction_clear(inst: *const CInstruction) {
+pub unsafe extern "C" fn qk_circuit_instruction_clear(inst: *mut CInstruction) {
+    if inst.is_null() {
+        return;
+    }
+
     // SAFETY: Loading the data from pointers contained in a CInstruction. These should only be
     // created by rust code and are constructed from Vecs internally or CStrings.
     unsafe {
-        let inst = const_ptr_as_ref(inst);
-        if inst.num_qubits > 0 {
+        let inst = mut_ptr_as_ref(inst);
+        if inst.num_qubits > 0 && !inst.qubits.is_null() {
             let qubits = std::slice::from_raw_parts_mut(inst.qubits, inst.num_qubits as usize);
-            let _ = Box::from_raw(qubits.as_mut_ptr());
+            let _: Box<[u32]> = Box::from_raw(qubits as *mut [u32]);
+            inst.qubits = std::ptr::null_mut();
         }
-        if inst.num_clbits > 0 {
+        inst.num_qubits = 0;
+        if inst.num_clbits > 0 && !inst.clbits.is_null() {
             let clbits = std::slice::from_raw_parts_mut(inst.clbits, inst.num_clbits as usize);
-            let _ = Box::from_raw(clbits.as_mut_ptr());
+            let _: Box<[u32]> = Box::from_raw(clbits as *mut [u32]);
+            inst.clbits = std::ptr::null_mut();
         }
-        if inst.num_params > 0 {
+        inst.num_clbits = 0;
+        if inst.num_params > 0 && !inst.params.is_null() {
             let params = std::slice::from_raw_parts_mut(inst.params, inst.num_params as usize);
-            let _ = Box::from_raw(params.as_mut_ptr());
+            let _ = Box::from_raw(params as *mut [f64]);
+            inst.params = std::ptr::null_mut();
         }
-        let _: Box<CStr> = Box::from(CStr::from_ptr(inst.name));
+        inst.num_params = 0;
+        if !inst.name.is_null() {
+            let _ = CString::from_raw(inst.name);
+            inst.name = std::ptr::null_mut();
+        }
     }
 }
 

--- a/releasenotes/notes/fix-qk-get-inst-leak-bb2e2299814515c3.yaml
+++ b/releasenotes/notes/fix-qk-get-inst-leak-bb2e2299814515c3.yaml
@@ -2,4 +2,4 @@
 fixes:
   - |
     Fixed a memory leak in the coordination of using
-    qk_circuit_get_instruction and qk_circuit_instruction_clear.
+    ``qk_circuit_get_instruction`` and ``qk_circuit_instruction_clear``.

--- a/releasenotes/notes/fix-qk-get-inst-leak-bb2e2299814515c3.yaml
+++ b/releasenotes/notes/fix-qk-get-inst-leak-bb2e2299814515c3.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a memory leak in the coordination of using
+    qk_circuit_get_instruction and qk_circuit_instruction_clear.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Previously, memory management of Vec was undefined behavior and subject to leak.

Also improves qk_circuit_instruction_clear to zero-out the struct fully, and make it take a mutable pointer for const-correctness.

### Details and comments

There were a couple of issues here that this resolves. The main thing is that we should be using `Vec::into_boxed_slice` when turning a `Vec` into something that we give back to C. As I understand it, this basically clears-out anything within the `Vec` other than the actual data buffer, and then gives back a `Box<[T]>` that owns just the buffer.

Previously, in `qk_circuit_instruction_clear` we were also not reconstructing the full array:

```rust
let qubits = std::slice::from_raw_parts_mut(inst.qubits, inst.num_qubits as usize);
let _ = Box::from_raw(qubits.as_mut_ptr());
```

This code was creating a `Box<T>`, not a `Box<[T]>`. Having an explicit type on the LHS is probably a good idea in these cases so we can be sure we're freeing the right thing.

In the case of `name`, it's also apparently important that if we use `CString::into_raw` we also use `CString::from_raw` during reconstruction. The docs for `CString::into_raw` state that doing otherwise _will_ leak memory:

```
/// The pointer which this function returns must be returned to Rust and reconstituted using
/// [`CString::from_raw`] to be properly deallocated. Specifically, one
/// should *not* use the standard C `free()` function to deallocate
/// this string.
///
/// Failure to call [`CString::from_raw`] will lead to a memory leak.
```