### PR TITLE
Add support for parameters in `Target::instruction_supported` in Rust.

### DIFF
--- a/crates/transpiler/src/passes/consolidate_blocks.rs
+++ b/crates/transpiler/src/passes/consolidate_blocks.rs
@@ -43,7 +43,7 @@ use qiskit_synthesis::two_qubit_decompose::{
 };
 
 use crate::passes::unitary_synthesis::{PARAM_SET, TWO_QUBIT_BASIS_SET};
-use crate::target::Target;
+use crate::target::{Target, Qargs};
 use qiskit_circuit::PhysicalQubit;
 
 #[allow(clippy::large_enum_variant)]
@@ -142,7 +142,10 @@ fn is_supported(
     qargs: &[PhysicalQubit],
 ) -> bool {
     match target {
-        Some(target) => target.instruction_supported(name, qargs),
+        Some(target) => {
+            let physical_qargs: Qargs = qargs.iter().map(|bit| PhysicalQubit(bit.0)).collect();
+            target.instruction_supported(name, &physical_qargs, &[], false)
+        }
         None => match basis_gates {
             Some(basis_gates) => basis_gates.contains(name),
             None => true,

--- a/crates/transpiler/src/passes/consolidate_blocks.rs
+++ b/crates/transpiler/src/passes/consolidate_blocks.rs
@@ -43,7 +43,7 @@ use qiskit_synthesis::two_qubit_decompose::{
 };
 
 use crate::passes::unitary_synthesis::{PARAM_SET, TWO_QUBIT_BASIS_SET};
-use crate::target::{Target, Qargs};
+use crate::target::{Qargs, Target};
 use qiskit_circuit::PhysicalQubit;
 
 #[allow(clippy::large_enum_variant)]

--- a/crates/transpiler/src/passes/gate_direction.rs
+++ b/crates/transpiler/src/passes/gate_direction.rs
@@ -189,7 +189,6 @@ pub fn fix_direction_target(dag: &mut DAGCircuit, target: &Target) -> PyResult<(
             PhysicalQubit::new(op_args[1].0),
         ];
 
-        // Take this path so Target can check for exact match of the parameterized gate's angle
         target.instruction_supported(inst.op.name(), qargs, inst.params_view(), false)
     };
 

--- a/crates/transpiler/src/passes/gate_direction.rs
+++ b/crates/transpiler/src/passes/gate_direction.rs
@@ -25,7 +25,7 @@ use qiskit_circuit::{
     operations::StandardGate, packed_instruction::PackedInstruction,
 };
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
-use smallvec::{SmallVec, smallvec};
+use smallvec::SmallVec;
 use std::f64::consts::PI;
 
 //#########################################################################
@@ -71,7 +71,7 @@ pub fn check_direction_target(dag: &DAGCircuit, target: &Target) -> PyResult<boo
             PhysicalQubit::new(op_args[1].0),
         ];
 
-        target.instruction_supported(inst.op.name(), &qargs)
+        target.instruction_supported(inst.op.name(), &qargs, &[], false)
     };
 
     check_gate_direction(dag, &target_check, None)
