### PR TITLE
Preserve registers in output TranspileLayout

### DIFF
--- a/crates/cext/src/transpiler/passes/elide_permutations.rs
+++ b/crates/cext/src/transpiler/passes/elide_permutations.rs
@@ -79,6 +79,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_elide_permutations(
                 Some(res.1.into_iter().map(Qubit::new).collect()),
                 circuit.qubits().objects().clone(),
                 num_input_qubits,
+                circuit.qregs().to_vec(),
             )))
         }
         None => std::ptr::null_mut(),

--- a/crates/cext/src/transpiler/passes/sabre_layout.rs
+++ b/crates/cext/src/transpiler/passes/sabre_layout.rs
@@ -160,5 +160,6 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_sabre_layout(
         Some(out_permutation),
         result.qubits().objects().clone(),
         num_input_qubits,
+        result.qregs().to_vec(),
     )))
 }

--- a/crates/cext/src/transpiler/passes/split_2q_unitaries.rs
+++ b/crates/cext/src/transpiler/passes/split_2q_unitaries.rs
@@ -70,12 +70,14 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_split_2q_unitaries(
             };
             let num_input_qubits = circuit.num_qubits() as u32;
             let qubits = out_circuit.qubits().objects().clone();
+            let qregs = out_circuit.qregs().to_vec();
             *circuit = out_circuit;
             Box::into_raw(Box::new(TranspileLayout::new(
                 None,
                 Some(permutation.into_iter().map(Qubit::new).collect()),
                 qubits,
                 num_input_qubits,
+                qregs,
             )))
         }
         None => {

--- a/crates/cext/src/transpiler/transpile_layout.rs
+++ b/crates/cext/src/transpiler/transpile_layout.rs
@@ -280,6 +280,7 @@ mod test {
             Some(routing_permutation),
             input_qubits,
             3,
+            vec![],
         );
         let result = layout.final_index_layout(true);
         let expected = vec![PhysicalQubit(3), PhysicalQubit(5), PhysicalQubit(2)];
@@ -323,6 +324,7 @@ mod test {
             Some(routing_permutation),
             input_qubits,
             3,
+            vec![],
         );
         let result = layout.final_index_layout(false);
         let expected = vec![
@@ -377,6 +379,7 @@ mod test {
             Some(routing_permutation),
             input_qubits,
             3,
+            vec![],
         );
         let expected: Vec<u32> = [PhysicalQubit(9), PhysicalQubit(4), PhysicalQubit(0)]
             .into_iter()
@@ -421,6 +424,7 @@ mod test {
             Some(routing_permutation),
             input_qubits,
             3,
+            vec![],
         );
         let mut result: Vec<u32> = vec![u32::MAX; layout.num_output_qubits() as usize];
         assert!(unsafe { qk_transpile_layout_initial_layout(&layout, false, result.as_mut_ptr()) });
@@ -430,7 +434,7 @@ mod test {
     #[test]
     fn test_initial_layout_no_layout() {
         let input_qubits = vec![ShareableQubit::new_anonymous(); 10000];
-        let layout = TranspileLayout::new(None, None, input_qubits, 10000);
+        let layout = TranspileLayout::new(None, None, input_qubits, 10000, vec![]);
         let mut result: Vec<u32> = vec![u32::MAX; layout.num_input_qubits() as usize];
         assert!(!unsafe { qk_transpile_layout_initial_layout(&layout, true, result.as_mut_ptr()) });
     }
@@ -469,6 +473,7 @@ mod test {
             Some(routing_permutation),
             input_qubits,
             3,
+            vec![],
         );
         let mut result: Vec<u32> = vec![u32::MAX; layout.num_output_qubits() as usize];
         assert!(unsafe { qk_transpile_layout_output_permutation(&layout, result.as_mut_ptr()) });
@@ -478,7 +483,7 @@ mod test {
     #[test]
     fn test_output_permutation_not_set() {
         let input_qubits = vec![ShareableQubit::new_anonymous(); 10000];
-        let layout = TranspileLayout::new(None, None, input_qubits, 10000);
+        let layout = TranspileLayout::new(None, None, input_qubits, 10000, vec![]);
         let mut result: Vec<u32> = vec![u32::MAX; layout.num_output_qubits() as usize];
         assert!(!unsafe { qk_transpile_layout_output_permutation(&layout, result.as_mut_ptr()) });
     }
@@ -488,7 +493,7 @@ mod test {
         let initial_layout_vec = (0..256).rev().map(PhysicalQubit::new).collect();
         let initial_layout = NLayout::from_virtual_to_physical(initial_layout_vec).unwrap();
         let input_qubits = vec![ShareableQubit::new_anonymous(); 256];
-        let layout = TranspileLayout::new(Some(initial_layout), None, input_qubits, 3);
+        let layout = TranspileLayout::new(Some(initial_layout), None, input_qubits, 3, vec![]);
         unsafe {
             assert_eq!(qk_transpile_layout_num_input_qubits(&layout), 3);
         }
@@ -499,7 +504,7 @@ mod test {
         let initial_layout_vec = (0..256).rev().map(PhysicalQubit::new).collect();
         let initial_layout = NLayout::from_virtual_to_physical(initial_layout_vec).unwrap();
         let input_qubits = vec![ShareableQubit::new_anonymous(); 256];
-        let layout = TranspileLayout::new(Some(initial_layout), None, input_qubits, 3);
+        let layout = TranspileLayout::new(Some(initial_layout), None, input_qubits, 3, vec![]);
         unsafe {
             assert_eq!(qk_transpile_layout_num_output_qubits(&layout), 256);
         }

--- a/crates/transpiler/src/passes/apply_layout.rs
+++ b/crates/transpiler/src/passes/apply_layout.rs
@@ -97,6 +97,7 @@ pub fn apply_layout(
         final_permutation,
         virtual_qubits,
         cur_layout.num_input_qubits(),
+        cur_layout.input_registers().to_vec(),
     );
 }
 
@@ -213,6 +214,7 @@ fn py_apply_layout<'py>(
         // We had to take `num_virtual_qubits` by value because the DAG might already have been
         // expanded with ancillas in the legacy mode.
         num_virtual_qubits,
+        dag.qregs().to_vec(),
     );
     apply_layout(dag, &mut cur_layout, num_physical_qubits, |v| {
         physical_from_virtual[v.index()]

--- a/crates/transpiler/src/transpiler.rs
+++ b/crates/transpiler/src/transpiler.rs
@@ -67,6 +67,7 @@ pub fn transpile(
         None,
         dag.qubits().objects().to_owned(),
         dag.num_qubits() as u32,
+        dag.qregs().to_vec(),
     );
 
     let unroll_3q_or_more = |dag: &mut DAGCircuit| -> Result<()> {
@@ -424,6 +425,7 @@ fn layout_from_sabre_result(
         final_layout,
         dag.qubits().objects().clone(),
         old_transpile_layout.num_input_qubits(),
+        dag.qregs().to_vec(),
     );
     if let Some(old_permutation) = old_transpile_layout.output_permutation() {
         new_transpile_layout


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the move of the ApplyLayout pass in Rust one detail of the initial layout was being lost in the translation from Python Layout -> Rust TranspileLayout -> Python TranspileLayout the registers tracked in the initial layout. To address this, a vec of registers is added to the Rust space `TranspileLayout` struct. This then gets populated when going from Python -> Rust from the initial layout, and when converting from a Rust TranspileLayout -> Python TranspileLayout the initial layout field adds the tracked registers.

Since the bug wasn't included in a full release no release note is included. It will be tagged for the changelog though to indicate the difference between 2.2.0rc1 and 2.2.0

### Details and comments

Fixes #15014