### PR TITLE
Fix schedule analysis passes with empty circuits

### DIFF
--- a/crates/transpiler/src/passes/alap_schedule_analysis.rs
+++ b/crates/transpiler/src/passes/alap_schedule_analysis.rs
@@ -190,50 +190,49 @@ pub fn py_run_alap_schedule_analysis(
     // Get the first duration type
     let mut iter = node_durations.iter();
     let py_dict = PyDict::new(py);
-    if let Some((_, first_duration)) = iter.next() {
-        if first_duration.extract::<u64>().is_ok() {
-            // All durations are of type u64
-            let mut op_durations = HashMap::new();
-            for (py_node, py_duration) in node_durations.iter() {
-                let node_idx = py_node
-                    .downcast_into::<DAGOpNode>()?
-                    .extract::<DAGNode>()?
-                    .node
-                    .expect("Node index not found.");
-                let val = py_duration.extract::<u64>()?;
-                op_durations.insert(node_idx, val);
-            }
-            let node_start_time =
-                run_alap_schedule_analysis::<u64>(dag, clbit_write_latency, op_durations)?;
-            for (node_idx, t1) in node_start_time {
-                let node = dag.get_node(py, node_idx)?;
-                py_dict.set_item(node, t1)?;
-            }
-        } else if first_duration.extract::<f64>().is_ok() {
-            // All durations are of type f64
-            let mut op_durations = HashMap::new();
-            for (py_node, py_duration) in node_durations.iter() {
-                let node_idx = py_node
-                    .downcast_into::<DAGOpNode>()?
-                    .extract::<DAGNode>()?
-                    .node
-                    .expect("Node index not found.");
-                let val = py_duration.extract::<f64>()?;
-                op_durations.insert(node_idx, val);
-            }
-            let node_start_time =
-                run_alap_schedule_analysis::<f64>(dag, clbit_write_latency as f64, op_durations)?;
-            for (node_idx, t1) in node_start_time {
-                let node = dag.get_node(py, node_idx)?;
-                py_dict.set_item(node, t1)?;
-            }
-        } else {
-            return Err(TranspilerError::new_err("Duration must be int or float"));
+    let Some((_, first_duration)) = iter.next() else {
+        // Empty circuit.
+        return Ok(py_dict.into());
+    };
+    if first_duration.extract::<u64>().is_ok() {
+        // All durations are of type u64
+        let mut op_durations = HashMap::new();
+        for (py_node, py_duration) in node_durations.iter() {
+            let node_idx = py_node
+                .downcast_into::<DAGOpNode>()?
+                .extract::<DAGNode>()?
+                .node
+                .expect("Node index not found.");
+            let val = py_duration.extract::<u64>()?;
+            op_durations.insert(node_idx, val);
+        }
+        let node_start_time =
+            run_alap_schedule_analysis::<u64>(dag, clbit_write_latency, op_durations)?;
+        for (node_idx, t1) in node_start_time {
+            let node = dag.get_node(py, node_idx)?;
+            py_dict.set_item(node, t1)?;
+        }
+    } else if first_duration.extract::<f64>().is_ok() {
+        // All durations are of type f64
+        let mut op_durations = HashMap::new();
+        for (py_node, py_duration) in node_durations.iter() {
+            let node_idx = py_node
+                .downcast_into::<DAGOpNode>()?
+                .extract::<DAGNode>()?
+                .node
+                .expect("Node index not found.");
+            let val = py_duration.extract::<f64>()?;
+            op_durations.insert(node_idx, val);
+        }
+        let node_start_time =
+            run_alap_schedule_analysis::<f64>(dag, clbit_write_latency as f64, op_durations)?;
+        for (node_idx, t1) in node_start_time {
+            let node = dag.get_node(py, node_idx)?;
+            py_dict.set_item(node, t1)?;
         }
     } else {
-        return Err(TranspilerError::new_err("No durations provided"));
+        return Err(TranspilerError::new_err("Duration must be int or float"));
     }
-
     Ok(py_dict.into())
 }
 

--- a/crates/transpiler/src/passes/asap_schedule_analysis.rs
+++ b/crates/transpiler/src/passes/asap_schedule_analysis.rs
@@ -167,50 +167,49 @@ pub fn py_run_asap_schedule_analysis(
     // Get the first duration type
     let mut iter = node_durations.iter();
     let py_dict = PyDict::new(py);
-    if let Some((_, first_duration)) = iter.next() {
-        if first_duration.extract::<u64>().is_ok() {
-            // All durations are of type u64
-            let mut op_durations = HashMap::new();
-            for (py_node, py_duration) in node_durations.iter() {
-                let node_idx = py_node
-                    .downcast_into::<DAGOpNode>()?
-                    .extract::<DAGNode>()?
-                    .node
-                    .expect("Node index not found.");
-                let val = py_duration.extract::<u64>()?;
-                op_durations.insert(node_idx, val);
-            }
-            let node_start_time =
-                run_asap_schedule_analysis::<u64>(dag, clbit_write_latency, op_durations)?;
-            for (node_idx, t1) in node_start_time {
-                let node = dag.get_node(py, node_idx)?;
-                py_dict.set_item(node, t1)?;
-            }
-        } else if first_duration.extract::<f64>().is_ok() {
-            // All durations are of type f64
-            let mut op_durations = HashMap::new();
-            for (py_node, py_duration) in node_durations.iter() {
-                let node_idx = py_node
-                    .downcast_into::<DAGOpNode>()?
-                    .extract::<DAGNode>()?
-                    .node
-                    .expect("Node index not found.");
-                let val = py_duration.extract::<f64>()?;
-                op_durations.insert(node_idx, val);
-            }
-            let node_start_time =
-                run_asap_schedule_analysis::<f64>(dag, clbit_write_latency as f64, op_durations)?;
-            for (node_idx, t1) in node_start_time {
-                let node = dag.get_node(py, node_idx)?;
-                py_dict.set_item(node, t1)?;
-            }
-        } else {
-            return Err(TranspilerError::new_err("Duration must be int or float"));
+    let Some((_, first_duration)) = iter.next() else {
+        // Empty circuit.
+        return Ok(py_dict.into());
+    };
+    if first_duration.extract::<u64>().is_ok() {
+        // All durations are of type u64
+        let mut op_durations = HashMap::new();
+        for (py_node, py_duration) in node_durations.iter() {
+            let node_idx = py_node
+                .downcast_into::<DAGOpNode>()?
+                .extract::<DAGNode>()?
+                .node
+                .expect("Node index not found.");
+            let val = py_duration.extract::<u64>()?;
+            op_durations.insert(node_idx, val);
+        }
+        let node_start_time =
+            run_asap_schedule_analysis::<u64>(dag, clbit_write_latency, op_durations)?;
+        for (node_idx, t1) in node_start_time {
+            let node = dag.get_node(py, node_idx)?;
+            py_dict.set_item(node, t1)?;
+        }
+    } else if first_duration.extract::<f64>().is_ok() {
+        // All durations are of type f64
+        let mut op_durations = HashMap::new();
+        for (py_node, py_duration) in node_durations.iter() {
+            let node_idx = py_node
+                .downcast_into::<DAGOpNode>()?
+                .extract::<DAGNode>()?
+                .node
+                .expect("Node index not found.");
+            let val = py_duration.extract::<f64>()?;
+            op_durations.insert(node_idx, val);
+        }
+        let node_start_time =
+            run_asap_schedule_analysis::<f64>(dag, clbit_write_latency as f64, op_durations)?;
+        for (node_idx, t1) in node_start_time {
+            let node = dag.get_node(py, node_idx)?;
+            py_dict.set_item(node, t1)?;
         }
     } else {
-        return Err(TranspilerError::new_err("No durations provided"));
+        return Err(TranspilerError::new_err("Duration must be int or float"));
     }
-
     Ok(py_dict.into())
 }
 

--- a/releasenotes/notes/fix-scheduling-empty-circuit-18a526082cac6925.yaml
+++ b/releasenotes/notes/fix-scheduling-empty-circuit-18a526082cac6925.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The scheduling passes, :class:`.ALAPScheduleAnalysis` and :class:`.ASAPScheduleAnalysis`, will
+    now correctly handle circuits with no operations in them.  Previously they would raise a
+    :exc:`.TranspilerError` falsely claiming "No durations provided".  Fixed `#15145 <https://github.com/Qiskit/qiskit/issues/15145>`__.


### PR DESCRIPTION
Internally the passes look for the time-unit type of the first operation in the circuit, to dispatch to wall-time or clock-cycle handlers.  This caused trouble if there _were_ no durations, even though the circuit is trivially scheduled.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

The diff is a bit awkward, but 90% of the changes are just indentation.

Fix #15145.

