### PR TITLE
Remove implicit seekable requirement from QPY 16.

### DIFF
--- a/qiskit/qpy/common.py
+++ b/qiskit/qpy/common.py
@@ -190,7 +190,7 @@ def write_type_key(file_obj, type_key):
         file_obj (File): A file like object that contains the QPY binary data.
         type_key (bytes): Type key to write.
     """
-    file_obj.write(struct.pack("!1c", type_key))
+    return file_obj.write(struct.pack("!1c", type_key))
 
 
 def data_to_binary(obj, serializer, **kwargs):

--- a/qiskit/qpy/common.py
+++ b/qiskit/qpy/common.py
@@ -116,8 +116,9 @@ def read_type_key(file_obj):
     Returns:
         bytes: Type key.
     """
-    key_size = struct.calcsize("!1c")
-    return struct.unpack("!1c", file_obj.read(key_size))[0]
+    return formats.TYPE_KEY._make(
+        struct.unpack(formats.TYPE_KEY_PACK, file_obj.read(formats.TYPE_KEY_SIZE))
+    ).key
 
 
 def write_generic_typed_data(file_obj, type_key, data_binary):
@@ -183,17 +184,14 @@ def write_mapping(file_obj, mapping, serializer, **kwargs):
         file_obj.write(datum_bytes)
 
 
-def write_type_key(file_obj, type_key) -> int:
+def write_type_key(file_obj, type_key):
     """Write a type key in the file like object.
 
     Args:
         file_obj (File): A file like object that contains the QPY binary data.
         type_key (bytes): Type key to write.
-
-    Returns:
-        int: The number of bytes written.
     """
-    return file_obj.write(struct.pack("!1c", type_key))
+    file_obj.write(struct.pack(formats.TYPE_KEY_PACK, type_key))
 
 
 def data_to_binary(obj, serializer, **kwargs):

--- a/qiskit/qpy/common.py
+++ b/qiskit/qpy/common.py
@@ -183,12 +183,15 @@ def write_mapping(file_obj, mapping, serializer, **kwargs):
         file_obj.write(datum_bytes)
 
 
-def write_type_key(file_obj, type_key):
+def write_type_key(file_obj, type_key) -> int:
     """Write a type key in the file like object.
 
     Args:
         file_obj (File): A file like object that contains the QPY binary data.
         type_key (bytes): Type key to write.
+
+    Returns:
+        int: The number of bytes written.
     """
     return file_obj.write(struct.pack("!1c", type_key))
 

