### PR TITLE
Fixing failing CI tests after Rustworkx 0.17 release

### DIFF
--- a/test/python/transpiler/test_high_level_synthesis.py
+++ b/test/python/transpiler/test_high_level_synthesis.py
@@ -1085,18 +1085,7 @@ class TestTokenSwapperPermutationPlugin(QiskitTestCase):
         synthesis_config = HLSConfig(permutation=[("token_swapper", {"trials": 10, "seed": 1})])
         qc_transpiled = PassManager(HighLevelSynthesis(synthesis_config)).run(qc)
 
-        # Construct the expected quantum circuit
-        # From the description below we can see that
-        #   0->6, 1->4, 2->5, 3->2, 4->0, 5->2->3->7, 6->0->4->1, 7->3
-        qc_expected = QuantumCircuit(8)
-        qc_expected.swap(2, 5)
-        qc_expected.swap(0, 6)
-        qc_expected.swap(2, 3)
-        qc_expected.swap(0, 4)
-        qc_expected.swap(1, 4)
-        qc_expected.swap(3, 7)
-
-        self.assertEqual(qc_transpiled, qc_expected)
+        self.assertEqual(Operator(qc_transpiled), Operator(qc))
 
     def test_concrete_synthesis(self):
         """Test concrete synthesis of a permutation gate (we have both the coupling map and the

--- a/test/python/transpiler/test_layout_transformation.py
+++ b/test/python/transpiler/test_layout_transformation.py
@@ -86,10 +86,10 @@ class TestLayoutTransformation(QiskitTestCase):
         self.assertEqual(circuit_to_dag(expected), output_dag)
 
     def test_full_connected_coupling_map(self):
-        """Test if the permutation {0->3,1->0,2->1,3->2} in a fully connected map."""
+        """Test if the permutation {0->3,1->2,2->1,3->0} is implemented correctly in a fully connected map."""
         v = QuantumRegister(4, "v")  # virtual qubits
         from_layout = Layout({v[0]: 0, v[1]: 1, v[2]: 2, v[3]: 3})
-        to_layout = Layout({v[0]: 3, v[1]: 0, v[2]: 1, v[3]: 2})
+        to_layout = Layout({v[0]: 3, v[1]: 2, v[2]: 1, v[3]: 0})
         ltpass = LayoutTransformation(
             coupling_map=None, from_layout=from_layout, to_layout=to_layout, seed=42
         )
@@ -98,9 +98,8 @@ class TestLayoutTransformation(QiskitTestCase):
         output_dag = ltpass.run(dag)
 
         expected = QuantumCircuit(4)
-        expected.swap(1, 0)
-        expected.swap(2, 1)
-        expected.swap(3, 2)
+        expected.swap(0, 3)
+        expected.swap(1, 2)
 
         self.assertEqual(circuit_to_dag(expected), output_dag)
 

--- a/test/python/transpiler/test_layout_transformation.py
+++ b/test/python/transpiler/test_layout_transformation.py
@@ -86,7 +86,9 @@ class TestLayoutTransformation(QiskitTestCase):
         self.assertEqual(circuit_to_dag(expected), output_dag)
 
     def test_full_connected_coupling_map(self):
-        """Test if the permutation {0->3,1->2,2->1,3->0} is implemented correctly in a fully connected map."""
+        """Test if the permutation {0->3,1->2,2->1,3->0} is implemented correctly in
+        a fully connected map.
+        """
         v = QuantumRegister(4, "v")  # virtual qubits
         from_layout = Layout({v[0]: 0, v[1]: 1, v[2]: 2, v[3]: 3})
         to_layout = Layout({v[0]: 3, v[1]: 2, v[2]: 1, v[3]: 0})


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

With the release of Rustworkx 0.17, some of the "randomness" on some of the platforms has changed, causing two tests to fail (on some of the platforms). This PR modifies the failing tests.

### Details and comments

For the token_swapper testcase, instead of checking that the circuit synthesizing a given PermutationGate is of some explicit form, we can check that the equality of operators for the original and the synthesized circuits.

For the layout testcase, there are multiple ways to implement the permutation `{0->3,1->0,2->1,3->2}`, so I have changed the permutation to `{0->3,1->2,2->1,3->0}` (so that exactly two commuting SWAP gates are needed, and this should have a unique decomposition, up to their order. Note that DAGCircuit equality works up to reordering).
