### PR TITLE
Avoid panics in `Optimize1qGatesDecomposition`

### DIFF
--- a/crates/transpiler/src/target/errors.rs
+++ b/crates/transpiler/src/target/errors.rs
@@ -51,3 +51,9 @@ pub enum TargetError {
     #[error["Lower bound {low} is not less than higher bound {high}."]]
     InvalidBounds { low: f64, high: f64 },
 }
+
+impl From<TargetError> for ::pyo3::PyErr {
+    fn from(val: TargetError) -> Self {
+        crate::TranspilerError::new_err(val.to_string())
+    }
+}

--- a/releasenotes/notes/fix-panic-optimize-1q-b3cdfb4968e86651.yaml
+++ b/releasenotes/notes/fix-panic-optimize-1q-b3cdfb4968e86651.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    :class:`.Optimize1qGatesDecomposition` will now raise a :exc:`.TranspilerError` instead of a
+    Rust-space panic when attempting to run on a circuit that is too large for the :class:`.Target`.


### PR DESCRIPTION
These pathways are still error conditions, but at a minimum, we should not be panicking on legitimate (if incorrect) inputs from Python space.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


Fix #15116.

I also wrote in the `expect` condition for a couple of other `unwrap` calls that really weren't obvious to me why we expected them to be ok.