### PR TITLE
Fix QASM3 export of Delay with 'ps' units.

### DIFF
--- a/qiskit/qasm3/exporter.py
+++ b/qiskit/qasm3/exporter.py
@@ -1177,7 +1177,7 @@ class QASM3Builder:
         if unit == "expr":
             return self.build_expression(duration)
         if unit == "ps":
-            return ast.DurationLiteral(1000 * duration, ast.DurationUnit.NANOSECOND)
+            return ast.DurationLiteral(duration / 1000, ast.DurationUnit.NANOSECOND)
         unit_map = {
             "ns": ast.DurationUnit.NANOSECOND,
             "us": ast.DurationUnit.MICROSECOND,

--- a/releasenotes/notes/fix-ps-delay-convert-qasm-d9616204f73281ca.yaml
+++ b/releasenotes/notes/fix-ps-delay-convert-qasm-d9616204f73281ca.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a correctness bug when exporting circuits with delay instructions
+    using 'ps' units to QASM3.

--- a/test/python/qasm3/test_export.py
+++ b/test/python/qasm3/test_export.py
@@ -747,7 +747,7 @@ c[1] = measure q[1];
                 "stretch t;",
                 "delay[100ms] qr[0];",
                 "delay[100.0ms] qr[0];",
-                "delay[2000ns] qr[1];",
+                "delay[0.002ns] qr[1];",
                 "delay[s / 2.0] qr[1];",
                 "delay[s * (1000dt / 200.0ns) + t] qr[0];",
                 "",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
When converting a delay duration with 'ps' units we've had conversion the wrong way around, so it's never been correct.



