### PR TITLE
Fix global phase handling in unitary_sim

### DIFF
--- a/crates/quantum_info/src/unitary_sim.rs
+++ b/crates/quantum_info/src/unitary_sim.rs
@@ -15,7 +15,7 @@ use num_complex::Complex64;
 use numpy::IntoPyArray;
 use pyo3::prelude::*;
 use qiskit_circuit::circuit_data::CircuitData;
-use qiskit_circuit::operations::{Operation, OperationRef, StandardInstruction};
+use qiskit_circuit::operations::{Operation, OperationRef, Param, StandardInstruction};
 
 use crate::{unitary_compose, QiskitError};
 
@@ -37,8 +37,16 @@ pub fn sim_unitary_circuit(circuit: &CircuitData) -> Result<Array2<Complex64>, S
         ));
     }
 
+    // e^{i * global_phase}
+    let global_phase_exp: Complex64 = if let Param::Float(p) = circuit.global_phase() {
+        Complex64::new(0., *p).exp()
+    } else {
+        return Err("Cannot simulate circuit involving non-float global phase.".to_string());
+    };
+
     // Product matrix holding the result
-    let mut product_mat = Array2::<Complex64>::eye(2_usize.pow(num_qubits as u32));
+    let mut product_mat: Array2<Complex64> =
+        Array2::<Complex64>::eye(2_usize.pow(num_qubits as u32)) * global_phase_exp;
 
     for inst in circuit.data() {
         if !circuit.get_cargs(inst.clbits).is_empty() {
@@ -76,4 +84,24 @@ pub fn py_sim_unitary_circuit(py: Python, circuit: &CircuitData) -> PyResult<Py<
 pub fn unitary_sim(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(py_sim_unitary_circuit))?;
     Ok(())
+}
+
+#[cfg(all(test, not(miri)))]
+mod test {
+    use super::sim_unitary_circuit;
+    use approx::abs_diff_eq;
+    use qiskit_circuit::operations::{Operation, StandardGate};
+
+    #[test]
+    fn test_sim_ecr_definition() {
+        // Check that the definition circuit for the ECRGate (which in particular involves
+        // a non-trivial global phase) gets simulated correctly.
+        let ecr_definition = StandardGate::ECR.definition(&[]).unwrap();
+
+        let simulated_matrix = sim_unitary_circuit(&ecr_definition).unwrap();
+        let expected_matrix = StandardGate::ECR.matrix(&[]).unwrap();
+
+        let close = abs_diff_eq!(simulated_matrix, expected_matrix, epsilon = 1e-12);
+        assert!(close);
+    }
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes the global phase handling in `unitary_sim`.


