### PR TITLE
Update to `macos-15-intel` in CI

### DIFF
--- a/.github/workflows/ctests.yml
+++ b/.github/workflows/ctests.yml
@@ -14,7 +14,7 @@ jobs:
         os:
           - ubuntu-latest
           # Used for the x86_64 builds.
-          - macos-13
+          - macos-15-intel
           # Used for the ARM builds.
           - macos-14
           - ubuntu-24.04-arm

--- a/.github/workflows/on-merge-queue.yml
+++ b/.github/workflows/on-merge-queue.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.13"]
-        runner: ["macos-13", "macos-14"]
+        runner: ["macos-15-intel", "macos-14"]
     with:
       python-version: ${{ matrix.python-version }}
       install-optionals: false

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        runner: ["macos-13", "macos-14"]
+        runner: ["macos-15-intel", "macos-14"]
 
     with:
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         python_version: ["3.9", "3.13"]
-        runner: ["macos-13", "macos-14"]
+        runner: ["macos-15-intel", "macos-14"]
     uses: ./.github/workflows/test-mac.yml
     with:
       python-version: ${{ matrix.python_version }}

--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -73,7 +73,7 @@ jobs:
         os:
           - ubuntu-latest
           # Used for the x86_64 builds.
-          - macos-13
+          - macos-15-intel
           # Used for the ARM builds.
           - macos-14
           - windows-latest


### PR DESCRIPTION
The `macos-13` image is being browned out on GitHub Actions, with complete removal on the 4th of December[^1].  This date is before the EOL of the `stable/2.2` branch, so we need to migrate it to use the newer images before then, to avoid having a two-week period where the 2.2 series is supported but we cannot push to the branch or make deployments of it.

[^1]: https://github.com/actions/runner-images/issues/13046#issue-3435017739

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

A couple of backport PRs were affected by the first brownout.
