### PR TITLE
Changed exception text for number of qubit/s or classical bit/s of 'o…

### DIFF
--- a/bug solving/test.ipynb
+++ b/bug solving/test.ipynb
@@ -1,0 +1,92 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "2fdb1b8a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import qiskit\n",
+    "from qiskit import QuantumCircuit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5c4fbb3f",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "CircuitError",
+     "evalue": "'Trying to compose another QuantumCircuit with more qubit/s than the defined QuantumCircuit (2 > 1)'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mCircuitError\u001b[39m                              Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[2]\u001b[39m\u001b[32m, line 2\u001b[39m\n\u001b[32m      1\u001b[39m qc = QuantumCircuit(\u001b[32m1\u001b[39m)\n\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m \u001b[43mqc\u001b[49m\u001b[43m.\u001b[49m\u001b[43mcompose\u001b[49m\u001b[43m(\u001b[49m\u001b[43mQuantumCircuit\u001b[49m\u001b[43m(\u001b[49m\u001b[32;43m2\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/qiskit_13935/qiskit/qiskit/circuit/quantumcircuit.py:2114\u001b[39m, in \u001b[36mQuantumCircuit.compose\u001b[39m\u001b[34m(self, other, qubits, clbits, front, inplace, wrap, copy, var_remap, inline_captures)\u001b[39m\n\u001b[32m   2108\u001b[39m \u001b[38;5;66;03m# if other.num_qubits > dest.num_qubits or other.num_clbits > dest.num_clbits:\u001b[39;00m\n\u001b[32m   2109\u001b[39m \u001b[38;5;66;03m#     raise CircuitError(\u001b[39;00m\n\u001b[32m   2110\u001b[39m \u001b[38;5;66;03m#         \"Trying to compose with another QuantumCircuit which has more 'in' edges.\"\u001b[39;00m\n\u001b[32m   2111\u001b[39m \u001b[38;5;66;03m#     )\u001b[39;00m\n\u001b[32m   2113\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m other.num_qubits > dest.num_qubits:\n\u001b[32m-> \u001b[39m\u001b[32m2114\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m CircuitError(\n\u001b[32m   2115\u001b[39m         \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mTrying to compose another QuantumCircuit with more qubit/s than the defined QuantumCircuit (\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mother.num_qubits\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m > \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mdest.num_qubits\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m)\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m   2116\u001b[39m     )\n\u001b[32m   2117\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m other.num_clbits > dest.num_clbits:\n\u001b[32m   2118\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m CircuitError(\n\u001b[32m   2119\u001b[39m         \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mTrying to compose another QuantumCircuit with more classical bit/s than the defined QuantumCircuit (\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mother.num_clbits\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m > \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mdest.num_clbits\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m)\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m   2120\u001b[39m     )\n",
+      "\u001b[31mCircuitError\u001b[39m: 'Trying to compose another QuantumCircuit with more qubit/s than the defined QuantumCircuit (2 > 1)'"
+     ]
+    }
+   ],
+   "source": [
+    "qc = QuantumCircuit(1)\n",
+    "qc.compose(QuantumCircuit(2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d7b2c683",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "CircuitError",
+     "evalue": "'Trying to compose another QuantumCircuit with more classical bit/s than the defined QuantumCircuit (2 > 1)'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mCircuitError\u001b[39m                              Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[3]\u001b[39m\u001b[32m, line 2\u001b[39m\n\u001b[32m      1\u001b[39m qc = QuantumCircuit(\u001b[32m1\u001b[39m, \u001b[32m1\u001b[39m)\n\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m \u001b[43mqc\u001b[49m\u001b[43m.\u001b[49m\u001b[43mcompose\u001b[49m\u001b[43m(\u001b[49m\u001b[43mQuantumCircuit\u001b[49m\u001b[43m(\u001b[49m\u001b[32;43m1\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[32;43m2\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/qiskit_13935/qiskit/qiskit/circuit/quantumcircuit.py:2118\u001b[39m, in \u001b[36mQuantumCircuit.compose\u001b[39m\u001b[34m(self, other, qubits, clbits, front, inplace, wrap, copy, var_remap, inline_captures)\u001b[39m\n\u001b[32m   2114\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m CircuitError(\n\u001b[32m   2115\u001b[39m         \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mTrying to compose another QuantumCircuit with more qubit/s than the defined QuantumCircuit (\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mother.num_qubits\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m > \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mdest.num_qubits\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m)\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m   2116\u001b[39m     )\n\u001b[32m   2117\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m other.num_clbits > dest.num_clbits:\n\u001b[32m-> \u001b[39m\u001b[32m2118\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m CircuitError(\n\u001b[32m   2119\u001b[39m         \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mTrying to compose another QuantumCircuit with more classical bit/s than the defined QuantumCircuit (\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mother.num_clbits\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m > \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mdest.num_clbits\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m)\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m   2120\u001b[39m     )\n\u001b[32m   2122\u001b[39m \u001b[38;5;66;03m# Maps bits in 'other' to bits in 'dest'.\u001b[39;00m\n\u001b[32m   2123\u001b[39m mapped_qubits: \u001b[38;5;28mlist\u001b[39m[Qubit]\n",
+      "\u001b[31mCircuitError\u001b[39m: 'Trying to compose another QuantumCircuit with more classical bit/s than the defined QuantumCircuit (2 > 1)'"
+     ]
+    }
+   ],
+   "source": [
+    "qc = QuantumCircuit(1, 1)\n",
+    "qc.compose(QuantumCircuit(1, 2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad2a7c62",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2105,9 +2105,18 @@ class QuantumCircuit:
                 dest.append(other, qargs=qubits, cargs=clbits, copy=copy)
             return None if inplace else dest
 
-        if other.num_qubits > dest.num_qubits or other.num_clbits > dest.num_clbits:
+        # if other.num_qubits > dest.num_qubits or other.num_clbits > dest.num_clbits:
+        #     raise CircuitError(
+        #         "Trying to compose with another QuantumCircuit which has more 'in' edges."
+        #     )
+
+        if other.num_qubits > dest.num_qubits:
             raise CircuitError(
-                "Trying to compose with another QuantumCircuit which has more 'in' edges."
+                f"Trying to compose another QuantumCircuit with more qubit/s than the defined QuantumCircuit ({other.num_qubits} > {dest.num_qubits})"
+            )
+        if other.num_clbits > dest.num_clbits:
+            raise CircuitError(
+                f"Trying to compose another QuantumCircuit with more classical bit/s than the defined QuantumCircuit ({other.num_clbits} > {dest.num_clbits})"
             )
 
         # Maps bits in 'other' to bits in 'dest'.

--- a/releasenotes/notes/short-description-string-2ed68d3a947d0c55.yaml
+++ b/releasenotes/notes/short-description-string-2ed68d3a947d0c55.yaml
@@ -1,0 +1,6 @@
+---
+other:
+  - |
+    Changed CircuitError exception text where number of qubit/s or classical 
+    bit/s in other QuantumCircuit being composed is more than that of the 
+    initialized QuantumCircuit.


### PR DESCRIPTION
…ther' greater than 'dest'

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Changed CircuitError exception text when the number of qubit/s or classical bit/s in the other composed QuantumCircuit is more than the initialised QuantumCircuit.
Enhancement for #13935 


### Details and comments


