### PR TITLE
Fix edge-order non-determinism when adding DAG nodes

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -43,7 +43,7 @@ use crate::variable_mapper::VariableMapper;
 use crate::{imports, vf2, Clbit, Qubit, Stretch, TupleLikeArg, Var, VarsMode};
 
 use hashbrown::{HashMap, HashSet};
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use itertools::{EitherOrBoth, Itertools};
 
 use pyo3::exceptions::{
@@ -5389,7 +5389,32 @@ impl DAGCircuit {
     /// This is mostly used to apply operations from one DAG to
     /// another that was created from the first via
     /// [DAGCircuit::copy_empty_like].
+    #[inline]
     pub fn push_back(&mut self, instr: PackedInstruction) -> PyResult<NodeIndex> {
+        self.push_external(instr, Direction::Outgoing)
+    }
+
+    /// Apply a [PackedInstruction] to the front of the circuit.
+    ///
+    /// The provided `instr` MUST be valid for this DAG, e.g. its
+    /// bits, registers, vars, and interner IDs must be valid in
+    /// this DAG.
+    ///
+    /// This is mostly used to apply operations from one DAG to
+    /// another that was created from the first via
+    /// [DAGCircuit::copy_empty_like].
+    #[inline]
+    pub fn push_front(&mut self, instr: PackedInstruction) -> PyResult<NodeIndex> {
+        self.push_external(instr, Direction::Incoming)
+    }
+
+    /// Push a [PackedInstruction] to become an external operation node on the DAG, with the edges
+    /// between the instruction and the DAG operations are the given direction, relative to the
+    /// DAG.
+    ///
+    /// Explicitly, [Direction::Outgoing] is equivalent to [push_back], whereas
+    /// [Direction::Incoming] is equivalent to [push_front].
+    fn push_external(&mut self, instr: PackedInstruction, dir: Direction) -> PyResult<NodeIndex> {
         let (all_cbits, vars) = self.get_classical_resources(&instr)?;
 
         // Increment the operation count
@@ -5397,35 +5422,55 @@ impl DAGCircuit {
 
         let qubits_id = instr.qubits;
         let new_node = self.dag.add_node(NodeType::Operation(instr));
-
+        let terminus_index = match dir {
+            Direction::Incoming => 0, // the "in" nodes
+            Direction::Outgoing => 1, // the "out" nodes
+        };
         // Put the new node in-between the previously "last" nodes on each wire
-        // and the output map.
-        let output_nodes: HashSet<NodeIndex> = self
+        // and the terminal map.
+        let termini: IndexSet<NodeIndex, ::ahash::RandomState> = self
             .qargs_interner
             .get(qubits_id)
             .iter()
-            .map(|q| self.qubit_io_map.get(q.index()).map(|x| x[1]).unwrap())
+            .map(|q| self.qubit_io_map[q.index()][terminus_index])
             .chain(
                 all_cbits
                     .iter()
-                    .map(|c| self.clbit_io_map.get(c.index()).map(|x| x[1]).unwrap()),
+                    .map(|c| self.clbit_io_map[c.index()][terminus_index]),
             )
             .chain(
                 vars.iter()
                     .flatten()
-                    .map(|v| self.var_io_map.get(v.index()).map(|x| x[1]).unwrap()),
+                    .map(|v| self.var_io_map[v.index()][terminus_index]),
             )
             .collect();
 
-        for output_node in output_nodes {
+        for terminus in termini {
             let last_edges: Vec<_> = self
                 .dag
-                .edges_directed(output_node, Incoming)
-                .map(|e| (e.source(), e.id(), *e.weight()))
+                .edges_directed(terminus, dir.opposite())
+                .map(|e| {
+                    (
+                        match dir {
+                            Direction::Outgoing => e.source(),
+                            Direction::Incoming => e.target(),
+                        },
+                        e.id(),
+                        *e.weight(),
+                    )
+                })
                 .collect();
-            for (source, old_edge, weight) in last_edges.into_iter() {
-                self.dag.add_edge(source, new_node, weight);
-                self.dag.add_edge(new_node, output_node, weight);
+            for (op_node, old_edge, weight) in last_edges.into_iter() {
+                match dir {
+                    Direction::Outgoing => {
+                        self.dag.add_edge(op_node, new_node, weight);
+                        self.dag.add_edge(new_node, terminus, weight);
+                    }
+                    Direction::Incoming => {
+                        self.dag.add_edge(terminus, new_node, weight);
+                        self.dag.add_edge(new_node, op_node, weight);
+                    }
+                }
                 self.dag.remove_edge(old_edge);
             }
         }
@@ -5439,8 +5484,8 @@ impl DAGCircuit {
     ) -> PyResult<(Vec<Clbit>, Option<Vec<Var>>)> {
         let (all_clbits, vars): (Vec<Clbit>, Option<Vec<Var>>) = {
             if self.may_have_additional_wires(instr.op.view()) {
-                let mut clbits: HashSet<Clbit> =
-                    HashSet::from_iter(self.cargs_interner.get(instr.clbits).iter().copied());
+                let mut clbits: IndexSet<Clbit, ::ahash::RandomState> =
+                    IndexSet::from_iter(self.cargs_interner.get(instr.clbits).iter().copied());
                 let (additional_clbits, additional_vars) =
                     Python::attach(|py| self.additional_wires(py, instr.op.view()))?;
                 for clbit in additional_clbits {
@@ -5452,68 +5497,6 @@ impl DAGCircuit {
             }
         };
         Ok((all_clbits, vars))
-    }
-
-    /// Apply a [PackedInstruction] to the front of the circuit.
-    ///
-    /// The provided `instr` MUST be valid for this DAG, e.g. its
-    /// bits, registers, vars, and interner IDs must be valid in
-    /// this DAG.
-    ///
-    /// This is mostly used to apply operations from one DAG to
-    /// another that was created from the first via
-    /// [DAGCircuit::copy_empty_like].
-    fn push_front(&mut self, inst: PackedInstruction) -> PyResult<NodeIndex> {
-        let op_name = inst.op.name();
-        let (all_cbits, vars): (Vec<Clbit>, Option<Vec<Var>>) = {
-            if self.may_have_additional_wires(inst.op.view()) {
-                let mut clbits: HashSet<Clbit> =
-                    HashSet::from_iter(self.cargs_interner.get(inst.clbits).iter().copied());
-                let (additional_clbits, additional_vars) =
-                    Python::attach(|py| self.additional_wires(py, inst.op.view()))?;
-                for clbit in additional_clbits {
-                    clbits.insert(clbit);
-                }
-                (clbits.into_iter().collect(), Some(additional_vars))
-            } else {
-                (self.cargs_interner.get(inst.clbits).to_vec(), None)
-            }
-        };
-
-        self.increment_op(op_name);
-
-        let qubits_id = inst.qubits;
-        let new_node = self.dag.add_node(NodeType::Operation(inst));
-
-        // Put the new node in-between the input map and the previously
-        // "first" nodes on each wire.
-        let mut input_nodes: Vec<NodeIndex> = self
-            .qargs_interner
-            .get(qubits_id)
-            .iter()
-            .map(|q| self.qubit_io_map[q.index()][0])
-            .chain(all_cbits.iter().map(|c| self.clbit_io_map[c.index()][0]))
-            .collect();
-        if let Some(vars) = vars {
-            for var in vars {
-                input_nodes.push(self.var_io_map[var.index()][0]);
-            }
-        }
-
-        for input_node in input_nodes {
-            let first_edges: Vec<_> = self
-                .dag
-                .edges_directed(input_node, Outgoing)
-                .map(|e| (e.target(), e.id(), *e.weight()))
-                .collect();
-            for (target, old_edge, weight) in first_edges.into_iter() {
-                self.dag.add_edge(input_node, new_node, weight);
-                self.dag.add_edge(new_node, target, weight);
-                self.dag.remove_edge(old_edge);
-            }
-        }
-
-        Ok(new_node)
     }
 
     /// Apply a [PackedOperation] to the back of the circuit.

--- a/releasenotes/notes/dag-apply-nondeterminism-dab879994ca2796b.yaml
+++ b/releasenotes/notes/dag-apply-nondeterminism-dab879994ca2796b.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    :meth:`.DAGCircuit.apply_operation_back`, :meth:`~.DAGCircuit.apply_operation_back` and
+    :func:`circuit_to_dag` will now add new edges in a deterministic order.  The previous behavior
+    could cause certain transpiler passes (such as :class:`.SabreSwap`) to traverse the DAG in
+    non-deterministic orders.
+  - |
+    :meth:`.DAGCircuit.apply_operation_front` can no longer insert invalid self loops when handling
+    nodes that include classical conditions.

--- a/test/python/converters/test_circuit_to_dag.py
+++ b/test/python/converters/test_circuit_to_dag.py
@@ -41,6 +41,16 @@ class TestCircuitToDag(QiskitTestCase):
         circuit_out = dag_to_circuit(dag)
         self.assertEqual(circuit_out, circuit_in)
 
+    def test_high_degree_determinism(self):
+        """Test that the converter is deterministic in edge order for high-degree nodes."""
+        qr = QuantumRegister(100, "q")
+        cr = ClassicalRegister(100, "c")
+        qc = QuantumCircuit(qr, cr)
+        # This is particularly testing the determinism for "extra" bits that don't appear in the
+        # cargs (aren't used in the circuit body).
+        qc.if_test(expr.equal(cr, 0), QuantumCircuit(qr), qr, [])
+        self.assertTrue(circuit_to_dag(qc).structurally_equal(circuit_to_dag(qc)))
+
     def test_wires_from_expr_nodes_condition(self):
         """Test that the classical wires implied by an `Expr` node in a control-flow op's
         `condition` are correctly transferred."""

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -644,6 +644,7 @@ class TestDagWireRemoval(QiskitTestCase):
         self.assertEqual(dag, expected)
 
 
+@ddt
 class TestDagApplyOperation(QiskitTestCase):
     """Test adding an op node to a dag."""
 
@@ -697,6 +698,37 @@ class TestDagApplyOperation(QiskitTestCase):
         reset_node = self.dag.op_nodes(op=Reset).pop()
 
         self.assertIn(reset_node, set(self.dag.predecessors(h_node)))
+
+    @data("front", "back")
+    def test_apply_operation_duplicate_wires(self, direction):
+        """The apply-front and apply-back methods should only attempt to add a single edge, even if
+        a classical variable is mentioned more than once."""
+        qc = QuantumCircuit()
+        a = qc.add_input("a", types.Bool())
+
+        dag = circuit_to_dag(qc)
+        op = IfElseOp(expr.logic_and(a, a), QuantumCircuit(), None)
+        if direction == "front":
+            dag.apply_operation_front(op, [], [])
+        else:
+            dag.apply_operation_back(op, [], [])
+        self.assertEqual(len(list(dag.edges())), 2)
+
+    @data("front", "back")
+    def test_apply_operation_determinism(self, direction):
+        """When adding a node with many qubits and clbits, the order of the edge ids should be
+        deterministic."""
+        qc = QuantumCircuit(100)
+        qubits = qc.qubits
+        if direction == "front":
+            apply = DAGCircuit.apply_operation_front
+        else:
+            apply = DAGCircuit.apply_operation_back
+        left = circuit_to_dag(qc)
+        apply(left, Barrier(len(qubits)), qubits, [])
+        right = circuit_to_dag(qc)
+        apply(right, Barrier(len(qubits)), qubits, [])
+        self.assertTrue(left.structurally_equal(right))
 
     def test_apply_operation_expr_condition(self):
         """Test that the operation-applying functions correctly handle wires implied from `Expr`


### PR DESCRIPTION
All of `DAGCircuit::push_back`, `DAGCircuit::push_front` and `DAGCircuitBuilder::push_back` had non-determinisms in the precise order that edges were added.  The two `DAGCircuit` methods had diverged, so exhibited _different_ behaviour.  Most of the effects were limited to nodes with multiple classical in edges, though `DAGCircuit::push_back` did have some problems with high-degree quantum nodes (like barriers) as well.

This commit unifies the code handled the two `DAGCircuit` methods to try and prevent divergences (especially since `apply_operation_front` is currently little used and little tested).  As a side effect, this fixed a bug in `apply_operation_front` around handling multiple references to the same clbit or var in classical expressions that was fixed in `apply_operation_back` some time prior.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Fix #15035.

Breaking determinism in the transpiler is a big deal, so this should probably go out sooner than later.
