### PR TITLE
Enable warnings as errors on MSVC

### DIFF
--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -3,12 +3,11 @@
 # https://cmake.org/cmake/help/book/mastering-cmake/chapter/Testing%20With%20CMake%20and%20CTest.html
 cmake_minimum_required (VERSION 3.27)
 
-# On GCC and Clang compilers, we fail upon any warnings and CI requires no warnings for these 
-# compilers. 
-# MSVC is not included since compiler warnings differ signficantly. Using the MSVC options /W2 /WX 
-# get close to the below, but might not include additional checks that we require in CI 
-# (and /W3 /WX includes some we do not require). 
-if (NOT MSVC) 
+# Convert warnings into errors. Note that MSVC and GCC/clang do not match here, and CI will
+# require all to pass without errors.
+if (MSVC) 
+    add_compile_options(/W3 /WX)
+else ()
     add_compile_options(-Wall -Wextra -Werror -Wshadow)
 endif ()
 

--- a/test/c/test_basis_translator.c
+++ b/test/c/test_basis_translator.c
@@ -38,7 +38,7 @@ static int test_circuit_in_basis(void) {
     if (circuit_len != 2) {
         result = EqualityError;
         printf(
-            "The number of gates resulting from the translation is incorrect. Expected 2, got %lu",
+            "The number of gates resulting from the translation is incorrect. Expected 2, got %zu",
             circuit_len);
         goto cleanup;
     }
@@ -85,7 +85,7 @@ static int test_basic_basis_translator(void) {
     if (result_op_counts.len != 1) {
         result = EqualityError;
         printf(
-            "The number of gates resulting from the translation is incorrect. Expected 1, got %lu",
+            "The number of gates resulting from the translation is incorrect. Expected 1, got %zu",
             result_op_counts.len);
         goto cleanup;
     }
@@ -126,7 +126,7 @@ static int test_toffoli_basis_translator(void) {
     if (result_op_counts.len != 4) {
         result = EqualityError;
         printf(
-            "The number of gates resulting from the translation is incorrect. Expected 1, got %lu",
+            "The number of gates resulting from the translation is incorrect. Expected 1, got %zu",
             result_op_counts.len);
         goto cleanup;
     }

--- a/test/c/test_consolidate_blocks.c
+++ b/test/c/test_consolidate_blocks.c
@@ -258,7 +258,7 @@ static int test_non_cx_target(void) {
     if (counts.len != 1) {
         result = EqualityError;
         printf("The pass run did not result in a circuit with one unitary gate. Expected 1 gate, "
-               "got %li.",
+               "got %zu.",
                counts.len);
         goto cleanup;
     }

--- a/test/c/test_optimize_1q_sequences.c
+++ b/test/c/test_optimize_1q_sequences.c
@@ -133,7 +133,8 @@ static bool compare_gate_counts(QkOpCounts *counts, char **gates, uint32_t *freq
  *
  * Transpile: 0:--[H]-[H]-[H]--
  */
-static int inner_optimize_h_gates(QkTarget *target, char **gates, uint32_t *freq, int num_gates) {
+static int inner_optimize_h_gates(QkTarget *target, char **gates, uint32_t *freq,
+                                  size_t num_gates) {
     int result = Ok;
     // Build circuit
     QkCircuit *circuit = qk_circuit_new(1, 0);

--- a/test/c/test_transpiler.c
+++ b/test/c/test_transpiler.c
@@ -170,7 +170,7 @@ static int test_transpile_idle_qubits(void) {
     qk_target_add_instruction(target, cx_entry);
     qk_target_add_instruction(target, qk_target_entry_new(QkGate_U));
 
-    for (unsigned short opt_level = 0; opt_level < 4; opt_level++) {
+    for (uint8_t opt_level = 0; opt_level < 4; opt_level++) {
         QkTranspileOptions transpile_options = {opt_level, 1234, 1.0};
         QkTranspileResult transpile_result;
         char *error;
@@ -182,23 +182,23 @@ static int test_transpile_idle_qubits(void) {
             qk_str_free(error);
             goto cleanup;
         }
-        uint32_t num_instructions = qk_circuit_num_instructions(transpile_result.circuit);
+        size_t num_instructions = qk_circuit_num_instructions(transpile_result.circuit);
         qk_circuit_free(transpile_result.circuit);
         qk_transpile_layout_free(transpile_result.layout);
         if (opt_level == 0 && num_instructions != 12) {
-            printf("opt_level: %d num_instructions: %d is not the expected value 12\n", opt_level,
+            printf("opt_level: %d num_instructions: %zu is not the expected value 12\n", opt_level,
                    num_instructions);
             result = EqualityError;
             goto cleanup;
         }
         if ((opt_level == 1 || opt_level == 3) && num_instructions != 8) {
-            printf("opt_level: %d num_instructions: %d is not the expected value 8\n", opt_level,
+            printf("opt_level: %d num_instructions: %zu is not the expected value 8\n", opt_level,
                    num_instructions);
             result = EqualityError;
             goto cleanup;
         }
         if (opt_level == 2 && num_instructions != 7) {
-            printf("opt_level: %d num_instructions: %d is not the expected value 7\n", opt_level,
+            printf("opt_level: %d num_instructions: %zu is not the expected value 7\n", opt_level,
                    num_instructions);
             result = EqualityError;
             goto cleanup;

--- a/test/c/test_version_info.c
+++ b/test/c/test_version_info.c
@@ -12,6 +12,7 @@
 
 #include "common.h"
 #include <qiskit.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -19,25 +20,28 @@
  * Build the version a string, based on the version numbers.
  */
 static char *build_version_string(void) {
-    char suffix[16];
+    const size_t suffix_len = 16;
+    char *suffix = calloc(suffix_len, sizeof(char));
     switch (QISKIT_RELEASE_LEVEL) {
     case QISKIT_RELEASE_LEVEL_DEV:
-        sprintf(suffix, "-dev");
+        snprintf(suffix, suffix_len, "-dev");
         break;
     case QISKIT_RELEASE_LEVEL_BETA:
-        sprintf(suffix, "-beta%u", QISKIT_RELEASE_SERIAL);
+        snprintf(suffix, suffix_len, "-beta%u", QISKIT_RELEASE_SERIAL);
         break;
     case QISKIT_RELEASE_LEVEL_RC:
-        sprintf(suffix, "-rc%u", QISKIT_RELEASE_SERIAL);
+        snprintf(suffix, suffix_len, "-rc%u", QISKIT_RELEASE_SERIAL);
         break;
     default:
         // no suffix
         break;
     }
 
-    char *version = calloc(32, sizeof(char));
-    sprintf(version, "%u.%u.%u%s", QISKIT_VERSION_MAJOR, QISKIT_VERSION_MINOR, QISKIT_VERSION_PATCH,
-            suffix);
+    const size_t version_len = 32;
+    char *version = calloc(version_len, sizeof(char));
+    snprintf(version, version_len, "%u.%u.%u%s", QISKIT_VERSION_MAJOR, QISKIT_VERSION_MINOR,
+             QISKIT_VERSION_PATCH, suffix);
+    free(suffix);
     return version;
 }
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Following up on a discussion with Jake: treating warnings as errors on MSVC helps us catch additional bugs and dangerous behaviors. Mainly this is important for Windows (as Tier 1 platform we should do this), but also it catches some things that GCC/clang don't.

### Details and comments

This wasn't done previously since we only committed to passing without warnings on GCC/clang and MSVC's standard warning level (`/W3`) included additional checks.
