### PR TITLE
Naming convention for the C transpiler passes

### DIFF
--- a/crates/cext/src/transpiler/passes/elide_permutations.rs
+++ b/crates/cext/src/transpiler/passes/elide_permutations.rs
@@ -50,7 +50,7 @@ use qiskit_transpiler::transpile_layout::TranspileLayout;
 ///             qk_circuit_gate(qc, QkGate_CX, qargs, NULL);
 ///         }
 ///     }
-///     QkTranspileLayout *elide_result = qk_transpiler_pass_standalone_elide_permutations(qc);
+///     QkTranspileLayout *elide_result = qk_transpiler_passes_elide_permutations_circuit(qc);
 /// ```
 ///
 /// # Safety
@@ -58,7 +58,7 @@ use qiskit_transpiler::transpile_layout::TranspileLayout;
 /// Behavior is undefined if ``circuit``  is not a valid, non-null pointer to a ``QkCircuit``.
 #[no_mangle]
 #[cfg(feature = "cbinding")]
-pub unsafe extern "C" fn qk_transpiler_pass_standalone_elide_permutations(
+pub unsafe extern "C" fn qk_transpiler_passes_elide_permutations_circuit(
     circuit: *mut CircuitData,
 ) -> *mut TranspileLayout {
     // SAFETY: Per documentation, the pointer is non-null and aligned.

--- a/crates/cext/src/transpiler/passes/gate_direction.rs
+++ b/crates/cext/src/transpiler/passes/gate_direction.rs
@@ -40,7 +40,7 @@ use qiskit_transpiler::target::Target;
 ///    QkCircuit *circuit = qk_circuit_new(2, 0);
 ///    qk_circuit_gate(circuit, QkGate_CX, (uint32_t[]){1,0}, NULL);
 ///
-///    bool direction_ok = qk_transpiler_pass_standalone_check_gate_direction(circuit, target);
+///    bool direction_ok = qk_transpiler_passes_check_gate_direction_circuit(circuit, target);
 /// ```
 ///
 /// # Safety
@@ -48,7 +48,7 @@ use qiskit_transpiler::target::Target;
 /// Behavior is undefined if ``circuit`` or ``target`` are not valid, non-null pointers to ``QkCircuit`` and ``QkTarget`` objects, respectively.
 #[no_mangle]
 #[cfg(feature = "cbinding")]
-pub unsafe extern "C" fn qk_transpiler_pass_standalone_check_gate_direction(
+pub unsafe extern "C" fn qk_transpiler_passes_check_gate_direction_circuit(
     circuit: *const CircuitData,
     target: *const Target,
 ) -> bool {
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_check_gate_direction(
 ///    QkCircuit *circuit = qk_circuit_new(3, 0);
 ///    qk_circuit_gate(circuit, QkGate_CX, (uint32_t[]){1,0}, NULL);
 ///
-///    qk_transpiler_pass_standalone_gate_direction(circuit, target);
+///    qk_transpiler_passes_gate_direction_circuit(circuit, target);
 /// ```
 ///
 /// # Safety
@@ -94,7 +94,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_check_gate_direction(
 /// Behavior is undefined if ``circuit`` or ``target`` are not valid, non-null pointers to ``QkCircuit`` and ``QkTarget`` objects, respectively.
 #[no_mangle]
 #[cfg(feature = "cbinding")]
-pub unsafe extern "C" fn qk_transpiler_pass_standalone_gate_direction(
+pub unsafe extern "C" fn qk_transpiler_passes_gate_direction_circuit(
     circuit: *mut CircuitData,
     target: *const Target,
 ) {

--- a/crates/cext/src/transpiler/passes/remove_diagonal_gates_before_measure.rs
+++ b/crates/cext/src/transpiler/passes/remove_diagonal_gates_before_measure.rs
@@ -30,7 +30,7 @@ use qiskit_transpiler::passes::run_remove_diagonal_before_measure;
 ///     QkCircuit *qc = qk_circuit_new(1, 1);
 ///     qk_circuit_gate(qc, QkGate_Z, {0}, NULL);
 ///     qk_circuit_measure(qc, 0, 0);
-///     qk_transpiler_pass_standalone_remove_diagonal_gates_before_measure(qc);
+///     qk_transpiler_passes_remove_diagonal_gates_before_measure_circuit(qc);
 ///     // ...
 ///     qk_circuit_free(qc);
 /// ```
@@ -40,7 +40,7 @@ use qiskit_transpiler::passes::run_remove_diagonal_before_measure;
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
 #[no_mangle]
 #[cfg(feature = "cbinding")]
-pub unsafe extern "C" fn qk_transpiler_pass_standalone_remove_diagonal_gates_before_measure(
+pub unsafe extern "C" fn qk_transpiler_passes_remove_diagonal_gates_before_measure_circuit(
     circuit: *mut CircuitData,
 ) {
     // SAFETY: Per documentation, the pointer is non-null and aligned.

--- a/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
+++ b/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
@@ -71,7 +71,7 @@ use qiskit_transpiler::target::Target;
 ///     uint32_t rz_qargs[1] = {1,};
 ///     double rz_params[1] = {0.,};
 ///     qk_circuit_gate(qc, QkGate_RZ, rz_qargs, rz_params);
-///     qk_transpiler_pass_standalone_remove_identity_equivalent(qc, target, 1.0);
+///     qk_transpiler_passes_remove_identity_equivalent_circuit(qc, target, 1.0);
 /// ```
 ///
 /// # Safety
@@ -79,7 +79,7 @@ use qiskit_transpiler::target::Target;
 /// Behavior is undefined if ``circuit`` or ``target`` is not a valid, non-null pointer to a ``QkCircuit`` and ``QkTarget``.
 #[no_mangle]
 #[cfg(feature = "cbinding")]
-pub unsafe extern "C" fn qk_transpiler_pass_standalone_remove_identity_equivalent(
+pub unsafe extern "C" fn qk_transpiler_passes_remove_identity_equivalent_circuit(
     circuit: *mut CircuitData,
     target: *const Target,
     approximation_degree: f64,

--- a/crates/cext/src/transpiler/passes/sabre_layout.rs
+++ b/crates/cext/src/transpiler/passes/sabre_layout.rs
@@ -23,7 +23,7 @@ use qiskit_transpiler::passes::sabre::sabre_layout_and_routing;
 use qiskit_transpiler::target::Target;
 use qiskit_transpiler::transpile_layout::TranspileLayout;
 
-/// The options for running ``qk_transpiler_pass_standalone_sabre_layout``. This struct is used
+/// The options for running ``qk_transpiler_passes_sabre_layout_circuit``. This struct is used
 /// as an input to control the behavior of the layout and routing algorithms.
 #[repr(C)]
 pub struct QkSabreLayoutOptions {
@@ -104,7 +104,7 @@ pub extern "C" fn qk_sabre_layout_options_default() -> QkSabreLayoutOptions {
 /// Behavior is undefined if ``circuit`` or ``target`` is not a valid, non-null pointer to a ``QkCircuit`` and ``QkTarget``.
 #[no_mangle]
 #[cfg(feature = "cbinding")]
-pub unsafe extern "C" fn qk_transpiler_pass_standalone_sabre_layout(
+pub unsafe extern "C" fn qk_transpiler_passes_sabre_layout_circuit(
     circuit: *mut CircuitData,
     target: *const Target,
     options: *const QkSabreLayoutOptions,

--- a/crates/cext/src/transpiler/passes/split_2q_unitaries.rs
+++ b/crates/cext/src/transpiler/passes/split_2q_unitaries.rs
@@ -41,7 +41,7 @@ use qiskit_transpiler::transpile_layout::TranspileLayout;
 ///         qk_circuit_gate(qc, QkGate_CX, qargs, NULL);
 ///     }
 /// }
-/// QkTranspileLayout *result = qk_transpiler_pass_standalone_split_2q_unitaries(qc, 1e-12, true)
+/// QkTranspileLayout *result = qk_transpiler_passes_split_2q_unitaries_circuit(qc, 1e-12, true)
 /// ```
 ///
 /// # Safety
@@ -49,7 +49,7 @@ use qiskit_transpiler::transpile_layout::TranspileLayout;
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
 #[no_mangle]
 #[cfg(feature = "cbinding")]
-pub unsafe extern "C" fn qk_transpiler_pass_standalone_split_2q_unitaries(
+pub unsafe extern "C" fn qk_transpiler_passes_split_2q_unitaries_circuit(
     circuit: *mut CircuitData,
     requested_fidelity: f64,
     split_swaps: bool,

--- a/crates/cext/src/transpiler/passes/vf2.rs
+++ b/crates/cext/src/transpiler/passes/vf2.rs
@@ -20,7 +20,7 @@ use qiskit_circuit::{PhysicalQubit, VirtualQubit};
 use qiskit_transpiler::passes::vf2_layout_pass;
 use qiskit_transpiler::target::Target;
 
-/// The result from ``qk_transpiler_pass_standalone_vf2_layout()``.
+/// The result from ``qk_transpiler_passes_vf2_layout_circuit()``.
 pub struct VF2LayoutResult(Option<HashMap<VirtualQubit, PhysicalQubit>>);
 
 /// @ingroup QkVF2LayoutResult
@@ -28,7 +28,7 @@ pub struct VF2LayoutResult(Option<HashMap<VirtualQubit, PhysicalQubit>>);
 ///
 /// @param layout a pointer to the layout
 ///
-/// @returns ``true`` if the ``qk_transpiler_pass_standalone_vf2_layout()`` run found a layout
+/// @returns ``true`` if the ``qk_transpiler_passes_vf2_layout_circuit()`` run found a layout
 ///
 /// # Safety
 ///
@@ -177,7 +177,7 @@ pub unsafe extern "C" fn qk_vf2_layout_result_free(layout: *mut VF2LayoutResult)
 ///             qk_circuit_gate(qc, QkGate_CX, qargs, NULL);
 ///         }
 ///     }
-///     QkVF2LayoutResult *layout_result = qk_transpiler_pass_standalone_vf2_layout(qc, target, false, -1, NAN, -1);
+///     QkVF2LayoutResult *layout_result = qk_transpiler_passes_vf2_layout_circuit(qc, target, false, -1, NAN, -1);
 ///     qk_vf2_layout_result_free(layout_result);
 /// ```
 ///
@@ -186,7 +186,7 @@ pub unsafe extern "C" fn qk_vf2_layout_result_free(layout: *mut VF2LayoutResult)
 /// Behavior is undefined if ``circuit`` or ``target`` is not a valid, non-null pointer to a ``QkCircuit`` and ``QkTarget``.
 #[no_mangle]
 #[cfg(feature = "cbinding")]
-pub unsafe extern "C" fn qk_transpiler_pass_standalone_vf2_layout(
+pub unsafe extern "C" fn qk_transpiler_passes_vf2_layout_circuit(
     circuit: *const CircuitData,
     target: *const Target,
     strict_direction: bool,

--- a/docs/cdoc/qk-sabre-layout-options.rst
+++ b/docs/cdoc/qk-sabre-layout-options.rst
@@ -2,7 +2,7 @@
 QkSabreLayoutOptions
 ====================
 
-When running the ``qk_transpiler_pass_standalone_sabre_layout`` function this type defines the options for running the pass.
+When running the ``qk_transpiler_passes_sabre_layout_circuit`` function this type defines the options for running the pass.
 
 Data Types
 ==========

--- a/docs/cdoc/qk-vf2-layout-result.rst
+++ b/docs/cdoc/qk-vf2-layout-result.rst
@@ -6,7 +6,7 @@ QkVF2LayoutResult
 
    typedef struct QkVF2LayoutResult QkVF2LayoutResult
 
-When running the ``qk_transpiler_pass_standalone_vf2_layout`` function it returns its analysis
+When running the ``qk_transpiler_passes_vf2_layout_circuit`` function it returns its analysis
 result as a ``QkVF2LayoutResult`` object. This object contains the outcome of the transpiler pass,
 whether the pass was able to find a layout or not, and what the layout selected by the pass was.
 

--- a/releasenotes/notes/add-remove-identity-equiv-c-4bc4354c54531156.yaml
+++ b/releasenotes/notes/add-remove-identity-equiv-c-4bc4354c54531156.yaml
@@ -2,6 +2,6 @@
 features_c:
   - |
     Added a new transpiler pass standalone function to the C API,
-    :cpp:func:`qk_transpiler_pass_standalone_remove_identity_equivalent`
+    :cpp:func:`qk_transpiler_passes_remove_identity_equivalent_circuit`
     which is equivalent to calling the :class:`.RemoveIdentityEquivalent`
     pass.

--- a/releasenotes/notes/add-split_2q_unitaries-c-api-5d9fb88999e06458.yaml
+++ b/releasenotes/notes/add-split_2q_unitaries-c-api-5d9fb88999e06458.yaml
@@ -2,6 +2,6 @@
 features_c:
   - |
     Added a new transpiler pass standalone function to the C API,
-    :cpp:func:`qk_transpiler_pass_standalone_split_2q_unitaries`
+    :cpp:func:`qk_transpiler_passes_split_2q_unitaries_circuit`
     which is equivalent to calling the :class:`.Split2QUnitaries`
     pass.

--- a/releasenotes/notes/c-api-gate-direction-f8b3fa586f2eec4b.yaml
+++ b/releasenotes/notes/c-api-gate-direction-f8b3fa586f2eec4b.yaml
@@ -1,6 +1,6 @@
 ---
 features_c:
   - |
-    Added new standalone transpiler pass functions :cpp:func:`qk_transpiler_pass_standalone_check_gate_direction` and
-    :cpp:func:`qk_transpiler_pass_standalone_gate_direction`, which can be used for running the
+    Added new standalone transpiler pass functions :cpp:func:`qk_transpiler_passes_check_gate_direction_circuit` and
+    :cpp:func:`qk_transpiler_passes_gate_direction_circuit`, which can be used for running the
     :class:`.CheckGateDirection` and :class:`.GateDirection`, passes respectively.

--- a/releasenotes/notes/elide_permutations_c-e2c66e8cd42a1afd.yaml
+++ b/releasenotes/notes/elide_permutations_c-e2c66e8cd42a1afd.yaml
@@ -2,7 +2,7 @@
 features_c:
   - |
     Added a new standalone transpiler pass function
-    ``qk_transpiler_pass_standalone_elide_permutations`` which is for running the
+    ``qk_transpiler_passes_elide_permutations_circuit`` which is for running the
     :class:`.ElidePermutations` transpiler pass. Calling this function in C is equivalent
     to running the pass in Python like::
 

--- a/releasenotes/notes/rm-diag-gates-before-meas-c-9bb9f2b5490cf0a2.yaml
+++ b/releasenotes/notes/rm-diag-gates-before-meas-c-9bb9f2b5490cf0a2.yaml
@@ -2,7 +2,7 @@
 features_c:
   - |
     Added a new standalone transpiler pass function
-    ``qk_transpiler_pass_standalone_remove_diagonal_gates_before_measure`` which is for running the
+    ``qk_transpiler_passes_remove_diagonal_gates_before_measure_circuit`` which is for running the
     :class:`.RemoveDiagonalGatesBeforeMeasure` transpiler pass. Calling this function in C is equivalent
     to running the pass in Python like::
       

--- a/releasenotes/notes/vf2_layout_c-33131d418cb41255.yaml
+++ b/releasenotes/notes/vf2_layout_c-33131d418cb41255.yaml
@@ -2,7 +2,7 @@
 features_c:
   - |
     Added a new standalone transpiler pass function
-    ``qk_transpiler_pass_standalone_vf2_layout`` which is for running the
+    ``qk_transpiler_passes_vf2_layout_circuit`` which is for running the
     :class:`.VF2Layout` transpiler pass. Calling this function in C is equivalent
     to running the pass in Python like::
 

--- a/test/c/test_elide_permutations.c
+++ b/test/c/test_elide_permutations.c
@@ -34,7 +34,7 @@ int test_elide_permutations_no_result(void) {
         }
     }
     int result = Ok;
-    QkTranspileLayout *pass_result = qk_transpiler_pass_standalone_elide_permutations(qc);
+    QkTranspileLayout *pass_result = qk_transpiler_passes_elide_permutations_circuit(qc);
     if (pass_result != NULL) {
         printf("A gate was elided when one shouldn't have been\n");
         qk_transpile_layout_free(pass_result);
@@ -60,7 +60,7 @@ int test_elide_permutations_swap_result(void) {
         }
     }
     int result = Ok;
-    QkTranspileLayout *pass_result = qk_transpiler_pass_standalone_elide_permutations(qc);
+    QkTranspileLayout *pass_result = qk_transpiler_passes_elide_permutations_circuit(qc);
     if (pass_result == NULL) {
         printf("A gate wasn't elided when one should have been\n");
         result = EqualityError;

--- a/test/c/test_gate_direction.c
+++ b/test/c/test_gate_direction.c
@@ -54,7 +54,7 @@ int test_check_gate_direction(void) {
         goto cleanup;
     }
 
-    bool check_pass = qk_transpiler_pass_standalone_check_gate_direction(circuit, target);
+    bool check_pass = qk_transpiler_passes_check_gate_direction_circuit(circuit, target);
     if (!check_pass)
         result = EqualityError;
     else {
@@ -63,7 +63,7 @@ int test_check_gate_direction(void) {
                    "test_check_gate_direction.");
             goto cleanup;
         }
-        check_pass = qk_transpiler_pass_standalone_check_gate_direction(circuit, target);
+        check_pass = qk_transpiler_passes_check_gate_direction_circuit(circuit, target);
         if (check_pass)
             result = EqualityError;
     }
@@ -98,7 +98,7 @@ int test_gate_direction(void) {
         goto cleanup;
     }
 
-    qk_transpiler_pass_standalone_gate_direction(circuit, target);
+    qk_transpiler_passes_gate_direction_circuit(circuit, target);
 
     if (qk_circuit_num_instructions(circuit) != 12) {
         result = EqualityError;

--- a/test/c/test_remove_diagonal_gates_before_measure.c
+++ b/test/c/test_remove_diagonal_gates_before_measure.c
@@ -35,7 +35,7 @@ int test_remove_z_gate(void) {
         goto cleanup;
     }
 
-    qk_transpiler_pass_standalone_remove_diagonal_gates_before_measure(qc);
+    qk_transpiler_passes_remove_diagonal_gates_before_measure_circuit(qc);
 
     if (1 != qk_circuit_num_instructions(qc)) {
         printf("Circuit should only have a single instruction");

--- a/test/c/test_remove_identity_equiv.c
+++ b/test/c/test_remove_identity_equiv.c
@@ -38,7 +38,7 @@ int test_remove_identity_equiv_removes_gates(void) {
     qk_circuit_gate(qc, QkGate_RZ, qargs, params_zero);
     qk_circuit_gate(qc, QkGate_RX, qargs, params);
 
-    qk_transpiler_pass_standalone_remove_identity_equivalent(qc, target, 1.0);
+    qk_transpiler_passes_remove_identity_equivalent_circuit(qc, target, 1.0);
     if (qk_circuit_num_instructions(qc) != 1) {
         result = EqualityError;
         printf("The gates weren't removed by this circuit");

--- a/test/c/test_sabre_layout.c
+++ b/test/c/test_sabre_layout.c
@@ -48,7 +48,7 @@ int test_sabre_layout_applies_layout(void) {
     QkSabreLayoutOptions options = qk_sabre_layout_options_default();
     options.seed = 2025;
     QkTranspileLayout *layout_result =
-        qk_transpiler_pass_standalone_sabre_layout(qc, target, &options);
+        qk_transpiler_passes_sabre_layout_circuit(qc, target, &options);
 
     QkOpCounts op_counts = qk_circuit_count_ops(qc);
     if (op_counts.len != 2) {
@@ -158,7 +158,7 @@ int test_sabre_layout_no_swap(void) {
     QkSabreLayoutOptions options = qk_sabre_layout_options_default();
     options.seed = 2025;
     QkTranspileLayout *layout_result =
-        qk_transpiler_pass_standalone_sabre_layout(qc, target, &options);
+        qk_transpiler_passes_sabre_layout_circuit(qc, target, &options);
     QkCircuit *expected_circuit = qk_circuit_new(5, 0);
     for (uint32_t i = 0; i < qk_circuit_num_qubits(qc) - 1; i++) {
         uint32_t qargs[2] = {i, i + 1};

--- a/test/c/test_split_2q_unitaries.c
+++ b/test/c/test_split_2q_unitaries.c
@@ -27,7 +27,7 @@ int test_split_2q_unitaries_no_unitaries(void) {
         }
     }
     QkTranspileLayout *split_result =
-        qk_transpiler_pass_standalone_split_2q_unitaries(qc, 1 - 1e-16, true);
+        qk_transpiler_passes_split_2q_unitaries_circuit(qc, 1 - 1e-16, true);
     int result = Ok;
     if (split_result != NULL) {
         result = EqualityError;
@@ -67,7 +67,7 @@ int test_split_2q_unitaries_x_y_unitary(void) {
     uint32_t qargs[2] = {0, 1};
     qk_circuit_unitary(qc, unitary, qargs, 2, true);
     QkTranspileLayout *split_result =
-        qk_transpiler_pass_standalone_split_2q_unitaries(qc, 1 - 1e-16, true);
+        qk_transpiler_passes_split_2q_unitaries_circuit(qc, 1 - 1e-16, true);
     int result = Ok;
     if (split_result != NULL) {
         result = EqualityError;
@@ -124,7 +124,7 @@ int test_split_2q_unitaries_swap_x_y_unitary(void) {
     uint32_t qargs[2] = {0, 1};
     qk_circuit_unitary(qc, unitary, qargs, 2, true);
     QkTranspileLayout *split_result =
-        qk_transpiler_pass_standalone_split_2q_unitaries(qc, 1 - 1e-16, true);
+        qk_transpiler_passes_split_2q_unitaries_circuit(qc, 1 - 1e-16, true);
     int result = Ok;
     if (split_result == NULL) {
         result = EqualityError;

--- a/test/c/test_vf2_layout.c
+++ b/test/c/test_vf2_layout.c
@@ -68,7 +68,7 @@ int test_vf2_layout_line(void) {
         }
     }
     QkVF2LayoutResult *layout_result =
-        qk_transpiler_pass_standalone_vf2_layout(qc, target, false, -1, 0.0, -1);
+        qk_transpiler_passes_vf2_layout_circuit(qc, target, false, -1, 0.0, -1);
     if (!qk_vf2_layout_result_has_match(layout_result)) {
         printf("No layout was found");
         result = EqualityError;
@@ -124,7 +124,7 @@ int test_vf2_no_layout_found(void) {
         }
     }
     QkVF2LayoutResult *layout_result =
-        qk_transpiler_pass_standalone_vf2_layout(qc, target, false, -1, 0.0, -1);
+        qk_transpiler_passes_vf2_layout_circuit(qc, target, false, -1, 0.0, -1);
     if (qk_vf2_layout_result_has_match(layout_result)) {
         printf("Unexpected layout found when one shouldn't be possible");
         result = EqualityError;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Before we release the C transpiler passes, I wanted to revisit the naming convention. The current naming `qk_transpiler_pass_standalone_<passname>` doesn't give the accurate namespace and "standalone" doesn't qualify that we're dealing with circuits. I wanted to propose the following
```c
// this one is already clear, not part of this proposal ;)
qk_transpile(circuit);  
// transpiler_passes is the namespace, rather than transpiler_pass
qk_transpiler_passes_<passname>(dag); 
// less accessible since we add the _circuit prefix, but easily recognizable as "the same" as the DAG version
qk_transpiler_passes_<passname>_circuit(circuit); 
```

The main thoughts going into this are:
* our C naming convention is `qk_<namespace>_<function>`
* we want to promote the DAG version over the circuit version (since the DAG one needs less conversions)
* remember this is not the final "user-friendly" API, for this we can have a C++ or other wrappers (so long names are fine...)

This would be merged after #14760 to avoid naming conflicts (and ofc this needs updating after the other passes are merged).

### Other proposals

A shorter version using only `transpiler` as namespace -- but this doesn't reflect the actual structure.
```c
qk_transpile(circuit);  
qk_transpiler_<passname>(dag); 
qk_transpiler_<passname>_circuit(circuit); 
```

A really short version -- but this type of user-friendliness I imagine is job of the C++/others API
```c
qk_transpile(circuit);  
qk_<passname>(dag); 
qk_circuit_<passname>(circuit); 
```

