### PR TITLE
Update to Black 2025

### DIFF
--- a/qiskit/circuit/classical/types/__init__.py
+++ b/qiskit/circuit/classical/types/__init__.py
@@ -46,7 +46,7 @@ timing-aware circuit operations.
 Working with types
 ==================
 
-There are some additional functions on these types documented in the subsequent sections. 
+There are some additional functions on these types documented in the subsequent sections.
 These are mostly expected to be used only in manipulations of the expression tree;
 users who are building expressions using the
 :ref:`user-facing construction interface <circuit-classical-expressions-expr-construction>` should

--- a/qiskit/circuit/commutation_library.py
+++ b/qiskit/circuit/commutation_library.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Provides a commutation checker that caches the determined commutation results during this session """
+"""Provides a commutation checker that caches the determined commutation results during this session"""
 
 from qiskit.circuit import CommutationChecker
 

--- a/qiskit/circuit/controlflow/_builder_utils.py
+++ b/qiskit/circuit/controlflow/_builder_utils.py
@@ -91,7 +91,7 @@ def node_resources(node: expr.Expr) -> LegacyResources:
 
 
 def condition_resources(
-    condition: tuple[ClassicalRegister, int] | tuple[Clbit, int] | expr.Expr
+    condition: tuple[ClassicalRegister, int] | tuple[Clbit, int] | expr.Expr,
 ) -> LegacyResources:
     """Get the legacy classical resources (:class:`.Clbit` and :class:`.ClassicalRegister`)
     referenced by a legacy condition or an :class:`~.expr.Expr`."""
@@ -154,7 +154,7 @@ def unify_circuit_resources(circuits: Iterable[QuantumCircuit]) -> Iterable[Quan
 
 
 def _unify_circuit_resources_rebuild(  # pylint: disable=invalid-name  # (it's too long?!)
-    circuits: Tuple[QuantumCircuit, ...]
+    circuits: Tuple[QuantumCircuit, ...],
 ) -> Tuple[QuantumCircuit, QuantumCircuit]:
     """
     Ensure that all the given circuits have all the same qubits and clbits, and that they

--- a/qiskit/circuit/random/__init__.py
+++ b/qiskit/circuit/random/__init__.py
@@ -20,10 +20,10 @@ Random Circuits (:mod:`qiskit.circuit.random`)
 Overview
 ========
 
-The :mod:`qiskit.circuit.random` module offers functions that can be used for generating 
-arbitrary circuits with gates randomly selected from a given set of gates. 
+The :mod:`qiskit.circuit.random` module offers functions that can be used for generating
+arbitrary circuits with gates randomly selected from a given set of gates.
 
-These circuits can be used for benchmarking existing quantum hardware and estimating 
+These circuits can be used for benchmarking existing quantum hardware and estimating
 the performance of quantum circuit transpilers and software infrastructure.
 The functions below can generate bespoke quantum circuits respecting various properties
 such as number of qubits, depth of the circuit, coupling map, gate set, etc.

--- a/qiskit/converters/__init__.py
+++ b/qiskit/converters/__init__.py
@@ -23,19 +23,19 @@ QuantumCircuit -> circuit components
 .. autofunction:: circuit_to_instruction
 .. autofunction:: circuit_to_gate
 
-QuantumCircuit <-> DagCircuit 
+QuantumCircuit <-> DagCircuit
 =============================
 
 .. autofunction:: circuit_to_dag
 .. autofunction:: dag_to_circuit
 
-QuantumCircuit <-> DagDependency 
+QuantumCircuit <-> DagDependency
 ================================
 
 .. autofunction:: dagdependency_to_circuit
 .. autofunction:: circuit_to_dagdependency
 
-DagCircuit <-> DagDependency 
+DagCircuit <-> DagDependency
 ============================
 
 .. autofunction:: dag_to_dagdependency

