### PR TITLE
Add `UnitaryGate` handling to `QkDag` C API

### DIFF
--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -679,6 +679,36 @@ fn is_unitary(matrix: &ArrayType, tol: f64) -> bool {
     !not_unitary // using double negation to use ``any`` (faster) instead of ``all``
 }
 
+/// Create a unitary matrix `ArrayType` from a pointer to a row-major contiguous matrix of the
+/// correct dimensions.
+///
+/// If `tol` is `Some`, the unitary matrix is checked for tolerance against the given value.  If the
+/// tolerance check fails, no array is returned.
+///
+/// The data is copied out of `matrix`.
+///
+/// # Safety
+///
+/// `matrix` must be aligned and valid for `4 ** num_qubits` reads.
+pub(crate) unsafe fn unitary_from_pointer(
+    matrix: *const Complex64,
+    num_qubits: u32,
+    tol: Option<f64>,
+) -> Option<ArrayType> {
+    let dim = 1 << num_qubits;
+    // SAFETY: per documentation, `matrix` is aligned and valid for `4**num_qubits` reads.
+    let raw = unsafe { ::std::slice::from_raw_parts(matrix, dim * dim) };
+    let mat = match num_qubits {
+        1 => ArrayType::OneQ(Matrix2::from_fn(|i, j| raw[i * dim + j])),
+        2 => ArrayType::TwoQ(Matrix4::from_fn(|i, j| raw[i * dim + j])),
+        _ => ArrayType::NDArray(Array2::from_shape_fn((dim, dim), |(i, j)| raw[i * dim + j])),
+    };
+    match tol {
+        Some(tol) => is_unitary(&mat, tol).then_some(mat),
+        None => Some(mat),
+    }
+}
+
 /// @ingroup QkCircuit
 /// Append an arbitrary unitary matrix to the circuit.
 ///
