### PR TITLE
Deprecate unsafe legacy format in Solovay Kitaev

### DIFF
--- a/qiskit/synthesis/discrete_basis/generate_basis_approximations.py
+++ b/qiskit/synthesis/discrete_basis/generate_basis_approximations.py
@@ -22,7 +22,7 @@ from .solovay_kitaev import SolovayKitaevDecomposition
 
 
 @deprecate_func(
-    since="2.1",
+    since="2.3",
     additional_msg=(
         "Use the SolovayKitaevDecomposition class directly, to generate, store, and load the "
         "basic approximations."

--- a/qiskit/synthesis/discrete_basis/generate_basis_approximations.py
+++ b/qiskit/synthesis/discrete_basis/generate_basis_approximations.py
@@ -27,7 +27,6 @@ from .solovay_kitaev import SolovayKitaevDecomposition
         "Use the SolovayKitaevDecomposition class directly, to generate, store, and load the "
         "basic approximations."
     ),
-    pending=True,
 )
 def generate_basic_approximations(
     basis_gates: list[str | Gate], depth: int, filename: str | None = None

--- a/qiskit/synthesis/discrete_basis/solovay_kitaev.py
+++ b/qiskit/synthesis/discrete_basis/solovay_kitaev.py
@@ -112,6 +112,12 @@ class SolovayKitaevDecomposition:
     def load_basic_approximations(data: list | str | dict) -> list[GateSequence]:
         """Load basic approximations.
 
+        .. note::
+
+            If ``data`` is given as string, this method internally relies on pickle to load
+            the file. This is a potential security vulnerability and only trusted files should be
+            loaded.
+
         Args:
             data: If a string, specifies the path to the file from where to load the data.
                 If a dictionary, directly specifies the decompositions as ``{gates: matrix}``
@@ -156,7 +162,6 @@ class SolovayKitaevDecomposition:
             else:
                 matrix, global_phase = matrix_and_phase, 0
 
-            # gates = [_1q_gates[element] for element in gatestring.split()]
             gates = normalize_gates(gatestring.split())
             sequence = GateSequence.from_gates_and_matrix(gates, matrix, global_phase)
             sequences.append(sequence)

--- a/qiskit/synthesis/discrete_basis/solovay_kitaev.py
+++ b/qiskit/synthesis/discrete_basis/solovay_kitaev.py
@@ -136,9 +136,8 @@ class SolovayKitaevDecomposition:
         warnings.warn(
             "It is suggested to pass basic_approximations in the binary format produced "
             "by SolovayKitaevDecomposition.save_basic_approximations, which is more "
-            "performant than other formats. Other formats are pending deprecation "
-            "and will be deprecated in a future release.",
-            category=PendingDeprecationWarning,
+            "performant than other formats.",
+            category=DeprecationWarning,
         )
 
         # is already a list of GateSequences
@@ -249,7 +248,6 @@ class SolovayKitaevDecomposition:
         since="2.1",
         additional_msg="Use query_basic_approximation instead, which takes a Gate or matrix "
         "as input and returns a QuantumCircuit object.",
-        pending=True,
     )
     def find_basic_approximation(self, sequence: GateSequence) -> GateSequence:
         """Find ``GateSequence`` in ``self._basic_approximations`` that approximates ``sequence``.

--- a/qiskit/synthesis/discrete_basis/solovay_kitaev.py
+++ b/qiskit/synthesis/discrete_basis/solovay_kitaev.py
@@ -46,6 +46,13 @@ class SolovayKitaevDecomposition:
         check_input: bool = False,
     ) -> None:
         """
+
+        .. note::
+
+            If ``basic_approximations`` is passed as ``.npy`` file, pickle is used internally
+            to load the data. This is a potential security vulnerability and only trusted files
+            should be loaded.
+
         Args:
             basic_approximations: A specification of the basic SO(3) approximations in terms
                 of discrete gates. At each iteration this algorithm, the remaining error is

--- a/qiskit/synthesis/discrete_basis/solovay_kitaev.py
+++ b/qiskit/synthesis/discrete_basis/solovay_kitaev.py
@@ -149,7 +149,8 @@ class SolovayKitaevDecomposition:
         warnings.warn(
             "It is suggested to pass basic_approximations in the binary format produced "
             "by SolovayKitaevDecomposition.save_basic_approximations, which is more "
-            "performant than other formats.",
+            "performant than other formats. Passing a .npy format is deprecated since Qiskit 2.3 "
+            "and support will be removed no sooner than 3 months after the release date.",
             category=DeprecationWarning,
         )
 
@@ -257,7 +258,7 @@ class SolovayKitaevDecomposition:
         return circuit
 
     @deprecate_func(
-        since="2.1",
+        since="2.3",
         additional_msg="Use query_basic_approximation instead, which takes a Gate or matrix "
         "as input and returns a QuantumCircuit object.",
     )

--- a/qiskit/transpiler/passes/synthesis/solovay_kitaev_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/solovay_kitaev_synthesis.py
@@ -119,9 +119,26 @@ class SolovayKitaev(TransformationPass):
 
             skd = SolovayKitaev(recursion_degree=2, basis_gates=basis)
 
-        To generate and store basic approximations in between runs, see
-        :class:`.SolovayKitaevDecomposition` and in particular the
-        :meth:`~.SolovayKitaevDecomposition.save_basic_approximations` method.
+        To generate and store basic approximations in between different instances, the
+        :class:`.SolovayKitaevDecomposition` and its
+        :meth:`~.SolovayKitaevDecomposition.save_basic_approximations` method can be used.
+
+        .. code-block:: python
+
+            from qiskit.transpiler.passes import SolovayKitaev
+            from qiskit.synthesis import SolovayKitaevDecomposition
+
+            # generate basic approximations
+            basis = ["s", "sdg", "t", "tdg", "z", "h"]
+            decomp = SolovayKitaevDecomposition(basis_gates=basis, depth=5)
+
+            # store them in a local file
+            fname = "sk_approx.bin"
+            decomp.save_basic_approximations(fname)
+
+            # load them for running Solovay-Kitaev
+            skd = SolovayKitaev(recursion_degree=2, basic_approximations=fname)
+
 
     References:
 

--- a/qiskit/transpiler/passes/synthesis/solovay_kitaev_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/solovay_kitaev_synthesis.py
@@ -107,28 +107,30 @@ class SolovayKitaev(TransformationPass):
                └───┘└───┘└───┘
             Error: 2.828408279166474
 
-        For individual basis gate sets, the ``generate_basic_approximations`` function can be used:
+        Individual basis gate sets can be specified in the initializer.
 
         .. plot::
            :include-source:
            :nofigs:
 
-            from qiskit.synthesis import generate_basic_approximations
             from qiskit.transpiler.passes import SolovayKitaev
 
             basis = ["s", "sdg", "t", "tdg", "z", "h"]
-            approx = generate_basic_approximations(basis, depth=3)
 
-            skd = SolovayKitaev(recursion_degree=2, basic_approximations=approx)
+            skd = SolovayKitaev(recursion_degree=2, basis_gates=basis)
+
+        To generate and store basic approximations in between runs, see
+        :class:`.SolovayKitaevDecomposition` and in particular the
+        :meth:`~.SolovayKitaevDecomposition.save_basic_approximations` method.
 
     References:
 
-        [1]: Kitaev, A Yu (1997). Quantum computations: algorithms and error correction.
-             Russian Mathematical Surveys. 52 (6): 1191–1249.
-             `Online <https://iopscience.iop.org/article/10.1070/RM1997v052n06ABEH002155>`_.
+    [1] Kitaev, A Yu (1997). Quantum computations: algorithms and error correction.
+    Russian Mathematical Surveys. 52 (6): 1191–1249.
+    `Online <https://iopscience.iop.org/article/10.1070/RM1997v052n06ABEH002155>`_.
 
-        [2]: Dawson, Christopher M.; Nielsen, Michael A. (2005) The Solovay-Kitaev Algorithm.
-             `arXiv:quant-ph/0505030 <https://arxiv.org/abs/quant-ph/0505030>`_.
+    [2] Dawson, Christopher M.; Nielsen, Michael A. (2005) The Solovay-Kitaev Algorithm.
+    `arXiv:quant-ph/0505030 <https://arxiv.org/abs/quant-ph/0505030>`_.
 
     """
 

