### PR TITLE
Fix textdrawer for controlflow with different regs

### DIFF
--- a/qiskit/visualization/circuit/text.py
+++ b/qiskit/visualization/circuit/text.py
@@ -1247,7 +1247,8 @@ class TextDrawing:
             add_connected_gate(node, gates, layer, current_cons, gate_wire_map)
 
         elif len(node.qargs) >= 2 and not node.cargs:
-            layer.set_qu_multibox(node.qargs, gate_text, conditional=conditional)
+            mapped_qargs = [self.qubits[gate_wire_map[q]] for q in node.qargs]
+            layer.set_qu_multibox(mapped_qargs, gate_text, conditional=conditional)
 
         elif node.qargs and node.cargs:
             layer._set_multibox(

--- a/releasenotes/notes/fix-textdraw-controlflow-61113092213662c2.yaml
+++ b/releasenotes/notes/fix-textdraw-controlflow-61113092213662c2.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a failure in the circuit text drawer, which could occur when circuit blocks inside
+    control flow operations were defined on different registers than the outer circuit.
+    This happened only when appending :class:`.ControlFlowOp` operations directly, not with
+    the builder interface.

--- a/releasenotes/notes/fix-textdraw-controlflow-61113092213662c2.yaml
+++ b/releasenotes/notes/fix-textdraw-controlflow-61113092213662c2.yaml
@@ -3,5 +3,5 @@ fixes:
   - |
     Fixed a failure in the circuit text drawer, which could occur when circuit blocks inside
     control flow operations were defined on different registers than the outer circuit.
-    This happened only when appending :class:`.ControlFlowOp` operations directly, not with
-    the builder interface.
+    This situation could for example happen when appending :class:`.ControlFlowOp` operations 
+    directly, or for circuits after transpilation.

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -41,6 +41,7 @@ from qiskit.visualization import circuit_drawer
 from qiskit.visualization.circuit import text as elements
 from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.circuit.classical import expr, types
+from qiskit.circuit.controlflow import ForLoopOp
 from qiskit.circuit.library import (
     HGate,
     U2Gate,
@@ -61,6 +62,7 @@ from qiskit.circuit.library import (
     UnitaryGate,
     HamiltonianGate,
     UCGate,
+    get_standard_gate_name_mapping,
 )
 from qiskit.transpiler.passes import ApplyLayout
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
@@ -4466,6 +4468,35 @@ class TestCircuitControlFlowOps(QiskitVisualizationTestCase):
 
         actual = str(qc.draw("text", fold=-1, initial_state=False))
         self.assertEqual(actual, expected)
+
+    def test_control_flow_different_registers(self):
+        """Test drawing with control flow where the blocks are defined on separate registers."""
+        for name, gate in get_standard_gate_name_mapping().items():
+            # known bug for classical bits: https://github.com/Qiskit/qiskit/issues/15154
+            if gate.num_clbits > 0:
+                continue
+
+            # if there are no bits, there's no register naming to be checked
+            if gate.num_qubits == 0:
+                continue
+
+            # define a block on custom registers
+            block_qreg = QuantumRegister(gate.num_qubits, "qb")
+            block_creg = ClassicalRegister(gate.num_clbits, "cb")
+            block = QuantumCircuit(block_qreg, block_creg)
+            block.append(gate, block_qreg, block_creg)
+            for_loop = ForLoopOp([0, 1, 2], None, block)
+
+            # append to a circuit and check drawing works
+            qreg = QuantumRegister(gate.num_qubits, name="qc")
+            creg = ClassicalRegister(gate.num_clbits, name="cc")
+            circuit = QuantumCircuit(qreg, creg)
+            circuit.append(for_loop, qreg, creg)
+
+            with self.subTest(name=name):
+                # we don't check the full drawing, we just check the drawing didn't fail
+                out = str(circuit_drawer(circuit, output="text"))
+                self.assertTrue("For-0 (0, 1, 2)" in out)
 
     def test_nested_switch_op_var(self):
         """Test switch with standalone Var."""


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixed a failure in the circuit text drawer, which could occur when circuit blocks inside
control flow operations were defined on different registers than the outer circuit.
This happened only when appending `ControlFlowOp` operations directly, not with
the builder interface.

### Details

This uncovered a related issue, #15154.