### PR TITLE
Un-provide `standard_operation` for `PyGate`

### DIFF
--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -256,7 +256,6 @@ pub trait Operation {
     fn blocks(&self) -> Vec<CircuitData>;
     fn matrix(&self, params: &[Param]) -> Option<Array2<Complex64>>;
     fn definition(&self, params: &[Param]) -> Option<CircuitData>;
-    fn standard_gate(&self) -> Option<StandardGate>;
     fn directive(&self) -> bool;
     fn matrix_as_static_1q(&self, params: &[Param]) -> Option<[[Complex64; 2]; 2]>;
     fn matrix_as_nalgebra_1q(&self, params: &[Param]) -> Option<Matrix2<Complex64>> {
@@ -367,17 +366,6 @@ impl Operation for OperationRef<'_> {
             Self::Instruction(instruction) => instruction.definition(params),
             Self::Operation(operation) => operation.definition(params),
             Self::Unitary(unitary) => unitary.definition(params),
-        }
-    }
-    #[inline]
-    fn standard_gate(&self) -> Option<StandardGate> {
-        match self {
-            Self::StandardGate(standard) => standard.standard_gate(),
-            Self::StandardInstruction(instruction) => instruction.standard_gate(),
-            Self::Gate(gate) => gate.standard_gate(),
-            Self::Instruction(instruction) => instruction.standard_gate(),
-            Self::Operation(operation) => operation.standard_gate(),
-            Self::Unitary(unitary) => unitary.standard_gate(),
         }
     }
     #[inline]
@@ -549,10 +537,6 @@ impl Operation for StandardInstruction {
     }
 
     fn definition(&self, _params: &[Param]) -> Option<CircuitData> {
-        None
-    }
-
-    fn standard_gate(&self) -> Option<StandardGate> {
         None
     }
 
@@ -2259,10 +2243,6 @@ impl Operation for StandardGate {
         }
     }
 
-    fn standard_gate(&self) -> Option<StandardGate> {
-        Some(*self)
-    }
-
     fn directive(&self) -> bool {
         false
     }
@@ -2555,9 +2535,6 @@ impl Operation for PyInstruction {
             }
         })
     }
-    fn standard_gate(&self) -> Option<StandardGate> {
-        None
-    }
 
     fn directive(&self) -> bool {
         Python::with_gil(|py| -> bool {
@@ -2659,9 +2636,6 @@ impl Operation for PyGate {
             }
         })
     }
-    fn standard_gate(&self) -> Option<StandardGate> {
-        None
-    }
     fn directive(&self) -> bool {
         false
     }
@@ -2744,10 +2718,6 @@ impl Operation for PyOperation {
     fn definition(&self, _params: &[Param]) -> Option<CircuitData> {
         None
     }
-    fn standard_gate(&self) -> Option<StandardGate> {
-        None
-    }
-
     fn directive(&self) -> bool {
         Python::with_gil(|py| -> bool {
             match self.operation.getattr(py, intern!(py, "_directive")) {
@@ -2831,10 +2801,6 @@ impl Operation for UnitaryGate {
         }
     }
     fn definition(&self, _params: &[Param]) -> Option<CircuitData> {
-        None
-    }
-
-    fn standard_gate(&self) -> Option<StandardGate> {
         None
     }
 

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -2660,12 +2660,7 @@ impl Operation for PyGate {
         })
     }
     fn standard_gate(&self) -> Option<StandardGate> {
-        Python::with_gil(|py| -> Option<StandardGate> {
-            match self.gate.getattr(py, intern!(py, "_standard_gate")) {
-                Ok(stdgate) => stdgate.extract(py).unwrap_or_default(),
-                Err(_) => None,
-            }
-        })
+        None
     }
     fn directive(&self) -> bool {
         false

--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -546,10 +546,6 @@ impl Operation for PackedOperation {
         self.view().definition(params)
     }
     #[inline]
-    fn standard_gate(&self) -> Option<StandardGate> {
-        self.view().standard_gate()
-    }
-    #[inline]
     fn directive(&self) -> bool {
         self.view().directive()
     }

--- a/releasenotes/notes/fix-commutation-checking-with-not-all-one-states-45fdd8a779ae4277.yaml
+++ b/releasenotes/notes/fix-commutation-checking-with-not-all-one-states-45fdd8a779ae4277.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a problem in `~.CommutationChecker`, where standard controlled gates
+    were not handled correctly if they were controlled on something other than
+    the all-ones state.
+    Fixed `#14974 <https://github.com/Qiskit/qiskit/issues/14974>`__

--- a/test/python/transpiler/test_commutative_inverse_cancellation.py
+++ b/test/python/transpiler/test_commutative_inverse_cancellation.py
@@ -925,6 +925,24 @@ class TestCommutativeInverseCancellation(QiskitTestCase):
         # The pass should run successfully but not reduce anything
         self.assertEqual(circuit, tqc)
 
+    def test_controlled_state_at_zero(self):
+        """Regression test of #14974.
+
+        Two gates with not-all-ones control-states were wrongly
+        detected to commute, leading to invalid simplification.
+        """
+        circuit = QuantumCircuit(2)
+        circuit.csdg(0, 1, ctrl_state=0)
+        circuit.crx(1, 0, 1, ctrl_state=0)
+        circuit.cs(0, 1, ctrl_state=0)
+        circuit.ry(1, 1)
+
+        pm = PassManager(CommutativeInverseCancellation())
+        tqc = pm.run(circuit)
+
+        # The pass should run successfully but not reduce anything
+        self.assertEqual(circuit, tqc)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Previously `PyGate` implemented the method `standard_gate`, which for example allowed to interpret a `PyGate` created for `CRX(controlled_state=0)` as `StandardGate::CRX`, effectively losing the control state and leading to problems down the line.

Fixes #14974.

### Details and comments

Jake's additional comments: the solution not provide that method at all - if we can’t treat it as a StandardGate during extraction, there’s no real need to guess at other times. There’s at least a couple of reasons we can’t do it:
* not-all-ones control state
* the base_gate of a controlledgate has extra attributes set (e.g. label) and we have tests that assert that the label of the base gate is propagated