--- a/qiskit/qpy/formats.py
+++ b/qiskit/qpy/formats.py
@@ -42,6 +42,9 @@ FILE_HEADER = namedtuple(
 FILE_HEADER_PACK = "!6sBBBBQ"
 FILE_HEADER_SIZE = struct.calcsize(FILE_HEADER_PACK)
 
+TYPE_KEY = namedtuple("TYPE_KEY", ["key"])
+TYPE_KEY_PACK = "!1c"
+TYPE_KEY_SIZE = struct.calcsize(TYPE_KEY_PACK)
 
 CIRCUIT_HEADER_V12 = namedtuple(
     "HEADER",

--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -200,8 +200,9 @@ def dump(
         len(programs),
         encoding,
     )
-    header_bytes_written = file_obj.write(header)
-    header_bytes_written += common.write_type_key(file_obj, type_keys.Program.CIRCUIT)
+    file_obj.write(header)
+    common.write_type_key(file_obj, type_keys.Program.CIRCUIT)
+    header_bytes_written = formats.FILE_HEADER_V10_SIZE + formats.TYPE_KEY_SIZE
 
     def _write_circuit(out_stream, circuit):
         binary_io.write_circuit(

--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import io
 from json import JSONEncoder, JSONDecoder
 from typing import Union, List, BinaryIO, Type, Optional, Callable, TYPE_CHECKING
 from collections.abc import Iterable, Mapping
@@ -198,25 +199,13 @@ def dump(
         len(programs),
         encoding,
     )
-    file_obj.write(header)
-    common.write_type_key(file_obj, type_keys.Program.CIRCUIT)
+    header_bytes_written = file_obj.write(header)
+    header_bytes_written += common.write_type_key(file_obj, type_keys.Program.CIRCUIT)
 
-    # Table of byte offsets for each program (supported in QPY v16+)
-    byte_offsets = []
-    table_start = None
-    if version >= 16:
-        table_start = file_obj.tell()
-        # Skip the file position to write the byte offsets later
-        file_obj.seek(len(programs) * formats.CIRCUIT_TABLE_ENTRY_SIZE, 1)
-
-    # Serialize each program and write it to the file
-    for program in programs:
-        if version >= 16:
-            # Determine the byte offset before writing each program
-            byte_offsets.append(file_obj.tell())
+    def _write_circuit(out_stream, circuit):
         binary_io.write_circuit(
-            file_obj,
-            program,
+            out_stream,
+            circuit,
             metadata_serializer=metadata_serializer,
             use_symengine=use_symengine,
             version=version,
@@ -224,14 +213,48 @@ def dump(
         )
 
     if version >= 16:
-        # Write the byte offsets for each program
-        file_obj.seek(table_start)
-        for offset in byte_offsets:
-            file_obj.write(
-                struct.pack(formats.CIRCUIT_TABLE_ENTRY_PACK, *formats.CIRCUIT_TABLE_ENTRY(offset))
-            )
-        # Seek to the end of the file
-        file_obj.seek(0, 2)
+        # We need a circuit table.
+        if file_obj.seekable():
+            # Fast path to write the seekable stream in place.
+            file_offsets = []
+            table_start = file_obj.tell()
+            # Skip past the circuit table to write circuit contents first.
+            file_obj.seek(len(programs) * formats.CIRCUIT_TABLE_ENTRY_SIZE, 1)
+            for program in programs:
+                file_offsets.append(file_obj.tell())
+                _write_circuit(file_obj, program)
+            # Seek back to the table start and write it out.
+            file_obj.seek(table_start)
+            for offset in file_offsets:
+                file_obj.write(
+                    struct.pack(
+                        formats.CIRCUIT_TABLE_ENTRY_PACK, *formats.CIRCUIT_TABLE_ENTRY(offset)
+                    )
+                )
+            # Seek to the end of the stream.
+            file_obj.seek(0, 2)
+        else:
+            # We need to create a temporary BytesIO buffer since the input
+            # stream isn't seekable.
+            buffer_offsets = []
+            with io.BytesIO() as circuits_buffer:
+                for program in programs:
+                    buffer_offsets.append(circuits_buffer.tell())
+                    _write_circuit(circuits_buffer, program)
+            # Write circuit table to input stream, adjusting offsets.
+            for offset in buffer_offsets:
+                file_obj.write(
+                    struct.pack(
+                        formats.CIRCUIT_TABLE_ENTRY_PACK,
+                        *formats.CIRCUIT_TABLE_ENTRY(header_bytes_written + offset),
+                    )
+                )
+            # Write circuits to the input stream.
+            file_obj.write(circuits_buffer.getbuffer())
+    else:
+        # No circuit table needed, just write the circuits sequentially.
+        for program in programs:
+            _write_circuit(file_obj, program)
 
 
 def load(

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -2250,7 +2250,7 @@ class TestLoadFromQPY(QiskitTestCase):
         ):
             dump(qc, fptr, version=version)
 
-    @ddt.idata(range(14, 16))
+    @ddt.idata(range(max(QPY_COMPATIBILITY_VERSION, 14), 16))
     def test_pre_v16_rejects_ps_duration(self, version):
         """Test that dumping to older QPY versions rejects Duration.ps."""
         from qiskit.circuit import Duration


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Removes the implicit requirement that the `file_obj` passed during `qpy.dump` be seekable accidentally introduced in: 

- #14571 

### Details and comments
As suggested in #14775, we use seeking only if it's supported by the input stream and otherwise fall back on creating a temporary `io.BytesIO` buffer for the circuits payload.

Fixes #14775 