### PR TITLE
Fix 1.1 release notes cross-reference

### DIFF
--- a/releasenotes/notes/1.1/prepare-1.1.0-732e167b70ab4d01.yaml
+++ b/releasenotes/notes/1.1/prepare-1.1.0-732e167b70ab4d01.yaml
@@ -18,7 +18,7 @@ prelude: >
 
         Additionally, the numeric methods used in :class:`.Isometry` have been moved to Rust,
         enabling large runtime speed-ups in particular for controlled unitary gate synthesis.
-        The decomposition for multi-controlled :class:.XGate` and :class:`.PhaseGate`  has been
+        The decomposition for multi-controlled :class:`.XGate` and :class:`.PhaseGate`  has been
         improved resulting in a reduction in the number of gates used in the synthesis by more
         than two orders of magnitude.
 


### PR DESCRIPTION
This PR fixes a broken cross-reference in the [Qiskit 1.1 release notes](https://quantum.cloud.ibm.com/docs/en/api/qiskit/release-notes/1.1#prelude-2)

<img width="768" height="111" alt="Screenshot 2025-09-25 at 14 45 15" src="https://github.com/user-attachments/assets/afa63575-9623-4783-a959-9c0f8909a187" />

