### PR TITLE
Fixed the statevector estimation of SparseObservables

### DIFF
--- a/releasenotes/notes/fix-statevector-estimation-of-SparseObservable-b32d1904c8e1a95f.yaml
+++ b/releasenotes/notes/fix-statevector-estimation-of-SparseObservable-b32d1904c8e1a95f.yaml
@@ -1,0 +1,8 @@
+---
+issues:
+  - Running `StatevectorEstimator` with non-Pauli observables used to raise a
+    `QiskitError` since the observables were assumed to be in a 
+    `SparsePauliOp` format.
+
+fixes:
+  - Now `StatevectorEstimator.run()` works with `SparseObservable`s.

--- a/test/python/primitives/test_statevector_estimator.py
+++ b/test/python/primitives/test_statevector_estimator.py
@@ -23,7 +23,7 @@ from qiskit.primitives import StatevectorEstimator
 from qiskit.primitives.containers.bindings_array import BindingsArray
 from qiskit.primitives.containers.estimator_pub import EstimatorPub
 from qiskit.primitives.containers.observables_array import ObservablesArray
-from qiskit.quantum_info import SparsePauliOp
+from qiskit.quantum_info import SparsePauliOp, SparseObservable
 
 
 class TestStatevectorEstimator(QiskitTestCase):
@@ -202,6 +202,7 @@ class TestStatevectorEstimator(QiskitTestCase):
         op = SparsePauliOp.from_list([("II", 1)])
         op2 = SparsePauliOp.from_list([("ZI", 1)])
         op3 = SparsePauliOp.from_list([("IZ", 1)])
+        op4 = SparseObservable.from_list([("++", 1), ("--", 2)])
 
         est = StatevectorEstimator()
         result = est.run([(qc, op)]).result()
@@ -221,6 +222,9 @@ class TestStatevectorEstimator(QiskitTestCase):
 
         result = est.run([(qc2, op3)]).result()
         np.testing.assert_allclose(result[0].data.evs, [-1])
+
+        result = est.run([(qc, op4)]).result()
+        np.testing.assert_allclose(result[0].data.evs, [0.75])
 
     def test_run_errors(self):
         """Test for errors"""


### PR DESCRIPTION
### Summary
`StatevectorEstimator.run()` had no support for `SparseObservable`s since it assumed every observable was passed in a `SparsePauliOp` format.

Now every input is interpreted as a `SparseObservable` and then casted to Pauli with `SparsePauliOp.from_sparse_observable()`.

### Why?
- Fixes #15113
- Closes inline note (`# TODO: support non Pauli operators`)

### Details and comments
Minor use of LLM tools (AI tool used: Microsoft Copilot Chat with GPT-4.1)

