### PR TITLE
Fix incorrect mapping of ControlFlow block qargs in `BasisTranslator`

### DIFF
--- a/crates/transpiler/src/passes/basis_translator/mod.rs
+++ b/crates/transpiler/src/passes/basis_translator/mod.rs
@@ -491,7 +491,7 @@ fn apply_translation(
                         bound_obj.call_method1("replace_blocks", (flow_blocks,))?;
                     new_op = Some(replaced_blocks.extract()?);
                     Ok(())
-                }).map_err(|err| BasisTranslatorError::BasisCircuitError(err.to_string()))?;
+                }).map_err(|_| BasisTranslatorError::BasisCircuitError("Error replacing control flow operation blocks".to_string()))?;
             }
             if let Some(new_op) = new_op {
                 out_dag_builder

--- a/crates/transpiler/src/passes/basis_translator/mod.rs
+++ b/crates/transpiler/src/passes/basis_translator/mod.rs
@@ -173,7 +173,7 @@ pub fn run_basis_translator(
             }
         } else {
             expanded_target = expanded_target
-                .union(&qargs_with_non_global_operation[&Qargs::from_iter(qargs.iter().copied())])
+                .union(&qargs_with_non_global_operation[&QargsRef::Concrete(qargs)])
                 .cloned()
                 .collect();
         }
@@ -213,6 +213,7 @@ pub fn run_basis_translator(
         &extra_inst_map,
         min_qubits,
         &qargs_with_non_global_operation,
+        None,
     )?;
     Ok(Some(out_dag))
 }
@@ -320,12 +321,22 @@ fn extract_basis_target(
         }
         if node_obj.op.control_flow() {
             for block in node_obj.op.blocks() {
+                // Generate a mapping with the absolute indices and the local ones.
+                let qarg_mapping: HashMap<Qubit, Qubit> = dag
+                    .qargs_interner()
+                    .get(node_obj.qubits)
+                    .iter()
+                    .copied()
+                    .zip((0..(block.num_qubits() as u32)).map(Qubit))
+                    .map(|(k, v)| (v, k))
+                    .collect();
                 extract_basis_target_circ(
                     &block,
                     source_basis,
                     qargs_local_source_basis,
                     min_qubits,
                     qargs_with_non_global_operation,
+                    &qarg_mapping,
                 );
             }
         }
