### PR TITLE
CI: Try installing doxygen from binaries.

### DIFF
--- a/.github/workflows/lint_docs.yml
+++ b/.github/workflows/lint_docs.yml
@@ -24,9 +24,11 @@ jobs:
         with:
           python-version: "3.9"
       - name: Install ubuntu docs dependencies
-        run: tools/install_ubuntu_docs_dependencies.sh ${{secrets.GITHUB_TOKEN}}
+        run: tools/install_ubuntu_docs_dependencies.sh
       - name: Run docs
         run: tox -e docs
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Clean up docs detritus
         run: rm -rf docs/_build/html/{.doctrees,.buildinfo}
       - name: Store built documentation artifact

--- a/.github/workflows/lint_docs.yml
+++ b/.github/workflows/lint_docs.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: "3.9"
       - name: Install ubuntu docs dependencies
-        run: tools/install_ubuntu_docs_dependencies.sh
+        run: tools/install_ubuntu_docs_dependencies.sh ${{secrets.GITHUB_TOKEN}}
       - name: Run docs
         run: tox -e docs
       - name: Clean up docs detritus

--- a/.github/workflows/lint_docs.yml
+++ b/.github/workflows/lint_docs.yml
@@ -25,10 +25,10 @@ jobs:
           python-version: "3.9"
       - name: Install ubuntu docs dependencies
         run: tools/install_ubuntu_docs_dependencies.sh
-      - name: Run docs
-        run: tox -e docs
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Run docs
+        run: tox -e docs
       - name: Clean up docs detritus
         run: rm -rf docs/_build/html/{.doctrees,.buildinfo}
       - name: Store built documentation artifact

