### PR TITLE
Port `ApplyLayout` to Rust

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -5144,9 +5144,8 @@ impl DAGCircuit {
         let mut new_io_map = vec![[<NodeIndex as IndexType>::max(); 2]; self.qubit_io_map.len()];
         for (old, [in_, out]) in self.qubit_io_map.iter().enumerate() {
             let new = map_fn(Qubit::new(old));
-            assert_eq!(
-                new_io_map[new.index()][0],
-                <NodeIndex as IndexType>::max(),
+            assert!(
+                new_io_map[new.index()][0] == <NodeIndex as IndexType>::max(),
                 "qubit {old} was reindexed to {new:?}, which was already assigned"
             );
             new_io_map[new.index()] = [*in_, *out];

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -62,7 +62,7 @@ use rustworkx_core::graph_ext::ContractNodesDirected;
 use rustworkx_core::petgraph;
 use rustworkx_core::petgraph::prelude::StableDiGraph;
 use rustworkx_core::petgraph::prelude::*;
-use rustworkx_core::petgraph::stable_graph::{EdgeReference, NodeIndex};
+use rustworkx_core::petgraph::stable_graph::{EdgeReference, IndexType, NodeIndex};
 use rustworkx_core::petgraph::unionfind::UnionFind;
 use rustworkx_core::petgraph::visit::{
     EdgeIndexable, IntoEdgeReferences, IntoNodeReferences, NodeFiltered, NodeIndexable,
@@ -5112,6 +5112,64 @@ impl DAGCircuit {
         });
         self.cregs.remove_registers(valid_names);
         Ok(())
+    }
+
+    /// Permute the qubit indices used by instructions.
+    ///
+    /// This does not modify the order of the [ShareableQubit]s, so "qubit 0" will still point to
+    /// the same [ShareableQubit] object.  It only rewrites the relative qubit indices that any
+    /// given qubit acts upon.
+    ///
+    /// `map_fn` must implement a permutation.  It is called many times on the same qubit without
+    /// caching; if the computation is expensive, consider using a function that indexes into a
+    /// slice.
+    ///
+    /// This is useful in situations where we're applying an initial layout.
+    ///
+    /// This takes time (individually) proportional to the number of qubits, the number of edges in
+    /// the graph, and the sum of the lengths of all distinct qargs.
+    ///
+    /// # Panics
+    ///
+    /// If `map_fn` returns an out-of-bounds qubit, or maps two different qubits to the same index.
+    pub fn reindex_qargs(&mut self, mut map_fn: impl FnMut(Qubit) -> Qubit) {
+        // The Python-space spiritual successors of this code (the `ApplyLayout` pass, e.g.) used to
+        // have to rebuild the whole DAG including reinferring the wire structure.  That is a
+        // foolproof way of doing things, but recalculates and reallocates more than necessary.  We
+        // can leave the graph structure unchanged, provided we change the labelling of the wires
+        // (including the in- and out-nodes), and update the interned copies of all the qargs.
+
+        // Prepare the new in- and out-node structure.  This doubles as the validity check of the
+        // input, so we avoid mutating the DAG until it's complete.
+        let mut new_io_map = vec![[<NodeIndex as IndexType>::max(); 2]; self.qubit_io_map.len()];
+        for (old, [in_, out]) in self.qubit_io_map.iter().enumerate() {
+            let new = map_fn(Qubit::new(old));
+            assert_eq!(
+                new_io_map[new.index()][0],
+                <NodeIndex as IndexType>::max(),
+                "qubit {old} was reindexed to {new:?}, which was already assigned"
+            );
+            new_io_map[new.index()] = [*in_, *out];
+        }
+
+        // From here on, everything should be infallible.
+        self.qubit_io_map = new_io_map;
+        for (new, [in_, out]) in self.qubit_io_map.iter().enumerate() {
+            let new = Qubit::new(new);
+            self.dag[*in_] = NodeType::QubitIn(new);
+            self.dag[*out] = NodeType::QubitOut(new);
+        }
+        for wire in self.dag.edge_weights_mut() {
+            if let Wire::Qubit(qubit) = *wire {
+                *wire = Wire::Qubit(map_fn(qubit));
+            }
+        }
+        self.qargs_interner.map_inplace(|mut qargs| {
+            for qubit in qargs.iter_mut() {
+                *qubit = map_fn(*qubit)
+            }
+            qargs
+        })
     }
 
     /// Merge the `qargs` in a different [Interner] into this DAG, remapping the qubits.

--- a/crates/circuit/src/interner.rs
+++ b/crates/circuit/src/interner.rs
@@ -476,6 +476,35 @@ where
         self.merge_map_using(other, map_fn, &mut out);
         out
     }
+
+    /// Rewrite all the interned values in `self` inplace, maintaining validity of all existing
+    /// [Interned] keys (just with mapped values).
+    ///
+    /// The `map_fn` will be called exactly once for each of the non-default values; the default
+    /// value will not be passed to the `map_fn`, as it is a requirement of the type that the
+    /// default key matches the default value.
+    ///
+    /// # Panics
+    ///
+    /// If the `map_fn` returns two equal values for non-equal inputs; if this happened, we wouldn't
+    /// have the same number of keys in the output.
+    pub fn map_inplace(
+        &mut self,
+        mut map_fn: impl FnMut(<T as ToOwned>::Owned) -> <T as ToOwned>::Owned,
+    ) {
+        // This isn't a one-at-a-time operation because we might have a collision, where a new
+        // value with an early key is equal to an old value with a later key.  That will be resolved
+        // by the end, but if we try to go one-at-a-time, we'll mess up the key order.  We can still
+        // re-use the allocation of the interner, though.
+        let mut values = self.0.drain(..).collect::<Vec<_>>().into_iter();
+        self.0
+            .insert(values.next().expect("must have at least the default key"));
+        for (i, value) in values.enumerate() {
+            let expected = i as u32 + 1;
+            let actual = self.insert_owned(map_fn(value)).index;
+            assert_eq!(actual, expected, "mapping returned a duplicate key");
+        }
+    }
 }
 
 impl<T> Interner<[T]>

