### PR TITLE
Mark internal C test functions as `static`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -703,7 +703,10 @@ to the following.
 // Individual tests may be implemented by custom functions. The return value
 // should be `Ok` (from `test/c/common.h`) when the test was successful or one
 // of the other error codes (`>0`) indicating the error type.
-int test_something()
+//
+// Individual test functions should be marked static; this is a double line of
+// defence so the compiler will error if you forget to add it to the runner.
+static int test_something()
 {
     return Ok;
 }

--- a/test/c/test_basis_translator.c
+++ b/test/c/test_basis_translator.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 
-int test_circuit_in_basis(void) {
+static int test_circuit_in_basis(void) {
     // Create circuit
     int result = Ok;
     QkCircuit *circuit = qk_circuit_new(2, 0);
@@ -67,7 +67,7 @@ cleanup:
     return result;
 }
 
-int test_basic_basis_translator(void) {
+static int test_basic_basis_translator(void) {
     // Create circuit
     int result = Ok;
     QkCircuit *circuit = qk_circuit_new(1, 0);
@@ -105,7 +105,7 @@ cleanup:
     return result;
 }
 
-int test_toffoli_basis_translator(void) {
+static int test_toffoli_basis_translator(void) {
     // Create circuit
     int result = Ok;
     QkCircuit *circuit = qk_circuit_new(3, 0);

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -22,7 +22,7 @@
 /**
  * Test the zero constructor.
  */
-int test_empty(void) {
+static int test_empty(void) {
     QkCircuit *qc = qk_circuit_new(0, 0);
     uint32_t num_qubits = qk_circuit_num_qubits(qc);
     uint32_t num_clbits = qk_circuit_num_clbits(qc);
@@ -53,7 +53,7 @@ int test_empty(void) {
     return Ok;
 }
 
-int test_circuit_with_quantum_reg(void) {
+static int test_circuit_with_quantum_reg(void) {
     QkCircuit *qc = qk_circuit_new(0, 0);
     QkQuantumRegister *qr = qk_quantum_register_new(1024, "my_little_register");
     qk_circuit_add_quantum_register(qc, qr);
@@ -77,7 +77,7 @@ int test_circuit_with_quantum_reg(void) {
     return Ok;
 }
 
-int test_circuit_copy(void) {
+static int test_circuit_copy(void) {
     QkCircuit *qc = qk_circuit_new(10, 10);
     QkCircuit *copy = qk_circuit_copy(qc);
     for (int i = 0; i < 10; i++) {
@@ -101,7 +101,7 @@ int test_circuit_copy(void) {
     return Ok;
 }
 
-int test_circuit_with_classical_reg(void) {
+static int test_circuit_with_classical_reg(void) {
     QkCircuit *qc = qk_circuit_new(0, 0);
     QkClassicalRegister *cr = qk_classical_register_new(2048, "my_less_little_register");
     qk_circuit_add_classical_register(qc, cr);
@@ -125,7 +125,7 @@ int test_circuit_with_classical_reg(void) {
     return Ok;
 }
 
-int test_circuit_copy_with_instructions(void) {
+static int test_circuit_copy_with_instructions(void) {
     QkCircuit *qc = qk_circuit_new(10, 10);
     for (int i = 0; i < 10; i++) {
         qk_circuit_measure(qc, i, i);
@@ -170,7 +170,7 @@ int test_circuit_copy_with_instructions(void) {
     return Ok;
 }
 
-int test_no_gate_1000_bits(void) {
+static int test_no_gate_1000_bits(void) {
     QkCircuit *qc = qk_circuit_new(1000, 1000);
     uint32_t num_qubits = qk_circuit_num_qubits(qc);
     uint32_t num_clbits = qk_circuit_num_clbits(qc);
@@ -193,7 +193,7 @@ int test_no_gate_1000_bits(void) {
     return Ok;
 }
 
-int test_gate_num_qubits(void) {
+static int test_gate_num_qubits(void) {
     for (uint8_t i = 0; i < 52; i++) {
         if (i == 0) {
             if (qk_gate_num_qubits(i) != 0) {
@@ -221,7 +221,7 @@ int test_gate_num_qubits(void) {
     return Ok;
 }
 
-bool value_in_array(uint8_t val, uint8_t *arr, size_t n) {
+static bool value_in_array(uint8_t val, uint8_t *arr, size_t n) {
     for (size_t i = 0; i < n; i++) {
         if (arr[i] == val)
             return true;
@@ -229,7 +229,7 @@ bool value_in_array(uint8_t val, uint8_t *arr, size_t n) {
     return false;
 }
 
-int test_gate_num_params(void) {
+static int test_gate_num_params(void) {
 
     uint8_t zero_param_gates[29] = {1,  2,  3,  4,  5,  11, 12, 13, 14, 15, 16, 21, 22, 23, 24,
                                     25, 26, 27, 28, 33, 34, 35, 45, 46, 47, 48, 49, 50, 51};
@@ -266,7 +266,7 @@ int test_gate_num_params(void) {
 /**
  * Test edge cases for getting the op counts.
  */
-int test_get_gate_counts(void) {
+static int test_get_gate_counts(void) {
     QkCircuit *qc = qk_circuit_new(3, 3);
 
     // test empty circuit
@@ -302,7 +302,7 @@ circuit_cleanup:
     return result;
 }
 
-int test_get_gate_counts_bv_no_measure(void) {
+static int test_get_gate_counts_bv_no_measure(void) {
     QkCircuit *qc = qk_circuit_new(1000, 1000);
     double *params = NULL;
     uint32_t i;
@@ -358,7 +358,7 @@ cleanup:
     return result;
 }
 
-int test_get_gate_counts_bv_measures(void) {
+static int test_get_gate_counts_bv_measures(void) {
     QkCircuit *qc = qk_circuit_new(1000, 1000);
     double *params = NULL;
     uint32_t i;
@@ -425,7 +425,7 @@ cleanup:
     return result;
 }
 
-int test_get_gate_counts_bv_barrier_and_measures(void) {
+static int test_get_gate_counts_bv_barrier_and_measures(void) {
     QkCircuit *qc = qk_circuit_new(1000, 1000);
     double *params = NULL;
     uint32_t i;
@@ -506,7 +506,7 @@ cleanup:
     return result;
 }
 
-int test_get_gate_counts_bv_resets_barrier_and_measures(void) {
+static int test_get_gate_counts_bv_resets_barrier_and_measures(void) {
     QkCircuit *qc = qk_circuit_new(1000, 1000);
     double *params = NULL;
     uint32_t q1[1] = {999};
@@ -732,7 +732,7 @@ cleanup:
 /**
  * Test appending a unitary gate.
  */
-int test_unitary_gate(void) {
+static int test_unitary_gate(void) {
     QkCircuit *qc = qk_circuit_new(2, 0);
     uint32_t qubits[2] = {0, 1};
 
@@ -782,7 +782,7 @@ cleanup:
 /**
  * Test appending a unitary gate.
  */
-int test_unitary_gate_1q(void) {
+static int test_unitary_gate_1q(void) {
     QkCircuit *qc = qk_circuit_new(2, 0);
     uint32_t qubits[1] = {0};
 
@@ -830,7 +830,7 @@ cleanup:
 /**
  * Test appending a unitary gate.
  */
-int test_unitary_gate_3q(void) {
+static int test_unitary_gate_3q(void) {
     QkCircuit *qc = qk_circuit_new(3, 0);
     uint32_t qubits[3] = {0, 1, 2};
 
@@ -883,7 +883,7 @@ cleanup:
 /**
  * Test passing a non-unitary gate returns the correct exit code.
  */
-int test_not_unitary_gate(void) {
+static int test_not_unitary_gate(void) {
     QkCircuit *qc = qk_circuit_new(2, 0);
     uint32_t qubits[2] = {0, 1};
 
@@ -915,7 +915,7 @@ cleanup:
     return result;
 }
 
-int test_delay_instruction(void) {
+static int test_delay_instruction(void) {
     QkCircuit *qc = qk_circuit_new(2, 0);
     int result = Ok;
 

--- a/test/c/test_commutative_cancellation.c
+++ b/test/c/test_commutative_cancellation.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 
-int test_commutative_cancellation_target(void) {
+static int test_commutative_cancellation_target(void) {
     const uint32_t num_qubits = 5;
     QkTarget *target = qk_target_new(num_qubits);
     qk_target_add_instruction(target, qk_target_entry_new(QkGate_Z));
@@ -59,7 +59,7 @@ cleanup:
     return result;
 }
 
-int test_commutative_cancellation_no_target(void) {
+static int test_commutative_cancellation_no_target(void) {
     int result = Ok;
 
     QkCircuit *qc = qk_circuit_new(2, 0);

--- a/test/c/test_complex.c
+++ b/test/c/test_complex.c
@@ -30,7 +30,7 @@ ComplexDouble make_complex(double real, double imag) { return real + I * imag; }
 /**
  * Test converting a native number to QkComplex64.
  */
-int test_from_native(void) {
+static int test_from_native(void) {
     const double real = -1;
     const double imag = 2;
     ComplexDouble native = make_complex(real, imag);
@@ -45,7 +45,7 @@ int test_from_native(void) {
 /**
  * Test converting QkComplex64 to native number.
  */
-int test_to_native(void) {
+static int test_to_native(void) {
     const double real = 1.65;
     const double imag = -5.21;
     QkComplex64 value = {real, imag};
@@ -76,7 +76,7 @@ int test_qkcomplex_roundtrip(void) {
 /**
  * Test roundtrips.
  */
-int test_native_roundtrip(void) {
+static int test_native_roundtrip(void) {
     const double real = 1.003;
     const double imag = 2.31;
     ComplexDouble native = make_complex(real, imag);

--- a/test/c/test_consolidate_blocks.c
+++ b/test/c/test_consolidate_blocks.c
@@ -20,12 +20,22 @@
 #include <stdio.h>
 #include <string.h>
 
-bool args_cmp(uint32_t *args1, uint32_t args1_len, uint32_t *args2, uint32_t args2_len);
+static bool args_cmp(uint32_t *args1, uint32_t args1_len, uint32_t *args2, uint32_t args2_len) {
+    if (args1_len != args2_len) {
+        return false;
+    }
+    for (size_t i = 0; i < args1_len; i++) {
+        if (args1[i] != args2[i]) {
+            return false;
+        }
+    }
+    return true;
+}
 
 /**
  * Test a small block of gates can be turned into a unitary on same wires
  */
-int test_consolidate_small_block(void) {
+static int test_consolidate_small_block(void) {
     int result = Ok;
 
     // Build circuit
@@ -60,7 +70,7 @@ cleanup:
 /**
  * Order of qubits and the corresponding unitary is correct
  */
-int test_wire_order(void) {
+static int test_wire_order(void) {
     int result = Ok;
 
     // Build circuit
@@ -98,7 +108,7 @@ cleanup:
 /**
  * blocks of more than 2 qubits work.
  */
-int test_3q_blocks(void) {
+static int test_3q_blocks(void) {
     int result = Ok;
 
     // Build circuit
@@ -134,7 +144,7 @@ cleanup:
 /**
  * Test a non-cx kak gate is consolidated correctly with a target.
  */
-int test_non_cx_target(void) {
+static int test_non_cx_target(void) {
     int result = Ok;
 
     // Create circuit
@@ -282,16 +292,4 @@ int test_consolidate_blocks(void) {
     fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);
 
     return num_failed;
-}
-
-bool args_cmp(uint32_t *args1, uint32_t args1_len, uint32_t *args2, uint32_t args2_len) {
-    if (args1_len != args2_len) {
-        return false;
-    }
-    for (size_t i = 0; i < args1_len; i++) {
-        if (args1[i] != args2[i]) {
-            return false;
-        }
-    }
-    return true;
 }

--- a/test/c/test_elide_permutations.c
+++ b/test/c/test_elide_permutations.c
@@ -12,7 +12,6 @@
 
 #include "common.h"
 #include <complex.h>
-#include <math.h>
 #include <qiskit.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -23,7 +22,7 @@
 /**
  * Test running the path with no elision.
  */
-int test_elide_permutations_no_result(void) {
+static int test_elide_permutations_no_result(void) {
     const uint32_t num_qubits = 5;
 
     QkCircuit *qc = qk_circuit_new(num_qubits, 0);
@@ -47,7 +46,7 @@ int test_elide_permutations_no_result(void) {
 /**
  * Test running the path with no elision.
  */
-int test_elide_permutations_swap_result(void) {
+static int test_elide_permutations_swap_result(void) {
     QkCircuit *qc = qk_circuit_new(5, 0);
     uint32_t swap_qargs[2] = {1, 3};
     for (uint32_t i = 0; i < qk_circuit_num_qubits(qc) - 1; i++) {

--- a/test/c/test_gate_direction.c
+++ b/test/c/test_gate_direction.c
@@ -39,7 +39,7 @@ static QkTarget *create_target() {
 /**
  * Test running CheckGateDirection on a simple circuit.
  */
-int test_check_gate_direction(void) {
+static int test_check_gate_direction(void) {
     QkTarget *target = create_target();
     if (!target)
         return RuntimeError;
@@ -77,7 +77,7 @@ cleanup:
 /**
  * Test running GateDirection on a simple circuit.
  */
-int test_gate_direction(void) {
+static int test_gate_direction_simple(void) {
     QkTarget *target = create_target();
     if (!target)
         return RuntimeError;
@@ -111,10 +111,10 @@ cleanup:
     return result;
 }
 
-int test_gate_direction_passes(void) {
+int test_gate_direction(void) {
     int num_failed = 0;
     num_failed += RUN_TEST(test_check_gate_direction);
-    num_failed += RUN_TEST(test_gate_direction);
+    num_failed += RUN_TEST(test_gate_direction_simple);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);

--- a/test/c/test_inverse_cancellation.c
+++ b/test/c/test_inverse_cancellation.c
@@ -22,7 +22,7 @@
 /**
  * Test inverse cancellation.
  */
-int test_inverse_cancellation_removes_gates(void) {
+static int test_inverse_cancellation_removes_gates(void) {
     int result = Ok;
 
     QkCircuit *qc = qk_circuit_new(2, 2);

--- a/test/c/test_remove_diagonal_gates_before_measure.c
+++ b/test/c/test_remove_diagonal_gates_before_measure.c
@@ -12,7 +12,6 @@
 
 #include "common.h"
 #include <complex.h>
-#include <math.h>
 #include <qiskit.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/test/c/test_remove_identity_equiv.c
+++ b/test/c/test_remove_identity_equiv.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 
-int test_remove_identity_equiv_removes_gates(void) {
+static int test_remove_identity_equiv_removes_gates(void) {
     const uint32_t num_qubits = 5;
     QkTarget *target = qk_target_new(num_qubits);
     int result = Ok;

--- a/test/c/test_sabre_layout.c
+++ b/test/c/test_sabre_layout.c
@@ -12,7 +12,6 @@
 
 #include "common.h"
 #include <complex.h>
-#include <math.h>
 #include <qiskit.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -23,7 +22,7 @@
 /**
  * Test running sabre layout that requires layout and routing
  */
-int test_sabre_layout_applies_layout(void) {
+static int test_sabre_layout_applies_layout(void) {
     int result = Ok;
 
     const uint32_t num_qubits = 5;
@@ -131,7 +130,7 @@ cleanup:
 /**
  * Test running sabre layout that performs no transformation.
  */
-int test_sabre_layout_no_swap(void) {
+static int test_sabre_layout_no_swap(void) {
     int result = Ok;
 
     const uint32_t num_qubits = 5;

--- a/test/c/test_sparse_observable.c
+++ b/test/c/test_sparse_observable.c
@@ -21,7 +21,7 @@
 /**
  * Test the zero constructor.
  */
-int test_zero(void) {
+static int test_zero(void) {
     QkObs *obs = qk_obs_zero(100);
     size_t num_terms = qk_obs_num_terms(obs);
     uint32_t num_qubits = qk_obs_num_qubits(obs);
@@ -33,7 +33,7 @@ int test_zero(void) {
 /**
  * Test the identity constructor.
  */
-int test_identity(void) {
+static int test_identity(void) {
     QkObs *obs = qk_obs_identity(100);
     size_t num_terms = qk_obs_num_terms(obs);
     uint32_t num_qubits = qk_obs_num_qubits(obs);
@@ -45,7 +45,7 @@ int test_identity(void) {
 /**
  * Test copying an observable.
  */
-int test_copy(void) {
+static int test_copy(void) {
     QkObs *obs = qk_obs_identity(100);
     QkObs *copied = qk_obs_copy(obs);
 
@@ -60,7 +60,7 @@ int test_copy(void) {
 /**
  * Test adding two observables.
  */
-int test_add(void) {
+static int test_add(void) {
     QkObs *left = qk_obs_identity(100);
     QkObs *right = qk_obs_identity(100);
     QkObs *obs = qk_obs_add(left, right);
@@ -77,7 +77,7 @@ int test_add(void) {
 /**
  * Test composing two observables.
  */
-int test_compose(void) {
+static int test_compose(void) {
     uint32_t num_qubits = 100;
 
     QkObs *op1 = qk_obs_zero(num_qubits);
@@ -119,7 +119,7 @@ int test_compose(void) {
 /**
  * Test composing two observables and specifying the qargs argument.
  */
-int test_compose_map(void) {
+static int test_compose_map(void) {
     uint32_t num_qubits = 100;
 
     QkObs *op1 = qk_obs_zero(num_qubits);
@@ -162,7 +162,7 @@ int test_compose_map(void) {
 /**
  * Test composing an observables with a scalar observable.
  */
-int test_compose_scalar(void) {
+static int test_compose_scalar(void) {
     uint32_t num_qubits = 100;
 
     QkObs *op = qk_obs_zero(num_qubits);
@@ -198,7 +198,7 @@ int test_compose_scalar(void) {
 /**
  * Test multiplying an observable by a complex coefficient.
  */
-int test_mult(void) {
+static int test_mult(void) {
     QkComplex64 coeffs[3] = {{2.0, 0.0}, {0.0, 2.0}, {2.0, 2.0}};
 
     for (int i = 0; i < 3; i++) {
@@ -232,7 +232,7 @@ int test_mult(void) {
 /**
  * Test bringing an observable into canonical form.
  */
-int test_canonicalize(void) {
+static int test_canonicalize(void) {
     QkObs *left = qk_obs_identity(100);
     QkObs *right = qk_obs_identity(100);
     QkObs *obs = qk_obs_add(left, right);
@@ -262,7 +262,7 @@ int test_canonicalize(void) {
 /**
  * Test getting the number of terms in an observable.
  */
-int test_num_terms(void) {
+static int test_num_terms(void) {
     int result = Ok;
     size_t num_terms;
 
@@ -286,7 +286,7 @@ int test_num_terms(void) {
 /**
  * Test getting the number of qubits in an observable.
  */
-int test_num_qubits(void) {
+static int test_num_qubits(void) {
     int result = Ok;
     uint32_t num_qubits;
 
@@ -310,7 +310,7 @@ int test_num_qubits(void) {
 /**
  * Test adding an individual term to an observable.
  */
-int test_custom_build(void) {
+static int test_custom_build(void) {
     uint32_t num_qubits = 100;
     QkObs *obs = qk_obs_zero(num_qubits);
 
@@ -337,7 +337,7 @@ int test_custom_build(void) {
 /**
  * Test getting the terms in an observable.
  */
-int test_term(void) {
+static int test_term(void) {
     uint32_t num_qubits = 100;
     QkObs *obs = qk_obs_identity(num_qubits);
 
@@ -404,7 +404,7 @@ int test_term(void) {
 /**
  * Test copying and modifying a term.
  */
-int test_copy_term(void) {
+static int test_copy_term(void) {
     // create an observable with the term X0 Y1 Z2
     uint32_t num_qubits = 100;
     QkObs *obs = qk_obs_zero(num_qubits);
@@ -465,7 +465,7 @@ int test_copy_term(void) {
 /**
  * Test getting the bit term labels.
  */
-int test_bitterm_label(void) {
+static int test_bitterm_label(void) {
     char expected[9] = {'X', '+', '-', 'Y', 'l', 'r', 'Z', '0', '1'};
     QkBitTerm bits[9] = {QkBitTerm_X, QkBitTerm_Plus, QkBitTerm_Minus,
                          QkBitTerm_Y, QkBitTerm_Left, QkBitTerm_Right,
@@ -484,7 +484,7 @@ int test_bitterm_label(void) {
 /**
  * Test the coeffs access.
  */
-int test_coeffs(void) {
+static int test_coeffs(void) {
     QkObs *obs = qk_obs_identity(2);
     QkComplex64 *coeffs = qk_obs_coeffs(obs);
 
@@ -509,7 +509,7 @@ int test_coeffs(void) {
 /**
  * Test the bit term access.
  */
-int test_bit_terms(void) {
+static int test_bit_terms(void) {
     QkBitTerm bits[6] = {QkBitTerm_Left,  QkBitTerm_Right, QkBitTerm_Plus,
                          QkBitTerm_Minus, QkBitTerm_Zero,  QkBitTerm_One};
     uint32_t indices[6] = {9, 8, 7, 6, 5, 4};
@@ -542,7 +542,7 @@ int test_bit_terms(void) {
 /**
  * Test the index access.
  */
-int test_indices(void) {
+static int test_indices(void) {
     QkBitTerm bits[6] = {QkBitTerm_Left,  QkBitTerm_Right, QkBitTerm_Plus,
                          QkBitTerm_Minus, QkBitTerm_Zero,  QkBitTerm_One};
     uint32_t indices[6] = {9, 8, 7, 6, 5, 4};
@@ -575,7 +575,7 @@ int test_indices(void) {
 /**
  * Test access to the term boundaries.
  */
-int test_boundaries(void) {
+static int test_boundaries(void) {
     uint32_t num_qubits = 100;
     QkObs *obs = qk_obs_identity(num_qubits);
 
@@ -605,7 +605,7 @@ int test_boundaries(void) {
 /**
  * Test direct setting.
  */
-int test_direct_build(void) {
+static int test_direct_build(void) {
     // define the raw data for the 100-qubit observable |01><01|_{0, 1} - |+-><+-|_{98, 99}
     uint32_t num_qubits = 100;
     size_t num_terms = 2;
@@ -652,7 +652,7 @@ int test_direct_build(void) {
 /**
  * Test direct setting fails.
  */
-int test_direct_fail(void) {
+static int test_direct_fail(void) {
     // define the faulty raw data
     uint32_t num_qubits = 100;
     size_t num_terms = 2;
@@ -679,7 +679,7 @@ int test_direct_fail(void) {
 /**
  * Test string generator for observable
  */
-int test_obs_str(void) {
+static int test_obs_str(void) {
     QkObs *obs = qk_obs_identity(100);
     char *string = qk_obs_str(obs);
     char *expected = "SparseObservable { num_qubits: 100, coeffs: [Complex { re: 1.0, im: 0.0 }], "
@@ -694,7 +694,7 @@ int test_obs_str(void) {
 /**
  * Test string generator for observable term
  */
-int test_obsterm_str(void) {
+static int test_obsterm_str(void) {
     // Initialize observable and add a term
     uint32_t num_qubits = 100;
     QkObs *obs = qk_obs_identity(num_qubits);
@@ -724,7 +724,7 @@ int test_obsterm_str(void) {
 /**
  * Test applying a layout in a full workflow.
  */
-int test_apply_layout(void) {
+static int test_apply_layout(void) {
     uint32_t num_qubits = 6;
     QkCircuit *qc = qk_circuit_new(num_qubits, 0);
 

--- a/test/c/test_split_2q_unitaries.c
+++ b/test/c/test_split_2q_unitaries.c
@@ -18,7 +18,7 @@
 #include <stdio.h>
 #include <string.h>
 
-int test_split_2q_unitaries_no_unitaries(void) {
+static int test_split_2q_unitaries_no_unitaries(void) {
     QkCircuit *qc = qk_circuit_new(5, 0);
     for (uint32_t i = 0; i < qk_circuit_num_qubits(qc) - 1; i++) {
         uint32_t qargs[2] = {i, i + 1};
@@ -56,7 +56,7 @@ cleanup:
     return result;
 }
 
-int test_split_2q_unitaries_x_y_unitary(void) {
+static int test_split_2q_unitaries_x_y_unitary(void) {
     QkCircuit *qc = qk_circuit_new(2, 0);
     QkComplex64 c0 = {0., 0.};
     QkComplex64 neg_im = {0., -1.};
@@ -113,7 +113,7 @@ cleanup:
     return result;
 }
 
-int test_split_2q_unitaries_swap_x_y_unitary(void) {
+static int test_split_2q_unitaries_swap_x_y_unitary(void) {
     QkCircuit *qc = qk_circuit_new(2, 0);
     QkComplex64 c0 = {0., 0.};
     QkComplex64 neg_im = {0., -1.};

--- a/test/c/test_target.c
+++ b/test/c/test_target.c
@@ -23,7 +23,7 @@
 /**
  * Test empty constructor for Target
  */
-int test_empty_target(void) {
+static int test_empty_target(void) {
     int result = Ok;
     QkTarget *target = qk_target_new(0);
     uint32_t num_qubits = qk_target_num_qubits(target);
@@ -76,7 +76,7 @@ cleanup:
 /**
  * Test constructor for Target
  */
-int test_target_construct(void) {
+static int test_target_construct(void) {
     int result = Ok;
     const uint32_t num_qubits = 2;
     const double dt = 10e-9;
@@ -143,7 +143,7 @@ cleanup:
 /*
  * Test target construction with a parameterized gate
  */
-int test_target_construction_ibm_like_target(void) {
+static int test_target_construction_ibm_like_target(void) {
     int result = Ok;
     QkTarget *target = qk_target_new(5);
     QkTargetEntry *cx_entry = qk_target_entry_new(QkGate_CX);
@@ -266,7 +266,7 @@ cleanup:
 /**
  * Test construction of a QkTargetEntry
  */
-int test_target_entry_construction(void) {
+static int test_target_entry_construction(void) {
     int result = Ok;
     QkTargetEntry *property_map = qk_target_entry_new(QkGate_CX);
 
@@ -312,7 +312,7 @@ cleanup:
 /**
  * Test adding an instruction to the Target.
  */
-int test_target_add_instruction(void) {
+static int test_target_add_instruction(void) {
     const uint32_t num_qubits = 1;
     // Let's create a target with one qubit for now
     QkTarget *target = qk_target_new(num_qubits);
@@ -493,7 +493,7 @@ cleanup:
  * Test updating an instruction property in the Target using
  * `update_instruction_property`.
  */
-int test_target_update_instruction(void) {
+static int test_target_update_instruction(void) {
     const uint32_t num_qubits = 1;
     // Let's create a target with one qubit for now
     QkTarget *target = qk_target_new(num_qubits);

--- a/test/c/test_transpiler.c
+++ b/test/c/test_transpiler.c
@@ -12,7 +12,6 @@
 
 #include "common.h"
 #include <complex.h>
-#include <math.h>
 #include <qiskit.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -20,7 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 
-int test_transpile_bv(void) {
+static int test_transpile_bv(void) {
     const uint32_t num_qubits = 10;
     QkTarget *target = qk_target_new(num_qubits);
     int result = Ok;
@@ -153,7 +152,7 @@ circuit_cleanup:
     return result;
 }
 
-int test_transpile_idle_qubits(void) {
+static int test_transpile_idle_qubits(void) {
     int result = Ok;
     uint32_t num_qubits = 3;
     QkCircuit *circuit = qk_circuit_new(num_qubits, 0);
@@ -212,7 +211,7 @@ cleanup:
     return result;
 }
 
-int test_transpile_options_null(void) {
+static int test_transpile_options_null(void) {
     const uint32_t n = 10;
     QkTarget *target = qk_target_new(n);
     qk_target_add_instruction(target, qk_target_entry_new(QkGate_SX));

--- a/test/c/test_unitary_synthesis.c
+++ b/test/c/test_unitary_synthesis.c
@@ -12,7 +12,6 @@
 
 #include "common.h"
 #include <complex.h>
-#include <math.h>
 #include <qiskit.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -20,7 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 
-int build_unitary_target(QkTarget *target, uint32_t num_qubits) {
+static int build_unitary_target(QkTarget *target, uint32_t num_qubits) {
     // Create a target with cx connectivity in a line.
     QkExitCode result_x = qk_target_add_instruction(target, qk_target_entry_new(QkGate_X));
     if (result_x != QkExitCode_Success) {
@@ -63,7 +62,7 @@ int build_unitary_target(QkTarget *target, uint32_t num_qubits) {
 /**
  * Test running UnitarySynthesis on a single gate
  */
-int test_unitary_synthesis_identity_matrix(void) {
+static int test_unitary_synthesis_identity_matrix(void) {
     const uint32_t num_qubits = 5;
     QkTarget *target = qk_target_new(num_qubits);
     int result = Ok;
@@ -95,7 +94,7 @@ cleanup:
 /**
  * Test running UnitarySynthesis on a single gate
  */
-int test_unitary_synthesis_multiqubit_identity_matrix(void) {
+static int test_unitary_synthesis_multiqubit_identity_matrix(void) {
     const uint32_t num_qubits = 5;
     QkTarget *target = qk_target_new(num_qubits);
     int result = Ok;

--- a/test/c/test_version_info.c
+++ b/test/c/test_version_info.c
@@ -18,7 +18,7 @@
 /**
  * Build the version a string, based on the version numbers.
  */
-char *build_version_string(void) {
+static char *build_version_string(void) {
     char suffix[16];
     switch (QISKIT_RELEASE_LEVEL) {
     case QISKIT_RELEASE_LEVEL_DEV:
@@ -44,7 +44,7 @@ char *build_version_string(void) {
 /**
  * Test the string version.
  */
-int test_version(void) {
+static int test_version(void) {
     char *ref = build_version_string();
     int result;
     if (strcmp(ref, QISKIT_VERSION) == 0)
@@ -61,7 +61,7 @@ int test_version(void) {
 /**
  * Test the version macro and HEX version.
  */
-int test_version_macros(void) {
+static int test_version_macros(void) {
     if (QISKIT_VERSION_MAJOR < 0 || QISKIT_VERSION_MINOR < 0 || QISKIT_VERSION_PATCH < 0) {
         return EqualityError;
     }

--- a/test/c/test_vf2_layout.c
+++ b/test/c/test_vf2_layout.c
@@ -12,7 +12,6 @@
 
 #include "common.h"
 #include <complex.h>
-#include <math.h>
 #include <qiskit.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -20,7 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 
-int build_target(QkTarget *target, uint32_t num_qubits) {
+static int build_target(QkTarget *target, uint32_t num_qubits) {
     // Create a target with cx connectivity in a line.
     QkExitCode result_x = qk_target_add_instruction(target, qk_target_entry_new(QkGate_X));
     if (result_x != QkExitCode_Success) {
@@ -51,7 +50,7 @@ int build_target(QkTarget *target, uint32_t num_qubits) {
 /**
  * Test running VF2Layout on a line connectivity
  */
-int test_vf2_layout_line(void) {
+static int test_vf2_layout_line(void) {
     const uint32_t num_qubits = 5;
     QkTarget *target = qk_target_new(num_qubits);
     int result = Ok;
@@ -105,7 +104,7 @@ cleanup:
 /**
  * Test VF2Layout where a solution isn't possible
  */
-int test_vf2_no_layout_found(void) {
+static int test_vf2_no_layout_found(void) {
     const uint32_t num_qubits = 5;
     QkTarget *target = qk_target_new(num_qubits);
     int result = Ok;


### PR DESCRIPTION
This makes all our C API test suite use `static` functions wherever possible, in the hope that all new tests will copy the existing style; we use `static` for the individual tests so that it is a compiler error if we forget to add it to the test runner (since the function will have internal linkage and consequently be detectable as unused).

Doing this turned up that the `test_gate_direction` tests were not all being run, because the runner function name did not match the convention.

This commit also removes forward declarations of functions from within the same file, and just defines the functions at the point of use (marked `static`, since they're all internal).  None of these functions need any mutual recursion, or any other construct that require the forward definition.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


