### PR TITLE
Cleanup of circuit library ``control`` methods

### DIFF
--- a/qiskit/circuit/annotated_operation.py
+++ b/qiskit/circuit/annotated_operation.py
@@ -43,9 +43,9 @@ class ControlModifier(Modifier):
     and has control state ``ctrl_state``."""
 
     num_ctrl_qubits: int = 0
-    ctrl_state: Union[int, str, None] = None
+    ctrl_state: int | str | None = None
 
-    def __init__(self, num_ctrl_qubits: int = 0, ctrl_state: Union[int, str, None] = None):
+    def __init__(self, num_ctrl_qubits: int = 0, ctrl_state: int | str | None = None):
         self.num_ctrl_qubits = num_ctrl_qubits
         self.ctrl_state = _ctrl_state_to_int(ctrl_state, num_ctrl_qubits)
 
@@ -161,22 +161,22 @@ class AnnotatedOperation(Operation):
         num_ctrl_qubits: int = 1,
         label: str | None = None,
         ctrl_state: int | str | None = None,
-        annotated: bool = True,
+        annotated: bool | None = None,
     ) -> AnnotatedOperation:
-        """
-        Return the controlled version of itself.
+        """Return the controlled version of itself.
 
-        Implemented as an annotated operation, see  :class:`.AnnotatedOperation`.
+        Implemented as :class:`.AnnotatedOperation`, regardless of the value of
+        ``annotated``.
 
         Args:
-            num_ctrl_qubits: number of controls to add to gate (default: ``1``)
-            label: ignored (used for consistency with other control methods)
-            ctrl_state: The control state in decimal or as a bitstring
-                (e.g. ``'111'``). If ``None``, use ``2**num_ctrl_qubits-1``.
-            annotated: ignored (used for consistency with other control methods)
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Ignored.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``.
+            annotated: Ignored.
 
         Returns:
-            Controlled version of the given operation.
+            A controlled version of the given operation.
         """
         # pylint: disable=unused-argument
         extended_modifiers = self.modifiers.copy()

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 import copy
-from typing import Optional, Union
 
 from qiskit.circuit.exceptions import CircuitError
 

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -33,11 +33,11 @@ class ControlledGate(Gate):
         name: str,
         num_qubits: int,
         params: list,
-        label: Optional[str] = None,
-        num_ctrl_qubits: Optional[int] = 1,
-        definition: Optional["QuantumCircuit"] = None,
-        ctrl_state: Optional[Union[int, str]] = None,
-        base_gate: Optional[Gate] = None,
+        label: str | None = None,
+        num_ctrl_qubits: int | None = 1,
+        definition: "QuantumCircuit" | None = None,
+        ctrl_state: int | str | None = None,
+        base_gate: Gate | None = None,
         *,
         _base_label=None,
     ):
@@ -200,7 +200,7 @@ class ControlledGate(Gate):
         return self._ctrl_state
 
     @ctrl_state.setter
-    def ctrl_state(self, ctrl_state: Union[int, str, None]):
+    def ctrl_state(self, ctrl_state: int | str | None):
         """Set the control state of this gate.
 
         Args:

--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -110,27 +110,23 @@ class Gate(Instruction):
     ):
         """Return the controlled version of itself.
 
-        Implemented either as a controlled gate (ref. :class:`.ControlledGate`)
-        or as an annotated operation (ref. :class:`.AnnotatedOperation`).
+        The controlled gate is implemented as :class:`.ControlledGate` when ``annotated``
+        is ``False``, and as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
 
         Args:
-            num_ctrl_qubits: number of controls to add to gate (default: ``1``)
-            label: optional gate label. Ignored if implemented as an annotated
-                operation.
-            ctrl_state: the control state in decimal or as a bitstring
-                (e.g. ``'111'``). If ``None``, use ``2**num_ctrl_qubits-1``.
-            annotated: indicates whether the controlled gate is implemented
-                as an annotated gate. If ``None``, this is set to ``False``
-                if the controlled gate can directly be constructed, and otherwise
-                set to ``True``. This allows defering the construction process in case the
-                synthesis of the controlled gate requires more information (e.g.
-                values of unbound parameters).
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+                Ignored if the controlled gate is implemented as an annotated operation.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``.
+            annotated: Indicates whether the controlled gate should be implemented as a controlled gate
+                or as an annotated operation. If ``None``, treated as ``False``.
 
         Returns:
-            Controlled version of the given operation.
+            A controlled version of this gate.
 
         Raises:
-            QiskitError: unrecognized mode or invalid ctrl_state
+            QiskitError: invalid ``ctrl_state``.
         """
         if not annotated:  # captures both None and False
             # pylint: disable=cyclic-import

--- a/qiskit/circuit/library/generalized_gates/mcmt.py
+++ b/qiskit/circuit/library/generalized_gates/mcmt.py
@@ -292,20 +292,38 @@ class MCMTGate(ControlledGate):
 
         return base_gate
 
-    def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None, annotated=False):
-        """Return the controlled version of the MCMT circuit."""
-        if not annotated:
-            ctrl_state = _ctrl_state_to_int(ctrl_state, num_ctrl_qubits)
-            new_ctrl_state = (self.ctrl_state << num_ctrl_qubits) | ctrl_state
+    def control(
+        self,
+        num_ctrl_qubits: int = 1,
+        label: str | None = None,
+        ctrl_state: str | int | None = None,
+        annotated: bool | None = None,
+    ):
+        """Return a controlled version of the MCMT gate.
 
-            gate = MCMTGate(
-                self.base_gate,
-                self.num_ctrl_qubits + num_ctrl_qubits,
-                self.num_target_qubits,
-                ctrl_state=new_ctrl_state,
-            )
-        else:
-            gate = super().control(num_ctrl_qubits, label, ctrl_state, annotated=annotated)
+        The controlled gate is implemented as :class:`.MCMTGate`, regardless of the
+        value of ``annotated``.
+
+        Args:
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
+            annotated: Ignored.
+
+        Returns:
+            A controlled version of this gate.
+        """
+        ctrl_state = _ctrl_state_to_int(ctrl_state, num_ctrl_qubits)
+        new_ctrl_state = (self.ctrl_state << num_ctrl_qubits) | ctrl_state
+
+        gate = MCMTGate(
+            self.base_gate,
+            self.num_ctrl_qubits + num_ctrl_qubits,
+            self.num_target_qubits,
+            ctrl_state=new_ctrl_state,
+            label=label,
+        )
 
         return gate
 

--- a/qiskit/circuit/library/generalized_gates/unitary.py
+++ b/qiskit/circuit/library/generalized_gates/unitary.py
@@ -177,18 +177,22 @@ class UnitaryGate(Gate):
         ctrl_state: int | str | None = None,
         annotated: bool | None = None,
     ) -> ControlledGate | AnnotatedOperation:
-        """Return controlled version of gate.
+        """Return a controlled version of itself.
+
+        The controlled gate is implemented as :class:`.ControlledGate` when ``annotated``
+        is ``False``, and as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
 
         Args:
-            num_ctrl_qubits: Number of controls to add to gate (default is 1).
-            label: Optional gate label.
-            ctrl_state: The control state in decimal or as a bit string (e.g. ``"1011"``).
-                If ``None``, use ``2**num_ctrl_qubits - 1``.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate. If ``None``, this is handled as ``False``.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``. Ignored if the controlled gate
+                is implemented as an annotated operation.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``.
+            annotated: Indicates whether the controlled gate should be implemented as a controlled gate
+                or as an annotated operation. If ``None``, treated as ``False``.
 
         Returns:
-            Controlled version of gate.
+            A controlled version of this gate.
         """
         if not annotated:
             mat = self.to_matrix()

--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -253,19 +253,21 @@ class PauliEvolutionGate(Gate):
         operator :math:`H`, tensored with :math:`|0\rangle\langle 0|` and
         :math:`|1\rangle\langle 1|` projectors (depending on the control state).
 
+        The controlled gate is implemented as :class:`.PauliEvolutionGate`,
+        regardless of the value of ``annotated``.
+
         Args:
-            num_ctrl_qubits: Number of controls to add to gate (default: ``1``).
-            label: Optional gate label. Ignored if implemented as an annotated
-                operation.
-            ctrl_state: The control state in decimal or as a bitstring
-                (e.g. ``"111"``). If ``None``, use ``2**num_ctrl_qubits - 1``.
-            annotated: Not applicable to this class. Usually, when this is ``True`` we return an
-                :class:`.AnnotatedOperation` with a control modifier set instead of a concrete
-                :class:`.Gate`. However, we can efficiently represent controlled Pauli evolutions
-                as :class:`.PauliEvolutionGate`, which is used here.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: A label for the resulting Pauli evolution gate, to display in visualizations.
+                Per default, the label is set to ``exp(-it <operators>)`` where ``<operators>``
+                is the sum of the Paulis. Note that the label does not include any coefficients
+                of the Paulis. See the class docstring for an example.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``.
+            annotated: Ignored.
 
         Returns:
-            Controlled version of the given operation.
+            A controlled version of this gate.
         """
         if ctrl_state is None:
             ctrl_state = "1" * num_ctrl_qubits

--- a/qiskit/circuit/library/standard_gates/h.py
+++ b/qiskit/circuit/library/standard_gates/h.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from math import sqrt
-from typing import Optional, Union
+from typing import Optional
 import numpy
 from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate, stdlib_singleton_key
 from qiskit.circuit._utils import with_gate_array, with_controlled_gate_array
@@ -85,22 +85,28 @@ class HGate(SingletonGate):
         ctrl_state: int | str | None = None,
         annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-H gate.
+        """Return a controlled version of the H gate.
 