--- a/crates/circuit/src/interner.rs
+++ b/crates/circuit/src/interner.rs
@@ -502,7 +502,7 @@ where
         for (i, value) in values.enumerate() {
             let expected = i as u32 + 1;
             let actual = self.insert_owned(map_fn(value)).index;
-            assert_eq!(actual, expected, "mapping returned a duplicate key");
+            assert!(actual == expected, "mapping returned a duplicate key");
         }
     }
 }

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -63,22 +63,24 @@ pub use nlayout::VirtualQubit;
 macro_rules! impl_circuit_identifier {
     ($type:ident) => {
         impl $type {
+            // The maximum storable index.
+            pub const MAX: Self = Self(u32::MAX);
+
             /// Construct a new identifier from a usize, if you have a u32 you can
             /// construct one directly via [$type()]. This will panic if the `usize`
             /// index exceeds `u32::MAX`.
             #[inline(always)]
-            pub fn new(index: usize) -> Self {
-                $type(index.try_into().unwrap_or_else(|_| {
-                    panic!(
-                        "Index value '{}' exceeds the maximum identifier width!",
-                        index
-                    )
-                }))
+            pub const fn new(index: usize) -> Self {
+                if index <= Self::MAX.index() {
+                    Self(index as u32)
+                } else {
+                    panic!("Index value exceeds the maximum identifier width!")
+                }
             }
 
             /// Convert to a usize.
             #[inline(always)]
-            pub fn index(&self) -> usize {
+            pub const fn index(&self) -> usize {
                 self.0 as usize
             }
         }

--- a/crates/circuit/src/nlayout.rs
+++ b/crates/circuit/src/nlayout.rs
@@ -41,6 +41,9 @@ macro_rules! qubit_newtype {
         pub struct $id(pub u32);
 
         impl $id {
+            /// The maximum storable index.
+            pub const MAX: Self = $id($crate::Qubit::MAX.index() as _);
+
             #[inline]
             pub fn new(val: u32) -> Self {
                 Self(val)
@@ -48,6 +51,17 @@ macro_rules! qubit_newtype {
             #[inline]
             pub fn index(&self) -> usize {
                 self.0 as usize
+            }
+        }
+
+        impl From<$id> for $crate::Qubit {
+            fn from(val: $id) -> Self {
+                $crate::Qubit(val.0)
+            }
+        }
+        impl From<$crate::Qubit> for $id {
+            fn from(val: $crate::Qubit) -> Self {
+                Self(val.0)
             }
         }
 
@@ -77,7 +91,7 @@ macro_rules! qubit_newtype {
                 self.0 as usize
             }
             fn max() -> Self {
-                Self(u32::MAX)
+                Self::MAX
             }
         }
     };

--- a/crates/pyext/src/lib.rs
+++ b/crates/pyext/src/lib.rs
@@ -30,6 +30,7 @@ where
 #[pymodule]
 fn _accelerate(m: &Bound<PyModule>) -> PyResult<()> {
     add_submodule(m, ::qiskit_transpiler::passes::alap_schedule_analysis_mod, "alap_schedule_analysis")?;
+    add_submodule(m, ::qiskit_transpiler::passes::apply_layout_mod, "apply_layout")?;
     add_submodule(m, ::qiskit_transpiler::passes::barrier_before_final_measurements_mod, "barrier_before_final_measurement")?;
     add_submodule(m, ::qiskit_transpiler::passes::basis_translator_mod, "basis_translator")?;
     add_submodule(m, ::qiskit_transpiler::passes::check_map_mod, "check_map")?;

--- a/crates/transpiler/src/passes/apply_layout.rs
+++ b/crates/transpiler/src/passes/apply_layout.rs
@@ -1,0 +1,258 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::wrap_pyfunction;
+
+use hashbrown::HashSet;
+
+use qiskit_circuit::bit::{QuantumRegister, Register};
+use qiskit_circuit::dag_circuit::DAGCircuit;
+use qiskit_circuit::nlayout::NLayout;
+use qiskit_circuit::{PhysicalQubit, Qubit, VirtualQubit};
+
+use crate::transpile_layout::TranspileLayout;
+
+/// Map the qubits of a DAG defined over virtual qubits into physical qubits.
+///
+/// This modifies the [DAGCircuit] and [TranspileLayout] in place, turning it into a "physical" DAG
+/// (including using the canonical physical-qubit register).  This includes ancilla expansion, if
+/// the number of physical qubits is greater than the number of virtual qubits.  Ancillas get
+/// implicit virtual-qubit indices that are in the range `dag.num_qubits..num_physical_qubits`.
+///
+/// # Panics
+///
+/// * if the DAG is too large to fit into the given number of physical qubits
+/// * if the `layout_fn` returns a `PhysicalQubit` that is out of range
+/// * if `cur_layout` already has an initial layout set (perhaps you meant [update_layout])
+pub fn apply_layout(
+    dag: &mut DAGCircuit,
+    cur_layout: &mut TranspileLayout,
+    num_physical_qubits: u32,
+    mut layout_fn: impl FnMut(VirtualQubit) -> PhysicalQubit,
+) {
+    if cur_layout.initial_layout(false).is_some() {
+        panic!("cannot apply a layout when one is already set");
+    }
+
+    let num_virtual_qubits = dag.num_qubits() as u32;
+    let mut virtuals = vec![VirtualQubit::MAX; num_physical_qubits as usize];
+    let mut physicals = Vec::with_capacity(num_physical_qubits as usize);
+    for virt in (0..num_virtual_qubits).map(VirtualQubit::new) {
+        let phys = layout_fn(virt);
+        let old_virt = ::std::mem::replace(&mut virtuals[phys.index()], virt);
+        assert_eq!(
+            old_virt,
+            VirtualQubit::MAX,
+            "both {virt:?} and {old_virt:?} were assigned to {phys:?}",
+        );
+        physicals.push(phys);
+    }
+    let unassigned = virtuals.iter_mut().enumerate().filter_map(|(i, virt)| {
+        (*virt == VirtualQubit::MAX).then_some((virt, PhysicalQubit::new(i as u32)))
+    });
+    for (ancilla, (slot, phys)) in (num_virtual_qubits..num_physical_qubits).zip(unassigned) {
+        physicals.push(phys);
+        *slot = VirtualQubit::new(ancilla);
+    }
+    let initial_layout = NLayout::from_vecs_unchecked(physicals, virtuals);
+
+    let final_permutation = cur_layout.output_permutation().map(|previous| {
+        let mut permutation = (0..num_physical_qubits as usize)
+            .map(Qubit::new)
+            .collect::<Vec<_>>();
+        for virt in (0..num_virtual_qubits).map(VirtualQubit::new) {
+            permutation[virt.to_phys(&initial_layout).index()] =
+                VirtualQubit::from(previous[virt.index()])
+                    .to_phys(&initial_layout)
+                    .into();
+        }
+        permutation
+    });
+    let mut virtual_qubits = dag.qubits().objects().to_vec();
+    let num_ancillas = num_physical_qubits - num_virtual_qubits;
+    if num_ancillas > 0 {
+        let reg_name = unique_ancilla_register_name(dag.qregs());
+        virtual_qubits.extend(QuantumRegister::new_owning(reg_name, num_ancillas).bits())
+    }
+
+    dag.make_physical(num_physical_qubits as usize);
+    dag.reindex_qargs(|virt| VirtualQubit::from(virt).to_phys(&initial_layout).into());
+    *cur_layout = TranspileLayout::new(
+        Some(initial_layout),
+        final_permutation,
+        virtual_qubits,
+        cur_layout.num_input_qubits(),
+    );
+}
+
+/// Permute the qubit indices of the [DAGCircuit] and the [TranspileLayout]
+///
+/// This is typically called to improve a previously set layout.
+///
+/// # Panics
+///
+/// * if the `layout_fn` returns a `PhysicalQubit` that is out of range.
+pub fn update_layout(
+    dag: &mut DAGCircuit,
+    cur_layout: &mut TranspileLayout,
+    mut layout_fn: impl FnMut(Qubit) -> Qubit,
+) {
+    dag.reindex_qargs(&mut layout_fn);
+    cur_layout.relabel_initial_layout(|q| layout_fn(q.into()).into());
+}
+
+fn unique_ancilla_register_name(qregs: &[QuantumRegister]) -> String {
+    let base = "ancilla";
+    if !qregs.iter().any(|qreg| qreg.name() == base) {
+        // Most likely we'll return out of here, and can avoid constructing a hash set.
+        return base.to_owned();
+    }
+    let names = qregs.iter().map(|qreg| qreg.name()).collect::<HashSet<_>>();
+    let mut i = 0;
+    loop {
+        let name = format!("{base}_{i}");
+        if !names.contains(name.as_str()) {
+            return name;
+        }
+        i += 1;
+    }
+}
+
+/// Apply a layout to the :class:`.DAGCircuit`.
+///
+/// Args:
+///     dag: the circuit.
+///     num_virtual_qubits: the original number of qubits in the input circuit.  When running in
+///         legacy mode, this might be less than the number of qubits in the :class:`.DAGCircuit`.
+///         In "normal" mode, where :class:`.ApplyLayout` is also embedded and expanding the virtual
+///         layout, this would be the same as the number of qubits in the :class:`.DAGCircuit`.
+///     num_physical_qubits: the number of physical qubits in the target we're compiling for.
+///     physical_from_virtual: the layout to apply.
+///     permutation: the current output permutation of the circuit.
+#[pyfunction]
+#[pyo3(name = "apply_layout")]
+fn py_apply_layout<'py>(
+    py: Python<'py>,
+    dag: &mut DAGCircuit,
+    num_virtual_qubits: u32,
+    num_physical_qubits: u32,
+    physical_from_virtual: Vec<PhysicalQubit>,
+    permutation: Option<Vec<Qubit>>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let num_dag_qubits = dag.num_qubits() as u32;
+    if num_dag_qubits > num_physical_qubits {
+        return Err(PyValueError::new_err(format!(
+            "More qubits in DAG ({num_dag_qubits}) than physical qubits ({num_physical_qubits})"
+        )));
+    }
+    if num_virtual_qubits > num_dag_qubits {
+        return Err(PyValueError::new_err(format!(
+            "More original input qubits ({num_virtual_qubits}) than in the DAG ({num_dag_qubits})"
+        )));
+    }
+    if physical_from_virtual.len() != dag.num_qubits() {
+        return Err(PyValueError::new_err(format!(
+            "Layout has different number of qubits ({}) than the DAG ({})",
+            physical_from_virtual.len(),
+            num_dag_qubits
+        )));
+    }
+    match permutation.as_ref().map(Vec::len) {
+        Some(len) if len != dag.num_qubits() => return Err(PyValueError::new_err(format!(
+            "Given permutation has difference number of qubits ({len}) than the DAG ({num_dag_qubits})"
+        ))),
+        _ => (),
+    }
+    if physical_from_virtual.len() != dag.num_qubits() {
+        return Err(PyValueError::new_err(format!(
+            "Layout has different number of qubits ({}) than the DAG ({})",
+            physical_from_virtual.len(),
+            num_dag_qubits
+        )));
+    }
+    let mut seen = vec![false; num_physical_qubits as usize];
+    for qubit in physical_from_virtual.iter() {
+        if qubit.index() >= num_physical_qubits as usize {
+            return Err(PyValueError::new_err(format!(
+                "Layout contains out-of-bounds qubit {}",
+                qubit.index()
+            )));
+        }
+        if ::std::mem::replace(&mut seen[qubit.index()], true) {
+            return Err(PyValueError::new_err(format!(
+                "Layout contains duplicate qubit {}",
+                qubit.index()
+            )));
+        }
+    }
+
+    // TODO: while Rust-space and Python-space `TranspileLayout` are two different objects, Python
+    // gets the short end of the "unnecessary conversion" stick, and we have to make a new object ot
+    // return to Python.  We don't accept the Python-space object into this function because it
+    // can't represent the state of "initial layout is not yet applied", so we may as well just make
+    // it ourselves.
+    let mut cur_layout = TranspileLayout::new(
+        None,
+        permutation,
+        dag.qubits().objects().to_vec(),
+        // We had to take `num_virtual_qubits` by value because the DAG might already have been
+        // expanded with ancillas in the legacy mode.
+        num_virtual_qubits,
+    );
+    apply_layout(dag, &mut cur_layout, num_physical_qubits, |v| {
+        physical_from_virtual[v.index()]
+    });
+    cur_layout.to_py_native(py, dag.qubits().objects())
+}
+
+#[pyfunction]
+#[pyo3(name = "update_layout")]
+fn py_update_layout<'py>(
+    dag: &mut DAGCircuit,
+    py_layout: &Bound<'py, PyAny>,
+    reorder: Vec<Qubit>,
+) -> PyResult<Bound<'py, PyAny>> {
+    if reorder.len() != dag.num_qubits() {
+        return Err(PyValueError::new_err(format!(
+            "Updated layout has different number of qubits ({}) to the DAG ({})",
+            reorder.len(),
+            dag.num_qubits()
+        )));
+    }
+    let mut seen = vec![false; dag.num_qubits()];
+    for qubit in reorder.iter() {
+        if qubit.index() >= dag.num_qubits() {
+            return Err(PyValueError::new_err(format!(
+                "Layout contains out-of-bounds qubit {}",
+                qubit.index()
+            )));
+        }
+        if ::std::mem::replace(&mut seen[qubit.index()], true) {
+            return Err(PyValueError::new_err(format!(
+                "Layout contains duplicate qubit {}",
+                qubit.index()
+            )));
+        }
+    }
+
+    let mut cur_layout = TranspileLayout::from_py_native(py_layout)?;
+    update_layout(dag, &mut cur_layout, |q| reorder[q.index()]);
+    cur_layout.to_py_native(py_layout.py(), dag.qubits().objects())
+}
+
+pub fn apply_layout_mod(m: &Bound<PyModule>) -> PyResult<()> {
+    m.add_wrapped(wrap_pyfunction!(py_apply_layout))?;
+    m.add_wrapped(wrap_pyfunction!(py_update_layout))?;
+    Ok(())
+}

--- a/crates/transpiler/src/passes/mod.rs
+++ b/crates/transpiler/src/passes/mod.rs
@@ -22,6 +22,7 @@
 //! for building Python submodules.
 
 mod alap_schedule_analysis;
+mod apply_layout;
 mod barrier_before_final_measurement;
 mod basis_translator;
 mod check_map;
@@ -48,6 +49,7 @@ mod unroll_3q_or_more;
 mod vf2;
 
 pub use alap_schedule_analysis::{alap_schedule_analysis_mod, run_alap_schedule_analysis};
+pub use apply_layout::{apply_layout, apply_layout_mod, update_layout};
 pub use barrier_before_final_measurement::{
     barrier_before_final_measurements_mod, run_barrier_before_final_measurements,
 };

--- a/crates/transpiler/src/transpile_layout.rs
+++ b/crates/transpiler/src/transpile_layout.rs
@@ -304,6 +304,55 @@ impl TranspileLayout {
         }
     }
 
+    /// Update the initial layout by permuting the output-space qubit indices from the input of the
+    /// `layout_fn` to its output.
+    ///
+    /// For example, if virtual qubit 0 is previously mapped to physical qubit 2, and this function
+    /// is called with a mapping that sends physical qubit 2 to physical qubit 4, the new layout
+    /// state will map virtual qubit 0 to physical qubit 4.
+    ///
+    /// This includes updating all of the other tracked objects.  If no `initial_layout` is set, it
+    /// is treated as equivalent to the identity mapping.
+    ///
+    /// # Panics
+    ///
+    /// If `layout_fn` returns and out-of-bounds [PhysicalQubit], or maps more than one
+    /// [PhysicalQubit] to the same new value.
+    pub fn relabel_initial_layout(
+        &mut self,
+        mut layout_fn: impl FnMut(PhysicalQubit) -> PhysicalQubit,
+    ) {
+        let initial_layout = match self.initial_layout.as_ref() {
+            Some(layout) => NLayout::from_virtual_to_physical(
+                (0..self.num_output_qubits())
+                    .map(|q| layout_fn(VirtualQubit::new(q).to_phys(layout)))
+                    .collect(),
+            )
+            .expect("all qubits should be in bounds and not duplicates"),
+            None => NLayout::from_virtual_to_physical(
+                (0..self.num_output_qubits())
+                    .map(|q| layout_fn(PhysicalQubit::new(q)))
+                    .collect(),
+            )
+            .expect("all qubits should be in bounds and not duplicates"),
+        };
+        let output_permutation = self.output_permutation.as_ref().map(|permutation| {
+            let mut new_permutation = vec![Qubit::MAX; permutation.len()];
+            for old in 0..permutation.len() as u32 {
+                let old = PhysicalQubit::new(old);
+                let new = layout_fn(old);
+                if new_permutation[new.index()] != Qubit::MAX {
+                    panic!("layout function returned duplicate qubit");
+                }
+                new_permutation[new.index()] = layout_fn(permutation[old.index()].into()).into();
+            }
+            new_permutation
+        });
+
+        self.initial_layout = Some(initial_layout);
+        self.output_permutation = output_permutation;
+    }
+
     // TODO: Conditionally compile this method so we don't depend on symbols from Python
     /// Return a Python space `TranspileLayout` object built from this rust space `TranspileLayout`
     ///

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -62,6 +62,7 @@ import qiskit._numpy_compat
 # and not have to rely on attribute access.  No action needed for top-level extension packages.
 
 sys.modules["qiskit._accelerate.alap_schedule_analysis"] = _accelerate.alap_schedule_analysis
+sys.modules["qiskit._accelerate.apply_layout"] = _accelerate.apply_layout
 sys.modules["qiskit._accelerate.circuit"] = _accelerate.circuit
 sys.modules["qiskit._accelerate.circuit.classical"] = _accelerate.circuit.classical
 sys.modules["qiskit._accelerate.circuit.classical.expr"] = _accelerate.circuit.classical.expr

--- a/qiskit/transpiler/layout.py
+++ b/qiskit/transpiler/layout.py
@@ -829,7 +829,6 @@ class TranspileLayout:
             virtual_permutation_layout = Layout(input_qubit_indices)
         if final_layout is None:
             final_layout = Layout(dict(enumerate(dag.qubits)))
-
         input_qubits = sorted(input_qubit_indices, key=input_qubit_indices.get)
 
         num_qubits = len(dag.qubits)

--- a/qiskit/transpiler/passes/layout/apply_layout.py
+++ b/qiskit/transpiler/passes/layout/apply_layout.py
@@ -12,27 +12,41 @@
 
 """Transform a circuit with virtual qubits into a circuit with physical qubits."""
 
-from qiskit.circuit import QuantumRegister
-from qiskit.dagcircuit import DAGCircuit, DAGOpNode
+from __future__ import annotations
+
+import typing
+
+from qiskit._accelerate.apply_layout import apply_layout, update_layout
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
-from qiskit.transpiler.layout import Layout
+from qiskit.transpiler.layout import TranspileLayout
+
+if typing.TYPE_CHECKING:
+    from qiskit.transpiler import Target
 
 
 class ApplyLayout(TransformationPass):
     """Transform a circuit with virtual qubits into a circuit with physical qubits.
 
-    Transforms a DAGCircuit with virtual qubits into a DAGCircuit with physical qubits
-    by applying the Layout given in `property_set`.
-    Requires either of passes to set/select Layout, e.g. `SetLayout`, `TrivialLayout`.
-    Assumes the Layout has full physical qubits.
+    Transforms a :class:`.DAGCircuit` with virtual qubits into a :class:`.DAGCircuit` with physical
+    qubits by applying the Layout given in ``property_set``.
 
-    If a post layout pass is run and sets the ``post_layout`` property set field with
-    a new layout to use after ``ApplyLayout`` has already run once this pass will
-    compact the layouts so that we apply
-    ``original_virtual`` -> ``existing_layout`` -> ``new_layout`` -> ``new_physical``
-    so that the output circuit and layout combination become:
-    ``original_virtual`` -> ``new_physical``
+    This pass has two modes of operation, depending on the state of the ``layout`` and
+    ``post_layout`` keys in the :class:`.PropertySet`:
+
+    1. Standard operation: ``post_layout`` is not set.  In this case, the ``layout`` field must have
+       been chosen by a layout pass (for example :class:`.SetLayout` or :class:`.VF2Layout`), and
+       both it and the :class:`.DAGCircuit` must have been expanded with ancillas (see
+       :class:`.EnlargeWithAncilla` and :class:`.FullAncillaAllocation`).
+
+    2. Improving a layout: ``post_layout`` is set (such as by :class:`.VF2PostLayout`).  In this
+       case, the ``post_layout`` must already be the correct size.  It is interpreted as an
+       _additional_ relabelling on top of the relabelling that is already applied to the input
+       :class:`.DAGCircuit`.
+
+       After the pass runs, the ``layout`` field will be updated to represent the composition of the
+       two relabellings, as will the :class:`.DAGCircuit` and any final permutation.  The
+       ``post_layout`` field will be removed.
     """
 
     def run(self, dag):
@@ -47,82 +61,46 @@ class ApplyLayout(TransformationPass):
         Raises:
             TranspilerError: if no layout is found in ``property_set`` or no full physical qubits.
         """
-        layout = self.property_set["layout"]
+        if (post_layout := self.property_set.pop("post_layout", None)) is not None:
+            return self._apply_post_layout(dag, post_layout)
+        return self._apply_layout(dag)
+
+    def _apply_layout(self, dag):
+        # We're going to put this layout back later, potentially after ancilla expansion, we just
+        # need it gone to be able to use `TranspileLayout.from_property_set` to normalise any
+        # `virtual_permutation_layout` and `final_layout` that might be there.
+        layout = self.property_set.pop("layout", None)
         if layout is None:
             raise TranspilerError(
                 "No 'layout' is found in property_set. Please run a Layout pass in advance."
             )
         if len(layout) != (1 + max(layout.get_physical_bits(), default=-1)):
             raise TranspilerError("The 'layout' must be full (with ancilla).")
+        num_physical_qubits = len(layout)
 
-        post_layout = self.property_set["post_layout"]
-        q = QuantumRegister(len(layout), "q")
-
-        new_dag = DAGCircuit()
-        new_dag.name = dag.name
-        new_dag.add_qreg(q)
-        for var in dag.iter_input_vars():
-            new_dag.add_input_var(var)
-        for var in dag.iter_captured_vars():
-            new_dag.add_captured_var(var)
-        for var in dag.iter_declared_vars():
-            new_dag.add_declared_var(var)
-        for stretch in dag.iter_captured_stretches():
-            new_dag.add_captured_stretch(stretch)
-        for stretch in dag.iter_declared_stretches():
-            new_dag.add_declared_stretch(stretch)
-        new_dag.metadata = dag.metadata
-        new_dag.add_clbits(dag.clbits)
-        for creg in dag.cregs.values():
-            new_dag.add_creg(creg)
-        if post_layout is None:
-            self.property_set["original_qubit_indices"] = {
-                bit: index for index, bit in enumerate(dag.qubits)
-            }
-            for qreg in dag.qregs.values():
-                self.property_set["layout"].add_register(qreg)
-            virtual_physical_map = layout.get_virtual_bits()
-            for node in dag.topological_op_nodes():
-                qargs = [q[virtual_physical_map[qarg]] for qarg in node.qargs]
-                new_dag._apply_op_node_back(
-                    DAGOpNode.from_instruction(
-                        node._to_circuit_instruction().replace(qubits=qargs)
-                    ),
-                    check=False,
-                )
+        prev_layout = TranspileLayout.from_property_set(dag, self.property_set)
+        if prev_layout is None:
+            permutation = None
+            num_virtual_qubits = self.property_set.get("num_input_qubits", None)
         else:
-            # First build a new layout object going from:
-            # old virtual -> old physical -> new virtual -> new physical
-            # to:
-            # old virtual -> new physical
-            full_layout = Layout()
-            old_phys_to_virtual = layout.get_physical_bits()
-            new_virtual_to_physical = post_layout.get_virtual_bits()
-            phys_map = list(range(len(new_dag.qubits)))
-            for new_virt, new_phys in new_virtual_to_physical.items():
-                old_phys = dag.find_bit(new_virt).index
-                old_virt = old_phys_to_virtual[old_phys]
-                phys_map[old_phys] = new_phys
-                full_layout.add(old_virt, new_phys)
-            for reg in layout.get_registers():
-                full_layout.add_register(reg)
-            # Apply new layout to the circuit
-            for node in dag.topological_op_nodes():
-                qargs = [q[new_virtual_to_physical[qarg]] for qarg in node.qargs]
-                new_dag._apply_op_node_back(
-                    DAGOpNode.from_instruction(
-                        node._to_circuit_instruction().replace(qubits=qargs)
-                    ),
-                    check=False,
-                )
-            self.property_set["layout"] = full_layout
-            if (final_layout := self.property_set["final_layout"]) is not None:
-                final_layout_mapping = {
-                    new_dag.qubits[phys_map[dag.find_bit(old_virt).index]]: phys_map[old_phys]
-                    for old_virt, old_phys in final_layout.get_virtual_bits().items()
-                }
-                out_layout = Layout(final_layout_mapping)
-                self.property_set["final_layout"] = out_layout
-        new_dag.global_phase = dag.global_phase
+            permutation = prev_layout.routing_permutation()
+            num_virtual_qubits = prev_layout._input_qubit_count
+        if num_virtual_qubits is None:
+            num_virtual_qubits = dag.num_qubits()
+        transpile_layout = apply_layout(
+            dag,
+            num_virtual_qubits,
+            num_physical_qubits,
+            [layout[qubit] for qubit in dag.qubits],
+            permutation,
+        )
+        transpile_layout.write_into_property_set(self.property_set)
+        return dag
 
-        return new_dag
+    def _apply_post_layout(self, dag, post_layout):
+        transpile_layout = TranspileLayout.from_property_set(dag, self.property_set)
+        transpile_layout = update_layout(
+            dag, transpile_layout, [post_layout[q] for q in dag.qubits]
+        )
+        transpile_layout.write_into_property_set(self.property_set)
+        return dag

--- a/qiskit/transpiler/passes/layout/apply_layout.py
+++ b/qiskit/transpiler/passes/layout/apply_layout.py
@@ -26,18 +26,19 @@ if typing.TYPE_CHECKING:
 
 
 class ApplyLayout(TransformationPass):
-    """Transform a circuit with virtual qubits into a circuit with physical qubits.
+    """Apply or update the mapping of virtual qubits to physical qubits in the :class:`.DAGCircuit`.
 
-    Transforms a :class:`.DAGCircuit` with virtual qubits into a :class:`.DAGCircuit` with physical
-    qubits by applying the Layout given in ``property_set``.
+    A "layout" in Qiskit is a mapping of virtual qubits (as the user typically creates circuits in
+    terms of) to the physical qubits used to represent them on hardware.
 
     This pass has two modes of operation, depending on the state of the ``layout`` and
     ``post_layout`` keys in the :class:`.PropertySet`:
 
-    1. Standard operation: ``post_layout`` is not set.  In this case, the ``layout`` field must have
-       been chosen by a layout pass (for example :class:`.SetLayout` or :class:`.VF2Layout`), and
-       both it and the :class:`.DAGCircuit` must have been expanded with ancillas (see
-       :class:`.EnlargeWithAncilla` and :class:`.FullAncillaAllocation`).
+    1. Standard operation: ``post_layout`` is not set.  This takes in a :class:`.DAGCircuit` defined
+       over virtual qubits, and rewrites it in terms of physical qubits.  In this case, the
+       ``layout`` field must have been chosen by a layout pass (for example :class:`.SetLayout` or
+       :class:`.VF2Layout`), and both it and the :class:`.DAGCircuit` must have been expanded with
+       ancillas (see :class:`.EnlargeWithAncilla` and :class:`.FullAncillaAllocation`).
 
     2. Improving a layout: ``post_layout`` is set (such as by :class:`.VF2PostLayout`).  In this
        case, the ``post_layout`` must already be the correct size.  It is interpreted as an

--- a/qiskit/transpiler/passes/layout/enlarge_with_ancilla.py
+++ b/qiskit/transpiler/passes/layout/enlarge_with_ancilla.py
@@ -12,6 +12,8 @@
 
 """Extend the dag with virtual qubits that are in layout but not in the circuit yet."""
 
+import itertools
+
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
 
@@ -37,6 +39,7 @@ class EnlargeWithAncilla(TransformationPass):
             TranspilerError: If there is no layout in the property set or not set at init time.
         """
         layout = self.property_set["layout"]
+        qubit_indices = self.property_set["original_qubit_indices"]
 
         if layout is None:
             raise TranspilerError('EnlargeWithAncilla requires property_set["layout"]')
@@ -44,6 +47,9 @@ class EnlargeWithAncilla(TransformationPass):
         new_qregs = {reg for reg in layout.get_registers() if reg not in dag.qregs.values()}
 
         for qreg in new_qregs:
+            if qubit_indices is not None:
+                qubit_indices.update(zip(qreg, itertools.count(dag.num_qubits())))
             dag.add_qreg(qreg)
 
+        self.property_set["original_qubit_indices"] = qubit_indices
         return dag

--- a/test/python/transpiler/test_apply_layout.py
+++ b/test/python/transpiler/test_apply_layout.py
@@ -166,16 +166,16 @@ class TestApplyLayout(QiskitTestCase):
                 first_layout_circ.qubits[4]: 3,
             }
         )
