### PR TITLE
Use QSD from rust in default unitary synthesis plugin

### DIFF
--- a/crates/cext/src/transpiler/passes/unitary_synthesis.rs
+++ b/crates/cext/src/transpiler/passes/unitary_synthesis.rs
@@ -26,9 +26,6 @@ use qiskit_transpiler::target::Target;
 /// The UnitarySynthesis transpiler pass will synthesize any UnitaryGates in the circuit into gates
 /// available in the target.
 ///
-/// Right now from C this pass only supports 1 and 2 qubit UnitaryGates. Larger unitary matrices
-/// will be supported in a future release.
-///
 /// @param circuit A pointer to the circuit to run UnitarySynthesis on
 /// @param target A pointer to the target to run UnitarySynthesis on
 /// @param min_qubits The minimum number of qubits in the unitary to synthesize. If the unitary

--- a/crates/transpiler/src/transpiler.rs
+++ b/crates/transpiler/src/transpiler.rs
@@ -70,7 +70,6 @@ pub fn transpile(
     );
 
     let unroll_3q_or_more = |dag: &mut DAGCircuit| -> Result<()> {
-        // This will panic if there is a 3q unitary until qsd is ported
         let mut out_dag = run_unitary_synthesis(
             dag,
             (0..dag.num_qubits()).collect(),

--- a/releasenotes/notes/multiq-unitary-synth-c-2a282071b8c08c07.yaml
+++ b/releasenotes/notes/multiq-unitary-synth-c-2a282071b8c08c07.yaml
@@ -1,0 +1,10 @@
+---
+features_c:
+  - |
+    The :c:func:`qk_transpiler_pass_standalone_unitary_synthesis` and
+    :c:func:`qk_transpile` now support synthesizing 3+ qubit
+    :class:`.UnitaryGate` objects in a circuit. In Qiskit 2.2 this was not
+    supported as the underlying synthesis algorithm :func:`.qs_decomposition`
+    used for 3+ qubit unitary synthesis was previously written in Python, but
+    now that it has been ported to Rust this functionality is now available
+    from C.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

With QSD ported to rust we no longer need to use python to run QSD in
the default unitary synthesis plugin which is written in rust. This
commit updates the unitary synthesis code to directly call qsd from
rust. Doing this also enables the C API transpiler from handling 3+ q
unitaries. The handling around multiqubit unitaries is updated to
indicate they are now supported.

### Details and comments

~This commit is based on top of #14797 and will need to be rebased after that merges. To view the contents of just this PR you can look at the HEAD commit on the PR branch: https://github.com/Qiskit/qiskit/commit/bbbc37a96abe700cc53746c63c3b3ebaef9c8625~ This has been rebased now