--- a/crates/cext/src/transpiler/passes/sabre_layout.rs
+++ b/crates/cext/src/transpiler/passes/sabre_layout.rs
@@ -89,7 +89,7 @@ pub extern "C" fn qk_sabre_layout_options_default() -> SabreLayoutOptions {
 ///
 /// [2] Li, Gushu, Yufei Ding, and Yuan Xie. "Tackling the qubit mapping problem
 /// for NISQ-era quantum devices." ASPLOS 2019.
-/// [`arXiv:1809.02573](https://arxiv.org/pdf/1809.02573.pdf)
+/// [arXiv:1809.02573](https://arxiv.org/pdf/1809.02573.pdf)
 ///
 /// @param circuit A pointer to the circuit to run SabreLayout on. The circuit
 ///     is modified in place and the original circuit's allocations are freed by this function.

--- a/crates/cext/src/transpiler/transpile_function.rs
+++ b/crates/cext/src/transpiler/transpile_function.rs
@@ -101,7 +101,7 @@ pub extern "C" fn qk_transpiler_default_options() -> TranspileOptions {
 ///   the members using the respective free functions.
 /// @param error A pointer to a pointer with an nul terminated string with an error description.
 ///   If the transpiler fails a pointer to the string with the error description will be written
-///   to this pointer. That pointer needs to be freed with ``qk_str_free```. This can be a null
+///   to this pointer. That pointer needs to be freed with ``qk_str_free``. This can be a null
 ///   pointer in which case the error will not be written out.
 ///
 /// @returns The return code for the transpiler, ``QkExitCode_Success`` means success and all
@@ -111,7 +111,7 @@ pub extern "C" fn qk_transpiler_default_options() -> TranspileOptions {
 ///
 /// Behavior is undefined if ``circuit``, ``target``, or ``result``, are not valid, non-null
 /// pointers to a ``QkCircuit``, ``QkTarget``, or ``QkTranspileResult`` respectively.
-/// ``options`` must be a valid pointer a to a ``QkTranspileOptions`` or ``NULL`.
+/// ``options`` must be a valid pointer a to a ``QkTranspileOptions`` or ``NULL``.
 /// ``error`` must be a valid pointer to a ``char`` pointer or ``NULL``.
 #[unsafe(no_mangle)]
 #[cfg(feature = "cbinding")]

--- a/tools/install_ubuntu_docs_dependencies.sh
+++ b/tools/install_ubuntu_docs_dependencies.sh
@@ -23,7 +23,6 @@ if [ $GITHUB_TOKEN ]; then
     DOXYGEN_DIR=$(find . -maxdepth 1 -type d  -name "doxygen*")
     cd $DOXYGEN_DIR
     # Run the remainder of the setup process
-    ./configure
     make
     sudo make install
 else

--- a/tools/install_ubuntu_docs_dependencies.sh
+++ b/tools/install_ubuntu_docs_dependencies.sh
@@ -23,7 +23,7 @@ if [ $GITHUB_TOKEN ]; then
     DOXYGEN_DIR=$(find . -maxdepth 1 -type d  -name "doxygen*")
     cd $DOXYGEN_DIR
     # Run the remainder of the setup process
-    make
+    sudo make
     sudo make install
 else
     echo "No github token provided"

--- a/tools/install_ubuntu_docs_dependencies.sh
+++ b/tools/install_ubuntu_docs_dependencies.sh
@@ -2,8 +2,7 @@
 #
 # Prepare an Ubuntu CI machine for running 'tox -e docs'.  Assumes that Python is available.
 
-if [[ -n "$GITHUB_TOKEN" ]]
-then
+if [ -n "$GITHUB_TOKEN" ]; then
     set -e
 
     python -m pip install --upgrade pip setuptools wheel

--- a/tools/install_ubuntu_docs_dependencies.sh
+++ b/tools/install_ubuntu_docs_dependencies.sh
@@ -2,7 +2,7 @@
 #
 # Prepare an Ubuntu CI machine for running 'tox -e docs'.  Assumes that Python is available.
 
-if [[ -n "$1" ]]
+if [[ -n "$GITHUB_TOKEN" ]]
 then
     set -e
 
@@ -13,7 +13,7 @@ then
     sudo apt-get install -y graphviz pandoc 
 
     # This command fetches the latest release of doxygen and its linux binaries
-    curl -H "Authorization: token $$1" \
+    curl -H "Authorization: token $$GITHUB_TOKEN" \
         https://api.github.com/repos/doxygen/doxygen/releases/latest | \
         jq '.["assets"][2]["browser_download_url"]' | \
         xargs -I {} wget {} -O ./doxygen.tar.gz

--- a/tools/install_ubuntu_docs_dependencies.sh
+++ b/tools/install_ubuntu_docs_dependencies.sh
@@ -19,7 +19,9 @@ if [ $GITHUB_TOKEN ]; then
 
     # The following commands install the binaries for doxygen
     tar -zxvf ./doxygen.tar.gz
-    cd ./doxygen
+    # Find the doxygen folder and pick the first option
+    find . -type d | grep doxygen -m 1 | xargs -I {} cd {}
+    # Run the remainder of the setup process
     ./configure
     make
     sudo make install

--- a/tools/install_ubuntu_docs_dependencies.sh
+++ b/tools/install_ubuntu_docs_dependencies.sh
@@ -5,22 +5,22 @@
 if [ $GITHUB_TOKEN ]; then
     set -e
 
-    python -m pip install --upgrade pip setuptools wheel
-    python -m pip install --upgrade tox
+    # python -m pip install --upgrade pip setuptools wheel
+    # python -m pip install --upgrade tox
 
-    sudo apt-get update
-    sudo apt-get install -y graphviz pandoc 
+    # sudo apt-get update
+    # sudo apt-get install -y graphviz pandoc 
 
     # This command fetches the latest release of doxygen and its linux binaries
-    curl -H "Authorization: token $GITHUB_TOKEN" \
-        https://api.github.com/repos/doxygen/doxygen/releases/latest | \
-        jq '.["assets"][2]["browser_download_url"]' | \
-        xargs -I {} wget {} -O ./doxygen.tar.gz
+    # curl -H "Authorization: token $GITHUB_TOKEN" \
+    #     https://api.github.com/repos/doxygen/doxygen/releases/latest | \
+    #     jq '.["assets"][2]["browser_download_url"]' | \
+    #     xargs -I {} wget {} -O ./doxygen.tar.gz
 
     # The following commands install the binaries for doxygen
     tar -zxvf ./doxygen.tar.gz
     # Find the doxygen folder and pick the first option
-    find . -type d | grep doxygen -m 1 | xargs -I {} cd {}
+    cd "$(find . -type d | grep doxygen -m 1)"
     # Run the remainder of the setup process
     ./configure
     make

--- a/tools/install_ubuntu_docs_dependencies.sh
+++ b/tools/install_ubuntu_docs_dependencies.sh
@@ -26,4 +26,5 @@ then
     sudo make install
 else
     echo "No github token provided"
+    exit 1
 fi

--- a/tools/install_ubuntu_docs_dependencies.sh
+++ b/tools/install_ubuntu_docs_dependencies.sh
@@ -8,4 +8,20 @@ python -m pip install --upgrade pip setuptools wheel
 python -m pip install --upgrade tox
 
 sudo apt-get update
-sudo apt-get install -y graphviz pandoc doxygen
+sudo apt-get install -y graphviz pandoc 
+
+# This command fetches the latest release of doxygen and its linux binaries
+curl -H "Authorization: token $$0" \
+    https://api.github.com/repos/doxygen/doxygen/releases/latest | \
+    jq '.["assets"][2]["browser_download_url"]' | \
+    xargs -I {} wget {} -O ./doxygen.tar.gz
+
+# The following commands install the binaries for doxygen
+tar -zxvf ./doxygen.tar.gz
+cd ./doxygen
+./configure
+make
+sudo make install
+
+
+

--- a/tools/install_ubuntu_docs_dependencies.sh
+++ b/tools/install_ubuntu_docs_dependencies.sh
@@ -2,26 +2,28 @@
 #
 # Prepare an Ubuntu CI machine for running 'tox -e docs'.  Assumes that Python is available.
 
-set -e
+if [[ -n "$1" ]]
+then
+    set -e
 
-python -m pip install --upgrade pip setuptools wheel
-python -m pip install --upgrade tox
+    python -m pip install --upgrade pip setuptools wheel
+    python -m pip install --upgrade tox
 
-sudo apt-get update
-sudo apt-get install -y graphviz pandoc 
+    sudo apt-get update
+    sudo apt-get install -y graphviz pandoc 
 
-# This command fetches the latest release of doxygen and its linux binaries
-curl -H "Authorization: token $$0" \
-    https://api.github.com/repos/doxygen/doxygen/releases/latest | \
-    jq '.["assets"][2]["browser_download_url"]' | \
-    xargs -I {} wget {} -O ./doxygen.tar.gz
+    # This command fetches the latest release of doxygen and its linux binaries
+    curl -H "Authorization: token $$1" \
+        https://api.github.com/repos/doxygen/doxygen/releases/latest | \
+        jq '.["assets"][2]["browser_download_url"]' | \
+        xargs -I {} wget {} -O ./doxygen.tar.gz
 
-# The following commands install the binaries for doxygen
-tar -zxvf ./doxygen.tar.gz
-cd ./doxygen
-./configure
-make
-sudo make install
-
-
-
+    # The following commands install the binaries for doxygen
+    tar -zxvf ./doxygen.tar.gz
+    cd ./doxygen
+    ./configure
+    make
+    sudo make install
+else
+    echo "No github token provided"
+fi

--- a/tools/install_ubuntu_docs_dependencies.sh
+++ b/tools/install_ubuntu_docs_dependencies.sh
@@ -2,7 +2,7 @@
 #
 # Prepare an Ubuntu CI machine for running 'tox -e docs'.  Assumes that Python is available.
 
-if [ -n "$GITHUB_TOKEN" ]; then
+if [ $GITHUB_TOKEN ]; then
     set -e
 
     python -m pip install --upgrade pip setuptools wheel
@@ -12,7 +12,7 @@ if [ -n "$GITHUB_TOKEN" ]; then
     sudo apt-get install -y graphviz pandoc 
 
     # This command fetches the latest release of doxygen and its linux binaries
-    curl -H "Authorization: token $$GITHUB_TOKEN" \
+    curl -H "Authorization: token $GITHUB_TOKEN" \
         https://api.github.com/repos/doxygen/doxygen/releases/latest | \
         jq '.["assets"][2]["browser_download_url"]' | \
         xargs -I {} wget {} -O ./doxygen.tar.gz

--- a/tools/install_ubuntu_docs_dependencies.sh
+++ b/tools/install_ubuntu_docs_dependencies.sh
@@ -5,17 +5,17 @@
 if [ $GITHUB_TOKEN ]; then
     set -e
 
-    # python -m pip install --upgrade pip setuptools wheel
-    # python -m pip install --upgrade tox
+    python -m pip install --upgrade pip setuptools wheel
+    python -m pip install --upgrade tox
 
-    # sudo apt-get update
-    # sudo apt-get install -y graphviz pandoc 
+    sudo apt-get update
+    sudo apt-get install -y graphviz pandoc 
 
     # This command fetches the latest release of doxygen and its linux binaries
-    # curl -H "Authorization: token $GITHUB_TOKEN" \
-    #     https://api.github.com/repos/doxygen/doxygen/releases/latest | \
-    #     jq '.["assets"][2]["browser_download_url"]' | \
-    #     xargs -I {} wget {} -O ./doxygen.tar.gz
+    curl -H "Authorization: token $GITHUB_TOKEN" \
+        https://api.github.com/repos/doxygen/doxygen/releases/latest | \
+        jq '.["assets"][2]["browser_download_url"]' | \
+        xargs -I {} wget {} -O ./doxygen.tar.gz
 
     # The following commands install the binaries for doxygen
     tar -zxvf ./doxygen.tar.gz

--- a/tools/install_ubuntu_docs_dependencies.sh
+++ b/tools/install_ubuntu_docs_dependencies.sh
@@ -2,30 +2,25 @@
 #
 # Prepare an Ubuntu CI machine for running 'tox -e docs'.  Assumes that Python is available.
 
-if [ $GITHUB_TOKEN ]; then
-    set -e
-
-    python -m pip install --upgrade pip setuptools wheel
-    python -m pip install --upgrade tox
-
-    sudo apt-get update
-    sudo apt-get install -y graphviz pandoc 
-
-    # This command fetches the latest release of doxygen and its linux binaries
-    curl -H "Authorization: token $GITHUB_TOKEN" \
-        https://api.github.com/repos/doxygen/doxygen/releases/latest | \
-        jq '.["assets"][2]["browser_download_url"]' | \
-        xargs -I {} wget {} -O ./doxygen.tar.gz
-
-    # The following commands install the binaries for doxygen
-    tar -zxvf ./doxygen.tar.gz
-    # Find the doxygen folder
-    DOXYGEN_DIR=$(find . -maxdepth 1 -type d  -name "doxygen*")
-    cd $DOXYGEN_DIR
-    # Run the remainder of the setup process
-    sudo make
-    sudo make install
-else
+set -e
+if [ -z $GITHUB_TOKEN ]; then
     echo "No github token provided"
     exit 1
 fi
+
+python -m pip install --upgrade pip setuptools wheel
+python -m pip install --upgrade tox
+
+sudo apt-get update
+sudo apt-get install -y graphviz pandoc 
+
+# This command fetches the latest release of doxygen and its linux binaries
+wget --header "Authorization: token $GITHUB_TOKEN" \
+    https://github.com/doxygen/doxygen/releases/download/Release_1_15_0/doxygen-1.15.0.linux.bin.tar.gz
+
+# The following commands install the binaries for doxygen
+tar -zxvf ./doxygen-1.15.0.linux.bin.tar.gz
+cd ./doxygen-1.15.0
+
+# Run the remainder of the setup process
+sudo make install

--- a/tools/install_ubuntu_docs_dependencies.sh
+++ b/tools/install_ubuntu_docs_dependencies.sh
@@ -19,8 +19,9 @@ if [ $GITHUB_TOKEN ]; then
 
     # The following commands install the binaries for doxygen
     tar -zxvf ./doxygen.tar.gz
-    # Find the doxygen folder and pick the first option
-    cd "$(find . -type d | grep doxygen -m 1)"
+    # Find the doxygen folder
+    DOXYGEN_DIR=$(find . -maxdepth 1 -type d  -name "doxygen*")
+    cd $DOXYGEN_DIR
     # Run the remainder of the setup process
     ./configure
     make


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
The following commits try to add a way of installing Doxygen from its latest binaries since apt only has 1.9.8 available causing the strange error we found during CI in #15306.

This new approach has hardcoded version 1.15.0 of doxygen as the default instalation for linux based systems.

### Details and comments
Based on an error found in #15306 

