### PR TITLE
Improve performance of quantum_info predicates

### DIFF
--- a/qiskit/quantum_info/operators/predicates.py
+++ b/qiskit/quantum_info/operators/predicates.py
@@ -15,11 +15,23 @@ Predicates for operators.
 """
 
 from __future__ import annotations
+import functools
 import numpy as np
 
 ATOL_DEFAULT = 1e-8
 RTOL_DEFAULT = 1e-5
 
+@functools.cache
+def _identity_matrix_cache(size):
+    m =  np.eye(size)
+    m.flags.writeable = False
+    return m
+
+def _identity_matrix(size):
+    """ Return identity matrix """
+    if size <= 64:
+        return _identity_matrix_cache(size)
+    return np.eye(size)
 
 def matrix_equal(mat1, mat2, ignore_phase=False, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT, props=None):
     # pylint: disable-next=consider-using-f-string
@@ -55,9 +67,9 @@ def matrix_equal(mat1, mat2, ignore_phase=False, rtol=RTOL_DEFAULT, atol=ATOL_DE
         rtol = RTOL_DEFAULT
 
     if not isinstance(mat1, np.ndarray):
-        mat1 = np.array(mat1)
+        mat1 = np.asarray(mat1)
     if not isinstance(mat2, np.ndarray):
-        mat2 = np.array(mat2)
+        mat2 = np.asarray(mat2)
 
     if mat1.shape != mat2.shape:
         return False
@@ -87,7 +99,7 @@ def matrix_equal(mat1, mat2, ignore_phase=False, rtol=RTOL_DEFAULT, atol=ATOL_DE
 
 def is_square_matrix(mat):
     """Test if an array is a square matrix."""
-    mat = np.array(mat)
+    mat = np.asarray(mat)
     if mat.ndim != 2:
         return False
     shape = mat.shape
@@ -100,7 +112,7 @@ def is_diagonal_matrix(mat, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT):
         atol = ATOL_DEFAULT
     if rtol is None:
         rtol = RTOL_DEFAULT
-    mat = np.array(mat)
+    mat = np.asarray(mat)
     if mat.ndim != 2:
         return False
     return np.allclose(mat, np.diag(np.diagonal(mat)), rtol=rtol, atol=atol)
@@ -112,7 +124,7 @@ def is_symmetric_matrix(op, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT):
         atol = ATOL_DEFAULT
     if rtol is None:
         rtol = RTOL_DEFAULT
-    mat = np.array(op)
+    mat = np.asarray(op)
     if mat.ndim != 2:
         return False
     return np.allclose(mat, mat.T, rtol=rtol, atol=atol)
@@ -124,7 +136,7 @@ def is_hermitian_matrix(mat, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT):
         atol = ATOL_DEFAULT
     if rtol is None:
         rtol = RTOL_DEFAULT
-    mat = np.array(mat)
+    mat = np.asarray(mat)
     if mat.ndim != 2:
         return False
     return np.allclose(mat, np.conj(mat.T), rtol=rtol, atol=atol)
@@ -152,7 +164,7 @@ def is_identity_matrix(mat, ignore_phase=False, rtol=RTOL_DEFAULT, atol=ATOL_DEF
         atol = ATOL_DEFAULT
     if rtol is None:
         rtol = RTOL_DEFAULT
-    mat = np.array(mat)
+    mat = np.asarray(mat)
     if mat.ndim != 2:
         return False
     if ignore_phase:
@@ -162,13 +174,13 @@ def is_identity_matrix(mat, ignore_phase=False, rtol=RTOL_DEFAULT, atol=ATOL_DEF
         theta = np.angle(mat[0, 0])
         mat = np.exp(-1j * theta) * mat
     # Check if square identity
-    iden = np.eye(len(mat))
+    iden = _identity_matrix(len(mat))
     return np.allclose(mat, iden, rtol=rtol, atol=atol)
 
 
 def is_unitary_matrix(mat, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT):
     """Test if an array is a unitary matrix."""
-    mat = np.array(mat)
+    mat = np.asarray(mat)
     # Compute A^dagger.A and see if it is identity matrix
     mat = np.conj(mat.T).dot(mat)
     return is_identity_matrix(mat, ignore_phase=False, rtol=rtol, atol=atol)
@@ -176,8 +188,8 @@ def is_unitary_matrix(mat, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT):
 
 def is_isometry(mat, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT):
     """Test if an array is an isometry."""
-    mat = np.array(mat)
+    mat = np.asarray(mat)
     # Compute A^dagger.A and see if it is identity matrix
-    iden = np.eye(mat.shape[1])
+    iden = _identity_matrix(mat.shape[1])
     mat = np.conj(mat.T).dot(mat)
     return np.allclose(mat, iden, rtol=rtol, atol=atol)

--- a/qiskit/quantum_info/operators/predicates.py
+++ b/qiskit/quantum_info/operators/predicates.py
@@ -21,17 +21,20 @@ import numpy as np
 ATOL_DEFAULT = 1e-8
 RTOL_DEFAULT = 1e-5
 
+
 @functools.cache
 def _identity_matrix_cache(size):
-    m =  np.eye(size)
+    m = np.eye(size)
     m.flags.writeable = False
     return m
 
+
 def _identity_matrix(size):
-    """ Return identity matrix """
+    """Return identity matrix"""
     if size <= 64:
         return _identity_matrix_cache(size)
     return np.eye(size)
+
 
 def matrix_equal(mat1, mat2, ignore_phase=False, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT, props=None):
     # pylint: disable-next=consider-using-f-string

--- a/qiskit/quantum_info/operators/predicates.py
+++ b/qiskit/quantum_info/operators/predicates.py
@@ -69,10 +69,8 @@ def matrix_equal(mat1, mat2, ignore_phase=False, rtol=RTOL_DEFAULT, atol=ATOL_DE
     if rtol is None:
         rtol = RTOL_DEFAULT
 
-    if not isinstance(mat1, np.ndarray):
-        mat1 = np.asarray(mat1)
-    if not isinstance(mat2, np.ndarray):
-        mat2 = np.asarray(mat2)
+    mat1 = np.asarray(mat1)
+    mat2 = np.asarray(mat2)
 
     if mat1.shape != mat2.shape:
         return False

--- a/qiskit/quantum_info/operators/predicates.py
+++ b/qiskit/quantum_info/operators/predicates.py
@@ -100,10 +100,9 @@ def matrix_equal(mat1, mat2, ignore_phase=False, rtol=RTOL_DEFAULT, atol=ATOL_DE
 
 def is_square_matrix(mat):
     """Test if an array is a square matrix."""
-    mat = np.asarray(mat)
-    if mat.ndim != 2:
+    shape = np.shape(mat)
+    if len(shape) != 2:
         return False
-    shape = mat.shape
     return shape[0] == shape[1]
 
 

--- a/releasenotes/notes/qi-predicates-b5ad9dfff3e32759.yaml
+++ b/releasenotes/notes/qi-predicates-b5ad9dfff3e32759.yaml
@@ -1,0 +1,5 @@
+---
+features_quantum_info:
+  - |
+    Several of the :mod:`~qiskit.quantum_info` "predicates" functions, such as
+    :func:`.is_identity_matrix`, were optimized to avoid unnecessary matrix allocations.

--- a/test/python/quantum_info/operators/test_predicates.py
+++ b/test/python/quantum_info/operators/test_predicates.py
@@ -1,0 +1,40 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=invalid-name
+
+"""Tests for Operator matrix linear operator class."""
+
+import unittest
+import logging
+
+import numpy as np
+
+from qiskit.quantum_info.operators.predicates import is_identity_matrix
+
+from test import QiskitTestCase  # pylint: disable=wrong-import-order
+
+logger = logging.getLogger(__name__)
+
+
+class PredicatesTestCase(QiskitTestCase):
+    """Test methods in predicates"""
+
+    def test_is_identity_matrix(self):
+        """Test is_identity_matrix for various sizes."""
+        for size in [1, 2, 4, 20]:
+            self.assertTrue(is_identity_matrix(np.eye(size)))
+            self.assertTrue(is_identity_matrix(np.eye(size, dtype=complex)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Improve performance of the method in `quantum_info/operators/predicates.py`.

### Details and comments

The performance of these methods came up when profiling the compilation of a large number of (small) circuits. The methods make copies of the input arrays, which is not needed since the arrays are not mutated. Also a cache is created for the numpy identity matrices (construction is relativly expensive, about 2.2 us for `np.eye(4)`). A remaining bottleneck is `np.allclose`, but that is best addressed in upstream numpy.

