### PR TITLE
Fixing inverse methods for MCPhase and MCU1 gates

### DIFF
--- a/qiskit/circuit/library/standard_gates/p.py
+++ b/qiskit/circuit/library/standard_gates/p.py
@@ -408,7 +408,9 @@ class MCPhaseGate(ControlledGate):
 
     def inverse(self, annotated: bool = False):
         r"""Return inverted MCPhase gate (:math:`MCPhase(\lambda)^{\dagger} = MCPhase(-\lambda)`)"""
-        return MCPhaseGate(-self.params[0], self.num_ctrl_qubits)
+        return MCPhaseGate(
+            -self.params[0], num_ctrl_qubits=self.num_ctrl_qubits, ctrl_state=self.ctrl_state
+        )
 
     def __eq__(self, other):
         return (

--- a/qiskit/circuit/library/standard_gates/u1.py
+++ b/qiskit/circuit/library/standard_gates/u1.py
@@ -456,7 +456,9 @@ class MCU1Gate(ControlledGate):
         Returns:
             MCU1Gate: inverse gate.
         """
-        return MCU1Gate(-self.params[0], self.num_ctrl_qubits)
+        return MCU1Gate(
+            -self.params[0], num_ctrl_qubits=self.num_ctrl_qubits, ctrl_state=self.ctrl_state
+        )
 
     def __eq__(self, other):
         return (

--- a/releasenotes/notes/fix-inverse-mcu1-and-mcphase-4f836142716bd7e3.yaml
+++ b/releasenotes/notes/fix-inverse-mcu1-and-mcphase-4f836142716bd7e3.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     Fixed the methods :meth:`.MCPhaseGate.inverse` and :meth:`.MCU1Gate.inverse` to
-    correctly preserve the control states of open-controlled gates when computing their
+    preserve the control states of open-controlled gates when computing their
     inverses.

--- a/releasenotes/notes/fix-inverse-mcu1-and-mcphase-4f836142716bd7e3.yaml
+++ b/releasenotes/notes/fix-inverse-mcu1-and-mcphase-4f836142716bd7e3.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed the methods :meth:`.MCPhaseGate.inverse` and :meth:`.MCU1Gate.inverse` to
+    correctly preserve the control states of open-controlled gates when computing their
+    inverses.

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -1096,7 +1096,7 @@ class TestControlledGate(QiskitTestCase):
     )
     def test_all_inverses(self, gate, num_ctrl_qubits, ctrl_state):
         """Test all standard gates except those that cannot be controlled."""
-        if not (issubclass(gate, ControlledGate) or issubclass(gate, allGates.IGate)):
+        if not issubclass(gate, ControlledGate):
             # only verify basic gates right now, as already controlled ones
             # will generate differing definitions
             try:
@@ -1122,13 +1122,13 @@ class TestControlledGate(QiskitTestCase):
         """Check that the inverse of the inverse of a controlled gate is
         unitary-equivalent to the original controlled gate.
         """
-        if not (issubclass(gate, ControlledGate) or issubclass(gate, allGates.IGate)):
+        if not issubclass(gate, ControlledGate):
             # Note that in general gate.inverse().inverse() might be different from gate.
             # For example, the inverse of the standard gate DCX is not a standard gate,
             # and hence DCXGate().inverse().inverse() is not DCXGate().
-            # However, the operators for DCXGate() is for DCXGate().inverse().inverse()
-            # must be equal. This catches bugs when the inverse method of a controlled gate
-            # loses the controlled state of the gate.
+            # However, the operators for DCXGate() and for DCXGate().inverse().inverse()
+            # must be equal. This test catches bugs when the inverse method of a controlled gate
+            # does not preserve the controlled state of the gate.
             try:
                 numargs = len(_get_free_params(gate))
                 args = [2] * numargs


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes ``MCPhaseGate.inverse`` and ``MCU1Gate.inverse`` as to preserve the control states when computing the inverse versions of the gates.


### Details and comments

I have added the tests checking that ``Operator(controlled_gate.inverse().inverse())`` is unitary-equal to ``Operator(controlled_gate)`` for all standard gates (which failed when the inverse method ignored ``ctrl_state``). 

But note that ``gate.inverse().inverse()`` is not always guaranteed to be the same as ``gate`` (for example, the inverse of ``DCXGate`` is of type ``Gate``, and the inverse of that is also of type ``Gate``).
