### PR TITLE
Use structural equality in symbol expression optimizations

### DIFF
--- a/releasenotes/notes/symbol-expr-canonical-fingerprint-9c1a7e8334a91f4b.yaml
+++ b/releasenotes/notes/symbol-expr-canonical-fingerprint-9c1a7e8334a91f4b.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    Equality on :class:`~qiskit.circuit.SymbolExpr` is now
+    structural on a canonicalized expression graph rather
+    than a string-based representation.


### PR DESCRIPTION
Changes:
- Introduced a `CanonicalValue` enum and numeric canonicalization routine so integers, reals, and complex values are normalized before encoding.
- Implemented canonical fingerprint generation for `SymbolExpr`, which flattens sums and products, sorts normalized terms, and encodes nodes, symbols, and operators into deterministic byte sequences.

Why?
- Closes #14819
