### PR TITLE
Convert Sabre's `lookahead` to layer-based tracking

### DIFF
--- a/crates/cext/src/transpiler/passes/sabre_layout.rs
+++ b/crates/cext/src/transpiler/passes/sabre_layout.rs
@@ -120,11 +120,13 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_sabre_layout(
             1.0,
             heuristic::SetScaling::Constant,
         )),
-        Some(heuristic::LookaheadHeuristic::new(
-            0.5,
-            20,
-            heuristic::SetScaling::Size,
-        )),
+        Some(
+            heuristic::LookaheadHeuristic::new(
+                vec![0.5 / target.num_qubits.unwrap_or(20) as f64],
+                heuristic::SetScaling::Constant,
+            )
+            .expect("number of layers should be valid"),
+        ),
         Some(heuristic::DecayHeuristic::new(0.001, 5)),
         Some(10 * target.num_qubits.unwrap() as usize),
         1e-10,

--- a/crates/transpiler/src/passes/sabre/heuristic.rs
+++ b/crates/transpiler/src/passes/sabre/heuristic.rs
@@ -79,33 +79,47 @@ impl BasicHeuristic {
     }
 }
 
-/// Define the characteristics of the lookahead heuristic.  This is a sum of the physical distances
-/// of every gate in the lookahead set, which is gates immediately after the front layer.
+/// Define the characteristics of the lookahead heuristic.
 #[pyclass(module = "qiskit._accelerate.sabre", frozen, from_py_object)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct LookaheadHeuristic {
     /// The relative weight of this heuristic.  Typically this is defined relative to the
     /// :class:`.BasicHeuristic`, which generally has its weight set to 1.0.
-    pub weight: f64,
-    /// Number of gates to consider in the heuristic.
-    pub size: usize,
-    /// Dynamic scaling of the heuristic weight depending on the lookahead set.
+    weights: Vec<f64>,
+    /// Dynamic scaling of the heuristic weight depending on the size of the layer.
     pub scale: SetScaling,
 }
