### PR TITLE
Add Clifford prepend gates internal methods to improve Clifford.dot 

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -37,7 +37,7 @@ from .clifford_circuits import (
     _append_circuit,
     _append_operation,
     _prepend_operation,
-    _prepend_reversed_circuit,
+    _prepend_circuit,
 )
 
 
@@ -440,7 +440,7 @@ class Clifford(BaseOperator, AdjointMixin, Operation):
                 return _append_operation(self.copy(), other, qargs=qargs)
         else:
             if isinstance(other, QuantumCircuit):
-                return _prepend_reversed_circuit(self.copy(), other, qargs=qargs)
+                return _prepend_circuit(self.copy(), other, qargs=qargs)
             if isinstance(other, Instruction):
                 return _prepend_operation(self.copy(), other, qargs=qargs)
 

--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -33,7 +33,12 @@ from qiskit.quantum_info.operators.scalar_op import ScalarOp
 from qiskit.quantum_info.operators.symplectic.base_pauli import _count_y
 
 from .base_pauli import BasePauli
-from .clifford_circuits import _append_circuit, _append_operation, _prepend_operation, _prepend_circuit
+from .clifford_circuits import (
+    _append_circuit,
+    _append_operation,
+    _prepend_operation,
+    _prepend_circuit,
+)
 
 
 class Clifford(BaseOperator, AdjointMixin, Operation):

--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -37,7 +37,7 @@ from .clifford_circuits import (
     _append_circuit,
     _append_operation,
     _prepend_operation,
-    _prepend_circuit,
+    _prepend_reversed_circuit,
 )
 
 
@@ -440,9 +440,9 @@ class Clifford(BaseOperator, AdjointMixin, Operation):
                 return _append_operation(self.copy(), other, qargs=qargs)
         else:
             if isinstance(other, QuantumCircuit):
-                return _prepend_circuit(self.copy(), other.reverse_ops(), qargs=qargs)
+                return _prepend_reversed_circuit(self.copy(), other, qargs=qargs)
             if isinstance(other, Instruction):
-                return _prepend_operation(self.copy(), other.reverse_ops(), qargs=qargs)
+                return _prepend_operation(self.copy(), other, qargs=qargs)
 
         if not isinstance(other, Clifford):
             # Not copying is safe since we're going to drop our only reference to `other` at the end

--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -33,7 +33,7 @@ from qiskit.quantum_info.operators.scalar_op import ScalarOp
 from qiskit.quantum_info.operators.symplectic.base_pauli import _count_y
 
 from .base_pauli import BasePauli
-from .clifford_circuits import _append_circuit, _append_operation
+from .clifford_circuits import _append_circuit, _append_operation, _prepend_operation, _prepend_circuit
 
 
 class Clifford(BaseOperator, AdjointMixin, Operation):
@@ -433,6 +433,11 @@ class Clifford(BaseOperator, AdjointMixin, Operation):
                 return _append_circuit(self.copy(), other, qargs=qargs)
             if isinstance(other, Instruction):
                 return _append_operation(self.copy(), other, qargs=qargs)
+        else:
+            if isinstance(other, QuantumCircuit):
+                return _prepend_circuit(self.copy(), other.reverse_ops(), qargs=qargs)
+            if isinstance(other, Instruction):
+                return _prepend_operation(self.copy(), other.reverse_ops(), qargs=qargs)
 
         if not isinstance(other, Clifford):
             # Not copying is safe since we're going to drop our only reference to `other` at the end

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -720,7 +720,6 @@ def _prepend_cx(clifford, control, target):
     return clifford
 
 
