### PR TITLE
Fix `SparseObservable` C API test invoking UB

### DIFF
--- a/test/c/test_sparse_observable.c
+++ b/test/c/test_sparse_observable.c
@@ -789,18 +789,28 @@ int test_apply_layout(void) {
 }
 
 /**
- * Test applying a layout to a too large observable fails.
+ * Test applying a layout with too large indices fails.
  */
-int test_apply_layout_too_small(void) {
-    // Build an observable that's too large for the layout
-    uint32_t layout[2] = {80, 2001};
-    QkObs *obs = qk_obs_identity(4);
-
-    // now apply our layout (this should fail)
+static int test_apply_layout_too_small(void) {
+    QkObs *obs = qk_obs_identity(2);
+    // The max index is too large.
+    uint32_t layout[2] = {80, 5001};
     int err = qk_obs_apply_layout(obs, layout, 3000);
     qk_obs_free(obs);
 
     return err == QkExitCode_IndexError ? Ok : EqualityError;
+}
+/**
+ * Test applying a layout with duplicate indices fails.
+ */
+static int test_apply_layout_duplicate(void) {
+    QkObs *obs = qk_obs_identity(2);
+    // There's a duplicate.
+    uint32_t layout[2] = {80, 80};
+    int err = qk_obs_apply_layout(obs, layout, 100);
+    qk_obs_free(obs);
+
+    return err == QkExitCode_DuplicateIndexError ? Ok : EqualityError;
 }
 
 int test_sparse_observable(void) {
@@ -830,6 +840,7 @@ int test_sparse_observable(void) {
     num_failed += RUN_TEST(test_obsterm_str);
     num_failed += RUN_TEST(test_apply_layout);
     num_failed += RUN_TEST(test_apply_layout_too_small);
+    num_failed += RUN_TEST(test_apply_layout_duplicate);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);


### PR DESCRIPTION
If it were possible to test for the failure mode attempted in the previous test, the function wouldn't need to be `unsafe` in Rust.  We cannot test this, because it invoked UB.

It probably _mostly_ worked previously because there were additional stack variables in the same frame, which might have been giving enough safe bytes to read to get an actual error out under optimisations made on the assumption that the read was valid.

This replaces the fundamentally broken test with two similar tests that are for checks we _can_ do.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Fix #15030.