### PR TITLE
Add qk_transpile_stage_optimization() to the C API

### DIFF
--- a/crates/cext/src/transpiler/transpile_function.rs
+++ b/crates/cext/src/transpiler/transpile_function.rs
@@ -230,7 +230,7 @@ pub unsafe extern "C" fn qk_transpile_stage_init(
 ///   for more details on the default values.
 /// @param error A pointer to a pointer with an nul terminated string with an error description.
 ///   If the transpiler fails a pointer to the string with the error description will be written
-///   to this pointer. That pointer needs to be freed with ``qk_str_free```. This can be a null
+///   to this pointer. That pointer needs to be freed with ``qk_str_free``. This can be a null
 ///   pointer in which case the error will not be written out.
 ///
 /// @returns The return code for the transpiler, ``QkExitCode_Success`` means success and all

--- a/crates/cext/src/transpiler/transpile_function.rs
+++ b/crates/cext/src/transpiler/transpile_function.rs
@@ -20,7 +20,7 @@ use qiskit_transpiler::target::Target;
 use qiskit_transpiler::transpile;
 use qiskit_transpiler::transpile_layout::TranspileLayout;
 use qiskit_transpiler::transpiler::{
-    get_sabre_heuristic, init_stage, layout_stage, translation_stage,
+    get_sabre_heuristic, init_stage, layout_stage, optimization_stage, translation_stage,
 };
 
 use crate::exit_codes::ExitCode;
@@ -181,6 +181,108 @@ pub unsafe extern "C" fn qk_transpile_stage_init(
             }
             ExitCode::Success
         }
