### PR TITLE
Add beginner-friendly Qiskit 2.x example: 2-qubit Bell state using Sampler

### DIFF
--- a/examples/bell_pair_example.py
+++ b/examples/bell_pair_example.py
@@ -1,0 +1,17 @@
+from qiskit import QuantumCircuit
+from qiskit_aer.primitives import Sampler
+
+qc = QuantumCircuit(2)
+qc.h(0)
+qc.cx(0, 1)
+qc.measure_all()
+
+sampler = Sampler()
+result = sampler.run([qc]).result()
+
+# Convert quasi-distributions to counts
+shots = 1000
+counts = {format(k, '0{}b'.format(qc.num_qubits)): int(v*shots)
+          for k, v in result.quasi_dists[0].items()}
+
+print("Bell state counts:", counts)


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR adds a simple Python example demonstrating the creation of a 2-qubit Bell state using the Qiskit 2.x `Sampler` primitive. 
It is intended as a beginner-friendly example for learners and contributors who are exploring the updated Qiskit API.

### Details and comments
- Creates a new script: `examples/bell_pair_example.py`
- Shows how to:
  - Initialize a 2-qubit quantum circuit
  - Apply Hadamard and CNOT gates to create a Bell state
  - Use the `Sampler` primitive from `qiskit_aer`
  - Convert quasi-probabilities to classical counts
  - Print counts to verify the Bell state
- This example aligns with Qiskit 2.x APIs and replaces older `execute()`-based examples.
- No issues are being fixed; this is an educational addition.
- AI tool used: ChatGPT (GPT-5) to generate the initial example code.
