### PR TITLE
Remove dead entries from Python `MANIFEST.in`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,13 +4,11 @@ recursive-include qiskit/qasm/libs *.inc
 include qiskit/VERSION.txt
 include qiskit/visualization/circuit/styles/*.json
 include qiskit/visualization/dag/styles/*.json
-recursive-include qiskit/providers/fake_provider/backends_v1 *.json
 
 # Include the tests files.
 recursive-include test *.py
 include test/python/qasm/*.qasm
 include test/python/visualization/references/*.png
-include test/python/notebooks/*.ipynb
 
 include Cargo.toml
 include Cargo.lock


### PR DESCRIPTION
These entries have been empty matches for quite some time, so have no effect other than triggering a minor packaging warning.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