-# ToDo: handle phases
 def _append_cz(clifford, control, target):
     """Apply a CZ gate to a Clifford.
 
@@ -760,6 +759,24 @@ def _prepend_cz(clifford, control, target):
 
     destab_control ^= stab_target
     destab_target ^= stab_control
+
+    from qiskit.quantum_info.operators.symplectic.pauli import Pauli
+
+    destab_x_c = clifford.destab_x[control]
+    destab_z_c = clifford.destab_z[control]
+    stab_x_c = clifford.stab_x[control]
+    stab_z_c = clifford.stab_z[control]
+    destab_x_t = clifford.destab_x[target]
+    destab_z_t = clifford.destab_z[target]
+    stab_x_t = clifford.stab_x[target]
+    stab_z_t = clifford.stab_z[target]
+    pauli_destab_c = Pauli((destab_x_c, destab_z_c))
+    pauli_stab_c = Pauli((stab_x_c, stab_z_c))
+    pauli_destab_t = Pauli((destab_x_t, destab_z_t))
+    pauli_stab_t = Pauli((stab_x_t, stab_z_t))
+
+    clifford.destab_phase[control] ^= (pauli_destab_c.compose(pauli_stab_t)).phase != 0
+    clifford.destab_phase[target] ^= (pauli_destab_t.compose(pauli_stab_c)).phase != 0
     return clifford
 
 

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -258,17 +258,17 @@ def _prepend_operation(clifford, operation, qargs=None):
         if theta == 0:
             clifford = _prepend_rz(clifford, qargs[0], lambd + phi)
         elif theta == 1:
-            clifford = _prepend_rz(clifford, qargs[0], lambd - 2)
-            clifford = _prepend_h(clifford, qargs[0])
             clifford = _prepend_rz(clifford, qargs[0], phi)
-        elif theta == 2:
-            clifford = _prepend_rz(clifford, qargs[0], lambd - 1)
-            clifford = _prepend_x(clifford, qargs[0])
-            clifford = _prepend_rz(clifford, qargs[0], phi + 1)
-        elif theta == 3:
-            clifford = _prepend_rz(clifford, qargs[0], lambd)
             clifford = _prepend_h(clifford, qargs[0])
+            clifford = _prepend_rz(clifford, qargs[0], lambd - 2)
+        elif theta == 2:
+            clifford = _prepend_rz(clifford, qargs[0], phi + 1)
+            clifford = _prepend_x(clifford, qargs[0])
+            clifford = _prepend_rz(clifford, qargs[0], lambd - 1)
+        elif theta == 3:
             clifford = _prepend_rz(clifford, qargs[0], phi + 2)
+            clifford = _prepend_h(clifford, qargs[0])
+            clifford = _prepend_rz(clifford, qargs[0], lambd)
         return clifford
 
     # If gate is a Clifford, we can either unroll the gate using the "to_circuit"

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -642,6 +642,27 @@ def _append_cz(clifford, control, target):
     return clifford
 
 
+def _prepend_cz(clifford, control, target):
+    """Apply a CZ gate before a Clifford.
+
+    Args:
+        clifford (Clifford): a Clifford.
+        control (int): gate control qubit index.
+        target (int): gate target qubit index.
+
+    Returns:
+        Clifford: the updated Clifford.
+    """
+    destab_target = clifford.destab[target, :]
+    stab_target = clifford.stab[target, :]
+    destab_control = clifford.destab[control, :]
+    stab_control = clifford.stab[control, :]
+
+    destab_control ^= stab_target
+    destab_target ^= stab_control
+    return clifford
+
+
 def _append_cy(clifford, control, target):
     """Apply a CY gate to a Clifford.
 

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -443,6 +443,23 @@ def _append_sx(clifford, qubit):
     return clifford
 
 
+def _prepend_sx(clifford, qubit):
+    """Apply an SX gate before a Clifford.
+
+    Args:
+        clifford (Clifford): a Clifford.
+        qubit (int): gate qubit index.
+
+    Returns:
+        Clifford: the updated Clifford.
+    """
+    destab = clifford.destab[qubit, :]
+    stab = clifford.stab[qubit, :]
+
+    stab ^= destab
+    return clifford
+
+
 def _append_sxdg(clifford, qubit):
     """Apply an SXdg gate to a Clifford.
 
@@ -458,6 +475,23 @@ def _append_sxdg(clifford, qubit):
 
     clifford.phase ^= x & z
     x ^= z
+    return clifford
+
+
+def _prepend_sxdg(clifford, qubit):
+    """Apply an SXdg gate before a Clifford.
+
+    Args:
+        clifford (Clifford): a Clifford.
+        qubit (int): gate qubit index.
+
+    Returns:
+        Clifford: the updated Clifford.
+    """
+    destab = clifford.destab[qubit, :]
+    stab = clifford.stab[qubit, :]
+
+    stab ^= destab
     return clifford
 
 
@@ -481,6 +515,28 @@ def _append_v(clifford, qubit):
     return clifford
 
 
+def _prepend_v(clifford, qubit):
+    """Apply a V gate before a Clifford.
+
+    This is equivalent to an Sdg gate followed by a H gate.
+
+    Args:
+        clifford (Clifford): a Clifford.
+        qubit (int): gate qubit index.
+
+    Returns:
+        Clifford: the updated Clifford.
+    """
+    destab = clifford.destab[qubit, :]
+    stab = clifford.stab[qubit, :]
+
+    tmp = destab.copy()
+    destab ^= stab
+    clifford.stab[qubit, :] = tmp
+
+    return clifford
+
+
 def _append_w(clifford, qubit):
     """Apply a W gate to a Clifford.
 
@@ -498,6 +554,28 @@ def _append_w(clifford, qubit):
     tmp = z.copy()
     z ^= x
     x[:] = tmp
+    return clifford
+
+
+def _prepend_w(clifford, qubit):
+    """Apply a W gate before a Clifford.
+
+    This is equivalent to an H gate followed by an S gate.
+
+    Args:
+        clifford (Clifford): a Clifford.
+        qubit (int): gate qubit index.
+
+    Returns:
+        Clifford: the updated Clifford.
+    """
+    destab = clifford.destab[qubit, :]
+    stab = clifford.stab[qubit, :]
+
+    tmp = stab.copy()
+    stab ^= destab
+    clifford.destab[qubit, :] = tmp
+
     return clifford
 
 

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -210,8 +210,43 @@ def _append_rz(clifford, qubit, multiple):
     return clifford
 
 
