### PR TITLE
Lower limits on `VF2PostLayout` in exact mode

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -616,6 +616,7 @@ class OptimizationPassManager(PassManagerStagePlugin):
                     optimization_level,
                     pass_manager_config.layout_method,
                     pass_manager_config.initial_layout,
+                    exact_match=True,
                 )
                 is_vf2_fully_bounded = vf2_call_limit and vf2_max_trials
                 if pass_manager_config.target is not None and is_vf2_fully_bounded:

--- a/releasenotes/notes/reduce-vf2post-limits-6a6ff25491f8ac4f.yaml
+++ b/releasenotes/notes/reduce-vf2post-limits-6a6ff25491f8ac4f.yaml
@@ -1,0 +1,6 @@
+---
+upgrade_transpiler:
+  - |
+    The maximum call and trial limits for the exact-matching run of :class:`.VF2PostLayout` at
+    ``optimization_level=3`` have been reduced to avoid excessive runtimes for highly symmetric
+    trial circuits being mapped to large coupling maps.


### PR DESCRIPTION
We currently run `VF2PostLayout(strict=True)` after the optimisation loop at optimisation level 3.  We use the same values for `call_limit` and `max_trials` as we do for the averaging methods, but the averaging methods are pure Rust with no semantic matching, whereas the exact-match have Python-space semantic matching, so are far slower.

We can look at raising the limits back to much higher values when these paths are in Rust and use the branch-and-bound scoring.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Fix #15064
