### PR TITLE
Add C/Python interop for `Target` and `DAGCircuit`

### DIFF
--- a/crates/cext/src/dag.rs
+++ b/crates/cext/src/dag.rs
@@ -1792,7 +1792,7 @@ pub unsafe extern "C" fn qk_dag_to_python(dag: *mut DAGCircuit) -> *mut ::pyo3::
     // SAFETY: per documentation, we are attached to a Python interpreter.
     let py = unsafe { ::pyo3::Python::assume_attached() };
     // SAFETY: per documentation, `dag` points to owned and valid data.
-    let dag = unsafe { Box::from_raw(mut_ptr_as_ref(dag)) };
+    let dag = unsafe { Box::from_raw(dag) };
     match ::pyo3::Bound::new(py, *dag) {
         Ok(ob) => ob.into_ptr(),
         Err(e) => {

--- a/crates/cext/src/dag.rs
+++ b/crates/cext/src/dag.rs
@@ -1848,7 +1848,7 @@ pub unsafe extern "C" fn qk_dag_borrow_from_python(
 ///
 /// @param object A borrowed Python object.
 /// @param address The location to write the output to.
-/// @return 0 on success, 1 on failure.
+/// @return 1 on success, 0 on failure.
 ///
 /// # Safety
 ///

--- a/crates/cext/src/dag.rs
+++ b/crates/cext/src/dag.rs
@@ -1771,3 +1771,96 @@ pub unsafe extern "C" fn qk_dag_substitute_node_with_unitary(
     )
     .expect("Failed to substitute op.")
 }
+
+/// Pass ownership of a `QkDag` object to Python.
+///
+/// It is not safe to use the `QkDag` pointer after calling this function.  In particular, you
+/// should not attempt to clear or free it.  The caller must own the `QkDag`, not hold a borrowed
+/// reference (for example, a `QkDag *` retrieved from `qk_dag_borrow_from_python` is not owned).
+///
+/// @param dag The owned object.
+/// @return An owned Python reference to the object.
+///
+/// # Safety
+///
+/// The caller must be attached to a Python interpreter.  Behavior is undefined if `dag` is not a
+/// valid non-null pointer to an initialized and owned `QkDag`.
+#[unsafe(no_mangle)]
+#[cfg(feature = "python_binding")]
+pub unsafe extern "C" fn qk_dag_to_python(dag: *mut DAGCircuit) -> *mut ::pyo3::ffi::PyObject {
+    // SAFETY: per documentation, we are attached to a Python interpreter.
+    let py = unsafe { ::pyo3::Python::assume_attached() };
+    // SAFETY: per documentation, `dag` points to owned and valid data.
+    let dag = unsafe { Box::from_raw(mut_ptr_as_ref(dag)) };
+    match ::pyo3::Bound::new(py, *dag) {
+        Ok(ob) => ob.into_ptr(),
+        Err(e) => {
+            e.restore(py);
+            ::std::ptr::null_mut()
+        }
+    }
+}
+
+/// @ingroup QkDag
+/// Retrieve a `QkDag` pointer from a Python object.
+///
+/// This borrows a Python reference and extracts the `QkDag` pointer for it, if it is of
+/// the correct type.  The returned pointer is borrowed from the `ob` pointer.  If the
+/// ``PyObject`` is not the correct type, the return value is ``NULL`` and the exception
+/// state of the Python interpreter is set.
+///
+/// You must be attached to a Python interpreter to call this function.
+///
+/// You can also use `qk_dag_convert_from_python`, which is logically the exact same as this
+/// function, but can be directly used as a "converter" function for the `PyArg_Parse*`
+/// family of Python converter functions.
+///
+/// @param ob A borrowed Python object.
+/// @return A pointer to the native object, or `NULL` if the Python object is the wrong type.
+///
+/// # Safety
+///
+/// The caller must be attached to a Python interpreter.  Behavior is undefined if `ob` is
+/// not a valid non-null pointer to a Python object.
+#[unsafe(no_mangle)]
+#[cfg(feature = "python_binding")]
+pub unsafe extern "C" fn qk_dag_borrow_from_python(
+    ob: *mut pyo3::ffi::PyObject,
+) -> *mut DAGCircuit {
+    // SAFETY: per documentation, we are attached to a Python interpreter, and `ob` points to a
+    // valid PyObject.
+    unsafe { crate::py::borrow(::pyo3::Python::assume_attached(), ob) }
+}
+
+/// @ingroup QkDag
+/// Retrieve a DAG pointer from a Python object.
+///
+/// This borrows a Python reference and extracts the `QkDag` pointer for it into ``address``, if it
+/// is of the correct type.  The returned pointer is borrowed from the `object` pointer.  If the
+/// ``PyObject`` is not the correct type, the return value is 1, the exception state of the Python
+/// interpreter is set, and ``address`` is unchanged.
+///
+/// You must be attached to a Python interpreter to call this function.
+///
+/// You can also use `qk_dag_borrow_from_python`, which is logically the exact same as this, but
+/// with a more natural signature for direct usage.
+///
+/// @param object A borrowed Python object.
+/// @param address The location to write the output to.
+/// @return 0 on success, 1 on failure.
+///
+/// # Safety
+///
+/// The caller must be attached to a Python interpreter.  Behavior is undefined if `object`
+/// is not a valid non-null pointer to a Python object, or if `address` is not a pointer to
+/// writeable data of the correct type.
+#[unsafe(no_mangle)]
+#[cfg(feature = "python_binding")]
+pub unsafe extern "C" fn qk_dag_convert_from_python(
+    object: *mut ::pyo3::ffi::PyObject,
+    address: *mut ::std::ffi::c_void,
+) -> ::std::ffi::c_int {
+    // SAFETY: per documentation, we are attached to a Python interpreter, `object` is a valid
+    // pointer to a PyObject, and `address` points to enough space to write a pointer.
+    unsafe { crate::py::convert::<DAGCircuit>(::pyo3::Python::assume_attached(), object, address) }
+}

--- a/crates/cext/src/dag.rs
+++ b/crates/cext/src/dag.rs
@@ -1772,6 +1772,7 @@ pub unsafe extern "C" fn qk_dag_substitute_node_with_unitary(
     .expect("Failed to substitute op.")
 }
 
+/// @ingroup QkDag
 /// Pass ownership of a `QkDag` object to Python.
 ///
 /// It is not safe to use the `QkDag` pointer after calling this function.  In particular, you

--- a/crates/cext/src/lib.rs
+++ b/crates/cext/src/lib.rs
@@ -12,6 +12,8 @@
 
 mod extras;
 mod pointers;
+#[cfg(feature = "python_binding")]
+mod py;
 
 pub mod circuit;
 pub mod circuit_library;

--- a/crates/cext/src/py.rs
+++ b/crates/cext/src/py.rs
@@ -1,0 +1,77 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+// The `boolean_struct` module here is `doc(hidden)` but `pub`.  We need it to specify the trait
+// bound correctly to make `borrow_mut` available.
+use pyo3::PyClass;
+use pyo3::prelude::*;
+use pyo3::pyclass::boolean_struct::False;
+
+/// Borrow a pointer to a Rust-native object from a Python object.
+///
+/// The returned pointer derives its lifetime from the lifetime of `ob`.  The reference `ob` is only
+/// borrowed by the function.
+///
+/// If the `PyObject` is not of the correct type, the null pointer is returned and the Python
+/// exception state is set.
+///
+/// # Safety
+///
+/// `ob` must point to a valid PyObject.
+pub unsafe fn borrow<T>(py: Python, ob: *mut ::pyo3::ffi::PyObject) -> *mut T
+where
+    T: PyClass<Frozen = False>,
+{
+    // SAFETY: per documentation, `ob` points to a valid PyObject.  The lifetime of the
+    // `Borrowed` is valid because we immediately consume it back into a pointer, whose
+    // lifetime is thus tied to the incoming `ob`.
+    match unsafe { Borrowed::from_ptr(py, ob) }.cast::<T>() {
+        Ok(ob) => &mut *ob.borrow_mut(),
+        Err(e) => {
+            PyErr::from(e).restore(py);
+            ::std::ptr::null_mut()
+        }
+    }
+}
+
+/// Extract a pointer to a Rust-native object from a PyObject representing a PyClass, storing the
+/// result in `address`.
+///
+/// This is used to define Python-space "converter" functions for use with the `PyArg_Parse*` family
+/// of functions.
+///
+/// On success, returns 1 and writes out the pointer in `address`.  On failure, returns 0, sets the
+/// Python exception state and leaves `address` untouched.
+///
+/// # Safety
+///
+/// `object` must point to a valid PyObject.  `address` must point to enough space to write a
+/// pointer to.
+pub unsafe fn convert<T>(
+    py: Python,
+    object: *mut ::pyo3::ffi::PyObject,
+    address: *mut ::std::ffi::c_void,
+) -> ::std::ffi::c_int
+where
+    T: PyClass<Frozen = False>,
+{
+    // SAFETY: per documentation, `object` points to a valid PyObject.
+    let native = unsafe { borrow::<T>(py, object) };
+    if native.is_null() {
+        0
+    } else {
+        // SAFETY: per documentation, `address` is a pointer to a valid storage location of
+        // the correct type.
+        unsafe { address.cast::<*mut T>().write(native) };
+        1
+    }
+}

--- a/crates/cext/src/transpiler/target.rs
+++ b/crates/cext/src/transpiler/target.rs
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn qk_target_borrow_from_python(ob: *mut pyo3::ffi::PyObje
 ///
 /// @param object A borrowed Python object.
 /// @param address The location to write the output to.
-/// @return 0 on success, 1 on failure.
+/// @return 1 on success, 0 on failure.
 ///
 /// # Safety
 ///

--- a/crates/cext/src/transpiler/target.rs
+++ b/crates/cext/src/transpiler/target.rs
@@ -61,6 +61,68 @@ pub extern "C" fn qk_target_new(num_qubits: u32) -> *mut Target {
 }
 
 /// @ingroup QkTarget
+/// Retrieve a `QkTarget` pointer from a Python object.
+///
+/// This borrows a Python reference and extracts the `QkTarget` pointer for it, if it is of
+/// the correct type.  The returned pointer is borrowed from the `ob` pointer.  If the
+/// ``PyObject`` is not the correct type, the return value is ``NULL`` and the exception
+/// state of the Python interpreter is set.
+///
+/// You must be attached to a Python interpreter to call this function.
+///
+/// You can also use `qk_target_convert_from_python`, which is logically the exact same as this
+/// function, but can be directly used as a "converter" function for the `PyArg_Parse*`
+/// family of Python converter functions.
+///
+/// @param ob A borrowed Python object.
+/// @return A pointer to the native object, or `NULL` if the Python object is the wrong type.
+///
+/// # Safety
+///
+/// The caller must be attached to a Python interpreter.  Behavior is undefined if `ob` is
+/// not a valid non-null pointer to a Python object.
+#[unsafe(no_mangle)]
+#[cfg(feature = "python_binding")]
+pub unsafe extern "C" fn qk_target_borrow_from_python(ob: *mut pyo3::ffi::PyObject) -> *mut Target {
+    // SAFETY: per documentation, we are attached to a Python interpreter and `ob` points to a valid
+    // Python object.
+    unsafe { crate::py::borrow(::pyo3::Python::assume_attached(), ob) }
+}
+
+/// @ingroup QkTarget
+/// Retrieve a Target pointer from a Python object.
+///
+/// This borrows a Python reference and extracts the `QkTarget` pointer for it into ``address``, if
+/// it is of the correct type.  The returned pointer is borrowed from the `object` pointer.  If the
+/// ``PyObject`` is not the correct type, the return value is 1, the exception state of the Python
+/// interpreter is set, and ``address`` is unchanged.
+///
+/// You must be attached to a Python interpreter to call this function.
+///
+/// You can also use `qk_target_borrow_from_python`, which is logically the exact same as this, but
+/// with a more natural signature for direct usage.
+///
+/// @param object A borrowed Python object.
+/// @param address The location to write the output to.
+/// @return 0 on success, 1 on failure.
+///
+/// # Safety
+///
+/// The caller must be attached to a Python interpreter.  Behavior is undefined if `object`
+/// is not a valid non-null pointer to a Python object, or if `address` is not a pointer to
+/// writeable data of the correct type.
+#[unsafe(no_mangle)]
+#[cfg(feature = "python_binding")]
+pub unsafe extern "C" fn qk_target_convert_from_python(
+    object: *mut ::pyo3::ffi::PyObject,
+    address: *mut ::std::ffi::c_void,
+) -> ::std::ffi::c_int {
+    // SAFETY: per documentation, we are attached to a Python interpreter, `ob` points to a valid
+    // Python object and `address` points to anough space to write a pointer.
+    unsafe { crate::py::convert::<Target>(::pyo3::Python::assume_attached(), object, address) }
+}
+
+/// @ingroup QkTarget
 /// Returns the number of qubits of this ``QkTarget``.
 ///
 /// @param target A pointer to the ``QkTarget``.

--- a/releasenotes/notes/c-dag-getter-00bce3ca7de3b19c.yaml
+++ b/releasenotes/notes/c-dag-getter-00bce3ca7de3b19c.yaml
@@ -1,0 +1,9 @@
+---
+features_c:
+  - |
+    The functions :c:func:`qk_dag_borrow_from_python` and :c:func:`qk_dag_convert_from_python` allow
+    for extracting C-native types from a Python-space :class:`.DAGCircuit`.  C modules can create a
+    Python-space :class:`.DAGCircuit` using :c:func:`qk_dag_into_python`.
+  - |
+    The functions :c:func:`qk_target_borrow_from_python` and :c:func:`qk_target_convert_from_python` allow
+    for extracting C-native types from a Python-space :class:`.Target`.

--- a/releasenotes/notes/c-dag-getter-00bce3ca7de3b19c.yaml
+++ b/releasenotes/notes/c-dag-getter-00bce3ca7de3b19c.yaml
@@ -3,7 +3,7 @@ features_c:
   - |
     The functions :c:func:`qk_dag_borrow_from_python` and :c:func:`qk_dag_convert_from_python` allow
     for extracting C-native types from a Python-space :class:`.DAGCircuit`.  C modules can create a
-    Python-space :class:`.DAGCircuit` using :c:func:`qk_dag_into_python`.
+    Python-space :class:`.DAGCircuit` using :c:func:`qk_dag_to_python`.
   - |
     The functions :c:func:`qk_target_borrow_from_python` and :c:func:`qk_target_convert_from_python` allow
     for extracting C-native types from a Python-space :class:`.Target`.


### PR DESCRIPTION
This adds the ability to retrieve a `QkDag *` from a Python `DAGCircuit` and a `QkTarget *`from a `Target`.  For `DAGCircuit`, which is directly the user-facing pyclass, this commit also includes a way of passing ownership from a `QkDag *` to a Python object.

Similar functionality could be added to `CircuitData` and `SparseObservable`, but this is sufficient for immediate demonstrations of transpiler passes.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


