### PR TITLE
Bump rustfmt style edition to 2024

### DIFF
--- a/crates/accelerate/src/circuit_duration.rs
+++ b/crates/accelerate/src/circuit_duration.rs
@@ -45,24 +45,18 @@ pub(crate) fn compute_estimated_duration(dag: &DAGCircuit, target: &Target) -> P
                             return if unit == DelayUnit::DT {
                                 if let Some(dt) = dt {
                                     match dur {
-                                        Param::Float(val) =>
-                                            {
-                                                Ok(val * dt)
-
-                                            },
-                                        Param::Obj(val) => {
-                                            Python::attach(|py| {
-                                                let dur_float: f64 = val.extract(py)?;
-                                                Ok(dur_float * dt)
-                                            })
-                                        },
+                                        Param::Float(val) => Ok(val * dt),
+                                        Param::Obj(val) => Python::attach(|py| {
+                                            let dur_float: f64 = val.extract(py)?;
+                                            Ok(dur_float * dt)
+                                        }),
                                         Param::ParameterExpression(_) => Err(QiskitError::new_err(
-                                            "Circuit contains parameterized delays, can't compute a duration estimate with this circuit"
+                                            "Circuit contains parameterized delays, can't compute a duration estimate with this circuit",
                                         )),
                                     }
                                 } else {
                                     Err(QiskitError::new_err(
-                                        "Circuit contains delays in dt but the target doesn't specify dt"
+                                        "Circuit contains delays in dt but the target doesn't specify dt",
                                     ))
                                 }
                             } else if unit == DelayUnit::S {
@@ -74,7 +68,7 @@ pub(crate) fn compute_estimated_duration(dag: &DAGCircuit, target: &Target) -> P
                                 }
                             } else {
                                 Err(QiskitError::new_err(
-                                    "Circuit contains delays in units other then seconds or dt, the circuit is not scheduled."
+                                    "Circuit contains delays in units other then seconds or dt, the circuit is not scheduled.",
                                 ))
                             };
                         } else if let StandardInstruction::Barrier(_) = op {

--- a/crates/accelerate/src/isometry.rs
+++ b/crates/accelerate/src/isometry.rs
@@ -14,9 +14,9 @@ use std::ops::BitAnd;
 
 use approx::abs_diff_eq;
 use num_complex::{Complex64, ComplexFloat};
+use pyo3::Python;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
-use pyo3::Python;
 
 use hashbrown::HashSet;
 use itertools::Itertools;

--- a/crates/accelerate/src/results/marginalization.rs
+++ b/crates/accelerate/src/results/marginalization.rs
@@ -17,8 +17,8 @@ use num_bigint::BigUint;
 use num_complex::Complex64;
 use numpy::IntoPyArray;
 use numpy::{PyReadonlyArray1, PyReadonlyArray2, PyReadonlyArray3};
-use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
+use pyo3::prelude::*;
 use qiskit_circuit::getenv_use_multiple_threads;
 use rayon::prelude::*;
 

--- a/crates/accelerate/src/twirling.rs
+++ b/crates/accelerate/src/twirling.rs
@@ -13,20 +13,21 @@
 use std::f64::consts::PI;
 
 use hashbrown::HashMap;
+use ndarray::ArrayView2;
 use ndarray::linalg::kron;
 use ndarray::prelude::*;
-use ndarray::ArrayView2;
 use num_complex::Complex64;
+use pyo3::IntoPyObjectExt;
+use pyo3::Python;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyList;
 use pyo3::wrap_pyfunction;
-use pyo3::IntoPyObjectExt;
-use pyo3::Python;
 use rand::prelude::*;
 use rand_pcg::Pcg64Mcg;
 use smallvec::SmallVec;
 
+use qiskit_circuit::VarsMode;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
 use qiskit_circuit::converters::dag_to_circuit;
@@ -36,7 +37,6 @@ use qiskit_circuit::imports::QUANTUM_CIRCUIT;
 use qiskit_circuit::operations::StandardGate::{I, X, Y, Z};
 use qiskit_circuit::operations::{Operation, OperationRef, Param, PyInstruction, StandardGate};
 use qiskit_circuit::packed_instruction::{PackedInstruction, PackedOperation};
-use qiskit_circuit::VarsMode;
 
 use crate::QiskitError;
 
@@ -375,9 +375,10 @@ pub(crate) fn twirl_circuit(
                     StandardGate::ECR => ECR_MASK,
                     StandardGate::ISwap => ISWAP_MASK,
                     _ => {
-                        return Err(QiskitError::new_err(
-                          format!("Provided gate to twirl, {}, is not currently supported you can only use cx, cz, ecr or iswap.", gate.name())
-                        ))
+                        return Err(QiskitError::new_err(format!(
+                            "Provided gate to twirl, {}, is not currently supported you can only use cx, cz, ecr or iswap.",
+                            gate.name()
+                        )));
                     }
                 };
                 out_mask |= new_mask;

--- a/crates/accelerate/src/uc_gate.rs
+++ b/crates/accelerate/src/uc_gate.rs
@@ -11,15 +11,15 @@
 // that they have been altered from the originals.
 
 use num_complex::{Complex64, ComplexFloat};
+use pyo3::Python;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
-use pyo3::Python;
 use std::f64::consts::{FRAC_1_SQRT_2, PI};
 
 use nalgebra::{Matrix2, MatrixView2, Vector2};
 use numpy::{IntoPyArray, PyReadonlyArray2, ToPyArray};
 
-use qiskit_circuit::util::{c64, C_ZERO, IM};
+use qiskit_circuit::util::{C_ZERO, IM, c64};
 
 const EPS: f64 = 1e-10;
 

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -10,7 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use std::ffi::{c_char, CStr, CString};
+use std::ffi::{CStr, CString, c_char};
 
 use crate::exit_codes::ExitCode;
 use crate::pointers::{const_ptr_as_ref, mut_ptr_as_ref};
@@ -33,7 +33,7 @@ use pyo3::ffi::PyObject;
 #[cfg(feature = "python_binding")]
 use pyo3::types::PyAnyMethods;
 #[cfg(feature = "python_binding")]
-use pyo3::{intern, Python};
+use pyo3::{Python, intern};
 #[cfg(feature = "python_binding")]
 use qiskit_circuit::imports::QUANTUM_CIRCUIT;
 

--- a/crates/cext/src/sparse_observable.rs
+++ b/crates/cext/src/sparse_observable.rs
@@ -10,7 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use std::ffi::{c_char, CString};
+use std::ffi::{CString, c_char};
 
 use crate::exit_codes::{CInputError, ExitCode};
 use crate::pointers::{check_ptr, const_ptr_as_ref, mut_ptr_as_ref};

--- a/crates/cext/src/transpiler/passes/commutative_cancellation.rs
+++ b/crates/cext/src/transpiler/passes/commutative_cancellation.rs
@@ -99,10 +99,10 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_commutative_cancellation(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use qiskit_circuit::Qubit;
     use qiskit_circuit::bit::ShareableQubit;
     use qiskit_circuit::circuit_data::CircuitData;
     use qiskit_circuit::operations::StandardGate;
-    use qiskit_circuit::Qubit;
 
     #[test]
     fn test_commutative_cancellation() {

--- a/crates/cext/src/transpiler/passes/elide_permutations.rs
+++ b/crates/cext/src/transpiler/passes/elide_permutations.rs
@@ -12,10 +12,10 @@
 
 use crate::pointers::mut_ptr_as_ref;
 
+use qiskit_circuit::Qubit;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::converters::dag_to_circuit;
 use qiskit_circuit::dag_circuit::DAGCircuit;
-use qiskit_circuit::Qubit;
 use qiskit_transpiler::passes::run_elide_permutations;
 use qiskit_transpiler::transpile_layout::TranspileLayout;
 

--- a/crates/cext/src/transpiler/passes/split_2q_unitaries.rs
+++ b/crates/cext/src/transpiler/passes/split_2q_unitaries.rs
@@ -12,10 +12,10 @@
 
 use crate::pointers::mut_ptr_as_ref;
 
+use qiskit_circuit::Qubit;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::converters::dag_to_circuit;
 use qiskit_circuit::dag_circuit::DAGCircuit;
-use qiskit_circuit::Qubit;
 use qiskit_transpiler::passes::run_split_2q_unitaries;
 use qiskit_transpiler::transpile_layout::TranspileLayout;
 

--- a/crates/cext/src/transpiler/passes/unitary_synthesis.rs
+++ b/crates/cext/src/transpiler/passes/unitary_synthesis.rs
@@ -114,13 +114,13 @@ mod tests {
 
     use std::sync::Arc;
 
+    use qiskit_circuit::Qubit;
     use qiskit_circuit::bit::ShareableQubit;
     use qiskit_circuit::circuit_data::CircuitData;
     use qiskit_circuit::operations::{ArrayType, Operation, Param, StandardGate, UnitaryGate};
     use qiskit_circuit::packed_instruction::PackedOperation;
     use qiskit_circuit::parameter::parameter_expression::ParameterExpression;
     use qiskit_circuit::parameter::symbol_expr::Symbol;
-    use qiskit_circuit::Qubit;
 
     #[test]
     fn test_pass_synthesis() {

--- a/crates/cext/src/transpiler/target.rs
+++ b/crates/cext/src/transpiler/target.rs
@@ -15,14 +15,14 @@ use std::sync::Arc;
 use crate::exit_codes::{CInputError, ExitCode};
 use crate::pointers::{check_ptr, const_ptr_as_ref, mut_ptr_as_ref};
 use indexmap::IndexMap;
+use qiskit_circuit::PhysicalQubit;
 use qiskit_circuit::operations::StandardInstruction;
 use qiskit_circuit::operations::{Operation, Param, StandardGate};
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::parameter::parameter_expression::ParameterExpression;
 use qiskit_circuit::parameter::symbol_expr::Symbol;
-use qiskit_circuit::PhysicalQubit;
 use qiskit_transpiler::target::{InstructionProperties, Qargs, Target};
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 
 /// @ingroup QkTarget
 /// Construct a new ``QkTarget`` with the given number of qubits.

--- a/crates/cext/src/transpiler/transpile_function.rs
+++ b/crates/cext/src/transpiler/transpile_function.rs
@@ -9,8 +9,8 @@
 // Any modifications or derivative works of this code must retain this
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
-use std::ffi::c_char;
 use std::ffi::CString;
+use std::ffi::c_char;
 
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_transpiler::target::Target;

--- a/crates/cext/src/transpiler/transpile_layout.rs
+++ b/crates/cext/src/transpiler/transpile_layout.rs
@@ -242,9 +242,9 @@ pub unsafe extern "C" fn qk_transpile_layout_free(layout: *mut TranspileLayout) 
 #[cfg(test)]
 mod test {
     use super::*;
+    use qiskit_circuit::Qubit;
     use qiskit_circuit::bit::ShareableQubit;
     use qiskit_circuit::nlayout::{NLayout, PhysicalQubit};
-    use qiskit_circuit::Qubit;
     use qiskit_transpiler::transpile_layout::TranspileLayout;
 
     #[test]

--- a/crates/circuit/src/bit.rs
+++ b/crates/circuit/src/bit.rs
@@ -15,16 +15,16 @@
 use std::{
     fmt::Debug,
     hash::Hash,
-    sync::atomic::{AtomicU32, AtomicU64, Ordering},
     sync::Arc,
+    sync::atomic::{AtomicU32, AtomicU64, Ordering},
 };
 
 use hashbrown::HashSet;
 use pyo3::prelude::*;
 use pyo3::{
+    IntoPyObjectExt, PyTypeInfo,
     exceptions::{PyIndexError, PyTypeError, PyValueError},
     types::{PyList, PyType},
-    IntoPyObjectExt, PyTypeInfo,
 };
 
 use crate::circuit_data::CircuitError;

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -22,7 +22,7 @@ use crate::bit::{
 use crate::bit_locator::BitLocator;
 use crate::circuit_instruction::{CircuitInstruction, OperationFromPython};
 use crate::classical::expr;
-use crate::dag_circuit::{add_global_phase, DAGStretchType, DAGVarType};
+use crate::dag_circuit::{DAGStretchType, DAGVarType, add_global_phase};
 use crate::imports::{ANNOTATED_OPERATION, QUANTUM_CIRCUIT};
 use crate::interner::{Interned, InternedMap, Interner};
 use crate::object_registry::ObjectRegistry;
@@ -37,11 +37,11 @@ use crate::{Clbit, Qubit, Stretch, Var, VarsMode};
 
 use num_complex::Complex64;
 use numpy::PyReadonlyArray1;
+use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::{PyRuntimeError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyDict, PyList, PySet, PyTuple, PyType};
-use pyo3::IntoPyObjectExt;
-use pyo3::{import_exception, intern, PyTraverseError, PyVisit};
+use pyo3::{PyTraverseError, PyVisit, import_exception, intern};
 
 use hashbrown::{HashMap, HashSet};
 use indexmap::IndexMap;

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -18,16 +18,16 @@ use pyo3::basic::CompareOp;
 use pyo3::exceptions::{PyDeprecationWarning, PyTypeError};
 use pyo3::prelude::*;
 
-use pyo3::types::{PyBool, PyList, PyTuple, PyType};
 use pyo3::IntoPyObjectExt;
-use pyo3::{intern, PyResult};
+use pyo3::types::{PyBool, PyList, PyTuple, PyType};
+use pyo3::{PyResult, intern};
 
 use nalgebra::{Dyn, MatrixView2, MatrixView4};
 use num_complex::Complex64;
 use smallvec::SmallVec;
 
 use crate::imports::{
-    CONTROLLED_GATE, CONTROL_FLOW_OP, GATE, INSTRUCTION, OPERATION, WARNINGS_WARN,
+    CONTROL_FLOW_OP, CONTROLLED_GATE, GATE, INSTRUCTION, OPERATION, WARNINGS_WARN,
 };
 use crate::operations::{
     ArrayType, Operation, OperationRef, Param, PyGate, PyInstruction, PyOperation, StandardGate,

--- a/crates/circuit/src/classical/expr/binary.rs
+++ b/crates/circuit/src/classical/expr/binary.rs
@@ -15,7 +15,7 @@ use crate::classical::types::Type;
 use crate::imports;
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
-use pyo3::{intern, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, intern};
 
 /// A binary expression.
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/circuit/src/classical/expr/cast.rs
+++ b/crates/circuit/src/classical/expr/cast.rs
@@ -14,7 +14,7 @@ use crate::classical::expr::{Expr, ExprKind, PyExpr};
 use crate::classical::types::Type;
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
-use pyo3::{intern, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, intern};
 
 /// A cast from one type to another, implied by the use of an expression in a different
 /// context.

--- a/crates/circuit/src/classical/expr/expr.rs
+++ b/crates/circuit/src/classical/expr/expr.rs
@@ -13,7 +13,7 @@
 use crate::classical::expr::{Binary, Cast, Index, Stretch, Unary, Value, Var};
 use crate::classical::types::Type;
 use pyo3::prelude::*;
-use pyo3::{intern, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, intern};
 
 /// A classical expression.
 ///

--- a/crates/circuit/src/classical/expr/index.rs
+++ b/crates/circuit/src/classical/expr/index.rs
@@ -14,7 +14,7 @@ use crate::classical::expr::{Expr, ExprKind, PyExpr};
 use crate::classical::types::Type;
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
-use pyo3::{intern, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, intern};
 
 /// An indexing expression.
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/circuit/src/classical/expr/stretch.rs
+++ b/crates/circuit/src/classical/expr/stretch.rs
@@ -15,7 +15,7 @@ use crate::classical::types::Type;
 use crate::imports::UUID;
 use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyTuple};
-use pyo3::{intern, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, intern};
 use uuid::Uuid;
 
 /// A stretch variable.

--- a/crates/circuit/src/classical/expr/unary.rs
+++ b/crates/circuit/src/classical/expr/unary.rs
@@ -15,7 +15,7 @@ use crate::classical::types::Type;
 use crate::imports;
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
-use pyo3::{intern, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, intern};
 
 /// A unary expression.
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/circuit/src/classical/expr/value.rs
+++ b/crates/circuit/src/classical/expr/value.rs
@@ -15,7 +15,7 @@ use crate::classical::types::Type;
 use crate::duration::Duration;
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
-use pyo3::{intern, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, intern};
 
 /// A single scalar value expression.
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/circuit/src/classical/expr/var.rs
+++ b/crates/circuit/src/classical/expr/var.rs
@@ -16,7 +16,7 @@ use crate::classical::types::Type;
 use crate::imports::UUID;
 use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyTuple};
-use pyo3::{intern, IntoPyObjectExt};
+use pyo3::{IntoPyObjectExt, intern};
 use uuid::Uuid;
 
 /// A classical variable expression.

--- a/crates/circuit/src/classical/types.rs
+++ b/crates/circuit/src/classical/types.rs
@@ -10,11 +10,11 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use pyo3::PyTypeInfo;
 use pyo3::exceptions::PyAttributeError;
 use pyo3::prelude::*;
 use pyo3::sync::PyOnceLock;
 use pyo3::types::PyTuple;
-use pyo3::PyTypeInfo;
 
 static BOOL_TYPE: PyOnceLock<Py<PyBool>> = PyOnceLock::new();
 static DURATION_TYPE: PyOnceLock<Py<PyDuration>> = PyOnceLock::new();

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -40,18 +40,18 @@ use crate::parameter::parameter_expression::ParameterExpression;
 use crate::register_data::RegisterData;
 use crate::slice::PySequenceIndex;
 use crate::variable_mapper::VariableMapper;
-use crate::{imports, vf2, Clbit, Qubit, Stretch, TupleLikeArg, Var, VarsMode};
+use crate::{Clbit, Qubit, Stretch, TupleLikeArg, Var, VarsMode, imports, vf2};
 
 use hashbrown::{HashMap, HashSet};
 use indexmap::{IndexMap, IndexSet};
 use itertools::{EitherOrBoth, Itertools};
 
+use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::{
     PyDeprecationWarning, PyIndexError, PyRuntimeError, PyTypeError, PyValueError,
 };
 use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::IntoPyObjectExt;
 
 use pyo3::types::{
     IntoPyDict, PyDict, PyInt, PyIterator, PyList, PySet, PyString, PyTuple, PyType,
@@ -61,6 +61,7 @@ use rustworkx_core::dag_algo::layers;
 use rustworkx_core::err::ContractError;
 use rustworkx_core::graph_ext::ContractNodesDirected;
 use rustworkx_core::petgraph;
+use rustworkx_core::petgraph::Incoming;
 use rustworkx_core::petgraph::prelude::StableDiGraph;
 use rustworkx_core::petgraph::prelude::*;
 use rustworkx_core::petgraph::stable_graph::{EdgeReference, IndexType, NodeIndex};
@@ -68,7 +69,6 @@ use rustworkx_core::petgraph::unionfind::UnionFind;
 use rustworkx_core::petgraph::visit::{
     EdgeIndexable, IntoEdgeReferences, IntoNodeReferences, NodeFiltered, NodeIndexable,
 };
-use rustworkx_core::petgraph::Incoming;
 use rustworkx_core::traversal::{
     ancestors as core_ancestors, bfs_predecessors as core_bfs_predecessors,
     bfs_successors as core_bfs_successors, descendants as core_descendants,
@@ -1239,7 +1239,7 @@ impl DAGCircuit {
             Err(_) => {
                 return Err(DAGCircuitError::new_err(format!(
                     "clbits not in circuit: {clbits:?}"
-                )))
+                )));
             }
         };
         self.remove_clbits(bit_iter)
@@ -1277,7 +1277,7 @@ impl DAGCircuit {
             Err(_) => {
                 return Err(DAGCircuitError::new_err(format!(
                     "qubits not in circuit: {qubits:?}"
-                )))
+                )));
             }
         };
         self.remove_qubits(bit_iter)
@@ -2122,16 +2122,20 @@ impl DAGCircuit {
                     };
                     match [inst1.op.view(), inst2.op.view()] {
                         [OperationRef::StandardGate(_), OperationRef::StandardGate(_)]
-                        | [OperationRef::StandardInstruction(_), OperationRef::StandardInstruction(_)] => {
-                            Ok(inst1.py_op_eq(py, inst2)?
-                                && check_args()
-                                && inst1
-                                    .params_view()
-                                    .iter()
-                                    .zip(inst2.params_view().iter())
-                                    .all(|(a, b)| a.is_close(b, 1e-10).unwrap()))
-                        }
-                        [OperationRef::Instruction(op1), OperationRef::Instruction(op2)] => {
+                        | [
+                            OperationRef::StandardInstruction(_),
+                            OperationRef::StandardInstruction(_),
+                        ] => Ok(inst1.py_op_eq(py, inst2)?
+                            && check_args()
+                            && inst1
+                                .params_view()
+                                .iter()
+                                .zip(inst2.params_view().iter())
+                                .all(|(a, b)| a.is_close(b, 1e-10).unwrap())),
+                        [
+                            OperationRef::Instruction(op1),
+                            OperationRef::Instruction(op2),
+                        ] => {
                             if op1.control_flow() && op2.control_flow() {
                                 let n1 = self.unpack_into(py, NodeIndex::new(0), n1)?;
                                 let n2 = other.unpack_into(py, NodeIndex::new(0), n2)?;
@@ -2173,10 +2177,14 @@ impl DAGCircuit {
                         // and we have mutable state set.
                         [OperationRef::StandardGate(_), OperationRef::Gate(_)]
                         | [OperationRef::Gate(_), OperationRef::StandardGate(_)]
-                        | [OperationRef::StandardInstruction(_), OperationRef::Instruction(_)]
-                        | [OperationRef::Instruction(_), OperationRef::StandardInstruction(_)] => {
-                            Ok(inst1.py_op_eq(py, inst2)? && check_args())
-                        }
+                        | [
+                            OperationRef::StandardInstruction(_),
+                            OperationRef::Instruction(_),
+                        ]
+                        | [
+                            OperationRef::Instruction(_),
+                            OperationRef::StandardInstruction(_),
+                        ] => Ok(inst1.py_op_eq(py, inst2)? && check_args()),
                         [OperationRef::Unitary(op_a), OperationRef::Unitary(op_b)] => {
                             match [&op_a.array, &op_b.array] {
                                 [ArrayType::NDArray(a), ArrayType::NDArray(b)] => {
@@ -3061,7 +3069,7 @@ impl DAGCircuit {
                     Err(_) => {
                         return Err(DAGCircuitError::new_err(format!(
                             "qubits not in circuit: {qubits:?}"
-                        )))
+                        )));
                     }
                 };
                 new_dag.remove_qubits(bit_iter)?; // TODO: this does not really work, some issue with remove_qubits itself
@@ -6220,7 +6228,9 @@ impl DAGCircuit {
             Some(var_map) => var_map,
             None => {
                 if self.num_vars() > 0 || other.num_vars() > 0 {
-                    unimplemented!("Inferring variable mapping in substitute_node_with_dag is not implemented yet. Consider using py_substitute_node_with_dag instead.");
+                    unimplemented!(
+                        "Inferring variable mapping in substitute_node_with_dag is not implemented yet. Consider using py_substitute_node_with_dag instead."
+                    );
                     // TODO: implement once additional_wires becomes Python-free
                 }
                 &HashMap::<expr::Var, expr::Var>::new()
@@ -6894,7 +6904,9 @@ impl DAGCircuit {
             let qubits = if let Wire::Qubit(qubit) = weight {
                 vec![qubit]
             } else {
-                panic!("This method only works if the gate being replaced has no classical incident wires")
+                panic!(
+                    "This method only works if the gate being replaced has no classical incident wires"
+                )
             };
             let inst = PackedInstruction {
                 op: new_op,
@@ -6924,7 +6936,7 @@ impl DAGCircuit {
             Param::Obj(_) => {
                 return Err(PyTypeError::new_err(
                     "Invalid parameter type, only float and parameter expression are supported",
-                ))
+                ));
             }
             _ => self.set_global_phase(add_global_phase(&self.global_phase, value)?)?,
         }
@@ -7266,12 +7278,12 @@ impl DAGCircuit {
                 Some(_) => {
                     return Err(DAGCircuitError::new_err(
                         "Nodes in 'node_block' must be of type 'DAGOpNode'.",
-                    ))
+                    ));
                 }
                 None => {
                     return Err(DAGCircuitError::new_err(
                         "Node in 'node_block' not found in DAG.",
-                    ))
+                    ));
                 }
             }
         }
@@ -7290,7 +7302,9 @@ impl DAGCircuit {
 
         if op.num_qubits() as usize != block_qargs.len() {
             return Err(DAGCircuitError::new_err(format!(
-                "Number of qubits in the replacement operation ({}) is not equal to the number of qubits in the block ({})!", op.num_qubits(), block_qargs.len()
+                "Number of qubits in the replacement operation ({}) is not equal to the number of qubits in the block ({})!",
+                op.num_qubits(),
+                block_qargs.len()
             )));
         }
 
@@ -7623,11 +7637,13 @@ impl DAGCircuit {
         if old_packed.op.num_qubits() != new_op.num_qubits()
             || old_packed.op.num_clbits() != new_op.num_clbits()
         {
-            return Err(DAGCircuitError::new_err(
-                format!(
-                    "Cannot replace node of width ({} qubits, {} clbits) with operation of mismatched width ({} qubits, {} clbits)",
-                    old_packed.op.num_qubits(), old_packed.op.num_clbits(), new_op.num_qubits(), new_op.num_clbits()
-                )));
+            return Err(DAGCircuitError::new_err(format!(
+                "Cannot replace node of width ({} qubits, {} clbits) with operation of mismatched width ({} qubits, {} clbits)",
+                old_packed.op.num_qubits(),
+                old_packed.op.num_clbits(),
+                new_op.num_qubits(),
+                new_op.num_clbits()
+            )));
         }
         let new_op_name = new_op.name().to_string();
         let new_weight = NodeType::Operation(PackedInstruction {
@@ -7682,11 +7698,13 @@ impl DAGCircuit {
         if old_packed.op.num_qubits() != new_op.operation.num_qubits()
             || old_packed.op.num_clbits() != new_op.operation.num_clbits()
         {
-            return Err(DAGCircuitError::new_err(
-                format!(
-                    "Cannot replace node of width ({} qubits, {} clbits) with operation of mismatched width ({} qubits, {} clbits)",
-                    old_packed.op.num_qubits(), old_packed.op.num_clbits(), new_op.operation.num_qubits(), new_op.operation.num_clbits()
-                )));
+            return Err(DAGCircuitError::new_err(format!(
+                "Cannot replace node of width ({} qubits, {} clbits) with operation of mismatched width ({} qubits, {} clbits)",
+                old_packed.op.num_qubits(),
+                old_packed.op.num_clbits(),
+                new_op.operation.num_qubits(),
+                new_op.operation.num_clbits()
+            )));
         }
 
         #[cfg(feature = "cache_pygates")]
@@ -7697,7 +7715,11 @@ impl DAGCircuit {
             // The new wires must be a non-strict subset of the current wires; if they add new
             // wires, we'd not know where to cut the existing wire to insert the new dependency.
             return Err(DAGCircuitError::new_err(format!(
-                "New operation '{:?}' does not span the same wires as the old node '{:?}'. New wires: {:?}, old_wires: {:?}.", op.str(), old_packed.op.view(), new_wires, current_wires
+                "New operation '{:?}' does not span the same wires as the old node '{:?}'. New wires: {:?}, old_wires: {:?}.",
+                op.str(),
+                old_packed.op.view(),
+                new_wires,
+                current_wires
             )));
         }
         let new_op_name = new_op.operation.name().to_string();

--- a/crates/circuit/src/dag_node.rs
+++ b/crates/circuit/src/dag_node.rs
@@ -14,10 +14,10 @@ use std::hash::Hasher;
 #[cfg(feature = "cache_pygates")]
 use std::sync::OnceLock;
 
+use crate::TupleLikeArg;
 use crate::circuit_instruction::{CircuitInstruction, OperationFromPython};
 use crate::imports::QUANTUM_CIRCUIT;
 use crate::operations::{Operation, OperationRef, Param, PythonOperation};
-use crate::TupleLikeArg;
 
 use ahash::AHasher;
 use approx::relative_eq;
@@ -26,11 +26,11 @@ use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
 use numpy::IntoPyArray;
 use numpy::PyArray2;
+use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
-use pyo3::IntoPyObjectExt;
-use pyo3::{intern, PyResult};
+use pyo3::{PyResult, intern};
 
 /// Parent class for DAGOpNode, DAGInNode, and DAGOutNode.
 #[pyclass(module = "qiskit._accelerate.circuit", subclass)]
@@ -62,7 +62,7 @@ impl DAGNode {
                         Err(_) => {
                             return Err(PyValueError::new_err(
                                 "Invalid node index, must be -1 or a non-negative integer",
-                            ))
+                            ));
                         }
                     };
                     Some(NodeIndex::new(index))
@@ -187,9 +187,10 @@ impl DAGOpNode {
                     [Param::Float(float_a), Param::Float(float_b)] => {
                         relative_eq!(float_a, float_b, max_relative = 1e-10)
                     }
-                    [Param::ParameterExpression(param_a), Param::ParameterExpression(param_b)] => {
-                        param_a == param_b
-                    }
+                    [
+                        Param::ParameterExpression(param_a),
+                        Param::ParameterExpression(param_b),
+                    ] => param_a == param_b,
                     [Param::Obj(param_a), Param::Obj(param_b)] => param_a.bind(py).eq(param_b)?,
                     _ => false,
                 };

--- a/crates/circuit/src/dot_utils.rs
+++ b/crates/circuit/src/dot_utils.rs
@@ -19,8 +19,8 @@ use std::collections::BTreeMap;
 use std::io::prelude::*;
 
 use crate::dag_circuit::{DAGCircuit, Wire};
-use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
+use pyo3::prelude::*;
 use rustworkx_core::petgraph::visit::{
     EdgeRef, IntoEdgeReferences, IntoNodeReferences, NodeIndexable, NodeRef,
 };

--- a/crates/circuit/src/duration.rs
+++ b/crates/circuit/src/duration.rs
@@ -10,9 +10,9 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
 use pyo3::PyTypeInfo;
+use pyo3::prelude::*;
 
 /// A length of time used to express circuit timing.
 ///

--- a/crates/circuit/src/gate_matrix.rs
+++ b/crates/circuit/src/gate_matrix.rs
@@ -14,8 +14,8 @@ use num_complex::Complex64;
 use std::f64::consts::FRAC_1_SQRT_2;
 
 use crate::util::{
-    c64, GateArray0Q, GateArray1Q, GateArray2Q, GateArray3Q, GateArray4Q, C_M_ONE, C_ONE, C_ZERO,
-    IM, M_IM,
+    C_M_ONE, C_ONE, C_ZERO, GateArray0Q, GateArray1Q, GateArray2Q, GateArray3Q, GateArray4Q, IM,
+    M_IM, c64,
 };
 
 pub static ONE_QUBIT_IDENTITY: GateArray1Q = [[C_ONE, C_ZERO], [C_ZERO, C_ONE]];

--- a/crates/circuit/src/imports.rs
+++ b/crates/circuit/src/imports.rs
@@ -17,7 +17,7 @@
 use pyo3::prelude::*;
 use pyo3::sync::PyOnceLock;
 
-use crate::operations::{StandardGate, STANDARD_GATE_SIZE};
+use crate::operations::{STANDARD_GATE_SIZE, StandardGate};
 
 /// Helper wrapper around `PyOnceLock` instances that are just intended to store a Python object
 /// that is lazily imported.

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -40,10 +40,10 @@ pub mod vf2;
 
 mod variable_mapper;
 
+use pyo3::PyTypeInfo;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PySequence, PyString, PyTuple};
-use pyo3::PyTypeInfo;
 
 #[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq, FromPyObject)]
 pub struct Qubit(pub u32);

--- a/crates/circuit/src/nlayout.rs
+++ b/crates/circuit/src/nlayout.rs
@@ -10,9 +10,9 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use pyo3::IntoPyObjectExt;
 use pyo3::prelude::*;
 use pyo3::types::PyList;
-use pyo3::IntoPyObjectExt;
 
 use hashbrown::HashMap;
 

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -16,18 +16,18 @@ use std::sync::Arc;
 use std::{fmt, vec};
 
 use crate::circuit_data::CircuitData;
-use crate::imports::{get_std_gate_class, BARRIER, DELAY, MEASURE, RESET};
+use crate::imports::{BARRIER, DELAY, MEASURE, RESET, get_std_gate_class};
 use crate::imports::{DEEPCOPY, QUANTUM_CIRCUIT, UNITARY_GATE};
 use crate::parameter::parameter_expression::{
     ParameterExpression, PyParameter, PyParameterExpression,
 };
 use crate::parameter::symbol_expr::{Symbol, Value};
-use crate::{gate_matrix, impl_intopyobject_for_copy_pyclass, Qubit};
+use crate::{Qubit, gate_matrix, impl_intopyobject_for_copy_pyclass};
 
 use nalgebra::{Matrix2, Matrix4};
-use ndarray::{array, aview2, Array2, ArrayView2, Dim, ShapeBuilder};
+use ndarray::{Array2, ArrayView2, Dim, ShapeBuilder, array, aview2};
 use num_complex::Complex64;
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 
 use numpy::IntoPyArray;
 use numpy::PyArray2;
@@ -36,7 +36,7 @@ use numpy::ToPyArray;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyDict, PyFloat, PyList, PyTuple};
-use pyo3::{intern, IntoPyObjectExt, Python};
+use pyo3::{IntoPyObjectExt, Python, intern};
 
 #[derive(Clone, Debug)]
 pub enum Param {
@@ -1130,9 +1130,12 @@ impl Operation for StandardGate {
                 _ => None,
             },
             Self::CU => match params {
-                [Param::Float(theta), Param::Float(phi), Param::Float(lam), Param::Float(gamma)] => {
-                    Some(aview2(&gate_matrix::cu_gate(*theta, *phi, *lam, *gamma)).to_owned())
-                }
+                [
+                    Param::Float(theta),
+                    Param::Float(phi),
+                    Param::Float(lam),
+                    Param::Float(gamma),
+                ] => Some(aview2(&gate_matrix::cu_gate(*theta, *phi, *lam, *gamma)).to_owned()),
                 _ => None,
             },
             Self::CU1 => match params[0] {
@@ -2423,7 +2426,10 @@ pub fn radd_param(param1: Param, param2: Param) -> Param {
         [Param::Float(theta), Param::Float(lambda)] => Param::Float(theta + lambda),
         [Param::Float(theta), Param::ParameterExpression(_lambda)] => add_param(&param2, *theta),
         [Param::ParameterExpression(_theta), Param::Float(lambda)] => add_param(&param1, *lambda),
-        [Param::ParameterExpression(theta), Param::ParameterExpression(lambda)] => {
+        [
+            Param::ParameterExpression(theta),
+            Param::ParameterExpression(lambda),
+        ] => {
             // TODO we could properly propagate the error here
             Param::ParameterExpression(Arc::new(
                 theta.add(lambda).expect("Name conflict during add."),

--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -21,7 +21,7 @@ use num_complex::Complex64;
 use smallvec::SmallVec;
 
 use crate::circuit_data::CircuitData;
-use crate::imports::{get_std_gate_class, BARRIER, DELAY, MEASURE, RESET, UNITARY_GATE};
+use crate::imports::{BARRIER, DELAY, MEASURE, RESET, UNITARY_GATE, get_std_gate_class};
 use crate::interner::Interned;
 use crate::operations::{
     Operation, OperationRef, Param, PyGate, PyInstruction, PyOperation, PythonOperation,
@@ -460,7 +460,7 @@ impl PackedOperation {
                 return get_std_gate_class(py, standard)?
                     .bind(py)
                     .downcast::<PyType>()?
-                    .is_subclass(py_type)
+                    .is_subclass(py_type);
             }
             OperationRef::StandardInstruction(standard) => {
                 return match standard {
@@ -480,7 +480,7 @@ impl PackedOperation {
                         .get_bound(py)
                         .downcast::<PyType>()?
                         .is_subclass(py_type),
-                }
+                };
             }
             OperationRef::Gate(gate) => gate.gate.bind(py),
             OperationRef::Instruction(instruction) => instruction.instruction.bind(py),

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -24,8 +24,8 @@ use std::collections::hash_map::DefaultHasher;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
-use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
+use pyo3::prelude::*;
 
 use crate::circuit_data::CircuitError;
 use crate::imports::{BUILTIN_HASH, SYMPIFY_PARAMETER_EXPRESSION, UUID};
@@ -33,7 +33,7 @@ use crate::parameter::symbol_expr;
 use crate::parameter::symbol_expr::SymbolExpr;
 use crate::parameter::symbol_parser::parse_expression;
 
-use super::symbol_expr::{Symbol, Value, SYMEXPR_EPSILON};
+use super::symbol_expr::{SYMEXPR_EPSILON, Symbol, Value};
 
 /// Errors for dealing with parameters and parameter expressions.
 #[derive(Error, Debug)]

--- a/crates/circuit/src/parameter/symbol_expr.rs
+++ b/crates/circuit/src/parameter/symbol_expr.rs
@@ -11,9 +11,9 @@
 // that they have been altered from the originals.
 
 use hashbrown::HashMap;
+use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyTypeError;
 use pyo3::exceptions::PyValueError;
-use pyo3::IntoPyObjectExt;
 use std::cmp::Ordering;
 use std::cmp::PartialOrd;
 use std::convert::From;
@@ -1127,19 +1127,19 @@ impl SymbolExpr {
                                             return match t.mul_opt(l_rhs, recursive) {
                                                 Some(e) => Some(e),
                                                 None => Some(_mul(t, l_rhs.as_ref().clone())),
-                                            }
+                                            };
                                         }
                                         (BinaryOp::Div, BinaryOp::Div) => {
                                             return match t.div_opt(l_rhs, recursive) {
                                                 Some(e) => Some(e),
                                                 None => Some(_div(t, l_rhs.as_ref().clone())),
-                                            }
+                                            };
                                         }
                                         (BinaryOp::Pow, BinaryOp::Pow) => {
                                             return match t.pow_opt(l_rhs) {
                                                 Some(e) => Some(e),
                                                 None => Some(_pow(t, l_rhs.as_ref().clone())),
-                                            }
+                                            };
                                         }
                                         (_, _) => (),
                                     }
@@ -1492,19 +1492,19 @@ impl SymbolExpr {
                                             return match t.mul_opt(l_rhs, recursive) {
                                                 Some(e) => Some(e),
                                                 None => Some(_mul(t, l_rhs.as_ref().clone())),
-                                            }
+                                            };
                                         }
                                         (BinaryOp::Div, BinaryOp::Div) => {
                                             return match t.div_opt(l_rhs, recursive) {
                                                 Some(e) => Some(e),
                                                 None => Some(_div(t, l_rhs.as_ref().clone())),
-                                            }
+                                            };
                                         }
                                         (BinaryOp::Pow, BinaryOp::Pow) => {
                                             return match t.pow_opt(l_rhs) {
                                                 Some(e) => Some(e),
                                                 None => Some(_pow(t, l_rhs.as_ref().clone())),
-                                            }
+                                            };
                                         }
                                         (_, _) => (),
                                     }

--- a/crates/circuit/src/parameter/symbol_parser.rs
+++ b/crates/circuit/src/parameter/symbol_parser.rs
@@ -13,16 +13,16 @@
 //! Parser for equation strings to generate symbolic expression
 use std::sync::Arc;
 
+use nom::IResult;
+use nom::Parser;
 use nom::branch::{alt, permutation};
 use nom::bytes::complete::tag;
 use nom::character::complete::{char, digit1, multispace0};
 use nom::combinator::{all_consuming, map_res, opt, recognize};
-use nom::error::{convert_error, VerboseError};
+use nom::error::{VerboseError, convert_error};
 use nom::multi::{many0, many0_count};
 use nom::number::complete::double;
 use nom::sequence::{delimited, pair, tuple};
-use nom::IResult;
-use nom::Parser;
 
 use num_complex::c64;
 

--- a/crates/circuit/src/vf2.rs
+++ b/crates/circuit/src/vf2.rs
@@ -27,7 +27,7 @@ use std::iter::Iterator;
 use std::marker;
 use std::num::NonZero;
 
-use hashbrown::{hash_map::Entry, HashMap};
+use hashbrown::{HashMap, hash_map::Entry};
 use indexmap::IndexMap;
 use smallvec::SmallVec;
 
@@ -42,6 +42,7 @@ use rustworkx_core::petgraph::{Direction, Graph, Incoming, Outgoing};
 mod alias {
     use std::hash::Hash;
 
+    use rustworkx_core::petgraph::Direction;
     use rustworkx_core::petgraph::data::DataMap;
     use rustworkx_core::petgraph::graph::IndexType;
     use rustworkx_core::petgraph::visit::{
@@ -49,7 +50,6 @@ mod alias {
         IntoEdgesDirected, IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers,
         NodeCompactIndexable, NodeCount, NodeIndexable,
     };
-    use rustworkx_core::petgraph::Direction;
 
     pub trait IntoVf2Graph:
         GraphBase<NodeId: Hash + Eq + 'static, EdgeId: 'static>
@@ -87,11 +87,7 @@ mod alias {
     where
         Self: 'a,
     {
-        type EdgeRef: EdgeRef<
-            NodeId = Self::NodeId,
-            EdgeId = Self::EdgeId,
-            Weight = Self::EdgeWeight,
-        >;
+        type EdgeRef: EdgeRef<NodeId = Self::NodeId, EdgeId = Self::EdgeId, Weight = Self::EdgeWeight>;
         type EdgeReferences: Iterator<Item = Self::EdgeRef>;
         type EdgesDirected: Iterator<Item = Self::EdgeRef>;
         type Neighbors: Iterator<Item = Self::NodeId>;
@@ -756,10 +752,10 @@ where
     where
         Scorer<NS>: Semantics<N::NodeWeight, H::NodeWeight>,
         Scorer<ES>: Semantics<
-            N::EdgeWeight,
-            H::EdgeWeight,
-            Score = <Scorer<NS> as Semantics<N::NodeWeight, H::NodeWeight>>::Score,
-        >,
+                N::EdgeWeight,
+                H::EdgeWeight,
+                Score = <Scorer<NS> as Semantics<N::NodeWeight, H::NodeWeight>>::Score,
+            >,
     {
         Vf2 {
             needle: self.needle,

--- a/crates/circuit_library/src/blocks.rs
+++ b/crates/circuit_library/src/blocks.rs
@@ -21,7 +21,7 @@ use qiskit_circuit::{
 };
 use smallvec::SmallVec;
 
-use crate::{entanglement::get_entanglement, QiskitError};
+use crate::{QiskitError, entanglement::get_entanglement};
 
 #[derive(Debug, Clone)]
 pub enum BlockOperation {

--- a/crates/circuit_library/src/entanglement.rs
+++ b/crates/circuit_library/src/entanglement.rs
@@ -14,8 +14,8 @@ use itertools::Itertools;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use pyo3::{
-    types::{PyAnyMethods, PyList, PyListMethods, PyString, PyTuple},
     Bound, PyAny, PyResult,
+    types::{PyAnyMethods, PyList, PyListMethods, PyString, PyTuple},
 };
 
 use crate::QiskitError;

--- a/crates/circuit_library/src/iqp.rs
+++ b/crates/circuit_library/src/iqp.rs
@@ -16,13 +16,13 @@ use ndarray::{Array2, ArrayView2};
 use numpy::PyReadonlyArray2;
 use pyo3::prelude::*;
 use qiskit_circuit::{
+    Qubit,
     circuit_data::CircuitData,
     operations::{Param, StandardGate},
-    Qubit,
 };
 use rand::{Rng, SeedableRng};
 use rand_pcg::Pcg64Mcg;
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 
 use crate::CircuitError;
 

--- a/crates/circuit_library/src/multi_local.rs
+++ b/crates/circuit_library/src/multi_local.rs
@@ -16,7 +16,7 @@ use hashbrown::HashSet;
 use pyo3::prelude::*;
 use pyo3::types::PyString;
 use qiskit_circuit::packed_instruction::PackedOperation;
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::operations::{Param, StandardInstruction};

--- a/crates/circuit_library/src/pauli_evolution.rs
+++ b/crates/circuit_library/src/pauli_evolution.rs
@@ -15,10 +15,10 @@ use pyo3::{intern, prelude::*};
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
 use qiskit_circuit::operations;
-use qiskit_circuit::operations::{multiply_param, radd_param, Param, StandardGate};
+use qiskit_circuit::operations::{Param, StandardGate, multiply_param, radd_param};
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::{Clbit, Qubit};
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 
 // custom type for a more readable code
 type Instruction = (

--- a/crates/circuit_library/src/pauli_feature_map.rs
+++ b/crates/circuit_library/src/pauli_feature_map.rs
@@ -15,16 +15,16 @@ use pyo3::types::PySequence;
 use pyo3::types::PyString;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::operations::{
-    add_param, multiply_param, multiply_params, Param, StandardGate, StandardInstruction,
+    Param, StandardGate, StandardInstruction, add_param, multiply_param, multiply_params,
 };
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::{Clbit, Qubit};
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 use std::f64::consts::PI;
 
+use crate::QiskitError;
 use crate::entanglement;
 use crate::pauli_evolution;
-use crate::QiskitError;
 
 type Instruction = (
     PackedOperation,

--- a/crates/circuit_library/src/quantum_volume.rs
+++ b/crates/circuit_library/src/quantum_volume.rs
@@ -26,7 +26,7 @@ use qiskit_circuit::getenv_use_multiple_threads;
 use qiskit_circuit::operations::{ArrayType, Param, UnitaryGate};
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::{Clbit, Qubit};
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 
 type Instruction = (
     PackedOperation,

--- a/crates/qasm2/src/lex.rs
+++ b/crates/qasm2/src/lex.rs
@@ -29,7 +29,7 @@ use pyo3::prelude::PyResult;
 
 use std::path::Path;
 
-use crate::error::{message_generic, Position, QASM2ParseError};
+use crate::error::{Position, QASM2ParseError, message_generic};
 
 /// Tokenized version information data.  This is more structured than the real number suggested by
 /// the specification.
@@ -557,7 +557,7 @@ impl TokenStream {
                     )))
                 } else {
                     self.lex_float_exponent(start_col)
-                }
+                };
             }
             _ => (),
         }
@@ -591,8 +591,9 @@ impl TokenStream {
                 b"OPENQASM" => Ok(TokenType::OpenQASM),
                 b"U" | b"CX" => Ok(TokenType::Id),
                 _ => Err(QASM2ParseError::new_err(message_generic(
-                        Some(&Position::new(&self.filename, self.line, start_col)),
-                        "identifiers cannot start with capital letters except for the builtins 'U' and 'CX'"))),
+                    Some(&Position::new(&self.filename, self.line, start_col)),
+                    "identifiers cannot start with capital letters except for the builtins 'U' and 'CX'",
+                ))),
             }
         } else {
             match text {
@@ -626,13 +627,13 @@ impl TokenStream {
                     return Err(QASM2ParseError::new_err(message_generic(
                         Some(&Position::new(&self.filename, self.line, start_col)),
                         "unexpected end-of-file while lexing string literal",
-                    )))
+                    )));
                 }
                 Some(b'\n' | b'\r') => {
                     return Err(QASM2ParseError::new_err(message_generic(
                         Some(&Position::new(&self.filename, self.line, start_col)),
                         "unexpected line break while lexing string literal",
-                    )))
+                    )));
                 }
                 Some(c) if c == terminator => {
                     return Ok(TokenType::Filename);

--- a/crates/qasm2/src/lib.rs
+++ b/crates/qasm2/src/lib.rs
@@ -10,8 +10,8 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use pyo3::prelude::*;
 use pyo3::Python;
+use pyo3::prelude::*;
 
 use crate::error::QASM2ParseError;
 

--- a/crates/qasm2/src/parse.rs
+++ b/crates/qasm2/src/parse.rs
@@ -21,7 +21,7 @@ use pyo3::prelude::*;
 
 use crate::bytecode::InternalBytecode;
 use crate::error::{
-    message_bad_eof, message_generic, message_incorrect_requirement, Position, QASM2ParseError,
+    Position, QASM2ParseError, message_bad_eof, message_generic, message_incorrect_requirement,
 };
 use crate::expr::{Expr, ExprParser};
 use crate::lex::{Token, TokenContext, TokenStream, TokenType, Version};
@@ -401,7 +401,7 @@ impl State {
                         cause.col,
                     )),
                     required,
-                )))
+                )));
             }
             Some(token) => token,
         };
