### PR TITLE
Update to PyO3 0.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,12 +738,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
-
-[[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,12 +761,12 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.15.5",
  "rayon",
 ]
 
@@ -1096,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2dba356160b54f5371b550575b78130a54718b4c6e46b3f33a6da74a27e78b"
+checksum = "0fa24ffc88cf9d43f7269d6b6a0d0a00010924a8cc90604a21ef9c433b66998d"
 dependencies = [
  "libc",
  "nalgebra",
@@ -1368,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.26.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+checksum = "37a6df7eab65fc7bee654a421404947e10a0f7085b6951bf2ea395f4659fb0cf"
 dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
@@ -1379,6 +1373,7 @@ dependencies = [
  "memoffset",
  "num-bigint",
  "num-complex",
+ "num-traits",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
@@ -1390,18 +1385,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.26.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
+checksum = "f77d387774f6f6eec64a004eac0ed525aab7fa1966d94b42f743797b3e395afb"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.26.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+checksum = "2dd13844a4242793e02df3e2ec093f540d948299a6a77ea9ce7afd8623f542be"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1409,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.26.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+checksum = "eaf8f9f1108270b90d3676b8679586385430e5c0bb78bb5f043f95499c821a71"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1421,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.26.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+checksum = "70a3b2274450ba5288bc9b8c1b69ff569d1d61189d4bff38f8d22e03d17f932b"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ license = "Apache-2.0"
 bytemuck = "1.24"
 bitfield-struct = "0.12.1"
 indexmap.version = "2.10.0"
-hashbrown.version = "0.15.2"
+hashbrown.version = "0.15.5"
 num-bigint = "0.4"
 num-complex = "0.4"
 nalgebra = "0.33"
-numpy = "0.26"
+numpy = "0.27"
 ndarray = "0.16"
 smallvec = "1.15"
 thiserror = "2.0"
@@ -44,7 +44,7 @@ uuid = { version = "1.18", features = ["v4", "fast-rng"], default-features = fal
 # distributions).  We only activate that feature when building the C extension module; we still need
 # it disabled for Rust-only tests to avoid linker errors with it not being loaded.  See
 # https://pyo3.rs/main/features#extension-module for more.
-pyo3 = { version = "0.26", features = ["abi3-py39"] }
+pyo3 = { version = "0.27", features = ["abi3-py39"] }
 
 # These are our own crates.
 qiskit-accelerate = { path = "crates/accelerate" }

--- a/crates/circuit/src/bit.rs
+++ b/crates/circuit/src/bit.rs
@@ -86,7 +86,7 @@ where
             self.index as usize,
             self.registers
                 .into_pyobject(py)?
-                .downcast_into::<PyList>()?
+                .cast_into::<PyList>()?
                 .unbind(),
         )
         .into_pyobject(py)
@@ -98,7 +98,7 @@ where
     R: Debug + Clone + Register + for<'a> IntoPyObject<'a> + for<'a> FromPyObject<'a>,
 {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        let ob_down = ob.downcast::<PyBitLocations>()?.borrow();
+        let ob_down = ob.cast::<PyBitLocations>()?.borrow();
         Ok(Self {
             index: ob_down.index as u32,
             registers: ob_down.registers.extract(ob.py())?,
@@ -511,7 +511,7 @@ macro_rules! create_bit_object {
 
         impl<'py> FromPyObject<'py> for $bit_struct {
             fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-                Ok(ob.downcast::<$pybit_struct>()?.borrow().0.clone())
+                Ok(ob.cast::<$pybit_struct>()?.borrow().0.clone())
             }
         }
         // The owning impl of `IntoPyObject` needs to be done manually, to better handle
@@ -631,7 +631,7 @@ macro_rules! create_bit_object {
 
         impl<'py> FromPyObject<'py> for $reg_struct {
             fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-                Ok(ob.downcast::<$pyreg_struct>()?.borrow().0.clone())
+                Ok(ob.cast::<$pyreg_struct>()?.borrow().0.clone())
             }
         }
         // The owning impl of `IntoPyObject` needs to be done manually, to better handle
@@ -761,7 +761,7 @@ macro_rules! create_bit_object {
                             Ok(PyList::new(ob.py(), s.into_iter().map(get_inner))?.into_any())
                         }
                     }
-                } else if let Ok(list) = ob.downcast::<PyList>() {
+                } else if let Ok(list) = ob.cast::<PyList>() {
                     let out = PyList::empty(ob.py());
                     for item in list.iter() {
                         out.append(get_inner(PySequenceIndex::convert_idx(

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -184,7 +184,7 @@ impl CircuitVarInfo {
     }
 
     fn from_pickle(ob: &Bound<PyAny>) -> PyResult<Self> {
-        let val_tuple = ob.downcast::<PyTuple>()?;
+        let val_tuple = ob.cast::<PyTuple>()?;
         Ok(CircuitVarInfo {
             var: Var(val_tuple.get_item(0)?.extract()?),
             type_: match val_tuple.get_item(1)?.extract::<u8>()? {
@@ -232,7 +232,7 @@ impl CircuitStretchInfo {
     }
 
     fn from_pickle(ob: &Bound<PyAny>) -> PyResult<Self> {
-        let val_tuple = ob.downcast::<PyTuple>()?;
+        let val_tuple = ob.cast::<PyTuple>()?;
         Ok(CircuitStretchInfo {
             stretch: Stretch(val_tuple.get_item(0)?.extract()?),
             type_: match val_tuple.get_item(1)?.extract::<u8>()? {
@@ -267,7 +267,7 @@ impl CircuitIdentifierInfo {
     }
 
     fn from_pickle(ob: &Bound<PyAny>) -> PyResult<Self> {
-        let val_tuple = ob.downcast::<PyTuple>()?;
+        let val_tuple = ob.cast::<PyTuple>()?;
         match val_tuple.get_item(0)?.extract::<u8>()? {
             0 => Ok(CircuitIdentifierInfo::Stretch(
                 CircuitStretchInfo::from_pickle(&val_tuple.get_item(1)?)?,
@@ -1104,7 +1104,7 @@ impl CircuitData {
         fn set_single(slf: &mut CircuitData, index: usize, value: &Bound<PyAny>) -> PyResult<()> {
             let py = value.py();
             slf.untrack_instruction_parameters(index)?;
-            slf.data[index] = slf.pack(py, &value.downcast::<CircuitInstruction>()?.borrow())?;
+            slf.data[index] = slf.pack(py, &value.cast::<CircuitInstruction>()?.borrow())?;
             slf.track_instruction_parameters(index)?;
             Ok(())
         }
@@ -1129,7 +1129,7 @@ impl CircuitData {
                     })?
                 } else {
                     for value in values[indices.len()..].iter().rev() {
-                        self.insert(stop as isize, value.downcast()?.borrow())?;
+                        self.insert(stop as isize, value.cast()?.borrow())?;
                     }
                 }
                 Ok(())
@@ -1225,7 +1225,7 @@ impl CircuitData {
     }
 
     pub fn extend(&mut self, itr: &Bound<PyAny>) -> PyResult<()> {
-        if let Ok(other) = itr.downcast::<CircuitData>() {
+        if let Ok(other) = itr.cast::<CircuitData>() {
             let other = other.borrow();
             // Fast path to avoid unnecessary construction of CircuitInstruction instances.
             self.data.reserve(other.data.len());
@@ -1259,7 +1259,7 @@ impl CircuitData {
             return Ok(());
         }
         for v in itr.try_iter()? {
-            self.append(v?.downcast()?)?;
+            self.append(v?.cast()?)?;
         }
         Ok(())
     }
@@ -1345,7 +1345,7 @@ impl CircuitData {
             return Ok(false);
         }
 
-        if let Ok(other_cd) = other.downcast::<CircuitData>() {
+        if let Ok(other_cd) = other.cast::<CircuitData>() {
             if !slf
                 .getattr("global_phase")?
                 .eq(other_cd.getattr("global_phase")?)?
@@ -3052,7 +3052,7 @@ where
                 })
                 .collect::<PyResult<_>>();
         }
-        let err_message = if let Ok(bit) = specifier.downcast::<PyBit>() {
+        let err_message = if let Ok(bit) = specifier.cast::<PyBit>() {
             format!(
                 "Incorrect bit type: expected '{}' but got '{}'",
                 stringify!(B),
@@ -3102,7 +3102,7 @@ where
             )))
         }
     } else {
-        let err_message = if let Ok(bit) = specifier.downcast::<PyBit>() {
+        let err_message = if let Ok(bit) = specifier.cast::<PyBit>() {
             format!(
                 "Incorrect bit type: expected '{}' but got '{}'",
                 stringify!(B),

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -668,7 +668,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for OperationFromPython {
         }
         Err(PyTypeError::new_err(format!(
             "invalid input: {}",
-            ob.repr()?
+            ob.to_owned()
         )))
     }
 }

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -415,7 +415,7 @@ impl CircuitInstruction {
             if other.is_instance_of::<PyTuple>() {
                 return Ok(Some(self_._legacy_format(py)?.eq(other)?));
             }
-            let Ok(other) = other.downcast::<CircuitInstruction>() else {
+            let Ok(other) = other.cast::<CircuitInstruction>() else {
                 return Ok(None);
             };
             let other = other.try_borrow()?;
@@ -473,7 +473,7 @@ impl<'py> FromPyObject<'py> for OperationFromPython {
         let ob_type = ob
             .getattr(intern!(py, "base_class"))
             .ok()
-            .map(|base| base.downcast_into::<PyType>())
+            .map(|base| base.cast_into::<PyType>())
             .transpose()?
             .unwrap_or_else(|| ob.get_type());
 
@@ -674,9 +674,9 @@ fn as_tuple<'py>(py: Python<'py>, seq: Option<Bound<'py, PyAny>>) -> PyResult<Bo
         return Ok(PyTuple::empty(py));
     };
     if seq.is_instance_of::<PyTuple>() {
-        Ok(seq.downcast_into_exact::<PyTuple>()?)
+        Ok(seq.cast_into_exact::<PyTuple>()?)
     } else if seq.is_instance_of::<PyList>() {
-        Ok(seq.downcast_exact::<PyList>()?.to_tuple())
+        Ok(seq.cast_exact::<PyList>()?.to_tuple())
     } else {
         // New tuple from iterable.
         PyTuple::new(

--- a/crates/circuit/src/classical/expr/binary.rs
+++ b/crates/circuit/src/classical/expr/binary.rs
@@ -76,8 +76,10 @@ impl<'py> IntoPyObject<'py> for Binary {
     }
 }
 
-impl<'py> FromPyObject<'py> for Binary {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Binary {
+    type Error = <PyBinary as FromPyObject<'a, 'py>>::Error;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         let PyBinary(b) = ob.extract()?;
         Ok(b)
     }
@@ -93,8 +95,10 @@ impl<'py> IntoPyObject<'py> for BinaryOp {
     }
 }
 
-impl<'py> FromPyObject<'py> for BinaryOp {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for BinaryOp {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         let value = ob.getattr(intern!(ob.py(), "value"))?;
         Ok(bytemuck::checked::cast(value.extract::<u8>()?))
     }

--- a/crates/circuit/src/classical/expr/cast.rs
+++ b/crates/circuit/src/classical/expr/cast.rs
@@ -36,8 +36,10 @@ impl<'py> IntoPyObject<'py> for Cast {
     }
 }
 
-impl<'py> FromPyObject<'py> for Cast {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Cast {
+    type Error = <PyCast as FromPyObject<'a, 'py>>::Error;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         let PyCast(c) = ob.extract()?;
         Ok(c)
     }

--- a/crates/circuit/src/classical/expr/expr.rs
+++ b/crates/circuit/src/classical/expr/expr.rs
@@ -455,7 +455,7 @@ impl<'py> IntoPyObject<'py> for Expr {
 
 impl<'py> FromPyObject<'py> for Expr {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        let expr: PyRef<'_, PyExpr> = ob.downcast()?.borrow();
+        let expr: PyRef<'_, PyExpr> = ob.cast()?.borrow();
         match expr.0 {
             ExprKind::Unary => Ok(Expr::Unary(Box::new(ob.extract()?))),
             ExprKind::Binary => Ok(Expr::Binary(Box::new(ob.extract()?))),

--- a/crates/circuit/src/classical/expr/expr.rs
+++ b/crates/circuit/src/classical/expr/expr.rs
@@ -453,8 +453,10 @@ impl<'py> IntoPyObject<'py> for Expr {
     }
 }
 
-impl<'py> FromPyObject<'py> for Expr {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Expr {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         let expr: PyRef<'_, PyExpr> = ob.cast()?.borrow();
         match expr.0 {
             ExprKind::Unary => Ok(Expr::Unary(Box::new(ob.extract()?))),

--- a/crates/circuit/src/classical/expr/index.rs
+++ b/crates/circuit/src/classical/expr/index.rs
@@ -35,8 +35,10 @@ impl<'py> IntoPyObject<'py> for Index {
     }
 }
 
-impl<'py> FromPyObject<'py> for Index {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Index {
+    type Error = <PyIndex as FromPyObject<'a, 'py>>::Error;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         let PyIndex(i) = ob.extract()?;
         Ok(i)
     }

--- a/crates/circuit/src/classical/expr/stretch.rs
+++ b/crates/circuit/src/classical/expr/stretch.rs
@@ -35,8 +35,10 @@ impl<'py> IntoPyObject<'py> for Stretch {
     }
 }
 
-impl<'py> FromPyObject<'py> for Stretch {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Stretch {
+    type Error = <PyStretch as FromPyObject<'a, 'py>>::Error;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         let PyStretch(s) = ob.extract()?;
         Ok(s)
     }

--- a/crates/circuit/src/classical/expr/unary.rs
+++ b/crates/circuit/src/classical/expr/unary.rs
@@ -60,8 +60,10 @@ impl<'py> IntoPyObject<'py> for Unary {
     }
 }
 
-impl<'py> FromPyObject<'py> for Unary {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Unary {
+    type Error = <PyUnary as FromPyObject<'a, 'py>>::Error;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         let PyUnary(u) = ob.extract()?;
         Ok(u)
     }
@@ -77,8 +79,10 @@ impl<'py> IntoPyObject<'py> for UnaryOp {
     }
 }
 
-impl<'py> FromPyObject<'py> for UnaryOp {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for UnaryOp {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         let value = ob.getattr(intern!(ob.py(), "value"))?;
         Ok(bytemuck::checked::cast(value.extract::<u8>()?))
     }

--- a/crates/circuit/src/classical/expr/value.rs
+++ b/crates/circuit/src/classical/expr/value.rs
@@ -35,8 +35,10 @@ impl<'py> IntoPyObject<'py> for Value {
     }
 }
 
-impl<'py> FromPyObject<'py> for Value {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Value {
+    type Error = <PyValue as FromPyObject<'a, 'py>>::Error;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         let PyValue(v) = ob.extract()?;
         Ok(v)
     }

--- a/crates/circuit/src/classical/expr/var.rs
+++ b/crates/circuit/src/classical/expr/var.rs
@@ -59,8 +59,10 @@ impl<'py> IntoPyObject<'py> for Var {
     }
 }
 
-impl<'py> FromPyObject<'py> for Var {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Var {
+    type Error = <PyVar as FromPyObject<'a, 'py>>::Error;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         let PyVar(v) = ob.extract()?;
         Ok(v)
     }

--- a/crates/circuit/src/classical/types.rs
+++ b/crates/circuit/src/classical/types.rs
@@ -48,8 +48,10 @@ impl<'py> IntoPyObject<'py> for Type {
     }
 }
 
-impl<'py> FromPyObject<'py> for Type {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Type {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         let PyType(kind) = ob.extract()?;
         Ok(match kind {
             TypeKind::Bool => Type::Bool,

--- a/crates/circuit/src/converters.rs
+++ b/crates/circuit/src/converters.rs
@@ -32,8 +32,10 @@ pub struct QuantumCircuitData<'py> {
     pub metadata: Option<Bound<'py, PyAny>>,
 }
 
-impl<'py> FromPyObject<'py> for QuantumCircuitData<'py> {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for QuantumCircuitData<'py> {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let circuit_data = ob.getattr("_data")?;
         let data_borrowed = circuit_data.extract::<CircuitData>()?;

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -1612,7 +1612,7 @@ impl DAGCircuit {
                         if q.is_instance_of::<PyInt>() {
                             Ok(self.qubits.get(Qubit::new(q.extract()?)).unwrap().clone())
                         } else {
-                            q.extract::<ShareableQubit>()
+                            q.extract::<ShareableQubit>().map_err(Into::into)
                         }
                     })
                     .collect::<PyResult<Vec<ShareableQubit>>>()
@@ -1627,7 +1627,7 @@ impl DAGCircuit {
                         if c.is_instance_of::<PyInt>() {
                             Ok(self.clbits.get(Clbit::new(c.extract()?)).unwrap().clone())
                         } else {
-                            c.extract::<ShareableClbit>()
+                            c.extract::<ShareableClbit>().map_err(Into::into)
                         }
                     })
                     .collect::<PyResult<Vec<ShareableClbit>>>()

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -255,8 +255,8 @@ fn condition_resources(condition: &Bound<PyAny>) -> PyResult<PyLegacyResources> 
         .get_bound(condition.py())
         .call1((condition,))?;
     Ok(PyLegacyResources {
-        clbits: res.getattr("clbits")?.downcast_into_exact()?.unbind(),
-        cregs: res.getattr("cregs")?.downcast_into_exact()?.unbind(),
+        clbits: res.getattr("clbits")?.cast_into_exact()?.unbind(),
+        cregs: res.getattr("cregs")?.cast_into_exact()?.unbind(),
     })
 }
 
@@ -265,8 +265,8 @@ fn node_resources(node: &Bound<PyAny>) -> PyResult<PyLegacyResources> {
         .get_bound(node.py())
         .call1((node,))?;
     Ok(PyLegacyResources {
-        clbits: res.getattr("clbits")?.downcast_into_exact()?.unbind(),
-        cregs: res.getattr("cregs")?.downcast_into_exact()?.unbind(),
+        clbits: res.getattr("clbits")?.cast_into_exact()?.unbind(),
+        cregs: res.getattr("cregs")?.cast_into_exact()?.unbind(),
     })
 }
 
@@ -296,11 +296,11 @@ impl PyBitLocations {
 
     fn __eq__(slf: Bound<Self>, other: Bound<PyAny>) -> PyResult<bool> {
         let borrowed = slf.borrow();
-        if let Ok(other) = other.downcast::<Self>() {
+        if let Ok(other) = other.cast::<Self>() {
             let other_borrowed = other.borrow();
             Ok(borrowed.index == other_borrowed.index
                 && slf.getattr("registers")?.eq(other.getattr("registers")?)?)
-        } else if let Ok(other) = other.downcast::<PyTuple>() {
+        } else if let Ok(other) = other.cast::<PyTuple>() {
             Ok(slf.getattr("index")?.eq(other.get_item(0)?)?
                 && slf.getattr("registers")?.eq(other.get_item(1)?)?)
         } else {
@@ -389,7 +389,7 @@ impl DAGVarInfo {
     }
 
     fn from_pickle(ob: &Bound<PyAny>) -> PyResult<Self> {
-        let val_tuple = ob.downcast::<PyTuple>()?;
+        let val_tuple = ob.cast::<PyTuple>()?;
         Ok(DAGVarInfo {
             var: Var(val_tuple.get_item(0)?.extract()?),
             type_: match val_tuple.get_item(1)?.extract::<u8>()? {
@@ -441,7 +441,7 @@ impl DAGStretchInfo {
     }
 
     fn from_pickle(ob: &Bound<PyAny>) -> PyResult<Self> {
-        let val_tuple = ob.downcast::<PyTuple>()?;
+        let val_tuple = ob.cast::<PyTuple>()?;
         Ok(DAGStretchInfo {
             stretch: Stretch(val_tuple.get_item(0)?.extract()?),
             type_: match val_tuple.get_item(1)?.extract::<u8>()? {
@@ -478,7 +478,7 @@ impl DAGIdentifierInfo {
     }
 
     fn from_pickle(ob: &Bound<PyAny>) -> PyResult<Self> {
-        let val_tuple = ob.downcast::<PyTuple>()?;
+        let val_tuple = ob.cast::<PyTuple>()?;
         match val_tuple.get_item(0)?.extract::<u8>()? {
             0 => Ok(DAGIdentifierInfo::Stretch(DAGStretchInfo::from_pickle(
                 &val_tuple.get_item(1)?,
@@ -796,7 +796,7 @@ impl DAGCircuit {
     }
 
     fn __setstate__(&mut self, py: Python, state: Py<PyAny>) -> PyResult<()> {
-        let dict_state = state.downcast_bound::<PyDict>(py)?;
+        let dict_state = state.cast_bound::<PyDict>(py)?;
         self.name = dict_state.get_item("name")?.unwrap().extract()?;
         self.metadata = dict_state.get_item("metadata")?.unwrap().extract()?;
         self.qregs =
@@ -814,7 +814,7 @@ impl DAGCircuit {
         self.global_phase = dict_state.get_item("global_phase")?.unwrap().extract()?;
         self.op_names = dict_state.get_item("op_name")?.unwrap().extract()?;
         let binding = dict_state.get_item("identifier_info")?.unwrap();
-        let identifier_info_raw = binding.downcast::<PyDict>().unwrap();
+        let identifier_info_raw = binding.cast::<PyDict>().unwrap();
         self.identifier_info =
             IndexMap::with_capacity_and_hasher(identifier_info_raw.len(), RandomState::default());
         for (key, value) in identifier_info_raw.iter() {
@@ -854,17 +854,17 @@ impl DAGCircuit {
             self.clbits.add(bit, false)?;
         }
         let binding = dict_state.get_item("vars")?.unwrap();
-        let vars_raw = binding.downcast::<PyList>()?;
+        let vars_raw = binding.cast::<PyList>()?;
         for v in vars_raw.iter() {
             self.vars.add(v.extract()?, false)?;
         }
         let binding = dict_state.get_item("stretches")?.unwrap();
-        let stretches_raw = binding.downcast::<PyList>()?;
+        let stretches_raw = binding.cast::<PyList>()?;
         for s in stretches_raw.iter() {
             self.stretches.add(s.extract()?, false)?;
         }
         let binding = dict_state.get_item("qubit_io_map")?.unwrap();
-        let qubit_index_map_raw = binding.downcast::<PyDict>().unwrap();
+        let qubit_index_map_raw = binding.cast::<PyDict>().unwrap();
         self.qubit_io_map = Vec::with_capacity(qubit_index_map_raw.len());
         for (_k, v) in qubit_index_map_raw.iter() {
             let indices: [usize; 2] = v.extract()?;
@@ -872,7 +872,7 @@ impl DAGCircuit {
                 .push([NodeIndex::new(indices[0]), NodeIndex::new(indices[1])]);
         }
         let binding = dict_state.get_item("clbit_io_map")?.unwrap();
-        let clbit_index_map_raw = binding.downcast::<PyDict>().unwrap();
+        let clbit_index_map_raw = binding.cast::<PyDict>().unwrap();
         self.clbit_io_map = Vec::with_capacity(clbit_index_map_raw.len());
         for (_k, v) in clbit_index_map_raw.iter() {
             let indices: [usize; 2] = v.extract()?;
@@ -880,7 +880,7 @@ impl DAGCircuit {
                 .push([NodeIndex::new(indices[0]), NodeIndex::new(indices[1])]);
         }
         let binding = dict_state.get_item("var_io_map")?.unwrap();
-        let var_index_map_raw = binding.downcast::<PyDict>().unwrap();
+        let var_index_map_raw = binding.cast::<PyDict>().unwrap();
         self.var_io_map = Vec::with_capacity(var_index_map_raw.len());
         for (_k, v) in var_index_map_raw.iter() {
             let indices: [usize; 2] = v.extract()?;
@@ -889,21 +889,21 @@ impl DAGCircuit {
         }
         // Rebuild Graph preserving index holes:
         let binding = dict_state.get_item("nodes")?.unwrap();
-        let nodes_lst = binding.downcast::<PyList>()?;
+        let nodes_lst = binding.cast::<PyList>()?;
         let binding = dict_state.get_item("edges")?.unwrap();
-        let edges_lst = binding.downcast::<PyList>()?;
+        let edges_lst = binding.cast::<PyList>()?;
         let node_removed: bool = dict_state.get_item("nodes_removed")?.unwrap().extract()?;
         self.dag = StableDiGraph::default();
         if !node_removed {
             for item in nodes_lst.iter() {
-                let node_w = item.downcast::<PyTuple>().unwrap().get_item(1).unwrap();
+                let node_w = item.cast::<PyTuple>().unwrap().get_item(1).unwrap();
                 let weight = self.pack_into(py, &node_w)?;
                 self.dag.add_node(weight);
             }
         } else if nodes_lst.len() == 1 {
             // graph has only one node, handle logic here to save one if in the loop later
             let binding = nodes_lst.get_item(0).unwrap();
-            let item = binding.downcast::<PyTuple>().unwrap();
+            let item = binding.cast::<PyTuple>().unwrap();
             let node_idx: usize = item.get_item(0).unwrap().extract().unwrap();
             let node_w = item.get_item(1).unwrap();
 
@@ -917,7 +917,7 @@ impl DAGCircuit {
             }
         } else {
             let binding = nodes_lst.get_item(nodes_lst.len() - 1).unwrap();
-            let last_item = binding.downcast::<PyTuple>().unwrap();
+            let last_item = binding.cast::<PyTuple>().unwrap();
 
             // list of temporary nodes that will be removed later to re-create holes
             let node_bound_1: usize = last_item.get_item(0).unwrap().extract().unwrap();
@@ -925,7 +925,7 @@ impl DAGCircuit {
                 Vec::with_capacity(node_bound_1 + 1 - nodes_lst.len());
 
             for item in nodes_lst {
-                let item = item.downcast::<PyTuple>().unwrap();
+                let item = item.cast::<PyTuple>().unwrap();
                 let next_index: usize = item.get_item(0).unwrap().extract().unwrap();
                 let weight: Py<PyAny> = item.get_item(1).unwrap().extract().unwrap();
                 while next_index > self.dag.node_bound() {
@@ -952,7 +952,7 @@ impl DAGCircuit {
                 self.dag
                     .add_edge(tmp_node, tmp_node, Wire::Qubit(Qubit(u32::MAX)));
             } else {
-                let triple = item.downcast::<PyTuple>().unwrap();
+                let triple = item.cast::<PyTuple>().unwrap();
                 let edge_p: usize = triple.get_item(0).unwrap().extract().unwrap();
                 let edge_c: usize = triple.get_item(1).unwrap().extract().unwrap();
                 let edge_w = Wire::from_pickle(&triple.get_item(2).unwrap())?;
@@ -2581,12 +2581,12 @@ impl DAGCircuit {
         let mut qubit_pos_map: HashMap<Qubit, usize> = HashMap::new();
         let mut clbit_pos_map: HashMap<Clbit, usize> = HashMap::new();
         for (bit, index) in wire_pos_map.iter() {
-            if bit.downcast::<PyQubit>().is_ok() {
+            if bit.cast::<PyQubit>().is_ok() {
                 qubit_pos_map.insert(
                     self.qubits.find(&bit.extract::<ShareableQubit>()?).unwrap(),
                     index.extract()?,
                 );
-            } else if bit.downcast::<PyClbit>().is_ok() {
+            } else if bit.cast::<PyClbit>().is_ok() {
                 clbit_pos_map.insert(
                     self.clbits.find(&bit.extract::<ShareableClbit>()?).unwrap(),
                     index.extract()?,
@@ -2655,7 +2655,7 @@ impl DAGCircuit {
                 2,
             ))?;
         }
-        let node_index = match node.downcast::<DAGOpNode>() {
+        let node_index = match node.cast::<DAGOpNode>() {
             Ok(bound_node) => bound_node.borrow().as_ref().node.unwrap(),
             Err(_) => return Err(DAGCircuitError::new_err("expected node DAGOpNode")),
         };
@@ -2706,7 +2706,7 @@ impl DAGCircuit {
             let mut clbit_wire_map = HashMap::new();
             let var_map = HashMap::new();
             for (index, wire) in wires.iter().enumerate() {
-                if wire.downcast::<PyQubit>().is_ok() {
+                if wire.cast::<PyQubit>().is_ok() {
                     if index >= qargs_len {
                         unreachable!()
                     }
@@ -2716,7 +2716,7 @@ impl DAGCircuit {
                         .unwrap();
                     let self_qubit: Qubit = self.qubits.find(qargs_list[index]).unwrap();
                     qubit_wire_map.insert(input_qubit, self_qubit);
-                } else if wire.downcast::<PyClbit>().is_ok() {
+                } else if wire.cast::<PyClbit>().is_ok() {
                     if index < qargs_len {
                         unreachable!()
                     }
@@ -2741,13 +2741,13 @@ impl DAGCircuit {
             HashMap<Clbit, Clbit>,
             HashMap<expr::Var, expr::Var>,
         ) = match wires {
-            Some(wires) => match wires.downcast::<PyDict>() {
+            Some(wires) => match wires.cast::<PyDict>() {
                 Ok(bound_wires) => {
                     let mut qubit_wire_map = HashMap::new();
                     let mut clbit_wire_map = HashMap::new();
                     let mut var_map = HashMap::new();
                     for (source_wire, target_wire) in bound_wires.iter() {
-                        if source_wire.downcast::<PyQubit>().is_ok() {
+                        if source_wire.cast::<PyQubit>().is_ok() {
                             qubit_wire_map.insert(
                                 input_dag
                                     .qubits
@@ -2757,7 +2757,7 @@ impl DAGCircuit {
                                     .find(&target_wire.extract::<ShareableQubit>()?)
                                     .unwrap(),
                             );
-                        } else if source_wire.downcast::<PyClbit>().is_ok() {
+                        } else if source_wire.cast::<PyClbit>().is_ok() {
                             clbit_wire_map.insert(
                                 input_dag
                                     .clbits
@@ -2774,7 +2774,7 @@ impl DAGCircuit {
                     (qubit_wire_map, clbit_wire_map, var_map)
                 }
                 Err(_) => {
-                    let wires: Bound<PyList> = match wires.downcast::<PyList>() {
+                    let wires: Bound<PyList> = match wires.cast::<PyList>() {
                         Ok(bound_list) => bound_list.clone(),
                         // If someone passes a sequence instead of an exact list (tuple is
                         // occasionally used) cast that to a list and then use it.
@@ -2915,7 +2915,7 @@ impl DAGCircuit {
                 2,
             ))?;
         }
-        let mut node: PyRefMut<DAGOpNode> = match node.downcast() {
+        let mut node: PyRefMut<DAGOpNode> = match node.cast() {
             Ok(node) => node.borrow_mut(),
             Err(_) => return Err(DAGCircuitError::new_err("Only DAGOpNodes can be replaced.")),
         };
@@ -3062,7 +3062,7 @@ impl DAGCircuit {
                     .idle_wires(py, None)?
                     .into_bound(py)
                     .map(|q| q.unwrap())
-                    .filter(|e| e.downcast::<PyQubit>().is_ok())
+                    .filter(|e| e.cast::<PyQubit>().is_ok())
                     .collect();
 
                 let qubits = PyTuple::new(py, idle_wires)?;
@@ -3208,7 +3208,7 @@ impl DAGCircuit {
     #[pyo3(signature=(nodes=None))]
     fn edges(&self, py: Python, nodes: Option<Bound<PyAny>>) -> PyResult<Py<PyIterator>> {
         let get_node_index = |obj: &Bound<PyAny>| -> PyResult<NodeIndex> {
-            Ok(obj.downcast::<DAGNode>()?.borrow().node.unwrap())
+            Ok(obj.cast::<DAGNode>()?.borrow().node.unwrap())
         };
 
         let actual_nodes: Vec<_> = match nodes {
@@ -3599,7 +3599,7 @@ impl DAGCircuit {
     /// Add edges from predecessors to successors.
     #[pyo3(name = "remove_op_node")]
     fn py_remove_op_node(&mut self, node: &Bound<PyAny>) -> PyResult<()> {
-        let node: PyRef<DAGOpNode> = match node.downcast::<DAGOpNode>() {
+        let node: PyRef<DAGOpNode> = match node.cast::<DAGOpNode>() {
             Ok(node) => node.borrow(),
             Err(_) => return Err(DAGCircuitError::new_err("Node not an DAGOpNode")),
         };
@@ -3910,10 +3910,10 @@ impl DAGCircuit {
         wire: &Bound<PyAny>,
         only_ops: bool,
     ) -> PyResult<Py<PyIterator>> {
-        let wire = if wire.downcast::<PyQubit>().is_ok() {
+        let wire = if wire.cast::<PyQubit>().is_ok() {
             let wire = wire.extract::<ShareableQubit>()?;
             self.qubits.find(&wire).map(Wire::Qubit)
-        } else if wire.downcast::<PyClbit>().is_ok() {
+        } else if wire.cast::<PyClbit>().is_ok() {
             let wire = wire.extract::<ShareableClbit>()?;
             self.clbits.find(&wire).map(Wire::Clbit)
         } else {
@@ -5758,7 +5758,7 @@ impl DAGCircuit {
                 }
                 if op.is_instance(imports::SWITCH_CASE_OP.get_bound(py))? {
                     let target = op.getattr(intern!(py, "target"))?;
-                    if target.downcast::<PyClbit>().is_ok() {
+                    if target.cast::<PyClbit>().is_ok() {
                         let target_clbit: ShareableClbit = target.extract()?;
                         clbits.push(self.clbits.find(&target_clbit).unwrap());
                     } else if target.is_instance_of::<PyClassicalRegister>() {
@@ -5968,7 +5968,7 @@ impl DAGCircuit {
     }
 
     fn pack_into(&mut self, py: Python, b: &Bound<PyAny>) -> Result<NodeType, PyErr> {
-        Ok(if let Ok(in_node) = b.downcast::<DAGInNode>() {
+        Ok(if let Ok(in_node) = b.cast::<DAGInNode>() {
             let in_node = in_node.borrow();
             let wire = in_node.wire.bind(py);
             if let Ok(qubit) = wire.extract::<ShareableQubit>() {
@@ -5979,7 +5979,7 @@ impl DAGCircuit {
                 let var = wire.extract::<expr::Var>()?;
                 NodeType::VarIn(self.vars.find(&var).unwrap())
             }
-        } else if let Ok(out_node) = b.downcast::<DAGOutNode>() {
+        } else if let Ok(out_node) = b.cast::<DAGOutNode>() {
             let out_node = out_node.borrow();
             let wire = out_node.wire.bind(py);
             if let Ok(qubit) = wire.extract::<ShareableQubit>() {
@@ -5990,7 +5990,7 @@ impl DAGCircuit {
                 let var = wire.extract::<expr::Var>()?;
                 NodeType::VarOut(self.vars.find(&var).unwrap())
             }
-        } else if let Ok(op_node) = b.downcast::<DAGOpNode>() {
+        } else if let Ok(op_node) = b.cast::<DAGOpNode>() {
             let op_node = op_node.borrow();
             let qubits = self.qargs_interner.insert_owned(
                 self.qubits
@@ -7258,7 +7258,7 @@ impl DAGCircuit {
                             Python::attach(|py| -> PyResult<()> {
                                 let op_bound = op.instruction.bind(py);
                                 let target = op_bound.getattr(intern!(py, "target"))?;
-                                if target.downcast::<PyClbit>().is_ok() {
+                                if target.cast::<PyClbit>().is_ok() {
                                     let target_clbit: ShareableClbit = target.extract()?;
                                     block_cargs.insert(self.clbits.find(&target_clbit).unwrap());
                                 } else if target.is_instance_of::<PyClassicalRegister>() {

--- a/crates/circuit/src/dag_node.rs
+++ b/crates/circuit/src/dag_node.rs
@@ -158,7 +158,7 @@ impl DAGOpNode {
         // like parameter equality are stricter to reject things like
         // Param::Float(0.1) == Param::ParameterExpression(0.1) (if the expression was
         // a python parameter equivalent to a bound value).
-        let Ok(other) = other.downcast::<Self>() else {
+        let Ok(other) = other.cast::<Self>() else {
             return Ok(false);
         };
         let borrowed_other = other.borrow();
@@ -474,7 +474,7 @@ impl DAGInNode {
     }
 
     fn __eq__(slf: PyRef<Self>, py: Python, other: &Bound<PyAny>) -> PyResult<bool> {
-        match other.downcast::<Self>() {
+        match other.cast::<Self>() {
             Ok(other) => {
                 let borrowed_other = other.borrow();
                 let other_super = borrowed_other.as_ref();
@@ -537,7 +537,7 @@ impl DAGOutNode {
     }
 
     fn __eq__(slf: PyRef<Self>, py: Python, other: &Bound<PyAny>) -> PyResult<bool> {
-        match other.downcast::<Self>() {
+        match other.cast::<Self>() {
             Ok(other) => {
                 let borrowed_other = other.borrow();
                 let other_super = borrowed_other.as_ref();

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -108,8 +108,10 @@ pub struct TupleLikeArg<'py> {
     value: Bound<'py, PyTuple>,
 }
 
-impl<'py> FromPyObject<'py> for TupleLikeArg<'py> {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for TupleLikeArg<'py> {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         let value = match ob.cast::<PySequence>() {
             Ok(seq) => seq.to_tuple()?,
             Err(_) => PyTuple::new(
@@ -170,8 +172,10 @@ pub enum VarsMode {
     Drop,
 }
 
-impl<'py> FromPyObject<'py> for VarsMode {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for VarsMode {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         match &*ob.cast::<PyString>()?.to_string_lossy() {
             "alike" => Ok(VarsMode::Alike),
             "captures" => Ok(VarsMode::Captures),

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -110,7 +110,7 @@ pub struct TupleLikeArg<'py> {
 
 impl<'py> FromPyObject<'py> for TupleLikeArg<'py> {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        let value = match ob.downcast::<PySequence>() {
+        let value = match ob.cast::<PySequence>() {
             Ok(seq) => seq.to_tuple()?,
             Err(_) => PyTuple::new(
                 ob.py(),
@@ -172,7 +172,7 @@ pub enum VarsMode {
 
 impl<'py> FromPyObject<'py> for VarsMode {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        match &*ob.downcast::<PyString>()?.to_string_lossy() {
+        match &*ob.cast::<PyString>()?.to_string_lossy() {
             "alike" => Ok(VarsMode::Alike),
             "captures" => Ok(VarsMode::Captures),
             "drop" => Ok(VarsMode::Drop),

--- a/crates/circuit/src/nlayout.rs
+++ b/crates/circuit/src/nlayout.rs
@@ -72,9 +72,11 @@ macro_rules! qubit_newtype {
             }
         }
 
-        impl pyo3::FromPyObject<'_> for $id {
-            fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
-                Ok(Self(ob.extract()?))
+        impl<'a, 'py> ::pyo3::FromPyObject<'a, 'py> for $id {
+            type Error = <u32 as FromPyObject<'a, 'py>>::Error;
+
+            fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+                ob.extract().map(Self)
             }
         }
 

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -130,7 +130,7 @@ impl Param {
                         .try_iter()?
                         .map(|elem| {
                             let elem = elem?;
-                            let py_param_bound = elem.downcast::<PyParameter>()?;
+                            let py_param_bound = elem.cast::<PyParameter>()?;
                             let py_param = py_param_bound.borrow();
                             let symbol = py_param.symbol();
                             Ok(symbol.clone())
@@ -2512,7 +2512,7 @@ impl Operation for PyInstruction {
             // We expect that if PyInstruction::control_flow is true then the operation WILL
             // have a 'blocks' attribute which is a tuple of the Python QuantumCircuit.
             let raw_blocks = self.instruction.getattr(py, "blocks").unwrap();
-            let blocks: &Bound<PyTuple> = raw_blocks.downcast_bound::<PyTuple>(py).unwrap();
+            let blocks: &Bound<PyTuple> = raw_blocks.cast_bound::<PyTuple>(py).unwrap();
             blocks
                 .iter()
                 .map(|b| {

--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -464,22 +464,18 @@ impl PackedOperation {
             }
             OperationRef::StandardInstruction(standard) => {
                 return match standard {
-                    StandardInstruction::Barrier(_) => BARRIER
-                        .get_bound(py)
-                        .cast::<PyType>()?
-                        .is_subclass(py_type),
-                    StandardInstruction::Delay(_) => DELAY
-                        .get_bound(py)
-                        .cast::<PyType>()?
-                        .is_subclass(py_type),
-                    StandardInstruction::Measure => MEASURE
-                        .get_bound(py)
-                        .cast::<PyType>()?
-                        .is_subclass(py_type),
-                    StandardInstruction::Reset => RESET
-                        .get_bound(py)
-                        .cast::<PyType>()?
-                        .is_subclass(py_type),
+                    StandardInstruction::Barrier(_) => {
+                        BARRIER.get_bound(py).cast::<PyType>()?.is_subclass(py_type)
+                    }
+                    StandardInstruction::Delay(_) => {
+                        DELAY.get_bound(py).cast::<PyType>()?.is_subclass(py_type)
+                    }
+                    StandardInstruction::Measure => {
+                        MEASURE.get_bound(py).cast::<PyType>()?.is_subclass(py_type)
+                    }
+                    StandardInstruction::Reset => {
+                        RESET.get_bound(py).cast::<PyType>()?.is_subclass(py_type)
+                    }
                 };
             }
             OperationRef::Gate(gate) => gate.gate.bind(py),

--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -459,26 +459,26 @@ impl PackedOperation {
             OperationRef::StandardGate(standard) => {
                 return get_std_gate_class(py, standard)?
                     .bind(py)
-                    .downcast::<PyType>()?
+                    .cast::<PyType>()?
                     .is_subclass(py_type);
             }
             OperationRef::StandardInstruction(standard) => {
                 return match standard {
                     StandardInstruction::Barrier(_) => BARRIER
                         .get_bound(py)
-                        .downcast::<PyType>()?
+                        .cast::<PyType>()?
                         .is_subclass(py_type),
                     StandardInstruction::Delay(_) => DELAY
                         .get_bound(py)
-                        .downcast::<PyType>()?
+                        .cast::<PyType>()?
                         .is_subclass(py_type),
                     StandardInstruction::Measure => MEASURE
                         .get_bound(py)
-                        .downcast::<PyType>()?
+                        .cast::<PyType>()?
                         .is_subclass(py_type),
                     StandardInstruction::Reset => RESET
                         .get_bound(py)
-                        .downcast::<PyType>()?
+                        .cast::<PyType>()?
                         .is_subclass(py_type),
                 };
             }
@@ -488,7 +488,7 @@ impl PackedOperation {
             OperationRef::Unitary(_) => {
                 return UNITARY_GATE
                     .get_bound(py)
-                    .downcast::<PyType>()?
+                    .cast::<PyType>()?
                     .is_subclass(py_type);
             }
         };

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -728,27 +728,27 @@ impl PyParameterExpression {
     /// * `Ok(Self)` - The extracted expression.
     /// * `Err(PyResult)` - An error if extraction to all above types failed.
     pub fn extract_coerce(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
-        if let Ok(i) = ob.downcast::<PyInt>() {
+        if let Ok(i) = ob.cast::<PyInt>() {
             Ok(ParameterExpression::new(
                 SymbolExpr::Value(Value::from(i.extract::<i64>()?)),
                 HashMap::new(),
             )
             .into())
-        } else if let Ok(r) = ob.downcast::<PyFloat>() {
+        } else if let Ok(r) = ob.cast::<PyFloat>() {
             let r: f64 = r.extract()?;
             if r.is_infinite() || r.is_nan() {
                 return Err(ParameterError::InvalidValue.into());
             }
             Ok(ParameterExpression::new(SymbolExpr::Value(Value::from(r)), HashMap::new()).into())
-        } else if let Ok(c) = ob.downcast::<PyComplex>() {
+        } else if let Ok(c) = ob.cast::<PyComplex>() {
             let c: Complex64 = c.extract()?;
             if c.is_infinite() || c.is_nan() {
                 return Err(ParameterError::InvalidValue.into());
             }
             Ok(ParameterExpression::new(SymbolExpr::Value(Value::from(c)), HashMap::new()).into())
-        } else if let Ok(element) = ob.downcast::<PyParameterVectorElement>() {
+        } else if let Ok(element) = ob.cast::<PyParameterVectorElement>() {
             Ok(ParameterExpression::from_symbol(element.borrow().symbol.clone()).into())
-        } else if let Ok(parameter) = ob.downcast::<PyParameter>() {
+        } else if let Ok(parameter) = ob.cast::<PyParameter>() {
             Ok(ParameterExpression::from_symbol(parameter.borrow().symbol.clone()).into())
         } else {
             ob.extract::<PyParameterExpression>()
@@ -1127,7 +1127,7 @@ impl PyParameterExpression {
     ///     A new expression parameterized by any parameters which were not bound by assignment.
     #[pyo3(name = "assign")]
     pub fn py_assign(&self, parameter: PyParameter, value: &Bound<PyAny>) -> PyResult<Self> {
-        if let Ok(expr) = value.downcast::<Self>() {
+        if let Ok(expr) = value.cast::<Self>() {
             let map = [(parameter, expr.borrow().clone())].into_iter().collect();
             self.py_subs(map, false)
         } else if value.extract::<Value>().is_ok() {
@@ -1631,7 +1631,7 @@ impl PyParameter {
         parameter: PyParameter,
         value: &Bound<'py, PyAny>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        if value.downcast::<PyParameterExpression>().is_ok() {
+        if value.cast::<PyParameterExpression>().is_ok() {
             let map = [(parameter, value.clone())].into_iter().collect();
             self.py_subs(py, map, false)
         } else if value.extract::<Value>().is_ok() {
@@ -1942,7 +1942,7 @@ impl OpCode {
     }
 
     fn __eq__(&self, other: &Bound<'_, PyAny>) -> bool {
-        if let Ok(code) = other.downcast::<OpCode>() {
+        if let Ok(code) = other.cast::<OpCode>() {
             *code.borrow() == *self
         } else {
             false

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -727,7 +727,7 @@ impl PyParameterExpression {
     ///
     /// * `Ok(Self)` - The extracted expression.
     /// * `Err(PyResult)` - An error if extraction to all above types failed.
-    pub fn extract_coerce(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
+    pub fn extract_coerce(ob: Borrowed<PyAny>) -> PyResult<Self> {
         if let Ok(i) = ob.cast::<PyInt>() {
             Ok(ParameterExpression::new(
                 SymbolExpr::Value(Value::from(i.extract::<i64>()?)),
@@ -751,7 +751,7 @@ impl PyParameterExpression {
         } else if let Ok(parameter) = ob.cast::<PyParameter>() {
             Ok(ParameterExpression::from_symbol(parameter.borrow().symbol.clone()).into())
         } else {
-            ob.extract::<PyParameterExpression>()
+            ob.extract::<PyParameterExpression>().map_err(Into::into)
         }
     }
 
@@ -816,7 +816,7 @@ impl PyParameterExpression {
     #[allow(non_snake_case)]
     #[staticmethod]
     pub fn _Value(value: &Bound<PyAny>) -> PyResult<Self> {
-        Self::extract_coerce(value)
+        Self::extract_coerce(value.as_borrowed())
     }
 
     /// Check if the expression corresponds to a plain symbol.
@@ -1153,7 +1153,7 @@ impl PyParameterExpression {
     }
 
     pub fn __eq__(&self, rhs: &Bound<PyAny>) -> PyResult<bool> {
-        if let Ok(rhs) = Self::extract_coerce(rhs) {
+        if let Ok(rhs) = Self::extract_coerce(rhs.as_borrowed()) {
             match rhs.inner.expr {
                 SymbolExpr::Value(v) => match self.inner.try_to_value(false) {
                     Ok(e) => Ok(e == v),
@@ -1183,7 +1183,7 @@ impl PyParameterExpression {
     }
 
     pub fn __add__(&self, rhs: &Bound<PyAny>) -> PyResult<Self> {
-        if let Ok(rhs) = Self::extract_coerce(rhs) {
+        if let Ok(rhs) = Self::extract_coerce(rhs.as_borrowed()) {
             Ok(self.inner.add(&rhs.inner)?.into())
         } else {
             Err(pyo3::exceptions::PyTypeError::new_err(
@@ -1193,7 +1193,7 @@ impl PyParameterExpression {
     }
 
     pub fn __radd__(&self, lhs: &Bound<PyAny>) -> PyResult<Self> {
-        if let Ok(lhs) = Self::extract_coerce(lhs) {
+        if let Ok(lhs) = Self::extract_coerce(lhs.as_borrowed()) {
             Ok(lhs.inner.add(&self.inner)?.into())
         } else {
             Err(pyo3::exceptions::PyTypeError::new_err(
@@ -1203,7 +1203,7 @@ impl PyParameterExpression {
     }
 
     pub fn __sub__(&self, rhs: &Bound<PyAny>) -> PyResult<Self> {
-        if let Ok(rhs) = Self::extract_coerce(rhs) {
+        if let Ok(rhs) = Self::extract_coerce(rhs.as_borrowed()) {
             Ok(self.inner.sub(&rhs.inner)?.into())
         } else {
             Err(pyo3::exceptions::PyTypeError::new_err(
@@ -1213,7 +1213,7 @@ impl PyParameterExpression {
     }
 
     pub fn __rsub__(&self, lhs: &Bound<PyAny>) -> PyResult<Self> {
-        if let Ok(lhs) = Self::extract_coerce(lhs) {
+        if let Ok(lhs) = Self::extract_coerce(lhs.as_borrowed()) {
             Ok(lhs.inner.sub(&self.inner)?.into())
         } else {
             Err(pyo3::exceptions::PyTypeError::new_err(
@@ -1224,7 +1224,7 @@ impl PyParameterExpression {
 
     pub fn __mul__<'py>(&self, rhs: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
         let py = rhs.py();
-        if let Ok(rhs) = Self::extract_coerce(rhs) {
+        if let Ok(rhs) = Self::extract_coerce(rhs.as_borrowed()) {
             match self.inner.mul(&rhs.inner) {
                 Ok(result) => PyParameterExpression::from(result).into_bound_py_any(py),
                 Err(e) => Err(PyErr::from(e)),
@@ -1235,7 +1235,7 @@ impl PyParameterExpression {
     }
 
     pub fn __rmul__(&self, lhs: &Bound<PyAny>) -> PyResult<Self> {
-        if let Ok(lhs) = Self::extract_coerce(lhs) {
+        if let Ok(lhs) = Self::extract_coerce(lhs.as_borrowed()) {
             Ok(lhs.inner.mul(&self.inner)?.into())
         } else {
             Err(pyo3::exceptions::PyTypeError::new_err(
@@ -1245,7 +1245,7 @@ impl PyParameterExpression {
     }
 
     pub fn __truediv__(&self, rhs: &Bound<PyAny>) -> PyResult<Self> {
-        if let Ok(rhs) = Self::extract_coerce(rhs) {
+        if let Ok(rhs) = Self::extract_coerce(rhs.as_borrowed()) {
             Ok(self.inner.div(&rhs.inner)?.into())
         } else {
             Err(pyo3::exceptions::PyTypeError::new_err(
@@ -1255,7 +1255,7 @@ impl PyParameterExpression {
     }
 
     pub fn __rtruediv__(&self, lhs: &Bound<PyAny>) -> PyResult<Self> {
-        if let Ok(lhs) = Self::extract_coerce(lhs) {
+        if let Ok(lhs) = Self::extract_coerce(lhs.as_borrowed()) {
             Ok(lhs.inner.div(&self.inner)?.into())
         } else {
             Err(pyo3::exceptions::PyTypeError::new_err(
@@ -1265,7 +1265,7 @@ impl PyParameterExpression {
     }
 
     pub fn __pow__(&self, rhs: &Bound<PyAny>, _modulo: Option<i32>) -> PyResult<Self> {
-        if let Ok(rhs) = Self::extract_coerce(rhs) {
+        if let Ok(rhs) = Self::extract_coerce(rhs.as_borrowed()) {
             Ok(self.inner.pow(&rhs.inner)?.into())
         } else {
             Err(pyo3::exceptions::PyTypeError::new_err(
@@ -1275,7 +1275,7 @@ impl PyParameterExpression {
     }
 
     pub fn __rpow__(&self, lhs: &Bound<PyAny>, _modulo: Option<i32>) -> PyResult<Self> {
-        if let Ok(lhs) = Self::extract_coerce(lhs) {
+        if let Ok(lhs) = Self::extract_coerce(lhs.as_borrowed()) {
             Ok(lhs.inner.pow(&self.inner)?.into())
         } else {
             Err(pyo3::exceptions::PyTypeError::new_err(
@@ -1600,7 +1600,7 @@ impl PyParameter {
             }
             Some(replacement) => {
                 if allow_unknown_parameters || parameter_values.len() == 1 {
-                    let expr = PyParameterExpression::extract_coerce(replacement)?;
+                    let expr = PyParameterExpression::extract_coerce(replacement.as_borrowed())?;
                     if let SymbolExpr::Value(_) = &expr.inner.expr {
                         expr.clone().into_bound_py_any(py)
                     } else {

--- a/crates/circuit/src/parameter/symbol_expr.rs
+++ b/crates/circuit/src/parameter/symbol_expr.rs
@@ -12,7 +12,6 @@
 
 use hashbrown::HashMap;
 use pyo3::IntoPyObjectExt;
-use pyo3::exceptions::PyTypeError;
 use pyo3::exceptions::PyValueError;
 use std::cmp::Ordering;
 use std::cmp::PartialOrd;
@@ -61,14 +60,16 @@ impl Hash for Symbol {
     }
 }
 
-impl<'py> FromPyObject<'py> for Symbol {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Symbol {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         if let Ok(py_vector_element) = ob.extract::<PyParameterVectorElement>() {
             Ok(py_vector_element.symbol().clone())
-        } else if let Ok(py_param) = ob.extract::<PyParameter>() {
-            Ok(py_param.symbol().clone())
         } else {
-            Err(PyTypeError::new_err("Cannot extract Symbol from {ob:?}"))
+            ob.extract::<PyParameter>()
+                .map(|ob| ob.symbol().clone())
+                .map_err(PyErr::from)
         }
     }
 }
@@ -156,18 +157,16 @@ pub enum Value {
     Complex(Complex64),
 }
 
-impl<'py> FromPyObject<'py> for Value {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Value {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         if let Ok(i) = ob.extract::<i64>() {
             Ok(Value::Int(i))
         } else if let Ok(r) = ob.extract::<f64>() {
             Ok(Value::Real(r))
-        } else if let Ok(c) = ob.extract::<Complex64>() {
-            Ok(Value::Complex(c))
         } else {
-            Err(PyValueError::new_err(
-                "Could not cast Bound<PyAny> to Value.",
-            ))
+            ob.extract::<Complex64>().map(Value::Complex)
         }
     }
 }

--- a/crates/circuit/src/parameter_table.rs
+++ b/crates/circuit/src/parameter_table.rs
@@ -62,10 +62,10 @@ impl ParameterUuid {
     /// Extract a UUID from a Python-space `Parameter` object. This assumes that the object is known
     /// to be a parameter.
     pub fn from_parameter(ob: &Bound<PyAny>) -> PyResult<Self> {
-        let uuid = if let Ok(param) = ob.downcast::<PyParameter>() {
+        let uuid = if let Ok(param) = ob.cast::<PyParameter>() {
             // this downcast should cover both PyParameterVectorElement and PyParameter
             param.borrow().symbol().uuid.as_u128()
-        } else if let Ok(expr) = ob.downcast::<PyParameterExpression>() {
+        } else if let Ok(expr) = ob.cast::<PyParameterExpression>() {
             let expr_borrowed = expr.borrow();
             // We know the ParameterExpression is in fact representing a single Symbol
             let symbol = &expr_borrowed.inner.try_to_symbol()?;

--- a/crates/circuit/src/slice.rs
+++ b/crates/circuit/src/slice.rs
@@ -34,7 +34,7 @@ impl<'py> FromPyObject<'py> for PySequenceIndex<'py> {
         // The `downcast_exact` check is just a pointer comparison, so while `slice` is the less
         // common input, doing that first has little-to-no impact on the speed of the `isize` path,
         // while the reverse makes `slice` inputs significantly slower.
-        if let Ok(slice) = ob.downcast_exact::<PySlice>() {
+        if let Ok(slice) = ob.cast_exact::<PySlice>() {
             return Ok(Self::Slice(slice.clone()));
         }
         Ok(Self::Int(ob.extract()?))

--- a/crates/circuit/src/slice.rs
+++ b/crates/circuit/src/slice.rs
@@ -28,16 +28,18 @@ pub enum PySequenceIndex<'py> {
     Slice(Bound<'py, PySlice>),
 }
 
-impl<'py> FromPyObject<'py> for PySequenceIndex<'py> {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for PySequenceIndex<'py> {
+    type Error = <isize as FromPyObject<'a, 'py>>::Error;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         // `slice` can't be subclassed in Python, so it's safe (and faster) to check for it exactly.
-        // The `downcast_exact` check is just a pointer comparison, so while `slice` is the less
+        // The `cast_exact` check is just a pointer comparison, so while `slice` is the less
         // common input, doing that first has little-to-no impact on the speed of the `isize` path,
         // while the reverse makes `slice` inputs significantly slower.
         if let Ok(slice) = ob.cast_exact::<PySlice>() {
-            return Ok(Self::Slice(slice.clone()));
+            return Ok(Self::Slice(slice.to_owned()));
         }
-        Ok(Self::Int(ob.extract()?))
+        ob.extract().map(Self::Int)
     }
 }
 

--- a/crates/circuit/src/variable_mapper.rs
+++ b/crates/circuit/src/variable_mapper.rs
@@ -14,7 +14,6 @@ use crate::bit::{ClassicalRegister, Register, ShareableClbit};
 use crate::classical::expr;
 use hashbrown::{HashMap, HashSet};
 use pyo3::prelude::*;
-use pyo3::{Bound, FromPyObject, PyAny, PyResult};
 use std::cell::RefCell;
 
 /// A control flow operation's condition.
@@ -27,8 +26,10 @@ pub(crate) enum Condition {
     Expr(expr::Expr),
 }
 
-impl<'py> FromPyObject<'py> for Condition {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Condition {
+    type Error = <expr::Expr as FromPyObject<'a, 'py>>::Error;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         if let Ok((bit, value)) = ob.extract::<(ShareableClbit, usize)>() {
             Ok(Condition::Bit(bit, value))
         } else if let Ok((register, value)) = ob.extract::<(ClassicalRegister, usize)>() {
@@ -49,8 +50,10 @@ pub(crate) enum SwitchTarget {
     Expr(expr::Expr),
 }
 
-impl<'py> FromPyObject<'py> for SwitchTarget {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for SwitchTarget {
+    type Error = <expr::Expr as FromPyObject<'a, 'py>>::Error;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         if let Ok(bit) = ob.extract::<ShareableClbit>() {
             Ok(SwitchTarget::Bit(bit))
         } else if let Ok(register) = ob.extract::<ClassicalRegister>() {

--- a/crates/circuit_library/src/blocks.rs
+++ b/crates/circuit_library/src/blocks.rs
@@ -45,7 +45,7 @@ impl BlockOperation {
                 let py_params = PyList::new(py, params.iter().map(|&p| p.clone()))?.into_any();
 
                 let job = builder.call1(py, (py_params,))?;
-                let result = job.downcast_bound::<PyTuple>(py)?;
+                let result = job.cast_bound::<PyTuple>(py)?;
 
                 let operation: OperationFromPython = result.get_item(0)?.extract()?;
                 let bound_params = result
@@ -134,10 +134,10 @@ impl Entanglement {
             .map(|layer| -> PyResult<LayerEntanglement> {
                 if entanglement.is_callable() {
                     let as_any = entanglement.call1((layer,))?;
-                    let as_list = as_any.downcast::<PyList>()?;
+                    let as_list = as_any.cast::<PyList>()?;
                     unpack_entanglement(num_qubits, layer, as_list, entanglement_blocks)
                 } else {
-                    let as_list = entanglement.downcast::<PyList>()?;
+                    let as_list = entanglement.cast::<PyList>()?;
                     unpack_entanglement(num_qubits, layer, as_list, entanglement_blocks)
                 }
             })

--- a/crates/circuit_library/src/blocks.rs
+++ b/crates/circuit_library/src/blocks.rs
@@ -51,7 +51,7 @@ impl BlockOperation {
                 let bound_params = result
                     .get_item(1)?
                     .try_iter()?
-                    .map(|ob| Param::extract_no_coerce(&ob?))
+                    .map(|ob| Param::extract_no_coerce(ob?.as_borrowed()))
                     .collect::<PyResult<SmallVec<[Param; 3]>>>()?;
 
                 Ok((operation.operation, bound_params))

--- a/crates/circuit_library/src/entanglement.rs
+++ b/crates/circuit_library/src/entanglement.rs
@@ -166,19 +166,19 @@ pub fn get_entanglement<'a>(
         entanglement.to_owned()
     };
 
-    if let Ok(strategy) = entanglement.downcast::<PyString>() {
+    if let Ok(strategy) = entanglement.cast::<PyString>() {
         let as_str = strategy.to_string();
         return Ok(Box::new(
             get_entanglement_from_str(num_qubits, block_size, as_str.as_str(), offset)?.map(Ok),
         ));
-    } else if let Ok(dict) = entanglement.downcast::<PyDict>() {
+    } else if let Ok(dict) = entanglement.cast::<PyDict>() {
         if let Some(value) = dict.get_item(block_size)? {
-            let list = value.downcast::<PyList>()?;
+            let list = value.cast::<PyList>()?;
             return _check_entanglement_list(list.to_owned(), block_size);
         } else {
             return Ok(Box::new(std::iter::empty()));
         }
-    } else if let Ok(list) = entanglement.downcast::<PyList>() {
+    } else if let Ok(list) = entanglement.cast::<PyList>() {
         return _check_entanglement_list(list.to_owned(), block_size);
     }
     Err(QiskitError::new_err(

--- a/crates/circuit_library/src/parameter_ledger.rs
+++ b/crates/circuit_library/src/parameter_ledger.rs
@@ -106,7 +106,7 @@ impl ParameterLedger {
             .get_bound(py)
             .call1((parameter_prefix, num_parameters))? // get the Python ParameterVector
             .try_iter()? // iterate over the elements and cast them to Rust Params
-            .map(|ob| Param::extract_no_coerce(&ob?))
+            .map(|ob| Param::extract_no_coerce(ob?.as_borrowed()))
             .collect::<PyResult<_>>()?;
 
         // finally, distribute the parameters onto the repetitions and blocks for each

--- a/crates/circuit_library/src/pauli_evolution.rs
+++ b/crates/circuit_library/src/pauli_evolution.rs
@@ -359,8 +359,8 @@ pub fn py_pauli_evolution(
 
     for el in sparse_paulis.iter() {
         let tuple = el.cast::<PyTuple>()?;
-        let pauli = tuple.get_item(0)?.cast::<PyString>()?.to_string();
-        let time = Param::extract_no_coerce(&tuple.get_item(2)?)?;
+        let pauli = tuple.get_borrowed_item(0)?.cast::<PyString>()?.to_string();
+        let time = Param::extract_no_coerce(tuple.get_borrowed_item(2)?)?;
 
         if pauli.as_str().chars().all(|p| p == 'i') {
             global_phase = radd_param(global_phase, time);

--- a/crates/circuit_library/src/pauli_evolution.rs
+++ b/crates/circuit_library/src/pauli_evolution.rs
@@ -358,8 +358,8 @@ pub fn py_pauli_evolution(
     let mut modified_phase = false; // keep track of whether we modified the phase
 
     for el in sparse_paulis.iter() {
-        let tuple = el.downcast::<PyTuple>()?;
-        let pauli = tuple.get_item(0)?.downcast::<PyString>()?.to_string();
+        let tuple = el.cast::<PyTuple>()?;
+        let pauli = tuple.get_item(0)?.cast::<PyString>()?.to_string();
         let time = Param::extract_no_coerce(&tuple.get_item(2)?)?;
 
         if pauli.as_str().chars().all(|p| p == 'i') {

--- a/crates/circuit_library/src/pauli_feature_map.rs
+++ b/crates/circuit_library/src/pauli_feature_map.rs
@@ -230,7 +230,7 @@ fn _get_paulis(
             v.iter() // iterate over the list of Paulis
                 .map(|el| {
                     // Get the string and check whether it fits the feature dimension
-                    let as_string = (*el.downcast::<PyString>()?).to_string();
+                    let as_string = (*el.cast::<PyString>()?).to_string();
                     if as_string.len() > feature_dimension as usize {
                         Err(QiskitError::new_err(format!(
                             "feature_dimension ({feature_dimension}) smaller than the Pauli ({as_string})"

--- a/crates/circuit_library/src/pauli_feature_map.rs
+++ b/crates/circuit_library/src/pauli_feature_map.rs
@@ -73,7 +73,7 @@ pub fn pauli_feature_map(
     // extract the parameters from the input variable ``parameters``
     let parameter_vector = parameters
         .try_iter()?
-        .map(|el| Param::extract_no_coerce(&el?))
+        .map(|el| Param::extract_no_coerce(el?.as_borrowed()))
         .collect::<PyResult<Vec<Param>>>()?;
 
     // construct a Barrier object Python side to (possibly) add to the circuit

--- a/crates/qasm3/src/build.rs
+++ b/crates/qasm3/src/build.rs
@@ -216,7 +216,7 @@ impl BuilderState {
             self.qc
                 .inner(py)
                 .getattr("qubits")?
-                .downcast::<PySequence>()?
+                .cast::<PySequence>()?
                 .to_tuple()?
         };
         let instruction = self.module.new_instruction(

--- a/crates/qasm3/src/circuit.rs
+++ b/crates/qasm3/src/circuit.rs
@@ -198,25 +198,25 @@ impl PyCircuitModule {
         Ok(Self {
             circuit: module
                 .getattr("QuantumCircuit")?
-                .downcast_into::<PyType>()?
+                .cast_into::<PyType>()?
                 .unbind(),
             qreg: module
                 .getattr("QuantumRegister")?
-                .downcast_into::<PyType>()?
+                .cast_into::<PyType>()?
                 .unbind(),
-            qubit: module.getattr("Qubit")?.downcast_into::<PyType>()?.unbind(),
+            qubit: module.getattr("Qubit")?.cast_into::<PyType>()?.unbind(),
             creg: module
                 .getattr("ClassicalRegister")?
-                .downcast_into::<PyType>()?
+                .cast_into::<PyType>()?
                 .unbind(),
-            clbit: module.getattr("Clbit")?.downcast_into::<PyType>()?.unbind(),
+            clbit: module.getattr("Clbit")?.cast_into::<PyType>()?.unbind(),
             circuit_instruction: module
                 .getattr("CircuitInstruction")?
-                .downcast_into::<PyType>()?
+                .cast_into::<PyType>()?
                 .unbind(),
             barrier: module
                 .getattr("Barrier")?
-                .downcast_into::<PyType>()?
+                .cast_into::<PyType>()?
                 .unbind(),
             // Measure is a singleton, so just store the object.
             measure: module.getattr("Measure")?.call0()?.into_py_any(py)?,
@@ -237,7 +237,7 @@ impl PyCircuitModule {
         Ok(PyQuantumRegister {
             items: PyList::type_object(py)
                 .call1((qreg.clone(),))?
-                .downcast_into::<PyList>()?
+                .cast_into::<PyList>()?
                 .unbind(),
             object: qreg,
         })
@@ -257,7 +257,7 @@ impl PyCircuitModule {
         Ok(PyClassicalRegister {
             items: PyList::type_object(py)
                 .call1((creg.clone(),))?
-                .downcast_into::<PyList>()?
+                .cast_into::<PyList>()?
                 .unbind(),
             object: creg,
         })

--- a/crates/qasm3/src/circuit.rs
+++ b/crates/qasm3/src/circuit.rs
@@ -214,10 +214,7 @@ impl PyCircuitModule {
                 .getattr("CircuitInstruction")?
                 .cast_into::<PyType>()?
                 .unbind(),
-            barrier: module
-                .getattr("Barrier")?
-                .cast_into::<PyType>()?
-                .unbind(),
+            barrier: module.getattr("Barrier")?.cast_into::<PyType>()?.unbind(),
             // Measure is a singleton, so just store the object.
             measure: module.getattr("Measure")?.call0()?.into_py_any(py)?,
         })

--- a/crates/qasm3/src/lib.rs
+++ b/crates/qasm3/src/lib.rs
@@ -203,10 +203,7 @@ pub fn dumps(
             options.indent = val.extract::<String>()?;
         }
     }
-    let circuit_data = circuit
-        .getattr("_data")?
-        .cast::<CircuitData>()?
-        .borrow();
+    let circuit_data = circuit.getattr("_data")?.cast::<CircuitData>()?.borrow();
 
     let islayout = !circuit.getattr("layout")?.is_none();
 
@@ -254,10 +251,7 @@ pub fn dump(
             options.indent = val.extract::<String>()?;
         }
     }
-    let circuit_data = circuit
-        .getattr("_data")?
-        .cast::<CircuitData>()?
-        .borrow();
+    let circuit_data = circuit.getattr("_data")?.cast::<CircuitData>()?.borrow();
 
     let islayout = !circuit.getattr("layout")?.is_none();
 

--- a/crates/qasm3/src/lib.rs
+++ b/crates/qasm3/src/lib.rs
@@ -205,7 +205,7 @@ pub fn dumps(
     }
     let circuit_data = circuit
         .getattr("_data")?
-        .downcast::<CircuitData>()?
+        .cast::<CircuitData>()?
         .borrow();
 
     let islayout = !circuit.getattr("layout")?.is_none();
@@ -256,7 +256,7 @@ pub fn dump(
     }
     let circuit_data = circuit
         .getattr("_data")?
-        .downcast::<CircuitData>()?
+        .cast::<CircuitData>()?
         .borrow();
 
     let islayout = !circuit.getattr("layout")?.is_none();

--- a/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -599,7 +599,7 @@ impl PyGeneratorTerm {
         if slf.is(&other) {
             return Ok(true);
         }
-        let Ok(other) = other.downcast_into::<Self>() else {
+        let Ok(other) = other.cast_into::<Self>() else {
             return Ok(false);
         };
         let slf = slf.borrow();
@@ -884,7 +884,7 @@ impl PyPauliLindbladMap {
                 "explicitly given 'num_qubits' ({num_qubits}) does not match operator ({other_qubits})"
             )))
         };
-        if let Ok(pauli_lindblad_map) = data.downcast_exact::<Self>() {
+        if let Ok(pauli_lindblad_map) = data.cast_exact::<Self>() {
             check_num_qubits(data)?;
             let borrowed = pauli_lindblad_map.borrow();
             let inner = borrowed.inner.read().map_err(|_| InnerReadError)?;
@@ -904,7 +904,7 @@ impl PyPauliLindbladMap {
             };
             return Self::from_sparse_list(vec, num_qubits);
         }
-        if let Ok(term) = data.downcast_exact::<PyGeneratorTerm>() {
+        if let Ok(term) = data.cast_exact::<PyGeneratorTerm>() {
             return term.borrow().to_pauli_lindblad_map();
         };
         if let Ok(pauli_lindblad_map) = Self::from_terms(data, num_qubits) {
@@ -1047,12 +1047,12 @@ impl PyPauliLindbladMap {
                         "cannot construct a PauliLindbladMap from an empty list without knowing `num_qubits`",
                     ));
                 };
-                let py_term = first?.downcast::<PyGeneratorTerm>()?.borrow();
+                let py_term = first?.cast::<PyGeneratorTerm>()?.borrow();
                 py_term.inner.to_pauli_lindblad_map()?
             }
         };
         for bound_py_term in iter {
-            let py_term = bound_py_term?.downcast::<PyGeneratorTerm>()?.borrow();
+            let py_term = bound_py_term?.cast::<PyGeneratorTerm>()?.borrow();
             inner.add_term(py_term.inner.view())?;
         }
         Ok(inner.into())
@@ -1728,7 +1728,7 @@ impl PyPauliLindbladMap {
         if slf.is(&other) {
             return Ok(true);
         }
-        let Ok(other) = other.downcast_into::<Self>() else {
+        let Ok(other) = other.cast_into::<Self>() else {
             return Ok(false);
         };
         let slf_borrowed = slf.borrow();
@@ -1810,7 +1810,7 @@ fn coerce_to_map<'py>(
     value: &Bound<'py, PyAny>,
 ) -> PyResult<Option<Bound<'py, PyPauliLindbladMap>>> {
     let py = value.py();
-    if let Ok(obs) = value.downcast_exact::<PyPauliLindbladMap>() {
+    if let Ok(obs) = value.cast_exact::<PyPauliLindbladMap>() {
         return Ok(Some(obs.clone()));
     }
     match PyPauliLindbladMap::py_new(value, None) {

--- a/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
@@ -800,7 +800,7 @@ impl PyPhasedQubitSparsePauli {
         if slf.is(&other) {
             return Ok(true);
         }
-        let Ok(other) = other.downcast_into::<Self>() else {
+        let Ok(other) = other.cast_into::<Self>() else {
             return Ok(false);
         };
         let slf = slf.borrow();
@@ -1039,7 +1039,7 @@ impl PyPhasedQubitSparsePauliList {
             }
             return Self::from_label(&label);
         }
-        if let Ok(pauli_list) = data.downcast_exact::<Self>() {
+        if let Ok(pauli_list) = data.cast_exact::<Self>() {
             check_num_qubits(data)?;
             let borrowed = pauli_list.borrow();
             let inner = borrowed.inner.read().map_err(|_| InnerReadError)?;
@@ -1059,7 +1059,7 @@ impl PyPhasedQubitSparsePauliList {
             };
             return Self::from_sparse_list(vec, num_qubits);
         }
-        if let Ok(term) = data.downcast_exact::<PyPhasedQubitSparsePauli>() {
+        if let Ok(term) = data.cast_exact::<PyPhasedQubitSparsePauli>() {
             return term.borrow().to_phased_qubit_sparse_pauli_list();
         };
         if let Ok(pauli_list) = Self::from_phased_qubit_sparse_paulis(data, num_qubits) {
@@ -1274,13 +1274,13 @@ impl PyPhasedQubitSparsePauliList {
                         "cannot construct an empty PhasedQubitSparsePauliList without knowing `num_qubits`",
                     ));
                 };
-                let py_term = first?.downcast::<PyPhasedQubitSparsePauli>()?.borrow();
+                let py_term = first?.cast::<PyPhasedQubitSparsePauli>()?.borrow();
                 py_term.inner.to_phased_qubit_sparse_pauli_list()
             }
         };
         for bound_py_term in iter {
             let py_term = bound_py_term?
-                .downcast::<PyPhasedQubitSparsePauli>()?
+                .cast::<PyPhasedQubitSparsePauli>()?
                 .borrow();
             inner.add_phased_qubit_sparse_pauli(py_term.inner.view())?;
         }
@@ -1537,7 +1537,7 @@ impl PyPhasedQubitSparsePauliList {
         if slf.is(&other) {
             return Ok(true);
         }
-        let Ok(other) = other.downcast_into::<Self>() else {
+        let Ok(other) = other.cast_into::<Self>() else {
             return Ok(false);
         };
         let slf_borrowed = slf.borrow();

--- a/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
@@ -1279,9 +1279,7 @@ impl PyPhasedQubitSparsePauliList {
             }
         };
         for bound_py_term in iter {
-            let py_term = bound_py_term?
-                .cast::<PyPhasedQubitSparsePauli>()?
-                .borrow();
+            let py_term = bound_py_term?.cast::<PyPhasedQubitSparsePauli>()?.borrow();
             inner.add_phased_qubit_sparse_pauli(py_term.inner.view())?;
         }
         Ok(inner.into())

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -968,7 +968,7 @@ fn make_py_pauli(py: Python) -> PyResult<Py<PyType>> {
         .getattr("property")?
         .call1((wrap_pyfunction!(pauli_label, py)?,))?;
     obj.setattr("label", label_property)?;
-    Ok(obj.downcast_into::<PyType>()?.unbind())
+    Ok(obj.cast_into::<PyType>()?.unbind())
 }
 
 // Return the relevant value from the Python-space sister enumeration.  These are Python-space
@@ -1470,7 +1470,7 @@ impl PyQubitSparsePauli {
         if slf.is(&other) {
             return Ok(true);
         }
-        let Ok(other) = other.downcast_into::<Self>() else {
+        let Ok(other) = other.cast_into::<Self>() else {
             return Ok(false);
         };
         let slf = slf.borrow();
@@ -1705,7 +1705,7 @@ impl PyQubitSparsePauliList {
             }
             return Self::from_label(&label).map_err(PyErr::from);
         }
-        if let Ok(pauli_list) = data.downcast_exact::<Self>() {
+        if let Ok(pauli_list) = data.cast_exact::<Self>() {
             check_num_qubits(data)?;
             let borrowed = pauli_list.borrow();
             let inner = borrowed.inner.read().map_err(|_| InnerReadError)?;
@@ -1725,7 +1725,7 @@ impl PyQubitSparsePauliList {
             };
             return Self::from_sparse_list(vec, num_qubits);
         }
-        if let Ok(term) = data.downcast_exact::<PyQubitSparsePauli>() {
+        if let Ok(term) = data.cast_exact::<PyQubitSparsePauli>() {
             return term.borrow().to_qubit_sparse_pauli_list();
         };
         if let Ok(pauli_list) = Self::from_qubit_sparse_paulis(data, num_qubits) {
@@ -1958,12 +1958,12 @@ impl PyQubitSparsePauliList {
                         "cannot construct an empty QubitSparsePauliList without knowing `num_qubits`",
                     ));
                 };
-                let py_term = first?.downcast::<PyQubitSparsePauli>()?.borrow();
+                let py_term = first?.cast::<PyQubitSparsePauli>()?.borrow();
                 py_term.inner.to_qubit_sparse_pauli_list()
             }
         };
         for bound_py_term in iter {
-            let py_term = bound_py_term?.downcast::<PyQubitSparsePauli>()?.borrow();
+            let py_term = bound_py_term?.cast::<PyQubitSparsePauli>()?.borrow();
             inner.add_qubit_sparse_pauli(py_term.inner.view())?;
         }
         Ok(inner.into())
@@ -2208,7 +2208,7 @@ impl PyQubitSparsePauliList {
         if slf.is(&other) {
             return Ok(true);
         }
-        let Ok(other) = other.downcast_into::<Self>() else {
+        let Ok(other) = other.cast_into::<Self>() else {
             return Ok(false);
         };
         let slf_borrowed = slf.borrow();

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -1005,8 +1005,10 @@ impl<'py> IntoPyObject<'py> for Pauli {
     }
 }
 
-impl<'py> FromPyObject<'py> for Pauli {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Pauli {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         let value = ob
             .extract::<isize>()
             .map_err(|_| match ob.get_type().repr() {

--- a/crates/quantum_info/src/sparse_observable/mod.rs
+++ b/crates/quantum_info/src/sparse_observable/mod.rs
@@ -1715,7 +1715,7 @@ fn make_py_bit_term(py: Python) -> PyResult<Py<PyType>> {
         .getattr("property")?
         .call1((wrap_pyfunction!(bit_term_label, py)?,))?;
     obj.setattr("label", label_property)?;
-    Ok(obj.downcast_into::<PyType>()?.unbind())
+    Ok(obj.cast_into::<PyType>()?.unbind())
 }
 
 // Return the relevant value from the Python-space sister enumeration.  These are Python-space
@@ -1846,7 +1846,7 @@ impl PySparseTerm {
         if slf.is(&other) {
             return Ok(true);
         }
-        let Ok(other) = other.downcast_into::<Self>() else {
+        let Ok(other) = other.cast_into::<Self>() else {
             return Ok(false);
         };
         let slf = slf.borrow();
@@ -2454,7 +2454,7 @@ impl PySparseObservable {
             }
             return Self::from_label(&label).map_err(PyErr::from);
         }
-        if let Ok(observable) = data.downcast_exact::<Self>() {
+        if let Ok(observable) = data.cast_exact::<Self>() {
             check_num_qubits(data)?;
             let borrowed = observable.borrow();
             let inner = borrowed.inner.read().map_err(|_| InnerReadError)?;
@@ -2474,7 +2474,7 @@ impl PySparseObservable {
             };
             return Self::from_sparse_list(vec, num_qubits);
         }
-        if let Ok(term) = data.downcast_exact::<PySparseTerm>() {
+        if let Ok(term) = data.cast_exact::<PySparseTerm>() {
             return term.borrow().to_observable();
         };
         if let Ok(observable) = Self::from_terms(data, num_qubits) {
@@ -3061,12 +3061,12 @@ impl PySparseObservable {
                         "cannot construct an observable from an empty list without knowing `num_qubits`",
                     ));
                 };
-                let py_term = first?.downcast::<PySparseTerm>()?.borrow();
+                let py_term = first?.cast::<PySparseTerm>()?.borrow();
                 py_term.inner.to_observable()
             }
         };
         for bound_py_term in iter {
-            let py_term = bound_py_term?.downcast::<PySparseTerm>()?.borrow();
+            let py_term = bound_py_term?.cast::<PySparseTerm>()?.borrow();
             inner.add_term(py_term.inner.view())?;
         }
         Ok(inner.into())
@@ -3622,7 +3622,7 @@ impl PySparseObservable {
         if slf.is(&other) {
             return Ok(true);
         }
-        let Ok(other) = other.downcast_into::<Self>() else {
+        let Ok(other) = other.cast_into::<Self>() else {
             return Ok(false);
         };
         let slf_borrowed = slf.borrow();
@@ -4151,7 +4151,7 @@ fn coerce_to_observable<'py>(
     value: &Bound<'py, PyAny>,
 ) -> PyResult<Option<Bound<'py, PySparseObservable>>> {
     let py = value.py();
-    if let Ok(obs) = value.downcast_exact::<PySparseObservable>() {
+    if let Ok(obs) = value.cast_exact::<PySparseObservable>() {
         return Ok(Some(obs.clone()));
     }
     match PySparseObservable::py_new(value, None) {

--- a/crates/synthesis/src/evolution/pauli_network.rs
+++ b/crates/synthesis/src/evolution/pauli_network.rs
@@ -314,9 +314,9 @@ pub fn pauli_network_synthesis_inner(
     // go over the input pauli network and extract a list of pauli rotations and
     // the corresponding rotation angles
     for item in pauli_network {
-        let tuple = item.downcast::<PyTuple>()?;
+        let tuple = item.cast::<PyTuple>()?;
 
-        let sparse_pauli: String = tuple.get_item(0)?.downcast::<PyString>()?.extract()?;
+        let sparse_pauli: String = tuple.get_item(0)?.cast::<PyString>()?.extract()?;
         let qubits: Vec<u32> = tuple.get_item(1)?.extract()?;
         let angle: Param = tuple.get_item(2)?.extract()?;
 

--- a/crates/transpiler/src/angle_bound_registry.rs
+++ b/crates/transpiler/src/angle_bound_registry.rs
@@ -32,7 +32,13 @@ impl CallbackType {
         match self {
             Self::Python(inner) => {
                 let qubits: Vec<usize> = qubits.iter().map(|x| x.index()).collect();
-                Python::attach(|py| inner.bind(py).call1((angles, qubits))?.extract())
+                Python::attach(|py| {
+                    inner
+                        .bind(py)
+                        .call1((angles, qubits))?
+                        .extract()
+                        .map_err(PyErr::from)
+                })
             }
             Self::Native(inner) => Ok(inner(angles, qubits)),
         }

--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -261,7 +261,7 @@ impl CommutationChecker {
     }
 
     fn __setstate__(&mut self, py: Python, state: Py<PyAny>) -> PyResult<()> {
-        let dict_state = state.downcast_bound::<PyDict>(py)?;
+        let dict_state = state.cast_bound::<PyDict>(py)?;
         self.cache_max_entries = dict_state
             .get_item("cache_max_entries")?
             .unwrap()
@@ -276,7 +276,7 @@ impl CommutationChecker {
         let raw_cache: Bound<PyDict> = dict_state.get_item("cache")?.unwrap().extract()?;
         self.cache = HashMap::with_capacity(raw_cache.len());
         for (key, value) in raw_cache.iter() {
-            let value_dict: &Bound<PyDict> = value.downcast()?;
+            let value_dict: &Bound<PyDict> = value.cast()?;
             self.cache.insert(
                 key.extract()?,
                 commutation_cache_entry_from_pydict(value_dict)?,
@@ -819,7 +819,7 @@ impl<'py> FromPyObject<'py> for CommutationLibraryEntry {
         if let Ok(b) = b.extract::<bool>() {
             return Ok(CommutationLibraryEntry::Commutes(b));
         }
-        let dict = b.downcast::<PyDict>()?;
+        let dict = b.cast::<PyDict>()?;
         let mut ret = hashbrown::HashMap::with_capacity(dict.len());
         for (k, v) in dict {
             let raw_key: SmallVec<[Option<u32>; 2]> = k.extract()?;

--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -814,14 +814,16 @@ impl<'py> IntoPyObject<'py> for CommutationLibraryEntry {
     }
 }
 
-impl<'py> FromPyObject<'py> for CommutationLibraryEntry {
-    fn extract_bound(b: &Bound<'py, PyAny>) -> Result<Self, PyErr> {
+impl<'a, 'py> FromPyObject<'a, 'py> for CommutationLibraryEntry {
+    type Error = PyErr;
+
+    fn extract(b: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         if let Ok(b) = b.extract::<bool>() {
             return Ok(CommutationLibraryEntry::Commutes(b));
         }
         let dict = b.cast::<PyDict>()?;
         let mut ret = hashbrown::HashMap::with_capacity(dict.len());
-        for (k, v) in dict {
+        for (k, v) in &*dict {
             let raw_key: SmallVec<[Option<u32>; 2]> = k.extract()?;
             let v: bool = v.extract()?;
             let key = raw_key.into_iter().map(|key| key.map(Qubit)).collect();

--- a/crates/transpiler/src/equivalence.rs
+++ b/crates/transpiler/src/equivalence.rs
@@ -47,8 +47,8 @@ use qiskit_circuit::packed_instruction::PackedOperation;
 use crate::standard_equivalence_library::generate_standard_equivalence_library;
 
 mod exceptions {
-    use pyo3::import_exception_bound;
-    import_exception_bound! {qiskit.circuit.exceptions, CircuitError}
+    use pyo3::import_exception;
+    import_exception! {qiskit.circuit.exceptions, CircuitError}
 }
 pub static PYDIGRAPH: ImportOnceCell = ImportOnceCell::new("rustworkx", "PyDiGraph");
 

--- a/crates/transpiler/src/equivalence.rs
+++ b/crates/transpiler/src/equivalence.rs
@@ -332,7 +332,7 @@ impl FromPyObject<'_> for CircuitFromPython {
     fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
         if ob.is_instance(QUANTUM_CIRCUIT.get_bound(ob.py()))? {
             let data: Bound<PyAny> = ob.getattr("_data")?;
-            let data_downcast: Bound<CircuitData> = data.downcast_into()?;
+            let data_downcast: Bound<CircuitData> = data.cast_into()?;
             let data_extract: CircuitData = data_downcast.extract()?;
             Ok(Self(data_extract))
         } else {
@@ -567,9 +567,9 @@ impl EquivalenceLibrary {
     fn __setstate__(mut slf: PyRefMut<Self>, state: &Bound<PyDict>) -> PyResult<()> {
         slf.rule_id = state.get_item("rule_id")?.unwrap().extract()?;
         let graph_nodes_ref: Bound<PyAny> = state.get_item("graph_nodes")?.unwrap();
-        let graph_nodes: &Bound<PyList> = graph_nodes_ref.downcast()?;
+        let graph_nodes: &Bound<PyList> = graph_nodes_ref.cast()?;
         let graph_edge_ref: Bound<PyAny> = state.get_item("graph_edges")?.unwrap();
-        let graph_edges: &Bound<PyList> = graph_edge_ref.downcast()?;
+        let graph_edges: &Bound<PyList> = graph_edge_ref.cast()?;
         slf.graph = GraphType::new();
         for node_weight in graph_nodes {
             slf.graph.add_node(node_weight.extract()?);

--- a/crates/transpiler/src/equivalence.rs
+++ b/crates/transpiler/src/equivalence.rs
@@ -293,8 +293,10 @@ pub struct GateOper {
     params: SmallVec<[Param; 3]>,
 }
 
-impl<'py> FromPyObject<'py> for GateOper {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for GateOper {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         let op_struct: OperationFromPython = ob.extract()?;
         Ok(Self {
             operation: op_struct.operation,
@@ -328,8 +330,10 @@ impl<'py> IntoPyObject<'py> for CircuitFromPython {
     }
 }
 
-impl FromPyObject<'_> for CircuitFromPython {
-    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for CircuitFromPython {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         if ob.is_instance(QUANTUM_CIRCUIT.get_bound(ob.py()))? {
             let data: Bound<PyAny> = ob.getattr("_data")?;
             let data_downcast: Bound<CircuitData> = data.cast_into()?;

--- a/crates/transpiler/src/lib.rs
+++ b/crates/transpiler/src/lib.rs
@@ -26,7 +26,7 @@ pub use transpiler::transpile;
 
 mod gate_metrics;
 
-use pyo3::import_exception_bound;
+use pyo3::import_exception;
 
-import_exception_bound! {qiskit.exceptions, QiskitError}
-import_exception_bound! {qiskit.transpiler.exceptions, TranspilerError}
+import_exception! {qiskit.exceptions, QiskitError}
+import_exception! {qiskit.transpiler.exceptions, TranspilerError}

--- a/crates/transpiler/src/passes/alap_schedule_analysis.rs
+++ b/crates/transpiler/src/passes/alap_schedule_analysis.rs
@@ -199,7 +199,7 @@ pub fn py_run_alap_schedule_analysis(
         let mut op_durations = HashMap::new();
         for (py_node, py_duration) in node_durations.iter() {
             let node_idx = py_node
-                .downcast_into::<DAGOpNode>()?
+                .cast_into::<DAGOpNode>()?
                 .extract::<DAGNode>()?
                 .node
                 .expect("Node index not found.");
@@ -217,7 +217,7 @@ pub fn py_run_alap_schedule_analysis(
         let mut op_durations = HashMap::new();
         for (py_node, py_duration) in node_durations.iter() {
             let node_idx = py_node
-                .downcast_into::<DAGOpNode>()?
+                .cast_into::<DAGOpNode>()?
                 .extract::<DAGNode>()?
                 .node
                 .expect("Node index not found.");

--- a/crates/transpiler/src/passes/asap_schedule_analysis.rs
+++ b/crates/transpiler/src/passes/asap_schedule_analysis.rs
@@ -176,7 +176,7 @@ pub fn py_run_asap_schedule_analysis(
         let mut op_durations = HashMap::new();
         for (py_node, py_duration) in node_durations.iter() {
             let node_idx = py_node
-                .downcast_into::<DAGOpNode>()?
+                .cast_into::<DAGOpNode>()?
                 .extract::<DAGNode>()?
                 .node
                 .expect("Node index not found.");
@@ -194,7 +194,7 @@ pub fn py_run_asap_schedule_analysis(
         let mut op_durations = HashMap::new();
         for (py_node, py_duration) in node_durations.iter() {
             let node_idx = py_node
-                .downcast_into::<DAGOpNode>()?
+                .cast_into::<DAGOpNode>()?
                 .extract::<DAGNode>()?
                 .node
                 .expect("Node index not found.");

--- a/crates/transpiler/src/passes/check_map.rs
+++ b/crates/transpiler/src/passes/check_map.rs
@@ -56,7 +56,7 @@ fn recurse(
                     let block_obj = raw_block?;
                     let block = block_obj
                         .getattr(intern!(py, "_data"))?
-                        .downcast::<CircuitData>()?
+                        .cast::<CircuitData>()?
                         .borrow();
                     let new_dag: DAGCircuit =
                         circuit_to_dag.call1((block_obj.clone(),))?.extract()?;

--- a/crates/transpiler/src/passes/disjoint_layout.rs
+++ b/crates/transpiler/src/passes/disjoint_layout.rs
@@ -365,7 +365,7 @@ fn build_interaction_graph<Ty: EdgeType>(
                     unreachable!("Control flow must be a python instruction");
                 };
                 let raw_blocks = py_inst.instruction.getattr(py, "blocks").unwrap();
-                let blocks: &Bound<PyTuple> = raw_blocks.downcast_bound::<PyTuple>(py).unwrap();
+                let blocks: &Bound<PyTuple> = raw_blocks.cast_bound::<PyTuple>(py).unwrap();
                 for block in blocks.iter() {
                     let mut inner_wire_map = vec![Qubit(u32::MAX); wire_map.len()];
                     let node_qargs = dag.get_qargs(inst.qubits);

--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -591,7 +591,7 @@ fn run_on_circuitdata(
                 // old_blocks_py keeps the original QuantumCircuit's appearing within control-flow ops
                 // new_blocks_py keeps the recursively synthesized circuits
                 let old_blocks_py = old_blocks_as_bound_obj.getattr(intern!(py, "blocks"))?;
-                let old_blocks_py = old_blocks_py.downcast::<PyTuple>()?;
+                let old_blocks_py = old_blocks_py.cast::<PyTuple>()?;
                 let mut new_blocks_py: Vec<Bound<PyAny>> = Vec::with_capacity(old_blocks_py.len());
 
                 // We do not allow using any additional qubits outside of the block.

--- a/crates/transpiler/src/passes/sabre/dag.rs
+++ b/crates/transpiler/src/passes/sabre/dag.rs
@@ -33,7 +33,7 @@ fn control_flow_block_dags<'a>(
         .instruction
         .bind(py)
         .getattr("blocks")?
-        .downcast::<PyTuple>()?
+        .cast::<PyTuple>()?
         .iter()
         .map(move |block| circuit_to_dag(block.extract()?, false, None, None)))
 }

--- a/crates/transpiler/src/passes/unitary_synthesis.rs
+++ b/crates/transpiler/src/passes/unitary_synthesis.rs
@@ -30,7 +30,7 @@ use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyDict, PyString, PyType};
 use pyo3::wrap_pyfunction;
 
-use qiskit_circuit::converters::{QuantumCircuitData, circuit_to_dag};
+use qiskit_circuit::converters::circuit_to_dag;
 use qiskit_circuit::dag_circuit::{DAGCircuit, DAGCircuitBuilder, NodeType};
 use qiskit_circuit::operations::{Operation, OperationRef, Param, PythonOperation, StandardGate};
 use qiskit_circuit::packed_instruction::{PackedInstruction, PackedOperation};
@@ -319,12 +319,7 @@ pub fn run_unitary_synthesis(
                         .map(|qarg| qubit_indices[qarg.0 as usize])
                         .collect_vec();
                     let res = run_unitary_synthesis(
-                        &mut circuit_to_dag(
-                            QuantumCircuitData::extract_bound(&raw_block?)?,
-                            false,
-                            None,
-                            None,
-                        )?,
+                        &mut circuit_to_dag(raw_block?.extract()?, false, None, None)?,
                         new_ids,
                         min_qubits,
                         target,

--- a/crates/transpiler/src/passes/unitary_synthesis.rs
+++ b/crates/transpiler/src/passes/unitary_synthesis.rs
@@ -684,7 +684,7 @@ fn get_2q_decomposers_from_target(
                     let py_type = module.getattr("type")?;
                     Ok(py_type
                         .call1((gate.clone().into_pyobject(py)?,))?
-                        .downcast_into::<PyType>()?
+                        .cast_into::<PyType>()?
                         .unbind())
                 })?;
                 RXXEquivalent::CustomPython(gate_type)

--- a/crates/transpiler/src/passes/vf2/vf2_layout.rs
+++ b/crates/transpiler/src/passes/vf2/vf2_layout.rs
@@ -361,7 +361,7 @@ impl<T: Default> VirtualInteractions<T> {
                     };
                     let wire_map: Vec<_> = qubits.iter().map(|i| wire_map[i.index()]).collect();
                     let blocks = py_inst.instruction.bind(py).getattr("blocks")?;
-                    for block in blocks.downcast::<PyTuple>()?.iter() {
+                    for block in blocks.cast::<PyTuple>()?.iter() {
                         if !self.add_interactions_from(
                             &circuit_to_dag(block.extract()?, false, None, None)?,
                             &wire_map,

--- a/crates/transpiler/src/target/mod.rs
+++ b/crates/transpiler/src/target/mod.rs
@@ -159,13 +159,15 @@ impl<'a, 'py> IntoPyObject<'py> for &'a NormalOperation {
     }
 }
 
-impl<'py> FromPyObject<'py> for NormalOperation {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for NormalOperation {
+    type Error = <OperationFromPython as FromPyObject<'a, 'py>>::Error;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         let operation: OperationFromPython = ob.extract()?;
         Ok(Self {
             operation: operation.operation,
             params: operation.params,
-            op_object: Ok(ob.clone().unbind()).into(),
+            op_object: Ok(ob.to_owned().unbind()).into(),
         })
     }
 }

--- a/crates/transpiler/src/target/mod.rs
+++ b/crates/transpiler/src/target/mod.rs
@@ -908,7 +908,7 @@ impl Target {
                 .extract::<Vec<(Qargs, HashSet<String>)>>()?,
         );
         let angle_bounds_raw = state.get_item("angle_bounds")?.unwrap();
-        let angle_bounds_dict = angle_bounds_raw.downcast::<PyDict>()?;
+        let angle_bounds_dict = angle_bounds_raw.cast::<PyDict>()?;
         type AngleBoundIterList = Vec<(String, SmallVec<[Option<[f64; 2]>; 3]>)>;
         let angle_bounds_list: AngleBoundIterList = angle_bounds_dict.items().extract()?;
         for (gate, bounds) in angle_bounds_list {

--- a/crates/transpiler/src/target/qargs.rs
+++ b/crates/transpiler/src/target/qargs.rs
@@ -99,8 +99,10 @@ impl<'py> IntoPyObject<'py> for &Qargs {
     }
 }
 
-impl<'py> FromPyObject<'py> for Qargs {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Qargs {
+    type Error = <TargetQargs as FromPyObject<'a, 'py>>::Error;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         let qargs: Option<TargetQargs> = ob.extract()?;
         match qargs {
             Some(qargs) => Ok(Self::Concrete(qargs)),

--- a/crates/transpiler/src/transpile_layout.rs
+++ b/crates/transpiler/src/transpile_layout.rs
@@ -569,7 +569,7 @@ impl TranspileLayout {
             .call_method0(intern!(py, "get_registers"))?
             .cast::<PySet>()?
             .iter()
-            .map(|x| x.extract::<QuantumRegister>())
+            .map(|x| x.extract::<QuantumRegister>().map_err(PyErr::from))
             .collect::<PyResult<Vec<QuantumRegister>>>()?;
         Ok(Self::new(
             initial_layout,

--- a/crates/transpiler/src/transpile_layout.rs
+++ b/crates/transpiler/src/transpile_layout.rs
@@ -543,7 +543,7 @@ impl TranspileLayout {
         };
         let index_map = py_layout
             .getattr(intern!(py, "input_qubit_mapping"))?
-            .downcast::<PyDict>()?
+            .cast::<PyDict>()?
             .iter()
             .map(|(k, v)| -> PyResult<(usize, ShareableQubit)> {
                 let index: usize = v.extract()?;
@@ -567,7 +567,7 @@ impl TranspileLayout {
         let input_registers: Vec<QuantumRegister> = py_layout
             .getattr(intern!(py, "initial_layout"))?
             .call_method0(intern!(py, "get_registers"))?
-            .downcast::<PySet>()?
+            .cast::<PySet>()?
             .iter()
             .map(|x| x.extract::<QuantumRegister>())
             .collect::<PyResult<Vec<QuantumRegister>>>()?;


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This small chain of commits follows the steps in the PyO3 migration guide to update from 0.26 to 0.27.

The main change is around the new `FromPyObject` signature.

The new form of the trait uses `Borrowed`, causing it to need another lifetime parameter, and an explicit `Error` type.  Where appropriate / easy, I switched the error types away from the complete `PyErr`, even if most of our handling of those errors does eventually convert them into `PyErr` for now.

In places where extraction delegates to other methods, particularly where those methods are logical mirrors to `FromPyObject`, this commit also updates the signatures to use `Borrowed` instead of `&Bound`.

In a couple of places, the extraction being in terms of `Borrowed` meant that trait implementations that are only accessible on `Bound` (for example `impl IntoIterator for &Bound<PyDict>`) needed some dereferencing inserted to re-satisfy the bounds.


### Details and comments

The downgrade of one particular instance of `hashbrown@0.16.0` to `0.15.5` is slightly coincidental - I had to undo some of the changes cargo applied while bumping PyO3, and apparently I was slightly overzealous.  It's actually better to have slightly fewer builds of it, though, and we largely need things to be aligned since `hashbrown` frequently leaks out in interfaces between Qiskit, rustworkx and (conversion traits in) PyO3.

Blocked on PyO3/rust-numpy#515 for now.

The lint failure is caused by the bug fixed in PyO3/pyo3#5538, which should be backported in PyO3 0.27.1 in a day or so.  If we want to merge this sooner, we can workspace-allow `clippy::declare_interior_mutable_const` in the root `Cargo.toml`.

See [PyO3 0.27's migration guide](https://pyo3.rs/v0.27.0/migration.html) for more information on some of the changes in here.