### PR TITLE
Fix new clippy warning in Rust 1.91

### DIFF
--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -1024,7 +1024,7 @@ pub unsafe extern "C" fn qk_opcounts_clear(op_counts: *mut OpCounts) {
         // SAFETY: We load the box from a slice pointer created from
         // the raw parts from the OpCounts::data attribute.
         unsafe {
-            let slice: Box<[OpCount]> = Box::from_raw(std::slice::from_raw_parts_mut(
+            let slice: Box<[OpCount]> = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
                 op_counts.data,
                 op_counts.len,
             ));


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The recent release of Rust 1.91 has brought with it new clippy warnings from either now enabled rules or improved checks for existing rules. This commit applies the fixes recommended by clippy which in the case of this release was a single rule `cast_slice_from_raw_parts` [1]

### Details and comments

[1] https://rust-lang.github.io/rust-clippy/beta/index.html#cast_slice_from_raw_parts