-        One control qubit returns a CH gate.
+        For a single control qubit, the controlled gate is implemented as :class:`.CHGate`,
+        regardless of the value of `annotated`.
+
+        For more than one control qubit,
+        the controlled gate is implemented as :class:`.ControlledGate` when ``annotated``
+        is ``False``, and as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate. If ``None``, this is handled as ``False``.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+                Ignored if the controlled gate is implemented as an annotated operation.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``.
+            annotated: Indicates whether the controlled gate should be implemented as a controlled gate
+                or as an annotated operation. If ``None``, treated as ``False``.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
-        if not annotated and num_ctrl_qubits == 1:
+        if num_ctrl_qubits == 1:
             gate = CHGate(label=label, ctrl_state=ctrl_state, _base_label=self.label)
         else:
             gate = super().control(
@@ -192,8 +198,8 @@ class CHGate(SingletonControlledGate):
 
     def __init__(
         self,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[int, str]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -20,7 +20,7 @@ import numpy
 
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
-from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType
+from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit._accelerate.circuit import StandardGate
 
 

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -109,9 +109,6 @@ class RXGate(Gate):
                 self.params[0], label=label, ctrl_state=ctrl_state, _base_label=self.label
             )
         else:
-            if annotated is None:
-                annotated = any(isinstance(p, ParameterExpression) for p in self.params)
-
             gate = super().control(
                 num_ctrl_qubits=num_ctrl_qubits,
                 label=label,

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -15,12 +15,12 @@
 from __future__ import annotations
 
 import math
-from typing import Optional, Union
+from typing import Optional
 import numpy
 
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
-from qiskit.circuit.parameterexpression import ParameterValueType
+from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType
 from qiskit._accelerate.circuit import StandardGate
 
 
@@ -81,26 +81,37 @@ class RXGate(Gate):
         ctrl_state: str | int | None = None,
         annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-RX gate.
+        """Return a controlled version of the RX gate.
+
+        For a single control qubit, the controlled gate is implemented as :class:`.CRXGate`,
+        regardless of the value of `annotated`.
+
+        For more than one control qubit, the controlled gate is implemented
+        either as :class:`.ControlledGate` when ``annotated`` is ``False``, or
+        as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
+        When ``annotated`` is ``None``, it is interpreted as ``True`` when the gate has free
+        parameters (in which case the gate cannot be synthesized at the construction time),
+        and as ``False`` otherwise.
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate. If ``None``, this is set to ``True`` if
-                the gate contains free parameters and more than one control qubit, in which
-                case it cannot yet be synthesized. Otherwise it is set to ``False``.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
+            annotated: Indicates whether the controlled gate should be implemented as a controlled gate
+                or as an annotated operation.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
-        # deliberately capture annotated in [None, False] here
-        if not annotated and num_ctrl_qubits == 1:
-            gate = CRXGate(self.params[0], label=label, ctrl_state=ctrl_state)
-            gate.base_gate.label = self.label
+        if num_ctrl_qubits == 1:
+            gate = CRXGate(
+                self.params[0], label=label, ctrl_state=ctrl_state, _base_label=self.label
+            )
         else:
+            if annotated is None:
+                annotated = any(isinstance(p, ParameterExpression) for p in self.params)
+
             gate = super().control(
                 num_ctrl_qubits=num_ctrl_qubits,
                 label=label,
@@ -207,8 +218,8 @@ class CRXGate(ControlledGate):
     def __init__(
         self,
         theta: ParameterValueType,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):

--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -100,43 +100,6 @@ class RXXGate(Gate):
             StandardGate.RXX._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
-    def control(
-        self,
-        num_ctrl_qubits: int = 1,
-        label: str | None = None,
-        ctrl_state: str | int | None = None,
-        annotated: bool | None = None,
-    ):
-        """Return a controlled version of the RXX gate.
-
-        The controlled gate is implemented either as :class:`.ControlledGate`
-        when ``annotated`` is ``False``, or as :class:`.AnnotatedOperation` when
-        ``annotated`` is ``True``. When ``annotated`` is ``None``, it is interpreted
-        as ``True`` when the gate has free parameters (in which case the gate
-        cannot be synthesized at the construction time), and as ``False`` otherwise.
-
-        Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate. Defaults to ``None``.
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate.
-
-        Returns:
-            A controlled version of this gate.
-        """
-        if annotated is None:
-            annotated = any(isinstance(p, ParameterExpression) for p in self.params)
-
-        gate = super().control(
-            num_ctrl_qubits=num_ctrl_qubits,
-            label=label,
-            ctrl_state=ctrl_state,
-            annotated=annotated,
-        )
-        return gate
-
     def inverse(self, annotated: bool = False):
         """Return inverse RXX gate (i.e. with the negative rotation angle).
 

--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -107,20 +107,24 @@ class RXXGate(Gate):
         ctrl_state: str | int | None = None,
         annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-RXX gate.
+        """Return a controlled version of the RXX gate.
+
+        The controlled gate is implemented either as :class:`.ControlledGate`
+        when ``annotated`` is ``False``, or as :class:`.AnnotatedOperation` when
+        ``annotated`` is ``True``. When ``annotated`` is ``None``, it is interpreted
+        as ``True`` when the gate has free parameters (in which case the gate
+        cannot be synthesized at the construction time), and as ``False`` otherwise.
 
         Args:
             num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
+            label: An optional label for the gate. Defaults to ``None``.
             ctrl_state: control state expressed as integer,
                 string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate. If ``None``, this is set to ``True`` if
-                the gate contains free parameters, in which case it cannot
-                yet be synthesized.
+                as an annotated gate.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
         if annotated is None:
             annotated = any(isinstance(p, ParameterExpression) for p in self.params)

--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -18,7 +18,7 @@ import math
 from typing import Optional
 import numpy
 from qiskit.circuit.gate import Gate
-from qiskit.circuit.parameterexpression import ParameterValueType, ParameterExpression
+from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit._accelerate.circuit import StandardGate
 
 

--- a/qiskit/circuit/library/standard_gates/ry.py
+++ b/qiskit/circuit/library/standard_gates/ry.py
@@ -109,9 +109,6 @@ class RYGate(Gate):
                 self.params[0], label=label, ctrl_state=ctrl_state, _base_label=self.label
             )
         else:
-            if annotated is None:
-                annotated = any(isinstance(p, ParameterExpression) for p in self.params)
-
             gate = super().control(
                 num_ctrl_qubits=num_ctrl_qubits,
                 label=label,

--- a/qiskit/circuit/library/standard_gates/ry.py
+++ b/qiskit/circuit/library/standard_gates/ry.py
@@ -19,7 +19,7 @@ from typing import Optional
 import numpy
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
-from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType
+from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit._accelerate.circuit import StandardGate
 
 

--- a/qiskit/circuit/library/standard_gates/ry.py
+++ b/qiskit/circuit/library/standard_gates/ry.py
@@ -15,11 +15,11 @@
 from __future__ import annotations
 
 import math
-from typing import Optional, Union
+from typing import Optional
 import numpy
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
-from qiskit.circuit.parameterexpression import ParameterValueType
+from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType
 from qiskit._accelerate.circuit import StandardGate
 
 
@@ -80,26 +80,38 @@ class RYGate(Gate):
         ctrl_state: str | int | None = None,
         annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-RY gate.
+        """Return a controlled version of the RY gate.
+
+        For a single control qubit, the controlled gate is implemented as :class:`.CRYGate`,
+        regardless of the value of ``annotated``.
+
+        For more than one control qubit, the controlled gate is implemented
+        either as :class:`.ControlledGate` when ``annotated`` is ``False``, or
+        as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
+        When ``annotated`` is ``None``, it is interpreted as ``True`` when the gate has free
+        parameters (in which case the gate cannot be synthesized at the construction time),
+        and as ``False`` otherwise.
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate. If ``None``, this is set to ``True`` if
-                the gate contains free parameters and more than one control qubit, in which
-                case it cannot yet be synthesized. Otherwise it is set to ``False``.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
+            annotated: Indicates whether the controlled gate should be implemented as a controlled gate
+                or as an annotated operation.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
         # deliberately capture annotated in [None, False] here
-        if not annotated and num_ctrl_qubits == 1:
-            gate = CRYGate(self.params[0], label=label, ctrl_state=ctrl_state)
-            gate.base_gate.label = self.label
+        if num_ctrl_qubits == 1:
+            gate = CRYGate(
+                self.params[0], label=label, ctrl_state=ctrl_state, _base_label=self.label
+            )
         else:
+            if annotated is None:
+                annotated = any(isinstance(p, ParameterExpression) for p in self.params)
+
             gate = super().control(
                 num_ctrl_qubits=num_ctrl_qubits,
                 label=label,
@@ -206,8 +218,8 @@ class CRYGate(ControlledGate):
     def __init__(
         self,
         theta: ParameterValueType,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):

--- a/qiskit/circuit/library/standard_gates/ryy.py
+++ b/qiskit/circuit/library/standard_gates/ryy.py
@@ -107,20 +107,24 @@ class RYYGate(Gate):
         ctrl_state: str | int | None = None,
         annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-YY gate.
+        """Return a controlled version of the RYY gate.
+
+        The controlled gate is implemented either as :class:`.ControlledGate`
+        when ``annotated`` is ``False``, or as :class:`.AnnotatedOperation` when
+        ``annotated`` is ``True``. When ``annotated`` is ``None``, it is interpreted
+        as ``True`` when the gate has free parameters (in which case the gate
+        cannot be synthesized at the construction time), and as ``False`` otherwise.
 
         Args:
             num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
+            label: An optional label for the gate. Defaults to ``None``.
             ctrl_state: control state expressed as integer,
                 string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate. If ``None``, this is set to ``True`` if
-                the gate contains free parameters, in which case it cannot
-                yet be synthesized.
+                as an annotated gate.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
         if annotated is None:
             annotated = any(isinstance(p, ParameterExpression) for p in self.params)

--- a/qiskit/circuit/library/standard_gates/ryy.py
+++ b/qiskit/circuit/library/standard_gates/ryy.py
@@ -18,7 +18,7 @@ import math
 from typing import Optional
 import numpy as np
 from qiskit.circuit.gate import Gate
-from qiskit.circuit.parameterexpression import ParameterValueType, ParameterExpression
+from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit._accelerate.circuit import StandardGate
 
 

--- a/qiskit/circuit/library/standard_gates/ryy.py
+++ b/qiskit/circuit/library/standard_gates/ryy.py
@@ -100,43 +100,6 @@ class RYYGate(Gate):
             StandardGate.RYY._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
-    def control(
-        self,
-        num_ctrl_qubits: int = 1,
-        label: str | None = None,
-        ctrl_state: str | int | None = None,
-        annotated: bool | None = None,
-    ):
-        """Return a controlled version of the RYY gate.
-
-        The controlled gate is implemented either as :class:`.ControlledGate`
-        when ``annotated`` is ``False``, or as :class:`.AnnotatedOperation` when
-        ``annotated`` is ``True``. When ``annotated`` is ``None``, it is interpreted
-        as ``True`` when the gate has free parameters (in which case the gate
-        cannot be synthesized at the construction time), and as ``False`` otherwise.
-
-        Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate. Defaults to ``None``.
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate.
-
-        Returns:
-            A controlled version of this gate.
-        """
-        if annotated is None:
-            annotated = any(isinstance(p, ParameterExpression) for p in self.params)
-
-        gate = super().control(
-            num_ctrl_qubits=num_ctrl_qubits,
-            label=label,
-            ctrl_state=ctrl_state,
-            annotated=annotated,
-        )
-        return gate
-
     def inverse(self, annotated: bool = False):
         """Return inverse RYY gate (i.e. with the negative rotation angle).
 

--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -121,9 +121,6 @@ class RZGate(Gate):
                 self.params[0], label=label, ctrl_state=ctrl_state, _base_label=self.label
             )
         else:
-            if annotated is None:
-                annotated = any(isinstance(p, ParameterExpression) for p in self.params)
-
             gate = super().control(
                 num_ctrl_qubits=num_ctrl_qubits,
                 label=label,

--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -15,10 +15,10 @@
 from __future__ import annotations
 
 from cmath import exp
-from typing import Optional, Union
+from typing import Optional
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.controlledgate import ControlledGate
-from qiskit.circuit.parameterexpression import ParameterValueType
+from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType
 from qiskit._accelerate.circuit import StandardGate
 
 
@@ -93,26 +93,37 @@ class RZGate(Gate):
         ctrl_state: str | int | None = None,
         annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-RZ gate.
+        """Return a controlled version of the RZ gate.
+
+        For a single control qubit, the controlled gate is implemented as :class:`.CRZGate`,
+        regardless of the value of `annotated`.
+
+        For more than one control qubit, the controlled gate is implemented
+        either as :class:`.ControlledGate` when ``annotated`` is ``False``, or
+        as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
+        When ``annotated`` is ``None``, it is interpreted as ``True`` when the gate has free
+        parameters (in which case the gate cannot be synthesized at the construction time),
+        and as ``False`` otherwise.
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate. If ``None``, this is set to ``True`` if
-                the gate contains free parameters and more than one control qubit, in which
-                case it cannot yet be synthesized. Otherwise it is set to ``False``.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
+            annotated: Indicates whether the controlled gate should be implemented as a controlled gate
+                or as an annotated operation.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
-        # deliberately capture annotated in [None, False] here
-        if not annotated and num_ctrl_qubits == 1:
-            gate = CRZGate(self.params[0], label=label, ctrl_state=ctrl_state)
-            gate.base_gate.label = self.label
+        if num_ctrl_qubits == 1:
+            gate = CRZGate(
+                self.params[0], label=label, ctrl_state=ctrl_state, _base_label=self.label
+            )
         else:
+            if annotated is None:
+                annotated = any(isinstance(p, ParameterExpression) for p in self.params)
+
             gate = super().control(
                 num_ctrl_qubits=num_ctrl_qubits,
                 label=label,
@@ -226,8 +237,8 @@ class CRZGate(ControlledGate):
     def __init__(
         self,
         theta: ParameterValueType,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):

--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -18,7 +18,7 @@ from cmath import exp
 from typing import Optional
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.controlledgate import ControlledGate
-from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType
+from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit._accelerate.circuit import StandardGate
 
 

--- a/qiskit/circuit/library/standard_gates/rzx.py
+++ b/qiskit/circuit/library/standard_gates/rzx.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import math
 from typing import Optional
 from qiskit.circuit.gate import Gate
-from qiskit.circuit.parameterexpression import ParameterValueType, ParameterExpression
+from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit._accelerate.circuit import StandardGate
 
 

--- a/qiskit/circuit/library/standard_gates/rzx.py
+++ b/qiskit/circuit/library/standard_gates/rzx.py
@@ -151,20 +151,24 @@ class RZXGate(Gate):
         ctrl_state: str | int | None = None,
         annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-RZX gate.
+        """Return a controlled version of the RZX gate.
+
+        The controlled gate is implemented either as :class:`.ControlledGate`
+        when ``annotated`` is ``False``, or as :class:`.AnnotatedOperation` when
+        ``annotated`` is ``True``. When ``annotated`` is ``None``, it is interpreted
+        as ``True`` when the gate has free parameters (in which case the gate
+        cannot be synthesized at the construction time), and as ``False`` otherwise.
 
         Args:
             num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
+            label: An optional label for the gate.  Defaults to ``None``.
             ctrl_state: control state expressed as integer,
                 string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate. If ``None``, this is set to ``True`` if
-                the gate contains free parameters, in which case it cannot
-                yet be synthesized.
+                as an annotated gate.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
         if annotated is None:
             annotated = any(isinstance(p, ParameterExpression) for p in self.params)

--- a/qiskit/circuit/library/standard_gates/rzx.py
+++ b/qiskit/circuit/library/standard_gates/rzx.py
@@ -144,43 +144,6 @@ class RZXGate(Gate):
             StandardGate.RZX._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
-    def control(
-        self,
-        num_ctrl_qubits: int = 1,
-        label: str | None = None,
-        ctrl_state: str | int | None = None,
-        annotated: bool | None = None,
-    ):
-        """Return a controlled version of the RZX gate.
-
-        The controlled gate is implemented either as :class:`.ControlledGate`
-        when ``annotated`` is ``False``, or as :class:`.AnnotatedOperation` when
-        ``annotated`` is ``True``. When ``annotated`` is ``None``, it is interpreted
-        as ``True`` when the gate has free parameters (in which case the gate
-        cannot be synthesized at the construction time), and as ``False`` otherwise.
-
-        Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate.  Defaults to ``None``.
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate.
-
-        Returns:
-            A controlled version of this gate.
-        """
-        if annotated is None:
-            annotated = any(isinstance(p, ParameterExpression) for p in self.params)
-
-        gate = super().control(
-            num_ctrl_qubits=num_ctrl_qubits,
-            label=label,
-            ctrl_state=ctrl_state,
-            annotated=annotated,
-        )
-        return gate
-
     def inverse(self, annotated: bool = False):
         """Return inverse RZX gate (i.e. with the negative rotation angle).
 

--- a/qiskit/circuit/library/standard_gates/rzz.py
+++ b/qiskit/circuit/library/standard_gates/rzz.py
@@ -111,43 +111,6 @@ class RZZGate(Gate):
             StandardGate.RZZ._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
-    def control(
-        self,
-        num_ctrl_qubits: int = 1,
-        label: str | None = None,
-        ctrl_state: str | int | None = None,
-        annotated: bool | None = None,
-    ):
-        """Return a controlled version of the RZZ gate.
-
-        The controlled gate is implemented either as :class:`.ControlledGate`
-        when ``annotated`` is ``False``, or as :class:`.AnnotatedOperation` when
-        ``annotated`` is ``True``. When ``annotated`` is ``None``, it is interpreted
-        as ``True`` when the gate has free parameters (in which case the gate
-        cannot be synthesized at the construction time), and as ``False`` otherwise.
-
-        Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate.  Defaults to ``None``.
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate.
-
-        Returns:
-            A controlled version of this gate.
-        """
-        if annotated is None:
-            annotated = any(isinstance(p, ParameterExpression) for p in self.params)
-
-        gate = super().control(
-            num_ctrl_qubits=num_ctrl_qubits,
-            label=label,
-            ctrl_state=ctrl_state,
-            annotated=annotated,
-        )
-        return gate
-
     def inverse(self, annotated: bool = False):
         """Return inverse RZZ gate (i.e. with the negative rotation angle).
 

--- a/qiskit/circuit/library/standard_gates/rzz.py
+++ b/qiskit/circuit/library/standard_gates/rzz.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from cmath import exp
 from typing import Optional
 from qiskit.circuit.gate import Gate
-from qiskit.circuit.parameterexpression import ParameterValueType, ParameterExpression
+from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit._accelerate.circuit import StandardGate
 
 

--- a/qiskit/circuit/library/standard_gates/rzz.py
+++ b/qiskit/circuit/library/standard_gates/rzz.py
@@ -118,20 +118,24 @@ class RZZGate(Gate):
         ctrl_state: str | int | None = None,
         annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-RZZ gate.
+        """Return a controlled version of the RZZ gate.
+
+        The controlled gate is implemented either as :class:`.ControlledGate`
+        when ``annotated`` is ``False``, or as :class:`.AnnotatedOperation` when
+        ``annotated`` is ``True``. When ``annotated`` is ``None``, it is interpreted
+        as ``True`` when the gate has free parameters (in which case the gate
+        cannot be synthesized at the construction time), and as ``False`` otherwise.
 
         Args:
             num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
+            label: An optional label for the gate.  Defaults to ``None``.
             ctrl_state: control state expressed as integer,
                 string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate. If ``None``, this is set to ``True`` if
-                the gate contains free parameters, in which case it cannot
-                yet be synthesized.
+                as an annotated gate.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
         if annotated is None:
             annotated = any(isinstance(p, ParameterExpression) for p in self.params)

--- a/qiskit/circuit/library/standard_gates/s.py
+++ b/qiskit/circuit/library/standard_gates/s.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Optional
 
 import numpy
 
@@ -89,22 +89,29 @@ class SGate(SingletonGate):
         ctrl_state: int | str | None = None,
         annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-S gate.
+        """Return a controlled version of the S gate.
 
-        One control qubit returns a :class:`.CSGate`.
+        For a single control qubit, the controlled gate is implemented as :class:`.CSGate`,
+        regardless of the value of ``annotated``.
+
+        For more than one control qubit,
+        the controlled gate is implemented as :class:`.ControlledGate` when ``annotated``
+        is ``False``, and as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate. If ``None``, this is handled as ``False``.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+                Ignored if the controlled gate is implemented as an annotated operation.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``.
+            annotated: Indicates whether the controlled gate should be implemented as a controlled gate
+                or as an annotated operation. If ``None``, treated as ``False``.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
-        if not annotated and num_ctrl_qubits == 1:
+
+        if num_ctrl_qubits == 1:
             gate = CSGate(label=label, ctrl_state=ctrl_state, _base_label=self.label)
         else:
             gate = super().control(
@@ -197,22 +204,28 @@ class SdgGate(SingletonGate):
         ctrl_state: int | str | None = None,
         annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-Sdg gate.
+        """Return a controlled version of the Sdg gate.
 
-        One control qubit returns a :class:`.CSdgGate`.
+        For a single control qubit, the controlled gate is implemented as :class:`.CSdgGate`,
+        regardless of the value of `annotated`.
+
+        For more than one control qubit,
+        the controlled gate is implemented as :class:`.ControlledGate` when ``annotated``
+        is ``False``, and as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate. If ``None``, this is handled as ``False``.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+                Ignored if the controlled gate is implemented as an annotated operation.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``.
+            annotated: Indicates whether the controlled gate should be implemented as a controlled gate
+                or as an annotated operation. If ``None``, treated as ``False``.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
-        if not annotated and num_ctrl_qubits == 1:
+        if num_ctrl_qubits == 1:
             gate = CSdgGate(label=label, ctrl_state=ctrl_state, _base_label=self.label)
         else:
             gate = super().control(
@@ -280,8 +293,8 @@ class CSGate(SingletonControlledGate):
 
     def __init__(
         self,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):
@@ -371,8 +384,8 @@ class CSdgGate(SingletonControlledGate):
 
     def __init__(
         self,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):

--- a/qiskit/circuit/library/standard_gates/swap.py
+++ b/qiskit/circuit/library/standard_gates/swap.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Optional
 import numpy
 from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate, stdlib_singleton_key
 from qiskit.circuit._utils import with_gate_array, with_controlled_gate_array
@@ -93,22 +93,28 @@ class SwapGate(SingletonGate):
         ctrl_state: str | int | None = None,
         annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-SWAP gate.
+        """Return a controlled version of the Swap gate.
 
-        One control returns a CSWAP (Fredkin) gate.
+        For a single control qubit, the controlled gate is implemented as :class:`.CSwapGate`
+        (also known as Fredkin gate), regardless of the value of `annotated`.
+
+        For more than one control qubit,
+        the controlled gate is implemented as :class:`.ControlledGate` when ``annotated``
+        is ``False``, and as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate. If ``None``, this is handled as ``False``.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+                Ignored if the controlled gate is implemented as an annotated operation.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``.
+            annotated: Indicates whether the controlled gate should be implemented as a controlled gate
+                or as an annotated operation. If ``None``, defaults to ``False``.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
-        if not annotated and num_ctrl_qubits == 1:
+        if num_ctrl_qubits == 1:
             gate = CSwapGate(label=label, ctrl_state=ctrl_state, _base_label=self.label)
         else:
             gate = super().control(
@@ -219,8 +225,8 @@ class CSwapGate(SingletonControlledGate):
 
     def __init__(
         self,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):

--- a/qiskit/circuit/library/standard_gates/sx.py
+++ b/qiskit/circuit/library/standard_gates/sx.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Optional
 from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate, stdlib_singleton_key
 from qiskit.circuit._utils import with_gate_array, with_controlled_gate_array
 from qiskit._accelerate.circuit import StandardGate
@@ -109,22 +109,29 @@ class SXGate(SingletonGate):
         ctrl_state: str | int | None = None,
         annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-SX gate.
+        """Return a controlled version of the SX gate.
 
-        One control returns a CSX gate.
+        For a single control qubit, the controlled gate is implemented as :class:`.CSXGate`,
+        regardless of the value of `annotated`.
+
+        For more than one control qubit,
+        the controlled gate is implemented as :class:`.ControlledGate` when ``annotated``
+        is ``False``, and as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
+
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate. If ``None``, this is handled as ``False``.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+                Ignored if the controlled gate is implemented as an annotated operation.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``.
+            annotated: Indicates whether the controlled gate should be implemented as a controlled gate
+                or as an annotated operation. If ``None``, treated as ``False``.
 
         Returns:
-            SingletonControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
-        if not annotated and num_ctrl_qubits == 1:
+        if num_ctrl_qubits == 1:
             gate = CSXGate(label=label, ctrl_state=ctrl_state, _base_label=self.label)
         else:
             gate = super().control(
@@ -270,8 +277,8 @@ class CSXGate(SingletonControlledGate):
 
     def __init__(
         self,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -22,7 +22,7 @@ from typing import Optional
 import numpy
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
-from qiskit.circuit.parameterexpression import ParameterValueType, ParameterExpression
+from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit._accelerate.circuit import StandardGate
 
 

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -154,11 +154,6 @@ class UGate(Gate):
             )
             gate.base_gate.label = self.label
         else:
-            # If the gate parameters contain free parameters, we cannot eagerly synthesize
-            # the controlled gate decomposition. In this case, we annotate the gate per default.
-            if annotated is None:
-                annotated = any(isinstance(p, ParameterExpression) for p in self.params)
-
             gate = super().control(
                 num_ctrl_qubits=num_ctrl_qubits,
                 label=label,

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -18,7 +18,7 @@ import cmath
 import copy as _copy
 import math
 from cmath import exp
-from typing import Optional, Union
+from typing import Optional
 import numpy
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
@@ -119,22 +119,31 @@ class UGate(Gate):
         ctrl_state: str | int | None = None,
         annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-U gate.
+        """Return a controlled version of the U gate.
+
+        For a single control qubit, the controlled gate is implemented as :class:`.CUGate`,
+        regardless of the value of `annotated`.
+
+        For more than one control qubit,
+        the controlled gate is implemented as :class:`.ControlledGate` when ``annotated``
+        is ``False``, and as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
+        When ``annotated`` is ``None``, it is interpreted as ``True`` when the gate has free
+        parameters (in which case the gate cannot be synthesized at the construction time),
+        and as ``False`` otherwise.
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate. If ``None``, this is set to ``True`` if
-                the gate contains free parameters and more than one control qubit, in which
-                case it cannot yet be synthesized. Otherwise it is set to ``False``.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Ignored if the controlled gate is implemented as an
+                annotated operation.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``.
+            annotated: Indicates whether the controlled gate should be implemented as a controlled gate
+                or as an annotated operation.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
-        if not annotated and num_ctrl_qubits == 1:
+        if num_ctrl_qubits == 1:
             gate = CUGate(
                 self.params[0],
                 self.params[1],
@@ -290,8 +299,8 @@ class CUGate(ControlledGate):
         phi: ParameterValueType,
         lam: ParameterValueType,
         gamma: ParameterValueType,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):

--- a/qiskit/circuit/library/standard_gates/u1.py
+++ b/qiskit/circuit/library/standard_gates/u1.py
@@ -117,34 +117,32 @@ class U1Gate(Gate):
         num_ctrl_qubits: int = 1,
         label: str | None = None,
         ctrl_state: str | int | None = None,
-        annotated: bool = False,
+        annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-U1 gate.
+        """Return a controlled version of the U1 gate.
+
+        For a single control qubit, the controlled gate is implemented as :class:`.CU1Gate`.
+        For more than one control qubits, the controlled gate is implemented as :class:`.MCU1Gate`.
+        In each case, the value of ``annotated`` is ignored.
+
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
+            annotated: Ignored.
+
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
-        if not annotated and num_ctrl_qubits == 1:
+
+        if num_ctrl_qubits == 1:
             gate = CU1Gate(self.params[0], label=label, ctrl_state=ctrl_state)
-            gate.base_gate.label = self.label
-        elif not annotated and ctrl_state is None and num_ctrl_qubits > 1:
-            gate = MCU1Gate(self.params[0], num_ctrl_qubits, label=label)
-            gate.base_gate.label = self.label
         else:
-            gate = super().control(
-                num_ctrl_qubits=num_ctrl_qubits,
-                label=label,
-                ctrl_state=ctrl_state,
-                annotated=annotated,
-            )
+            gate = MCU1Gate(self.params[0], num_ctrl_qubits, ctrl_state=ctrl_state, label=label)
+        gate.base_gate.label = self.label
         return gate
 
     def inverse(self, annotated: bool = False):
@@ -266,31 +264,34 @@ class CU1Gate(ControlledGate):
         num_ctrl_qubits: int = 1,
         label: str | None = None,
         ctrl_state: str | int | None = None,
-        annotated: bool = False,
+        annotated: bool | None = None,
     ):
-        """Controlled version of this gate.
+        """Return a controlled version of the CU1 gate.
+
+        The controlled gate is implemented as :class:`.MCU1Gate`, regardless of
+        the value of ``annotated``.
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
+            annotated: Ignored.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
-        if not annotated and ctrl_state is None:
-            gate = MCU1Gate(self.params[0], num_ctrl_qubits=num_ctrl_qubits + 1, label=label)
-            gate.base_gate.label = self.label
-        else:
-            gate = super().control(
-                num_ctrl_qubits=num_ctrl_qubits,
-                label=label,
-                ctrl_state=ctrl_state,
-                annotated=annotated,
-            )
+        ctrl_state = _ctrl_state_to_int(ctrl_state, num_ctrl_qubits)
+        new_ctrl_state = (self.ctrl_state << num_ctrl_qubits) | ctrl_state
+
+        gate = MCU1Gate(
+            self.params[0],
+            num_ctrl_qubits=num_ctrl_qubits + 1,
+            ctrl_state=new_ctrl_state,
+            label=label,
+        )
+        gate.base_gate.label = self.label
+
         return gate
 
     def inverse(self, annotated: bool = False):
@@ -409,38 +410,32 @@ class MCU1Gate(ControlledGate):
         num_ctrl_qubits: int = 1,
         label: str | None = None,
         ctrl_state: str | int | None = None,
-        annotated: bool = False,
+        annotated: bool | None = None,
     ):
-        """Controlled version of this gate.
+        """Return a controlled version of the MCU1 gate.
+
+        The controlled gate is implemented as :class:`.MCU1Gate`, regardless of
+        the value of ``annotated``.
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
+            annotated: Ignored.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
-        if not annotated:
-            ctrl_state = _ctrl_state_to_int(ctrl_state, num_ctrl_qubits)
-            new_ctrl_state = (self.ctrl_state << num_ctrl_qubits) | ctrl_state
-            gate = MCU1Gate(
-                self.params[0],
-                num_ctrl_qubits=num_ctrl_qubits + self.num_ctrl_qubits,
-                label=label,
-                ctrl_state=new_ctrl_state,
-            )
-            gate.base_gate.label = self.label
-        else:
-            gate = super().control(
-                num_ctrl_qubits=num_ctrl_qubits,
-                label=label,
-                ctrl_state=ctrl_state,
-                annotated=annotated,
-            )
+        ctrl_state = _ctrl_state_to_int(ctrl_state, num_ctrl_qubits)
+        new_ctrl_state = (self.ctrl_state << num_ctrl_qubits) | ctrl_state
+        gate = MCU1Gate(
+            self.params[0],
+            num_ctrl_qubits=num_ctrl_qubits + self.num_ctrl_qubits,
+            label=label,
+            ctrl_state=new_ctrl_state,
+        )
+        gate.base_gate.label = self.label
         return gate
 
     def inverse(self, annotated: bool = False):

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -20,7 +20,7 @@ from typing import Optional
 import numpy
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
-from qiskit.circuit.parameterexpression import ParameterValueType, ParameterExpression
+from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit._accelerate.circuit import StandardGate
 
 

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import math
 from cmath import exp
-from typing import Optional, Union
+from typing import Optional
 import numpy
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
@@ -124,22 +124,31 @@ class U3Gate(Gate):
         ctrl_state: str | int | None = None,
         annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-U3 gate.
+        """Return a controlled version of the U3 gate.
+
+        For a single control qubit, the controlled gate is implemented as :class:`.CU3Gate`,
+        regardless of the value of `annotated`.
+
+        For more than one control qubit,
+        the controlled gate is implemented as :class:`.ControlledGate` when ``annotated``
+        is ``False``, and as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
+        When ``annotated`` is ``None``, it is interpreted as ``True`` when the gate has free
+        parameters (in which case the gate cannot be synthesized at the construction time)
+        and as ``False`` otherwise.
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate. If ``None``, this is set to ``True`` if
-                the gate contains free parameters and more than one control qubit, in which
-                case it cannot yet be synthesized. Otherwise it is set to ``False``.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+                Ignored if the controlled gate is implemented as an annotated operation.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``.
+            annotated: Indicates whether the controlled gate should be implemented as a controlled gate
+                or as an annotated operation. If ``None``, treated as ``False``
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
-        if not annotated and num_ctrl_qubits == 1:
+        if num_ctrl_qubits == 1:
             gate = CU3Gate(*self.params, label=label, ctrl_state=ctrl_state)
             gate.base_gate.label = self.label
         else:
@@ -275,8 +284,8 @@ class CU3Gate(ControlledGate):
         theta: ParameterValueType,
         phi: ParameterValueType,
         lam: ParameterValueType,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -152,11 +152,6 @@ class U3Gate(Gate):
             gate = CU3Gate(*self.params, label=label, ctrl_state=ctrl_state)
             gate.base_gate.label = self.label
         else:
-            # If the gate parameters contain free parameters, we cannot eagerly synthesize
-            # the controlled gate decomposition. In this case, we annotate the gate per default.
-            if annotated is None:
-                annotated = any(isinstance(p, ParameterExpression) for p in self.params)
-
             gate = super().control(
                 num_ctrl_qubits=num_ctrl_qubits,
                 label=label,

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -13,7 +13,7 @@
 """X, CX, CCX and multi-controlled X gates."""
 from __future__ import annotations
 import warnings
-from typing import Optional, Union, Type
+from typing import Optional, Type
 import numpy
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate, stdlib_singleton_key
@@ -99,26 +99,26 @@ class XGate(SingletonGate):
     def control(
         self,
         num_ctrl_qubits: int = 1,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
-        annotated: bool = False,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
+        annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-X gate.
+        """Return a controlled version of the X gate.
 
-        One control returns a CX gate. Two controls returns a CCX gate.
+        The controlled gate is implemented as :class:`.CXGate` for a single control qubit,
+        as :class:`.CCXGate` for two control qubits, and as :class:`.MCXGate`
+        for three or more control qubits. In each case, the value of ``annotated``
+        is ignored.
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g. ``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: when set to ``True``, this is typically used to return an
-                :class:`.AnnotatedOperation` with a control modifier set instead of a concrete
-                :class:`.Gate`. However, for this class this argument is ignored as a controlled
-                X gate is a multi-controlled X-gate.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
+            annotated: Ignored.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
         gate = MCXGate(
             num_ctrl_qubits=num_ctrl_qubits,
@@ -215,8 +215,8 @@ class CXGate(SingletonControlledGate):
 
     def __init__(
         self,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):
@@ -237,24 +237,25 @@ class CXGate(SingletonControlledGate):
     def control(
         self,
         num_ctrl_qubits: int = 1,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
-        annotated: bool = False,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
+        annotated: bool | None = None,
     ):
-        """Return a controlled-X gate with more control lines.
+        """Return a controlled version of the CX gate.
+
+        The controlled gate is implemented as :class:`.CCXGate` for a single control
+        qubit, and as :class:`.MCXGate` for two or more control qubits.
+        The value of ``annotated`` is ignored.
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g. ``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: when set to ``True``, this is typically used to return an
-                :class:`.AnnotatedOperation` with a control modifier set instead of a concrete
-                :class:`.Gate`. However, for this class this argument is ignored as a controlled
-                CX gate is a multi-controlled X-gate.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
+            annotated: Ignored.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
         ctrl_state = _ctrl_state_to_int(ctrl_state, num_ctrl_qubits)
         new_ctrl_state = (self.ctrl_state << num_ctrl_qubits) | ctrl_state
@@ -357,8 +358,8 @@ class CCXGate(SingletonControlledGate):
 
     def __init__(
         self,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):
@@ -395,24 +396,24 @@ class CCXGate(SingletonControlledGate):
     def control(
         self,
         num_ctrl_qubits: int = 1,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
-        annotated: bool = False,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
+        annotated: bool | None = None,
     ):
-        """Controlled version of this gate.
+        """Return a controlled version of the CCX gate.
+
+        The controlled gate is implemented as :class:`.MCXGate`.
+        The value of `annotated` is ignored.
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g. ``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: when set to ``True``, this is typically used to return an
-                :class:`.AnnotatedOperation` with a control modifier set instead of a concrete
-                :class:`.Gate`. However, for this class this argument is ignored as a controlled
-                CCX gate is a multi-controlled X-gate.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
+            annotated: Ignored.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
         ctrl_state = _ctrl_state_to_int(ctrl_state, num_ctrl_qubits)
         new_ctrl_state = (self.ctrl_state << num_ctrl_qubits) | ctrl_state
@@ -513,8 +514,8 @@ class C3SXGate(SingletonControlledGate):
 
     def __init__(
         self,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):
@@ -563,8 +564,8 @@ class C3XGate(SingletonControlledGate):
 
     def __init__(
         self,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):
@@ -594,24 +595,24 @@ class C3XGate(SingletonControlledGate):
     def control(
         self,
         num_ctrl_qubits: int = 1,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
-        annotated: bool = False,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
+        annotated: bool | None = None,
     ):
-        """Controlled version of this gate.
+        """Return a controlled version of the C3X gate.
+
+        The controlled gate is implemented as :class:`.MCXGate`.
+        The value of ``annotated`` is ignored.
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g. ``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: when set to ``True``, this is typically used to return an
-                :class:`.AnnotatedOperation` with a control modifier set instead of a concrete
-                :class:`.Gate`. However, for this class this argument is ignored as a controlled
-                C3X gate is a multi-controlled X-gate.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
+            annotated: Ignored.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
         ctrl_state = _ctrl_state_to_int(ctrl_state, num_ctrl_qubits)
         new_ctrl_state = (self.ctrl_state << num_ctrl_qubits) | ctrl_state
@@ -710,8 +711,8 @@ class C4XGate(SingletonControlledGate):
 
     def __init__(
         self,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):
@@ -758,24 +759,24 @@ class C4XGate(SingletonControlledGate):
     def control(
         self,
         num_ctrl_qubits: int = 1,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
-        annotated: bool = False,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
+        annotated: bool | None = None,
     ):
-        """Controlled version of this gate.
+        """Return a controlled version of the C4X gate.
+
+        The controlled gate is implemented as :class:`.MCXGate`.
+        The value of ``annotated`` is ignored.
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g. ``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: when set to ``True``, this is typically used to return an
-                :class:`.AnnotatedOperation` with a control modifier set instead of a concrete
-                :class:`.Gate`. However, for this class this argument is ignored as a controlled
-                C4X gate is a multi-controlled X-gate.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
+            annotated: Ignored.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
         ctrl_state = _ctrl_state_to_int(ctrl_state, num_ctrl_qubits)
         new_ctrl_state = (self.ctrl_state << num_ctrl_qubits) | ctrl_state
@@ -814,9 +815,9 @@ class MCXGate(ControlledGate):
 
     def __new__(
         cls,
-        num_ctrl_qubits: Optional[int] = None,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        num_ctrl_qubits: int | None = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):
@@ -845,8 +846,8 @@ class MCXGate(ControlledGate):
     def __init__(
         self,
         num_ctrl_qubits: int,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _name="mcx",
         _base_label=None,
@@ -939,24 +940,24 @@ class MCXGate(ControlledGate):
     def control(
         self,
         num_ctrl_qubits: int = 1,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
-        annotated: bool = False,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
+        annotated: bool | None = None,
     ):
-        """Return a multi-controlled-X gate with more control lines.
+        """Return a controlled version of the MCX gate.
+
+        The controlled gate is implemented as :class:`.MCXGate`.
+        The value of ``annotated`` is ignored.
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g. ``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: when set to ``True``, this is typically used to return an
-                :class:`.AnnotatedOperation` with a control modifier set instead of a concrete
-                :class:`.Gate`. However, for this class this argument is ignored as a controlled
-                multi-controlled X gate is another multi-controlled X-gate.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
+            annotated: Ignored.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
         ctrl_state = _ctrl_state_to_int(ctrl_state, num_ctrl_qubits)
         new_ctrl_state = (self.ctrl_state << num_ctrl_qubits) | ctrl_state
@@ -1038,9 +1039,9 @@ class MCXGrayCode(MCXGate):
     )
     def __new__(
         cls,
-        num_ctrl_qubits: Optional[int] = None,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        num_ctrl_qubits: int | None = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):
@@ -1066,8 +1067,8 @@ class MCXGrayCode(MCXGate):
     def __init__(
         self,
         num_ctrl_qubits: int,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
     ):
         super().__init__(num_ctrl_qubits, label=label, ctrl_state=ctrl_state, _name="mcx_gray")
 
@@ -1123,9 +1124,9 @@ class MCXRecursive(MCXGate):
     )
     def __new__(
         cls,
-        num_ctrl_qubits: Optional[int] = None,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        num_ctrl_qubits: int | None = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):
@@ -1134,8 +1135,8 @@ class MCXRecursive(MCXGate):
     def __init__(
         self,
         num_ctrl_qubits: int,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):
@@ -1196,10 +1197,10 @@ class MCXVChain(MCXGate):
     )
     def __new__(
         cls,
-        num_ctrl_qubits: Optional[int] = None,
+        num_ctrl_qubits: int | None = None,
         dirty_ancillas: bool = False,  # pylint: disable=unused-argument
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
         relative_phase: bool = False,  # pylint: disable=unused-argument
@@ -1221,8 +1222,8 @@ class MCXVChain(MCXGate):
         self,
         num_ctrl_qubits: int,
         dirty_ancillas: bool = False,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
         relative_phase: bool = False,

--- a/qiskit/circuit/library/standard_gates/xx_minus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_minus_yy.py
@@ -87,43 +87,6 @@ class XXMinusYYGate(Gate):
             StandardGate.XXMinusYY._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
-    def control(
-        self,
-        num_ctrl_qubits: int = 1,
-        label: str | None = None,
-        ctrl_state: str | int | None = None,
-        annotated: bool | None = None,
-    ):
-        """Return a controlled version of the (XX-YY) gate.
-
-        The controlled gate is implemented either as :class:`.ControlledGate`
-        when ``annotated`` is ``False``, or as :class:`.AnnotatedOperation` when
-        ``annotated`` is ``True``. When ``annotated`` is ``None``, it is interpreted
-        as ``True`` when the gate has free parameters (in which case the gate
-        cannot be synthesized at the construction time), and as ``False`` otherwise.
-
-        Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate. Defaults to ``None``.
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate.
-
-        Returns:
-            A controlled version of this gate.
-        """
-        if annotated is None:
-            annotated = any(isinstance(p, ParameterExpression) for p in self.params)
-
-        gate = super().control(
-            num_ctrl_qubits=num_ctrl_qubits,
-            label=label,
-            ctrl_state=ctrl_state,
-            annotated=annotated,
-        )
-        return gate
-
     def inverse(self, annotated: bool = False):
         """Inverse gate.
 

--- a/qiskit/circuit/library/standard_gates/xx_minus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_minus_yy.py
@@ -21,7 +21,7 @@ from typing import Optional
 import numpy as np
 
 from qiskit.circuit.gate import Gate
-from qiskit.circuit.parameterexpression import ParameterValueType, ParameterExpression
+from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit._accelerate.circuit import StandardGate
 

--- a/qiskit/circuit/library/standard_gates/xx_minus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_minus_yy.py
@@ -94,20 +94,24 @@ class XXMinusYYGate(Gate):
         ctrl_state: str | int | None = None,
         annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-(XX-YY) gate.
+        """Return a controlled version of the (XX-YY) gate.
+
+        The controlled gate is implemented either as :class:`.ControlledGate`
+        when ``annotated`` is ``False``, or as :class:`.AnnotatedOperation` when
+        ``annotated`` is ``True``. When ``annotated`` is ``None``, it is interpreted
+        as ``True`` when the gate has free parameters (in which case the gate
+        cannot be synthesized at the construction time), and as ``False`` otherwise.
 
         Args:
             num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
+            label: An optional label for the gate. Defaults to ``None``.
             ctrl_state: control state expressed as integer,
                 string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate. If ``None``, this is set to ``True`` if
-                the gate contains free parameters, in which case it cannot
-                yet be synthesized.
+                as an annotated gate.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
         if annotated is None:
             annotated = any(isinstance(p, ParameterExpression) for p in self.params)

--- a/qiskit/circuit/library/standard_gates/xx_plus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_plus_yy.py
@@ -127,20 +127,24 @@ class XXPlusYYGate(Gate):
         ctrl_state: str | int | None = None,
         annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-(XX+YY) gate.
+        """Return a controlled version of the (XX+YY) gate.
+
+        The controlled gate is implemented either as :class:`.ControlledGate`
+        when ``annotated`` is ``False``, or as :class:`.AnnotatedOperation` when
+        ``annotated`` is ``True``. When ``annotated`` is ``None``, it is interpreted
+        as ``True`` when the gate has free parameters (in which case the gate
+        cannot be synthesized at the construction time), and as ``False`` otherwise.
 
         Args:
             num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
+            label: An optional label for the gate. Defaults to ``None``.
             ctrl_state: control state expressed as integer,
                 string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
             annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate. If ``None``, this is set to ``True`` if
-                the gate contains free parameters, in which case it cannot
-                yet be synthesized.
+                as an annotated gate.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
         if annotated is None:
             annotated = any(isinstance(p, ParameterExpression) for p in self.params)

--- a/qiskit/circuit/library/standard_gates/xx_plus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_plus_yy.py
@@ -21,7 +21,7 @@ from typing import Optional
 import numpy
 
 from qiskit.circuit.gate import Gate
-from qiskit.circuit.parameterexpression import ParameterValueType, ParameterExpression
+from qiskit.circuit.parameterexpression import ParameterValueType
 from qiskit._accelerate.circuit import StandardGate
 
 

--- a/qiskit/circuit/library/standard_gates/xx_plus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_plus_yy.py
@@ -120,43 +120,6 @@ class XXPlusYYGate(Gate):
             StandardGate.XXPlusYY._get_definition(self.params), legacy_qubits=True, name=self.name
         )
 
-    def control(
-        self,
-        num_ctrl_qubits: int = 1,
-        label: str | None = None,
-        ctrl_state: str | int | None = None,
-        annotated: bool | None = None,
-    ):
-        """Return a controlled version of the (XX+YY) gate.
-
-        The controlled gate is implemented either as :class:`.ControlledGate`
-        when ``annotated`` is ``False``, or as :class:`.AnnotatedOperation` when
-        ``annotated`` is ``True``. When ``annotated`` is ``None``, it is interpreted
-        as ``True`` when the gate has free parameters (in which case the gate
-        cannot be synthesized at the construction time), and as ``False`` otherwise.
-
-        Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate. Defaults to ``None``.
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate.
-
-        Returns:
-            A controlled version of this gate.
-        """
-        if annotated is None:
-            annotated = any(isinstance(p, ParameterExpression) for p in self.params)
-
-        gate = super().control(
-            num_ctrl_qubits=num_ctrl_qubits,
-            label=label,
-            ctrl_state=ctrl_state,
-            annotated=annotated,
-        )
-        return gate
-
     def inverse(self, annotated: bool = False):
         """Return inverse XX+YY gate (i.e. with the negative rotation angle and same phase angle).
 

--- a/qiskit/circuit/library/standard_gates/y.py
+++ b/qiskit/circuit/library/standard_gates/y.py
@@ -12,7 +12,9 @@
 
 """Y and CY gates."""
 
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import Optional
 
 # pylint: disable=cyclic-import
 from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate, stdlib_singleton_key
@@ -96,26 +98,32 @@ class YGate(SingletonGate):
     def control(
         self,
         num_ctrl_qubits: int = 1,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
-        annotated: bool = False,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
+        annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-Y gate.
+        """Return a controlled version of the Y gate.
 
-        One control returns a CY gate.
+        For a single control qubit, the controlled gate is implemented as :class:`.CYGate`,
+        regardless of the value of `annotated`.
+
+        For more than one control qubit,
+        the controlled gate is implemented as :class:`.ControlledGate` when ``annotated``
+        is ``False``, and as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+                Ignored if the controlled gate is implemented as an annotated operation.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``.
+            annotated: Indicates whether the controlled gate should be implemented as a controlled gate
+                or as an annotated operation. If ``None``, treated as ``False``.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
-        if not annotated and num_ctrl_qubits == 1:
+        if num_ctrl_qubits == 1:
             gate = CYGate(label=label, ctrl_state=ctrl_state, _base_label=self.label)
         else:
             gate = super().control(
@@ -206,8 +214,8 @@ class CYGate(SingletonControlledGate):
 
     def __init__(
         self,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):

--- a/qiskit/circuit/library/standard_gates/z.py
+++ b/qiskit/circuit/library/standard_gates/z.py
@@ -12,11 +12,13 @@
 
 """Z, CZ and CCZ gates."""
 
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import Optional
 
 import numpy
 
-from qiskit.circuit._utils import with_gate_array, with_controlled_gate_array
+from qiskit.circuit._utils import _ctrl_state_to_int, with_gate_array, with_controlled_gate_array
 from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate, stdlib_singleton_key
 from qiskit._accelerate.circuit import StandardGate
 
@@ -99,27 +101,36 @@ class ZGate(SingletonGate):
     def control(
         self,
         num_ctrl_qubits: int = 1,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
-        annotated: bool = False,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
+        annotated: bool | None = None,
     ):
-        """Return a (multi-)controlled-Z gate.
+        """Return a controlled version of the Z gate.
 
-        One control returns a CZ gate.
+        For a single control qubit, the controlled gate is implemented as a
+        :class:`.CZGate`. For two control qubits, the controlled gate is implemented
+        as a :class:`.CCZGate`. In these cases, the the value of ``annotated`` is ignored.
+
+        For three or more control qubits, the controlled gate is implemented
+        as either :class:`.ControlledGate` when ``annotated`` is ``False``, and
+        as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
 
         Args:
-            num_ctrl_qubits: number of control qubits.
-            label: An optional label for the gate [Default: ``None``]
-            ctrl_state: control state expressed as integer,
-                string (e.g.``'110'``), or ``None``. If ``None``, use all 1s.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+                Ignored if the controlled gate is implemented as an annotated operation.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``.
+            annotated: Indicates whether the controlled gate should be implemented as a controlled gate
+                or as an annotated operation. If ``None``, treated as ``False``.
 
         Returns:
-            ControlledGate: controlled version of this gate.
+            A controlled version of this gate.
         """
-        if not annotated and num_ctrl_qubits == 1:
+        if num_ctrl_qubits == 1:
             gate = CZGate(label=label, ctrl_state=ctrl_state, _base_label=self.label)
+        elif num_ctrl_qubits == 2:
+            gate = CCZGate(label=label, ctrl_state=ctrl_state, _base_label=self.label)
         else:
             gate = super().control(
                 num_ctrl_qubits=num_ctrl_qubits,
@@ -188,8 +199,8 @@ class CZGate(SingletonControlledGate):
 
     def __init__(
         self,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):
@@ -233,6 +244,48 @@ class CZGate(SingletonControlledGate):
             CZGate: inverse gate (self-inverse).
         """
         return CZGate(ctrl_state=self.ctrl_state)  # self-inverse
+
+    def control(
+        self,
+        num_ctrl_qubits: int = 1,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
+        annotated: bool | None = None,
+    ):
+        """Return a controlled version of the CZ gate.
+
+        For a single control qubit, the controlled gate is implemented as a
+        :class:`.CCZGate`, regardless of the value of ``annotated``.
+
+        For two or more control qubits, the controlled gate is implemented
+        as either :class:`.ControlledGate` when ``annotated`` is ``False``, and
+        as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
+
+        Args:
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: Optional gate label. Defaults to ``None``.
+                Ignored if the controlled gate is implemented as an annotated operation.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``.
+            annotated: Indicates whether the controlled gate should be implemented as a controlled gate
+                or as an annotated operation. If ``None``, treated as ``False``.
+
+        Returns:
+            A controlled version of this gate.
+        """
+
+        if num_ctrl_qubits == 1:
+            ctrl_state = _ctrl_state_to_int(ctrl_state, num_ctrl_qubits)
+            new_ctrl_state = (self.ctrl_state << num_ctrl_qubits) | ctrl_state
+            gate = CCZGate(label=label, ctrl_state=new_ctrl_state, _base_label=self.label)
+        else:
+            gate = super().control(
+                num_ctrl_qubits=num_ctrl_qubits,
+                label=label,
+                ctrl_state=ctrl_state,
+                annotated=annotated,
+            )
+        return gate
 
     def __eq__(self, other):
         return isinstance(other, CZGate) and self.ctrl_state == other.ctrl_state
@@ -282,8 +335,8 @@ class CCZGate(SingletonControlledGate):
 
     def __init__(
         self,
-        label: Optional[str] = None,
-        ctrl_state: Optional[Union[str, int]] = None,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
         *,
         _base_label=None,
     ):

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1965,17 +1965,24 @@ class QuantumCircuit:
         num_ctrl_qubits: int = 1,
         label: str | None = None,
         ctrl_state: str | int | None = None,
-        annotated: bool = False,
+        annotated: bool | None = None,
     ) -> "QuantumCircuit":
-        """Control this circuit on ``num_ctrl_qubits`` qubits.
+        """Return the controlled version of this circuit.
+
+        The original circuit is converted into a gate, and the resulting circuit contains
+        the controlled version of this gate.
+        This controlled gate is implemented as :class:`.ControlledGate` when ``annotated``
+        is ``False``, and as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
 
         Args:
-            num_ctrl_qubits (int): The number of control qubits.
-            label (str): An optional label to give the controlled operation for visualization.
-            ctrl_state (str or int): The control state in decimal or as a bitstring
-                (e.g. '111'). If None, use ``2**num_ctrl_qubits - 1``.
-            annotated: indicates whether the controlled gate should be implemented
-                as an annotated gate.
+            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            label: An optional label to give the controlled gate for visualization.
+                Defaults to ``None``. Ignored if the controlled gate is implemented as an annotated
+                operation.
+            ctrl_state: The control state of the gate, specified either as an integer or a bitstring
+                (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``.
+            annotated: Indicates whether the controlled gate should be implemented as a controlled gate
+                or as an annotated operation.
 
         Returns:
             QuantumCircuit: The controlled version of this circuit.

--- a/releasenotes/notes/update-gate-control-methods-3d6ea2619fab86fe.yaml
+++ b/releasenotes/notes/update-gate-control-methods-3d6ea2619fab86fe.yaml
@@ -16,13 +16,6 @@ upgrade_circuits:
       and ``MCMT`` gates.
 
   - |
-    For two or more controls, the controlled ``RX``,``RY`` and ``RZ`` gates that depend on
-    free parameters are now represented as :class:`.AnnotatedOperation` instead of
-    :class:`.ControlledGate`. This change does not affect the resulting synthesized circuits,
-    but defers synthesis from gate creation time to transpilation time. In addition,
-    this makes the handling of controlled parameterized gates more consistent across the standard
-    circuit library.
-  - |
     The default value of the argument ``annotated`` in :meth:`QuantumCircuit.control` is now
     ``None`` instead of ``False``. This does not affect the actual circuits, but is consistent
     with the default value of ``annotated`` used across the circuit library.

--- a/releasenotes/notes/update-gate-control-methods-3d6ea2619fab86fe.yaml
+++ b/releasenotes/notes/update-gate-control-methods-3d6ea2619fab86fe.yaml
@@ -1,0 +1,28 @@
+---
+upgrade_circuits:
+  - |
+    The method ``gate.control`` no longer returns an :class:`.AnnotatedOperation` when
+    the argument ``annotated`` is set to ``True`` when a native controlled-gate class
+    is available. This change is consistent with how the argument ``annotated``
+    is used across the standard circuit library, and enables more efficient decompositions
+    of control-annotated gates. The affected gates are:
+
+    * Single-controlled ``H``, ``S``, ``Sdg``, ``U3``, ``Y``, ``Z``, ``SX``, ``RX``, ``RY``,
+      ``RZ``, ``Swap`` and ``CZ`` gates;
+
+    * Double-controlled ``Z``-gate;
+
+    * arbitrarily-controlled ``Phase``, ``CPhase``, ``MCPhase``, ``U1``, ``CU1``, ``MCU1``
+      and ``MCMT`` gates.
+
+  - |
+    For two or more controls, the controlled ``RX``,``RY`` and ``RZ`` gates that depend on
+    free parameters are now represented as :class:`.AnnotatedOperation` instead of
+    :class:`.ControlledGate`. This change does not affect the resulting synthesized circuits,
+    but defers synthesis from gate creation time to transpilation time. In addition,
+    this makes the handling of controlled parameterized gates more consistent across the standard
+    circuit library.
+  - |
+    The default value of the argument ``annotated`` in :meth:`QuantumCircuit.control` is now
+    ``None`` instead of ``False``. This does not affect the actual circuits, but is consistent
+    with the default value of ``annotated`` used across the circuit library.

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -83,6 +83,7 @@ from qiskit.circuit.library import (
     GlobalPhaseGate,
     UnitaryGate,
     MCMTGate,
+    CCZGate,
 )
 from qiskit.circuit._utils import _compute_control_matrix
 import qiskit.circuit.library.standard_gates as allGates
@@ -117,9 +118,14 @@ class TestControlledGate(QiskitTestCase):
         self.assertEqual(HGate().control(), CHGate())
 
     def test_controlled_phase(self):
-        """Test the creation of a controlled U1 gate."""
+        """Test the creation of a controlled phase gate."""
         theta = 0.5
         self.assertEqual(PhaseGate(theta).control(), CPhaseGate(theta))
+
+    def test_controlled_cphase(self):
+        """Test the creation of a controlled cphase gate."""
+        theta = 0.5
+        self.assertEqual(CPhaseGate(theta).control(1), MCPhaseGate(theta, 2))
 
     def test_double_controlled_phase(self):
         """Test the creation of a controlled phase gate."""
@@ -877,6 +883,26 @@ class TestControlledGate(QiskitTestCase):
         cugate = ugate.control(num_ctrl_qubits, ctrl_state=ctrl_state)
         ref_mat = _compute_control_matrix(umat, num_ctrl_qubits, ctrl_state=ctrl_state)
         self.assertEqual(Operator(cugate), Operator(ref_mat))
+
+    def test_open_controlled_cz(self):
+        """Test open-controlled CZ-gates."""
+        controlled_cz = CZGate(ctrl_state=1).control(1, ctrl_state=0)
+        expected = CCZGate(ctrl_state=2)
+        self.assertEqual(Operator(controlled_cz), Operator(expected))
+
+    def test_open_controlled_cphase(self):
+        """Test open-controlled CPhase-gates."""
+        theta = 0.1
+        controlled_cphase = CPhaseGate(theta, ctrl_state=1).control(1, ctrl_state=0)
+        expected = MCPhaseGate(theta, num_ctrl_qubits=2, ctrl_state=2)
+        self.assertEqual(Operator(controlled_cphase), Operator(expected))
+
+    def test_open_controlled_cu1(self):
+        """Test open-controlled CU1-gates."""
+        theta = 0.1
+        controlled_cphase = CU1Gate(theta, ctrl_state=1).control(1, ctrl_state=0)
+        expected = MCU1Gate(theta, num_ctrl_qubits=2, ctrl_state=2)
+        self.assertEqual(Operator(controlled_cphase), Operator(expected))
 
     def test_controlled_controlled_rz(self):
         """Test that UnitaryGate with control returns params."""
@@ -1772,121 +1798,46 @@ class TestControlledGateLabel(QiskitTestCase):
 class TestControlledAnnotatedGate(QiskitTestCase):
     """Tests for controlled gates and the AnnotatedOperation class."""
 
-    def test_controlled_x(self):
-        """Test creation of controlled x gate"""
-        controlled = XGate().control(annotated=False)
-        annotated = XGate().control(annotated=True)
+    @data(
+        (XGate(), 1),
+        (XGate(), 2),
+        (XGate(), 4),
+        (PhaseGate(0.5), 1),
+        (PhaseGate(0.5), 2),
+        (U1Gate(0.5), 1),
+        (U1Gate(0.5), 2),
+        (UGate(0.1, 0.2, 0.3), 1),
+        (CXGate(), 1),
+        (CXGate(), 2),
+    )
+    @unpack
+    def test_native_controlled_gates(self, base_gate, num_controls):
+        """Test creation of controlled gates for a gate which have a
+        native gate class for its controlled version.
+        """
+        controlled = base_gate.control(num_controls, annotated=False)
+        annotated = base_gate.control(num_controls, annotated=True)
         self.assertNotIsInstance(controlled, AnnotatedOperation)
         self.assertNotIsInstance(annotated, AnnotatedOperation)
-        self.assertEqual(Operator(controlled), Operator(annotated))
 
-    def test_controlled_y(self):
-        """Test creation of controlled y gate"""
-        controlled = YGate().control(annotated=False)
-        annotated = YGate().control(annotated=True)
-        self.assertNotIsInstance(controlled, AnnotatedOperation)
-        self.assertIsInstance(annotated, AnnotatedOperation)
-        self.assertEqual(Operator(controlled), Operator(annotated))
-
-    def test_controlled_z(self):
-        """Test creation of controlled z gate"""
-        controlled = ZGate().control(annotated=False)
-        annotated = ZGate().control(annotated=True)
-        self.assertNotIsInstance(controlled, AnnotatedOperation)
-        self.assertIsInstance(annotated, AnnotatedOperation)
-        self.assertEqual(Operator(controlled), Operator(annotated))
-
-    def test_controlled_h(self):
-        """Test the creation of a controlled H gate."""
-        controlled = HGate().control(annotated=False)
-        annotated = HGate().control(annotated=True)
-        self.assertNotIsInstance(controlled, AnnotatedOperation)
-        self.assertIsInstance(annotated, AnnotatedOperation)
-        self.assertEqual(Operator(controlled), Operator(annotated))
-
-    def test_controlled_phase(self):
-        """Test the creation of a controlled U1 gate."""
-        theta = 0.5
-        controlled = PhaseGate(theta).control(annotated=False)
-        annotated = PhaseGate(theta).control(annotated=True)
-        self.assertNotIsInstance(controlled, AnnotatedOperation)
-        self.assertIsInstance(annotated, AnnotatedOperation)
-        self.assertEqual(Operator(controlled), Operator(annotated))
-
-    def test_controlled_u1(self):
-        """Test the creation of a controlled U1 gate."""
-        theta = 0.5
-        controlled = U1Gate(theta).control(annotated=False)
-        annotated = U1Gate(theta).control(annotated=True)
-        self.assertNotIsInstance(controlled, AnnotatedOperation)
-        self.assertIsInstance(annotated, AnnotatedOperation)
-        self.assertEqual(Operator(controlled), Operator(annotated))
-
-    def test_controlled_rz(self):
-        """Test the creation of a controlled RZ gate."""
-        theta = 0.5
-        controlled = RZGate(theta).control(annotated=False)
-        annotated = RZGate(theta).control(annotated=True)
-        self.assertNotIsInstance(controlled, AnnotatedOperation)
-        self.assertIsInstance(annotated, AnnotatedOperation)
-        self.assertEqual(Operator(controlled), Operator(annotated))
-
-    def test_controlled_ry(self):
-        """Test the creation of a controlled RY gate."""
-        theta = 0.5
-        controlled = RYGate(theta).control(annotated=False)
-        annotated = RYGate(theta).control(annotated=True)
-        self.assertNotIsInstance(controlled, AnnotatedOperation)
-        self.assertIsInstance(annotated, AnnotatedOperation)
-        self.assertEqual(Operator(controlled), Operator(annotated))
-
-    def test_controlled_rx(self):
-        """Test the creation of a controlled RX gate."""
-        theta = 0.5
-        controlled = RXGate(theta).control(annotated=False)
-        annotated = RXGate(theta).control(annotated=True)
-        self.assertNotIsInstance(controlled, AnnotatedOperation)
-        self.assertIsInstance(annotated, AnnotatedOperation)
-        self.assertEqual(Operator(controlled), Operator(annotated))
-
-    def test_controlled_u(self):
-        """Test the creation of a controlled U gate."""
-        theta, phi, lamb = 0.1, 0.2, 0.3
-        controlled = UGate(theta, phi, lamb).control(annotated=False)
-        annotated = UGate(theta, phi, lamb).control(annotated=True)
-        self.assertNotIsInstance(controlled, AnnotatedOperation)
-        self.assertIsInstance(annotated, AnnotatedOperation)
-        self.assertEqual(Operator(controlled), Operator(annotated))
-
-    def test_controlled_u3(self):
-        """Test the creation of a controlled U3 gate."""
-        theta, phi, lamb = 0.1, 0.2, 0.3
-        controlled = U3Gate(theta, phi, lamb).control(annotated=False)
-        annotated = U3Gate(theta, phi, lamb).control(annotated=True)
-        self.assertNotIsInstance(controlled, AnnotatedOperation)
-        self.assertIsInstance(annotated, AnnotatedOperation)
-        self.assertEqual(Operator(controlled), Operator(annotated))
-
-    def test_controlled_cx(self):
-        """Test creation of controlled cx gate"""
-        controlled = CXGate().control(annotated=False)
-        annotated = CXGate().control(annotated=True)
-        self.assertNotIsInstance(controlled, AnnotatedOperation)
-        self.assertNotIsInstance(annotated, AnnotatedOperation)
-        self.assertEqual(Operator(controlled), Operator(annotated))
-
-    def test_controlled_swap(self):
-        """Test creation of controlled swap gate"""
-        controlled = SwapGate().control(annotated=False)
-        annotated = SwapGate().control(annotated=True)
-        self.assertNotIsInstance(controlled, AnnotatedOperation)
-        self.assertIsInstance(annotated, AnnotatedOperation)
-        self.assertEqual(Operator(controlled), Operator(annotated))
-
-    def test_controlled_sx(self):
-        """Test creation of controlled SX gate"""
-        controlled = SXGate().control(annotated=False)
-        annotated = SXGate().control(annotated=True)
+    @data(
+        (YGate(), 2),
+        (ZGate(), 3),
+        (HGate(), 2),
+        (RZGate(0.5), 2),
+        (RYGate(0.5), 2),
+        (RXGate(0.5), 2),
+        (SXGate(), 2),
+        (SwapGate(), 2),
+        (U3Gate(0.1, 0.2, 0.3), 2),
+    )
+    @unpack
+    def test_controlled_vs_annotated(self, base_gate, num_controls):
+        """Test creation of controlled vs annotated gates for gates
+        that do not have a native gate class for its controlled version.
+        """
+        controlled = base_gate.control(num_controls, annotated=False)
+        annotated = base_gate.control(num_controls, annotated=True)
         self.assertNotIsInstance(controlled, AnnotatedOperation)
         self.assertIsInstance(annotated, AnnotatedOperation)
         self.assertEqual(Operator(controlled), Operator(annotated))

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -1485,17 +1485,17 @@ class TestControlledGate(QiskitTestCase):
         XXMinusYYGate,
         XXPlusYYGate,
     )
-    def test_mc_without_annotation(self, gate_cls):
-        """Test multi-controlled gates with and without annotation."""
+    def test_synthesis_of_controlled_parameterized_gates(self, gate_cls):
+        """Test that circuits with multi-controlled parameterized gates
+        can be synthesized after all parameters are bound (regardless of the value of
+        ``annotated`` used for constructing the multi-controlled gate).
+        """
         theta = Parameter("theta")
         num_params = len(_get_free_params(gate_cls.__init__, ignore=["self"]))
         params = [theta] + (num_params - 1) * [1.234]
 
-        for annotated in [False, None]:
+        for annotated in [False, True, None]:
             with self.subTest(annotated=annotated):
-                # if annotated is False, check that a sensible error is raised
-                # else, check that the gate can be synthesized after all parameters
-                # have been bound
                 mc_gate = gate_cls(*params).control(5)
 
                 circuit = QuantumCircuit(mc_gate.num_qubits)

--- a/test/python/transpiler/test_optimize_annotated.py
+++ b/test/python/transpiler/test_optimize_annotated.py
@@ -405,8 +405,8 @@ class TestOptimizeSwapBeforeMeasure(QiskitTestCase):
         """Test conjugate reduction optimization for control-SWAP."""
 
         # Create a circuit with a control-annotated swap
-        qc = QuantumCircuit(3)
-        qc.append(SwapGate().control(annotated=True), [0, 1, 2])
+        qc = QuantumCircuit(4)
+        qc.append(SwapGate().control(2, annotated=True), [0, 1, 2, 3])
 
         # Run optimization pass
         qc_optimized = OptimizeAnnotated(basis_gates=["cx", "u"])(qc)
@@ -414,7 +414,7 @@ class TestOptimizeSwapBeforeMeasure(QiskitTestCase):
         # Check that the optimization is correct
         self.assertEqual(Operator(qc), Operator(qc_optimized))
 
-        # Swap(0, 1) gets translated to CX(0, 1), CX(1, 0), CX(0, 1).
+        # CSwap(0, 1) gets translated to CCX(0, 1), CCX(1, 0), CCX(0, 1).
         # The first and the last of the CXs should be detected as inverse of each other.
         new_def_ops = dict(qc_optimized[0].operation.definition.count_ops())
         self.assertEqual(new_def_ops, {"annotated": 1, "cx": 2})


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary (updated on 19.11.2025)

This PR cleans up and unifies the handling of ``gate.control`` methods for gates in our circuit library. The principles behind these changes are:

* using native gate classes for controlled gates when available
* set the default value for ``annotated`` to ``None`` for all ``gate.control`` methods. This change has no effect on the synthesized circuits since ``None`` is essentially treated as ``False``.
* improve type hints and docstrings for ``gate.control`` methods across the library

These changes do not affect the transpiled circuits (or only make the results better).



### Details and comments

The method `gate.control(annotated=True)` no longer returns an annotated operation when a native controlled-gate class is available. This change enables the most efficient decompositions of such gates, and is consistent with how the argument ``annotated`` is used across the standard circuit library. The affected gates are:
    * Single-controlled ``H``, ``S``, ``Sdg``, ``U3``, ``Y``, ``Z``, ``SX``, ``RX``, ``RY``, ``RZ``, ``Swap`` and ``CZ`` gates;
    * Double-controlled ``Z``-gate;
    * arbitrarily-controlled ``Phase``, ``CPhase``, ``MCPhase``, ``U1``, ``CU1``, ``MCU1`` and ``MCMT`` gates.

The default value for ``annotated`` in ``QuantumCircuit.control`` was also changed from ``False`` to ``None``. This has absolutely no effiect on the sythesized circuits, but again makes the default argument consistent with the rest of the control methods.

Most importantly, this brings us significantly closer to set ``annotated=True`` by default in Qiskit 3.0, allowing significantly more efficient decompositions of nested circuits with controlled gates. 

Some additional history: see #12752, #13507.