+def _prepend_rz(clifford, qubit, multiple):
+    """Apply an Rz gate before a Clifford.
+
+    Args:
+        clifford (Clifford): a Clifford.
+        qubit (int): gate qubit index.
+        multiple (int): z-rotation angle in a multiple of pi/2
+
+    Returns:
+        Clifford: the updated Clifford.
+    """
+    if multiple % 4 == 1:
+        return _prepend_s(clifford, qubit)
+    if multiple % 4 == 2:
+        return _prepend_z(clifford, qubit)
+    if multiple % 4 == 3:
+        return _prepend_sdg(clifford, qubit)
+
+    return clifford
+
+
 def _append_i(clifford, qubit):
     """Apply an I gate to a Clifford.
+
+    Args:
+        clifford (Clifford): a Clifford.
+        qubit (int): gate qubit index.
+
+    Returns:
+        Clifford: the updated Clifford.
+    """
+    # pylint: disable=unused-argument
+    return clifford
+
+
+def _prepend_i(clifford, qubit):
+    """Apply an I gate before a Clifford.
 
     Args:
         clifford (Clifford): a Clifford.

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -238,6 +238,20 @@ def _append_x(clifford, qubit):
     return clifford
 
 
+def _prepend_x(clifford, qubit):
+    """Apply an X gate before a Clifford.
+
+    Args:
+        clifford (Clifford): a Clifford.
+        qubit (int): gate qubit index.
+
+    Returns:
+        Clifford: the updated Clifford.
+    """
+    clifford.stab_phase[qubit] ^= True
+    return clifford
+
+
 def _append_y(clifford, qubit):
     """Apply a Y gate to a Clifford.
 
@@ -254,6 +268,21 @@ def _append_y(clifford, qubit):
     return clifford
 
 
+def _prepend_y(clifford, qubit):
+    """Apply a Y gate before a Clifford.
+
+    Args:
+        clifford (Clifford): a Clifford.
+        qubit (int): gate qubit index.
+
+    Returns:
+        Clifford: the updated Clifford.
+    """
+    clifford.stab_phase[qubit] ^= True
+    clifford.destab_phase[qubit] ^= True
+    return clifford
+
+
 def _append_z(clifford, qubit):
     """Apply an Z gate to a Clifford.
 
@@ -265,6 +294,20 @@ def _append_z(clifford, qubit):
         Clifford: the updated Clifford.
     """
     clifford.phase ^= clifford.x[:, qubit]
+    return clifford
+
+
+def _prepend_z(clifford, qubit):
+    """Apply a Z gate before a Clifford.
+
+    Args:
+        clifford (Clifford): a Clifford.
+        qubit (int): gate qubit index.
+
+    Returns:
+        Clifford: the updated Clifford.
+    """
+    clifford.destab_phase[qubit] ^= True
     return clifford
 
 
@@ -287,6 +330,25 @@ def _append_h(clifford, qubit):
     return clifford
 
 
+def _prepend_h(clifford, qubit):
+    """Apply a H gate before a Clifford.
+
+    Args:
+        clifford (Clifford): a Clifford.
+        qubit (int): gate qubit index.
+
+    Returns:
+        Clifford: the updated Clifford.
+    """
+    destab = clifford.destab[qubit, :]
+    stab = clifford.stab[qubit, :]
+
+    tmp = destab.copy()
+    destab[:] = stab
+    stab[:] = tmp
+    return clifford
+
+
 def _append_s(clifford, qubit):
     """Apply an S gate to a Clifford.
 
@@ -305,6 +367,30 @@ def _append_s(clifford, qubit):
     return clifford
 
 
+def _prepend_s(clifford, qubit):
+    """Apply an S gate before a Clifford.
+
+    Args:
+        clifford (Clifford): a Clifford.
+        qubit (int): gate qubit index.
+
+    Returns:
+        Clifford: the updated Clifford.
+    """
+    destab_x = clifford.destab_x[qubit, :]
+    stab_x = clifford.stab_x[qubit, :]
+    destab_z = clifford.destab_z[qubit, :]
+    stab_z = clifford.stab_z[qubit, :]
+
+    # destab_phase = clifford.destab_phase[qubit]
+    # stab_phase = clifford.stab_phase[qubit]
+
+    destab_x ^= stab_x
+    destab_z ^= stab_z
+    # clifford.destab_phase ^= clifford.stab_phase
+    return clifford
+
+
 def _append_sdg(clifford, qubit):
     """Apply an Sdg gate to a Clifford.
 
@@ -319,6 +405,23 @@ def _append_sdg(clifford, qubit):
     z = clifford.z[:, qubit]
     clifford.phase ^= x & ~z
     z ^= x
