### PR TITLE
Fix qubit mapping in `ConsolidateBlocks` control-flow blocks

### DIFF
--- a/crates/circuit/src/nlayout.rs
+++ b/crates/circuit/src/nlayout.rs
@@ -52,6 +52,13 @@ macro_rules! qubit_newtype {
             pub fn index(&self) -> usize {
                 self.0 as usize
             }
+
+            /// Specialise a slice of `Qubit` values into a slice of this type's values.
+            pub fn lift_slice(slice: &[$crate::Qubit]) -> &[$id] {
+                // SAFETY: `Qubit` and this type share the exact same set of valid bit patterns and
+                // alignments.
+                unsafe { ::std::slice::from_raw_parts(slice.as_ptr() as *const $id, slice.len()) }
+            }
         }
 
         impl From<$id> for $crate::Qubit {

--- a/releasenotes/notes/fix-consolidate-recursion-82ebcb195c12996a.yaml
+++ b/releasenotes/notes/fix-consolidate-recursion-82ebcb195c12996a.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The :class:`.ConsolidateBlocks` transpiler pass will now correctly evaluate whether a given
+    gate is hardware-supported while recursing into control-flow operations.


### PR DESCRIPTION
The pass previously recursed over control-flow blocks without mapping back to the hardware qubits, meaning it could consolidate things as "out of basis" even if they actually were inside the basis.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


