### PR TITLE
change: printf to fprintf(stderr,..) for c tests

### DIFF
--- a/test/c/common.c
+++ b/test/c/common.c
@@ -64,7 +64,7 @@ void print_circuit(const QkCircuit *qc) {
 
 bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
     if (qk_circuit_num_instructions(res) != qk_circuit_num_instructions(expected)) {
-        printf("Number of instructions in circuit is mismatched\n");
+        fprintf(stderr,"Number of instructions in circuit is mismatched\n");
         return false;
     }
     QkCircuitInstruction res_inst;
@@ -74,14 +74,14 @@ bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
         qk_circuit_get_instruction(expected, i, &expected_inst);
         int result = strcmp(res_inst.name, expected_inst.name);
         if (result != 0) {
-            printf("Gate %zu have different gates %s was found and expected %s\n", i, res_inst.name,
+            fprintf(stderr,"Gate %zu have different gates %s was found and expected %s\n", i, res_inst.name,
                    expected_inst.name);
             qk_circuit_instruction_clear(&res_inst);
             qk_circuit_instruction_clear(&expected_inst);
             return false;
         }
         if (res_inst.num_qubits != expected_inst.num_qubits) {
-            printf("Gate %zu have different number of qubits %d was found and expected %d\n", i,
+            fprintf(stderr,"Gate %zu have different number of qubits %d was found and expected %d\n", i,
                    res_inst.num_qubits, expected_inst.num_qubits);
             qk_circuit_instruction_clear(&res_inst);
             qk_circuit_instruction_clear(&expected_inst);
@@ -89,11 +89,11 @@ bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
         }
         for (uint32_t j = 0; j < res_inst.num_qubits; j++) {
             if (res_inst.qubits[j] != expected_inst.qubits[j]) {
-                printf("Qubit %d for gate %zu are different %d was found and expected %d\n", j, i,
+                fprintf(stderr,"Qubit %d for gate %zu are different %d was found and expected %d\n", j, i,
                        res_inst.qubits[j], expected_inst.qubits[j]);
-                printf("Expected circuit instructions:\n");
+                fprintf(stderr,"Expected circuit instructions:\n");
                 print_circuit(expected);
-                printf("Result circuit:\n");
+                fprintf(stderr,"Result circuit:\n");
                 print_circuit(res);
                 qk_circuit_instruction_clear(&res_inst);
                 qk_circuit_instruction_clear(&expected_inst);
@@ -101,7 +101,7 @@ bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
             }
         }
         if (res_inst.num_clbits != expected_inst.num_clbits) {
-            printf("Gate %zu have different number of clbits %d was found and expected %d\n", i,
+            fprintf(stderr,"Gate %zu have different number of clbits %d was found and expected %d\n", i,
                    res_inst.num_clbits, expected_inst.num_clbits);
             qk_circuit_instruction_clear(&res_inst);
             qk_circuit_instruction_clear(&expected_inst);
@@ -109,7 +109,7 @@ bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
         }
         for (uint32_t j = 0; j < res_inst.num_clbits; j++) {
             if (res_inst.clbits[j] != expected_inst.clbits[j]) {
-                printf("Clbit %d for gate %zu are different %d was found and expected %d\n", j, i,
+                fprintf(stderr,"Clbit %d for gate %zu are different %d was found and expected %d\n", j, i,
                        res_inst.clbits[j], expected_inst.clbits[j]);
                 qk_circuit_instruction_clear(&res_inst);
                 qk_circuit_instruction_clear(&expected_inst);
@@ -117,7 +117,7 @@ bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
             }
         }
         if (res_inst.num_params != expected_inst.num_params) {
-            printf("Gate %zu have different number of params %d was found and expected %d\n", i,
+            fprintf(stderr,"Gate %zu have different number of params %d was found and expected %d\n", i,
                    res_inst.num_params, expected_inst.num_params);
             qk_circuit_instruction_clear(&res_inst);
             qk_circuit_instruction_clear(&expected_inst);
@@ -125,7 +125,7 @@ bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
         }
         for (uint32_t j = 0; j < res_inst.num_params; j++) {
             if (res_inst.params[j] != expected_inst.params[j]) {
-                printf("Parameter %d for gate %zu are different %f was found and expected %f\n", j,
+                fprintf(stderr,"Parameter %d for gate %zu are different %f was found and expected %f\n", j,
                        i, res_inst.params[j], expected_inst.params[j]);
                 qk_circuit_instruction_clear(&res_inst);
                 qk_circuit_instruction_clear(&expected_inst);

--- a/test/c/common.c
+++ b/test/c/common.c
@@ -64,7 +64,7 @@ void print_circuit(const QkCircuit *qc) {
 
 bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
     if (qk_circuit_num_instructions(res) != qk_circuit_num_instructions(expected)) {
-        fprintf(stderr,"Number of instructions in circuit is mismatched\n");
+        fprintf(stderr, "Number of instructions in circuit is mismatched\n");
         return false;
     }
     QkCircuitInstruction res_inst;
@@ -74,26 +74,28 @@ bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
         qk_circuit_get_instruction(expected, i, &expected_inst);
         int result = strcmp(res_inst.name, expected_inst.name);
         if (result != 0) {
-            fprintf(stderr,"Gate %zu have different gates %s was found and expected %s\n", i, res_inst.name,
-                   expected_inst.name);
+            fprintf(stderr, "Gate %zu have different gates %s was found and expected %s\n", i,
+                    res_inst.name, expected_inst.name);
             qk_circuit_instruction_clear(&res_inst);
             qk_circuit_instruction_clear(&expected_inst);
             return false;
         }
         if (res_inst.num_qubits != expected_inst.num_qubits) {
-            fprintf(stderr,"Gate %zu have different number of qubits %d was found and expected %d\n", i,
-                   res_inst.num_qubits, expected_inst.num_qubits);
+            fprintf(stderr,
+                    "Gate %zu have different number of qubits %d was found and expected %d\n", i,
+                    res_inst.num_qubits, expected_inst.num_qubits);
             qk_circuit_instruction_clear(&res_inst);
             qk_circuit_instruction_clear(&expected_inst);
             return false;
         }
         for (uint32_t j = 0; j < res_inst.num_qubits; j++) {
             if (res_inst.qubits[j] != expected_inst.qubits[j]) {
-                fprintf(stderr,"Qubit %d for gate %zu are different %d was found and expected %d\n", j, i,
-                       res_inst.qubits[j], expected_inst.qubits[j]);
-                fprintf(stderr,"Expected circuit instructions:\n");
+                fprintf(stderr,
+                        "Qubit %d for gate %zu are different %d was found and expected %d\n", j, i,
+                        res_inst.qubits[j], expected_inst.qubits[j]);
+                fprintf(stderr, "Expected circuit instructions:\n");
                 print_circuit(expected);
-                fprintf(stderr,"Result circuit:\n");
+                fprintf(stderr, "Result circuit:\n");
                 print_circuit(res);
                 qk_circuit_instruction_clear(&res_inst);
                 qk_circuit_instruction_clear(&expected_inst);
@@ -101,32 +103,36 @@ bool compare_circuits(const QkCircuit *res, const QkCircuit *expected) {
             }
         }
         if (res_inst.num_clbits != expected_inst.num_clbits) {
-            fprintf(stderr,"Gate %zu have different number of clbits %d was found and expected %d\n", i,
-                   res_inst.num_clbits, expected_inst.num_clbits);
+            fprintf(stderr,
+                    "Gate %zu have different number of clbits %d was found and expected %d\n", i,
+                    res_inst.num_clbits, expected_inst.num_clbits);
             qk_circuit_instruction_clear(&res_inst);
             qk_circuit_instruction_clear(&expected_inst);
             return false;
         }
         for (uint32_t j = 0; j < res_inst.num_clbits; j++) {
             if (res_inst.clbits[j] != expected_inst.clbits[j]) {
-                fprintf(stderr,"Clbit %d for gate %zu are different %d was found and expected %d\n", j, i,
-                       res_inst.clbits[j], expected_inst.clbits[j]);
+                fprintf(stderr,
+                        "Clbit %d for gate %zu are different %d was found and expected %d\n", j, i,
+                        res_inst.clbits[j], expected_inst.clbits[j]);
                 qk_circuit_instruction_clear(&res_inst);
                 qk_circuit_instruction_clear(&expected_inst);
                 return false;
             }
         }
         if (res_inst.num_params != expected_inst.num_params) {
-            fprintf(stderr,"Gate %zu have different number of params %d was found and expected %d\n", i,
-                   res_inst.num_params, expected_inst.num_params);
+            fprintf(stderr,
+                    "Gate %zu have different number of params %d was found and expected %d\n", i,
+                    res_inst.num_params, expected_inst.num_params);
             qk_circuit_instruction_clear(&res_inst);
             qk_circuit_instruction_clear(&expected_inst);
             return false;
         }
         for (uint32_t j = 0; j < res_inst.num_params; j++) {
             if (res_inst.params[j] != expected_inst.params[j]) {
-                fprintf(stderr,"Parameter %d for gate %zu are different %f was found and expected %f\n", j,
-                       i, res_inst.params[j], expected_inst.params[j]);
+                fprintf(stderr,
+                        "Parameter %d for gate %zu are different %f was found and expected %f\n", j,
+                        i, res_inst.params[j], expected_inst.params[j]);
                 qk_circuit_instruction_clear(&res_inst);
                 qk_circuit_instruction_clear(&expected_inst);
                 return false;

--- a/test/c/test_basis_translator.c
+++ b/test/c/test_basis_translator.c
@@ -96,9 +96,10 @@ static int test_basic_basis_translator(void) {
     QkOpCount u_count = result_op_counts.data[0];
     if (u_count.count != 1 || strcmp(u_count.name, "u") != 0) {
         result = EqualityError;
-        fprintf(stderr,"The operation resulting from this translation was incorrect. Expected 'u' gate, "
-               "got '%s'",
-               u_count.name);
+        fprintf(stderr,
+                "The operation resulting from this translation was incorrect. Expected 'u' gate, "
+                "got '%s'",
+                u_count.name);
     }
 
 cleanup:

--- a/test/c/test_basis_translator.c
+++ b/test/c/test_basis_translator.c
@@ -37,7 +37,8 @@ static int test_circuit_in_basis(void) {
     size_t circuit_len = qk_circuit_num_instructions(circuit);
     if (circuit_len != 2) {
         result = EqualityError;
-        printf(
+        fprintf(
+            stderr,
             "The number of gates resulting from the translation is incorrect. Expected 2, got %lu",
             circuit_len);
         goto cleanup;
@@ -51,7 +52,8 @@ static int test_circuit_in_basis(void) {
 
         if (strcmp(inst.name, gate_names[idx]) != 0) {
             result = EqualityError;
-            printf(
+            fprintf(
+                stderr,
                 "The operation resulting from this translation was incorrect. Expected '%s' gate, "
                 "got '%s'",
                 gate_names[idx], inst.name);
@@ -84,7 +86,8 @@ static int test_basic_basis_translator(void) {
 
     if (result_op_counts.len != 1) {
         result = EqualityError;
-        printf(
+        fprintf(
+            stderr,
             "The number of gates resulting from the translation is incorrect. Expected 1, got %lu",
             result_op_counts.len);
         goto cleanup;
@@ -93,7 +96,7 @@ static int test_basic_basis_translator(void) {
     QkOpCount u_count = result_op_counts.data[0];
     if (u_count.count != 1 || strcmp(u_count.name, "u") != 0) {
         result = EqualityError;
-        printf("The operation resulting from this translation was incorrect. Expected 'u' gate, "
+        fprintf(stderr,"The operation resulting from this translation was incorrect. Expected 'u' gate, "
                "got '%s'",
                u_count.name);
     }
@@ -125,7 +128,8 @@ static int test_toffoli_basis_translator(void) {
 
     if (result_op_counts.len != 4) {
         result = EqualityError;
-        printf(
+        fprintf(
+            stderr,
             "The number of gates resulting from the translation is incorrect. Expected 1, got %lu",
             result_op_counts.len);
         goto cleanup;
@@ -138,7 +142,8 @@ static int test_toffoli_basis_translator(void) {
         QkOpCount gate_count = result_op_counts.data[idx];
         if (gate_count.count != freqs[idx] || strcmp(gate_count.name, gates[idx]) != 0) {
             result = EqualityError;
-            printf(
+            fprintf(
+                stderr,
                 "The operation resulting from this translation was incorrect. Expected '%s' gate, "
                 "got '%s'",
                 gates[idx], gate_count.name);

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -35,19 +35,19 @@ static int test_empty(void) {
     qk_circuit_free(qc);
 
     if (opcount != 0) {
-        fprintf(stderr,"The operation count %zu is not 0", opcount);
+        fprintf(stderr, "The operation count %zu is not 0", opcount);
         return EqualityError;
     }
     if (num_qubits != 0) {
-        fprintf(stderr,"The number of qubits %d is not 0", num_qubits);
+        fprintf(stderr, "The number of qubits %d is not 0", num_qubits);
         return EqualityError;
     }
     if (num_clbits != 0) {
-        fprintf(stderr,"The number of clbits %d is not 0", num_clbits);
+        fprintf(stderr, "The number of clbits %d is not 0", num_clbits);
         return EqualityError;
     }
     if (num_instructions != 0) {
-        fprintf(stderr,"The number of instructions %zu is not 0", num_instructions);
+        fprintf(stderr, "The number of instructions %zu is not 0", num_instructions);
         return EqualityError;
     }
     return Ok;
@@ -63,15 +63,15 @@ static int test_circuit_with_quantum_reg(void) {
     qk_circuit_free(qc);
     qk_quantum_register_free(qr);
     if (num_qubits != 1024) {
-        fprintf(stderr,"The number of qubits %d is not 1024", num_qubits);
+        fprintf(stderr, "The number of qubits %d is not 1024", num_qubits);
         return EqualityError;
     }
     if (num_clbits != 0) {
-        fprintf(stderr,"The number of clbits %d is not 0", num_clbits);
+        fprintf(stderr, "The number of clbits %d is not 0", num_clbits);
         return EqualityError;
     }
     if (num_instructions != 0) {
-        fprintf(stderr,"The number of instructions %zu is not 0", num_instructions);
+        fprintf(stderr, "The number of instructions %zu is not 0", num_instructions);
         return EqualityError;
     }
     return Ok;
@@ -94,8 +94,8 @@ static int test_circuit_copy(void) {
     qk_circuit_free(qc);
     qk_circuit_free(copy);
     if (num_instructions == num_copy_instructions) {
-        fprintf(stderr,"The number of instructions %zu is equal to the copied %zu", num_instructions,
-               num_copy_instructions);
+        fprintf(stderr, "The number of instructions %zu is equal to the copied %zu",
+                num_instructions, num_copy_instructions);
         return EqualityError;
     }
     return Ok;
@@ -111,15 +111,15 @@ static int test_circuit_with_classical_reg(void) {
     qk_circuit_free(qc);
     qk_classical_register_free(cr);
     if (num_qubits != 0) {
-        fprintf(stderr,"The number of qubits %d is not 0", num_qubits);
+        fprintf(stderr, "The number of qubits %d is not 0", num_qubits);
         return EqualityError;
     }
     if (num_clbits != 2048) {
-        fprintf(stderr,"The number of clbits %d is not 2048", num_clbits);
+        fprintf(stderr, "The number of clbits %d is not 2048", num_clbits);
         return EqualityError;
     }
     if (num_instructions != 0) {
-        fprintf(stderr,"The number of instructions %zu is not 0", num_instructions);
+        fprintf(stderr, "The number of instructions %zu is not 0", num_instructions);
         return EqualityError;
     }
     return Ok;
@@ -138,8 +138,8 @@ static int test_circuit_copy_with_instructions(void) {
     size_t num_instructions = qk_circuit_num_instructions(qc);
     size_t num_copy_instructions = qk_circuit_num_instructions(copy);
     if (num_instructions != num_copy_instructions) {
-        fprintf(stderr,"The number of instructions %zu does not equal the copied %zu", num_instructions,
-               num_copy_instructions);
+        fprintf(stderr, "The number of instructions %zu does not equal the copied %zu",
+                num_instructions, num_copy_instructions);
         return EqualityError;
     }
 
@@ -163,8 +163,8 @@ static int test_circuit_copy_with_instructions(void) {
     qk_circuit_free(qc);
     qk_circuit_free(copy);
     if (num_instructions == num_copy_instructions) {
-        fprintf(stderr,"The number of instructions %zu is equal to the copied %zu", num_instructions,
-               num_copy_instructions);
+        fprintf(stderr, "The number of instructions %zu is equal to the copied %zu",
+                num_instructions, num_copy_instructions);
         return EqualityError;
     }
     return Ok;
@@ -178,15 +178,15 @@ static int test_no_gate_1000_bits(void) {
     qk_circuit_free(qc);
 
     if (num_qubits != 1000) {
-        fprintf(stderr,"The number of qubits %d is not 1000", num_qubits);
+        fprintf(stderr, "The number of qubits %d is not 1000", num_qubits);
         return EqualityError;
     }
     if (num_clbits != 1000) {
-        fprintf(stderr,"The number of clbits %d is not 1000", num_clbits);
+        fprintf(stderr, "The number of clbits %d is not 1000", num_clbits);
         return EqualityError;
     }
     if (num_instructions != 0) {
-        fprintf(stderr,"The number of instructions %zu is not 0", num_instructions);
+        fprintf(stderr, "The number of instructions %zu is not 0", num_instructions);
         return EqualityError;
     }
 
@@ -898,14 +898,14 @@ static int test_not_unitary_gate(void) {
 
     int result = Ok;
     if (exit_code != QkExitCode_ExpectedUnitary) {
-        fprintf(stderr,"Got exit code %i but expected %i", exit_code, QkExitCode_ExpectedUnitary);
+        fprintf(stderr, "Got exit code %i but expected %i", exit_code, QkExitCode_ExpectedUnitary);
         result = EqualityError;
         goto cleanup;
     }
 
     size_t num_inst = qk_circuit_num_instructions(qc);
     if (num_inst != 0) { // we expect no gate was added
-        fprintf(stderr,"Found gate when none should be added");
+        fprintf(stderr, "Found gate when none should be added");
         result = EqualityError;
         goto cleanup;
     }

--- a/test/c/test_circuit.c
+++ b/test/c/test_circuit.c
@@ -35,19 +35,19 @@ static int test_empty(void) {
     qk_circuit_free(qc);
 
     if (opcount != 0) {
-        printf("The operation count %zu is not 0", opcount);
+        fprintf(stderr,"The operation count %zu is not 0", opcount);
         return EqualityError;
     }
     if (num_qubits != 0) {
-        printf("The number of qubits %d is not 0", num_qubits);
+        fprintf(stderr,"The number of qubits %d is not 0", num_qubits);
         return EqualityError;
     }
     if (num_clbits != 0) {
-        printf("The number of clbits %d is not 0", num_clbits);
+        fprintf(stderr,"The number of clbits %d is not 0", num_clbits);
         return EqualityError;
     }
     if (num_instructions != 0) {
-        printf("The number of instructions %zu is not 0", num_instructions);
+        fprintf(stderr,"The number of instructions %zu is not 0", num_instructions);
         return EqualityError;
     }
     return Ok;
@@ -63,15 +63,15 @@ static int test_circuit_with_quantum_reg(void) {
     qk_circuit_free(qc);
     qk_quantum_register_free(qr);
     if (num_qubits != 1024) {
-        printf("The number of qubits %d is not 1024", num_qubits);
+        fprintf(stderr,"The number of qubits %d is not 1024", num_qubits);
         return EqualityError;
     }
     if (num_clbits != 0) {
-        printf("The number of clbits %d is not 0", num_clbits);
+        fprintf(stderr,"The number of clbits %d is not 0", num_clbits);
         return EqualityError;
     }
     if (num_instructions != 0) {
-        printf("The number of instructions %zu is not 0", num_instructions);
+        fprintf(stderr,"The number of instructions %zu is not 0", num_instructions);
         return EqualityError;
     }
     return Ok;
@@ -94,7 +94,7 @@ static int test_circuit_copy(void) {
     qk_circuit_free(qc);
     qk_circuit_free(copy);
     if (num_instructions == num_copy_instructions) {
-        printf("The number of instructions %zu is equal to the copied %zu", num_instructions,
+        fprintf(stderr,"The number of instructions %zu is equal to the copied %zu", num_instructions,
                num_copy_instructions);
         return EqualityError;
     }
@@ -111,15 +111,15 @@ static int test_circuit_with_classical_reg(void) {
     qk_circuit_free(qc);
     qk_classical_register_free(cr);
     if (num_qubits != 0) {
-        printf("The number of qubits %d is not 0", num_qubits);
+        fprintf(stderr,"The number of qubits %d is not 0", num_qubits);
         return EqualityError;
     }
     if (num_clbits != 2048) {
-        printf("The number of clbits %d is not 2048", num_clbits);
+        fprintf(stderr,"The number of clbits %d is not 2048", num_clbits);
         return EqualityError;
     }
     if (num_instructions != 0) {
-        printf("The number of instructions %zu is not 0", num_instructions);
+        fprintf(stderr,"The number of instructions %zu is not 0", num_instructions);
         return EqualityError;
     }
     return Ok;
@@ -138,7 +138,7 @@ static int test_circuit_copy_with_instructions(void) {
     size_t num_instructions = qk_circuit_num_instructions(qc);
     size_t num_copy_instructions = qk_circuit_num_instructions(copy);
     if (num_instructions != num_copy_instructions) {
-        printf("The number of instructions %zu does not equal the copied %zu", num_instructions,
+        fprintf(stderr,"The number of instructions %zu does not equal the copied %zu", num_instructions,
                num_copy_instructions);
         return EqualityError;
     }
@@ -163,7 +163,7 @@ static int test_circuit_copy_with_instructions(void) {
     qk_circuit_free(qc);
     qk_circuit_free(copy);
     if (num_instructions == num_copy_instructions) {
-        printf("The number of instructions %zu is equal to the copied %zu", num_instructions,
+        fprintf(stderr,"The number of instructions %zu is equal to the copied %zu", num_instructions,
                num_copy_instructions);
         return EqualityError;
     }
@@ -178,15 +178,15 @@ static int test_no_gate_1000_bits(void) {
     qk_circuit_free(qc);
 
     if (num_qubits != 1000) {
-        printf("The number of qubits %d is not 1000", num_qubits);
+        fprintf(stderr,"The number of qubits %d is not 1000", num_qubits);
         return EqualityError;
     }
     if (num_clbits != 1000) {
-        printf("The number of clbits %d is not 1000", num_clbits);
+        fprintf(stderr,"The number of clbits %d is not 1000", num_clbits);
         return EqualityError;
     }
     if (num_instructions != 0) {
-        printf("The number of instructions %zu is not 0", num_instructions);
+        fprintf(stderr,"The number of instructions %zu is not 0", num_instructions);
         return EqualityError;
     }
 
@@ -898,14 +898,14 @@ static int test_not_unitary_gate(void) {
 
     int result = Ok;
     if (exit_code != QkExitCode_ExpectedUnitary) {
-        printf("Got exit code %i but expected %i", exit_code, QkExitCode_ExpectedUnitary);
+        fprintf(stderr,"Got exit code %i but expected %i", exit_code, QkExitCode_ExpectedUnitary);
         result = EqualityError;
         goto cleanup;
     }
 
     size_t num_inst = qk_circuit_num_instructions(qc);
     if (num_inst != 0) { // we expect no gate was added
-        printf("Found gate when none should be added");
+        fprintf(stderr,"Found gate when none should be added");
         result = EqualityError;
         goto cleanup;
     }

--- a/test/c/test_commutative_cancellation.c
+++ b/test/c/test_commutative_cancellation.c
@@ -45,13 +45,13 @@ static int test_commutative_cancellation_target(void) {
 
     result = qk_transpiler_pass_standalone_commutative_cancellation(qc, target, 1.0);
     if (result != 0) {
-        printf("Running the pass failed");
+        fprintf(stderr,"Running the pass failed");
         goto cleanup;
     }
 
     if (qk_circuit_num_instructions(qc) != 1) {
         result = EqualityError;
-        printf("The gates weren't removed by this circuit");
+        fprintf(stderr,"The gates weren't removed by this circuit");
     }
 cleanup:
     qk_circuit_free(qc);
@@ -79,13 +79,13 @@ static int test_commutative_cancellation_no_target(void) {
 
     result = qk_transpiler_pass_standalone_commutative_cancellation(qc, NULL, 1.0);
     if (result != 0) {
-        printf("Running the pass failed");
+        fprintf(stderr,"Running the pass failed");
         goto cleanup;
     }
 
     if (qk_circuit_num_instructions(qc) != 1) {
         result = EqualityError;
-        printf("The gates weren't removed by this circuit");
+        fprintf(stderr,"The gates weren't removed by this circuit");
     }
 cleanup:
     qk_circuit_free(qc);

--- a/test/c/test_commutative_cancellation.c
+++ b/test/c/test_commutative_cancellation.c
@@ -45,13 +45,13 @@ static int test_commutative_cancellation_target(void) {
 
     result = qk_transpiler_pass_standalone_commutative_cancellation(qc, target, 1.0);
     if (result != 0) {
-        fprintf(stderr,"Running the pass failed");
+        fprintf(stderr, "Running the pass failed");
         goto cleanup;
     }
 
     if (qk_circuit_num_instructions(qc) != 1) {
         result = EqualityError;
-        fprintf(stderr,"The gates weren't removed by this circuit");
+        fprintf(stderr, "The gates weren't removed by this circuit");
     }
 cleanup:
     qk_circuit_free(qc);
@@ -79,13 +79,13 @@ static int test_commutative_cancellation_no_target(void) {
 
     result = qk_transpiler_pass_standalone_commutative_cancellation(qc, NULL, 1.0);
     if (result != 0) {
-        fprintf(stderr,"Running the pass failed");
+        fprintf(stderr, "Running the pass failed");
         goto cleanup;
     }
 
     if (qk_circuit_num_instructions(qc) != 1) {
         result = EqualityError;
-        fprintf(stderr,"The gates weren't removed by this circuit");
+        fprintf(stderr, "The gates weren't removed by this circuit");
     }
 cleanup:
     qk_circuit_free(qc);

--- a/test/c/test_consolidate_blocks.c
+++ b/test/c/test_consolidate_blocks.c
@@ -257,7 +257,7 @@ static int test_non_cx_target(void) {
     QkOpCounts counts = qk_circuit_count_ops(qc);
     if (counts.len != 1) {
         result = EqualityError;
-        printf("The pass run did not result in a circuit with one unitary gate. Expected 1 gate, "
+        fprintf(stderr,"The pass run did not result in a circuit with one unitary gate. Expected 1 gate, "
                "got %li.",
                counts.len);
         goto cleanup;
@@ -267,7 +267,7 @@ static int test_non_cx_target(void) {
     qk_circuit_get_instruction(qc, 0, &unitary);
     if (strcmp(unitary.name, "unitary") != 0) {
         result = EqualityError;
-        printf("The pass run did not result in a circuit with one unitary gate. Expected 'unitary' "
+        fprintf(stderr,"The pass run did not result in a circuit with one unitary gate. Expected 'unitary' "
                "gate, got '%s'.",
                unitary.name);
         goto cleanup_inst;

--- a/test/c/test_consolidate_blocks.c
+++ b/test/c/test_consolidate_blocks.c
@@ -257,9 +257,10 @@ static int test_non_cx_target(void) {
     QkOpCounts counts = qk_circuit_count_ops(qc);
     if (counts.len != 1) {
         result = EqualityError;
-        fprintf(stderr,"The pass run did not result in a circuit with one unitary gate. Expected 1 gate, "
-               "got %li.",
-               counts.len);
+        fprintf(stderr,
+                "The pass run did not result in a circuit with one unitary gate. Expected 1 gate, "
+                "got %li.",
+                counts.len);
         goto cleanup;
     }
 
@@ -267,9 +268,11 @@ static int test_non_cx_target(void) {
     qk_circuit_get_instruction(qc, 0, &unitary);
     if (strcmp(unitary.name, "unitary") != 0) {
         result = EqualityError;
-        fprintf(stderr,"The pass run did not result in a circuit with one unitary gate. Expected 'unitary' "
-               "gate, got '%s'.",
-               unitary.name);
+        fprintf(
+            stderr,
+            "The pass run did not result in a circuit with one unitary gate. Expected 'unitary' "
+            "gate, got '%s'.",
+            unitary.name);
         goto cleanup_inst;
     }
 cleanup_inst:

--- a/test/c/test_elide_permutations.c
+++ b/test/c/test_elide_permutations.c
@@ -35,7 +35,7 @@ static int test_elide_permutations_no_result(void) {
     int result = Ok;
     QkTranspileLayout *pass_result = qk_transpiler_pass_standalone_elide_permutations(qc);
     if (pass_result != NULL) {
-        printf("A gate was elided when one shouldn't have been\n");
+        fprintf(stderr,"A gate was elided when one shouldn't have been\n");
         qk_transpile_layout_free(pass_result);
         result = EqualityError;
     }
@@ -61,7 +61,7 @@ static int test_elide_permutations_swap_result(void) {
     int result = Ok;
     QkTranspileLayout *pass_result = qk_transpiler_pass_standalone_elide_permutations(qc);
     if (pass_result == NULL) {
-        printf("A gate wasn't elided when one should have been\n");
+        fprintf(stderr,"A gate wasn't elided when one should have been\n");
         result = EqualityError;
         goto cleanup;
     }
@@ -70,21 +70,21 @@ static int test_elide_permutations_swap_result(void) {
     uint32_t expected_permutation[5] = {0, 3, 2, 1, 4};
     for (int i = 0; i < 5; i++) {
         if (permutation[i] != expected_permutation[i]) {
-            printf("Permutation doesn't match expected\n");
+            fprintf(stderr,"Permutation doesn't match expected\n");
             result = EqualityError;
             goto result_cleanup;
         }
     }
     QkOpCounts op_counts = qk_circuit_count_ops(qc);
     if (op_counts.len != 1) {
-        printf("More than 1 type of gates in circuit\n");
+        fprintf(stderr,"More than 1 type of gates in circuit\n");
         result = EqualityError;
         goto ops_cleanup;
     }
     for (size_t i = 0; i < op_counts.len; i++) {
         int swap_gate = strcmp(op_counts.data[i].name, "swap");
         if (swap_gate == 0) {
-            printf("Swap gate in circuit which should have been elided\n");
+            fprintf(stderr,"Swap gate in circuit which should have been elided\n");
             result = EqualityError;
             goto ops_cleanup;
         }

--- a/test/c/test_elide_permutations.c
+++ b/test/c/test_elide_permutations.c
@@ -35,7 +35,7 @@ static int test_elide_permutations_no_result(void) {
     int result = Ok;
     QkTranspileLayout *pass_result = qk_transpiler_pass_standalone_elide_permutations(qc);
     if (pass_result != NULL) {
-        fprintf(stderr,"A gate was elided when one shouldn't have been\n");
+        fprintf(stderr, "A gate was elided when one shouldn't have been\n");
         qk_transpile_layout_free(pass_result);
         result = EqualityError;
     }
@@ -61,7 +61,7 @@ static int test_elide_permutations_swap_result(void) {
     int result = Ok;
     QkTranspileLayout *pass_result = qk_transpiler_pass_standalone_elide_permutations(qc);
     if (pass_result == NULL) {
-        fprintf(stderr,"A gate wasn't elided when one should have been\n");
+        fprintf(stderr, "A gate wasn't elided when one should have been\n");
         result = EqualityError;
         goto cleanup;
     }
@@ -70,21 +70,21 @@ static int test_elide_permutations_swap_result(void) {
     uint32_t expected_permutation[5] = {0, 3, 2, 1, 4};
     for (int i = 0; i < 5; i++) {
         if (permutation[i] != expected_permutation[i]) {
-            fprintf(stderr,"Permutation doesn't match expected\n");
+            fprintf(stderr, "Permutation doesn't match expected\n");
             result = EqualityError;
             goto result_cleanup;
         }
     }
     QkOpCounts op_counts = qk_circuit_count_ops(qc);
     if (op_counts.len != 1) {
-        fprintf(stderr,"More than 1 type of gates in circuit\n");
+        fprintf(stderr, "More than 1 type of gates in circuit\n");
         result = EqualityError;
         goto ops_cleanup;
     }
     for (size_t i = 0; i < op_counts.len; i++) {
         int swap_gate = strcmp(op_counts.data[i].name, "swap");
         if (swap_gate == 0) {
-            fprintf(stderr,"Swap gate in circuit which should have been elided\n");
+            fprintf(stderr, "Swap gate in circuit which should have been elided\n");
             result = EqualityError;
             goto ops_cleanup;
         }

--- a/test/c/test_gate_direction.c
+++ b/test/c/test_gate_direction.c
@@ -28,7 +28,7 @@ static QkTarget *create_target() {
         qk_target_add_instruction(target, cx_entry) != Ok ||
         qk_target_entry_add_property(rzx_entry, qargs, 2, 0.0, 0.0) != Ok ||
         qk_target_add_instruction(target, rzx_entry) != Ok) {
-        fprintf(stderr,"Unexpected error encountered in create_target.");
+        fprintf(stderr, "Unexpected error encountered in create_target.");
         qk_target_free(target);
         return NULL;
     }
@@ -50,7 +50,8 @@ static int test_check_gate_direction(void) {
 
     if ((result = qk_circuit_gate(circuit, QkGate_CX, qargs, NULL)) != Ok ||
         (result = qk_circuit_gate(circuit, QkGate_CX, &qargs[1], NULL)) != Ok) {
-        fprintf(stderr,"Unexpected error encountered while adding CX gates in test_check_gate_direction.");
+        fprintf(stderr,
+                "Unexpected error encountered while adding CX gates in test_check_gate_direction.");
         goto cleanup;
     }
 
@@ -59,8 +60,8 @@ static int test_check_gate_direction(void) {
         result = EqualityError;
     else {
         if ((result = qk_circuit_gate(circuit, QkGate_CX, &qargs[2], NULL)) != Ok) {
-            fprintf(stderr,"Unexpected error encountered while adding a CX gate in "
-                   "test_check_gate_direction.");
+            fprintf(stderr, "Unexpected error encountered while adding a CX gate in "
+                            "test_check_gate_direction.");
             goto cleanup;
         }
         check_pass = qk_transpiler_pass_standalone_check_gate_direction(circuit, target);
@@ -94,7 +95,7 @@ static int test_gate_direction_simple(void) {
             Ok || // would be replaced by 5 gates
         (result = qk_circuit_gate(circuit, QkGate_RZX, &qargs[3], params)) !=
             Ok) { // would be replaced by 5 gates
-        fprintf(stderr,"Unexpected error encountered while adding gates in test_gate_direction.");
+        fprintf(stderr, "Unexpected error encountered while adding gates in test_gate_direction.");
         goto cleanup;
     }
 

--- a/test/c/test_gate_direction.c
+++ b/test/c/test_gate_direction.c
@@ -28,7 +28,7 @@ static QkTarget *create_target() {
         qk_target_add_instruction(target, cx_entry) != Ok ||
         qk_target_entry_add_property(rzx_entry, qargs, 2, 0.0, 0.0) != Ok ||
         qk_target_add_instruction(target, rzx_entry) != Ok) {
-        printf("Unexpected error encountered in create_target.");
+        fprintf(stderr,"Unexpected error encountered in create_target.");
         qk_target_free(target);
         return NULL;
     }
@@ -50,7 +50,7 @@ static int test_check_gate_direction(void) {
 
     if ((result = qk_circuit_gate(circuit, QkGate_CX, qargs, NULL)) != Ok ||
         (result = qk_circuit_gate(circuit, QkGate_CX, &qargs[1], NULL)) != Ok) {
-        printf("Unexpected error encountered while adding CX gates in test_check_gate_direction.");
+        fprintf(stderr,"Unexpected error encountered while adding CX gates in test_check_gate_direction.");
         goto cleanup;
     }
 
@@ -59,7 +59,7 @@ static int test_check_gate_direction(void) {
         result = EqualityError;
     else {
         if ((result = qk_circuit_gate(circuit, QkGate_CX, &qargs[2], NULL)) != Ok) {
-            printf("Unexpected error encountered while adding a CX gate in "
+            fprintf(stderr,"Unexpected error encountered while adding a CX gate in "
                    "test_check_gate_direction.");
             goto cleanup;
         }
@@ -94,7 +94,7 @@ static int test_gate_direction_simple(void) {
             Ok || // would be replaced by 5 gates
         (result = qk_circuit_gate(circuit, QkGate_RZX, &qargs[3], params)) !=
             Ok) { // would be replaced by 5 gates
-        printf("Unexpected error encountered while adding gates in test_gate_direction.");
+        fprintf(stderr,"Unexpected error encountered while adding gates in test_gate_direction.");
         goto cleanup;
     }
 

--- a/test/c/test_remove_diagonal_gates_before_measure.c
+++ b/test/c/test_remove_diagonal_gates_before_measure.c
@@ -29,7 +29,7 @@ int test_remove_z_gate(void) {
     qk_circuit_measure(qc, 0, 0);
 
     if (2 != qk_circuit_num_instructions(qc)) {
-        fprintf(stderr,"Circuit build failure");
+        fprintf(stderr, "Circuit build failure");
         result = RuntimeError;
         goto cleanup;
     }
@@ -37,7 +37,7 @@ int test_remove_z_gate(void) {
     qk_transpiler_pass_standalone_remove_diagonal_gates_before_measure(qc);
 
     if (1 != qk_circuit_num_instructions(qc)) {
-        fprintf(stderr,"Circuit should only have a single instruction");
+        fprintf(stderr, "Circuit should only have a single instruction");
         result = EqualityError;
         goto cleanup;
     }
@@ -46,8 +46,9 @@ int test_remove_z_gate(void) {
     qk_circuit_get_instruction(qc, 0, &inst);
 
     if (0 != strcmp("measure", inst.name)) {
-        fprintf(stderr,"Circuit should contain a single 'measure' instruction. Instead, it has one: '%s'.",
-               inst.name);
+        fprintf(stderr,
+                "Circuit should contain a single 'measure' instruction. Instead, it has one: '%s'.",
+                inst.name);
         result = EqualityError;
         goto cleanup_inst;
     }

--- a/test/c/test_remove_diagonal_gates_before_measure.c
+++ b/test/c/test_remove_diagonal_gates_before_measure.c
@@ -29,7 +29,7 @@ int test_remove_z_gate(void) {
     qk_circuit_measure(qc, 0, 0);
 
     if (2 != qk_circuit_num_instructions(qc)) {
-        printf("Circuit build failure");
+        fprintf(stderr,"Circuit build failure");
         result = RuntimeError;
         goto cleanup;
     }
@@ -37,7 +37,7 @@ int test_remove_z_gate(void) {
     qk_transpiler_pass_standalone_remove_diagonal_gates_before_measure(qc);
 
     if (1 != qk_circuit_num_instructions(qc)) {
-        printf("Circuit should only have a single instruction");
+        fprintf(stderr,"Circuit should only have a single instruction");
         result = EqualityError;
         goto cleanup;
     }
@@ -46,7 +46,7 @@ int test_remove_z_gate(void) {
     qk_circuit_get_instruction(qc, 0, &inst);
 
     if (0 != strcmp("measure", inst.name)) {
-        printf("Circuit should contain a single 'measure' instruction. Instead, it has one: '%s'.",
+        fprintf(stderr,"Circuit should contain a single 'measure' instruction. Instead, it has one: '%s'.",
                inst.name);
         result = EqualityError;
         goto cleanup_inst;

--- a/test/c/test_remove_identity_equiv.c
+++ b/test/c/test_remove_identity_equiv.c
@@ -41,7 +41,7 @@ static int test_remove_identity_equiv_removes_gates(void) {
     qk_transpiler_pass_standalone_remove_identity_equivalent(qc, target, 1.0);
     if (qk_circuit_num_instructions(qc) != 1) {
         result = EqualityError;
-        fprintf(stderr,"The gates weren't removed by this circuit");
+        fprintf(stderr, "The gates weren't removed by this circuit");
     }
 
     qk_circuit_free(qc);

--- a/test/c/test_remove_identity_equiv.c
+++ b/test/c/test_remove_identity_equiv.c
@@ -41,7 +41,7 @@ static int test_remove_identity_equiv_removes_gates(void) {
     qk_transpiler_pass_standalone_remove_identity_equivalent(qc, target, 1.0);
     if (qk_circuit_num_instructions(qc) != 1) {
         result = EqualityError;
-        printf("The gates weren't removed by this circuit");
+        fprintf(stderr,"The gates weren't removed by this circuit");
     }
 
     qk_circuit_free(qc);

--- a/test/c/test_sabre_layout.c
+++ b/test/c/test_sabre_layout.c
@@ -51,7 +51,7 @@ static int test_sabre_layout_applies_layout(void) {
 
     QkOpCounts op_counts = qk_circuit_count_ops(qc);
     if (op_counts.len != 2) {
-        fprintf(stderr,"More than 2 types of gates in circuit, circuit's instructions are:\n");
+        fprintf(stderr, "More than 2 types of gates in circuit, circuit's instructions are:\n");
         print_circuit(qc);
         result = EqualityError;
         goto cleanup;
@@ -61,13 +61,13 @@ static int test_sabre_layout_applies_layout(void) {
         int swap_gate = strcmp(name, "swap");
         int cx_gate = strcmp(name, "cx");
         if (cx_gate != 0 && swap_gate != 0) {
-            fprintf(stderr,"Gate type of %s found in the circuit which isn't expected\n", name);
+            fprintf(stderr, "Gate type of %s found in the circuit which isn't expected\n", name);
             result = EqualityError;
             goto cleanup;
         }
         size_t count = op_counts.data[i].count;
         if (swap_gate == 0 && count != 2) {
-            fprintf(stderr,"Unexpected number of swaps %zu found in the circuit.\n", count);
+            fprintf(stderr, "Unexpected number of swaps %zu found in the circuit.\n", count);
             result = EqualityError;
             goto cleanup;
         }
@@ -77,8 +77,8 @@ static int test_sabre_layout_applies_layout(void) {
     qk_transpile_layout_initial_layout(layout_result, false, result_initial_layout);
     for (uint32_t i = 0; i < 5; i++) {
         if (result_initial_layout[i] != expected_initial_layout[i]) {
-            fprintf(stderr,"Initial layout maps qubit %d to %d, expected %d instead\n", i,
-                   result_initial_layout[i], expected_initial_layout[i]);
+            fprintf(stderr, "Initial layout maps qubit %d to %d, expected %d instead\n", i,
+                    result_initial_layout[i], expected_initial_layout[i]);
             result = EqualityError;
             goto cleanup;
         }
@@ -89,8 +89,8 @@ static int test_sabre_layout_applies_layout(void) {
     qk_transpile_layout_output_permutation(layout_result, result_permutation);
     for (uint32_t i = 0; i < 5; i++) {
         if (result_permutation[i] != expected_permutation[i]) {
-            fprintf(stderr,"Output permutation maps qubit %d to %d, expected %d instead\n", i,
-                   result_permutation[i], expected_permutation[i]);
+            fprintf(stderr, "Output permutation maps qubit %d to %d, expected %d instead\n", i,
+                    result_permutation[i], expected_permutation[i]);
             result = EqualityError;
             goto cleanup;
         }
@@ -175,8 +175,8 @@ static int test_sabre_layout_no_swap(void) {
     qk_transpile_layout_initial_layout(layout_result, false, result_initial_layout);
     for (uint32_t i = 0; i < 5; i++) {
         if (result_initial_layout[i] != expected_initial_layout[i]) {
-            fprintf(stderr,"Initial layout maps qubit %d to %d, expected %d instead\n", i,
-                   result_initial_layout[i], expected_initial_layout[i]);
+            fprintf(stderr, "Initial layout maps qubit %d to %d, expected %d instead\n", i,
+                    result_initial_layout[i], expected_initial_layout[i]);
             result = EqualityError;
             goto cleanup;
         }
@@ -186,8 +186,8 @@ static int test_sabre_layout_no_swap(void) {
     qk_transpile_layout_output_permutation(layout_result, result_permutation);
     for (uint32_t i = 0; i < 5; i++) {
         if (result_permutation[i] != expected_permutation[i]) {
-            fprintf(stderr,"Output permutation maps qubit %d to %d, expected %d instead\n", i,
-                   result_permutation[i], expected_permutation[i]);
+            fprintf(stderr, "Output permutation maps qubit %d to %d, expected %d instead\n", i,
+                    result_permutation[i], expected_permutation[i]);
             result = EqualityError;
             goto cleanup;
         }

--- a/test/c/test_sabre_layout.c
+++ b/test/c/test_sabre_layout.c
@@ -51,7 +51,7 @@ static int test_sabre_layout_applies_layout(void) {
 
     QkOpCounts op_counts = qk_circuit_count_ops(qc);
     if (op_counts.len != 2) {
-        printf("More than 2 types of gates in circuit, circuit's instructions are:\n");
+        fprintf(stderr,"More than 2 types of gates in circuit, circuit's instructions are:\n");
         print_circuit(qc);
         result = EqualityError;
         goto cleanup;
@@ -61,13 +61,13 @@ static int test_sabre_layout_applies_layout(void) {
         int swap_gate = strcmp(name, "swap");
         int cx_gate = strcmp(name, "cx");
         if (cx_gate != 0 && swap_gate != 0) {
-            printf("Gate type of %s found in the circuit which isn't expected\n", name);
+            fprintf(stderr,"Gate type of %s found in the circuit which isn't expected\n", name);
             result = EqualityError;
             goto cleanup;
         }
         size_t count = op_counts.data[i].count;
         if (swap_gate == 0 && count != 2) {
-            printf("Unexpected number of swaps %zu found in the circuit.\n", count);
+            fprintf(stderr,"Unexpected number of swaps %zu found in the circuit.\n", count);
             result = EqualityError;
             goto cleanup;
         }
@@ -77,7 +77,7 @@ static int test_sabre_layout_applies_layout(void) {
     qk_transpile_layout_initial_layout(layout_result, false, result_initial_layout);
     for (uint32_t i = 0; i < 5; i++) {
         if (result_initial_layout[i] != expected_initial_layout[i]) {
-            printf("Initial layout maps qubit %d to %d, expected %d instead\n", i,
+            fprintf(stderr,"Initial layout maps qubit %d to %d, expected %d instead\n", i,
                    result_initial_layout[i], expected_initial_layout[i]);
             result = EqualityError;
             goto cleanup;
@@ -89,7 +89,7 @@ static int test_sabre_layout_applies_layout(void) {
     qk_transpile_layout_output_permutation(layout_result, result_permutation);
     for (uint32_t i = 0; i < 5; i++) {
         if (result_permutation[i] != expected_permutation[i]) {
-            printf("Output permutation maps qubit %d to %d, expected %d instead\n", i,
+            fprintf(stderr,"Output permutation maps qubit %d to %d, expected %d instead\n", i,
                    result_permutation[i], expected_permutation[i]);
             result = EqualityError;
             goto cleanup;
@@ -175,7 +175,7 @@ static int test_sabre_layout_no_swap(void) {
     qk_transpile_layout_initial_layout(layout_result, false, result_initial_layout);
     for (uint32_t i = 0; i < 5; i++) {
         if (result_initial_layout[i] != expected_initial_layout[i]) {
-            printf("Initial layout maps qubit %d to %d, expected %d instead\n", i,
+            fprintf(stderr,"Initial layout maps qubit %d to %d, expected %d instead\n", i,
                    result_initial_layout[i], expected_initial_layout[i]);
             result = EqualityError;
             goto cleanup;
@@ -186,7 +186,7 @@ static int test_sabre_layout_no_swap(void) {
     qk_transpile_layout_output_permutation(layout_result, result_permutation);
     for (uint32_t i = 0; i < 5; i++) {
         if (result_permutation[i] != expected_permutation[i]) {
-            printf("Output permutation maps qubit %d to %d, expected %d instead\n", i,
+            fprintf(stderr,"Output permutation maps qubit %d to %d, expected %d instead\n", i,
                    result_permutation[i], expected_permutation[i]);
             result = EqualityError;
             goto cleanup;

--- a/test/c/test_split_2q_unitaries.c
+++ b/test/c/test_split_2q_unitaries.c
@@ -31,20 +31,20 @@ static int test_split_2q_unitaries_no_unitaries(void) {
     int result = Ok;
     if (split_result != NULL) {
         result = EqualityError;
-        printf("Permutation returned for a circuit that shouldn't split\n");
+        fprintf(stderr,"Permutation returned for a circuit that shouldn't split\n");
         qk_transpile_layout_free(split_result);
         goto cleanup;
     }
     QkOpCounts counts = qk_circuit_count_ops(qc);
     if (counts.len != 1) {
-        printf("More than 1 type of gate in the circuit\n");
+        fprintf(stderr,"More than 1 type of gate in the circuit\n");
         result = EqualityError;
         goto ops_cleanup;
     }
     for (size_t i = 0; i < counts.len; i++) {
         int gate = strcmp(counts.data[i].name, "cx");
         if (gate != 0) {
-            printf("gates changed when there should be no circuit changes\n");
+            fprintf(stderr,"gates changed when there should be no circuit changes\n");
             result = EqualityError;
             goto cleanup;
         }
@@ -71,26 +71,26 @@ static int test_split_2q_unitaries_x_y_unitary(void) {
     int result = Ok;
     if (split_result != NULL) {
         result = EqualityError;
-        printf("Permutation returned for a circuit that shouldn't isn't a swap equivalent\n");
+        fprintf(stderr,"Permutation returned for a circuit that shouldn't isn't a swap equivalent\n");
         qk_transpile_layout_free(split_result);
         goto cleanup;
     }
     QkOpCounts counts = qk_circuit_count_ops(qc);
     if (counts.len != 1) {
-        printf("More than 1 type of gate in the circuit\n");
+        fprintf(stderr,"More than 1 type of gate in the circuit\n");
         result = EqualityError;
         goto ops_cleanup;
     }
     for (size_t i = 0; i < counts.len; i++) {
         int gate = strcmp(counts.data[i].name, "unitary");
         if (gate != 0) {
-            printf("Gates outside expected set in output circuit\n");
+            fprintf(stderr,"Gates outside expected set in output circuit\n");
             result = EqualityError;
             goto ops_cleanup;
         }
         size_t count = counts.data[i].count;
         if (count != 2) {
-            printf("Unexpected gate counts found\n");
+            fprintf(stderr,"Unexpected gate counts found\n");
             result = EqualityError;
             goto ops_cleanup;
         }
@@ -99,7 +99,7 @@ static int test_split_2q_unitaries_x_y_unitary(void) {
     for (size_t i = 0; i < qk_circuit_num_instructions(qc); i++) {
         qk_circuit_get_instruction(qc, i, &inst);
         if (inst.num_qubits != 1) {
-            printf("Gate %zu operates on more than 1 qubit: %u\n", i, inst.num_qubits);
+            fprintf(stderr,"Gate %zu operates on more than 1 qubit: %u\n", i, inst.num_qubits);
             result = EqualityError;
             goto ops_cleanup;
         }
@@ -128,7 +128,7 @@ static int test_split_2q_unitaries_swap_x_y_unitary(void) {
     int result = Ok;
     if (split_result == NULL) {
         result = EqualityError;
-        printf("Permutation not returned for a circuit that should have one\n");
+        fprintf(stderr,"Permutation not returned for a circuit that should have one\n");
         goto cleanup;
     }
     uint32_t permutation[2];
@@ -136,7 +136,7 @@ static int test_split_2q_unitaries_swap_x_y_unitary(void) {
     uint32_t expected[2] = {1, 0};
     for (int i = 0; i < 2; i++) {
         if (permutation[i] != expected[i]) {
-            printf("Permutation at position %d not as expected, found %u expected %u\n", i,
+            fprintf(stderr,"Permutation at position %d not as expected, found %u expected %u\n", i,
                    permutation[i], expected[i]);
             goto cleanup;
         }
@@ -144,20 +144,20 @@ static int test_split_2q_unitaries_swap_x_y_unitary(void) {
 
     QkOpCounts counts = qk_circuit_count_ops(qc);
     if (counts.len != 1) {
-        printf("More than 1 type of gate in the circuit\n");
+        fprintf(stderr,"More than 1 type of gate in the circuit\n");
         result = EqualityError;
         goto ops_cleanup;
     }
     for (size_t i = 0; i < counts.len; i++) {
         int gate = strcmp(counts.data[i].name, "unitary");
         if (gate != 0) {
-            printf("Gates outside expected set in output circuit\n");
+            fprintf(stderr,"Gates outside expected set in output circuit\n");
             result = EqualityError;
             goto ops_cleanup;
         }
         size_t count = counts.data[i].count;
         if (count != 2) {
-            printf("Unexpected gate counts found\n");
+            fprintf(stderr,"Unexpected gate counts found\n");
             result = EqualityError;
             goto ops_cleanup;
         }
@@ -166,7 +166,7 @@ static int test_split_2q_unitaries_swap_x_y_unitary(void) {
     for (size_t i = 0; i < qk_circuit_num_instructions(qc); i++) {
         qk_circuit_get_instruction(qc, i, &inst);
         if (inst.num_qubits != 1) {
-            printf("Gate %zu operates on more than 1 qubit: %u\n", i, inst.num_qubits);
+            fprintf(stderr,"Gate %zu operates on more than 1 qubit: %u\n", i, inst.num_qubits);
             result = EqualityError;
             goto ops_cleanup;
         }

--- a/test/c/test_split_2q_unitaries.c
+++ b/test/c/test_split_2q_unitaries.c
@@ -31,20 +31,20 @@ static int test_split_2q_unitaries_no_unitaries(void) {
     int result = Ok;
     if (split_result != NULL) {
         result = EqualityError;
-        fprintf(stderr,"Permutation returned for a circuit that shouldn't split\n");
+        fprintf(stderr, "Permutation returned for a circuit that shouldn't split\n");
         qk_transpile_layout_free(split_result);
         goto cleanup;
     }
     QkOpCounts counts = qk_circuit_count_ops(qc);
     if (counts.len != 1) {
-        fprintf(stderr,"More than 1 type of gate in the circuit\n");
+        fprintf(stderr, "More than 1 type of gate in the circuit\n");
         result = EqualityError;
         goto ops_cleanup;
     }
     for (size_t i = 0; i < counts.len; i++) {
         int gate = strcmp(counts.data[i].name, "cx");
         if (gate != 0) {
-            fprintf(stderr,"gates changed when there should be no circuit changes\n");
+            fprintf(stderr, "gates changed when there should be no circuit changes\n");
             result = EqualityError;
             goto cleanup;
         }
@@ -71,26 +71,27 @@ static int test_split_2q_unitaries_x_y_unitary(void) {
     int result = Ok;
     if (split_result != NULL) {
         result = EqualityError;
-        fprintf(stderr,"Permutation returned for a circuit that shouldn't isn't a swap equivalent\n");
+        fprintf(stderr,
+                "Permutation returned for a circuit that shouldn't isn't a swap equivalent\n");
         qk_transpile_layout_free(split_result);
         goto cleanup;
     }
     QkOpCounts counts = qk_circuit_count_ops(qc);
     if (counts.len != 1) {
-        fprintf(stderr,"More than 1 type of gate in the circuit\n");
+        fprintf(stderr, "More than 1 type of gate in the circuit\n");
         result = EqualityError;
         goto ops_cleanup;
     }
     for (size_t i = 0; i < counts.len; i++) {
         int gate = strcmp(counts.data[i].name, "unitary");
         if (gate != 0) {
-            fprintf(stderr,"Gates outside expected set in output circuit\n");
+            fprintf(stderr, "Gates outside expected set in output circuit\n");
             result = EqualityError;
             goto ops_cleanup;
         }
         size_t count = counts.data[i].count;
         if (count != 2) {
-            fprintf(stderr,"Unexpected gate counts found\n");
+            fprintf(stderr, "Unexpected gate counts found\n");
             result = EqualityError;
             goto ops_cleanup;
         }
@@ -99,7 +100,7 @@ static int test_split_2q_unitaries_x_y_unitary(void) {
     for (size_t i = 0; i < qk_circuit_num_instructions(qc); i++) {
         qk_circuit_get_instruction(qc, i, &inst);
         if (inst.num_qubits != 1) {
-            fprintf(stderr,"Gate %zu operates on more than 1 qubit: %u\n", i, inst.num_qubits);
+            fprintf(stderr, "Gate %zu operates on more than 1 qubit: %u\n", i, inst.num_qubits);
             result = EqualityError;
             goto ops_cleanup;
         }
@@ -128,7 +129,7 @@ static int test_split_2q_unitaries_swap_x_y_unitary(void) {
     int result = Ok;
     if (split_result == NULL) {
         result = EqualityError;
-        fprintf(stderr,"Permutation not returned for a circuit that should have one\n");
+        fprintf(stderr, "Permutation not returned for a circuit that should have one\n");
         goto cleanup;
     }
     uint32_t permutation[2];
@@ -136,28 +137,28 @@ static int test_split_2q_unitaries_swap_x_y_unitary(void) {
     uint32_t expected[2] = {1, 0};
     for (int i = 0; i < 2; i++) {
         if (permutation[i] != expected[i]) {
-            fprintf(stderr,"Permutation at position %d not as expected, found %u expected %u\n", i,
-                   permutation[i], expected[i]);
+            fprintf(stderr, "Permutation at position %d not as expected, found %u expected %u\n", i,
+                    permutation[i], expected[i]);
             goto cleanup;
         }
     }
 
     QkOpCounts counts = qk_circuit_count_ops(qc);
     if (counts.len != 1) {
-        fprintf(stderr,"More than 1 type of gate in the circuit\n");
+        fprintf(stderr, "More than 1 type of gate in the circuit\n");
         result = EqualityError;
         goto ops_cleanup;
     }
     for (size_t i = 0; i < counts.len; i++) {
         int gate = strcmp(counts.data[i].name, "unitary");
         if (gate != 0) {
-            fprintf(stderr,"Gates outside expected set in output circuit\n");
+            fprintf(stderr, "Gates outside expected set in output circuit\n");
             result = EqualityError;
             goto ops_cleanup;
         }
         size_t count = counts.data[i].count;
         if (count != 2) {
-            fprintf(stderr,"Unexpected gate counts found\n");
+            fprintf(stderr, "Unexpected gate counts found\n");
             result = EqualityError;
             goto ops_cleanup;
         }
@@ -166,7 +167,7 @@ static int test_split_2q_unitaries_swap_x_y_unitary(void) {
     for (size_t i = 0; i < qk_circuit_num_instructions(qc); i++) {
         qk_circuit_get_instruction(qc, i, &inst);
         if (inst.num_qubits != 1) {
-            fprintf(stderr,"Gate %zu operates on more than 1 qubit: %u\n", i, inst.num_qubits);
+            fprintf(stderr, "Gate %zu operates on more than 1 qubit: %u\n", i, inst.num_qubits);
             result = EqualityError;
             goto ops_cleanup;
         }

--- a/test/c/test_target.c
+++ b/test/c/test_target.c
@@ -29,42 +29,42 @@ static int test_empty_target(void) {
     uint32_t num_qubits = qk_target_num_qubits(target);
 
     if (num_qubits != 0) {
-        printf("The number of qubits %u is not 0.", num_qubits);
+        fprintf(stderr,"The number of qubits %u is not 0.", num_qubits);
         result = EqualityError;
         goto cleanup;
     }
 
     double retrieved_dt = qk_target_dt(target);
     if (!isnan(retrieved_dt)) {
-        printf("The dt value of this target %f is not %f.", retrieved_dt, NAN);
+        fprintf(stderr,"The dt value of this target %f is not %f.", retrieved_dt, NAN);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t retrieved_granularity = qk_target_granularity(target);
     if (retrieved_granularity != 1) {
-        printf("The granularity %u is not 1.", retrieved_granularity);
+        fprintf(stderr,"The granularity %u is not 1.", retrieved_granularity);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t retrieved_min_length = qk_target_min_length(target);
     if (retrieved_min_length != 1) {
-        printf("The min_length %u is not 1.", retrieved_min_length);
+        fprintf(stderr,"The min_length %u is not 1.", retrieved_min_length);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t pulse_alignment = qk_target_pulse_alignment(target);
     if (pulse_alignment != 1) {
-        printf("The pulse_alignment values %u is not 1.", pulse_alignment);
+        fprintf(stderr,"The pulse_alignment values %u is not 1.", pulse_alignment);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t acquire_alignment = qk_target_acquire_alignment(target);
     if (acquire_alignment != 1) {
-        printf("The acquire_alignment values %u is not 1.", acquire_alignment);
+        fprintf(stderr,"The acquire_alignment values %u is not 1.", acquire_alignment);
         result = EqualityError;
         goto cleanup;
     }
@@ -95,42 +95,42 @@ static int test_target_construct(void) {
 
     uint32_t retrieved_num_qubits = qk_target_num_qubits(target);
     if (retrieved_num_qubits != 2) {
-        printf("The number of qubits %u is not 0.", num_qubits);
+        fprintf(stderr,"The number of qubits %u is not 0.", num_qubits);
         result = EqualityError;
         goto cleanup;
     }
 
     double retrieved_dt = qk_target_dt(target);
     if (retrieved_dt != dt) {
-        printf("The dt value of this target %f is not %f.", retrieved_dt, dt);
+        fprintf(stderr,"The dt value of this target %f is not %f.", retrieved_dt, dt);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t retrieved_granularity = qk_target_granularity(target);
     if (retrieved_granularity != 2) {
-        printf("The granularity %u is not 2.", retrieved_granularity);
+        fprintf(stderr,"The granularity %u is not 2.", retrieved_granularity);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t retrieved_min_length = qk_target_min_length(target);
     if (retrieved_min_length != 3) {
-        printf("The min_length %u is not 3.", retrieved_min_length);
+        fprintf(stderr,"The min_length %u is not 3.", retrieved_min_length);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t pulse_alignment = qk_target_pulse_alignment(target);
     if (pulse_alignment != 4) {
-        printf("The pulse_alignment values %u is not 4.", pulse_alignment);
+        fprintf(stderr,"The pulse_alignment values %u is not 4.", pulse_alignment);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t acquire_alignment = qk_target_acquire_alignment(target);
     if (acquire_alignment != 1) {
-        printf("The acquire_alignment values %u is not 1.", acquire_alignment);
+        fprintf(stderr,"The acquire_alignment values %u is not 1.", acquire_alignment);
         result = EqualityError;
         goto cleanup;
     }
@@ -150,7 +150,7 @@ static int test_target_construction_ibm_like_target(void) {
     uint32_t cx_qargs[2] = {0, 1};
     QkExitCode result_prop = qk_target_entry_add_property(cx_entry, cx_qargs, 2, 2.2e-4, 6.2e-9);
     if (result_prop != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding entry.");
+        fprintf(stderr,"Unexpected error occurred when adding entry.");
         qk_target_entry_free(cx_entry);
         result = EqualityError;
         goto cleanup;
@@ -158,7 +158,7 @@ static int test_target_construction_ibm_like_target(void) {
     cx_qargs[0] = 2;
     result_prop = qk_target_entry_add_property(cx_entry, cx_qargs, 2, 3.2e-4, 4.2e-9);
     if (result_prop != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding entry.");
+        fprintf(stderr,"Unexpected error occurred when adding entry.");
         qk_target_entry_free(cx_entry);
         result = EqualityError;
         goto cleanup;
@@ -166,7 +166,7 @@ static int test_target_construction_ibm_like_target(void) {
     cx_qargs[1] = 3;
     result_prop = qk_target_entry_add_property(cx_entry, cx_qargs, 2, 1.2e-4, 4.2e-8);
     if (result_prop != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding entry.");
+        fprintf(stderr,"Unexpected error occurred when adding entry.");
         qk_target_entry_free(cx_entry);
         result = EqualityError;
         goto cleanup;
@@ -174,14 +174,14 @@ static int test_target_construction_ibm_like_target(void) {
     cx_qargs[0] = 4;
     result_prop = qk_target_entry_add_property(cx_entry, cx_qargs, 2, 1.2e-3, 2.2e-8);
     if (result_prop != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding entry.");
+        fprintf(stderr,"Unexpected error occurred when adding entry.");
         qk_target_entry_free(cx_entry);
         result = EqualityError;
         goto cleanup;
     }
     QkExitCode result_cx = qk_target_add_instruction(target, cx_entry);
     if (result_cx != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a CX gate.");
+        fprintf(stderr,"Unexpected error occurred when adding a CX gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -191,7 +191,7 @@ static int test_target_construction_ibm_like_target(void) {
         uint32_t qargs[1] = {i};
         result_prop = qk_target_entry_add_property(rz_entry, qargs, 1, 0, 0);
         if (result_prop != QkExitCode_Success) {
-            printf("Unexpected error occurred when adding entry.");
+            fprintf(stderr,"Unexpected error occurred when adding entry.");
             result = EqualityError;
             qk_target_entry_free(rz_entry);
             goto cleanup;
@@ -199,7 +199,7 @@ static int test_target_construction_ibm_like_target(void) {
     }
     QkExitCode result_rz = qk_target_add_instruction(target, rz_entry);
     if (result_rz != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a parameterized RZ gate.");
+        fprintf(stderr,"Unexpected error occurred when adding a parameterized RZ gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -209,7 +209,7 @@ static int test_target_construction_ibm_like_target(void) {
         uint32_t qargs[1] = {i};
         result_prop = qk_target_entry_add_property(sx_entry, qargs, 1, 1.928e-10, 7.9829e-11);
         if (result_prop != QkExitCode_Success) {
-            printf("Unexpected error occurred when adding entry.");
+            fprintf(stderr,"Unexpected error occurred when adding entry.");
             result = EqualityError;
             qk_target_entry_free(sx_entry);
             goto cleanup;
@@ -217,7 +217,7 @@ static int test_target_construction_ibm_like_target(void) {
     }
     QkExitCode result_sx = qk_target_add_instruction(target, sx_entry);
     if (result_sx != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a parameterized RZ gate.");
+        fprintf(stderr,"Unexpected error occurred when adding a parameterized RZ gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -227,7 +227,7 @@ static int test_target_construction_ibm_like_target(void) {
         uint32_t qargs[1] = {i};
         result_prop = qk_target_entry_add_property(x_entry, qargs, 1, 1.928e-10, 7.9829e-11);
         if (result_prop != QkExitCode_Success) {
-            printf("Unexpected error occurred when adding entry.");
+            fprintf(stderr,"Unexpected error occurred when adding entry.");
             result = EqualityError;
             qk_target_entry_free(x_entry);
             goto cleanup;
@@ -235,7 +235,7 @@ static int test_target_construction_ibm_like_target(void) {
     }
     QkExitCode result_x = qk_target_add_instruction(target, x_entry);
     if (result_x != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a parameterized RZ gate.");
+        fprintf(stderr,"Unexpected error occurred when adding a parameterized RZ gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -245,7 +245,7 @@ static int test_target_construction_ibm_like_target(void) {
         uint32_t qargs[1] = {i};
         result_prop = qk_target_entry_add_property(measure_entry, qargs, 1, 1.928e-10, 7.9829e-11);
         if (result_prop != QkExitCode_Success) {
-            printf("Unexpected error occurred when adding entry.");
+            fprintf(stderr,"Unexpected error occurred when adding entry.");
             result = EqualityError;
             qk_target_entry_free(measure_entry);
             goto cleanup;
@@ -253,7 +253,7 @@ static int test_target_construction_ibm_like_target(void) {
     }
     QkExitCode result_measure = qk_target_add_instruction(target, measure_entry);
     if (result_measure != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a parameterized RZ gate.");
+        fprintf(stderr,"Unexpected error occurred when adding a parameterized RZ gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -273,7 +273,7 @@ static int test_target_entry_construction(void) {
     // Test length
     const size_t length = qk_target_entry_num_properties(property_map);
     if (length != 0) {
-        printf("The initial length of the provided property map was not zero: %zu", length);
+        fprintf(stderr,"The initial length of the provided property map was not zero: %zu", length);
         result = EqualityError;
         goto cleanup;
     }
@@ -283,13 +283,13 @@ static int test_target_entry_construction(void) {
 
     QkExitCode result_prop = qk_target_entry_add_property(property_map, qargs, 2, 0.00018, 0.00002);
     if (result_prop != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding entry.");
+        fprintf(stderr,"Unexpected error occurred when adding entry.");
     }
 
     // Test length
     const size_t new_length = qk_target_entry_num_properties(property_map);
     if (new_length != 1) {
-        printf("The initial length of the provided property map was not 1: %zu", length);
+        fprintf(stderr,"The initial length of the provided property map was not 1: %zu", length);
         result = EqualityError;
         goto cleanup;
     }
@@ -301,7 +301,7 @@ static int test_target_entry_construction(void) {
     QkExitCode error_result =
         qk_target_entry_add_property(property_map, invalid_qargs, 3, 0.00018, 0.00002);
     if (error_result != QkExitCode_TargetQargMismatch) {
-        printf("The operation did not fail as expected for invalid qargs.");
+        fprintf(stderr,"The operation did not fail as expected for invalid qargs.");
     }
 
 cleanup:
@@ -322,7 +322,7 @@ static int test_target_add_instruction(void) {
     // This operation is global, no property map is provided
     QkExitCode result_x = qk_target_add_instruction(target, qk_target_entry_new(QkGate_X));
     if (result_x != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a global X gate.");
+        fprintf(stderr,"Unexpected error occurred when adding a global X gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -330,7 +330,7 @@ static int test_target_add_instruction(void) {
     // Re-add same gate, check if it fails
     QkExitCode result_x_readded = qk_target_add_instruction(target, qk_target_entry_new(QkGate_X));
     if (result_x_readded != QkExitCode_TargetInstAlreadyExists) {
-        printf("The addition of a repeated gate did not fail as expected.");
+        fprintf(stderr,"The addition of a repeated gate did not fail as expected.");
         result = EqualityError;
         goto cleanup;
     }
@@ -338,14 +338,14 @@ static int test_target_add_instruction(void) {
     // Number of qubits of the target should not change.
     uint32_t current_num_qubits = qk_target_num_qubits(target);
     if (current_num_qubits != 1) {
-        printf("The number of qubits this target is compatible with is not 1: %u",
+        fprintf(stderr,"The number of qubits this target is compatible with is not 1: %u",
                current_num_qubits);
         result = EqualityError;
         goto cleanup;
     }
     size_t current_size = qk_target_num_instructions(target);
     if (current_size != 1) {
-        printf("The size of this target is not correct: Expected 1, got %zu", current_size);
+        fprintf(stderr,"The size of this target is not correct: Expected 1, got %zu", current_size);
         result = EqualityError;
         goto cleanup;
     }
@@ -361,14 +361,14 @@ static int test_target_add_instruction(void) {
     QkExitCode result_cx_props =
         qk_target_entry_add_property(cx_entry, qargs, 2, inst_duration, inst_error);
     if (result_cx_props != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding property to a CX gate entry.");
+        fprintf(stderr,"Unexpected error occurred when adding property to a CX gate entry.");
         result = EqualityError;
         goto cleanup;
     }
 
     QkExitCode result_cx = qk_target_add_instruction(target, cx_entry);
     if (result_cx != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a CX gate.");
+        fprintf(stderr,"Unexpected error occurred when adding a CX gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -376,14 +376,14 @@ static int test_target_add_instruction(void) {
     // Number of qubits of the target should change to 2.
     current_num_qubits = qk_target_num_qubits(target);
     if (current_num_qubits != 2) {
-        printf("The number of qubits this target is compatible with is not 2: %u",
+        fprintf(stderr,"The number of qubits this target is compatible with is not 2: %u",
                current_num_qubits);
         result = EqualityError;
         goto cleanup;
     }
     current_size = qk_target_num_instructions(target);
     if (current_size != 2) {
-        printf("The size of this target is not correct: Expected 2, got %zu", current_size);
+        fprintf(stderr,"The size of this target is not correct: Expected 2, got %zu", current_size);
         result = EqualityError;
         goto cleanup;
     }
@@ -399,14 +399,14 @@ static int test_target_add_instruction(void) {
     QkExitCode result_crx_props =
         qk_target_entry_add_property(crx_entry, crx_qargs, 2, crx_inst_duration, crx_inst_error);
     if (result_crx_props != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding property to a CX gate entry.");
+        fprintf(stderr,"Unexpected error occurred when adding property to a CX gate entry.");
         result = EqualityError;
         goto cleanup;
     }
 
     QkExitCode result_crx = qk_target_add_instruction(target, crx_entry);
     if (result_crx != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a CX gate.");
+        fprintf(stderr,"Unexpected error occurred when adding a CX gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -414,14 +414,14 @@ static int test_target_add_instruction(void) {
     // Number of qubits of the target should change to 3.
     current_num_qubits = qk_target_num_qubits(target);
     if (current_num_qubits != 3) {
-        printf("The number of qubits this target is compatible with is not 3: %d",
+        fprintf(stderr,"The number of qubits this target is compatible with is not 3: %d",
                current_num_qubits);
         result = EqualityError;
         goto cleanup;
     }
     current_size = qk_target_num_instructions(target);
     if (current_size != 3) {
-        printf("The size of this target is not correct: Expected 3, got %zu", current_size);
+        fprintf(stderr,"The size of this target is not correct: Expected 3, got %zu", current_size);
         result = EqualityError;
         goto cleanup;
     }
@@ -434,7 +434,7 @@ static int test_target_add_instruction(void) {
     }
     size_t num_meas = qk_target_entry_num_properties(meas);
     if (num_meas != 3) {
-        printf("Expected 3 measurement entries but got: %zu", num_meas);
+        fprintf(stderr,"Expected 3 measurement entries but got: %zu", num_meas);
         result = EqualityError;
         qk_target_entry_free(meas);
         goto cleanup;
@@ -442,14 +442,14 @@ static int test_target_add_instruction(void) {
 
     QkExitCode result_meas_props = qk_target_add_instruction(target, meas);
     if (result_meas_props != 0) {
-        printf("Failed adding measurement instruction.");
+        fprintf(stderr,"Failed adding measurement instruction.");
         result = EqualityError;
         goto cleanup;
     }
     // Number of qubits of the target should remain 3.
     current_num_qubits = qk_target_num_qubits(target);
     if (current_num_qubits != 3) {
-        printf("The number of qubits this target is compatible with is not 3: %d",
+        fprintf(stderr,"The number of qubits this target is compatible with is not 3: %d",
                current_num_qubits);
         result = EqualityError;
         goto cleanup;
@@ -457,7 +457,7 @@ static int test_target_add_instruction(void) {
 
     current_size = qk_target_num_instructions(target);
     if (current_size != 4) {
-        printf("The size of this target is not correct: Expected 4, got %zu", current_size);
+        fprintf(stderr,"The size of this target is not correct: Expected 4, got %zu", current_size);
         result = EqualityError;
         goto cleanup;
     }
@@ -470,7 +470,7 @@ static int test_target_add_instruction(void) {
     }
     size_t num_reset = qk_target_entry_num_properties(reset);
     if (num_reset != 3) {
-        printf("Expected 3 reset entries but got: %zu", num_reset);
+        fprintf(stderr,"Expected 3 reset entries but got: %zu", num_reset);
         result = EqualityError;
         qk_target_entry_free(reset);
         goto cleanup;
@@ -479,7 +479,7 @@ static int test_target_add_instruction(void) {
     qk_target_add_instruction(target, reset);
     current_size = qk_target_num_instructions(target);
     if (current_size != 5) {
-        printf("The size of this target is not correct: Expected 5, got %zu", current_size);
+        fprintf(stderr,"The size of this target is not correct: Expected 5, got %zu", current_size);
         result = EqualityError;
         goto cleanup;
     }
@@ -515,7 +515,7 @@ static int test_target_update_instruction(void) {
     QkExitCode result_1 = qk_target_update_property(target, QkGate_CX, qargs, 2,
                                                     cx_new_inst_duration, cx_new_inst_error);
     if (result_1 != QkExitCode_Success) {
-        printf("An unexpected error occured while modifying the property.");
+        fprintf(stderr,"An unexpected error occured while modifying the property.");
         result = RuntimeError;
         goto cleanup;
     }
@@ -524,7 +524,7 @@ static int test_target_update_instruction(void) {
     QkExitCode result_2 = qk_target_update_property(target, QkGate_CH, qargs, 2,
                                                     cx_new_inst_duration, cx_new_inst_error);
     if (result_2 != QkExitCode_TargetInvalidInstKey) {
-        printf("The function did not fail as expected when querying the wrong instruction.");
+        fprintf(stderr,"The function did not fail as expected when querying the wrong instruction.");
         result = RuntimeError;
         goto cleanup;
     }
@@ -534,7 +534,7 @@ static int test_target_update_instruction(void) {
     QkExitCode result_3 = qk_target_update_property(target, QkGate_CX, new_qargs, 2,
                                                     cx_new_inst_duration, cx_new_inst_error);
     if (result_3 != QkExitCode_TargetInvalidQargsKey) {
-        printf("The function did not fail as expected when querying with wrong qargs.");
+        fprintf(stderr,"The function did not fail as expected when querying with wrong qargs.");
         result = RuntimeError;
         goto cleanup;
     }

--- a/test/c/test_target.c
+++ b/test/c/test_target.c
@@ -29,42 +29,42 @@ static int test_empty_target(void) {
     uint32_t num_qubits = qk_target_num_qubits(target);
 
     if (num_qubits != 0) {
-        fprintf(stderr,"The number of qubits %u is not 0.", num_qubits);
+        fprintf(stderr, "The number of qubits %u is not 0.", num_qubits);
         result = EqualityError;
         goto cleanup;
     }
 
     double retrieved_dt = qk_target_dt(target);
     if (!isnan(retrieved_dt)) {
-        fprintf(stderr,"The dt value of this target %f is not %f.", retrieved_dt, NAN);
+        fprintf(stderr, "The dt value of this target %f is not %f.", retrieved_dt, NAN);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t retrieved_granularity = qk_target_granularity(target);
     if (retrieved_granularity != 1) {
-        fprintf(stderr,"The granularity %u is not 1.", retrieved_granularity);
+        fprintf(stderr, "The granularity %u is not 1.", retrieved_granularity);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t retrieved_min_length = qk_target_min_length(target);
     if (retrieved_min_length != 1) {
-        fprintf(stderr,"The min_length %u is not 1.", retrieved_min_length);
+        fprintf(stderr, "The min_length %u is not 1.", retrieved_min_length);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t pulse_alignment = qk_target_pulse_alignment(target);
     if (pulse_alignment != 1) {
-        fprintf(stderr,"The pulse_alignment values %u is not 1.", pulse_alignment);
+        fprintf(stderr, "The pulse_alignment values %u is not 1.", pulse_alignment);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t acquire_alignment = qk_target_acquire_alignment(target);
     if (acquire_alignment != 1) {
-        fprintf(stderr,"The acquire_alignment values %u is not 1.", acquire_alignment);
+        fprintf(stderr, "The acquire_alignment values %u is not 1.", acquire_alignment);
         result = EqualityError;
         goto cleanup;
     }
@@ -95,42 +95,42 @@ static int test_target_construct(void) {
 
     uint32_t retrieved_num_qubits = qk_target_num_qubits(target);
     if (retrieved_num_qubits != 2) {
-        fprintf(stderr,"The number of qubits %u is not 0.", num_qubits);
+        fprintf(stderr, "The number of qubits %u is not 0.", num_qubits);
         result = EqualityError;
         goto cleanup;
     }
 
     double retrieved_dt = qk_target_dt(target);
     if (retrieved_dt != dt) {
-        fprintf(stderr,"The dt value of this target %f is not %f.", retrieved_dt, dt);
+        fprintf(stderr, "The dt value of this target %f is not %f.", retrieved_dt, dt);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t retrieved_granularity = qk_target_granularity(target);
     if (retrieved_granularity != 2) {
-        fprintf(stderr,"The granularity %u is not 2.", retrieved_granularity);
+        fprintf(stderr, "The granularity %u is not 2.", retrieved_granularity);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t retrieved_min_length = qk_target_min_length(target);
     if (retrieved_min_length != 3) {
-        fprintf(stderr,"The min_length %u is not 3.", retrieved_min_length);
+        fprintf(stderr, "The min_length %u is not 3.", retrieved_min_length);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t pulse_alignment = qk_target_pulse_alignment(target);
     if (pulse_alignment != 4) {
-        fprintf(stderr,"The pulse_alignment values %u is not 4.", pulse_alignment);
+        fprintf(stderr, "The pulse_alignment values %u is not 4.", pulse_alignment);
         result = EqualityError;
         goto cleanup;
     }
 
     uint32_t acquire_alignment = qk_target_acquire_alignment(target);
     if (acquire_alignment != 1) {
-        fprintf(stderr,"The acquire_alignment values %u is not 1.", acquire_alignment);
+        fprintf(stderr, "The acquire_alignment values %u is not 1.", acquire_alignment);
         result = EqualityError;
         goto cleanup;
     }
@@ -150,7 +150,7 @@ static int test_target_construction_ibm_like_target(void) {
     uint32_t cx_qargs[2] = {0, 1};
     QkExitCode result_prop = qk_target_entry_add_property(cx_entry, cx_qargs, 2, 2.2e-4, 6.2e-9);
     if (result_prop != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding entry.");
+        fprintf(stderr, "Unexpected error occurred when adding entry.");
         qk_target_entry_free(cx_entry);
         result = EqualityError;
         goto cleanup;
@@ -158,7 +158,7 @@ static int test_target_construction_ibm_like_target(void) {
     cx_qargs[0] = 2;
     result_prop = qk_target_entry_add_property(cx_entry, cx_qargs, 2, 3.2e-4, 4.2e-9);
     if (result_prop != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding entry.");
+        fprintf(stderr, "Unexpected error occurred when adding entry.");
         qk_target_entry_free(cx_entry);
         result = EqualityError;
         goto cleanup;
@@ -166,7 +166,7 @@ static int test_target_construction_ibm_like_target(void) {
     cx_qargs[1] = 3;
     result_prop = qk_target_entry_add_property(cx_entry, cx_qargs, 2, 1.2e-4, 4.2e-8);
     if (result_prop != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding entry.");
+        fprintf(stderr, "Unexpected error occurred when adding entry.");
         qk_target_entry_free(cx_entry);
         result = EqualityError;
         goto cleanup;
@@ -174,14 +174,14 @@ static int test_target_construction_ibm_like_target(void) {
     cx_qargs[0] = 4;
     result_prop = qk_target_entry_add_property(cx_entry, cx_qargs, 2, 1.2e-3, 2.2e-8);
     if (result_prop != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding entry.");
+        fprintf(stderr, "Unexpected error occurred when adding entry.");
         qk_target_entry_free(cx_entry);
         result = EqualityError;
         goto cleanup;
     }
     QkExitCode result_cx = qk_target_add_instruction(target, cx_entry);
     if (result_cx != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding a CX gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a CX gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -191,7 +191,7 @@ static int test_target_construction_ibm_like_target(void) {
         uint32_t qargs[1] = {i};
         result_prop = qk_target_entry_add_property(rz_entry, qargs, 1, 0, 0);
         if (result_prop != QkExitCode_Success) {
-            fprintf(stderr,"Unexpected error occurred when adding entry.");
+            fprintf(stderr, "Unexpected error occurred when adding entry.");
             result = EqualityError;
             qk_target_entry_free(rz_entry);
             goto cleanup;
@@ -199,7 +199,7 @@ static int test_target_construction_ibm_like_target(void) {
     }
     QkExitCode result_rz = qk_target_add_instruction(target, rz_entry);
     if (result_rz != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding a parameterized RZ gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a parameterized RZ gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -209,7 +209,7 @@ static int test_target_construction_ibm_like_target(void) {
         uint32_t qargs[1] = {i};
         result_prop = qk_target_entry_add_property(sx_entry, qargs, 1, 1.928e-10, 7.9829e-11);
         if (result_prop != QkExitCode_Success) {
-            fprintf(stderr,"Unexpected error occurred when adding entry.");
+            fprintf(stderr, "Unexpected error occurred when adding entry.");
             result = EqualityError;
             qk_target_entry_free(sx_entry);
             goto cleanup;
@@ -217,7 +217,7 @@ static int test_target_construction_ibm_like_target(void) {
     }
     QkExitCode result_sx = qk_target_add_instruction(target, sx_entry);
     if (result_sx != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding a parameterized RZ gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a parameterized RZ gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -227,7 +227,7 @@ static int test_target_construction_ibm_like_target(void) {
         uint32_t qargs[1] = {i};
         result_prop = qk_target_entry_add_property(x_entry, qargs, 1, 1.928e-10, 7.9829e-11);
         if (result_prop != QkExitCode_Success) {
-            fprintf(stderr,"Unexpected error occurred when adding entry.");
+            fprintf(stderr, "Unexpected error occurred when adding entry.");
             result = EqualityError;
             qk_target_entry_free(x_entry);
             goto cleanup;
@@ -235,7 +235,7 @@ static int test_target_construction_ibm_like_target(void) {
     }
     QkExitCode result_x = qk_target_add_instruction(target, x_entry);
     if (result_x != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding a parameterized RZ gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a parameterized RZ gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -245,7 +245,7 @@ static int test_target_construction_ibm_like_target(void) {
         uint32_t qargs[1] = {i};
         result_prop = qk_target_entry_add_property(measure_entry, qargs, 1, 1.928e-10, 7.9829e-11);
         if (result_prop != QkExitCode_Success) {
-            fprintf(stderr,"Unexpected error occurred when adding entry.");
+            fprintf(stderr, "Unexpected error occurred when adding entry.");
             result = EqualityError;
             qk_target_entry_free(measure_entry);
             goto cleanup;
@@ -253,7 +253,7 @@ static int test_target_construction_ibm_like_target(void) {
     }
     QkExitCode result_measure = qk_target_add_instruction(target, measure_entry);
     if (result_measure != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding a parameterized RZ gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a parameterized RZ gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -273,7 +273,8 @@ static int test_target_entry_construction(void) {
     // Test length
     const size_t length = qk_target_entry_num_properties(property_map);
     if (length != 0) {
-        fprintf(stderr,"The initial length of the provided property map was not zero: %zu", length);
+        fprintf(stderr, "The initial length of the provided property map was not zero: %zu",
+                length);
         result = EqualityError;
         goto cleanup;
     }
@@ -283,13 +284,13 @@ static int test_target_entry_construction(void) {
 
     QkExitCode result_prop = qk_target_entry_add_property(property_map, qargs, 2, 0.00018, 0.00002);
     if (result_prop != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding entry.");
+        fprintf(stderr, "Unexpected error occurred when adding entry.");
     }
 
     // Test length
     const size_t new_length = qk_target_entry_num_properties(property_map);
     if (new_length != 1) {
-        fprintf(stderr,"The initial length of the provided property map was not 1: %zu", length);
+        fprintf(stderr, "The initial length of the provided property map was not 1: %zu", length);
         result = EqualityError;
         goto cleanup;
     }
@@ -301,7 +302,7 @@ static int test_target_entry_construction(void) {
     QkExitCode error_result =
         qk_target_entry_add_property(property_map, invalid_qargs, 3, 0.00018, 0.00002);
     if (error_result != QkExitCode_TargetQargMismatch) {
-        fprintf(stderr,"The operation did not fail as expected for invalid qargs.");
+        fprintf(stderr, "The operation did not fail as expected for invalid qargs.");
     }
 
 cleanup:
@@ -322,7 +323,7 @@ static int test_target_add_instruction(void) {
     // This operation is global, no property map is provided
     QkExitCode result_x = qk_target_add_instruction(target, qk_target_entry_new(QkGate_X));
     if (result_x != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding a global X gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a global X gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -330,7 +331,7 @@ static int test_target_add_instruction(void) {
     // Re-add same gate, check if it fails
     QkExitCode result_x_readded = qk_target_add_instruction(target, qk_target_entry_new(QkGate_X));
     if (result_x_readded != QkExitCode_TargetInstAlreadyExists) {
-        fprintf(stderr,"The addition of a repeated gate did not fail as expected.");
+        fprintf(stderr, "The addition of a repeated gate did not fail as expected.");
         result = EqualityError;
         goto cleanup;
     }
@@ -338,14 +339,15 @@ static int test_target_add_instruction(void) {
     // Number of qubits of the target should not change.
     uint32_t current_num_qubits = qk_target_num_qubits(target);
     if (current_num_qubits != 1) {
-        fprintf(stderr,"The number of qubits this target is compatible with is not 1: %u",
-               current_num_qubits);
+        fprintf(stderr, "The number of qubits this target is compatible with is not 1: %u",
+                current_num_qubits);
         result = EqualityError;
         goto cleanup;
     }
     size_t current_size = qk_target_num_instructions(target);
     if (current_size != 1) {
-        fprintf(stderr,"The size of this target is not correct: Expected 1, got %zu", current_size);
+        fprintf(stderr, "The size of this target is not correct: Expected 1, got %zu",
+                current_size);
         result = EqualityError;
         goto cleanup;
     }
@@ -361,14 +363,14 @@ static int test_target_add_instruction(void) {
     QkExitCode result_cx_props =
         qk_target_entry_add_property(cx_entry, qargs, 2, inst_duration, inst_error);
     if (result_cx_props != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding property to a CX gate entry.");
+        fprintf(stderr, "Unexpected error occurred when adding property to a CX gate entry.");
         result = EqualityError;
         goto cleanup;
     }
 
     QkExitCode result_cx = qk_target_add_instruction(target, cx_entry);
     if (result_cx != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding a CX gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a CX gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -376,14 +378,15 @@ static int test_target_add_instruction(void) {
     // Number of qubits of the target should change to 2.
     current_num_qubits = qk_target_num_qubits(target);
     if (current_num_qubits != 2) {
-        fprintf(stderr,"The number of qubits this target is compatible with is not 2: %u",
-               current_num_qubits);
+        fprintf(stderr, "The number of qubits this target is compatible with is not 2: %u",
+                current_num_qubits);
         result = EqualityError;
         goto cleanup;
     }
     current_size = qk_target_num_instructions(target);
     if (current_size != 2) {
-        fprintf(stderr,"The size of this target is not correct: Expected 2, got %zu", current_size);
+        fprintf(stderr, "The size of this target is not correct: Expected 2, got %zu",
+                current_size);
         result = EqualityError;
         goto cleanup;
     }
@@ -399,14 +402,14 @@ static int test_target_add_instruction(void) {
     QkExitCode result_crx_props =
         qk_target_entry_add_property(crx_entry, crx_qargs, 2, crx_inst_duration, crx_inst_error);
     if (result_crx_props != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding property to a CX gate entry.");
+        fprintf(stderr, "Unexpected error occurred when adding property to a CX gate entry.");
         result = EqualityError;
         goto cleanup;
     }
 
     QkExitCode result_crx = qk_target_add_instruction(target, crx_entry);
     if (result_crx != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding a CX gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a CX gate.");
         result = EqualityError;
         goto cleanup;
     }
@@ -414,14 +417,15 @@ static int test_target_add_instruction(void) {
     // Number of qubits of the target should change to 3.
     current_num_qubits = qk_target_num_qubits(target);
     if (current_num_qubits != 3) {
-        fprintf(stderr,"The number of qubits this target is compatible with is not 3: %d",
-               current_num_qubits);
+        fprintf(stderr, "The number of qubits this target is compatible with is not 3: %d",
+                current_num_qubits);
         result = EqualityError;
         goto cleanup;
     }
     current_size = qk_target_num_instructions(target);
     if (current_size != 3) {
-        fprintf(stderr,"The size of this target is not correct: Expected 3, got %zu", current_size);
+        fprintf(stderr, "The size of this target is not correct: Expected 3, got %zu",
+                current_size);
         result = EqualityError;
         goto cleanup;
     }
@@ -434,7 +438,7 @@ static int test_target_add_instruction(void) {
     }
     size_t num_meas = qk_target_entry_num_properties(meas);
     if (num_meas != 3) {
-        fprintf(stderr,"Expected 3 measurement entries but got: %zu", num_meas);
+        fprintf(stderr, "Expected 3 measurement entries but got: %zu", num_meas);
         result = EqualityError;
         qk_target_entry_free(meas);
         goto cleanup;
@@ -442,22 +446,23 @@ static int test_target_add_instruction(void) {
 
     QkExitCode result_meas_props = qk_target_add_instruction(target, meas);
     if (result_meas_props != 0) {
-        fprintf(stderr,"Failed adding measurement instruction.");
+        fprintf(stderr, "Failed adding measurement instruction.");
         result = EqualityError;
         goto cleanup;
     }
     // Number of qubits of the target should remain 3.
     current_num_qubits = qk_target_num_qubits(target);
     if (current_num_qubits != 3) {
-        fprintf(stderr,"The number of qubits this target is compatible with is not 3: %d",
-               current_num_qubits);
+        fprintf(stderr, "The number of qubits this target is compatible with is not 3: %d",
+                current_num_qubits);
         result = EqualityError;
         goto cleanup;
     }
 
     current_size = qk_target_num_instructions(target);
     if (current_size != 4) {
-        fprintf(stderr,"The size of this target is not correct: Expected 4, got %zu", current_size);
+        fprintf(stderr, "The size of this target is not correct: Expected 4, got %zu",
+                current_size);
         result = EqualityError;
         goto cleanup;
     }
@@ -470,7 +475,7 @@ static int test_target_add_instruction(void) {
     }
     size_t num_reset = qk_target_entry_num_properties(reset);
     if (num_reset != 3) {
-        fprintf(stderr,"Expected 3 reset entries but got: %zu", num_reset);
+        fprintf(stderr, "Expected 3 reset entries but got: %zu", num_reset);
         result = EqualityError;
         qk_target_entry_free(reset);
         goto cleanup;
@@ -479,7 +484,8 @@ static int test_target_add_instruction(void) {
     qk_target_add_instruction(target, reset);
     current_size = qk_target_num_instructions(target);
     if (current_size != 5) {
-        fprintf(stderr,"The size of this target is not correct: Expected 5, got %zu", current_size);
+        fprintf(stderr, "The size of this target is not correct: Expected 5, got %zu",
+                current_size);
         result = EqualityError;
         goto cleanup;
     }
@@ -515,7 +521,7 @@ static int test_target_update_instruction(void) {
     QkExitCode result_1 = qk_target_update_property(target, QkGate_CX, qargs, 2,
                                                     cx_new_inst_duration, cx_new_inst_error);
     if (result_1 != QkExitCode_Success) {
-        fprintf(stderr,"An unexpected error occured while modifying the property.");
+        fprintf(stderr, "An unexpected error occured while modifying the property.");
         result = RuntimeError;
         goto cleanup;
     }
@@ -524,7 +530,8 @@ static int test_target_update_instruction(void) {
     QkExitCode result_2 = qk_target_update_property(target, QkGate_CH, qargs, 2,
                                                     cx_new_inst_duration, cx_new_inst_error);
     if (result_2 != QkExitCode_TargetInvalidInstKey) {
-        fprintf(stderr,"The function did not fail as expected when querying the wrong instruction.");
+        fprintf(stderr,
+                "The function did not fail as expected when querying the wrong instruction.");
         result = RuntimeError;
         goto cleanup;
     }
@@ -534,7 +541,7 @@ static int test_target_update_instruction(void) {
     QkExitCode result_3 = qk_target_update_property(target, QkGate_CX, new_qargs, 2,
                                                     cx_new_inst_duration, cx_new_inst_error);
     if (result_3 != QkExitCode_TargetInvalidQargsKey) {
-        fprintf(stderr,"The function did not fail as expected when querying with wrong qargs.");
+        fprintf(stderr, "The function did not fail as expected when querying with wrong qargs.");
         result = RuntimeError;
         goto cleanup;
     }

--- a/test/c/test_transpiler.c
+++ b/test/c/test_transpiler.c
@@ -88,7 +88,7 @@ static int test_transpile_bv(void) {
     options.seed = 42;
     int result_code = qk_transpile(qc, target, &options, &transpile_result, &error);
     if (result_code != 0) {
-        fprintf(stderr,"Transpilation failed with: %s\n", error);
+        fprintf(stderr, "Transpilation failed with: %s\n", error);
         result = EqualityError;
         qk_str_free(error);
         goto circuit_cleanup;
@@ -96,7 +96,7 @@ static int test_transpile_bv(void) {
 
     QkOpCounts op_counts = qk_circuit_count_ops(transpile_result.circuit);
     if (op_counts.len != 4) {
-        fprintf(stderr,"More than 4 types of gates in circuit, circuit's instructions are:\n");
+        fprintf(stderr, "More than 4 types of gates in circuit, circuit's instructions are:\n");
         print_circuit(transpile_result.circuit);
         result = EqualityError;
         goto transpile_cleanup;
@@ -107,8 +107,8 @@ static int test_transpile_bv(void) {
         int x_gate = strcmp(op_counts.data[i].name, "x");
         int rz_gate = strcmp(op_counts.data[i].name, "rz");
         if (sx_gate != 0 && ecr_gate != 0 && x_gate != 0 && rz_gate != 0) {
-            fprintf(stderr,"Gate type of %s found in the circuit which isn't expected\n",
-                   op_counts.data[i].name);
+            fprintf(stderr, "Gate type of %s found in the circuit which isn't expected\n",
+                    op_counts.data[i].name);
             result = EqualityError;
             goto transpile_cleanup;
         }
@@ -118,7 +118,7 @@ static int test_transpile_bv(void) {
         qk_circuit_get_instruction(transpile_result.circuit, i, &inst);
         if (strcmp(inst.name, "ecr") == 0) {
             if (inst.num_qubits != 2) {
-                fprintf(stderr,"Unexpected number of qubits for ecr: %d\n", inst.num_qubits);
+                fprintf(stderr, "Unexpected number of qubits for ecr: %d\n", inst.num_qubits);
                 result = EqualityError;
                 qk_circuit_instruction_clear(&inst);
                 goto transpile_cleanup;
@@ -131,8 +131,8 @@ static int test_transpile_bv(void) {
                 }
             }
             if (valid == false) {
-                fprintf(stderr,"ECR Gate outside target on qubits: {%u, %u}\n", inst.qubits[0],
-                       inst.qubits[1]);
+                fprintf(stderr, "ECR Gate outside target on qubits: {%u, %u}\n", inst.qubits[0],
+                        inst.qubits[1]);
                 result = EqualityError;
                 qk_circuit_instruction_clear(&inst);
                 goto transpile_cleanup;
@@ -177,7 +177,7 @@ static int test_transpile_idle_qubits(void) {
         int result_code =
             qk_transpile(circuit, target, &transpile_options, &transpile_result, &error);
         if (result_code != 0) {
-            fprintf(stderr,"Transpilation failed %s\n", error);
+            fprintf(stderr, "Transpilation failed %s\n", error);
             result = EqualityError;
             qk_str_free(error);
             goto cleanup;
@@ -186,20 +186,20 @@ static int test_transpile_idle_qubits(void) {
         qk_circuit_free(transpile_result.circuit);
         qk_transpile_layout_free(transpile_result.layout);
         if (opt_level == 0 && num_instructions != 12) {
-            fprintf(stderr,"opt_level: %d num_instructions: %d is not the expected value 12\n", opt_level,
-                   num_instructions);
+            fprintf(stderr, "opt_level: %d num_instructions: %d is not the expected value 12\n",
+                    opt_level, num_instructions);
             result = EqualityError;
             goto cleanup;
         }
         if ((opt_level == 1 || opt_level == 3) && num_instructions != 8) {
-            fprintf(stderr,"opt_level: %d num_instructions: %d is not the expected value 8\n", opt_level,
-                   num_instructions);
+            fprintf(stderr, "opt_level: %d num_instructions: %d is not the expected value 8\n",
+                    opt_level, num_instructions);
             result = EqualityError;
             goto cleanup;
         }
         if (opt_level == 2 && num_instructions != 7) {
-            fprintf(stderr,"opt_level: %d num_instructions: %d is not the expected value 7\n", opt_level,
-                   num_instructions);
+            fprintf(stderr, "opt_level: %d num_instructions: %d is not the expected value 7\n",
+                    opt_level, num_instructions);
             result = EqualityError;
             goto cleanup;
         }
@@ -236,7 +236,7 @@ static int test_transpile_options_null(void) {
     size_t num_inst = qk_circuit_num_instructions(transpile_result.circuit);
     if (num_inst != 9) {
         result = EqualityError;
-        fprintf(stderr,"Expected 9 instruction, but got %zu\n", num_inst);
+        fprintf(stderr, "Expected 9 instruction, but got %zu\n", num_inst);
     }
 
 cleanup:

--- a/test/c/test_transpiler.c
+++ b/test/c/test_transpiler.c
@@ -88,7 +88,7 @@ static int test_transpile_bv(void) {
     options.seed = 42;
     int result_code = qk_transpile(qc, target, &options, &transpile_result, &error);
     if (result_code != 0) {
-        printf("Transpilation failed with: %s\n", error);
+        fprintf(stderr,"Transpilation failed with: %s\n", error);
         result = EqualityError;
         qk_str_free(error);
         goto circuit_cleanup;
@@ -96,7 +96,7 @@ static int test_transpile_bv(void) {
 
     QkOpCounts op_counts = qk_circuit_count_ops(transpile_result.circuit);
     if (op_counts.len != 4) {
-        printf("More than 4 types of gates in circuit, circuit's instructions are:\n");
+        fprintf(stderr,"More than 4 types of gates in circuit, circuit's instructions are:\n");
         print_circuit(transpile_result.circuit);
         result = EqualityError;
         goto transpile_cleanup;
@@ -107,7 +107,7 @@ static int test_transpile_bv(void) {
         int x_gate = strcmp(op_counts.data[i].name, "x");
         int rz_gate = strcmp(op_counts.data[i].name, "rz");
         if (sx_gate != 0 && ecr_gate != 0 && x_gate != 0 && rz_gate != 0) {
-            printf("Gate type of %s found in the circuit which isn't expected\n",
+            fprintf(stderr,"Gate type of %s found in the circuit which isn't expected\n",
                    op_counts.data[i].name);
             result = EqualityError;
             goto transpile_cleanup;
@@ -118,7 +118,7 @@ static int test_transpile_bv(void) {
         qk_circuit_get_instruction(transpile_result.circuit, i, &inst);
         if (strcmp(inst.name, "ecr") == 0) {
             if (inst.num_qubits != 2) {
-                printf("Unexpected number of qubits for ecr: %d\n", inst.num_qubits);
+                fprintf(stderr,"Unexpected number of qubits for ecr: %d\n", inst.num_qubits);
                 result = EqualityError;
                 qk_circuit_instruction_clear(&inst);
                 goto transpile_cleanup;
@@ -131,7 +131,7 @@ static int test_transpile_bv(void) {
                 }
             }
             if (valid == false) {
-                printf("ECR Gate outside target on qubits: {%u, %u}\n", inst.qubits[0],
+                fprintf(stderr,"ECR Gate outside target on qubits: {%u, %u}\n", inst.qubits[0],
                        inst.qubits[1]);
                 result = EqualityError;
                 qk_circuit_instruction_clear(&inst);
@@ -177,7 +177,7 @@ static int test_transpile_idle_qubits(void) {
         int result_code =
             qk_transpile(circuit, target, &transpile_options, &transpile_result, &error);
         if (result_code != 0) {
-            printf("Transpilation failed %s\n", error);
+            fprintf(stderr,"Transpilation failed %s\n", error);
             result = EqualityError;
             qk_str_free(error);
             goto cleanup;
@@ -186,19 +186,19 @@ static int test_transpile_idle_qubits(void) {
         qk_circuit_free(transpile_result.circuit);
         qk_transpile_layout_free(transpile_result.layout);
         if (opt_level == 0 && num_instructions != 12) {
-            printf("opt_level: %d num_instructions: %d is not the expected value 12\n", opt_level,
+            fprintf(stderr,"opt_level: %d num_instructions: %d is not the expected value 12\n", opt_level,
                    num_instructions);
             result = EqualityError;
             goto cleanup;
         }
         if ((opt_level == 1 || opt_level == 3) && num_instructions != 8) {
-            printf("opt_level: %d num_instructions: %d is not the expected value 8\n", opt_level,
+            fprintf(stderr,"opt_level: %d num_instructions: %d is not the expected value 8\n", opt_level,
                    num_instructions);
             result = EqualityError;
             goto cleanup;
         }
         if (opt_level == 2 && num_instructions != 7) {
-            printf("opt_level: %d num_instructions: %d is not the expected value 7\n", opt_level,
+            fprintf(stderr,"opt_level: %d num_instructions: %d is not the expected value 7\n", opt_level,
                    num_instructions);
             result = EqualityError;
             goto cleanup;
@@ -236,7 +236,7 @@ static int test_transpile_options_null(void) {
     size_t num_inst = qk_circuit_num_instructions(transpile_result.circuit);
     if (num_inst != 9) {
         result = EqualityError;
-        printf("Expected 9 instruction, but got %zu\n", num_inst);
+        fprintf(stderr,"Expected 9 instruction, but got %zu\n", num_inst);
     }
 
 cleanup:

--- a/test/c/test_unitary_synthesis.c
+++ b/test/c/test_unitary_synthesis.c
@@ -23,18 +23,18 @@ static int build_unitary_target(QkTarget *target, uint32_t num_qubits) {
     // Create a target with cx connectivity in a line.
     QkExitCode result_x = qk_target_add_instruction(target, qk_target_entry_new(QkGate_X));
     if (result_x != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding a global X gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a global X gate.");
         return RuntimeError;
     }
     QkExitCode result_sx = qk_target_add_instruction(target, qk_target_entry_new(QkGate_SX));
     if (result_sx != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding a global SX gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a global SX gate.");
         return RuntimeError;
     }
 
     QkExitCode result_rz = qk_target_add_instruction(target, qk_target_entry_new(QkGate_RZ));
     if (result_rz != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding a global RZ gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a global RZ gate.");
         return RuntimeError;
     }
 
@@ -47,13 +47,13 @@ static int build_unitary_target(QkTarget *target, uint32_t num_qubits) {
         QkExitCode result_cx_props =
             qk_target_entry_add_property(cx_entry, qargs, 2, inst_duration, inst_error);
         if (result_cx_props != QkExitCode_Success) {
-            fprintf(stderr,"Unexpected error occurred when adding property to a CX gate entry.");
+            fprintf(stderr, "Unexpected error occurred when adding property to a CX gate entry.");
             return RuntimeError;
         }
     }
     QkExitCode result_cx = qk_target_add_instruction(target, cx_entry);
     if (result_cx != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding a CX gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a CX gate.");
         return RuntimeError;
     }
     return Ok;
@@ -81,7 +81,7 @@ static int test_unitary_synthesis_identity_matrix(void) {
     qk_transpiler_pass_standalone_unitary_synthesis(qc, target, 0, 1.0);
     size_t num_instructions = qk_circuit_num_instructions(qc);
     if (num_instructions != 0) {
-        fprintf(stderr,"Identity unitary not removed from the circuit as expected");
+        fprintf(stderr, "Identity unitary not removed from the circuit as expected");
         result = EqualityError;
     }
     qk_circuit_free(qc);
@@ -115,7 +115,7 @@ static int test_unitary_synthesis_multiqubit_identity_matrix(void) {
     qk_transpiler_pass_standalone_unitary_synthesis(qc, target, 0, 1.0);
     size_t num_instructions = qk_circuit_num_instructions(qc);
     if (num_instructions != 0) {
-        fprintf(stderr,"Identity unitary not removed from the circuit as expected");
+        fprintf(stderr, "Identity unitary not removed from the circuit as expected");
         result = EqualityError;
     }
     qk_circuit_free(qc);

--- a/test/c/test_unitary_synthesis.c
+++ b/test/c/test_unitary_synthesis.c
@@ -23,18 +23,18 @@ static int build_unitary_target(QkTarget *target, uint32_t num_qubits) {
     // Create a target with cx connectivity in a line.
     QkExitCode result_x = qk_target_add_instruction(target, qk_target_entry_new(QkGate_X));
     if (result_x != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a global X gate.");
+        fprintf(stderr,"Unexpected error occurred when adding a global X gate.");
         return RuntimeError;
     }
     QkExitCode result_sx = qk_target_add_instruction(target, qk_target_entry_new(QkGate_SX));
     if (result_sx != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a global SX gate.");
+        fprintf(stderr,"Unexpected error occurred when adding a global SX gate.");
         return RuntimeError;
     }
 
     QkExitCode result_rz = qk_target_add_instruction(target, qk_target_entry_new(QkGate_RZ));
     if (result_rz != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a global RZ gate.");
+        fprintf(stderr,"Unexpected error occurred when adding a global RZ gate.");
         return RuntimeError;
     }
 
@@ -47,13 +47,13 @@ static int build_unitary_target(QkTarget *target, uint32_t num_qubits) {
         QkExitCode result_cx_props =
             qk_target_entry_add_property(cx_entry, qargs, 2, inst_duration, inst_error);
         if (result_cx_props != QkExitCode_Success) {
-            printf("Unexpected error occurred when adding property to a CX gate entry.");
+            fprintf(stderr,"Unexpected error occurred when adding property to a CX gate entry.");
             return RuntimeError;
         }
     }
     QkExitCode result_cx = qk_target_add_instruction(target, cx_entry);
     if (result_cx != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a CX gate.");
+        fprintf(stderr,"Unexpected error occurred when adding a CX gate.");
         return RuntimeError;
     }
     return Ok;
@@ -81,7 +81,7 @@ static int test_unitary_synthesis_identity_matrix(void) {
     qk_transpiler_pass_standalone_unitary_synthesis(qc, target, 0, 1.0);
     size_t num_instructions = qk_circuit_num_instructions(qc);
     if (num_instructions != 0) {
-        printf("Identity unitary not removed from the circuit as expected");
+        fprintf(stderr,"Identity unitary not removed from the circuit as expected");
         result = EqualityError;
     }
     qk_circuit_free(qc);
@@ -115,7 +115,7 @@ static int test_unitary_synthesis_multiqubit_identity_matrix(void) {
     qk_transpiler_pass_standalone_unitary_synthesis(qc, target, 0, 1.0);
     size_t num_instructions = qk_circuit_num_instructions(qc);
     if (num_instructions != 0) {
-        printf("Identity unitary not removed from the circuit as expected");
+        fprintf(stderr,"Identity unitary not removed from the circuit as expected");
         result = EqualityError;
     }
     qk_circuit_free(qc);

--- a/test/c/test_version_info.c
+++ b/test/c/test_version_info.c
@@ -50,7 +50,8 @@ static int test_version(void) {
     if (strcmp(ref, QISKIT_VERSION) == 0)
         result = Ok;
     else {
-        fprintf(stderr,"Qiskit version (%s) didn't match the expectation (%s)", QISKIT_VERSION, ref);
+        fprintf(stderr, "Qiskit version (%s) didn't match the expectation (%s)", QISKIT_VERSION,
+                ref);
         result = EqualityError;
     }
 

--- a/test/c/test_version_info.c
+++ b/test/c/test_version_info.c
@@ -50,7 +50,7 @@ static int test_version(void) {
     if (strcmp(ref, QISKIT_VERSION) == 0)
         result = Ok;
     else {
-        printf("Qiskit version (%s) didn't match the expectation (%s)", QISKIT_VERSION, ref);
+        fprintf(stderr,"Qiskit version (%s) didn't match the expectation (%s)", QISKIT_VERSION, ref);
         result = EqualityError;
     }
 

--- a/test/c/test_vf2_layout.c
+++ b/test/c/test_vf2_layout.c
@@ -23,7 +23,7 @@ static int build_target(QkTarget *target, uint32_t num_qubits) {
     // Create a target with cx connectivity in a line.
     QkExitCode result_x = qk_target_add_instruction(target, qk_target_entry_new(QkGate_X));
     if (result_x != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding a global X gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a global X gate.");
         return RuntimeError;
     }
     QkTargetEntry *cx_entry = qk_target_entry_new(QkGate_CX);
@@ -35,13 +35,13 @@ static int build_target(QkTarget *target, uint32_t num_qubits) {
         QkExitCode result_cx_props =
             qk_target_entry_add_property(cx_entry, qargs, 2, inst_duration, inst_error);
         if (result_cx_props != QkExitCode_Success) {
-            fprintf(stderr,"Unexpected error occurred when adding property to a CX gate entry.");
+            fprintf(stderr, "Unexpected error occurred when adding property to a CX gate entry.");
             return RuntimeError;
         }
     }
     QkExitCode result_cx = qk_target_add_instruction(target, cx_entry);
     if (result_cx != QkExitCode_Success) {
-        fprintf(stderr,"Unexpected error occurred when adding a CX gate.");
+        fprintf(stderr, "Unexpected error occurred when adding a CX gate.");
         return RuntimeError;
     }
     return Ok;
@@ -69,13 +69,13 @@ static int test_vf2_layout_line(void) {
     QkVF2LayoutResult *layout_result =
         qk_transpiler_pass_standalone_vf2_layout(qc, target, false, -1, 0.0, -1);
     if (!qk_vf2_layout_result_has_match(layout_result)) {
-        fprintf(stderr,"No layout was found");
+        fprintf(stderr, "No layout was found");
         result = EqualityError;
         goto layout_cleanup;
     }
     if (qk_vf2_layout_result_num_qubits(layout_result) != qk_circuit_num_qubits(qc)) {
-        fprintf(stderr,"Layout doesn't contain the same number of qubits as the circuit, %d != %d",
-               qk_vf2_layout_result_num_qubits(layout_result), qk_circuit_num_qubits(qc));
+        fprintf(stderr, "Layout doesn't contain the same number of qubits as the circuit, %d != %d",
+                qk_vf2_layout_result_num_qubits(layout_result), qk_circuit_num_qubits(qc));
         result = EqualityError;
         goto layout_cleanup;
     }
@@ -87,7 +87,8 @@ static int test_vf2_layout_line(void) {
     for (uint32_t i = 0; i < qk_vf2_layout_result_num_qubits(layout_result); i++) {
         uint32_t phys = qk_vf2_layout_result_map_virtual_qubit(layout_result, i);
         if (phys != expected[i]) {
-            fprintf(stderr,"Unexpected layout result virtual qubit %d mapped to %d", phys, expected[i]);
+            fprintf(stderr, "Unexpected layout result virtual qubit %d mapped to %d", phys,
+                    expected[i]);
             result = EqualityError;
             goto layout_cleanup;
         }
@@ -125,7 +126,7 @@ static int test_vf2_no_layout_found(void) {
     QkVF2LayoutResult *layout_result =
         qk_transpiler_pass_standalone_vf2_layout(qc, target, false, -1, 0.0, -1);
     if (qk_vf2_layout_result_has_match(layout_result)) {
-        fprintf(stderr,"Unexpected layout found when one shouldn't be possible");
+        fprintf(stderr, "Unexpected layout found when one shouldn't be possible");
         result = EqualityError;
         goto layout_cleanup;
     }

--- a/test/c/test_vf2_layout.c
+++ b/test/c/test_vf2_layout.c
@@ -23,7 +23,7 @@ static int build_target(QkTarget *target, uint32_t num_qubits) {
     // Create a target with cx connectivity in a line.
     QkExitCode result_x = qk_target_add_instruction(target, qk_target_entry_new(QkGate_X));
     if (result_x != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a global X gate.");
+        fprintf(stderr,"Unexpected error occurred when adding a global X gate.");
         return RuntimeError;
     }
     QkTargetEntry *cx_entry = qk_target_entry_new(QkGate_CX);
@@ -35,13 +35,13 @@ static int build_target(QkTarget *target, uint32_t num_qubits) {
         QkExitCode result_cx_props =
             qk_target_entry_add_property(cx_entry, qargs, 2, inst_duration, inst_error);
         if (result_cx_props != QkExitCode_Success) {
-            printf("Unexpected error occurred when adding property to a CX gate entry.");
+            fprintf(stderr,"Unexpected error occurred when adding property to a CX gate entry.");
             return RuntimeError;
         }
     }
     QkExitCode result_cx = qk_target_add_instruction(target, cx_entry);
     if (result_cx != QkExitCode_Success) {
-        printf("Unexpected error occurred when adding a CX gate.");
+        fprintf(stderr,"Unexpected error occurred when adding a CX gate.");
         return RuntimeError;
     }
     return Ok;
@@ -69,12 +69,12 @@ static int test_vf2_layout_line(void) {
     QkVF2LayoutResult *layout_result =
         qk_transpiler_pass_standalone_vf2_layout(qc, target, false, -1, 0.0, -1);
     if (!qk_vf2_layout_result_has_match(layout_result)) {
-        printf("No layout was found");
+        fprintf(stderr,"No layout was found");
         result = EqualityError;
         goto layout_cleanup;
     }
     if (qk_vf2_layout_result_num_qubits(layout_result) != qk_circuit_num_qubits(qc)) {
-        printf("Layout doesn't contain the same number of qubits as the circuit, %d != %d",
+        fprintf(stderr,"Layout doesn't contain the same number of qubits as the circuit, %d != %d",
                qk_vf2_layout_result_num_qubits(layout_result), qk_circuit_num_qubits(qc));
         result = EqualityError;
         goto layout_cleanup;
@@ -87,7 +87,7 @@ static int test_vf2_layout_line(void) {
     for (uint32_t i = 0; i < qk_vf2_layout_result_num_qubits(layout_result); i++) {
         uint32_t phys = qk_vf2_layout_result_map_virtual_qubit(layout_result, i);
         if (phys != expected[i]) {
-            printf("Unexpected layout result virtual qubit %d mapped to %d", phys, expected[i]);
+            fprintf(stderr,"Unexpected layout result virtual qubit %d mapped to %d", phys, expected[i]);
             result = EqualityError;
             goto layout_cleanup;
         }
@@ -125,7 +125,7 @@ static int test_vf2_no_layout_found(void) {
     QkVF2LayoutResult *layout_result =
         qk_transpiler_pass_standalone_vf2_layout(qc, target, false, -1, 0.0, -1);
     if (qk_vf2_layout_result_has_match(layout_result)) {
-        printf("Unexpected layout found when one shouldn't be possible");
+        fprintf(stderr,"Unexpected layout found when one shouldn't be possible");
         result = EqualityError;
         goto layout_cleanup;
     }


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Converted all the instances of `printf` to `fprintf(stderr,..)` in the C test suite. 
Fixes #15097 

All the tests were ran after changes to the code was made and tests passed successfully. 

### Details and comments

I am sorry if this does not meet the standards of the repository. This is my first "real" open source contribution:) Please let me know if there is anything to improve/change.


