### PR TITLE
Add indexing of `NLayout`

### DIFF
--- a/crates/circuit/src/nlayout.rs
+++ b/crates/circuit/src/nlayout.rs
@@ -291,6 +291,18 @@ impl NLayout {
         }
     }
 }
+impl ::std::ops::Index<VirtualQubit> for NLayout {
+    type Output = PhysicalQubit;
+    fn index(&self, index: VirtualQubit) -> &PhysicalQubit {
+        &self.virt_to_phys[index.index()]
+    }
+}
+impl ::std::ops::Index<PhysicalQubit> for NLayout {
+    type Output = VirtualQubit;
+    fn index(&self, index: PhysicalQubit) -> &VirtualQubit {
+        &self.phys_to_virt[index.index()]
+    }
+}
 
 pub fn nlayout(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<NLayout>()?;


### PR DESCRIPTION
This allows `NLayout` to be indexed by `VirtualQubit` and `PhysicalQubit`, which is a shorter way of writing `VirtualQubit::to_phys` and `PhysicalQubit::to_virt`.