--- a/qiskit/dagcircuit/dagdependency.py
+++ b/qiskit/dagcircuit/dagdependency.py
@@ -10,8 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""DAGDependency class for representing non-commutativity in a circuit.
-"""
+"""DAGDependency class for representing non-commutativity in a circuit."""
 from __future__ import annotations
 
 import math

--- a/qiskit/dagcircuit/dagdependency_v2.py
+++ b/qiskit/dagcircuit/dagdependency_v2.py
@@ -10,8 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""_DAGDependencyV2 class for representing non-commutativity in a circuit.
-"""
+"""_DAGDependencyV2 class for representing non-commutativity in a circuit."""
 
 import itertools
 import math

--- a/qiskit/primitives/__init__.py
+++ b/qiskit/primitives/__init__.py
@@ -31,11 +31,11 @@ Qiskit offers a reference implementation for each of these abstractions in the
 :class:`~.StatevectorSampler` and :class:`~.StatevectorEstimator` classes.
 
 The earlier versions of the sampler and estimator abstractions are defined by :class:`~.BaseSamplerV1`
-and :class:`~.BaseEstimatorV1`. These interfaces follow a different and less flexible input-output 
-format for the ``run`` method and have been largely replaced in practice by :class:`~.BaseSamplerV2` and 
-:class:`~.BaseEstimatorV2`. However, the original abstract interface definitions have been 
-retained for backward compatibility. Check the migration section of this page to see further details 
-on the difference between V1 and V2. 
+and :class:`~.BaseEstimatorV1`. These interfaces follow a different and less flexible input-output
+format for the ``run`` method and have been largely replaced in practice by :class:`~.BaseSamplerV2` and
+:class:`~.BaseEstimatorV2`. However, the original abstract interface definitions have been
+retained for backward compatibility. Check the migration section of this page to see further details
+on the difference between V1 and V2.
 
 Overview of EstimatorV2
 =======================
@@ -174,11 +174,11 @@ Here is an example of how a sampler is used.
 Overview of EstimatorV1
 =======================
 
-There are currently no implementations of the legacy ``EstimatorV1`` interface in Qiskit. 
-However, the abstract interface definition from :class:`~BaseEstimatorV1` is still part 
-of the package to provide backwards compatibility for external implementations. 
+There are currently no implementations of the legacy ``EstimatorV1`` interface in Qiskit.
+However, the abstract interface definition from :class:`~BaseEstimatorV1` is still part
+of the package to provide backwards compatibility for external implementations.
 
-An ``EstimatorV1`` implementation is initialized with an empty parameter set. 
+An ``EstimatorV1`` implementation is initialized with an empty parameter set.
 :class:`~BaseEstimatorV1` can be called via the ``.run()`` method with the following parameters:
 
 * quantum circuits (:math:`\psi_i(\theta)`): list of (parameterized) quantum circuits
@@ -201,14 +201,14 @@ the estimation.
     \langle\psi_i(\theta_k)|H_j|\psi_i(\theta_k)\rangle
 
 Here is an example of how an ``EstimatorV1`` implementation would be used.
-Note that there are currently no implementations of the legacy ``EstimatorV1`` 
-interface in Qiskit. 
+Note that there are currently no implementations of the legacy ``EstimatorV1``
+interface in Qiskit.
 
 .. code-block:: python
 
     # This is a fictional import path.
     # There are currently no EstimatorV1 implementations in Qiskit.
-    from estimator_v1_location import EstimatorV1 
+    from estimator_v1_location import EstimatorV1
     from qiskit.circuit.library import RealAmplitudes
     from qiskit.quantum_info import SparsePauliOp
 
@@ -245,13 +245,13 @@ interface in Qiskit.
 Overview of SamplerV1
 =====================
 
-There are currently no implementations of the legacy ``SamplerV1`` interface in Qiskit. 
-However, the abstract interface definition from :class:`~BaseSamplerV1` is still part 
-of the package to provide backward compatibility for external implementations. 
+There are currently no implementations of the legacy ``SamplerV1`` interface in Qiskit.
+However, the abstract interface definition from :class:`~BaseSamplerV1` is still part
+of the package to provide backward compatibility for external implementations.
 
 Sampler classes calculate probabilities or quasi-probabilities of bitstrings from quantum circuits.
 
