### PR TITLE
Make `ParameterTable` use rust-native errors.

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -1492,7 +1492,8 @@ impl CircuitData {
                 ) {
                     Ok(_)
                     | Err(ParameterTableError::ParameterNotTracked(_))
-                    | Err(ParameterTableError::UsageNotTracked(_)) => (),
+                    | Err(ParameterTableError::UsageNotTracked(_))
+                    | Err(ParameterTableError::ConflictingName(_)) => (),
                     // Any errors added later might want propagating.
                 }
             }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
- Add one new error variant, `ConflictingName`, to `ParameterTableError`, to account for instances with conflicting names.
- Add type `ParameterResult<T>` as a shorthand result handler for `ParameterTableError`.
- Added variant `ConflictingName` to condition in `CircuitData::set_global_phase`.

### Details and comments
- Prelude to #15027

