### PR TITLE
Add no-overhead `ParameterExpression.num_parameters` attribute

### DIFF
--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -852,6 +852,15 @@ impl PyParameterExpression {
         py_sympify.call1(py, (self.clone(),))
     }
 
+    /// The number of unbound parameters in the expression.
+    ///
+    /// This is equivalent to ``len(expr.parameters)`` but does not involve the overhead of creating
+    /// a set and counting its length.
+    #[getter]
+    pub fn num_parameters(&self) -> usize {
+        self.inner.num_symbols()
+    }
+
     /// Get the parameters present in the expression.
     ///
     /// .. note::

--- a/releasenotes/notes/parameter-num-parameters-be2a410b8f09e3b0.yaml
+++ b/releasenotes/notes/parameter-num-parameters-be2a410b8f09e3b0.yaml
@@ -1,0 +1,6 @@
+---
+features_circuits:
+  - |
+    :class:`.ParameterExpression` now has a :attr:`~.ParameterExpression.num_parameters` attribute,
+    which is equal to the length of its :attr:`~.ParameterExpression.parameters` set, but calculated
+    with less overhead.

--- a/test/python/circuit/test_parameter_expression.py
+++ b/test/python/circuit/test_parameter_expression.py
@@ -71,6 +71,10 @@ real_values = [0.41, 0.9, -0.83, math.pi, -math.pi / 124, -42.42]
 class TestParameterExpression(QiskitTestCase):
     """Test parameter expression."""
 
+    @ddt.data(param_x, param_x + param_y, (param_x + 1.0).bind({param_x: 1.0}))
+    def test_num_parameters(self, expr):
+        self.assertEqual(len(expr.parameters), expr.num_parameters)
+
     @combine(
         left=operands,
         right=operands,

--- a/test/python/circuit/test_parameter_expression.py
+++ b/test/python/circuit/test_parameter_expression.py
@@ -73,6 +73,7 @@ class TestParameterExpression(QiskitTestCase):
 
     @ddt.data(param_x, param_x + param_y, (param_x + 1.0).bind({param_x: 1.0}))
     def test_num_parameters(self, expr):
+        """Do the two ways of getting the number of unbound parameters agree?"""
         self.assertEqual(len(expr.parameters), expr.num_parameters)
 
     @combine(


### PR DESCRIPTION
Currently, accessing the number of unbound parameters in an expression is relatively expensive from Python-space, involving the creation and querying of a set.  This information is already available for free in Rust space.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


