### PR TITLE
Fix: Send token during docs_deploy workflow

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -5,7 +5,7 @@ on:
       - main
     tags:
       # Only match non-prerelease tags.
-      - '[0-9]+.[0-9]+.[0-9]'
+      - "[0-9]+.[0-9]+.[0-9]"
   workflow_dispatch:
 
 jobs:
@@ -24,11 +24,12 @@ jobs:
         name: Install Python
         with:
           # Sync with 'documentationPythonVersion' in 'azure-pipelines.yml'.
-          python-version: '3.9'
+          python-version: "3.9"
 
       - name: Install dependencies
         run: tools/install_ubuntu_docs_dependencies.sh
-
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Determine GitHub branch name
         run: |
           # Tags like 1.0.0 and 1.0.0rc1 should point to their stable branch. We do this


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Due to an oversight in #15314, we forgot to pass the github token when installing doxygen from source in the `docs_deploy` workflow. The following commits should fix that behavior.


### Details and comments
Reference run: https://github.com/Qiskit/qiskit/actions/runs/19304212009

