### PR TITLE
Skip intermediate PyList in PauliProductMeasurement::create_py_op()

### DIFF
--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -2963,8 +2963,8 @@ impl Operation for PauliProductMeasurement {
 
 impl PauliProductMeasurement {
     pub fn create_py_op(&self, py: Python, label: Option<&str>) -> PyResult<Py<PyAny>> {
-        let z = self.z.clone().into_bound_py_any(py)?;
-        let x = self.x.clone().into_bound_py_any(py)?;
+        let z = self.z.to_pyarray(py);
+        let x = self.x.to_pyarray(py);
 
         let phase = if self.neg { 2 } else { 0 };
 


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the recently merged #15126 the PauliProductMeasurement operation being added to Rust was unecessarily creating a pylist to go from `Vec<bool>` -> `np.array[bool]` for the z and x parameters while we can leverage rust-numpy to go straight from a Vec to a numpy array. This was raised in review for the PR, but the fix just changed the mechanism a Pylist was created by and didn't actually remove the python list creation. `into_bound_py_any()` just is a short cut for using the default IntoPyObject trait's conversion and casting it as a PyAny. In the case of `Vec<T>` that means it's converting to a `PyList<T>`. Doing this still results in 2 copies, one of which is done in Python. This commit fixes the issue by using `to_pyarray()` to copy the Vec<bool> directly into a numpy owned array. We have to copy still since we aren't deleting the owning PauliProductMeasurement in Rust so we can't use `into_pyarray()` which would avoid that copy. But this sill reduces the numbers of copies needed to make the numpy arrays in Python.

### Details and comments


