### PR TITLE
Fix circuit classical cross-references

### DIFF
--- a/qiskit/circuit/classical/expr/constructors.py
+++ b/qiskit/circuit/classical/expr/constructors.py
@@ -701,8 +701,8 @@ def div(left: typing.Any, right: typing.Any) -> Expr:
     lifting the values into :class:`Value` nodes if required.
 
     This can be used to divide numeric operands of the same type kind, to divide a
-    :class`~.types.Duration` operand by a numeric operand, or to divide two
-    :class`~.types.Duration` operands which yields an expression of type
+    :class:`~.types.Duration` operand by a numeric operand, or to divide two
+    :class:`~.types.Duration` operands which yields an expression of type
     :class:`~.types.Float`.
 
     Examples:


### PR DESCRIPTION
This PR fixes two broken cross-references in the [circuit classical](https://quantum.cloud.ibm.com/docs/en/api/qiskit/circuit_classical#div) docs.

In the following screenshot we can see how it's currently rendered:

<img width="767" height="90" alt="Screenshot 2025-09-25 at 13 59 10" src="https://github.com/user-attachments/assets/a67ed04b-f1fb-4c5c-ad35-fe770aa8e2c1" />

This change will need a backport to the stable branches.