### PR TITLE
Add CI support for Python 3.14

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -28,7 +28,7 @@ jobs:
       - run: ':'
     outputs:
       python-old: '3.10'
-      python-new: '3.13'
+      python-new: '3.14'
       runner-linux-x86_64: 'ubuntu-latest'
       runner-linux-arm64: 'ubuntu-24.04-arm'
       runner-macos-arm64: 'macos-15'

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-python@v6
         name: Install Python
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: tools/install_ubuntu_docs_dependencies.sh

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -19,7 +19,7 @@ jobs:
     uses: ./.github/workflows/test-linux.yml
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         runner: ["ubuntu-latest", "ubuntu-24.04-arm"]
     with:
       python-version: ${{ matrix.python-version }}
@@ -30,7 +30,7 @@ jobs:
     uses: ./.github/workflows/test-mac.yml
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         runner: ["macos-14"]
 
     with:
@@ -42,7 +42,7 @@ jobs:
     uses: ./.github/workflows/test-windows.yml
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         runner: ["windows-latest"]
     with:
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -60,7 +60,7 @@ on:
       python-version:
         description: "The Python version to use to host the build runner."
         type: string
-        default: "3.13"
+        default: "3.14"
         required: false
 
       pgo:

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -17,7 +17,7 @@
     "dvcs": "git",
     "environment_type": "virtualenv",
     "show_commit_url": "https://github.com/Qiskit/qiskit/commit/",
-    "pythons": ["3.10", "3.11", "3.12", "3.13"],
+    "pythons": ["3.10", "3.11", "3.12", "3.13", "3.14"],
     "benchmark_dir": "test/benchmarks",
     "env_dir": ".asv/env",
     "results_dir": ".asv/results"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
 ]
 # These are configured in the `tool.setuptools.dynamic` table.
@@ -279,7 +280,7 @@ include = ["qiskit", "qiskit.*"]
 
 [tool.black]
 line-length = 100
-target-version = ['py310', 'py311']
+target-version = ['py310', 'py311', 'py312', 'py313']
 
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux_2_28"


### PR DESCRIPTION
We already build wheels that are compatible with Python 3.14, so this moves our "latest supported" version in CI to reflect that.

There is one visualisation test that was asserting an exact string match of a particular Numpy array that has changed the sign of some zero. This is irrelevant to the actual test (which seems to be testing internals of a method anyway), so we can just make it match regardless of signedness.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Fix #15135