### PR TITLE
Deprecate annotated=None in control methods

### DIFF
--- a/crates/circuit_library/src/pauli_evolution.rs
+++ b/crates/circuit_library/src/pauli_evolution.rs
@@ -490,7 +490,7 @@ fn add_control(gate: StandardGate, params: &[Param], control_state: &[bool]) -> 
             .call_method1(
                 py,
                 intern!(py, "control"),
-                (num_controls, label, py_control_state),
+                (num_controls, label, py_control_state, false),
             )
             .expect("Failed to call .control()")
             .extract::<OperationFromPython>(py)

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -266,7 +266,7 @@ class ControlledGate(Gate):
         """Invert this gate by calling inverse on the base gate."""
         if not annotated:
             inverse_gate = self.base_gate.inverse().control(
-                self.num_ctrl_qubits, ctrl_state=self.ctrl_state
+                self.num_ctrl_qubits, ctrl_state=self.ctrl_state, annotated=annotated
             )
         else:
             inverse_gate = super().inverse(annotated=annotated)

--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.circuit.exceptions import CircuitError
+from qiskit.utils.deprecation import deprecate_arg
 from .annotated_operation import AnnotatedOperation, ControlModifier, PowerModifier
 from .instruction import Instruction
 
@@ -101,6 +102,21 @@ class Gate(Instruction):
         gate.params = self.params
         return gate
 
+    @deprecate_arg(
+        name="annotated",
+        since="2.3",
+        additional_msg=(
+            "The method Gate.control() no longer accepts `annotated=None`. The new default is "
+            "`annotated=True`, which represents the controlled gate as an `AnnotatedOperation` "
+            "(unless a dedicated controlled-gate class already exists). You can explicitly set "
+            "`annotated=False` to preserve the previous behavior. However, using `annotated=True` "
+            "is recommended, as it defers construction of the controlled circuit to transpiler, "
+            "and furthermore enables additional controlled-gate ptimizations (typically leading "
+            "to higher-quality circuits)."
+        ),
+        predicate=lambda my_arg: my_arg is None,
+        removal_timeline="in Qiskit 3.0",
+    )
     def control(
         self,
         num_ctrl_qubits: int = 1,

--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -111,7 +111,7 @@ class Gate(Instruction):
             "(unless a dedicated controlled-gate class already exists). You can explicitly set "
             "`annotated=False` to preserve the previous behavior. However, using `annotated=True` "
             "is recommended, as it defers construction of the controlled circuit to transpiler, "
-            "and furthermore enables additional controlled-gate ptimizations (typically leading "
+            "and furthermore enables additional controlled-gate optimizations (typically leading "
             "to higher-quality circuits)."
         ),
         predicate=lambda my_arg: my_arg is None,

--- a/qiskit/circuit/library/arithmetic/exact_reciprocal.py
+++ b/qiskit/circuit/library/arithmetic/exact_reciprocal.py
@@ -119,7 +119,7 @@ class ExactReciprocalGate(Gate):
 
         if self.neg_vals:
             circuit.append(
-                UCRYGate([-theta for theta in angles]).control(),
+                UCRYGate([-theta for theta in angles]).control(annotated=False),
                 [qr_state[-1]] + [qr_flag[0]] + qr_state[:-1],
             )
             angles_neg = [0.0]
@@ -131,7 +131,8 @@ class ExactReciprocalGate(Gate):
                 else:
                     angles_neg.append(0.0)
             circuit.append(
-                UCRYGate(angles_neg).control(), [qr_state[-1]] + [qr_flag[0]] + qr_state[:-1]
+                UCRYGate(angles_neg).control(annotated=False),
+                [qr_state[-1]] + [qr_flag[0]] + qr_state[:-1],
             )
 
         self.definition = circuit

--- a/qiskit/circuit/library/arithmetic/multipliers/hrs_cumulative_multiplier.py
+++ b/qiskit/circuit/library/arithmetic/multipliers/hrs_cumulative_multiplier.py
@@ -132,7 +132,7 @@ class HRSCumulativeMultiplier(Multiplier):
             else:
                 num_adder_qubits = num_state_qubits - excess_qubits + 1
                 adder_for_current_step = CDKMRippleCarryAdder(num_adder_qubits, kind="fixed")
-            controlled_adder = adder_for_current_step.to_gate().control(1)
+            controlled_adder = adder_for_current_step.to_gate().control(1, annotated=False)
             qr_list = (
                 [qr_a[i]]
                 + qr_b[:num_adder_qubits]

--- a/qiskit/circuit/library/arithmetic/multipliers/rg_qft_multiplier.py
+++ b/qiskit/circuit/library/arithmetic/multipliers/rg_qft_multiplier.py
@@ -99,7 +99,7 @@ class RGQFTMultiplier(Multiplier):
                 for k in range(1, self.num_result_qubits + 1):
                     lam = (2 * np.pi) / (2 ** (i + j + k - 2 * num_state_qubits))
                     circuit.append(
-                        PhaseGate(lam).control(2),
+                        PhaseGate(lam).control(2, annotated=False),
                         [qr_a[num_state_qubits - j], qr_b[num_state_qubits - i], qr_out[k - 1]],
                     )
 

--- a/qiskit/circuit/library/arithmetic/piecewise_linear_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/piecewise_linear_pauli_rotations.py
@@ -277,7 +277,10 @@ class PiecewiseLinearPauliRotations(FunctionalPauliRotations):
                         offset=self.mapped_offsets[i],
                         basis=self.basis,
                     )
-                circuit.append(lin_r.to_gate().control(), qr_compare[:] + qr_state[:] + qr_target)
+                circuit.append(
+                    lin_r.to_gate().control(annotated=False),
+                    qr_compare[:] + qr_state[:] + qr_target,
+                )
 
                 # uncompute comparator
                 circuit.append(comp.to_gate(), qr[:] + qr_helper[: comp.num_ancillas])
@@ -386,7 +389,9 @@ class PiecewiseLinearPauliRotationsGate(Gate):
                     offset=mapped_offsets[i],
                     basis=self.basis,
                 )
-                circuit.append(lin_r.control(), qr_compare[:] + qr_state[:] + qr_target)
+                circuit.append(
+                    lin_r.control(annotated=False), qr_compare[:] + qr_state[:] + qr_target
+                )
 
                 # uncompute comparator (which is its self-inverse)
                 circuit.append(comp, qr[:])

--- a/qiskit/circuit/library/arithmetic/piecewise_polynomial_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/piecewise_polynomial_pauli_rotations.py
@@ -312,7 +312,8 @@ class PiecewisePolynomialPauliRotations(FunctionalPauliRotations):
                         basis=self.basis,
                     )
                 circuit.append(
-                    poly_r.to_gate().control(), [qr_ancilla[0]] + qr_state[:] + qr_target
+                    poly_r.to_gate().control(annotated=False),
+                    [qr_ancilla[0]] + qr_state[:] + qr_target,
                 )
 
                 # uncompute comparator
@@ -490,7 +491,9 @@ class PiecewisePolynomialPauliRotationsGate(Gate):
                     coeffs=mapped_coeffs[i],
                     basis=self.basis,
                 )
-                circuit.append(poly_r.control(), qr_compare + qr_state[:] + qr_target)
+                circuit.append(
+                    poly_r.control(annotated=False), qr_compare + qr_state[:] + qr_target
+                )
 
                 # uncompute comparator
                 circuit.append(comp, qr_state_full[:])

--- a/qiskit/circuit/library/phase_estimation.py
+++ b/qiskit/circuit/library/phase_estimation.py
@@ -98,7 +98,9 @@ class PhaseEstimation(QuantumCircuit):
         circuit.h(qr_eval)  # hadamards on evaluation qubits
 
         for j in range(num_evaluation_qubits):  # controlled powers
-            circuit.compose(unitary.power(2**j).control(), qubits=[j] + qr_state[:], inplace=True)
+            circuit.compose(
+                unitary.power(2**j).control(annotated=False), qubits=[j] + qr_state[:], inplace=True
+            )
 
         circuit.compose(iqft, qubits=qr_eval[:], inplace=True)  # final QFT
 
@@ -170,7 +172,9 @@ def phase_estimation(
     circuit.h(qr_eval)  # hadamards on evaluation qubits
 
     for j in range(num_evaluation_qubits):  # controlled powers
-        circuit.compose(unitary.power(2**j).control(), qubits=[j] + qr_state[:], inplace=True)
+        circuit.compose(
+            unitary.power(2**j).control(annotated=False), qubits=[j] + qr_state[:], inplace=True
+        )
 
     circuit.append(QFTGate(num_evaluation_qubits).inverse(), qr_eval[:])
 

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1970,7 +1970,7 @@ class QuantumCircuit:
             "(unless a dedicated controlled-gate class already exists). You can explicitly set "
             "`annotated=False` to preserve the previous behavior. However, using `annotated=True` "
             "is recommended, as it defers construction of the controlled circuit to transpiler, "
-            "and furthermore enables additional controlled-gate ptimizations (typically leading "
+            "and furthermore enables additional controlled-gate optimizations (typically leading "
             "to higher-quality circuits)."
         ),
         predicate=lambda my_arg: my_arg is None,

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1960,6 +1960,22 @@ class QuantumCircuit:
         power_circuit.append(gate.power(power, annotated=annotated), list(range(gate.num_qubits)))
         return power_circuit
 
