### PR TITLE
Fix register aliasing of qubits in Rust-defined circuits

### DIFF
--- a/qiskit/circuit/library/iqp.py
+++ b/qiskit/circuit/library/iqp.py
@@ -142,7 +142,7 @@ def iqp(
     else:
         name = "iqp"
 
-    circuit = QuantumCircuit._from_circuit_data(py_iqp(interactions), add_regs=True)
+    circuit = QuantumCircuit._from_circuit_data(py_iqp(interactions), legacy_qubits=True)
     circuit.name = name
     return circuit
 
@@ -175,6 +175,6 @@ def random_iqp(
         An IQP circuit.
     """
     # set the label -- if the number of qubits is too large, do not show the interactions matrix
-    circuit = QuantumCircuit._from_circuit_data(py_random_iqp(num_qubits, seed), add_regs=True)
+    circuit = QuantumCircuit._from_circuit_data(py_random_iqp(num_qubits, seed), legacy_qubits=True)
     circuit.name = "iqp"
     return circuit

--- a/qiskit/circuit/library/n_local/evolved_operator_ansatz.py
+++ b/qiskit/circuit/library/n_local/evolved_operator_ansatz.py
@@ -142,7 +142,7 @@ def evolved_operator_ansatz(
                 ]
 
         data = pauli_evolution(num_qubits, expanded_paulis, insert_barriers, False)
-        circuit = QuantumCircuit._from_circuit_data(data, add_regs=True)
+        circuit = QuantumCircuit._from_circuit_data(data, legacy_qubits=True)
         circuit.name = name
 
         return circuit

--- a/qiskit/circuit/library/n_local/n_local.py
+++ b/qiskit/circuit/library/n_local/n_local.py
@@ -260,7 +260,7 @@ def n_local(
         skip_final_rotation_layer=skip_final_rotation_layer,
         skip_unentangled_qubits=skip_unentangled_qubits,
     )
-    circuit = QuantumCircuit._from_circuit_data(data, add_regs=True, name=name)
+    circuit = QuantumCircuit._from_circuit_data(data, legacy_qubits=True, name=name)
 
     return circuit
 

--- a/qiskit/circuit/library/standard_gates/dcx.py
+++ b/qiskit/circuit/library/standard_gates/dcx.py
@@ -69,7 +69,7 @@ class DCXGate(SingletonGate):
         #      └───┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.DCX._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.DCX._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def __eq__(self, other):

--- a/qiskit/circuit/library/standard_gates/ecr.py
+++ b/qiskit/circuit/library/standard_gates/ecr.py
@@ -105,7 +105,7 @@ class ECRGate(SingletonGate):
         #      └────┘└───┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.ECR._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.ECR._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def inverse(self, annotated: bool = False):

--- a/qiskit/circuit/library/standard_gates/global_phase.py
+++ b/qiskit/circuit/library/standard_gates/global_phase.py
@@ -50,7 +50,9 @@ class GlobalPhaseGate(Gate):
         from qiskit.circuit import QuantumCircuit
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.GlobalPhase._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.GlobalPhase._get_definition(self.params),
+            legacy_qubits=True,
+            name=self.name,
         )
 
     def inverse(self, annotated: bool = False):

--- a/qiskit/circuit/library/standard_gates/h.py
+++ b/qiskit/circuit/library/standard_gates/h.py
@@ -72,7 +72,7 @@ class HGate(SingletonGate):
         #    └────────────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.H._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.H._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(
@@ -219,7 +219,7 @@ class CHGate(SingletonControlledGate):
         #      └───┘└───┘└───┘└───┘└─────┘└───┘└─────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.CH._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.CH._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def inverse(self, annotated: bool = False):

--- a/qiskit/circuit/library/standard_gates/iswap.py
+++ b/qiskit/circuit/library/standard_gates/iswap.py
@@ -105,7 +105,7 @@ class iSwapGate(SingletonGate):
         #      └───┘     └───┘     └───┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.ISwap._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.ISwap._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def power(self, exponent: float, annotated: bool = False):

--- a/qiskit/circuit/library/standard_gates/p.py
+++ b/qiskit/circuit/library/standard_gates/p.py
@@ -91,7 +91,7 @@ class PhaseGate(Gate):
         #    └──────────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.Phase._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.Phase._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(
@@ -233,7 +233,7 @@ class CPhaseGate(ControlledGate):
         #                └───┘└─────────┘└───┘└────────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.CPhase._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.CPhase._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(

--- a/qiskit/circuit/library/standard_gates/r.py
+++ b/qiskit/circuit/library/standard_gates/r.py
@@ -70,7 +70,7 @@ class RGate(Gate):
         #    └───────────────────────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.R._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.R._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def inverse(self, annotated: bool = False):

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -67,7 +67,7 @@ class RXGate(Gate):
         #    └────────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.RX._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.RX._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(
@@ -230,7 +230,7 @@ class CRXGate(ControlledGate):
         #      └───┘└───┘└──────────────┘└───┘└───────────┘└─────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.CRX._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.CRX._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def inverse(self, annotated: bool = False):

--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -93,7 +93,7 @@ class RXXGate(Gate):
         #      └───┘└───┘└───────┘└───┘└───┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.RXX._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.RXX._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(

--- a/qiskit/circuit/library/standard_gates/ry.py
+++ b/qiskit/circuit/library/standard_gates/ry.py
@@ -66,7 +66,7 @@ class RYGate(Gate):
         #    └──────────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.RY._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.RY._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(
@@ -229,7 +229,7 @@ class CRYGate(ControlledGate):
         #      └─────────┘└───┘└──────────┘└───┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.CRY._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.CRY._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def inverse(self, annotated: bool = False):

--- a/qiskit/circuit/library/standard_gates/ryy.py
+++ b/qiskit/circuit/library/standard_gates/ryy.py
@@ -93,7 +93,7 @@ class RYYGate(Gate):
         #      └──────┘└───┘└───────┘└───┘└────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.RYY._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.RYY._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(

--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -79,7 +79,7 @@ class RZGate(Gate):
         #    └──────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.RZ._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.RZ._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(
@@ -249,7 +249,7 @@ class CRZGate(ControlledGate):
         #      └─────────┘└───┘└──────────┘└───┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.CRZ._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.CRZ._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def inverse(self, annotated: bool = False):

--- a/qiskit/circuit/library/standard_gates/rzx.py
+++ b/qiskit/circuit/library/standard_gates/rzx.py
@@ -137,7 +137,7 @@ class RZXGate(Gate):
         #      └───┘└───┘└───────┘└───┘└───┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.RZX._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.RZX._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(

--- a/qiskit/circuit/library/standard_gates/rzz.py
+++ b/qiskit/circuit/library/standard_gates/rzz.py
@@ -104,7 +104,7 @@ class RZZGate(Gate):
         #      └───┘└───────┘└───┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.RZZ._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.RZZ._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(

--- a/qiskit/circuit/library/standard_gates/s.py
+++ b/qiskit/circuit/library/standard_gates/s.py
@@ -76,7 +76,7 @@ class SGate(SingletonGate):
         #    └────────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.S._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.S._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(
@@ -184,7 +184,7 @@ class SdgGate(SingletonGate):
         #    └─────────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.Sdg._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.Sdg._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(
@@ -308,7 +308,7 @@ class CSGate(SingletonControlledGate):
         #           └───┘└─────┘└───┘└───┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.CS._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.CS._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def inverse(self, annotated: bool = False):
@@ -398,7 +398,7 @@ class CSdgGate(SingletonControlledGate):
         #             └───┘└───┘└───┘└─────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.CSdg._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.CSdg._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def inverse(self, annotated: bool = False):

--- a/qiskit/circuit/library/standard_gates/swap.py
+++ b/qiskit/circuit/library/standard_gates/swap.py
@@ -80,7 +80,7 @@ class SwapGate(SingletonGate):
         #      └───┘     └───┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.Swap._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.Swap._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(
@@ -247,7 +247,7 @@ class CSwapGate(SingletonControlledGate):
         #           └───┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.CSwap._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.CSwap._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def inverse(self, annotated: bool = False):

--- a/qiskit/circuit/library/standard_gates/sx.py
+++ b/qiskit/circuit/library/standard_gates/sx.py
@@ -82,7 +82,7 @@ class SXGate(SingletonGate):
         #    └─────┘└───┘└─────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.SX._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.SX._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def inverse(self, annotated: bool = False):
@@ -184,7 +184,7 @@ class SXdgGate(SingletonGate):
         #    └───┘└───┘└───┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.SXdg._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.SXdg._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def inverse(self, annotated: bool = False):
@@ -296,7 +296,7 @@ class CSXGate(SingletonControlledGate):
         #      └───┘└───┘└───┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.CSX._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.CSX._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def __eq__(self, other):

--- a/qiskit/circuit/library/standard_gates/t.py
+++ b/qiskit/circuit/library/standard_gates/t.py
@@ -72,7 +72,7 @@ class TGate(SingletonGate):
         #    └────────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.T._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.T._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def inverse(self, annotated: bool = False):
@@ -145,7 +145,7 @@ class TdgGate(SingletonGate):
         #    └─────────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.Tdg._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.Tdg._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def inverse(self, annotated: bool = False):

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -305,7 +305,7 @@ class CUGate(ControlledGate):
         #      └──────────────┘                └───┘└──────────────────────┘└───┘└────────────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.CU._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.CU._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def inverse(self, annotated: bool = False):

--- a/qiskit/circuit/library/standard_gates/u1.py
+++ b/qiskit/circuit/library/standard_gates/u1.py
@@ -108,7 +108,7 @@ class U1Gate(Gate):
         #    └──────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.U1._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.U1._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(
@@ -257,7 +257,7 @@ class CU1Gate(ControlledGate):
         #                └───┘└─────────┘└───┘└────────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.CU1._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.CU1._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(

--- a/qiskit/circuit/library/standard_gates/u2.py
+++ b/qiskit/circuit/library/standard_gates/u2.py
@@ -107,7 +107,7 @@ class U2Gate(Gate):
         #    └────────────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.U2._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.U2._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def inverse(self, annotated: bool = False):

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -160,7 +160,7 @@ class U3Gate(Gate):
         #    └──────────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.U3._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.U3._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def __array__(self, dtype=None, copy=None):
@@ -297,7 +297,7 @@ class CU3Gate(ControlledGate):
         #      └──────────────┘└───┘└──────────────────────┘└───┘└────────────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.CU3._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.CU3._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def inverse(self, annotated: bool = False):

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -90,7 +90,7 @@ class XGate(SingletonGate):
         #    └──────────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.X._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.X._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(
@@ -386,7 +386,7 @@ class CCXGate(SingletonControlledGate):
         #      └───┘└───┘└─────┘└───┘└───┘└───┘└─────┘└───┘└───┘ └───┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.CCX._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.CCX._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(
@@ -489,7 +489,7 @@ class RCCXGate(SingletonGate):
         #      └───┘└───┘└───┘└─────┘└───┘└───┘└───┘└─────┘└───┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.RCCX._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.RCCX._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def __eq__(self, other):
@@ -542,7 +542,7 @@ class C3SXGate(SingletonControlledGate):
         from qiskit.circuit import QuantumCircuit
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.C3SX._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.C3SX._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def __eq__(self, other):
@@ -585,7 +585,7 @@ class C3XGate(SingletonControlledGate):
         from qiskit.circuit import QuantumCircuit
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.C3X._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.C3X._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(
@@ -686,7 +686,7 @@ class RC3XGate(SingletonGate):
         from qiskit.circuit import QuantumCircuit
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.RC3X._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.RC3X._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def __eq__(self, other):

--- a/qiskit/circuit/library/standard_gates/xx_minus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_minus_yy.py
@@ -85,7 +85,7 @@ class XXMinusYYGate(Gate):
         #      └────────┘└───┘      └───┘└──────────┘└───┘└─────┘└───────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.XXMinusYY._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.XXMinusYY._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(

--- a/qiskit/circuit/library/standard_gates/xx_plus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_plus_yy.py
@@ -118,7 +118,7 @@ class XXPlusYYGate(Gate):
         #       └─────┘ └────┘└───┘     └──────────┘     └─────┘ └──────┘ └───┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.XXPlusYY._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.XXPlusYY._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(

--- a/qiskit/circuit/library/standard_gates/y.py
+++ b/qiskit/circuit/library/standard_gates/y.py
@@ -87,7 +87,7 @@ class YGate(SingletonGate):
         #    └──────────────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.Y._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.Y._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(
@@ -232,7 +232,7 @@ class CYGate(SingletonControlledGate):
         #      └─────┘└───┘└───┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.CY._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.CY._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def inverse(self, annotated: bool = False):

--- a/qiskit/circuit/library/standard_gates/z.py
+++ b/qiskit/circuit/library/standard_gates/z.py
@@ -90,7 +90,7 @@ class ZGate(SingletonGate):
         #    └──────┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.Z._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.Z._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def control(
@@ -214,7 +214,7 @@ class CZGate(SingletonControlledGate):
         #      └───┘└───┘└───┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.CZ._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.CZ._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def inverse(self, annotated: bool = False):
@@ -310,7 +310,7 @@ class CCZGate(SingletonControlledGate):
         #      └───┘└───┘└───┘
 
         self.definition = QuantumCircuit._from_circuit_data(
-            StandardGate.CCZ._get_definition(self.params), add_regs=True, name=self.name
+            StandardGate.CCZ._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
     def inverse(self, annotated: bool = False):

--- a/qiskit/synthesis/clifford/clifford_decompose_bm.py
+++ b/qiskit/synthesis/clifford/clifford_decompose_bm.py
@@ -41,6 +41,8 @@ def synth_clifford_bm(clifford: Clifford) -> QuantumCircuit:
            `arXiv:2003.09412 [quant-ph] <https://arxiv.org/abs/2003.09412>`_
     """
     circuit = QuantumCircuit._from_circuit_data(
-        synth_clifford_bm_inner(clifford.tableau.astype(bool)), add_regs=True, name=str(clifford)
+        synth_clifford_bm_inner(clifford.tableau.astype(bool)),
+        legacy_qubits=True,
+        name=str(clifford),
     )
     return circuit

--- a/qiskit/synthesis/clifford/clifford_decompose_greedy.py
+++ b/qiskit/synthesis/clifford/clifford_decompose_greedy.py
@@ -52,7 +52,7 @@ def synth_clifford_greedy(clifford: Clifford) -> QuantumCircuit:
     """
     circuit = QuantumCircuit._from_circuit_data(
         synth_clifford_greedy_inner(clifford.tableau.astype(bool)),
-        add_regs=True,
+        legacy_qubits=True,
         name=str(clifford),
     )
     return circuit

--- a/qiskit/synthesis/discrete_basis/solovay_kitaev.py
+++ b/qiskit/synthesis/discrete_basis/solovay_kitaev.py
@@ -226,7 +226,7 @@ class SolovayKitaevDecomposition:
         if check_input != self_check_input:
             self._sk.do_checks = self_check_input
 
-        circuit = QuantumCircuit._from_circuit_data(data, add_regs=True)
+        circuit = QuantumCircuit._from_circuit_data(data, legacy_qubits=True)
 
         if return_dag:
             from qiskit.converters import circuit_to_dag  # pylint: disable=cyclic-import
@@ -242,7 +242,7 @@ class SolovayKitaevDecomposition:
         else:
             data = self._sk.query_basic_approximation_matrix(gate)
 
-        circuit = QuantumCircuit._from_circuit_data(data, add_regs=True)
+        circuit = QuantumCircuit._from_circuit_data(data, legacy_qubits=True)
         return circuit
 
     @deprecate_func(

--- a/qiskit/synthesis/evolution/pauli_network.py
+++ b/qiskit/synthesis/evolution/pauli_network.py
@@ -76,5 +76,5 @@ def synth_pauli_network_rustiq(
         upto_phase=upto_phase,
         resynth_clifford_method=resynth_clifford_method,
     )
-    circuit = QuantumCircuit._from_circuit_data(out, add_regs=True)
+    circuit = QuantumCircuit._from_circuit_data(out, legacy_qubits=True)
     return circuit

--- a/qiskit/synthesis/evolution/product_formula.py
+++ b/qiskit/synthesis/evolution/product_formula.py
@@ -145,7 +145,7 @@ class ProductFormula(EvolutionSynthesis):
             # this is the fast path, where the whole evolution is constructed Rust-side
             cx_fountain = self._cx_structure == "fountain"
             data = pauli_evolution(num_qubits, pauli_rotations, self.insert_barriers, cx_fountain)
-            circuit = QuantumCircuit._from_circuit_data(data, add_regs=True)
+            circuit = QuantumCircuit._from_circuit_data(data, legacy_qubits=True)
 
         return circuit
 

--- a/qiskit/synthesis/linear/cnot_synth.py
+++ b/qiskit/synthesis/linear/cnot_synth.py
@@ -66,4 +66,4 @@ def synth_cnot_count_full_pmh(
     circuit_data = fast_pmh(normalized, section_size)
 
     # construct circuit from the data
-    return QuantumCircuit._from_circuit_data(circuit_data, add_regs=True)
+    return QuantumCircuit._from_circuit_data(circuit_data, legacy_qubits=True)

--- a/qiskit/synthesis/linear/linear_depth_lnn.py
+++ b/qiskit/synthesis/linear/linear_depth_lnn.py
@@ -58,4 +58,4 @@ def synth_cnot_depth_line_kms(mat: np.ndarray[bool]) -> QuantumCircuit:
     circuit_data = fast_kms(mat)
 
     # construct circuit from the data
-    return QuantumCircuit._from_circuit_data(circuit_data, add_regs=True)
+    return QuantumCircuit._from_circuit_data(circuit_data, legacy_qubits=True)

--- a/qiskit/synthesis/linear_phase/cx_cz_depth_lnn.py
+++ b/qiskit/synthesis/linear_phase/cx_cz_depth_lnn.py
@@ -58,4 +58,4 @@ def synth_cx_cz_depth_line_my(mat_x: np.ndarray, mat_z: np.ndarray) -> QuantumCi
            `arXiv:2210.16195 <https://arxiv.org/abs/2210.16195>`_.
     """
     circuit_data = py_synth_cx_cz_depth_line_my(mat_x.astype(bool), mat_z.astype(bool))
-    return QuantumCircuit._from_circuit_data(circuit_data, add_regs=True)
+    return QuantumCircuit._from_circuit_data(circuit_data, legacy_qubits=True)

--- a/qiskit/synthesis/linear_phase/cz_depth_lnn.py
+++ b/qiskit/synthesis/linear_phase/cz_depth_lnn.py
@@ -54,5 +54,5 @@ def synth_cz_depth_line_mr(mat: np.ndarray) -> QuantumCircuit:
 
     # Call Rust implementaton
     return QuantumCircuit._from_circuit_data(
-        synth_cz_depth_line_mr_inner(mat.astype(bool)), add_regs=True
+        synth_cz_depth_line_mr_inner(mat.astype(bool)), legacy_qubits=True
     )

--- a/qiskit/synthesis/one_qubit/one_qubit_decompose.py
+++ b/qiskit/synthesis/one_qubit/one_qubit_decompose.py
@@ -225,7 +225,7 @@ class OneQubitEulerDecomposer:
             euler_one_qubit_decomposer.unitary_to_circuit(
                 unitary, [self.basis], 0, None, simplify, atol
             ),
-            add_regs=True,
+            legacy_qubits=True,
         )
 
     @property

--- a/qiskit/synthesis/permutation/permutation_full.py
+++ b/qiskit/synthesis/permutation/permutation_full.py
@@ -42,7 +42,7 @@ def synth_permutation_basic(pattern: list[int] | np.ndarray[int]) -> QuantumCirc
     Returns:
         The synthesized quantum circuit.
     """
-    return QuantumCircuit._from_circuit_data(_synth_permutation_basic(pattern), add_regs=True)
+    return QuantumCircuit._from_circuit_data(_synth_permutation_basic(pattern), legacy_qubits=True)
 
 
 def synth_permutation_acg(pattern: list[int] | np.ndarray[int]) -> QuantumCircuit:
@@ -75,4 +75,4 @@ def synth_permutation_acg(pattern: list[int] | np.ndarray[int]) -> QuantumCircui
            *Routing Permutations on Graphs Via Matchings.*,
            `(Full paper) <https://www.cs.tau.ac.il/~nogaa/PDFS/r.pdf>`_
     """
-    return QuantumCircuit._from_circuit_data(_synth_permutation_acg(pattern), add_regs=True)
+    return QuantumCircuit._from_circuit_data(_synth_permutation_acg(pattern), legacy_qubits=True)

--- a/qiskit/synthesis/permutation/permutation_lnn.py
+++ b/qiskit/synthesis/permutation/permutation_lnn.py
@@ -50,5 +50,5 @@ def synth_permutation_depth_lnn_kms(pattern: list[int] | np.ndarray[int]) -> Qua
     # [2, 4, 3, 0, 1] means that 0 maps to 2, 1 to 3, 2 to 3, 3 to 0, and 4 to 1.
     # This is why we invert the pattern.
     return QuantumCircuit._from_circuit_data(
-        _synth_permutation_depth_lnn_kms(pattern), add_regs=True
+        _synth_permutation_depth_lnn_kms(pattern), legacy_qubits=True
     )

--- a/qiskit/synthesis/permutation/permutation_reverse_lnn.py
+++ b/qiskit/synthesis/permutation/permutation_reverse_lnn.py
@@ -89,5 +89,5 @@ def synth_permutation_reverse_lnn_kms(num_qubits: int) -> QuantumCircuit:
 
     # Call Rust implementation
     return QuantumCircuit._from_circuit_data(
-        synth_permutation_reverse_lnn_kms_inner(num_qubits), add_regs=True
+        synth_permutation_reverse_lnn_kms_inner(num_qubits), legacy_qubits=True
     )

--- a/qiskit/synthesis/qft/qft_decompose_lnn.py
+++ b/qiskit/synthesis/qft/qft_decompose_lnn.py
@@ -57,5 +57,5 @@ def synth_qft_line(
     return QuantumCircuit._from_circuit_data(
         # From rust
         _synth_qft_line(num_qubits, do_swaps, approximation_degree),
-        add_regs=True,
+        legacy_qubits=True,
     )

--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -207,7 +207,7 @@ class TwoQubitWeylDecomposition:
         circuit_data = self._inner_decomposition.circuit(
             euler_basis=euler_basis, simplify=simplify, atol=atol
         )
-        return QuantumCircuit._from_circuit_data(circuit_data, add_regs=True)
+        return QuantumCircuit._from_circuit_data(circuit_data, legacy_qubits=True)
 
     def actual_fidelity(self, **kwargs) -> float:
         """Calculates the actual fidelity of the decomposed circuit to the input unitary."""
@@ -314,7 +314,7 @@ class TwoQubitControlledUDecomposer:
         Note: atol is passed to OneQubitEulerDecomposer.
         """
         circ_data = self._inner_decomposer(np.asarray(unitary, dtype=complex), atol)
-        return QuantumCircuit._from_circuit_data(circ_data, add_regs=True)
+        return QuantumCircuit._from_circuit_data(circ_data, legacy_qubits=True)
 
 
 class TwoQubitBasisDecomposer:
@@ -467,7 +467,7 @@ class TwoQubitBasisDecomposer:
                 approximate,
                 _num_basis_uses=_num_basis_uses,
             )
-            return QuantumCircuit._from_circuit_data(circ_data, add_regs=True)
+            return QuantumCircuit._from_circuit_data(circ_data, legacy_qubits=True)
 
     def traces(self, target):
         r"""


### PR DESCRIPTION
Various Rust-defined methods created circuits in terms of anonymous qubits, then used `QuantumCircuit._from_circuit_data(add_regs=True)` to add a dummy `q` register.  However, while the added register superficially looked like the register created by the `QuantumCircuit(int)` constructor, it was instead a register alias, which made it fragile to use.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Fix #14718.  That immediate bug isn't released, and we don't _know_ of another trigger.

I didn't really write a test, because the only real way that this would be broken would be a _new_ function getting added and failing to call the relevant function, which the test wouldn't catch. Hopefully this behaviour is something we can drop at some point, when we change the story around physical qubits anyway.