### PR TITLE
Add py cls name method

### DIFF
--- a/crates/circuit/src/imports.rs
+++ b/crates/circuit/src/imports.rs
@@ -335,3 +335,11 @@ pub fn get_std_gate_class(py: Python, rs_gate: StandardGate) -> PyResult<&'stati
         Ok(py.import(py_mod)?.getattr(py_class)?.unbind())
     })
 }
+
+/// Get the Python module path and class name for a StandardGate.
+/// This is used for QPY serialization and other cases where the Python class name
+/// is needed without going through Python.
+#[inline]
+pub fn get_std_gate_import_path(rs_gate: StandardGate) -> [&'static str; 2] {
+    STDGATE_IMPORT_PATHS[rs_gate as usize]
+}

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -40,6 +40,9 @@ pub mod vf2;
 
 mod variable_mapper;
 
+#[cfg(test)]
+pub mod tests;
+
 use pyo3::PyTypeInfo;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -2408,7 +2408,6 @@ impl Operation for StandardGate {
     }
     
     fn py_cls_name(&self) -> Option<(&str, &str)> {
-        let idx = *self as usize;
         let [module_path, class_name] = crate::imports::get_std_gate_import_path(*self);
         Some((module_path, class_name))
     }

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -261,6 +261,23 @@ pub trait Operation {
         self.matrix_as_static_1q(params)
             .map(|arr| Matrix2::new(arr[0][0], arr[0][1], arr[1][0], arr[1][1]))
     }
+    /// Returns the Python class name for this operation.
+    ///
+    /// This method provides a Python-free way to get the Python module path and class name
+    /// for gates and instructions. It is used for QPY serialization and other cases where
+    /// the Python class name is needed without going through Python.
+    ///
+    /// # Returns
+    ///
+    /// * `Option<(&str, &str)>` - If the operation has a corresponding Python class,
+    ///   returns `Some((module_path, class_name))` where `module_path` is the Python
+    ///   module path (e.g., "qiskit.circuit.library.standard_gates.h") and `class_name`
+    ///   is the Python class name (e.g., "HGate"). Returns `None` if there is no
+    ///   corresponding Python class or if it cannot be determined without Python.
+    fn py_cls_name(&self) -> Option<(&str, &str)> {
+        // Default implementation returns None
+        None
+    }
 }
 
 /// Unpacked view object onto a `PackedOperation`.  This is the return value of
@@ -388,6 +405,18 @@ impl Operation for OperationRef<'_> {
             Self::Instruction(instruction) => instruction.matrix_as_static_1q(params),
             Self::Operation(operation) => operation.matrix_as_static_1q(params),
             Self::Unitary(unitary) => unitary.matrix_as_static_1q(params),
+        }
+    }
+    
+    #[inline]
+    fn py_cls_name(&self) -> Option<(&str, &str)> {
+        match self {
+            Self::StandardGate(standard) => standard.py_cls_name(),
+            Self::StandardInstruction(instruction) => instruction.py_cls_name(),
+            Self::Gate(_) => None,
+            Self::Instruction(_) => None,
+            Self::Operation(_) => None,
+            Self::Unitary(_) => Some(("qiskit.circuit.library.generalized_gates.unitary", "UnitaryGate")),
         }
     }
 }
@@ -549,6 +578,15 @@ impl Operation for StandardInstruction {
 
     fn matrix_as_static_1q(&self, _params: &[Param]) -> Option<[[Complex64; 2]; 2]> {
         None
+    }
+    
+    fn py_cls_name(&self) -> Option<(&str, &str)> {
+        match self {
+            StandardInstruction::Barrier(_) => Some(("qiskit.circuit", "Barrier")),
+            StandardInstruction::Delay(_) => Some(("qiskit.circuit", "Delay")),
+            StandardInstruction::Measure => Some(("qiskit.circuit", "Measure")),
+            StandardInstruction::Reset => Some(("qiskit.circuit", "Reset")),
+        }
     }
 }
 
@@ -2367,6 +2405,12 @@ impl Operation for StandardGate {
             Self::C3SX => None,
             Self::RC3X => None,
         }
+    }
+    
+    fn py_cls_name(&self) -> Option<(&str, &str)> {
+        let idx = *self as usize;
+        let [module_path, class_name] = crate::imports::get_std_gate_import_path(*self);
+        Some((module_path, class_name))
     }
 }
 

