### PR TITLE
Add deprecation system to C API

### DIFF
--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -281,6 +281,9 @@ text, and cannot contain the `|` separator.  The `<version>` field should be the
 that the deprecation started in (e.g. `2.3.0`).  We don't use Doxygen's built-in `\deprecated`
 command because that is free-form and doesn't retain the version in a structured location.
 
+For functions, put the `\qk_deprecated` command immediate before the `@param`/`@returns` list, if present,
+or immediately after the main body of descriptive text (before the "Examples" or "Safety" sections).
+
 We have `cbindgen` configured to interpret `#[deprecated]` directives on C API functions.  The
 macros that emit the deprecations are in the `qiskit/attributes.h` header file.  You can use the
 basic `#[deprecated]`, the `#[deprecated = <reason>]` or the `#[deprecated(note = <reason>)]` forms.

--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -253,3 +253,50 @@ https://github.com/Qiskit/documentation/tree/main/docs/api/migration-guides. Onc
 the migration guide is written and published, deprecation
 messages and documentation should link to it (use the `additional_msg` argument for
 `@deprecate_arg` and `@deprecate_func`).
+
+
+## Deprecations in the C API
+
+Prior to Qiskit 3.0, the C API is explicitly unstable.  Despite this, we will still attempt to issue
+suitable deprecations before removing functions, but this is on a best-effort basis only.  Functions
+may still change signatures without warning between versions.  We will still attempt to minimize the
+disruption from deprecations in the C API, but we do not commit to warning ahead of every change nor
+following the timescales of deprecations in the Python API.
+
+As of Qiskit 2.3, we do not have testing scaffolding that is capable of testing that deprecations
+are being emitted during a compilation.
+
+### Issuing a C-API deprecation
+
+C API functions should be marked deprecated in two separate places:
+
+1. in the function documentation, using the `\qk_deprecated{<version>|<reason>}` custom Doxygen
+   command.
+2. as a Rust attribute `#[deprecated]` on the function itself.
+
+The `\qk_deprecated` command is defined in the Doxygen configuration file (`docs/Doxyfile`) as an
+alias.  The `reason` field is expanded inside a "verbatim rST" block, so should use rST directly
+(unlike other parts of the C API documentation).  The `reason` field should be a single line of
+text, and cannot contain the `|` separator.  The `<version>` field should be the version of Qiskit
+that the deprecated started in (e.g. `2.3.0`).  We don't use Doxygen's built-in `\deprecated`
+command because that is free-form and doesn't retain the version in a structured location.
+
+We have `cbindgen` configured to interpret `#[deprecated]` directives on C API functions.  The
+macros that emit the deprecations are in the `qiskit/attributes.h` header file.  You can use the
+basic `#[deprecated]`, the `#[deprecated = <reason>]` or the `#[deprecated(note = <reason>)]` forms.
+You *cannot* use `#[deprecated(since = <version>)]`; `cbindgen` does not support this, and if you
+forget to include a `note`, it will silently drop the deprecated attribute, so C users will not see
+it.
+
+As an example:
+
+```rust
+/// @ingroup QkTy
+/// Do the old thing.
+///
+/// \qk_deprecated{2.3.0|use :c:func:`qk_ty_new_function` instead.}
+#[deprecated = "use `qk_ty_new_function` instead"]
+#[unsafe(no_mangle)]
+#[cfg(feature = "cbinding")]
+pub extern "C" fn qk_ty_old_function() {}
+```

--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -275,10 +275,10 @@ C API functions should be marked deprecated in two separate places:
 2. as a Rust attribute `#[deprecated]` on the function itself.
 
 The `\qk_deprecated` command is defined in the Doxygen configuration file (`docs/Doxyfile`) as an
-alias.  The `reason` field is expanded inside a "verbatim rST" block, so should use rST directly
-(unlike other parts of the C API documentation).  The `reason` field should be a single line of
+alias.  The `<reason>` field is expanded inside a "verbatim rST" block, so should use rST directly
+(unlike other parts of the C API documentation).  The `<reason>` field should be a single line of
 text, and cannot contain the `|` separator.  The `<version>` field should be the version of Qiskit
-that the deprecated started in (e.g. `2.3.0`).  We don't use Doxygen's built-in `\deprecated`
+that the deprecation started in (e.g. `2.3.0`).  We don't use Doxygen's built-in `\deprecated`
 command because that is free-form and doesn't retain the version in a structured location.
 
 We have `cbindgen` configured to interpret `#[deprecated]` directives on C API functions.  The