+    return clifford
+
+
+def _prepend_sdg(clifford, qubit):
+    """Apply an Sdg gate before a Clifford.
+
+    Args:
+        clifford (Clifford): a Clifford.
+        qubit (int): gate qubit index.
+
+    Returns:
+        Clifford: the updated Clifford.
+    """
+    destab = clifford.destab[qubit, :]
+    stab = clifford.stab[qubit, :]
+
+    destab ^= stab
     return clifford
 
 
@@ -416,6 +519,27 @@ def _append_cx(clifford, control, target):
     clifford.phase ^= (x1 ^ z0 ^ True) & z1 & x0
     x1 ^= x0
     z0 ^= z1
+    return clifford
+
+
+def _prepend_cx(clifford, control, target):
+    """Apply a CX gate before a Clifford.
+
+    Args:
+        clifford (Clifford): a Clifford.
+        control (int): gate control qubit index.
+        target (int): gate target qubit index.
+
+    Returns:
+        Clifford: the updated Clifford.
+    """
+    destab_target = clifford.destab[target, :]
+    stab_target = clifford.stab[target, :]
+    destab_control = clifford.destab[control, :]
+    stab_control = clifford.stab[control, :]
+
+    destab_control ^= destab_target
+    stab_target ^= stab_control
     return clifford
 
 

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -50,7 +50,7 @@ def _append_circuit(clifford, circuit, qargs=None):
     return clifford
 
 
-def _prepend_reversed_circuit(clifford, circuit, qargs=None):
+def _prepend_circuit(clifford, circuit, qargs=None):
     """Update Clifford inplace by prepending a Clifford circuit.
 
     Args:
@@ -303,7 +303,7 @@ def _prepend_operation(clifford, operation, qargs=None):
     # If fails, we need to restore the clifford that was before attempting to unroll and append.
     if gate.definition is not None:
         try:
-            return _prepend_reversed_circuit(clifford.copy(), gate.definition, qargs)
+            return _prepend_circuit(clifford.copy(), gate.definition, qargs)
         except QiskitError:
             pass
 

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -580,15 +580,15 @@ def _prepend_s(clifford, qubit):
     Returns:
         Clifford: the updated Clifford.
     """
-    destab = clifford.destab[qubit, :]
-    stab = clifford.stab[qubit, :]
-
-    destab ^= stab
-
     destab_x = clifford.destab_x[qubit, :]
     stab_x = clifford.stab_x[qubit, :]
     destab_z = clifford.destab_z[qubit, :]
     stab_z = clifford.stab_z[qubit, :]
+    stab_phase = clifford.stab_phase[qubit]
+
+    destab_x ^= stab_x
+    destab_z ^= stab_z
+    clifford.destab_phase[qubit] ^= stab_phase
 
     phase = _calculate_composed_phased(destab_x, destab_z, stab_x, stab_z)
     if phase == 1:
@@ -624,15 +624,15 @@ def _prepend_sdg(clifford, qubit):
     Returns:
         Clifford: the updated Clifford.
     """
-    destab = clifford.destab[qubit, :]
-    stab = clifford.stab[qubit, :]
-
-    destab ^= stab
-
     destab_x = clifford.destab_x[qubit, :]
     stab_x = clifford.stab_x[qubit, :]
     destab_z = clifford.destab_z[qubit, :]
     stab_z = clifford.stab_z[qubit, :]
+    stab_phase = clifford.stab_phase[qubit]
+
+    destab_x ^= stab_x
+    destab_z ^= stab_z
+    clifford.destab_phase[qubit] ^= stab_phase
 
     phase = _calculate_composed_phased(destab_x, destab_z, stab_x, stab_z)
     if phase == 3:
@@ -669,15 +669,15 @@ def _prepend_sx(clifford, qubit):
     Returns:
         Clifford: the updated Clifford.
     """
-    destab = clifford.destab[qubit, :]
-    stab = clifford.stab[qubit, :]
-
-    stab ^= destab
-
     destab_x = clifford.destab_x[qubit, :]
     stab_x = clifford.stab_x[qubit, :]
     destab_z = clifford.destab_z[qubit, :]
     stab_z = clifford.stab_z[qubit, :]
+    destab_phase = clifford.destab_phase[qubit]
+
+    stab_x ^= destab_x
+    stab_z ^= destab_z
+    clifford.stab_phase[qubit] ^= destab_phase
 
     phase = _calculate_composed_phased(stab_x, stab_z, destab_x, destab_z)
     if phase == 1:
@@ -714,15 +714,15 @@ def _prepend_sxdg(clifford, qubit):
     Returns:
         Clifford: the updated Clifford.
     """
-    destab = clifford.destab[qubit, :]
-    stab = clifford.stab[qubit, :]
-
-    stab ^= destab
-
     destab_x = clifford.destab_x[qubit, :]
     stab_x = clifford.stab_x[qubit, :]
     destab_z = clifford.destab_z[qubit, :]
     stab_z = clifford.stab_z[qubit, :]
+    destab_phase = clifford.destab_phase[qubit]
+
+    stab_x ^= destab_x
+    stab_z ^= destab_z
+    clifford.stab_phase[qubit] ^= destab_phase
 
     phase = _calculate_composed_phased(stab_x, stab_z, destab_x, destab_z)
     if phase == 3:
@@ -865,14 +865,6 @@ def _prepend_cx(clifford, control, target):
     Returns:
         Clifford: the updated Clifford.
     """
