### PR TITLE
Oxidize `CircuitData` blocks (to also be `CircuitData`s).

### DIFF
--- a/crates/cext/src/transpiler/passes/unitary_synthesis.rs
+++ b/crates/cext/src/transpiler/passes/unitary_synthesis.rs
@@ -182,7 +182,7 @@ mod tests {
             None,    // concurrent_measurements
         )
         .unwrap();
-        let params: Option<Parameters<Py<PyAny>>> = Some(Parameters::Params(smallvec![
+        let params: Option<Parameters<CircuitData>> = Some(Parameters::Params(smallvec![
             Param::ParameterExpression(Arc::new(ParameterExpression::from_symbol(Symbol::new(
                 "ϴ", None, None,
             )))),

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -12,6 +12,7 @@
 
 use std::fmt::Debug;
 use std::hash::{Hash, RandomState};
+use std::sync::Arc;
 #[cfg(feature = "cache_pygates")]
 use std::sync::OnceLock;
 
@@ -130,7 +131,7 @@ pub struct CircuitData {
     /// Clbits registered in the circuit.
     clbits: ObjectRegistry<Clbit, ShareableClbit>,
     /// Basic blocks registered in the circuit.
-    blocks: Vec<CircuitData>,
+    blocks: Vec<Arc<CircuitData>>,
     /// QuantumRegisters stored in the circuit
     qregs: RegisterData<QuantumRegister>,
     /// ClassicalRegisters stored in the circuit
@@ -1047,7 +1048,7 @@ impl CircuitData {
                     let mut circuits = Vec::with_capacity(blocks.len());
                     for block in blocks {
                         let circuit = &self.blocks[block.index()];
-                        circuits.push(circuit.clone());
+                        circuits.push(circuit.as_ref().clone());
                     }
                     Some(Parameters::Blocks(circuits))
                 }
@@ -1815,7 +1816,7 @@ impl CircuitData {
 impl CircuitData {
     /// Iterate over the blocks registered to the DAG.
     pub fn iter_blocks(&self) -> impl ExactSizeIterator<Item = &CircuitData> {
-        self.blocks.iter()
+        self.blocks.iter().map(|b| b.as_ref())
     }
 
     /// Build a reference to the Python-space operation object (the `Gate`, etc) packed into an
@@ -1843,7 +1844,7 @@ impl CircuitData {
                 let mut circuits = Vec::new();
                 for block in blocks {
                     let circuit = self.blocks[block.index()].clone();
-                    circuits.push(circuit);
+                    circuits.push(circuit.as_ref().clone());
                 }
                 Some(Parameters::Blocks(circuits))
             }
@@ -1873,7 +1874,7 @@ impl CircuitData {
     /// within the circuit.
     pub fn add_block(&mut self, block: CircuitData) -> Block {
         let id = self.blocks.len();
-        self.blocks.push(block);
+        self.blocks.push(Arc::new(block));
         Block::new(id)
     }
 
@@ -1911,7 +1912,10 @@ impl CircuitData {
             ControlFlow::IfElse { condition, .. } => ControlFlowView::IfElse {
                 condition,
                 true_body: &self.blocks[instr.blocks_view()[0].index()],
-                false_body: instr.blocks_view().get(1).map(|b| &self.blocks[b.index()]),
+                false_body: instr
+                    .blocks_view()
+                    .get(1)
+                    .map(|b| self.blocks[b.index()].as_ref()),
             },
             ControlFlow::Switch {
                 target, label_spec, ..
@@ -1922,7 +1926,7 @@ impl CircuitData {
                         instr
                             .blocks_view()
                             .iter()
-                            .map(|case| &self.blocks[case.index()]),
+                            .map(|case| self.blocks[case.index()].as_ref()),
                     )
                     .collect();
                 ControlFlowView::Switch {
@@ -2107,7 +2111,7 @@ impl CircuitData {
     pub fn from_packed_instructions<I>(
         qubits: ObjectRegistry<Qubit, ShareableQubit>,
         clbits: ObjectRegistry<Clbit, ShareableClbit>,
-        blocks: Vec<CircuitData>,
+        blocks: Vec<Arc<CircuitData>>,
         qargs_interner: Interner<[Qubit]>,
         cargs_interner: Interner<[Clbit]>,
         qregs: RegisterData<QuantumRegister>,
@@ -2828,9 +2832,13 @@ impl CircuitData {
                                 }
                             }?;
                             if !seen_blocks.contains(&block_to_edit) {
-                                self.blocks[block_to_edit.index()].assign_parameters_from_mapping(
-                                    [(ParameterUuid::from_symbol(&symbol), &value)],
-                                )?;
+                                let mut new_block =
+                                    self.blocks[block_to_edit.index()].as_ref().clone();
+                                new_block.assign_parameters_from_mapping([(
+                                    ParameterUuid::from_symbol(&symbol),
+                                    &value,
+                                )])?;
+                                self.blocks[block_to_edit.index()] = Arc::new(new_block);
                                 seen_blocks.insert(block_to_edit);
                             }
                             for uuid in uuids.iter() {

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -13,7 +13,7 @@
 #[cfg(feature = "cache_pygates")]
 use std::sync::OnceLock;
 
-use numpy::{IntoPyArray, PyArray2, PyReadonlyArray2};
+use numpy::{IntoPyArray, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
 use pyo3::IntoPyObjectExt;
 use pyo3::basic::CompareOp;
 use pyo3::exceptions::{PyDeprecationWarning, PyTypeError, PyValueError};

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -36,6 +36,7 @@ use crate::operations::{
 };
 use crate::packed_instruction::PackedOperation;
 use crate::parameter::parameter_expression::ParameterExpression;
+use crate::parameter::symbol_expr::Symbol;
 use nalgebra::{Dyn, MatrixView2, MatrixView4};
 use num_complex::Complex64;
 use smallvec::SmallVec;
@@ -718,11 +719,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for OperationFromPython {
                                 .map(|index| index?.extract())
                                 .collect::<PyResult<_>>()?
                         };
-                        let loop_param = params
-                            .next()
-                            .unwrap()?
-                            .extract::<Option<Bound<PyAny>>>()?
-                            .map(|p| p.unbind());
+                        let loop_param = params.next().unwrap()?.extract::<Option<Symbol>>()?;
                         ControlFlow::ForLoop {
                             indexset,
                             loop_param,

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -14,11 +14,10 @@
 use std::sync::OnceLock;
 
 use numpy::{IntoPyArray, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
+use pyo3::IntoPyObjectExt;
 use pyo3::basic::CompareOp;
 use pyo3::exceptions::{PyDeprecationWarning, PyTypeError, PyValueError};
 use pyo3::prelude::*;
-
-use pyo3::IntoPyObjectExt;
 use pyo3::types::{PyBool, PyList, PyTuple, PyType};
 use pyo3::{PyResult, intern};
 

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -13,7 +13,7 @@
 #[cfg(feature = "cache_pygates")]
 use std::sync::OnceLock;
 
-use numpy::{IntoPyArray, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
+use numpy::{IntoPyArray, PyArray2, PyReadonlyArray2};
 use pyo3::IntoPyObjectExt;
 use pyo3::basic::CompareOp;
 use pyo3::exceptions::{PyDeprecationWarning, PyTypeError, PyValueError};
@@ -222,7 +222,7 @@ impl CircuitInstruction {
                     ..
                 } => [
                     indexset.into_py_any(py)?,
-                    loop_param.into_py_any(py)?,
+                    loop_param.clone().into_py_any(py)?,
                     data_to_circuit(self.blocks_view()[0].clone())?,
                 ]
                 .into_py_any(py),

--- a/crates/circuit/src/converters.rs
+++ b/crates/circuit/src/converters.rs
@@ -12,6 +12,7 @@
 
 use pyo3::intern;
 use pyo3::prelude::*;
+use std::sync::Arc;
 
 use crate::bit::{ShareableClbit, ShareableQubit};
 use crate::circuit_data::{CircuitData, CircuitVar};
@@ -59,7 +60,7 @@ pub fn dag_to_circuit(dag: &DAGCircuit, copy_operations: bool) -> PyResult<Circu
         let dag_blocks = dag.iter_blocks();
         let mut circuit_blocks = Vec::with_capacity(dag_blocks.len());
         for dag_block in dag_blocks {
-            circuit_blocks.push(dag_to_circuit(dag_block, copy_operations)?);
+            circuit_blocks.push(Arc::new(dag_to_circuit(dag_block, copy_operations)?));
         }
         circuit_blocks
     };

--- a/crates/circuit/src/converters.rs
+++ b/crates/circuit/src/converters.rs
@@ -17,9 +17,7 @@ use crate::bit::{ShareableClbit, ShareableQubit};
 use crate::circuit_data::{CircuitData, CircuitVar};
 use crate::dag_circuit::DAGIdentifierInfo;
 use crate::dag_circuit::{DAGCircuit, NodeType};
-use crate::object_registry::{ObjectRegistry, PyObjectAsKey};
 use crate::operations::{OperationRef, PythonOperation};
-use crate::{Block, imports};
 
 /// An extractable representation of a QuantumCircuit reserved only for
 /// conversion purposes.
@@ -59,19 +57,11 @@ pub fn circuit_to_dag(
 pub fn dag_to_circuit(dag: &DAGCircuit, copy_operations: bool) -> PyResult<CircuitData> {
     let blocks = {
         let dag_blocks = dag.iter_blocks();
-        let mut registry: ObjectRegistry<Block, PyObjectAsKey> =
-            ObjectRegistry::with_capacity(dag_blocks.len());
-        if dag_blocks.len() > 0 {
-            Python::attach(|py| -> PyResult<()> {
-                let dag_to_circuit = imports::DAG_TO_CIRCUIT.get_bound(py);
-                for dag_block in dag_blocks {
-                    let block = dag_to_circuit.call1((dag_block.clone(),))?;
-                    registry.add(PyObjectAsKey::new(&block), false)?;
-                }
-                Ok(())
-            })?
+        let mut circuit_blocks = Vec::with_capacity(dag_blocks.len());
+        for dag_block in dag_blocks {
+            circuit_blocks.push(dag_to_circuit(dag_block, copy_operations)?);
         }
-        registry
+        circuit_blocks
     };
     CircuitData::from_packed_instructions(
         dag.qubits().clone(),

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -2354,15 +2354,10 @@ impl DAGCircuit {
                                                 .call1((Uuid::new_v4().to_string(),))?;
                                             let mut body_a_circuit =
                                                 converters::dag_to_circuit(body_a, false)?;
-                                            if body_a_circuit
-                                                .get_parameters(py)?
-                                                .contains(loop_param_a)?
-                                            {
+                                            if body_a_circuit.parameters().contains(loop_param_a) {
                                                 body_a_circuit.assign_parameters_from_mapping([
                                                     (
-                                                        ParameterUuid::from_parameter(
-                                                            loop_param_a.bind(py),
-                                                        )?,
+                                                        ParameterUuid::from_symbol(loop_param_a),
                                                         Param::ParameterExpression(Arc::new(
                                                             ParameterExpression::from_symbol(
                                                                 sentinel.clone().extract()?,
@@ -2371,31 +2366,21 @@ impl DAGCircuit {
                                                     ),
                                                 ])?;
                                             }
-                                            let body_a = DAGCircuit::from_circuit(
-                                                QuantumCircuitData {
-                                                    data: body_a_circuit,
-                                                    name: body_a.name.clone(),
-                                                    metadata: body_a
-                                                        .metadata
-                                                        .as_ref()
-                                                        .map(|m| m.bind(py).clone()),
-                                                },
+                                            let body_a = DAGCircuit::from_circuit_data(
+                                                &body_a_circuit,
                                                 false,
+                                                None,
+                                                None,
                                                 None,
                                                 None,
                                             )?;
 
                                             let mut body_b_circuit =
                                                 converters::dag_to_circuit(body_b, false)?;
-                                            if body_b_circuit
-                                                .get_parameters(py)?
-                                                .contains(loop_param_b)?
-                                            {
+                                            if body_b_circuit.parameters().contains(loop_param_b) {
                                                 body_b_circuit.assign_parameters_from_mapping([
                                                     (
-                                                        ParameterUuid::from_parameter(
-                                                            loop_param_b.bind(py),
-                                                        )?,
+                                                        ParameterUuid::from_symbol(loop_param_b),
                                                         Param::ParameterExpression(Arc::new(
                                                             ParameterExpression::from_symbol(
                                                                 sentinel.clone().extract()?,
@@ -2404,16 +2389,11 @@ impl DAGCircuit {
                                                     ),
                                                 ])?;
                                             }
-                                            let body_b = DAGCircuit::from_circuit(
-                                                QuantumCircuitData {
-                                                    data: body_b_circuit,
-                                                    name: body_b.name.clone(),
-                                                    metadata: body_b
-                                                        .metadata
-                                                        .as_ref()
-                                                        .map(|m| m.bind(py).clone()),
-                                                },
+                                            let body_b = DAGCircuit::from_circuit_data(
+                                                &body_b_circuit,
                                                 false,
+                                                None,
+                                                None,
                                                 None,
                                                 None,
                                             )?;

--- a/crates/circuit/src/dag_node.rs
+++ b/crates/circuit/src/dag_node.rs
@@ -24,6 +24,7 @@ use approx::relative_eq;
 use num_complex::Complex64;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
+use crate::dag_circuit::DAGCircuit;
 use crate::instruction::Instruction;
 use numpy::IntoPyArray;
 use numpy::PyArray2;
@@ -211,7 +212,9 @@ impl DAGOpNode {
                 let other_blocks = borrowed_other.instruction.blocks_view();
                 let mut params_eq = true;
                 for (a, b) in slf_blocks.iter().zip(other_blocks) {
-                    if !a.bind(py).eq(b)? {
+                    let a = DAGCircuit::from_circuit_data(a, false, None, None, None, None)?;
+                    let b = DAGCircuit::from_circuit_data(b, false, None, None, None, None)?;
+                    if !a.__eq__(py, &b)? {
                         params_eq = false;
                         break;
                     }

--- a/crates/circuit/src/instruction.rs
+++ b/crates/circuit/src/instruction.rs
@@ -12,6 +12,7 @@
 
 use crate::circuit_data::CircuitData;
 use crate::operations::{OperationRef, Param};
+use crate::parameter::symbol_expr::Symbol;
 use ndarray::Array2;
 use num_complex::Complex64;
 use pyo3::prelude::*;

--- a/crates/circuit/src/instruction.rs
+++ b/crates/circuit/src/instruction.rs
@@ -12,7 +12,6 @@
 
 use crate::circuit_data::CircuitData;
 use crate::operations::{OperationRef, Param};
-use crate::parameter::symbol_expr::Symbol;
 use ndarray::Array2;
 use num_complex::Complex64;
 use pyo3::prelude::*;

--- a/crates/circuit/src/instruction.rs
+++ b/crates/circuit/src/instruction.rs
@@ -10,6 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use crate::circuit_data::CircuitData;
 use crate::operations::{OperationRef, Param};
 use ndarray::Array2;
 use num_complex::Complex64;
@@ -76,7 +77,7 @@ pub trait Instruction {
     ///
     /// For standard gates without parameters this may be [None] or a
     /// `Some(Parameters::Param(smallvec![]))`.
-    fn parameters(&self) -> Option<&Parameters<Py<PyAny>>>;
+    fn parameters(&self) -> Option<&Parameters<CircuitData>>;
 
     /// Get the label for this instruction.
     fn label(&self) -> Option<&str>;
@@ -94,7 +95,7 @@ pub trait Instruction {
 
     /// Get a slice view onto the contained blocks.
     #[inline]
-    fn blocks_view(&self) -> &[Py<PyAny>] {
+    fn blocks_view(&self) -> &[CircuitData] {
         self.parameters()
             .and_then(|p| match p {
                 Parameters::Blocks(b) => Some(b.as_slice()),
@@ -117,7 +118,7 @@ pub trait Instruction {
 pub fn create_py_op(
     py: Python,
     op: OperationRef,
-    params: Option<Parameters<Py<PyAny>>>,
+    params: Option<Parameters<CircuitData>>,
     label: Option<&str>,
 ) -> PyResult<Py<PyAny>> {
     match op {

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -491,7 +491,7 @@ impl ControlFlowInstruction {
     pub fn create_py_op(
         &self,
         py: Python,
-        blocks: Option<Vec<Py<PyAny>>>,
+        blocks: Option<Vec<CircuitData>>,
         label: Option<&str>,
     ) -> PyResult<Py<PyAny>> {
         let mut blocks = blocks.into_iter().flatten();

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -491,12 +491,12 @@ impl ControlFlowInstruction {
             .unwrap_or_default()
             .iter()
             .map(|b| {
-                Ok(QUANTUM_CIRCUIT
+                Ok(imports::QUANTUM_CIRCUIT
                     .get_bound(py)
                     .call_method1(intern!(py, "_from_circuit_data"), (b.clone(),))?
                     .unbind())
             })
-            .collect::<Vec<PyResult<_>>>()?
+            .collect::<PyResult<Vec<_>>>()?
             .into_iter();
         let kwargs = label
             .map(|label| [("label", label.into_py_any(py)?)].into_py_dict(py))

--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -17,7 +17,6 @@ use num_complex::Complex;
 use numpy::IntoPyArray;
 use pyo3::Bound;
 use pyo3::IntoPyObjectExt;
-use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyAny;
 use qiskit_circuit::bit::ShareableQubit;
@@ -27,7 +26,7 @@ use qiskit_circuit::converters::QuantumCircuitData;
 use qiskit_circuit::converters::dag_to_circuit;
 use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_circuit::gate_matrix::CX_GATE;
-use qiskit_circuit::imports::{HLS_SYNTHESIZE_OP_USING_PLUGINS, QS_DECOMPOSITION, QUANTUM_CIRCUIT};
+use qiskit_circuit::imports::{HLS_SYNTHESIZE_OP_USING_PLUGINS, QS_DECOMPOSITION};
 use qiskit_circuit::operations::{
     Operation, OperationRef, Param, StandardGate, StandardInstruction, radd_param,
 };
@@ -575,12 +574,11 @@ fn run_on_circuitdata(
         // Check if synthesis for this operation can be skipped
         if definitely_skip_op(py, data, &inst.op, &op_qubits) {
             if let Some(cf) = input_circuit.try_view_control_flow(inst) {
-                let blocks: Vec<_> = Python::attach(|py| {
-                    cf.blocks()
-                        .into_iter()
-                        .map(|b| output_circuit.add_block(b.bind(py)))
-                        .collect()
-                });
+                let blocks: Vec<_> = cf
+                    .blocks()
+                    .into_iter()
+                    .map(|b| output_circuit.add_block(b.clone()))
+                    .collect();
                 output_circuit.push(PackedInstruction {
                     params: (!blocks.is_empty()).then(|| Box::new(Parameters::Blocks(blocks))),
                     ..inst.clone()
@@ -599,16 +597,8 @@ fn run_on_circuitdata(
         // avoid complications related to tracking qubit status for while- loops.
         // In the future, this handling can potentially be improved.
         if let Some(control_flow) = input_circuit.try_view_control_flow(inst) {
-            let quantum_circuit_cls = QUANTUM_CIRCUIT.get_bound(py);
-
-            // old_blocks_py keeps the original QuantumCircuit's appearing within control-flow ops
-            // new_blocks_py keeps the recursively synthesized circuits
-            let old_blocks_py: Vec<Bound<PyAny>> = control_flow
-                .blocks()
-                .into_iter()
-                .map(|b| b.bind(py).clone())
-                .collect();
-            let mut new_blocks_py: Vec<Bound<PyAny>> = Vec::with_capacity(old_blocks_py.len());
+            let old_blocks = control_flow.blocks();
+            let mut new_blocks: Vec<CircuitData> = Vec::with_capacity(old_blocks.len());
 
             // We do not allow using any additional qubits outside of the block.
             let mut block_tracker = tracker.clone();
@@ -618,30 +608,15 @@ fn run_on_circuitdata(
             block_tracker.disable(to_disable);
             block_tracker.set_dirty(&op_qubits);
 
-            for block_py in old_blocks_py {
-                let old_block_py: QuantumCircuitData = block_py.extract()?;
-                let (new_block, _) = run_on_circuitdata(
-                    py,
-                    &old_block_py.data,
-                    &op_qubits,
-                    data,
-                    &mut block_tracker,
-                )?;
-                let new_block = new_block.into_bound_py_any(py)?;
-
-                // We create the new quantum circuit by calling copy_empty_like on the old quantum circuit
-                // and manually set the circuit data to the (recursively synthesized) data.
-                // This makes sure that all the python-space information (qregs, cregs, input variables)
-                // get copied correctly.
-                let new_block_py: Bound<'_, PyAny> = quantum_circuit_cls
-                    .call_method1(intern!(py, "copy_empty_like"), (block_py,))?;
-                new_block_py.setattr(intern!(py, "_data"), &new_block)?;
-                new_blocks_py.push(new_block_py);
+            for old_block in old_blocks {
+                let (new_block, _) =
+                    run_on_circuitdata(py, old_block, &op_qubits, data, &mut block_tracker)?;
+                new_blocks.push(new_block);
             }
 
-            let blocks = new_blocks_py
+            let blocks = new_blocks
                 .into_iter()
-                .map(|b| output_circuit.add_block(&b))
+                .map(|b| output_circuit.add_block(b))
                 .collect();
             let packed_instruction = PackedInstruction::from_control_flow(
                 inst.op.control_flow().clone(),

--- a/crates/transpiler/src/target/mod.rs
+++ b/crates/transpiler/src/target/mod.rs
@@ -49,6 +49,7 @@ use qiskit_circuit::packed_instruction::PackedOperation;
 
 use crate::TranspilerError;
 use bounds::AngleBound;
+use qiskit_circuit::circuit_data::CircuitData;
 
 // Custom types
 type GateMap = IndexMap<String, PropsMap, RandomState>;
@@ -73,10 +74,20 @@ impl TargetOperation {
         }
     }
 
+    /// Gets the parameters of a [TargetOperation], will panic if the operation is [TargetOperation::Variadic].
+    pub fn params(&self) -> Option<&Parameters<CircuitData>> {
+        match &self {
+            TargetOperation::Normal(normal) => normal.parameters(),
+            TargetOperation::Variadic(_) => {
+                panic!("'parameters' property doesn't exist for Variadic operations")
+            }
+        }
+    }
+
     /// Creates a [TargetOperation] from an instance of [PackedOperation]
     pub fn from_packed_operation(
         operation: PackedOperation,
-        params: Option<Parameters<Py<PyAny>>>,
+        params: Option<Parameters<CircuitData>>,
     ) -> Self {
         NormalOperation::from_packed_operation(operation, params).into()
     }
@@ -93,7 +104,7 @@ impl From<NormalOperation> for TargetOperation {
 #[derive(Debug)]
 pub struct NormalOperation {
     pub operation: PackedOperation,
-    pub params: Option<Parameters<Py<PyAny>>>,
+    pub params: Option<Parameters<CircuitData>>,
     op_object: OnceLock<PyResult<Py<PyAny>>>,
 }
 
@@ -101,7 +112,7 @@ impl NormalOperation {
     /// Creates a of [TargetOperation] from an instance of [PackedOperation]
     pub fn from_packed_operation(
         operation: PackedOperation,
-        params: Option<Parameters<Py<PyAny>>>,
+        params: Option<Parameters<CircuitData>>,
     ) -> Self {
         Self {
             operation,
@@ -116,7 +127,7 @@ impl Instruction for NormalOperation {
         self.operation.view()
     }
 
-    fn parameters(&self) -> Option<&Parameters<Py<PyAny>>> {
+    fn parameters(&self) -> Option<&Parameters<CircuitData>> {
         self.params.as_ref()
     }
 
@@ -946,7 +957,7 @@ impl Target {
     pub fn add_instruction(
         &mut self,
         operation: PackedOperation,
-        params: Option<Parameters<Py<PyAny>>>,
+        params: Option<Parameters<CircuitData>>,
         name: Option<&str>,
         props_map: Option<PropsMap>,
     ) -> Result<(), TargetError> {

--- a/crates/transpiler/src/target/mod.rs
+++ b/crates/transpiler/src/target/mod.rs
@@ -74,16 +74,6 @@ impl TargetOperation {
         }
     }
 
-    /// Gets the parameters of a [TargetOperation], will panic if the operation is [TargetOperation::Variadic].
-    pub fn params(&self) -> Option<&Parameters<CircuitData>> {
-        match &self {
-            TargetOperation::Normal(normal) => normal.parameters(),
-            TargetOperation::Variadic(_) => {
-                panic!("'parameters' property doesn't exist for Variadic operations")
-            }
-        }
-    }
-
     /// Creates a [TargetOperation] from an instance of [PackedOperation]
     pub fn from_packed_operation(
         operation: PackedOperation,

--- a/crates/transpiler/src/transpiler.rs
+++ b/crates/transpiler/src/transpiler.rs
@@ -544,7 +544,7 @@ mod tests {
 
     fn build_universal_star_target() -> Target {
         let mut target = Target::default();
-        let u_params: Option<Parameters<Py<PyAny>>> = Some(Parameters::Params(smallvec![
+        let u_params: Option<Parameters<CircuitData>> = Some(Parameters::Params(smallvec![
             Param::ParameterExpression(Arc::new(ParameterExpression::from_symbol(Symbol::new(
                 "a", None, None,
             )))),


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Built on top of #14568. This is just the mechanical change of moving `CircuitData`'s block type to also be `CircuitData` instead of `Py<PyAny>`.

For a readable diff until that merges, see here:
https://github.com/kevinhartman/qiskit/compare/oxidize-ctrl-flow...kevinhartman:qiskit:oxidize-circ-blocks

### Details and comments

Todo:

- [ ] Release note.
- [ ] Improve this description a bit.