@@ -473,7 +473,7 @@ impl State {
                         name,
                         symbol.describe()
                     ),
-                )))
+                )));
             }
             None => {
                 return Err(QASM2ParseError::new_err(message_generic(
@@ -483,7 +483,7 @@ impl State {
                         name_token.col,
                     )),
                     &format!("'{name}' is not defined in this scope"),
-                )))
+                )));
             }
         };
         self.complete_operand(&name, register_size, register_start)
@@ -578,7 +578,7 @@ impl State {
                         name,
                         symbol.describe()
                     ),
-                )))
+                )));
             }
             None => {
                 return Err(QASM2ParseError::new_err(message_generic(
@@ -588,7 +588,7 @@ impl State {
                         name_token.col,
                     )),
                     &format!("'{name}' is not defined in this scope"),
-                )))
+                )));
             }
         };
         self.complete_operand(&name, register_size, register_start)
@@ -811,7 +811,7 @@ impl State {
                             lbrace_token.col,
                         )),
                         "a closing brace '}' of the gate body",
-                    )))
+                    )));
                 }
             }
         }
@@ -1038,7 +1038,7 @@ impl State {
                                 lparen_token.col,
                             )),
                             "non-constant expression in program body",
-                        )))
+                        )));
                     }
                 }
                 seen_params += 1;

