### PR TITLE
Fix `PauliEvolutionGate.to_matrix` to return the exact matrix exponential

### DIFF
--- a/releasenotes/notes/fix-paulievo-matrix-5fdcad75c8f568ec.yaml
+++ b/releasenotes/notes/fix-paulievo-matrix-5fdcad75c8f568ec.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    The :meth:`.PauliEvolutionGate.to_matrix` method now returns the exact matrix
+    exponential :math:`\exp(-it H)`, where :math:`H` is the ``operator`` and :math:`t`
+    the ``time`` passed to the gate. This fixes an unexpected behavior, since the
+    :class:`.PauliEvolutionGate` is documented to represent the *exact* time evolution,
+    but previously the matrix was dependent on how the compiler approximates the
+    time evolution. The ``to_matrix`` method is now consistent with the documentation.

--- a/releasenotes/notes/improve-paulievo-power-control-ff73d1ab0d213493.yaml
+++ b/releasenotes/notes/improve-paulievo-power-control-ff73d1ab0d213493.yaml
@@ -1,7 +1,10 @@
 ---
 features_circuits:
   - |
-    Improved :meth:`.PauliEvolutionGate.control` and :meth:`.PauliEvolutionGate.power` to return
-    more efficient representations in terms of a :class:`.PauliEvolutionGate`. This change leads
-    to significantly shallower circuits and gate counts compared to the previously used
-    generic power and control mechanisms.
+    Improved :meth:`.PauliEvolutionGate.control`, :meth:`.PauliEvolutionGate.power` and 
+    :meth:`.PauliEvolutionGate.inverse` to return more efficient representations in terms of 
+    a :class:`.PauliEvolutionGate`. For computing the controlled and exponentiated versions of the 
+    evolution gate this change leads to significantly shallower circuits and lower
+    gate counts compared to the previously used generic mechanisms. The inverse decomposition
+    does not change but is now generated more efficiently and allows for better compiler 
+    optimizations.

--- a/test/python/circuit/library/test_evolution_gate.py
+++ b/test/python/circuit/library/test_evolution_gate.py
@@ -60,16 +60,37 @@ class TestEvolutionGate(QiskitTestCase):
         self.assertTrue(Operator(gate).equiv(exact_gate))
 
     def test_matrix_decomposition(self):
-        """Test the default decomposition."""
+        """Test the matrix decomposition."""
         op = (X ^ X ^ X) + (Y ^ Y ^ Y) + (Z ^ Z ^ Z)
         time = 0.123
 
         matrix = op.to_matrix()
         evolved = scipy.linalg.expm(-1j * time * matrix)
 
-        evo_gate = PauliEvolutionGate(op, time, synthesis=MatrixExponential())
+        with self.subTest(msg="test MatrixExponential"):
+            evo_gate = PauliEvolutionGate(op, time, synthesis=MatrixExponential())
+            self.assertTrue(Operator(evo_gate).equiv(evolved))
 
-        self.assertTrue(Operator(evo_gate).equiv(evolved))
+        with self.subTest(msg="test to_matrix"):
+            evo_gate = PauliEvolutionGate(op, time)
+            self.assertTrue(np.allclose(evolved, evo_gate.to_matrix()))
+
+    def test_to_matrix_commuting_blocks(self):
+        """Test to_matrix if the evolution is specified with commuting blocks."""
+        block_1q = (X ^ I) + (I ^ X)
+        block_2q = (X ^ X) + (Y ^ Y) + (Z ^ Z)
+
+        evo = PauliEvolutionGate([block_1q, block_2q])
+        matrix = evo.to_matrix()
+
+        expected = PauliEvolutionGate(block_1q + block_2q).to_matrix()
+        self.assertTrue(np.allclose(expected, matrix))
+
+    def test_to_matrix_invalid_time(self):
+        """Test calling to_matrix with a non-numeric time fails."""
+        evo = PauliEvolutionGate(Z, time=Parameter("time"))
+        with self.assertRaises(ValueError):
+            _ = evo.to_matrix()
 
     def test_reorder_paulis_invariant(self):
         """
@@ -430,6 +451,19 @@ class TestEvolutionGate(QiskitTestCase):
         circuit.append(evo.inverse(), circuit.qubits)
 
         self.assertTrue(Operator(circuit).equiv(np.identity(2**circuit.num_qubits)))
+
+    def test_inverse_to_matrix(self):
+        """Test inverse().to_matrix()."""
+        op = X + Y
+        time = 0.512
+        exact = scipy.linalg.expm(-1j * time * op.to_matrix())
+        exact_inv = np.transpose(np.conjugate(exact))
+
+        evo = PauliEvolutionGate(op, time)
+        evo_inv = evo.inverse()
+
+        self.assertTrue(np.allclose(exact, evo.to_matrix()))
+        self.assertTrue(np.allclose(exact_inv, evo_inv.to_matrix()))
 
     def test_power(self):
         """Test calling the power method."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR updates `PauliEvolutionGate.to_matrix` to return the exact matrix exponential $exp(-it H)$. This fixes an unexpected behavior, since the `PauliEvolutionGate` is documented to represent the *exact* time evolution (#14581 clarifies the docstring on this), but previously the matrix was dependent on the how the compiler approximates the time evolution. 

To make this change consistent,`PauliEvolutionGate.inverse` has been updated to return a `PauliEvolutionGate` instead of a generic `Gate` to ensure that calling ``to_matrix`` on the inverse still provides the exact matrix exponential.

### Details and comments

I don't think we need to backport this since this change makes most sense after #14581 and there haven't been any bug reports in the past on this. It might be safer to just include this in 2.2 together with #14581.

