### PR TITLE
Fix reuse of `ConsolidateBlocks` instances

### DIFF
--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -62,6 +62,12 @@ class ConsolidateBlocks(TransformationPass):
     the same qubits into a Unitary node, to be resynthesized later,
     to a potentially more optimal subcircuit.
 
+    This pass reads the :class:`.PropertySet` key ``ConsolidateBlocks_qubit_map`` which it uses to
+    communicate with recursive worker instances of itself for control-flow operations.  The key
+    should never be observable in a user-facing :class:`.PassManager` pipeline (it is only set in
+    internal :class:`.PassManager` instances), but the pass may return incorrect results or error if
+    another pass sets this key.
+
     Notes:
         This pass assumes that the 'blocks_list' property that it reads is
         given such that blocks are in topological order. The blocks are

--- a/releasenotes/notes/fix-consolidate-blocks-reuse-a18828999cef56ee.yaml
+++ b/releasenotes/notes/fix-consolidate-blocks-reuse-a18828999cef56ee.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed re-use of the same :class:`.ConsolidateBlocks` instance on multiple circuits, including
+    calls to :func:`.transpile` with more than one circuit and no process-based parallelization.  A
+    bug introduced in Qiskit 2.2.2 caused the pass to panic or produce invalid output if the same
+    instance was re-used on differing circuits.

--- a/releasenotes/notes/fix-consolidate-blocks-reuse-a18828999cef56ee.yaml
+++ b/releasenotes/notes/fix-consolidate-blocks-reuse-a18828999cef56ee.yaml
@@ -5,3 +5,8 @@ fixes:
     calls to :func:`.transpile` with more than one circuit and no process-based parallelization.  A
     bug introduced in Qiskit 2.2.2 caused the pass to panic or produce invalid output if the same
     instance was re-used on differing circuits.
+upgrade:
+  - |
+    :class:`.ConsolidateBlocks` now reads a :class:`.PropertySet` key ``ConsolidateBlocks_qubit_map``
+    on entry.  This key and its value are not public and should not be read or written to by other
+    passes.

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -2379,6 +2379,8 @@ class TestTranspile(QiskitTestCase):
         shared_circuits = [shared_pm.run(circuit) for circuit in circuits]
         own_circuits = [make_pm().run(circuit) for circuit in circuits]
         self.assertEqual(shared_circuits, own_circuits)
+        together_circuits = make_pm().run(circuits)
+        self.assertEqual(together_circuits, own_circuits)
 
 
 @ddt

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -728,6 +728,24 @@ class TestConsolidateBlocks(QiskitTestCase):
         self.assertEqual(actual_outer.data[0].operation.blocks[0], block)
         self.assertEqual(actual_outer.data[1].operation.blocks[0].data[0].name, "unitary")
 
+    def test_pass_reuse(self):
+        """Test that the pass can be used more than once on different circuits."""
+        # It matters that these have different numbers of qubits.
+        hadamard = QuantumCircuit(1, 1)
+        hadamard.h(0)
+        hadamard.measure(0, 0)
+        bell = QuantumCircuit(2, 2)
+        bell.h(0)
+        bell.cx(0, 1)
+        bell.measure([0, 1], [0, 1])
+
+        def make_pass():
+            return ConsolidateBlocks(force_consolidate=True)
+
+        shared = make_pass()
+        self.assertEqual(shared(hadamard), make_pass()(hadamard))
+        self.assertEqual(shared(bell), make_pass()(bell))
+
     def test_invalid_python_data_does_not_panic(self):
         """If a user feeds in invalid/old data, Rust space shouldn't panic."""
         # It doesn't really matter _what_ the failure mode is, just that we should return a regular


### PR DESCRIPTION
The `_qubit_map` state added to `ConsolidateBlocks` in #15083 (cb103d95) was attempting to get round an awkward internal `PassManager` use to pass the mapping into recursive calls.  Unfortunately, the state was not cleared on exit to the pass, so re-use of the pass object would be invalid, such as by calling the `PassManager.run` method on the result of `generate_preset_pass_manager` more than once on circuits with different sizes.

Rather than trying to plaster over the poor use of state, this commit instead moves the runtime logic to be in the `PropertySet`, so re-use troubles are limited to single executions.  It's still technically possible for the `PropertySet` to become polluted if `ConsolidateBlocks` throws an internal exception that is forcibly suppressed such that the pipeline continues, but this is completely non-standard, would require significant effort to achieve, and most likely there are large numbers of transpiler passes that are not completely exception-safe anyway.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Fix #15255
