### PR TITLE
Expose `Neighbors` publicly from `qiskit-transpiler`

### DIFF
--- a/crates/transpiler/src/lib.rs
+++ b/crates/transpiler/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod angle_bound_registry;
 pub mod commutation_checker;
 pub mod equivalence;
+pub mod neighbors;
 pub mod passes;
 pub mod standard_equivalence_library;
 pub mod standard_gates_commutations;

--- a/crates/transpiler/src/neighbors.rs
+++ b/crates/transpiler/src/neighbors.rs
@@ -12,6 +12,7 @@
 
 use qiskit_circuit::PhysicalQubit;
 use rustworkx_core::petgraph::visit::*;
+use thiserror::Error;
 
 /// A hash-free fixed-size sparse adjacency-list representation of the neighbors of a node.
 ///
@@ -24,10 +25,10 @@ use rustworkx_core::petgraph::visit::*;
 /// containing the neighbours.  Looking whether a node _is_ a neighbour is done by iterating through
 /// the slice (it's allowable to binary search, but in practice the degree is likely sufficiently
 /// small that a linear search is faster).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Neighbors {
-    pub(crate) neighbors: Vec<PhysicalQubit>,
-    pub(crate) partition: Vec<usize>,
+    neighbors: Vec<PhysicalQubit>,
+    partition: Vec<usize>,
 }
 impl Neighbors {
     /// Construct the neighbor adjacency table from a coupling graph.
@@ -142,6 +143,61 @@ impl Neighbors {
         }
     }
 
+    /// Construct the object from its two constituent arrays.
+    ///
+    /// The `partition` array should:
+    ///
+    /// * be monotonically increasing for `0` to `neighbors.len()`
+    /// * be of length `num_qubits + 1`
+    ///
+    /// The `neighbors` array represents the connections between qubits.  Each slice
+    /// `neighbors[partition[i]..partition[i+1]]` represents the qubits that qubit `i` neighbors.
+    /// Each of these slices should:
+    ///
+    /// * contain only qubit indices that are less than `partition.len()`
+    /// * be in sorted order
+    /// * contain no duplicates
+    pub fn from_parts(
+        neighbors: Vec<PhysicalQubit>,
+        partition: Vec<usize>,
+    ) -> Result<Self, ConstructionError> {
+        if partition.first().copied() != Some(0)
+            || partition.last().copied() != Some(neighbors.len())
+            || !partition.iter().is_sorted()
+        {
+            return Err(ConstructionError::PartitionInconsistent);
+        }
+        let max_index = partition.len() - 1;
+        if neighbors.iter().any(|q| q.index() >= max_index) {
+            return Err(ConstructionError::QubitOutOfBounds);
+        }
+        if std::iter::zip(&partition, &partition[1..])
+            // `is_sorted` allows `<=`, but we want to reject equality (duplicates) too.
+            .any(|(&start, &end)| !neighbors[start..end].is_sorted_by(|a, b| a < b))
+        {
+            return Err(ConstructionError::Unsorted);
+        }
+        Ok(Self {
+            neighbors,
+            partition,
+        })
+    }
+
+    /// Directly construct this object without checking the values for coherence.
+    ///
+    /// See [from_parts] for an error-checking variant of this function.
+    pub fn from_parts_unchecked(neighbors: Vec<PhysicalQubit>, partition: Vec<usize>) -> Self {
+        Self {
+            neighbors,
+            partition,
+        }
+    }
+
+    /// Destructure this object into its "neighbor-list" and "partitions" components.
+    pub fn take(self) -> (Vec<PhysicalQubit>, Vec<usize>) {
+        (self.neighbors, self.partition)
+    }
+
     #[inline]
     pub fn num_qubits(&self) -> usize {
         self.partition.len() - 1
@@ -157,6 +213,7 @@ impl Neighbors {
         self[left].contains(&right)
     }
 }
