### PR TITLE
Fix HLS for custom gate calibrations

### DIFF
--- a/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
@@ -336,6 +336,7 @@ class HighLevelSynthesis(TransformationPass):
 
         for node in dag.topological_op_nodes():
             qubits = tuple(dag.find_bit(q).index for q in node.qargs)
+            global_qubits = context.to_globals(qubits)
             processed = False
             synthesized = None
             synthesized_context = None
@@ -349,12 +350,12 @@ class HighLevelSynthesis(TransformationPass):
 
             elif node.op.name == "reset":
                 # reset qubits to 0
-                tracker.set_clean(context.to_globals(qubits))
+                tracker.set_clean(global_qubits)
                 processed = True
 
             # check if synthesis for the operation can be skipped
-            elif self._definitely_skip_node(node, qubits, dag):
-                tracker.set_dirty(context.to_globals(qubits))
+            elif self._definitely_skip_node(node, global_qubits, dag):
+                tracker.set_dirty(global_qubits)
 
             # next check control flow
             elif node.is_control_flow():

--- a/releasenotes/notes/fix-hls-calibrations-2b47543cb2bc6521.yaml
+++ b/releasenotes/notes/fix-hls-calibrations-2b47543cb2bc6521.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.HighLevelSynthesis`, where custom gate calibrations were
+    not recognized if the gate appeared inside a nested instruction.


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixed a bug in HLS where custom gate calibrations were not recognized if the gate appeared inside a nested instruction. 
This fixes parts related to #13728, but doesn't fix that issue yet since there's still an issue with the basis translator. Nevertheless, this commit fixes a bug on its own.