-    destab_target = clifford.destab[target, :]
-    stab_target = clifford.stab[target, :]
-    destab_control = clifford.destab[control, :]
-    stab_control = clifford.stab[control, :]
-
-    destab_control ^= destab_target
-    stab_target ^= stab_control
-
     destab_x_c = clifford.destab_x[control]
     destab_z_c = clifford.destab_z[control]
     stab_x_c = clifford.stab_x[control]
@@ -881,6 +873,13 @@ def _prepend_cx(clifford, control, target):
     destab_z_t = clifford.destab_z[target]
     stab_x_t = clifford.stab_x[target]
     stab_z_t = clifford.stab_z[target]
+
+    destab_x_c ^= destab_x_t
+    destab_z_c ^= destab_z_t
+    stab_x_t ^= stab_x_c
+    stab_z_t ^= stab_z_c
+    clifford.destab_phase[control] ^= clifford.destab_phase[target]
+    clifford.stab_phase[target] ^= clifford.stab_phase[control]
 
     phase_control = _calculate_composed_phased(destab_x_c, destab_z_c, destab_x_t, destab_z_t)
     phase_target = _calculate_composed_phased(stab_x_c, stab_z_c, stab_x_t, stab_z_t)
@@ -921,14 +920,6 @@ def _prepend_cz(clifford, control, target):
     Returns:
         Clifford: the updated Clifford.
     """
-    destab_target = clifford.destab[target, :]
-    stab_target = clifford.stab[target, :]
-    destab_control = clifford.destab[control, :]
-    stab_control = clifford.stab[control, :]
-
-    destab_control ^= stab_target
-    destab_target ^= stab_control
-
     destab_x_c = clifford.destab_x[control]
     destab_z_c = clifford.destab_z[control]
     stab_x_c = clifford.stab_x[control]
@@ -937,6 +928,13 @@ def _prepend_cz(clifford, control, target):
     destab_z_t = clifford.destab_z[target]
     stab_x_t = clifford.stab_x[target]
     stab_z_t = clifford.stab_z[target]
+
+    destab_x_c ^= stab_x_t
+    destab_z_c ^= stab_z_t
+    destab_x_t ^= stab_x_c
+    destab_z_t ^= stab_z_c
+    clifford.destab_phase[control] ^= clifford.stab_phase[target]
+    clifford.destab_phase[target] ^= clifford.stab_phase[control]
 
     phase_control = _calculate_composed_phased(destab_x_c, destab_z_c, stab_x_t, stab_z_t)
     phase_target = _calculate_composed_phased(destab_x_t, destab_z_t, stab_x_c, stab_z_c)

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -412,17 +412,22 @@ def _prepend_s(clifford, qubit):
     Returns:
         Clifford: the updated Clifford.
     """
+    destab = clifford.destab[qubit, :]
+    stab = clifford.stab[qubit, :]
+
+    destab ^= stab
+
     destab_x = clifford.destab_x[qubit, :]
     stab_x = clifford.stab_x[qubit, :]
     destab_z = clifford.destab_z[qubit, :]
     stab_z = clifford.stab_z[qubit, :]
 
-    # destab_phase = clifford.destab_phase[qubit]
-    # stab_phase = clifford.stab_phase[qubit]
+    from qiskit.quantum_info.operators.symplectic.pauli import Pauli
 
-    destab_x ^= stab_x
-    destab_z ^= stab_z
-    # clifford.destab_phase ^= clifford.stab_phase
+    pp = Pauli((destab_x, destab_z)).compose(Pauli((stab_x, stab_z)))
+    if pp.phase == 1:
+        clifford.destab_phase[qubit] ^= True
+
     return clifford
 
 
@@ -457,6 +462,18 @@ def _prepend_sdg(clifford, qubit):
     stab = clifford.stab[qubit, :]
 
     destab ^= stab
+
+    destab_x = clifford.destab_x[qubit, :]
+    stab_x = clifford.stab_x[qubit, :]
+    destab_z = clifford.destab_z[qubit, :]
+    stab_z = clifford.stab_z[qubit, :]
+
+    from qiskit.quantum_info.operators.symplectic.pauli import Pauli
+
+    pp = Pauli((destab_x, destab_z)).compose(Pauli((stab_x, stab_z)))
+    if pp.phase == 3:
+        clifford.destab_phase[qubit] ^= True
+
     return clifford
 
 
@@ -492,6 +509,18 @@ def _prepend_sx(clifford, qubit):
     stab = clifford.stab[qubit, :]
 
     stab ^= destab