-impl_intopyobject_for_copy_pyclass!(LookaheadHeuristic);
+impl LookaheadHeuristic {
+    /// Construct a new lookahead heuristic.
+    ///
+    /// Fails if `weights` has $2^{16}$ or more elements (these are layers - 65,536 is too many!).
+    pub fn new(weights: Vec<f64>, scale: SetScaling) -> Option<Self> {
+        let _: u16 = weights.len().try_into().ok()?;
+        Some(Self { weights, scale })
+    }
+
+    pub fn num_layers(&self) -> u16 {
+        self.weights
+            .len()
+            .try_into()
+            .expect("constructor enforces sufficiently few layers")
+    }
+
+    #[inline]
+    pub fn weights(&self) -> &[f64] {
+        &self.weights
+    }
+}
 #[pymethods]
 impl LookaheadHeuristic {
     #[new]
-    pub fn new(weight: f64, size: usize, scale: SetScaling) -> Self {
-        Self {
-            weight,
-            size,
-            scale,
-        }
+    pub fn py_new(weights: Vec<f64>, scale: SetScaling) -> PyResult<Self> {
+        Self::new(weights, scale)
+            .ok_or_else(|| PyValueError::new_err("must have fewer than 65,536 layers"))
     }
 
     pub fn __getnewargs__(&self, py: Python) -> PyResult<Py<PyAny>> {
-        (self.weight, self.size, self.scale).into_py_any(py)
+        (self.weights.as_slice().into_pyobject(py)?, self.scale).into_py_any(py)
     }
 
     pub fn __eq__(&self, py: Python, other: Py<PyAny>) -> bool {
@@ -113,9 +127,12 @@ impl LookaheadHeuristic {
     }
 
     pub fn __repr__(&self, py: Python) -> PyResult<Py<PyAny>> {
-        let fmt = "LookaheadHeuristic(weight={!r}, size={!r}, scale={!r})";
+        let fmt = "LookaheadHeuristic(weights={!r}, scale={!r})";
         PyString::new(py, fmt)
-            .call_method1("format", (self.weight, self.size, self.scale))?
+            .call_method1(
+                "format",
+                (self.weights.as_slice().into_pyobject(py)?, self.scale),
+            )?
             .into_py_any(py)
     }
 }
@@ -159,6 +176,14 @@ impl DecayHeuristic {
 
 /// A complete description of the heuristic that Sabre will use.  See the individual elements for a
 /// greater description.
+///
+/// .. note::
+///
+///     This is an internal Qiskit object, not a formal part of the API.  You can use this for
+///     fine-grained control over the Sabre heuristic, including for research, but beware that the
+///     available options and configuration of it may change without warning in minor versions of
+///     Qiskit.  If you are doing research using this, be sure to pin the version of Qiskit in your
+///     requirements.
 #[pyclass(module = "qiskit._accelerate.sabre", frozen, eq, skip_from_py_object)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Heuristic {
@@ -205,7 +230,7 @@ impl Heuristic {
     pub fn __getnewargs__(&self, py: Python) -> PyResult<Py<PyAny>> {
         (
             self.basic,
-            self.lookahead,
+            self.lookahead.clone(),
             self.decay,
             self.attempt_limit,
             self.best_epsilon,
@@ -223,15 +248,11 @@ impl Heuristic {
         }
     }
 
-    /// Set the weight and extended-set size of the ``lookahead`` heuristic.  The weight here
-    /// should typically be less than that of ``basic``.
-    pub fn with_lookahead(&self, weight: f64, size: usize, scale: SetScaling) -> Self {
+    /// Set the layer weights of the ``lookahead`` heuristic.  The weight here should typically be
+    /// less than that of ``basic``.  The number of weights dictates the number of layers.
+    pub fn with_lookahead(&self, weights: Vec<f64>, scale: SetScaling) -> Self {
         Self {
-            lookahead: Some(LookaheadHeuristic {
-                weight,
-                size,
-                scale,
-            }),
+            lookahead: Some(LookaheadHeuristic { weights, scale }),
             ..self.clone()
         }
     }
@@ -256,7 +277,7 @@ impl Heuristic {
                 "format",
                 (
                     self.basic,
-                    self.lookahead,
+                    self.lookahead.clone(),
                     self.decay,
                     self.attempt_limit,
                     self.best_epsilon,

--- a/crates/transpiler/src/passes/sabre/heuristic.rs
+++ b/crates/transpiler/src/passes/sabre/heuristic.rs
@@ -83,10 +83,10 @@ impl BasicHeuristic {
 #[pyclass(module = "qiskit._accelerate.sabre", frozen, from_py_object)]
 #[derive(Clone, PartialEq, Debug)]
 pub struct LookaheadHeuristic {
-    /// The relative weight of this heuristic.  Typically this is defined relative to the
-    /// :class:`.BasicHeuristic`, which generally has its weight set to 1.0.
+    /// The relative weights of each sequential layer in this heuristic.  Typically each of these is
+    /// defined relative to the :class:`.BasicHeuristic`, which generally has its weight set to 1.0.
     weights: Vec<f64>,
-    /// Dynamic scaling of the heuristic weight depending on the size of the layer.
+    /// Dynamic scaling of the heuristic weight depending on the size of each layer.
     pub scale: SetScaling,
 }
 impl LookaheadHeuristic {

--- a/crates/transpiler/src/passes/sabre/layer.rs
+++ b/crates/transpiler/src/passes/sabre/layer.rs
@@ -18,9 +18,11 @@ use qiskit_circuit::PhysicalQubit;
 
 use super::vec_map::VecMap;
 
-/// A container for the current non-routable parts of the front layer.  This only ever holds
-/// two-qubit gates; the only reason a 0q- or 1q operation can be unroutable is because it has an
-/// unsatisfied 2q predecessor, which disqualifies it from being in the front layer.
+/// A container for 2q gates in a layer that are yet to be routed.
+///
+/// The graph nodes in this structure always refer to `TwoQ` entries, since `Synchronize` nodes do
+/// not impact the scoring; they only affect when nodes are eligible to move forwards a layer, or to
+/// become routed.
 ///
 /// It would be more algorithmically natural for this struct to work in terms of virtual qubits,
 /// because then a swap insertion would not change the data contained.  However, for each swap we
@@ -40,8 +42,8 @@ pub struct Layer {
 impl Layer {
     pub fn new(num_qubits: u32) -> Self {
         Layer {
-            // This is the maximum capacity of the front layer, since each qubit must be one of a
-            // pair, and can only have one gate in the layer.
+            // This is the maximum capacity of the layer, since each qubit must be one of a pair,
+            // and can only have one gate in the layer.
             nodes: IndexMap::with_capacity_and_hasher(
                 num_qubits as usize / 2,
                 ::ahash::RandomState::default(),
@@ -61,7 +63,7 @@ impl Layer {
         &self.qubits
     }
 
-    /// Add a node into the front layer, with the two qubits it operates on.
+    /// Add a node into the layer, with the two qubits it operates on.
     pub fn insert(&mut self, index: NodeIndex, qubits: [PhysicalQubit; 2]) {
         let [a, b] = qubits;
         self.qubits[a] = Some((index, b));
@@ -69,7 +71,7 @@ impl Layer {
         self.nodes.insert(index, qubits);
     }
 
-    /// Remove a node from the front layer.
+    /// Remove a node from the layer.
     pub fn remove(&mut self, index: &NodeIndex) {
         // The actual order in the indexmap doesn't matter as long as it's reproducible.
         // Swap-remove is more efficient than a full shift-remove.
@@ -98,12 +100,9 @@ impl Layer {
     /// Calculate the score _difference_ caused by this swap, compared to not making the swap.
     #[inline(always)]
     pub fn score(&self, swap: [PhysicalQubit; 2], dist: &ArrayView2<f64>) -> f64 {
-        // At most there can be two affected gates in the front layer (one on each qubit in the
-        // swap), since any gate whose closest path passes through the swapped qubit link has its
-        // "virtual-qubit path" order changed, but not the total weight.  In theory, we should
-        // never consider the same gate in both `if let` branches, because if we did, the gate would
-        // already be routable.  It doesn't matter, though, because the two distances would be
-        // equal anyway, so not affect the score.
+        // At most there can be two affected gates in the layer (one on each qubit in the swap),
+        // since any gate whose closest path passes through the swapped qubit link has its
+        // "virtual-qubit path" order changed, but not the total weight.
         let [a, b] = swap;
         let mut total = 0.0;
         if let Some((_, c)) = self.qubits[a] {
@@ -118,7 +117,7 @@ impl Layer {
         total
     }
 
-    /// Calculate the total absolute of the current front layer on the given layer.
+    /// Calculate the total absolute score of the layer for the set layout.
     pub fn total_score(&self, dist: &ArrayView2<f64>) -> f64 {
         self.iter()
             .map(|(_, &[a, b])| dist[[a.index(), b.index()]])

--- a/crates/transpiler/src/passes/sabre/route.rs
+++ b/crates/transpiler/src/passes/sabre/route.rs
@@ -35,8 +35,8 @@ use rustworkx_core::token_swapper::token_swapper;
 use smallvec::{SmallVec, smallvec};
 
 use super::dag::{InteractionKind, SabreDAG};
-use super::heuristic::{BasicHeuristic, DecayHeuristic, Heuristic, LookaheadHeuristic, SetScaling};
-use super::layer::{ExtendedSet, FrontLayer};
+use super::heuristic::{BasicHeuristic, DecayHeuristic, Heuristic, SetScaling};
+use super::layer::Layer;
 use super::vec_map::VecMap;
 use crate::TranspilerError;
 use crate::neighbors::Neighbors;
@@ -448,8 +448,8 @@ impl<'a> RoutingProblem<'a> {
 /// is mostly just a convenience, so we don't have to pass everything from function to function.
 struct State {
     layout: NLayout,
-    front_layer: FrontLayer,
-    extended_set: ExtendedSet,
+    front_layer: Layer,
+    lookahead_layers: Box<[Layer]>,
     /// How many predecessors still need to be satisfied for each node index before it is at the
     /// front of the topological iteration through the nodes as they're routed.
     required_predecessors: VecMap<NodeIndex, u32>,
@@ -470,7 +470,9 @@ impl State {
     #[inline]
     fn apply_swap(&mut self, swap: [PhysicalQubit; 2]) {
         self.front_layer.apply_swap(swap);
-        self.extended_set.apply_swap(swap);
+        for layer in self.lookahead_layers.iter_mut() {
+            layer.apply_swap(swap);
+        }
         self.layout.swap_physical(swap[0], swap[1]);
     }
 
@@ -615,38 +617,45 @@ impl State {
         result
     }
 
-    /// Fill the given `extended_set` with the next nodes that would be reachable after the front
+    /// Fill the given lookahead layers with the next nodes that would be reachable after the front
     /// layer (and themselves).  This uses `required_predecessors` as scratch space for efficiency,
     /// but returns it to the same state as the input on return.
     fn populate_extended_set(&mut self, problem: RoutingProblem) {
-        let extended_set_size =
-            if let Some(LookaheadHeuristic { size, .. }) = problem.heuristic.lookahead {
-                size
-            } else {
-                return;
-            };
-        let mut to_visit = self.front_layer.iter_nodes().copied().collect::<Vec<_>>();
+        let mut next_visit = self.front_layer.iter_nodes().copied().collect::<Vec<_>>();
+        let mut to_visit = Vec::new();
         let mut decremented: IndexMap<NodeIndex, u32, ahash::RandomState> =
             IndexMap::with_hasher(ahash::RandomState::default());
-        let mut i = 0;
-        while i < to_visit.len() && self.extended_set.len() < extended_set_size {
-            let node = to_visit[i];
-            for edge in problem.sabre.dag.edges_directed(node, Direction::Outgoing) {
-                let successor = edge.target();
-                *decremented.entry(successor).or_insert(0) += 1;
-                self.required_predecessors[successor] -= 1;
-                if self.required_predecessors[successor] == 0 {
-                    // TODO: this looks "through" control-flow ops without seeing them, but we
-                    // actually eagerly route control-flow blocks as soon as they're eligible, so
-                    // they should be reflected in the extended set.
-                    if let InteractionKind::TwoQ([a, b]) = &problem.sabre.dag[successor].kind {
-                        self.extended_set
-                            .push([a.to_phys(&self.layout), b.to_phys(&self.layout)]);
+        for layer in self.lookahead_layers.iter_mut() {
+            for node in next_visit.drain(..) {
+                for edge in problem.sabre.dag.edges_directed(node, Direction::Outgoing) {
+                    let successor = edge.target();
+                    *decremented.entry(successor).or_insert(0) += 1;
+                    self.required_predecessors[successor] -= 1;
+                    if self.required_predecessors[successor] == 0 {
+                        to_visit.push(successor);
                     }
-                    to_visit.push(successor);
                 }
             }
-            i += 1;
+
+            let mut i = 0;
+            while i < to_visit.len() {
+                let node = to_visit[i];
+                if let InteractionKind::TwoQ([a, b]) = &problem.sabre.dag[node].kind {
+                    layer.insert(node, [self.layout[*a], self.layout[*b]]);
+                    next_visit.push(node);
+                } else {
+                    for edge in problem.sabre.dag.edges_directed(node, Direction::Outgoing) {
+                        let successor = edge.target();
+                        *decremented.entry(successor).or_insert(0) += 1;
+                        self.required_predecessors[successor] -= 1;
+                        if self.required_predecessors[successor] == 0 {
+                            to_visit.push(successor);
+                        }
+                    }
+                }
+                i += 1;
+            }
+            to_visit.clear();
         }
         for (node, amount) in decremented.iter() {
             self.required_predecessors[*node] += *amount;
@@ -747,20 +756,22 @@ impl State {
             }
         }
 
-        if let Some(LookaheadHeuristic { weight, scale, .. }) = problem.heuristic.lookahead {
-            let weight = match scale {
-                SetScaling::Constant => weight,
-                SetScaling::Size => {
-                    if self.extended_set.is_empty() {
-                        0.0
-                    } else {
-                        weight / (self.extended_set.len() as f64)
+        if let Some(lookahead) = &problem.heuristic.lookahead {
+            for (layer, weight) in self.lookahead_layers.iter().zip(lookahead.weights()) {
+                let weight = match lookahead.scale {
+                    SetScaling::Constant => *weight,
+                    SetScaling::Size => {
+                        if layer.is_empty() {
+                            0.0
+                        } else {
+                            *weight / (layer.len() as f64)
+                        }
                     }
+                };
+                absolute_score += weight * layer.total_score(dist);
+                for (swap, score) in self.swap_scores.iter_mut() {
+                    *score += weight * layer.score(*swap, dist);
                 }
-            };
-            absolute_score += weight * self.extended_set.total_score(dist);
-            for (swap, score) in self.swap_scores.iter_mut() {
-                *score += weight * self.extended_set.score(*swap, dist);
             }
         }
 
@@ -865,8 +876,17 @@ pub fn swap_map_trial<'a>(
         required_predecessors[edge.target()] += 1;
     }
     let mut state = State {
-        front_layer: FrontLayer::new(num_qubits),
-        extended_set: ExtendedSet::new(num_qubits),
+        front_layer: Layer::new(num_qubits),
+        lookahead_layers: vec![
+            Layer::new(num_qubits);
+            problem
+                .heuristic
+                .lookahead
+                .as_ref()
+                .map(|x| x.num_layers() as usize)
+                .unwrap_or(0)
+        ]
+        .into(),
         decay: vec![1.; num_qubits as usize].into(),
         required_predecessors,
         layout: initial_layout.clone(),
@@ -878,11 +898,10 @@ pub fn swap_map_trial<'a>(
     state.update_route(problem, &mut order, &problem.sabre.first_layer, None);
     state.populate_extended_set(problem);
 
-    // Main logic loop; the front layer only becomes empty when all nodes have been routed.  At
-    // each iteration of this loop, we route either one or two gates.
     let mut routable_nodes = Vec::<NodeIndex>::with_capacity(2);
     let mut num_search_steps = 0;
-
+    // The front layer only becomes empty when all nodes have been routed.  At each iteration of
+    // this loop, we route either one or two gates.
     while !state.front_layer.is_empty() {
         let mut current_swaps: Vec<[PhysicalQubit; 2]> = Vec::new();
         // Swap-mapping loop.  This is the main part of the algorithm, which we repeat until we
@@ -891,6 +910,9 @@ pub fn swap_map_trial<'a>(
             let best_swap = state.choose_best_swap(problem);
             state.apply_swap(best_swap);
             current_swaps.push(best_swap);
+            // These two nodes can't be the same; if they are, then the gate is on both qubits of
+            // the swap, and so it would have been routable before we applied the swap too, i.e.
+            // during the last iteration of the loop.
             if let Some(node) = state.routable_node_on_qubit(problem, best_swap[1]) {
                 routable_nodes.push(node);
             }
@@ -926,7 +948,7 @@ pub fn swap_map_trial<'a>(
         state.update_route(problem, &mut order, &routable_nodes, Some(current_swaps));
         // Ideally we'd know how to mutate the extended set directly, but since its limited size
         // easy to do better than just emptying it and rebuilding.
-        state.extended_set.clear();
+        state.lookahead_layers.iter_mut().for_each(Layer::clear);
         state.populate_extended_set(problem);
 
         if problem.heuristic.decay.is_some() {

--- a/crates/transpiler/src/transpiler.rs
+++ b/crates/transpiler/src/transpiler.rs
@@ -450,7 +450,10 @@ pub fn get_sabre_heuristic(target: &Target) -> Result<sabre::Heuristic> {
         1e-10,
     )
     .with_basic(1.0, sabre::SetScaling::Constant)
-    .with_lookahead(0.5, 20, sabre::SetScaling::Size)
+    .with_lookahead(
+        vec![0.5 / target.num_qubits.unwrap_or(20) as f64],
+        sabre::SetScaling::Constant,
+    )
     .with_decay(0.001, 5)?)
 }
 

--- a/qiskit/transpiler/passes/layout/sabre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_layout.py
@@ -266,7 +266,7 @@ class SabreLayout(TransformationPass):
         heuristic = (
             Heuristic(attempt_limit=10 * self.target.num_qubits)
             .with_basic(1.0, SetScaling.Constant)
-            .with_lookahead(0.5, 20, SetScaling.Size)
+            .with_lookahead([0.5 / self.target.num_qubits], SetScaling.Constant)
             .with_decay(0.001, 5)
         )
         sabre_start = time.perf_counter()

--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -217,13 +217,13 @@ class SabreSwap(TransformationPass):
             heuristic = (
                 Heuristic(attempt_limit=10 * num_dag_qubits)
                 .with_basic(1.0, SetScaling.Constant)
-                .with_lookahead(0.5, 20, SetScaling.Size)
+                .with_lookahead([0.5 / num_coupling_qubits], SetScaling.Constant)
             )
         elif self.heuristic == "decay":
             heuristic = (
                 Heuristic(attempt_limit=10 * num_dag_qubits)
                 .with_basic(1.0, SetScaling.Constant)
-                .with_lookahead(0.5, 20, SetScaling.Size)
+                .with_lookahead([0.5 / num_coupling_qubits], SetScaling.Constant)
                 .with_decay(0.001, 5)
             )
         else:

--- a/releasenotes/notes/sabre-lookahead-layers-c00ad07aebfc751c.yaml
+++ b/releasenotes/notes/sabre-lookahead-layers-c00ad07aebfc751c.yaml
@@ -1,0 +1,8 @@
+---
+features_transpiler:
+  - During Sabre layout and routing (:class:`.SabreLayout` and :class:`.SabreRouting`), the
+    ``lookahead`` heuristic is now defined in terms of numbers of circuit layers, rather than numbers
+    of circuit gates.  This reduces bias in the heuristic; for narrow circuits the previous
+    heuristic could consider very far-off gates at equal weight to nearly routable gates, while for
+    wide circuits (more than 40 qubits) it would not be able to track all the gates only a single
+    layer behind the frontier.

--- a/releasenotes/notes/sabre-lookahead-layers-c00ad07aebfc751c.yaml
+++ b/releasenotes/notes/sabre-lookahead-layers-c00ad07aebfc751c.yaml
@@ -4,5 +4,5 @@ features_transpiler:
     ``lookahead`` heuristic is now defined in terms of numbers of circuit layers, rather than numbers
     of circuit gates.  This reduces bias in the heuristic; for narrow circuits the previous
     heuristic could consider very far-off gates at equal weight to nearly routable gates, while for
-    wide circuits (more than 40 qubits) it would not be able to track all the gates only a single
+    wide circuits (more than 40 qubits) it would not be able to track all the gates even in the single
     layer behind the frontier.

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -2286,17 +2286,19 @@ class TestTranspile(QiskitTestCase):
         # `dt` set.  For that test to work, we need to check that compiling explicitly without
         # errors produces a different layout to transpiling with them, so we can then later check
         # that the "custom dt" transpile matches the "with errors" case.
-
-        tqc_no_error = transpile(qc, coupling_map=coupling_map, seed_transpiler=4242)
+        seed_transpiler = 2025_07_07
+        tqc_no_error = transpile(qc, coupling_map=coupling_map, seed_transpiler=seed_transpiler)
         # transpile with gate errors
-        tqc_no_dt = transpile(qc, backend=backend, seed_transpiler=4242)
-        # confirm that the output layouts are different
+        tqc_no_dt = transpile(qc, backend=backend, seed_transpiler=seed_transpiler)
+        # confirm that the output layouts are different. This can fail spurious if the built-in
+        # layout pass happened to choose the same initial layout that the noise-aware remapping
+        # converges to.  In that case, you can bump the transpiler seed.
         self.assertNotEqual(
             tqc_no_dt.layout.final_index_layout(), tqc_no_error.layout.final_index_layout()
         )
         # now modify dt with gate errors
-        tqc_dt = transpile(qc, backend=backend, seed_transpiler=4242, dt=backend.dt * 2)
-        # confirm that dt doesn't affect layout
+        tqc_dt = transpile(qc, backend=backend, seed_transpiler=seed_transpiler, dt=backend.dt * 2)
+        # confirm that dt doesn't affect layout.
         self.assertEqual(tqc_no_dt.layout.final_index_layout(), tqc_dt.layout.final_index_layout())
 
     @combine(optimization_level=[0, 1, 2, 3], control_flow=[False, True])
@@ -2795,9 +2797,9 @@ class TestPostTranspileIntegration(QiskitTestCase):
         for i in range(5):
             qc.cx(i % qubits, int(i + qubits / 2) % qubits)
 
-        tqc = transpile(qc, backend=backend, seed_transpiler=4242, callback=callback)
+        tqc = transpile(qc, backend=backend, seed_transpiler=2025_07_07, callback=callback)
         self.assertTrue(vf2_post_layout_called)
-        self.assertEqual([1, 3, 4], _get_index_layout(tqc, qubits))
+        self.assertEqual([1, 4, 3], _get_index_layout(tqc, qubits))
 
     @data("sabre", "lookahead", "basic")
     def test_final_layout_combined_correctly(self, routing):

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -1057,9 +1057,9 @@ class TestFinalLayouts(QiskitTestCase):
                     qc.cx(qubit_control, qubit_target)
         expected_layouts = [
             [0, 1, 2, 3, 4],
-            [5, 6, 10, 11, 0],
-            [5, 6, 0, 11, 10],
-            [5, 6, 0, 10, 11],
+            [5, 6, 10, 0, 11],
+            [5, 6, 10, 0, 11],
+            [5, 11, 6, 0, 10],
         ]
         backend = GenericBackendV2(num_qubits=20, coupling_map=TOKYO_CMAP, seed=42)
         result = transpile(qc, backend, optimization_level=level, seed_transpiler=42)

--- a/test/python/transpiler/test_sabre_layout.py
+++ b/test/python/transpiler/test_sabre_layout.py
@@ -67,7 +67,7 @@ class TestSabreLayout(QiskitTestCase):
         pass_.run(dag)
 
         layout = pass_.property_set["layout"]
-        self.assertEqual([layout[q] for q in circuit.qubits], [3, 6, 8, 7, 12])
+        self.assertEqual([layout[q] for q in circuit.qubits], [11, 8, 12, 7, 13])
 
     def test_6q_circuit_20q_coupling(self):
         """Test finds layout for 6q circuit on 20q device."""
@@ -208,7 +208,7 @@ rz(0) q4835[1];
         self.assertIsInstance(res, QuantumCircuit)
         layout = res._layout.initial_layout
         self.assertEqual(
-            [layout[q] for q in qc.qubits], [2, 0, 5, 1, 7, 3, 14, 6, 9, 8, 10, 11, 4, 12]
+            [layout[q] for q in qc.qubits], [4, 0, 12, 1, 16, 7, 21, 11, 26, 15, 3, 18, 10, 2]
         )
 
     def test_layout_many_search_trials(self):
@@ -270,7 +270,7 @@ barrier q18585[5],q18585[2],q18585[8],q18585[3],q18585[6];
         self.assertIsInstance(res, QuantumCircuit)
         layout = res._layout.initial_layout
         self.assertEqual(
-            [layout[q] for q in qc.qubits], [8, 21, 12, 16, 10, 4, 14, 23, 13, 9, 11, 19, 2, 20]
+            [layout[q] for q in qc.qubits], [13, 7, 18, 22, 17, 8, 14, 10, 11, 3, 16, 25, 23, 19]
         )
 
     def test_support_var_with_rust_fastpath(self):
@@ -290,7 +290,7 @@ barrier q18585[5],q18585[2],q18585[8],q18585[3],q18585[6];
         out = SabreLayout(CouplingMap.from_line(8), seed=0, swap_trials=2, layout_trials=2)(qc)
 
         self.assertIsInstance(out, QuantumCircuit)
-        self.assertEqual(out.layout.initial_index_layout(), [6, 5, 4, 2, 3, 0, 1, 7])
+        self.assertEqual(out.layout.initial_index_layout(), [2, 3, 4, 6, 5, 0, 1, 7])
 
     def test_support_var_with_explicit_routing_pass(self):
         """Test that the logic works if an explicit routing pass is given."""

--- a/test/python/transpiler/test_sabre_swap.py
+++ b/test/python/transpiler/test_sabre_swap.py
@@ -312,7 +312,7 @@ class TestSabreSwap(QiskitTestCase):
     def test_no_infinite_loop(self):
         """Test that the 'release value' mechanisms allow SabreSwap to make progress even on
         circuits that get stuck in a stable local minimum of the lookahead parameters."""
-        # This is an approximation to the "lookahaed" heuristic described by the original Sabre
+        # This is an approximation to the "lookahead" heuristic described by the original Sabre
         # paper.  For the particular circuit we're using, the layer-based lookahead Qiskit uses is
         # the same as the max-size depth-agnostic set of the original Sabre paper, since there's
         # only two (disjoint) gates that aren't in the front layer.  We use this here because

--- a/test/python/transpiler/test_sabre_swap.py
+++ b/test/python/transpiler/test_sabre_swap.py
@@ -312,13 +312,15 @@ class TestSabreSwap(QiskitTestCase):
     def test_no_infinite_loop(self):
         """Test that the 'release value' mechanisms allow SabreSwap to make progress even on
         circuits that get stuck in a stable local minimum of the lookahead parameters."""
-        # This is Qiskit's "legacy" lookahead heuristic, which is the same as described in the
-        # original Sabre paper.  We use this here because Qiskit's modern default heuristics don't
-        # hit the release valve.
+        # This is an approximation to the "lookahaed" heuristic described by the original Sabre
+        # paper.  For the particular circuit we're using, the layer-based lookahead Qiskit uses is
+        # the same as the max-size depth-agnostic set of the original Sabre paper, since there's
+        # only two (disjoint) gates that aren't in the front layer.  We use this here because
+        # Qiskit's modern default heuristics don't get stuck with this circuit.
         heuristic = (
             Heuristic(attempt_limit=100)
             # The basic heuristic scaling by size is the problematic bit.
-            .with_basic(1.0, SetScaling.Size).with_lookahead(0.5, 20, SetScaling.Size)
+            .with_basic(1.0, SetScaling.Size).with_lookahead([0.5], SetScaling.Size)
         )
         qc = looping_circuit(3, 1)
         qc.measure_all()


### PR DESCRIPTION
The previous Sabre extended set was just the "next N" 2q gates topologically on from the front layer, where Qiskit reliably used `N = 20` ever since its introduction.  For small-width circuits (as were common when the original Sabre paper was written, and when it was first implemented in Qiskit), this could mean the extended set was reliably several layers deep.  This could also be the case for star-like circuits.  For the wider circuits in use now, at the 100q order of magnitude, the 20-gate limit reliably means that denser circuits cannot have their entire next layer considered by the lookahead set.

This commit modifies the lookahead heuristic to be based specifically on layers.  This regularises much of the structure of the heuristic with respect to circuit and target topology; we reliably "look ahead" by the same "distance" as far as routing is concerned.  It comes with the additional benefits:

- we can use the same `Layer` structure for both the front layer and the lookahead layers, which reduces the amount of scoring code

- the lookahead score of a swap can now affect at most two gates per layer, just like the front-layer scoring, and we can do this statically without loops

- we no longer risk "biasing" the lookahead heuristic in either case of long chains of dependent gates (e.g. a gate that has 10 predecessors weights the score the same as a gate with only 1) or wide circuits (some qubits have their next layer counted in the score, but others don't because the extended set reached capacity).

- applying a swap to the lookahead now has a time complexity that is constant per layer, regardless of the number of gates stored in it, whereas previously it was proportional to the number of gates stored (and the implementation in the parent of this commit is proportional to the number of qubits in the circuit).

This change alone is mostly a set up, which enables further computational complexity improvements by modifying the lookahead layers in place after a gate routes, rather than rebuilding them from scratch, and subsequently only updating _swap scores_ based on routing changes, rather than recalculating all from scratch.

