### PR TITLE
Update operator list prints in `PauliEvolutionGate` 

### DIFF
--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -336,18 +336,9 @@ def _to_sparse_op(
 def _operator_label(operator):
     if isinstance(operator, SparseObservable):
         if len(operator) == 1:
-            term = operator[0]
-            labels = term.bit_labels()
-            indices = term.indices
-            return " ".join(f"{label}{idx}" for label, idx in zip(labels, indices))
+            return _sparse_term_label(operator[0])
 
-        term_strs = []
-        for term in operator:
-            labels = term.bit_labels()
-            indices = term.indices
-            term_str = " ".join(f"{label}{idx}" for label, idx in zip(labels, indices))
-            term_strs.append(term_str)
-        return "(" + " + ".join(term_strs) + ")"
+        return "(" + " + ".join(_sparse_term_label(term) for term in operator) + ")"
 
     # else: is a SparsePauliOp
     if len(operator.paulis) == 1:
@@ -355,7 +346,13 @@ def _operator_label(operator):
     return "(" + " + ".join(operator.paulis.to_labels()) + ")"
 
 
+def _sparse_term_label(term) -> str:
+    labels = term.bit_labels()
+    indices = term.indices
+    return " ".join(f"{label}{idx}" for label, idx in zip(labels, indices))
+
+
 def _get_default_label(operator):
     if isinstance(operator, list):
-        return f"exp(-it ({[_operator_label(op) for op in operator]}))"
+        return "exp(-it [" + ", ".join(_operator_label(op) for op in operator) + "])"
     return f"exp(-it {_operator_label(operator)})"


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Short follow up on #15173:
* Fix the test usage which should be using `QiskitTestCase` as baseclass and `unittest`'s methods instead of a plain `assert`
* Remove dangling quotes when printing lists of operators. I.e. update
  ```
  exp(-it (['(IIXX + IYYI + ZZII)', 'XXII']))
  ```
  to
  ```
  exp(-it [(IIXX + IYYI + ZZII), XXII])
  ```




