### PR TITLE
Remove unnecessary `cargo install cbindgen`

### DIFF
--- a/.github/workflows/ctests.yml
+++ b/.github/workflows/ctests.yml
@@ -19,7 +19,5 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Install dependencies
-        run: cargo install cbindgen
       - name: Run tests
         run: make ctest


### PR DESCRIPTION
Since gh-14013 we use a `build.rs` script that calls `cbindgen` internally, making it subject to our `Cargo.lock` file.  Separately installing `cbindgen` is no longer necessary, and can cause problems (as the 0.29.1 release has) if it fails to build for any reason.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

This should fix all current C API CI failures.
