### PR TITLE
Fix `TranspileLayout.initial_index_layout` with unordered virtuals

### DIFF
--- a/qiskit/transpiler/layout.py
+++ b/qiskit/transpiler/layout.py
@@ -603,10 +603,10 @@ class TranspileLayout:
             output = [None] * self._input_qubit_count
         else:
             output = [None] * len(virtual_map)
-        for index, (virt, phys) in enumerate(virtual_map.items()):
-            if filter_ancillas and index >= self._input_qubit_count:
-                break
+        for virt, phys in virtual_map.items():
             pos = self.input_qubit_mapping[virt]
+            if filter_ancillas and pos >= self._input_qubit_count:
+                continue
             output[pos] = phys
         return output
 

--- a/releasenotes/notes/transpile-layout-initial-index-befe1a1bf3580357.yaml
+++ b/releasenotes/notes/transpile-layout-initial-index-befe1a1bf3580357.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    :meth:`.TranspileLayout.initial_index_layout` will now correctly handle the ``filter_ancillas=True``
+    argument if the virtual qubits in the :attr:`~.TranspileLayout.initial_layout` were not specified
+    by the constructor in index order.


### PR DESCRIPTION
We were previously `enumerate`'ing over a `dict.items()` call.  The "enumeration" index there has nothing to do with the virtual qubits (what we were using it for); it just refers to the order that the bits were added to the dictionary.  There is no reason to think that they should have been in input order.

What's weird is that we did the correct index check only two lines below that.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Fix #14712