-A ``SamplerV1`` is initialized with an empty parameter set. :class:`~BaseSamplerV1` implementations can 
+A ``SamplerV1`` is initialized with an empty parameter set. :class:`~BaseSamplerV1` implementations can
 be called via the ``.run()`` method with the following parameters:
 
 * quantum circuits (:math:`\psi_i(\theta)`): list of (parameterized) quantum circuits.
@@ -267,14 +267,14 @@ object, which contains probabilities or quasi-probabilities of bitstrings,
 plus optional metadata like error bars in the samples.
 
 Here is an example of how a ``SamplerV1`` implementation would be used.
-Note that there are currently no implementations of the legacy ``SamplerV1`` 
-interface in Qiskit. 
+Note that there are currently no implementations of the legacy ``SamplerV1``
+interface in Qiskit.
 
 .. code-block:: python
 
     # This is a fictional import path.
     # There are currently no SamplerV1 implementations in Qiskit.
-    from sampler_v1_location import Sampler 
+    from sampler_v1_location import Sampler
     from qiskit import QuantumCircuit
     from qiskit.circuit.library import RealAmplitudes
 

--- a/qiskit/providers/basic_provider/basic_provider_tools.py
+++ b/qiskit/providers/basic_provider/basic_provider_tools.py
@@ -10,9 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Contains functions used by the basic provider simulators.
-
-"""
+"""Contains functions used by the basic provider simulators."""
 from __future__ import annotations
 
 from string import ascii_uppercase, ascii_lowercase

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -403,9 +403,9 @@ encoding scheme used for symbolic expressions:
         char symbolic_encoding;
     }
 
-From V16 on, the file header struct is immediately followed by a circuit start table 
+From V16 on, the file header struct is immediately followed by a circuit start table
 containing the byte offsets of each circuit payload in the file. There are ``num_circuits``
-entries in the circuit start table, each of which is of type ``uint64_t``. In all previous 
+entries in the circuit start table, each of which is of type ``uint64_t``. In all previous
 versions, the file header is immediately followed by the circuit payloads in sequence
 without any padding in-between.
 

--- a/qiskit/transpiler/passes/layout/sabre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_layout.py
@@ -10,8 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Layout selection using the SABRE bidirectional search approach from Li et al.
-"""
+"""Layout selection using the SABRE bidirectional search approach from Li et al."""
 
 import copy
 import logging

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_gate_router.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_gate_router.py
@@ -279,7 +279,7 @@ class Commuting2qGateRouter(TransformationPass):
 
     @staticmethod
     def _greedy_build_sub_layers(
-        current_layer: dict[tuple[int, int], Gate]
+        current_layer: dict[tuple[int, int], Gate],
     ) -> list[dict[tuple[int, int], Gate]]:
         """The greedy method of building sub-layers of commuting gates."""
         sub_layers = []

--- a/qiskit/transpiler/passes/synthesis/hls_plugins.py
+++ b/qiskit/transpiler/passes/synthesis/hls_plugins.py
@@ -286,7 +286,7 @@ MCMT Synthesis
    MCMTSynthesisXGate
    MCMTSynthesisDefault
 
-   
+
 Integer comparators
 '''''''''''''''''''
 
@@ -299,8 +299,8 @@ Integer comparators
       - Auxiliary qubits
     * - ``"twos"``
       - :class:`~.IntComparatorSynthesis2s`
-      - use addition with two's complement 
-      - ``n - 1`` clean 
+      - use addition with two's complement
+      - ``n - 1`` clean
     * - ``"noaux"``
       - :class:`~.IntComparatorSynthesisNoAux`
       - flip the target controlled on all :math:`O(2^l)` allowed integer values
@@ -317,7 +317,7 @@ Integer comparators
    IntComparatorSynthesisNoAux
    IntComparatorSynthesisDefault
 
