### PR TITLE
Make cbindgen map usize to size_t

### DIFF
--- a/crates/cext/cbindgen.toml
+++ b/crates/cext/cbindgen.toml
@@ -3,6 +3,7 @@ include_version = true
 include_guard = "QISKIT_H"
 style = "type"
 cpp_compat = true
+usize_is_size_t = true
 
 after_includes = """
 #ifdef QISKIT_C_PYTHON_INTERFACE

--- a/crates/cext/src/sparse_observable.rs
+++ b/crates/cext/src/sparse_observable.rs
@@ -496,7 +496,7 @@ pub unsafe extern "C" fn qk_obs_indices(obs: *mut SparseObservable) -> *mut u32 
 ///    qk_obs_add_term(obs, &term);
 ///
 ///    size_t num_terms = qk_obs_num_terms(obs);
-///    uintptr_t *boundaries = qk_obs_boundaries(obs);
+///    size_t *boundaries = qk_obs_boundaries(obs);
 ///
 ///    for (size_t i = 0; i < num_terms + 1; i++) {
 ///        printf("boundary %i: %i\n", i, boundaries[i]);

--- a/crates/cext/src/transpiler/passes/vf2.rs
+++ b/crates/cext/src/transpiler/passes/vf2.rs
@@ -192,7 +192,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_vf2_layout(
     strict_direction: bool,
     call_limit: i64,
     time_limit: f64,
-    max_trials: i32,
+    max_trials: i64,
 ) -> *mut VF2LayoutResult {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { const_ptr_as_ref(circuit) };
@@ -216,7 +216,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_vf2_layout(
     } else if max_trials == 0 {
         None
     } else {
-        Some(max_trials)
+        Some(max_trials as isize)
     };
     let layout = match vf2_layout_pass(
         &dag,

--- a/crates/cext/src/transpiler/passes/vf2.rs
+++ b/crates/cext/src/transpiler/passes/vf2.rs
@@ -192,7 +192,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_vf2_layout(
     strict_direction: bool,
     call_limit: i64,
     time_limit: f64,
-    max_trials: isize,
+    max_trials: i32,
 ) -> *mut VF2LayoutResult {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { const_ptr_as_ref(circuit) };

--- a/crates/transpiler/src/passes/vf2/vf2_layout.rs
+++ b/crates/transpiler/src/passes/vf2/vf2_layout.rs
@@ -373,7 +373,7 @@ pub fn vf2_layout_pass(
     strict_direction: bool,
     call_limit: Option<usize>,
     time_limit: Option<f64>,
-    max_trials: Option<i32>,
+    max_trials: Option<isize>,
     avg_error_map: Option<ErrorMap>,
 ) -> PyResult<Option<HashMap<VirtualQubit, PhysicalQubit>>> {
     if strict_direction {

--- a/crates/transpiler/src/passes/vf2/vf2_layout.rs
+++ b/crates/transpiler/src/passes/vf2/vf2_layout.rs
@@ -373,7 +373,7 @@ pub fn vf2_layout_pass(
     strict_direction: bool,
     call_limit: Option<usize>,
     time_limit: Option<f64>,
-    max_trials: Option<isize>,
+    max_trials: Option<i32>,
     avg_error_map: Option<ErrorMap>,
 ) -> PyResult<Option<HashMap<VirtualQubit, PhysicalQubit>>> {
     if strict_direction {

--- a/releasenotes/notes/cbindgen-usize-to-size_t-544294518fdfcbb0.yaml
+++ b/releasenotes/notes/cbindgen-usize-to-size_t-544294518fdfcbb0.yaml
@@ -1,0 +1,6 @@
+---
+upgrade_c:
+  - |
+    Changed the behavior of `cbindgen` to map Rust's `usize` type to C's `size_t` in the generated C API. This makes `usize`
+    struct fields, function parameters and function return values accurately aligned in their variable type to their intended
+    usage in C.


### PR DESCRIPTION
### Summary
The default in cbindgen is to map Rust's `usize` type to `uintptr_t` in C (as well as `isize` to `intptr_t`). This default results in several struct fields and return values in our C API, which are clearly integral, to be represented as `uintptr_t`. For example, the `count` field of the `QkOpcount` struct and the return value of `qk_circuit_num_instructions`. Although `uintptr_t` works in those cases because of C's implicit casting, it's still weird to have this type instead of an unsigned integer. 

### Details and comments
This PR adds a flag to `cbindgen.toml` to change the mapping to more sensible targets for our C API. 
It also changes the `max_trials` parameter of the `vf2` pass to be of type ~~`i32`~~ `i64` so it's not mapped to `intptr_t`.