+
+    destab_x = clifford.destab_x[qubit, :]
+    stab_x = clifford.stab_x[qubit, :]
+    destab_z = clifford.destab_z[qubit, :]
+    stab_z = clifford.stab_z[qubit, :]
+
+    from qiskit.quantum_info.operators.symplectic.pauli import Pauli
+
+    pp = Pauli((stab_x, stab_z)).compose(Pauli((destab_x, destab_z)))
+    if pp.phase == 1:
+        clifford.stab_phase[qubit] ^= True
+
     return clifford
 
 
@@ -527,6 +556,18 @@ def _prepend_sxdg(clifford, qubit):
     stab = clifford.stab[qubit, :]
 
     stab ^= destab
+
+    destab_x = clifford.destab_x[qubit, :]
+    stab_x = clifford.stab_x[qubit, :]
+    destab_z = clifford.destab_z[qubit, :]
+    stab_z = clifford.stab_z[qubit, :]
+
+    from qiskit.quantum_info.operators.symplectic.pauli import Pauli
+
+    pp = Pauli((stab_x, stab_z)).compose(Pauli((destab_x, destab_z)))
+    if pp.phase == 3:
+        clifford.stab_phase[qubit] ^= True
+
     return clifford
 
 
@@ -569,6 +610,17 @@ def _prepend_v(clifford, qubit):
     destab ^= stab
     clifford.stab[qubit, :] = tmp
 
+    destab_x = clifford.destab_x[qubit, :]
+    stab_x = clifford.stab_x[qubit, :]
+    destab_z = clifford.destab_z[qubit, :]
+    stab_z = clifford.stab_z[qubit, :]
+
+    from qiskit.quantum_info.operators.symplectic.pauli import Pauli
+
+    pp = Pauli((destab_x, destab_z)).compose(Pauli((stab_x, stab_z)))
+    if pp.phase == 3:
+        clifford.destab_phase[qubit] ^= True
+
     return clifford
 
 
@@ -610,6 +662,17 @@ def _prepend_w(clifford, qubit):
     tmp = stab.copy()
     stab ^= destab
     clifford.destab[qubit, :] = tmp
+
+    destab_x = clifford.destab_x[qubit, :]
+    stab_x = clifford.stab_x[qubit, :]
+    destab_z = clifford.destab_z[qubit, :]
+    stab_z = clifford.stab_z[qubit, :]
+
+    from qiskit.quantum_info.operators.symplectic.pauli import Pauli
+
+    pp = Pauli((stab_x, stab_z)).compose(Pauli((destab_x, destab_z)))
+    if pp.phase == 1:
+        clifford.stab_phase[qubit] ^= True
 
     return clifford
 

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -696,6 +696,22 @@ def _append_swap(clifford, qubit0, qubit1):
     return clifford
 
 
+def _prepend_swap(clifford, qubit0, qubit1):
+    """Apply a Swap gate before a Clifford.
+
+    Args:
+        clifford (Clifford): a Clifford.
+        qubit0 (int): first qubit index.
+        qubit1 (int): second  qubit index.
+
+    Returns:
+        Clifford: the updated Clifford.
+    """
+    clifford.stab[[qubit0, qubit1], :] = clifford.stab[[qubit1, qubit0], :]
+    clifford.destab[[qubit0, qubit1], :] = clifford.destab[[qubit1, qubit0], :]
+    return clifford
+
+
 def _append_iswap(clifford, qubit0, qubit1):
     """Apply a iSwap gate to a Clifford.
 

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -701,7 +701,6 @@ def _append_cx(clifford, control, target):
     return clifford
 
 
-# ToDo: handle phases
 def _prepend_cx(clifford, control, target):
     """Apply a CX gate before a Clifford.
 
@@ -720,6 +719,20 @@ def _prepend_cx(clifford, control, target):
 
     destab_control ^= destab_target
     stab_target ^= stab_control
+
+    destab_x_c = clifford.destab_x[control]
+    destab_z_c = clifford.destab_z[control]
+    stab_x_c = clifford.stab_x[control]
+    stab_z_c = clifford.stab_z[control]
+    destab_x_t = clifford.destab_x[target]
+    destab_z_t = clifford.destab_z[target]
+    stab_x_t = clifford.stab_x[target]
+    stab_z_t = clifford.stab_z[target]
+
+    phase_control = _calculate_composed_phased(destab_x_c, destab_z_c, destab_x_t, destab_z_t)
+    phase_target = _calculate_composed_phased(stab_x_c, stab_z_c, stab_x_t, stab_z_t)
+    clifford.destab_phase[control] ^= phase_control != 0
+    clifford.stab_phase[target] ^= phase_target != 0
     return clifford
 
 

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -809,6 +809,23 @@ def _append_cy(clifford, control, target):
     return clifford
 
 
