### PR TITLE
Add custom `DAGCircuit.__deepcopy__` implementation

### DIFF
--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -213,6 +213,20 @@ impl Param {
             Param::Obj(obj) => Param::Obj(obj.clone_ref(py)),
         }
     }
+
+    pub fn py_deepcopy<'py>(
+        &self,
+        py: Python<'py>,
+        memo: Option<&Bound<'py, PyDict>>,
+    ) -> PyResult<Self> {
+        match self {
+            Param::Float(f) => Ok(Param::Float(*f)),
+            _ => DEEPCOPY
+                .get_bound(py)
+                .call1((self.clone(), memo))?
+                .extract(),
+        }
+    }
 }
 
 // This impl allows for shared usage between [Param] and &[Param].

--- a/releasenotes/notes/dag-deepcopy-db6e6823b0f5fb56.yaml
+++ b/releasenotes/notes/dag-deepcopy-db6e6823b0f5fb56.yaml
@@ -1,0 +1,6 @@
+---
+features_transpiler:
+  - |
+    :class:`.DAGCircuit` now has a manual implementation of :meth:`~object.__deepcopy__`.  This is
+    orders of magnitude faster than the previous implicit implementation from the pickle protocol,
+    especially for large circuits, and directly benefits compilation at `optimization_level=3`.


### PR DESCRIPTION
Previously we were relying on the pickling behaviour.  This was desperately slow, and gets slower over time as more of our data is Rust native and need to be serialised to and from Python in order to interact with pickle.

Instead, we can use the `Clone` implementation of `StableGraph`, which preserves node and edge ids (including holes), then only thread through the deepcopy nature to the few parts of the data model where we still store Python objects.  In casual testing, this sped up a microbenchmark:

```python
import copy
from qiskit.converters import circuit_to_dag
from qiskit.circuit.library import quantum_volume

qv = quantum_volume(100, 100, seed=1).decompose()
dag = circuit_to_dag(qv)
%timeit copy.deepcopy(dag)
```

from about 1.05s to 6ms on my machine.

This is directly relevant for the performance of `optimization_level=3`, which needs to deepcopy as part of its `MinimumPoint` check in the optimisation loop.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


`transpile(optimization_level=3)` currently spends a completely inordinate amount of time in `MinimumPoint` because of this cost (it can be more expensive than `UnitarySynthesis`!).  Our pickle implementation for `DAGCircuit` and probably `CircuitData` could likely use some love, but actually for the deep-copy operation, we don't need to rely on pickle at all, which means we don't need to eat huge serialisation costs to and from Python for data that isn't natively Python-space.