### PR TITLE
Add descriptions of primitives container objects

### DIFF
--- a/qiskit/primitives/base/base_primitive_job.py
+++ b/qiskit/primitives/base/base_primitive_job.py
@@ -24,7 +24,45 @@ StatusT = TypeVar("StatusT")
 
 
 class BasePrimitiveJob(ABC, Generic[ResultT, StatusT]):
-    """Primitive job abstract base class."""
+    """Primitive job abstract base class.
+
+    This defines the functionality of the "job handle" object you get by a call to
+    ``primitive.run()``.  Typically this object represents a handle to an asynchronous task, where
+    the :meth:`status`, :meth:`done`, :meth:`running`, :meth:`cancelled` and :meth:`in_final_state`
+    methods return non-blocking information on the state of the task.
+
+    The method :meth:`result` is typically implemented as a blocking call that waits for the
+    execution result to return.  Use of this job object almost invariably ends in a call to
+    :meth:`result`.
+
+    .. note::
+
+        This is an abstract base class, defining an interface.  Each primitives provider (for
+        example, :mod:`qiskit_aer` or :mod:`qiskit_ibm_runtime`) will have its own subclass of this
+        object, which may provide additional functionality on top of this interface.
+
+    Subclassing
+    ===========
+
+    Each implementer of the primitives should provide a concrete implementation of this interface.
+    There are no provided methods on the base implementation, other than the :meth:`job_id` getter,
+    since a string key uniquely identifying jobs is a requirement of all primitives.
+
+    The ``ResultT`` generic type should be set to a subclass of the appropriate versioned primitive
+    result.  This typically will mean setting it to :class:`.PrimitiveResult` (for V2), or an
+    implementation-specific subclass of this.
+
+    The ``StatusT`` generic type is completely freeform; your implementation can provide any status
+    object you like and there is no defined interface.  Instead, the :meth:`done`, :meth:`running`,
+    :meth:`cancelled` and :meth:`in_final_state` methods of this interface should be implemented to
+    give the user simple programmatic access to coarse-grained status information.  You can provide
+    additional details in the complete ``StatusT`` generic.
+
+    Creating this "job" handle is conventionally expected (but not strictly *required*) to be fast
+    and non-blocking, and for this object to hold an internal asynchronous handle to the actual job.
+    The :meth:`result` method should typically block until ready, if called before the job has
+    completed.
+    """
 
     def __init__(self, job_id: str, **kwargs) -> None:
         """Initializes the primitive job.

--- a/qiskit/primitives/containers/bit_array.py
+++ b/qiskit/primitives/containers/bit_array.py
@@ -62,6 +62,19 @@ class BitArray(ShapedMixin):
     This object contains a single, contiguous block of data that represents an array of bitstrings.
     The last axis is over packed bits, the second last axis is over shots, and the preceding axes
     correspond to the shape of the pub that was executed to sample these bits.
+
+    You typically get this object back as one part of a :class:`.DataBin` accessed through
+    a single :class:`.PubResult.data`.  Users do not typically need to create this class themselves.
+
+    This class supports the bitwise ``&`` (and), ``|`` (or), ``^`` (xor) and ``~`` (not) operators,
+    where the binary operators act on two :class:`BitArray` instances.
+
+    The class also supports the "indexing" syntax ``bit_array[indices]``.  These ``indices`` select
+    a single entry, or multi-dimensional slice of entries, from the same shape as the corresponding
+    pub.  The allowed indices match :class:`numpy.ndarray`: you can use single integers, slices
+    (``a:b``) or Numpy arrays for each dimension, and use a tuple of items to slice multiple
+    dimensions at once. The indexing syntax cannot be used to slice along the "shots" or "bits"
+    axes; for these, use :meth:`slice_shots` and :meth:`slice_bits`, respectively.
     """
 
     def __init__(self, array: NDArray[np.uint8], num_bits: int):

--- a/qiskit/primitives/containers/bit_array.py
+++ b/qiskit/primitives/containers/bit_array.py
@@ -64,7 +64,13 @@ class BitArray(ShapedMixin):
     correspond to the shape of the pub that was executed to sample these bits.
 
     You typically get this object back as one part of a :class:`.DataBin` accessed through
