### PR TITLE
Swap to `setuptools>=77.0` licence specification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,20 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools-rust"]
+# We duplicate the `requires` in `requirements-dev.txt` as a
+# convenience for developers.
+requires = [
+    "setuptools>=77.0",
+    "setuptools-rust",
+]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "qiskit"
 description = "An open-source SDK for working with quantum computers at the level of extended quantum circuits, operators, and primitives."
 requires-python = ">=3.9"
-license = {text = "Apache 2.0"}
+license = "Apache-2.0"
+license-files = [
+    "LICENSE.txt",
+]
 authors = [
     { name = "Qiskit Development Team", email = "qiskit@us.ibm.com" },
 ]
@@ -22,7 +30,6 @@ classifiers = [
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",

--- a/releasenotes/notes/bump-setuptools-6e1d2c92924b4e61.yaml
+++ b/releasenotes/notes/bump-setuptools-6e1d2c92924b4e61.yaml
@@ -1,0 +1,7 @@
+---
+other:
+  - |
+    When building or packaging Qiskit from source, the version of `setuptools` required is now at
+    least version 77.0 (released in March 2025).  This is to support the new license-metadata
+    specifications of `PEP 639 <https://peps.python.org/pep-0639/>`__.  This dependency is specified
+    in the build requirements, and so no manual action should be needed.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,10 @@
 # possible so it's easy to develop multiple packages from the same venv.
 
 # Build Rust directly
-setuptools
+#
+# The normative version of these is in `pyproject.toml`, and are included here
+# as a convenience for setting up a build/dev environment without isolation.
+setuptools>=77.0
 setuptools-rust
 
 # Style


### PR DESCRIPTION
PEP 639[^1] introduced a new way of specifying the licence information of projects, both in the `pyproject.toml` metadata and in the resulting `METADATA` object of the package.  Setuptools 77 (released in March 2025) both began accepting the new form and immediately deprecated the old form.  We avoided moving to the new TOML keys in `pyproject.toml` immediately because we didn't want to rely on a too-recent version of the build toolchain, but given `setuptools`' development process, a six-month delay seems about the right trade-off between supporting older packages and not breaking on new releases.

The `License ::` trove classifiers in the metadata were simultaneously deprecated as part of PEP 639, since the licence-expression form of the metadata now serves that purpose in a more general and well-supported manner.

[^1]: https://peps.python.org/pep-0639/

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Fix #14144
