### PR TITLE
Unitary synthesis bug fix

### DIFF
--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -143,6 +143,7 @@ class UnitarySynthesis(TransformationPass):
         self._target = target if target is not None and len(target.operation_names) > 0 else None
         if target is not None:
             self._coupling_map = target.build_coupling_map()
+            self._basis_gates = set(target.operation_names)
         if synth_gates:
             self._synth_gates = synth_gates
         else:

--- a/releasenotes/notes/fix-target-overrides-basis-7802f9918933e12d.yaml
+++ b/releasenotes/notes/fix-target-overrides-basis-7802f9918933e12d.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.UnitarySynthesis` transpiler pass, when it is called
+    with a non-default synthesis plugin (specified via ``method``) that supports
+    ``basis_gates`` but not ``target``. The pass now correctly passes the basis
+    gates from the ``target`` to the plugin.


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

A small bug fix to the unitary synthesis pass in the case that a non-default plugin in specified, and this plugin supports the basis gates but not the target. When ``target`` is specified, it should override both ``basis_gates`` and ``coupling_map``, that is the plugin should be called with ``basis_gates`` and ``coupling_map`` coming from the target, and not from the standalone arguments. Previously the argument ``coupling_map`` was indeed taken from the target, but ``basis_gates`` were not.

Needed for #14952.

