### PR TITLE
Drop macOS x86_64 to tier 2

### DIFF
--- a/.github/workflows/ctests.yml
+++ b/.github/workflows/ctests.yml
@@ -13,8 +13,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          # Used for the x86_64 builds.
-          - macos-13
           # Used for the ARM builds.
           - macos-14
           - ubuntu-24.04-arm

--- a/.github/workflows/on-merge-queue.yml
+++ b/.github/workflows/on-merge-queue.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.13"]
-        runner: ["macos-13", "macos-14"]
+        runner: ["macos-14"]
     with:
       python-version: ${{ matrix.python-version }}
       install-optionals: false

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        runner: ["macos-13", "macos-14"]
+        runner: ["macos-14"]
 
     with:
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         python_version: ["3.9", "3.13"]
-        runner: ["macos-13", "macos-14"]
+        runner: ["macos-14"]
     uses: ./.github/workflows/test-mac.yml
     with:
       python-version: ${{ matrix.python_version }}

--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -35,6 +35,14 @@ on:
         default: "default"
         required: false
 
+      wheels-macos-intel:
+        description: >-
+          The action to take for macOS x86_64 wheels.
+          Choose from 'default', 'build', or 'skip'.
+        type: string
+        default: "default"
+        required: false
+
       wheels-linux-ppc64le:
         description: >-
           The action to take for Linux ppc64le wheels.
@@ -73,7 +81,6 @@ jobs:
         os:
           - ubuntu-latest
           # Used for the x86_64 builds.
-          - macos-15-intel
           # Used for the ARM builds.
           - macos-14
           - windows-latest
@@ -115,6 +122,24 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
           name: ${{ inputs.artifact-prefix }}wheels-tier-1-${{ matrix.os }}
+  wheels-macos-intel:
+    name: "Wheels / macOS x86_64"
+    if: (inputs.wheels-macos-intel == 'default' && inputs.default-action || inputs.wheels-macos-intel) == 'build'
+    runs-on: macos-15-intel
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        name: Install Python
+        with:
+          python-version: ${{ inputs.python-version }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: pypa/cibuildwheel@v3.0.1
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: ${{ inputs.artifact-prefix }}wheels-macos-intel
+
+
   wheels-linux-s390x:
     name: "Wheels / Linux s390x"
     if: (inputs.wheels-linux-s390x == 'default' && inputs.default-action || inputs.wheels-linux-s390x) == 'build'

--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -73,7 +73,7 @@ jobs:
         os:
           - ubuntu-latest
           # Used for the x86_64 builds.
-          - macos-13
+          - macos-15-intel
           # Used for the ARM builds.
           - macos-14
           - windows-latest

--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -80,7 +80,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          # Used for the x86_64 builds.
           # Used for the ARM builds.
           - macos-14
           - windows-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,7 @@ repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} && pipx run abi3
 
 [tool.cibuildwheel.macos]
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} && pipx run abi3audit --strict --report {wheel}"
+environment = "MACOSX_DEPLOYMENT_TARGET='10.12' RUSTUP_TOOLCHAIN=stable"
 
 [tool.cibuildwheel.windows]
 test-command = "cp -r {project}/test . && stestr --test-path test/python run --abbreviate"

--- a/releasenotes/notes/macos-x86_64-tier-2-023a00d34984665f.yaml
+++ b/releasenotes/notes/macos-x86_64-tier-2-023a00d34984665f.yaml
@@ -1,0 +1,16 @@
+---
+upgrade:
+  - |
+    Support for macOS x86_64 has been downgraded from tier 1 to tier 2. This means that
+    tests are no longer run on the platform for every proposed change to Qiskit and that
+    the platform is only tested when building the wheels for publishing at release time.
+    This change was due to Apple marking the platform support as deprecated and will no
+    longer continue supporting the CPU architecture on their platform. Subsequently
+    Github decreasing their support for using the platform in Github actions which Qiskit
+    relies on for CI resources to run tests.
+
+    While platform support hasn't been removed yet it is worth pointing out that this
+    will likely happen in the lead up to Fall 2027 when Github has documented that they
+    will retire the only images with support for running on x86_64 macOS. [#]_
+
+    .. [#] https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

With Apple deprecating the platform support and removing it in future OS versions, github is similarly marking the end of support for x86_64 macOS suppport in github actions:

https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

With this our hands our tied as we rely on github actions to test and build on the platform in CI. As the platform is still supported for now this commit starts the process of dropping it as a supported platform by downgrading it to tier 2. This means that we are no longer running tests on x86_64 macOS in PR CI jobs, it is relegated to only run during the wheel builds. This commit makes the necessary CI configuration changes to do this and adds a release note to document the downgrade of support. We should update the platform support docs page at:

https://quantum.cloud.ibm.com/docs/en/guides/install-qiskit#operating-system-support

when we are preparing the 2.3.0 release to indicate this change there too.

### Details and comments


