### PR TITLE
Fix grammar typos in `BoxOp` doc

### DIFF
--- a/qiskit/circuit/controlflow/box.py
+++ b/qiskit/circuit/controlflow/box.py
@@ -52,9 +52,9 @@ class BoxOp(ControlFlowOp):
         Default constructor of :class:`BoxOp`.
 
         Args:
-            body: the circuit to use as the body of the box.  This should explicit close over any
+            body: the circuit to use as the body of the box.  This should explicitly close over any
                 :class:`.expr.Var` variables that must be incident from the outer circuit.  The
-                expected number of qubit and clbits for the resulting instruction are inferred from
+                required number of qubit and clbits for the resulting instruction are inferred from
                 the number in the circuit, even if they are idle.
             duration: an optional duration for the box as a whole.
             unit: the unit of the ``duration``.
@@ -98,7 +98,7 @@ class BoxOp(ControlFlowOp):
     def body(self):
         """The ``body`` :class:`.QuantumCircuit` of the operation.
 
-        This is the same as object returned as the sole entry in :meth:`params` and :meth:`blocks`.
+        This is the same object returned as the sole entry in :meth:`params` and :meth:`blocks`.
         """
         # Not settable via this property; the only meaningful way to replace a body is via
         # larger `QuantumCircuit` methods, or using `replace_blocks`.

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -279,7 +279,7 @@ class Instruction(Operation):
                 self._params.append(self.validate_parameter(single_param))
 
     def validate_parameter(self, parameter):
-        """Instruction parameters has no validation or normalization."""
+        """Instruction parameter has no validation or normalization."""
         return parameter
 
     def is_parameterized(self):


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes a few grammar typos in the docs for `BoxOp` (and one for `Instruction`)

I also made one word choice change.