### PR TITLE
Pass command-line arguments to `run_cargo_test`

### DIFF
--- a/tools/run_cargo_test.py
+++ b/tools/run_cargo_test.py
@@ -22,6 +22,7 @@ found by PyO3 / our Rust test executable.
 import os
 import subprocess
 import site
+import sys
 import sysconfig
 
 # This allows the Python interpreter baked into our test executable to find the
@@ -40,4 +41,4 @@ os.environ["LD_LIBRARY_PATH"] = os.pathsep.join(
 # The '--no-default-features' flag is used here to disable PyO3's
 # 'extension-module' when running the tests (which would otherwise cause link
 # errors).
-subprocess.run(["cargo", "test", "--no-default-features"], check=True)
+subprocess.run(["cargo", "test", "--no-default-features"] + sys.argv[1:], check=True)


### PR DESCRIPTION
`cargo test` can take a bunch of command-line arguments to use as filters.  This lets us pass the same arguments to the wrapper script and have them forwarded.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


