### PR TITLE
Fix docstrings for CheckMap pass and tests

### DIFF
--- a/qiskit/transpiler/passes/utils/check_map.py
+++ b/qiskit/transpiler/passes/utils/check_map.py
@@ -36,8 +36,8 @@ class CheckMap(AnalysisPass):
         Args:
             coupling_map (Union[CouplingMap, Target]): Directed graph representing a coupling map.
             property_set_field (str): An optional string to specify the property set field to
-                store the result of the check. If not default the result is stored in
-                ``"is_swap_mapped"``.
+                store the result of the check. If not provided the result is stored in
+                the property set field ``"is_swap_mapped"``.
         """
         super().__init__()
         if property_set_field is None:
@@ -59,8 +59,8 @@ class CheckMap(AnalysisPass):
     def run(self, dag):
         """Run the CheckMap pass on `dag`.
 
-        If `dag` is mapped to `coupling_map`, the property
-        `is_swap_mapped` is set to True (or to False otherwise).
+        If ``dag`` is mapped to the configured :class:`.Target`, the property whose name is
+        specified in ``self.property_set_field`` is set to ``True`` (or to ``False`` otherwise).
 
         Args:
             dag (DAGCircuit): DAG to map.

--- a/test/python/transpiler/test_check_map.py
+++ b/test/python/transpiler/test_check_map.py
@@ -65,11 +65,14 @@ class TestCheckMapCX(QiskitTestCase):
 
     def test_swap_mapped_true(self):
         """Mapped is easy to check
-        qr0:--(+)-[H]-(+)-
-               |       |
-        qr1:---.-------|--
-                       |
-        qr2:-----------.--
+
+                   ┌───┐
+        qr_0: ──■──┤ H ├──■──
+              ┌─┴─┐└───┘  │
+        qr_1: ┤ X ├───────┼──
+              └───┘     ┌─┴─┐
+        qr_2: ──────────┤ X ├
+                        └───┘
 
         CouplingMap map: [1]--[0]--[2]
         """
@@ -88,9 +91,11 @@ class TestCheckMapCX(QiskitTestCase):
 
     def test_swap_mapped_false(self):
         """Needs [0]-[1] in a [0]--[2]--[1]
-        qr0:--(+)--
-               |
-        qr1:---.---
+
+        qr_0: ──■──
+              ┌─┴─┐
+        qr_1: ┤ X ├
+              └───┘
 
         CouplingMap map: [0]--[2]--[1]
         """
@@ -107,9 +112,11 @@ class TestCheckMapCX(QiskitTestCase):
 
     def test_swap_mapped_false_target(self):
         """Needs [0]-[1] in a [0]--[2]--[1]
-        qr0:--(+)--
-               |
-        qr1:---.---
+
+        qr_0: ──■──
+              ┌─┴─┐
+        qr_1: ┤ X ├
+              └───┘
 
         CouplingMap map: [0]--[2]--[1]
         """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes something pointed out in the review of #14885 where the docstring for the CheckMap transpiler pass where it wasn't clearly documenting the behavior of the pass. Additionally, there were mistakes in some test docstrings. This was spun out into a separate PR so it could be backported to fix the documentation in stable releases.

### Details and comments


