### PR TITLE
Update documentation on setting reno's `earliest-version`

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -6,14 +6,18 @@ The information detailed here is mostly related to Qiskit releases and other int
 
 ## Package Version
 
-The version of the Qiskit package and crates is set in a few places:
+The version of the Qiskit package and crates is mentioned in a few places:
 
-* `qiskit/VERSION.txt` for the Python package and docs
-* `Cargo.toml` for the Rust crates
-* `crates/cext/cbindgen.toml` for the C header file
+* `qiskit/VERSION.txt` for defining the Python package and docs
+* `Cargo.toml` for defining the Rust crates
+* `crates/cext/cbindgen.toml` for defining the C header file
+* `docs/release_notes.rst` for configuring the release-notes documentation build
 
-In principle, all three version numbers should be the same at all times.
+In principle, the first three version numbers should be the same at all times.
 However, the different languages have different conventions about formatting.
+
+The `docs/release_notes.rst` version (in the `:earliest-version:` directive to `reno`) should match the git tag of the earliest release in the series (including pre-releases).
+We use Python version-number formatting for our git tags.
 
 ### Version-number formatting
 
@@ -39,6 +43,9 @@ The package version stored into the repository should be changed as follows:
 
 - on a stable branch, the version number should be whatever the most recent release on the stable branch was; it is incremented as part of the release process.
   For example, the `stable/2.3` branch is created from the commit that bumps the version number to `2.3.0rc1`.
+
+  The `:earliest-version:` number in `docs/release_notes.rst` should be the earliest tag (including pre-releases) in that minor series.
+  For example, `stable/2.2`'s earliest release is `2.2.0b1`, whereas `stable/2.1`'s is `2.1.0rc1`.
 
 The procedure for a new minor-version release, with respect to version numbers is:
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -5,9 +5,20 @@ Qiskit |version| release notes
 ==============================
 
 ..
-    These release notes get converted into Markdown files via the infrastructure at https://github.com/Qiskit/documentation, which then gets deployed to https://quantum.cloud.ibm.com/docs/api/qiskit/release-notes. Changes to these release notes will update those release notes the next time the API docs are generated for this version.
+    These release notes get converted into Markdown files via the infrastructure at
+    https://github.com/Qiskit/documentation, which then gets deployed to
+    https://quantum.cloud.ibm.com/docs/api/qiskit/release-notes. Changes to these release notes will
+    update those release notes the next time the API docs are generated for this version.
 
-    `:earliest-version:` should be set to the rc1 release for the current minor release series. For example, the stable/1.1 branch should set it to 1.1.0rc1. If on `main`, set to the prior minor version's rc1, like `1.0.0rc1`.
+    You should set `earliest-version` to:
+
+    * if on a `stable` branch, then the _earliest_ tagged release of the minor series.  For
+      `stable/2.1` this would be `2.1.0rc1`.  For `stable/2.2` this would be `2.2.0b1`.  Typically
+      you should update this as part of making the `x.y.0` "final" release (e.g. when tagging
+      `2.2.0` or `2.3.0`).
+    * if on `main`: it doesn't matter all too much; it just affects how many old release notes
+      are built and tested as part of the release.  It still needs to be a tag reachable on `main`,
+      though, which is typically `rc1` tags.
 
 .. release-notes::
-   :earliest-version: 1.1.0rc1
+   :earliest-version: 2.2.0rc1


### PR DESCRIPTION
The important thing for `reno` is that it pulls in _all_ pre-releases in the given minor cycle.  That doesn't always mean starting at `rc1`; sometimes we make "beta" preview releases, and we still want to include release notes that came in before those tags.  If we ever made an "alpha" tag, we'd want to include that too.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