@@ -700,27 +730,25 @@ fn is_unitary(matrix: &ArrayType, tol: f64) -> bool {
 ///
 /// # Example
 /// ```c
-///   QkComplex64 c0 = {0, 0};  // 0+0i
-///   QkComplex64 c1 = {1, 0};  // 1+0i
+/// QkComplex64 c0 = {0, 0};  // 0+0i
+/// QkComplex64 c1 = {1, 0};  // 1+0i
 ///
-///   const uint32_t num_qubits = 1;
-///   QkComplex64 unitary[2*2] = {c0, c1,  // row 0
-///                                     c1, c0}; // row 1
+/// const uint32_t num_qubits = 1;
+/// QkComplex64 unitary[2*2] = {c0, c1,  // row 0
+///                             c1, c0}; // row 1
 ///
-///   QkCircuit *circuit = qk_circuit_new(1, 0);  // 1 qubit circuit
-///   uint32_t qubit[1] = {0};  // qubit to apply the unitary on
-///   qk_circuit_unitary(circuit, unitary, qubit, num_qubits, true);
+/// QkCircuit *circuit = qk_circuit_new(1, 0);  // 1 qubit circuit
+/// uint32_t qubit[1] = {0};  // qubit to apply the unitary on
+/// qk_circuit_unitary(circuit, unitary, qubit, num_qubits, true);
 /// ```
 ///
 /// # Safety
 ///
 /// Behavior is undefined if any of the following is violated:
 ///
-///   * ``circuit`` is a valid, non-null pointer to a ``QkCircuit``
-///   * ``matrix`` is a pointer to a nested array of ``QkComplex64`` of dimension
-///     ``2 ^ num_qubits x 2 ^ num_qubits``
-///   * ``qubits`` is a pointer to ``num_qubits`` readable element of type ``uint32_t``
-///
+/// * ``circuit`` is a valid, non-null pointer to a ``QkCircuit``
+/// * ``matrix`` is an aligned pointer to ``4**num_qubits`` initialized ``QkComplex64`` values
+/// * ``qubits`` is an aligned pointer to ``num_qubits`` initialized ``uint32_t`` values
 #[unsafe(no_mangle)]
 #[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_unitary(
@@ -732,31 +760,24 @@ pub unsafe extern "C" fn qk_circuit_unitary(
 ) -> ExitCode {
     // SAFETY: Caller quarantees pointer validation, alignment
     let circuit = unsafe { mut_ptr_as_ref(circuit) };
-
-    // Dimension of the unitart: 2^n
-    let dim = 1 << num_qubits;
-
-    // Build ndarray::Array2
-    let raw = unsafe { std::slice::from_raw_parts(matrix, dim * dim * 2) };
-    let mat = match num_qubits {
-        1 => ArrayType::OneQ(Matrix2::from_fn(|i, j| raw[i * dim + j])),
-        2 => ArrayType::TwoQ(Matrix4::from_fn(|i, j| raw[i * dim + j])),
-        _ => ArrayType::NDArray(Array2::from_shape_fn((dim, dim), |(i, j)| raw[i * dim + j])),
-    };
-
-    // verify the matrix is unitary
-    if check_input && !is_unitary(&mat, 1e-12) {
+    let mat = unsafe { unitary_from_pointer(matrix, num_qubits, check_input.then_some(1e-12)) };
+    let Some(mat) = mat else {
         return ExitCode::ExpectedUnitary;
-    }
-
-    // Build qubit slice
-    let qargs: &[Qubit] =
-        unsafe { std::slice::from_raw_parts(qubits as *const Qubit, num_qubits as usize) };
+    };
+    let qubits = if num_qubits == 0 {
+        // This handles the case of C passing us a null pointer for a scalar matrix; Rust slices
+        // can't be backed by the null pointer.
+        &[]
+    } else {
+        // SAFETY: per documentation, `qubits` is aligned and valid for `num_qubits` reads.  Per
+        // previous check, `num_qubits` is nonzero so `qubits` cannot be null.
+        unsafe { ::std::slice::from_raw_parts(qubits as *const Qubit, num_qubits as usize) }
+    };
 
     // Create PackedOperation -> push to circuit_data
     let u_gate = Box::new(UnitaryGate { array: mat });
     let op = PackedOperation::from_unitary(u_gate);
-    circuit.push_packed_operation(op, &[], qargs, &[]).unwrap();
+    circuit.push_packed_operation(op, &[], qubits, &[]).unwrap();
     // Return success
     ExitCode::Success
 }

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -765,8 +765,8 @@ pub unsafe extern "C" fn qk_circuit_unitary(
         return ExitCode::ExpectedUnitary;
     };
     let qubits = if num_qubits == 0 {
-        // This handles the case of C passing us a null pointer for a scalar matrix; Rust slices
-        // can't be backed by the null pointer.
+        // This handles the case of C passing us a null pointer for the qubits; Rust slices
+        // can't be backed by the null pointer even when empty.
         &[]
     } else {
         // SAFETY: per documentation, `qubits` is aligned and valid for `num_qubits` reads.  Per

--- a/crates/cext/src/dag.rs
+++ b/crates/cext/src/dag.rs
@@ -10,15 +10,18 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use crate::pointers::{const_ptr_as_ref, mut_ptr_as_ref};
+use num_complex::Complex64;
 use smallvec::smallvec;
 
 use qiskit_circuit::Qubit;
 use qiskit_circuit::bit::{ClassicalRegister, QuantumRegister};
 use qiskit_circuit::dag_circuit::{DAGCircuit, NodeIndex, NodeType};
 use qiskit_circuit::operations::{
-    Operation, OperationRef, Param, StandardGate, StandardInstruction,
+    ArrayType, Operation, OperationRef, Param, StandardGate, StandardInstruction, UnitaryGate,
 };
+
+use crate::circuit::unitary_from_pointer;
+use crate::pointers::{const_ptr_as_ref, mut_ptr_as_ref};
 
 /// @ingroup QkDag
 /// Construct a new empty DAG.
@@ -584,6 +587,81 @@ pub unsafe extern "C" fn qk_dag_apply_gate(
 }
 
 /// @ingroup QkDag
+/// Apply a unitary gate to a DAG.
+///
+/// The values in `matrix` should form a row-major unitary matrix of the correct size for the number
+/// of qubits.  The data is copied out of the pointer, and only needs to be valid for reads until
+/// this function returns.
+///
+/// See @verbatim embed:rst:inline ::ref:`circuit-conventions` @endverbatim for detail on the
+/// bit-labelling and matrix conventions of Qiskit.
+///
+/// @param dag The circuit to apply to.
+/// @param matrix An initialized row-major unitary matrix of total size ``4**num_qubits``.
+/// @param qubits An array of distinct ``uint32_t`` indices of the qubits.
+/// @param num_qubits The number of qubits the gate applies to.
+/// @param front Whether to apply the gate at the start of the circuit. Usually `false`.
+///
+/// @return The node index of the created instruction.
+///
+/// # Safety
+///
+/// Behavior is undefined if any of:
+/// * `dag` is not an aligned, non-null pointer to a valid ``QkDag``,
+/// * `matrix` is not an aligned pointer to `4**num_qubits` initialized values,
+/// * `qubits` is not an aligned pointer to `num_qubits` initialized values.
+#[unsafe(no_mangle)]
+#[cfg(feature = "cbinding")]
+pub unsafe extern "C" fn qk_dag_apply_unitary(
+    dag: *mut DAGCircuit,
+    matrix: *const Complex64,
+    qubits: *const u32,
+    num_qubits: u32,
+    front: bool,
+) -> u32 {
+    // SAFETY: per documentation, `dag` points to valid data.
+    let dag = unsafe { mut_ptr_as_ref(dag) };
+    // SAFETY: per documentation, `matrix` is aligned and valid for `4**num_qubits` reads of
+    // initialised data.
+    let array = unsafe { unitary_from_pointer(matrix, num_qubits, None) }
+        .expect("infallible without tolerance checking");
+    let qubits = if num_qubits == 0 {
+        // This handles the case of C passing us a null pointer for a scalar matrix; Rust slices
+        // can't be backed by the null pointer.
+        &[]
+    } else {
+        // SAFETY: per documentation, `qubits` is aligned and valid for `num_qubits` reads.  Per
+        // previous check, `num_qubits` is nonzero so `qubits` cannot be null.
+        unsafe { ::std::slice::from_raw_parts(qubits as *const Qubit, num_qubits as usize) }
+    };
+    if front {
+        dag.apply_operation_front(
+            Box::new(UnitaryGate { array }).into(),
+            qubits,
+            &[],
+            None,
+            None,
+            #[cfg(feature = "cache_pygates")]
+            None,
+        )
+        .expect("caller is responsible for passing inbounds bits")
+        .index() as u32
+    } else {
+        dag.apply_operation_back(
+            Box::new(UnitaryGate { array }).into(),
+            qubits,
+            &[],
+            None,
+            None,
+            #[cfg(feature = "cache_pygates")]
+            None,
+        )
+        .expect("caller is responsible for passing inbounds bits")
+        .index() as u32
+    }
+}
+
+/// @ingroup QkDag
 /// Retrieve the standard gate of the specified node.
 ///
 /// Panics if the node is not a standard gate operation.
@@ -646,6 +724,61 @@ pub unsafe extern "C" fn qk_dag_op_node_gate_op(
         }
     }
     instr.standard_gate().unwrap()
+}
+
+/// @ingroup QkDag
+/// Copy out the unitary matrix of the corresponding node index.
+///
+/// Panics if the node is not a unitary gate.
+///
+/// @param dag The circuit to read from.
+/// @param node The node index of the unitary matrix instruction.
+/// @param out Allocated and aligned memory for `4**num_qubits` complex values in row-major order,
+///     where `num_qubits` is the number of qubits the gate applies to.
+///
+/// # Safety
+///
+/// Behavior is undefined if `dag` is not a non-null pointer to a valid `QkDag`, if `out` is
+/// unaligned, or if `out` is not valid for `4**num_qubits` writes of `QkComplex64`.
+#[unsafe(no_mangle)]
+#[cfg(feature = "cbinding")]
+pub unsafe extern "C" fn qk_dag_op_node_unitary(
+    dag: *const DAGCircuit,
+    node: u32,
+    out: *mut Complex64,
+) {
+    // SAFETY: Per documentation, the pointer is to valid data.
+    let dag = unsafe { const_ptr_as_ref(dag) };
+    let instr = &dag[NodeIndex::new(node as usize)].unwrap_operation();
+    let OperationRef::Unitary(unitary) = instr.op.view() else {
+        panic!("requested node {node} was not a unitary gate");
+    };
+    match &unitary.array {
+        ArrayType::OneQ(array) => {
+            let dim = 2;
+            for row in 0..dim {
+                for col in 0..dim {
+                    // SAFETY: per documentation, `out` is aligned and valid for 4 writes.
+                    unsafe { out.add(dim * row + col).write(array[(row, col)]) };
+                }
+            }
+        }
+        ArrayType::TwoQ(array) => {
+            let dim = 4;
+            for row in 0..dim {
+                for col in 0..dim {
+                    // SAFETY: per documentation, `out` is aligned and valid for 16 writes.
+                    unsafe { out.add(dim * row + col).write(array[(row, col)]) };
+                }
+            }
+        }
+        ArrayType::NDArray(array) => {
+            for (i, val) in array.iter().enumerate() {
+                // SAFETY: per documentation, `out` is aligned and valid for `array.size()` writes.
+                unsafe { out.add(i).write(*val) };
+            }
+        }
+    }
 }
 
 /// The operation's kind.

