### PR TITLE
Add method wrappers for circuit and DAG converters

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -4087,6 +4087,27 @@ impl DAGCircuit {
         ]))
     }
 
+    /// Convert this DAG to a :class:`.QuantumCircuit`.
+    ///
+    /// This is a simple wrapper around :func:`.dag_to_circuit`.
+    ///
+    /// Args:
+    ///     copy_operations: whether to deep copy the individual instructions.  If set to ``False``,
+    ///         the operation is cheaper but mutations to the instructions in the circuit will
+    ///         affect the original circuit.
+    ///
+    /// Returns:
+    ///     a :class:`.QuantumCircuit` representing this same DAG.
+    // If updating this signature, update `dag_to_circuit` as well.
+    #[pyo3(signature=(*, copy_operations=true))]
+    fn to_circuit(slf_: PyRef<Self>, copy_operations: bool) -> PyResult<Bound<PyAny>> {
+        // We go via Python space here to make sure all the extra Python-space components not yet
+        // tracked in `CircuitData` are copied too.
+        imports::DAG_TO_CIRCUIT
+            .get_bound(slf_.py())
+            .call1((slf_, copy_operations))
+    }
+
     /// Draws the dag circuit.
     ///
     /// This function needs `Graphviz <https://www.graphviz.org/>`_ to be

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -846,7 +846,7 @@ class QuantumCircuit:
     .. automethod:: has_control_flow_op
 
 
-    Converting circuits to single objects
+    Converting circuits to other objects
     -------------------------------------
 
     As discussed in :ref:`circuit-append-compose`, you can convert a circuit to either an
@@ -854,6 +854,10 @@ class QuantumCircuit:
 
     .. automethod:: to_instruction
     .. automethod:: to_gate
+
+    In addition, you can convert the entire circuit into the :class:`.DAGCircuit` representation:
+
+    .. automethod:: to_dag
 
 
     Helper mutation methods
@@ -3824,6 +3828,24 @@ class QuantumCircuit:
 
         # do not copy operations, this is done in the conversion with circuit_to_dag
         return dag_to_circuit(dag, copy_operations=False)
+
+    def to_dag(self, *, copy_operations: bool = True) -> qiskit.dagcircuit.DAGCircuit:
+        """Convert this circuit to a :class:`.DAGCircuit`.
+
+        This is a simple wrapper around :func:`.circuit_to_dag`.
+
+        Args:
+            copy_operations: whether to deep copy the individual instructions.  If set to ``False``,
+                the operation is cheaper but mutations to the instructions in the DAG will affect
+                the original circuit.
+
+        Returns:
+            a DAG representing this same circuit.
+        """
+        # pylint: disable=cyclic-import
+        from qiskit.converters import circuit_to_dag
+
+        return circuit_to_dag(self, copy_operations=copy_operations)
 
     def draw(
         self,

--- a/qiskit/converters/circuit_to_dag.py
+++ b/qiskit/converters/circuit_to_dag.py
@@ -19,6 +19,8 @@ from qiskit._accelerate.converters import circuit_to_dag as core_circuit_to_dag
 def circuit_to_dag(circuit, copy_operations=True, *, qubit_order=None, clbit_order=None):
     """Build a :class:`.DAGCircuit` object from a :class:`.QuantumCircuit`.
 
+    This is also accessible as :meth:`.QuantumCircuit.to_dag`.
+
     Args:
         circuit (QuantumCircuit): the input circuit.
         copy_operations (bool): Deep copy the operation objects

--- a/qiskit/converters/dag_to_circuit.py
+++ b/qiskit/converters/dag_to_circuit.py
@@ -19,6 +19,8 @@ from qiskit._accelerate.converters import dag_to_circuit as dag_to_circuit_rs
 def dag_to_circuit(dag, copy_operations=True):
     """Build a ``QuantumCircuit`` object from a ``DAGCircuit``.
 
+    This is also accessible as :meth:`.DAGCircuit.to_circuit`.
+
     Args:
         dag (DAGCircuit): the input dag.
         copy_operations (bool): Deep copy the operation objects

--- a/releasenotes/notes/converter-methods-511d3710f3cbccb4.yaml
+++ b/releasenotes/notes/converter-methods-511d3710f3cbccb4.yaml
@@ -1,0 +1,9 @@
+---
+features_circuits:
+  - |
+    A new :meth:`.QuantumCircuit.to_dag` method now provides a convenient
+    wrapper around :func:`.circuit_to_dag`.
+features_transpiler:
+  - |
+    A new :meth:`.DAGCircuit.to_circuit` method now provides a convenient
+    wrapper around :func:`.dag_to_circuit`.

--- a/test/python/converters/test_circuit_to_dag.py
+++ b/test/python/converters/test_circuit_to_dag.py
@@ -15,7 +15,14 @@
 import unittest
 
 from qiskit.dagcircuit import DAGCircuit
-from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit, Clbit, SwitchCaseOp
+from qiskit.circuit import (
+    QuantumRegister,
+    ClassicalRegister,
+    QuantumCircuit,
+    Clbit,
+    SwitchCaseOp,
+    Qubit,
+)
 from qiskit.circuit.library import HGate, Measure
 from qiskit.circuit.classical import expr, types
 from qiskit.converters import dag_to_circuit, circuit_to_dag
@@ -133,6 +140,38 @@ class TestCircuitToDag(QiskitTestCase):
         blocks = roundtrip.data[-1].operation.blocks
         self.assertEqual(set(blocks[0].iter_captured_vars()), {c, d})
         self.assertEqual(set(blocks[1].iter_captured_vars()), {a})
+
+    def test_circuit_method(self):
+        """Test that the circuit method can be used as a wrapper."""
+        qregs = [QuantumRegister(3, "q1"), QuantumRegister(2, "q2")]
+        cregs = [ClassicalRegister(3, "c1"), ClassicalRegister(2, "c2")]
+        a = expr.Var.new("a", types.Bool())
+        b = expr.Var.new("b", types.Bool())
+        qc = QuantumCircuit(
+            *qregs,
+            [Qubit(), Clbit()],
+            *cregs,
+            name="test circuit",
+            metadata={"hello": "world"},
+            global_phase=2.0,
+            inputs=[a],
+            declarations={b: expr.lift(True)},
+        )
+        qc.add_stretch("c")
+        dag = qc.to_dag()
+        self.assertEqual(dag.name, qc.name)
+        self.assertEqual(dag.metadata, qc.metadata)
+        self.assertEqual(dag.global_phase, qc.global_phase)
+        self.assertEqual(dag.qregs, {qreg.name: qreg for qreg in qc.qregs})
+        self.assertEqual(dag.cregs, {creg.name: creg for creg in qc.cregs})
+        self.assertEqual(dag.qubits, qc.qubits)
+        self.assertEqual(dag.clbits, qc.clbits)
+        self.assertEqual(list(dag.iter_input_vars()), list(qc.iter_input_vars()))
+        self.assertEqual(list(dag.iter_declared_vars()), list(qc.iter_declared_vars()))
+        self.assertEqual(list(dag.iter_declared_stretches()), list(qc.iter_declared_stretches()))
+
+        # ... and test the roundtrip back.
+        self.assertEqual(dag.to_circuit(), qc)
 
     def test_wire_order(self):
         """Test that the `qubit_order` and `clbit_order` parameters are respected."""


### PR DESCRIPTION
It's very wordy to have to import from `qiskit.converters`, and it makes quick iterative playing easier if we can convert more directly between the two objects.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

I got sick of typing the import...