-    a single :class:`.PubResult.data`.  Users do not typically need to create this class themselves.
+    a single :class:`.PubResult.data`.  Users do not typically create this class themselves, however
+    if you have bitstring-like data in an alternate form that you would like to convert to a
+    :class:`BitArray`, you can use one of :meth:`from_bool_array`, :meth:`from_counts` or
+    :meth:`from_samples`.
+
+    You can "unpack" the bitstrings into expanded array of :class:`bool` by using the
+    :meth:`to_bool_array` method.
 
     This class supports the bitwise ``&`` (and), ``|`` (or), ``^`` (xor) and ``~`` (not) operators,
     where the binary operators act on two :class:`BitArray` instances.

--- a/qiskit/primitives/containers/data_bin.py
+++ b/qiskit/primitives/containers/data_bin.py
@@ -40,7 +40,7 @@ class DataBin(ShapedMixin):
     This class will have different attributes and keys, depending on the primitive used and the
     pub submitted.  These "special" attributes will have names that match the keys.  For example, if
     you submitted a :class:`.SamplerV2` job, typically the attributes and keys are the names of the
-    :class:`.ClassicalRegister`s that were in the circuit defining this pub.
+    :class:`.ClassicalRegister` objects that were in the circuit defining this pub.
 
     All of the attributes and keys have the same shape associated with them, which is the
     n-dimensional shape of the corresponding pub.  The attributes and keys will typically either be

--- a/qiskit/primitives/containers/data_bin.py
+++ b/qiskit/primitives/containers/data_bin.py
@@ -30,7 +30,27 @@ def _value_repr(value: Any) -> str:
 
 
 class DataBin(ShapedMixin):
-    """Namespace for storing data.
+    """The main data return from a single pub out of :class:`.PubResult`.
+
+    You access the data within this object either by attribute access (``data_bin.my_field``) or by
+    :class:`dict`-like string keys (``data_bin["my_field"]``).  This class behaves as a Python
+    immutable mapping, so you can (for example) query the available keys with :meth:`keys`, and
+    iterate through both keys and values with :meth:`items`.
+
+    This class will have different attributes and keys, depending on the primitive used and the
+    pub submitted.  These "special" attributes will have names that match the keys.  For example, if
+    you submitted a :class:`.SamplerV2` job, typically the attributes and keys are the names of the
+    :class:`.ClassicalRegister`s that were in the circuit defining this pub.
+
+    All of the attributes and keys have the same shape associated with them, which is the
+    n-dimensional shape of the corresponding pub.  The attributes and keys will typically either be
+    :class:`.BitArray` or :class:`numpy.ndarray` instances, depending on the primitive used and the
+    input pub.
+
+    Users do not typically construct this class themselves.  Instead, you receive it as the
+    :attr:`.PubResult.data` field for a single pub's result out of a complete execution.
+
+    Examples:
 
     .. plot::
        :include-source:

--- a/qiskit/primitives/containers/primitive_result.py
+++ b/qiskit/primitives/containers/primitive_result.py
@@ -23,7 +23,25 @@ T = TypeVar("T", bound=PubResult)
 
 
 class PrimitiveResult(Generic[T]):
-    """A container for multiple pub results and global metadata."""
+    """A container for multiple pub results and global metadata.
+
+    This is the return value from any V2 primitive's ``run`` method.  This object corresponds to the
+    *entire* execution, not any single pub; it does not contain any actual data, but may contain
+    freeform :attr:`metadata` returned by the primitive implementer about the entire submission (as
+    opposed to :attr:`.PubResult.metadata`, which is metadata about a single pub).
+
+    You access the actual data of each individual pub either by iterating through this object (``for
+    pub_result in primitive_result: ...``), or by direct list-like index access ``pub_result =
+    primitive_result[0]``.  The type of each individual pub result is :class:`.PubResult`, or
+    potentially a primitive- and implementation-specific subclass of that.
+
+    Most likely, if you submitted a single pub to a primitive like::
+
+        primitive_result = primitive.run([(qc,)]).result()
+
+    then the data you care about is in ``primitive_result[0].data``, which is a :class:`.DataBin`.
+    The object ``primitive_result[0]`` is a :class:`.PubResult`.
+    """
 
     def __init__(self, pub_results: Iterable[T], metadata: dict[str, Any] | None = None):
         """

--- a/qiskit/primitives/containers/primitive_result.py
+++ b/qiskit/primitives/containers/primitive_result.py
@@ -25,8 +25,8 @@ T = TypeVar("T", bound=PubResult)
 class PrimitiveResult(Generic[T]):
     """A container for multiple pub results and global metadata.
 
