### PR TITLE
Revert "Added VF2PostLayout at the end of optimization stage for level 3 (#14120)"

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -14,7 +14,6 @@
 
 import os
 
-from qiskit.transpiler.passes.layout.vf2_post_layout import VF2PostLayout
 from qiskit.transpiler.passes.optimization.split_2q_unitaries import Split2QUnitaries
 from qiskit.transpiler.passmanager import PassManager
 from qiskit.transpiler.exceptions import TranspilerError
@@ -668,23 +667,6 @@ class OptimizationPassManager(PassManagerStagePlugin):
                 else _opt + _unroll_if_out_of_basis + _depth_check + _size_check
             )
             optimization.append(DoWhileController(opt_loop, do_while=_opt_control))
-
-            if optimization_level == 3 and pass_manager_config.coupling_map:
-                vf2_call_limit, vf2_max_trials = common.get_vf2_limits(
-                    optimization_level,
-                    pass_manager_config.layout_method,
-                    pass_manager_config.initial_layout,
-                )
-                optimization.append(
-                    VF2PostLayout(
-                        target=pass_manager_config.target,
-                        seed=-1,
-                        call_limit=vf2_call_limit,
-                        max_trials=vf2_max_trials,
-                        strict_direction=True,
-                    )
-                )
-
             return optimization
         else:
             return None

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -36,8 +36,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     The pass manager then transforms the circuit to match the coupling constraints.
     It is then unrolled to the basis, and any flipped cx directions are fixed.
     Finally, optimizations in the form of commutative gate cancellation, resynthesis
-    of two-qubit unitary blocks, redundant reset removal and final layout improvements are
-    performed.
+    of two-qubit unitary blocks, and redundant reset removal are performed.
 
     Args:
         pass_manager_config: configuration of the pass manager.
@@ -56,6 +55,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     layout_method = pass_manager_config.layout_method or "default"
     routing_method = pass_manager_config.routing_method or "default"
     translation_method = pass_manager_config.translation_method or "default"
+    scheduling_method = pass_manager_config.scheduling_method
     optimization_method = pass_manager_config.optimization_method or "default"
     scheduling_method = pass_manager_config.scheduling_method or "default"
     target = pass_manager_config.target

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -55,7 +55,6 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     layout_method = pass_manager_config.layout_method or "default"
     routing_method = pass_manager_config.routing_method or "default"
     translation_method = pass_manager_config.translation_method or "default"
-    scheduling_method = pass_manager_config.scheduling_method
     optimization_method = pass_manager_config.optimization_method or "default"
     scheduling_method = pass_manager_config.scheduling_method or "default"
     target = pass_manager_config.target

--- a/releasenotes/notes/disable-vf2post-level3-9c2daa70556ddf1f.yaml
+++ b/releasenotes/notes/disable-vf2post-level3-9c2daa70556ddf1f.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    In Qiskit 2.2.0 the :class:`.VF2PostLayout` transpiler pass was added to
+    the ``optimization`` stage of the preset pass manager when
+    ``optimization_level=3``. However, the output of the pass was not ever
+    applied to the circuit. This release removes the pass from the preset pass
+    manager's ``optimization`` stage to save the runtime cost. In Qiskit 2.2.0
+    the pass will be part of the ``optimization`` stage and the output will
+    be applied if the pass finds a better layout.

--- a/releasenotes/notes/disable-vf2post-level3-9c2daa70556ddf1f.yaml
+++ b/releasenotes/notes/disable-vf2post-level3-9c2daa70556ddf1f.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    In Qiskit 2.2.0 the :class:`.VF2PostLayout` transpiler pass was added to
+    In Qiskit 2.1.0 the :class:`.VF2PostLayout` transpiler pass was added to
     the ``optimization`` stage of the preset pass manager when
     ``optimization_level=3``. However, the output of the pass was not ever
     applied to the circuit. This release removes the pass from the preset pass


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



This temporarily reverts commit a8d23667ff5fb0d58738b115d1f1023160f36aa2 due to multiple bugs found around the implementation see #14867 and #14869. Since fixing the bugs will have a large impact on the transpilation results it is better to just disable it and save the runtime overhead which has been reported in a few places (see #14855 and the end of the discussion in #14653). This functionality will be fixed in 2.2.0 and re-enabled there, but for the rest of the 2.1.x release series we should just leave it disabled.

### Details and comments

This PR is against stable/2.1 while on main this will be fixed instead of reverted with #14869 but that isn't suitable for backport. So this PR only applies against stable/2.1