--- a/crates/qasm3/src/exporter.rs
+++ b/crates/qasm3/src/exporter.rs
@@ -25,8 +25,8 @@ use std::io::Write;
 use crate::printer::BasicPrinter;
 use hashbrown::{HashMap, HashSet};
 use indexmap::IndexMap;
-use pyo3::prelude::*;
 use pyo3::Python;
+use pyo3::prelude::*;
 use qiskit_circuit::bit::{
     ClassicalRegister, QuantumRegister, Register, ShareableClbit, ShareableQubit,
 };

--- a/crates/qasm3/src/expr.rs
+++ b/crates/qasm3/src/expr.rs
@@ -10,9 +10,9 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use pyo3::IntoPyObjectExt;
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
-use pyo3::IntoPyObjectExt;
 
 use hashbrown::HashMap;
 

--- a/crates/qasm3/src/lib.rs
+++ b/crates/qasm3/src/lib.rs
@@ -67,11 +67,13 @@ pub fn loads(
 ) -> PyResult<circuit::PyCircuit> {
     let default_include_path = || -> PyResult<Vec<OsString>> {
         let filename: PyBackedStr = py.import("qiskit")?.filename()?.try_into()?;
-        Ok(vec![Path::new(filename.deref())
-            .parent()
-            .unwrap()
-            .join(["qasm", "libs", "dummy"].iter().collect::<PathBuf>())
-            .into_os_string()])
+        Ok(vec![
+            Path::new(filename.deref())
+                .parent()
+                .unwrap()
+                .join(["qasm", "libs", "dummy"].iter().collect::<PathBuf>())
+                .into_os_string(),
+        ])
     };
     let include_path = include_path.map(Ok).unwrap_or_else(default_include_path)?;
     let result = parse_source_string(source, None, Some(&include_path));

--- a/crates/qasm3/src/printer.rs
+++ b/crates/qasm3/src/printer.rs
@@ -18,10 +18,10 @@ use crate::ast::{
     Alias, Assignment, Barrier, Binary, BinaryOp, BitArray, BooleanLiteral, Cast,
     ClassicalDeclaration, ClassicalType, Constant, Delay, DurationLiteral, Expression, Float,
     GateCall, Header, Identifier, IdentifierOrSubscripted, Include, Index, IndexSet, Int,
-    IntegerLiteral, Node, Parameter, Program, ProgramBlock, QuantumBlock, QuantumDeclaration,
+    IntegerLiteral, Node, OP, Parameter, Program, ProgramBlock, QuantumBlock, QuantumDeclaration,
     QuantumGateDefinition, QuantumGateModifier, QuantumGateModifierName, QuantumGateSignature,
     QuantumInstruction, QuantumMeasurement, QuantumMeasurementAssignment, Range, Reset, Statement,
-    SubscriptedIdentifier, Uint, Unary, UnaryOp, Version, OP,
+    SubscriptedIdentifier, Uint, Unary, UnaryOp, Version,
 };
 
 #[derive(Debug)]

--- a/crates/quantum_info/src/clifford.rs
+++ b/crates/quantum_info/src/clifford.rs
@@ -11,7 +11,7 @@
 // that they have been altered from the originals.
 use std::fmt;
 
-use ndarray::{azip, s, Array2};
+use ndarray::{Array2, azip, s};
 
 /// Symplectic matrix.
 pub struct SymplecticMatrix {

--- a/crates/quantum_info/src/convert_2q_block_matrix.rs
+++ b/crates/quantum_info/src/convert_2q_block_matrix.rs
@@ -10,25 +10,25 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use pyo3::Python;
 use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::Python;
 
 use num_complex::Complex64;
-use numpy::ndarray::{arr2, aview2, Array2, ArrayView2, ArrayViewMut2};
 use numpy::PyReadonlyArray2;
+use numpy::ndarray::{Array2, ArrayView2, ArrayViewMut2, arr2, aview2};
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
+use qiskit_circuit::Qubit;
 use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_circuit::gate_matrix::TWO_QUBIT_IDENTITY;
 use qiskit_circuit::imports::QI_OPERATOR;
 use qiskit_circuit::interner::Interner;
 use qiskit_circuit::operations::{ArrayType, Operation, OperationRef};
 use qiskit_circuit::packed_instruction::PackedInstruction;
-use qiskit_circuit::Qubit;
 
-use crate::versor_u2::{VersorSU2, VersorU2, VersorU2Error};
 use crate::QiskitError;
+use crate::versor_u2::{VersorSU2, VersorU2, VersorU2Error};
 
 #[inline]
 pub fn get_matrix_from_inst(inst: &PackedInstruction) -> PyResult<Array2<Complex64>> {

--- a/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -13,11 +13,11 @@
 use hashbrown::HashSet;
 use numpy::{PyArray1, PyArrayMethods, ToPyArray};
 use pyo3::{
+    IntoPyObjectExt, PyErr,
     exceptions::{PyTypeError, PyValueError},
     intern,
     prelude::*,
     types::{PyList, PyString, PyTuple, PyType},
-    IntoPyObjectExt, PyErr,
 };
 use std::{
     collections::btree_map,
@@ -31,9 +31,9 @@ use rand_pcg::Pcg64Mcg;
 use qiskit_circuit::slice::{PySequenceIndex, SequenceIndex};
 
 use super::qubit_sparse_pauli::{
-    raw_parts_from_sparse_list, ArithmeticError, CoherenceError, InnerReadError, InnerWriteError,
-    LabelError, Pauli, PyQubitSparsePauli, PyQubitSparsePauliList, QubitSparsePauli,
-    QubitSparsePauliList, QubitSparsePauliView,
+    ArithmeticError, CoherenceError, InnerReadError, InnerWriteError, LabelError, Pauli,
+    PyQubitSparsePauli, PyQubitSparsePauliList, QubitSparsePauli, QubitSparsePauliList,
+    QubitSparsePauliView, raw_parts_from_sparse_list,
 };
 
 /// A Pauli Lindblad map that stores its data in a qubit-sparse format. Note that gamma,
@@ -1575,7 +1575,7 @@ impl PyPauliLindbladMap {
         for non_negative in inner.non_negative_rates.iter() {
             if !non_negative {
                 return Err(PyValueError::new_err(
-                    "PauliLindbladMap.sample called for a map with negative rates. Use PauliLindbladMap.signed_sample"
+                    "PauliLindbladMap.sample called for a map with negative rates. Use PauliLindbladMap.signed_sample",
                 ));
             }
         }
@@ -1710,7 +1710,7 @@ impl PyPauliLindbladMap {
                 return PyGeneratorTerm {
                     inner: inner.term(index).to_term(),
                 }
-                .into_bound_py_any(py)
+                .into_bound_py_any(py);
             }
             indices => indices,
         };

--- a/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
@@ -12,11 +12,11 @@
 
 use numpy::{PyArray1, PyArrayMethods, PyReadonlyArray1};
 use pyo3::{
+    IntoPyObjectExt, PyErr,
     exceptions::{PyTypeError, PyValueError},
     intern,
     prelude::*,
     types::{PyInt, PyList, PyString, PyTuple, PyType},
-    IntoPyObjectExt, PyErr,
 };
 use std::{
     collections::btree_map,
@@ -26,9 +26,9 @@ use std::{
 use qiskit_circuit::slice::{PySequenceIndex, SequenceIndex};
 
 use super::qubit_sparse_pauli::{
-    raw_parts_from_sparse_list, ArithmeticError, CoherenceError, InnerReadError, InnerWriteError,
-    LabelError, Pauli, PyQubitSparsePauli, QubitSparsePauli, QubitSparsePauliList,
-    QubitSparsePauliView,
+    ArithmeticError, CoherenceError, InnerReadError, InnerWriteError, LabelError, Pauli,
+    PyQubitSparsePauli, QubitSparsePauli, QubitSparsePauliList, QubitSparsePauliView,
+    raw_parts_from_sparse_list,
 };
 use crate::imports;
 
@@ -1521,7 +1521,7 @@ impl PyPhasedQubitSparsePauliList {
                 return PyPhasedQubitSparsePauli {
                     inner: inner.term(index).to_term(),
                 }
-                .into_bound_py_any(py)
+                .into_bound_py_any(py);
             }
             indices => indices,
         };

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -15,12 +15,12 @@ use hashbrown::HashSet;
 use ndarray::Array2;
 use numpy::{IntoPyArray, PyArray1, PyArray2, PyArrayMethods, PyReadonlyArray1};
 use pyo3::{
+    IntoPyObjectExt, PyErr,
     exceptions::{PyRuntimeError, PyTypeError, PyValueError},
     intern,
     prelude::*,
     sync::PyOnceLock,
     types::{IntoPyDict, PyList, PyString, PyTuple, PyType},
-    IntoPyObjectExt, PyErr,
 };
 use std::{
     collections::btree_map,
@@ -169,7 +169,9 @@ pub enum CoherenceError {
     MismatchedItemCount { paulis: usize, indices: usize },
     #[error("the first item of `boundaries` ({0}) must be 0")]
     BadInitialBoundary(usize),
-    #[error("the last item of `boundaries` ({last}) must match the length of `paulis` and `indices` ({items})")]
+    #[error(
+        "the last item of `boundaries` ({last}) must match the length of `paulis` and `indices` ({items})"
+    )]
     BadFinalBoundary { last: usize, items: usize },
     #[error("all qubit indices must be less than the number of qubits")]
     BitIndexTooHigh,
@@ -2190,7 +2192,7 @@ impl PyQubitSparsePauliList {
                 return PyQubitSparsePauli {
                     inner: inner.term(index).to_term(),
                 }
-                .into_bound_py_any(py)
+                .into_bound_py_any(py);
             }
             indices => indices,
         };

--- a/crates/quantum_info/src/sparse_observable/mod.rs
+++ b/crates/quantum_info/src/sparse_observable/mod.rs
@@ -23,12 +23,12 @@ use numpy::{
     PyReadonlyArray1, PyReadonlyArray2, PyUntypedArrayMethods,
 };
 use pyo3::{
+    IntoPyObjectExt, PyErr,
     exceptions::{PyRuntimeError, PyTypeError, PyValueError, PyZeroDivisionError},
     intern,
     prelude::*,
     sync::PyOnceLock,
     types::{IntoPyDict, PyList, PyString, PyTuple, PyType},
-    IntoPyObjectExt, PyErr,
 };
 use std::{
     cmp::Ordering,
@@ -243,7 +243,9 @@ pub enum CoherenceError {
     MismatchedItemCount { bit_terms: usize, indices: usize },
     #[error("the first item of `boundaries` ({0}) must be 0")]
     BadInitialBoundary(usize),
-    #[error("the last item of `boundaries` ({last}) must match the length of `bit_terms` and `indices` ({items})")]
+    #[error(
+        "the last item of `boundaries` ({last}) must match the length of `bit_terms` and `indices` ({items})"
+    )]
     BadFinalBoundary { last: usize, items: usize },
     #[error("all qubit indices must be less than the number of qubits")]
     BitIndexTooHigh,
@@ -3604,7 +3606,7 @@ impl PySparseObservable {
                 return PySparseTerm {
                     inner: inner.term(index).to_term(),
                 }
-                .into_bound_py_any(py)
+                .into_bound_py_any(py);
             }
             indices => indices,
         };

--- a/crates/quantum_info/src/sparse_pauli_op.rs
+++ b/crates/quantum_info/src/sparse_pauli_op.rs
@@ -11,24 +11,24 @@
 // that they have been altered from the originals.
 
 use ahash::RandomState;
+use pyo3::Python;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
 use pyo3::wrap_pyfunction;
-use pyo3::Python;
 
 use numpy::prelude::*;
 use numpy::{PyArray1, PyArray2, PyReadonlyArray1, PyReadonlyArray2, PyUntypedArrayMethods};
 
 use hashbrown::HashMap;
 use indexmap::IndexMap;
-use ndarray::{s, ArrayView1, ArrayView2, Axis};
+use ndarray::{ArrayView1, ArrayView2, Axis, s};
 use num_complex::Complex64;
 use num_traits::Zero;
 use rayon::prelude::*;
 use thiserror::Error;
 
-use qiskit_circuit::util::{c64, C_ZERO};
+use qiskit_circuit::util::{C_ZERO, c64};
 
 use crate::rayon_ext::*;
 
@@ -1268,7 +1268,7 @@ pub fn sparse_pauli_op(m: &Bound<PyModule>) -> PyResult<()> {
 
 #[cfg(test)]
 mod tests {
-    use ndarray::{aview2, Array1};
+    use ndarray::{Array1, aview2};
 
     use super::*;
     use crate::test::*;

--- a/crates/quantum_info/src/unitary_sim.rs
+++ b/crates/quantum_info/src/unitary_sim.rs
@@ -17,7 +17,7 @@ use pyo3::prelude::*;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::operations::{Operation, OperationRef, Param, StandardInstruction};
 
-use crate::{unitary_compose, QiskitError};
+use crate::{QiskitError, unitary_compose};
 
 // The code is based on top of unitary_compose. For circuits with 13 or more qubits, einsum
 // throws an "index out of bounds" error.
@@ -33,7 +33,7 @@ pub fn sim_unitary_circuit(circuit: &CircuitData) -> Result<Array2<Complex64>, S
 
     if num_qubits > MAX_NUM_QUBITS {
         return Err(format!(
-            "The number of circuit qubits ({num_qubits}) exceeds the maximum allowed number of qubits allowed for simulation ({MAX_NUM_QUBITS})."  
+            "The number of circuit qubits ({num_qubits}) exceeds the maximum allowed number of qubits allowed for simulation ({MAX_NUM_QUBITS})."
         ));
     }
 

--- a/crates/quantum_info/src/versor_u2.rs
+++ b/crates/quantum_info/src/versor_u2.rs
@@ -480,7 +480,7 @@ mod test {
 
     use approx::AbsDiffEq;
     use ndarray::aview2;
-    use qiskit_circuit::operations::{Operation, Param, StandardGate, STANDARD_GATE_SIZE};
+    use qiskit_circuit::operations::{Operation, Param, STANDARD_GATE_SIZE, StandardGate};
 
     #[cfg(not(miri))]
     const ATOL: f64 = 1e-15;

--- a/crates/synthesis/src/clifford/bm_synthesis.rs
+++ b/crates/synthesis/src/clifford/bm_synthesis.rs
@@ -12,9 +12,9 @@
 
 use crate::clifford::utils::CliffordGatesVec;
 use itertools::iproduct;
-use ndarray::{arr1, arr2, s, ArrayView2};
-use qiskit_circuit::operations::StandardGate;
+use ndarray::{ArrayView2, arr1, arr2, s};
 use qiskit_circuit::Qubit;
+use qiskit_circuit::operations::StandardGate;
 use qiskit_quantum_info::clifford::Clifford;
 use smallvec::smallvec;
 
@@ -43,11 +43,7 @@ fn cx_cost2(clifford: &Clifford) -> usize {
         clifford.tableau[[2, 1]],
         clifford.tableau[[2, 3]],
     );
-    if r00 == 2 {
-        r01
-    } else {
-        r01 + 1 - r00
-    }
+    if r00 == 2 { r01 } else { r01 + 1 - r00 }
 }
 
 /// Return the rank of a 2x2 boolean matrix.

--- a/crates/synthesis/src/clifford/greedy_synthesis.rs
+++ b/crates/synthesis/src/clifford/greedy_synthesis.rs
@@ -12,15 +12,15 @@
 
 use ahash::RandomState;
 use indexmap::IndexSet;
-use ndarray::{s, ArrayView2};
+use ndarray::{ArrayView2, s};
 use smallvec::smallvec;
 
 use crate::clifford::utils::{
-    adjust_final_pauli_gates, clifford_from_gate_sequence, CliffordGatesVec, SymplecticMatrix,
+    CliffordGatesVec, SymplecticMatrix, adjust_final_pauli_gates, clifford_from_gate_sequence,
 };
 
-use qiskit_circuit::operations::StandardGate;
 use qiskit_circuit::Qubit;
+use qiskit_circuit::operations::StandardGate;
 
 /// Converts a pair of Paulis pauli_x and pauli_z acting on a specific qubit
 /// to the corresponding index in [PauliPairsClass] or [SingleQubitGate] classes.

--- a/crates/synthesis/src/clifford/mod.rs
+++ b/crates/synthesis/src/clifford/mod.rs
@@ -15,9 +15,9 @@ pub(crate) mod greedy_synthesis;
 mod random_clifford;
 pub(crate) mod utils;
 
+use crate::QiskitError;
 use crate::clifford::bm_synthesis::synth_clifford_bm_inner;
 use crate::clifford::greedy_synthesis::GreedyCliffordSynthesis;
-use crate::QiskitError;
 use numpy::{IntoPyArray, PyArray2, PyReadonlyArray2};
 use pyo3::prelude::*;
 use qiskit_circuit::circuit_data::CircuitData;

--- a/crates/synthesis/src/clifford/random_clifford.rs
+++ b/crates/synthesis/src/clifford/random_clifford.rs
@@ -13,7 +13,7 @@
 use crate::linear::utils::{
     binary_matmul_inner, calc_inverse_matrix_inner, replace_row_inner, swap_rows_inner,
 };
-use ndarray::{concatenate, s, Array1, Array2, ArrayView2, ArrayViewMut2, Axis};
+use ndarray::{Array1, Array2, ArrayView2, ArrayViewMut2, Axis, concatenate, s};
 use rand::{Rng, SeedableRng};
 use rand_pcg::Pcg64Mcg;
 

--- a/crates/synthesis/src/clifford/utils.rs
+++ b/crates/synthesis/src/clifford/utils.rs
@@ -11,11 +11,11 @@
 // that they have been altered from the originals.
 
 use crate::linear::utils::calc_inverse_matrix_inner;
-use ndarray::{azip, s, Array1, Array2, ArrayView2};
-use qiskit_circuit::operations::{Param, StandardGate};
+use ndarray::{Array1, Array2, ArrayView2, azip, s};
 use qiskit_circuit::Qubit;
+use qiskit_circuit::operations::{Param, StandardGate};
 use qiskit_quantum_info::clifford::Clifford;
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 
 /// Symplectic matrix.
 /// Currently this class is internal to the synthesis library.

--- a/crates/synthesis/src/discrete_basis/basic_approximations.rs
+++ b/crates/synthesis/src/discrete_basis/basic_approximations.rs
@@ -17,10 +17,10 @@ use num_traits::FloatConst;
 use numpy::{Complex64, PyReadonlyArray2};
 use pyo3::{exceptions::PyValueError, prelude::*};
 use qiskit_circuit::{
+    Qubit,
     circuit_data::CircuitData,
     circuit_instruction::OperationFromPython,
     operations::{Operation, OperationRef, Param, StandardGate},
-    Qubit,
 };
 use rstar::{Point, RTree};
 use serde::{Deserialize, Serialize};

--- a/crates/synthesis/src/discrete_basis/solovay_kitaev.rs
+++ b/crates/synthesis/src/discrete_basis/solovay_kitaev.rs
@@ -279,7 +279,7 @@ impl SolovayKitaevSynthesis {
             None => {
                 return Err(PyValueError::new_err(
                     "Failed to construct matrix representation.",
-                ))
+                ));
             }
         };
 

--- a/crates/synthesis/src/euler_one_qubit_decomposer.rs
+++ b/crates/synthesis/src/euler_one_qubit_decomposer.rs
@@ -15,17 +15,17 @@
 
 use hashbrown::HashMap;
 use num_complex::{Complex64, ComplexFloat};
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 use std::cmp::Ordering;
 use std::f64::consts::PI;
 use std::str::FromStr;
 
+use pyo3::IntoPyObjectExt;
+use pyo3::Python;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyList, PyString};
 use pyo3::wrap_pyfunction;
-use pyo3::IntoPyObjectExt;
-use pyo3::Python;
 
 use ndarray::prelude::*;
 use numpy::PyReadonlyArray2;
@@ -36,7 +36,7 @@ use qiskit_circuit::dag_node::DAGOpNode;
 use qiskit_circuit::operations::{Operation, Param, StandardGate};
 use qiskit_circuit::slice::{PySequenceIndex, SequenceIndex};
 use qiskit_circuit::util::c64;
-use qiskit_circuit::{impl_intopyobject_for_copy_pyclass, Qubit};
+use qiskit_circuit::{Qubit, impl_intopyobject_for_copy_pyclass};
 
 pub const ANGLE_ZERO_EPSILON: f64 = 1e-12;
 

--- a/crates/synthesis/src/evolution/pauli_network.rs
+++ b/crates/synthesis/src/evolution/pauli_network.rs
@@ -10,16 +10,16 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::clifford::greedy_synthesis::resynthesize_clifford_circuit;
 use crate::QiskitError;
+use crate::clifford::greedy_synthesis::resynthesize_clifford_circuit;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyList, PyString, PyTuple};
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 
-use qiskit_circuit::circuit_data::CircuitData;
-use qiskit_circuit::operations::{multiply_param, radd_param, Param, StandardGate};
 use qiskit_circuit::Qubit;
+use qiskit_circuit::circuit_data::CircuitData;
+use qiskit_circuit::operations::{Param, StandardGate, multiply_param, radd_param};
 
 use rustiq_core::structures::{
     CliffordCircuit, CliffordGate, IsometryTableau, Metric, PauliLike, PauliSet,
@@ -27,9 +27,9 @@ use rustiq_core::structures::{
 use rustiq_core::synthesis::clifford::isometry::isometry_synthesis;
 use rustiq_core::synthesis::pauli_network::greedy_pauli_network;
 
+use rustworkx_core::petgraph::Incoming;
 use rustworkx_core::petgraph::graph::NodeIndex;
 use rustworkx_core::petgraph::prelude::StableDiGraph;
-use rustworkx_core::petgraph::Incoming;
 
 /// A Qiskit gate. The quantum circuit data returned by the pauli network
 /// synthesis algorithm will consist of clifford and rotation gates.

--- a/crates/synthesis/src/linear/lnn.rs
+++ b/crates/synthesis/src/linear/lnn.rs
@@ -16,9 +16,9 @@ use numpy::PyReadonlyArray2;
 use smallvec::smallvec;
 
 use pyo3::prelude::*;
+use qiskit_circuit::Qubit;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::operations::{Param, StandardGate};
-use qiskit_circuit::Qubit;
 
 // Optimize the synthesis of an n-qubit circuit contains only CX gates for
 // linear nearest neighbor (LNN) connectivity.

--- a/crates/synthesis/src/linear/mod.rs
+++ b/crates/synthesis/src/linear/mod.rs
@@ -12,8 +12,8 @@
 
 use crate::QiskitError;
 use numpy::{IntoPyArray, PyArray2, PyReadonlyArray2, PyReadwriteArray2};
-use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
+use pyo3::prelude::*;
 
 pub mod lnn;
 mod pmh;

--- a/crates/synthesis/src/linear/pmh.rs
+++ b/crates/synthesis/src/linear/pmh.rs
@@ -11,14 +11,14 @@
 // that they have been altered from the originals.
 
 use hashbrown::HashMap;
-use ndarray::{s, Array1, Array2, ArrayViewMut2, Axis};
+use ndarray::{Array1, Array2, ArrayViewMut2, Axis, s};
 use numpy::PyReadonlyArray2;
 use smallvec::smallvec;
 use std::cmp;
 
+use qiskit_circuit::Qubit;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::operations::{Param, StandardGate};
-use qiskit_circuit::Qubit;
 
 use pyo3::prelude::*;
 
@@ -26,11 +26,7 @@ use super::utils::_add_row_or_col;
 
 /// This helper function allows transposed access to a matrix.
 fn _index(transpose: bool, i: usize, j: usize) -> (usize, usize) {
-    if transpose {
-        (j, i)
-    } else {
-        (i, j)
-    }
+    if transpose { (j, i) } else { (i, j) }
 }
 
 fn _ceil_fraction(numerator: usize, denominator: usize) -> usize {

--- a/crates/synthesis/src/linear/utils.rs
+++ b/crates/synthesis/src/linear/utils.rs
@@ -11,7 +11,7 @@
 // that they have been altered from the originals.
 
 use ndarray::{
-    azip, concatenate, s, Array1, Array2, ArrayView1, ArrayView2, ArrayViewMut2, Axis, Zip,
+    Array1, Array2, ArrayView1, ArrayView2, ArrayViewMut2, Axis, Zip, azip, concatenate, s,
 };
 use rand::{Rng, SeedableRng};
 use rand_pcg::Pcg64Mcg;

--- a/crates/synthesis/src/linear_phase/cx_cz_depth_lnn.rs
+++ b/crates/synthesis/src/linear_phase/cx_cz_depth_lnn.rs
@@ -14,15 +14,15 @@ use crate::linear::lnn::synth_cnot_lnn_instructions;
 use crate::linear::utils::calc_inverse_matrix_inner;
 
 use hashbrown::HashSet;
-use ndarray::{s, Array2, ArrayView2};
+use ndarray::{Array2, ArrayView2, s};
 use numpy::PyReadonlyArray2;
 use smallvec::smallvec;
 use std::cmp::{max, min};
 
 use pyo3::prelude::*;
+use qiskit_circuit::Qubit;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::operations::{Param, StandardGate};
-use qiskit_circuit::Qubit;
 
 enum CircuitInstructions {
     CX(u32, u32),

--- a/crates/synthesis/src/linear_phase/cz_depth_lnn.rs
+++ b/crates/synthesis/src/linear_phase/cz_depth_lnn.rs
@@ -17,10 +17,10 @@ use itertools::Itertools;
 use ndarray::{Array1, ArrayView2};
 
 use qiskit_circuit::{
-    operations::{Param, StandardGate},
     Qubit,
+    operations::{Param, StandardGate},
 };
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 
 use crate::permutation::{_append_cx_stage1, _append_cx_stage2};
 

--- a/crates/synthesis/src/linear_phase/mod.rs
+++ b/crates/synthesis/src/linear_phase/mod.rs
@@ -12,9 +12,9 @@
 
 use numpy::PyReadonlyArray2;
 use pyo3::{
-    pyfunction,
+    Bound, PyResult, pyfunction,
     types::{PyModule, PyModuleMethods},
-    wrap_pyfunction, Bound, PyResult,
+    wrap_pyfunction,
 };
 use qiskit_circuit::{circuit_data::CircuitData, operations::Param};
 mod cx_cz_depth_lnn;

--- a/crates/synthesis/src/multi_controlled/mcmt.rs
+++ b/crates/synthesis/src/multi_controlled/mcmt.rs
@@ -16,7 +16,7 @@ use qiskit_circuit::circuit_instruction::OperationFromPython;
 use qiskit_circuit::operations::{Param, StandardGate};
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::{Clbit, Qubit};
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 
 use crate::QiskitError;
 

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -16,7 +16,7 @@ use pyo3::{PyResult, Python};
 use qiskit_circuit::circuit_data::{CircuitData, CircuitError};
 use qiskit_circuit::imports;
 use qiskit_circuit::operations::{
-    multiply_param, Operation, OperationRef, Param, PyGate, StandardGate,
+    Operation, OperationRef, Param, PyGate, StandardGate, multiply_param,
 };
 use qiskit_circuit::{Clbit, Qubit, VarsMode};
 use smallvec::SmallVec;

--- a/crates/synthesis/src/permutation/mod.rs
+++ b/crates/synthesis/src/permutation/mod.rs
@@ -16,9 +16,9 @@ use smallvec::smallvec;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 
+use qiskit_circuit::Qubit;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::operations::{Param, StandardGate};
-use qiskit_circuit::Qubit;
 
 use super::linear_phase::cz_depth_lnn::LnnGatesVec;
 

--- a/crates/synthesis/src/qft/qft_decompose_lnn.rs
+++ b/crates/synthesis/src/qft/qft_decompose_lnn.rs
@@ -13,9 +13,9 @@
 use crate::linear_phase::cz_depth_lnn::LnnGatesVec;
 use crate::permutation::_append_reverse_permutation_lnn_kms;
 use pyo3::prelude::*;
+use qiskit_circuit::Qubit;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::operations::{Param, StandardGate};
-use qiskit_circuit::Qubit;
 use smallvec::smallvec;
 use std::f64::consts::PI;
 

--- a/crates/synthesis/src/qsd.rs
+++ b/crates/synthesis/src/qsd.rs
@@ -15,7 +15,7 @@ use std::sync::OnceLock;
 
 use approx::abs_diff_eq;
 use hashbrown::HashMap;
-use nalgebra::{stack, DMatrix, DMatrixView, DVector, Matrix4, QR};
+use nalgebra::{DMatrix, DMatrixView, DVector, Matrix4, QR, stack};
 use ndarray::prelude::*;
 use num_complex::Complex64;
 use numpy::PyReadonlyArray2;
@@ -24,10 +24,10 @@ use pyo3::prelude::*;
 use smallvec::smallvec;
 
 use crate::euler_one_qubit_decomposer::{
-    unitary_to_gate_sequence_inner, EulerBasis, EulerBasisSet,
+    EulerBasis, EulerBasisSet, unitary_to_gate_sequence_inner,
 };
 use crate::linalg::{closest_unitary, is_hermitian_matrix, svd_decomposition, verify_unitary};
-use crate::two_qubit_decompose::{two_qubit_decompose_up_to_diagonal, TwoQubitBasisDecomposer};
+use crate::two_qubit_decompose::{TwoQubitBasisDecomposer, two_qubit_decompose_up_to_diagonal};
 use qiskit_circuit::bit::ShareableQubit;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::interner::Interned;

--- a/crates/synthesis/src/two_qubit_decompose.rs
+++ b/crates/synthesis/src/two_qubit_decompose.rs
@@ -21,31 +21,31 @@
 use approx::{abs_diff_eq, relative_eq};
 use num_complex::{Complex, Complex64, ComplexFloat};
 use num_traits::Zero;
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 use std::f64::consts::{FRAC_1_SQRT_2, PI};
 use std::ops::Deref;
 
 use faer::Side::Lower;
-use faer::{prelude::*, Mat, MatRef, Scale};
+use faer::{Mat, MatRef, Scale, prelude::*};
 use faer_ext::{IntoFaer, IntoNdarray};
+use ndarray::Zip;
 use ndarray::linalg::kron;
 use ndarray::prelude::*;
-use ndarray::Zip;
 use numpy::{IntoPyArray, ToPyArray};
 use numpy::{PyArray2, PyArrayLike2, PyReadonlyArray1, PyReadonlyArray2};
 
+use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyValueError;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::PyType;
-use pyo3::IntoPyObjectExt;
 
-use crate::euler_one_qubit_decomposer::{
-    angles_from_unitary, det_one_qubit, unitary_to_gate_sequence_inner, EulerBasis, EulerBasisSet,
-    OneQubitGateSequence, ANGLE_ZERO_EPSILON,
-};
 use crate::QiskitError;
+use crate::euler_one_qubit_decomposer::{
+    ANGLE_ZERO_EPSILON, EulerBasis, EulerBasisSet, OneQubitGateSequence, angles_from_unitary,
+    det_one_qubit, unitary_to_gate_sequence_inner,
+};
 use qiskit_quantum_info::convert_2q_block_matrix::change_basis;
 
 use rand::prelude::*;
@@ -56,11 +56,11 @@ use qiskit_circuit::bit::ShareableQubit;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
 use qiskit_circuit::dag_circuit::DAGCircuit;
-use qiskit_circuit::gate_matrix::{CX_GATE, H_GATE, ONE_QUBIT_IDENTITY, SDG_GATE, S_GATE};
+use qiskit_circuit::gate_matrix::{CX_GATE, H_GATE, ONE_QUBIT_IDENTITY, S_GATE, SDG_GATE};
 use qiskit_circuit::operations::{Operation, OperationRef, Param, StandardGate};
 use qiskit_circuit::packed_instruction::PackedOperation;
-use qiskit_circuit::util::{c64, GateArray1Q, GateArray2Q, C_M_ONE, C_ONE, C_ZERO, IM, M_IM};
-use qiskit_circuit::{impl_intopyobject_for_copy_pyclass, Qubit};
+use qiskit_circuit::util::{C_M_ONE, C_ONE, C_ZERO, GateArray1Q, GateArray2Q, IM, M_IM, c64};
+use qiskit_circuit::{Qubit, impl_intopyobject_for_copy_pyclass};
 
 const PI2: f64 = PI / 2.;
 const PI4: f64 = PI / 4.;
@@ -1046,9 +1046,7 @@ impl TwoQubitWeylDecomposition {
             if specialized.calculated_fidelity + 1.0e-13 < fid {
                 return Err(QiskitError::new_err(format!(
                     "Specialization: {:?} calculated fidelity: {} is worse than requested fidelity: {}",
-                    specialized.specialization,
-                    specialized.calculated_fidelity,
-                    fid
+                    specialized.specialization, specialized.calculated_fidelity, fid
                 )));
             }
         }
@@ -1476,7 +1474,7 @@ impl TwoQubitBasisDecomposer {
         global_phase -= 3. * self.basis_decomposer.global_phase;
         global_phase = global_phase.rem_euclid(TWO_PI);
         let atol = 1e-10; // absolute tolerance for floats
-                          // Decompose source unitaries to zxz
+        // Decompose source unitaries to zxz
         let euler_q0: Vec<[f64; 3]> = decomposition
             .iter()
             .step_by(2)

--- a/crates/transpiler/src/angle_bound_registry.rs
+++ b/crates/transpiler/src/angle_bound_registry.rs
@@ -12,14 +12,14 @@
 
 use hashbrown::HashMap;
 
+use pyo3::Python;
 use pyo3::exceptions::PyKeyError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use pyo3::Python;
 
 use crate::TranspilerError;
-use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_circuit::PhysicalQubit;
+use qiskit_circuit::dag_circuit::DAGCircuit;
 
 #[derive(Clone)]
 pub(crate) enum CallbackType {

--- a/crates/transpiler/src/gate_metrics.rs
+++ b/crates/transpiler/src/gate_metrics.rs
@@ -12,7 +12,7 @@
 
 use ndarray::ArrayView2;
 use num_complex::{Complex64, ComplexFloat};
-use qiskit_circuit::{operations::StandardGate, Qubit};
+use qiskit_circuit::{Qubit, operations::StandardGate};
 
 use qiskit_quantum_info::unitary_compose;
 

--- a/crates/transpiler/src/passes/alap_schedule_analysis.rs
+++ b/crates/transpiler/src/passes/alap_schedule_analysis.rs
@@ -31,11 +31,7 @@ impl TimeOps for u64 {
         0
     }
     fn max<'a>(a: &'a Self, b: &'a Self) -> &'a Self {
-        if a >= b {
-            a
-        } else {
-            b
-        }
+        if a >= b { a } else { b }
     }
 }
 
@@ -44,11 +40,7 @@ impl TimeOps for f64 {
         0.0
     }
     fn max<'a>(a: &'a Self, b: &'a Self) -> &'a Self {
-        if a >= b {
-            a
-        } else {
-            b
-        }
+        if a >= b { a } else { b }
     }
 }
 

--- a/crates/transpiler/src/passes/apply_layout.rs
+++ b/crates/transpiler/src/passes/apply_layout.rs
@@ -174,9 +174,11 @@ fn py_apply_layout<'py>(
         )));
     }
     match permutation.as_ref().map(Vec::len) {
-        Some(len) if len != dag.num_qubits() => return Err(PyValueError::new_err(format!(
-            "Given permutation has difference number of qubits ({len}) than the DAG ({num_dag_qubits})"
-        ))),
+        Some(len) if len != dag.num_qubits() => {
+            return Err(PyValueError::new_err(format!(
+                "Given permutation has difference number of qubits ({len}) than the DAG ({num_dag_qubits})"
+            )));
+        }
         _ => (),
     }
     if physical_from_virtual.len() != dag.num_qubits() {

--- a/crates/transpiler/src/passes/asap_schedule_analysis.rs
+++ b/crates/transpiler/src/passes/asap_schedule_analysis.rs
@@ -10,8 +10,8 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::passes::alap_schedule_analysis::TimeOps;
 use crate::TranspilerError;
+use crate::passes::alap_schedule_analysis::TimeOps;
 use hashbrown::HashMap;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;

--- a/crates/transpiler/src/passes/barrier_before_final_measurement.rs
+++ b/crates/transpiler/src/passes/barrier_before_final_measurement.rs
@@ -14,10 +14,10 @@ use pyo3::prelude::*;
 use rayon::prelude::*;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
+use qiskit_circuit::Qubit;
 use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType};
 use qiskit_circuit::operations::{OperationRef, StandardInstruction};
 use qiskit_circuit::packed_instruction::{PackedInstruction, PackedOperation};
-use qiskit_circuit::Qubit;
 
 const PARALLEL_THRESHOLD: usize = 150;
 

--- a/crates/transpiler/src/passes/basis_translator/basis_search.rs
+++ b/crates/transpiler/src/passes/basis_translator/basis_search.rs
@@ -18,7 +18,7 @@ use crate::equivalence::{EdgeData, Equivalence, EquivalenceLibrary, Key, NodeDat
 use qiskit_circuit::operations::Operation;
 use rustworkx_core::petgraph::stable_graph::{EdgeReference, NodeIndex, StableDiGraph};
 use rustworkx_core::petgraph::visit::Control;
-use rustworkx_core::traversal::{dijkstra_search, DijkstraEvent};
+use rustworkx_core::traversal::{DijkstraEvent, dijkstra_search};
 
 use super::compose_transforms::{BasisTransformIn, GateIdentifier};
 

--- a/crates/transpiler/src/passes/basis_translator/compose_transforms.rs
+++ b/crates/transpiler/src/passes/basis_translator/compose_transforms.rs
@@ -15,15 +15,15 @@ use std::sync::OnceLock;
 use hashbrown::HashMap;
 use indexmap::{IndexMap, IndexSet};
 use pyo3::prelude::*;
+use qiskit_circuit::Qubit;
 use qiskit_circuit::bit::QuantumRegister;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
 use qiskit_circuit::imports::GATE;
-use qiskit_circuit::operations::{get_standard_gate_names, StandardGate, StandardInstruction};
+use qiskit_circuit::operations::{StandardGate, StandardInstruction, get_standard_gate_names};
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::parameter::parameter_expression::ParameterExpression;
 use qiskit_circuit::parameter::symbol_expr::Symbol;
 use qiskit_circuit::parameter_table::ParameterUuid;
-use qiskit_circuit::Qubit;
 use qiskit_circuit::{
     circuit_data::CircuitData,
     dag_circuit::DAGCircuit,

--- a/crates/transpiler/src/passes/basis_translator/mod.rs
+++ b/crates/transpiler/src/passes/basis_translator/mod.rs
@@ -38,12 +38,12 @@ use qiskit_circuit::parameter::parameter_expression::ParameterExpression;
 use qiskit_circuit::parameter::symbol_expr::Symbol;
 use qiskit_circuit::parameter::symbol_expr::SymbolExpr;
 use qiskit_circuit::parameter::symbol_expr::Value;
+use qiskit_circuit::{Clbit, PhysicalQubit, Qubit, VarsMode};
 use qiskit_circuit::{
     circuit_data::CircuitData,
     dag_circuit::DAGCircuit,
     operations::{Operation, OperationRef, PythonOperation},
 };
-use qiskit_circuit::{Clbit, PhysicalQubit, Qubit, VarsMode};
 use smallvec::SmallVec;
 
 use crate::equivalence::EquivalenceLibrary;

--- a/crates/transpiler/src/passes/commutation_analysis.rs
+++ b/crates/transpiler/src/passes/commutation_analysis.rs
@@ -14,14 +14,14 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::PyModule;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
-use pyo3::{pyfunction, wrap_pyfunction, Bound, PyResult, Python};
+use pyo3::{Bound, PyResult, Python, pyfunction, wrap_pyfunction};
 
 use indexmap::IndexMap;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
 use crate::commutation_checker::CommutationChecker;
-use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType, Wire};
 use qiskit_circuit::Qubit;
+use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType, Wire};
 
 // Custom types to store the commutation sets and node indices,
 // see the docstring below for more information.

--- a/crates/transpiler/src/passes/consolidate_blocks.rs
+++ b/crates/transpiler/src/passes/consolidate_blocks.rs
@@ -13,11 +13,12 @@
 use hashbrown::{HashMap, HashSet};
 use nalgebra::Matrix2;
 use ndarray::ArrayView2;
-use ndarray::{aview2, Array2};
+use ndarray::{Array2, aview2};
 use num_complex::Complex64;
 use numpy::PyReadonlyArray2;
 use pyo3::intern;
 use pyo3::prelude::*;
+use qiskit_circuit::Qubit;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_circuit::gate_matrix::{
@@ -28,11 +29,10 @@ use qiskit_circuit::imports::{QI_OPERATOR, QUANTUM_CIRCUIT};
 use qiskit_circuit::operations::StandardGate;
 use qiskit_circuit::operations::{ArrayType, Operation, Param, UnitaryGate};
 use qiskit_circuit::packed_instruction::PackedOperation;
-use qiskit_circuit::Qubit;
 use qiskit_synthesis::two_qubit_decompose::RXXEquivalent;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
-use smallvec::smallvec;
 use smallvec::SmallVec;
+use smallvec::smallvec;
 
 use super::optimize_1q_gates_decomposition::matmul_1q;
 use qiskit_quantum_info::convert_2q_block_matrix::{blocks_to_matrix, get_matrix_from_inst};
@@ -486,8 +486,8 @@ mod test_consolidate_blocks {
     use indexmap::IndexMap;
 
     use qiskit_circuit::{
-        circuit_data::CircuitData, converters::dag_to_circuit, dag_circuit::DAGCircuit,
-        operations::StandardGate, PhysicalQubit, Qubit,
+        PhysicalQubit, Qubit, circuit_data::CircuitData, converters::dag_to_circuit,
+        dag_circuit::DAGCircuit, operations::StandardGate,
     };
     use smallvec::smallvec;
 
@@ -558,7 +558,10 @@ mod test_consolidate_blocks {
 
         let data = circ_result.data();
         if !data.is_empty() {
-            panic!("The output circuit had {} instructions but all instruction should have cancelled out", data.len());
+            panic!(
+                "The output circuit had {} instructions but all instruction should have cancelled out",
+                data.len()
+            );
         }
     }
 }

--- a/crates/transpiler/src/passes/dense_layout.rs
+++ b/crates/transpiler/src/passes/dense_layout.rs
@@ -19,9 +19,9 @@ use numpy::IntoPyArray;
 use numpy::PyReadonlyArray2;
 use rayon::prelude::*;
 
+use pyo3::Python;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
-use pyo3::Python;
 
 use qiskit_circuit::getenv_use_multiple_threads;
 

--- a/crates/transpiler/src/passes/disjoint_layout.rs
+++ b/crates/transpiler/src/passes/disjoint_layout.rs
@@ -20,9 +20,9 @@ use pyo3::prelude::*;
 use pyo3::types::{PyList, PyTuple};
 use rayon::prelude::*;
 use rustworkx_core::connectivity::connected_components;
+use rustworkx_core::petgraph::EdgeType;
 use rustworkx_core::petgraph::prelude::*;
 use rustworkx_core::petgraph::visit::{IntoEdgeReferences, IntoNodeReferences, NodeFiltered};
-use rustworkx_core::petgraph::EdgeType;
 use smallvec::SmallVec;
 use uuid::Uuid;
 
@@ -34,8 +34,8 @@ use qiskit_circuit::operations::{Operation, OperationRef, Param, StandardInstruc
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::{Clbit, PhysicalQubit, Qubit, VarsMode, VirtualQubit};
 
-use crate::target::{Qargs, Target};
 use crate::TranspilerError;
+use crate::target::{Qargs, Target};
 
 create_exception!(qiskit, MultiQEncountered, pyo3::exceptions::PyException);
 
@@ -284,7 +284,9 @@ fn map_components(
             }
         }
         if !found {
-            return Err(TranspilerError::new_err("A connected component of the DAGCircuit is too large for any of the connected components in the coupling map"));
+            return Err(TranspilerError::new_err(
+                "A connected component of the DAGCircuit is too large for any of the connected components in the coupling map",
+            ));
         }
     }
     Ok(out_mapping)

--- a/crates/transpiler/src/passes/gate_direction.rs
+++ b/crates/transpiler/src/passes/gate_direction.rs
@@ -10,22 +10,22 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::target::Target;
 use crate::TranspilerError;
+use crate::target::Target;
 use hashbrown::HashSet;
 use pyo3::{intern, prelude::*};
+use qiskit_circuit::PhysicalQubit;
 use qiskit_circuit::bit::{QuantumRegister, Register};
 use qiskit_circuit::converters::dag_to_circuit;
 use qiskit_circuit::imports::QUANTUM_CIRCUIT;
 use qiskit_circuit::operations::OperationRef;
 use qiskit_circuit::packed_instruction::PackedOperation;
-use qiskit_circuit::PhysicalQubit;
 use qiskit_circuit::{
-    dag_circuit::DAGCircuit, operations::Operation, operations::Param, operations::StandardGate,
-    packed_instruction::PackedInstruction, Qubit,
+    Qubit, dag_circuit::DAGCircuit, operations::Operation, operations::Param,
+    operations::StandardGate, packed_instruction::PackedInstruction,
 };
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 use std::f64::consts::PI;
 
 //#########################################################################
@@ -302,7 +302,12 @@ where
         }
         // No matching replacement found
         if gate_complies(packed_inst, &[op_args1, op_args0]) {
-            return Err(TranspilerError::new_err(format!("{} would be supported on {:?} if the direction was swapped, but no rules are known to do that. {:?} can be automatically flipped.", packed_inst.op.name(), op_args, vec!["cx", "cz", "ecr", "swap", "rzx", "rxx", "ryy", "rzz"])));
+            return Err(TranspilerError::new_err(format!(
+                "{} would be supported on {:?} if the direction was swapped, but no rules are known to do that. {:?} can be automatically flipped.",
+                packed_inst.op.name(),
+                op_args,
+                vec!["cx", "cz", "ecr", "swap", "rzx", "rxx", "ryy", "rzz"]
+            )));
             // NOTE: Make sure to update the list of the supported gates if adding more replacements
         } else {
             return Err(TranspilerError::new_err(format!(

--- a/crates/transpiler/src/passes/gates_in_basis.rs
+++ b/crates/transpiler/src/passes/gates_in_basis.rs
@@ -15,11 +15,11 @@ use pyo3::prelude::*;
 use qiskit_circuit::circuit_data::CircuitData;
 
 use crate::target::{Qargs, Target};
+use qiskit_circuit::PhysicalQubit;
+use qiskit_circuit::Qubit;
 use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_circuit::operations::{Operation, Param};
 use qiskit_circuit::packed_instruction::PackedInstruction;
-use qiskit_circuit::PhysicalQubit;
-use qiskit_circuit::Qubit;
 
 #[pyfunction]
 #[pyo3(name = "any_gate_missing_from_target")]

--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -15,36 +15,36 @@ use hashbrown::HashSet;
 use ndarray::prelude::*;
 use num_complex::Complex;
 use numpy::IntoPyArray;
+use pyo3::Bound;
+use pyo3::IntoPyObjectExt;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyAny;
 use pyo3::types::PyTuple;
-use pyo3::Bound;
-use pyo3::IntoPyObjectExt;
 use qiskit_circuit::bit::ShareableQubit;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
-use qiskit_circuit::converters::dag_to_circuit;
 use qiskit_circuit::converters::QuantumCircuitData;
+use qiskit_circuit::converters::dag_to_circuit;
 use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_circuit::gate_matrix::CX_GATE;
 use qiskit_circuit::imports::{HLS_SYNTHESIZE_OP_USING_PLUGINS, QS_DECOMPOSITION, QUANTUM_CIRCUIT};
 use qiskit_circuit::operations::Operation;
 use qiskit_circuit::operations::OperationRef;
 use qiskit_circuit::operations::StandardGate;
-use qiskit_circuit::operations::{radd_param, Param};
+use qiskit_circuit::operations::{Param, radd_param};
 use qiskit_circuit::packed_instruction::PackedInstruction;
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::{Clbit, Qubit, VarsMode};
 use smallvec::SmallVec;
 
+use crate::TranspilerError;
 use crate::equivalence::EquivalenceLibrary;
 use crate::target::Qargs;
 use crate::target::Target;
-use crate::TranspilerError;
 use qiskit_circuit::PhysicalQubit;
-use qiskit_synthesis::euler_one_qubit_decomposer::angles_from_unitary;
 use qiskit_synthesis::euler_one_qubit_decomposer::EulerBasis;
+use qiskit_synthesis::euler_one_qubit_decomposer::angles_from_unitary;
 use qiskit_synthesis::two_qubit_decompose::TwoQubitBasisDecomposer;
 
 /// Track global qubits by their state.
@@ -380,7 +380,17 @@ impl HighLevelSynthesisData {
     fn __str__(&self) -> String {
         format!(
             "HighLevelSynthesisData(hls_config: {:?}, hls_plugin_manager: {:?}, hls_op_names: {:?}, coupling_map: {:?}, target: {:?},  equivalence_library: {:?}, device_insts: {:?}, use_physical_indices: {:?}, min_qubits: {:?}, unroll_definitions: {:?}, optimize_clifford_t: {:?})",
-            self.hls_config, self.hls_plugin_manager, self.hls_op_names, self.coupling_map, self.target, self.equivalence_library, self.device_insts,  self.use_physical_indices, self.min_qubits, self.unroll_definitions, self.optimize_clifford_t,
+            self.hls_config,
+            self.hls_plugin_manager,
+            self.hls_op_names,
+            self.coupling_map,
+            self.target,
+            self.equivalence_library,
+            self.device_insts,
+            self.use_physical_indices,
+            self.min_qubits,
+            self.unroll_definitions,
+            self.optimize_clifford_t,
         )
     }
 }

--- a/crates/transpiler/src/passes/litinski_transformation.rs
+++ b/crates/transpiler/src/passes/litinski_transformation.rs
@@ -15,7 +15,7 @@ use pyo3::prelude::*;
 use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType};
 use qiskit_circuit::imports::PAULI_EVOLUTION_GATE;
 use qiskit_circuit::operations::{
-    multiply_param, Operation, OperationRef, Param, PyGate, StandardGate,
+    Operation, OperationRef, Param, PyGate, StandardGate, multiply_param,
 };
 use qiskit_circuit::packed_instruction::PackedInstruction;
 use qiskit_circuit::{Clbit, Qubit, VarsMode};

--- a/crates/transpiler/src/passes/mod.rs
+++ b/crates/transpiler/src/passes/mod.rs
@@ -60,7 +60,7 @@ pub use basis_translator::{basis_translator_mod, run_basis_translator};
 pub use check_map::{check_map_mod, run_check_map};
 pub use commutation_analysis::{analyze_commutations, commutation_analysis_mod};
 pub use commutation_cancellation::{cancel_commutations, commutation_cancellation_mod};
-pub use consolidate_blocks::{consolidate_blocks_mod, run_consolidate_blocks, DecomposerType};
+pub use consolidate_blocks::{DecomposerType, consolidate_blocks_mod, run_consolidate_blocks};
 pub use dense_layout::{best_subset, dense_layout_mod};
 pub use disjoint_layout::{combine_barriers, disjoint_utils_mod, distribute_components};
 pub use elide_permutations::{elide_permutations_mod, run_elide_permutations};
@@ -71,7 +71,7 @@ pub use gate_direction::{
 };
 pub use gates_in_basis::{gates_in_basis_mod, gates_missing_from_basis, gates_missing_from_target};
 pub use high_level_synthesis::{
-    high_level_synthesis_mod, run_high_level_synthesis, HighLevelSynthesisData,
+    HighLevelSynthesisData, high_level_synthesis_mod, run_high_level_synthesis,
 };
 pub use instruction_duration_check::{
     instruction_duration_check_mod, run_instruction_duration_check,
@@ -88,5 +88,5 @@ pub use remove_identity_equiv::{remove_identity_equiv_mod, run_remove_identity_e
 pub use split_2q_unitaries::{run_split_2q_unitaries, split_2q_unitaries_mod};
 pub use unitary_synthesis::{run_unitary_synthesis, unitary_synthesis_mod};
 pub use unroll_3q_or_more::{run_unroll_3q_or_more, unroll_3q_or_more_mod};
-pub use vf2::{error_map_mod, score_layout, vf2_layout_mod, vf2_layout_pass, ErrorMap};
+pub use vf2::{ErrorMap, error_map_mod, score_layout, vf2_layout_mod, vf2_layout_pass};
 pub use wrap_angles::{run_wrap_angles, wrap_angles_mod};

--- a/crates/transpiler/src/passes/optimize_1q_gates_decomposition.rs
+++ b/crates/transpiler/src/passes/optimize_1q_gates_decomposition.rs
@@ -23,10 +23,10 @@ use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType};
 use qiskit_circuit::operations::{Operation, Param};
 
 use crate::target::Target;
-use qiskit_circuit::{gate_matrix, PhysicalQubit};
+use qiskit_circuit::{PhysicalQubit, gate_matrix};
 use qiskit_synthesis::euler_one_qubit_decomposer::{
-    unitary_to_gate_sequence_inner, EulerBasis, EulerBasisSet, OneQubitGateSequence, EULER_BASES,
-    EULER_BASIS_NAMES,
+    EULER_BASES, EULER_BASIS_NAMES, EulerBasis, EulerBasisSet, OneQubitGateSequence,
+    unitary_to_gate_sequence_inner,
 };
 
 fn compute_error_term_from_target(gate: &str, target: &Target, qubit: PhysicalQubit) -> f64 {

--- a/crates/transpiler/src/passes/remove_identity_equiv.rs
+++ b/crates/transpiler/src/passes/remove_identity_equiv.rs
@@ -16,13 +16,13 @@ use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
 use crate::gate_metrics::rotation_trace_and_dim;
 use crate::target::Target;
+use qiskit_circuit::PhysicalQubit;
 use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_circuit::operations::Operation;
 use qiskit_circuit::operations::OperationRef;
 use qiskit_circuit::operations::Param;
 use qiskit_circuit::operations::StandardGate;
 use qiskit_circuit::packed_instruction::PackedInstruction;
-use qiskit_circuit::PhysicalQubit;
 
 const MINIMUM_TOL: f64 = 1e-12;
 

--- a/crates/transpiler/src/passes/sabre/heuristic.rs
+++ b/crates/transpiler/src/passes/sabre/heuristic.rs
@@ -10,11 +10,11 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use pyo3::IntoPyObjectExt;
+use pyo3::Python;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyString;
-use pyo3::IntoPyObjectExt;
-use pyo3::Python;
 
 use qiskit_circuit::impl_intopyobject_for_copy_pyclass;
 

--- a/crates/transpiler/src/passes/sabre/layout.rs
+++ b/crates/transpiler/src/passes/sabre/layout.rs
@@ -22,19 +22,19 @@ use rustworkx_core::petgraph::graph::NodeIndex;
 
 use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_circuit::nlayout::NLayout;
-use qiskit_circuit::{getenv_use_multiple_threads, PhysicalQubit, VirtualQubit};
+use qiskit_circuit::{PhysicalQubit, VirtualQubit, getenv_use_multiple_threads};
 
+use crate::TranspilerError;
 use crate::passes::{
     dense_layout,
     disjoint_layout::{self, DisjointSplit},
 };
 use crate::target::{Target, TargetCouplingError};
-use crate::TranspilerError;
 
 use super::dag::SabreDAG;
 use super::heuristic::Heuristic;
 use super::neighbors::Neighbors;
-use super::route::{swap_map, swap_map_trial, RoutingProblem, RoutingResult, RoutingTarget};
+use super::route::{RoutingProblem, RoutingResult, RoutingTarget, swap_map, swap_map_trial};
 
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
@@ -75,7 +75,7 @@ pub fn sabre_layout_and_routing(
             return Ok((out, trivial.clone(), trivial));
         }
         Err(e @ TargetCouplingError::MultiQ(_)) => {
-            return Err(TranspilerError::new_err(e.to_string()))
+            return Err(TranspilerError::new_err(e.to_string()));
         }
     };
     let mut starting_layouts = (0..num_random_trials)

--- a/crates/transpiler/src/passes/sabre/route.rs
+++ b/crates/transpiler/src/passes/sabre/route.rs
@@ -16,9 +16,9 @@ use std::convert::Infallible;
 use std::num::NonZero;
 
 use numpy::{PyArray2, ToPyArray};
+use pyo3::Python;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use pyo3::Python;
 
 use hashbrown::HashSet;
 use indexmap::IndexMap;
@@ -31,17 +31,17 @@ use rustworkx_core::petgraph::prelude::*;
 use rustworkx_core::petgraph::visit::{EdgeCount, EdgeRef};
 use rustworkx_core::shortest_path::dijkstra;
 use rustworkx_core::token_swapper::token_swapper;
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 
 use qiskit_circuit::circuit_instruction::OperationFromPython;
 use qiskit_circuit::dag_circuit::{DAGCircuit, DAGCircuitBuilder, NodeType, Wire};
 use qiskit_circuit::nlayout::NLayout;
 use qiskit_circuit::operations::{OperationRef, StandardGate};
 use qiskit_circuit::packed_instruction::PackedInstruction;
-use qiskit_circuit::{getenv_use_multiple_threads, imports, PhysicalQubit, Qubit, VirtualQubit};
+use qiskit_circuit::{PhysicalQubit, Qubit, VirtualQubit, getenv_use_multiple_threads, imports};
 
-use crate::target::{Target, TargetCouplingError};
 use crate::TranspilerError;
+use crate::target::{Target, TargetCouplingError};
 
 use super::dag::{InteractionKind, SabreDAG};
 use super::distance::distance_matrix;
@@ -366,7 +366,7 @@ impl PyRoutingTarget {
             Ok(coupling) => coupling,
             Err(TargetCouplingError::AllToAll) => return Ok(Self(None)),
             Err(e @ TargetCouplingError::MultiQ(_)) => {
-                return Err(TranspilerError::new_err(e.to_string()))
+                return Err(TranspilerError::new_err(e.to_string()));
             }
         };
         Ok(Self(Some(RoutingTarget::from_neighbors(

--- a/crates/transpiler/src/passes/split_2q_unitaries.rs
+++ b/crates/transpiler/src/passes/split_2q_unitaries.rs
@@ -16,7 +16,7 @@ use nalgebra::Matrix2;
 use num_complex::Complex64;
 use pyo3::prelude::*;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 
 use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType, Wire};
 use qiskit_circuit::operations::{ArrayType, Operation, OperationRef, Param, UnitaryGate};

--- a/crates/transpiler/src/passes/unitary_synthesis.rs
+++ b/crates/transpiler/src/passes/unitary_synthesis.rs
@@ -24,24 +24,24 @@ use numpy::{IntoPyArray, ToPyArray};
 use qiskit_circuit::circuit_instruction::OperationFromPython;
 use smallvec::SmallVec;
 
+use pyo3::Python;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyDict, PyString, PyType};
 use pyo3::wrap_pyfunction;
-use pyo3::Python;
 
-use qiskit_circuit::converters::{circuit_to_dag, QuantumCircuitData};
+use qiskit_circuit::converters::{QuantumCircuitData, circuit_to_dag};
 use qiskit_circuit::dag_circuit::{DAGCircuit, DAGCircuitBuilder, NodeType};
 use qiskit_circuit::operations::{Operation, OperationRef, Param, PythonOperation, StandardGate};
 use qiskit_circuit::packed_instruction::{PackedInstruction, PackedOperation};
-use qiskit_circuit::{imports, Qubit, VarsMode};
+use qiskit_circuit::{Qubit, VarsMode, imports};
 
+use crate::QiskitError;
 use crate::target::{NormalOperation, Target, TargetOperation};
 use crate::target::{Qargs, QargsRef};
-use crate::QiskitError;
 use qiskit_circuit::PhysicalQubit;
 use qiskit_synthesis::euler_one_qubit_decomposer::{
-    unitary_to_gate_sequence_inner, EulerBasis, EulerBasisSet, EULER_BASES, EULER_BASIS_NAMES,
+    EULER_BASES, EULER_BASIS_NAMES, EulerBasis, EulerBasisSet, unitary_to_gate_sequence_inner,
 };
 use qiskit_synthesis::qsd::quantum_shannon_decomposition;
 use qiskit_synthesis::two_qubit_decompose::{
@@ -222,7 +222,7 @@ fn apply_synth_sequence(
             _ => {
                 return Err(QiskitError::new_err(
                     "Decomposed gate sequence contains unexpected operations.",
-                ))
+                ));
             }
         };
 
@@ -1435,13 +1435,13 @@ fn run_2q_unitary_synthesis(
     let synth_sequence = synth_errors_sequence
         .iter()
         .enumerate()
-        .min_by(|error1, error2| error1.1 .1.partial_cmp(&error2.1 .1).unwrap())
+        .min_by(|error1, error2| error1.1.1.partial_cmp(&error2.1.1).unwrap())
         .map(|(index, _)| &synth_errors_sequence[index]);
 
     let synth_dag = synth_errors_dag
         .iter()
         .enumerate()
-        .min_by(|error1, error2| error1.1 .1.partial_cmp(&error2.1 .1).unwrap())
+        .min_by(|error1, error2| error1.1.1.partial_cmp(&error2.1.1).unwrap())
         .map(|(index, _)| &synth_errors_dag[index]);
 
     match (synth_sequence, synth_dag) {

--- a/crates/transpiler/src/passes/unroll_3q_or_more.rs
+++ b/crates/transpiler/src/passes/unroll_3q_or_more.rs
@@ -14,8 +14,8 @@ use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
-use crate::target::Target;
 use crate::QiskitError;
+use crate::target::Target;
 use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_circuit::operations::Operation;
 use thiserror::Error;
@@ -59,7 +59,7 @@ pub fn run_unroll_3q_or_more(
                 let definition = match inst.op.definition(inst.params_view()) {
                     Some(def) => def,
                     None => {
-                        return Some(Err(Unroll3qError::NoDefinition(inst.op.name().to_string())))
+                        return Some(Err(Unroll3qError::NoDefinition(inst.op.name().to_string())));
                     }
                 };
                 let mut decomp_dag =

--- a/crates/transpiler/src/passes/vf2/error_map.rs
+++ b/crates/transpiler/src/passes/vf2/error_map.rs
@@ -10,9 +10,9 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyIndexError;
 use pyo3::prelude::*;
-use pyo3::IntoPyObjectExt;
 
 use qiskit_circuit::PhysicalQubit;
 

--- a/crates/transpiler/src/passes/vf2/mod.rs
+++ b/crates/transpiler/src/passes/vf2/mod.rs
@@ -13,5 +13,5 @@
 mod error_map;
 mod vf2_layout;
 
-pub use error_map::{error_map_mod, ErrorMap};
+pub use error_map::{ErrorMap, error_map_mod};
 pub use vf2_layout::{score_layout, vf2_layout_mod, vf2_layout_pass};

--- a/crates/transpiler/src/passes/vf2/vf2_layout.rs
+++ b/crates/transpiler/src/passes/vf2/vf2_layout.rs
@@ -336,11 +336,7 @@ fn map_free_qubits(
 
     let normalize = |err: Option<&f64>| -> f64 {
         let err = err.copied().unwrap_or(f64::INFINITY);
-        if err.is_nan() {
-            0.0
-        } else {
-            err
-        }
+        if err.is_nan() { 0.0 } else { err }
     };
 
     let mut free_physical = (0..num_physical_qubits)

--- a/crates/transpiler/src/passes/wrap_angles.rs
+++ b/crates/transpiler/src/passes/wrap_angles.rs
@@ -16,9 +16,9 @@ use rustworkx_core::petgraph::prelude::*;
 
 use crate::angle_bound_registry::{PyWrapAngleRegistry, WrapAngleRegistry};
 use crate::target::Target;
+use qiskit_circuit::PhysicalQubit;
 use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_circuit::operations::{Operation, Param};
-use qiskit_circuit::PhysicalQubit;
 
 #[pyfunction]
 #[pyo3(name = "wrap_angles")]

--- a/crates/transpiler/src/standard_equivalence_library.rs
+++ b/crates/transpiler/src/standard_equivalence_library.rs
@@ -14,12 +14,12 @@ use std::f64::consts::PI;
 use std::sync::Arc;
 
 use pyo3::prelude::*;
+use qiskit_circuit::Qubit;
 use qiskit_circuit::bit::QuantumRegister;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::operations::{Operation, Param, StandardGate};
 use qiskit_circuit::parameter::parameter_expression::ParameterExpression;
 use qiskit_circuit::parameter::symbol_expr::Symbol;
-use qiskit_circuit::Qubit;
 
 use crate::equivalence::{EquivalenceError, EquivalenceLibrary};
 

--- a/crates/transpiler/src/target/errors.rs
+++ b/crates/transpiler/src/target/errors.rs
@@ -28,7 +28,9 @@ pub enum TargetError {
         instruction: String,
         arguments: String,
     },
-    #[error("The number of parameters for {instruction}: {instruction_num} does not match the provided number of parameters: {argument_num}.")]
+    #[error(
+        "The number of parameters for {instruction}: {instruction_num} does not match the provided number of parameters: {argument_num}."
+    )]
     ParamsMismatch {
         instruction: String,
         instruction_num: usize,

--- a/crates/transpiler/src/target/mod.rs
+++ b/crates/transpiler/src/target/mod.rs
@@ -31,11 +31,11 @@ use hashbrown::HashSet;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use pyo3::{
+    IntoPyObjectExt,
     exceptions::{PyAttributeError, PyIndexError, PyKeyError, PyValueError},
     prelude::*,
     pyclass,
     types::{PyDict, PyList, PySet},
-    IntoPyObjectExt,
 };
 use rustworkx_core::petgraph::prelude::*;
 use smallvec::SmallVec;
@@ -1071,11 +1071,7 @@ impl Target {
                                 qarg_slice.iter().fold(
                                     0,
                                     |acc, x| {
-                                        if acc > x.0 {
-                                            acc
-                                        } else {
-                                            x.0
-                                        }
+                                        if acc > x.0 { acc } else { x.0 }
                                     },
                                 ) + 1,
                             ));
@@ -1556,7 +1552,7 @@ impl Target {
             None => {
                 return Err(TargetError::InvalidKey(format!(
                     "{name} is not an instruction in the target."
-                )))
+                )));
             }
         };
         if num_bounds != num_params {
@@ -1679,7 +1675,7 @@ mod test {
     use std::sync::Arc;
 
     use qiskit_circuit::operations::{
-        get_standard_gate_names, Operation, Param, StandardGate, STANDARD_GATE_SIZE,
+        Operation, Param, STANDARD_GATE_SIZE, StandardGate, get_standard_gate_names,
     };
     use qiskit_circuit::packed_instruction::PackedOperation;
     use qiskit_circuit::parameter::parameter_expression::ParameterExpression;
@@ -1689,7 +1685,7 @@ mod test {
     use crate::target::QargsRef;
     use qiskit_circuit::PhysicalQubit;
 
-    use super::{instruction_properties::InstructionProperties, Qargs, Target, TargetError};
+    use super::{Qargs, Target, TargetError, instruction_properties::InstructionProperties};
 
     #[test]
     fn test_invalid_params_instruction() {
@@ -1770,7 +1766,10 @@ mod test {
         let Err(res) = result else {
             panic!("The operation did not fail as expected.");
         };
-        let expected_message = format!("The number of qubits for cz does not match the number of qubits in the properties dictionary: {:?}.", Qargs::Concrete(qargs));
+        let expected_message = format!(
+            "The number of qubits for cz does not match the number of qubits in the properties dictionary: {:?}.",
+            Qargs::Concrete(qargs)
+        );
         assert_eq!(res.to_string(), expected_message);
     }
 

--- a/crates/transpiler/src/target/qargs.rs
+++ b/crates/transpiler/src/target/qargs.rs
@@ -11,7 +11,7 @@
 // that they have been altered from the originals.
 
 use indexmap::Equivalent;
-use pyo3::{prelude::*, types::PyTuple, IntoPyObject};
+use pyo3::{IntoPyObject, prelude::*, types::PyTuple};
 use smallvec::SmallVec;
 
 use qiskit_circuit::PhysicalQubit;

--- a/crates/transpiler/src/transpile_layout.rs
+++ b/crates/transpiler/src/transpile_layout.rs
@@ -12,10 +12,10 @@
 
 use hashbrown::HashMap;
 
+use qiskit_circuit::Qubit;
 use qiskit_circuit::bit::QuantumRegister;
 use qiskit_circuit::bit::ShareableQubit;
 use qiskit_circuit::nlayout::{NLayout, PhysicalQubit, VirtualQubit};
-use qiskit_circuit::Qubit;
 
 // TODO: Conditionally compile these imports for Python builds
 use pyo3::intern;
@@ -584,9 +584,9 @@ impl TranspileLayout {
 #[cfg(test)]
 mod test_transpile_layout {
     use super::TranspileLayout;
+    use qiskit_circuit::Qubit;
     use qiskit_circuit::bit::ShareableQubit;
     use qiskit_circuit::nlayout::{NLayout, PhysicalQubit, VirtualQubit};
-    use qiskit_circuit::Qubit;
 
     #[test]
     fn test_final_index_layout() {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
 edition = "2024"
-style_edition = "2021"
+style_edition = "2024"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #14876 we bumped the rust edition used for Qiskit to edition 2024. However, as part of that PR we left the rustfmt style edition at 2021 to minimize the diff and also have an independent commit that we can add to the git blame exclude list that only changes the code formatting. This commit follows up from there and bumps the style edition used by rustfmt to 2024. When this commit merges we should add the sha1 of the merged PR to `.git-blame-ignore-revs` so the code formatting doesn't show in git blame.

### Details and comments