@@ -339,6 +350,7 @@ fn extract_basis_target_circ(
     qargs_local_source_basis: &mut AhashIndexMap<PhysicalQargs, AhashIndexSet<GateIdentifier>>,
     min_qubits: usize,
     qargs_with_non_global_operation: &AhashIndexMap<Qargs, AhashIndexSet<&str>>,
+    qarg_mapping: &HashMap<Qubit, Qubit>,
 ) {
     for node_obj in circuit.iter() {
         let qargs = circuit.get_qargs(node_obj.qubits);
@@ -354,7 +366,12 @@ fn extract_basis_target_circ(
         // single qubit operation for (1,) as valid. This pattern also holds
         // true for > 2q ops too (so for 4q operations we need to check for 3q, 2q,
         // and 1q operations in the same manner)
-        let physical_qargs: PhysicalQargs = qargs.iter().map(|x| PhysicalQubit(x.0)).collect();
+        // Make sure to also map to the physical qubits of the target rather than
+        // the virtual locations within the circuit or control-flow operation block.
+        let physical_qargs: PhysicalQargs = qargs
+            .iter()
+            .map(|x| PhysicalQubit(qarg_mapping[x].0))
+            .collect();
         let physical_qargs_as_set: AhashIndexSet<PhysicalQubit> =
             AhashIndexSet::from_iter(physical_qargs.iter().copied());
         let physical_qargs: Qargs = physical_qargs.into();
@@ -389,12 +406,22 @@ fn extract_basis_target_circ(
         }
         if node_obj.op.control_flow() {
             for block in node_obj.op.blocks() {
+                // Generate a mapping with the absolute qubit indices and the current local ones.
+                let qarg_mapping: HashMap<Qubit, Qubit> = circuit
+                    .qargs_interner()
+                    .get(node_obj.qubits)
+                    .iter()
+                    .copied()
+                    .zip((0..(block.num_qubits() as u32)).map(Qubit))
+                    .map(|(k, v)| (v, qarg_mapping[&k]))
+                    .collect();
                 extract_basis_target_circ(
                     &block,
                     source_basis,
                     qargs_local_source_basis,
                     min_qubits,
                     qargs_with_non_global_operation,
+                    &qarg_mapping,
                 );
             }
         }
@@ -408,6 +435,7 @@ fn apply_translation(
     extra_inst_map: &ExtraInstructionMap,
     min_qubits: usize,
     qargs_with_non_global_operation: &AhashIndexMap<Qargs, AhashIndexSet<&str>>,
+    qarg_mapping: Option<&HashMap<Qubit, Qubit>>,
 ) -> Result<(DAGCircuit, bool), BasisTranslatorError> {
     let mut is_updated = false;
     let out_dag = dag.copy_empty_like(VarsMode::Alike).map_err(|_| {
@@ -436,6 +464,13 @@ fn apply_translation(
                     for block in node_obj.op.blocks() {
                         let dag_block: DAGCircuit = DAGCircuit::from_circuit_data(&block, true, None, None, None, None)?;
                         let updated_dag: DAGCircuit;
+                        // Generate a mapping between the absolute and local qubit indices
+                        // which will be used to correctly map the operation onto the dag.
+                        let qarg_mapping: HashMap<Qubit, Qubit> = if let Some(qarg_mapping) = qarg_mapping {
+                            dag.qargs_interner().get(node_obj.qubits).iter().zip((0..(block.num_qubits() as u32)).map(Qubit)).map(|(k, v)| (v, qarg_mapping[k])).collect()
+                        } else {
+                            dag.qargs_interner().get(node_obj.qubits).iter().zip((0..(block.num_qubits() as u32)).map(Qubit)).map(|(k, v)| (v, *k)).collect()
+                        };
                         (updated_dag, is_updated) = apply_translation(
                             &dag_block,
                             target_basis,
@@ -443,6 +478,7 @@ fn apply_translation(
                             extra_inst_map,
                             min_qubits,
                             qargs_with_non_global_operation,
+                            Some(&qarg_mapping)
                         ).map_err(PyErr::from)?;
                         let flow_circ_block = if is_updated {
                             QUANTUM_CIRCUIT.get_bound(py).call_method1(intern!(py, "_from_circuit_data"), (dag_to_circuit(&updated_dag, true)?,))?
@@ -455,7 +491,7 @@ fn apply_translation(
                         bound_obj.call_method1("replace_blocks", (flow_blocks,))?;
                     new_op = Some(replaced_blocks.extract()?);
                     Ok(())
-                }).map_err(|_| BasisTranslatorError::BasisCircuitError("Error replacing control flow operation blocks".to_string()))?;
+                }).map_err(|err| BasisTranslatorError::BasisCircuitError(err.to_string()))?;
             }
             if let Some(new_op) = new_op {
                 out_dag_builder
@@ -496,7 +532,16 @@ fn apply_translation(
             }
             continue;
         }
-        let node_qarg_as_physical: Qargs = node_qarg.iter().map(|x| PhysicalQubit(x.0)).collect();
+        // Map to the absolute indices when provided to avoid mistakenly tracking
+        // the operation as global.
+        let node_qarg_as_physical: Qargs = if let Some(qarg_mapping) = qarg_mapping {
+            node_qarg
+                .iter()
+                .map(|x| PhysicalQubit(qarg_mapping[x].0))
+                .collect()
+        } else {
+            node_qarg.iter().map(|x| PhysicalQubit(x.0)).collect()
+        };
         if qargs_with_non_global_operation.contains_key(&node_qarg_as_physical)
             && qargs_with_non_global_operation[&node_qarg_as_physical].contains(node_obj.op.name())
         {

--- a/crates/transpiler/src/passes/basis_translator/mod.rs
+++ b/crates/transpiler/src/passes/basis_translator/mod.rs
@@ -563,7 +563,15 @@ fn apply_translation(
             continue;
         }
 
-        let unique_qargs: PhysicalQargs = qubit_set.iter().map(|x| PhysicalQubit(x.0)).collect();
+        // Map the unique qargs with the absolute indices as well
+        let unique_qargs: PhysicalQargs = if let Some(qarg_mapping) = qarg_mapping {
+            qubit_set
+                .iter()
+                .map(|x| PhysicalQubit(qarg_mapping[x].0))
+                .collect()
+        } else {
+            qubit_set.iter().map(|x| PhysicalQubit(x.0)).collect()
+        };
         if extra_inst_map.contains_key(&unique_qargs) {
             replace_node(
                 &mut out_dag_builder,

--- a/releasenotes/notes/fix-basis-control-custom-gate-b62fd53c73776085.yaml
+++ b/releasenotes/notes/fix-basis-control-custom-gate-b62fd53c73776085.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed incorrect behavior in the :class:`.BasisTranslator` pass where a multi-qubit
+    gate within a :class:`.ControlFlowOp` block would track with its local qubit indices
+    instead of using the absolute indices from the source circuit.


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
When extracting the basis of the target and applying the translations onto the dag, the `BasisTranslator` would not use the absolute indices of the operating qubits when a control flow operation block was processed during recursion. The following commit adds a mapping to the following `BasisTranslator` methods:
- `extract_target_basis_circuit` which only gets called during a recursion step.
- `apply_translation` in which it is always `None` unless a recursion step happens.

The provided mapping will correctly direct local block qubit indices into the absolute ones stored by the original circuit from which the operation comes from.

### Details and comments
This should help fix #13728.


