### PR TITLE
Fix some edge cases in the C transpile function

### DIFF
--- a/crates/cext/src/sparse_observable.rs
+++ b/crates/cext/src/sparse_observable.rs
@@ -858,8 +858,15 @@ pub unsafe extern "C" fn qk_obs_str(obs: *const SparseObservable) -> *mut c_char
 #[no_mangle]
 #[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_str_free(string: *mut c_char) {
-    unsafe {
-        let _ = CString::from_raw(string);
+    if !string.is_null() {
+        if !string.is_aligned() {
+            panic!("Attempted to free a non-aligned pointer.")
+        }
+        // SAFETY: Per docstring the pointer is obtained by Qiskit functions, which are
+        // returning strings from CString::new or CString::into_raw.
+        unsafe {
+            let _ = CString::from_raw(string);
+        }
     }
 }
 

--- a/crates/cext/src/sparse_observable.rs
+++ b/crates/cext/src/sparse_observable.rs
@@ -863,7 +863,7 @@ pub unsafe extern "C" fn qk_str_free(string: *mut c_char) {
             panic!("Attempted to free a non-aligned pointer.")
         }
         // SAFETY: Per docstring the pointer is obtained by Qiskit functions, which are
-        // returning strings from CString::new or CString::into_raw.
+        // returning strings from CString::into_raw.
         unsafe {
             let _ = CString::from_raw(string);
         }

--- a/crates/cext/src/transpiler/transpile_function.rs
+++ b/crates/cext/src/transpiler/transpile_function.rs
@@ -90,7 +90,7 @@ pub extern "C" fn qk_transpiler_default_options() -> TranspileOptions {
 ///
 /// @param circuit A pointer to the circuit to run the transpiler on.
 /// @param target A pointer to the target to compile the circuit for.
-/// @params options A pointer to an options object that defines user options. If this is a null
+/// @param options A pointer to an options object that defines user options. If this is a null
 ///   pointer the default values will be used. See ``qk_transpile_default_options``
 ///   for more details on the default values.
 /// @param result A pointer to the memory location of the transpiler result. On a successful


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix some edge cases in ``qk_transpile`` that came up when playing with the function:

- Per documentation, ``options`` can be NULL -- but this was not actually supported. This commit supports it to match the docs (the alternative here would be to just change the docs and require ``options`` to never be NULL). A test for this is added.
- ``qk_str_free`` was previously safe to use since we never had empty strings. Since we now tell users to free the ``char* error`` with this function, we need to handle null pointers too.
- Fix some typos.

No reno as ``qk_transpile`` is not released yet.
