### PR TITLE
Correctly link C documentation to the C domain

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,9 @@ extensions = [
 
 breathe_projects = {"qiskit": "xml/"}
 breathe_default_project = "qiskit"
+breathe_domain_by_extension = {
+    "h" : "c",
+}
 
 templates_path = ["_templates"]
 

--- a/releasenotes/notes/2.2/add-inverse-cancellation-to-c-5e48ba7ceff2e80c.yaml
+++ b/releasenotes/notes/2.2/add-inverse-cancellation-to-c-5e48ba7ceff2e80c.yaml
@@ -2,6 +2,6 @@
 features_c:
   - |
     Added a new transpiler pass standalone function to the C API,
-    :cpp:func:`qk_transpiler_pass_standalone_inverse_cancellation`
+    :c:func:`qk_transpiler_pass_standalone_inverse_cancellation`
     which is equivalent to calling the :class:`.InverseCancellation`
     pass with ``gates_to_cancel=None``.

--- a/releasenotes/notes/2.2/add-remove-identity-equiv-c-4bc4354c54531156.yaml
+++ b/releasenotes/notes/2.2/add-remove-identity-equiv-c-4bc4354c54531156.yaml
@@ -2,6 +2,6 @@
 features_c:
   - |
     Added a new transpiler pass standalone function to the C API,
-    :cpp:func:`qk_transpiler_pass_standalone_remove_identity_equivalent`
+    :c:func:`qk_transpiler_pass_standalone_remove_identity_equivalent`
     which is equivalent to calling the :class:`.RemoveIdentityEquivalent`
     pass.

--- a/releasenotes/notes/2.2/add-split_2q_unitaries-c-api-5d9fb88999e06458.yaml
+++ b/releasenotes/notes/2.2/add-split_2q_unitaries-c-api-5d9fb88999e06458.yaml
@@ -2,6 +2,6 @@
 features_c:
   - |
     Added a new transpiler pass standalone function to the C API,
-    :cpp:func:`qk_transpiler_pass_standalone_split_2q_unitaries`
+    :c:func:`qk_transpiler_pass_standalone_split_2q_unitaries`
     which is equivalent to calling the :class:`.Split2QUnitaries`
     pass.

--- a/releasenotes/notes/2.2/c-api-basis-translator-fd3b1a8d30011f2c.yaml
+++ b/releasenotes/notes/2.2/c-api-basis-translator-fd3b1a8d30011f2c.yaml
@@ -2,7 +2,7 @@
 features_c:
   - |
     Add support for the :class:`.BasisTranslator` transpiler pass to the C API
-    through the function :cpp:func:`qk_transpiler_pass_standalone_basis_translator`.
+    through the function :c:func:`qk_transpiler_pass_standalone_basis_translator`.
 
     Here's an example of how it should be used.
 

--- a/releasenotes/notes/2.2/c-api-consolidate-blocks-a1248e1f01cf1736.yaml
+++ b/releasenotes/notes/2.2/c-api-consolidate-blocks-a1248e1f01cf1736.yaml
@@ -2,7 +2,7 @@
 features_c:
   - |
     Add support for the :class:`.ConsolidateBlocks` transpiler pass to the C
-    API via the method :cpp:func:`qk_transpiler_pass_standalone_consolidate_blocks`.
+    API via the method :c:func:`qk_transpiler_pass_standalone_consolidate_blocks`.
 
     Here's an example:
 

--- a/releasenotes/notes/2.2/c-api-gate-direction-f8b3fa586f2eec4b.yaml
+++ b/releasenotes/notes/2.2/c-api-gate-direction-f8b3fa586f2eec4b.yaml
@@ -1,6 +1,6 @@
 ---
 features_c:
   - |
-    Added new standalone transpiler pass functions :cpp:func:`qk_transpiler_pass_standalone_check_gate_direction` and
-    :cpp:func:`qk_transpiler_pass_standalone_gate_direction`, which can be used for running the
+    Added new standalone transpiler pass functions :c:func:`qk_transpiler_pass_standalone_check_gate_direction` and
+    :c:func:`qk_transpiler_pass_standalone_gate_direction`, which can be used for running the
     :class:`.CheckGateDirection` and :class:`.GateDirection`, passes respectively.

--- a/releasenotes/notes/2.2/c-api-ops-count-bug-f633d349de315e89.yaml
+++ b/releasenotes/notes/2.2/c-api-ops-count-bug-f633d349de315e89.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     Fixed memory leakage issues during the creation of
-    a :cpp:struct:`QkOpCounts` instance and during any calls to
-    :cpp:func:`qk_opcounts_clear` whenever an empty instance is passed.
+    a :c:struct:`QkOpCounts` instance and during any calls to
+    :c:func:`qk_opcounts_clear` whenever an empty instance is passed.

--- a/releasenotes/notes/2.2/c-api-optimize-1q-decomp-88954adfe952e91f.yaml
+++ b/releasenotes/notes/2.2/c-api-optimize-1q-decomp-88954adfe952e91f.yaml
@@ -2,7 +2,7 @@
 features_c:
   - |
     Add support for the :class:`.Optimize1qGatesDecomposition` transpiler pass through
-    the C API, via the :cpp:func:`qk_transpiler_standalone_optimize_1q_sequences`
+    the C API, via the :c:func:`qk_transpiler_standalone_optimize_1q_sequences`
     method.
 
     Here's an example:

--- a/releasenotes/notes/add-qv-c-f82841337c921dd5.yaml
+++ b/releasenotes/notes/add-qv-c-f82841337c921dd5.yaml
@@ -1,5 +1,5 @@
 ---
 features_c:
   - |
-    Added a new function :cpp:func:`qk_circuit_library_quantum_volume` to
+    Added a new function :c:func:`qk_circuit_library_quantum_volume` to
     generate a quantum volume model circuit to the C API.


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
The following commits fix the incorrect linking of C domain references in our documentation, which currently only links to the C++ domain.


### Details and comments
Due to the nature of `breathe`, it is assumed all documentation was coming from the c domain because it was coming from a header file with an unspecified language (h files can be either C++ or C). The following commits add an attribute to the "conf.py" file in docs that specifies that files with a ".h" extension are in the C domain.

