### PR TITLE
Set up C tests to fail upon warnings

### DIFF
--- a/crates/cext/include/complex.h
+++ b/crates/cext/include/complex.h
@@ -29,10 +29,10 @@ typedef struct {
 // Complex number typedefs conversions.
 #ifdef __cplusplus
 #include <complex>
-static std::complex<double> qk_complex64_to_native(QkComplex64 *value) {
+static inline std::complex<double> qk_complex64_to_native(QkComplex64 *value) {
     return std::complex<double>(value->re, value->im);
 }
-static QkComplex64 qk_complex64_from_native(std::complex<double> *value) {
+static inline QkComplex64 qk_complex64_from_native(std::complex<double> *value) {
     QkComplex64 ret = {value->real(), value->imag()};
     return ret;
 }
@@ -40,17 +40,17 @@ static QkComplex64 qk_complex64_from_native(std::complex<double> *value) {
 #include <complex.h>
 
 #ifdef _MSC_VER
-static _Dcomplex qk_complex64_to_native(QkComplex64 *value) {
+static inline _Dcomplex qk_complex64_to_native(QkComplex64 *value) {
     return (_Dcomplex){value->re, value->im};
 }
-static QkComplex64 qk_complex64_from_native(_Dcomplex *value) {
+static inline QkComplex64 qk_complex64_from_native(_Dcomplex *value) {
     return (QkComplex64){creal(*value), cimag(*value)};
 }
 #else
-static double _Complex qk_complex64_to_native(QkComplex64 *value) {
+static inline double _Complex qk_complex64_to_native(QkComplex64 *value) {
     return value->re + I * value->im;
 }
-static QkComplex64 qk_complex64_from_native(double _Complex *value) {
+static inline QkComplex64 qk_complex64_from_native(double _Complex *value) {
     return (QkComplex64){creal(*value), cimag(*value)};
 }
 #endif // _MSC_VER

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required (VERSION 3.27)
 
 # We fail upon any warnings.
 if (MSVC) 
-    add_compile_options(/W4 /WX)
+    add_compile_options(/W3 /WX)
 else ()
     add_compile_options(-Wall -Wextra -Werror -Wshadow)
 endif ()

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -3,6 +3,9 @@
 # https://cmake.org/cmake/help/book/mastering-cmake/chapter/Testing%20With%20CMake%20and%20CTest.html
 cmake_minimum_required (VERSION 3.27)
 
+# We fail upon any warnings.
+add_compile_options(-Wall -Wextra -Werror)
+
 # All files in this directory (non-recursively! use GLOB_RECURSE if that becomes
 # necessary) which match the pattern `test_*.c` are discovered as test files by
 # the command below. All paths are stored relative to the location of this file.

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -3,10 +3,11 @@
 # https://cmake.org/cmake/help/book/mastering-cmake/chapter/Testing%20With%20CMake%20and%20CTest.html
 cmake_minimum_required (VERSION 3.27)
 
-# We fail upon any warnings.
-if (MSVC) 
-    add_compile_options(/W2 /WX)
-else ()
+# On GCC compilers, we fail upon any warnings. MSVC is not included since compiler warnings
+# differ to GCC and we only commit to a single standard which is tested in CI.
+# On MSVC, using the options /W2 /WX get close to the below, but might not include additional checks 
+# that we require in CI. 
+if (NOT MSVC) 
     add_compile_options(-Wall -Wextra -Werror -Wshadow)
 endif ()
 

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -4,7 +4,11 @@
 cmake_minimum_required (VERSION 3.27)
 
 # We fail upon any warnings.
-add_compile_options(-Wall -Wextra -Werror)
+if (MSVC) 
+    add_compile_options(/W4 /WX)
+else ()
+    add_compile_options(-Wall -Wextra -Werror)
+endif ()
 
 # All files in this directory (non-recursively! use GLOB_RECURSE if that becomes
 # necessary) which match the pattern `test_*.c` are discovered as test files by

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required (VERSION 3.27)
 if (MSVC) 
     add_compile_options(/W4 /WX)
 else ()
-    add_compile_options(-Wall -Wextra -Werror)
+    add_compile_options(-Wall -Wextra -Werror -Wshadow)
 endif ()
 
 # All files in this directory (non-recursively! use GLOB_RECURSE if that becomes

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required (VERSION 3.27)
 
 # We fail upon any warnings.
 if (MSVC) 
-    add_compile_options(/W3 /WX)
+    add_compile_options(/W2 /WX)
 else ()
     add_compile_options(-Wall -Wextra -Werror -Wshadow)
 endif ()

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -3,10 +3,11 @@
 # https://cmake.org/cmake/help/book/mastering-cmake/chapter/Testing%20With%20CMake%20and%20CTest.html
 cmake_minimum_required (VERSION 3.27)
 
-# On GCC compilers, we fail upon any warnings. MSVC is not included since compiler warnings
-# differ to GCC and we only commit to a single standard which is tested in CI.
-# On MSVC, using the options /W2 /WX get close to the below, but might not include additional checks 
-# that we require in CI. 
+# On GCC and Clang compilers, we fail upon any warnings and CI requires no warnings for these 
+# compilers. 
+# MSVC is not included since compiler warnings differ signficantly. Using the MSVC options /W2 /WX 
+# get close to the below, but might not include additional checks that we require in CI 
+# (and /W3 /WX includes some we do not require). 
 if (NOT MSVC) 
     add_compile_options(-Wall -Wextra -Werror -Wshadow)
 endif ()

--- a/test/c/common.c
+++ b/test/c/common.c
@@ -74,14 +74,14 @@ bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
         qk_circuit_get_instruction(expected, i, &expected_inst);
         int result = strcmp(res_inst.name, expected_inst.name);
         if (result != 0) {
-            printf("Gate %d have different gates %s was found and expected %s\n", i, res_inst.name,
+            printf("Gate %zu have different gates %s was found and expected %s\n", i, res_inst.name,
                    expected_inst.name);
             qk_circuit_instruction_clear(&res_inst);
             qk_circuit_instruction_clear(&expected_inst);
             return false;
         }
         if (res_inst.num_qubits != expected_inst.num_qubits) {
-            printf("Gate %d have different number of qubits %d was found and expected %d\n", i,
+            printf("Gate %zu have different number of qubits %d was found and expected %d\n", i,
                    res_inst.num_qubits, expected_inst.num_qubits);
             qk_circuit_instruction_clear(&res_inst);
             qk_circuit_instruction_clear(&expected_inst);
@@ -89,8 +89,8 @@ bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
         }
         for (uint32_t j = 0; j < res_inst.num_qubits; j++) {
             if (res_inst.qubits[j] != expected_inst.qubits[j]) {
-                printf("Qubit %d for gate %d are different %d was found and expected %d\n", j, i,
-                       res_inst.qubits[j] != expected_inst.qubits[j]);
+                printf("Qubit %d for gate %zu are different %d was found and expected %d\n", j, i,
+                       res_inst.qubits[j], expected_inst.qubits[j]);
                 printf("Expected circuit instructions:\n");
                 print_circuit(expected);
                 printf("Result circuit:\n");
@@ -101,7 +101,7 @@ bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
             }
         }
         if (res_inst.num_clbits != expected_inst.num_clbits) {
-            printf("Gate %d have different number of clbits %d was found and expected %d\n", i,
+            printf("Gate %zu have different number of clbits %d was found and expected %d\n", i,
                    res_inst.num_clbits, expected_inst.num_clbits);
             qk_circuit_instruction_clear(&res_inst);
             qk_circuit_instruction_clear(&expected_inst);
@@ -109,15 +109,15 @@ bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
         }
         for (uint32_t j = 0; j < res_inst.num_clbits; j++) {
             if (res_inst.clbits[j] != expected_inst.clbits[j]) {
-                printf("Clbit %d for gate %d are different %d was found and expected %d\n", j, i,
-                       res_inst.clbits[j] != expected_inst.clbits[j]);
+                printf("Clbit %d for gate %zu are different %d was found and expected %d\n", j, i,
+                       res_inst.clbits[j], expected_inst.clbits[j]);
                 qk_circuit_instruction_clear(&res_inst);
                 qk_circuit_instruction_clear(&expected_inst);
                 return false;
             }
         }
         if (res_inst.num_params != expected_inst.num_params) {
-            printf("Gate %d have different number of params %d was found and expected %d\n", i,
+            printf("Gate %zu have different number of params %d was found and expected %d\n", i,
                    res_inst.num_params, expected_inst.num_params);
             qk_circuit_instruction_clear(&res_inst);
             qk_circuit_instruction_clear(&expected_inst);
@@ -125,8 +125,8 @@ bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
         }
         for (uint32_t j = 0; j < res_inst.num_params; j++) {
             if (res_inst.params[j] != expected_inst.params[j]) {
-                printf("Parameter %d for gate %d are different %d was found and expected %d\n", j,
-                       i, res_inst.params[j] != expected_inst.params[j]);
+                printf("Parameter %d for gate %zu are different %f was found and expected %f\n", j,
+                       i, res_inst.params[j], expected_inst.params[j]);
                 qk_circuit_instruction_clear(&res_inst);
                 qk_circuit_instruction_clear(&expected_inst);
                 return false;

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -590,8 +590,8 @@ int test_get_gate_counts_bv_resets_barrier_and_measures(void) {
             if (result != 0) {
                 goto loop_exit;
             }
-            for (uint32_t j = 0; i < 1000; j++) {
-                if (inst.qubits[i] != i) {
+            for (uint32_t j = 0; j < 1000; j++) {
+                if (inst.qubits[j] != j) {
                     result = EqualityError;
                     goto loop_exit;
                 }
@@ -622,8 +622,8 @@ int test_get_gate_counts_bv_resets_barrier_and_measures(void) {
             if (result != 0) {
                 goto loop_exit;
             }
-            for (uint32_t j = 0; i < 1000; j++) {
-                if (inst.qubits[i] != i) {
+            for (uint32_t j = 0; j < 1000; j++) {
+                if (inst.qubits[j] != j) {
                     result = EqualityError;
                     goto loop_exit;
                 }

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -257,20 +257,22 @@ int test_gate_num_params(void) {
 int test_get_gate_counts_bv_no_measure(void) {
     QkCircuit *qc = qk_circuit_new(1000, 1000);
     double *params = NULL;
-    uint32_t i = 0;
-    uint32_t qubits[1] = {999};
-    qk_circuit_gate(qc, QkGate_X, qubits, params);
+    uint32_t i;
+    uint32_t q1[1] = {999};
+    uint32_t q2[2] = {0, 999};
+
+    qk_circuit_gate(qc, QkGate_X, q1, params);
     for (i = 0; i < 1000; i++) {
-        uint32_t qubits[1] = {i};
-        qk_circuit_gate(qc, QkGate_H, qubits, params);
+        q1[0] = i;
+        qk_circuit_gate(qc, QkGate_H, q1, params);
     }
     for (i = 0; i < 1000; i += 2) {
-        uint32_t qubits[2] = {i, 999};
-        qk_circuit_gate(qc, QkGate_CX, qubits, params);
+        q2[0] = i;
+        qk_circuit_gate(qc, QkGate_CX, q2, params);
     }
     for (i = 0; i < 999; i++) {
-        uint32_t qubits[1] = {i};
-        qk_circuit_gate(qc, QkGate_H, qubits, params);
+        q1[0] = i;
+        qk_circuit_gate(qc, QkGate_H, q1, params);
     }
     QkOpCounts op_counts = qk_circuit_count_ops(qc);
     int result = Ok;
@@ -311,20 +313,22 @@ cleanup:
 int test_get_gate_counts_bv_measures(void) {
     QkCircuit *qc = qk_circuit_new(1000, 1000);
     double *params = NULL;
-    uint32_t i = 0;
-    uint32_t qubits[1] = {999};
-    qk_circuit_gate(qc, QkGate_X, qubits, params);
+    uint32_t i;
+    uint32_t q1[1] = {999};
+    uint32_t q2[2] = {0, 999};
+
+    qk_circuit_gate(qc, QkGate_X, q1, params);
     for (i = 0; i < 1000; i++) {
-        uint32_t qubits[1] = {i};
-        qk_circuit_gate(qc, QkGate_H, qubits, params);
+        q1[0] = i;
+        qk_circuit_gate(qc, QkGate_H, q1, params);
     }
     for (i = 0; i < 1000; i += 2) {
-        uint32_t qubits[2] = {i, 999};
-        qk_circuit_gate(qc, QkGate_CX, qubits, params);
+        q2[0] = i;
+        qk_circuit_gate(qc, QkGate_CX, q2, params);
     }
     for (i = 0; i < 999; i++) {
-        uint32_t qubits[1] = {i};
-        qk_circuit_gate(qc, QkGate_H, qubits, params);
+        q1[0] = i;
+        qk_circuit_gate(qc, QkGate_H, q1, params);
     }
     for (i = 0; i < 999; i++) {
         qk_circuit_measure(qc, i, i);
@@ -376,12 +380,14 @@ cleanup:
 int test_get_gate_counts_bv_barrier_and_measures(void) {
     QkCircuit *qc = qk_circuit_new(1000, 1000);
     double *params = NULL;
-    uint32_t i = 0;
-    uint32_t qubits[1] = {999};
-    qk_circuit_gate(qc, QkGate_X, qubits, params);
+    uint32_t i;
+    uint32_t q1[1] = {999};
+    uint32_t q2[2] = {0, 999};
+
+    qk_circuit_gate(qc, QkGate_X, q1, params);
     for (i = 0; i < 1000; i++) {
-        uint32_t qubits[1] = {i};
-        qk_circuit_gate(qc, QkGate_H, qubits, params);
+        q1[0] = i;
+        qk_circuit_gate(qc, QkGate_H, q1, params);
     }
     uint32_t barrier_qubits[1000];
     for (i = 0; i < 1000; i++) {
@@ -389,13 +395,13 @@ int test_get_gate_counts_bv_barrier_and_measures(void) {
     }
     qk_circuit_barrier(qc, barrier_qubits, 1000);
     for (i = 0; i < 1000; i += 2) {
-        uint32_t qubits[2] = {i, 999};
-        qk_circuit_gate(qc, QkGate_CX, qubits, params);
+        q2[0] = i;
+        qk_circuit_gate(qc, QkGate_CX, q2, params);
     }
     qk_circuit_barrier(qc, barrier_qubits, 1000);
     for (i = 0; i < 999; i++) {
-        uint32_t qubits[1] = {i};
-        qk_circuit_gate(qc, QkGate_H, qubits, params);
+        q1[0] = i;
+        qk_circuit_gate(qc, QkGate_H, q1, params);
     }
     for (i = 0; i < 999; i++) {
         qk_circuit_measure(qc, i, i);
@@ -456,31 +462,32 @@ cleanup:
 int test_get_gate_counts_bv_resets_barrier_and_measures(void) {
     QkCircuit *qc = qk_circuit_new(1000, 1000);
     double *params = NULL;
-    uint32_t i = 0;
-    uint32_t qubits[1] = {999};
-    for (i = 0; i < 1000; i++) {
+    uint32_t q1[1] = {999};
+    uint32_t q2[2] = {0, 999};
+
+    for (uint32_t i = 0; i < 1000; i++) {
         qk_circuit_reset(qc, i);
     }
-    qk_circuit_gate(qc, QkGate_X, qubits, params);
-    for (i = 0; i < 1000; i++) {
-        uint32_t qubits[1] = {i};
-        qk_circuit_gate(qc, QkGate_H, qubits, params);
+    qk_circuit_gate(qc, QkGate_X, q1, params);
+    for (uint32_t i = 0; i < 1000; i++) {
+        q1[0] = i;
+        qk_circuit_gate(qc, QkGate_H, q1, params);
     }
     uint32_t barrier_qubits[1000];
-    for (i = 0; i < 1000; i++) {
+    for (uint32_t i = 0; i < 1000; i++) {
         barrier_qubits[i] = i;
     }
     qk_circuit_barrier(qc, barrier_qubits, 1000);
-    for (i = 0; i < 1000; i += 2) {
-        uint32_t qubits[2] = {i, 999};
-        qk_circuit_gate(qc, QkGate_CX, qubits, params);
+    for (uint32_t i = 0; i < 1000; i += 2) {
+        q2[0] = i;
+        qk_circuit_gate(qc, QkGate_CX, q2, params);
     }
     qk_circuit_barrier(qc, barrier_qubits, 1000);
-    for (i = 0; i < 999; i++) {
-        uint32_t qubits[1] = {i};
-        qk_circuit_gate(qc, QkGate_H, qubits, params);
+    for (uint32_t i = 0; i < 999; i++) {
+        q1[0] = i;
+        qk_circuit_gate(qc, QkGate_H, q1, params);
     }
-    for (i = 0; i < 999; i++) {
+    for (uint32_t i = 0; i < 999; i++) {
         qk_circuit_measure(qc, i, i);
     }
     QkOpCounts op_counts = qk_circuit_count_ops(qc);

--- a/test/c/test_elide_permutations.c
+++ b/test/c/test_elide_permutations.c
@@ -48,8 +48,6 @@ int test_elide_permutations_no_result(void) {
  * Test running the path with no elision.
  */
 int test_elide_permutations_swap_result(void) {
-    const uint32_t num_qubits = 5;
-
     QkCircuit *qc = qk_circuit_new(5, 0);
     uint32_t swap_qargs[2] = {1, 3};
     for (uint32_t i = 0; i < qk_circuit_num_qubits(qc) - 1; i++) {
@@ -84,7 +82,7 @@ int test_elide_permutations_swap_result(void) {
         result = EqualityError;
         goto ops_cleanup;
     }
-    for (int i = 0; i < op_counts.len; i++) {
+    for (size_t i = 0; i < op_counts.len; i++) {
         int swap_gate = strcmp(op_counts.data[i].name, "swap");
         if (swap_gate == 0) {
             printf("Swap gate in circuit which should have been elided\n");

--- a/test/c/test_remove_diagonal_gates_before_measure.c
+++ b/test/c/test_remove_diagonal_gates_before_measure.c
@@ -26,7 +26,7 @@
 int test_remove_z_gate(void) {
     int result = Ok;
     QkCircuit *qc = qk_circuit_new(1, 1);
-    qk_circuit_gate(qc, QkGate_Z, (int[]){0}, NULL);
+    qk_circuit_gate(qc, QkGate_Z, (uint32_t[1]){0}, NULL);
     qk_circuit_measure(qc, 0, 0);
 
     if (2 != qk_circuit_num_instructions(qc)) {

--- a/test/c/test_sabre_layout.c
+++ b/test/c/test_sabre_layout.c
@@ -55,22 +55,22 @@ int test_sabre_layout_applies_layout(void) {
         printf("More than 2 types of gates in circuit, circuit's instructions are:\n");
         print_circuit(qc);
         result = EqualityError;
-        goto layout_cleanup;
+        goto cleanup;
     }
-    for (int i = 0; i < op_counts.len; i++) {
+    for (size_t i = 0; i < op_counts.len; i++) {
         const char *name = op_counts.data[i].name;
         int swap_gate = strcmp(name, "swap");
         int cx_gate = strcmp(name, "cx");
         if (cx_gate != 0 && swap_gate != 0) {
             printf("Gate type of %s found in the circuit which isn't expected\n", name);
             result = EqualityError;
-            goto layout_cleanup;
+            goto cleanup;
         }
         size_t count = op_counts.data[i].count;
         if (swap_gate == 0 && count != 2) {
             printf("Unexpected number of swaps %zu found in the circuit.\n", count);
             result = EqualityError;
-            goto layout_cleanup;
+            goto cleanup;
         }
     }
     uint32_t expected_initial_layout[5] = {1, 0, 2, 3, 4};
@@ -81,7 +81,7 @@ int test_sabre_layout_applies_layout(void) {
             printf("Initial layout maps qubit %d to %d, expected %d instead\n", i,
                    result_initial_layout[i], expected_initial_layout[i]);
             result = EqualityError;
-            goto layout_cleanup;
+            goto cleanup;
         }
     }
 
@@ -93,7 +93,7 @@ int test_sabre_layout_applies_layout(void) {
             printf("Output permutation maps qubit %d to %d, expected %d instead\n", i,
                    result_permutation[i], expected_permutation[i]);
             result = EqualityError;
-            goto layout_cleanup;
+            goto cleanup;
         }
     }
     QkCircuit *expected_circuit = qk_circuit_new(5, 0);
@@ -120,12 +120,10 @@ int test_sabre_layout_applies_layout(void) {
     }
     qk_circuit_free(expected_circuit);
 
-layout_cleanup:
+cleanup:
     qk_opcounts_free(op_counts);
     qk_transpile_layout_free(layout_result);
-circuit_cleanup:
     qk_circuit_free(qc);
-cleanup:
     qk_target_free(target);
     return result;
 }
@@ -171,7 +169,7 @@ int test_sabre_layout_no_swap(void) {
     bool circuit_eq = compare_circuits(qc, expected_circuit);
     if (!circuit_eq) {
         result = EqualityError;
-        goto layout_cleanup;
+        goto cleanup;
     }
     uint32_t expected_initial_layout[5] = {0, 1, 2, 3, 4};
     uint32_t result_initial_layout[5];
@@ -181,7 +179,7 @@ int test_sabre_layout_no_swap(void) {
             printf("Initial layout maps qubit %d to %d, expected %d instead\n", i,
                    result_initial_layout[i], expected_initial_layout[i]);
             result = EqualityError;
-            goto layout_cleanup;
+            goto cleanup;
         }
     }
     uint32_t expected_permutation[5] = {0, 1, 2, 3, 4};
@@ -192,17 +190,16 @@ int test_sabre_layout_no_swap(void) {
             printf("Output permutation maps qubit %d to %d, expected %d instead\n", i,
                    result_permutation[i], expected_permutation[i]);
             result = EqualityError;
-            goto layout_cleanup;
+            goto cleanup;
         }
     }
 
-layout_cleanup:
+cleanup:
     qk_circuit_free(expected_circuit);
     qk_transpile_layout_free(layout_result);
-circuit_cleanup:
     qk_circuit_free(qc);
-cleanup:
     qk_target_free(target);
+
     return result;
 }
 

--- a/test/c/test_sabre_layout.c
+++ b/test/c/test_sabre_layout.c
@@ -58,15 +58,17 @@ int test_sabre_layout_applies_layout(void) {
         goto layout_cleanup;
     }
     for (int i = 0; i < op_counts.len; i++) {
-        int swap_gate = strcmp(op_counts.data[i].name, "swap");
-        int cx_gate = strcmp(op_counts.data[i].name, "cx");
+        const char *name = op_counts.data[i].name;
+        int swap_gate = strcmp(name, "swap");
+        int cx_gate = strcmp(name, "cx");
         if (cx_gate != 0 && swap_gate != 0) {
-            printf("Gate type of %s found in the circuit which isn't expected\n");
+            printf("Gate type of %s found in the circuit which isn't expected\n", name);
             result = EqualityError;
             goto layout_cleanup;
         }
-        if (swap_gate == 0 && op_counts.data[i].count != 2) {
-            printf("Unexpected number of swaps %d found in the circuit.\n");
+        size_t count = op_counts.data[i].count;
+        if (swap_gate == 0 && count != 2) {
+            printf("Unexpected number of swaps %zu found in the circuit.\n", count);
             result = EqualityError;
             goto layout_cleanup;
         }

--- a/test/c/test_split_2q_unitaries.c
+++ b/test/c/test_split_2q_unitaries.c
@@ -88,7 +88,7 @@ int test_split_2q_unitaries_x_y_unitary(void) {
             result = EqualityError;
             goto ops_cleanup;
         }
-        unsigned int count = counts.data[i].count;
+        size_t count = counts.data[i].count;
         if (count != 2) {
             printf("Unexpected gate counts found\n");
             result = EqualityError;
@@ -155,7 +155,7 @@ int test_split_2q_unitaries_swap_x_y_unitary(void) {
             result = EqualityError;
             goto ops_cleanup;
         }
-        unsigned int count = counts.data[i].count;
+        size_t count = counts.data[i].count;
         if (count != 2) {
             printf("Unexpected gate counts found\n");
             result = EqualityError;

--- a/test/c/test_split_2q_unitaries.c
+++ b/test/c/test_split_2q_unitaries.c
@@ -41,7 +41,7 @@ int test_split_2q_unitaries_no_unitaries(void) {
         result = EqualityError;
         goto ops_cleanup;
     }
-    for (int i = 0; i < counts.len; i++) {
+    for (size_t i = 0; i < counts.len; i++) {
         int gate = strcmp(counts.data[i].name, "cx");
         if (gate != 0) {
             printf("gates changed when there should be no circuit changes\n");
@@ -81,7 +81,7 @@ int test_split_2q_unitaries_x_y_unitary(void) {
         result = EqualityError;
         goto ops_cleanup;
     }
-    for (int i = 0; i < counts.len; i++) {
+    for (size_t i = 0; i < counts.len; i++) {
         int gate = strcmp(counts.data[i].name, "unitary");
         if (gate != 0) {
             printf("Gates outside expected set in output circuit\n");
@@ -148,7 +148,7 @@ int test_split_2q_unitaries_swap_x_y_unitary(void) {
         result = EqualityError;
         goto ops_cleanup;
     }
-    for (int i = 0; i < counts.len; i++) {
+    for (size_t i = 0; i < counts.len; i++) {
         int gate = strcmp(counts.data[i].name, "unitary");
         if (gate != 0) {
             printf("Gates outside expected set in output circuit\n");

--- a/test/c/test_target.c
+++ b/test/c/test_target.c
@@ -434,7 +434,7 @@ int test_target_add_instruction(void) {
     }
     size_t num_meas = qk_target_entry_num_properties(meas);
     if (num_meas != 3) {
-        printf("Expected 3 measurement entries but got: %u", num_meas);
+        printf("Expected 3 measurement entries but got: %zu", num_meas);
         result = EqualityError;
         qk_target_entry_free(meas);
         goto cleanup;
@@ -470,7 +470,7 @@ int test_target_add_instruction(void) {
     }
     size_t num_reset = qk_target_entry_num_properties(reset);
     if (num_reset != 3) {
-        printf("Expected 3 reset entries but got: %u", num_reset);
+        printf("Expected 3 reset entries but got: %zu", num_reset);
         result = EqualityError;
         qk_target_entry_free(reset);
         goto cleanup;

--- a/test/c/test_target.c
+++ b/test/c/test_target.c
@@ -441,6 +441,11 @@ int test_target_add_instruction(void) {
     }
 
     QkExitCode result_meas_props = qk_target_add_instruction(target, meas);
+    if (result_meas_props != 0) {
+        printf("Failed adding measurement instruction.");
+        result = EqualityError;
+        goto cleanup;
+    }
     // Number of qubits of the target should remain 3.
     current_num_qubits = qk_target_num_qubits(target);
     if (current_num_qubits != 3) {

--- a/test/c/test_target.c
+++ b/test/c/test_target.c
@@ -432,7 +432,7 @@ int test_target_add_instruction(void) {
         uint32_t q[1] = {i};
         qk_target_entry_add_property(meas, q, 1, 1e-6, 1e-4);
     }
-    uint32_t num_meas = qk_target_entry_num_properties(meas);
+    size_t num_meas = qk_target_entry_num_properties(meas);
     if (num_meas != 3) {
         printf("Expected 3 measurement entries but got: %u", num_meas);
         result = EqualityError;
@@ -468,7 +468,7 @@ int test_target_add_instruction(void) {
         uint32_t q[1] = {i};
         qk_target_entry_add_property(reset, q, 1, 2e-6, 2e-4);
     }
-    uint32_t num_reset = qk_target_entry_num_properties(reset);
+    size_t num_reset = qk_target_entry_num_properties(reset);
     if (num_reset != 3) {
         printf("Expected 3 reset entries but got: %u", num_reset);
         result = EqualityError;

--- a/test/c/test_version_info.c
+++ b/test/c/test_version_info.c
@@ -57,7 +57,7 @@ int test_version(void) {
 /**
  * Test the version macro and HEX version.
  */
-int test_version_macros() {
+int test_version_macros(void) {
     if (QISKIT_VERSION_MAJOR < 0 || QISKIT_VERSION_MINOR < 0 || QISKIT_VERSION_PATCH < 0) {
         return EqualityError;
     }
@@ -69,7 +69,7 @@ int test_version_macros() {
     return Ok;
 }
 
-int test_version_info() {
+int test_version_info(void) {
     int num_failed = 0;
     num_failed += RUN_TEST(test_version);
     num_failed += RUN_TEST(test_version_macros);

--- a/test/c/test_vf2_layout.c
+++ b/test/c/test_vf2_layout.c
@@ -96,7 +96,6 @@ int test_vf2_layout_line(void) {
 
 layout_cleanup:
     qk_vf2_layout_result_free(layout_result);
-circuit_cleanup:
     qk_circuit_free(qc);
 cleanup:
     qk_target_free(target);
@@ -133,7 +132,6 @@ int test_vf2_no_layout_found(void) {
     }
 layout_cleanup:
     qk_vf2_layout_result_free(layout_result);
-circuit_cleanup:
     qk_circuit_free(qc);
 cleanup:
     qk_target_free(target);


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In a couple of places we were using wrong string formatters (e.g. %d instead of %zu), sometimes the number of formatters didn't match the arguments, and sometimes the inline type annotation was too broad (int[] instead of uint32_t[]). 

Interestingly in #14095 this leads to CI failure, maybe something just change in a tool we were using? Anyways it's good to fix these warnings before they accumulate.

### Details and comments


