### PR TITLE
Cleanup ``DAGCircuit::new`` by removing ``PyResult``

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -4482,6 +4482,12 @@ impl<'a> DAGCircuit {
     }
 }
 
+impl Default for DAGCircuit {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DAGCircuit {
     pub fn new() -> Self {
         DAGCircuit {
@@ -4617,7 +4623,7 @@ impl DAGCircuit {
             Some(num_ops),
             Some(num_edges),
             Some(num_stretches),
-        )?;
+        );
         target_dag.name.clone_from(&self.name);
         target_dag.global_phase = self.global_phase.clone();
         target_dag.duration.clone_from(&self.duration);
@@ -6672,7 +6678,7 @@ impl DAGCircuit {
         num_ops: Option<usize>,
         num_edges: Option<usize>,
         num_stretches: Option<usize>,
-    ) -> PyResult<Self> {
+    ) -> Self {
         let num_ops: usize = num_ops.unwrap_or_default();
         let num_vars = num_vars.unwrap_or_default();
         let num_stretches = num_stretches.unwrap_or_default();
@@ -6688,7 +6694,7 @@ impl DAGCircuit {
             num_vars * 2 +  // One input + output node per variable
             num_ops;
 
-        Ok(Self {
+        Self {
             name: None,
             metadata: None,
             dag: StableDiGraph::with_capacity(num_nodes, num_edges),
@@ -6718,7 +6724,7 @@ impl DAGCircuit {
             vars_declare: HashSet::new(),
             stretches_capture: HashSet::new(),
             stretches_declare: Vec::new(),
-        })
+        }
     }
 
     /// Get qargs from an intern index
@@ -7008,7 +7014,7 @@ impl DAGCircuit {
             Some(num_ops),
             None,
             Some(num_stretches),
-        )?;
+        );
 
         // Assign other necessary data
         new_dag.name = name;

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -3566,7 +3566,7 @@ impl DAGCircuit {
     }
 
     /// Remove all of the ancestor operation nodes of node.
-    fn remove_ancestors_of(&mut self, node: &DAGNode) -> PyResult<()> {
+    fn remove_ancestors_of(&mut self, node: &DAGNode) {
         let ancestors: Vec<_> = core_ancestors(&self.dag, node.node.unwrap())
             .filter(|next| {
                 next != &node.node.unwrap()
@@ -3576,11 +3576,10 @@ impl DAGCircuit {
         for a in ancestors {
             self.dag.remove_node(a);
         }
-        Ok(())
     }
 
     /// Remove all of the descendant operation nodes of node.
-    fn remove_descendants_of(&mut self, node: &DAGNode) -> PyResult<()> {
+    fn remove_descendants_of(&mut self, node: &DAGNode) {
         let descendants: Vec<_> = core_descendants(&self.dag, node.node.unwrap())
             .filter(|next| {
                 next != &node.node.unwrap()
@@ -3590,11 +3589,10 @@ impl DAGCircuit {
         for d in descendants {
             self.dag.remove_node(d);
         }
-        Ok(())
     }
 
     /// Remove all of the non-ancestors operation nodes of node.
-    fn remove_nonancestors_of(&mut self, node: &DAGNode) -> PyResult<()> {
+    fn remove_nonancestors_of(&mut self, node: &DAGNode) {
         let ancestors: HashSet<_> = core_ancestors(&self.dag, node.node.unwrap())
             .filter(|next| {
                 next != &node.node.unwrap()
@@ -3609,11 +3607,10 @@ impl DAGCircuit {
         for na in non_ancestors {
             self.dag.remove_node(na);
         }
-        Ok(())
     }
 
     /// Remove all of the non-descendants operation nodes of node.
-    fn remove_nondescendants_of(&mut self, node: &DAGNode) -> PyResult<()> {
+    fn remove_nondescendants_of(&mut self, node: &DAGNode) {
         let descendants: HashSet<_> = core_descendants(&self.dag, node.node.unwrap())
             .filter(|next| {
                 next != &node.node.unwrap()
@@ -3628,7 +3625,6 @@ impl DAGCircuit {
         for nd in non_descendants {
             self.dag.remove_node(nd);
         }
-        Ok(())
     }
 
     /// Return a list of op nodes in the first layer of this dag.
@@ -4883,7 +4879,7 @@ impl DAGCircuit {
 
         // Remove DAG in/out nodes etc.
         for bit in qubits.iter() {
-            self.remove_idle_wire(Wire::Qubit(*bit))?;
+            self.remove_idle_wire(Wire::Qubit(*bit));
         }
 
         // Copy the current qubit mapping so we can use it while remapping
@@ -5011,7 +5007,7 @@ impl DAGCircuit {
 
         // Remove DAG in/out nodes etc.
         for bit in clbits.iter() {
-            self.remove_idle_wire(Wire::Clbit(*bit))?;
+            self.remove_idle_wire(Wire::Clbit(*bit));
         }
 
         // Copy the current clbit mapping so we can use it while remapping
@@ -5788,7 +5784,7 @@ impl DAGCircuit {
         nodes
     }
 
-    fn remove_idle_wire(&mut self, wire: Wire) -> PyResult<()> {
+    fn remove_idle_wire(&mut self, wire: Wire) {
         let [in_node, out_node] = match wire {
             Wire::Qubit(qubit) => self.qubit_io_map[qubit.index()],
             Wire::Clbit(clbit) => self.clbit_io_map[clbit.index()],
@@ -5796,7 +5792,6 @@ impl DAGCircuit {
         };
         self.dag.remove_node(in_node);
         self.dag.remove_node(out_node);
-        Ok(())
     }
 
     pub fn add_qubit_unchecked(&mut self, bit: ShareableQubit) -> PyResult<Qubit> {
@@ -6665,12 +6660,12 @@ impl DAGCircuit {
     /// Alternative constructor, builds a DAGCircuit with a fixed capacity.
     ///
     /// # Arguments:
-    /// - `py`: Python GIL token
     /// - `num_qubits`: Number of qubits in the circuit
     /// - `num_clbits`: Number of classical bits in the circuit.
     /// - `num_vars`: (Optional) number of variables in the circuit.
     /// - `num_ops`: (Optional) number of operations in the circuit.
-    /// - `num_edges`: (Optional) If known, number of edges in the circuit.
+    /// - `num_edges`: (Optional) number of edges in the circuit.
+    /// - `num_stretches`: (Optional) number of stretches in the circuit.
     pub fn with_capacity(
         num_qubits: usize,
         num_clbits: usize,
@@ -6807,8 +6802,7 @@ impl DAGCircuit {
         py: Python, // Unused if cache_pygates isn't enabled
         node: NodeIndex,
         insert: F,
-    ) -> PyResult<()>
-    where
+    ) where
         F: Fn(Wire) -> (PackedOperation, SmallVec<[Param; 3]>),
     {
         let mut edge_list: Vec<(NodeIndex, NodeIndex, Wire)> = Vec::with_capacity(2);
@@ -6867,7 +6861,6 @@ impl DAGCircuit {
             }
             _ => panic!("Must be called with valid operation node"),
         }
-        Ok(())
     }
 
     pub fn add_global_phase(&mut self, value: &Param) -> PyResult<()> {

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -494,7 +494,7 @@ impl DAGIdentifierInfo {
 impl DAGCircuit {
     #[new]
     pub fn py_new(py: Python) -> PyResult<Self> {
-        let mut out = Self::new()?;
+        let mut out = Self::new();
         out.metadata = Some(PyDict::new(py).unbind().into());
         Ok(out)
     }
@@ -4483,8 +4483,8 @@ impl<'a> DAGCircuit {
 }
 
 impl DAGCircuit {
-    pub fn new() -> PyResult<Self> {
-        Ok(DAGCircuit {
+    pub fn new() -> Self {
+        DAGCircuit {
             name: None,
             metadata: None,
             dag: StableDiGraph::default(),
@@ -4511,7 +4511,7 @@ impl DAGCircuit {
             vars_declare: HashSet::new(),
             stretches_capture: HashSet::new(),
             stretches_declare: Vec::new(),
-        })
+        }
     }
 
     /// Create an empty DAG, but with all the same qubit data, classical data and metadata
@@ -6955,7 +6955,7 @@ impl DAGCircuit {
         PyErr: From<E>,
     {
         let mut new_nodes = Vec::new();
-        let mut replacement_dag = DAGCircuit::new()?;
+        let mut replacement_dag = DAGCircuit::new();
         std::mem::swap(self, &mut replacement_dag);
         let mut dag_builder = replacement_dag.into_builder();
         for inst in iter {
@@ -7964,7 +7964,7 @@ mod test {
     fn new_dag(qubits: u32, clbits: u32) -> DAGCircuit {
         let qreg = QuantumRegister::new_owning("q".to_owned(), qubits);
         let creg = ClassicalRegister::new_owning("c".to_owned(), clbits);
-        let mut dag = DAGCircuit::new().unwrap();
+        let mut dag = DAGCircuit::new();
         dag.add_qreg(qreg).unwrap();
         dag.add_creg(creg).unwrap();
         dag
@@ -8140,7 +8140,7 @@ mod test {
 
     #[test]
     fn test_physical_empty_like() -> PyResult<()> {
-        let mut dag = DAGCircuit::new()?;
+        let mut dag = DAGCircuit::new();
         let qr = QuantumRegister::new_owning("virtual".to_owned(), 5);
         let cr = ClassicalRegister::new_owning("classical".to_owned(), 5);
         dag.name = Some("my dag".to_owned());

--- a/crates/synthesis/src/two_qubit_decompose.rs
+++ b/crates/synthesis/src/two_qubit_decompose.rs
@@ -2236,8 +2236,7 @@ impl TwoQubitBasisDecomposer {
     ) -> PyResult<DAGCircuit> {
         let sequence =
             self.generate_sequence(unitary, basis_fidelity, approximate, _num_basis_uses)?;
-        let mut dag =
-            DAGCircuit::with_capacity(2, 0, None, Some(sequence.gates.len()), None, None)?;
+        let mut dag = DAGCircuit::with_capacity(2, 0, None, Some(sequence.gates.len()), None, None);
         dag.set_global_phase(Param::Float(sequence.global_phase))?;
         dag.add_qubit_unchecked(ShareableQubit::new_anonymous())?;
         dag.add_qubit_unchecked(ShareableQubit::new_anonymous())?;

--- a/crates/transpiler/src/passes/basis_translator/compose_transforms.rs
+++ b/crates/transpiler/src/passes/basis_translator/compose_transforms.rs
@@ -52,7 +52,7 @@ pub(super) fn compose_transforms<'a>(
             .call1((&gate_name, num_params))?
             .extract()?;
 
-        let mut dag = DAGCircuit::new()?;
+        let mut dag = DAGCircuit::new();
         // Create the mock gate and add to the circuit, use Python for this.
         let qubits = QuantumRegister::new_owning("q".to_string(), gate_num_qubits);
         dag.add_qreg(qubits)?;

--- a/crates/transpiler/src/passes/disjoint_layout.rs
+++ b/crates/transpiler/src/passes/disjoint_layout.rs
@@ -564,7 +564,7 @@ fn split_barriers(dag: &mut DAGCircuit) -> PyResult<()> {
             Some(label) => format!("{}_uuid={}", label, Uuid::new_v4()),
             None => format!("_none_uuid={}", Uuid::new_v4()),
         };
-        let mut split_dag = DAGCircuit::new()?;
+        let mut split_dag = DAGCircuit::new();
         for q in 0..num_qubits {
             split_dag.add_qubit_unchecked(ShareableQubit::new_anonymous())?;
             split_dag.apply_operation_back(

--- a/crates/transpiler/src/passes/gate_direction.rs
+++ b/crates/transpiler/src/passes/gate_direction.rs
@@ -421,7 +421,7 @@ fn apply_operation_back(
 }
 
 fn cx_replacement_dag() -> PyResult<DAGCircuit> {
-    let new_dag = &mut DAGCircuit::new()?;
+    let new_dag = &mut DAGCircuit::new();
     let qargs = add_qreg(new_dag, 2)?;
     let qargs = qargs.as_slice();
 
@@ -435,7 +435,7 @@ fn cx_replacement_dag() -> PyResult<DAGCircuit> {
 }
 
 fn ecr_replacement_dag() -> PyResult<DAGCircuit> {
-    let new_dag = &mut DAGCircuit::new()?;
+    let new_dag = &mut DAGCircuit::new();
     new_dag.add_global_phase(&Param::Float(-PI / 2.0))?;
     let qargs = add_qreg(new_dag, 2)?;
     let qargs = qargs.as_slice();
@@ -454,7 +454,7 @@ fn ecr_replacement_dag() -> PyResult<DAGCircuit> {
 }
 
 fn cz_replacement_dag() -> PyResult<DAGCircuit> {
-    let new_dag = &mut DAGCircuit::new()?;
+    let new_dag = &mut DAGCircuit::new();
     let qargs = add_qreg(new_dag, 2)?;
     let qargs = qargs.as_slice();
 
@@ -464,7 +464,7 @@ fn cz_replacement_dag() -> PyResult<DAGCircuit> {
 }
 
 fn swap_replacement_dag() -> PyResult<DAGCircuit> {
-    let new_dag = &mut DAGCircuit::new()?;
+    let new_dag = &mut DAGCircuit::new();
     let qargs = add_qreg(new_dag, 2)?;
     let qargs = qargs.as_slice();
 
@@ -474,7 +474,7 @@ fn swap_replacement_dag() -> PyResult<DAGCircuit> {
 }
 
 fn rxx_replacement_dag(param: &[Param]) -> PyResult<DAGCircuit> {
-    let new_dag = &mut DAGCircuit::new()?;
+    let new_dag = &mut DAGCircuit::new();
     let qargs = add_qreg(new_dag, 2)?;
     let qargs = qargs.as_slice();
 
@@ -489,7 +489,7 @@ fn rxx_replacement_dag(param: &[Param]) -> PyResult<DAGCircuit> {
 }
 
 fn ryy_replacement_dag(param: &[Param]) -> PyResult<DAGCircuit> {
-    let new_dag = &mut DAGCircuit::new()?;
+    let new_dag = &mut DAGCircuit::new();
     let qargs = add_qreg(new_dag, 2)?;
     let qargs = qargs.as_slice();
 
@@ -504,7 +504,7 @@ fn ryy_replacement_dag(param: &[Param]) -> PyResult<DAGCircuit> {
 }
 
 fn rzz_replacement_dag(param: &[Param]) -> PyResult<DAGCircuit> {
-    let new_dag = &mut DAGCircuit::new()?;
+    let new_dag = &mut DAGCircuit::new();
     let qargs = add_qreg(new_dag, 2)?;
     let qargs = qargs.as_slice();
 
@@ -519,7 +519,7 @@ fn rzz_replacement_dag(param: &[Param]) -> PyResult<DAGCircuit> {
 }
 
 fn rzx_replacement_dag(param: &[Param]) -> PyResult<DAGCircuit> {
-    let new_dag = &mut DAGCircuit::new()?;
+    let new_dag = &mut DAGCircuit::new();
     let qargs = add_qreg(new_dag, 2)?;
     let qargs = qargs.as_slice();
 

--- a/crates/transpiler/src/passes/split_2q_unitaries.rs
+++ b/crates/transpiler/src/passes/split_2q_unitaries.rs
@@ -89,7 +89,7 @@ pub fn run_split_2q_unitaries(
                         (PackedOperation::from_unitary(k1l_gate), smallvec![])
                     }
                 };
-                dag.replace_node_with_1q_ops(py, node, insert_fn)?;
+                dag.replace_node_with_1q_ops(py, node, insert_fn);
                 dag.add_global_phase(&Param::Float(decomp.global_phase))?;
             }
         }


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The ``new`` method is infallible so we can remove the PyResult wrapper, which simplifies error handling further down the pipelines.

### Details and comments

Came up in https://github.com/Qiskit/qiskit/pull/14659#discussion_r2278471512 and will simplify the logic in that PR.