+        Err(e) => {
+            if !error.is_null() {
+                unsafe {
+                    // Right now we return a backtrace of the error. This at least gives a hint as to
+                    // which pass failed when we have rust errors normalized we can actually have error
+                    // messages which are user facing. But most likely this will be a PyErr and panic
+                    // when trying to extract the string.
+                    *error = CString::new(format!(
+                        "Transpilation failed with this backtrace: {}",
+                        e.backtrace()
+                    ))
+                    .unwrap()
+                    .into_raw();
+                }
+            }
+            ExitCode::TranspilerError
+        }
+    }
+}
+
+/// @ingroup QkTranspiler
+/// Run the preset optimization stage of the transpiler on a circuit
+///
+/// The Qiskit transpiler is a quantum circuit compiler that rewrites a given
+/// input circuit to match the constraints of a QPU and optimizes the circuit
+/// for execution. This function runs the fourth stage of the preset pass manager,
+/// **optimization**, which optimizes the circuit for the given target after the
+/// circuit has been transformed into a physical circuit. You can refer to
+/// @verbatim embed:rst:inline :ref:`transpiler-preset-stage-optimization` @endverbatim for
+/// more details.
+///
+/// This function should only be used with circuits constructed
+/// using Qiskit's C API. It makes assumptions on the circuit only using features exposed via C,
+/// if you are in a mixed Python and C environment it is typically better to invoke the transpiler
+/// via Python.
+///
+/// This function is multithreaded internally and will launch a thread pool
+/// with threads equal to the number of CPUs reported by the operating system by default.
+/// This will include logical cores on CPUs with simultaneous multithreading. You can tune the
+/// number of threads with the ``RAYON_NUM_THREADS`` environment variable. For example, setting
+/// ``RAYON_NUM_THREADS=4`` would limit the thread pool to 4 threads.
+///
+/// @param dag A pointer to the circuit to run the transpiler on.
+/// @param target A pointer to the target to compile the circuit for.
+/// @param options A pointer to an options object that defines user options. If this is a null
+///   pointer the default values will be used. See ``qk_transpile_default_options``
+///   for more details on the default values.
+/// @param error A pointer to a pointer with an nul terminated string with an error description.
+///   If the transpiler fails a pointer to the string with the error description will be written
+///   to this pointer. That pointer needs to be freed with ``qk_str_free```. This can be a null
+///   pointer in which case the error will not be written out.
+///
+/// @returns The return code for the transpiler, ``QkExitCode_Success`` means success and all
+///   other values indicate an error.
+///
+/// # Safety
+///
+/// Behavior is undefined if ``dag`` and ``target`` are not valid, non-null
+/// pointers to a ``QkDag``, or a ``QkTarget`` respectively. ``options`` must
+/// be a valid pointer a to a ``QkTranspileOptions`` or ``NULL``. ``error`` must
+/// be a valid pointer to a ``char`` pointer or ``NULL``.
+#[unsafe(no_mangle)]
+#[cfg(feature = "cbinding")]
+pub unsafe extern "C" fn qk_transpile_stage_optimization(
+    dag: *mut DAGCircuit,
+    target: *const Target,
+    options: *const TranspileOptions,
+    error: *mut *mut c_char,
+) -> ExitCode {
+    // SAFETY: Per documentation, the pointers are non-null and aligned.
+    let dag = unsafe { mut_ptr_as_ref(dag) };
+    let target = unsafe { const_ptr_as_ref(target) };
+    let options = if options.is_null() {
+        &TranspileOptions::default()
+    } else {
+        // SAFETY: We checked the pointer is not null, then, per documentation, it is a valid
+        // and aligned pointer.
+        unsafe { const_ptr_as_ref(options) }
+    };
+
+    let approximation_degree = if options.approximation_degree.is_nan() {
+        None
+    } else {
+        if !(0.0..=1.0).contains(&options.approximation_degree) {
+            panic!(
+                "Invalid value provided for approximation degree, only NAN or values between 0.0 and 1.0 inclusive are valid"
+            );
+        }
+        Some(options.approximation_degree)
+    };
+    let mut equiv_lib = generate_standard_equivalence_library();
+    let mut commutation_checker = get_standard_commutation_checker();
+
+    match optimization_stage(
+        dag,
+        target,
+        options.optimization_level.into(),
+        approximation_degree,
+        &mut commutation_checker,
+        &mut equiv_lib,
+    ) {
+        Ok(_) => ExitCode::Success,
         Err(e) => {
             if !error.is_null() {
                 unsafe {

--- a/releasenotes/notes/transpile_init_c-89e73e83589c3c36.yaml
+++ b/releasenotes/notes/transpile_init_c-89e73e83589c3c36.yaml
@@ -1,7 +1,17 @@
 ---
 features_c:
   - |
-    Added a new function :c:func:`qk_transpile_stage_init` to the C API.
-    This function is used to run the init stage from the preset pass manager
-    on a ``QkDag`` object. The goal of this function is to enable composable
+    Added new functions for running transpiler stages to the C API. These
+    functions are:
+
+      * :c:func:`qk_transpile_stage_init`
+      * :c:func:`qk_transpile_stage_layout`
+      * :c:func:`qk_transpile_stage_translation`
+      * :c:func:`qk_transpile_stage_optimization`
+
+    run the :ref:`transpiler-preset-stage-init`, :ref:`transpiler-preset-stage-layout`,
+    :ref:`transpiler-preset-stage-translation`, and
+    :ref:`transpiler-preset-stage-optimization` respectively.
+    These function are used to run these stages from the preset pass manager
+    on a ``QkDag`` object. The goal of these functions are to enable composable
     transpilation workflows from C when combined with custom transpiler passes.

--- a/test/c/test_transpiler.c
+++ b/test/c/test_transpiler.c
@@ -354,6 +354,37 @@ cleanup:
     return result;
 }
 
+int test_optimization_stage_empty(void) {
+    int result = Ok;
+    uint32_t num_qubits = 2048;
+    QkTarget *target = qk_target_new(num_qubits);
+    QkTargetEntry *cx_entry = qk_target_entry_new(QkGate_CX);
+    for (uint32_t i = 0; i < num_qubits - 1; i++) {
+        qk_target_entry_add_property(cx_entry, (uint32_t[]){i, i + 1}, 2, 0.001 * i, 0.002 * i);
+    }
+    qk_target_add_instruction(target, cx_entry);
+    qk_target_add_instruction(target, qk_target_entry_new(QkGate_U));
+
+    QkDag *dag = qk_dag_new();
+    QkQuantumRegister *qr = qk_quantum_register_new(2048, "qr");
+    qk_dag_add_quantum_register(dag, qr);
+    int compile_result = qk_transpile_stage_optimization(dag, target, NULL, NULL);
+    if (compile_result != 0) {
+        result = EqualityError;
+        printf("Running the optimization stage failed\n");
+        goto cleanup;
+    }
+    uint32_t num_dag_qubits = qk_dag_num_qubits(dag);
+    if (num_dag_qubits != 2048) {
+        result = EqualityError;
+        printf("Number of dag qubits %u does not match expected result 2048", num_dag_qubits);
+    }
+cleanup:
+    qk_target_free(target);
+    qk_dag_free(dag);
+    return result;
+}
+
 int test_transpiler(void) {
     int num_failed = 0;
     num_failed += RUN_TEST(test_transpile_bv);
@@ -362,6 +393,7 @@ int test_transpiler(void) {
     num_failed += RUN_TEST(test_init_stage_empty);
     num_failed += RUN_TEST(test_layout_stage_empty);
     num_failed += RUN_TEST(test_translation_stage_empty);
+    num_failed += RUN_TEST(test_optimization_stage_empty);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new function to the C API,
`qk_transpile_stage_optimization()`, which is used to run just the optimization stage
of the preset pass manager. The intended use case for this is to enable
using stages from the preset pass manager with custom transpiler passes
to build custom compilation workflows from C.

### Details and comments

~This commit is based on top of https://github.com/Qiskit/qiskit/pull/15293 and will need to be rebased after that merges. In the meantime you can view the content of just this PR by looking at the HEAD commit: https://github.com/Qiskit/qiskit/commit/1bc9cb4e2d63529f4dd899f5814ece66f6e3134d~ This has been rebased on main now.
