### PR TITLE
Fix pickling of SabreSwap

### DIFF
--- a/crates/transpiler/src/passes/sabre/neighbors.rs
+++ b/crates/transpiler/src/passes/sabre/neighbors.rs
@@ -26,8 +26,8 @@ use rustworkx_core::petgraph::visit::*;
 /// small that a linear search is faster).
 #[derive(Clone, Debug)]
 pub struct Neighbors {
-    neighbors: Vec<PhysicalQubit>,
-    partition: Vec<usize>,
+    pub(crate) neighbors: Vec<PhysicalQubit>,
+    pub(crate) partition: Vec<usize>,
 }
 impl Neighbors {
     /// Construct the neighbor adjacency table from a coupling graph.

--- a/releasenotes/notes/fix-sabre-swap-pickle-a1215f58853f81d1.yaml
+++ b/releasenotes/notes/fix-sabre-swap-pickle-a1215f58853f81d1.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed an issue with :mod:`pickle` support for the :class:`.SabreSwap` where a
+    :class:`.SabreSwap` instance would error when being pickled after the
+    :meth:`.SabreSwap.run` method was run.
+    Fixed `#15071 <https://github.com/Qiskit/qiskit/issues/15071>`__.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes the support for pickling SabreSwap. In #14317 a new RoutingTarget rust struct was added to encapsulate the target details, and this was exposed to Python so that the Python class for the transpiler pass was able to reuse the object between multiple runs. However, this new type didn't implement pickle support and it would cause a failure when trying to pickle a SabreSwap instance that had a routing target populated. This commit fixes this oversight and implements pickle support for the RoutingTarget so that SabreSwap can always be pickled.


### Details and comments

Fixes #15071