-        out_pass(first_layout_circ)
+        out_pass.run(circuit_to_dag(first_layout_circ))
         self.assertEqual(
             out_pass.property_set["final_layout"],
             Layout(
                 {
                     first_layout_circ.qubits[0]: 0,
-                    first_layout_circ.qubits[2]: 1,
-                    first_layout_circ.qubits[4]: 4,
                     first_layout_circ.qubits[1]: 3,
+                    first_layout_circ.qubits[2]: 1,
                     first_layout_circ.qubits[3]: 2,
+                    first_layout_circ.qubits[4]: 4,
                 }
             ),
         )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This adds and uses the Rust-space paths for `ApplyLayout`.  The Rust interface is deliberately forwards looking; it uses the new Rust-space `TranspileLayout` and all the surrounding infrastructure to begin the process of transitioning our passes to move the `TranspileLayout` to an inherent field on `DAGCircuit`, and updated by all relevant passes in Qiskit directly, rather than the ad-hoc, frequently temporarily out-of-sync collection of properties in the `PropertySet`.

The Rust-space version of `ApplyLayout` is split into the two forms: "apply a layout for the first time" (`apply_layout`) and "improve an already set layout" (`update_layout`).  `apply_layout` can also handle the allocation of explicit ancillas automatically.  The Python-space version of the class is not yet upgraded to allow this functionality, but that can be done in a follow-up.


### Details and comments

The actual mechanics of porting `ApplyLayout` are mostly straightforward.  The reason this PR is tricky is because the Rust-space `ApplyLayout` interface is forward-facing to the next iteration of Qiskit's compilation tracking.  In other words, it's based around the Rust-space `TranspileLayout`, and sets up and then uses the Python-space paths for gentle migration from the Python-space `TranspileLayout` to the Rust-space one within the transpiler.  This means we have to deal with new pathways through the compositions of `initial_layout`, `virtual_permutation_layout`, and `final_layout`.


Close #12262

~*edit*: currently on hold because it's based on #14826, which needs reviewing first.~