-   
+
 Sums
 ''''
 
@@ -351,7 +351,7 @@ Pauli Evolution Synthesis
       - Targeted connectivity
     * - ``"rustiq"``
       - :class:`~.PauliEvolutionSynthesisRustiq`
-      - use the synthesis method from `Rustiq circuit synthesis library 
+      - use the synthesis method from `Rustiq circuit synthesis library
         <https://github.com/smartiel/rustiq-core>`_
       - all-to-all
     * - ``"default"``

--- a/qiskit/transpiler/passes/utils/unroll_forloops.py
+++ b/qiskit/transpiler/passes/utils/unroll_forloops.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" UnrollForLoops transpilation pass """
+"""UnrollForLoops transpilation pass"""
 
 from qiskit.circuit import ForLoopOp, ContinueLoopOp, BreakLoopOp, IfElseOp
 from qiskit.transpiler.basepasses import TransformationPass

--- a/qiskit/visualization/timeline/stylesheet.py
+++ b/qiskit/visualization/timeline/stylesheet.py
@@ -263,7 +263,7 @@ def default_style() -> Dict[str, Any]:
             "measure": r"{\rm Measure}",
         },
         "formatter.latex_symbol.frame_change": r"\circlearrowleft",
-        "formatter.unicode_symbol.frame_change": "\u21BA",
+        "formatter.unicode_symbol.frame_change": "\u21ba",
         "formatter.box_height.gate": 0.5,
         "formatter.box_height.timeslot": 0.6,
         "formatter.layer.gate": 3,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ setuptools>=77.0
 setuptools-rust
 
 # Style
-black[jupyter]~=24.1
+black[jupyter]~=25.1
 
 
 # Lint

--- a/test/python/providers/fake_provider/test_generic_backend_v2.py
+++ b/test/python/providers/fake_provider/test_generic_backend_v2.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test of GenericBackendV2 backend"""
+"""Test of GenericBackendV2 backend"""
 
 import math
 import operator

--- a/test/python/synthesis/test_adder_counts.py
+++ b/test/python/synthesis/test_adder_counts.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test gate counts of synthesis algorithms for adder circuits."""
+"""Test gate counts of synthesis algorithms for adder circuits."""
 
 from __future__ import annotations
 import unittest

--- a/test/python/transpiler/test_inverse_cancellation.py
+++ b/test/python/transpiler/test_inverse_cancellation.py
@@ -181,7 +181,7 @@ class TestInverseCancellation(QiskitTestCase):
         qc.rx(np.pi / 4, 0)
         qc.rx(np.pi / 4, 0)
         with self.assertRaises(TranspilerError):
-            InverseCancellation([(RXGate(np.pi / 4))])
+            InverseCancellation([RXGate(np.pi / 4)])
 
     def test_string_gate_error(self):
         """Test that when gate is passed as a string an error is raised."""

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -330,7 +330,7 @@ def generate_parameter_vector_expression():  # pylint: disable=invalid-name
     qc = QuantumCircuit(7, name="vector_expansion")
     entanglement = [[i, i + 1] for i in range(7 - 1)]
     input_params = ParameterVector("x_par", 14)
-    user_params = ParameterVector("\u03B8_par", 1)
+    user_params = ParameterVector("\u03b8_par", 1)
 
     for i in range(qc.num_qubits):
         qc.ry(user_params[0], qc.qubits[i])

--- a/tools/build_standard_commutations.py
+++ b/tools/build_standard_commutations.py
@@ -11,8 +11,8 @@
 # that they have been altered from the originals.
 
 """Determines a commutation library over the unparameterizable standard gates, i.e. a dictionary for
-   each pair of parameterizable standard gates and all qubit overlaps that maps to either True or False,
-   depending on the present commutation relation.
+each pair of parameterizable standard gates and all qubit overlaps that maps to either True or False,
+depending on the present commutation relation.
 """
 
 import io


### PR DESCRIPTION
We're only 9 months late on this one...

The vast majority of changes are just because `black` is now better at fixing up spacing in docstrings.  The other couple of changes are removing unnecessary parentheses and being more consistent with trailing commas on split function-call parameter lists.

There's fairly little in here that should cause any significant problems with existing PRs.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

As mentioned in #15224, the version of `black` used in CI is too old to know about the `py314` option.  As it stands, only `black==25.9` seems to have added the `py314` option, which is only a month or so old, and we're not in a hurry (the mode is completely dominated by the lowest value anyway), so we can just wait til Black 2026.