### PR TITLE
Fix variable remapping of `Delay` expressions in `QuantumCircuit.compose`

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2320,6 +2320,9 @@ class QuantumCircuit:
                     n_op = Store(
                         variable_mapper.map_expr(n_op.lvalue), variable_mapper.map_expr(n_op.rvalue)
                     )
+                elif isinstance(n_op, Delay) and n_op.unit == "expr":
+                    n_op = n_op.copy()
+                    n_op.duration = variable_mapper.map_expr(n_op.duration)
                 return n_op.copy() if n_op is op and copy else n_op
 
             instructions = source._data.copy(copy_instructions=copy)

--- a/releasenotes/notes/remap-delay-expr-d3fdea803a987ca1.yaml
+++ b/releasenotes/notes/remap-delay-expr-d3fdea803a987ca1.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    :meth:`.QuantumCircuit.compose` will now correctly remap anyway variables and stretches used in
+    :class:`~.circuit.Delay` instructions when the ``var_remap`` argument is specified.

--- a/test/python/circuit/test_compose.py
+++ b/test/python/circuit/test_compose.py
@@ -869,6 +869,19 @@ class TestCircuitCompose(QiskitTestCase):
         self.assertEqual([a1, c], list(out.iter_captured_stretches()))
         self.assertEqual([a1, c], list(out.iter_stretches()))
 
+    def test_remap_stretch_inside_var(self):
+        """Test that the variable remapper checks inside `Delay` nodes."""
+        qc = QuantumCircuit(1)
+        a = qc.add_stretch("a")
+        qc.delay(expr.mul(2, a), 0)
+
+        other = QuantumCircuit(1)
+        b = other.add_stretch("b")
+        other.delay(expr.mul(2, b), 0)
+
+        actual = QuantumCircuit(1).compose(other, var_remap={b: a})
+        self.assertEqual(qc, actual)
+
     def test_simple_inline_captures(self):
         """We should be able to inline captures onto other variables."""
         a = expr.Var.new("a", types.Bool())


### PR DESCRIPTION

The `Delay.duration` field was fairly recently updated to allow it to be an expression, but we forgot to add it to the tracked list of expression locations in `QuantumCircuit.compose`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Fix #15019.
