### PR TITLE
Fix passmanager task handling

### DIFF
--- a/qiskit/passmanager/passmanager.py
+++ b/qiskit/passmanager/passmanager.py
@@ -20,12 +20,12 @@ from itertools import chain
 from typing import Any
 
 import dill
-
 from qiskit.utils.parallel import parallel_map, should_run_in_parallel
-from .base_tasks import Task, PassManagerIR
+
+from .base_tasks import PassManagerIR, Task
+from .compilation_status import PassManagerState, PropertySet, WorkflowStatus
 from .exceptions import PassManagerError
 from .flow_controllers import FlowControllerLinear
-from .compilation_status import PropertySet, WorkflowStatus, PassManagerState
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +119,9 @@ class BasePassManager(ABC):
 
     def __getitem__(self, index):
         new_passmanager = self.__class__(max_iteration=self.max_iteration)
-        new_passmanager._tasks = [self._tasks[index]] if isinstance(index, int) else list(self._tasks[index])
+        new_passmanager._tasks = (
+            [self._tasks[index]] if isinstance(index, int) else list(self._tasks[index])
+        )
         return new_passmanager
 
     def __add__(self, other):
@@ -305,7 +307,9 @@ def _run_workflow(
     initial_status = WorkflowStatus()
 
     property_set = (
-        PropertySet() if initial_property_set is None else PropertySet(initial_property_set)
+        PropertySet()
+        if initial_property_set is None
+        else PropertySet(initial_property_set)
     )
     pass_manager.property_set = property_set
     passmanager_ir = pass_manager._passmanager_frontend(

--- a/qiskit/passmanager/passmanager.py
+++ b/qiskit/passmanager/passmanager.py
@@ -88,6 +88,10 @@ class BasePassManager(ABC):
             TypeError: When any element of tasks is not a subclass of passmanager Task.
             PassManagerError: If the index is not found.
         """
+        if isinstance(tasks, Task):
+            tasks = [tasks]
+        if any(not isinstance(t, Task) for t in tasks):
+            raise TypeError("Added tasks are not all valid pass manager task types.")
         try:
             self._tasks[index] = tasks
         except IndexError as ex:
@@ -115,14 +119,14 @@ class BasePassManager(ABC):
 
     def __getitem__(self, index):
         new_passmanager = self.__class__(max_iteration=self.max_iteration)
-        new_passmanager._tasks = self._tasks[index]
+        new_passmanager._tasks = [self._tasks[index]] if isinstance(index, int) else list(self._tasks[index])
         return new_passmanager
 
     def __add__(self, other):
         new_passmanager = self.__class__(max_iteration=self.max_iteration)
-        new_passmanager._tasks = self._tasks
+        new_passmanager._tasks = list(self._tasks)
         if isinstance(other, self.__class__):
-            new_passmanager._tasks += other._tasks
+            new_passmanager._tasks += list(other._tasks)
             return new_passmanager
         else:
             try:

--- a/qiskit/passmanager/passmanager.py
+++ b/qiskit/passmanager/passmanager.py
@@ -307,9 +307,7 @@ def _run_workflow(
     initial_status = WorkflowStatus()
 
     property_set = (
-        PropertySet()
-        if initial_property_set is None
-        else PropertySet(initial_property_set)
+        PropertySet() if initial_property_set is None else PropertySet(initial_property_set)
     )
     pass_manager.property_set = property_set
     passmanager_ir = pass_manager._passmanager_frontend(

--- a/releasenotes/notes/passmanager-copy-tasks-b506e3ef839602c9.yaml
+++ b/releasenotes/notes/passmanager-copy-tasks-b506e3ef839602c9.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    :class:`~qiskit.passmanager.BasePassManager` now copies scheduled tasks when
+    sliced or combined, so mutating the new pass manager no longer affects the
+    original schedule.


### PR DESCRIPTION
Changes:
- Reworked pass-manager mutation helpers to validate tasks, copy schedules, and avoid cross-manager state leaks or incorrect slicing.