+def _prepend_cy(clifford, control, target):
+    """Apply a CY gate before a Clifford.
+
+    Args:
+        clifford (Clifford): a Clifford.
+        control (int): gate control qubit index.
+        target (int): gate target qubit index.
+
+    Returns:
+        Clifford: the updated Clifford.
+    """
+    clifford = _prepend_sdg(clifford, target)
+    clifford = _prepend_cx(clifford, control, target)
+    clifford = _prepend_s(clifford, target)
+    return clifford
+
+
 def _append_swap(clifford, qubit0, qubit1):
     """Apply a Swap gate to a Clifford.
 
@@ -861,6 +878,26 @@ def _append_iswap(clifford, qubit0, qubit1):
     return clifford
 
 
+def _prepend_iswap(clifford, qubit0, qubit1):
+    """Apply a iSwap gate before a Clifford.
+
+    Args:
+        clifford (Clifford): a Clifford.
+        qubit0 (int): first qubit index.
+        qubit1 (int): second  qubit index.
+
+    Returns:
+        Clifford: the updated Clifford.
+    """
+    clifford = _prepend_s(clifford, qubit0)
+    clifford = _prepend_h(clifford, qubit0)
+    clifford = _prepend_s(clifford, qubit1)
+    clifford = _prepend_cx(clifford, qubit0, qubit1)
+    clifford = _prepend_cx(clifford, qubit1, qubit0)
+    clifford = _prepend_h(clifford, qubit1)
+    return clifford
+
+
 def _append_dcx(clifford, qubit0, qubit1):
     """Apply a DCX gate to a Clifford.
 
@@ -874,6 +911,22 @@ def _append_dcx(clifford, qubit0, qubit1):
     """
     clifford = _append_cx(clifford, qubit0, qubit1)
     clifford = _append_cx(clifford, qubit1, qubit0)
+    return clifford
+
+
+def _prepend_dcx(clifford, qubit0, qubit1):
+    """Apply a DCX gate before a Clifford.
+
+    Args:
+        clifford (Clifford): a Clifford.
+        qubit0 (int): first qubit index.
+        qubit1 (int): second  qubit index.
+
+    Returns:
+        Clifford: the updated Clifford.
+    """
+    clifford = _prepend_cx(clifford, qubit0, qubit1)
+    clifford = _prepend_cx(clifford, qubit1, qubit0)
     return clifford
 
 
@@ -892,6 +945,25 @@ def _append_ecr(clifford, qubit0, qubit1):
     clifford = _append_sx(clifford, qubit1)
     clifford = _append_cx(clifford, qubit0, qubit1)
     clifford = _append_x(clifford, qubit0)
+
+    return clifford
+
+
+def _prepend_ecr(clifford, qubit0, qubit1):
+    """Apply an ECR gate before a Clifford.
+
+    Args:
+        clifford (Clifford): a Clifford.
+        qubit0 (int): first qubit index.
+        qubit1 (int): second  qubit index.
+
+    Returns:
+        Clifford: the updated Clifford.
+    """
+    clifford = _prepend_s(clifford, qubit0)
+    clifford = _prepend_sx(clifford, qubit1)
+    clifford = _prepend_cx(clifford, qubit0, qubit1)
+    clifford = _prepend_x(clifford, qubit0)
 
     return clifford
 

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -698,6 +698,7 @@ def _append_cx(clifford, control, target):
     return clifford
 
 
+# ToDo: handle phases
 def _prepend_cx(clifford, control, target):
     """Apply a CX gate before a Clifford.
 
@@ -719,6 +720,7 @@ def _prepend_cx(clifford, control, target):
     return clifford
 
 
