### PR TITLE
Update README transpiler example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,16 @@ The power of quantum computing cannot be simulated on classical computers and yo
 However, running a quantum circuit on hardware requires rewriting to the basis gates and connectivity of the quantum hardware.
 The tool that does this is the [transpiler](https://quantum.cloud.ibm.com/docs/api/qiskit/transpiler), and Qiskit includes transpiler passes for synthesis, optimization, mapping, and scheduling.
 However, it also includes a default compiler, which works very well in most examples.
-The following code will map the example circuit to the `basis_gates = ["cz", "sx", "rz"]` and a linear chain of qubits $0 \rightarrow 1 \rightarrow 2$ with the `coupling_map = [[0, 1], [1, 2]]`.
+The following code will map the example circuit to the `basis_gates = ["cz", "sx", "rz"]` and a
+bidirectional linear chain of qubits $0 \leftrightarrow 1 \leftrightarrow 2$ with the
+`coupling_map = [[0, 1], [1, 0], [1, 2], [2, 1]]`.
 
 ```python
 from qiskit import transpile
 from qiskit.transpiler import Target, CouplingMap
 target = Target.from_configuration(
     basis_gates=["cz", "sx", "rz"],
-    coupling_map=CouplingMap.from_line(3, bidirectional=False),
+    coupling_map=CouplingMap.from_line(3),
 )
 qc_transpiled = transpile(qc, target)
 ```

--- a/README.md
+++ b/README.md
@@ -97,7 +97,12 @@ The following code will map the example circuit to the `basis_gates = ["cz", "sx
 
 ```python
 from qiskit import transpile
-qc_transpiled = transpile(qc, basis_gates=["cz", "sx", "rz"], coupling_map=[[0, 1], [1, 2]], optimization_level=3)
+from qiskit.transpiler import Target, CouplingMap
+target = Target.from_configuration(
+    basis_gates=["cz", "sx", "rz"],
+    coupling_map=CouplingMap.from_line(3, bidirectional=False),
+)
+qc_transpiled = transpile(qc, target)
 ```
 
 ### Executing your code on real quantum hardware

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ target = Target.from_configuration(
     basis_gates=["cz", "sx", "rz"],
     coupling_map=CouplingMap.from_line(3),
 )
-qc_transpiled = transpile(qc, target)
+qc_transpiled = transpile(qc, target=target)
 ```
 
 ### Executing your code on real quantum hardware


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the README transpiler usage to use better practices slightly. The first is it changes the use of loose constraints to create a Target explicitly. While the transpile() function does this internally it's good to get people thinking in terms of the target up front so this constructs the target from the same basic values. Secondly it removes the optimization level 3, transpile() has a default optimization level of 2 now and we should just use that as it's the best balance between runtime and optimization. Optimization level 3 spends more runtime and typically doesn't yield significantly better results.


### Details and comments