--- a/releasenotes/notes/deprecate-sk-legacy-format-7e2770aa302ce6d3.yaml
+++ b/releasenotes/notes/deprecate-sk-legacy-format-7e2770aa302ce6d3.yaml
@@ -1,0 +1,12 @@
+---
+deprecations_transpiler:
+  - |
+    Deprecated the legacy serialization format used in :class:`.SolovayKitaevDecomposition`,
+    which was based on pickling the basic approximations in form of a Python dictionary.
+    This loading process is a potential vulnerability and should only be used with trusted files
+    and the new format does not have this problem.
+    The functions to generate the legacy format, :func:`.generate_basic_approximations`, and load it,
+    :meth:`.SolovayKitaevDecomposition.load_basic_approximations` and in the initializer
+    of :class:`.SolovayKitaevDecomposition`, have been deprecated.
+    Instead, use :meth:`.SolovayKitaevDecomposition.save_basic_approximations` to generate a format
+    that can safely be loaded in the class initializer.

--- a/releasenotes/notes/deprecate-sk-legacy-format-7e2770aa302ce6d3.yaml
+++ b/releasenotes/notes/deprecate-sk-legacy-format-7e2770aa302ce6d3.yaml
@@ -3,8 +3,8 @@ deprecations_transpiler:
   - |
     Deprecated the legacy serialization format used in :class:`.SolovayKitaevDecomposition`,
     which was based on pickling the basic approximations in form of a Python dictionary.
