### PR TITLE
Document an import path to `WRAP_ANGLE_REGISTRY`

### DIFF
--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -174,6 +174,20 @@ Additional Passes
    RemoveFinalMeasurements
    UnrollForLoops
    WrapAngles
+
+
+Additional data
+===============
+
+.. py:data:: qiskit.transpiler.passes.utils.wrap_angles.WRAP_ANGLE_REGISTRY
+
+    A global instance of :class:`.WrapAngleRegistry` that is used by default by
+    :class:`.WrapAngles` when no explicit registry is specified.  See the documentation of
+    :class:`.WrapAngles` for how to add entries to a registry.
+
+    .. note::
+        Due to an oversight in Qiskit 2.2, this import path is the only valid way to access the
+        object in that version, despite traversing two non-public internal modules.
 """
 
 # layout selection (placement)

--- a/qiskit/transpiler/passes/utils/wrap_angles.py
+++ b/qiskit/transpiler/passes/utils/wrap_angles.py
@@ -40,8 +40,7 @@ class WrapAngles(TransformationPass):
        from qiskit.circuit.library import RZGate
        from qiskit.dagcircuit import DAGCircuit
        from qiskit.transpiler.passes import WrapAngles
-       from qiskit.transpiler.target import Target
-       from qiskit.transpiler import WrapAngleRegistry
+       from qiskit.transpiler import Target, WrapAngleRegistry
 
        param = Parameter("a")
        circuit = QuantumCircuit(1)
@@ -68,13 +67,14 @@ class WrapAngles(TransformationPass):
        res.draw("mpl")
 
     Args:
-        target(Target): The :class:`.Target` that
-        registry(WrapAngleRegistry): The registry of wrapping functions used
+        target (Target): The :class:`.Target` representing the target QPU.
+        registry (WrapAngleRegistry): The registry of wrapping functions used
             by the pass to wrap the angles of a gate. If not specified the
-            global ``WRAP_ANGLE_REGISTRY`` object defined in this module will be used.
+            global :data:`.WRAP_ANGLE_REGISTRY` object will be used.
+
             Unless you are planning to run this pass standalone or are building a
             custom :class:`~.transpiler.PassManager` including this pass you will want
-            to rely on ``WRAP_ANGLE_REGISTRY``.
+            to rely on :data:`.WRAP_ANGLE_REGISTRY`.
     """
 
     def __init__(self, target, registry=None):

--- a/releasenotes/notes/2.2/add-wrap-instructions-32335ea783203be9.yaml
+++ b/releasenotes/notes/2.2/add-wrap-instructions-32335ea783203be9.yaml
@@ -14,7 +14,7 @@ features_transpiler:
     There are several methods available for working with the angle bounds on the target. The first is
     :meth:`.Target.add_instruction` which has a new ``angle_bounds`` keyword argument that is used to
     add an angle bound to an instruction in the :class:`.Target`. To work with angle bounds you will also
-    want to register a callback function to the global ``WRAP_ANGLE_REGISTRY`` registry that will tell the
+    want to register a callback function to the global :data:`.WRAP_ANGLE_REGISTRY` registry that will tell the
     transpiler and :class:`.WrapAngles` pass how to adjust gates for angle bounds. The callback function
     will take a list of  arbitrary ``float`` values representing the gate angles from the circuit, as well
     as the qubit indices in the circuit the gate was operating on and it will return a :class:`.DAGCircuit`
@@ -24,7 +24,7 @@ features_transpiler:
         import math
 
         from qiskit.dagcircuit import DAGCircuit
-        from qiskit.transpiler import target
+        from qiskit.transpiler import Target
         from qiskit.transpiler.passes.utils.wrap_angles import WRAP_ANGLE_REGISTRY
 
         target = Target(num_qubits=1)


### PR DESCRIPTION
We forgot to do this in Qiskit 2.2.0, while including examples saying that it was something you were allowed to do.  This meant that we were breaking our own public-API policy: suggesting that people use an object that was not correctly documented at any path.

This corrects the documentation oversight in a stable manner, but unfortunately we cannot give it a more sensible import path within the 2.2 series, and we've inadvertently made this very wordy import path subject to the deprecation policy.  Regardless, it would be better to follow up by giving it a better location.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


