### PR TITLE
Relax inexact FP test of `PauliLindbladMap`

### DIFF
--- a/test/python/quantum_info/test_pauli_lindblad_map.py
+++ b/test/python/quantum_info/test_pauli_lindblad_map.py
@@ -1122,21 +1122,21 @@ class TestPauliLindbladMap(QiskitTestCase):
             [("XY", [0, 1], 1.23), ("Z", [1], -0.23), ("X", [2], 0.3)], num_qubits=4
         )
         self.assertEqual(pauli_lindblad_map.pauli_fidelity(QubitSparsePauli(("X", [0]), 4)), 1.0)
-        self.assertEqual(
-            pauli_lindblad_map.pauli_fidelity(QubitSparsePauli(("Y", [0]), 4)), np.exp(-2 * 1.23)
+        np.testing.assert_array_max_ulp(
+            pauli_lindblad_map.pauli_fidelity(QubitSparsePauli(("Y", [0]), 4)),
+            np.exp(-2 * 1.23),
+            maxulp=3,
         )
-        self.assertEqual(
-            pauli_lindblad_map.pauli_fidelity(QubitSparsePauli(("X", [1]), 4)), np.exp(-2 * 1.0)
+        np.testing.assert_array_max_ulp(
+            pauli_lindblad_map.pauli_fidelity(QubitSparsePauli(("X", [1]), 4)),
+            np.exp(-2 * 1.0),
+            maxulp=3,
         )
         self.assertEqual(pauli_lindblad_map.pauli_fidelity(QubitSparsePauli(("Z", [3]), 4)), 1.0)
-        # np.allclose needed for machine precision
-        self.assertTrue(
-            np.allclose(
-                pauli_lindblad_map.pauli_fidelity(QubitSparsePauli(("ZXY", [0, 1, 2]), 4)),
-                np.exp(-2 * 0.07),
-                atol=1e-12,
-                rtol=1e-12,
-            )
+        np.testing.assert_array_max_ulp(
+            pauli_lindblad_map.pauli_fidelity(QubitSparsePauli(("ZXY", [0, 1, 2]), 4)),
+            np.exp(-2 * 0.07),
+            maxulp=3,
         )
 
         self.assertEqual(


### PR DESCRIPTION
This has been slightly flaky in CI, because some of the assertions are for exact floating-point equality through a fairly complex special function, which isn't guaranteed to any overly precise rounding.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Example failing test: https://github.com/Qiskit/qiskit/actions/runs/18192961549/job/51792053316

