### PR TITLE
Fix passmanager to preserve falsy pass outputs instead of reverting to input

### DIFF
--- a/qiskit/passmanager/base_tasks.py
+++ b/qiskit/passmanager/base_tasks.py
@@ -26,6 +26,8 @@ logger = logging.getLogger(__name__)
 # Type alias
 PassManagerIR = Any
 
+_UNSET = object()
+
 
 class Task(ABC):
     """An interface of the pass manager task.
@@ -91,7 +93,7 @@ class GenericPass(Task, ABC):
             )
 
         run_state = None
-        ret = None
+        ret: PassManagerIR | object = _UNSET
         start_time = time.time()
         try:
             if self not in state.workflow_status.completed_passes:
@@ -103,7 +105,8 @@ class GenericPass(Task, ABC):
             run_state = RunState.FAIL
             raise
         finally:
-            ret = ret or passmanager_ir
+            if ret is _UNSET or ret is None:
+                ret = passmanager_ir
             if run_state != RunState.SKIP:
                 running_time = time.time() - start_time
                 logger.info("Pass: %s - %.5f (ms)", self.name(), running_time * 1000)

--- a/qiskit/passmanager/base_tasks.py
+++ b/qiskit/passmanager/base_tasks.py
@@ -26,8 +26,6 @@ logger = logging.getLogger(__name__)
 # Type alias
 PassManagerIR = Any
 
-_UNSET = object()
-
 
 class Task(ABC):
     """An interface of the pass manager task.
@@ -93,7 +91,7 @@ class GenericPass(Task, ABC):
             )
 
         run_state = None
-        ret: PassManagerIR | object = _UNSET
+        ret = None
         start_time = time.time()
         try:
             if self not in state.workflow_status.completed_passes:
@@ -105,8 +103,7 @@ class GenericPass(Task, ABC):
             run_state = RunState.FAIL
             raise
         finally:
-            if ret is _UNSET or ret is None:
-                ret = passmanager_ir
+            ret = passmanager_ir if ret is None else ret
             if run_state != RunState.SKIP:
                 running_time = time.time() - start_time
                 logger.info("Pass: %s - %.5f (ms)", self.name(), running_time * 1000)

--- a/releasenotes/notes/preserve-falsy-pass-output-6849d360ba696fd9.yaml
+++ b/releasenotes/notes/preserve-falsy-pass-output-6849d360ba696fd9.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    :class:`.BasePassManager` no longer replaces falsy but valid outputs from
+    passes with the original input program. A pass returning ``0``, ``False``
+    or another falsy value will now be preserved, and only ``None`` indicates
+    failure.

--- a/test/python/passmanager/test_passmanager.py
+++ b/test/python/passmanager/test_passmanager.py
@@ -145,3 +145,25 @@ class TestPassManager(PassManagerTestCase):
         self.assertIs(pm.property_set["check_property"], sentinel)
         pm.run(1)
         self.assertIs(pm.property_set["check_property"], sentinel)
+
+    def test_pass_returning_falsy_value_is_not_replaced(self):
+        """A pass returning a falsy output should not be overwritten."""
+
+        class ZeroPass(GenericPass):
+            def run(self, passmanager_ir):
+                """Return the integer ``0`` to test falsy values."""
+                del passmanager_ir
+                return 0
+
+        class IntPassManager(BasePassManager):
+            def __init__(self, passes):
+                super().__init__(passes)
+
+            def _passmanager_frontend(self, input_program, **kwargs):
+                return input_program
+
+            def _passmanager_backend(self, passmanager_ir, in_program, **kwargs):
+                return passmanager_ir
+
+        pm = IntPassManager([ZeroPass()])
+        self.assertEqual(pm.run(5), 0)


### PR DESCRIPTION
Changes:
- Changed the fallback to only use the input IR when the pass returns `None`.

Why?
- The previous fallback used `ret or passmanager_ir`, which replaces any falsy return (e.g., 0, "", [], {}) with the original IR. Some passes legitimately produce an empty/zero IR (e.g., after pruning), so this silently reverted valid outputs.