### PR TITLE
Fix globbing in copyright-header lint script

### DIFF
--- a/crates/cext/include/complex.h
+++ b/crates/cext/include/complex.h
@@ -1,3 +1,15 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
 #ifndef QISKIT__COMPLEX_H
 #define QISKIT__COMPLEX_H
 

--- a/crates/cext/src/transpiler/passes/elide_permutations.rs
+++ b/crates/cext/src/transpiler/passes/elide_permutations.rs
@@ -1,3 +1,5 @@
+// This code is part of Qiskit.
+//
 // (C) Copyright IBM 2025
 //
 // This code is licensed under the Apache License, Version 2.0. You may

--- a/crates/cext/src/transpiler/passes/mod.rs
+++ b/crates/cext/src/transpiler/passes/mod.rs
@@ -1,3 +1,15 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+//
 pub mod elide_permutations;
 pub mod remove_diagonal_gates_before_measure;
 pub mod remove_identity_equiv;

--- a/crates/circuit/src/classical/mod.rs
+++ b/crates/circuit/src/classical/mod.rs
@@ -4,6 +4,9 @@
 //
 // This code is licensed under the Apache License, Version 2.0. You may
 // obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 

--- a/crates/circuit/src/parameter/mod.rs
+++ b/crates/circuit/src/parameter/mod.rs
@@ -1,3 +1,15 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
 pub mod parameter_expression;
 pub mod symbol_expr;
 pub mod symbol_parser;

--- a/tools/verify_headers.py
+++ b/tools/verify_headers.py
@@ -36,7 +36,7 @@ def discover_files(code_paths):
         for path in code_paths
         for file in pathlib.Path(path).glob(f"**/*.{extension}")
         # CMake generates some files inside the tree.
-        if not file.full_match("test/c/build/**")
+        if not file.is_relative_to("test/c/build")
     ]
 
 

--- a/tools/verify_headers.py
+++ b/tools/verify_headers.py
@@ -18,6 +18,7 @@
 import argparse
 import multiprocessing
 import os
+import pathlib
 import sys
 import re
 
@@ -29,18 +30,14 @@ copyright_line = re.compile(r"^(\/\/|#) \(C\) Copyright IBM 20")
 
 def discover_files(code_paths):
     """Find all .py, .rs, .c, and .h files in a list of trees"""
-    out_paths = []
-    for path in code_paths:
-        if os.path.isfile(path):
-            out_paths.append(path)
-        else:
-            for directory in os.walk(path):
-                dir_path = directory[0]
-                for subfile in directory[2]:
-                    ending = subfile.rsplit(".", 1)[-1]
-                    if ending in (".py", ".rs", ".c", ".h"):
-                        out_paths.append(os.path.join(dir_path, subfile))
-    return out_paths
+    return [
+        file
+        for extension in ("py", "rs", "c", "h")
+        for path in code_paths
+        for file in pathlib.Path(path).glob(f"**/*.{extension}")
+        # CMake generates some files inside the tree.
+        if not file.full_match("test/c/build/**")
+    ]
 
 
 def validate_header(file_path):
@@ -84,8 +81,7 @@ def validate_header(file_path):
             start = index
             break
 
-    ending = file_path.rsplit(".", 1)[-1]
-    if ending in (".rs", ".c", ".h"):
+    if file_path.suffix in (".rs", ".c", ".h"):
         if "".join(lines[start : start + 2]) != header_slashes:
             return (file_path, False, f"Header up to copyright line does not match: {header}")
         if not copyright_line.search(lines[start + 2]):


### PR DESCRIPTION
The previous version made strong assumptions about what the directory structure looked like, which does not agree with reality.  This generalises it to regular recursive globbing.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