-    This loading process is a potential vulnerability and should only be used with trusted files
-    and the new format does not have this problem.
+    The loading process is a potential security vulnerability and should only be used with trusted files.
+    The new serialization format avoids this vulnerability.
     The functions to generate the legacy format, :func:`.generate_basic_approximations`, and load it,
     :meth:`.SolovayKitaevDecomposition.load_basic_approximations` and in the initializer
     of :class:`.SolovayKitaevDecomposition`, have been deprecated.

--- a/test/python/transpiler/test_solovay_kitaev.py
+++ b/test/python/transpiler/test_solovay_kitaev.py
@@ -74,7 +74,10 @@ class TestSolovayKitaev(QiskitTestCase):
     def setUp(self):
         super().setUp()
 
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            r".* is deprecated as of Qiskit 2\.3\. .* Use the SolovayKitaevDecomposition class",
+        ):
             self.basic_approx = generate_basic_approximations([HGate(), TGate(), TdgGate()], 3)
         self.default_sk = SolovayKitaev()
 
@@ -154,8 +157,16 @@ class TestSolovayKitaev(QiskitTestCase):
         circuit = QuantumCircuit(1)
         circuit.rx(0.8, 0)
 
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            r".* is deprecated as of Qiskit 2\.3\. .* Use the SolovayKitaevDecomposition class",
+        ):
             basic_approx = generate_basic_approximations(["h", "t", "s"], 3)
+
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            r"basic_approximations in the binary format produced by .* deprecated since Qiskit 2.3 ",
+        ):
             sk = SolovayKitaev(3, basic_approx)
 
         dag = circuit_to_dag(circuit)
