### PR TITLE
Check target gates are parameterized in optimize1qgatesdecomposition

### DIFF
--- a/releasenotes/notes/fix-1q-decomp-non-param-gates-99624b82227e5608.yaml
+++ b/releasenotes/notes/fix-1q-decomp-non-param-gates-99624b82227e5608.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed an issue in the :class:`.Optimize1qGatesDecomposition` when the
+    pass was initialized with a target that contains 1q gates with fixed angle
+    parameters. Previously, the pass would potential output gates outside
+    the target as it wasn't checking that the gate in the target supported
+    arbitrary parameter values.
+    Fixed `#14743 <https://github.com/Qiskit/qiskit/issues/14743>`__.

--- a/releasenotes/notes/fix-1q-decomp-non-param-gates-99624b82227e5608.yaml
+++ b/releasenotes/notes/fix-1q-decomp-non-param-gates-99624b82227e5608.yaml
@@ -2,8 +2,8 @@
 fixes:
   - |
     Fixed an issue in the :class:`.Optimize1qGatesDecomposition` when the
-    pass was initialized with a target that contains 1q gates with fixed angle
-    parameters. Previously, the pass would potential output gates outside
+    pass was initialized with a :class:`.Target` that contains 1q gates with fixed angle
+    parameters. Previously, the pass would potentially output gates outside
     the target as it wasn't checking that the gate in the target supported
     arbitrary parameter values.
     Fixed `#14743 <https://github.com/Qiskit/qiskit/issues/14743>`__.

--- a/test/python/transpiler/test_optimize_1q_decomposition.py
+++ b/test/python/transpiler/test_optimize_1q_decomposition.py
@@ -782,6 +782,21 @@ class TestOptimize1qGatesDecomposition(QiskitTestCase):
         expected.u(0, 0, np.pi / 2, [0])
         self.assertEqual(result, expected)
 
+    def test_target_fixed_angle_1q_gate(self):
+        """Test that a fixed angle gate is not used for decomposition."""
+        target = Target(num_qubits=1)
+        target.add_instruction(UGate(3.14, 0, -3.14), {(0,): None})
+        target.add_instruction(SXGate(), {(0,): None})
+        target.add_instruction(RZGate(Parameter("t")), {(0,): None})
+
+        opt_pass = Optimize1qGatesDecomposition(target=target)
+        qc = QuantumCircuit(1)
+        qc.u(1, 2, 3, 0)
+        res = opt_pass(qc)
+        self.assertNotIn("u", res.count_ops())
+        self.assertIn("rz", res.count_ops())
+        self.assertIn("sx", res.count_ops())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the Optimize1qGatesDecomposition transpiler pass to check the defined operation in the target to ensure it's a valid gate to use for the decomposition. Previously the pass would just use the gate name for each qubit and treat that as a basis gate list. However this ignored the extra details that the target provides as a target gate can match the name but not be valid for use in synthesis. This commit fixes that oversight by checking the gates directly and ensuring they're valid for use in the decomposition.

### Details and comments

Fixes #14743