### PR TITLE
fix: added error handling for unsupported duration units

### DIFF
--- a/qiskit/qasm3/exporter.py
+++ b/qiskit/qasm3/exporter.py
@@ -1185,7 +1185,11 @@ class QASM3Builder:
             "s": ast.DurationUnit.SECOND,
             "dt": ast.DurationUnit.SAMPLE,
         }
-        return ast.DurationLiteral(duration, unit_map[unit])
+        try:
+            unit_enum = unit_map[unit]
+        except KeyError as exc:  # pragma: no cover - defensive guard
+            raise QASM3ExporterError(f"Unsupported duration unit: {unit!r}") from exc
+        return ast.DurationLiteral(duration, unit_enum)
 
     def build_integer(self, value) -> ast.IntegerLiteral:
         """Build an integer literal, raising a :obj:`.QASM3ExporterError` if the input is not

--- a/test/python/qasm3/test_export.py
+++ b/test/python/qasm3/test_export.py
@@ -2679,6 +2679,20 @@ class TestQASM3ExporterFailurePaths(QiskitTestCase):
         self.assertIsInstance(cm.exception.__cause__, QASM3ExporterError)
         self.assertRegex(cm.exception.__cause__.message, "cannot use the keyword 'reset'")
 
+    def test_duration_builder_rejects_unknown_unit(self):
+        """Test the builder rejects unknown duration units."""
+        builder = QASM3Builder(
+            QuantumCircuit(),
+            includeslist=(),
+            basis_gates=("U",),
+            disable_constants=False,
+            allow_aliasing=False,
+        )
+        with self.assertRaisesRegex(
+            QASM3ExporterError, "Unsupported duration unit: 'lightyear'"
+        ):
+            builder.build_duration(1, "lightyear")
+
 
 class TestQASM3ExporterRust(QiskitTestCase):
     """Tests of the Rust QASM3 exporter."""


### PR DESCRIPTION
Changes:
- Added error handling in the QASM3 exporter so unsupported duration units raise a dedicated `QASM3ExporterError` rather than failing with a `KeyError`.
- Added a test to ensure the exporter raises `QASM3ExporterError` when encountering an unknown duration unit, keeping error handling explicit and robust.