@@ -211,12 +222,18 @@ class TestSolovayKitaev(QiskitTestCase):
 
         depth = 4
         basis_gates = ["h", "t", "tdg", "s", "sdg", "z"]
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            r".* is deprecated as of Qiskit 2\.3\. .* Use the SolovayKitaevDecomposition class",
+        ):
             gate_approx_library = generate_basic_approximations(
                 basis_gates=basis_gates, depth=depth
             )
 
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            r"basic_approximations in the binary format produced by .* deprecated since Qiskit 2.3 ",
+        ):
             skd = SolovayKitaev(recursion_degree=2, basic_approximations=gate_approx_library)
         discretized = skd(circuit)
 
@@ -234,7 +251,10 @@ class TestSolovayKitaev(QiskitTestCase):
             fullpath = os.path.join(tmp_dir, filename)
 
             # dump approximations to file
-            with self.assertWarns(DeprecationWarning):
+            with self.assertWarnsRegex(
+                DeprecationWarning,
+                r".* is deprecated as of Qiskit 2\.3\. .* Use the SolovayKitaevDecomposition class",
+            ):
                 gate_approx_library = generate_basic_approximations(
                     basis_gates=["h", "s", "sdg"], depth=3, filename=fullpath
                 )
@@ -244,7 +264,10 @@ class TestSolovayKitaev(QiskitTestCase):
             circuit.rx(0.8, 0)
 
             # Run SK pass using gate_approx_library
-            with self.assertWarns(DeprecationWarning):
+            with self.assertWarnsRegex(
+                DeprecationWarning,
+                r"basic_approximations in the binary format produced by .* deprecated since Qiskit 2.3 ",
+            ):
                 reference = SolovayKitaev(basic_approximations=gate_approx_library)(circuit)
 
             # Run SK pass using stored basis_approximations
@@ -284,11 +307,17 @@ class TestSolovayKitaev(QiskitTestCase):
             circuit.rx(0.8, 0)
 
             # Run SK pass using gate_approx_library
-            with self.assertWarns(DeprecationWarning):
+            with self.assertWarnsRegex(
+                DeprecationWarning,
+                r"basic_approximations in the binary format produced by .* deprecated since Qiskit 2.3 ",
+            ):
                 reference = SolovayKitaev(basic_approximations=approximations)(circuit)
 
             # Run SK pass using stored basis_approximations
-            with self.assertWarns(DeprecationWarning):
+            with self.assertWarnsRegex(
+                DeprecationWarning,
+                r"basic_approximations in the binary format produced by .* deprecated since Qiskit 2.3 ",
+            ):
                 discretized = SolovayKitaev(basic_approximations=fullpath)(circuit)
 
         # Check that both flows produce the same result