--- a/crates/cext/cbindgen.toml
+++ b/crates/cext/cbindgen.toml
@@ -11,6 +11,7 @@ after_includes = """
 #endif
 
 #include "qiskit/version.h"
+#include "qiskit/attributes.h"
 #include "qiskit/complex.h"
 
 // Always expose [cfg(feature = "cbinding")] -- workaround for
@@ -31,6 +32,11 @@ include = ["qiskit-quantum-info", "qiskit-circuit", "qiskit-transpiler"]
 
 [enum]
 prefix_with_name = true
+
+[fn]
+# These are defined in the custom `qiskit/attributes.h` header file.
+deprecated = "Qk_DEPRECATED_FN"
+deprecated_with_note = "Qk_DEPRECATED_FN_NOTE({})"
 
 [export]
 prefix = "Qk"

--- a/crates/cext/include/qiskit/attributes.h
+++ b/crates/cext/include/qiskit/attributes.h
@@ -1,0 +1,28 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+#ifndef QISKIT_ATTRIBUTES_H
+#define QISKIT_ATTRIBUTES_H
+
+// Macros for deprecated functions.
+#if defined(__GNUC__) || defined(__clang__)
+#define Qk_DEPRECATED_FN __attribute__((deprecated))
+#define Qk_DEPRECATED_FN_NOTE(note) __attribute__((deprecated(note)))
+#elif defined(_MSC_VER)
+#define Qk_DEPRECATED_FN __declspec(deprecated)
+#define Qk_DEPRECATED_FN_NOTE(note) __declspec(deprecated(note))
+#else
+#define Qk_DEPRECATED_FN
+#define Qk_DEPRECATED_FN_NOTE(note)
+#endif
+
+#endif // QISKIT_ATTRIBUTES_H

--- a/crates/cext/src/transpiler/passes/vf2.rs
+++ b/crates/cext/src/transpiler/passes/vf2.rs
@@ -478,6 +478,8 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_vf2_layout_exact(
 /// about how it handles the error heuristic (it averages over all gates in the `QkTarget` for a
 /// given qubit or link).
 ///
+/// \qk_deprecated{2.3.0|Replaced by :c:func:`qk_transpiler_pass_standalone_vf2_layout_average`.}
+///
 /// @param circuit As in `qk_transpiler_pass_standalone_vf2_layout_average`.
 /// @param target As in `qk_transpiler_pass_standalone_vf2_layout_average`.
 /// @param strict_direction As in `qk_transpiler_pass_standalone_vf2_layout_average`.
@@ -487,8 +489,6 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_vf2_layout_exact(
 /// @param max_trials As in `qk_vf2_layout_configuration_set_max_trials`.
 ///
 /// @return As in `qk_transpiler_pass_standalone_vf2_layout_average`.
-///
-/// \qk_deprecated{2.3.0|Replaced by :c:func:`qk_transpiler_pass_standalone_vf2_layout_average`.}
 ///
 /// # Safety
 ///

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -18,3 +18,10 @@ PREDEFINED = QISKIT_C_PYTHON_INTERFACE=1
 
 GENERATE_HTML = NO
 GENERATE_LATEX = NO
+
+# The command `\qk_deprecated{<version>|<note>}` (e.g. \qk_deprecated{2.3.0|Use :c:func:`other_fn` instead})
+# for outputting correct deprecation information across the Breathe bridge to Sphinx.
+#
+# We don't use the built-in `\deprecated` command in Doxygen because that only accepts free-form
+# input, but we want to retain the version information in the structured Sphinx output.
+ALIASES += qk_deprecated{2|}="\verbatim embed:rst^^.. deprecated:: \1^^    \2^^\endverbatim"


### PR DESCRIPTION
This adds infrastructure to apply deprecations to C API functions, which causes them to raise warnings when user code is compiled against them (with gcc/clang/MSVC, at least).  We also introduce a custom Doxygen function that can be used to add deprecation information to the docstring in a way that Sphinx will understand it.

To illustrate the use (and to follow, at least partially, the spirit of our deprecation policies), this re-introduces the C API function `qk_transpiler_pass_standalone_vf2_layout` function, which was removed by the VF2-pruning PR chain.  We leave it with the Qiskit 2.2 API, marking it as deprecated.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

This conflicts slightly with #14864, but the two commits are designed to work together.  There's just a minor ordering problem, and I'll fix up the conflicts with whichever merges first.