### PR TITLE
Fix duration unit and refine QASM3 exporter

### DIFF
--- a/crates/qasm3/src/ast.rs
+++ b/crates/qasm3/src/ast.rs
@@ -138,7 +138,7 @@ impl Display for DurationUnit {
         let unit_str = match self {
             DurationUnit::Nanosecond => "ns",
             DurationUnit::Microsecond => "us",
-            DurationUnit::Millisecond => "us",
+            DurationUnit::Millisecond => "ms",
             DurationUnit::Second => "s",
             DurationUnit::Sample => "dt",
         };
@@ -443,4 +443,18 @@ pub struct Continue {}
 pub enum OP<'a> {
     UnaryOp(&'a UnaryOp),
     BinaryOp(&'a BinaryOp),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DurationUnit;
+
+    #[test]
+    fn duration_unit_display_formats_correctly() {
+        assert_eq!(format!("{}", DurationUnit::Millisecond), "ms");
+        assert_eq!(format!("{}", DurationUnit::Microsecond), "us");
+        assert_eq!(format!("{}", DurationUnit::Nanosecond), "ns");
+        assert_eq!(format!("{}", DurationUnit::Second), "s");
+        assert_eq!(format!("{}", DurationUnit::Sample), "dt");
+    }
 }

--- a/crates/qasm3/src/exporter.rs
+++ b/crates/qasm3/src/exporter.rs
@@ -1375,7 +1375,7 @@ fn duration_literal_from_delay(
             return Err(QASM3ExporterError::Error(format!(
                 "Unknown delay unit: {}",
                 delay_unit
-            )))
+            )));
         }
     };
 

--- a/qiskit/qasm3/exporter.py
+++ b/qiskit/qasm3/exporter.py
@@ -1273,7 +1273,11 @@ class QASM3Builder:
             "s": ast.DurationUnit.SECOND,
             "dt": ast.DurationUnit.SAMPLE,
         }
-        return ast.DurationLiteral(duration, unit_map[unit])
+        try:
+            unit_enum = unit_map[unit]
+        except KeyError as exc:  # pragma: no cover - defensive guard
+            raise QASM3ExporterError(f"Unsupported duration unit: {unit!r}") from exc
+        return ast.DurationLiteral(duration, unit_enum)
 
     def build_integer(self, value) -> ast.IntegerLiteral:
         """Build an integer literal, raising a :obj:`.QASM3ExporterError` if the input is not

--- a/releasenotes/notes/millisecond-display-fix-b611f6c8fcdb6103.yaml
+++ b/releasenotes/notes/millisecond-display-fix-b611f6c8fcdb6103.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Correct the text representation of ``DurationUnit::Millisecond`` in the QASM3 AST to use
+    ``"ms"`` instead of ``"us"``.

--- a/releasenotes/notes/unsupported-duration-unit-error-8d16bbf2fe2be31d.yaml
+++ b/releasenotes/notes/unsupported-duration-unit-error-8d16bbf2fe2be31d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The QASM3 exporter now raises ``QASM3ExporterError`` when given an unsupported
+    duration unit instead of a ``KeyError``.


### PR DESCRIPTION
Changes:
- Corrected `DurationUnit::Millisecond` to `ms` instead of `us`.
- Refactored the Rust QASM3 exporter to convert delay units through a dedicated `duration_literal_from_delay` helper, simplifying the delay builder logic.
- Added appropiate tests to check duration unit display formats correctly.

Follow up from #14892