### PR TITLE
circuit: harden controlled RX/RY/RZ (use gate.params[0] instead of definition)

### DIFF
--- a/qiskit/circuit/_add_control.py
+++ b/qiskit/circuit/_add_control.py
@@ -222,32 +222,33 @@ def apply_basic_controlled_gate(circuit, gate, controls, target):
         circuit.mcx(controls, target)
 
     elif gate.name == "rx":
-        angle = gate.params[0]
-        circuit.mcrx(
-            angle,
-            controls,
-            target,
-            use_basis_gates=False,
-        )
+    angle = gate.params[0]
+    circuit.mcrx(
+        angle,
+        controls,
+        target,
+        use_basis_gates=False,
+    )
 
-    elif gate.name == "ry":
-        angle = gate.params[0]
-        circuit.mcry(
-            angle,
-            controls,
-            target,
-            mode="noancilla",
-            use_basis_gates=False,
-        )
+elif gate.name == "ry":
+    angle = gate.params[0]
+    circuit.mcry(
+        angle,
+        controls,
+        target,
+        mode="noancilla",
+        use_basis_gates=False,
+    )
 
-    elif gate.name == "rz":
-        angle = gate.params[0]
-        circuit.mcrz(
-            angle,
-            controls,
-            target,
-            use_basis_gates=False,
-        )
+elif gate.name == "rz":
+    angle = gate.params[0]
+    circuit.mcrz(
+        angle,
+        controls,
+        target,
+        use_basis_gates=False,
+    )
+
 
     elif gate.name == "p":
         from qiskit.circuit.library import MCPhaseGate

--- a/qiskit/circuit/_add_control.py
+++ b/qiskit/circuit/_add_control.py
@@ -328,7 +328,6 @@ def apply_basic_controlled_gate(circuit, gate, controls, target):
         raise CircuitError(f"Gate {gate} not in supported basis.")
 
 
-
 def _gate_to_circuit(operation):
     """Converts a gate instance to a QuantumCircuit"""
     if hasattr(operation, "definition") and operation.definition is not None:

--- a/qiskit/circuit/_add_control.py
+++ b/qiskit/circuit/_add_control.py
@@ -223,31 +223,17 @@ def apply_basic_controlled_gate(circuit, gate, controls, target):
 
     elif gate.name == "rx":
         angle = gate.params[0]
-        circuit.mcrx(
-            angle,
-            controls,
-            target,
-            use_basis_gates=False,
-        )
+        circuit.mcrx(angle, controls, target, use_basis_gates=False)
 
     elif gate.name == "ry":
         angle = gate.params[0]
-        circuit.mcry(
-            angle,
-            controls,
-            target,
-            mode="noancilla",
-            use_basis_gates=False,
-        )
+        circuit.mcry(angle, controls, target, mode="noancilla", use_basis_gates=False)
+
 
     elif gate.name == "rz":
         angle = gate.params[0]
-        circuit.mcrz(
-            angle,
-            controls,
-            target,
-            use_basis_gates=False,
-        )
+        circuit.mcrz(angle, controls, target, use_basis_gates=False)
+
 
 
     elif gate.name == "p":

--- a/qiskit/circuit/_add_control.py
+++ b/qiskit/circuit/_add_control.py
@@ -222,33 +222,32 @@ def apply_basic_controlled_gate(circuit, gate, controls, target):
         circuit.mcx(controls, target)
 
     elif gate.name == "rx":
-    angle = gate.params[0]
-    circuit.mcrx(
-        angle,
-        controls,
-        target,
-        use_basis_gates=False,
-    )
+        angle = gate.params[0]
+        circuit.mcrx(
+            angle,
+            controls,
+            target,
+            use_basis_gates=False,
+        )
 
-elif gate.name == "ry":
-    angle = gate.params[0]
-    circuit.mcry(
-        angle,
-        controls,
-        target,
-        mode="noancilla",
-        use_basis_gates=False,
-    )
+    elif gate.name == "ry":
+        angle = gate.params[0]
+        circuit.mcry(
+            angle,
+            controls,
+            target,
+            mode="noancilla",
+            use_basis_gates=False,
+        )
 
-elif gate.name == "rz":
-    angle = gate.params[0]
-    circuit.mcrz(
-        angle,
-        controls,
-        target,
-        use_basis_gates=False,
-    )
-
+    elif gate.name == "rz":
+        angle = gate.params[0]
+        circuit.mcrz(
+            angle,
+            controls,
+            target,
+            use_basis_gates=False,
+        )
 
     elif gate.name == "p":
         from qiskit.circuit.library import MCPhaseGate

--- a/qiskit/circuit/_add_control.py
+++ b/qiskit/circuit/_add_control.py
@@ -229,15 +229,13 @@ def apply_basic_controlled_gate(circuit, gate, controls, target):
         angle = gate.params[0]
         circuit.mcry(angle, controls, target, mode="noancilla", use_basis_gates=False)
 
