### PR TITLE
Add `use_seeking` kwarg to qpy.dump for manual override of seek behaviour

### DIFF
--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -219,10 +219,7 @@ def dump(
 
     if version >= 16:
         # Determine if we can safely use the in-place seek path
-        can_seek = (
-            file_obj.seekable()
-            and not isinstance(file_obj, KNOWN_BAD_SEEKERS)
-        )
+        can_seek = file_obj.seekable() and not isinstance(file_obj, KNOWN_BAD_SEEKERS)
         # Note: This isinstance() check may not catch all problematic stream types that
         # incorrectly report seekable=True. For most common cases (e.g., gzip.GzipFile),
         # this is sufficient, but if new problematic types are found, consider adding

--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -225,10 +225,7 @@ def dump(
     if version >= 16:
         # Determine whether to use the fast seek path
         if use_seeking is None:
-            can_seek = (
-                file_obj.seekable()
-                and not isinstance(file_obj, KNOWN_BAD_SEEKERS)
-            )
+            can_seek = file_obj.seekable() and not isinstance(file_obj, KNOWN_BAD_SEEKERS)
         else:
             can_seek = use_seeking
         # Note: This isinstance() check may not catch all problematic stream types that


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This PR builds on top of #15158  and introduces an optional `use_seeking` keyword argument to qpy.dump. Fixes #15157 

### Details and comments

This provides explicit user control over whether QPY uses the in-place seek table or the buffered write path.

 - `use_seeking=None` -> automatic detection (based on `seekable()` and `KNOWN_BAD_SEEKERS`).
 - `use_seeking=True` -> force the in-place seek path.
 - `use_seeking=False` -> force the buffered path.

This gives users full control in environments with custom stream wrappers.

This PR should target Qiskit 2.3, while #15158 remains the bug-fix-only change backported to 2.2.2.