-    This is the return value from any V2 primitive's ``run`` method.  This object corresponds to the
-    *entire* execution, not any single pub; it does not contain any actual data, but may contain
+    This is the return value from any V2 primitive's ``run().result()``.  This object corresponds to
+    the *entire* execution, not any single pub; it does not contain any actual data, but may contain
     freeform :attr:`metadata` returned by the primitive implementer about the entire submission (as
     opposed to :attr:`.PubResult.metadata`, which is metadata about a single pub).
 

--- a/qiskit/primitives/containers/pub_result.py
+++ b/qiskit/primitives/containers/pub_result.py
@@ -22,7 +22,21 @@ from .data_bin import DataBin
 
 
 class PubResult:
-    """Result of Primitive Unified Bloc."""
+    """The result object for a single pub (primitive unified bloc).
+
+    Each :class:`.PubResult` is a single element of a greater :class:`.PrimitiveResult`.  Within
+    this result, there is implementation-defined freeform :attr:`metadata`, and a :class:`.DataBin`
+    in the :attr:`data` field.
+
+    Most likely, you care about accessing the processed data of your execution.  This is in the
+    :attr:`data` attribute.  The :attr:`metadata` object may contain extra information about the
+    execution of this pub, including implementation-specific information, which should be documented
+    by your primitive provider (as opposed to :attr:`.PrimitiveResult.metadata`, which is metadata
+    about the entire submission).
+
+    You typically get instances of this class by iterating over or indexing into a
+    :class:`.PrimitiveResult`, which is what you get from ``MyPritimive().run().result()``.
+    """
 
     __slots__ = ("_data", "_metadata")
 

--- a/qiskit/primitives/containers/sampler_pub_result.py
+++ b/qiskit/primitives/containers/sampler_pub_result.py
@@ -25,7 +25,13 @@ from .pub_result import PubResult
 
 
 class SamplerPubResult(PubResult):
-    """Result of Sampler Pub."""
+    """Result of Sampler Pub.
+
+    This is a :class:`.SamplerV2`-specific subclass of :class:`.PubResult` that adds helper methods
+    to deal with the bit-array like :class:`.BitArray` data directly (implicitly going via the
+    :class:`.DataBin` in :attr:`data`).  See :class:`.PubResult` for more documentation on how to
+    use this class.
+    """
 
     def join_data(self, names: Iterable[str] | None = None) -> BitArray | np.ndarray:
         """Join data from many registers into one data container.

--- a/qiskit/primitives/primitive_job.py
+++ b/qiskit/primitives/primitive_job.py
@@ -23,8 +23,13 @@ from .base.base_primitive_job import BasePrimitiveJob, ResultT
 
 
 class PrimitiveJob(BasePrimitiveJob[ResultT, JobStatus]):
-    """
-    Primitive job class for the reference implementations of Primitives.
+    """Handle to a job from the reference implementations of the primitives in Qiskit.
+
+    This is a concrete implementation of the :class:`.BasePrimitiveJob` interface.  See the
+    documentation of that class for a discussion of the interface.
+
+    Primitives implementers looking to create their own job classes should not subclass this, but
+    instead subclass the interface definition :class:`.BasePrimitiveJob`.
     """
 
     def __init__(self, function, *args, **kwargs):


### PR DESCRIPTION
This adds prose descriptions of the "container" and "handle" objects of `qiskit.primitives`, which previously had stub documentation.  When users are using the primitives and the returned objects interactively, it can be very difficult to tell how to use each individual object, especially because several of them are implemented using "magic methods", which do not get suggested by code completion, and were not alluded to in the per-class API documentation.

This PR doesn't include per-object examples - I didn't feel entirely comfortable trying to fill that in myself - but the prose should hopefully already be a significant improvement.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