-
     elif gate.name == "rz":
         angle = gate.params[0]
         circuit.mcrz(angle, controls, target, use_basis_gates=False)
 
-
-
     elif gate.name == "p":
         from qiskit.circuit.library import MCPhaseGate
+
         circuit.append(
             MCPhaseGate(gate.params[0], num_ctrl_qubits),
             controls[:] + [target],

--- a/qiskit/circuit/_add_control.py
+++ b/qiskit/circuit/_add_control.py
@@ -249,6 +249,7 @@ def apply_basic_controlled_gate(circuit, gate, controls, target):
             use_basis_gates=False,
         )
 
+
     elif gate.name == "p":
         from qiskit.circuit.library import MCPhaseGate
         circuit.append(

--- a/qiskit/circuit/_add_control.py
+++ b/qiskit/circuit/_add_control.py
@@ -215,46 +215,53 @@ def apply_basic_controlled_gate(circuit, gate, controls, target):
 
     This implements multi-control operations for every gate in
     ``EFFICIENTLY_CONTROLLED_GATES``.
-
     """
     num_ctrl_qubits = len(controls)
 
     if gate.name == "x":
         circuit.mcx(controls, target)
+
     elif gate.name == "rx":
+        angle = gate.params[0]
         circuit.mcrx(
-            gate.definition.data[0].operation.params[0],
+            angle,
             controls,
             target,
             use_basis_gates=False,
         )
+
     elif gate.name == "ry":
+        angle = gate.params[0]
         circuit.mcry(
-            gate.definition.data[0].operation.params[0],
+            angle,
             controls,
             target,
             mode="noancilla",
             use_basis_gates=False,
         )
+
     elif gate.name == "rz":
+        angle = gate.params[0]
         circuit.mcrz(
-            gate.definition.data[0].operation.params[0],
+            angle,
             controls,
             target,
             use_basis_gates=False,
         )
+
     elif gate.name == "p":
         from qiskit.circuit.library import MCPhaseGate
-
         circuit.append(
             MCPhaseGate(gate.params[0], num_ctrl_qubits),
             controls[:] + [target],
         )
+
     elif gate.name == "cx":
         circuit.mcx(
             controls[:] + [target[0]],  # CX has two targets
             target[1],
         )
+
     elif gate.name == "cz":
         circuit.h(target[1])
         circuit.mcx(
@@ -262,6 +269,7 @@ def apply_basic_controlled_gate(circuit, gate, controls, target):
             target[1],
         )
         circuit.h(target[1])
+
     elif gate.name == "u":
         theta, phi, lamb = gate.params
         if num_ctrl_qubits == 1:
@@ -286,14 +294,17 @@ def apply_basic_controlled_gate(circuit, gate, controls, target):
                 circuit.mcry(theta, controls, target, use_basis_gates=False)
                 circuit.mcrz(phi, controls, target, use_basis_gates=False)
                 circuit.mcp((phi + lamb) / 2, controls[1:], controls[0])
+
     elif gate.name == "z":
         circuit.h(target)
         circuit.mcx(controls, target)
         circuit.h(target)
+
     elif gate.name == "y":
         circuit.sdg(target)
         circuit.mcx(controls, target)
         circuit.s(target)
+
     elif gate.name == "h":
         circuit.s(target)
         circuit.h(target)
@@ -302,16 +313,20 @@ def apply_basic_controlled_gate(circuit, gate, controls, target):
         circuit.tdg(target)
         circuit.h(target)
         circuit.sdg(target)
+
     elif gate.name == "sx":
         circuit.h(target)
         circuit.mcp(pi / 2, controls, target)
         circuit.h(target)
+
     elif gate.name == "sxdg":
         circuit.h(target)
         circuit.mcp(3 * pi / 2, controls, target)
         circuit.h(target)
+
     else:
         raise CircuitError(f"Gate {gate} not in supported basis.")
+
 
 
 def _gate_to_circuit(operation):


### PR DESCRIPTION
### Summary
Read RX/RY/RZ angles from the public API (`gate.params[0]`) instead of inspecting the internal definition. No behavior change intended.

### Motivation
Avoid coupling to internal gate decompositions. This is consistent with how `p` is handled and with public API usage.

### What’s changed
- `qiskit/circuit/_add_control.py`: in `apply_basic_controlled_gate`, use:
  - `angle = gate.params[0]`
  - `mcrx(angle, ...)`, `mcry(angle, ...)`, `mcrz(angle, ...)`
- No other files changed.

### Testing
Existing tests cover controlled RX/RY/RZ semantics; this is a refactor without behavior change.

### Checklist
- [x] Only one file changed (`_add_control.py`)
- [x] Style and naming match existing code
- [x] Rebased on latest `main`