+    @deprecate_arg(
+        name="annotated",
+        since="2.3",
+        additional_msg=(
+            "The method QuantumCircuit.control() no longer accepts `annotated=None`. "
+            "The new default is `annotated=True`, which represents the controlled gate "
+            "in the new quantum circuit as an `AnnotatedOperation` "
+            "(unless a dedicated controlled-gate class already exists). You can explicitly set "
+            "`annotated=False` to preserve the previous behavior. However, using `annotated=True` "
+            "is recommended, as it defers construction of the controlled circuit to transpiler, "
+            "and furthermore enables additional controlled-gate ptimizations (typically leading "
+            "to higher-quality circuits)."
+        ),
+        predicate=lambda my_arg: my_arg is None,
+        removal_timeline="in Qiskit 3.0",
+    )
     def control(
         self,
         num_ctrl_qubits: int = 1,

--- a/qiskit/synthesis/arithmetic/multipliers/rg_qft_multiplier.py
+++ b/qiskit/synthesis/arithmetic/multipliers/rg_qft_multiplier.py
@@ -91,7 +91,7 @@ def multiplier_qft_r17(
                 # note: if we can synthesize the QFT without swaps, we can implement this circuit
                 # more efficiently and just apply phase gate on qr_out[(k - 1)] instead
                 circuit.append(
-                    PhaseGate(lam).control(2),
+                    PhaseGate(lam).control(2, annotated=False),
                     [qr_a[num_state_qubits - j], qr_b[num_state_qubits - i], qr_out[~(k - 1)]],
                 )
 

--- a/qiskit/synthesis/boolean/boolean_expression_synth.py
+++ b/qiskit/synthesis/boolean/boolean_expression_synth.py
@@ -95,7 +95,9 @@ def synth_phase_oracle_from_esop(esop, num_qubits):
                 qc.x(qubit_indices[0])
         else:  # use custom controlled-Z gate
             # we use the last qubit as the target, flipping it if the control is 0 for that qubit
-            gate = ZGate().control(len(qubit_indices) - 1, ctrl_state=control_state[:-1][::-1])
+            gate = ZGate().control(
+                len(qubit_indices) - 1, ctrl_state=control_state[:-1][::-1], annotated=False
+            )
             if control_state[-1] == "0":
                 qc.x(qubit_indices[-1])
             qc.append(gate, qubit_indices)
@@ -119,6 +121,6 @@ def synth_bit_oracle_from_esop(esop, num_qubits):
     for qubit_indices, control_data in clause_data:
         control_state = "".join(control_data)
         # use custom controlled-X gate
-        gate = XGate().control(len(qubit_indices), ctrl_state=control_state[::-1])
+        gate = XGate().control(len(qubit_indices), ctrl_state=control_state[::-1], annotated=False)
         qc.append(gate, qubit_indices + (output_index,))
     return qc

--- a/qiskit/synthesis/multi_controlled/mcmt_vchain.py
+++ b/qiskit/synthesis/multi_controlled/mcmt_vchain.py
@@ -56,6 +56,6 @@ def synth_mcmt_vchain(
         raise ValueError("Only single qubit gates are supported as input.")
 
     circ = QuantumCircuit._from_circuit_data(
-        mcmt_v_chain(gate.control(), num_ctrl_qubits, num_target_qubits, ctrl_state)
+        mcmt_v_chain(gate.control(annotated=False), num_ctrl_qubits, num_target_qubits, ctrl_state)
     )
     return circ

--- a/qiskit/transpiler/passes/synthesis/hls_plugins.py
+++ b/qiskit/transpiler/passes/synthesis/hls_plugins.py
@@ -1587,7 +1587,9 @@ class MCMTSynthesisNoAux(HighLevelSynthesisPlugin):
             # no broadcasting needed (makes for better circuit diagrams)
             circuit = QuantumCircuit(high_level_object.num_qubits)
             circuit.append(
-                base_gate.control(high_level_object.num_ctrl_qubits, ctrl_state=ctrl_state),
+                base_gate.control(
+                    high_level_object.num_ctrl_qubits, ctrl_state=ctrl_state, annotated=False
+                ),
                 circuit.qubits,
             )
 
@@ -1596,7 +1598,9 @@ class MCMTSynthesisNoAux(HighLevelSynthesisPlugin):
             for i in range(high_level_object.num_target_qubits):
                 base.append(base_gate, [i], [])
 
-            circuit = base.control(high_level_object.num_ctrl_qubits, ctrl_state=ctrl_state)
+            circuit = base.control(
+                high_level_object.num_ctrl_qubits, ctrl_state=ctrl_state, annotated=False
+            )
 
         return circuit.decompose()
 

--- a/releasenotes/notes/deprecate-control-annotated-none-223bda4f23ce74e9.yaml
+++ b/releasenotes/notes/deprecate-control-annotated-none-223bda4f23ce74e9.yaml
@@ -1,0 +1,21 @@
+---
+deprecations_circuits:
+  - |
+    Since Qiskit 1.0, the methods :meth:`.Gate.control` and :meth:`.QuantumCircuit.control`
+    accept the argument ``annotated`` which can be either ``False``, ``True`` or ``None``.
+    Presently, a controlled gate is represented using a deidicated controlled-gate class 
+    when it exists, regardless of the value of ``annotated``, for instance a two-controlled
+    version of an  :class:`.XGate` is a :class:`.CCXGate`. If a dedicated controlled-gate
+    class does not exist, the controlled gate is represented as a :class:`.ControlledGate`
+    when ``annotated=False`` and as an :class:`.AnnotatedOperation` when ``annotated=True``.
+    The default value ``annotated=None`` is treated exactly the same as ``False``. 
+    
+    In Qiskit 3.0, we will no longer allow setting ``annotated=None`` and instead change
+    set the default to ``annotated=True``. This is recommended, as it defers the
+    construction of the controlled circuit from the circuit construction to the transpiler,
+    and enables additional controlled-gate optimizations, typically leading to higher-quality
+    circuits (especially for hierarhical circuits).
+
+    However, you will still be able to explicitly set ``annotated=False`` to preserve the
+    previous behavior.
+    

--- a/releasenotes/notes/deprecate-control-annotated-none-223bda4f23ce74e9.yaml
+++ b/releasenotes/notes/deprecate-control-annotated-none-223bda4f23ce74e9.yaml
@@ -18,4 +18,3 @@ deprecations_circuits:
 
     However, you will still be able to explicitly set ``annotated=False`` to preserve the
     previous behavior.
-    

--- a/releasenotes/notes/deprecate-control-annotated-none-223bda4f23ce74e9.yaml
+++ b/releasenotes/notes/deprecate-control-annotated-none-223bda4f23ce74e9.yaml
@@ -3,7 +3,7 @@ deprecations_circuits:
   - |
     Since Qiskit 1.0, the methods :meth:`.Gate.control` and :meth:`.QuantumCircuit.control`
     accept the argument ``annotated`` which can be either ``False``, ``True`` or ``None``.
-    Presently, a controlled gate is represented using a deidicated controlled-gate class 
+    Presently, a controlled gate is represented using a dedicated controlled-gate class
     when it exists, regardless of the value of ``annotated``, for instance a two-controlled
     version of an  :class:`.XGate` is a :class:`.CCXGate`. If a dedicated controlled-gate
     class does not exist, the controlled gate is represented as a :class:`.ControlledGate`

--- a/test/benchmarks/utils.py
+++ b/test/benchmarks/utils.py
@@ -268,7 +268,7 @@ def multi_control_circuit(num_qubits):
     qc = QuantumCircuit(num_qubits)
     qc.compose(gate, range(gate.num_qubits), inplace=True)
     for _ in range(num_qubits - 1):
-        gate = gate.control()
+        gate = gate.control(annotated=False)
         qc.compose(gate, range(gate.num_qubits), inplace=True)
     return qc
 

--- a/test/python/circuit/library/test_evolution_gate.py
+++ b/test/python/circuit/library/test_evolution_gate.py
@@ -489,10 +489,10 @@ class TestEvolutionGate(QiskitTestCase):
         block_2q = (Z ^ Z) + (Y ^ Y) + (X ^ X)
 
         evo = PauliEvolutionGate([block_1q, block_2q], time=1, synthesis=LieTrotter())
-        controlled = evo.control(2, ctrl_state="01")
+        controlled = evo.control(2, ctrl_state="01", annotated=False)
 
         summed = PauliEvolutionGate(block_1q + block_2q, time=1, synthesis=LieTrotter())
-        reference = summed.control(2, ctrl_state="01")
+        reference = summed.control(2, ctrl_state="01", annotated=False)
 
         self.assertEqual(reference, controlled)
 
@@ -675,7 +675,9 @@ class TestEvolutionGate(QiskitTestCase):
         reference.h([4, 5])
 
         reference.x(0)
-        reference.append(PhaseGate(-1.0).control(5, ctrl_state="11001"), reference.qubits[::-1])
+        reference.append(
+            PhaseGate(-1.0).control(5, ctrl_state="11001", annotated=False), reference.qubits[::-1]
+        )
         reference.x(0)
 
         reference.sxdg([2, 3])
@@ -799,12 +801,12 @@ class TestEvolutionGate(QiskitTestCase):
         """Test controlled evolution gate with a control state."""
         obs = SparseObservable("ZZ")
         evo = PauliEvolutionGate(obs)
-        controlled = evo.control(num_ctrl_qubits=3, ctrl_state=ctrl_state)
+        controlled = evo.control(num_ctrl_qubits=3, ctrl_state=ctrl_state, annotated=False)
         qc = controlled.definition
 
         reference = QuantumCircuit(*qc.qregs)
         reference.cx(4, 3)
-        reference.append(RZGate(2).control(3, ctrl_state="011"), [2, 1, 0, 3])
+        reference.append(RZGate(2).control(3, ctrl_state="011", annotated=False), [2, 1, 0, 3])
         reference.cx(4, 3)
         with self.subTest("check decomp"):
             self.assertEqual(reference, qc)

--- a/test/python/circuit/library/test_mcmt.py
+++ b/test/python/circuit/library/test_mcmt.py
@@ -331,7 +331,7 @@ class TestMCMT(QiskitTestCase):
         circuit.append(mcmt, circuit.qubits)  # append the MCMT circuit as gate called "MCMT"
 
         transpiled = transpile(circuit, basis_gates=["u", "cx"])
-        self.assertEqual(Operator(transpiled), Operator(gate.control(1)))
+        self.assertEqual(Operator(transpiled), Operator(gate.control(1, annotated=False)))
 
 
 if __name__ == "__main__":

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -211,7 +211,7 @@ class TestLoadFromQPY(QiskitTestCase):
         qc = QuantumCircuit(2)
         unitary = np.array([[0, 1], [1, 0]])
         gate = UnitaryGate(unitary)
-        qc.append(gate.control(1), [0, 1])
+        qc.append(gate.control(1, annotated=False), [0, 1])
 
         with io.BytesIO() as qpy_file:
             dump(qc, qpy_file)
@@ -1441,7 +1441,7 @@ class TestLoadFromQPY(QiskitTestCase):
     def test_controlled_gate(self):
         """Test a custom controlled gate."""
         qc = QuantumCircuit(3)
-        controlled_gate = DCXGate().control(1)
+        controlled_gate = DCXGate().control(1, annotated=False)
         qc.append(controlled_gate, [0, 1, 2])
         qpy_file = io.BytesIO()
         dump(qc, qpy_file)
@@ -1453,7 +1453,7 @@ class TestLoadFromQPY(QiskitTestCase):
     def test_controlled_gate_open_controls(self):
         """Test a controlled gate with open controls round-trips exactly."""
         qc = QuantumCircuit(3)
-        controlled_gate = DCXGate().control(1, ctrl_state=0)
+        controlled_gate = DCXGate().control(1, ctrl_state=0, annotated=False)
         qc.append(controlled_gate, [0, 1, 2])
         qpy_file = io.BytesIO()
         dump(qc, qpy_file)
@@ -1473,7 +1473,7 @@ class TestLoadFromQPY(QiskitTestCase):
 
         qc = QuantumCircuit(3)
         qc.append(custom_gate, [0])
-        controlled_gate = custom_gate.control(2)
+        controlled_gate = custom_gate.control(2, annotated=False)
         qc.append(controlled_gate, [0, 1, 2])
         qpy_file = io.BytesIO()
         dump(qc, qpy_file)
@@ -1562,7 +1562,7 @@ class TestLoadFromQPY(QiskitTestCase):
 
         qc = QuantumCircuit(3)
         for i in range(3):
-            c2ry = RYGate(i + 1).control(2)
+            c2ry = RYGate(i + 1).control(2, annotated=False)
             qc.append(c2ry, [i % 3, (i + 1) % 3, (i + 2) % 3])
         qpy_file = io.BytesIO()
         dump(qc, qpy_file)
@@ -1942,8 +1942,8 @@ class TestLoadFromQPY(QiskitTestCase):
         outer_2.append(inner_2.to_gate(), [0], [])
 
         qc = QuantumCircuit(2)
-        qc.append(outer_1.to_gate().control(1), [0, 1], [])
-        qc.append(outer_2.to_gate().control(1), [0, 1], [])
+        qc.append(outer_1.to_gate().control(1, annotated=False), [0, 1], [])
+        qc.append(outer_2.to_gate().control(1, annotated=False), [0, 1], [])
 
         with io.BytesIO() as fptr:
             dump(qc, fptr)

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -1194,7 +1194,7 @@ class TestCircuitOperations(QiskitTestCase):
         qc = QuantumCircuit(2, name="my_qc")
         qc.cry(0.2, 0, 1)
 
-        c_qc = qc.control()
+        c_qc = qc.control(annotated=False)
         with self.subTest("return type is circuit"):
             self.assertIsInstance(c_qc, QuantumCircuit)
 
@@ -1202,19 +1202,19 @@ class TestCircuitOperations(QiskitTestCase):
             self.assertEqual(c_qc.name, "c_my_qc")
 
         with self.subTest("repeated control"):
-            cc_qc = c_qc.control()
+            cc_qc = c_qc.control(annotated=False)
             self.assertEqual(cc_qc.num_qubits, c_qc.num_qubits + 1)
 
         with self.subTest("controlled circuit has same parameter"):
             param = Parameter("p")
             qc.rx(param, 0)
-            c_qc = qc.control()
+            c_qc = qc.control(annotated=False)
             self.assertEqual(qc.parameters, c_qc.parameters)
 
         with self.subTest("non-unitary operation raises"):
             qc.reset(0)
             with self.assertRaises(CircuitError):
-                _ = qc.control()
+                _ = qc.control(annotated=False)
 
     def test_control_implementation(self):
         """Run a test case for controlling the circuit, which should use ``Gate.control``."""
@@ -1222,12 +1222,12 @@ class TestCircuitOperations(QiskitTestCase):
         qc.cx(0, 1)
         qc.cry(0.2, 0, 1)
         qc.t(0)
-        qc.append(SGate().control(2), [0, 1, 2])
+        qc.append(SGate().control(2, annotated=False), [0, 1, 2])
         qc.iswap(2, 0)
 
-        c_qc = qc.control(2, ctrl_state="10")
+        c_qc = qc.control(2, ctrl_state="10", annotated=False)
 
-        cgate = qc.to_gate().control(2, ctrl_state="10")
+        cgate = qc.to_gate().control(2, ctrl_state="10", annotated=False)
         ref = QuantumCircuit(*c_qc.qregs)
         ref.append(cgate, ref.qubits)
 

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -360,7 +360,7 @@ class TestCommutationChecker(QiskitTestCase):
     def test_c7x_gate(self):
         """Test wide gate works correctly."""
         qargs = [Qubit() for _ in [None] * 8]
-        res = scc.commute(XGate(), qargs[:1], [], XGate().control(7), qargs, [])
+        res = scc.commute(XGate(), qargs[:1], [], XGate().control(7, annotated=False), qargs, [])
         self.assertFalse(res)
 
     def test_wide_gates_over_nondisjoint_qubits(self):

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -103,24 +103,24 @@ class TestControlledGate(QiskitTestCase):
 
     def test_controlled_x(self):
         """Test creation of controlled x gate"""
-        self.assertEqual(XGate().control(), CXGate())
+        self.assertEqual(XGate().control(annotated=False), CXGate())
 
     def test_controlled_y(self):
         """Test creation of controlled y gate"""
-        self.assertEqual(YGate().control(), CYGate())
+        self.assertEqual(YGate().control(annotated=False), CYGate())
 
     def test_controlled_z(self):
         """Test creation of controlled z gate"""
-        self.assertEqual(ZGate().control(), CZGate())
+        self.assertEqual(ZGate().control(annotated=False), CZGate())
 
     def test_controlled_h(self):
         """Test the creation of a controlled H gate."""
-        self.assertEqual(HGate().control(), CHGate())
+        self.assertEqual(HGate().control(annotated=False), CHGate())
 
     def test_controlled_phase(self):
         """Test the creation of a controlled phase gate."""
         theta = 0.5
-        self.assertEqual(PhaseGate(theta).control(), CPhaseGate(theta))
+        self.assertEqual(PhaseGate(theta).control(annotated=False), CPhaseGate(theta))
 
     def test_controlled_cphase(self):
         """Test the creation of a controlled cphase gate."""
@@ -130,12 +130,12 @@ class TestControlledGate(QiskitTestCase):
     def test_double_controlled_phase(self):
         """Test the creation of a controlled phase gate."""
         theta = 0.5
-        self.assertEqual(PhaseGate(theta).control(2), MCPhaseGate(theta, 2))
+        self.assertEqual(PhaseGate(theta).control(2, annotated=False), MCPhaseGate(theta, 2))
 
     def test_controlled_u1(self):
         """Test the creation of a controlled U1 gate."""
         theta = 0.5
-        self.assertEqual(U1Gate(theta).control(), CU1Gate(theta))
+        self.assertEqual(U1Gate(theta).control(annotated=False), CU1Gate(theta))
 
         circ = QuantumCircuit(1)
         circ.append(U1Gate(theta), circ.qregs[0])
@@ -143,7 +143,7 @@ class TestControlledGate(QiskitTestCase):
         basis_translator = BasisTranslator(std_eqlib, ["cx", "u", "p"])
         ctrl_circ_gate = dag_to_circuit(
             basis_translator.run(unroller.run(circuit_to_dag(circ)))
-        ).control()
+        ).control(annotated=False)
         ctrl_circ = QuantumCircuit(2)
         ctrl_circ.append(ctrl_circ_gate, ctrl_circ.qregs[0])
         ctrl_circ = ctrl_circ.decompose().decompose()
@@ -152,41 +152,53 @@ class TestControlledGate(QiskitTestCase):
     def test_controlled_rz(self):
         """Test the creation of a controlled RZ gate."""
         theta = 0.5
-        self.assertEqual(RZGate(theta).control(), CRZGate(theta))
+        self.assertEqual(RZGate(theta).control(annotated=False), CRZGate(theta))
 
     def test_control_parameters(self):
         """Test different ctrl_state formats for control function."""
         theta = 0.5
 
         self.assertEqual(
-            CRYGate(theta).control(2, ctrl_state="01"), CRYGate(theta).control(2, ctrl_state=1)
+            CRYGate(theta).control(2, ctrl_state="01", annotated=False),
+            CRYGate(theta).control(2, ctrl_state=1, annotated=False),
         )
         self.assertEqual(
-            CRYGate(theta).control(2, ctrl_state=None), CRYGate(theta).control(2, ctrl_state=3)
+            CRYGate(theta).control(2, ctrl_state=None, annotated=False),
+            CRYGate(theta).control(2, ctrl_state=3, annotated=False),
         )
 
-        self.assertEqual(CCXGate().control(2, ctrl_state="01"), CCXGate().control(2, ctrl_state=1))
-        self.assertEqual(CCXGate().control(2, ctrl_state=None), CCXGate().control(2, ctrl_state=3))
+        self.assertEqual(
+            CCXGate().control(2, ctrl_state="01", annotated=False),
+            CCXGate().control(2, ctrl_state=1, annotated=False),
+        )
+        self.assertEqual(
+            CCXGate().control(2, ctrl_state=None, annotated=False),
+            CCXGate().control(2, ctrl_state=3, annotated=False),
+        )
 
     def test_controlled_ry(self):
         """Test the creation of a controlled RY gate."""
         theta = 0.5
-        self.assertEqual(RYGate(theta).control(), CRYGate(theta))
+        self.assertEqual(RYGate(theta).control(annotated=False), CRYGate(theta))
 
     def test_controlled_rx(self):
         """Test the creation of a controlled RX gate."""
         theta = 0.5
-        self.assertEqual(RXGate(theta).control(), CRXGate(theta))
+        self.assertEqual(RXGate(theta).control(annotated=False), CRXGate(theta))
 
     def test_controlled_u(self):
         """Test the creation of a controlled U gate."""
         theta, phi, lamb = 0.1, 0.2, 0.3
-        self.assertEqual(UGate(theta, phi, lamb).control(), CUGate(theta, phi, lamb, 0))
+        self.assertEqual(
+            UGate(theta, phi, lamb).control(annotated=False), CUGate(theta, phi, lamb, 0)
+        )
 
     def test_controlled_u3(self):
         """Test the creation of a controlled U3 gate."""
         theta, phi, lamb = 0.1, 0.2, 0.3
-        self.assertEqual(U3Gate(theta, phi, lamb).control(), CU3Gate(theta, phi, lamb))
+        self.assertEqual(
+            U3Gate(theta, phi, lamb).control(annotated=False), CU3Gate(theta, phi, lamb)
+        )
 
         circ = QuantumCircuit(1)
         circ.append(U3Gate(theta, phi, lamb), circ.qregs[0])
@@ -194,7 +206,7 @@ class TestControlledGate(QiskitTestCase):
         basis_translator = BasisTranslator(std_eqlib, ["cx", "u", "p"])
         ctrl_circ_gate = dag_to_circuit(
             basis_translator.run(unroller.run(circuit_to_dag(circ)))
-        ).control()
+        ).control(annotated=False)
         ctrl_circ = QuantumCircuit(2)
         ctrl_circ.append(ctrl_circ_gate, ctrl_circ.qregs[0])
         ctrl_circ = ctrl_circ.decompose().decompose()
@@ -203,15 +215,16 @@ class TestControlledGate(QiskitTestCase):
 
     def test_controlled_cx(self):
         """Test creation of controlled cx gate"""
-        self.assertEqual(CXGate().control(), CCXGate())
+        self.assertEqual(CXGate().control(annotated=False), CCXGate())
 
     def test_controlled_swap(self):
         """Test creation of controlled swap gate"""
-        self.assertEqual(SwapGate().control(), CSwapGate())
+        self.assertEqual(SwapGate().control(annotated=False), CSwapGate())
 
     def test_special_cases_equivalent_to_controlled_base_gate(self):
         """Test that ``ControlledGate`` subclasses for more efficient representations give
-        equivalent matrices and definitions to the naive ``base_gate.control(n)``."""
+        equivalent matrices and definitions to the naive ``base_gate.control(n, annotated=False)``.
+        """
         # Angles used here are not important, we just pick slightly strange values to ensure that
         # there are no coincidental equivalences.
         tests = [
@@ -240,7 +253,9 @@ class TestControlledGate(QiskitTestCase):
         ]
         for special_case_gate, n_controls in tests:
             with self.subTest(gate=special_case_gate.name):
-                naive_operator = Operator(special_case_gate.base_gate.control(n_controls))
+                naive_operator = Operator(
+                    special_case_gate.base_gate.control(n_controls, annotated=False)
+                )
                 # Ensure that both the array form (if the gate overrides `__array__`) and the
                 # circuit-definition form are tested.
                 self.assertTrue(Operator(special_case_gate).equiv(naive_operator))
@@ -258,24 +273,28 @@ class TestControlledGate(QiskitTestCase):
         """Test creation of a GlobalPhaseGate."""
         base = GlobalPhaseGate(np.pi / 7)
         expected_1q = PhaseGate(np.pi / 7)
-        self.assertEqual(Operator(base.control()), Operator(expected_1q))
+        self.assertEqual(Operator(base.control(annotated=False)), Operator(expected_1q))
 
-        expected_2q = PhaseGate(np.pi / 7).control()
-        self.assertEqual(Operator(base.control(2)), Operator(expected_2q))
+        expected_2q = PhaseGate(np.pi / 7).control(annotated=False)
+        self.assertEqual(Operator(base.control(2, annotated=False)), Operator(expected_2q))
 
         expected_open = QuantumCircuit(1)
         expected_open.x(0)
         expected_open.p(np.pi / 7, 0)
         expected_open.x(0)
-        self.assertEqual(Operator(base.control(ctrl_state=0)), Operator(expected_open))
+        self.assertEqual(
+            Operator(base.control(ctrl_state=0, annotated=False)), Operator(expected_open)
+        )
 
     def test_circuit_append(self):
         """Test appending a controlled gate to a quantum circuit."""
         circ = QuantumCircuit(5)
         inst = CXGate()
-        circ.append(inst.control(), qargs=[0, 2, 1])
-        circ.append(inst.control(2), qargs=[0, 3, 1, 2])
-        circ.append(inst.control().control(), qargs=[0, 3, 1, 2])  # should be same as above
+        circ.append(inst.control(annotated=False), qargs=[0, 2, 1])
+        circ.append(inst.control(2, annotated=False), qargs=[0, 3, 1, 2])
+        circ.append(
+            inst.control().control(annotated=False), qargs=[0, 3, 1, 2]
+        )  # should be same as above
         self.assertEqual(circ[1].operation, circ[2].operation)
         self.assertEqual(circ.depth(), 3)
         self.assertEqual(circ[0].operation.num_ctrl_qubits, 2)
@@ -308,7 +327,7 @@ class TestControlledGate(QiskitTestCase):
         cgate.t(sub_q[0])
         num_target = cgate.width()
         gate = cgate.to_gate()
-        cont_gate = gate.control(num_ctrl_qubits=num_ctrl)
+        cont_gate = gate.control(num_ctrl_qubits=num_ctrl, annotated=False)
         control = QuantumRegister(num_ctrl)
         target = QuantumRegister(num_target)
         qc = QuantumCircuit(control, target)
@@ -328,7 +347,7 @@ class TestControlledGate(QiskitTestCase):
         cgate.cx(sub_q[0], sub_q[1])
         num_target = cgate.width()
         gate = cgate.to_gate()
-        cont_gate = gate.control(num_ctrl_qubits=num_ctrl)
+        cont_gate = gate.control(num_ctrl_qubits=num_ctrl, annotated=False)
         control = QuantumRegister(num_ctrl, "control")
         target = QuantumRegister(num_target, "target")
         qc = QuantumCircuit(control, target)
@@ -340,9 +359,9 @@ class TestControlledGate(QiskitTestCase):
 
     def test_control_open_controlled_gate(self):
         """Test control(2) vs control.control where inner gate has open controls."""
-        gate1pre = ZGate().control(1, ctrl_state=0)
-        gate1 = gate1pre.control(1, ctrl_state=1)
-        gate2 = ZGate().control(2, ctrl_state=1)
+        gate1pre = ZGate().control(1, ctrl_state=0, annotated=False)
+        gate1 = gate1pre.control(1, ctrl_state=1, annotated=False)
+        gate2 = ZGate().control(2, ctrl_state=1, annotated=False)
         expected = Operator(_compute_control_matrix(ZGate().to_matrix(), 2, ctrl_state=1))
         self.assertEqual(expected, Operator(gate1))
         self.assertEqual(expected, Operator(gate2))
@@ -351,7 +370,7 @@ class TestControlledGate(QiskitTestCase):
         """Test a multi controlled Z gate."""
         qc = QuantumCircuit(1)
         qc.z(0)
-        ctr_gate = qc.to_gate().control(2)
+        ctr_gate = qc.to_gate().control(2, annotated=False)
 
         ctr_circ = QuantumCircuit(3)
         ctr_circ.append(ctr_gate, range(3))
@@ -812,7 +831,7 @@ class TestControlledGate(QiskitTestCase):
     @data(1, 2, 3, 4)
     def test_inverse_x(self, num_ctrl_qubits):
         """Test inverting the controlled X gate."""
-        cnx = XGate().control(num_ctrl_qubits)
+        cnx = XGate().control(num_ctrl_qubits, annotated=False)
         inv_cnx = cnx.inverse()
         result = Operator(cnx).compose(Operator(inv_cnx))
         np.testing.assert_array_almost_equal(result.data, np.identity(result.dim[0]))
@@ -826,7 +845,7 @@ class TestControlledGate(QiskitTestCase):
         qc.cx(1, 2)
         qc.rx(np.pi / 4, [0, 1, 2])
         gate = qc.to_gate()
-        cgate = gate.control(num_ctrl_qubits)
+        cgate = gate.control(num_ctrl_qubits, annotated=False)
         inv_cgate = cgate.inverse()
         result = Operator(cgate).compose(Operator(inv_cgate))
         np.testing.assert_array_almost_equal(result.data, np.identity(result.dim[0]))
@@ -839,7 +858,7 @@ class TestControlledGate(QiskitTestCase):
         qc.cx(0, 1)
         qc.cx(1, 2)
         qc.rx(np.pi / 4, [0, 1, 2])
-        cqc = qc.control(num_ctrl_qubits)
+        cqc = qc.control(num_ctrl_qubits, annotated=False)
         cqc_inv = cqc.inverse()
         result = Operator(cqc).compose(Operator(cqc_inv))
         np.testing.assert_array_almost_equal(result.data, np.identity(result.dim[0]))
@@ -857,7 +876,7 @@ class TestControlledGate(QiskitTestCase):
         # get UnitaryGate version of circuit
         base_op = Operator(qc1)
         base_mat = base_op.data
-        cgate = base_gate.control(num_ctrl_qubits)
+        cgate = base_gate.control(num_ctrl_qubits, annotated=False)
         test_op = Operator(cgate)
         cop_mat = _compute_control_matrix(base_mat, num_ctrl_qubits)
         self.assertTrue(is_unitary_matrix(base_mat))
@@ -870,7 +889,7 @@ class TestControlledGate(QiskitTestCase):
             2**num_target, seed=10 * num_ctrl_qubits + num_target
         ).to_instruction()
         base_mat = base_gate.to_matrix()
-        cgate = base_gate.control(num_ctrl_qubits)
+        cgate = base_gate.control(num_ctrl_qubits, annotated=False)
         test_op = Operator(cgate)
         cop_mat = _compute_control_matrix(base_mat, num_ctrl_qubits)
         self.assertTrue(matrix_equal(cop_mat, test_op.data, atol=1e-8))
@@ -880,27 +899,29 @@ class TestControlledGate(QiskitTestCase):
         """Test that UnitaryGate with control returns params."""
         umat = np.array([[1, 0], [0, -1]])
         ugate = UnitaryGate(umat)
-        cugate = ugate.control(num_ctrl_qubits, ctrl_state=ctrl_state)
+        cugate = ugate.control(num_ctrl_qubits, ctrl_state=ctrl_state, annotated=False)
         ref_mat = _compute_control_matrix(umat, num_ctrl_qubits, ctrl_state=ctrl_state)
         self.assertEqual(Operator(cugate), Operator(ref_mat))
 
     def test_open_controlled_cz(self):
         """Test open-controlled CZ-gates."""
-        controlled_cz = CZGate(ctrl_state=1).control(1, ctrl_state=0)
+        controlled_cz = CZGate(ctrl_state=1).control(1, ctrl_state=0, annotated=False)
         expected = CCZGate(ctrl_state=2)
         self.assertEqual(Operator(controlled_cz), Operator(expected))
 
     def test_open_controlled_cphase(self):
         """Test open-controlled CPhase-gates."""
         theta = 0.1
-        controlled_cphase = CPhaseGate(theta, ctrl_state=1).control(1, ctrl_state=0)
+        controlled_cphase = CPhaseGate(theta, ctrl_state=1).control(
+            1, ctrl_state=0, annotated=False
+        )
         expected = MCPhaseGate(theta, num_ctrl_qubits=2, ctrl_state=2)
         self.assertEqual(Operator(controlled_cphase), Operator(expected))
 
     def test_open_controlled_cu1(self):
         """Test open-controlled CU1-gates."""
         theta = 0.1
-        controlled_cphase = CU1Gate(theta, ctrl_state=1).control(1, ctrl_state=0)
+        controlled_cphase = CU1Gate(theta, ctrl_state=1).control(1, ctrl_state=0, annotated=False)
         expected = MCU1Gate(theta, num_ctrl_qubits=2, ctrl_state=2)
         self.assertEqual(Operator(controlled_cphase), Operator(expected))
 
@@ -909,17 +930,17 @@ class TestControlledGate(QiskitTestCase):
         qc = QuantumCircuit(1)
         qc.rz(0.2, 0)
         controlled = QuantumCircuit(2)
-        controlled.compose(qc.control(), inplace=True)
+        controlled.compose(qc.control(annotated=False), inplace=True)
         self.assertEqual(Operator(controlled), Operator(CRZGate(0.2)))
-        self.assertEqual(Operator(controlled), Operator(RZGate(0.2).control()))
+        self.assertEqual(Operator(controlled), Operator(RZGate(0.2).control(annotated=False)))
 
     def test_controlled_controlled_unitary(self):
         """Test that global phase in iso decomposition of unitary is handled."""
         umat = np.array([[1, 0], [0, -1]])
         ugate = UnitaryGate(umat)
-        cugate = ugate.control()
-        ccugate = cugate.control()
-        ccugate2 = ugate.control(2)
+        cugate = ugate.control(annotated=False)
+        ccugate = cugate.control(annotated=False)
+        ccugate2 = ugate.control(2, annotated=False)
         ref_mat = _compute_control_matrix(umat, 2)
         self.assertTrue(Operator(ccugate2).equiv(Operator(ref_mat)))
         self.assertTrue(Operator(ccugate).equiv(Operator(ccugate2)))
@@ -1078,11 +1099,11 @@ class TestControlledGate(QiskitTestCase):
         # create controlled composite gate
         cqreg = QuantumRegister(3)
         qc = QuantumCircuit(cqreg)
-        qc.append(bell.control(ctrl_state=0), qc.qregs[0][:])
+        qc.append(bell.control(ctrl_state=0, annotated=False), qc.qregs[0][:])
         # create reference circuit
         ref_circuit = QuantumCircuit(cqreg)
         ref_circuit.x(cqreg[0])
-        ref_circuit.append(bell.control(), [cqreg[0], cqreg[1], cqreg[2]])
+        ref_circuit.append(bell.control(annotated=False), [cqreg[0], cqreg[1], cqreg[2]])
         ref_circuit.x(cqreg[0])
         self.assertEqualTranslated(qc, ref_circuit, ["x", "u1", "cbell"])
 
@@ -1107,7 +1128,7 @@ class TestControlledGate(QiskitTestCase):
                     free_params[i] = 3
 
         base_gate = gate_class(*free_params)
-        cgate = base_gate.control()
+        cgate = base_gate.control(annotated=False)
 
         # the base gate of CU is U (3 params), the base gate of CCU is CU (4 params)
         if gate_class == CUGate:
@@ -1131,8 +1152,8 @@ class TestControlledGate(QiskitTestCase):
                 gate = gate(*args)
 
                 self.assertEqual(
-                    gate.inverse().control(num_ctrl_qubits, ctrl_state=ctrl_state),
-                    gate.control(num_ctrl_qubits, ctrl_state=ctrl_state).inverse(),
+                    gate.inverse().control(num_ctrl_qubits, ctrl_state=ctrl_state, annotated=False),
+                    gate.control(num_ctrl_qubits, ctrl_state=ctrl_state, annotated=False).inverse(),
                 )
 
             except AttributeError:
@@ -1159,7 +1180,9 @@ class TestControlledGate(QiskitTestCase):
                 numargs = len(_get_free_params(gate))
                 args = [2] * numargs
                 gate = gate(*args)
-                controlled_gate = gate.control(num_ctrl_qubits, ctrl_state=ctrl_state)
+                controlled_gate = gate.control(
+                    num_ctrl_qubits, ctrl_state=ctrl_state, annotated=False
+                )
                 controlled_gate_ii = controlled_gate.inverse().inverse()
 
                 self.assertEqual(Operator(controlled_gate), Operator(controlled_gate_ii))
@@ -1211,27 +1234,27 @@ class TestControlledGate(QiskitTestCase):
         num_ctrl_qubits = 3
 
         ctrl_state = 5
-        cgate = base_gate.control(num_ctrl_qubits, ctrl_state=ctrl_state)
+        cgate = base_gate.control(num_ctrl_qubits, ctrl_state=ctrl_state, annotated=False)
         target_mat = _compute_control_matrix(base_mat, num_ctrl_qubits, ctrl_state=ctrl_state)
         self.assertEqual(Operator(cgate), Operator(target_mat))
 
         ctrl_state = None
-        cgate = base_gate.control(num_ctrl_qubits, ctrl_state=ctrl_state)
+        cgate = base_gate.control(num_ctrl_qubits, ctrl_state=ctrl_state, annotated=False)
         target_mat = _compute_control_matrix(base_mat, num_ctrl_qubits, ctrl_state=ctrl_state)
         self.assertEqual(Operator(cgate), Operator(target_mat))
 
         ctrl_state = 0
-        cgate = base_gate.control(num_ctrl_qubits, ctrl_state=ctrl_state)
+        cgate = base_gate.control(num_ctrl_qubits, ctrl_state=ctrl_state, annotated=False)
         target_mat = _compute_control_matrix(base_mat, num_ctrl_qubits, ctrl_state=ctrl_state)
         self.assertEqual(Operator(cgate), Operator(target_mat))
 
         ctrl_state = 7
-        cgate = base_gate.control(num_ctrl_qubits, ctrl_state=ctrl_state)
+        cgate = base_gate.control(num_ctrl_qubits, ctrl_state=ctrl_state, annotated=False)
         target_mat = _compute_control_matrix(base_mat, num_ctrl_qubits, ctrl_state=ctrl_state)
         self.assertEqual(Operator(cgate), Operator(target_mat))
 
         ctrl_state = "110"
-        cgate = base_gate.control(num_ctrl_qubits, ctrl_state=ctrl_state)
+        cgate = base_gate.control(num_ctrl_qubits, ctrl_state=ctrl_state, annotated=False)
         target_mat = _compute_control_matrix(base_mat, num_ctrl_qubits, ctrl_state=ctrl_state)
         self.assertEqual(Operator(cgate), Operator(target_mat))
 
@@ -1242,11 +1265,11 @@ class TestControlledGate(QiskitTestCase):
         base_gate = XGate()
         num_ctrl_qubits = 3
         with self.assertRaises(CircuitError):
-            base_gate.control(num_ctrl_qubits, ctrl_state=-1)
+            base_gate.control(num_ctrl_qubits, ctrl_state=-1, annotated=False)
         with self.assertRaises(CircuitError):
-            base_gate.control(num_ctrl_qubits, ctrl_state=2**num_ctrl_qubits)
+            base_gate.control(num_ctrl_qubits, ctrl_state=2**num_ctrl_qubits, annotated=False)
         with self.assertRaises(CircuitError):
-            base_gate.control(num_ctrl_qubits, ctrl_state="201")
+            base_gate.control(num_ctrl_qubits, ctrl_state="201", annotated=False)
 
     def test_base_gate_params_reference(self):
         """
@@ -1268,7 +1291,7 @@ class TestControlledGate(QiskitTestCase):
 
                 base_gate = gate_class(*free_params)
                 if base_gate.params:
-                    cgate = base_gate.control(num_ctrl_qubits)
+                    cgate = base_gate.control(num_ctrl_qubits, annotated=False)
                     self.assertIs(cgate.base_gate.params, cgate.params)
 
     def test_assign_parameters(self):
@@ -1334,7 +1357,7 @@ class TestControlledGate(QiskitTestCase):
         theta = Parameter("t")
         qc_c = QuantumCircuit(2)
         qc_c.crx(theta, 1, 0)
-        custom_gate = qc_c.to_gate().control()
+        custom_gate = qc_c.to_gate().control(annotated=False)
         qc = QuantumCircuit(3)
         qc.append(custom_gate, [0, 1, 2])
         assigned = qc.assign_parameters({theta: 0.5})
@@ -1382,15 +1405,25 @@ class TestControlledGate(QiskitTestCase):
         Test open controlled gates are equal if their base gates and control states are equal.
         """
 
-        self.assertEqual(XGate().control(1), XGate().control(1))
+        self.assertEqual(XGate().control(1, annotated=False), XGate().control(1, annotated=False))
 
-        self.assertNotEqual(XGate().control(1), YGate().control(1))
+        self.assertNotEqual(
+            XGate().control(1, annotated=False), YGate().control(1, annotated=False)
+        )
 
-        self.assertNotEqual(XGate().control(1), XGate().control(2))
+        self.assertNotEqual(
+            XGate().control(1, annotated=False), XGate().control(2, annotated=False)
+        )
 
-        self.assertEqual(XGate().control(1, ctrl_state="0"), XGate().control(1, ctrl_state="0"))
+        self.assertEqual(
+            XGate().control(1, ctrl_state="0", annotated=False),
+            XGate().control(1, ctrl_state="0", annotated=False),
+        )
 
-        self.assertNotEqual(XGate().control(1, ctrl_state="0"), XGate().control(1, ctrl_state="1"))
+        self.assertNotEqual(
+            XGate().control(1, ctrl_state="0", annotated=False),
+            XGate().control(1, ctrl_state="1", annotated=False),
+        )
 
     def test_cx_global_phase(self):
         """
@@ -1402,7 +1435,7 @@ class TestControlledGate(QiskitTestCase):
         cx = circ.to_gate()
         self.assertNotEqual(Operator(CXGate()), Operator(cx))
 
-        ccx = cx.control(1)
+        ccx = cx.control(1, annotated=False)
         base_mat = Operator(cx).data
         target = _compute_control_matrix(base_mat, 1)
         self.assertEqual(Operator(ccx), Operator(target))
@@ -1422,8 +1455,8 @@ class TestControlledGate(QiskitTestCase):
         base_gate = circ.to_gate()
         base_mat = Operator(base_gate).data
         target = _compute_control_matrix(base_mat, num_ctrl_qubits)
-        cgate = base_gate.control(num_ctrl_qubits)
-        ccirc = circ.control(num_ctrl_qubits)
+        cgate = base_gate.control(num_ctrl_qubits, annotated=False)
+        ccirc = circ.control(num_ctrl_qubits, annotated=False)
         self.assertEqual(Operator(cgate), Operator(target))
         self.assertEqual(Operator(ccirc), Operator(target))
 
@@ -1436,9 +1469,9 @@ class TestControlledGate(QiskitTestCase):
         circ = QuantumCircuit(2, global_phase=theta)
         circ.rz(0.1, 0)
         circ.rz(0.2, 1)
-        ccirc = circ.control(num_ctrl_qubits)
+        ccirc = circ.control(num_ctrl_qubits, annotated=False)
         base_gate = circ.to_gate()
-        cgate = base_gate.control(num_ctrl_qubits)
+        cgate = base_gate.control(num_ctrl_qubits, annotated=False)
         base_mat = Operator(base_gate).data
         target = _compute_control_matrix(base_mat, num_ctrl_qubits)
         self.assertEqual(Operator(cgate), Operator(target))
@@ -1456,7 +1489,7 @@ class TestControlledGate(QiskitTestCase):
 
         qc = QuantumCircuit(1)
         qc.append(v, [0])
-        ctrl_qc = qc.control(num_ctrl_qubits)
+        ctrl_qc = qc.control(num_ctrl_qubits, annotated=False)
 
         base_mat = Operator(qc).data
         target = _compute_control_matrix(base_mat, num_ctrl_qubits)
@@ -1467,7 +1500,7 @@ class TestControlledGate(QiskitTestCase):
         """Test that a zero-operand gate (such as a make-shift global-phase gate) can be
         controlled."""
         gate = QuantumCircuit(global_phase=np.pi).to_gate()
-        controlled = gate.control(num_ctrl_qubits)
+        controlled = gate.control(num_ctrl_qubits, annotated=False)
         self.assertIsInstance(controlled, ControlledGate)
         self.assertEqual(controlled.num_ctrl_qubits, num_ctrl_qubits)
         self.assertEqual(controlled.num_qubits, num_ctrl_qubits)
@@ -1496,7 +1529,7 @@ class TestControlledGate(QiskitTestCase):
 
         for annotated in [False, True, None]:
             with self.subTest(annotated=annotated):
-                mc_gate = gate_cls(*params).control(5)
+                mc_gate = gate_cls(*params).control(5, annotated=False)
 
                 circuit = QuantumCircuit(mc_gate.num_qubits)
                 circuit.append(mc_gate, circuit.qubits)
@@ -1571,7 +1604,7 @@ class TestSingleControlledRotationGates(QiskitTestCase):
         """Test the controlled rotation gates controlled on one qubit."""
         as_circuit = QuantumCircuit(1)
         as_circuit.append(gate, [0])
-        cgate = as_circuit.control(num_ctrl_qubits=2)
+        cgate = as_circuit.control(num_ctrl_qubits=2, annotated=False)
 
         if gate.name == "rz":
             iden = Operator.from_label("I")
@@ -1604,10 +1637,10 @@ class TestSingleControlledRotationGates(QiskitTestCase):
         """Test composite gate count."""
         qreg = QuantumRegister(self.num_ctrl + self.num_target)
         qc = QuantumCircuit(qreg, name="composite")
-        qc.append(self.grx.control(self.num_ctrl), qreg)
-        qc.append(self.gry.control(self.num_ctrl), qreg)
+        qc.append(self.grx.control(self.num_ctrl, annotated=False), qreg)
+        qc.append(self.gry.control(self.num_ctrl, annotated=False), qreg)
         qc.append(self.gry, qreg[0 : self.gry.num_qubits])
-        qc.append(self.grz.control(self.num_ctrl), qreg)
+        qc.append(self.grz.control(self.num_ctrl, annotated=False), qreg)
 
         dag = circuit_to_dag(qc)
         unroller = UnrollCustomDefinitions(std_eqlib, ["u", "cx"])
@@ -1629,7 +1662,7 @@ class TestSingleControlledRotationGates(QiskitTestCase):
         num_qubits = 6
         angle = np.pi / 7
         qc = QuantumCircuit(num_qubits)
-        qc.append(RZGate(angle).control(num_qubits - 1), qc.qubits)
+        qc.append(RZGate(angle).control(num_qubits - 1, annotated=False), qc.qubits)
 
         isa_qc = pm.run(qc)
 
@@ -1683,7 +1716,7 @@ class TestControlledStandardGates(QiskitTestCase):
                     # skip matrices that include ancilla qubits
                     continue
                 try:
-                    cgate = gate.control(num_ctrl_qubits, ctrl_state=ctrl_state)
+                    cgate = gate.control(num_ctrl_qubits, ctrl_state=ctrl_state, annotated=False)
                 except (AttributeError, QiskitError):
                     # 'object has no attribute "control"'
                     # skipping Id and Barrier
@@ -1720,7 +1753,8 @@ class TestParameterCtrlState(QiskitTestCase):
         See https://github.com/Qiskit/qiskit-terra/pull/4025
         """
         self.assertEqual(
-            Operator(gate.control(1, ctrl_state="1")), Operator(controlled_gate.to_matrix())
+            Operator(gate.control(1, ctrl_state="1", annotated=False)),
+            Operator(controlled_gate.to_matrix()),
         )
 
 
@@ -1773,7 +1807,7 @@ class TestControlledGateLabel(QiskitTestCase):
     @unpack
     def test_control_label(self, gate, args):
         """Test gate(label=...).control(label=...)"""
-        cgate = gate(*args, label="a gate").control(label="a controlled gate")
+        cgate = gate(*args, label="a gate").control(annotated=False, label="a controlled gate")
         self.assertEqual(cgate.label, "a controlled gate")
         self.assertEqual(cgate.base_gate.label, "a gate")
 
@@ -1781,7 +1815,7 @@ class TestControlledGateLabel(QiskitTestCase):
     @unpack
     def test_control_label_1(self, gate, args):
         """Test gate(label=...).control(1, label=...)"""
-        cgate = gate(*args, label="a gate").control(1, label="a controlled gate")
+        cgate = gate(*args, label="a gate").control(1, annotated=False, label="a controlled gate")
         self.assertEqual(cgate.label, "a controlled gate")
         self.assertEqual(cgate.base_gate.label, "a gate")
 

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -101,6 +101,13 @@ from .gate_utils import _get_free_params
 class TestControlledGate(QiskitTestCase):
     """Tests for controlled gates and the ControlledGate class."""
 
+    def test_raises_warning_without_annotated(self):
+        """Test warning is raised when annotated is not explicitly set
+        and ControlledGate needs to be created.
+        """
+        with self.assertWarns(DeprecationWarning):
+            _ = HGate().control(3)
+
     def test_controlled_x(self):
         """Test creation of controlled x gate"""
         self.assertEqual(XGate().control(annotated=False), CXGate())

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -393,7 +393,7 @@ class TestControlledGate(QiskitTestCase):
         cu3gate = u3.CU3Gate(alpha, beta, gamma)
 
         # cnu3 gate
-        cnu3 = u3gate.control(num_ctrl)
+        cnu3 = u3gate.control(num_ctrl, annotated=False)
         width = cnu3.num_qubits
         qr = QuantumRegister(width)
         qcnu3 = QuantumCircuit(qr)
@@ -412,7 +412,7 @@ class TestControlledGate(QiskitTestCase):
         qr = QuantumRegister(width)
         qc_cu3 = QuantumCircuit(qr)
 
-        c_cu3 = cu3gate.control(1)
+        c_cu3 = cu3gate.control(1, annotated=False)
         qc_cu3.append(c_cu3, qr, [])
 
         # Circuit unitaries
@@ -720,7 +720,7 @@ class TestControlledGate(QiskitTestCase):
         rot_matrix = base_gate(val).to_matrix()
         mc_matrix = _compute_control_matrix(rot_matrix, num_controls)
 
-        mc_gate = base_gate(*params).control(num_controls)
+        mc_gate = base_gate(*params).control(num_controls, annotated=False)
         circuit = QuantumCircuit(mc_gate.num_qubits)
         circuit.append(mc_gate, circuit.qubits)
 

--- a/test/python/circuit/test_singleton.py
+++ b/test/python/circuit/test_singleton.py
@@ -123,7 +123,7 @@ class TestSingleton(QiskitTestCase):
     def test_control_a_singleton(self):
         singleton_gate = HGate()
         gate = HGate(label="special")
-        ch = gate.control(label="my_ch")
+        ch = gate.control(annotated=False, label="my_ch")
         self.assertEqual(ch.base_gate.label, "special")
         self.assertIsNot(ch.base_gate, singleton_gate)
 
@@ -487,7 +487,7 @@ class TestSingletonControlledGate(QiskitTestCase):
     def test_control_a_singleton(self):
         singleton_gate = CHGate()
         gate = CHGate(label="special")
-        ch = gate.control(label="my_ch")
+        ch = gate.control(annotated=False, label="my_ch")
         self.assertEqual(ch.base_gate.label, "special")
         self.assertIsNot(ch.base_gate, singleton_gate)
 
@@ -542,20 +542,20 @@ class TestSingletonControlledGate(QiskitTestCase):
 
     def test_inner_gate_label(self):
         inner_gate = HGate(label="my h gate")
-        controlled_gate = inner_gate.control()
+        controlled_gate = inner_gate.control(annotated=False)
         self.assertTrue(controlled_gate.mutable)
         self.assertEqual("my h gate", controlled_gate.base_gate.label)
 
     def test_inner_gate_label_outer_label_too(self):
         inner_gate = HGate(label="my h gate")
-        controlled_gate = inner_gate.control(label="foo")
+        controlled_gate = inner_gate.control(annotated=False, label="foo")
         self.assertTrue(controlled_gate.mutable)
         self.assertEqual("my h gate", controlled_gate.base_gate.label)
         self.assertEqual("foo", controlled_gate.label)
 
     def test_inner_outer_label_pickle(self):
         inner_gate = XGate(label="my h gate")
-        controlled_gate = inner_gate.control(label="foo")
+        controlled_gate = inner_gate.control(annotated=False, label="foo")
         self.assertTrue(controlled_gate.mutable)
         self.assertEqual("my h gate", controlled_gate.base_gate.label)
         self.assertEqual("foo", controlled_gate.label)

--- a/test/python/circuit/test_tensor.py
+++ b/test/python/circuit/test_tensor.py
@@ -240,7 +240,7 @@ class TestCircuitCompose(QiskitTestCase):
             larger = QuantumCircuit(4)
             larger.h(range(3))
             larger.append(sub.to_instruction(), [3, 2, 1])
-            larger.append(sub.control(), [0, 1, 2, 3])
+            larger.append(sub.control(annotated=False), [0, 1, 2, 3])
 
             circuit = larger.tensor(larger)
             operator = Operator(larger).tensor(Operator(larger))

--- a/test/python/circuit/test_unitary.py
+++ b/test/python/circuit/test_unitary.py
@@ -265,6 +265,6 @@ class TestUnitaryCircuit(QiskitTestCase):
     def test_unitary_control(self):
         """Test parameters of controlled - unitary."""
         mat = numpy.array([[0, 1], [1, 0]])
-        gate = UnitaryGate(mat).control()
+        gate = UnitaryGate(mat).control(annotated=False)
         self.assertTrue(numpy.allclose(gate.params, mat))
         self.assertTrue(numpy.allclose(gate.base_gate.params, mat))

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -150,7 +150,7 @@ class TestStatevector(QiskitTestCase):
         qc.x(0)
         qc.h(1)
         gate = qc.to_gate()
-        gate_ctrl = gate.control()
+        gate_ctrl = gate.control(annotated=False)
 
         circuit = QuantumCircuit(3)
         circuit.x(0)

--- a/test/python/synthesis/test_qsd_synthesis.py
+++ b/test/python/synthesis/test_qsd_synthesis.py
@@ -249,7 +249,7 @@ class TestQuantumShannonDecomposer(QiskitTestCase):
         qc = QuantumCircuit(3)
         qc.append(gate, range(3))
         try:
-            qc.to_gate().control(1)
+            qc.to_gate().control(1, annotated=False)
         except UnboundLocalError as uerr:
             self.fail(str(uerr))
 
@@ -350,7 +350,7 @@ class TestQuantumShannonDecomposer(QiskitTestCase):
         layout = tuple(np.random.permutation(range(num_qubits)))
         # create gate with "control" on different qubits
         qc = QuantumCircuit(num_qubits)
-        gate = base_gate.control(num_qubits - 1)
+        gate = base_gate.control(num_qubits - 1, annotated=False)
         qc.append(gate, layout)
 
         hidden_op = Operator(qc)
@@ -373,7 +373,7 @@ class TestQuantumShannonDecomposer(QiskitTestCase):
         # create gate with "control" on different qubits
         base_gate = UnitaryGate(random_unitary(4, seed=1234))
         qc = QuantumCircuit(num_qubits)
-        gate = base_gate.control(num_qubits - 2)
+        gate = base_gate.control(num_qubits - 2, annotated=False)
         qc.append(gate, layout)
 
         hidden_op = Operator(qc)

--- a/test/python/transpiler/test_high_level_synthesis.py
+++ b/test/python/transpiler/test_high_level_synthesis.py
@@ -773,14 +773,14 @@ class TestHighLevelSynthesisQuality(QiskitTestCase):
     def test_controlled_x(self):
         """Test default synthesis of controlled-X gate."""
         qc = QuantumCircuit(15)
-        qc.append(XGate().control(6), [0, 1, 2, 3, 4, 5, 6])
+        qc.append(XGate().control(6, annotated=False), [0, 1, 2, 3, 4, 5, 6])
         qct = HighLevelSynthesis(basis_gates=["cx", "u"])(qc)
         self.assertLessEqual(qct.count_ops()["cx"], 30)
 
     def test_controlled_cx(self):
         """Test default synthesis of controlled-CX gate."""
         qc = QuantumCircuit(15)
-        qc.append(CXGate().control(5), [0, 1, 2, 3, 4, 5, 6])
+        qc.append(CXGate().control(5, annotated=False), [0, 1, 2, 3, 4, 5, 6])
         qct = HighLevelSynthesis(basis_gates=["cx", "u"])(qc)
         self.assertLessEqual(qct.count_ops()["cx"], 30)
 
@@ -797,14 +797,14 @@ class TestHighLevelSynthesisQuality(QiskitTestCase):
     def test_controlled_z(self):
         """Test default synthesis of controlled-X gate."""
         qc = QuantumCircuit(15)
-        qc.append(ZGate().control(6), [0, 1, 2, 3, 4, 5, 6])
+        qc.append(ZGate().control(6, annotated=False), [0, 1, 2, 3, 4, 5, 6])
         qct = HighLevelSynthesis(basis_gates=["cx", "u"])(qc)
         self.assertLessEqual(qct.count_ops()["cx"], 30)
 
     def test_controlled_cz(self):
         """Test default synthesis of controlled-CZ gate."""
         qc = QuantumCircuit(15)
-        qc.append(CZGate().control(5), [0, 1, 2, 3, 4, 5, 6])
+        qc.append(CZGate().control(5, annotated=False), [0, 1, 2, 3, 4, 5, 6])
         qct = HighLevelSynthesis(basis_gates=["cx", "u"])(qc)
         self.assertLessEqual(qct.count_ops()["cx"], 30)
 
@@ -1254,9 +1254,9 @@ class TestHighLevelSynthesisModifiers(QiskitTestCase):
         circuit.append(lazy_gate2, [0, 1, 2])
         circuit.append(lazy_gate3, [2, 3])
         transpiled_circuit = HighLevelSynthesis()(circuit)
-        controlled_gate1 = SwapGate().control(2)
-        controlled_gate2 = CXGate().control(1)
-        controlled_gate3 = RZGate(np.pi / 4).control(1)
+        controlled_gate1 = SwapGate().control(2, annotated=False)
+        controlled_gate2 = CXGate().control(1, annotated=False)
+        controlled_gate3 = RZGate(np.pi / 4).control(1, annotated=False)
         expected_circuit = QuantumCircuit(4)
         expected_circuit.append(controlled_gate1, [0, 1, 2, 3])
         expected_circuit.append(controlled_gate2, [0, 1, 2])
@@ -1276,7 +1276,7 @@ class TestHighLevelSynthesisModifiers(QiskitTestCase):
         circuit.append(AnnotatedOperation(gate, ControlModifier(2)), [0, 1, 2, 3])
         transpiled_circuit = HighLevelSynthesis()(circuit)
         expected_circuit = QuantumCircuit(4)
-        expected_circuit.append(gate.control(2), [0, 1, 2, 3])
+        expected_circuit.append(gate.control(2, annotated=False), [0, 1, 2, 3])
         self.assertEqual(transpiled_circuit, expected_circuit)
 
     def test_control_clifford(self):
@@ -1297,7 +1297,7 @@ class TestHighLevelSynthesisModifiers(QiskitTestCase):
         circuit.append(lazy_gate1, [0, 1, 2, 3, 4])
         transpiled_circuit = HighLevelSynthesis()(circuit)
         expected_circuit = QuantumCircuit(5)
-        expected_circuit.append(SwapGate().control(3), [0, 1, 2, 3, 4])
+        expected_circuit.append(SwapGate().control(3, annotated=False), [0, 1, 2, 3, 4])
         self.assertEqual(transpiled_circuit, expected_circuit)
 
     def test_nested_controls(self):
@@ -1308,7 +1308,7 @@ class TestHighLevelSynthesisModifiers(QiskitTestCase):
         circuit.append(lazy_gate2, [0, 1, 2, 3, 4])
         transpiled_circuit = HighLevelSynthesis()(circuit)
         expected_circuit = QuantumCircuit(5)
-        expected_circuit.append(SwapGate().control(3), [0, 1, 2, 3, 4])
+        expected_circuit.append(SwapGate().control(3, annotated=False), [0, 1, 2, 3, 4])
         self.assertEqual(transpiled_circuit, expected_circuit)
 
     def test_nested_controls_permutation(self):
@@ -1596,7 +1596,7 @@ class TestHighLevelSynthesisModifiers(QiskitTestCase):
         circuit.append(gate, [0, 1, 2, 3])
         transpiled_circuit = HighLevelSynthesis()(circuit)
         expected_circuit = QuantumCircuit(6)
-        expected_circuit.append(SwapGate().control(2), [0, 1, 2, 3])
+        expected_circuit.append(SwapGate().control(2, annotated=False), [0, 1, 2, 3])
         self.assertEqual(circuit, transpiled_circuit)
 
     def test_control_high_level_object(self):
@@ -3171,7 +3171,7 @@ class TestAnnotatedSynthesisPlugins(QiskitTestCase):
         # Optimized circuit with non-controlled phase gates
         qc_expected = QuantumCircuit(5)
         qc_expected.append(PhaseGate(1), [4])
-        qc_expected.append(HGate().control(4), [0, 1, 2, 3, 4])
+        qc_expected.append(HGate().control(4, annotated=False), [0, 1, 2, 3, 4])
         qc_expected.append(PhaseGate(-1), [4])
 
         qc_main_tranpiled = self._pass(qc_main)
@@ -3193,9 +3193,9 @@ class TestAnnotatedSynthesisPlugins(QiskitTestCase):
 
         # Non-optimized circuit with controlled phase gates
         qc_expected = QuantumCircuit(5)
-        qc_expected.append(PhaseGate(1).control(4), [0, 1, 2, 3, 4])
-        qc_expected.append(HGate().control(4), [0, 1, 2, 3, 4])
-        qc_expected.append(PhaseGate(-2).control(4), [0, 1, 2, 3, 4])
+        qc_expected.append(PhaseGate(1).control(4, annotated=False), [0, 1, 2, 3, 4])
+        qc_expected.append(HGate().control(4, annotated=False), [0, 1, 2, 3, 4])
+        qc_expected.append(PhaseGate(-2).control(4, annotated=False), [0, 1, 2, 3, 4])
 
         qc_main_tranpiled = self._pass(qc_main)
         qc_expected_transpiled = self._pass(qc_expected)
@@ -3218,7 +3218,7 @@ class TestAnnotatedSynthesisPlugins(QiskitTestCase):
         # Optimized circuit with non-controlled phase gates
         qc_expected = QuantumCircuit(5)
         qc_expected.append(PhaseGate(1), [4])
-        qc_expected.append(HGate().control(4), [0, 1, 2, 3, 4])
+        qc_expected.append(HGate().control(4, annotated=False), [0, 1, 2, 3, 4])
         qc_expected.append(PhaseGate(-1), [4])
 
         qc_main_tranpiled = self._pass(qc_main)
@@ -3240,9 +3240,9 @@ class TestAnnotatedSynthesisPlugins(QiskitTestCase):
 
         # Non-optimized circuit with controlled phase gates
         qc_expected = QuantumCircuit(5)
-        qc_expected.append(PhaseGate(1).control(4), [0, 1, 2, 3, 4])
-        qc_expected.append(HGate().control(4), [0, 1, 2, 3, 4])
-        qc_expected.append(PhaseGate(-2).control(4), [0, 1, 2, 3, 4])
+        qc_expected.append(PhaseGate(1).control(4, annotated=False), [0, 1, 2, 3, 4])
+        qc_expected.append(HGate().control(4, annotated=False), [0, 1, 2, 3, 4])
+        qc_expected.append(PhaseGate(-2).control(4, annotated=False), [0, 1, 2, 3, 4])
 
         qc_main_tranpiled = self._pass(qc_main)
         qc_expected_transpiled = self._pass(qc_expected)

--- a/test/python/transpiler/test_hoare_opt.py
+++ b/test/python/transpiler/test_hoare_opt.py
@@ -445,7 +445,7 @@ class TestHoareOptimizer(QiskitTestCase):
         circuit.ccx(6, 3, 2)
         circuit.ccx(2, 3, 5)
         circuit.ccx(6, 5, 4)
-        circuit.append(XGate().control(3), [4, 5, 6, 7], [])
+        circuit.append(XGate().control(3, annotated=False), [4, 5, 6, 7], [])
         for i in range(1, -1, -1):
             circuit.ccx(i * 2, i * 2 + 1, i * 2 + 3)
         circuit.cx(3, 5)
@@ -614,12 +614,12 @@ class TestHoareOptimizer(QiskitTestCase):
         """The is_identity function determines whether a pair of gates
         forms the identity, when ignoring control qubits.
         """
-        seq = [DAGOpNode(op=XGate().control()), DAGOpNode(op=XGate().control(2))]
+        seq = [DAGOpNode(op=XGate().control()), DAGOpNode(op=XGate().control(2, annotated=False))]
         self.assertTrue(HoareOptimizer()._is_identity(seq))
 
         seq = [
-            DAGOpNode(op=RZGate(-pi / 2).control()),
-            DAGOpNode(op=RZGate(pi / 2).control(2)),
+            DAGOpNode(op=RZGate(-pi / 2).control(annotated=False)),
+            DAGOpNode(op=RZGate(pi / 2).control(2, annotated=False)),
         ]
         self.assertTrue(HoareOptimizer()._is_identity(seq))
 

--- a/test/python/visualization/test_circuit_latex.py
+++ b/test/python/visualization/test_circuit_latex.py
@@ -266,7 +266,9 @@ class TestLatexSourceGenerator(QiskitVisualizationTestCase):
         circuit.x(0)
         circuit.cx(0, 1)
         circuit.ccx(0, 1, 2)
-        circuit.append(XGate().control(3, ctrl_state="010"), [qr[2], qr[3], qr[0], qr[1]])
+        circuit.append(
+            XGate().control(3, ctrl_state="010", annotated=False), [qr[2], qr[3], qr[0], qr[1]]
+        )
         circuit.append(MCXGate(num_ctrl_qubits=3, ctrl_state="101"), [qr[0], qr[1], qr[2], qr[4]])
 
         circuit_drawer(circuit, filename=filename, output="latex_source")
@@ -307,7 +309,7 @@ class TestLatexSourceGenerator(QiskitVisualizationTestCase):
         circuit.append(U2Gate(3 * pi / 2, 2 * pi / 3), [1])
         circuit.append(U3Gate(3 * pi / 2, 4.5, pi / 4), [2])
         circuit.append(CU1Gate(pi / 4), [0, 1])
-        circuit.append(U2Gate(pi / 2, 3 * pi / 2).control(1), [2, 3])
+        circuit.append(U2Gate(pi / 2, 3 * pi / 2).control(1, annotated=False), [2, 3])
         circuit.append(CU3Gate(3 * pi / 2, -3 * pi / 4, -pi / 2), [0, 1])
 
         circuit_drawer(circuit, filename=filename, output="latex_source")
@@ -366,7 +368,9 @@ class TestLatexSourceGenerator(QiskitVisualizationTestCase):
         circuit.x(0)
         circuit.x(1)
         circuit.cswap(0, 1, 2)
-        circuit.append(RZZGate(3 * pi / 4).control(3, ctrl_state="010"), [2, 1, 4, 3, 0])
+        circuit.append(
+            RZZGate(3 * pi / 4).control(3, ctrl_state="010", annotated=False), [2, 1, 4, 3, 0]
+        )
 
         circuit_drawer(circuit, filename=filename, output="latex_source")
 
@@ -382,7 +386,7 @@ class TestLatexSourceGenerator(QiskitVisualizationTestCase):
         ghz_circuit.cx(0, 1)
         ghz_circuit.cx(1, 2)
         ghz = ghz_circuit.to_gate()
-        ccghz = ghz.control(2, ctrl_state="10")
+        ccghz = ghz.control(2, ctrl_state="10", annotated=False)
         circuit.append(ccghz, [4, 0, 1, 3, 2])
 
         circuit_drawer(circuit, filename=filename, output="latex_source")
@@ -467,10 +471,10 @@ class TestLatexSourceGenerator(QiskitVisualizationTestCase):
         circuit.ccx(0, 1, 2)
         circuit.swap(0, 1)
         circuit.cswap(0, 1, 2)
-        circuit.append(SwapGate().control(2), [0, 1, 2, 3])
+        circuit.append(SwapGate().control(2, annotated=False), [0, 1, 2, 3])
         circuit.dcx(0, 1)
-        circuit.append(DCXGate().control(1), [0, 1, 2])
-        circuit.append(DCXGate().control(2), [0, 1, 2, 3])
+        circuit.append(DCXGate().control(1, annotated=False), [0, 1, 2])
+        circuit.append(DCXGate().control(2, annotated=False), [0, 1, 2, 3])
         circuit.z(4)
         circuit.s(4)
         circuit.sdg(4)

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -1594,7 +1594,7 @@ class TestTextDrawerLabels(QiskitTestCase):
             ]
         )
         circuit = QuantumCircuit(2)
-        circuit.append(HGate(label="an H gate").control(1), [0, 1])
+        circuit.append(HGate(label="an H gate").control(1, annotated=False), [0, 1])
 
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
@@ -1611,7 +1611,7 @@ class TestTextDrawerLabels(QiskitTestCase):
         )
 
         circuit = QuantumCircuit(2)
-        circuit.append(HGate().control(1, label="a controlled H gate"), [0, 1])
+        circuit.append(HGate().control(1, annotated=False, label="a controlled H gate"), [0, 1])
 
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
@@ -1895,7 +1895,7 @@ class TestTextDrawerMultiQGates(QiskitTestCase):
         qr = QuantumRegister(2, "q")
         circ = QuantumCircuit(qr)
         hgate = HGate(label="my h")
-        controlh = hgate.control(label="my ch")
+        controlh = hgate.control(annotated=False, label="my ch")
         circ.append(hgate, [0])
         circ.append(controlh, [0, 1])
         circ.append(controlh, [1, 0])
@@ -2645,7 +2645,7 @@ class TestTextControlledGate(QiskitTestCase):
         )
         qr = QuantumRegister(3, "q")
         circuit = QuantumCircuit(qr)
-        circuit.append(HGate().control(2), [qr[0], qr[1], qr[2]])
+        circuit.append(HGate().control(2, annotated=False), [qr[0], qr[1], qr[2]])
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_cch_mid(self):
@@ -2663,7 +2663,7 @@ class TestTextControlledGate(QiskitTestCase):
         )
         qr = QuantumRegister(3, "q")
         circuit = QuantumCircuit(qr)
-        circuit.append(HGate().control(2), [qr[0], qr[2], qr[1]])
+        circuit.append(HGate().control(2, annotated=False), [qr[0], qr[2], qr[1]])
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_cch_top(self):
@@ -2681,7 +2681,7 @@ class TestTextControlledGate(QiskitTestCase):
         )
         qr = QuantumRegister(3, "q")
         circuit = QuantumCircuit(qr)
-        circuit.append(HGate().control(2), [qr[2], qr[1], qr[0]])
+        circuit.append(HGate().control(2, annotated=False), [qr[2], qr[1], qr[0]])
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_c3h(self):
@@ -2701,7 +2701,7 @@ class TestTextControlledGate(QiskitTestCase):
         )
         qr = QuantumRegister(4, "q")
         circuit = QuantumCircuit(qr)
-        circuit.append(HGate().control(3), [qr[0], qr[1], qr[2], qr[3]])
+        circuit.append(HGate().control(3, annotated=False), [qr[0], qr[1], qr[2], qr[3]])
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_c3h_middle(self):
@@ -2721,7 +2721,7 @@ class TestTextControlledGate(QiskitTestCase):
         )
         qr = QuantumRegister(4, "q")
         circuit = QuantumCircuit(qr)
-        circuit.append(HGate().control(3), [qr[0], qr[3], qr[2], qr[1]])
+        circuit.append(HGate().control(3, annotated=False), [qr[0], qr[3], qr[2], qr[1]])
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_c3u2(self):
@@ -2741,7 +2741,9 @@ class TestTextControlledGate(QiskitTestCase):
         )
         qr = QuantumRegister(4, "q")
         circuit = QuantumCircuit(qr)
-        circuit.append(U2Gate(pi, -5 * pi / 8).control(3), [qr[0], qr[3], qr[2], qr[1]])
+        circuit.append(
+            U2Gate(pi, -5 * pi / 8).control(3, annotated=False), [qr[0], qr[3], qr[2], qr[1]]
+        )
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_controlled_composite_gate_edge(self):
@@ -2765,7 +2767,7 @@ class TestTextControlledGate(QiskitTestCase):
         ghz_circuit.cx(0, 1)
         ghz_circuit.cx(1, 2)
         ghz = ghz_circuit.to_gate()
-        cghz = ghz.control(1)
+        cghz = ghz.control(1, annotated=False)
         circuit = QuantumCircuit(4)
         circuit.append(cghz, [1, 0, 2, 3])
 
@@ -2791,7 +2793,7 @@ class TestTextControlledGate(QiskitTestCase):
         ghz_circuit.cx(0, 1)
         ghz_circuit.cx(1, 2)
         ghz = ghz_circuit.to_gate()
-        cghz = ghz.control(1)
+        cghz = ghz.control(1, annotated=False)
         circuit = QuantumCircuit(4)
         circuit.append(cghz, [0, 1, 3, 2])
 
@@ -2817,7 +2819,7 @@ class TestTextControlledGate(QiskitTestCase):
         ghz_circuit.cx(0, 1)
         ghz_circuit.cx(1, 2)
         ghz = ghz_circuit.to_gate()
-        cghz = ghz.control(1)
+        cghz = ghz.control(1, annotated=False)
         circuit = QuantumCircuit(4)
         circuit.append(cghz, [3, 1, 0, 2])
 
@@ -2845,7 +2847,7 @@ class TestTextControlledGate(QiskitTestCase):
         ghz_circuit.cx(0, 1)
         ghz_circuit.cx(1, 2)
         ghz = ghz_circuit.to_gate()
-        ccghz = ghz.control(2)
+        ccghz = ghz.control(2, annotated=False)
         circuit = QuantumCircuit(5)
         circuit.append(ccghz, [4, 0, 1, 2, 3])
 
@@ -2875,7 +2877,7 @@ class TestTextControlledGate(QiskitTestCase):
         ghz_circuit.cx(0, 1)
         ghz_circuit.cx(1, 2)
         ghz = ghz_circuit.to_gate()
-        ccghz = ghz.control(3)
+        ccghz = ghz.control(3, annotated=False)
         circuit = QuantumCircuit(6)
         circuit.append(ccghz, [0, 2, 5, 1, 3, 4])
 
@@ -2903,7 +2905,7 @@ class TestTextControlledGate(QiskitTestCase):
         ghz_circuit.cx(0, 1)
         ghz_circuit.cx(1, 2)
         ghz = ghz_circuit.to_gate()
-        ccghz = ghz.control(2)
+        ccghz = ghz.control(2, annotated=False)
         circuit = QuantumCircuit(5)
         circuit.append(ccghz, [4, 0, 1, 2, 3])
 
@@ -2926,7 +2928,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         # fmt: on
         qr = QuantumRegister(2, "q")
         circuit = QuantumCircuit(qr)
-        circuit.append(HGate().control(1, ctrl_state=0), [qr[0], qr[1]])
+        circuit.append(HGate().control(1, ctrl_state=0, annotated=False), [qr[0], qr[1]])
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_cz_bot(self):
@@ -2940,7 +2942,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         # fmt: on
         qr = QuantumRegister(2, "q")
         circuit = QuantumCircuit(qr)
-        circuit.append(ZGate().control(1, ctrl_state=0), [qr[0], qr[1]])
+        circuit.append(ZGate().control(1, ctrl_state=0, annotated=False), [qr[0], qr[1]])
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_ccz_bot(self):
@@ -2958,7 +2960,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         )
         qr = QuantumRegister(3, "q")
         circuit = QuantumCircuit(qr)
-        circuit.append(ZGate().control(2, ctrl_state="01"), [qr[0], qr[1], qr[2]])
+        circuit.append(ZGate().control(2, ctrl_state="01", annotated=False), [qr[0], qr[1], qr[2]])
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_cch_bot(self):
@@ -2976,7 +2978,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         )
         qr = QuantumRegister(3, "q")
         circuit = QuantumCircuit(qr)
-        circuit.append(HGate().control(2, ctrl_state="10"), [qr[0], qr[1], qr[2]])
+        circuit.append(HGate().control(2, ctrl_state="10", annotated=False), [qr[0], qr[1], qr[2]])
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_cch_mid(self):
@@ -2994,7 +2996,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         )
         qr = QuantumRegister(3, "q")
         circuit = QuantumCircuit(qr)
-        circuit.append(HGate().control(2, ctrl_state="10"), [qr[0], qr[2], qr[1]])
+        circuit.append(HGate().control(2, ctrl_state="10", annotated=False), [qr[0], qr[2], qr[1]])
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_cch_top(self):
@@ -3012,7 +3014,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         )
         qr = QuantumRegister(3, "q")
         circuit = QuantumCircuit(qr)
-        circuit.append(HGate().control(2, ctrl_state="10"), [qr[1], qr[2], qr[0]])
+        circuit.append(HGate().control(2, ctrl_state="10", annotated=False), [qr[1], qr[2], qr[0]])
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_c3h(self):
@@ -3032,7 +3034,9 @@ class TestTextOpenControlledGate(QiskitTestCase):
         )
         qr = QuantumRegister(4, "q")
         circuit = QuantumCircuit(qr)
-        circuit.append(HGate().control(3, ctrl_state="100"), [qr[0], qr[1], qr[2], qr[3]])
+        circuit.append(
+            HGate().control(3, ctrl_state="100", annotated=False), [qr[0], qr[1], qr[2], qr[3]]
+        )
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_c3h_middle(self):
@@ -3052,7 +3056,9 @@ class TestTextOpenControlledGate(QiskitTestCase):
         )
         qr = QuantumRegister(4, "q")
         circuit = QuantumCircuit(qr)
-        circuit.append(HGate().control(3, ctrl_state="010"), [qr[0], qr[3], qr[2], qr[1]])
+        circuit.append(
+            HGate().control(3, ctrl_state="010", annotated=False), [qr[0], qr[3], qr[2], qr[1]]
+        )
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
     def test_c3u2(self):
@@ -3073,7 +3079,8 @@ class TestTextOpenControlledGate(QiskitTestCase):
         qr = QuantumRegister(4, "q")
         circuit = QuantumCircuit(qr)
         circuit.append(
-            U2Gate(pi, -5 * pi / 8).control(3, ctrl_state="100"), [qr[0], qr[3], qr[2], qr[1]]
+            U2Gate(pi, -5 * pi / 8).control(3, ctrl_state="100", annotated=False),
+            [qr[0], qr[3], qr[2], qr[1]],
         )
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
@@ -3098,7 +3105,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         ghz_circuit.cx(0, 1)
         ghz_circuit.cx(1, 2)
         ghz = ghz_circuit.to_gate()
-        cghz = ghz.control(1, ctrl_state="0")
+        cghz = ghz.control(1, ctrl_state="0", annotated=False)
         circuit = QuantumCircuit(4)
         circuit.append(cghz, [1, 0, 2, 3])
 
@@ -3124,7 +3131,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         ghz_circuit.cx(0, 1)
         ghz_circuit.cx(1, 2)
         ghz = ghz_circuit.to_gate()
-        cghz = ghz.control(1, ctrl_state="0")
+        cghz = ghz.control(1, ctrl_state="0", annotated=False)
         circuit = QuantumCircuit(4)
         circuit.append(cghz, [0, 1, 3, 2])
 
@@ -3150,7 +3157,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         ghz_circuit.cx(0, 1)
         ghz_circuit.cx(1, 2)
         ghz = ghz_circuit.to_gate()
-        cghz = ghz.control(1, ctrl_state="0")
+        cghz = ghz.control(1, ctrl_state="0", annotated=False)
         circuit = QuantumCircuit(4)
         circuit.append(cghz, [3, 1, 0, 2])
 
@@ -3178,7 +3185,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         ghz_circuit.cx(0, 1)
         ghz_circuit.cx(1, 2)
         ghz = ghz_circuit.to_gate()
-        ccghz = ghz.control(2, ctrl_state="01")
+        ccghz = ghz.control(2, ctrl_state="01", annotated=False)
         circuit = QuantumCircuit(5)
         circuit.append(ccghz, [4, 0, 1, 2, 3])
 
@@ -3208,7 +3215,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         ghz_circuit.cx(0, 1)
         ghz_circuit.cx(1, 2)
         ghz = ghz_circuit.to_gate()
-        ccghz = ghz.control(3, ctrl_state="000")
+        ccghz = ghz.control(3, ctrl_state="000", annotated=False)
         circuit = QuantumCircuit(6)
         circuit.append(ccghz, [0, 2, 5, 1, 3, 4])
 
@@ -3234,15 +3241,15 @@ class TestTextOpenControlledGate(QiskitTestCase):
         )
         qreg = QuantumRegister(5, "qr")
         circuit = QuantumCircuit(qreg)
-        control1 = XGate().control(1, ctrl_state="0")
+        control1 = XGate().control(1, ctrl_state="0", annotated=False)
         circuit.append(control1, [0, 1])
-        control2 = XGate().control(2, ctrl_state="00")
+        control2 = XGate().control(2, ctrl_state="00", annotated=False)
         circuit.append(control2, [0, 1, 2])
-        control2_2 = XGate().control(2, ctrl_state="10")
+        control2_2 = XGate().control(2, ctrl_state="10", annotated=False)
         circuit.append(control2_2, [0, 1, 2])
-        control3 = XGate().control(3, ctrl_state="010")
+        control3 = XGate().control(3, ctrl_state="010", annotated=False)
         circuit.append(control3, [0, 1, 2, 3])
-        control3 = XGate().control(4, ctrl_state="0101")
+        control3 = XGate().control(4, ctrl_state="0101", annotated=False)
         circuit.append(control3, [0, 1, 4, 2, 3])
 
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
@@ -3267,15 +3274,15 @@ class TestTextOpenControlledGate(QiskitTestCase):
         )
         qreg = QuantumRegister(5, "qr")
         circuit = QuantumCircuit(qreg)
-        control1 = YGate().control(1, ctrl_state="0")
+        control1 = YGate().control(1, ctrl_state="0", annotated=False)
         circuit.append(control1, [0, 1])
-        control2 = YGate().control(2, ctrl_state="00")
+        control2 = YGate().control(2, ctrl_state="00", annotated=False)
         circuit.append(control2, [0, 1, 2])
-        control2_2 = YGate().control(2, ctrl_state="10")
+        control2_2 = YGate().control(2, ctrl_state="10", annotated=False)
         circuit.append(control2_2, [0, 1, 2])
-        control3 = YGate().control(3, ctrl_state="010")
+        control3 = YGate().control(3, ctrl_state="010", annotated=False)
         circuit.append(control3, [0, 1, 2, 3])
-        control3 = YGate().control(4, ctrl_state="0101")
+        control3 = YGate().control(4, ctrl_state="0101", annotated=False)
         circuit.append(control3, [0, 1, 4, 2, 3])
 
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
@@ -3299,15 +3306,15 @@ class TestTextOpenControlledGate(QiskitTestCase):
         )
         qreg = QuantumRegister(5, "qr")
         circuit = QuantumCircuit(qreg)
-        control1 = ZGate().control(1, ctrl_state="0")
+        control1 = ZGate().control(1, ctrl_state="0", annotated=False)
         circuit.append(control1, [0, 1])
-        control2 = ZGate().control(2, ctrl_state="00")
+        control2 = ZGate().control(2, ctrl_state="00", annotated=False)
         circuit.append(control2, [0, 1, 2])
-        control2_2 = ZGate().control(2, ctrl_state="10")
+        control2_2 = ZGate().control(2, ctrl_state="10", annotated=False)
         circuit.append(control2_2, [0, 1, 2])
-        control3 = ZGate().control(3, ctrl_state="010")
+        control3 = ZGate().control(3, ctrl_state="010", annotated=False)
         circuit.append(control3, [0, 1, 2, 3])
-        control3 = ZGate().control(4, ctrl_state="0101")
+        control3 = ZGate().control(4, ctrl_state="0101", annotated=False)
         circuit.append(control3, [0, 1, 4, 2, 3])
 
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
@@ -3331,15 +3338,15 @@ class TestTextOpenControlledGate(QiskitTestCase):
         )
         qreg = QuantumRegister(5, "qr")
         circuit = QuantumCircuit(qreg)
-        control1 = U1Gate(0.1).control(1, ctrl_state="0")
+        control1 = U1Gate(0.1).control(1, ctrl_state="0", annotated=False)
         circuit.append(control1, [0, 1])
-        control2 = U1Gate(0.2).control(2, ctrl_state="00")
+        control2 = U1Gate(0.2).control(2, ctrl_state="00", annotated=False)
         circuit.append(control2, [0, 1, 2])
-        control2_2 = U1Gate(0.3).control(2, ctrl_state="10")
+        control2_2 = U1Gate(0.3).control(2, ctrl_state="10", annotated=False)
         circuit.append(control2_2, [0, 1, 2])
-        control3 = U1Gate(0.4).control(3, ctrl_state="010")
+        control3 = U1Gate(0.4).control(3, ctrl_state="010", annotated=False)
         circuit.append(control3, [0, 1, 2, 3])
-        control3 = U1Gate(0.5).control(4, ctrl_state="0101")
+        control3 = U1Gate(0.5).control(4, ctrl_state="0101", annotated=False)
         circuit.append(control3, [0, 1, 4, 2, 3])
 
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
@@ -3363,13 +3370,13 @@ class TestTextOpenControlledGate(QiskitTestCase):
         )
         qreg = QuantumRegister(5, "qr")
         circuit = QuantumCircuit(qreg)
-        control1 = SwapGate().control(1, ctrl_state="0")
+        control1 = SwapGate().control(1, ctrl_state="0", annotated=False)
         circuit.append(control1, [0, 1, 2])
-        control2 = SwapGate().control(2, ctrl_state="00")
+        control2 = SwapGate().control(2, ctrl_state="00", annotated=False)
         circuit.append(control2, [0, 1, 2, 3])
-        control2_2 = SwapGate().control(2, ctrl_state="10")
+        control2_2 = SwapGate().control(2, ctrl_state="10", annotated=False)
         circuit.append(control2_2, [0, 1, 2, 3])
-        control3 = SwapGate().control(3, ctrl_state="010")
+        control3 = SwapGate().control(3, ctrl_state="010", annotated=False)
         circuit.append(control3, [0, 1, 2, 3, 4])
 
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
@@ -3393,13 +3400,13 @@ class TestTextOpenControlledGate(QiskitTestCase):
         )
         qreg = QuantumRegister(5, "qr")
         circuit = QuantumCircuit(qreg)
-        control1 = RZZGate(1).control(1, ctrl_state="0")
+        control1 = RZZGate(1).control(1, ctrl_state="0", annotated=False)
         circuit.append(control1, [0, 1, 2])
-        control2 = RZZGate(1).control(2, ctrl_state="00")
+        control2 = RZZGate(1).control(2, ctrl_state="00", annotated=False)
         circuit.append(control2, [0, 1, 2, 3])
-        control2_2 = RZZGate(1).control(2, ctrl_state="10")
+        control2_2 = RZZGate(1).control(2, ctrl_state="10", annotated=False)
         circuit.append(control2_2, [0, 1, 2, 3])
-        control3 = RZZGate(1).control(3, ctrl_state="010")
+        control3 = RZZGate(1).control(3, ctrl_state="010", annotated=False)
         circuit.append(control3, [0, 1, 2, 3, 4])
 
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
@@ -3424,7 +3431,9 @@ class TestTextOpenControlledGate(QiskitTestCase):
         )
         qr = QuantumRegister(5, "q")
         circuit = QuantumCircuit(qr)
-        circuit.append(XGate().control(3, ctrl_state="101"), [qr[0], qr[3], qr[1], qr[2]])
+        circuit.append(
+            XGate().control(3, ctrl_state="101", annotated=False), [qr[0], qr[3], qr[1], qr[2]]
+        )
 
         self.assertEqual(str(circuit_drawer(circuit, output="text", initial_state=True)), expected)
 
@@ -4676,7 +4685,7 @@ class TestCircuitAnnotatedOperations(QiskitVisualizationTestCase):
         circuit.append(cliff, [0, 1])
         circuit.x(0)
         circuit.h(1)
-        circuit.append(SGate().control(2, ctrl_state=1), [0, 2, 1])
+        circuit.append(SGate().control(2, ctrl_state=1, annotated=False), [0, 2, 1])
         circuit.ccx(0, 1, 2)
         op1 = AnnotatedOperation(
             SGate(), [InverseModifier(), ControlModifier(2, 1), PowerModifier(3.29)]

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -560,11 +560,14 @@ def generate_calibrated_circuits():
     return circuits
 
 
-def generate_controlled_gates():
+def generate_controlled_gates(version):
     """Test QPY serialization with custom ControlledGates."""
     circuits = []
     qc = QuantumCircuit(3, name="custom_controlled_gates")
-    controlled_gate = DCXGate().control(1, annotated=False)
+    if version >= (2, 3, 0):
+        controlled_gate = DCXGate().control(1, annotated=False)
+    else:
+        controlled_gate = DCXGate().control(1)
     qc.append(controlled_gate, [0, 1, 2])
     circuits.append(qc)
     custom_gate = Gate("black_box", 1, [])
@@ -574,7 +577,10 @@ def generate_controlled_gates():
     custom_gate.definition = custom_definition
     nested_qc = QuantumCircuit(3, name="nested_qc")
     qc.append(custom_gate, [0])
-    controlled_gate = custom_gate.control(2, annotated=False)
+    if version >= (2, 3, 0):
+        controlled_gate = custom_gate.control(2, annotated=False)
+    else:
+        ontrolled_gate = custom_gate.control(2)
     nested_qc.append(controlled_gate, [0, 1, 2])
     circuits.append(nested_qc)
     qc_open = QuantumCircuit(2, name="open_cx")
@@ -587,7 +593,10 @@ def generate_open_controlled_gates(version):
     """Test QPY serialization with custom ControlledGates with open controls."""
     circuits = []
     qc = QuantumCircuit(3, name="open_controls_simple")
-    controlled_gate = DCXGate().control(1, ctrl_state=0, annotated=False)
+    if version >= (2, 3, 0):
+        controlled_gate = DCXGate().control(1, ctrl_state=0, annotated=False)
+    else:
+        controlled_gate = DCXGate().control(1, ctrl_state=0)
     qc.append(controlled_gate, [0, 1, 2])
     circuits.append(qc)
 
@@ -979,7 +988,7 @@ def generate_circuits(version_parts, current_version, load_context=False):
         output_circuits["open_controlled_gates.qpy"] = generate_open_controlled_gates(
             current_version
         )
-        output_circuits["controlled_gates.qpy"] = generate_controlled_gates()
+        output_circuits["controlled_gates.qpy"] = generate_controlled_gates(current_version)
     if version_parts >= (0, 24, 2):
         output_circuits["layout.qpy"] = generate_layout_circuits()
     if version_parts >= (0, 25, 0) and version_parts < (2, 0):

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -583,7 +583,7 @@ def generate_controlled_gates():
     return circuits
 
 
-def generate_open_controlled_gates():
+def generate_open_controlled_gates(version):
     """Test QPY serialization with custom ControlledGates with open controls."""
     circuits = []
     qc = QuantumCircuit(3, name="open_controls_simple")
@@ -598,7 +598,10 @@ def generate_open_controlled_gates():
     custom_gate.definition = custom_definition
     nested_qc = QuantumCircuit(3, name="open_controls_nested")
     nested_qc.append(custom_gate, [0])
-    controlled_gate = custom_gate.control(2, ctrl_state=1, annotated=False)
+    if version >= (2, 3, 0):
+        controlled_gate = custom_gate.control(2, ctrl_state=1, annotated=False)
+    else:
+        controlled_gate = custom_gate.control(2, ctrl_state=1)
     nested_qc.append(controlled_gate, [0, 1, 2])
     circuits.append(nested_qc)
 
@@ -973,7 +976,9 @@ def generate_circuits(version_parts, current_version, load_context=False):
     if version_parts >= (0, 24, 0):
         output_circuits["control_flow_switch.qpy"] = generate_control_flow_switch_circuits()
     if version_parts >= (0, 24, 1):
-        output_circuits["open_controlled_gates.qpy"] = generate_open_controlled_gates()
+        output_circuits["open_controlled_gates.qpy"] = generate_open_controlled_gates(
+            current_version
+        )
         output_circuits["controlled_gates.qpy"] = generate_controlled_gates()
     if version_parts >= (0, 24, 2):
         output_circuits["layout.qpy"] = generate_layout_circuits()

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -564,7 +564,7 @@ def generate_controlled_gates():
     """Test QPY serialization with custom ControlledGates."""
     circuits = []
     qc = QuantumCircuit(3, name="custom_controlled_gates")
-    controlled_gate = DCXGate().control(1)
+    controlled_gate = DCXGate().control(1, annotated=False)
     qc.append(controlled_gate, [0, 1, 2])
     circuits.append(qc)
     custom_gate = Gate("black_box", 1, [])
@@ -574,7 +574,7 @@ def generate_controlled_gates():
     custom_gate.definition = custom_definition
     nested_qc = QuantumCircuit(3, name="nested_qc")
     qc.append(custom_gate, [0])
-    controlled_gate = custom_gate.control(2)
+    controlled_gate = custom_gate.control(2, annotated=False)
     nested_qc.append(controlled_gate, [0, 1, 2])
     circuits.append(nested_qc)
     qc_open = QuantumCircuit(2, name="open_cx")
@@ -587,7 +587,7 @@ def generate_open_controlled_gates():
     """Test QPY serialization with custom ControlledGates with open controls."""
     circuits = []
     qc = QuantumCircuit(3, name="open_controls_simple")
-    controlled_gate = DCXGate().control(1, ctrl_state=0)
+    controlled_gate = DCXGate().control(1, ctrl_state=0, annotated=False)
     qc.append(controlled_gate, [0, 1, 2])
     circuits.append(qc)
 
@@ -598,7 +598,7 @@ def generate_open_controlled_gates():
     custom_gate.definition = custom_definition
     nested_qc = QuantumCircuit(3, name="open_controls_nested")
     nested_qc.append(custom_gate, [0])
-    controlled_gate = custom_gate.control(2, ctrl_state=1)
+    controlled_gate = custom_gate.control(2, ctrl_state=1, annotated=False)
     nested_qc.append(controlled_gate, [0, 1, 2])
     circuits.append(nested_qc)
 

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -580,7 +580,7 @@ def generate_controlled_gates(version):
     if version >= (2, 3, 0):
         controlled_gate = custom_gate.control(2, annotated=False)
     else:
-        ontrolled_gate = custom_gate.control(2)
+        controlled_gate = custom_gate.control(2)
     nested_qc.append(controlled_gate, [0, 1, 2])
     circuits.append(nested_qc)
     qc_open = QuantumCircuit(2, name="open_cx")

--- a/test/visual/mpl/circuit/test_circuit_matplotlib_drawer.py
+++ b/test/visual/mpl/circuit/test_circuit_matplotlib_drawer.py
@@ -366,7 +366,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
             XGate().control(3, ctrl_state="010", annotated=False), [qr[2], qr[3], qr[0], qr[1]]
         )
         circuit.append(
-            MCXGate(num_ctrl_qubits=3, ctrl_state="101", annotated=False),
+            MCXGate(num_ctrl_qubits=3, ctrl_state="101"),
             [qr[0], qr[1], qr[2], qr[4]],
         )
         with self.assertWarns(DeprecationWarning):

--- a/test/visual/mpl/circuit/test_circuit_matplotlib_drawer.py
+++ b/test/visual/mpl/circuit/test_circuit_matplotlib_drawer.py
@@ -362,8 +362,13 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.x(0)
         circuit.cx(0, 1)
         circuit.ccx(0, 1, 2)
-        circuit.append(XGate().control(3, ctrl_state="010"), [qr[2], qr[3], qr[0], qr[1]])
-        circuit.append(MCXGate(num_ctrl_qubits=3, ctrl_state="101"), [qr[0], qr[1], qr[2], qr[4]])
+        circuit.append(
+            XGate().control(3, ctrl_state="010", annotated=False), [qr[2], qr[3], qr[0], qr[1]]
+        )
+        circuit.append(
+            MCXGate(num_ctrl_qubits=3, ctrl_state="101", annotated=False),
+            [qr[0], qr[1], qr[2], qr[4]],
+        )
         with self.assertWarns(DeprecationWarning):
             circuit.append(MCXVChain(3, dirty_ancillas=True), [qr[0], qr[1], qr[2], qr[3], qr[5]])
 
@@ -385,9 +390,9 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.z(0)
         circuit.cz(0, 1)
-        circuit.append(ZGate().control(3, ctrl_state="101"), [0, 1, 2, 3])
-        circuit.append(ZGate().control(2), [1, 2, 3])
-        circuit.append(ZGate().control(1, ctrl_state="0", label="CZ Gate"), [2, 3])
+        circuit.append(ZGate().control(3, ctrl_state="101", annotated=False), [0, 1, 2, 3])
+        circuit.append(ZGate().control(2, annotated=False), [1, 2, 3])
+        circuit.append(ZGate().control(1, ctrl_state="0", annotated=False, label="CZ Gate"), [2, 3])
 
         fname = "cz.png"
         self.circuit_drawer(circuit, output="mpl", filename=fname)
@@ -501,7 +506,9 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.cu(pi / 2, pi / 2, pi / 2, 0, 2, 3, label="Top U label")
         circuit.ch(0, 1, label="Top H label")
         circuit.append(
-            HGate(label="H gate label").control(3, label="H control label", ctrl_state="010"),
+            HGate(label="H gate label").control(
+                3, label="H control label", ctrl_state="010", annotated=False
+            ),
             [qr[1], qr[2], qr[3], qr[0]],
         )
 
@@ -522,7 +529,9 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         qr = QuantumRegister(5, "q")
         circuit = QuantumCircuit(qr)
         circuit.cswap(0, 1, 2)
-        circuit.append(RZZGate(3 * pi / 4).control(3, ctrl_state="010"), [2, 1, 4, 3, 0])
+        circuit.append(
+            RZZGate(3 * pi / 4).control(3, ctrl_state="010", annotated=False), [2, 1, 4, 3, 0]
+        )
 
         fname = "cswap_rzz.png"
         self.circuit_drawer(circuit, output="mpl", filename=fname)
@@ -545,7 +554,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         ghz_circuit.cx(0, 1)
         ghz_circuit.cx(1, 2)
         ghz = ghz_circuit.to_gate()
-        ccghz = ghz.control(2, ctrl_state="10")
+        ccghz = ghz.control(2, ctrl_state="10", annotated=False)
         circuit.append(ccghz, [4, 0, 1, 3, 2])
 
         fname = "ghz_to_gate.png"
@@ -694,10 +703,10 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
                 circuit.swap(0, 1)
                 circuit.iswap(2, 3)
                 circuit.cswap(0, 1, 2)
-                circuit.append(SwapGate().control(2), [0, 1, 2, 3])
+                circuit.append(SwapGate().control(2, annotated=False), [0, 1, 2, 3])
                 circuit.dcx(0, 1)
-                circuit.append(DCXGate().control(1), [0, 1, 2])
-                circuit.append(DCXGate().control(2), [0, 1, 2, 3])
+                circuit.append(DCXGate().control(1, annotated=False), [0, 1, 2])
+                circuit.append(DCXGate().control(2, annotated=False), [0, 1, 2, 3])
                 circuit.z(4)
                 circuit.s(4)
                 circuit.sdg(4)
@@ -780,10 +789,10 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.ccx(0, 1, 2)
         circuit.swap(0, 1)
         circuit.cswap(0, 1, 2)
-        circuit.append(SwapGate().control(2), [0, 1, 2, 3])
+        circuit.append(SwapGate().control(2, annotated=False), [0, 1, 2, 3])
         circuit.dcx(0, 1)
-        circuit.append(DCXGate().control(1), [0, 1, 2])
-        circuit.append(DCXGate().control(2), [0, 1, 2, 3])
+        circuit.append(DCXGate().control(1, annotated=False), [0, 1, 2])
+        circuit.append(DCXGate().control(2, annotated=False), [0, 1, 2, 3])
         circuit.z(4)
         circuit.append(SGate(label="S1"), [4])
         circuit.sdg(4)
@@ -1868,7 +1877,7 @@ class TestCircuitMatplotlibDrawer(QiskitTestCase):
         circuit.append(cliff, [0, 1])
         circuit.x(0)
         circuit.h(1)
-        circuit.append(SGate().control(2, ctrl_state=1), [0, 2, 1])
+        circuit.append(SGate().control(2, ctrl_state=1, annotated=False), [0, 2, 1])
         circuit.ccx(0, 1, 2)
         op1 = AnnotatedOperation(
             SGate(), [InverseModifier(), ControlModifier(2, 1), PowerModifier(3.29)]


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This PR adds the deprecation message that setting ``annotated=None`` will not be possible in Qiskit 3.0 and that the new default value will be ``annotated=True``, corresponding to creating an ``AnnotatedOperation`` over a ``ControlledGate``.

Changing the default argument from `False` to `True` is a breaking change, this is why it would be nice to add the deprecation message in 2.3.

### Details and comments

Also updated all usages of `control` in code + tests with explicitly specifying the argument `annotated=False` (when not otherwise available).