### PR TITLE
Enable arbitrary arguments to Target.__new__

### DIFF
--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -233,6 +233,8 @@ class Target(BaseTarget):
         acquire_alignment: int = 1,
         qubit_properties: list | None = None,
         concurrent_measurements: list | None = None,
+        *args,
+        **kwargs,
     ):
         """
         Create a new ``Target`` object


### PR DESCRIPTION


<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds back the `*args` and `**kwargs` to the signature on Target.__new__(). This was removed in #14921 as part of cleaning up some internal interfaces because in a strict sense it wasn't required. However, this had unexpected impact for users that subclass the Target. Subclassing the target is supported for the purpose of adding custom information to the target, however because much of the target is in rust you can't typically override built-in fields or data. To facilitate this use case this commit adds back these catch-alls to the __new__ signature so that users don't have to define a custom __new__ in addition to __init__.

### Details and comments

Fixes #15142