+
 impl std::ops::Index<PhysicalQubit> for Neighbors {
     type Output = [PhysicalQubit];
 
@@ -165,6 +222,17 @@ impl std::ops::Index<PhysicalQubit> for Neighbors {
         let index = index.index();
         &self.neighbors[self.partition[index]..self.partition[index + 1]]
     }
+}
+
+/// The reasons that direct construction of a `Neighbors` object might fail.
+#[derive(Error, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConstructionError {
+    #[error("the per-qubit neighbor lists are not in sorted order or contain parallel edges")]
+    Unsorted,
+    #[error("a qubit in the adjacency list exceeds the maximum set by the partitions")]
+    QubitOutOfBounds,
+    #[error("the partitions do not monotonically increase from 0 to the length of the adjacencies")]
+    PartitionInconsistent,
 }
 
 /// Implementations of the various `petgraph` graph-visiting traits, which makes [Neighbors] (or
@@ -370,4 +438,55 @@ mod visit {
         }
     }
     impl ExactSizeIterator for Edges<'_> {}
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn from_parts_catches_errors() {
+        let lift = |idx: Vec<u32>| idx.into_iter().map(PhysicalQubit).collect::<Vec<_>>();
+        // Parition doesn't start from zero.
+        assert_eq!(
+            Neighbors::from_parts(lift(vec![1, 0]), vec![1, 2, 2]),
+            Err(ConstructionError::PartitionInconsistent)
+        );
+
+        // Partition doesn't match the length.
+        assert_eq!(
+            Neighbors::from_parts(lift(vec![]), vec![]),
+            Err(ConstructionError::PartitionInconsistent)
+        );
+        assert_eq!(
+            Neighbors::from_parts(lift(vec![1, 0]), vec![0, 1, 1]),
+            Err(ConstructionError::PartitionInconsistent),
+        );
+        assert_eq!(
+            Neighbors::from_parts(lift(vec![1, 0]), vec![0, 1, 3]),
+            Err(ConstructionError::PartitionInconsistent),
+        );
+
+        // Partition not monotonically increasing.
+        assert_eq!(
+            Neighbors::from_parts(lift(vec![1, 0]), vec![0, 3, 2]),
+            Err(ConstructionError::PartitionInconsistent),
+        );
+
+        // Neighbors not in sorted order.
+        assert_eq!(
+            Neighbors::from_parts(lift(vec![2, 1, 0, 0]), vec![0, 2, 3, 4]),
+            Err(ConstructionError::Unsorted),
+        );
+        // Neighbors contains duplicates.
+        assert_eq!(
+            Neighbors::from_parts(lift(vec![1, 1, 0, 0]), vec![0, 2, 4]),
+            Err(ConstructionError::Unsorted),
+        );
+        // Neighbors contains out-of-bounds qubits.
+        assert_eq!(
+            Neighbors::from_parts(lift(vec![2, 0]), vec![0, 1, 2]),
+            Err(ConstructionError::QubitOutOfBounds),
+        );
+    }
 }

--- a/crates/transpiler/src/passes/sabre/layout.rs
+++ b/crates/transpiler/src/passes/sabre/layout.rs
@@ -25,6 +25,7 @@ use qiskit_circuit::nlayout::NLayout;
 use qiskit_circuit::{PhysicalQubit, VirtualQubit, getenv_use_multiple_threads};
 
 use crate::TranspilerError;
+use crate::neighbors::Neighbors;
 use crate::passes::{
     dense_layout,
     disjoint_layout::{self, DisjointSplit},
@@ -33,7 +34,6 @@ use crate::target::{Target, TargetCouplingError};
 
 use super::dag::SabreDAG;
 use super::heuristic::Heuristic;
-use super::neighbors::Neighbors;
 use super::route::{RoutingProblem, RoutingResult, RoutingTarget, swap_map, swap_map_trial};
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/transpiler/src/passes/sabre/mod.rs
+++ b/crates/transpiler/src/passes/sabre/mod.rs
@@ -15,7 +15,6 @@ mod distance;
 pub mod heuristic;
 mod layer;
 mod layout;
-mod neighbors;
 pub(crate) mod route;
 
 use pyo3::prelude::*;


### PR DESCRIPTION
`Neighbors` was previously a Sabre-only internal object that was a cache-local representation of a weight-less coupling graph.  This is a good format for us to expose to C, so this PR prepares the object to be more publicly accessible, including restricting the previous `pub(crate)` access on the internals and replacing it with safe destructuring and direct-construction methods.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Close #15232