### PR TITLE
Bump PyO3 and rust-numpy to 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f1dee9aa8d3f6f8e8b9af3803006101bb3653866ef056d530d53ae68587191"
+checksum = "9b2dba356160b54f5371b550575b78130a54718b4c6e46b3f33a6da74a27e78b"
 dependencies = [
  "libc",
  "nalgebra",
@@ -1367,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
@@ -1389,19 +1389,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1409,9 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1421,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ hashbrown.version = "0.15.2"
 num-bigint = "0.4"
 num-complex = "0.4"
 nalgebra = "0.33"
-numpy = "0.25"
+numpy = "0.26"
 ndarray = "0.16"
 smallvec = "1.15"
 thiserror = "2.0"
@@ -43,7 +43,7 @@ uuid = { version = "1.18", features = ["v4", "fast-rng"], default-features = fal
 # distributions).  We only activate that feature when building the C extension module; we still need
 # it disabled for Rust-only tests to avoid linker errors with it not being loaded.  See
 # https://pyo3.rs/main/features#extension-module for more.
-pyo3 = { version = "0.25.1", features = ["abi3-py39"] }
+pyo3 = { version = "0.26", features = ["abi3-py39"] }
 
 # These are our own crates.
 qiskit-accelerate = { path = "crates/accelerate" }

--- a/crates/accelerate/src/circuit_duration.rs
+++ b/crates/accelerate/src/circuit_duration.rs
@@ -51,7 +51,7 @@ pub(crate) fn compute_estimated_duration(dag: &DAGCircuit, target: &Target) -> P
 
                                             },
                                         Param::Obj(val) => {
-                                            Python::with_gil(|py| {
+                                            Python::attach(|py| {
                                                 let dur_float: f64 = val.extract(py)?;
                                                 Ok(dur_float * dt)
                                             })

--- a/crates/accelerate/src/circuit_library/pauli_evolution.rs
+++ b/crates/accelerate/src/circuit_library/pauli_evolution.rs
@@ -472,7 +472,7 @@ fn cx_fountain(qubits: Vec<Qubit>) -> Box<dyn DoubleEndedIterator<Item = Instruc
 fn add_control(gate: StandardGate, params: &[Param], control_state: &[bool]) -> PackedOperation {
     // This function does not return a PyResult to keep the evolution functions free from PyO3.
     // We know that all calls here should be valid and unwrap eagerly.
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let pygate = gate
             .create_py_op(py, Some(params), None)
             .expect("Failed to create Py version of standard gate.");

--- a/crates/accelerate/src/isometry.rs
+++ b/crates/accelerate/src/isometry.rs
@@ -34,7 +34,7 @@ pub fn reverse_qubit_state(
     state: [Complex64; 2],
     basis_state: usize,
     epsilon: f64,
-) -> PyObject {
+) -> Py<PyAny> {
     reverse_qubit_state_inner(&state, basis_state, epsilon)
         .into_pyarray(py)
         .into_any()
@@ -82,7 +82,7 @@ pub fn find_squs_for_disentangling(
     s: usize,
     epsilon: f64,
     n: usize,
-) -> Vec<PyObject> {
+) -> Vec<Py<PyAny>> {
     let v = v.as_array();
     let k_prime = 0;
     let i_start = if b(k, s + 1) == 0 {
@@ -116,7 +116,7 @@ pub fn apply_ucg(
     m: PyReadonlyArray2<Complex64>,
     k: usize,
     single_qubit_gates: Vec<PyReadonlyArray2<Complex64>>,
-) -> PyObject {
+) -> Py<PyAny> {
     let mut m = m.as_array().to_owned();
     let shape = m.shape();
     let num_qubits = shape[0].ilog2();
@@ -148,7 +148,7 @@ pub fn apply_diagonal_gate(
     m: PyReadonlyArray2<Complex64>,
     action_qubit_labels: Vec<usize>,
     diag: PyReadonlyArray1<Complex64>,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     let diag = diag.as_slice()?;
     let mut m = m.as_array().to_owned();
     let shape = m.shape();
@@ -225,7 +225,7 @@ pub fn apply_multi_controlled_gate(
     control_labels: Vec<usize>,
     target_label: usize,
     gate: PyReadonlyArray2<Complex64>,
-) -> PyObject {
+) -> Py<PyAny> {
     let mut m = m.as_array().to_owned();
     let gate = gate.as_array();
     let shape = m.shape();
@@ -304,7 +304,7 @@ pub fn merge_ucgate_and_diag(
     py: Python,
     single_qubit_gates: Vec<PyReadonlyArray2<Complex64>>,
     diag: Vec<Complex64>,
-) -> Vec<PyObject> {
+) -> Vec<Py<PyAny>> {
     single_qubit_gates
         .iter()
         .enumerate()

--- a/crates/accelerate/src/results/marginalization.rs
+++ b/crates/accelerate/src/results/marginalization.rs
@@ -128,7 +128,7 @@ pub fn marginal_memory(
     return_int: bool,
     return_hex: bool,
     parallel_threshold: usize,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     let run_in_parallel = getenv_use_multiple_threads();
     let first_elem = memory.first();
     if first_elem.is_none() {
@@ -173,7 +173,7 @@ pub fn marginal_measure_level_0(
     py: Python,
     memory: PyReadonlyArray3<Complex64>,
     indices: Vec<usize>,
-) -> PyObject {
+) -> Py<PyAny> {
     let mem_arr: ArrayView3<Complex64> = memory.as_array();
     let input_shape = mem_arr.shape();
     let new_shape = [input_shape[0], indices.len(), input_shape[2]];
@@ -187,7 +187,7 @@ pub fn marginal_measure_level_0_avg(
     py: Python,
     memory: PyReadonlyArray2<Complex64>,
     indices: Vec<usize>,
-) -> PyObject {
+) -> Py<PyAny> {
     let mem_arr: ArrayView2<Complex64> = memory.as_array();
     let input_shape = mem_arr.shape();
     let new_shape = [indices.len(), input_shape[1]];
@@ -201,7 +201,7 @@ pub fn marginal_measure_level_1(
     py: Python,
     memory: PyReadonlyArray2<Complex64>,
     indices: Vec<usize>,
-) -> PyObject {
+) -> Py<PyAny> {
     let mem_arr: ArrayView2<Complex64> = memory.as_array();
     let input_shape = mem_arr.shape();
     let new_shape = [input_shape[0], indices.len()];
@@ -215,7 +215,7 @@ pub fn marginal_measure_level_1_avg(
     py: Python,
     memory: PyReadonlyArray1<Complex64>,
     indices: Vec<usize>,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     let mem_arr: &[Complex64] = memory.as_slice()?;
     let out_arr: Vec<Complex64> = indices.into_iter().map(|idx| mem_arr[idx]).collect();
     Ok(out_arr.into_pyarray(py).into_any().unbind())

--- a/crates/accelerate/src/twirling.rs
+++ b/crates/accelerate/src/twirling.rs
@@ -276,10 +276,10 @@ fn generate_twirled_circuit(
             },
             OperationRef::Instruction(py_inst) => {
                 if py_inst.control_flow() {
-                    let new_blocks: PyResult<Vec<PyObject>> = py_inst
+                    let new_blocks: PyResult<Vec<Py<PyAny>>> = py_inst
                         .blocks()
                         .iter()
-                        .map(|block| -> PyResult<PyObject> {
+                        .map(|block| -> PyResult<Py<PyAny>> {
                             let new_block = generate_twirled_circuit(
                                 py,
                                 block,

--- a/crates/accelerate/src/uc_gate.rs
+++ b/crates/accelerate/src/uc_gate.rs
@@ -121,7 +121,7 @@ pub fn dec_ucg_help(
     py: Python,
     sq_gates: Vec<PyReadonlyArray2<Complex64>>,
     num_qubits: u32,
-) -> (Vec<PyObject>, PyObject) {
+) -> (Vec<Py<PyAny>>, Py<PyAny>) {
     let mut single_qubit_gates: Vec<Matrix2<Complex64>> = sq_gates
         .into_iter()
         .map(|x| {

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -1067,7 +1067,7 @@ pub unsafe extern "C" fn qk_opcounts_clear(op_counts: *mut OpCounts) {
 pub unsafe extern "C" fn qk_circuit_to_python(circuit: *mut CircuitData) -> *mut PyObject {
     unsafe {
         let circuit = Box::from_raw(mut_ptr_as_ref(circuit));
-        let py = Python::assume_gil_acquired();
+        let py = Python::assume_attached();
         QUANTUM_CIRCUIT
             .get_bound(py)
             .call_method1(intern!(py, "_from_circuit_data"), (*circuit,))

--- a/crates/cext/src/sparse_observable.rs
+++ b/crates/cext/src/sparse_observable.rs
@@ -1059,7 +1059,7 @@ pub unsafe extern "C" fn qk_obs_to_python(obs: *const SparseObservable) -> *mut 
 
     // SAFETY: the C caller is required to hold the GIL.
     unsafe {
-        let py = Python::assume_gil_acquired();
+        let py = Python::assume_attached();
         Py::new(py, py_obs)
             .expect("Unable to create a Python object")
             .into_ptr()

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -20,7 +20,7 @@ use pyo3::prelude::*;
 
 use pyo3::types::{PyBool, PyList, PyTuple, PyType};
 use pyo3::IntoPyObjectExt;
-use pyo3::{intern, PyObject, PyResult};
+use pyo3::{intern, PyResult};
 
 use nalgebra::{Dyn, MatrixView2, MatrixView4};
 use num_complex::Complex64;
@@ -156,7 +156,7 @@ impl CircuitInstruction {
 
     /// The logical operation that this instruction represents an execution of.
     #[getter]
-    pub fn get_operation(&self, py: Python) -> PyResult<PyObject> {
+    pub fn get_operation(&self, py: Python) -> PyResult<Py<PyAny>> {
         // This doesn't use `get_or_init` because a) the initialiser is fallible and
         // `get_or_try_init` isn't stable, and b) the initialiser can yield to the Python
         // interpreter, which might suspend the thread and allow another to inadvertantly attempt to
@@ -307,7 +307,7 @@ impl CircuitInstruction {
         }
     }
 
-    pub fn __getnewargs__(&self, py: Python<'_>) -> PyResult<PyObject> {
+    pub fn __getnewargs__(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         (
             self.get_operation(py)?,
             self.qubits.bind(py),
@@ -345,7 +345,7 @@ impl CircuitInstruction {
         )
     }
 
-    pub fn __getitem__(&self, py: Python<'_>, key: &Bound<PyAny>) -> PyResult<PyObject> {
+    pub fn __getitem__(&self, py: Python<'_>, key: &Bound<PyAny>) -> PyResult<Py<PyAny>> {
         warn_on_legacy_circuit_instruction_iteration(py)?;
         self._legacy_format(py)?
             .as_any()
@@ -353,7 +353,7 @@ impl CircuitInstruction {
             .into_py_any(py)
     }
 
-    pub fn __iter__(&self, py: Python<'_>) -> PyResult<PyObject> {
+    pub fn __iter__(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         warn_on_legacy_circuit_instruction_iteration(py)?;
         self._legacy_format(py)?
             .as_any()
@@ -371,7 +371,7 @@ impl CircuitInstruction {
         other: &Bound<PyAny>,
         op: CompareOp,
         py: Python<'_>,
-    ) -> PyResult<PyObject> {
+    ) -> PyResult<Py<PyAny>> {
         fn params_eq(py: Python, left: &[Param], right: &[Param]) -> PyResult<bool> {
             if left.len() != right.len() {
                 return Ok(false);
@@ -683,7 +683,7 @@ fn as_tuple<'py>(py: Python<'py>, seq: Option<Bound<'py, PyAny>>) -> PyResult<Bo
             py,
             seq.try_iter()?
                 .map(|o| Ok(o?.unbind()))
-                .collect::<PyResult<Vec<PyObject>>>()?,
+                .collect::<PyResult<Vec<Py<PyAny>>>>()?,
         )
     }
 }

--- a/crates/circuit/src/classical/types.rs
+++ b/crates/circuit/src/classical/types.rs
@@ -12,13 +12,13 @@
 
 use pyo3::exceptions::PyAttributeError;
 use pyo3::prelude::*;
-use pyo3::sync::GILOnceCell;
+use pyo3::sync::PyOnceLock;
 use pyo3::types::PyTuple;
 use pyo3::PyTypeInfo;
 
-static BOOL_TYPE: GILOnceCell<Py<PyBool>> = GILOnceCell::new();
-static DURATION_TYPE: GILOnceCell<Py<PyDuration>> = GILOnceCell::new();
-static FLOAT_TYPE: GILOnceCell<Py<PyFloat>> = GILOnceCell::new();
+static BOOL_TYPE: PyOnceLock<Py<PyBool>> = PyOnceLock::new();
+static DURATION_TYPE: PyOnceLock<Py<PyDuration>> = PyOnceLock::new();
+static FLOAT_TYPE: PyOnceLock<Py<PyFloat>> = PyOnceLock::new();
 
 /// A classical expression's "type".
 ///

--- a/crates/circuit/src/converters.rs
+++ b/crates/circuit/src/converters.rs
@@ -75,13 +75,13 @@ pub fn dag_to_circuit(dag: &DAGCircuit, copy_operations: bool) -> PyResult<Circu
             if copy_operations {
                 let op = match instr.op.view() {
                     OperationRef::Gate(gate) => {
-                        Python::with_gil(|py| gate.py_deepcopy(py, None))?.into()
+                        Python::attach(|py| gate.py_deepcopy(py, None))?.into()
                     }
                     OperationRef::Instruction(instruction) => {
-                        Python::with_gil(|py| instruction.py_deepcopy(py, None))?.into()
+                        Python::attach(|py| instruction.py_deepcopy(py, None))?.into()
                     }
                     OperationRef::Operation(operation) => {
-                        Python::with_gil(|py| operation.py_deepcopy(py, None))?.into()
+                        Python::attach(|py| operation.py_deepcopy(py, None))?.into()
                     }
                     OperationRef::StandardGate(gate) => gate.into(),
                     OperationRef::StandardInstruction(instruction) => instruction.into(),

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -148,7 +148,7 @@ impl From<Var> for Wire {
 }
 
 impl Wire {
-    fn to_pickle(self, py: Python) -> PyResult<PyObject> {
+    fn to_pickle(self, py: Python) -> PyResult<Py<PyAny>> {
         match self {
             Self::Qubit(bit) => (0, bit.0.into_py_any(py)?),
             Self::Clbit(bit) => (1, bit.0.into_py_any(py)?),
@@ -186,7 +186,7 @@ pub struct DAGCircuit {
     pub name: Option<String>,
     /// Circuit metadata
     #[pyo3(get, set)]
-    pub metadata: Option<PyObject>,
+    pub metadata: Option<Py<PyAny>>,
 
     dag: StableDiGraph<NodeType, Wire>,
 
@@ -208,7 +208,7 @@ pub struct DAGCircuit {
     /// Global phase.
     global_phase: Param,
     /// Duration.
-    duration: Option<PyObject>,
+    duration: Option<Py<PyAny>>,
     /// Unit of duration.
     unit: String,
 
@@ -327,8 +327,8 @@ impl PyBitLocations {
         Ok((slf.getattr("index")?, slf.getattr("registers")?))
     }
 
-    fn __getitem__(&self, py: Python, index: PySequenceIndex<'_>) -> PyResult<PyObject> {
-        let getter = |index: usize| -> PyResult<PyObject> {
+    fn __getitem__(&self, py: Python, index: PySequenceIndex<'_>) -> PyResult<Py<PyAny>> {
+        let getter = |index: usize| -> PyResult<Py<PyAny>> {
             match index {
                 0 => self.index.into_py_any(py),
                 1 => Ok(self.registers.clone_ref(py).into_any()),
@@ -378,7 +378,7 @@ pub struct DAGVarInfo {
 }
 
 impl DAGVarInfo {
-    fn to_pickle(&self, py: Python) -> PyResult<PyObject> {
+    fn to_pickle(&self, py: Python) -> PyResult<Py<PyAny>> {
         (
             self.var.0,
             self.type_ as u8,
@@ -436,7 +436,7 @@ pub struct DAGStretchInfo {
 }
 
 impl DAGStretchInfo {
-    fn to_pickle(&self, py: Python) -> PyResult<PyObject> {
+    fn to_pickle(&self, py: Python) -> PyResult<Py<PyAny>> {
         (self.stretch.0, self.type_ as u8).into_py_any(py)
     }
 
@@ -470,7 +470,7 @@ pub enum DAGIdentifierInfo {
 }
 
 impl DAGIdentifierInfo {
-    fn to_pickle(&self, py: Python) -> PyResult<PyObject> {
+    fn to_pickle(&self, py: Python) -> PyResult<Py<PyAny>> {
         match self {
             DAGIdentifierInfo::Stretch(info) => (0, info.to_pickle(py)?).into_py_any(py),
             DAGIdentifierInfo::Var(info) => (1, info.to_pickle(py)?).into_py_any(py),
@@ -563,7 +563,7 @@ impl DAGCircuit {
     ///
     /// DEPRECATED since Qiskit 1.3.0 and will be removed in Qiskit 3.0.0
     #[setter("duration")]
-    fn set_duration(&mut self, py: Python, duration: Option<PyObject>) -> PyResult<()> {
+    fn set_duration(&mut self, py: Python, duration: Option<Py<PyAny>>) -> PyResult<()> {
         imports::WARNINGS_WARN.get_bound(py).call1((
             intern!(
                 py,
@@ -583,7 +583,7 @@ impl DAGCircuit {
     ///
     /// To be removed with set_duration.
     #[setter("_duration")]
-    fn set_internal_duration(&mut self, duration: Option<PyObject>) {
+    fn set_internal_duration(&mut self, duration: Option<Py<PyAny>>) {
         self.duration = duration
     }
 
@@ -763,7 +763,7 @@ impl DAGCircuit {
         out_dict.set_item("clbits", self.clbits.objects())?;
         out_dict.set_item("vars", self.vars.objects().clone())?;
         out_dict.set_item("stretches", self.stretches.objects().clone())?;
-        let mut nodes: Vec<PyObject> = Vec::with_capacity(self.dag.node_count());
+        let mut nodes: Vec<Py<PyAny>> = Vec::with_capacity(self.dag.node_count());
         for node_idx in self.dag.node_indices() {
             let node_data = self.get_node(py, node_idx)?;
             nodes.push((node_idx.index(), node_data).into_py_any(py)?);
@@ -773,7 +773,7 @@ impl DAGCircuit {
             "nodes_removed",
             self.dag.node_count() != self.dag.node_bound(),
         )?;
-        let mut edges: Vec<PyObject> = Vec::with_capacity(self.dag.edge_bound());
+        let mut edges: Vec<Py<PyAny>> = Vec::with_capacity(self.dag.edge_bound());
         // edges are saved with none (deleted edges) instead of their index to save space
         for i in 0..self.dag.edge_bound() {
             let idx = EdgeIndex::new(i);
@@ -795,7 +795,7 @@ impl DAGCircuit {
         Ok(out_dict.unbind())
     }
 
-    fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
+    fn __setstate__(&mut self, py: Python, state: Py<PyAny>) -> PyResult<()> {
         let dict_state = state.downcast_bound::<PyDict>(py)?;
         self.name = dict_state.get_item("name")?.unwrap().extract()?;
         self.metadata = dict_state.get_item("metadata")?.unwrap().extract()?;
@@ -927,7 +927,7 @@ impl DAGCircuit {
             for item in nodes_lst {
                 let item = item.downcast::<PyTuple>().unwrap();
                 let next_index: usize = item.get_item(0).unwrap().extract().unwrap();
-                let weight: PyObject = item.get_item(1).unwrap().extract().unwrap();
+                let weight: Py<PyAny> = item.get_item(1).unwrap().extract().unwrap();
                 while next_index > self.dag.node_bound() {
                     // node does not exist
                     let tmp_node = self.dag.add_node(NodeType::QubitIn(Qubit(u32::MAX)));
@@ -1591,7 +1591,7 @@ impl DAGCircuit {
         front: bool,
         inplace: bool,
         inline_captures: bool,
-    ) -> PyResult<Option<PyObject>> {
+    ) -> PyResult<Option<Py<PyAny>>> {
         if front {
             return Err(DAGCircuitError::new_err(
                 "Front composition not supported yet.",
@@ -1668,7 +1668,7 @@ impl DAGCircuit {
     ///     DAGCircuitError: If the DAG is invalid
     #[pyo3(signature=(ignore=None))]
     fn idle_wires(&self, py: Python, ignore: Option<&Bound<PyList>>) -> PyResult<Py<PyIterator>> {
-        let mut result: Vec<PyObject> = Vec::new();
+        let mut result: Vec<Py<PyAny>> = Vec::new();
         let wires = (0..self.qubit_io_map.len())
             .map(|idx| Wire::Qubit(Qubit::new(idx)))
             .chain((0..self.clbit_io_map.len()).map(|idx| Wire::Clbit(Clbit::new(idx))))
@@ -1755,7 +1755,7 @@ impl DAGCircuit {
                 " but see this method's documentation for the meaning of this."
             )));
         }
-        Python::with_gil(|py| -> PyResult<()> {
+        Python::attach(|py| -> PyResult<()> {
             // Handle recursively.
             let circuit_to_dag = imports::CIRCUIT_TO_DAG.get_bound(py);
             for node in self.dag.node_weights() {
@@ -1836,7 +1836,7 @@ impl DAGCircuit {
                 " but see this method's documentation for the meaning of this."
             )));
         }
-        let node_lookup = Python::with_gil(|py| -> PyResult<HashMap<NodeIndex, usize>> {
+        let node_lookup = Python::attach(|py| -> PyResult<HashMap<NodeIndex, usize>> {
             // Handle recursively.
             let circuit_to_dag = imports::CIRCUIT_TO_DAG.get_bound(py);
             let mut node_lookup: HashMap<NodeIndex, usize> = HashMap::new();
@@ -2332,7 +2332,7 @@ impl DAGCircuit {
             match (left, right) {
                 (Param::Float(a), Param::Float(b)) => Ok(a.total_cmp(b) == Ordering::Equal),
                 (Param::ParameterExpression(a), Param::ParameterExpression(b)) => Ok(a.eq(b)),
-                (Param::Obj(a), Param::Obj(b)) => Python::with_gil(|py| a.bind(py).eq(b.bind(py))),
+                (Param::Obj(a), Param::Obj(b)) => Python::attach(|py| a.bind(py).eq(b.bind(py))),
                 _ => Ok(false),
             }
         };
@@ -2380,13 +2380,13 @@ impl DAGCircuit {
                 ) => Ok(left == right),
                 (OperationRef::Unitary(left), OperationRef::Unitary(right)) => Ok(left == right),
                 (OperationRef::Gate(left), OperationRef::Gate(right)) => {
-                    Python::with_gil(|py| left.gate.bind(py).eq(&right.gate))
+                    Python::attach(|py| left.gate.bind(py).eq(&right.gate))
                 }
                 (OperationRef::Instruction(left), OperationRef::Instruction(right)) => {
-                    Python::with_gil(|py| left.instruction.bind(py).eq(&right.instruction))
+                    Python::attach(|py| left.instruction.bind(py).eq(&right.instruction))
                 }
                 (OperationRef::Operation(left), OperationRef::Operation(right)) => {
-                    Python::with_gil(|py| left.operation.bind(py).eq(&right.operation))
+                    Python::attach(|py| left.operation.bind(py).eq(&right.operation))
                 }
                 _ => Ok(false),
             }
@@ -2671,7 +2671,7 @@ impl DAGCircuit {
                 HashSet::from_iter(cargs_list.iter().cloned());
             if self.may_have_additional_wires(node.op.view()) {
                 let (add_cargs, _add_vars) =
-                    Python::with_gil(|py| self.additional_wires(py, node.op.view()))?;
+                    Python::attach(|py| self.additional_wires(py, node.op.view()))?;
                 for wire in add_cargs {
                     let clbit = self.clbits.get(wire).unwrap();
                     if !cargs_set.contains(clbit) {
@@ -3372,7 +3372,7 @@ impl DAGCircuit {
     }
 
     /// Returns the longest path in the dag as a list of DAGOpNodes, DAGInNodes, and DAGOutNodes.
-    fn longest_path(&self, py: Python) -> PyResult<Vec<PyObject>> {
+    fn longest_path(&self, py: Python) -> PyResult<Vec<Py<PyAny>>> {
         let weight_fn = |_| -> Result<usize, Infallible> { Ok(1) };
         match rustworkx_core::dag_algo::longest_path(&self.dag, weight_fn).unwrap() {
             Some(res) => res.0,
@@ -3519,7 +3519,7 @@ impl DAGCircuit {
     /// recursively contain the predecessors of each predecessor.
     #[pyo3(name = "ancestors")]
     fn py_ancestors(&self, py: Python, node: &DAGNode) -> PyResult<Py<PySet>> {
-        let ancestors: PyResult<Vec<PyObject>> = self
+        let ancestors: PyResult<Vec<Py<PyAny>>> = self
             .ancestors(node.node.unwrap())
             .map(|node| self.get_node(py, node))
             .collect();
@@ -3533,7 +3533,7 @@ impl DAGCircuit {
     /// whereas this method contains all the successors' succesors.
     #[pyo3(name = "descendants")]
     fn py_descendants(&self, py: Python, node: &DAGNode) -> PyResult<Py<PySet>> {
-        let descendants: PyResult<Vec<PyObject>> = self
+        let descendants: PyResult<Vec<Py<PyAny>>> = self
             .descendants(node.node.unwrap())
             .map(|node| self.get_node(py, node))
             .collect();
@@ -3544,9 +3544,11 @@ impl DAGCircuit {
     /// current node and ``[DAGNodes]`` is a list of the successors in BFS order.
     #[pyo3(name = "bfs_successors")]
     fn py_bfs_successors(&self, py: Python, node: &DAGNode) -> PyResult<Py<PyIterator>> {
-        let successor_index: PyResult<Vec<(PyObject, Vec<PyObject>)>> = self
+        type PyIteratorVec = Vec<(Py<PyAny>, Vec<Py<PyAny>>)>;
+
+        let successor_index: PyResult<PyIteratorVec> = self
             .bfs_successors(node.node.unwrap())
-            .map(|(node, nodes)| -> PyResult<(PyObject, Vec<PyObject>)> {
+            .map(|(node, nodes)| -> PyResult<(Py<PyAny>, Vec<Py<PyAny>>)> {
                 Ok((
                     self.get_node(py, node)?,
                     nodes
@@ -3783,13 +3785,13 @@ impl DAGCircuit {
     /// Yield layers of the multigraph.
     #[pyo3(name = "multigraph_layers")]
     fn py_multigraph_layers(&self, py: Python) -> PyResult<Py<PyIterator>> {
-        let graph_layers = self.multigraph_layers().map(|layer| -> Vec<PyObject> {
+        let graph_layers = self.multigraph_layers().map(|layer| -> Vec<Py<PyAny>> {
             layer
                 .into_iter()
                 .filter_map(|index| self.get_node(py, index).ok())
                 .collect()
         });
-        let list: Bound<PyList> = PyList::new(py, graph_layers.collect::<Vec<Vec<PyObject>>>())?;
+        let list: Bound<PyList> = PyList::new(py, graph_layers.collect::<Vec<Vec<Py<PyAny>>>>())?;
         Ok(PyIterator::from_object(&list)?.unbind())
     }
 
@@ -3930,7 +3932,7 @@ impl DAGCircuit {
     /// Returns:
     ///     Mapping[str, int]: a mapping of operation names to the number of times it appears.
     #[pyo3(name = "count_ops", signature = (*, recurse=true))]
-    fn py_count_ops(&self, py: Python, recurse: bool) -> PyResult<PyObject> {
+    fn py_count_ops(&self, py: Python, recurse: bool) -> PyResult<Py<PyAny>> {
         self.count_ops(py, recurse)?.into_py_any(py)
     }
 
@@ -4054,7 +4056,7 @@ impl DAGCircuit {
     }
 
     /// Return a dictionary of circuit properties.
-    fn properties(&self, py: Python) -> PyResult<HashMap<&str, PyObject>> {
+    fn properties(&self, py: Python) -> PyResult<HashMap<&str, Py<PyAny>>> {
         Ok(HashMap::from_iter([
             ("size", self.size(false)?.into_py_any(py)?),
             ("depth", self.depth(false)?.into_py_any(py)?),
@@ -4102,8 +4104,8 @@ impl DAGCircuit {
         &self,
         py: Python<'py>,
         graph_attrs: Option<BTreeMap<String, String>>,
-        node_attrs: Option<PyObject>,
-        edge_attrs: Option<PyObject>,
+        node_attrs: Option<Py<PyAny>>,
+        edge_attrs: Option<Py<PyAny>>,
     ) -> PyResult<Bound<'py, PyString>> {
         let mut buffer = Vec::<u8>::new();
         build_dot(py, self, &mut buffer, graph_attrs, node_attrs, edge_attrs)?;
@@ -4427,7 +4429,7 @@ impl DAGCircuit {
             .collect()
     }
 
-    fn _in_wires(&self, py: Python, node_index: usize) -> Vec<PyObject> {
+    fn _in_wires(&self, py: Python, node_index: usize) -> Vec<Py<PyAny>> {
         self.dag
             .edges_directed(NodeIndex::new(node_index), Incoming)
             .map(|wire| match wire.weight() {
@@ -4438,7 +4440,7 @@ impl DAGCircuit {
             .collect()
     }
 
-    fn _out_wires(&self, py: Python, node_index: usize) -> Vec<PyObject> {
+    fn _out_wires(&self, py: Python, node_index: usize) -> Vec<Py<PyAny>> {
         self.dag
             .edges_directed(NodeIndex::new(node_index), Outgoing)
             .map(|wire| match wire.weight() {
@@ -4454,7 +4456,7 @@ impl DAGCircuit {
         py: Python,
         node_index: usize,
         edge_checker: &Bound<PyAny>,
-    ) -> PyResult<Vec<PyObject>> {
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let mut result = Vec::new();
         for e in self
             .dag
@@ -4473,7 +4475,7 @@ impl DAGCircuit {
         Ok(result)
     }
 
-    fn _edges(&self, py: Python) -> PyResult<Vec<PyObject>> {
+    fn _edges(&self, py: Python) -> PyResult<Vec<Py<PyAny>>> {
         self.dag
             .edge_indices()
             .map(|index| {
@@ -5440,7 +5442,7 @@ impl DAGCircuit {
                 let mut clbits: HashSet<Clbit> =
                     HashSet::from_iter(self.cargs_interner.get(instr.clbits).iter().copied());
                 let (additional_clbits, additional_vars) =
-                    Python::with_gil(|py| self.additional_wires(py, instr.op.view()))?;
+                    Python::attach(|py| self.additional_wires(py, instr.op.view()))?;
                 for clbit in additional_clbits {
                     clbits.insert(clbit);
                 }
@@ -5468,7 +5470,7 @@ impl DAGCircuit {
                 let mut clbits: HashSet<Clbit> =
                     HashSet::from_iter(self.cargs_interner.get(inst.clbits).iter().copied());
                 let (additional_clbits, additional_vars) =
-                    Python::with_gil(|py| self.additional_wires(py, inst.op.view()))?;
+                    Python::attach(|py| self.additional_wires(py, inst.op.view()))?;
                 for clbit in additional_clbits {
                     clbits.insert(clbit);
                 }
@@ -5522,7 +5524,7 @@ impl DAGCircuit {
         cargs: &[Clbit],
         params: Option<SmallVec<[Param; 3]>>,
         label: Option<String>,
-        #[cfg(feature = "cache_pygates")] py_op: Option<PyObject>,
+        #[cfg(feature = "cache_pygates")] py_op: Option<Py<PyAny>>,
     ) -> PyResult<NodeIndex> {
         self.inner_apply_op(
             op,
@@ -5544,7 +5546,7 @@ impl DAGCircuit {
         cargs: &[Clbit],
         params: Option<SmallVec<[Param; 3]>>,
         label: Option<String>,
-        #[cfg(feature = "cache_pygates")] py_op: Option<PyObject>,
+        #[cfg(feature = "cache_pygates")] py_op: Option<Py<PyAny>>,
     ) -> PyResult<NodeIndex> {
         self.inner_apply_op(
             op,
@@ -5567,7 +5569,7 @@ impl DAGCircuit {
         cargs: &[Clbit],
         params: Option<SmallVec<[Param; 3]>>,
         label: Option<String>,
-        #[cfg(feature = "cache_pygates")] py_op: Option<PyObject>,
+        #[cfg(feature = "cache_pygates")] py_op: Option<Py<PyAny>>,
         front: bool,
     ) -> PyResult<NodeIndex> {
         // Check that all qargs are within an acceptable range
@@ -6169,11 +6171,11 @@ impl DAGCircuit {
     /// * node_index: The node in the DAGCircuit to replace.
     /// * other: The replacement DAGCircuit.
     /// * qubit_map: A mapping from the replacement DAGCircuit qubits to the replaced node's qargs.
-    ///         If None, trivial mapping will be used.
+    ///   If None, trivial mapping will be used.
     /// * clbit_map: A mapping from the replacement DAGCircuit clbits to the replaced node's clbits.
-    ///         If None, trivial mapping will be used.
+    ///   If None, trivial mapping will be used.
     /// * var_map: A mapping from the replacement DAGCircuit variables to the replaced node's variables.
-    ///         Note: Inferring variable mapping automatically is currently not implemented.
+    ///   Note: Inferring variable mapping automatically is currently not implemented.
     ///
     /// # Returns
     ///
@@ -6270,7 +6272,7 @@ impl DAGCircuit {
             };
 
             if old_op.name() == "switch_case" {
-                Python::with_gil(|py| -> PyResult<()> {
+                Python::attach(|py| -> PyResult<()> {
                     let target = old_op.instruction.bind(py).getattr("target")?.extract()?;
                     let kwargs = PyDict::new(py);
                     kwargs.set_item(
@@ -6310,7 +6312,7 @@ impl DAGCircuit {
                     Ok(())
                 })?;
             } else if old_inst.op.control_flow() {
-                Python::with_gil(|py| -> PyResult<()> {
+                Python::attach(|py| -> PyResult<()> {
                     if let Ok(condition) = old_op
                         .instruction
                         .bind(py)
@@ -6726,7 +6728,7 @@ impl DAGCircuit {
         }
 
         if self.may_have_additional_wires(inst.op.view()) {
-            let (clbits, vars) = Python::with_gil(|py| self.additional_wires(py, inst.op.view()))?;
+            let (clbits, vars) = Python::attach(|py| self.additional_wires(py, inst.op.view()))?;
             for b in clbits {
                 if !self.clbit_io_map.len() - 1 < b.index() {
                     return Err(DAGCircuitError::new_err(format!(
@@ -7061,7 +7063,7 @@ impl DAGCircuit {
         qc_data: &CircuitData,
         copy_op: bool,
         name: Option<String>,
-        metadata: Option<PyObject>,
+        metadata: Option<Py<PyAny>>,
         qubit_order: Option<Vec<ShareableQubit>>,
         clbit_order: Option<Vec<ShareableClbit>>,
     ) -> PyResult<Self> {
@@ -7204,13 +7206,13 @@ impl DAGCircuit {
                 op: if copy_op {
                     match instr.op.view() {
                         OperationRef::Gate(gate) => {
-                            Python::with_gil(|py| gate.py_deepcopy(py, None))?.into()
+                            Python::attach(|py| gate.py_deepcopy(py, None))?.into()
                         }
                         OperationRef::Instruction(instruction) => {
-                            Python::with_gil(|py| instruction.py_deepcopy(py, None))?.into()
+                            Python::attach(|py| instruction.py_deepcopy(py, None))?.into()
                         }
                         OperationRef::Operation(operation) => {
-                            Python::with_gil(|py| operation.py_deepcopy(py, None))?.into()
+                            Python::attach(|py| operation.py_deepcopy(py, None))?.into()
                         }
                         OperationRef::StandardGate(gate) => gate.into(),
                         OperationRef::StandardInstruction(instruction) => instruction.into(),
@@ -7255,7 +7257,7 @@ impl DAGCircuit {
                     // Add classical bits from SwitchCaseOp, if applicable.
                     if let OperationRef::Instruction(op) = packed.op.view() {
                         if op.name() == "switch_case" {
-                            Python::with_gil(|py| -> PyResult<()> {
+                            Python::attach(|py| -> PyResult<()> {
                                 let op_bound = op.instruction.bind(py);
                                 let target = op_bound.getattr(intern!(py, "target"))?;
                                 if target.downcast::<PyClbit>().is_ok() {
@@ -7526,7 +7528,7 @@ impl DAGCircuit {
                         let OperationRef::Instruction(op) = inst.op.view() else {
                             unreachable!("All control_flow ops should be PyInstruction");
                         };
-                        let py_op = Python::with_gil(|py| -> PyResult<Py<PyAny>> {
+                        let py_op = Python::attach(|py| -> PyResult<Py<PyAny>> {
                             let py_op = op.instruction.bind(py);
                             let py_op = py_op.call_method0(intern!(py, "to_mutable"))?;
                             if py_op.is_instance(imports::IF_ELSE_OP.get_bound(py))?
@@ -7692,7 +7694,7 @@ impl DAGCircuit {
             )
             .collect();
         let (additional_clbits, additional_vars) =
-            Python::with_gil(|py| self.additional_wires(py, new_op.operation.view()))?;
+            Python::attach(|py| self.additional_wires(py, new_op.operation.view()))?;
         new_wires.extend(additional_clbits.iter().map(|x| Wire::Clbit(*x)));
         new_wires.extend(additional_vars.iter().map(|x| Wire::Var(*x)));
 
@@ -7749,7 +7751,7 @@ impl DAGCircuit {
     }
 
     // Returns an immutable reference to 'metadata'
-    pub fn get_metadata(&self) -> Option<&PyObject> {
+    pub fn get_metadata(&self) -> Option<&Py<PyAny>> {
         self.metadata.as_ref()
     }
 }
@@ -7829,7 +7831,7 @@ impl DAGCircuitBuilder {
         clbits: &[Clbit],
         params: Option<SmallVec<[Param; 3]>>,
         label: Option<String>,
-        #[cfg(feature = "cache_pygates")] py_op: Option<PyObject>,
+        #[cfg(feature = "cache_pygates")] py_op: Option<Py<PyAny>>,
     ) -> PyResult<NodeIndex> {
         let instruction = self.pack_instruction(
             op,
@@ -7937,7 +7939,7 @@ impl DAGCircuitBuilder {
         clbits: &[Clbit],
         params: Option<SmallVec<[Param; 3]>>,
         label: Option<String>,
-        #[cfg(feature = "cache_pygates")] py_op: Option<PyObject>,
+        #[cfg(feature = "cache_pygates")] py_op: Option<Py<PyAny>>,
     ) -> PackedInstruction {
         #[cfg(feature = "cache_pygates")]
         let py_op = if let Some(py_op) = py_op {

--- a/crates/circuit/src/dag_node.rs
+++ b/crates/circuit/src/dag_node.rs
@@ -30,7 +30,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
 use pyo3::IntoPyObjectExt;
-use pyo3::{intern, PyObject, PyResult};
+use pyo3::{intern, PyResult};
 
 /// Parent class for DAGOpNode, DAGInNode, and DAGOutNode.
 #[pyclass(module = "qiskit._accelerate.circuit", subclass)]
@@ -225,7 +225,7 @@ impl DAGOpNode {
         py: Python,
         mut instruction: CircuitInstruction,
         deepcopy: bool,
-    ) -> PyResult<PyObject> {
+    ) -> PyResult<Py<PyAny>> {
         if deepcopy {
             instruction.operation = match instruction.operation.view() {
                 OperationRef::Gate(gate) => gate.py_deepcopy(py, None)?.into(),
@@ -245,7 +245,7 @@ impl DAGOpNode {
         Py::new(py, sub)?.into_py_any(py)
     }
 
-    fn __reduce__(slf: PyRef<Self>, py: Python) -> PyResult<PyObject> {
+    fn __reduce__(slf: PyRef<Self>, py: Python) -> PyResult<Py<PyAny>> {
         let state = slf.as_ref().node.map(|node| node.index());
         let temp = (
             slf.instruction.get_operation(py)?,
@@ -295,7 +295,7 @@ impl DAGOpNode {
     }
 
     #[getter]
-    fn get_op(&self, py: Python) -> PyResult<PyObject> {
+    fn get_op(&self, py: Python) -> PyResult<Py<PyAny>> {
         self.instruction.get_operation(py)
     }
 
@@ -415,7 +415,7 @@ impl DAGOpNode {
 
     /// Sets the Instruction name corresponding to the op for this node
     #[setter]
-    fn set_name(&mut self, py: Python, new_name: PyObject) -> PyResult<()> {
+    fn set_name(&mut self, py: Python, new_name: Py<PyAny>) -> PyResult<()> {
         let op = self.instruction.get_operation_mut(py)?;
         op.setattr(intern!(py, "name"), new_name)?;
         self.instruction.operation = op.extract::<OperationFromPython>()?.operation;
@@ -437,11 +437,11 @@ impl DAGOpNode {
 #[pyclass(module = "qiskit._accelerate.circuit", extends=DAGNode)]
 pub struct DAGInNode {
     #[pyo3(get)]
-    pub wire: PyObject,
+    pub wire: Py<PyAny>,
 }
 
 impl DAGInNode {
-    pub fn new(node: NodeIndex, wire: PyObject) -> (Self, DAGNode) {
+    pub fn new(node: NodeIndex, wire: Py<PyAny>) -> (Self, DAGNode) {
         (DAGInNode { wire }, DAGNode { node: Some(node) })
     }
 }
@@ -449,7 +449,7 @@ impl DAGInNode {
 #[pymethods]
 impl DAGInNode {
     #[new]
-    fn py_new(wire: PyObject) -> PyResult<(Self, DAGNode)> {
+    fn py_new(wire: Py<PyAny>) -> PyResult<(Self, DAGNode)> {
         Ok((DAGInNode { wire }, DAGNode { node: None }))
     }
 
@@ -495,11 +495,11 @@ impl DAGInNode {
 #[pyclass(module = "qiskit._accelerate.circuit", extends=DAGNode)]
 pub struct DAGOutNode {
     #[pyo3(get)]
-    pub wire: PyObject,
+    pub wire: Py<PyAny>,
 }
 
 impl DAGOutNode {
-    pub fn new(node: NodeIndex, wire: PyObject) -> (Self, DAGNode) {
+    pub fn new(node: NodeIndex, wire: Py<PyAny>) -> (Self, DAGNode) {
         (DAGOutNode { wire }, DAGNode { node: Some(node) })
     }
 }
@@ -507,11 +507,11 @@ impl DAGOutNode {
 #[pymethods]
 impl DAGOutNode {
     #[new]
-    fn py_new(wire: PyObject) -> PyResult<(Self, DAGNode)> {
+    fn py_new(wire: Py<PyAny>) -> PyResult<(Self, DAGNode)> {
         Ok((DAGOutNode { wire }, DAGNode { node: None }))
     }
 
-    fn __reduce__(slf: PyRef<Self>, py: Python) -> PyResult<PyObject> {
+    fn __reduce__(slf: PyRef<Self>, py: Python) -> PyResult<Py<PyAny>> {
         let state = slf.as_ref().node.map(|node| node.index());
         (py.get_type::<Self>(), (&slf.wire,), state).into_py_any(py)
     }

--- a/crates/circuit/src/dot_utils.rs
+++ b/crates/circuit/src/dot_utils.rs
@@ -33,8 +33,8 @@ pub fn build_dot<T>(
     dag: &DAGCircuit,
     file: &mut T,
     graph_attrs: Option<BTreeMap<String, String>>,
-    node_attrs: Option<PyObject>,
-    edge_attrs: Option<PyObject>,
+    node_attrs: Option<Py<PyAny>>,
+    edge_attrs: Option<Py<PyAny>>,
 ) -> PyResult<()>
 where
     T: Write,
@@ -80,7 +80,7 @@ static ATTRS_TO_ESCAPE: [&str; 2] = ["label", "tooltip"];
 /// Convert an attr map to an output string
 fn attr_map_to_string<'py, T: IntoPyObject<'py>>(
     py: Python<'py>,
-    attrs: Option<&'py PyObject>,
+    attrs: Option<&'py Py<PyAny>>,
     weight: T,
 ) -> PyResult<String>
 where

--- a/crates/circuit/src/duration.rs
+++ b/crates/circuit/src/duration.rs
@@ -69,7 +69,7 @@ impl Duration {
     /// This will be a Python ``int`` if the :meth:`~Duration.unit` is ``"dt"``,
     /// else a ``float``.
     #[pyo3(name = "value")]
-    fn py_value(&self, py: Python) -> PyResult<PyObject> {
+    fn py_value(&self, py: Python) -> PyResult<Py<PyAny>> {
         match self {
             Duration::dt(v) => v.into_py_any(py),
             Duration::ps(v)

--- a/crates/circuit/src/imports.rs
+++ b/crates/circuit/src/imports.rs
@@ -15,16 +15,16 @@
 // python side casting
 
 use pyo3::prelude::*;
-use pyo3::sync::GILOnceCell;
+use pyo3::sync::PyOnceLock;
 
 use crate::operations::{StandardGate, STANDARD_GATE_SIZE};
 
-/// Helper wrapper around `GILOnceCell` instances that are just intended to store a Python object
+/// Helper wrapper around `PyOnceLock` instances that are just intended to store a Python object
 /// that is lazily imported.
 pub struct ImportOnceCell {
     module: &'static str,
     object: &'static str,
-    cell: GILOnceCell<Py<PyAny>>,
+    cell: PyOnceLock<Py<PyAny>>,
 }
 
 impl ImportOnceCell {
@@ -32,7 +32,7 @@ impl ImportOnceCell {
         Self {
             module,
             object,
-            cell: GILOnceCell::new(),
+            cell: PyOnceLock::new(),
         }
     }
 
@@ -273,59 +273,59 @@ static STDGATE_IMPORT_PATHS: [[&str; 2]; STANDARD_GATE_SIZE] = [
 ///
 /// NOTE: the order here is significant it must match the StandardGate variant's number must match
 /// index of it's entry in this table. This is all done statically for performance
-static STDGATE_PYTHON_GATES: [GILOnceCell<PyObject>; STANDARD_GATE_SIZE] = [
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
-    GILOnceCell::new(),
+static STDGATE_PYTHON_GATES: [PyOnceLock<Py<PyAny>>; STANDARD_GATE_SIZE] = [
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
+    PyOnceLock::new(),
 ];
 
 #[inline]

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -116,7 +116,7 @@ impl<'py> FromPyObject<'py> for TupleLikeArg<'py> {
                 ob.py(),
                 ob.try_iter()?
                     .map(|o| Ok(o?.unbind()))
-                    .collect::<PyResult<Vec<PyObject>>>()?,
+                    .collect::<PyResult<Vec<Py<PyAny>>>>()?,
             )?,
         };
         Ok(TupleLikeArg { value })

--- a/crates/circuit/src/object_registry.rs
+++ b/crates/circuit/src/object_registry.rs
@@ -30,7 +30,7 @@ pub struct PyObjectAsKey {
     /// Python's `hash()` of the wrapped instance.
     hash: isize,
     /// The wrapped instance.
-    ob: PyObject,
+    ob: Py<PyAny>,
 }
 
 impl PyObjectAsKey {
@@ -93,7 +93,7 @@ impl<'a, 'py> IntoPyObject<'py> for &'a PyObjectAsKey {
 impl PartialEq for PyObjectAsKey {
     fn eq(&self, other: &Self) -> bool {
         self.ob.is(&other.ob)
-            || Python::with_gil(|py| {
+            || Python::attach(|py| {
                 self.ob
                     .bind(py)
                     .repr()

--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -614,7 +614,7 @@ pub struct PackedInstruction {
     /// which is a simple null-pointer check.
     ///
     /// WARNING: remember that `OnceLock`'s `get_or_init` method is no-reentrant, so the initialiser
-    /// must not yield the GIL to Python space.  We avoid using `GILOnceCell` here because it
+    /// must not yield the GIL to Python space.  We avoid using `PyOnceLock` here because it
     /// requires the GIL to even `get` (of course!), which makes implementing `Clone` hard for us.
     /// We can revisit once we're on PyO3 0.22+ and have been able to disable its `py-clone`
     /// feature.

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -736,7 +736,7 @@ impl PyParameterExpression {
         }
     }
 
-    pub fn coerce_into_py(&self, py: Python) -> PyResult<PyObject> {
+    pub fn coerce_into_py(&self, py: Python) -> PyResult<Py<PyAny>> {
         if let Ok(value) = self.inner.try_to_value(true) {
             match value {
                 Value::Int(i) => Ok(PyInt::new(py, i).unbind().into_any()),
@@ -816,7 +816,7 @@ impl PyParameterExpression {
     ///         if the expression represents a numeric value, regardless of unbound symbols.
     ///         For example ``(0 * Parameter("x"))`` is 0 but has the symbol ``x`` present.
     #[pyo3(signature = (strict=true))]
-    pub fn numeric(&self, py: Python, strict: bool) -> PyResult<PyObject> {
+    pub fn numeric(&self, py: Python, strict: bool) -> PyResult<Py<PyAny>> {
         match self.inner.try_to_value(strict)? {
             Value::Real(r) => r.into_py_any(py),
             Value::Int(i) => i.into_py_any(py),
@@ -828,7 +828,7 @@ impl PyParameterExpression {
     ///
     /// Returns:
     ///     A SymPy equivalent of this expression.
-    pub fn sympify(&self, py: Python) -> PyResult<PyObject> {
+    pub fn sympify(&self, py: Python) -> PyResult<Py<PyAny>> {
         let py_sympify = SYMPIFY_PARAMETER_EXPRESSION.get(py);
         py_sympify.call1(py, (self.clone(),))
     }
@@ -843,7 +843,7 @@ impl PyParameterExpression {
     ///
     #[getter]
     pub fn parameters<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PySet>> {
-        let py_parameters: Vec<PyObject> = self
+        let py_parameters: Vec<Py<PyAny>> = self
             .inner
             .name_map
             .values()
@@ -955,7 +955,7 @@ impl PyParameterExpression {
     /// Returns:
     ///     The derivative as either a constant numeric value or a symbolic
     ///     :class:`.ParameterExpression`.
-    pub fn gradient(&self, param: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+    pub fn gradient(&self, param: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
         let symbol = symbol_from_py_parameter(param)?;
         let d_expr = self.inner.derivative(&symbol)?;
 
@@ -971,7 +971,7 @@ impl PyParameterExpression {
     }
 
     /// Return all values in this equation.
-    pub fn _values(&self, py: Python) -> PyResult<Vec<PyObject>> {
+    pub fn _values(&self, py: Python) -> PyResult<Vec<Py<PyAny>>> {
         self.inner
             .expr
             .values()
@@ -1466,7 +1466,7 @@ impl PyParameter {
     fn py_new(
         py: Python<'_>,
         name: String,
-        uuid: Option<PyObject>,
+        uuid: Option<Py<PyAny>>,
     ) -> PyResult<PyClassInitializer<Self>> {
         let uuid = uuid_from_py(py, uuid)?;
         let symbol = Symbol::new(name.as_str(), uuid, None);
@@ -1490,7 +1490,7 @@ impl PyParameter {
     /// :class:`.Parameter` constructor to produce an instance that compares
     /// equal to another instance.
     #[getter]
-    fn uuid(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn uuid(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         uuid_to_py(py, self.symbol.uuid)
     }
 
@@ -1672,9 +1672,9 @@ impl PyParameterVectorElement {
     #[pyo3(signature = (vector, index, uuid=None))]
     pub fn py_new(
         py: Python<'_>,
-        vector: PyObject,
+        vector: Py<PyAny>,
         index: u32,
-        uuid: Option<PyObject>,
+        uuid: Option<Py<PyAny>>,
     ) -> PyResult<PyClassInitializer<Self>> {
         let vector_name = vector.getattr(py, "name")?.extract::<String>(py)?;
         let uuid = uuid_from_py(py, uuid)?.unwrap_or(Uuid::new_v4());
@@ -1692,7 +1692,7 @@ impl PyParameterVectorElement {
         Ok(py_parameter.add_subclass(py_element))
     }
 
-    pub fn __getnewargs__(&self, py: Python) -> PyResult<(PyObject, u32, Option<PyObject>)> {
+    pub fn __getnewargs__(&self, py: Python) -> PyResult<(Py<PyAny>, u32, Option<Py<PyAny>>)> {
         let vector = self
             .symbol
             .vector
@@ -1711,14 +1711,14 @@ impl PyParameterVectorElement {
         PyString::new(py, str.as_str())
     }
 
-    pub fn __getstate__(&self, py: Python) -> PyResult<(PyObject, u32, Option<PyObject>)> {
+    pub fn __getstate__(&self, py: Python) -> PyResult<(Py<PyAny>, u32, Option<Py<PyAny>>)> {
         self.__getnewargs__(py)
     }
 
     pub fn __setstate__(
         &mut self,
         py: Python,
-        state: (PyObject, u32, Option<PyObject>),
+        state: (Py<PyAny>, u32, Option<Py<PyAny>>),
     ) -> PyResult<()> {
         let vector = state.0;
         let index = state.1;
@@ -1738,7 +1738,7 @@ impl PyParameterVectorElement {
 
     /// Get the parent vector instance.
     #[getter]
-    pub fn vector(&self) -> PyObject {
+    pub fn vector(&self) -> Py<PyAny> {
         self.symbol
             .clone()
             .vector
@@ -1748,7 +1748,7 @@ impl PyParameterVectorElement {
     /// For backward compatibility only. This should not be used and we ought to update those
     /// usages!
     #[getter]
-    pub fn _vector(&self) -> PyObject {
+    pub fn _vector(&self) -> Py<PyAny> {
         self.vector()
     }
 
@@ -1764,7 +1764,7 @@ impl PyParameterVectorElement {
 }
 
 /// Try to extract a Uuid from a Python object, which could be a Python UUID or int.
-fn uuid_from_py(py: Python<'_>, uuid: Option<PyObject>) -> PyResult<Option<Uuid>> {
+fn uuid_from_py(py: Python<'_>, uuid: Option<Py<PyAny>>) -> PyResult<Option<Uuid>> {
     if let Some(val) = uuid {
         // construct from u128
         let as_u128 = if let Ok(as_u128) = val.extract::<u128>(py) {
@@ -1783,7 +1783,7 @@ fn uuid_from_py(py: Python<'_>, uuid: Option<PyObject>) -> PyResult<Option<Uuid>
 }
 
 /// Convert a Rust Uuid object to a Python UUID object.
-fn uuid_to_py(py: Python<'_>, uuid: Uuid) -> PyResult<PyObject> {
+fn uuid_to_py(py: Python<'_>, uuid: Uuid) -> PyResult<Py<PyAny>> {
     let uuid = uuid.as_u128();
     let kwargs = [("int", uuid)].into_py_dict(py)?;
     Ok(UUID.get_bound(py).call((), Some(&kwargs))?.unbind())

--- a/crates/circuit/src/parameter/symbol_expr.rs
+++ b/crates/circuit/src/parameter/symbol_expr.rs
@@ -34,10 +34,10 @@ pub const SYMEXPR_EPSILON: f64 = f64::EPSILON * 8.0;
 
 #[derive(Debug, Clone)]
 pub struct Symbol {
-    name: String,                 // the name of the symbol
-    pub uuid: Uuid,               // the unique identifier
-    pub index: Option<u32>,       // an optional index, if part of a vector
-    pub vector: Option<PyObject>, // Python only: a reference to the vector, if it is an element
+    name: String,                  // the name of the symbol
+    pub uuid: Uuid,                // the unique identifier
+    pub index: Option<u32>,        // an optional index, if part of a vector
+    pub vector: Option<Py<PyAny>>, // Python only: a reference to the vector, if it is an element
 }
 
 /// Custom implementations of Eq, PartialEq, PartialOrd and Hash to ignore the ``vector`` field
@@ -102,7 +102,7 @@ impl Symbol {
         name: &str,
         uuid: Option<u128>,
         index: Option<u32>,
-        vector: Option<PyObject>,
+        vector: Option<Py<PyAny>>,
     ) -> PyResult<Self> {
         if index.is_some() != vector.is_some() {
             return Err(PyValueError::new_err(

--- a/crates/qasm2/src/bytecode.rs
+++ b/crates/qasm2/src/bytecode.rs
@@ -28,7 +28,7 @@ pub struct Bytecode {
     #[pyo3(get)]
     opcode: OpCode,
     #[pyo3(get)]
-    operands: PyObject,
+    operands: Py<PyAny>,
 }
 
 /// The operations that are represented by the "bytecode" passed to Python.
@@ -84,7 +84,7 @@ pub struct ExprUnary {
     #[pyo3(get)]
     pub opcode: UnaryOpCode,
     #[pyo3(get)]
-    pub argument: PyObject,
+    pub argument: Py<PyAny>,
 }
 
 /// A binary operation acting on two other parts of the expression tree.
@@ -94,9 +94,9 @@ pub struct ExprBinary {
     #[pyo3(get)]
     pub opcode: BinaryOpCode,
     #[pyo3(get)]
-    pub left: PyObject,
+    pub left: Py<PyAny>,
     #[pyo3(get)]
-    pub right: PyObject,
+    pub right: Py<PyAny>,
 }
 
 /// Some custom callable Python function that the user told us about.
@@ -104,9 +104,9 @@ pub struct ExprBinary {
 #[derive(Clone)]
 pub struct ExprCustom {
     #[pyo3(get)]
-    pub callable: PyObject,
+    pub callable: Py<PyAny>,
     #[pyo3(get)]
-    pub arguments: Vec<PyObject>,
+    pub arguments: Vec<Py<PyAny>>,
 }
 
 /// Discriminator for the different types of unary operator.  We could have a separate class for

--- a/crates/qasm2/src/lib.rs
+++ b/crates/qasm2/src/lib.rs
@@ -56,14 +56,14 @@ impl CustomInstruction {
 pub struct CustomClassical {
     pub name: String,
     pub num_params: usize,
-    pub callable: PyObject,
+    pub callable: Py<PyAny>,
 }
 
 #[pymethods]
 impl CustomClassical {
     #[new]
     #[pyo3(text_signature = "(name, num_params, callable, /)")]
-    fn __new__(name: String, num_params: usize, callable: PyObject) -> Self {
+    fn __new__(name: String, num_params: usize, callable: Py<PyAny>) -> Self {
         Self {
             name,
             num_params,

--- a/crates/qasm2/src/parse.rs
+++ b/crates/qasm2/src/parse.rs
@@ -111,7 +111,7 @@ pub enum GlobalSymbol {
         index: GateId,
     },
     Classical {
-        callable: PyObject,
+        callable: Py<PyAny>,
         num_params: usize,
     },
 }

--- a/crates/qasm3/src/exporter.rs
+++ b/crates/qasm3/src/exporter.rs
@@ -793,7 +793,7 @@ impl<'a> QASM3Builder {
     }
 
     fn hoist_global_params(&mut self) -> ExporterResult<()> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             for param in self.circuit_scope.circuit_data.get_parameters(py)? {
                 let raw_name: String = match param.getattr("name") {
                     Ok(attr) => match attr.extract() {
@@ -1187,7 +1187,7 @@ impl<'a> QASM3Builder {
             ));
         };
         let param = &instr.params_view()[0];
-        let duration: f64 = Python::with_gil(|py| match param {
+        let duration: f64 = Python::attach(|py| match param {
             Param::Float(val) => *val,
             Param::ParameterExpression(p) => {
                 if let Ok(symbol_expr::Value::Real(val)) = p.try_to_value(true) {
@@ -1267,7 +1267,7 @@ impl<'a> QASM3Builder {
             self.define_gate(instr)?;
         }
         let params = if self.disable_constants {
-            Python::with_gil(|_py| {
+            Python::attach(|_py| {
                 instr
                     .params_view()
                     .iter()

--- a/crates/quantum_info/src/convert_2q_block_matrix.rs
+++ b/crates/quantum_info/src/convert_2q_block_matrix.rs
@@ -42,7 +42,7 @@ pub fn get_matrix_from_inst(inst: &PackedInstruction) -> PyResult<Array2<Complex
         // and use an Operator. Otherwise, using op.matrix() should work.
         // A user should not be able to reach this condition in Rust standalone
         // mode.
-        Python::with_gil(|py| -> PyResult<_> {
+        Python::attach(|py| -> PyResult<_> {
             Ok(QI_OPERATOR
                 .get_bound(py)
                 .call1((gate.gate.clone_ref(py),))?

--- a/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -1528,7 +1528,7 @@ impl PyPauliLindbladMap {
         seed: Option<u64>,
     ) -> PyResult<Bound<'py, PyTuple>> {
         let inner = self.inner.read().map_err(|_| InnerReadError)?;
-        let (signs, paulis) = py.allow_threads(|| inner.sample(num_samples, seed));
+        let (signs, paulis) = py.detach(|| inner.sample(num_samples, seed));
 
         let signs = PyArray1::from_vec(py, signs);
         let paulis = paulis.into_pyobject(py).unwrap();
@@ -1580,7 +1580,7 @@ impl PyPauliLindbladMap {
             }
         }
 
-        let (_, paulis) = py.allow_threads(|| inner.sample(num_samples, seed));
+        let (_, paulis) = py.detach(|| inner.sample(num_samples, seed));
 
         paulis.into_pyobject(py)
     }

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -18,7 +18,7 @@ use pyo3::{
     exceptions::{PyRuntimeError, PyTypeError, PyValueError},
     intern,
     prelude::*,
-    sync::GILOnceCell,
+    sync::PyOnceLock,
     types::{IntoPyDict, PyList, PyString, PyTuple, PyType},
     IntoPyObjectExt, PyErr,
 };
@@ -33,8 +33,8 @@ use qiskit_circuit::slice::{PySequenceIndex, SequenceIndex};
 
 use crate::imports;
 
-static PAULI_PY_ENUM: GILOnceCell<Py<PyType>> = GILOnceCell::new();
-static PAULI_INTO_PY: GILOnceCell<[Option<Py<PyAny>>; 16]> = GILOnceCell::new();
+static PAULI_PY_ENUM: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+static PAULI_INTO_PY: PyOnceLock<[Option<Py<PyAny>>; 16]> = PyOnceLock::new();
 
 /// Named handle to the alphabet of single-qubit terms.
 ///

--- a/crates/quantum_info/src/sparse_observable/mod.rs
+++ b/crates/quantum_info/src/sparse_observable/mod.rs
@@ -26,7 +26,7 @@ use pyo3::{
     exceptions::{PyRuntimeError, PyTypeError, PyValueError, PyZeroDivisionError},
     intern,
     prelude::*,
-    sync::GILOnceCell,
+    sync::PyOnceLock,
     types::{IntoPyDict, PyList, PyString, PyTuple, PyType},
     IntoPyObjectExt, PyErr,
 };
@@ -47,8 +47,8 @@ static PAULI_TYPE: ImportOnceCell = ImportOnceCell::new("qiskit.quantum_info", "
 static PAULI_LIST_TYPE: ImportOnceCell = ImportOnceCell::new("qiskit.quantum_info", "PauliList");
 static SPARSE_PAULI_OP_TYPE: ImportOnceCell =
     ImportOnceCell::new("qiskit.quantum_info", "SparsePauliOp");
-static BIT_TERM_PY_ENUM: GILOnceCell<Py<PyType>> = GILOnceCell::new();
-static BIT_TERM_INTO_PY: GILOnceCell<[Option<Py<PyAny>>; 16]> = GILOnceCell::new();
+static BIT_TERM_PY_ENUM: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+static BIT_TERM_INTO_PY: PyOnceLock<[Option<Py<PyAny>>; 16]> = PyOnceLock::new();
 
 /// Named handle to the alphabet of single-qubit terms.
 ///

--- a/crates/quantum_info/src/sparse_pauli_op.rs
+++ b/crates/quantum_info/src/sparse_pauli_op.rs
@@ -51,7 +51,7 @@ use crate::rayon_ext::*;
 ///         - the indices of the unique array that reconstruct the input array
 ///
 #[pyfunction]
-pub fn unordered_unique(py: Python, array: PyReadonlyArray2<u16>) -> (PyObject, PyObject) {
+pub fn unordered_unique(py: Python, array: PyReadonlyArray2<u16>) -> (Py<PyAny>, Py<PyAny>) {
     let array = array.as_array();
     let shape = array.shape();
     let mut table = HashMap::<ArrayView1<u16>, usize>::with_capacity(shape[0]);
@@ -408,7 +408,7 @@ pub fn decompose_dense(
     tolerance: f64,
 ) -> PyResult<ZXPaulis> {
     let array_view = operator.as_array();
-    let out = py.allow_threads(|| decompose_dense_inner(array_view, tolerance))?;
+    let out = py.detach(|| decompose_dense_inner(array_view, tolerance))?;
     Ok(ZXPaulis {
         z: PyArray1::from_vec(py, out.z)
             .reshape([out.phases.len(), out.num_qubits])?

--- a/crates/quantum_info/src/unitary_sim.rs
+++ b/crates/quantum_info/src/unitary_sim.rs
@@ -68,7 +68,7 @@ pub fn sim_unitary_circuit(circuit: &CircuitData) -> Result<Array2<Complex64>, S
 /// Create a unitary matrix for a circuit.
 #[pyfunction]
 #[pyo3(name = "sim_unitary_circuit")]
-pub fn py_sim_unitary_circuit(py: Python, circuit: &CircuitData) -> PyResult<PyObject> {
+pub fn py_sim_unitary_circuit(py: Python, circuit: &CircuitData) -> PyResult<Py<PyAny>> {
     let product_mat = sim_unitary_circuit(circuit).map_err(QiskitError::new_err)?;
     Ok(product_mat.into_pyarray(py).into_any().unbind())
 }

--- a/crates/synthesis/src/euler_one_qubit_decomposer.rs
+++ b/crates/synthesis/src/euler_one_qubit_decomposer.rs
@@ -103,7 +103,7 @@ impl OneQubitGateSequence {
         Ok(self.gates.len())
     }
 
-    fn __getitem__(&self, py: Python, idx: PySequenceIndex) -> PyResult<PyObject> {
+    fn __getitem__(&self, py: Python, idx: PySequenceIndex) -> PyResult<Py<PyAny>> {
         match idx.with_len(self.gates.len())? {
             SequenceIndex::Int(idx) => Ok((&self.gates[idx]).into_py_any(py)?),
             indices => Ok(PyList::new(

--- a/crates/synthesis/src/linear/mod.rs
+++ b/crates/synthesis/src/linear/mod.rs
@@ -38,7 +38,7 @@ fn gauss_elimination_with_perm(
     mut mat: PyReadwriteArray2<bool>,
     ncols: Option<usize>,
     full_elim: Option<bool>,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     let matmut = mat.as_array_mut();
     let perm = utils::gauss_elimination_with_perm_inner(matmut, ncols, full_elim);
     perm.into_py_any(py)
@@ -71,7 +71,7 @@ fn gauss_elimination(
 ///     mat: a boolean matrix after gaussian elimination
 /// Returns:
 ///     rank: the rank of the matrix
-fn compute_rank_after_gauss_elim(py: Python, mat: PyReadonlyArray2<bool>) -> PyResult<PyObject> {
+fn compute_rank_after_gauss_elim(py: Python, mat: PyReadonlyArray2<bool>) -> PyResult<Py<PyAny>> {
     let view = mat.as_array();
     let rank = utils::compute_rank_after_gauss_elim_inner(view);
     rank.into_py_any(py)
@@ -84,7 +84,7 @@ fn compute_rank_after_gauss_elim(py: Python, mat: PyReadonlyArray2<bool>) -> PyR
 ///     mat: a boolean matrix
 /// Returns:
 ///     rank: the rank of the matrix
-fn compute_rank(py: Python, mat: PyReadonlyArray2<bool>) -> PyResult<PyObject> {
+fn compute_rank(py: Python, mat: PyReadonlyArray2<bool>) -> PyResult<Py<PyAny>> {
     let rank = utils::compute_rank_inner(mat.as_array());
     rank.into_py_any(py)
 }

--- a/crates/synthesis/src/permutation/mod.rs
+++ b/crates/synthesis/src/permutation/mod.rs
@@ -27,7 +27,7 @@ mod utils;
 /// Checks whether an array of size N is a permutation of 0, 1, ..., N - 1.
 #[pyfunction]
 #[pyo3(signature = (pattern))]
-pub fn _validate_permutation(py: Python, pattern: PyArrayLike1<i64>) -> PyResult<PyObject> {
+pub fn _validate_permutation(py: Python, pattern: PyArrayLike1<i64>) -> PyResult<Py<PyAny>> {
     let view = pattern.as_array();
     utils::validate_permutation(&view)?;
     Ok(py.None())
@@ -36,7 +36,7 @@ pub fn _validate_permutation(py: Python, pattern: PyArrayLike1<i64>) -> PyResult
 /// Finds inverse of a permutation pattern.
 #[pyfunction]
 #[pyo3(signature = (pattern))]
-pub fn _inverse_pattern(py: Python, pattern: PyArrayLike1<i64>) -> PyResult<PyObject> {
+pub fn _inverse_pattern(py: Python, pattern: PyArrayLike1<i64>) -> PyResult<Py<PyAny>> {
     let view = pattern.as_array();
     let inverse_i64: Vec<i64> = utils::invert(&view).iter().map(|&x| x as i64).collect();
     Ok(inverse_i64.into_pyobject(py)?.unbind())

--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -260,7 +260,7 @@ impl CommutationChecker {
         Ok(out_dict.unbind())
     }
 
-    fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
+    fn __setstate__(&mut self, py: Python, state: Py<PyAny>) -> PyResult<()> {
         let dict_state = state.downcast_bound::<PyDict>(py)?;
         self.cache_max_entries = dict_state
             .get_item("cache_max_entries")?
@@ -626,7 +626,7 @@ fn get_matrix(operation: &OperationRef, params: &[Param]) -> Option<Array2<Compl
         Some(matrix)
     } else {
         match operation {
-            OperationRef::Gate(gate) => Python::with_gil(|py| -> Option<_> {
+            OperationRef::Gate(gate) => Python::attach(|py| -> Option<_> {
                 Some(
                     QI_OPERATOR
                         .get_bound(py)
@@ -640,7 +640,7 @@ fn get_matrix(operation: &OperationRef, params: &[Param]) -> Option<Array2<Compl
                         .to_owned(),
                 )
             }),
-            OperationRef::Operation(operation) => Python::with_gil(|py| -> Option<_> {
+            OperationRef::Operation(operation) => Python::attach(|py| -> Option<_> {
                 Some(
                     QI_OPERATOR
                         .get_bound(py)

--- a/crates/transpiler/src/equivalence.rs
+++ b/crates/transpiler/src/equivalence.rs
@@ -359,7 +359,7 @@ pub struct EquivalenceLibrary {
     graph: GraphType,
     key_to_node_index: KTIType,
     rule_id: usize,
-    _graph: Option<PyObject>,
+    _graph: Option<Py<PyAny>>,
 }
 
 #[pymethods]
@@ -489,7 +489,7 @@ impl EquivalenceLibrary {
     /// Returns:
     ///     PyDiGraph: A graph object with equivalence data in each node.
     #[getter]
-    fn get_graph(&mut self, py: Python) -> PyResult<PyObject> {
+    fn get_graph(&mut self, py: Python) -> PyResult<Py<PyAny>> {
         if let Some(graph) = &self._graph {
             Ok(graph.clone_ref(py))
         } else {
@@ -516,7 +516,7 @@ impl EquivalenceLibrary {
     /// Returns:
     ///     List: Keys to the key to node index map.
     #[pyo3(name = "keys")]
-    fn py_keys(slf: PyRef<Self>) -> PyResult<PyObject> {
+    fn py_keys(slf: PyRef<Self>) -> PyResult<Py<PyAny>> {
         let py_dict = PyDict::new(slf.py());
         for key in slf.keys() {
             py_dict.set_item(key.clone(), slf.py().None())?;
@@ -810,7 +810,10 @@ impl Display for EquivalenceError {
 
 // Conversion helpers
 
-fn to_pygraph<'py, N, E>(py: Python<'py>, pet_graph: &'py StableDiGraph<N, E>) -> PyResult<PyObject>
+fn to_pygraph<'py, N, E>(
+    py: Python<'py>,
+    pet_graph: &'py StableDiGraph<N, E>,
+) -> PyResult<Py<PyAny>>
 where
     N: IntoPyObject<'py> + Clone,
     E: IntoPyObject<'py> + Clone,

--- a/crates/transpiler/src/passes/basis_translator/compose_transforms.rs
+++ b/crates/transpiler/src/passes/basis_translator/compose_transforms.rs
@@ -74,7 +74,7 @@ pub(super) fn compose_transforms<'a>(
         let gate = if let Some(op) = name_to_packed_operation(&gate_name, gate_num_qubits) {
             op
         } else {
-            let extract_py = Python::with_gil(|py| -> PyResult<OperationFromPython> {
+            let extract_py = Python::attach(|py| -> PyResult<OperationFromPython> {
                 GATE.get_bound(py)
                     .call1((&gate_name, gate_num_qubits, placeholder_params.as_ref()))?
                     .extract()

--- a/crates/transpiler/src/passes/basis_translator/mod.rs
+++ b/crates/transpiler/src/passes/basis_translator/mod.rs
@@ -424,7 +424,7 @@ fn apply_translation(
         let mut new_op: Option<OperationFromPython> = None;
         if target_basis.contains(node_obj.op.name()) || node_qarg.len() < min_qubits {
             if node_obj.op.control_flow() {
-                Python::with_gil(|py| -> PyResult<()> {
+                Python::attach(|py| -> PyResult<()> {
                     // This part is only executed through python because `ControlFlowOp`
                     // does not exist in Rust space yet, and we need the method `replace_blocks`.
                     // TODO: Refactor this condition block once https://github.com/Qiskit/qiskit/pull/14568 merges.
@@ -582,15 +582,15 @@ fn replace_node(
                 .collect();
             let new_op: PackedOperation = match inner_node.op.view() {
                 OperationRef::Gate(gate) => {
-                    Python::with_gil(|py| gate.py_copy(py).map(|op| op.into()))
+                    Python::attach(|py| gate.py_copy(py).map(|op| op.into()))
                         .expect("Error while copying gate instance.")
                 }
                 OperationRef::Instruction(instruction) => {
-                    Python::with_gil(|py| instruction.py_copy(py).map(|op| op.into()))
+                    Python::attach(|py| instruction.py_copy(py).map(|op| op.into()))
                         .expect("Error while copying instruction instance.")
                 }
                 OperationRef::Operation(operation) => {
-                    Python::with_gil(|py| operation.py_copy(py).map(|op| op.into()))
+                    Python::attach(|py| operation.py_copy(py).map(|op| op.into()))
                         .expect("Error while copying operation instance.")
                 }
                 OperationRef::StandardGate(gate) => gate.into(),
@@ -656,17 +656,17 @@ fn replace_node(
                 .map(|clbit| old_cargs[clbit.0 as usize])
                 .collect();
             let new_op: PackedOperation = match inner_node.op.view() {
-                OperationRef::Gate(gate) => Python::with_gil(|py| {
+                OperationRef::Gate(gate) => Python::attach(|py| {
                     gate.py_copy(py).map(|op| op.into())
                 })
                 .map_err(|err| BasisTranslatorError::BasisDAGCircuitError(err.to_string()))?,
                 OperationRef::Instruction(instruction) => {
-                    Python::with_gil(|py| instruction.py_copy(py).map(|op| op.into())).map_err(
+                    Python::attach(|py| instruction.py_copy(py).map(|op| op.into())).map_err(
                         |err| BasisTranslatorError::BasisDAGCircuitError(err.to_string()),
                     )?
                 }
                 OperationRef::Operation(operation) => {
-                    Python::with_gil(|py| operation.py_copy(py).map(|op| op.into())).map_err(
+                    Python::attach(|py| operation.py_copy(py).map(|op| op.into())).map_err(
                         |err| BasisTranslatorError::BasisDAGCircuitError(err.to_string()),
                     )?
                 }
@@ -696,7 +696,7 @@ fn replace_node(
                     // TODO: Remove this.
                     // Acquire the gil if the operation is not native to set the operation parameters in
                     // Python.
-                    Python::with_gil(|py| -> Result<(), BasisTranslatorError> {
+                    Python::attach(|py| -> Result<(), BasisTranslatorError> {
                         match new_op.view() {
                             OperationRef::Instruction(inst) => inst
                                 .instruction
@@ -771,7 +771,7 @@ fn param_expr_assignment(
                 bind_map.insert(key, Value::Real(*val));
             }
             Param::Obj(val) => {
-                let val = Python::with_gil(|py| val.extract::<Value>(py))
+                let val = Python::attach(|py| val.extract::<Value>(py))
                     .map_err(|_| ParameterError::InvalidValue)?;
                 bind_map.insert(key, val);
             }

--- a/crates/transpiler/src/passes/consolidate_blocks.rs
+++ b/crates/transpiler/src/passes/consolidate_blocks.rs
@@ -52,7 +52,7 @@ pub enum DecomposerType {
     TwoQubitControlledU(TwoQubitControlledUDecomposer),
 }
 
-fn get_matrix(gate: &StandardGate) -> ArrayView2<Complex64> {
+fn get_matrix(gate: &StandardGate) -> ArrayView2<'_, Complex64> {
     match gate {
         StandardGate::CX => aview2(&CX_GATE),
         StandardGate::CY => aview2(&CY_GATE),
@@ -273,7 +273,7 @@ fn py_run_consolidate_blocks(
                 }),
                 Param::Float(0.),
             )?;
-            let matrix = Python::with_gil(|py| -> PyResult<_> {
+            let matrix = Python::attach(|py| -> PyResult<_> {
                 let circuit = QUANTUM_CIRCUIT
                     .get_bound(py)
                     .call_method1(intern!(py, "_from_circuit_data"), (circuit_data,))?;

--- a/crates/transpiler/src/passes/dense_layout.rs
+++ b/crates/transpiler/src/passes/dense_layout.rs
@@ -110,7 +110,7 @@ pub fn py_best_subset(
     use_error: bool,
     symmetric_coupling_map: bool,
     error_matrix: PyReadonlyArray2<f64>,
-) -> (PyObject, PyObject, PyObject) {
+) -> (Py<PyAny>, Py<PyAny>, Py<PyAny>) {
     let coupling_adj_mat = coupling_adjacency.as_array();
     let err = error_matrix.as_array();
     let [rows, cols, best_map] = best_subset(

--- a/crates/transpiler/src/passes/disjoint_layout.rs
+++ b/crates/transpiler/src/passes/disjoint_layout.rs
@@ -92,9 +92,9 @@ pub fn py_run_pass_over_connected_components(
     dag: Bound<DAGCircuit>,
     target: &Target,
     run_func: Bound<PyAny>,
-) -> PyResult<Option<Vec<PyObject>>> {
+) -> PyResult<Option<Vec<Py<PyAny>>>> {
     let py = dag.py();
-    let func = |dag: Bound<DAGCircuit>, cmap: &CouplingMap| -> PyResult<PyObject> {
+    let func = |dag: Bound<DAGCircuit>, cmap: &CouplingMap| -> PyResult<Py<PyAny>> {
         let py = run_func.py();
         let coupling_map_cls = COUPLING_MAP.get_bound(py);
         let endpoints: Vec<[usize; 2]> = cmap
@@ -358,7 +358,7 @@ fn build_interaction_graph<Ty: EdgeType>(
 ) -> PyResult<()> {
     for (_index, inst) in dag.op_nodes(false) {
         if inst.op.control_flow() {
-            Python::with_gil(|py| -> PyResult<_> {
+            Python::attach(|py| -> PyResult<_> {
                 let OperationRef::Instruction(py_inst) = inst.op.view() else {
                     unreachable!("Control flow must be a python instruction");
                 };

--- a/crates/transpiler/src/passes/elide_permutations.rs
+++ b/crates/transpiler/src/passes/elide_permutations.rs
@@ -50,7 +50,7 @@ pub fn run_elide_permutations(dag: &DAGCircuit) -> PyResult<Option<(DAGCircuit, 
                     mapping.swap(index0, index1);
                 }
                 OperationRef::Gate(gate) if gate.name() == "permutation" => {
-                    Python::with_gil(|py| -> PyResult<()> {
+                    Python::attach(|py| -> PyResult<()> {
                         if let Param::Obj(ref pyobj) = inst.params.as_ref().unwrap()[0] {
                             let pyarray: PyReadonlyArray1<i32> = pyobj.extract(py)?;
                             let pattern = pyarray.as_array();

--- a/crates/transpiler/src/passes/gate_direction.rs
+++ b/crates/transpiler/src/passes/gate_direction.rs
@@ -315,7 +315,7 @@ where
     }
 
     if !ops_to_replace.is_empty() {
-        Python::with_gil(|py| -> PyResult<()> {
+        Python::attach(|py| -> PyResult<()> {
             for (node, op_blocks) in ops_to_replace {
                 let packed_inst = dag[node].unwrap_operation();
                 let OperationRef::Instruction(py_inst) = packed_inst.op.view() else {

--- a/crates/transpiler/src/passes/sabre/dag.rs
+++ b/crates/transpiler/src/passes/sabre/dag.rs
@@ -65,7 +65,7 @@ impl InteractionKind {
             let OperationRef::Instruction(inst) = op.view() else {
                 panic!("control-flow ops should always be PyInstruction");
             };
-            let blocks = Python::with_gil(|py| {
+            let blocks = Python::attach(|py| {
                 control_flow_block_dags(py, inst)?
                     .map(|dag| {
                         dag.and_then(|dag| Ok((SabreDAG::from_dag(&dag)?, dag)))

--- a/crates/transpiler/src/passes/sabre/route.rs
+++ b/crates/transpiler/src/passes/sabre/route.rs
@@ -239,7 +239,7 @@ impl RoutingResult<'_> {
                             idle.push(qubit);
                         }
                     }
-                    let new_inst = Python::with_gil(|py| -> PyResult<_> {
+                    let new_inst = Python::attach(|py| -> PyResult<_> {
                         // TODO: have to use Python-space `dag_to_circuit` because the Rust-space is
                         // only half the conversion (since it doesn't handle vars or stretches).
                         let dag_to_circuit = imports::DAG_TO_CIRCUIT.get_bound(py);

--- a/crates/transpiler/src/passes/unitary_synthesis.rs
+++ b/crates/transpiler/src/passes/unitary_synthesis.rs
@@ -114,7 +114,7 @@ pub(crate) use {PARAM_SET, TWO_QUBIT_BASIS_SET};
 enum DecomposerType {
     TwoQubitBasis(Box<TwoQubitBasisDecomposer>),
     TwoQubitControlledU(Box<TwoQubitControlledUDecomposer>),
-    XX(PyObject),
+    XX(Py<PyAny>),
 }
 
 #[derive(Clone, Debug)]
@@ -212,7 +212,7 @@ fn apply_synth_sequence(
         let mapped_qargs: Vec<Qubit> = qubit_ids.iter().map(|id| out_qargs[*id as usize]).collect();
 
         let new_op: PackedOperation = match packed_op.view() {
-            OperationRef::Gate(gate) => Python::with_gil(|py| -> PyResult<PackedOperation> {
+            OperationRef::Gate(gate) => Python::attach(|py| -> PyResult<PackedOperation> {
                 let new_gate = gate.py_copy(py)?;
                 new_gate.gate.setattr(py, "params", params)?;
                 Ok(Box::new(new_gate).into())
@@ -300,7 +300,7 @@ pub fn run_unitary_synthesis(
             let OperationRef::Instruction(py_instr) = packed_instr.op.view() else {
                 unreachable!("Control flow op must be an instruction")
             };
-            let new_node_op: OperationFromPython = Python::with_gil(|py| {
+            let new_node_op: OperationFromPython = Python::attach(|py| {
                 let raw_blocks: Vec<PyResult<Bound<PyAny>>> = py_instr
                     .instruction
                     .getattr(py, "blocks")?
@@ -474,7 +474,7 @@ pub fn run_unitary_synthesis(
                         "3q+ unitary decomposition requires Python",
                     ));
                 } else {
-                    let synth_dag = Python::with_gil(|py| {
+                    let synth_dag = Python::attach(|py| {
                         let qs_decomposition: &Bound<'_, PyAny> =
                             imports::QS_DECOMPOSITION.get_bound(py);
                         let synth_circ = match packed_instr.op.view() {
@@ -685,7 +685,7 @@ fn get_2q_decomposers_from_target(
             let rxx_equivalent_gate = if let Some(std_gate) = gate.operation.try_standard_gate() {
                 RXXEquivalent::Standard(std_gate)
             } else {
-                let gate_type: Py<PyType> = Python::with_gil(|py| -> PyResult<Py<PyType>> {
+                let gate_type: Py<PyType> = Python::attach(|py| -> PyResult<Py<PyType>> {
                     let module = PyModule::import(py, "builtins")?;
                     let py_type = module.getattr("type")?;
                     Ok(py_type
@@ -815,7 +815,7 @@ fn get_2q_decomposers_from_target(
             .collect();
 
     let mut pi2_basis: Option<&str> = None;
-    Python::with_gil(|py| -> PyResult<()> {
+    Python::attach(|py| -> PyResult<()> {
         let xx_embodiments: &Bound<'_, PyAny> = imports::XX_EMBODIMENTS.get_bound(py);
         // The Python XXDecomposer args are the interaction strength (f64), basis_2q_fidelity (f64),
         // and embodiments (Bound<'_, PyAny>).
@@ -1094,7 +1094,7 @@ fn reversed_synth_su4_sequence(
 fn synth_su4_xx_decomposer(
     py: Python,
     su4_mat: ArrayView2<Complex64>,
-    decomposer_2q: &PyObject,
+    decomposer_2q: &Py<PyAny>,
     preferred_direction: Option<bool>,
     approximation_degree: Option<f64>,
     packed_op: PackedOperation,
@@ -1340,7 +1340,7 @@ fn run_2q_unitary_synthesis(
                         "No valid decomposer is present without Python",
                     ));
                 }
-                Python::with_gil(|py| -> PyResult<()> {
+                Python::attach(|py| -> PyResult<()> {
                     let synth = synth_su4_xx_decomposer(
                         py,
                         unitary,
@@ -1402,7 +1402,7 @@ fn run_2q_unitary_synthesis(
                 synth_errors_sequence.push(synth_sequence(decomposer, preferred_dir)?);
             }
             DecomposerType::XX(xx_decomposer) => {
-                Python::with_gil(|py| -> PyResult<()> {
+                Python::attach(|py| -> PyResult<()> {
                     let synth_dag = synth_su4_xx_decomposer(
                         py,
                         unitary,

--- a/crates/transpiler/src/passes/vf2/error_map.rs
+++ b/crates/transpiler/src/passes/vf2/error_map.rs
@@ -106,8 +106,8 @@ impl ErrorMap {
         &self,
         py: Python,
         key: [PhysicalQubit; 2],
-        default: Option<PyObject>,
-    ) -> PyResult<PyObject> {
+        default: Option<Py<PyAny>>,
+    ) -> PyResult<Py<PyAny>> {
         Ok(match self.error_map.get(&key).copied() {
             Some(val) => val.into_py_any(py)?,
             None => match default {

--- a/crates/transpiler/src/passes/vf2/vf2_layout.rs
+++ b/crates/transpiler/src/passes/vf2/vf2_layout.rs
@@ -145,7 +145,7 @@ fn build_interaction_graph<Ty: EdgeType>(
 ) -> PyResult<()> {
     for (_index, inst) in dag.op_nodes(false) {
         if inst.op.control_flow() {
-            Python::with_gil(|py| -> PyResult<_> {
+            Python::attach(|py| -> PyResult<_> {
                 let inner_weight = if inst.op.name() == "for_loop" {
                     let Param::Obj(ref indexset) = inst.params_view()[0] else {
                         unreachable!("Invalid for loop definition");

--- a/crates/transpiler/src/target/mod.rs
+++ b/crates/transpiler/src/target/mod.rs
@@ -59,7 +59,7 @@ type PropsMap = IndexMap<Qargs, Option<InstructionProperties>, RandomState>;
 #[derive(FromPyObject, Debug, Clone, IntoPyObjectRef)]
 pub enum TargetOperation {
     Normal(NormalOperation),
-    Variadic(PyObject),
+    Variadic(Py<PyAny>),
 }
 
 impl TargetOperation {
@@ -101,13 +101,13 @@ impl From<NormalOperation> for TargetOperation {
 pub struct NormalOperation {
     pub operation: PackedOperation,
     pub params: SmallVec<[Param; 3]>,
-    op_object: OnceLock<PyResult<PyObject>>,
+    op_object: OnceLock<PyResult<Py<PyAny>>>,
 }
 
 impl NormalOperation {
     // Creates a python Operation type based on the operation's internal data.
     #[inline]
-    fn create_py_op(&self, py: Python, label: Option<&str>) -> PyResult<PyObject> {
+    fn create_py_op(&self, py: Python, label: Option<&str>) -> PyResult<Py<PyAny>> {
         let obj = match self.operation.view() {
             OperationRef::StandardGate(standard_gate) => {
                 standard_gate.create_py_op(py, Some(&self.params), label)?
@@ -439,7 +439,7 @@ impl Target {
     /// Raises:
     ///     KeyError: If qargs is not in target
     #[pyo3(name = "operations_for_qargs", signature=(qargs, /))]
-    pub fn py_operations_for_qargs(&self, py: Python, qargs: Qargs) -> PyResult<Vec<PyObject>> {
+    pub fn py_operations_for_qargs(&self, py: Python, qargs: Qargs) -> PyResult<Vec<Py<PyAny>>> {
         // Move to rust native once Gates are in rust
         Ok(self
             .py_operation_names_for_qargs(qargs)?
@@ -637,9 +637,9 @@ impl Target {
                         let matching_params = match (obj_at_index, params) {
                             (Param::Float(obj_f), Param::Float(param_f)) => obj_f == param_f,
                             (Param::ParameterExpression(_), _) => true,
-                            _ => Python::with_gil(|py| {
-                                python_compare(py, params, &obj_params[index])
-                            })?,
+                            _ => {
+                                Python::attach(|py| python_compare(py, params, &obj_params[index]))?
+                            }
                         };
 
                         if !matching_params {
@@ -773,7 +773,7 @@ impl Target {
     /// The set of qargs in the target.
     #[getter]
     #[pyo3(name = "qargs")]
-    fn py_qargs(&self, py: Python) -> PyResult<PyObject> {
+    fn py_qargs(&self, py: Python) -> PyResult<Py<PyAny>> {
         if let Some(qargs) = self.qargs() {
             let set = PySet::new(py, qargs)?;
             Ok(set.into_any().unbind())


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit bumps the rust-numpy and pyo3 release to the latest version 0.26. This upgrade could be a straight version bump as there are no build failures. However, this pyo3 release deprecates numerous APIs, mainly for more clear naming. This would cause a build failure in CI where we make compile warnings fatal, so this commit does the renaming now to avoid the failures.

### Details and comments