--- a/crates/circuit/src/tests/mod.rs
+++ b/crates/circuit/src/tests/mod.rs
@@ -1,0 +1,15 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2024
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+mod test_py_cls_name;
+
+

--- a/crates/circuit/src/tests/test_py_cls_name.rs
+++ b/crates/circuit/src/tests/test_py_cls_name.rs
@@ -1,0 +1,83 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2024
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use crate::operations::{Operation, OperationRef, StandardGate, StandardInstruction};
+
+#[test]
+fn test_standard_gate_py_cls_name() {
+    // Test a few representative gates
+    let h_gate = StandardGate::H;
+    let x_gate = StandardGate::X;
+    let cx_gate = StandardGate::CX;
+    let rz_gate = StandardGate::RZ;
+
+    // Check that the py_cls_name method returns the expected values
+    assert_eq!(
+        h_gate.py_cls_name(),
+        Some(("qiskit.circuit.library.standard_gates.h", "HGate"))
+    );
+    assert_eq!(
+        x_gate.py_cls_name(),
+        Some(("qiskit.circuit.library.standard_gates.x", "XGate"))
+    );
+    assert_eq!(
+        cx_gate.py_cls_name(),
+        Some(("qiskit.circuit.library.standard_gates.x", "CXGate"))
+    );
+    assert_eq!(
+        rz_gate.py_cls_name(),
+        Some(("qiskit.circuit.library.standard_gates.rz", "RZGate"))
+    );
+}
+
+#[test]
+fn test_standard_instruction_py_cls_name() {
+    // Test all standard instructions
+    let barrier = StandardInstruction::Barrier(2);
+    let delay = StandardInstruction::Delay(crate::operations::DelayUnit::NS);
+    let measure = StandardInstruction::Measure;
+    let reset = StandardInstruction::Reset;
+
+    // Check that the py_cls_name method returns the expected values
+    assert_eq!(barrier.py_cls_name(), Some(("qiskit.circuit", "Barrier")));
+    assert_eq!(delay.py_cls_name(), Some(("qiskit.circuit", "Delay")));
+    assert_eq!(measure.py_cls_name(), Some(("qiskit.circuit", "Measure")));
+    assert_eq!(reset.py_cls_name(), Some(("qiskit.circuit", "Reset")));
+}
+
+#[test]
+fn test_operation_ref_py_cls_name() {
+    // Test OperationRef with StandardGate and StandardInstruction
+    let h_gate = StandardGate::H;
+    let measure = StandardInstruction::Measure;
+
+    let op_ref_gate = OperationRef::StandardGate(h_gate);
+    let op_ref_inst = OperationRef::StandardInstruction(measure);
+
+    // Check that the py_cls_name method returns the expected values
+    assert_eq!(
+        op_ref_gate.py_cls_name(),
+        Some(("qiskit.circuit.library.standard_gates.h", "HGate"))
+    );
+    assert_eq!(op_ref_inst.py_cls_name(), Some(("qiskit.circuit", "Measure")));
+
+    // Test that UnitaryGate returns the expected value
+    let unitary_gate = crate::operations::UnitaryGate {
+        array: crate::operations::ArrayType::OneQ(nalgebra::Matrix2::identity()),
+    };
+    let op_ref_unitary = OperationRef::Unitary(&unitary_gate);
+    assert_eq!(
+        op_ref_unitary.py_cls_name(),
+        Some(("qiskit.circuit.library.generalized_gates.unitary", "UnitaryGate"))
+    );
+
+}


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This PR adds a new `py_cls_name` method to the `Operation` trait that provides a Python-free way to get Python class names for gates and instructions. This is needed for QPY implementation in Rust, as mentioned in issue #15095.

The implementation includes:
- Adding the method to the `Operation` trait with comprehensive documentation
- Implementing it for `StandardGate` using the `STDGATE_IMPORT_PATHS` array
- Implementing it for `StandardInstruction` with hardcoded values
- Implementing it for `OperationRef` to delegate to the appropriate implementation
- Adding a helper function in imports.rs to safely access gate class mappings
- Adding tests to verify the implementation works correctly

### Details and comments

This implementation allows QPY serialization in Rust to get Python class names for gates and instructions without requiring Python, which is a key requirement for the Rust-based QPY implementation.

AI tool used: Claude 3.5 Sonnet






