### PR TITLE
Fix 2.1 release notes cross-reference

### DIFF
--- a/releasenotes/notes/2.1/observables-array-7d7544b3bb3fbaa3.yaml
+++ b/releasenotes/notes/2.1/observables-array-7d7544b3bb3fbaa3.yaml
@@ -5,7 +5,7 @@ features_primitives:
     defined using :class:`.SparseObservable` objects for the observable component of the PUB.
     This is in addition to the existing supported types of: ``str``,
     :class:`~qiskit.quantum_info.Pauli`, :class:`.SparsePauliOp`, and
-    a mapping of ``str`` or :class`~qiskit.quantum_info.Pauli` to ``float`` values.
+    a mapping of ``str`` or :class:`~qiskit.quantum_info.Pauli` to ``float`` values.
     However, if the :class:`.SparseObservable` contains
     projectors, support for handling that depends on the primitive implementation. As of this release the implementations
     in Qiskit (:class:`.StatevectorEstimator` and :class:`.BackendEstimatorV2`), ``qiskit-ibm-runtime``


### PR DESCRIPTION
This PR fixes a broken cross-reference in the [Qiskit 2.1 release notes](https://quantum.cloud.ibm.com/docs/en/api/qiskit/release-notes/2.1#primitives-features)

<img width="800" height="117" alt="Screenshot 2025-09-25 at 13 50 45" src="https://github.com/user-attachments/assets/1972d1cc-206d-430d-bd31-6675f83a4215" />
