### PR TITLE
Fix compiler warning with latest stable Rust compiler

### DIFF
--- a/crates/quantum_info/src/sparse_observable/mod.rs
+++ b/crates/quantum_info/src/sparse_observable/mod.rs
@@ -3892,7 +3892,7 @@ impl PySparseObservable {
 }
 impl PySparseObservable {
     /// This is an immutable reference as opposed to a `copy`.
-    pub fn as_inner(&self) -> Result<RwLockReadGuard<SparseObservable>, InnerReadError> {
+    pub fn as_inner(&self) -> Result<RwLockReadGuard<'_, SparseObservable>, InnerReadError> {
         let data = self.inner.read().map_err(|_| InnerReadError)?;
         Ok(data)
     }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes a warning emitted by the latest stable Rust compiler. In Rust 1.90 (and 1.89) the compiler warns about hiding an elided lifetime, citing that it might make the signature confusing. While we only test in CI with our MSRV of Rust 1.85 building locally and for the release builds we will encounter this warning. Additionally when our MSRV is raised to be >=1.89 (probably not for some time) this will cause a build failure in CI, so it's better to fix this now rather than let it fester.


### Details and comments