@@ -184,29 +184,13 @@ pub fn fix_direction_coupling_map(
 #[pyo3(name = "fix_gate_direction_target")]
 pub fn fix_direction_target(dag: &mut DAGCircuit, target: &Target) -> PyResult<()> {
     let target_check = |inst: &PackedInstruction, op_args: &[Qubit]| -> bool {
-        let qargs = smallvec![
+        let qargs: &[PhysicalQubit] = &[
             PhysicalQubit::new(op_args[0].0),
-            PhysicalQubit::new(op_args[1].0)
+            PhysicalQubit::new(op_args[1].0),
         ];
 
         // Take this path so Target can check for exact match of the parameterized gate's angle
-        if let OperationRef::StandardGate(std_gate) = inst.op.view() {
-            match std_gate {
-                StandardGate::RXX | StandardGate::RYY | StandardGate::RZZ | StandardGate::RZX => {
-                    return target
-                        .py_instruction_supported(
-                            Some(std_gate.get_name().to_string()),
-                            qargs.into(),
-                            None,
-                            Some(inst.params_view().to_vec()),
-                            false,
-                        )
-                        .unwrap_or(false);
-                }
-                _ => {}
-            }
-        }
-        target.instruction_supported(inst.op.name(), &qargs)
+        target.instruction_supported(inst.op.name(), qargs, inst.params_view(), true)
     };
 
     fix_gate_direction(dag, &target_check, None)

--- a/crates/transpiler/src/passes/gate_direction.rs
+++ b/crates/transpiler/src/passes/gate_direction.rs
@@ -190,7 +190,7 @@ pub fn fix_direction_target(dag: &mut DAGCircuit, target: &Target) -> PyResult<(
         ];
 
         // Take this path so Target can check for exact match of the parameterized gate's angle
-        target.instruction_supported(inst.op.name(), qargs, inst.params_view(), true)
+        target.instruction_supported(inst.op.name(), qargs, inst.params_view(), false)
     };
 
     fix_gate_direction(dag, &target_check, None)

--- a/crates/transpiler/src/passes/gates_in_basis.rs
+++ b/crates/transpiler/src/passes/gates_in_basis.rs
@@ -18,7 +18,7 @@ use crate::target::{Qargs, Target};
 use qiskit_circuit::PhysicalQubit;
 use qiskit_circuit::Qubit;
 use qiskit_circuit::dag_circuit::DAGCircuit;
-use qiskit_circuit::operations::{Operation, Param};
+use qiskit_circuit::operations::Operation;
 use qiskit_circuit::packed_instruction::PackedInstruction;
 
 #[pyfunction]
@@ -36,28 +36,17 @@ pub fn gates_missing_from_target(dag: &DAGCircuit, target: &Target) -> PyResult<
         wire_map: &HashMap<Qubit, PhysicalQubit>,
     ) -> PyResult<bool> {
         let qargs_mapped: Qargs = qargs.iter().map(|q| wire_map[q]).collect();
-        if !target.instruction_supported(gate.op.name(), &qargs_mapped) {
+        // Skip parameter checking if the gate is control flow.
+        if !target.instruction_supported(
+            gate.op.name(),
+            &qargs_mapped,
+            (!gate.op.control_flow())
+                .then_some(gate.params_view())
+                .unwrap_or_default(),
+            !gate.is_parameterized() && !gate.op.control_flow(),
+        ) {
             return Ok(true);
         }
-        if target.has_angle_bounds()
-            && target.gate_has_angle_bounds(gate.op.name())
-            && !gate.is_parameterized()
-        {
-            let params: Vec<f64> = gate
-                .params
-                .as_ref()
-                .unwrap()
-                .iter()
-                .map(|x| {
-                    let Param::Float(val) = x else { unreachable!() };
-                    *val
-                })
-                .collect();
-            if !target.gate_supported_angle_bound(gate.op.name(), &params) {
-                return Ok(true);
-            }
-        }
-
         if gate.op.control_flow() {
             for block in gate.op.blocks() {
                 let block_qubits = (0..block.num_qubits()).map(Qubit::new);

--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -418,7 +418,8 @@ fn all_instructions_supported(
                 if borrowed_data.use_physical_indices {
                     return Ok(false);
                 }
-                Ok(op_keys.all(|name| target.instruction_supported(name, &Qargs::Global)))
+                Ok(op_keys
+                    .all(|name| target.instruction_supported(name, &Qargs::Global, &[], false)))
             } else {
                 // If we do not have the target, we check whether every operation
                 // in op_names is inside the basis gates.
@@ -444,9 +445,9 @@ fn instruction_supported(
                 if borrowed_data.use_physical_indices {
                     let physical_qubits: Qargs =
                         qubits.iter().map(|q| PhysicalQubit(q.0)).collect();
-                    target.instruction_supported(name, &physical_qubits)
+                    target.instruction_supported(name, &physical_qubits, &[], false)
                 } else {
-                    target.instruction_supported(name, &Qargs::Global)
+                    target.instruction_supported(name, &Qargs::Global, &[], false)
                 }
             } else {
                 borrowed_data.device_insts.contains(name)

--- a/crates/transpiler/src/target/mod.rs
+++ b/crates/transpiler/src/target/mod.rs
@@ -1348,7 +1348,7 @@ impl Target {
     ///
     /// # Returns
     ///
-    /// * `true`` if the instruction compatible with the target, `false` if otherwise.
+    /// * `true` if the instruction is compatible with the target, `false` if otherwise.
     pub fn instruction_supported<'a, T>(
         &self,
         operation_name: &str,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #14957

- Add the `parameters` and `check_angle_bounds` arguments to the Rust-native `instruction_supported` method for `Target`. This enables users to use parameter checks with rust native structure.
- The following passes have been updated to use this path:
    - `ConsolidateBlocks`.
    - `GateDirection`.
    - `HighLevelSynthesis`.
    - `GatesInBasis`.
- Add docstring to rust native `instruction_supported`.


### Details and comments


