### PR TITLE
Refactor/abstract qubit sparse pauli-type interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,6 +776,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "inventory"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,6 +1412,7 @@ dependencies = [
  "hashbrown 0.15.4",
  "indexmap",
  "indoc",
+ "inventory",
  "libc",
  "memoffset",
  "num-bigint",

--- a/crates/quantum_info/Cargo.toml
+++ b/crates/quantum_info/Cargo.toml
@@ -44,7 +44,7 @@ features = ["rayon"]
 
 [dependencies.pyo3]
 workspace = true
-features = ["hashbrown", "indexmap", "num-complex", "num-bigint", "smallvec"]
+features = ["hashbrown", "indexmap", "num-complex", "num-bigint", "smallvec", "multiple-pymethods"]
 
 [lints]
 workspace = true

--- a/crates/quantum_info/src/pauli_lindblad_map/mod.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/mod.rs
@@ -10,6 +10,30 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+
+/// macro for generating pymethods for QubitSparsePauliListLike python interfaces
+macro_rules! impl_py_qspl_methods {
+    ($ty:ty) => {
+        #[pymethods]
+        impl $ty {
+            #[getter]
+            #[inline]
+            pub fn num_qubits(&self) -> PyResult<u32> {
+                let inner = self.inner.read().map_err(|_| InnerReadError)?;
+                Ok(inner.num_qubits())
+            }
+
+            /// The number of elements in the list.
+            #[getter]
+            #[inline]
+            pub fn num_terms(&self) -> PyResult<usize> {
+                let inner = self.inner.read().map_err(|_| InnerReadError)?;
+                Ok(inner.num_terms())
+            }
+        }
+    }
+}
+
 use pauli_lindblad_map_class::PyPauliLindbladMap;
 use phased_qubit_sparse_pauli::{PyPhasedQubitSparsePauli, PyPhasedQubitSparsePauliList};
 use pyo3::prelude::*;

--- a/crates/quantum_info/src/pauli_lindblad_map/mod.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/mod.rs
@@ -11,14 +11,14 @@
 // that they have been altered from the originals.
 
 use pauli_lindblad_map_class::PyPauliLindbladMap;
+use phased_qubit_sparse_pauli::{PyPhasedQubitSparsePauli, PyPhasedQubitSparsePauliList};
 use pyo3::prelude::*;
 use qiskit_circuit::bit::PyQubit;
 use qubit_sparse_pauli::{PyQubitSparsePauli, PyQubitSparsePauliList};
-use phased_qubit_sparse_pauli::{PyPhasedQubitSparsePauli, PyPhasedQubitSparsePauliList};
 
 pub mod pauli_lindblad_map_class;
-pub mod qubit_sparse_pauli;
 pub mod phased_qubit_sparse_pauli;
+pub mod qubit_sparse_pauli;
 
 pub fn pauli_lindblad_map(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<PyPauliLindbladMap>()?;

--- a/crates/quantum_info/src/pauli_lindblad_map/mod.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/mod.rs
@@ -12,14 +12,19 @@
 
 use pauli_lindblad_map_class::PyPauliLindbladMap;
 use pyo3::prelude::*;
+use qiskit_circuit::bit::PyQubit;
 use qubit_sparse_pauli::{PyQubitSparsePauli, PyQubitSparsePauliList};
+use phased_qubit_sparse_pauli::{PyPhasedQubitSparsePauli, PyPhasedQubitSparsePauliList};
 
 pub mod pauli_lindblad_map_class;
 pub mod qubit_sparse_pauli;
+pub mod phased_qubit_sparse_pauli;
 
 pub fn pauli_lindblad_map(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<PyPauliLindbladMap>()?;
     m.add_class::<PyQubitSparsePauli>()?;
     m.add_class::<PyQubitSparsePauliList>()?;
+    m.add_class::<PyPhasedQubitSparsePauli>()?;
+    m.add_class::<PyPhasedQubitSparsePauliList>()?;
     Ok(())
 }

--- a/crates/quantum_info/src/pauli_lindblad_map/mod.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/mod.rs
@@ -13,7 +13,6 @@
 use pauli_lindblad_map_class::PyPauliLindbladMap;
 use phased_qubit_sparse_pauli::{PyPhasedQubitSparsePauli, PyPhasedQubitSparsePauliList};
 use pyo3::prelude::*;
-use qiskit_circuit::bit::PyQubit;
 use qubit_sparse_pauli::{PyQubitSparsePauli, PyQubitSparsePauliList};
 
 pub mod pauli_lindblad_map_class;

--- a/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -56,6 +56,26 @@ pub struct PauliLindbladMap {
     non_negative_rates: Vec<bool>,
 }
 
+impl QubitSparsePauliListLike for PauliLindbladMap {
+    fn pauli_list(&self) -> &QubitSparsePauliList {
+        &self.qubit_sparse_pauli_list
+    }
+
+    fn pauli_list_mut(&mut self) -> &mut QubitSparsePauliList {
+        &mut self.qubit_sparse_pauli_list
+    }
+
+    /// Drop every Pauli on the given `indices`, effectively replacing them with an identity.
+    ///
+    /// It ignores all the indices that are larger than `self.num_qubits`.
+    fn drop_paulis(&self, indices: HashSet<u32>) -> Result<Self, CoherenceError> {
+        Self::new(
+            self.rates().to_vec(),
+            self.pauli_list().drop_paulis(indices)?
+        )
+    }
+}
+
 impl PauliLindbladMap {
     pub fn new(
         rates: Vec<f64>,
@@ -93,18 +113,6 @@ impl PauliLindbladMap {
             })
     }
 
-    /// Get the number of qubits the map is defined on.
-    #[inline]
-    pub fn num_qubits(&self) -> u32 {
-        self.qubit_sparse_pauli_list.num_qubits()
-    }
-
-    /// Get the number of generator terms in the map.
-    #[inline]
-    pub fn num_terms(&self) -> usize {
-        self.rates.len()
-    }
-
     /// Get the rates of the generator terms.
     #[inline]
     pub fn rates(&self) -> &[f64] {
@@ -121,24 +129,6 @@ impl PauliLindbladMap {
     #[inline]
     pub fn non_negative_rates(&self) -> &[bool] {
         &self.non_negative_rates
-    }
-
-    /// Get the indices of each [Pauli].
-    #[inline]
-    pub fn indices(&self) -> &[u32] {
-        self.qubit_sparse_pauli_list.indices()
-    }
-
-    /// Get the boundaries of each term.
-    #[inline]
-    pub fn boundaries(&self) -> &[usize] {
-        self.qubit_sparse_pauli_list.boundaries()
-    }
-
-    /// Get the [Pauli]s in the map.
-    #[inline]
-    pub fn paulis(&self) -> &[Pauli] {
-        self.qubit_sparse_pauli_list.paulis()
     }
 
     /// Create a [PauliLindbladMap] representing the identity map on ``num_qubits`` qubits.

--- a/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -33,7 +33,7 @@ use qiskit_circuit::slice::{PySequenceIndex, SequenceIndex};
 use super::qubit_sparse_pauli::{
     raw_parts_from_sparse_list, ArithmeticError, CoherenceError, InnerReadError, InnerWriteError,
     LabelError, Pauli, PyQubitSparsePauli, PyQubitSparsePauliList, QubitSparsePauli,
-    QubitSparsePauliList, QubitSparsePauliListLike, QubitSparsePauliView,
+    QubitSparsePauliList, QubitSparsePauliListLike, QubitSparsePauliView
 };
 
 /// A Pauli Lindblad map that stores its data in a qubit-sparse format. Note that gamma,
@@ -791,6 +791,8 @@ pub struct PyPauliLindbladMap {
     inner: Arc<RwLock<PauliLindbladMap>>,
 }
 
+impl_py_qspl_methods!(PyPauliLindbladMap);
+
 #[pymethods]
 impl PyPauliLindbladMap {
     #[pyo3(signature = (data, /, num_qubits=None))]
@@ -1069,25 +1071,6 @@ impl PyPauliLindbladMap {
     fn copy(&self) -> PyResult<Self> {
         let inner = self.inner.read().map_err(|_| InnerReadError)?;
         Ok(inner.clone().into())
-    }
-
-    /// The number of qubits the map acts on.
-    ///
-    /// This is not inferable from any other shape or values, since identities are not stored
-    /// explicitly.
-    #[getter]
-    #[inline]
-    pub fn num_qubits(&self) -> PyResult<u32> {
-        let inner = self.inner.read().map_err(|_| InnerReadError)?;
-        Ok(inner.num_qubits())
-    }
-
-    /// The number of generator terms in the exponent for this map.
-    #[getter]
-    #[inline]
-    pub fn num_terms(&self) -> PyResult<usize> {
-        let inner = self.inner.read().map_err(|_| InnerReadError)?;
-        Ok(inner.num_terms())
     }
 
     /// Calculate the :math:`\gamma` for the map.

--- a/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -74,6 +74,18 @@ impl QubitSparsePauliListLike for PauliLindbladMap {
             self.pauli_list().drop_paulis(indices)?
         )
     }
+
+    /// Apply a transpiler layout.
+    fn apply_layout(
+        &self,
+        layout: Option<&[u32]>,
+        num_qubits: u32,
+    ) -> Result<Self, CoherenceError> {
+        let qubit_sparse_pauli_list = self
+            .pauli_list()
+            .apply_layout(layout, num_qubits)?;
+        PauliLindbladMap::new(self.rates.clone(), qubit_sparse_pauli_list)
+    }
 }
 
 impl PauliLindbladMap {
@@ -150,18 +162,6 @@ impl PauliLindbladMap {
         self.probabilities.push(p);
         self.non_negative_rates.push(pr);
         Ok(())
-    }
-
-    /// Apply a transpiler layout.
-    pub fn apply_layout(
-        &self,
-        layout: Option<&[u32]>,
-        num_qubits: u32,
-    ) -> Result<Self, CoherenceError> {
-        let qubit_sparse_pauli_list = self
-            .qubit_sparse_pauli_list
-            .apply_layout(layout, num_qubits)?;
-        PauliLindbladMap::new(self.rates.clone(), qubit_sparse_pauli_list)
     }
 
     /// Create a new identity map (with zero generator) with pre-allocated space for the given

--- a/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -33,7 +33,7 @@ use qiskit_circuit::slice::{PySequenceIndex, SequenceIndex};
 use super::qubit_sparse_pauli::{
     raw_parts_from_sparse_list, ArithmeticError, CoherenceError, InnerReadError, InnerWriteError,
     LabelError, Pauli, PyQubitSparsePauli, PyQubitSparsePauliList, QubitSparsePauli,
-    QubitSparsePauliList, QubitSparsePauliView,
+    QubitSparsePauliList, QubitSparsePauliListLike, QubitSparsePauliView,
 };
 
 /// A Pauli Lindblad map that stores its data in a qubit-sparse format. Note that gamma,

--- a/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
@@ -1272,7 +1272,7 @@ impl PyPhasedQubitSparsePauliList {
             for bit in view.qubit_sparse_pauli_view.paulis.iter() {
                 pauli_string.push_str(bit.py_label());
             }
-            let py_int = PyInt::new(py, view.phase).unbind();
+            let py_int = PyInt::new(py, (view.phase - view.qubit_sparse_pauli_view.num_ys()).rem_euclid(4)).unbind();
             let py_string = PyString::new(py, &pauli_string).unbind();
             let py_indices = PyList::new(py, view.qubit_sparse_pauli_view.indices.iter())?.unbind();
 
@@ -1290,14 +1290,14 @@ impl PyPhasedQubitSparsePauliList {
         self.num_terms()
     }
 
-    //fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyTuple>> {
-    //    let inner = self.inner.read().map_err(|_| InnerReadError)?;
-    //    (
-    //        py.get_type::<Self>().getattr("from_sparse_list")?,
-    //        (self.to_sparse_list(py)?, inner.num_qubits()),
-    //    )
-    //        .into_pyobject(py)
-    //}
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyTuple>> {
+        let inner = self.inner.read().map_err(|_| InnerReadError)?;
+        (
+            py.get_type::<Self>().getattr("from_sparse_list")?,
+            (self.to_sparse_list(py)?, inner.num_qubits()),
+        )
+            .into_pyobject(py)
+    }
 
     fn __getitem__<'py>(
         &self,

--- a/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
@@ -1362,7 +1362,7 @@ impl PyPhasedQubitSparsePauliList {
                 .join(", ")
         };
         Ok(format!(
-            "<QubitSparsePauliList with {str_num_terms} on {str_num_qubits}: [{str_terms}]>"
+            "<PhasedQubitSparsePauliList with {str_num_terms} on {str_num_qubits}: [{str_terms}]>"
         ))
     }
 }

--- a/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
@@ -68,6 +68,16 @@ impl QubitSparsePauliListLike for PhasedQubitSparsePauliList {
         )
     }
 
+    /// Drop qubits corresponding to the given `indices`.
+    ///
+    /// It ignores all the indices that are larger than `self.num_qubits`.
+    fn drop_qubits(&self, indices: HashSet<u32>) -> Result<Self, CoherenceError> {
+        Self::new(
+            self.pauli_list().drop_qubits(indices)?,
+            self.phases.to_vec(),
+        )
+    }
+
     /// Apply a transpiler layout.
     fn apply_layout(
         &self,

--- a/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
@@ -350,14 +350,14 @@ impl PyPhasedQubitSparsePauli {
             }
             return Self::from_label(&label);
         }
-        //if let Ok(sparse_label) = data.extract() {
-        //    let Some(num_qubits) = num_qubits else {
-        //        return Err(PyValueError::new_err(
-        //            "if using the sparse-label form, 'num_qubits' must be provided",
-        //        ));
-        //    };
-        //    return Self::from_sparse_label(sparse_label, num_qubits);
-        //}
+        if let Ok(sparse_label) = data.extract() {
+            let Some(num_qubits) = num_qubits else {
+                return Err(PyValueError::new_err(
+                    "if using the sparse-label form, 'num_qubits' must be provided",
+                ));
+            };
+            return Self::from_sparse_label(sparse_label, num_qubits);
+        }
         Err(PyTypeError::new_err(format!(
             "unknown input format for 'PhasedQubitSparsePauli': {}",
             data.get_type().repr()?,
@@ -475,14 +475,14 @@ impl PyPhasedQubitSparsePauli {
         Ok(inner.into())
     }
 
-    /// Construct a qubit sparse Pauli from a sparse label, given as a tuple of a string of Paulis,
-    /// and the indices of the corresponding qubits.
+    /// Construct a phased qubit sparse Pauli from a sparse label, given as a tuple of an int for
+    /// phase, a string of Paulis, and the indices of the corresponding qubits.
     ///
     /// This is analogous to :meth:`.SparsePauliOp.from_sparse_list`.
     ///
     /// Args:
-    ///     sparse_label (tuple[str, Sequence[int]]): labels and the qubits each single-qubit term
-    ///         applies to.
+    ///     sparse_label (tuple[int, str, Sequence[int]]): labels and the qubits each single-qubit
+    ///         term applies to.
     ///
     ///     num_qubits (int): the number of qubits the operator acts on.
     ///
@@ -490,19 +490,19 @@ impl PyPhasedQubitSparsePauli {
     ///
     ///     Construct a simple Pauli::
     ///
-    ///         >>> QubitSparsePauli.from_sparse_label(
-    ///         ...     ("ZX", (1, 4)),
+    ///         >>> PhasedQubitSparsePauli.from_sparse_label(
+    ///         ...     (0, "ZX", (1, 4)),
     ///         ...     num_qubits=5,
     ///         ... )
-    ///         <QubitSparsePauli on 5 qubits: X_4 Z_1>
+    ///         <PhasedQubitSparsePauli on 5 qubits: X_4 Z_1>
     ///
     ///     This method can replicate the behavior of :meth:`from_label`, if the qubit-arguments
     ///     field of the tuple is set to decreasing integers::
     ///
     ///         >>> label = "XYXZ"
-    ///         >>> from_label = QubitSparsePauli.from_label(label)
-    ///         >>> from_sparse_label = QubitSparsePauli.from_sparse_label(
-    ///         ...     (label, (3, 2, 1, 0)),
+    ///         >>> from_label = PhasedQubitSparsePauli.from_label(label)
+    ///         >>> from_sparse_label = PhasedQubitSparsePauli.from_sparse_label(
+    ///         ...     (0, label, (3, 2, 1, 0)),
     ///         ...     num_qubits=4
     ///         ... )
     ///         >>> assert from_label == from_sparse_label

--- a/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
@@ -10,39 +10,31 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use hashbrown::HashSet;
-
 use numpy::{PyArray1, PyArrayMethods, PyReadonlyArray1};
 use pyo3::{
-    exceptions::{PyRuntimeError, PyTypeError, PyValueError},
+    exceptions::{PyTypeError, PyValueError},
     intern,
     prelude::*,
-    sync::GILOnceCell,
-    types::{IntoPyDict, PyInt, PyList, PyString, PyTuple, PyType},
+    types::{PyInt, PyList, PyString, PyTuple, PyType},
     IntoPyObjectExt, PyErr,
 };
 use std::{
     collections::btree_map,
     sync::{Arc, RwLock},
 };
-use thiserror::Error;
 
 use qiskit_circuit::{
-    bit::PyQubit,
     imports::ImportOnceCell,
     slice::{PySequenceIndex, SequenceIndex},
 };
 
-use crate::pauli_lindblad_map::qubit_sparse_pauli;
-
 use super::qubit_sparse_pauli::{
     raw_parts_from_sparse_list, ArithmeticError, CoherenceError, InnerReadError, InnerWriteError,
-    LabelError, Pauli, PyQubitSparsePauli, PyQubitSparsePauliList, QubitSparsePauli,
-    QubitSparsePauliList, QubitSparsePauliView,
+    LabelError, Pauli, PyQubitSparsePauli, QubitSparsePauli, QubitSparsePauliList,
+    QubitSparsePauliView,
 };
 
 static PAULI_TYPE: ImportOnceCell = ImportOnceCell::new("qiskit.quantum_info", "Pauli");
-static PAULI_PY_ENUM: GILOnceCell<Py<PyType>> = GILOnceCell::new();
 
 /// A list of Pauli operators stored in a qubit-sparse format.
 ///
@@ -110,7 +102,7 @@ impl PhasedQubitSparsePauliList {
             .zip(self.qubit_sparse_pauli_list.iter())
             .map(|(phase, qspv)| PhasedQubitSparsePauliView {
                 qubit_sparse_pauli_view: qspv,
-                phase: &phase,
+                phase,
             })
     }
 
@@ -190,7 +182,7 @@ impl PhasedQubitSparsePauliList {
             }
         }
 
-        return true;
+        true
     }
     /// Apply a transpiler layout.
     pub fn apply_layout(
@@ -395,7 +387,7 @@ impl PhasedQubitSparsePauli {
             });
         }
 
-        return self.qubit_sparse_pauli.commutes(&other.qubit_sparse_pauli);
+        self.qubit_sparse_pauli.commutes(&other.qubit_sparse_pauli)
     }
 
     // Check equality of operators
@@ -750,7 +742,7 @@ impl PyPhasedQubitSparsePauli {
         let qubit_sparse_pauli: QubitSparsePauli = QubitSparsePauli::from_dense_label(label)?;
         let num_ys = qubit_sparse_pauli.view().num_ys();
         let inner = PhasedQubitSparsePauli {
-            qubit_sparse_pauli: qubit_sparse_pauli,
+            qubit_sparse_pauli,
             phase: num_ys.rem_euclid(4),
         };
         Ok(inner.into())
@@ -777,7 +769,7 @@ impl PyPhasedQubitSparsePauli {
         let phase = borrowed.inner.phase;
 
         let num_ys = borrowed.inner.qubit_sparse_pauli.view().num_ys();
-        return (phase - num_ys).rem_euclid(4);
+        (phase - num_ys).rem_euclid(4)
     }
 
     /// Convert this Pauli into a single element :class:`PhasedQubitSparsePauliList`.

--- a/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
@@ -295,6 +295,11 @@ impl PhasedQubitSparsePauli {
 
         return self.qubit_sparse_pauli.commutes(&other.qubit_sparse_pauli)
     }
+
+    // Check equality of operators
+    fn eq(&self, other: &PhasedQubitSparsePauli) -> bool {
+        ((self.phase - other.phase).rem_euclid(4) == 0) && self.qubit_sparse_pauli == other.qubit_sparse_pauli
+    }
 }
 
 

--- a/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
@@ -414,6 +414,34 @@ impl PyPhasedQubitSparsePauli {
         Ok(inner.into())
     }
 
+    /// Construct from a dense string label.
+    ///
+    /// The label must be a sequence of the alphabet ``'IXYZ'``.  The label is interpreted
+    /// analogously to a bitstring.  In other words, the right-most letter is associated with qubit
+    /// 0, and so on.  This is the same as the labels for :class:`~.quantum_info.Pauli` and
+    /// :class:`.SparsePauliOp`.
+    ///
+    /// Args:
+    ///     label (str): the dense label.
+    ///
+    /// Examples:
+    ///
+    ///     .. code-block:: python
+    ///
+    ///         >>> QubitSparsePauli.from_label("IIIIXZI")
+    ///         <QubitSparsePauli on 7 qubits: X_2 Z_1>
+    ///         >>> label = "IYXZI"
+    ///         >>> pauli = Pauli(label)
+    ///         >>> assert QubitSparsePauli.from_label(label) == QubitSparsePauli.from_pauli(pauli)
+    //#[staticmethod]
+    //#[pyo3(signature = (label, /))]
+    //fn from_label(label: &str) -> PyResult<Self> {
+    //    
+    //    let temp_pauli: PyQubitSparsePauli = PyQubitSparsePauli::from_label(label)?;
+
+
+    //}
+
 
     /// Get the identity operator for a given number of qubits.
     ///

--- a/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
@@ -1,0 +1,665 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use super::qubit_sparse_pauli::{
+    raw_parts_from_sparse_list, ArithmeticError, CoherenceError, InnerReadError, InnerWriteError,
+    LabelError, Pauli, PyQubitSparsePauli, PyQubitSparsePauliList, QubitSparsePauli,
+    QubitSparsePauliList, QubitSparsePauliView,
+};
+
+
+/// A list of Pauli operators stored in a qubit-sparse format.
+///
+/// See [PyQubitSparsePauliList] for detailed docs.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PhasedQubitSparsePauliList {
+    /// The paulis.
+    qubit_sparse_pauli_list: QubitSparsePauliList,
+    /// Phases.
+    phases: Vec<u8>,
+}
+
+impl PhasedQubitSparsePauliList {
+    /// Create a new phased qubit-sparse Pauli list from the raw components that make it up.
+    ///
+    /// This checks the input values for data coherence on entry.  If you are certain you have the
+    /// correct values, you can call `new_unchecked` instead.
+    pub fn new(
+        qubit_sparse_pauli_list: QubitSparsePauliList,
+        phases: Vec<u8>,
+    ) -> Result<Self, CoherenceError> {
+        if phases.len() != qubit_sparse_pauli_list.len() {
+            return Err(CoherenceError::MismatchedPhaseCount {
+                phases: phases.len(),
+                qspl: qubit_sparse_pauli_list.len(),
+            });
+        }
+        // SAFETY: we've just done the coherence checks.
+        Ok(unsafe { Self::new_unchecked(qubit_sparse_pauli_list, phases) })
+    }
+
+    /// Create a new [QubitSparsePauliList] from the raw components without checking data coherence.
+    ///
+    /// # Safety
+    ///
+    /// It is up to the caller to ensure that the data-coherence requirements, as enumerated in the
+    /// struct-level documentation, have been upheld.
+    #[inline(always)]
+    pub unsafe fn new_unchecked(
+        qubit_sparse_pauli_list: QubitSparsePauliList,
+        phases: Vec<u8>,
+    ) -> Self {
+        Self {
+            qubit_sparse_pauli_list,
+            phases,
+        }
+    }
+
+    /// Get the number of elements in the list.
+    #[inline]
+    pub fn num_terms(&self) -> usize {
+        self.phases.len()
+    }
+}
+
+/// A view object onto a single term of a `QubitSparsePauliList`.
+///
+/// The lengths of `paulis` and `indices` are guaranteed to be created equal, but might be zero
+/// (in the case that the term is the identity).
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct PhasedQubitSparsePauliView<'a> {
+    pub qubit_sparse_pauli_view: QubitSparsePauliView,
+    pub phase: &'a u8,
+}
+impl PhasedQubitSparsePauliView<'_> {
+    /// Convert this `PhasedQubitSparsePauliView` into an owning [PhasedQubitSparsePauli] of the same data.
+    pub fn to_term(&self) -> PhasedQubitSparsePauli {
+        PhasedQubitSparsePauli {
+            qubit_sparse_pauli: self.qubit_sparse_pauli_view.to_term(),
+            phase: phase.into()
+        }
+    }
+
+    pub fn to_sparse_str(self) -> String {
+        let paulis = self
+            .indices
+            .iter()
+            .zip(self.paulis)
+            .rev()
+            .map(|(i, op)| format!("{}_{}", op.py_label(), i))
+            .collect::<Vec<String>>()
+            .join(" ");
+        paulis.to_string()
+    }
+}
+
+/// A single phased qubit-sparse Pauli operator.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PhasedQubitSparsePauli {
+    /// The qubit sparse Pauli.
+    qubit_sparse_pauli: QubitSparsePauli,
+    /// phase.
+    phase: u8,
+}
+
+impl PhasedQubitSparsePauli {
+    /// Create a new phased qubit-sparse Pauli from the raw components that make it up.
+    pub fn new(
+        qubit_sparse_pauli: QubitSparsePauli,
+        phase: u8,
+    ) -> Self {
+
+        Self {
+            qubit_sparse_pauli,
+            phase,
+        }
+    }
+
+    /// Get the number of qubits the paulis are defined on.
+    #[inline]
+    pub fn num_qubits(&self) -> u32 {
+        self.qubit_sparse_pauli.num_qubits
+    }
+
+    /// Create the identity [QubitSparsePauli] on ``num_qubits`` qubits.
+    pub fn identity(num_qubits: u32) -> Self {
+        Self {
+            qubit_sparse_pauli: QubitSparsePauli.identity(num_qubits),
+            phase: 0
+        }
+    }
+
+    /// Get a view version of this object.
+    pub fn view(&self) -> QubitSparsePauliView<'_> {
+        QubitSparsePauliView {
+            num_qubits: self.num_qubits,
+            paulis: &self.paulis,
+            indices: &self.indices,
+        }
+    }
+
+    /// Convert this single Pauli into a :class:`PhasedQubitSparsePauliList`.
+    pub fn to_phased_qubit_sparse_pauli_list(&self) -> PhasedQubitSparsePauliList {
+        PhasedQubitSparsePauliList {
+            qubit_sparse_pauli_list: self.qubit_sparse_pauli.to_qubit_sparse_pauli_list(),
+            phases: vec![self.phase],
+        }
+    }
+
+    // Check if `self` commutes with `other`
+    pub fn commutes(&self, other: &QubitSparsePauli) -> Result<bool, ArithmeticError> {
+        if self.num_qubits != other.num_qubits {
+            return Err(ArithmeticError::MismatchedQubits {
+                left: self.num_qubits,
+                right: other.num_qubits,
+            });
+        }
+
+        return self.qubit_sparse_pauli.commutes(other)
+    }
+}
+
+#[derive(Error, Debug)]
+pub struct InnerReadError;
+
+#[derive(Error, Debug)]
+pub struct InnerWriteError;
+
+impl ::std::fmt::Display for InnerReadError {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "Failed acquiring lock for reading.")
+    }
+}
+
+impl ::std::fmt::Display for InnerWriteError {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "Failed acquiring lock for writing.")
+    }
+}
+
+impl From<InnerReadError> for PyErr {
+    fn from(value: InnerReadError) -> PyErr {
+        PyRuntimeError::new_err(value.to_string())
+    }
+}
+impl From<InnerWriteError> for PyErr {
+    fn from(value: InnerWriteError) -> PyErr {
+        PyRuntimeError::new_err(value.to_string())
+    }
+}
+
+impl From<PauliFromU8Error> for PyErr {
+    fn from(value: PauliFromU8Error) -> PyErr {
+        PyValueError::new_err(value.to_string())
+    }
+}
+impl From<CoherenceError> for PyErr {
+    fn from(value: CoherenceError) -> PyErr {
+        PyValueError::new_err(value.to_string())
+    }
+}
+impl From<LabelError> for PyErr {
+    fn from(value: LabelError) -> PyErr {
+        PyValueError::new_err(value.to_string())
+    }
+}
+impl From<ArithmeticError> for PyErr {
+    fn from(value: ArithmeticError) -> PyErr {
+        PyValueError::new_err(value.to_string())
+    }
+}
+
+
+#[pyclass(name = "PhasedQubitSparsePauli", frozen, module = "qiskit.quantum_info")]
+#[derive(Clone, Debug)]
+pub struct PyPhasedQubitSparsePauli {
+    inner: PhasedQubitSparsePauli,
+}
+
+impl PyPhasedQubitSparsePauli {
+    pub fn inner(&self) -> &PhasedQubitSparsePauli {
+        &self.inner
+    }
+}
+
+#[pymethods]
+impl PyPhasedQubitSparsePauli {
+    #[new]
+    #[pyo3(signature = (data, /, num_qubits=None))]
+    fn py_new(data: &Bound<PyAny>, num_qubits: Option<u32>) -> PyResult<Self> {
+        let py = data.py();
+        let check_num_qubits = |data: &Bound<PyAny>| -> PyResult<()> {
+            let Some(num_qubits) = num_qubits else {
+                return Ok(());
+            };
+            let other_qubits = data.getattr(intern!(py, "num_qubits"))?.extract::<u32>()?;
+            if num_qubits == other_qubits {
+                return Ok(());
+            }
+            Err(PyValueError::new_err(format!(
+                "explicitly given 'num_qubits' ({num_qubits}) does not match operator ({other_qubits})"
+            )))
+        };
+        if data.is_instance(PAULI_TYPE.get_bound(py))? {
+            check_num_qubits(data)?;
+            return Self::from_pauli(data);
+        }
+        //if let Ok(label) = data.extract::<String>() {
+        //    let num_qubits = num_qubits.unwrap_or(label.len() as u32);
+        //    if num_qubits as usize != label.len() {
+        //        return Err(PyValueError::new_err(format!(
+        //            "explicitly given 'num_qubits' ({}) does not match label ({})",
+        //            num_qubits,
+        //            label.len(),
+        //        )));
+        //    }
+        //    return Self::from_label(&label);
+        //}
+        //if let Ok(sparse_label) = data.extract() {
+        //    let Some(num_qubits) = num_qubits else {
+        //        return Err(PyValueError::new_err(
+        //            "if using the sparse-label form, 'num_qubits' must be provided",
+        //        ));
+        //    };
+        //    return Self::from_sparse_label(sparse_label, num_qubits);
+        //}
+        Err(PyTypeError::new_err(format!(
+            "unknown input format for 'PhasedQubitSparsePauli': {}",
+            data.get_type().repr()?,
+        )))
+    }
+
+    /// Construct a :class:`.QubitSparsePauli` from a single :class:`~.quantum_info.Pauli` instance.
+    ///
+    /// Note that the phase of the Pauli is dropped.
+    ///
+    /// Args:
+    ///     pauli (:class:`~.quantum_info.Pauli`): the single Pauli to convert.
+    ///
+    /// Examples:
+    ///
+    ///     .. code-block:: python
+    ///
+    ///         >>> label = "IYXZI"
+    ///         >>> pauli = Pauli(label)
+    ///         >>> QubitSparsePauli.from_pauli(pauli)
+    ///         <QubitSparsePauli on 5 qubits: Y_3 X_2 Z_1>
+    ///         >>> assert QubitSparsePauli.from_label(label) == QubitSparsePauli.from_pauli(pauli)
+    #[staticmethod]
+    #[pyo3(signature = (pauli, /))]
+    fn from_pauli(pauli: &Bound<PyAny>) -> PyResult<Self> {
+        let py = pauli.py();
+        let num_qubits = pauli.getattr(intern!(py, "num_qubits"))?.extract::<u32>()?;
+        let z = pauli
+            .getattr(intern!(py, "z"))?
+            .extract::<PyReadonlyArray1<bool>>()?;
+        let x = pauli
+            .getattr(intern!(py, "x"))?
+            .extract::<PyReadonlyArray1<bool>>()?;
+        let mut paulis = Vec::new();
+        let mut indices = Vec::new();
+        for (i, (x, z)) in x.as_array().iter().zip(z.as_array().iter()).enumerate() {
+            // The only failure case possible here is the identity, because of how we're
+            // constructing the value to convert.
+            let Ok(term) = ::bytemuck::checked::try_cast(((*x as u8) << 1) | (*z as u8)) else {
+                continue;
+            };
+            indices.push(i as u32);
+            paulis.push(term);
+        }
+        let inner = PhasedQubitSparsePauli::new(
+            QubitSparsePauli::new(
+                num_qubits,
+                paulis.into_boxed_slice(),
+                indices.into_boxed_slice(),
+            )?,
+            phase=0
+        );
+        Ok(inner.into())
+    }
+
+
+    /// Get the identity operator for a given number of qubits.
+    ///
+    /// Examples:
+    ///
+    ///     Get the identity on 100 qubits::
+    ///
+    ///         >>> QubitSparsePauli.identity(100)
+    ///         <QubitSparsePauli on 100 qubits: >
+    #[pyo3(signature = (/, num_qubits))]
+    #[staticmethod]
+    pub fn identity(num_qubits: u32) -> Self {
+        PhasedQubitSparsePauli::identity(num_qubits).into()
+    }
+
+    /// Convert this Pauli into a single element :class:`PhaseddQubitSparsePauliList`.
+    fn to_phased_qubit_sparse_pauli_list(&self) -> PyResult<PyPhasedQubitSparsePauliList> {
+        Ok(self.inner.to_phased_qubit_sparse_pauli_list().into())
+    }
+
+    /// Check if `self`` commutes with another qubit sparse pauli.
+    ///
+    /// Args:
+    ///     other (PhasedQubitSparsePauli): the qubit sparse Pauli to check for commutation with.
+    fn commutes(&self, other: PyPhasedQubitSparsePauli) -> PyResult<bool> {
+        Ok(self.inner.commutes(&other.inner)?)
+    }
+
+    fn __eq__(slf: Bound<Self>, other: Bound<PyAny>) -> PyResult<bool> {
+        if slf.is(&other) {
+            return Ok(true);
+        }
+        let Ok(other) = other.downcast_into::<Self>() else {
+            return Ok(false);
+        };
+        let slf = slf.borrow();
+        let other = other.borrow();
+        Ok(slf.inner.eq(&other.inner))
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!(
+            "<{} on {} qubit{}: {}>",
+            "PhasedQubitSparsePauli",
+            self.inner.num_qubits(),
+            if self.inner.num_qubits() == 1 {
+                ""
+            } else {
+                "s"
+            },
+            self.inner.view().to_sparse_str(),
+        ))
+    }
+
+    fn __getnewargs__(slf_: Bound<Self>) -> PyResult<Bound<PyTuple>> {
+        let py = slf_.py();
+        let borrowed = slf_.borrow();
+        (
+            borrowed.inner.num_qubits(),
+            Self::get_paulis(slf_.clone()),
+            Self::get_indices(slf_),
+        )
+            .into_pyobject(py)
+    }
+
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyTuple>> {
+        let paulis: &[u8] = ::bytemuck::cast_slice(self.inner.paulis());
+        (
+            py.get_type::<Self>().getattr("from_raw_parts")?,
+            (
+                self.inner.num_qubits(),
+                PyArray1::from_slice(py, paulis),
+                PyArray1::from_slice(py, self.inner.indices()),
+            ),
+        )
+            .into_pyobject(py)
+    }
+
+    /// Get a copy of this term.
+    fn copy(&self) -> Self {
+        self.clone()
+    }
+
+    /// The number of qubits the term is defined on.
+    #[getter]
+    fn get_num_qubits(&self) -> u32 {
+        self.inner.num_qubits()
+    }
+}
+
+#[pyclass(
+    name = "PhasedQubitSparsePauliList",
+    module = "qiskit.quantum_info",
+    sequence
+)]
+#[derive(Debug)]
+pub struct PyPhasedQubitSparsePauliList {
+    // This class keeps a pointer to a pure Rust-SparseTerm and serves as interface from Python.
+    pub inner: Arc<RwLock<PhasedQubitSparsePauliList>>,
+}
+#[pymethods]
+impl PyPhasedQubitSparsePauliList {
+    #[pyo3(signature = (data, /, num_qubits=None))]
+    #[new]
+    fn py_new(data: &Bound<PyAny>, num_qubits: Option<u32>) -> PyResult<Self> {
+        let py = data.py();
+        let check_num_qubits = |data: &Bound<PyAny>| -> PyResult<()> {
+            let Some(num_qubits) = num_qubits else {
+                return Ok(());
+            };
+            let other_qubits = data.getattr(intern!(py, "num_qubits"))?.extract::<u32>()?;
+            if num_qubits == other_qubits {
+                return Ok(());
+            }
+            Err(PyValueError::new_err(format!(
+                "explicitly given 'num_qubits' ({num_qubits}) does not match operator ({other_qubits})"
+            )))
+        };
+        if data.is_instance(PAULI_TYPE.get_bound(py))? {
+            check_num_qubits(data)?;
+            return Self::from_pauli(data);
+        }
+        //if let Ok(label) = data.extract::<String>() {
+        //    let num_qubits = num_qubits.unwrap_or(label.len() as u32);
+        //    if num_qubits as usize != label.len() {
+        //        return Err(PyValueError::new_err(format!(
+        //            "explicitly given 'num_qubits' ({}) does not match label ({})",
+        //            num_qubits,
+        //            label.len(),
+        //        )));
+        //    }
+        //    return Self::from_label(&label).map_err(PyErr::from);
+        //}
+        //if let Ok(pauli_list) = data.downcast_exact::<Self>() {
+        //    check_num_qubits(data)?;
+        //    let borrowed = pauli_list.borrow();
+        //    let inner = borrowed.inner.read().map_err(|_| InnerReadError)?;
+        //    return Ok(inner.clone().into());
+        //}
+        // The type of `vec` is inferred from the subsequent calls to `Self::from_list` or
+        // `Self::from_sparse_list` to be either the two-tuple or the three-tuple form during the
+        // `extract`.  The empty list will pass either, but it means the same to both functions.
+        //if let Ok(vec) = data.extract() {
+        //    return Self::from_list(vec, num_qubits);
+        //}
+        //if let Ok(vec) = data.extract() {
+        //    let Some(num_qubits) = num_qubits else {
+        //        return Err(PyValueError::new_err(
+        //            "if using the sparse-list form, 'num_qubits' must be provided",
+        //        ));
+        //    };
+        //    return Self::from_sparse_list(vec, num_qubits);
+        //}
+        if let Ok(term) = data.downcast_exact::<PyPhasedQubitSparsePauli>() {
+            return term.borrow().to_phased_qubit_sparse_pauli_list();
+        };
+        //if let Ok(pauli_list) = Self::from_qubit_sparse_paulis(data, num_qubits) {
+        //    return Ok(pauli_list);
+        //}
+        //Err(PyTypeError::new_err(format!(
+        //    "unknown input format for 'QubitSparsePauliList': {}",
+        //    data.get_type().repr()?,
+        //)))
+    }
+
+    /// Get a copy of this qubit sparse Pauli list.
+    ///
+    /// Examples:
+    ///
+    ///     .. code-block:: python
+    ///
+    ///         >>> qubit_sparse_pauli_list = QubitSparsePauliList.from_list(["IXZXYYZZ", "ZXIXYYZZ"])
+    ///         >>> assert qubit_sparse_pauli_list == qubit_sparse_pauli_list.copy()
+    ///         >>> assert qubit_sparse_pauli_list is not qubit_sparse_pauli_list.copy()
+    fn copy(&self) -> PyResult<Self> {
+        let inner = self.inner.read().map_err(|_| InnerReadError)?;
+        Ok(inner.clone().into())
+    }
+
+    /// The number of qubits the operators in the list act on.
+    ///
+    /// This is not inferable from any other shape or values, since identities are not stored
+    /// explicitly.
+    #[getter]
+    #[inline]
+    pub fn num_qubits(&self) -> PyResult<u32> {
+        let inner = self.inner.read().map_err(|_| InnerReadError)?;
+        Ok(inner.num_qubits())
+    }
+
+    /// The number of elements in the list.
+    #[getter]
+    #[inline]
+    pub fn num_terms(&self) -> PyResult<usize> {
+        let inner = self.inner.read().map_err(|_| InnerReadError)?;
+        Ok(inner.num_terms())
+    }
+
+    /// Get the empty list for a given number of qubits.
+    ///
+    /// The empty list contains no elements, and is the identity element for joining two
+    /// :class:`QubitSparsePauliList` instances.
+    ///
+    /// Examples:
+    ///
+    ///     Get the empty list on 100 qubits::
+    ///
+    ///         >>> QubitSparsePauliList.empty(100)
+    ///         <QubitSparsePauliList with 0 elements on 100 qubits: []>
+    #[pyo3(signature = (/, num_qubits))]
+    #[staticmethod]
+    pub fn empty(num_qubits: u32) -> Self {
+        PhasedQubitSparsePauliList::empty(num_qubits).into()
+    }
+
+    /// Construct a :class:`.QubitSparsePauliList` from a single :class:`~.quantum_info.Pauli`
+    /// instance.
+    ///
+    /// The output list will have a single term. Note that the phase is dropped.
+    ///
+    /// Args:
+    ///     pauli (:class:`~.quantum_info.Pauli`): the single Pauli to convert.
+    ///
+    /// Examples:
+    ///
+    ///     .. code-block:: python
+    ///
+    ///         >>> label = "IYXZI"
+    ///         >>> pauli = Pauli(label)
+    ///         >>> QubitSparsePauliList.from_pauli(pauli)
+    ///         <QubitSparsePauliList with 1 element on 5 qubits: [Y_3 X_2 Z_1]>
+    ///         >>> assert QubitSparsePauliList.from_label(label) == QubitSparsePauliList.from_pauli(pauli)
+    #[staticmethod]
+    #[pyo3(signature = (pauli, /))]
+    fn from_pauli(pauli: &Bound<PyAny>) -> PyResult<Self> {
+        let py = pauli.py();
+        let num_qubits = pauli.getattr(intern!(py, "num_qubits"))?.extract::<u32>()?;
+        let z = pauli
+            .getattr(intern!(py, "z"))?
+            .extract::<PyReadonlyArray1<bool>>()?;
+        let x = pauli
+            .getattr(intern!(py, "x"))?
+            .extract::<PyReadonlyArray1<bool>>()?;
+        let mut paulis = Vec::new();
+        let mut indices = Vec::new();
+        for (i, (x, z)) in x.as_array().iter().zip(z.as_array().iter()).enumerate() {
+            // The only failure case possible here is the identity, because of how we're
+            // constructing the value to convert.
+            let Ok(term) = ::bytemuck::checked::try_cast(((*x as u8) << 1) | (*z as u8)) else {
+                continue;
+            };
+            indices.push(i as u32);
+            paulis.push(term);
+        }
+        let boundaries = vec![0, indices.len()];
+        let inner = QubitSparsePauliList::new(num_qubits, paulis, indices, boundaries)?;
+        Ok(inner.into())
+    }
+
+    /// Clear all the elements from the list, making it equal to the empty list again.
+    ///
+    /// This does not change the capacity of the internal allocations, so subsequent addition or
+    /// substraction operations resulting from composition may not need to reallocate.
+    ///
+    /// Examples:
+    ///
+    ///     .. code-block:: python
+    ///
+    ///         >>> pauli_list = QubitSparsePauliList.from_list(["IXXXYY", "ZZYZII"])
+    ///         >>> pauli_list.clear()
+    ///         >>> assert pauli_list == QubitSparsePauliList.empty(pauli_list.num_qubits)
+    pub fn clear(&mut self) -> PyResult<()> {
+        let mut inner = self.inner.write().map_err(|_| InnerWriteError)?;
+        inner.clear();
+        Ok(())
+    }
+
+    fn __len__(&self) -> PyResult<usize> {
+        self.num_terms()
+    }
+
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyTuple>> {
+        let inner = self.inner.read().map_err(|_| InnerReadError)?;
+        (
+            py.get_type::<Self>().getattr("from_sparse_list")?,
+            (self.to_sparse_list(py)?, inner.num_qubits()),
+        )
+            .into_pyobject(py)
+    }
+
+    fn __eq__(slf: Bound<Self>, other: Bound<PyAny>) -> PyResult<bool> {
+        // this is also important to check before trying to read both slf and other
+        if slf.is(&other) {
+            return Ok(true);
+        }
+        let Ok(other) = other.downcast_into::<Self>() else {
+            return Ok(false);
+        };
+        let slf_borrowed = slf.borrow();
+        let other_borrowed = other.borrow();
+        let slf_inner = slf_borrowed.inner.read().map_err(|_| InnerReadError)?;
+        let other_inner = other_borrowed.inner.read().map_err(|_| InnerReadError)?;
+        Ok(slf_inner.eq(&other_inner))
+    }
+}
+
+impl From<PhasedQubitSparsePauli> for PhasedPyQubitSparsePauli {
+    fn from(val: PhasedQubitSparsePauli) -> PyPhasedQubitSparsePauli {
+        PyPhasedQubitSparsePauli { inner: val }
+    }
+}
+impl<'py> IntoPyObject<'py> for QubitSparsePauli {
+    type Target = PyPhasedQubitSparsePauli;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> PyResult<Self::Output> {
+        PyPhasedQubitSparsePauli::from(self).into_pyobject(py)
+    }
+}
+impl From<PhasedQubitSparsePauliList> for PyPhasedQubitSparsePauliList {
+    fn from(val: PhasedQubitSparsePauliList) -> PyPhasedQubitSparsePauliList {
+        PyPhasedQubitSparsePauliList {
+            inner: Arc::new(RwLock::new(val)),
+        }
+    }
+}
+impl<'py> IntoPyObject<'py> for PhasedQubitSparsePauliList {
+    type Target = PyPhasedQubitSparsePauliList;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> PyResult<Self::Output> {
+        PyPhasedQubitSparsePauliList::from(self).into_pyobject(py)
+    }
+}

