### PR TITLE
Fix `VF2PostLayout` with uncoupled qubits in `strict_direction=True`

### DIFF
--- a/qiskit/transpiler/passes/layout/vf2_post_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_post_layout.py
@@ -153,11 +153,19 @@ class VF2PostLayout(AnalysisPass):
             self.property_set["VF2PostLayout_stop_reason"] = VF2PostLayoutStopReason.MORE_THAN_2Q
             return
         im_graph, im_graph_node_map, reverse_im_graph_node_map, free_nodes = result
-        if len(free_nodes) > 1 and self.strict_direction:
-            self.property_set["VF2PostLayout_stop_reason"] = (
-                VF2PostLayoutStopReason.NO_BETTER_SOLUTION_FOUND
-            )
-            return
+        if self.strict_direction and free_nodes:
+            # If there are uncoupled qubits, in non-strict modes we just allocate them to the
+            # lowest-error states at the end.  However, in strict mode, we have to consider them at
+            # the same time to handle heterogeneous targets correctly.  This risks a factorial
+            # combinatoric explosion in complexity, though, so we put a limit on how many we'll
+            # handle.  The builder still builds the graph entirely, it just returns the free nodes
+            # for us to check on, so we clear that out after we've checked it.
+            if len(free_nodes) > 1:
+                self.property_set["VF2PostLayout_stop_reason"] = (
+                    VF2PostLayoutStopReason.NO_BETTER_SOLUTION_FOUND
+                )
+                return
+            free_nodes.clear()
         scoring_bit_list = vf2_utils.build_bit_list(im_graph, im_graph_node_map)
         scoring_edge_list = vf2_utils.build_edge_list(im_graph)
 


### PR DESCRIPTION
When `VF2PostLayout` is set in strict mode, we have to include even active but uncoupled qubits in the interaction graph, because of the semantic constraints.  We need to limit the number of these uncoupled qubits we'll consider, though, because there's a factorial overhead to handling them.

A previous commit[^1] added this skip to `strict_direction=False`, but didn't correctly handle the continuation case where we're within the limit.  This commit ~ups the limit to 3 uncoupled qubits (a potential 6x overhead) and~ correctly clears out the uncoupled-qubit metadata that was causing problems in later layout reconstruction.

[^1]: b4094ddc: Fix calls to `VF2PostLayout` after optimization loop at O3

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

No release note because the bug isn't released.

Fix #14997 