+# ToDo: handle phases
 def _append_cz(clifford, control, target):
     """Apply a CZ gate to a Clifford.
 

--- a/releasenotes/notes/improve-performance-clifford-dot-method-299df21a64408045.yaml
+++ b/releasenotes/notes/improve-performance-clifford-dot-method-299df21a64408045.yaml
@@ -1,0 +1,9 @@
+---
+features_quantum_info:
+  - |
+    Improve the performance of :meth:`~qiskit.quantum_info.Clifford.dot`,
+    when it is composed with a :class:`QuantumCircuit`.
+    In this case, we use new internal methods to iteratively update the Clifford
+    by prepending with standard Clifford gates.
+    This scheme is significantly more efficient than the previous method of converting
+    the gates to Clifford and composing the Clifford tableaux.

--- a/releasenotes/notes/improve-performance-clifford-dot-method-299df21a64408045.yaml
+++ b/releasenotes/notes/improve-performance-clifford-dot-method-299df21a64408045.yaml
@@ -1,9 +1,12 @@
 ---
 features_quantum_info:
   - |
-    Improve the performance of :meth:`~qiskit.quantum_info.Clifford.dot`,
-    when it is composed with a :class:`QuantumCircuit`.
-    In this case, we iteratively update the Clifford by prepending it with standard Clifford gates.
-    This scheme is significantly more efficient than the previous method of converting
-    the gates to Clifford and composing the Clifford tableaux, when the number of prepended
-    gates is small compared to the Clifford size.
+    Improve the performance of :meth:`.Clifford.dot` and of :meth:`.Clifford.compose`
+    when called with `front=True`, in the case that the Clifford is composed with a
+    :class:`.QuantumCircuit` consisting of Clifford operations (for instance, of standard
+    Clifford gates). The new method consists of iteratively updating the Clifford by
+    prepending it with Clifford operations, similarly to the current behavior of
+    :meth:`.Clifford.compose` when called with `front=False`. When the number of
+    operations in the circuit is small, this method is significantly more efficient than
+    the old method consisting of converting the circuit into a Clifford and composing
+    the two Cliffords.

--- a/releasenotes/notes/improve-performance-clifford-dot-method-299df21a64408045.yaml
+++ b/releasenotes/notes/improve-performance-clifford-dot-method-299df21a64408045.yaml
@@ -3,7 +3,7 @@ features_quantum_info:
   - |
     Improve the performance of :meth:`~qiskit.quantum_info.Clifford.dot`,
     when it is composed with a :class:`QuantumCircuit`.
-    In this case, we use new internal methods to iteratively update the Clifford
-    by prepending with standard Clifford gates.
+    In this case, we iteratively update the Clifford by prepending it with standard Clifford gates.
     This scheme is significantly more efficient than the previous method of converting
-    the gates to Clifford and composing the Clifford tableaux.
+    the gates to Clifford and composing the Clifford tableaux, when the number of prepended
+    gates is small compared to the Clifford size.

--- a/test/python/quantum_info/operators/symplectic/test_clifford.py
+++ b/test/python/quantum_info/operators/symplectic/test_clifford.py
@@ -234,7 +234,7 @@ class TestCliffordGates(QiskitTestCase):
 
     @combine(
         gate=[CXGate(), CZGate(), CYGate(), SwapGate(), iSwapGate(), ECRGate(), DCXGate()],
-        num_qubits=[1, 2, 3],
+        num_qubits=[2, 3],
     )
     def test_append_2_qubits(self, gate, num_qubits):
         """Test _append_operation method for 2-qubit gates"""
@@ -252,7 +252,7 @@ class TestCliffordGates(QiskitTestCase):
 
     @combine(
         gate=[CXGate(), CZGate(), CYGate(), SwapGate(), iSwapGate(), ECRGate(), DCXGate()],
-        num_qubits=[1, 2, 3],
+        num_qubits=[2, 3],
     )
     def test_prepend_2_qubits(self, gate, num_qubits):
         """Test _prepend_operation method for 2-qubit gates"""
@@ -795,6 +795,8 @@ class TestCliffordOperators(QiskitTestCase):
             value = cliff1.compose(cliff2)
             target = Clifford(circ1.compose(circ2))
             self.assertEqual(target, value)
+            value_circ_composed = cliff1.compose(circ2)
+            self.assertEqual(target, value_circ_composed)
 
     @combine(num_qubits=[1, 2, 3])
     def test_dot_method(self, num_qubits):
@@ -813,6 +815,8 @@ class TestCliffordOperators(QiskitTestCase):
             value = cliff1.dot(cliff2)
             target = Clifford(circ2.compose(circ1))
             self.assertEqual(target, value)
+            value_circ_composed = cliff1.dot(circ2)
+            self.assertEqual(target, value_circ_composed)
 
     @combine(num_qubits_1=[1, 2, 3], num_qubits_2=[1, 2, 3])
     def test_tensor_method(self, num_qubits_1, num_qubits_2):

--- a/test/python/quantum_info/operators/symplectic/test_clifford.py
+++ b/test/python/quantum_info/operators/symplectic/test_clifford.py
@@ -243,7 +243,7 @@ class TestCliffordGates(QiskitTestCase):
         seed = 800
         gates = "all"
         for i in range(samples):
-            for qubits in list(itertools.combinations(range(num_qubits), 2)):
+            for qubits in itertools.combinations(range(num_qubits), 2):
                 circ = random_clifford_circuit(num_qubits, num_gates, gates=gates, seed=seed + i)
                 cliff = Clifford(circ)
                 cliff = _append_operation(cliff, gate.name, qubits)
@@ -261,7 +261,7 @@ class TestCliffordGates(QiskitTestCase):
         seed = 800
         gates = "all"
         for i in range(samples):
-            for qubits in list(itertools.combinations(range(num_qubits), 2)):
+            for qubits in itertools.combinations(range(num_qubits), 2):
                 circ = random_clifford_circuit(num_qubits, num_gates, gates=gates, seed=seed + i)
                 cliff = Clifford(circ)
                 cliff = _prepend_operation(cliff, gate.name, qubits)


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Close #15052 
Adding to the Clifford circuits the prepend gates internal methods. This should make the `Clifford.dot` method faster, as it could handle prepending the Clifford gates directly, without converting them into a Clifford Tableau.

### Details and comments
The prepending of the Clifford gates (I,X,Y,Z,S,Sdg,SX,SXdg,V,W,CZ,CX) is phase(=paulis) correct. 
The `Clifford.dot` method has been updated to use this functionality.

In a future PR, we plan to port this functionality to rust.