--- a/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
@@ -121,6 +121,22 @@ impl PhasedQubitSparsePauliList {
         self.qubit_sparse_pauli_list.clear();
         self.phases.clear();
     }
+
+    // Check equality of operators
+    fn eq(&self, other: &PhasedQubitSparsePauliList) -> bool {
+        if self.qubit_sparse_pauli_list != other.qubit_sparse_pauli_list {
+            return false
+        }
+
+        // assume here number of terms is equal
+        for (self_phase, other_phase) in self.phases.iter().zip(other.phases.iter()) {
+            if (self_phase - other_phase).rem_euclid(4) != 0 {
+                return false
+            }
+        }
+
+        return true
+    }
 }
 
 /// A view object onto a single term of a `QubitSparsePauliList`.

--- a/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
@@ -1019,6 +1019,9 @@ pub struct PyPhasedQubitSparsePauliList {
     // This class keeps a pointer to a pure Rust-SparseTerm and serves as interface from Python.
     pub inner: Arc<RwLock<PhasedQubitSparsePauliList>>,
 }
+
+impl_py_qspl_methods!(PyPhasedQubitSparsePauliList);
+
 #[pymethods]
 impl PyPhasedQubitSparsePauliList {
     #[pyo3(signature = (data, /, num_qubits=None))]
@@ -1096,25 +1099,6 @@ impl PyPhasedQubitSparsePauliList {
     fn copy(&self) -> PyResult<Self> {
         let inner = self.inner.read().map_err(|_| InnerReadError)?;
         Ok(inner.clone().into())
-    }
-
-    /// The number of qubits the operators in the list act on.
-    ///
-    /// This is not inferable from any other shape or values, since identities are not stored
-    /// explicitly.
-    #[getter]
-    #[inline]
-    pub fn num_qubits(&self) -> PyResult<u32> {
-        let inner = self.inner.read().map_err(|_| InnerReadError)?;
-        Ok(inner.num_qubits())
-    }
-
-    /// The number of elements in the list.
-    #[getter]
-    #[inline]
-    pub fn num_terms(&self) -> PyResult<usize> {
-        let inner = self.inner.read().map_err(|_| InnerReadError)?;
-        Ok(inner.num_terms())
     }
 
     /// Get the empty list for a given number of qubits.

--- a/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
@@ -31,7 +31,7 @@ use qiskit_circuit::{
 use super::qubit_sparse_pauli::{
     raw_parts_from_sparse_list, ArithmeticError, CoherenceError, InnerReadError, InnerWriteError,
     LabelError, Pauli, PyQubitSparsePauli, QubitSparsePauli, QubitSparsePauliList,
-    QubitSparsePauliView,
+    QubitSparsePauliView, QubitSparsePauliListLike
 };
 
 static PAULI_TYPE: ImportOnceCell = ImportOnceCell::new("qiskit.quantum_info", "Pauli");

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -579,6 +579,14 @@ impl QubitSparsePauliView<'_> {
         }
     }
 
+    pub fn num_ys(self) -> isize {
+        let mut num_ys = 0;
+        for pauli in self.paulis{
+            num_ys += (*pauli == Pauli::Y) as isize;
+        }
+        return num_ys
+    }
+
     pub fn to_sparse_str(self) -> String {
         let paulis = self
             .indices
@@ -1267,7 +1275,7 @@ impl PyQubitSparsePauli {
     ///         >>> assert QubitSparsePauli.from_label(label) == QubitSparsePauli.from_pauli(pauli)
     #[staticmethod]
     #[pyo3(signature = (pauli, /))]
-    fn from_pauli(pauli: &Bound<PyAny>) -> PyResult<Self> {
+    pub fn from_pauli(pauli: &Bound<PyAny>) -> PyResult<Self> {
         let py = pauli.py();
         let num_qubits = pauli.getattr(intern!(py, "num_qubits"))?.extract::<u32>()?;
         let z = pauli

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -2062,7 +2062,7 @@ impl PyQubitSparsePauliList {
         };
 
         // Normalize the number of qubits in the layout and the layout itself, depending on the
-        // input types, before calling PauliLindbladMap.apply_layout to do the actual work.
+        // input types, before calling QubitSparsePauliList.apply_layout to do the actual work.
         let (num_qubits, layout): (u32, Option<Vec<u32>>) = if layout.is_none() {
             (num_qubits.unwrap_or(inner.num_qubits()), None)
         } else if layout.is_instance(

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -1104,9 +1104,9 @@ impl<'py> FromPyObject<'py> for Pauli {
 ///                                 string label and the qubits they apply to.
 ///
 ///   :meth:`from_pauli`            Raise a single :class:`~.quantum_info.Pauli` into a
-///                                 single-element :class:`.QubitSparsePauli`.
+///                                 :class:`.QubitSparsePauli`.
 ///
-///   :meth:`from_raw_parts`        Build the list from :ref:`the raw data arrays
+///   :meth:`from_raw_parts`        Build the operator from :ref:`the raw data arrays
 ///                                 <qubit-sparse-pauli-arrays>`.
 ///   ============================  ================================================================
 ///

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -161,6 +161,8 @@ impl ::std::convert::TryFrom<u8> for Pauli {
 /// failures on entry to Rust from Python space will automatically raise `TypeError`.
 #[derive(Error, Debug)]
 pub enum CoherenceError {
+    #[error("`phases` ({phases}) must be the same length as `qubit_sparse_pauli_list` ({qspl})")]
+    MismatchedPhaseCount { phases: usize, qspl: usize },
     #[error("`rates` ({rates}) must be the same length as `qubit_sparse_pauli_list` ({qspl})")]
     MismatchedTermCount { rates: usize, qspl: usize },
     #[error("`paulis` ({paulis}) and `indices` ({indices}) must be the same length")]

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -110,7 +110,7 @@ impl Pauli {
     /// returning `Ok(None)` for it.  All other letters outside the alphabet return the complete
     /// error condition.
     #[inline]
-    fn try_from_u8(value: u8) -> Result<Option<Self>, PauliFromU8Error> {
+    pub fn try_from_u8(value: u8) -> Result<Option<Self>, PauliFromU8Error> {
         match value {
             b'I' => Ok(None),
             b'X' => Ok(Some(Pauli::X)),

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -1756,6 +1756,9 @@ pub struct PyQubitSparsePauliList {
     // This class keeps a pointer to a pure Rust-SparseTerm and serves as interface from Python.
     pub inner: Arc<RwLock<QubitSparsePauliList>>,
 }
+
+impl_py_qspl_methods!(PyQubitSparsePauliList);
+
 #[pymethods]
 impl PyQubitSparsePauliList {
     #[pyo3(signature = (data, /, num_qubits=None))]
@@ -1839,20 +1842,13 @@ impl PyQubitSparsePauliList {
     ///
     /// This is not inferable from any other shape or values, since identities are not stored
     /// explicitly.
-    #[getter]
-    #[inline]
-    pub fn num_qubits(&self) -> PyResult<u32> {
-        let inner = self.inner.read().map_err(|_| InnerReadError)?;
-        Ok(inner.num_qubits())
-    }
+    //#[getter]
+    //#[inline]
+    //pub fn num_qubits(&self) -> PyResult<u32> {
+    //    let inner = self.inner.read().map_err(|_| InnerReadError)?;
+    //    Ok(inner.num_qubits())
+    //}
 
-    /// The number of elements in the list.
-    #[getter]
-    #[inline]
-    pub fn num_terms(&self) -> PyResult<usize> {
-        let inner = self.inner.read().map_err(|_| InnerReadError)?;
-        Ok(inner.num_terms())
-    }
 
     /// Get the empty list for a given number of qubits.
     ///

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -229,6 +229,83 @@ pub struct QubitSparsePauliList {
     boundaries: Vec<usize>,
 }
 
+pub trait QubitSparsePauliListLike {
+    fn pauli_list(&self) -> &QubitSparsePauliList;
+    fn pauli_list_mut(&mut self) -> &mut QubitSparsePauliList;
+
+    /// Get the number of qubits the paulis are defined on.
+    #[inline]
+    fn num_qubits(&self) -> u32 {
+        self.pauli_list().num_qubits()
+    }
+
+    /// Get the number of elements in the list.
+    #[inline]
+    fn num_terms(&self) -> usize {
+        self.pauli_list().boundaries().len() - 1
+    }
+
+    /// Get the indices of each [Pauli].
+    #[inline]
+    fn indices(&self) -> &[u32] {
+        &self.pauli_list().indices()
+    }
+
+    /// Get the boundaries of each term.
+    #[inline]
+    fn boundaries(&self) -> &[usize] {
+        &self.pauli_list().boundaries()
+    }
+
+    /// Get the [Pauli]s in the list.
+    #[inline]
+    fn paulis(&self) -> &[Pauli] {
+        &self.pauli_list().paulis()
+    }
+}
+
+
+impl QubitSparsePauliListLike for QubitSparsePauliList {
+
+    fn pauli_list(&self) -> &QubitSparsePauliList {
+        &self
+    }
+
+    fn pauli_list_mut(&mut self) -> &mut QubitSparsePauliList {
+        self
+    }
+
+    /// Get the number of qubits the paulis are defined on.
+    #[inline]
+    fn num_qubits(&self) -> u32 {
+        self.num_qubits
+    }
+
+    /// Get the number of elements in the list.
+    #[inline]
+    fn num_terms(&self) -> usize {
+        self.boundaries.len() - 1
+    }
+
+    /// Get the indices of each [Pauli].
+    #[inline]
+    fn indices(&self) -> &[u32] {
+        &self.indices
+    }
+
+    /// Get the boundaries of each term.
+    #[inline]
+    fn boundaries(&self) -> &[usize] {
+        &self.boundaries
+    }
+
+    /// Get the [Pauli]s in the list.
+    #[inline]
+    fn paulis(&self) -> &[Pauli] {
+        &self.paulis
+    }
+}
+
 impl QubitSparsePauliList {
     /// Create a new qubit-sparse Pauli list from the raw components that make it up.
     ///
@@ -330,36 +407,6 @@ impl QubitSparsePauliList {
                 indices: &self.indices[start..end],
             }
         })
-    }
-
-    /// Get the number of qubits the paulis are defined on.
-    #[inline]
-    pub fn num_qubits(&self) -> u32 {
-        self.num_qubits
-    }
-
-    /// Get the number of elements in the list.
-    #[inline]
-    pub fn num_terms(&self) -> usize {
-        self.boundaries.len() - 1
-    }
-
-    /// Get the indices of each [Pauli].
-    #[inline]
-    pub fn indices(&self) -> &[u32] {
-        &self.indices
-    }
-
-    /// Get the boundaries of each term.
-    #[inline]
-    pub fn boundaries(&self) -> &[usize] {
-        &self.boundaries
-    }
-
-    /// Get the [Pauli]s in the list.
-    #[inline]
-    pub fn paulis(&self) -> &[Pauli] {
-        &self.paulis
     }
 
     /// Create a [QubitSparsePauliList] representing the empty list on ``num_qubits`` qubits.

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -1527,7 +1527,7 @@ impl PyQubitSparsePauli {
     // :class:`QubitSparsePauliList`.
     #[allow(non_snake_case)]
     #[classattr]
-    fn Pauli(py: Python) -> PyResult<Py<PyType>> {
+    pub fn Pauli(py: Python) -> PyResult<Py<PyType>> {
         PAULI_PY_ENUM
             .get_or_try_init(py, || make_py_pauli(py))
             .map(|obj| obj.clone_ref(py))

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -581,10 +581,10 @@ impl QubitSparsePauliView<'_> {
 
     pub fn num_ys(self) -> isize {
         let mut num_ys = 0;
-        for pauli in self.paulis{
+        for pauli in self.paulis {
             num_ys += (*pauli == Pauli::Y) as isize;
         }
-        return num_ys
+        return num_ys;
     }
 
     pub fn to_sparse_str(self) -> String {
@@ -655,11 +655,13 @@ impl QubitSparsePauli {
                 }
             }
         }
-        Ok(unsafe {QubitSparsePauli::new_unchecked(
-            num_qubits,
-            paulis.into_boxed_slice(),
-            indices.into_boxed_slice(),
-        )})
+        Ok(unsafe {
+            QubitSparsePauli::new_unchecked(
+                num_qubits,
+                paulis.into_boxed_slice(),
+                indices.into_boxed_slice(),
+            )
+        })
     }
 
     /// Create a new [QubitSparsePauli] from the raw components without checking data coherence.

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -584,7 +584,7 @@ impl QubitSparsePauliView<'_> {
         for pauli in self.paulis {
             num_ys += (*pauli == Pauli::Y) as isize;
         }
-        return num_ys;
+        num_ys
     }
 
     pub fn to_sparse_str(self) -> String {

--- a/qiskit/quantum_info/__init__.py
+++ b/qiskit/quantum_info/__init__.py
@@ -122,6 +122,8 @@ from __future__ import annotations
 from qiskit._accelerate.pauli_lindblad_map import (
     QubitSparsePauliList,
     QubitSparsePauli,
+    PhasedQubitSparsePauli,
+    PhasedQubitSparsePauliList,
     PauliLindbladMap,
 )
 from qiskit._accelerate.sparse_observable import SparseObservable

--- a/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
@@ -1150,63 +1150,63 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
             PhasedQubitSparsePauli.from_raw_parts(5, [pauli.Z, pauli.Y], [1, 4]),
         ]
         self.assertEqual(list(pauli_list), expected)
-    '''
+
     def test_indexing(self):
-        pauli_list = QubitSparsePauliList.from_sparse_list(
+        pauli_list = PhasedQubitSparsePauliList.from_sparse_list(
             [
-                ("XYY", (4, 2, 1)),
-                ("", ()),
-                ("ZZ", (3, 0)),
-                ("XX", (2, 1)),
-                ("YZ", (4, 1)),
+                (0, "XYY", (4, 2, 1)),
+                (1, "", ()),
+                (1, "ZZ", (3, 0)),
+                (2, "XX", (2, 1)),
+                (0, "YZ", (4, 1)),
             ],
             num_qubits=5,
         )
-        pauli = QubitSparsePauli.Pauli
+        pauli = PhasedQubitSparsePauli.Pauli
         expected = [
-            QubitSparsePauli.from_raw_parts(5, [pauli.Y, pauli.Y, pauli.X], [1, 2, 4]),
-            QubitSparsePauli.from_raw_parts(5, [], []),
-            QubitSparsePauli.from_raw_parts(5, [pauli.Z, pauli.Z], [0, 3]),
-            QubitSparsePauli.from_raw_parts(5, [pauli.X, pauli.X], [1, 2]),
-            QubitSparsePauli.from_raw_parts(5, [pauli.Z, pauli.Y], [1, 4]),
+            PhasedQubitSparsePauli.from_raw_parts(5, [pauli.Y, pauli.Y, pauli.X], [1, 2, 4]),
+            PhasedQubitSparsePauli.from_raw_parts(5, [], [], 1),
+            PhasedQubitSparsePauli.from_raw_parts(5, [pauli.Z, pauli.Z], [0, 3], 1),
+            PhasedQubitSparsePauli.from_raw_parts(5, [pauli.X, pauli.X], [1, 2], 2),
+            PhasedQubitSparsePauli.from_raw_parts(5, [pauli.Z, pauli.Y], [1, 4]),
         ]
         self.assertEqual(pauli_list[0], expected[0])
         self.assertEqual(pauli_list[-2], expected[-2])
-        self.assertEqual(pauli_list[2:4], QubitSparsePauliList(expected[2:4]))
-        self.assertEqual(pauli_list[1::2], QubitSparsePauliList(expected[1::2]))
-        self.assertEqual(pauli_list[:], QubitSparsePauliList(expected))
-        self.assertEqual(pauli_list[-1:-4:-1], QubitSparsePauliList(expected[-1:-4:-1]))
+        self.assertEqual(pauli_list[2:4], PhasedQubitSparsePauliList(expected[2:4]))
+        self.assertEqual(pauli_list[1::2], PhasedQubitSparsePauliList(expected[1::2]))
+        self.assertEqual(pauli_list[:], PhasedQubitSparsePauliList(expected))
+        self.assertEqual(pauli_list[-1:-4:-1], PhasedQubitSparsePauliList(expected[-1:-4:-1]))
 
     def test_to_sparse_list(self):
         """Test converting to a sparse list."""
         with self.subTest(msg="empty"):
-            pauli_list = QubitSparsePauliList.empty(100)
+            pauli_list = PhasedQubitSparsePauliList.empty(100)
             expected = []
             self.assertEqual(expected, pauli_list.to_sparse_list())
 
         with self.subTest(msg="IXYZ"):
-            pauli_list = QubitSparsePauliList(["IXYZ"])
-            expected = [("ZYX", [0, 1, 2])]
+            pauli_list = PhasedQubitSparsePauliList(Pauli("-iIXYZ"))
+            expected = [(1, "ZYX", [0, 1, 2])]
             self.assertEqual(
                 canonicalize_sparse_list(expected),
                 canonicalize_sparse_list(pauli_list.to_sparse_list()),
             )
 
         with self.subTest(msg="multiple"):
-            pauli_list = QubitSparsePauliList.from_list(["XXIZ", "YYIZ"])
-            expected = [("XXZ", [3, 2, 0]), ("ZYY", [0, 2, 3])]
+            pauli_list = PhasedQubitSparsePauliList.from_list(["XXIZ", "YYIZ"])
+            expected = [(0, "XXZ", [3, 2, 0]), (0, "ZYY", [0, 2, 3])]
             self.assertEqual(
                 canonicalize_sparse_list(expected),
                 canonicalize_sparse_list(pauli_list.to_sparse_list()),
             )
 
 
-def canonicalize_term(pauli, indices):
+def canonicalize_term(phase, pauli, indices):
     # canonicalize a sparse list term by sorting by indices (which is unique as
     # indices cannot be repeated)
     idcs = np.argsort(indices)
     sorted_paulis = "".join(pauli[i] for i in idcs)
-    return (sorted_paulis, np.asarray(indices)[idcs].tolist())
+    return (phase, sorted_paulis, np.asarray(indices)[idcs].tolist())
 
 
 def canonicalize_sparse_list(sparse_list):
@@ -1215,7 +1215,7 @@ def canonicalize_sparse_list(sparse_list):
     canonicalized_terms = [canonicalize_term(*term) for term in sparse_list]
     return sorted(canonicalized_terms)
 
-'''
+
 def lnn_target(num_qubits):
     """Create a simple `Target` object with an arbitrary basis-gate set, and open-path
     connectivity."""

--- a/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
@@ -122,7 +122,7 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
                     PhasedQubitSparsePauli.Pauli.X,
                 ],
                 [0, 1, 2, 4, 5, 7, 8, 11, 12],
-                3
+                0
             ),
         )
 

--- a/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
@@ -672,7 +672,7 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
             QubitSparsePauliList.from_list(["IIZ", "IXI"], num_qubits=4)
         with self.assertRaisesRegex(ValueError, "cannot construct.*without knowing `num_qubits`"):
             QubitSparsePauliList.from_list([])
-
+    
     def test_from_sparse_list(self):
         self.assertEqual(
             QubitSparsePauliList.from_sparse_list(
@@ -799,8 +799,8 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
             )
         )
         self.assertEqual(from_paulis, from_lists)
-
-    def test_from_qubit_sparse_paulis(self):
+    
+    def test_from_phased_qubit_sparse_paulis(self):
         self.assertEqual(
             QubitSparsePauliList.from_qubit_sparse_paulis([], num_qubits=5),
             QubitSparsePauliList.empty(5),

--- a/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
@@ -439,7 +439,7 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
             p0.compose(p1)
         with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits: 3, 4"):
             p1.compose(p0)
-    """
+
     def test_commutes(self):
         p0 = PhasedQubitSparsePauli("XIY")
         p1 = PhasedQubitSparsePauli("IZI")
@@ -473,7 +473,7 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
             p0.commutes(p1)
         with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits: 3, 4"):
             p1.commutes(p0)
-    """
+
 @ddt.ddt
 class TestPhasedQubitSparsePauliList(QiskitTestCase):
     pass

--- a/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
@@ -509,67 +509,67 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
         self.assertEqual(
             PhasedQubitSparsePauliList(Pauli("")), PhasedQubitSparsePauliList.from_pauli(Pauli(""))
         )
-    '''
+
     def test_default_constructor_list(self):
         data = ["IXIIZ", "XIXII", "IIXYI"]
-        self.assertEqual(QubitSparsePauliList(data), QubitSparsePauliList.from_list(data))
+        self.assertEqual(PhasedQubitSparsePauliList(data), PhasedQubitSparsePauliList.from_list(data))
         self.assertEqual(
-            QubitSparsePauliList(data, num_qubits=5), QubitSparsePauliList.from_list(data)
+            PhasedQubitSparsePauliList(data, num_qubits=5), PhasedQubitSparsePauliList.from_list(data)
         )
         with self.assertRaisesRegex(ValueError, "label with length 5 cannot be added"):
-            QubitSparsePauliList(data, num_qubits=4)
+            PhasedQubitSparsePauliList(data, num_qubits=4)
         with self.assertRaisesRegex(ValueError, "label with length 5 cannot be added"):
-            QubitSparsePauliList(data, num_qubits=6)
+            PhasedQubitSparsePauliList(data, num_qubits=6)
         self.assertEqual(
-            QubitSparsePauliList([], num_qubits=5), QubitSparsePauliList.from_list([], num_qubits=5)
+            PhasedQubitSparsePauliList([], num_qubits=5), PhasedQubitSparsePauliList.from_list([], num_qubits=5)
         )
 
     def test_default_constructor_sparse_list(self):
-        data = [("ZX", (0, 3)), ("XY", (2, 4)), ("ZY", (2, 1))]
+        data = [(0, "ZX", (0, 3)), (1, "XY", (2, 4)), (2, "ZY", (2, 1))]
         self.assertEqual(
-            QubitSparsePauliList(data, num_qubits=5),
-            QubitSparsePauliList.from_sparse_list(data, num_qubits=5),
+            PhasedQubitSparsePauliList(data, num_qubits=5),
+            PhasedQubitSparsePauliList.from_sparse_list(data, num_qubits=5),
         )
         self.assertEqual(
-            QubitSparsePauliList(data, num_qubits=10),
-            QubitSparsePauliList.from_sparse_list(data, num_qubits=10),
+            PhasedQubitSparsePauliList(data, num_qubits=10),
+            PhasedQubitSparsePauliList.from_sparse_list(data, num_qubits=10),
         )
         with self.assertRaisesRegex(ValueError, "'num_qubits' must be provided"):
-            QubitSparsePauliList(data)
+            PhasedQubitSparsePauliList(data)
         self.assertEqual(
-            QubitSparsePauliList([], num_qubits=5),
-            QubitSparsePauliList.from_sparse_list([], num_qubits=5),
+            PhasedQubitSparsePauliList([], num_qubits=5),
+            PhasedQubitSparsePauliList.from_sparse_list([], num_qubits=5),
         )
 
     def test_default_constructor_label(self):
         data = "IIXIXXIZZYYIYZ"
-        self.assertEqual(QubitSparsePauliList(data), QubitSparsePauliList.from_label(data))
+        self.assertEqual(PhasedQubitSparsePauliList(data), PhasedQubitSparsePauliList.from_label(data))
         self.assertEqual(
-            QubitSparsePauliList(data, num_qubits=len(data)), QubitSparsePauliList.from_label(data)
+            PhasedQubitSparsePauliList(data, num_qubits=len(data)), PhasedQubitSparsePauliList.from_label(data)
         )
         with self.assertRaisesRegex(ValueError, "explicitly given 'num_qubits'"):
-            QubitSparsePauliList(data, num_qubits=len(data) + 1)
+            PhasedQubitSparsePauliList(data, num_qubits=len(data) + 1)
 
     def test_default_constructor_copy(self):
-        base = QubitSparsePauliList.from_list(["IXIZIY", "XYZIII"])
-        copied = QubitSparsePauliList(base)
+        base = PhasedQubitSparsePauliList.from_list(["IXIZIY", "XYZIII"])
+        copied = PhasedQubitSparsePauliList(base)
         self.assertEqual(base, copied)
         self.assertIsNot(base, copied)
 
         with self.assertRaisesRegex(ValueError, "explicitly given 'num_qubits'"):
-            QubitSparsePauliList(base, num_qubits=base.num_qubits + 1)
+            PhasedQubitSparsePauliList(base, num_qubits=base.num_qubits + 1)
 
     def test_default_constructor_term(self):
-        expected = QubitSparsePauliList.from_list(["IIZXII"])
-        self.assertEqual(QubitSparsePauliList(expected[0]), expected)
+        expected = PhasedQubitSparsePauliList.from_list(["IIZXII"])
+        self.assertEqual(PhasedQubitSparsePauliList(expected[0]), expected)
 
     def test_default_constructor_term_iterable(self):
-        expected = QubitSparsePauliList.from_list(["IIZXII", "IIIIII"])
+        expected = PhasedQubitSparsePauliList.from_list(["IIZXII", "IIIIII"])
         terms = [expected[0], expected[1]]
-        self.assertEqual(QubitSparsePauliList(list(terms)), expected)
-        self.assertEqual(QubitSparsePauliList(tuple(terms)), expected)
-        self.assertEqual(QubitSparsePauliList(term for term in terms), expected)
-    '''
+        self.assertEqual(PhasedQubitSparsePauliList(list(terms)), expected)
+        self.assertEqual(PhasedQubitSparsePauliList(tuple(terms)), expected)
+        self.assertEqual(PhasedQubitSparsePauliList(term for term in terms), expected)
+
     def test_from_label(self):
         # The label is interpreted like a bitstring, with the right-most item associated with qubit
         # 0, and increasing as we move to the left (like `Pauli`, and other bitstring conventions).
@@ -755,29 +755,28 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
             PhasedQubitSparsePauliList.from_sparse_list([(0, "XZ", (3, 3))], num_qubits=5)
         with self.assertRaisesRegex(ValueError, "index 3 is duplicated"):
             PhasedQubitSparsePauliList.from_sparse_list([(0, "XYZXZ", (3, 0, 1, 2, 3))], num_qubits=5)
-    '''
+
     def test_from_pauli(self):
         # This function should be infallible provided `Pauli` doesn't change its interface and the
         # user doesn't violate the typing.
 
         # Simple check that the labels are interpreted in the same order.
         self.assertEqual(
-            QubitSparsePauliList.from_pauli(Pauli("IIXZI")),
-            QubitSparsePauliList.from_label("IIXZI"),
+            PhasedQubitSparsePauliList.from_pauli(Pauli("IIXZI")),
+            PhasedQubitSparsePauliList.from_label("IIXZI"),
         )
 
-        # `Pauli` accepts a phase in its label, which gets dropped
         self.assertEqual(
-            QubitSparsePauliList.from_pauli(Pauli("iIXZIX")),
-            QubitSparsePauliList.from_list(["IXZIX"]),
+            PhasedQubitSparsePauliList.from_pauli(Pauli("iIXZIX")),
+            PhasedQubitSparsePauli((3, "XZX", (0, 2, 3)), 5).to_phased_qubit_sparse_pauli_list(),
         )
         self.assertEqual(
-            QubitSparsePauliList.from_pauli(Pauli("-iIXZIX")),
-            QubitSparsePauliList.from_list(["IXZIX"]),
+            PhasedQubitSparsePauliList.from_pauli(Pauli("-iIXZIX")),
+            PhasedQubitSparsePauli((1, "XZX", (0, 2, 3)), 5).to_phased_qubit_sparse_pauli_list(),
         )
         self.assertEqual(
-            QubitSparsePauliList.from_pauli(Pauli("-IXZIX")),
-            QubitSparsePauliList.from_list(["IXZIX"]),
+            PhasedQubitSparsePauliList.from_pauli(Pauli("-IXZIX")),
+            PhasedQubitSparsePauli((2, "XZX", (0, 2, 3)), 5).to_phased_qubit_sparse_pauli_list(),
         )
 
         # `Pauli` has its internal phase convention for how it stores `Y`; we should get this right
@@ -785,50 +784,42 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
         paulis = {"IXYZ" * n: Pauli("IXYZ" * n) for n in range(1, 5)}
         from_paulis, from_labels = zip(
             *(
-                (QubitSparsePauliList.from_pauli(pauli), QubitSparsePauliList.from_label(label))
+                (PhasedQubitSparsePauliList.from_pauli(pauli), PhasedQubitSparsePauliList.from_label(label))
                 for label, pauli in paulis.items()
             )
         )
         self.assertEqual(from_paulis, from_labels)
 
-        phased_paulis = {"IXYZ" * n: Pauli("j" + "IXYZ" * n) for n in range(1, 5)}
-        from_paulis, from_lists = zip(
-            *(
-                (QubitSparsePauliList.from_pauli(pauli), QubitSparsePauliList.from_list([label]))
-                for label, pauli in phased_paulis.items()
-            )
-        )
-        self.assertEqual(from_paulis, from_lists)
-    
+
     def test_from_phased_qubit_sparse_paulis(self):
         self.assertEqual(
-            QubitSparsePauliList.from_qubit_sparse_paulis([], num_qubits=5),
-            QubitSparsePauliList.empty(5),
+            PhasedQubitSparsePauliList.from_phased_qubit_sparse_paulis([], num_qubits=5),
+            PhasedQubitSparsePauliList.empty(5),
         )
         self.assertEqual(
-            QubitSparsePauliList.from_qubit_sparse_paulis((), num_qubits=0),
-            QubitSparsePauliList.empty(0),
+            PhasedQubitSparsePauliList.from_phased_qubit_sparse_paulis((), num_qubits=0),
+            PhasedQubitSparsePauliList.empty(0),
         )
         self.assertEqual(
-            QubitSparsePauliList.from_qubit_sparse_paulis((None for _ in []), num_qubits=3),
-            QubitSparsePauliList.empty(3),
+            PhasedQubitSparsePauliList.from_phased_qubit_sparse_paulis((None for _ in []), num_qubits=3),
+            PhasedQubitSparsePauliList.empty(3),
         )
 
-        expected = QubitSparsePauliList.from_sparse_list(
+        expected = PhasedQubitSparsePauliList.from_sparse_list(
             [
-                ("XYZ", (4, 2, 1)),
-                ("XXYY", (8, 5, 3, 2)),
-                ("ZZ", (5, 0)),
+                (0, "XYZ", (4, 2, 1)),
+                (0, "XXYY", (8, 5, 3, 2)),
+                (0, "ZZ", (5, 0)),
             ],
             num_qubits=10,
         )
-        self.assertEqual(QubitSparsePauliList.from_qubit_sparse_paulis(list(expected)), expected)
-        self.assertEqual(QubitSparsePauliList.from_qubit_sparse_paulis(tuple(expected)), expected)
+        self.assertEqual(PhasedQubitSparsePauliList.from_phased_qubit_sparse_paulis(list(expected)), expected)
+        self.assertEqual(PhasedQubitSparsePauliList.from_phased_qubit_sparse_paulis(tuple(expected)), expected)
         self.assertEqual(
-            QubitSparsePauliList.from_qubit_sparse_paulis(term for term in expected), expected
+            PhasedQubitSparsePauliList.from_phased_qubit_sparse_paulis(term for term in expected), expected
         )
         self.assertEqual(
-            QubitSparsePauliList.from_qubit_sparse_paulis(
+            PhasedQubitSparsePauliList.from_phased_qubit_sparse_paulis(
                 (term for term in expected), num_qubits=expected.num_qubits
             ),
             expected,
@@ -836,79 +827,48 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
 
     def test_from_qubit_sparse_paulis_failures(self):
         with self.assertRaisesRegex(ValueError, "cannot construct.*without knowing `num_qubits`"):
-            QubitSparsePauliList.from_qubit_sparse_paulis([])
+            PhasedQubitSparsePauliList.from_phased_qubit_sparse_paulis([])
 
         left, right = (
-            QubitSparsePauliList(["IIXYI"])[0],
-            QubitSparsePauliList(["IIIIIIIIX"])[0],
+            PhasedQubitSparsePauliList(["IIXYI"])[0],
+            PhasedQubitSparsePauliList(["IIIIIIIIX"])[0],
         )
         with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits"):
-            QubitSparsePauliList.from_qubit_sparse_paulis([left, right])
+            PhasedQubitSparsePauliList.from_phased_qubit_sparse_paulis([left, right])
         with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits"):
-            QubitSparsePauliList.from_qubit_sparse_paulis([left], num_qubits=100)
+            PhasedQubitSparsePauliList.from_phased_qubit_sparse_paulis([left], num_qubits=100)
 
     def test_default_constructor_failed_inference(self):
         with self.assertRaises(TypeError):
             # Mixed dense/sparse list.
-            QubitSparsePauliList(["IIXIZ", ("IZ", (2, 3))], num_qubits=5)
+            PhasedQubitSparsePauliList(["IIXIZ", (0, "IZ", (2, 3))], num_qubits=5)
 
     def test_num_qubits(self):
-        self.assertEqual(QubitSparsePauliList.empty(0).num_qubits, 0)
-        self.assertEqual(QubitSparsePauliList.empty(10).num_qubits, 10)
+        self.assertEqual(PhasedQubitSparsePauliList.empty(0).num_qubits, 0)
+        self.assertEqual(PhasedQubitSparsePauliList.empty(10).num_qubits, 10)
 
     def test_num_terms(self):
-        self.assertEqual(QubitSparsePauliList.empty(0).num_terms, 0)
-        self.assertEqual(QubitSparsePauliList.empty(10).num_terms, 0)
-        self.assertEqual(QubitSparsePauliList.from_list(["IIIXIZ", "YYXXII"]).num_terms, 2)
+        self.assertEqual(PhasedQubitSparsePauliList.empty(0).num_terms, 0)
+        self.assertEqual(PhasedQubitSparsePauliList.empty(10).num_terms, 0)
+        self.assertEqual(PhasedQubitSparsePauliList.from_list(["IIIXIZ", "YYXXII"]).num_terms, 2)
 
     def test_empty(self):
-        empty_5 = QubitSparsePauliList.empty(5)
+        empty_5 = PhasedQubitSparsePauliList.empty(5)
         self.assertEqual(empty_5.num_qubits, 5)
         self.assertEqual(len(empty_5), 0)
         self.assertEqual(empty_5.to_sparse_list(), [])
 
-        empty_0 = QubitSparsePauliList.empty(0)
+        empty_0 = PhasedQubitSparsePauliList.empty(0)
         self.assertEqual(empty_0.num_qubits, 0)
         self.assertEqual(len(empty_0), 0)
         self.assertEqual(empty_0.to_sparse_list(), [])
 
     def test_len(self):
-        self.assertEqual(len(QubitSparsePauliList.empty(0)), 0)
-        self.assertEqual(len(QubitSparsePauliList.empty(10)), 0)
-        self.assertEqual(len(QubitSparsePauliList.from_list(["IIIXIZ", "YYXXII"])), 2)
+        self.assertEqual(len(PhasedQubitSparsePauliList.empty(0)), 0)
+        self.assertEqual(len(PhasedQubitSparsePauliList.empty(10)), 0)
+        self.assertEqual(len(PhasedQubitSparsePauliList.from_list(["IIIXIZ", "YYXXII"])), 2)
 
-    def test_pauli_enum(self):
-        # These are very explicit tests that effectively just duplicate magic numbers, but the point
-        # is that those magic numbers are required to be constant as their values are part of the
-        # public interface.
-
-        self.assertEqual(
-            set(QubitSparsePauli.Pauli),
-            {
-                QubitSparsePauli.Pauli.X,
-                QubitSparsePauli.Pauli.Y,
-                QubitSparsePauli.Pauli.Z,
-            },
-        )
-        # All the enumeration items should also be integers.
-        self.assertIsInstance(QubitSparsePauli.Pauli.X, int)
-        values = {
-            "X": 0b10,
-            "Y": 0b11,
-            "Z": 0b01,
-        }
-        self.assertEqual({name: getattr(QubitSparsePauli.Pauli, name) for name in values}, values)
-
-        # The single-character label aliases can be accessed with index notation.
-        labels = {
-            "X": QubitSparsePauli.Pauli.X,
-            "Y": QubitSparsePauli.Pauli.Y,
-            "Z": QubitSparsePauli.Pauli.Z,
-        }
-        self.assertEqual({label: QubitSparsePauli.Pauli[label] for label in labels}, labels)
-        # The `label` property returns known values.
-        self.assertEqual({pauli.label: pauli for pauli in QubitSparsePauli.Pauli}, labels)
-
+    '''
     @ddt.idata(single_cases_list())
     def test_pickle(self, qubit_sparse_pauli_list):
         self.assertEqual(qubit_sparse_pauli_list, copy.copy(qubit_sparse_pauli_list))

--- a/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
@@ -133,79 +133,79 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
         with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
             # Unicode shenangigans.
             PhasedQubitSparsePauli.from_label("🐍")
-    '''
+
     def test_from_sparse_label(self):
         self.assertEqual(
-            QubitSparsePauli.from_sparse_label(("XY", (0, 1)), num_qubits=5),
-            QubitSparsePauli.from_label("IIIYX"),
+            PhasedQubitSparsePauli.from_sparse_label((1, "XY", (0, 1)), num_qubits=5),
+            PhasedQubitSparsePauli(Pauli("-iIIIYX")),
         )
         self.assertEqual(
-            QubitSparsePauli.from_sparse_label(("XX", (1, 3)), num_qubits=5),
-            QubitSparsePauli.from_label("IXIXI"),
+            PhasedQubitSparsePauli.from_sparse_label((0, "XX", (1, 3)), num_qubits=5),
+            PhasedQubitSparsePauli.from_label("IXIXI"),
         )
         self.assertEqual(
-            QubitSparsePauli.from_sparse_label(("YYZ", (0, 2, 4)), num_qubits=5),
-            QubitSparsePauli.from_label("ZIYIY"),
+            PhasedQubitSparsePauli.from_sparse_label((3, "YYZ", (0, 2, 4)), num_qubits=5),
+            PhasedQubitSparsePauli(Pauli("iZIYIY")),
         )
 
         # The indices should be allowed to be given in unsorted order, but they should be term-wise
         # sorted in the output.
-        from_unsorted = QubitSparsePauli.from_sparse_label(("XYZ", (2, 0, 1)), num_qubits=3)
-        self.assertEqual(from_unsorted, QubitSparsePauli.from_label("XZY"))
+        from_unsorted = PhasedQubitSparsePauli.from_sparse_label((0, "XYZ", (2, 0, 1)), num_qubits=3)
+        self.assertEqual(from_unsorted, PhasedQubitSparsePauli.from_label("XZY"))
         np.testing.assert_equal(from_unsorted.indices, np.array([0, 1, 2], dtype=np.uint32))
 
         # Explicit identities should still work, just be skipped over.
-        explicit_identity = QubitSparsePauli.from_sparse_label(("ZXI", (0, 1, 2)), num_qubits=10)
+        explicit_identity = PhasedQubitSparsePauli.from_sparse_label((0, "ZXI", (0, 1, 2)), num_qubits=10)
         self.assertEqual(
             explicit_identity,
-            QubitSparsePauli.from_sparse_label(("XZ", (1, 0)), num_qubits=10),
+            PhasedQubitSparsePauli.from_sparse_label((0, "XZ", (1, 0)), num_qubits=10),
         )
         np.testing.assert_equal(explicit_identity.indices, np.array([0, 1], dtype=np.uint32))
 
-        explicit_identity = QubitSparsePauli.from_sparse_label(
-            ("XYIII", (0, 1, 2, 3, 8)), num_qubits=10
+        explicit_identity = PhasedQubitSparsePauli.from_sparse_label(
+            (0, "XYIII", (0, 1, 2, 3, 8)), num_qubits=10
         )
         self.assertEqual(
             explicit_identity,
-            QubitSparsePauli.from_sparse_label(("YX", (1, 0)), num_qubits=10),
+            PhasedQubitSparsePauli.from_sparse_label((0, "YX", (1, 0)), num_qubits=10),
         )
         np.testing.assert_equal(explicit_identity.indices, np.array([0, 1], dtype=np.uint32))
 
-    def test_from_sparse_list_failures(self):
+    def test_from_sparse_label_failures(self):
         with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
             # Bad letters that are still ASCII.
-            QubitSparsePauli.from_sparse_label(("+$", (2, 1)), num_qubits=8)
+            PhasedQubitSparsePauli.from_sparse_label((0, "+$", (2, 1)), num_qubits=8)
         # Unicode shenangigans.  These two should fail with a `ValueError`, but the exact message
         # isn't important.  "\xff" is "ÿ", which is two bytes in UTF-8 (so has a length of 2 in
         # Rust), but has a length of 1 in Python, so try with both a length-1 and length-2 index
         # sequence, and both should still raise `ValueError`.
         with self.assertRaises(ValueError):
-            QubitSparsePauli.from_sparse_label(("\xff", (1,)), num_qubits=5)
+            PhasedQubitSparsePauli.from_sparse_label((0, "\xff", (1,)), num_qubits=5)
         with self.assertRaises(ValueError):
-            QubitSparsePauli.from_sparse_label(("\xff", (1, 2)), num_qubits=5)
+            PhasedQubitSparsePauli.from_sparse_label((0, "\xff", (1, 2)), num_qubits=5)
 
         with self.assertRaisesRegex(
             ValueError, "label with length 2 does not match indices of length 1"
         ):
-            QubitSparsePauli.from_sparse_label(("XZ", (0,)), num_qubits=5)
+            PhasedQubitSparsePauli.from_sparse_label((0, "XZ", (0,)), num_qubits=5)
         with self.assertRaisesRegex(
             ValueError, "label with length 2 does not match indices of length 3"
         ):
-            QubitSparsePauli.from_sparse_label(("XZ", (0, 1, 2)), num_qubits=5)
+            PhasedQubitSparsePauli.from_sparse_label((0, "XZ", (0, 1, 2)), num_qubits=5)
 
         with self.assertRaisesRegex(ValueError, "index 3 is out of range for a 3-qubit operator"):
-            QubitSparsePauli.from_sparse_label(("XZY", (0, 1, 3)), num_qubits=3)
+            PhasedQubitSparsePauli.from_sparse_label((2, "XZY", (0, 1, 3)), num_qubits=3)
         with self.assertRaisesRegex(ValueError, "index 4 is out of range for a 3-qubit operator"):
-            QubitSparsePauli.from_sparse_label(("XZY", (0, 1, 4)), num_qubits=3)
+            PhasedQubitSparsePauli.from_sparse_label((1, "XZY", (0, 1, 4)), num_qubits=3)
         with self.assertRaisesRegex(ValueError, "index 3 is out of range for a 3-qubit operator"):
             # ... even if it's for an explicit identity.
-            QubitSparsePauli.from_sparse_label(("XXI", (0, 1, 3)), num_qubits=3)
+            PhasedQubitSparsePauli.from_sparse_label((4, "XXI", (0, 1, 3)), num_qubits=3)
 
         with self.assertRaisesRegex(ValueError, "index 3 is duplicated"):
-            QubitSparsePauli.from_sparse_label(("XZ", (3, 3)), num_qubits=5)
+            PhasedQubitSparsePauli.from_sparse_label((0, "XZ", (3, 3)), num_qubits=5)
         with self.assertRaisesRegex(ValueError, "index 3 is duplicated"):
-            QubitSparsePauli.from_sparse_label(("XYZXZ", (3, 0, 1, 2, 3)), num_qubits=5)
-    '''
+            PhasedQubitSparsePauli.from_sparse_label((0, "XYZXZ", (3, 0, 1, 2, 3)), num_qubits=5)
+
 
     def test_from_pauli(self):
         # This function should be infallible provided `Pauli` doesn't change its interface and the

--- a/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
@@ -485,31 +485,31 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
 
 @ddt.ddt
 class TestPhasedQubitSparsePauliList(QiskitTestCase):
-    pass
-    '''
+
+    
     def test_default_constructor_pauli(self):
         data = Pauli("IXYIZ")
-        self.assertEqual(QubitSparsePauliList(data), QubitSparsePauliList.from_pauli(data))
+        self.assertEqual(PhasedQubitSparsePauliList(data), PhasedQubitSparsePauliList.from_pauli(data))
         self.assertEqual(
-            QubitSparsePauliList(data, num_qubits=data.num_qubits),
-            QubitSparsePauliList.from_pauli(data),
+            PhasedQubitSparsePauliList(data, num_qubits=data.num_qubits),
+            PhasedQubitSparsePauliList.from_pauli(data),
         )
         with self.assertRaisesRegex(ValueError, "explicitly given 'num_qubits'"):
-            QubitSparsePauliList(data, num_qubits=data.num_qubits + 1)
+            PhasedQubitSparsePauliList(data, num_qubits=data.num_qubits + 1)
 
         with_phase = Pauli("-jIYYXY")
         self.assertEqual(
-            QubitSparsePauliList(with_phase), QubitSparsePauliList.from_pauli(with_phase)
+            PhasedQubitSparsePauliList(with_phase), PhasedQubitSparsePauliList.from_pauli(with_phase)
         )
         self.assertEqual(
-            QubitSparsePauliList(with_phase, num_qubits=data.num_qubits),
-            QubitSparsePauliList.from_pauli(with_phase),
+            PhasedQubitSparsePauliList(with_phase, num_qubits=data.num_qubits),
+            PhasedQubitSparsePauliList.from_pauli(with_phase),
         )
 
         self.assertEqual(
-            QubitSparsePauliList(Pauli("")), QubitSparsePauliList.from_pauli(Pauli(""))
+            PhasedQubitSparsePauliList(Pauli("")), PhasedQubitSparsePauliList.from_pauli(Pauli(""))
         )
-
+    '''
     def test_default_constructor_list(self):
         data = ["IXIIZ", "XIXII", "IIXYI"]
         self.assertEqual(QubitSparsePauliList(data), QubitSparsePauliList.from_list(data))
@@ -755,7 +755,7 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
             QubitSparsePauliList.from_sparse_list([("XZ", (3, 3))], num_qubits=5)
         with self.assertRaisesRegex(ValueError, "index 3 is duplicated"):
             QubitSparsePauliList.from_sparse_list([("XYZXZ", (3, 0, 1, 2, 3))], num_qubits=5)
-
+    
     def test_from_pauli(self):
         # This function should be infallible provided `Pauli` doesn't change its interface and the
         # user doesn't violate the typing.

--- a/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
@@ -75,16 +75,16 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
         self.assertEqual(PhasedQubitSparsePauli(with_phase).phase, 1)
 
         self.assertEqual(PhasedQubitSparsePauli(Pauli("")), PhasedQubitSparsePauli.from_pauli(Pauli("")))
-    '''
+    
     def test_default_constructor_label(self):
         data = "IXIIZ"
-        self.assertEqual(QubitSparsePauli(data), QubitSparsePauli.from_label(data))
-        self.assertEqual(QubitSparsePauli(data, num_qubits=5), QubitSparsePauli.from_label(data))
+        self.assertEqual(PhasedQubitSparsePauli(data), PhasedQubitSparsePauli.from_label(data))
+        self.assertEqual(PhasedQubitSparsePauli(data, num_qubits=5), PhasedQubitSparsePauli.from_label(data))
         with self.assertRaisesRegex(ValueError, "does not match label"):
-            QubitSparsePauli(data, num_qubits=4)
+            PhasedQubitSparsePauli(data, num_qubits=4)
         with self.assertRaisesRegex(ValueError, "does not match label"):
-            QubitSparsePauli(data, num_qubits=6)
-
+            PhasedQubitSparsePauli(data, num_qubits=6)
+    '''
     def test_default_constructor_sparse_label(self):
         data = ("ZX", (0, 3))
         self.assertEqual(
@@ -101,25 +101,25 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
             QubitSparsePauli(("", []), num_qubits=5),
             QubitSparsePauli.from_sparse_label(("", []), num_qubits=5),
         )
-
+    '''
     def test_from_label(self):
         # The label is interpreted like a bitstring, with the right-most item associated with qubit
         # 0, and increasing as we move to the left (like `Pauli`, and other bitstring conventions).
         self.assertEqual(
             # Ruler for counting terms:  dcba9876543210
-            QubitSparsePauli.from_label("IXXIIZZIYYIXYZ"),
+            PhasedQubitSparsePauli.from_label("IXXIIZZIYYIXYZ"),
             QubitSparsePauli.from_raw_parts(
                 14,
                 [
-                    QubitSparsePauli.Pauli.Z,
-                    QubitSparsePauli.Pauli.Y,
-                    QubitSparsePauli.Pauli.X,
-                    QubitSparsePauli.Pauli.Y,
-                    QubitSparsePauli.Pauli.Y,
-                    QubitSparsePauli.Pauli.Z,
-                    QubitSparsePauli.Pauli.Z,
-                    QubitSparsePauli.Pauli.X,
-                    QubitSparsePauli.Pauli.X,
+                    PhasedQubitSparsePauli.Pauli.Z,
+                    PhasedQubitSparsePauli.Pauli.Y,
+                    PhasedQubitSparsePauli.Pauli.X,
+                    PhasedQubitSparsePauli.Pauli.Y,
+                    PhasedQubitSparsePauli.Pauli.Y,
+                    PhasedQubitSparsePauli.Pauli.Z,
+                    PhasedQubitSparsePauli.Pauli.Z,
+                    PhasedQubitSparsePauli.Pauli.X,
+                    PhasedQubitSparsePauli.Pauli.X,
                 ],
                 [0, 1, 2, 4, 5, 7, 8, 11, 12],
             ),
@@ -128,11 +128,11 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
     def test_from_label_failures(self):
         with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
             # Bad letters that are still ASCII.
-            QubitSparsePauli.from_label("I+-$%I")
+            PhasedQubitSparsePauli.from_label("I+-$%I")
         with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
             # Unicode shenangigans.
-            QubitSparsePauli.from_label("🐍")
-
+            PhasedQubitSparsePauli.from_label("🐍")
+    '''
     def test_from_sparse_label(self):
         self.assertEqual(
             QubitSparsePauli.from_sparse_label(("XY", (0, 1)), num_qubits=5),

--- a/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
@@ -569,110 +569,110 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
         self.assertEqual(QubitSparsePauliList(list(terms)), expected)
         self.assertEqual(QubitSparsePauliList(tuple(terms)), expected)
         self.assertEqual(QubitSparsePauliList(term for term in terms), expected)
-
+    '''
     def test_from_label(self):
         # The label is interpreted like a bitstring, with the right-most item associated with qubit
         # 0, and increasing as we move to the left (like `Pauli`, and other bitstring conventions).
-        qs_list = QubitSparsePauliList.from_label("IXXIIZZIYYIXYZ")
+        qs_list = PhasedQubitSparsePauliList.from_label("IXXIIZZIYYIXYZ")
         self.assertEqual(len(qs_list), 1)
 
-        self.assertEqual(qs_list[0], QubitSparsePauli.from_label("IXXIIZZIYYIXYZ"))
+        self.assertEqual(qs_list[0], PhasedQubitSparsePauli.from_label("IXXIIZZIYYIXYZ"))
 
     def test_from_label_failures(self):
         with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
             # Bad letters that are still ASCII.
-            QubitSparsePauliList.from_label("I+-$%I")
+            PhasedQubitSparsePauliList.from_label("I+-$%I")
         with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
             # Unicode shenangigans.
-            QubitSparsePauliList.from_label("🐍")
+            PhasedQubitSparsePauliList.from_label("🐍")
 
     def test_from_list(self):
         label = "IXYIZZY"
         self.assertEqual(
-            QubitSparsePauliList.from_list([label]), QubitSparsePauliList.from_label(label)
+            PhasedQubitSparsePauliList.from_list([label]), PhasedQubitSparsePauliList.from_label(label)
         )
         self.assertEqual(
-            QubitSparsePauliList.from_list([label], num_qubits=len(label)),
-            QubitSparsePauliList.from_label(label),
+            PhasedQubitSparsePauliList.from_list([label], num_qubits=len(label)),
+            PhasedQubitSparsePauliList.from_label(label),
         )
         self.assertEqual(
-            QubitSparsePauliList.from_list([label])[0],
-            QubitSparsePauli.from_raw_parts(
+            PhasedQubitSparsePauliList.from_list([label])[0],
+            PhasedQubitSparsePauli.from_raw_parts(
                 len(label),
                 [
-                    QubitSparsePauli.Pauli.Y,
-                    QubitSparsePauli.Pauli.Z,
-                    QubitSparsePauli.Pauli.Z,
-                    QubitSparsePauli.Pauli.Y,
-                    QubitSparsePauli.Pauli.X,
+                    PhasedQubitSparsePauli.Pauli.Y,
+                    PhasedQubitSparsePauli.Pauli.Z,
+                    PhasedQubitSparsePauli.Pauli.Z,
+                    PhasedQubitSparsePauli.Pauli.Y,
+                    PhasedQubitSparsePauli.Pauli.X,
                 ],
                 [0, 1, 2, 4, 5],
             ),
         )
         self.assertEqual(
-            QubitSparsePauliList.from_list([label], num_qubits=len(label))[0],
-            QubitSparsePauli.from_raw_parts(
+            PhasedQubitSparsePauliList.from_list([label], num_qubits=len(label))[0],
+            PhasedQubitSparsePauli.from_raw_parts(
                 len(label),
                 [
-                    QubitSparsePauli.Pauli.Y,
-                    QubitSparsePauli.Pauli.Z,
-                    QubitSparsePauli.Pauli.Z,
-                    QubitSparsePauli.Pauli.Y,
-                    QubitSparsePauli.Pauli.X,
+                    PhasedQubitSparsePauli.Pauli.Y,
+                    PhasedQubitSparsePauli.Pauli.Z,
+                    PhasedQubitSparsePauli.Pauli.Z,
+                    PhasedQubitSparsePauli.Pauli.Y,
+                    PhasedQubitSparsePauli.Pauli.X,
                 ],
                 [0, 1, 2, 4, 5],
             ),
         )
 
         self.assertEqual(
-            QubitSparsePauliList.from_list(["IIIXZI", "XXIIII"])[0],
-            QubitSparsePauli.from_raw_parts(
+            PhasedQubitSparsePauliList.from_list(["IIIXZI", "XXIIII"])[0],
+            PhasedQubitSparsePauli.from_raw_parts(
                 6,
                 [
-                    QubitSparsePauli.Pauli.Z,
-                    QubitSparsePauli.Pauli.X,
+                    PhasedQubitSparsePauli.Pauli.Z,
+                    PhasedQubitSparsePauli.Pauli.X,
                 ],
                 [1, 2],
             ),
         )
 
         self.assertEqual(
-            QubitSparsePauliList.from_list(["IIIXZI", "XXIIII"])[1],
-            QubitSparsePauli.from_raw_parts(
+            PhasedQubitSparsePauliList.from_list(["IIIXZI", "XXIIII"])[1],
+            PhasedQubitSparsePauli.from_raw_parts(
                 6,
                 [
-                    QubitSparsePauli.Pauli.X,
-                    QubitSparsePauli.Pauli.X,
+                    PhasedQubitSparsePauli.Pauli.X,
+                    PhasedQubitSparsePauli.Pauli.X,
                 ],
                 [4, 5],
             ),
         )
 
         self.assertEqual(
-            QubitSparsePauliList.from_list([], num_qubits=5), QubitSparsePauliList.empty(5)
+            PhasedQubitSparsePauliList.from_list([], num_qubits=5), PhasedQubitSparsePauliList.empty(5)
         )
         self.assertEqual(
-            QubitSparsePauliList.from_list([], num_qubits=0), QubitSparsePauliList.empty(0)
+            PhasedQubitSparsePauliList.from_list([], num_qubits=0), PhasedQubitSparsePauliList.empty(0)
         )
 
     def test_from_list_failures(self):
         with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
             # Bad letters that are still ASCII.
-            QubitSparsePauliList.from_list(["XZIIZY", "I+-$%I"])
+            PhasedQubitSparsePauliList.from_list(["XZIIZY", "I+-$%I"])
         with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
             # Unicode shenangigans.
-            QubitSparsePauliList.from_list(["🐍"])
+            PhasedQubitSparsePauliList.from_list(["🐍"])
         with self.assertRaisesRegex(ValueError, "label with length 4 cannot be added"):
-            QubitSparsePauliList.from_list(["IIZ", "IIXI"])
+            PhasedQubitSparsePauliList.from_list(["IIZ", "IIXI"])
         with self.assertRaisesRegex(ValueError, "label with length 2 cannot be added"):
-            QubitSparsePauliList.from_list(["IIZ", "II"])
+            PhasedQubitSparsePauliList.from_list(["IIZ", "II"])
         with self.assertRaisesRegex(ValueError, "label with length 3 cannot be added"):
-            QubitSparsePauliList.from_list(["IIZ", "IXI"], num_qubits=2)
+            PhasedQubitSparsePauliList.from_list(["IIZ", "IXI"], num_qubits=2)
         with self.assertRaisesRegex(ValueError, "label with length 3 cannot be added"):
-            QubitSparsePauliList.from_list(["IIZ", "IXI"], num_qubits=4)
+            PhasedQubitSparsePauliList.from_list(["IIZ", "IXI"], num_qubits=4)
         with self.assertRaisesRegex(ValueError, "cannot construct.*without knowing `num_qubits`"):
-            QubitSparsePauliList.from_list([])
-    
+            PhasedQubitSparsePauliList.from_list([])
+    '''
     def test_from_sparse_list(self):
         self.assertEqual(
             QubitSparsePauliList.from_sparse_list(

--- a/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
@@ -1,0 +1,1261 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2025
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=missing-module-docstring,missing-class-docstring,missing-function-docstring
+
+import copy
+import pickle
+import itertools
+import random
+
+import ddt
+import numpy as np
+
+from qiskit import transpile
+from qiskit.circuit import Measure, Parameter, library, QuantumCircuit
+from qiskit.quantum_info import (
+    PhasedQubitSparsePauli,
+    PhasedQubitSparsePauliList,
+    Pauli,
+)
+from qiskit.transpiler import Target
+
+from test import QiskitTestCase  # pylint: disable=wrong-import-order
+
+"""
+def single_cases():
+    return [
+        QubitSparsePauli(""),
+        QubitSparsePauli("I" * 10),
+        QubitSparsePauli.from_label("IIXIZI"),
+        QubitSparsePauli.from_label("ZZYYXX"),
+    ]
+
+
+def single_cases_list():
+    return [
+        QubitSparsePauliList.empty(0),
+        QubitSparsePauliList.empty(10),
+        QubitSparsePauliList.from_label("IIXIZI"),
+        QubitSparsePauliList.from_list(["YIXZII", "ZZYYXX"]),
+        # Includes a duplicate entry.
+        QubitSparsePauliList.from_list(["IXZ", "ZZI", "IXZ"]),
+    ]
+"""
+
+@ddt.ddt
+class TestPhasedQubitSparsePauli(QiskitTestCase):
+
+    def test_default_constructor_pauli(self):
+        data = Pauli("IXYIZ")
+        self.assertEqual(PhasedQubitSparsePauli(data), PhasedQubitSparsePauli.from_pauli(data))
+        self.assertEqual(
+            PhasedQubitSparsePauli(data, num_qubits=data.num_qubits), PhasedQubitSparsePauli.from_pauli(data)
+        )
+        self.assertEqual(PhasedQubitSparsePauli(data).phase, 0)
+
+        with self.assertRaisesRegex(ValueError, "explicitly given 'num_qubits'"):
+            PhasedQubitSparsePauli(data, num_qubits=data.num_qubits + 1)
+
+        with_phase = Pauli("-jIYYXY")
+        self.assertEqual(PhasedQubitSparsePauli(with_phase), PhasedQubitSparsePauli.from_pauli(with_phase))
+        self.assertEqual(
+            PhasedQubitSparsePauli(with_phase, num_qubits=data.num_qubits),
+            PhasedQubitSparsePauli.from_pauli(with_phase),
+        )
+        self.assertEqual(PhasedQubitSparsePauli(with_phase).phase, 1)
+
+        self.assertEqual(PhasedQubitSparsePauli(Pauli("")), PhasedQubitSparsePauli.from_pauli(Pauli("")))
+    '''
+    def test_default_constructor_label(self):
+        data = "IXIIZ"
+        self.assertEqual(QubitSparsePauli(data), QubitSparsePauli.from_label(data))
+        self.assertEqual(QubitSparsePauli(data, num_qubits=5), QubitSparsePauli.from_label(data))
+        with self.assertRaisesRegex(ValueError, "does not match label"):
+            QubitSparsePauli(data, num_qubits=4)
+        with self.assertRaisesRegex(ValueError, "does not match label"):
+            QubitSparsePauli(data, num_qubits=6)
+
+    def test_default_constructor_sparse_label(self):
+        data = ("ZX", (0, 3))
+        self.assertEqual(
+            QubitSparsePauli(data, num_qubits=5),
+            QubitSparsePauli.from_sparse_label(data, num_qubits=5),
+        )
+        self.assertEqual(
+            QubitSparsePauli(data, num_qubits=10),
+            QubitSparsePauli.from_sparse_label(data, num_qubits=10),
+        )
+        with self.assertRaisesRegex(ValueError, "'num_qubits' must be provided"):
+            QubitSparsePauli(data)
+        self.assertEqual(
+            QubitSparsePauli(("", []), num_qubits=5),
+            QubitSparsePauli.from_sparse_label(("", []), num_qubits=5),
+        )
+
+    def test_from_label(self):
+        # The label is interpreted like a bitstring, with the right-most item associated with qubit
+        # 0, and increasing as we move to the left (like `Pauli`, and other bitstring conventions).
+        self.assertEqual(
+            # Ruler for counting terms:  dcba9876543210
+            QubitSparsePauli.from_label("IXXIIZZIYYIXYZ"),
+            QubitSparsePauli.from_raw_parts(
+                14,
+                [
+                    QubitSparsePauli.Pauli.Z,
+                    QubitSparsePauli.Pauli.Y,
+                    QubitSparsePauli.Pauli.X,
+                    QubitSparsePauli.Pauli.Y,
+                    QubitSparsePauli.Pauli.Y,
+                    QubitSparsePauli.Pauli.Z,
+                    QubitSparsePauli.Pauli.Z,
+                    QubitSparsePauli.Pauli.X,
+                    QubitSparsePauli.Pauli.X,
+                ],
+                [0, 1, 2, 4, 5, 7, 8, 11, 12],
+            ),
+        )
+
+    def test_from_label_failures(self):
+        with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
+            # Bad letters that are still ASCII.
+            QubitSparsePauli.from_label("I+-$%I")
+        with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
+            # Unicode shenangigans.
+            QubitSparsePauli.from_label("🐍")
+
+    def test_from_sparse_label(self):
+        self.assertEqual(
+            QubitSparsePauli.from_sparse_label(("XY", (0, 1)), num_qubits=5),
+            QubitSparsePauli.from_label("IIIYX"),
+        )
+        self.assertEqual(
+            QubitSparsePauli.from_sparse_label(("XX", (1, 3)), num_qubits=5),
+            QubitSparsePauli.from_label("IXIXI"),
+        )
+        self.assertEqual(
+            QubitSparsePauli.from_sparse_label(("YYZ", (0, 2, 4)), num_qubits=5),
+            QubitSparsePauli.from_label("ZIYIY"),
+        )
+
+        # The indices should be allowed to be given in unsorted order, but they should be term-wise
+        # sorted in the output.
+        from_unsorted = QubitSparsePauli.from_sparse_label(("XYZ", (2, 0, 1)), num_qubits=3)
+        self.assertEqual(from_unsorted, QubitSparsePauli.from_label("XZY"))
+        np.testing.assert_equal(from_unsorted.indices, np.array([0, 1, 2], dtype=np.uint32))
+
+        # Explicit identities should still work, just be skipped over.
+        explicit_identity = QubitSparsePauli.from_sparse_label(("ZXI", (0, 1, 2)), num_qubits=10)
+        self.assertEqual(
+            explicit_identity,
+            QubitSparsePauli.from_sparse_label(("XZ", (1, 0)), num_qubits=10),
+        )
+        np.testing.assert_equal(explicit_identity.indices, np.array([0, 1], dtype=np.uint32))
+
+        explicit_identity = QubitSparsePauli.from_sparse_label(
+            ("XYIII", (0, 1, 2, 3, 8)), num_qubits=10
+        )
+        self.assertEqual(
+            explicit_identity,
+            QubitSparsePauli.from_sparse_label(("YX", (1, 0)), num_qubits=10),
+        )
+        np.testing.assert_equal(explicit_identity.indices, np.array([0, 1], dtype=np.uint32))
+
+    def test_from_sparse_list_failures(self):
+        with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
+            # Bad letters that are still ASCII.
+            QubitSparsePauli.from_sparse_label(("+$", (2, 1)), num_qubits=8)
+        # Unicode shenangigans.  These two should fail with a `ValueError`, but the exact message
+        # isn't important.  "\xff" is "ÿ", which is two bytes in UTF-8 (so has a length of 2 in
+        # Rust), but has a length of 1 in Python, so try with both a length-1 and length-2 index
+        # sequence, and both should still raise `ValueError`.
+        with self.assertRaises(ValueError):
+            QubitSparsePauli.from_sparse_label(("\xff", (1,)), num_qubits=5)
+        with self.assertRaises(ValueError):
+            QubitSparsePauli.from_sparse_label(("\xff", (1, 2)), num_qubits=5)
+
+        with self.assertRaisesRegex(
+            ValueError, "label with length 2 does not match indices of length 1"
+        ):
+            QubitSparsePauli.from_sparse_label(("XZ", (0,)), num_qubits=5)
+        with self.assertRaisesRegex(
+            ValueError, "label with length 2 does not match indices of length 3"
+        ):
+            QubitSparsePauli.from_sparse_label(("XZ", (0, 1, 2)), num_qubits=5)
+
+        with self.assertRaisesRegex(ValueError, "index 3 is out of range for a 3-qubit operator"):
+            QubitSparsePauli.from_sparse_label(("XZY", (0, 1, 3)), num_qubits=3)
+        with self.assertRaisesRegex(ValueError, "index 4 is out of range for a 3-qubit operator"):
+            QubitSparsePauli.from_sparse_label(("XZY", (0, 1, 4)), num_qubits=3)
+        with self.assertRaisesRegex(ValueError, "index 3 is out of range for a 3-qubit operator"):
+            # ... even if it's for an explicit identity.
+            QubitSparsePauli.from_sparse_label(("XXI", (0, 1, 3)), num_qubits=3)
+
+        with self.assertRaisesRegex(ValueError, "index 3 is duplicated"):
+            QubitSparsePauli.from_sparse_label(("XZ", (3, 3)), num_qubits=5)
+        with self.assertRaisesRegex(ValueError, "index 3 is duplicated"):
+            QubitSparsePauli.from_sparse_label(("XYZXZ", (3, 0, 1, 2, 3)), num_qubits=5)
+
+    def test_from_pauli(self):
+        # This function should be infallible provided `Pauli` doesn't change its interface and the
+        # user doesn't violate the typing.
+
+        # Simple check that the labels are interpreted in the same order.
+        self.assertEqual(
+            QubitSparsePauli.from_pauli(Pauli("IIXZI")), QubitSparsePauli.from_label("IIXZI")
+        )
+
+        # `Pauli` accepts a phase in its label, which gets dropped
+        self.assertEqual(
+            QubitSparsePauli.from_pauli(Pauli("iIXZIX")),
+            QubitSparsePauli.from_label("IXZIX"),
+        )
+        self.assertEqual(
+            QubitSparsePauli.from_pauli(Pauli("-iIXZIX")),
+            QubitSparsePauli.from_label("IXZIX"),
+        )
+        self.assertEqual(
+            QubitSparsePauli.from_pauli(Pauli("-IXZIX")),
+            QubitSparsePauli.from_label("IXZIX"),
+        )
+
+        # `Pauli` has its internal phase convention for how it stores `Y`; we should get this right
+        # regardless of how many Ys are in the label, or if there's a phase.
+        paulis = {"IXYZ" * n: Pauli("IXYZ" * n) for n in range(1, 5)}
+        from_paulis, from_labels = zip(
+            *(
+                (QubitSparsePauli.from_pauli(pauli), QubitSparsePauli.from_label(label))
+                for label, pauli in paulis.items()
+            )
+        )
+        self.assertEqual(from_paulis, from_labels)
+
+        phased_paulis = {"IXYZ" * n: Pauli("j" + "IXYZ" * n) for n in range(1, 5)}
+        from_paulis, from_lists = zip(
+            *(
+                (QubitSparsePauli.from_pauli(pauli), QubitSparsePauli.from_label(label))
+                for label, pauli in phased_paulis.items()
+            )
+        )
+        self.assertEqual(from_paulis, from_lists)
+
+    def test_default_constructor_failed_inference(self):
+        with self.assertRaises(TypeError):
+            QubitSparsePauli(5, num_qubits=5)
+
+    def test_num_qubits(self):
+        self.assertEqual(QubitSparsePauli("").num_qubits, 0)
+        self.assertEqual(QubitSparsePauli("I" * 10).num_qubits, 10)
+
+    def test_pauli_enum(self):
+        # These are very explicit tests that effectively just duplicate magic numbers, but the point
+        # is that those magic numbers are required to be constant as their values are part of the
+        # public interface.
+
+        self.assertEqual(
+            set(QubitSparsePauli.Pauli),
+            {
+                QubitSparsePauli.Pauli.X,
+                QubitSparsePauli.Pauli.Y,
+                QubitSparsePauli.Pauli.Z,
+            },
+        )
+        # All the enumeration items should also be integers.
+        self.assertIsInstance(QubitSparsePauli.Pauli.X, int)
+        values = {
+            "X": 0b10,
+            "Y": 0b11,
+            "Z": 0b01,
+        }
+        self.assertEqual({name: getattr(QubitSparsePauli.Pauli, name) for name in values}, values)
+
+        # The single-character label aliases can be accessed with index notation.
+        labels = {
+            "X": QubitSparsePauli.Pauli.X,
+            "Y": QubitSparsePauli.Pauli.Y,
+            "Z": QubitSparsePauli.Pauli.Z,
+        }
+        self.assertEqual({label: QubitSparsePauli.Pauli[label] for label in labels}, labels)
+        # The `label` property returns known values.
+        self.assertEqual({pauli.label: pauli for pauli in QubitSparsePauli.Pauli}, labels)
+
+    @ddt.idata(single_cases())
+    def test_pickle(self, qubit_sparse_pauli):
+        self.assertEqual(qubit_sparse_pauli, copy.copy(qubit_sparse_pauli))
+        self.assertIsNot(qubit_sparse_pauli, copy.copy(qubit_sparse_pauli))
+        self.assertEqual(qubit_sparse_pauli, copy.deepcopy(qubit_sparse_pauli))
+        self.assertEqual(qubit_sparse_pauli, pickle.loads(pickle.dumps(qubit_sparse_pauli)))
+
+    @ddt.data(
+        QubitSparsePauli.from_label("IIXIZI"),
+        QubitSparsePauli.from_label("X"),
+        QubitSparsePauli.from_label("III"),
+    )
+    def test_repr(self, data):
+        # The purpose of this is just to test that the `repr` doesn't crash, rather than asserting
+        # that it has any particular form.
+        self.assertIsInstance(repr(data), str)
+        self.assertIn("QubitSparsePauli", repr(data))
+
+    @ddt.idata(single_cases())
+    def test_copy(self, qubit_sparse_pauli):
+        self.assertEqual(qubit_sparse_pauli, qubit_sparse_pauli.copy())
+        self.assertIsNot(qubit_sparse_pauli, qubit_sparse_pauli.copy())
+
+    def test_equality(self):
+        sparse_data = ("XYY", (3, 1, 0))
+        pauli = QubitSparsePauli.from_sparse_label(sparse_data, num_qubits=5)
+        self.assertEqual(pauli, pauli.copy())
+        # Take care that Rust space allows multiple views onto the same object.
+        self.assertEqual(pauli, pauli)
+
+        # Comparison to some other object shouldn't fail.
+        self.assertNotEqual(pauli, None)
+
+        # Difference in qubit count.
+        self.assertNotEqual(
+            pauli, QubitSparsePauli.from_sparse_label(sparse_data, num_qubits=pauli.num_qubits + 1)
+        )
+
+        # Difference in bit terms.
+        self.assertNotEqual(
+            QubitSparsePauli.from_label("IIXZI"),
+            QubitSparsePauli.from_label("IIYZI"),
+        )
+        self.assertNotEqual(
+            QubitSparsePauli.from_label("XXYYZ"),
+            QubitSparsePauli.from_label("XXYYY"),
+        )
+
+        # Difference in indices.
+        self.assertNotEqual(
+            QubitSparsePauli.from_label("IIXZI"),
+            QubitSparsePauli.from_label("IXIZI"),
+        )
+        self.assertNotEqual(
+            QubitSparsePauli.from_label("XIYYZ"),
+            QubitSparsePauli.from_label("IXYYZ"),
+        )
+
+    def test_attributes_sequence(self):
+        """Test attributes of the `Sequence` protocol."""
+        # Length
+        pauli = QubitSparsePauli.from_label("XZY")
+        self.assertEqual(len(pauli.indices), 3)
+        self.assertEqual(len(pauli.paulis), 3)
+
+        # Iteration
+        self.assertEqual(tuple(pauli.indices), (0, 1, 2))
+        # multiple iteration through same object
+        paulis = pauli.paulis
+        self.assertEqual(set(paulis), {QubitSparsePauli.Pauli[x] for x in "XZY"})
+
+        # Implicit iteration methods.
+        self.assertIn(QubitSparsePauli.Pauli.Y, pauli.paulis)
+        self.assertNotIn(4, pauli.indices)
+
+        # Index by scalar
+        self.assertEqual(pauli.indices[-1], 2)
+        self.assertEqual(pauli.paulis[0], QubitSparsePauli.Pauli.Y)
+
+        # Index by slice.  This is API guaranteed to be a Numpy array to make it easier to
+        # manipulate subslices with mathematic operations.
+        self.assertIsInstance(pauli.indices[::-1], np.ndarray)
+        np.testing.assert_array_equal(
+            pauli.indices[::-1],
+            np.array([2, 1, 0], dtype=np.uint32),
+            strict=True,
+        )
+        self.assertIsInstance(pauli.paulis[0:2], np.ndarray)
+        np.testing.assert_array_equal(
+            pauli.paulis[0:2],
+            np.array([QubitSparsePauli.Pauli.Y, QubitSparsePauli.Pauli.Z], dtype=np.uint8),
+            strict=True,
+        )
+
+    def test_attributes_to_array(self):
+        pauli = QubitSparsePauli.from_label("XZY")
+
+        # Natural dtypes.
+        np.testing.assert_array_equal(
+            pauli.indices, np.array([0, 1, 2], dtype=np.uint32), strict=True
+        )
+        np.testing.assert_array_equal(
+            pauli.paulis,
+            np.array([QubitSparsePauli.Pauli[x] for x in "YZX"], dtype=np.uint8),
+            strict=True,
+        )
+
+        # Cast dtypes.
+        np.testing.assert_array_equal(
+            np.array(pauli.indices, dtype=np.uint8),
+            np.array([0, 1, 2], dtype=np.uint8),
+            strict=True,
+        )
+
+    def test_identity(self):
+        identity_5 = QubitSparsePauli.identity(5)
+        self.assertEqual(identity_5.num_qubits, 5)
+        self.assertEqual(len(identity_5.paulis), 0)
+        self.assertEqual(len(identity_5.indices), 0)
+
+        identity_0 = QubitSparsePauli.identity(0)
+        self.assertEqual(identity_0.num_qubits, 0)
+        self.assertEqual(len(identity_0.paulis), 0)
+        self.assertEqual(len(identity_0.indices), 0)
+
+    def test_compose(self):
+        p0 = QubitSparsePauli.from_label("XZY")
+        p1 = QubitSparsePauli.from_label("ZIY")
+
+        self.assertEqual(p0.compose(p1), QubitSparsePauli.from_label("YZI"))
+        self.assertEqual(p1.compose(p0), QubitSparsePauli.from_label("YZI"))
+
+        p0 = QubitSparsePauli.from_label("III")
+        p1 = QubitSparsePauli.from_label("ZIY")
+
+        self.assertEqual(p0 @ p1, QubitSparsePauli.from_label("ZIY"))
+        self.assertEqual(p1 @ p0, QubitSparsePauli.from_label("ZIY"))
+
+        p0 = QubitSparsePauli.from_label("IIIXXY")
+        p1 = QubitSparsePauli.from_label("ZIYIII")
+
+        self.assertEqual(p0 @ p1, QubitSparsePauli.from_label("ZIYXXY"))
+        self.assertEqual(p1 @ p0, QubitSparsePauli.from_label("ZIYXXY"))
+
+        p0 = QubitSparsePauli.from_label("IIIXXYZIXIZIZ")
+        p1 = QubitSparsePauli.from_label("ZIYIIIXYZIYIX")
+
+        self.assertEqual(p0 @ p1, QubitSparsePauli.from_label("ZIYXXYYYYIXIY"))
+        self.assertEqual(p1 @ p0, QubitSparsePauli.from_label("ZIYXXYYYYIXIY"))
+
+        self.assertEqual(p0 @ p0, QubitSparsePauli.from_label("I" * 13))
+        self.assertEqual(p1 @ p1, QubitSparsePauli.from_label("I" * 13))
+
+    def test_compose_errors(self):
+        p0 = QubitSparsePauli.from_label("XZYI")
+        p1 = QubitSparsePauli.from_label("ZIY")
+        with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits: 4, 3"):
+            p0.compose(p1)
+        with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits: 3, 4"):
+            p1.compose(p0)
+
+    def test_commutes(self):
+        p0 = QubitSparsePauli("XIY")
+        p1 = QubitSparsePauli("IZI")
+        self.assertTrue(p0.commutes(p1))
+        self.assertTrue(p1.commutes(p0))
+
+        p0 = QubitSparsePauli("XXY")
+        p1 = QubitSparsePauli("IZI")
+        self.assertFalse(p0.commutes(p1))
+        self.assertFalse(p1.commutes(p0))
+
+        p0 = QubitSparsePauli("XXY")
+        p1 = QubitSparsePauli("IZX")
+        self.assertTrue(p0.commutes(p1))
+        self.assertTrue(p1.commutes(p0))
+
+        p0 = QubitSparsePauli("XXYY")
+        p1 = QubitSparsePauli("IZXY")
+        self.assertTrue(p0.commutes(p1))
+        self.assertTrue(p1.commutes(p0))
+
+        p0 = QubitSparsePauli("XXYYZ")
+        p1 = QubitSparsePauli("IZXYX")
+        self.assertFalse(p0.commutes(p1))
+        self.assertFalse(p1.commutes(p0))
+
+    def test_commutes_errors(self):
+        p0 = QubitSparsePauli.from_label("XZYI")
+        p1 = QubitSparsePauli.from_label("ZIY")
+        with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits: 4, 3"):
+            p0.commutes(p1)
+        with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits: 3, 4"):
+            p1.commutes(p0)
+    '''
+
+@ddt.ddt
+class TestPhasedQubitSparsePauliList(QiskitTestCase):
+    pass
+    '''
+    def test_default_constructor_pauli(self):
+        data = Pauli("IXYIZ")
+        self.assertEqual(QubitSparsePauliList(data), QubitSparsePauliList.from_pauli(data))
+        self.assertEqual(
+            QubitSparsePauliList(data, num_qubits=data.num_qubits),
+            QubitSparsePauliList.from_pauli(data),
+        )
+        with self.assertRaisesRegex(ValueError, "explicitly given 'num_qubits'"):
+            QubitSparsePauliList(data, num_qubits=data.num_qubits + 1)
+
+        with_phase = Pauli("-jIYYXY")
+        self.assertEqual(
+            QubitSparsePauliList(with_phase), QubitSparsePauliList.from_pauli(with_phase)
+        )
+        self.assertEqual(
+            QubitSparsePauliList(with_phase, num_qubits=data.num_qubits),
+            QubitSparsePauliList.from_pauli(with_phase),
+        )
+
+        self.assertEqual(
+            QubitSparsePauliList(Pauli("")), QubitSparsePauliList.from_pauli(Pauli(""))
+        )
+
+    def test_default_constructor_list(self):
+        data = ["IXIIZ", "XIXII", "IIXYI"]
+        self.assertEqual(QubitSparsePauliList(data), QubitSparsePauliList.from_list(data))
+        self.assertEqual(
+            QubitSparsePauliList(data, num_qubits=5), QubitSparsePauliList.from_list(data)
+        )
+        with self.assertRaisesRegex(ValueError, "label with length 5 cannot be added"):
+            QubitSparsePauliList(data, num_qubits=4)
+        with self.assertRaisesRegex(ValueError, "label with length 5 cannot be added"):
+            QubitSparsePauliList(data, num_qubits=6)
+        self.assertEqual(
+            QubitSparsePauliList([], num_qubits=5), QubitSparsePauliList.from_list([], num_qubits=5)
+        )
+
+    def test_default_constructor_sparse_list(self):
+        data = [("ZX", (0, 3)), ("XY", (2, 4)), ("ZY", (2, 1))]
+        self.assertEqual(
+            QubitSparsePauliList(data, num_qubits=5),
+            QubitSparsePauliList.from_sparse_list(data, num_qubits=5),
+        )
+        self.assertEqual(
+            QubitSparsePauliList(data, num_qubits=10),
+            QubitSparsePauliList.from_sparse_list(data, num_qubits=10),
+        )
+        with self.assertRaisesRegex(ValueError, "'num_qubits' must be provided"):
+            QubitSparsePauliList(data)
+        self.assertEqual(
+            QubitSparsePauliList([], num_qubits=5),
+            QubitSparsePauliList.from_sparse_list([], num_qubits=5),
+        )
+
+    def test_default_constructor_label(self):
+        data = "IIXIXXIZZYYIYZ"
+        self.assertEqual(QubitSparsePauliList(data), QubitSparsePauliList.from_label(data))
+        self.assertEqual(
+            QubitSparsePauliList(data, num_qubits=len(data)), QubitSparsePauliList.from_label(data)
+        )
+        with self.assertRaisesRegex(ValueError, "explicitly given 'num_qubits'"):
+            QubitSparsePauliList(data, num_qubits=len(data) + 1)
+
+    def test_default_constructor_copy(self):
+        base = QubitSparsePauliList.from_list(["IXIZIY", "XYZIII"])
+        copied = QubitSparsePauliList(base)
+        self.assertEqual(base, copied)
+        self.assertIsNot(base, copied)
+
+        with self.assertRaisesRegex(ValueError, "explicitly given 'num_qubits'"):
+            QubitSparsePauliList(base, num_qubits=base.num_qubits + 1)
+
+    def test_default_constructor_term(self):
+        expected = QubitSparsePauliList.from_list(["IIZXII"])
+        self.assertEqual(QubitSparsePauliList(expected[0]), expected)
+
+    def test_default_constructor_term_iterable(self):
+        expected = QubitSparsePauliList.from_list(["IIZXII", "IIIIII"])
+        terms = [expected[0], expected[1]]
+        self.assertEqual(QubitSparsePauliList(list(terms)), expected)
+        self.assertEqual(QubitSparsePauliList(tuple(terms)), expected)
+        self.assertEqual(QubitSparsePauliList(term for term in terms), expected)
+
+    def test_from_label(self):
+        # The label is interpreted like a bitstring, with the right-most item associated with qubit
+        # 0, and increasing as we move to the left (like `Pauli`, and other bitstring conventions).
+        qs_list = QubitSparsePauliList.from_label("IXXIIZZIYYIXYZ")
+        self.assertEqual(len(qs_list), 1)
+
+        self.assertEqual(qs_list[0], QubitSparsePauli.from_label("IXXIIZZIYYIXYZ"))
+
+    def test_from_label_failures(self):
+        with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
+            # Bad letters that are still ASCII.
+            QubitSparsePauliList.from_label("I+-$%I")
+        with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
+            # Unicode shenangigans.
+            QubitSparsePauliList.from_label("🐍")
+
+    def test_from_list(self):
+        label = "IXYIZZY"
+        self.assertEqual(
+            QubitSparsePauliList.from_list([label]), QubitSparsePauliList.from_label(label)
+        )
+        self.assertEqual(
+            QubitSparsePauliList.from_list([label], num_qubits=len(label)),
+            QubitSparsePauliList.from_label(label),
+        )
+        self.assertEqual(
+            QubitSparsePauliList.from_list([label])[0],
+            QubitSparsePauli.from_raw_parts(
+                len(label),
+                [
+                    QubitSparsePauli.Pauli.Y,
+                    QubitSparsePauli.Pauli.Z,
+                    QubitSparsePauli.Pauli.Z,
+                    QubitSparsePauli.Pauli.Y,
+                    QubitSparsePauli.Pauli.X,
+                ],
+                [0, 1, 2, 4, 5],
+            ),
+        )
+        self.assertEqual(
+            QubitSparsePauliList.from_list([label], num_qubits=len(label))[0],
+            QubitSparsePauli.from_raw_parts(
+                len(label),
+                [
+                    QubitSparsePauli.Pauli.Y,
+                    QubitSparsePauli.Pauli.Z,
+                    QubitSparsePauli.Pauli.Z,
+                    QubitSparsePauli.Pauli.Y,
+                    QubitSparsePauli.Pauli.X,
+                ],
+                [0, 1, 2, 4, 5],
+            ),
+        )
+
+        self.assertEqual(
+            QubitSparsePauliList.from_list(["IIIXZI", "XXIIII"])[0],
+            QubitSparsePauli.from_raw_parts(
+                6,
+                [
+                    QubitSparsePauli.Pauli.Z,
+                    QubitSparsePauli.Pauli.X,
+                ],
+                [1, 2],
+            ),
+        )
+
+        self.assertEqual(
+            QubitSparsePauliList.from_list(["IIIXZI", "XXIIII"])[1],
+            QubitSparsePauli.from_raw_parts(
+                6,
+                [
+                    QubitSparsePauli.Pauli.X,
+                    QubitSparsePauli.Pauli.X,
+                ],
+                [4, 5],
+            ),
+        )
+
+        self.assertEqual(
+            QubitSparsePauliList.from_list([], num_qubits=5), QubitSparsePauliList.empty(5)
+        )
+        self.assertEqual(
+            QubitSparsePauliList.from_list([], num_qubits=0), QubitSparsePauliList.empty(0)
+        )
+
+    def test_from_list_failures(self):
+        with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
+            # Bad letters that are still ASCII.
+            QubitSparsePauliList.from_list(["XZIIZY", "I+-$%I"])
+        with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
+            # Unicode shenangigans.
+            QubitSparsePauliList.from_list(["🐍"])
+        with self.assertRaisesRegex(ValueError, "label with length 4 cannot be added"):
+            QubitSparsePauliList.from_list(["IIZ", "IIXI"])
+        with self.assertRaisesRegex(ValueError, "label with length 2 cannot be added"):
+            QubitSparsePauliList.from_list(["IIZ", "II"])
+        with self.assertRaisesRegex(ValueError, "label with length 3 cannot be added"):
+            QubitSparsePauliList.from_list(["IIZ", "IXI"], num_qubits=2)
+        with self.assertRaisesRegex(ValueError, "label with length 3 cannot be added"):
+            QubitSparsePauliList.from_list(["IIZ", "IXI"], num_qubits=4)
+        with self.assertRaisesRegex(ValueError, "cannot construct.*without knowing `num_qubits`"):
+            QubitSparsePauliList.from_list([])
+
+    def test_from_sparse_list(self):
+        self.assertEqual(
+            QubitSparsePauliList.from_sparse_list(
+                [
+                    ("XY", (0, 1)),
+                    ("XX", (1, 3)),
+                    ("YYZ", (0, 2, 4)),
+                ],
+                num_qubits=5,
+            ),
+            QubitSparsePauliList.from_list(["IIIYX", "IXIXI", "ZIYIY"]),
+        )
+
+        # The indices should be allowed to be given in unsorted order, but they should be term-wise
+        # sorted in the output.
+        from_unsorted = QubitSparsePauliList.from_sparse_list(
+            [
+                ("XYZ", (2, 1, 0)),
+                ("XYZ", (2, 0, 1)),
+            ],
+            num_qubits=3,
+        )
+        self.assertEqual(from_unsorted, QubitSparsePauliList.from_list(["XYZ", "XZY"]))
+        np.testing.assert_equal(from_unsorted[0].indices, np.array([0, 1, 2], dtype=np.uint32))
+        np.testing.assert_equal(from_unsorted[1].indices, np.array([0, 1, 2], dtype=np.uint32))
+
+        # Explicit identities should still work, just be skipped over.
+        explicit_identity = QubitSparsePauliList.from_sparse_list(
+            [
+                ("ZXI", (0, 1, 2)),
+                ("XYIII", (0, 1, 2, 3, 8)),
+            ],
+            num_qubits=10,
+        )
+        self.assertEqual(
+            explicit_identity,
+            QubitSparsePauliList.from_sparse_list([("XZ", (1, 0)), ("YX", (1, 0))], num_qubits=10),
+        )
+        np.testing.assert_equal(explicit_identity[0].indices, np.array([0, 1], dtype=np.uint32))
+        np.testing.assert_equal(explicit_identity[1].indices, np.array([0, 1], dtype=np.uint32))
+
+        self.assertEqual(
+            QubitSparsePauliList.from_sparse_list([], num_qubits=1_000_000),
+            QubitSparsePauliList.empty(1_000_000),
+        )
+        self.assertEqual(
+            QubitSparsePauliList.from_sparse_list([], num_qubits=0),
+            QubitSparsePauliList.empty(0),
+        )
+
+    def test_from_sparse_list_failures(self):
+        with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
+            # Bad letters that are still ASCII.
+            QubitSparsePauliList.from_sparse_list(
+                [("XZZY", (5, 3, 1, 0)), ("+$", (2, 1))], num_qubits=8
+            )
+        # Unicode shenangigans.  These two should fail with a `ValueError`, but the exact message
+        # isn't important.  "\xff" is "ÿ", which is two bytes in UTF-8 (so has a length of 2 in
+        # Rust), but has a length of 1 in Python, so try with both a length-1 and length-2 index
+        # sequence, and both should still raise `ValueError`.
+        with self.assertRaises(ValueError):
+            QubitSparsePauliList.from_sparse_list([("\xff", (1,))], num_qubits=5)
+        with self.assertRaises(ValueError):
+            QubitSparsePauliList.from_sparse_list([("\xff", (1, 2))], num_qubits=5)
+
+        with self.assertRaisesRegex(ValueError, "label with length 2 does not match indices"):
+            QubitSparsePauliList.from_sparse_list([("XZ", (0,))], num_qubits=5)
+        with self.assertRaisesRegex(ValueError, "label with length 2 does not match indices"):
+            QubitSparsePauliList.from_sparse_list([("XZ", (0, 1, 2))], num_qubits=5)
+
+        with self.assertRaisesRegex(ValueError, "index 3 is out of range for a 3-qubit operator"):
+            QubitSparsePauliList.from_sparse_list([("XZY", (0, 1, 3))], num_qubits=3)
+        with self.assertRaisesRegex(ValueError, "index 4 is out of range for a 3-qubit operator"):
+            QubitSparsePauliList.from_sparse_list([("XZY", (0, 1, 4))], num_qubits=3)
+        with self.assertRaisesRegex(ValueError, "index 3 is out of range for a 3-qubit operator"):
+            # ... even if it's for an explicit identity.
+            QubitSparsePauliList.from_sparse_list([("XXI", (0, 1, 3))], num_qubits=3)
+
+        with self.assertRaisesRegex(ValueError, "index 3 is duplicated"):
+            QubitSparsePauliList.from_sparse_list([("XZ", (3, 3))], num_qubits=5)
+        with self.assertRaisesRegex(ValueError, "index 3 is duplicated"):
+            QubitSparsePauliList.from_sparse_list([("XYZXZ", (3, 0, 1, 2, 3))], num_qubits=5)
+
+    def test_from_pauli(self):
+        # This function should be infallible provided `Pauli` doesn't change its interface and the
+        # user doesn't violate the typing.
+
+        # Simple check that the labels are interpreted in the same order.
+        self.assertEqual(
+            QubitSparsePauliList.from_pauli(Pauli("IIXZI")),
+            QubitSparsePauliList.from_label("IIXZI"),
+        )
+
+        # `Pauli` accepts a phase in its label, which gets dropped
+        self.assertEqual(
+            QubitSparsePauliList.from_pauli(Pauli("iIXZIX")),
+            QubitSparsePauliList.from_list(["IXZIX"]),
+        )
+        self.assertEqual(
+            QubitSparsePauliList.from_pauli(Pauli("-iIXZIX")),
+            QubitSparsePauliList.from_list(["IXZIX"]),
+        )
+        self.assertEqual(
+            QubitSparsePauliList.from_pauli(Pauli("-IXZIX")),
+            QubitSparsePauliList.from_list(["IXZIX"]),
+        )
+
+        # `Pauli` has its internal phase convention for how it stores `Y`; we should get this right
+        # regardless of how many Ys are in the label, or if there's a phase.
+        paulis = {"IXYZ" * n: Pauli("IXYZ" * n) for n in range(1, 5)}
+        from_paulis, from_labels = zip(
+            *(
+                (QubitSparsePauliList.from_pauli(pauli), QubitSparsePauliList.from_label(label))
+                for label, pauli in paulis.items()
+            )
+        )
+        self.assertEqual(from_paulis, from_labels)
+
+        phased_paulis = {"IXYZ" * n: Pauli("j" + "IXYZ" * n) for n in range(1, 5)}
+        from_paulis, from_lists = zip(
+            *(
+                (QubitSparsePauliList.from_pauli(pauli), QubitSparsePauliList.from_list([label]))
+                for label, pauli in phased_paulis.items()
+            )
+        )
+        self.assertEqual(from_paulis, from_lists)
+
+    def test_from_qubit_sparse_paulis(self):
+        self.assertEqual(
+            QubitSparsePauliList.from_qubit_sparse_paulis([], num_qubits=5),
+            QubitSparsePauliList.empty(5),
+        )
+        self.assertEqual(
+            QubitSparsePauliList.from_qubit_sparse_paulis((), num_qubits=0),
+            QubitSparsePauliList.empty(0),
+        )
+        self.assertEqual(
+            QubitSparsePauliList.from_qubit_sparse_paulis((None for _ in []), num_qubits=3),
+            QubitSparsePauliList.empty(3),
+        )
+
+        expected = QubitSparsePauliList.from_sparse_list(
+            [
+                ("XYZ", (4, 2, 1)),
+                ("XXYY", (8, 5, 3, 2)),
+                ("ZZ", (5, 0)),
+            ],
+            num_qubits=10,
+        )
+        self.assertEqual(QubitSparsePauliList.from_qubit_sparse_paulis(list(expected)), expected)
+        self.assertEqual(QubitSparsePauliList.from_qubit_sparse_paulis(tuple(expected)), expected)
+        self.assertEqual(
+            QubitSparsePauliList.from_qubit_sparse_paulis(term for term in expected), expected
+        )
+        self.assertEqual(
+            QubitSparsePauliList.from_qubit_sparse_paulis(
+                (term for term in expected), num_qubits=expected.num_qubits
+            ),
+            expected,
+        )
+
+    def test_from_qubit_sparse_paulis_failures(self):
+        with self.assertRaisesRegex(ValueError, "cannot construct.*without knowing `num_qubits`"):
+            QubitSparsePauliList.from_qubit_sparse_paulis([])
+
+        left, right = (
+            QubitSparsePauliList(["IIXYI"])[0],
+            QubitSparsePauliList(["IIIIIIIIX"])[0],
+        )
+        with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits"):
+            QubitSparsePauliList.from_qubit_sparse_paulis([left, right])
+        with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits"):
+            QubitSparsePauliList.from_qubit_sparse_paulis([left], num_qubits=100)
+
+    def test_default_constructor_failed_inference(self):
+        with self.assertRaises(TypeError):
+            # Mixed dense/sparse list.
+            QubitSparsePauliList(["IIXIZ", ("IZ", (2, 3))], num_qubits=5)
+
+    def test_num_qubits(self):
+        self.assertEqual(QubitSparsePauliList.empty(0).num_qubits, 0)
+        self.assertEqual(QubitSparsePauliList.empty(10).num_qubits, 10)
+
+    def test_num_terms(self):
+        self.assertEqual(QubitSparsePauliList.empty(0).num_terms, 0)
+        self.assertEqual(QubitSparsePauliList.empty(10).num_terms, 0)
+        self.assertEqual(QubitSparsePauliList.from_list(["IIIXIZ", "YYXXII"]).num_terms, 2)
+
+    def test_empty(self):
+        empty_5 = QubitSparsePauliList.empty(5)
+        self.assertEqual(empty_5.num_qubits, 5)
+        self.assertEqual(len(empty_5), 0)
+        self.assertEqual(empty_5.to_sparse_list(), [])
+
+        empty_0 = QubitSparsePauliList.empty(0)
+        self.assertEqual(empty_0.num_qubits, 0)
+        self.assertEqual(len(empty_0), 0)
+        self.assertEqual(empty_0.to_sparse_list(), [])
+
+    def test_len(self):
+        self.assertEqual(len(QubitSparsePauliList.empty(0)), 0)
+        self.assertEqual(len(QubitSparsePauliList.empty(10)), 0)
+        self.assertEqual(len(QubitSparsePauliList.from_list(["IIIXIZ", "YYXXII"])), 2)
+
+    def test_pauli_enum(self):
+        # These are very explicit tests that effectively just duplicate magic numbers, but the point
+        # is that those magic numbers are required to be constant as their values are part of the
+        # public interface.
+
+        self.assertEqual(
+            set(QubitSparsePauli.Pauli),
+            {
+                QubitSparsePauli.Pauli.X,
+                QubitSparsePauli.Pauli.Y,
+                QubitSparsePauli.Pauli.Z,
+            },
+        )
+        # All the enumeration items should also be integers.
+        self.assertIsInstance(QubitSparsePauli.Pauli.X, int)
+        values = {
+            "X": 0b10,
+            "Y": 0b11,
+            "Z": 0b01,
+        }
+        self.assertEqual({name: getattr(QubitSparsePauli.Pauli, name) for name in values}, values)
+
+        # The single-character label aliases can be accessed with index notation.
+        labels = {
+            "X": QubitSparsePauli.Pauli.X,
+            "Y": QubitSparsePauli.Pauli.Y,
+            "Z": QubitSparsePauli.Pauli.Z,
+        }
+        self.assertEqual({label: QubitSparsePauli.Pauli[label] for label in labels}, labels)
+        # The `label` property returns known values.
+        self.assertEqual({pauli.label: pauli for pauli in QubitSparsePauli.Pauli}, labels)
+
+    @ddt.idata(single_cases_list())
+    def test_pickle(self, qubit_sparse_pauli_list):
+        self.assertEqual(qubit_sparse_pauli_list, copy.copy(qubit_sparse_pauli_list))
+        self.assertIsNot(qubit_sparse_pauli_list, copy.copy(qubit_sparse_pauli_list))
+        self.assertEqual(qubit_sparse_pauli_list, copy.deepcopy(qubit_sparse_pauli_list))
+        self.assertEqual(
+            qubit_sparse_pauli_list, pickle.loads(pickle.dumps(qubit_sparse_pauli_list))
+        )
+
+    @ddt.data(
+        QubitSparsePauliList.empty(0),
+        QubitSparsePauliList.empty(1),
+        QubitSparsePauliList.empty(10),
+        QubitSparsePauliList.from_label("IIXIZI"),
+        QubitSparsePauliList.from_label("X"),
+        QubitSparsePauliList.from_list(["YIXZII"]),
+        QubitSparsePauliList.from_list(["YIXZII", "ZZYYXX"]),
+        QubitSparsePauliList.from_list(["IIIIII", "ZZYYXX"]),
+    )
+    def test_repr(self, data):
+        # The purpose of this is just to test that the `repr` doesn't crash, rather than asserting
+        # that it has any particular form.
+        self.assertIsInstance(repr(data), str)
+        self.assertIn("QubitSparsePauliList", repr(data))
+
+    @ddt.idata(single_cases_list())
+    def test_copy(self, qubit_sparse_pauli_list):
+        self.assertEqual(qubit_sparse_pauli_list, qubit_sparse_pauli_list.copy())
+        self.assertIsNot(qubit_sparse_pauli_list, qubit_sparse_pauli_list.copy())
+
+    def test_equality(self):
+        sparse_data = [("XZ", (1, 0)), ("XYY", (3, 1, 0))]
+        pauli_list = QubitSparsePauliList.from_sparse_list(sparse_data, num_qubits=5)
+        self.assertEqual(pauli_list, pauli_list.copy())
+        # Take care that Rust space allows multiple views onto the same object.
+        self.assertEqual(pauli_list, pauli_list)
+
+        # Comparison to some other object shouldn't fail.
+        self.assertNotEqual(pauli_list, None)
+
+        # Difference in qubit count.
+        self.assertNotEqual(
+            pauli_list,
+            QubitSparsePauliList.from_sparse_list(
+                sparse_data, num_qubits=pauli_list.num_qubits + 1
+            ),
+        )
+        self.assertNotEqual(QubitSparsePauliList.empty(2), QubitSparsePauliList.empty(3))
+
+        # Difference in bit terms.
+        self.assertNotEqual(
+            QubitSparsePauliList.from_list(["IIXZI", "XXYYZ"]),
+            QubitSparsePauliList.from_list(["IIYZI", "XXYYZ"]),
+        )
+        self.assertNotEqual(
+            QubitSparsePauliList.from_list(["IIXZI", "XXYYZ"]),
+            QubitSparsePauliList.from_list(["IIXZI", "XXYYY"]),
+        )
+
+        # Difference in indices.
+        self.assertNotEqual(
+            QubitSparsePauliList.from_list(["IIXZI", "XXYYZ"]),
+            QubitSparsePauliList.from_list(["IXIZI", "XXYYZ"]),
+        )
+        self.assertNotEqual(
+            QubitSparsePauliList.from_list(["IIXZI", "XIYYZ"]),
+            QubitSparsePauliList.from_list(["IIXZI", "IXYYZ"]),
+        )
+
+        # Difference in boundaries.
+        self.assertNotEqual(
+            QubitSparsePauliList.from_sparse_list([("XZ", (0, 1)), ("XX", (2, 3))], num_qubits=5),
+            QubitSparsePauliList.from_sparse_list([("XZX", (0, 1, 2)), ("X", (3,))], num_qubits=5),
+        )
+
+    @ddt.idata(single_cases_list())
+    def test_clear(self, pauli_list):
+        num_qubits = pauli_list.num_qubits
+        pauli_list.clear()
+        self.assertEqual(pauli_list, QubitSparsePauliList.empty(num_qubits))
+
+    def test_apply_layout_list(self):
+        self.assertEqual(
+            QubitSparsePauliList.empty(5).apply_layout([4, 3, 2, 1, 0]),
+            QubitSparsePauliList.empty(5),
+        )
+        self.assertEqual(
+            QubitSparsePauliList.empty(3).apply_layout([0, 2, 1], 8), QubitSparsePauliList.empty(8)
+        )
+        self.assertEqual(
+            QubitSparsePauliList.empty(2).apply_layout([1, 0]), QubitSparsePauliList.empty(2)
+        )
+        self.assertEqual(
+            QubitSparsePauliList.empty(3).apply_layout([100, 10_000, 3], 100_000_000),
+            QubitSparsePauliList.empty(100_000_000),
+        )
+
+        terms = [
+            ("ZYX", (4, 2, 1)),
+            ("", ()),
+            ("XXYYZZ", (10, 8, 6, 4, 2, 0)),
+        ]
+
+        def map_indices(terms, layout):
+            return [(terms, tuple(layout[bit] for bit in bits)) for terms, bits in terms]
+
+        identity = list(range(12))
+        self.assertEqual(
+            QubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(identity),
+            QubitSparsePauliList.from_sparse_list(terms, num_qubits=12),
+        )
+        # We've already tested elsewhere that `QubitSparsePauliList.from_sparse_list` produces termwise
+        # sorted indices, so these tests also ensure `apply_layout` is maintaining that invariant.
+        backwards = list(range(12))[::-1]
+        self.assertEqual(
+            QubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(backwards),
+            QubitSparsePauliList.from_sparse_list(map_indices(terms, backwards), num_qubits=12),
+        )
+        shuffled = [4, 7, 1, 10, 0, 11, 3, 2, 8, 5, 6, 9]
+        self.assertEqual(
+            QubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(shuffled),
+            QubitSparsePauliList.from_sparse_list(map_indices(terms, shuffled), num_qubits=12),
+        )
+        self.assertEqual(
+            QubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(shuffled, 100),
+            QubitSparsePauliList.from_sparse_list(map_indices(terms, shuffled), num_qubits=100),
+        )
+        expanded = [78, 69, 82, 68, 32, 97, 108, 101, 114, 116, 33]
+        self.assertEqual(
+            QubitSparsePauliList.from_sparse_list(terms, num_qubits=11).apply_layout(expanded, 120),
+            QubitSparsePauliList.from_sparse_list(map_indices(terms, expanded), num_qubits=120),
+        )
+
+    def test_apply_layout_transpiled(self):
+        base = QubitSparsePauliList.from_sparse_list(
+            [
+                ("ZYX", (4, 2, 1)),
+                ("", ()),
+                ("XXY", (3, 2, 0)),
+            ],
+            num_qubits=5,
+        )
+
+        qc = QuantumCircuit(5)
+        initial_list = [3, 4, 0, 2, 1]
+        no_routing = transpile(
+            qc, target=lnn_target(5), initial_layout=initial_list, seed_transpiler=2024_10_25_0
+        ).layout
+        # It's easiest here to test against the `list` form, which we verify separately and
+        # explicitly.
+        self.assertEqual(base.apply_layout(no_routing), base.apply_layout(initial_list))
+
+        expanded = transpile(
+            qc, target=lnn_target(100), initial_layout=initial_list, seed_transpiler=2024_10_25_1
+        ).layout
+        self.assertEqual(
+            base.apply_layout(expanded), base.apply_layout(initial_list, num_qubits=100)
+        )
+
+        qc = QuantumCircuit(5)
+        qargs = list(itertools.permutations(range(5), 2))
+        random.Random(2024_10_25_2).shuffle(qargs)
+        for pair in qargs:
+            qc.cx(*pair)
+
+        routed = transpile(qc, target=lnn_target(5), seed_transpiler=2024_10_25_3).layout
+        self.assertEqual(
+            base.apply_layout(routed),
+            base.apply_layout(routed.final_index_layout(filter_ancillas=True)),
+        )
+
+        routed_expanded = transpile(qc, target=lnn_target(20), seed_transpiler=2024_10_25_3).layout
+        self.assertEqual(
+            base.apply_layout(routed_expanded),
+            base.apply_layout(
+                routed_expanded.final_index_layout(filter_ancillas=True), num_qubits=20
+            ),
+        )
+
+    def test_apply_layout_none(self):
+        self.assertEqual(
+            QubitSparsePauliList.empty(0).apply_layout(None), QubitSparsePauliList.empty(0)
+        )
+        self.assertEqual(
+            QubitSparsePauliList.empty(0).apply_layout(None, 3), QubitSparsePauliList.empty(3)
+        )
+        self.assertEqual(
+            QubitSparsePauliList.empty(5).apply_layout(None), QubitSparsePauliList.empty(5)
+        )
+        self.assertEqual(
+            QubitSparsePauliList.empty(3).apply_layout(None, 8), QubitSparsePauliList.empty(8)
+        )
+        self.assertEqual(
+            QubitSparsePauliList.empty(0).apply_layout(None), QubitSparsePauliList.empty(0)
+        )
+        self.assertEqual(
+            QubitSparsePauliList.empty(0).apply_layout(None, 8), QubitSparsePauliList.empty(8)
+        )
+        self.assertEqual(
+            QubitSparsePauliList.empty(2).apply_layout(None), QubitSparsePauliList.empty(2)
+        )
+        self.assertEqual(
+            QubitSparsePauliList.empty(3).apply_layout(None, 100_000_000),
+            QubitSparsePauliList.empty(100_000_000),
+        )
+
+        terms = [
+            ("ZYX", (2, 1, 0)),
+            ("", ()),
+            ("XXYYZZ", (10, 8, 6, 4, 2, 0)),
+        ]
+        self.assertEqual(
+            QubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(None),
+            QubitSparsePauliList.from_sparse_list(terms, num_qubits=12),
+        )
+        self.assertEqual(
+            QubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(
+                None, num_qubits=200
+            ),
+            QubitSparsePauliList.from_sparse_list(terms, num_qubits=200),
+        )
+
+    def test_apply_layout_failures(self):
+        obs = QubitSparsePauliList.from_list(["IIYI", "IIIX"])
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            obs.apply_layout([0, 0, 1, 2])
+        with self.assertRaisesRegex(ValueError, "does not account for all contained qubits"):
+            obs.apply_layout([0, 1])
+        with self.assertRaisesRegex(ValueError, "less than the number of qubits"):
+            obs.apply_layout([0, 2, 4, 6])
+        with self.assertRaisesRegex(ValueError, "cannot shrink"):
+            obs.apply_layout([0, 1], num_qubits=2)
+        with self.assertRaisesRegex(ValueError, "cannot shrink"):
+            obs.apply_layout(None, num_qubits=2)
+
+        qc = QuantumCircuit(3)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+        qc.cx(2, 0)
+        layout = transpile(qc, target=lnn_target(3), seed_transpiler=2024_10_25).layout
+        with self.assertRaisesRegex(ValueError, "cannot shrink"):
+            obs.apply_layout(layout, num_qubits=2)
+
+    def test_iteration(self):
+        self.assertEqual(list(QubitSparsePauliList.empty(5)), [])
+        self.assertEqual(tuple(QubitSparsePauliList.empty(0)), ())
+
+        pauli_list = QubitSparsePauliList.from_sparse_list(
+            [
+                ("XYY", (4, 2, 1)),
+                ("", ()),
+                ("ZZ", (3, 0)),
+                ("XX", (2, 1)),
+                ("YZ", (4, 1)),
+            ],
+            num_qubits=5,
+        )
+        pauli = QubitSparsePauli.Pauli
+        expected = [
+            QubitSparsePauli.from_raw_parts(5, [pauli.Y, pauli.Y, pauli.X], [1, 2, 4]),
+            QubitSparsePauli.from_raw_parts(5, [], []),
+            QubitSparsePauli.from_raw_parts(5, [pauli.Z, pauli.Z], [0, 3]),
+            QubitSparsePauli.from_raw_parts(5, [pauli.X, pauli.X], [1, 2]),
+            QubitSparsePauli.from_raw_parts(5, [pauli.Z, pauli.Y], [1, 4]),
+        ]
+        self.assertEqual(list(pauli_list), expected)
+
+    def test_indexing(self):
+        pauli_list = QubitSparsePauliList.from_sparse_list(
+            [
+                ("XYY", (4, 2, 1)),
+                ("", ()),
+                ("ZZ", (3, 0)),
+                ("XX", (2, 1)),
+                ("YZ", (4, 1)),
+            ],
+            num_qubits=5,
+        )
+        pauli = QubitSparsePauli.Pauli
+        expected = [
+            QubitSparsePauli.from_raw_parts(5, [pauli.Y, pauli.Y, pauli.X], [1, 2, 4]),
+            QubitSparsePauli.from_raw_parts(5, [], []),
+            QubitSparsePauli.from_raw_parts(5, [pauli.Z, pauli.Z], [0, 3]),
+            QubitSparsePauli.from_raw_parts(5, [pauli.X, pauli.X], [1, 2]),
+            QubitSparsePauli.from_raw_parts(5, [pauli.Z, pauli.Y], [1, 4]),
+        ]
+        self.assertEqual(pauli_list[0], expected[0])
+        self.assertEqual(pauli_list[-2], expected[-2])
+        self.assertEqual(pauli_list[2:4], QubitSparsePauliList(expected[2:4]))
+        self.assertEqual(pauli_list[1::2], QubitSparsePauliList(expected[1::2]))
+        self.assertEqual(pauli_list[:], QubitSparsePauliList(expected))
+        self.assertEqual(pauli_list[-1:-4:-1], QubitSparsePauliList(expected[-1:-4:-1]))
+
+    def test_to_sparse_list(self):
+        """Test converting to a sparse list."""
+        with self.subTest(msg="empty"):
+            pauli_list = QubitSparsePauliList.empty(100)
+            expected = []
+            self.assertEqual(expected, pauli_list.to_sparse_list())
+
+        with self.subTest(msg="IXYZ"):
+            pauli_list = QubitSparsePauliList(["IXYZ"])
+            expected = [("ZYX", [0, 1, 2])]
+            self.assertEqual(
+                canonicalize_sparse_list(expected),
+                canonicalize_sparse_list(pauli_list.to_sparse_list()),
+            )
+
+        with self.subTest(msg="multiple"):
+            pauli_list = QubitSparsePauliList.from_list(["XXIZ", "YYIZ"])
+            expected = [("XXZ", [3, 2, 0]), ("ZYY", [0, 2, 3])]
+            self.assertEqual(
+                canonicalize_sparse_list(expected),
+                canonicalize_sparse_list(pauli_list.to_sparse_list()),
+            )
+
+
+def canonicalize_term(pauli, indices):
+    # canonicalize a sparse list term by sorting by indices (which is unique as
+    # indices cannot be repeated)
+    idcs = np.argsort(indices)
+    sorted_paulis = "".join(pauli[i] for i in idcs)
+    return (sorted_paulis, np.asarray(indices)[idcs].tolist())
+
+
+def canonicalize_sparse_list(sparse_list):
+    # sort a sparse list representation by canonicalizing the terms and then applying
+    # Python's built-in sort
+    canonicalized_terms = [canonicalize_term(*term) for term in sparse_list]
+    return sorted(canonicalized_terms)
+
+
+def lnn_target(num_qubits):
+    """Create a simple `Target` object with an arbitrary basis-gate set, and open-path
+    connectivity."""
+    out = Target()
+    out.add_instruction(library.RZGate(Parameter("a")), {(q,): None for q in range(num_qubits)})
+    out.add_instruction(library.SXGate(), {(q,): None for q in range(num_qubits)})
+    out.add_instruction(Measure(), {(q,): None for q in range(num_qubits)})
+    out.add_instruction(
+        library.CXGate(),
+        {
+            pair: None
+            for lower in range(num_qubits - 1)
+            for pair in [(lower, lower + 1), (lower + 1, lower)]
+        },
+    )
+    return out
+    '''

--- a/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
@@ -403,43 +403,43 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
         self.assertEqual(identity_0.num_qubits, 0)
         self.assertEqual(len(identity_0.paulis), 0)
         self.assertEqual(len(identity_0.indices), 0)
-    '''
+
     def test_compose(self):
-        p0 = QubitSparsePauli.from_label("XZY")
-        p1 = QubitSparsePauli.from_label("ZIY")
+        p0 = PhasedQubitSparsePauli("XZY")
+        p1 = PhasedQubitSparsePauli("ZIY")
 
-        self.assertEqual(p0.compose(p1), QubitSparsePauli.from_label("YZI"))
-        self.assertEqual(p1.compose(p0), QubitSparsePauli.from_label("YZI"))
+        self.assertEqual(p0.compose(p1), PhasedQubitSparsePauli(Pauli("-iYZI")))
+        self.assertEqual(p1.compose(p0), PhasedQubitSparsePauli(Pauli("iYZI")))
 
-        p0 = QubitSparsePauli.from_label("III")
-        p1 = QubitSparsePauli.from_label("ZIY")
+        p0 = PhasedQubitSparsePauli.from_label("III")
+        p1 = PhasedQubitSparsePauli.from_label("ZIY")
 
-        self.assertEqual(p0 @ p1, QubitSparsePauli.from_label("ZIY"))
-        self.assertEqual(p1 @ p0, QubitSparsePauli.from_label("ZIY"))
+        self.assertEqual(p0 @ p1, PhasedQubitSparsePauli.from_label("ZIY"))
+        self.assertEqual(p1 @ p0, PhasedQubitSparsePauli.from_label("ZIY"))
 
-        p0 = QubitSparsePauli.from_label("IIIXXY")
-        p1 = QubitSparsePauli.from_label("ZIYIII")
+        p0 = PhasedQubitSparsePauli.from_label("IIIXXY")
+        p1 = PhasedQubitSparsePauli.from_label("ZIYIII")
 
-        self.assertEqual(p0 @ p1, QubitSparsePauli.from_label("ZIYXXY"))
-        self.assertEqual(p1 @ p0, QubitSparsePauli.from_label("ZIYXXY"))
+        self.assertEqual(p0 @ p1, PhasedQubitSparsePauli.from_label("ZIYXXY"))
+        self.assertEqual(p1 @ p0, PhasedQubitSparsePauli.from_label("ZIYXXY"))
 
-        p0 = QubitSparsePauli.from_label("IIIXXYZIXIZIZ")
-        p1 = QubitSparsePauli.from_label("ZIYIIIXYZIYIX")
+        p0 = PhasedQubitSparsePauli(Pauli("IIIXXYZIXIZIZ"))
+        p1 = PhasedQubitSparsePauli(Pauli("ZIYIIIXYZIYIX"))
 
-        self.assertEqual(p0 @ p1, QubitSparsePauli.from_label("ZIYXXYYYYIXIY"))
-        self.assertEqual(p1 @ p0, QubitSparsePauli.from_label("ZIYXXYYYYIXIY"))
+        self.assertEqual(p0 @ p1, PhasedQubitSparsePauli(Pauli("IIIXXYZIXIZIZ") @ Pauli("ZIYIIIXYZIYIX")))
+        self.assertEqual(p1 @ p0, PhasedQubitSparsePauli(Pauli("ZIYIIIXYZIYIX") @ Pauli("IIIXXYZIXIZIZ")))
 
-        self.assertEqual(p0 @ p0, QubitSparsePauli.from_label("I" * 13))
-        self.assertEqual(p1 @ p1, QubitSparsePauli.from_label("I" * 13))
+        self.assertEqual(p0 @ p0, PhasedQubitSparsePauli.from_label("I" * 13))
+        self.assertEqual(p1 @ p1, PhasedQubitSparsePauli.from_label("I" * 13))
 
     def test_compose_errors(self):
-        p0 = QubitSparsePauli.from_label("XZYI")
-        p1 = QubitSparsePauli.from_label("ZIY")
+        p0 = PhasedQubitSparsePauli.from_label("XZYI")
+        p1 = PhasedQubitSparsePauli.from_label("ZIY")
         with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits: 4, 3"):
             p0.compose(p1)
         with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits: 3, 4"):
             p1.compose(p0)
-    '''
+    """
     def test_commutes(self):
         p0 = PhasedQubitSparsePauli("XIY")
         p1 = PhasedQubitSparsePauli("IZI")
@@ -473,7 +473,7 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
             p0.commutes(p1)
         with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits: 3, 4"):
             p1.commutes(p0)
-
+    """
 @ddt.ddt
 class TestPhasedQubitSparsePauliList(QiskitTestCase):
     pass

--- a/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
@@ -84,24 +84,24 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
             PhasedQubitSparsePauli(data, num_qubits=4)
         with self.assertRaisesRegex(ValueError, "does not match label"):
             PhasedQubitSparsePauli(data, num_qubits=6)
-    '''
+
     def test_default_constructor_sparse_label(self):
-        data = ("ZX", (0, 3))
+        data = (1, "ZX", (0, 3))
         self.assertEqual(
-            QubitSparsePauli(data, num_qubits=5),
-            QubitSparsePauli.from_sparse_label(data, num_qubits=5),
+            PhasedQubitSparsePauli(data, num_qubits=5),
+            PhasedQubitSparsePauli.from_sparse_label(data, num_qubits=5),
         )
         self.assertEqual(
-            QubitSparsePauli(data, num_qubits=10),
-            QubitSparsePauli.from_sparse_label(data, num_qubits=10),
+            PhasedQubitSparsePauli(data, num_qubits=10),
+            PhasedQubitSparsePauli.from_sparse_label(data, num_qubits=10),
         )
         with self.assertRaisesRegex(ValueError, "'num_qubits' must be provided"):
-            QubitSparsePauli(data)
+            PhasedQubitSparsePauli(data)
         self.assertEqual(
-            QubitSparsePauli(("", []), num_qubits=5),
-            QubitSparsePauli.from_sparse_label(("", []), num_qubits=5),
+            PhasedQubitSparsePauli((0, "", []), num_qubits=5),
+            PhasedQubitSparsePauli.from_sparse_label((0, "", []), num_qubits=5),
         )
-    '''
+
     def test_from_label(self):
         # The label is interpreted like a bitstring, with the right-most item associated with qubit
         # 0, and increasing as we move to the left (like `Pauli`, and other bitstring conventions).

--- a/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
@@ -49,7 +49,7 @@ def single_cases_list():
         PhasedQubitSparsePauliList.from_list(["YIXZII", "ZZYYXX"]),
         # Includes a duplicate entry.
         PhasedQubitSparsePauliList.from_list(["IXZ", "ZZI", "IXZ"]),
-        PhasedQubitSparsePauli(Pauli("iZZYYXX")).to_phased_qubit_sparse_pauli_list()
+        PhasedQubitSparsePauli(Pauli("iZZYYXX")).to_phased_qubit_sparse_pauli_list(),
     ]
 
 
@@ -60,7 +60,8 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
         data = Pauli("IXYIZ")
         self.assertEqual(PhasedQubitSparsePauli(data), PhasedQubitSparsePauli.from_pauli(data))
         self.assertEqual(
-            PhasedQubitSparsePauli(data, num_qubits=data.num_qubits), PhasedQubitSparsePauli.from_pauli(data)
+            PhasedQubitSparsePauli(data, num_qubits=data.num_qubits),
+            PhasedQubitSparsePauli.from_pauli(data),
         )
         self.assertEqual(PhasedQubitSparsePauli(data).phase, 0)
 
@@ -68,19 +69,25 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
             PhasedQubitSparsePauli(data, num_qubits=data.num_qubits + 1)
 
         with_phase = Pauli("-jIYYXY")
-        self.assertEqual(PhasedQubitSparsePauli(with_phase), PhasedQubitSparsePauli.from_pauli(with_phase))
+        self.assertEqual(
+            PhasedQubitSparsePauli(with_phase), PhasedQubitSparsePauli.from_pauli(with_phase)
+        )
         self.assertEqual(
             PhasedQubitSparsePauli(with_phase, num_qubits=data.num_qubits),
             PhasedQubitSparsePauli.from_pauli(with_phase),
         )
         self.assertEqual(PhasedQubitSparsePauli(with_phase).phase, 1)
 
-        self.assertEqual(PhasedQubitSparsePauli(Pauli("")), PhasedQubitSparsePauli.from_pauli(Pauli("")))
-    
+        self.assertEqual(
+            PhasedQubitSparsePauli(Pauli("")), PhasedQubitSparsePauli.from_pauli(Pauli(""))
+        )
+
     def test_default_constructor_label(self):
         data = "IXIIZ"
         self.assertEqual(PhasedQubitSparsePauli(data), PhasedQubitSparsePauli.from_label(data))
-        self.assertEqual(PhasedQubitSparsePauli(data, num_qubits=5), PhasedQubitSparsePauli.from_label(data))
+        self.assertEqual(
+            PhasedQubitSparsePauli(data, num_qubits=5), PhasedQubitSparsePauli.from_label(data)
+        )
         with self.assertRaisesRegex(ValueError, "does not match label"):
             PhasedQubitSparsePauli(data, num_qubits=4)
         with self.assertRaisesRegex(ValueError, "does not match label"):
@@ -123,7 +130,7 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
                     PhasedQubitSparsePauli.Pauli.X,
                 ],
                 [0, 1, 2, 4, 5, 7, 8, 11, 12],
-                0
+                0,
             ),
         )
 
@@ -151,12 +158,16 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
 
         # The indices should be allowed to be given in unsorted order, but they should be term-wise
         # sorted in the output.
-        from_unsorted = PhasedQubitSparsePauli.from_sparse_label((0, "XYZ", (2, 0, 1)), num_qubits=3)
+        from_unsorted = PhasedQubitSparsePauli.from_sparse_label(
+            (0, "XYZ", (2, 0, 1)), num_qubits=3
+        )
         self.assertEqual(from_unsorted, PhasedQubitSparsePauli.from_label("XZY"))
         np.testing.assert_equal(from_unsorted.indices, np.array([0, 1, 2], dtype=np.uint32))
 
         # Explicit identities should still work, just be skipped over.
-        explicit_identity = PhasedQubitSparsePauli.from_sparse_label((0, "ZXI", (0, 1, 2)), num_qubits=10)
+        explicit_identity = PhasedQubitSparsePauli.from_sparse_label(
+            (0, "ZXI", (0, 1, 2)), num_qubits=10
+        )
         self.assertEqual(
             explicit_identity,
             PhasedQubitSparsePauli.from_sparse_label((0, "XZ", (1, 0)), num_qubits=10),
@@ -207,14 +218,14 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
         with self.assertRaisesRegex(ValueError, "index 3 is duplicated"):
             PhasedQubitSparsePauli.from_sparse_label((0, "XYZXZ", (3, 0, 1, 2, 3)), num_qubits=5)
 
-
     def test_from_pauli(self):
         # This function should be infallible provided `Pauli` doesn't change its interface and the
         # user doesn't violate the typing.
 
         # Simple check that the labels are interpreted in the same order.
         self.assertEqual(
-            PhasedQubitSparsePauli.from_pauli(Pauli("IIXZI")), PhasedQubitSparsePauli.from_label("IIXZI")
+            PhasedQubitSparsePauli.from_pauli(Pauli("IIXZI")),
+            PhasedQubitSparsePauli.from_label("IIXZI"),
         )
 
         self.assertEqual(
@@ -267,7 +278,9 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
             "Y": 0b11,
             "Z": 0b01,
         }
-        self.assertEqual({name: getattr(PhasedQubitSparsePauli.Pauli, name) for name in values}, values)
+        self.assertEqual(
+            {name: getattr(PhasedQubitSparsePauli.Pauli, name) for name in values}, values
+        )
 
         # The single-character label aliases can be accessed with index notation.
         labels = {
@@ -278,14 +291,16 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
         self.assertEqual({label: PhasedQubitSparsePauli.Pauli[label] for label in labels}, labels)
         # The `label` property returns known values.
         self.assertEqual({pauli.label: pauli for pauli in PhasedQubitSparsePauli.Pauli}, labels)
-    
+
     @ddt.idata(single_cases())
     def test_pickle(self, phased_qubit_sparse_pauli):
         self.assertEqual(phased_qubit_sparse_pauli, copy.copy(phased_qubit_sparse_pauli))
         self.assertIsNot(phased_qubit_sparse_pauli, copy.copy(phased_qubit_sparse_pauli))
         self.assertEqual(phased_qubit_sparse_pauli, copy.deepcopy(phased_qubit_sparse_pauli))
-        self.assertEqual(phased_qubit_sparse_pauli, pickle.loads(pickle.dumps(phased_qubit_sparse_pauli)))
-    
+        self.assertEqual(
+            phased_qubit_sparse_pauli, pickle.loads(pickle.dumps(phased_qubit_sparse_pauli))
+        )
+
     @ddt.data(
         PhasedQubitSparsePauli.from_label("IIXIZI"),
         PhasedQubitSparsePauli.from_label("X"),
@@ -296,12 +311,12 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
         # that it has any particular form.
         self.assertIsInstance(repr(data), str)
         self.assertIn("PhasedQubitSparsePauli", repr(data))
-    
+
     @ddt.idata(single_cases())
     def test_copy(self, phased_qubit_sparse_pauli):
         self.assertEqual(phased_qubit_sparse_pauli, phased_qubit_sparse_pauli.copy())
         self.assertIsNot(phased_qubit_sparse_pauli, phased_qubit_sparse_pauli.copy())
-    
+
     def test_equality(self):
         sparse_data = (1, "XYY", (3, 1, 0))
         pauli = PhasedQubitSparsePauli.from_sparse_label(sparse_data, num_qubits=5)
@@ -314,7 +329,8 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
 
         # Difference in qubit count.
         self.assertNotEqual(
-            pauli, PhasedQubitSparsePauli.from_sparse_label(sparse_data, num_qubits=pauli.num_qubits + 1)
+            pauli,
+            PhasedQubitSparsePauli.from_sparse_label(sparse_data, num_qubits=pauli.num_qubits + 1),
         )
 
         # Difference in bit terms.
@@ -346,7 +362,7 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
             PhasedQubitSparsePauli(Pauli("iXIYYZ")),
             PhasedQubitSparsePauli(Pauli("-iXIYYZ")),
         )
-    
+
     def test_attributes_sequence(self):
         """Test attributes of the `Sequence` protocol."""
         # Length
@@ -379,7 +395,9 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
         self.assertIsInstance(pauli.paulis[0:2], np.ndarray)
         np.testing.assert_array_equal(
             pauli.paulis[0:2],
-            np.array([PhasedQubitSparsePauli.Pauli.Y, PhasedQubitSparsePauli.Pauli.Z], dtype=np.uint8),
+            np.array(
+                [PhasedQubitSparsePauli.Pauli.Y, PhasedQubitSparsePauli.Pauli.Z], dtype=np.uint8
+            ),
             strict=True,
         )
 
@@ -436,8 +454,12 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
         p0 = PhasedQubitSparsePauli(Pauli("IIIXXYZIXIZIZ"))
         p1 = PhasedQubitSparsePauli(Pauli("ZIYIIIXYZIYIX"))
 
-        self.assertEqual(p0 @ p1, PhasedQubitSparsePauli(Pauli("IIIXXYZIXIZIZ") @ Pauli("ZIYIIIXYZIYIX")))
-        self.assertEqual(p1 @ p0, PhasedQubitSparsePauli(Pauli("ZIYIIIXYZIYIX") @ Pauli("IIIXXYZIXIZIZ")))
+        self.assertEqual(
+            p0 @ p1, PhasedQubitSparsePauli(Pauli("IIIXXYZIXIZIZ") @ Pauli("ZIYIIIXYZIYIX"))
+        )
+        self.assertEqual(
+            p1 @ p0, PhasedQubitSparsePauli(Pauli("ZIYIIIXYZIYIX") @ Pauli("IIIXXYZIXIZIZ"))
+        )
 
         self.assertEqual(p0 @ p0, PhasedQubitSparsePauli.from_label("I" * 13))
         self.assertEqual(p1 @ p1, PhasedQubitSparsePauli.from_label("I" * 13))
@@ -484,13 +506,15 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
         with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits: 3, 4"):
             p1.commutes(p0)
 
+
 @ddt.ddt
 class TestPhasedQubitSparsePauliList(QiskitTestCase):
 
-    
     def test_default_constructor_pauli(self):
         data = Pauli("IXYIZ")
-        self.assertEqual(PhasedQubitSparsePauliList(data), PhasedQubitSparsePauliList.from_pauli(data))
+        self.assertEqual(
+            PhasedQubitSparsePauliList(data), PhasedQubitSparsePauliList.from_pauli(data)
+        )
         self.assertEqual(
             PhasedQubitSparsePauliList(data, num_qubits=data.num_qubits),
             PhasedQubitSparsePauliList.from_pauli(data),
@@ -500,7 +524,8 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
 
         with_phase = Pauli("-jIYYXY")
         self.assertEqual(
-            PhasedQubitSparsePauliList(with_phase), PhasedQubitSparsePauliList.from_pauli(with_phase)
+            PhasedQubitSparsePauliList(with_phase),
+            PhasedQubitSparsePauliList.from_pauli(with_phase),
         )
         self.assertEqual(
             PhasedQubitSparsePauliList(with_phase, num_qubits=data.num_qubits),
@@ -513,16 +538,20 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
 
     def test_default_constructor_list(self):
         data = ["IXIIZ", "XIXII", "IIXYI"]
-        self.assertEqual(PhasedQubitSparsePauliList(data), PhasedQubitSparsePauliList.from_list(data))
         self.assertEqual(
-            PhasedQubitSparsePauliList(data, num_qubits=5), PhasedQubitSparsePauliList.from_list(data)
+            PhasedQubitSparsePauliList(data), PhasedQubitSparsePauliList.from_list(data)
+        )
+        self.assertEqual(
+            PhasedQubitSparsePauliList(data, num_qubits=5),
+            PhasedQubitSparsePauliList.from_list(data),
         )
         with self.assertRaisesRegex(ValueError, "label with length 5 cannot be added"):
             PhasedQubitSparsePauliList(data, num_qubits=4)
         with self.assertRaisesRegex(ValueError, "label with length 5 cannot be added"):
             PhasedQubitSparsePauliList(data, num_qubits=6)
         self.assertEqual(
-            PhasedQubitSparsePauliList([], num_qubits=5), PhasedQubitSparsePauliList.from_list([], num_qubits=5)
+            PhasedQubitSparsePauliList([], num_qubits=5),
+            PhasedQubitSparsePauliList.from_list([], num_qubits=5),
         )
 
     def test_default_constructor_sparse_list(self):
@@ -544,9 +573,12 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
 
     def test_default_constructor_label(self):
         data = "IIXIXXIZZYYIYZ"
-        self.assertEqual(PhasedQubitSparsePauliList(data), PhasedQubitSparsePauliList.from_label(data))
         self.assertEqual(
-            PhasedQubitSparsePauliList(data, num_qubits=len(data)), PhasedQubitSparsePauliList.from_label(data)
+            PhasedQubitSparsePauliList(data), PhasedQubitSparsePauliList.from_label(data)
+        )
+        self.assertEqual(
+            PhasedQubitSparsePauliList(data, num_qubits=len(data)),
+            PhasedQubitSparsePauliList.from_label(data),
         )
         with self.assertRaisesRegex(ValueError, "explicitly given 'num_qubits'"):
             PhasedQubitSparsePauliList(data, num_qubits=len(data) + 1)
@@ -590,7 +622,8 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
     def test_from_list(self):
         label = "IXYIZZY"
         self.assertEqual(
-            PhasedQubitSparsePauliList.from_list([label]), PhasedQubitSparsePauliList.from_label(label)
+            PhasedQubitSparsePauliList.from_list([label]),
+            PhasedQubitSparsePauliList.from_label(label),
         )
         self.assertEqual(
             PhasedQubitSparsePauliList.from_list([label], num_qubits=len(label)),
@@ -650,10 +683,12 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
         )
 
         self.assertEqual(
-            PhasedQubitSparsePauliList.from_list([], num_qubits=5), PhasedQubitSparsePauliList.empty(5)
+            PhasedQubitSparsePauliList.from_list([], num_qubits=5),
+            PhasedQubitSparsePauliList.empty(5),
         )
         self.assertEqual(
-            PhasedQubitSparsePauliList.from_list([], num_qubits=0), PhasedQubitSparsePauliList.empty(0)
+            PhasedQubitSparsePauliList.from_list([], num_qubits=0),
+            PhasedQubitSparsePauliList.empty(0),
         )
 
     def test_from_list_failures(self):
@@ -710,7 +745,9 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
         )
         self.assertEqual(
             explicit_identity,
-            PhasedQubitSparsePauliList.from_sparse_list([(0, "XZ", (1, 0)), (0, "YX", (1, 0))], num_qubits=10),
+            PhasedQubitSparsePauliList.from_sparse_list(
+                [(0, "XZ", (1, 0)), (0, "YX", (1, 0))], num_qubits=10
+            ),
         )
         np.testing.assert_equal(explicit_identity[0].indices, np.array([0, 1], dtype=np.uint32))
         np.testing.assert_equal(explicit_identity[1].indices, np.array([0, 1], dtype=np.uint32))
@@ -755,7 +792,9 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
         with self.assertRaisesRegex(ValueError, "index 3 is duplicated"):
             PhasedQubitSparsePauliList.from_sparse_list([(0, "XZ", (3, 3))], num_qubits=5)
         with self.assertRaisesRegex(ValueError, "index 3 is duplicated"):
-            PhasedQubitSparsePauliList.from_sparse_list([(0, "XYZXZ", (3, 0, 1, 2, 3))], num_qubits=5)
+            PhasedQubitSparsePauliList.from_sparse_list(
+                [(0, "XYZXZ", (3, 0, 1, 2, 3))], num_qubits=5
+            )
 
     def test_from_pauli(self):
         # This function should be infallible provided `Pauli` doesn't change its interface and the
@@ -785,12 +824,14 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
         paulis = {"IXYZ" * n: Pauli("IXYZ" * n) for n in range(1, 5)}
         from_paulis, from_labels = zip(
             *(
-                (PhasedQubitSparsePauliList.from_pauli(pauli), PhasedQubitSparsePauliList.from_label(label))
+                (
+                    PhasedQubitSparsePauliList.from_pauli(pauli),
+                    PhasedQubitSparsePauliList.from_label(label),
+                )
                 for label, pauli in paulis.items()
             )
         )
         self.assertEqual(from_paulis, from_labels)
-
 
     def test_from_phased_qubit_sparse_paulis(self):
         self.assertEqual(
@@ -802,7 +843,9 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
             PhasedQubitSparsePauliList.empty(0),
         )
         self.assertEqual(
-            PhasedQubitSparsePauliList.from_phased_qubit_sparse_paulis((None for _ in []), num_qubits=3),
+            PhasedQubitSparsePauliList.from_phased_qubit_sparse_paulis(
+                (None for _ in []), num_qubits=3
+            ),
             PhasedQubitSparsePauliList.empty(3),
         )
 
@@ -814,10 +857,15 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
             ],
             num_qubits=10,
         )
-        self.assertEqual(PhasedQubitSparsePauliList.from_phased_qubit_sparse_paulis(list(expected)), expected)
-        self.assertEqual(PhasedQubitSparsePauliList.from_phased_qubit_sparse_paulis(tuple(expected)), expected)
         self.assertEqual(
-            PhasedQubitSparsePauliList.from_phased_qubit_sparse_paulis(term for term in expected), expected
+            PhasedQubitSparsePauliList.from_phased_qubit_sparse_paulis(list(expected)), expected
+        )
+        self.assertEqual(
+            PhasedQubitSparsePauliList.from_phased_qubit_sparse_paulis(tuple(expected)), expected
+        )
+        self.assertEqual(
+            PhasedQubitSparsePauliList.from_phased_qubit_sparse_paulis(term for term in expected),
+            expected,
         )
         self.assertEqual(
             PhasedQubitSparsePauliList.from_phased_qubit_sparse_paulis(
@@ -869,7 +917,6 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
         self.assertEqual(len(PhasedQubitSparsePauliList.empty(10)), 0)
         self.assertEqual(len(PhasedQubitSparsePauliList.from_list(["IIIXIZ", "YYXXII"])), 2)
 
-    
     @ddt.idata(single_cases_list())
     def test_pickle(self, qubit_sparse_pauli_list):
         self.assertEqual(qubit_sparse_pauli_list, copy.copy(qubit_sparse_pauli_list))
@@ -901,7 +948,7 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
     def test_copy(self, phased_qubit_sparse_pauli_list):
         self.assertEqual(phased_qubit_sparse_pauli_list, phased_qubit_sparse_pauli_list.copy())
         self.assertIsNot(phased_qubit_sparse_pauli_list, phased_qubit_sparse_pauli_list.copy())
-    
+
     def test_equality(self):
         sparse_data = [(0, "XZ", (1, 0)), (1, "XYY", (3, 1, 0))]
         pauli_list = PhasedQubitSparsePauliList.from_sparse_list(sparse_data, num_qubits=5)
@@ -919,7 +966,9 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
                 sparse_data, num_qubits=pauli_list.num_qubits + 1
             ),
         )
-        self.assertNotEqual(PhasedQubitSparsePauliList.empty(2), PhasedQubitSparsePauliList.empty(3))
+        self.assertNotEqual(
+            PhasedQubitSparsePauliList.empty(2), PhasedQubitSparsePauliList.empty(3)
+        )
 
         # Difference in bit terms.
         self.assertNotEqual(
@@ -943,20 +992,32 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
 
         # Difference in boundaries.
         self.assertNotEqual(
-            PhasedQubitSparsePauliList.from_sparse_list([(0, "XZ", (0, 1)), (0, "XX", (2, 3))], num_qubits=5),
-            PhasedQubitSparsePauliList.from_sparse_list([(0, "XZX", (0, 1, 2)), (0, "X", (3,))], num_qubits=5),
+            PhasedQubitSparsePauliList.from_sparse_list(
+                [(0, "XZ", (0, 1)), (0, "XX", (2, 3))], num_qubits=5
+            ),
+            PhasedQubitSparsePauliList.from_sparse_list(
+                [(0, "XZX", (0, 1, 2)), (0, "X", (3,))], num_qubits=5
+            ),
         )
 
         # Difference in phase.
         self.assertNotEqual(
-            PhasedQubitSparsePauliList.from_sparse_list([(0, "XZ", (0, 1)), (0, "XX", (2, 3))], num_qubits=5),
-            PhasedQubitSparsePauliList.from_sparse_list([(0, "XZ", (0, 1)), (2, "XX", (2, 3))], num_qubits=5),
+            PhasedQubitSparsePauliList.from_sparse_list(
+                [(0, "XZ", (0, 1)), (0, "XX", (2, 3))], num_qubits=5
+            ),
+            PhasedQubitSparsePauliList.from_sparse_list(
+                [(0, "XZ", (0, 1)), (2, "XX", (2, 3))], num_qubits=5
+            ),
         )
 
         # Same phase mod 4.
         self.assertEqual(
-            PhasedQubitSparsePauliList.from_sparse_list([(0, "XZ", (0, 1)), (2, "XX", (2, 3))], num_qubits=5),
-            PhasedQubitSparsePauliList.from_sparse_list([(4, "XZ", (0, 1)), (10, "XX", (2, 3))], num_qubits=5),
+            PhasedQubitSparsePauliList.from_sparse_list(
+                [(0, "XZ", (0, 1)), (2, "XX", (2, 3))], num_qubits=5
+            ),
+            PhasedQubitSparsePauliList.from_sparse_list(
+                [(4, "XZ", (0, 1)), (10, "XX", (2, 3))], num_qubits=5
+            ),
         )
 
     @ddt.idata(single_cases_list())
@@ -971,10 +1032,12 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
             PhasedQubitSparsePauliList.empty(5),
         )
         self.assertEqual(
-            PhasedQubitSparsePauliList.empty(3).apply_layout([0, 2, 1], 8), PhasedQubitSparsePauliList.empty(8)
+            PhasedQubitSparsePauliList.empty(3).apply_layout([0, 2, 1], 8),
+            PhasedQubitSparsePauliList.empty(8),
         )
         self.assertEqual(
-            PhasedQubitSparsePauliList.empty(2).apply_layout([1, 0]), PhasedQubitSparsePauliList.empty(2)
+            PhasedQubitSparsePauliList.empty(2).apply_layout([1, 0]),
+            PhasedQubitSparsePauliList.empty(2),
         )
         self.assertEqual(
             PhasedQubitSparsePauliList.empty(3).apply_layout([100, 10_000, 3], 100_000_000),
@@ -988,33 +1051,53 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
         ]
 
         def map_indices(terms, layout):
-            return [(phase, terms, tuple(layout[bit] for bit in bits)) for phase, terms, bits in terms]
+            return [
+                (phase, terms, tuple(layout[bit] for bit in bits)) for phase, terms, bits in terms
+            ]
 
         identity = list(range(12))
         self.assertEqual(
-            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(identity),
+            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(
+                identity
+            ),
             PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=12),
         )
         # We've already tested elsewhere that `PhasedQubitSparsePauliList.from_sparse_list` produces termwise
         # sorted indices, so these tests also ensure `apply_layout` is maintaining that invariant.
         backwards = list(range(12))[::-1]
         self.assertEqual(
-            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(backwards),
-            PhasedQubitSparsePauliList.from_sparse_list(map_indices(terms, backwards), num_qubits=12),
+            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(
+                backwards
+            ),
+            PhasedQubitSparsePauliList.from_sparse_list(
+                map_indices(terms, backwards), num_qubits=12
+            ),
         )
         shuffled = [4, 7, 1, 10, 0, 11, 3, 2, 8, 5, 6, 9]
         self.assertEqual(
-            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(shuffled),
-            PhasedQubitSparsePauliList.from_sparse_list(map_indices(terms, shuffled), num_qubits=12),
+            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(
+                shuffled
+            ),
+            PhasedQubitSparsePauliList.from_sparse_list(
+                map_indices(terms, shuffled), num_qubits=12
+            ),
         )
         self.assertEqual(
-            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(shuffled, 100),
-            PhasedQubitSparsePauliList.from_sparse_list(map_indices(terms, shuffled), num_qubits=100),
+            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(
+                shuffled, 100
+            ),
+            PhasedQubitSparsePauliList.from_sparse_list(
+                map_indices(terms, shuffled), num_qubits=100
+            ),
         )
         expanded = [78, 69, 82, 68, 32, 97, 108, 101, 114, 116, 33]
         self.assertEqual(
-            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=11).apply_layout(expanded, 120),
-            PhasedQubitSparsePauliList.from_sparse_list(map_indices(terms, expanded), num_qubits=120),
+            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=11).apply_layout(
+                expanded, 120
+            ),
+            PhasedQubitSparsePauliList.from_sparse_list(
+                map_indices(terms, expanded), num_qubits=120
+            ),
         )
 
     def test_apply_layout_transpiled(self):
@@ -1065,25 +1148,32 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
 
     def test_apply_layout_none(self):
         self.assertEqual(
-            PhasedQubitSparsePauliList.empty(0).apply_layout(None), PhasedQubitSparsePauliList.empty(0)
+            PhasedQubitSparsePauliList.empty(0).apply_layout(None),
+            PhasedQubitSparsePauliList.empty(0),
         )
         self.assertEqual(
-            PhasedQubitSparsePauliList.empty(0).apply_layout(None, 3), PhasedQubitSparsePauliList.empty(3)
+            PhasedQubitSparsePauliList.empty(0).apply_layout(None, 3),
+            PhasedQubitSparsePauliList.empty(3),
         )
         self.assertEqual(
-            PhasedQubitSparsePauliList.empty(5).apply_layout(None), PhasedQubitSparsePauliList.empty(5)
+            PhasedQubitSparsePauliList.empty(5).apply_layout(None),
+            PhasedQubitSparsePauliList.empty(5),
         )
         self.assertEqual(
-            PhasedQubitSparsePauliList.empty(3).apply_layout(None, 8), PhasedQubitSparsePauliList.empty(8)
+            PhasedQubitSparsePauliList.empty(3).apply_layout(None, 8),
+            PhasedQubitSparsePauliList.empty(8),
         )
         self.assertEqual(
-            PhasedQubitSparsePauliList.empty(0).apply_layout(None), PhasedQubitSparsePauliList.empty(0)
+            PhasedQubitSparsePauliList.empty(0).apply_layout(None),
+            PhasedQubitSparsePauliList.empty(0),
         )
         self.assertEqual(
-            PhasedQubitSparsePauliList.empty(0).apply_layout(None, 8), PhasedQubitSparsePauliList.empty(8)
+            PhasedQubitSparsePauliList.empty(0).apply_layout(None, 8),
+            PhasedQubitSparsePauliList.empty(8),
         )
         self.assertEqual(
-            PhasedQubitSparsePauliList.empty(2).apply_layout(None), PhasedQubitSparsePauliList.empty(2)
+            PhasedQubitSparsePauliList.empty(2).apply_layout(None),
+            PhasedQubitSparsePauliList.empty(2),
         )
         self.assertEqual(
             PhasedQubitSparsePauliList.empty(3).apply_layout(None, 100_000_000),

--- a/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
@@ -1062,8 +1062,9 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
             ),
             PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=12),
         )
-        # We've already tested elsewhere that `PhasedQubitSparsePauliList.from_sparse_list` produces termwise
-        # sorted indices, so these tests also ensure `apply_layout` is maintaining that invariant.
+        # We've already tested elsewhere that `PhasedQubitSparsePauliList.from_sparse_list` produces
+        # termwise sorted indices, so these tests also ensure `apply_layout` is maintaining that
+        # invariant.
         backwards = list(range(12))[::-1]
         self.assertEqual(
             PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(

--- a/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
@@ -964,65 +964,65 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
         num_qubits = pauli_list.num_qubits
         pauli_list.clear()
         self.assertEqual(pauli_list, PhasedQubitSparsePauliList.empty(num_qubits))
-    '''
+
     def test_apply_layout_list(self):
         self.assertEqual(
-            QubitSparsePauliList.empty(5).apply_layout([4, 3, 2, 1, 0]),
-            QubitSparsePauliList.empty(5),
+            PhasedQubitSparsePauliList.empty(5).apply_layout([4, 3, 2, 1, 0]),
+            PhasedQubitSparsePauliList.empty(5),
         )
         self.assertEqual(
-            QubitSparsePauliList.empty(3).apply_layout([0, 2, 1], 8), QubitSparsePauliList.empty(8)
+            PhasedQubitSparsePauliList.empty(3).apply_layout([0, 2, 1], 8), PhasedQubitSparsePauliList.empty(8)
         )
         self.assertEqual(
-            QubitSparsePauliList.empty(2).apply_layout([1, 0]), QubitSparsePauliList.empty(2)
+            PhasedQubitSparsePauliList.empty(2).apply_layout([1, 0]), PhasedQubitSparsePauliList.empty(2)
         )
         self.assertEqual(
-            QubitSparsePauliList.empty(3).apply_layout([100, 10_000, 3], 100_000_000),
-            QubitSparsePauliList.empty(100_000_000),
+            PhasedQubitSparsePauliList.empty(3).apply_layout([100, 10_000, 3], 100_000_000),
+            PhasedQubitSparsePauliList.empty(100_000_000),
         )
 
         terms = [
-            ("ZYX", (4, 2, 1)),
-            ("", ()),
-            ("XXYYZZ", (10, 8, 6, 4, 2, 0)),
+            (0, "ZYX", (4, 2, 1)),
+            (1, "", ()),
+            (2, "XXYYZZ", (10, 8, 6, 4, 2, 0)),
         ]
 
         def map_indices(terms, layout):
-            return [(terms, tuple(layout[bit] for bit in bits)) for terms, bits in terms]
+            return [(phase, terms, tuple(layout[bit] for bit in bits)) for phase, terms, bits in terms]
 
         identity = list(range(12))
         self.assertEqual(
-            QubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(identity),
-            QubitSparsePauliList.from_sparse_list(terms, num_qubits=12),
+            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(identity),
+            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=12),
         )
-        # We've already tested elsewhere that `QubitSparsePauliList.from_sparse_list` produces termwise
+        # We've already tested elsewhere that `PhasedQubitSparsePauliList.from_sparse_list` produces termwise
         # sorted indices, so these tests also ensure `apply_layout` is maintaining that invariant.
         backwards = list(range(12))[::-1]
         self.assertEqual(
-            QubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(backwards),
-            QubitSparsePauliList.from_sparse_list(map_indices(terms, backwards), num_qubits=12),
+            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(backwards),
+            PhasedQubitSparsePauliList.from_sparse_list(map_indices(terms, backwards), num_qubits=12),
         )
         shuffled = [4, 7, 1, 10, 0, 11, 3, 2, 8, 5, 6, 9]
         self.assertEqual(
-            QubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(shuffled),
-            QubitSparsePauliList.from_sparse_list(map_indices(terms, shuffled), num_qubits=12),
+            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(shuffled),
+            PhasedQubitSparsePauliList.from_sparse_list(map_indices(terms, shuffled), num_qubits=12),
         )
         self.assertEqual(
-            QubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(shuffled, 100),
-            QubitSparsePauliList.from_sparse_list(map_indices(terms, shuffled), num_qubits=100),
+            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(shuffled, 100),
+            PhasedQubitSparsePauliList.from_sparse_list(map_indices(terms, shuffled), num_qubits=100),
         )
         expanded = [78, 69, 82, 68, 32, 97, 108, 101, 114, 116, 33]
         self.assertEqual(
-            QubitSparsePauliList.from_sparse_list(terms, num_qubits=11).apply_layout(expanded, 120),
-            QubitSparsePauliList.from_sparse_list(map_indices(terms, expanded), num_qubits=120),
+            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=11).apply_layout(expanded, 120),
+            PhasedQubitSparsePauliList.from_sparse_list(map_indices(terms, expanded), num_qubits=120),
         )
 
     def test_apply_layout_transpiled(self):
-        base = QubitSparsePauliList.from_sparse_list(
+        base = PhasedQubitSparsePauliList.from_sparse_list(
             [
-                ("ZYX", (4, 2, 1)),
-                ("", ()),
-                ("XXY", (3, 2, 0)),
+                (0, "ZYX", (4, 2, 1)),
+                (1, "", ()),
+                (2, "XXY", (3, 2, 0)),
             ],
             num_qubits=5,
         )
@@ -1065,49 +1065,49 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
 
     def test_apply_layout_none(self):
         self.assertEqual(
-            QubitSparsePauliList.empty(0).apply_layout(None), QubitSparsePauliList.empty(0)
+            PhasedQubitSparsePauliList.empty(0).apply_layout(None), PhasedQubitSparsePauliList.empty(0)
         )
         self.assertEqual(
-            QubitSparsePauliList.empty(0).apply_layout(None, 3), QubitSparsePauliList.empty(3)
+            PhasedQubitSparsePauliList.empty(0).apply_layout(None, 3), PhasedQubitSparsePauliList.empty(3)
         )
         self.assertEqual(
-            QubitSparsePauliList.empty(5).apply_layout(None), QubitSparsePauliList.empty(5)
+            PhasedQubitSparsePauliList.empty(5).apply_layout(None), PhasedQubitSparsePauliList.empty(5)
         )
         self.assertEqual(
-            QubitSparsePauliList.empty(3).apply_layout(None, 8), QubitSparsePauliList.empty(8)
+            PhasedQubitSparsePauliList.empty(3).apply_layout(None, 8), PhasedQubitSparsePauliList.empty(8)
         )
         self.assertEqual(
-            QubitSparsePauliList.empty(0).apply_layout(None), QubitSparsePauliList.empty(0)
+            PhasedQubitSparsePauliList.empty(0).apply_layout(None), PhasedQubitSparsePauliList.empty(0)
         )
         self.assertEqual(
-            QubitSparsePauliList.empty(0).apply_layout(None, 8), QubitSparsePauliList.empty(8)
+            PhasedQubitSparsePauliList.empty(0).apply_layout(None, 8), PhasedQubitSparsePauliList.empty(8)
         )
         self.assertEqual(
-            QubitSparsePauliList.empty(2).apply_layout(None), QubitSparsePauliList.empty(2)
+            PhasedQubitSparsePauliList.empty(2).apply_layout(None), PhasedQubitSparsePauliList.empty(2)
         )
         self.assertEqual(
-            QubitSparsePauliList.empty(3).apply_layout(None, 100_000_000),
-            QubitSparsePauliList.empty(100_000_000),
+            PhasedQubitSparsePauliList.empty(3).apply_layout(None, 100_000_000),
+            PhasedQubitSparsePauliList.empty(100_000_000),
         )
 
         terms = [
-            ("ZYX", (2, 1, 0)),
-            ("", ()),
-            ("XXYYZZ", (10, 8, 6, 4, 2, 0)),
+            (0, "ZYX", (2, 1, 0)),
+            (1, "", ()),
+            (3, "XXYYZZ", (10, 8, 6, 4, 2, 0)),
         ]
         self.assertEqual(
-            QubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(None),
-            QubitSparsePauliList.from_sparse_list(terms, num_qubits=12),
+            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(None),
+            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=12),
         )
         self.assertEqual(
-            QubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(
+            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=12).apply_layout(
                 None, num_qubits=200
             ),
-            QubitSparsePauliList.from_sparse_list(terms, num_qubits=200),
+            PhasedQubitSparsePauliList.from_sparse_list(terms, num_qubits=200),
         )
 
     def test_apply_layout_failures(self):
-        obs = QubitSparsePauliList.from_list(["IIYI", "IIIX"])
+        obs = PhasedQubitSparsePauliList.from_list(["IIYI", "IIIX"])
         with self.assertRaisesRegex(ValueError, "duplicate"):
             obs.apply_layout([0, 0, 1, 2])
         with self.assertRaisesRegex(ValueError, "does not account for all contained qubits"):
@@ -1128,29 +1128,29 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
             obs.apply_layout(layout, num_qubits=2)
 
     def test_iteration(self):
-        self.assertEqual(list(QubitSparsePauliList.empty(5)), [])
-        self.assertEqual(tuple(QubitSparsePauliList.empty(0)), ())
+        self.assertEqual(list(PhasedQubitSparsePauliList.empty(5)), [])
+        self.assertEqual(tuple(PhasedQubitSparsePauliList.empty(0)), ())
 
-        pauli_list = QubitSparsePauliList.from_sparse_list(
+        pauli_list = PhasedQubitSparsePauliList.from_sparse_list(
             [
-                ("XYY", (4, 2, 1)),
-                ("", ()),
-                ("ZZ", (3, 0)),
-                ("XX", (2, 1)),
-                ("YZ", (4, 1)),
+                (0, "XYY", (4, 2, 1)),
+                (2, "", ()),
+                (0, "ZZ", (3, 0)),
+                (3, "XX", (2, 1)),
+                (0, "YZ", (4, 1)),
             ],
             num_qubits=5,
         )
-        pauli = QubitSparsePauli.Pauli
+        pauli = PhasedQubitSparsePauli.Pauli
         expected = [
-            QubitSparsePauli.from_raw_parts(5, [pauli.Y, pauli.Y, pauli.X], [1, 2, 4]),
-            QubitSparsePauli.from_raw_parts(5, [], []),
-            QubitSparsePauli.from_raw_parts(5, [pauli.Z, pauli.Z], [0, 3]),
-            QubitSparsePauli.from_raw_parts(5, [pauli.X, pauli.X], [1, 2]),
-            QubitSparsePauli.from_raw_parts(5, [pauli.Z, pauli.Y], [1, 4]),
+            PhasedQubitSparsePauli.from_raw_parts(5, [pauli.Y, pauli.Y, pauli.X], [1, 2, 4]),
+            PhasedQubitSparsePauli.from_raw_parts(5, [], [], 2),
+            PhasedQubitSparsePauli.from_raw_parts(5, [pauli.Z, pauli.Z], [0, 3]),
+            PhasedQubitSparsePauli.from_raw_parts(5, [pauli.X, pauli.X], [1, 2], 3),
+            PhasedQubitSparsePauli.from_raw_parts(5, [pauli.Z, pauli.Y], [1, 4]),
         ]
         self.assertEqual(list(pauli_list), expected)
-
+    '''
     def test_indexing(self):
         pauli_list = QubitSparsePauliList.from_sparse_list(
             [
@@ -1215,7 +1215,7 @@ def canonicalize_sparse_list(sparse_list):
     canonicalized_terms = [canonicalize_term(*term) for term in sparse_list]
     return sorted(canonicalized_terms)
 
-
+'''
 def lnn_target(num_qubits):
     """Create a simple `Target` object with an arbitrary basis-gate set, and open-path
     connectivity."""
@@ -1232,4 +1232,3 @@ def lnn_target(num_qubits):
         },
     )
     return out
-    '''

--- a/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
@@ -108,7 +108,7 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
         self.assertEqual(
             # Ruler for counting terms:  dcba9876543210
             PhasedQubitSparsePauli.from_label("IXXIIZZIYYIXYZ"),
-            QubitSparsePauli.from_raw_parts(
+            PhasedQubitSparsePauli.from_raw_parts(
                 14,
                 [
                     PhasedQubitSparsePauli.Pauli.Z,
@@ -122,6 +122,7 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
                     PhasedQubitSparsePauli.Pauli.X,
                 ],
                 [0, 1, 2, 4, 5, 7, 8, 11, 12],
+                3
             ),
         )
 
@@ -204,57 +205,46 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
             QubitSparsePauli.from_sparse_label(("XZ", (3, 3)), num_qubits=5)
         with self.assertRaisesRegex(ValueError, "index 3 is duplicated"):
             QubitSparsePauli.from_sparse_label(("XYZXZ", (3, 0, 1, 2, 3)), num_qubits=5)
-    
+    '''
+
     def test_from_pauli(self):
         # This function should be infallible provided `Pauli` doesn't change its interface and the
         # user doesn't violate the typing.
 
         # Simple check that the labels are interpreted in the same order.
         self.assertEqual(
-            QubitSparsePauli.from_pauli(Pauli("IIXZI")), QubitSparsePauli.from_label("IIXZI")
+            PhasedQubitSparsePauli.from_pauli(Pauli("IIXZI")), PhasedQubitSparsePauli.from_label("IIXZI")
         )
 
-        # `Pauli` accepts a phase in its label, which gets dropped
         self.assertEqual(
-            QubitSparsePauli.from_pauli(Pauli("iIXZIX")),
-            QubitSparsePauli.from_label("IXZIX"),
+            PhasedQubitSparsePauli.from_pauli(Pauli("iIXZIX")).phase,
+            3,
         )
         self.assertEqual(
-            QubitSparsePauli.from_pauli(Pauli("-iIXZIX")),
-            QubitSparsePauli.from_label("IXZIX"),
+            PhasedQubitSparsePauli.from_pauli(Pauli("-iIXZIX")).phase,
+            1,
         )
         self.assertEqual(
-            QubitSparsePauli.from_pauli(Pauli("-IXZIX")),
-            QubitSparsePauli.from_label("IXZIX"),
+            PhasedQubitSparsePauli.from_pauli(Pauli("-IXZIX")).phase,
+            2,
         )
 
-        # `Pauli` has its internal phase convention for how it stores `Y`; we should get this right
-        # regardless of how many Ys are in the label, or if there's a phase.
         paulis = {"IXYZ" * n: Pauli("IXYZ" * n) for n in range(1, 5)}
         from_paulis, from_labels = zip(
             *(
-                (QubitSparsePauli.from_pauli(pauli), QubitSparsePauli.from_label(label))
+                (PhasedQubitSparsePauli.from_pauli(pauli), PhasedQubitSparsePauli.from_label(label))
                 for label, pauli in paulis.items()
             )
         )
         self.assertEqual(from_paulis, from_labels)
 
-        phased_paulis = {"IXYZ" * n: Pauli("j" + "IXYZ" * n) for n in range(1, 5)}
-        from_paulis, from_lists = zip(
-            *(
-                (QubitSparsePauli.from_pauli(pauli), QubitSparsePauli.from_label(label))
-                for label, pauli in phased_paulis.items()
-            )
-        )
-        self.assertEqual(from_paulis, from_lists)
-
     def test_default_constructor_failed_inference(self):
         with self.assertRaises(TypeError):
-            QubitSparsePauli(5, num_qubits=5)
+            PhasedQubitSparsePauli(5, num_qubits=5)
 
     def test_num_qubits(self):
-        self.assertEqual(QubitSparsePauli("").num_qubits, 0)
-        self.assertEqual(QubitSparsePauli("I" * 10).num_qubits, 10)
+        self.assertEqual(PhasedQubitSparsePauli("").num_qubits, 0)
+        self.assertEqual(PhasedQubitSparsePauli("I" * 10).num_qubits, 10)
 
     def test_pauli_enum(self):
         # These are very explicit tests that effectively just duplicate magic numbers, but the point
@@ -262,32 +252,32 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
         # public interface.
 
         self.assertEqual(
-            set(QubitSparsePauli.Pauli),
+            set(PhasedQubitSparsePauli.Pauli),
             {
-                QubitSparsePauli.Pauli.X,
-                QubitSparsePauli.Pauli.Y,
-                QubitSparsePauli.Pauli.Z,
+                PhasedQubitSparsePauli.Pauli.X,
+                PhasedQubitSparsePauli.Pauli.Y,
+                PhasedQubitSparsePauli.Pauli.Z,
             },
         )
         # All the enumeration items should also be integers.
-        self.assertIsInstance(QubitSparsePauli.Pauli.X, int)
+        self.assertIsInstance(PhasedQubitSparsePauli.Pauli.X, int)
         values = {
             "X": 0b10,
             "Y": 0b11,
             "Z": 0b01,
         }
-        self.assertEqual({name: getattr(QubitSparsePauli.Pauli, name) for name in values}, values)
+        self.assertEqual({name: getattr(PhasedQubitSparsePauli.Pauli, name) for name in values}, values)
 
         # The single-character label aliases can be accessed with index notation.
         labels = {
-            "X": QubitSparsePauli.Pauli.X,
-            "Y": QubitSparsePauli.Pauli.Y,
-            "Z": QubitSparsePauli.Pauli.Z,
+            "X": PhasedQubitSparsePauli.Pauli.X,
+            "Y": PhasedQubitSparsePauli.Pauli.Y,
+            "Z": PhasedQubitSparsePauli.Pauli.Z,
         }
-        self.assertEqual({label: QubitSparsePauli.Pauli[label] for label in labels}, labels)
+        self.assertEqual({label: PhasedQubitSparsePauli.Pauli[label] for label in labels}, labels)
         # The `label` property returns known values.
-        self.assertEqual({pauli.label: pauli for pauli in QubitSparsePauli.Pauli}, labels)
-
+        self.assertEqual({pauli.label: pauli for pauli in PhasedQubitSparsePauli.Pauli}, labels)
+    '''
     @ddt.idata(single_cases())
     def test_pickle(self, qubit_sparse_pauli):
         self.assertEqual(qubit_sparse_pauli, copy.copy(qubit_sparse_pauli))
@@ -401,18 +391,19 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
             np.array([0, 1, 2], dtype=np.uint8),
             strict=True,
         )
+    '''
 
     def test_identity(self):
-        identity_5 = QubitSparsePauli.identity(5)
+        identity_5 = PhasedQubitSparsePauli.identity(5)
         self.assertEqual(identity_5.num_qubits, 5)
         self.assertEqual(len(identity_5.paulis), 0)
         self.assertEqual(len(identity_5.indices), 0)
 
-        identity_0 = QubitSparsePauli.identity(0)
+        identity_0 = PhasedQubitSparsePauli.identity(0)
         self.assertEqual(identity_0.num_qubits, 0)
         self.assertEqual(len(identity_0.paulis), 0)
         self.assertEqual(len(identity_0.indices), 0)
-
+    '''
     def test_compose(self):
         p0 = QubitSparsePauli.from_label("XZY")
         p1 = QubitSparsePauli.from_label("ZIY")
@@ -448,41 +439,40 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
             p0.compose(p1)
         with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits: 3, 4"):
             p1.compose(p0)
-
+    '''
     def test_commutes(self):
-        p0 = QubitSparsePauli("XIY")
-        p1 = QubitSparsePauli("IZI")
+        p0 = PhasedQubitSparsePauli("XIY")
+        p1 = PhasedQubitSparsePauli("IZI")
         self.assertTrue(p0.commutes(p1))
         self.assertTrue(p1.commutes(p0))
 
-        p0 = QubitSparsePauli("XXY")
-        p1 = QubitSparsePauli("IZI")
+        p0 = PhasedQubitSparsePauli(Pauli("-XXY"))
+        p1 = PhasedQubitSparsePauli("IZI")
         self.assertFalse(p0.commutes(p1))
         self.assertFalse(p1.commutes(p0))
 
-        p0 = QubitSparsePauli("XXY")
-        p1 = QubitSparsePauli("IZX")
+        p0 = PhasedQubitSparsePauli("XXY")
+        p1 = PhasedQubitSparsePauli(Pauli("-iIZX"))
         self.assertTrue(p0.commutes(p1))
         self.assertTrue(p1.commutes(p0))
 
-        p0 = QubitSparsePauli("XXYY")
-        p1 = QubitSparsePauli("IZXY")
+        p0 = PhasedQubitSparsePauli(Pauli("-jXXYY"))
+        p1 = PhasedQubitSparsePauli(Pauli("jIZXY"))
         self.assertTrue(p0.commutes(p1))
         self.assertTrue(p1.commutes(p0))
 
-        p0 = QubitSparsePauli("XXYYZ")
-        p1 = QubitSparsePauli("IZXYX")
+        p0 = PhasedQubitSparsePauli("XXYYZ")
+        p1 = PhasedQubitSparsePauli("IZXYX")
         self.assertFalse(p0.commutes(p1))
         self.assertFalse(p1.commutes(p0))
 
     def test_commutes_errors(self):
-        p0 = QubitSparsePauli.from_label("XZYI")
-        p1 = QubitSparsePauli.from_label("ZIY")
+        p0 = PhasedQubitSparsePauli.from_label("XZYI")
+        p1 = PhasedQubitSparsePauli(Pauli("jZIY"))
         with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits: 4, 3"):
             p0.commutes(p1)
         with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits: 3, 4"):
             p1.commutes(p0)
-    '''
 
 @ddt.ddt
 class TestPhasedQubitSparsePauliList(QiskitTestCase):

--- a/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
@@ -672,90 +672,90 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
             PhasedQubitSparsePauliList.from_list(["IIZ", "IXI"], num_qubits=4)
         with self.assertRaisesRegex(ValueError, "cannot construct.*without knowing `num_qubits`"):
             PhasedQubitSparsePauliList.from_list([])
-    '''
+
     def test_from_sparse_list(self):
         self.assertEqual(
-            QubitSparsePauliList.from_sparse_list(
+            PhasedQubitSparsePauliList.from_sparse_list(
                 [
-                    ("XY", (0, 1)),
-                    ("XX", (1, 3)),
-                    ("YYZ", (0, 2, 4)),
+                    (0, "XY", (0, 1)),
+                    (0, "XX", (1, 3)),
+                    (0, "YYZ", (0, 2, 4)),
                 ],
                 num_qubits=5,
             ),
-            QubitSparsePauliList.from_list(["IIIYX", "IXIXI", "ZIYIY"]),
+            PhasedQubitSparsePauliList.from_list(["IIIYX", "IXIXI", "ZIYIY"]),
         )
 
         # The indices should be allowed to be given in unsorted order, but they should be term-wise
         # sorted in the output.
-        from_unsorted = QubitSparsePauliList.from_sparse_list(
+        from_unsorted = PhasedQubitSparsePauliList.from_sparse_list(
             [
-                ("XYZ", (2, 1, 0)),
-                ("XYZ", (2, 0, 1)),
+                (0, "XYZ", (2, 1, 0)),
+                (0, "XYZ", (2, 0, 1)),
             ],
             num_qubits=3,
         )
-        self.assertEqual(from_unsorted, QubitSparsePauliList.from_list(["XYZ", "XZY"]))
+        self.assertEqual(from_unsorted, PhasedQubitSparsePauliList.from_list(["XYZ", "XZY"]))
         np.testing.assert_equal(from_unsorted[0].indices, np.array([0, 1, 2], dtype=np.uint32))
         np.testing.assert_equal(from_unsorted[1].indices, np.array([0, 1, 2], dtype=np.uint32))
 
         # Explicit identities should still work, just be skipped over.
-        explicit_identity = QubitSparsePauliList.from_sparse_list(
+        explicit_identity = PhasedQubitSparsePauliList.from_sparse_list(
             [
-                ("ZXI", (0, 1, 2)),
-                ("XYIII", (0, 1, 2, 3, 8)),
+                (0, "ZXI", (0, 1, 2)),
+                (0, "XYIII", (0, 1, 2, 3, 8)),
             ],
             num_qubits=10,
         )
         self.assertEqual(
             explicit_identity,
-            QubitSparsePauliList.from_sparse_list([("XZ", (1, 0)), ("YX", (1, 0))], num_qubits=10),
+            PhasedQubitSparsePauliList.from_sparse_list([(0, "XZ", (1, 0)), (0, "YX", (1, 0))], num_qubits=10),
         )
         np.testing.assert_equal(explicit_identity[0].indices, np.array([0, 1], dtype=np.uint32))
         np.testing.assert_equal(explicit_identity[1].indices, np.array([0, 1], dtype=np.uint32))
 
         self.assertEqual(
-            QubitSparsePauliList.from_sparse_list([], num_qubits=1_000_000),
-            QubitSparsePauliList.empty(1_000_000),
+            PhasedQubitSparsePauliList.from_sparse_list([], num_qubits=1_000_000),
+            PhasedQubitSparsePauliList.empty(1_000_000),
         )
         self.assertEqual(
-            QubitSparsePauliList.from_sparse_list([], num_qubits=0),
-            QubitSparsePauliList.empty(0),
+            PhasedQubitSparsePauliList.from_sparse_list([], num_qubits=0),
+            PhasedQubitSparsePauliList.empty(0),
         )
 
     def test_from_sparse_list_failures(self):
         with self.assertRaisesRegex(ValueError, "labels must only contain letters from"):
             # Bad letters that are still ASCII.
-            QubitSparsePauliList.from_sparse_list(
-                [("XZZY", (5, 3, 1, 0)), ("+$", (2, 1))], num_qubits=8
+            PhasedQubitSparsePauliList.from_sparse_list(
+                [(0, "XZZY", (5, 3, 1, 0)), (0, "+$", (2, 1))], num_qubits=8
             )
         # Unicode shenangigans.  These two should fail with a `ValueError`, but the exact message
         # isn't important.  "\xff" is "ÿ", which is two bytes in UTF-8 (so has a length of 2 in
         # Rust), but has a length of 1 in Python, so try with both a length-1 and length-2 index
         # sequence, and both should still raise `ValueError`.
         with self.assertRaises(ValueError):
-            QubitSparsePauliList.from_sparse_list([("\xff", (1,))], num_qubits=5)
+            PhasedQubitSparsePauliList.from_sparse_list([(0, "\xff", (1,))], num_qubits=5)
         with self.assertRaises(ValueError):
-            QubitSparsePauliList.from_sparse_list([("\xff", (1, 2))], num_qubits=5)
+            PhasedQubitSparsePauliList.from_sparse_list([(0, "\xff", (1, 2))], num_qubits=5)
 
         with self.assertRaisesRegex(ValueError, "label with length 2 does not match indices"):
-            QubitSparsePauliList.from_sparse_list([("XZ", (0,))], num_qubits=5)
+            PhasedQubitSparsePauliList.from_sparse_list([(0, "XZ", (0,))], num_qubits=5)
         with self.assertRaisesRegex(ValueError, "label with length 2 does not match indices"):
-            QubitSparsePauliList.from_sparse_list([("XZ", (0, 1, 2))], num_qubits=5)
+            PhasedQubitSparsePauliList.from_sparse_list([(0, "XZ", (0, 1, 2))], num_qubits=5)
 
         with self.assertRaisesRegex(ValueError, "index 3 is out of range for a 3-qubit operator"):
-            QubitSparsePauliList.from_sparse_list([("XZY", (0, 1, 3))], num_qubits=3)
+            PhasedQubitSparsePauliList.from_sparse_list([(0, "XZY", (0, 1, 3))], num_qubits=3)
         with self.assertRaisesRegex(ValueError, "index 4 is out of range for a 3-qubit operator"):
-            QubitSparsePauliList.from_sparse_list([("XZY", (0, 1, 4))], num_qubits=3)
+            PhasedQubitSparsePauliList.from_sparse_list([(0, "XZY", (0, 1, 4))], num_qubits=3)
         with self.assertRaisesRegex(ValueError, "index 3 is out of range for a 3-qubit operator"):
             # ... even if it's for an explicit identity.
-            QubitSparsePauliList.from_sparse_list([("XXI", (0, 1, 3))], num_qubits=3)
+            PhasedQubitSparsePauliList.from_sparse_list([(0, "XXI", (0, 1, 3))], num_qubits=3)
 
         with self.assertRaisesRegex(ValueError, "index 3 is duplicated"):
-            QubitSparsePauliList.from_sparse_list([("XZ", (3, 3))], num_qubits=5)
+            PhasedQubitSparsePauliList.from_sparse_list([(0, "XZ", (3, 3))], num_qubits=5)
         with self.assertRaisesRegex(ValueError, "index 3 is duplicated"):
-            QubitSparsePauliList.from_sparse_list([("XYZXZ", (3, 0, 1, 2, 3))], num_qubits=5)
-    
+            PhasedQubitSparsePauliList.from_sparse_list([(0, "XYZXZ", (3, 0, 1, 2, 3))], num_qubits=5)
+    '''
     def test_from_pauli(self):
         # This function should be infallible provided `Pauli` doesn't change its interface and the
         # user doesn't violate the typing.

--- a/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
@@ -204,7 +204,7 @@ class TestPhasedQubitSparsePauli(QiskitTestCase):
             QubitSparsePauli.from_sparse_label(("XZ", (3, 3)), num_qubits=5)
         with self.assertRaisesRegex(ValueError, "index 3 is duplicated"):
             QubitSparsePauli.from_sparse_label(("XYZXZ", (3, 0, 1, 2, 3)), num_qubits=5)
-
+    
     def test_from_pauli(self):
         # This function should be infallible provided `Pauli` doesn't change its interface and the
         # user doesn't violate the typing.

--- a/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_phased_qubit_sparse_pauli.py
@@ -40,17 +40,18 @@ def single_cases():
         PhasedQubitSparsePauli(Pauli("iZZYYXX")),
     ]
 
-"""
+
 def single_cases_list():
     return [
-        QubitSparsePauliList.empty(0),
-        QubitSparsePauliList.empty(10),
-        QubitSparsePauliList.from_label("IIXIZI"),
-        QubitSparsePauliList.from_list(["YIXZII", "ZZYYXX"]),
+        PhasedQubitSparsePauliList.empty(0),
+        PhasedQubitSparsePauliList.empty(10),
+        PhasedQubitSparsePauliList.from_label("IIXIZI"),
+        PhasedQubitSparsePauliList.from_list(["YIXZII", "ZZYYXX"]),
         # Includes a duplicate entry.
-        QubitSparsePauliList.from_list(["IXZ", "ZZI", "IXZ"]),
+        PhasedQubitSparsePauliList.from_list(["IXZ", "ZZI", "IXZ"]),
+        PhasedQubitSparsePauli(Pauli("iZZYYXX")).to_phased_qubit_sparse_pauli_list()
     ]
-"""
+
 
 @ddt.ddt
 class TestPhasedQubitSparsePauli(QiskitTestCase):
@@ -868,7 +869,7 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
         self.assertEqual(len(PhasedQubitSparsePauliList.empty(10)), 0)
         self.assertEqual(len(PhasedQubitSparsePauliList.from_list(["IIIXIZ", "YYXXII"])), 2)
 
-    '''
+    
     @ddt.idata(single_cases_list())
     def test_pickle(self, qubit_sparse_pauli_list):
         self.assertEqual(qubit_sparse_pauli_list, copy.copy(qubit_sparse_pauli_list))
@@ -877,7 +878,7 @@ class TestPhasedQubitSparsePauliList(QiskitTestCase):
         self.assertEqual(
             qubit_sparse_pauli_list, pickle.loads(pickle.dumps(qubit_sparse_pauli_list))
         )
-
+    '''
     @ddt.data(
         QubitSparsePauliList.empty(0),
         QubitSparsePauliList.empty(1),

--- a/test/python/quantum_info/test_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_qubit_sparse_pauli.py
@@ -873,38 +873,6 @@ class TestQubitSparsePauliList(QiskitTestCase):
         self.assertEqual(len(QubitSparsePauliList.empty(10)), 0)
         self.assertEqual(len(QubitSparsePauliList.from_list(["IIIXIZ", "YYXXII"])), 2)
 
-    def test_pauli_enum(self):
-        # These are very explicit tests that effectively just duplicate magic numbers, but the point
-        # is that those magic numbers are required to be constant as their values are part of the
-        # public interface.
-
-        self.assertEqual(
-            set(QubitSparsePauli.Pauli),
-            {
-                QubitSparsePauli.Pauli.X,
-                QubitSparsePauli.Pauli.Y,
-                QubitSparsePauli.Pauli.Z,
-            },
-        )
-        # All the enumeration items should also be integers.
-        self.assertIsInstance(QubitSparsePauli.Pauli.X, int)
-        values = {
-            "X": 0b10,
-            "Y": 0b11,
-            "Z": 0b01,
-        }
-        self.assertEqual({name: getattr(QubitSparsePauli.Pauli, name) for name in values}, values)
-
-        # The single-character label aliases can be accessed with index notation.
-        labels = {
-            "X": QubitSparsePauli.Pauli.X,
-            "Y": QubitSparsePauli.Pauli.Y,
-            "Z": QubitSparsePauli.Pauli.Z,
-        }
-        self.assertEqual({label: QubitSparsePauli.Pauli[label] for label in labels}, labels)
-        # The `label` property returns known values.
-        self.assertEqual({pauli.label: pauli for pauli in QubitSparsePauli.Pauli}, labels)
-
     @ddt.idata(single_cases_list())
     def test_pickle(self, qubit_sparse_pauli_list):
         self.assertEqual(qubit_sparse_pauli_list, copy.copy(qubit_sparse_pauli_list))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

## Summary

This PR follows up #14759 (which adds phased versions of `QubitSparsePauli` and `QubitSparsePauliList`), and anticipates adding even more similar classes (`QubitSparsePauliSet` and `PhasedQubitSparsePauliSet`). These classes all share overlapping behaviour, and also have high maintenance cost due to needing to define both rust and python interfaces. As such it is worth "getting it right" by taking some time to define their interfaces more carefully and to refactor their shared behaviour into a single location/implementation where possible.

The PR currently contains an initial pass for the "collection-type" objects: currently the list classes`QubitSparsePauliList` and `PhasedQubitSparsePauliList`, the unimplemented "set" objects, and also `PauliLindbladMap`. I view these as classes that store a collection of qubit-sparse Paulis along with contextual data (e.g. `phase`, or `rates`, `probabilities`, etc...). I think one of the things that's unclear to me is how much the "contextual data" will impact the ability to centralize functionality (i.e. cases of very similar behaviour but where it doesn't make sense to use the same signature), but in any case I think it's clearly useful to do this to the degree that it is possible.

To do this we need to define both rust and python interfaces. As suggested by @jakelishman , it seems the technical path forward is:

1. Use `trait`s to define rust interfaces and default implementations.
2. Use macro rules to define the python interfaces, as `trait`s unfortunately don't interact well with pyo3.

## Details and comments

### Rust interface

For the rust interface, I've currently defined a `QubitSparsePauliListLike` trait in `qubit_sparse_pauli.rs", which starts with the interface definitions (code from @jakelishman ):
```
pub trait QubitSparsePauliListLike {
    fn pauli_list(&self) -> &QubitSparsePauliList;
    fn pauli_list_mut(&mut self) -> &mut QubitSparsePauliList;
```
For `QubitSparsePauliList` these return `self`, but other classes will need to return the internally stored `QubitSparsePauliList` (or simply generate it if it is no longer part of the interal data structure).

From there, "property" methods are defined in terms of these:
```
/// Get the indices of each [Pauli].
    #[inline]
    fn indices(&self) -> &[u32] {
        &self.pauli_list().indices()
    }

    /// Get the boundaries of each term.
    #[inline]
    fn boundaries(&self) -> &[usize] {
        &self.pauli_list().boundaries()
    }

    /// Get the [Pauli]s in the list.
    #[inline]
    fn paulis(&self) -> &[Pauli] {
        &self.pauli_list().paulis()
    }
```

Lastly, some methods that are primarily based around modifying the qubit-sparse pauli structure:
```
    /// Drop every Pauli on the given `indices`, effectively replacing them with an identity.
    fn drop_paulis(&self, indices: HashSet<u32>) -> Result<Self, CoherenceError> where Self: Sized;

    /// Apply a transpiler layout.
    fn apply_layout(&self, layout: Option<&[u32]>, num_qubits: u32) -> Result<Self, CoherenceError> where Self: Sized;

    /// Drop qubits corresponding to the given `indices`.
    fn drop_qubits(&self, indices: HashSet<u32>) -> Result<Self, CoherenceError> where Self: Sized;
}
```

Both `QubitSparsePauliList` and `PhasedQubitSparsePauli` list have implementations of this trait. Note that the implementations of the last three methods would be extremely similar for all of the considered classes: calling the same method on the underlying `QubitSparsePauliList` and putting the result, along with copies of the context-dependant data in each class implementing the trait, into a new instance of said class. If there is a way to write a default implementation of such functions that could copy over all other data, irrespective of what it is, that'd be very nice. 


## Python interface

This is quite minimal but I've currently defined:
```
/// macro for generating pymethods for QubitSparsePauliListLike python interfaces
macro_rules! impl_py_qspl_methods {
    ($ty:ty) => {
        #[pymethods]
        impl $ty {
            #[getter]
            #[inline]
            pub fn num_qubits(&self) -> PyResult<u32> {
                let inner = self.inner.read().map_err(|_| InnerReadError)?;
                Ok(inner.num_qubits())
            }

            /// The number of elements in the list.
            #[getter]
            #[inline]
            pub fn num_terms(&self) -> PyResult<usize> {
                let inner = self.inner.read().map_err(|_| InnerReadError)?;
                Ok(inner.num_terms())
            }
        }
    }
}
```
 in the `src/pauli_lindblad_map/mod.rs` file. I've defined there because the rules for where macros live are more constrained; this was the first thing I tried that compiled but presumably we'll want to find a better place for it. I haven't included it yet but I'll add `apply_layout`, `drop_paulis`/`keep_paulis`, and `drop_qubits`/`keep_qubits` (I haven't looked super closely at what else).

The python version of the classes again have a lot of similarly defined methods, but with slightly different signatures. E.g. many of the constructors are similar in spirit, and iteration/indexing over the constituent units is similar. I figure these things may be handle-able somehow with macros but it'll require a better understanding of rust typing than I have.

### Other classes

The other classes to consider are `QubitSparsePauli`, `PhasedQubitSparsePauli`, and `GeneratorTerm` (the "single-element" version of a `PauliLindbladMap`). These classes are much simpler so I think the maintenance cost is less of a concern, but it'd be nice to do a similar `trait`/macro setup for them.