@@ -377,7 +406,10 @@ class TestSolovayKitaev(QiskitTestCase):
         Regression test of Qiskit/qiskit-terra#9585.
         """
         basis = ["i", "x", "y", "z", "h", "t", "tdg", "s", "sdg", "sx", "sxdg"]
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            r".* is deprecated as of Qiskit 2\.3\. .* Use the SolovayKitaevDecomposition class",
+        ):
             approx = generate_basic_approximations(basis, depth=2)
 
         # This mainly checks that there are no errors in the generation (like

--- a/test/python/transpiler/test_solovay_kitaev.py
+++ b/test/python/transpiler/test_solovay_kitaev.py
@@ -74,7 +74,8 @@ class TestSolovayKitaev(QiskitTestCase):
     def setUp(self):
         super().setUp()
 
-        self.basic_approx = generate_basic_approximations([HGate(), TGate(), TdgGate()], 3)
+        with self.assertWarns(DeprecationWarning):
+            self.basic_approx = generate_basic_approximations([HGate(), TGate(), TdgGate()], 3)
         self.default_sk = SolovayKitaev()
 
     def test_unitary_synthesis(self):
@@ -153,8 +154,9 @@ class TestSolovayKitaev(QiskitTestCase):
         circuit = QuantumCircuit(1)
         circuit.rx(0.8, 0)
 
-        basic_approx = generate_basic_approximations(["h", "t", "s"], 3)
-        sk = SolovayKitaev(3, basic_approx)
+        with self.assertWarns(DeprecationWarning):
+            basic_approx = generate_basic_approximations(["h", "t", "s"], 3)
+            sk = SolovayKitaev(3, basic_approx)
 
         dag = circuit_to_dag(circuit)
         discretized = dag_to_circuit(sk.run(dag))
@@ -209,9 +211,13 @@ class TestSolovayKitaev(QiskitTestCase):
 
         depth = 4
         basis_gates = ["h", "t", "tdg", "s", "sdg", "z"]
-        gate_approx_library = generate_basic_approximations(basis_gates=basis_gates, depth=depth)
+        with self.assertWarns(DeprecationWarning):
+            gate_approx_library = generate_basic_approximations(
+                basis_gates=basis_gates, depth=depth
+            )
 
-        skd = SolovayKitaev(recursion_degree=2, basic_approximations=gate_approx_library)
+        with self.assertWarns(DeprecationWarning):
+            skd = SolovayKitaev(recursion_degree=2, basic_approximations=gate_approx_library)
         discretized = skd(circuit)
 
         included_gates = set(discretized.count_ops().keys())
@@ -228,16 +234,18 @@ class TestSolovayKitaev(QiskitTestCase):
             fullpath = os.path.join(tmp_dir, filename)
 
             # dump approximations to file
-            gate_approx_library = generate_basic_approximations(
-                basis_gates=["h", "s", "sdg"], depth=3, filename=fullpath
-            )
+            with self.assertWarns(DeprecationWarning):
+                gate_approx_library = generate_basic_approximations(
+                    basis_gates=["h", "s", "sdg"], depth=3, filename=fullpath
+                )
 
             # circuit to decompose and reference decomp
             circuit = QuantumCircuit(1)
             circuit.rx(0.8, 0)
 
             # Run SK pass using gate_approx_library
-            reference = SolovayKitaev(basic_approximations=gate_approx_library)(circuit)
+            with self.assertWarns(DeprecationWarning):
+                reference = SolovayKitaev(basic_approximations=gate_approx_library)(circuit)
 
             # Run SK pass using stored basis_approximations
             discretized = SolovayKitaev(basic_approximations=fullpath)(circuit)
@@ -276,10 +284,12 @@ class TestSolovayKitaev(QiskitTestCase):
             circuit.rx(0.8, 0)
 
             # Run SK pass using gate_approx_library
-            reference = SolovayKitaev(basic_approximations=approximations)(circuit)
+            with self.assertWarns(DeprecationWarning):
+                reference = SolovayKitaev(basic_approximations=approximations)(circuit)
 
             # Run SK pass using stored basis_approximations
-            discretized = SolovayKitaev(basic_approximations=fullpath)(circuit)
+            with self.assertWarns(DeprecationWarning):
+                discretized = SolovayKitaev(basic_approximations=fullpath)(circuit)
 
         # Check that both flows produce the same result
         self.assertEqual(discretized, reference)
@@ -367,7 +377,8 @@ class TestSolovayKitaev(QiskitTestCase):
         Regression test of Qiskit/qiskit-terra#9585.
         """
         basis = ["i", "x", "y", "z", "h", "t", "tdg", "s", "sdg", "sx", "sxdg"]
-        approx = generate_basic_approximations(basis, depth=2)
+        with self.assertWarns(DeprecationWarning):
+            approx = generate_basic_approximations(basis, depth=2)
 
         # This mainly checks that there are no errors in the generation (like
         # in computing the inverse as described in #9585), so a simple check is enough.


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Deprecate the legacy `.npy` format for serializing the basic approximations in Solovay Kitaev. This internally relies on pickle and could be potentially unsafe.