--- a/test/c/test_dag.c
+++ b/test/c/test_dag.c
@@ -312,6 +312,128 @@ cleanup:
     return result;
 }
 
+static inline QkComplex64 complex_mul(QkComplex64 left, QkComplex64 right) {
+    return (QkComplex64){left.re * right.re - left.im * right.im,
+                         left.re * right.im + left.im * right.re};
+}
+
+static void kron(const QkComplex64 *left, size_t left_qubits, const QkComplex64 *right,
+                 size_t right_qubits, QkComplex64 *out) {
+    size_t left_dim = 1LLU << left_qubits;
+    size_t right_dim = 1LLU << right_qubits;
+    size_t out_dim = 1LLU << (left_qubits + right_qubits);
+    for (size_t left_row = 0; left_row < left_dim; left_row++) {
+        for (size_t right_row = 0; right_row < right_dim; right_row++) {
+            size_t out_row = right_dim * left_row + right_row;
+            for (size_t left_col = 0; left_col < left_dim; left_col++) {
+                for (size_t right_col = 0; right_col < right_dim; right_col++) {
+                    size_t out_col = right_dim * left_col + right_col;
+                    out[out_dim * out_row + out_col] =
+                        complex_mul(left[left_dim * left_row + left_col],
+                                    right[right_dim * right_row + right_col]);
+                }
+            }
+        }
+    }
+}
+
+static int check_unitary(const char *func, QkDag *dag, QkComplex64 scalar, const char *pauli,
+                         uint32_t *qubits, bool front) {
+    int res = Ok;
+    static const QkComplex64 mat_i[4] = {{1, 0}, {0, 0}, {0, 0}, {1, 0}};
+    static const QkComplex64 mat_x[4] = {{0, 0}, {1, 0}, {1, 0}, {0, 0}};
+    static const QkComplex64 mat_y[4] = {{0, 0}, {0, -1}, {0, 1}, {0, 0}};
+    static const QkComplex64 mat_z[4] = {{1, 0}, {0, 0}, {0, 0}, {-1, 0}};
+    uint32_t num_qubits = (uint32_t)strlen(pauli);
+    size_t dim = 1LLU << num_qubits;
+    const QkComplex64 *mat;
+    QkComplex64 *tmp;
+    QkComplex64 *cur = malloc(sizeof(*cur) * dim * dim);
+    QkComplex64 *next = malloc(sizeof(*next) * dim * dim);
+    cur[0] = scalar;
+    for (uint32_t qubit = 0; qubit < num_qubits; qubit++) {
+        switch (pauli[num_qubits - qubit - 1]) {
+        case 'I': {
+            mat = mat_i;
+            break;
+        }
+        case 'X': {
+            mat = mat_x;
+            break;
+        }
+        case 'Y': {
+            mat = mat_y;
+            break;
+        }
+        case 'Z': {
+            mat = mat_z;
+            break;
+        }
+        default: {
+            res = EqualityError;
+            printf("%s: bad pauli string '%s'\n", func, pauli);
+            goto cleanup;
+        }
+        }
+        kron(mat, 1, cur, qubit, next);
+        tmp = cur;
+        cur = next;
+        next = tmp;
+    }
+    // Zero out the other array, just to ensure that we've got clear invalid things to test
+    // against.
+    memset(next, 0, sizeof(*next) * dim * dim);
+    uint32_t node = qk_dag_apply_unitary(dag, cur, qubits, num_qubits, front);
+    QkOperationKind kind = qk_dag_op_node_kind(dag, node);
+    if (kind != QkOperationKind_Unitary) {
+        res = EqualityError;
+        printf("%s: %s kind incorrect: %d\n", func, pauli, kind);
+        goto cleanup;
+    }
+    qk_dag_op_node_unitary(dag, node, next);
+    if (memcmp(cur, next, sizeof(*cur) * dim * dim)) {
+        res = EqualityError;
+        printf("%s: %s matrices unequal\n", func, pauli);
+        goto cleanup;
+    }
+cleanup:
+    free(cur);
+    free(next);
+    return res;
+}
+
+static int test_unitary_gates(void) {
+    int res = Ok;
+    uint32_t qubits[] = {0, 1, 2};
+
+    QkDag *dag = qk_dag_new();
+    QkQuantumRegister *qr = qk_quantum_register_new(3, "q");
+    qk_dag_add_quantum_register(dag, qr);
+    qk_quantum_register_free(qr);
+
+    if ((res = check_unitary(__func__, dag, (QkComplex64){1, 0}, "X", qubits, false)))
+        goto cleanup;
+    if ((res = check_unitary(__func__, dag, (QkComplex64){1, 0}, "Y", qubits, true)))
+        goto cleanup;
+    if ((res = check_unitary(__func__, dag, (QkComplex64){0, 1}, "XY", qubits, false)))
+        goto cleanup;
+    if ((res = check_unitary(__func__, dag, (QkComplex64){-1, 0}, "YZ", &qubits[1], true)))
+        goto cleanup;
+    if ((res = check_unitary(__func__, dag, (QkComplex64){0, -1}, "XYZ", qubits, false)))
+        goto cleanup;
+    if ((res = check_unitary(__func__, dag, (QkComplex64){1, 0}, "YZZ", qubits, false)))
+        goto cleanup;
+    if ((res = check_unitary(__func__, dag, (QkComplex64){1, 0}, "", qubits, false)))
+        goto cleanup;
+    // Check that nothing bad happens if we use a null pointer for no qubits.
+    if ((res = check_unitary(__func__, dag, (QkComplex64){0, 1}, "", NULL, false)))
+        goto cleanup;
+
+cleanup:
+    qk_dag_free(dag);
+    return res;
+}
+
 int test_dag(void) {
     int num_failed = 0;
     num_failed += RUN_TEST(test_empty);
@@ -321,6 +443,7 @@ int test_dag(void) {
     num_failed += RUN_TEST(test_dag_node_type);
     num_failed += RUN_TEST(test_dag_endpoint_node_value);
     num_failed += RUN_TEST(test_op_node_bits_explicit);
+    num_failed += RUN_TEST(test_unitary_gates);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This adds methods to add and retrieve unitary matrices from `QkDag`.  We likely need something similar to retrieve the matrices from `QkCircuit` as well at some point.

This commit uses copy-out semantics for the arrays to ensure that the output is always row-major, but it's quite possible that we might want an alternative method that fills in some sort of

```c
struct QkMatView {
    QkComplex64 *mat;
    size_t shape[2];
    size_t stride[2];
}
```

by just populating the pointer, and the metadata, so it's much cheaper.  We'd need to include the strides because Qiskit internally already can't guarantee its matrices are contiguous, and the `OneQ`/`TwoQ` variants are col-major while the `NDArray` variant is (usually) row-major.



### Details and comments


Close #15312