### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/ctests.yml
+++ b/.github/workflows/ctests.yml
@@ -19,5 +19,9 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
       - name: Run tests
         run: make ctest

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -23,8 +23,7 @@ jobs:
       - uses: actions/setup-python@v6
         name: Install Python
         with:
-          # Sync with 'documentationPythonVersion' in 'azure-pipelines.yml'.
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install dependencies
         run: tools/install_ubuntu_docs_dependencies.sh

--- a/.github/workflows/lint_docs.yml
+++ b/.github/workflows/lint_docs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install ubuntu docs dependencies
         run: tools/install_ubuntu_docs_dependencies.sh
         env:
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install dependencies
         run: python -m pip install --upgrade tox
       - name: Run lint

--- a/.github/workflows/on-merge-queue.yml
+++ b/.github/workflows/on-merge-queue.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         runner: ["ubuntu-latest", "ubuntu-24.04-arm"]
     with:
-      python-version: 3.9
+      python-version: 3.10
       install-optionals: true
       runner: ${{ matrix.runner }}
   test-linux-3-13:
@@ -47,14 +47,14 @@ jobs:
     if: github.repository_owner == 'Qiskit'
     uses: ./.github/workflows/rust-tests.yml
     with:
-      python-version: "3.9"
+      python-version: "3.10"
       runner: "ubuntu-latest"
   test-images:
     name: Image Comparison Tests
     if: github.repository_owner == 'Qiskit'
     uses: ./.github/workflows/image-tests.yml
     with:
-      python-version: "3.9"
+      python-version: "3.10"
       runner: "ubuntu-latest"
   test-mac:
     name: Python Unit Tests

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -19,7 +19,7 @@ jobs:
     uses: ./.github/workflows/test-linux.yml
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         runner: ["ubuntu-latest", "ubuntu-24.04-arm"]
     with:
       python-version: ${{ matrix.python-version }}
@@ -30,7 +30,7 @@ jobs:
     uses: ./.github/workflows/test-mac.yml
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         runner: ["macos-14"]
 
     with:
@@ -42,7 +42,7 @@ jobs:
     uses: ./.github/workflows/test-windows.yml
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         runner: ["windows-latest"]
     with:
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -20,18 +20,18 @@ jobs:
     uses: ./.github/workflows/rust-tests.yml
     if: github.repository_owner == 'Qiskit'
     with:
-      python-version: "3.9"
+      python-version: "3.10"
       runner: ubuntu-latest
   main-tests-images:
     name: Image Comparison Tests
     uses: ./.github/workflows/image-tests.yml
     if: github.repository_owner == 'Qiskit'
     with:
-      python-version: "3.9"
+      python-version: "3.10"
       runner: ubuntu-latest
   # The rest of the PR pipeline is to test the oldest and newest supported
   # versions of Python.
-  main-tests-ubuntu-3-9:
+  main-tests-ubuntu-3-10:
     name: Python Unit Tests
     uses: ./.github/workflows/test-linux.yml
     if: github.repository_owner == 'Qiskit'
@@ -39,7 +39,7 @@ jobs:
       matrix:
         runner: [ubuntu-latest, ubuntu-24.04-arm]
     with:
-      python-version: "3.9"
+      python-version: "3.10"
       install-optionals: true
       runner: ${{ matrix.runner }}
   main-tests-ubuntu-3-13:
@@ -60,12 +60,12 @@ jobs:
     name: Python Unit Tests
     strategy:
       matrix:
-        python_version: ["3.9", "3.13"]
+        python_version: ["3.10", "3.13"]
         runner: ["macos-14"]
     uses: ./.github/workflows/test-mac.yml
     with:
       python-version: ${{ matrix.python_version }}
-      install-optionals: ${{ matrix.python_version == '3.9'}}
+      install-optionals: ${{ matrix.python_version == '3.10'}}
       runner: ${{ matrix.runner }}
 
   main-tests-windows:
@@ -73,12 +73,12 @@ jobs:
     name: Python Unit Tests
     strategy:
       matrix:
-        python_version: ["3.9", "3.13"]
+        python_version: ["3.10", "3.13"]
         runner: ["windows-latest"]
     uses: ./.github/workflows/test-windows.yml
     with:
       python-version: ${{ matrix.python_version }}
-      install-optionals: ${{ matrix.python_version == '3.9'}}
+      install-optionals: ${{ matrix.python_version == '3.10'}}
       runner: ${{ matrix.runner }}
   c-tests:
     if: github.repository_owner == 'Qiskit'

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -10,18 +10,18 @@ jobs:
     if: github.repository_owner == 'Qiskit'
     uses: ./.github/workflows/test-linux.yml
     with:
-      python-version: "3.9"
+      python-version: "3.10"
       install-optionals: false
       runner: ubuntu-latest
   test-rust:
     if: github.repository_owner == 'Qiskit'
     uses: ./.github/workflows/rust-tests.yml
     with:
-      python-version: "3.9"
+      python-version: "3.10"
       runner: ubuntu-latest
   test-images:
     if: github.repository_owner == 'Qiskit'
     uses: ./.github/workflows/image-tests.yml
     with:
-      python-version: "3.9"
+      python-version: "3.10"
       runner: ubuntu-latest

--- a/.github/workflows/qpy.yml
+++ b/.github/workflows/qpy.yml
@@ -21,8 +21,10 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
+        # This version needs to be large enough to support Qiskit on `main`, and old enough to
+        # support the oldest version of Symengine we test against.
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -444,8 +444,7 @@ environment that tox sets up matches the CI environment more closely and it
 runs the tests in parallel (resulting in much faster execution). To run tests
 on all installed supported python versions and lint/style checks you can simply
 run `tox`. Or if you just want to run the tests once run for a specific python
-version: `tox -epy310` (or replace py310 with the python version you want to use,
-py39 or py311).
+version: `tox -epy313` (or replace py313 with the python version you want to use).
 
 If you just want to run a subset of tests you can pass a selection regex to
 the test runner. For example, if you want to run all tests that have "dag" in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ uuid = { version = "1.18", features = ["v4", "fast-rng"], default-features = fal
 # distributions).  We only activate that feature when building the C extension module; we still need
 # it disabled for Rust-only tests to avoid linker errors with it not being loaded.  See
 # https://pyo3.rs/main/features#extension-module for more.
-pyo3 = { version = "0.27", features = ["abi3-py39"] }
+pyo3 = { version = "0.27", features = ["abi3-py310"] }
 
 # These are our own crates.
 qiskit-accelerate = { path = "crates/accelerate" }

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -17,7 +17,7 @@
     "dvcs": "git",
     "environment_type": "virtualenv",
     "show_commit_url": "http://github.com/Qiskit/qiskit/commit/",
-    "pythons": ["3.9", "3.10", "3.11", "3.12", "3.13"],
+    "pythons": ["3.10", "3.11", "3.12", "3.13"],
     "benchmark_dir": "test/benchmarks",
     "env_dir": ".asv/env",
     "results_dir": ".asv/results"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "qiskit"
 description = "An open-source SDK for working with quantum computers at the level of extended quantum circuits, operators, and primitives."
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 license-files = [
     "LICENSE.txt",
@@ -34,7 +34,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -186,14 +185,14 @@ include = ["qiskit", "qiskit.*"]
 
 [tool.black]
 line-length = 100
-target-version = ['py39', 'py310', 'py311']
+target-version = ['py310', 'py311']
 
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux2014"
 manylinux-ppc64le-image = "manylinux2014"
 manylinux-s390x-image = "manylinux2014"
-skip = "cp38-* *musllinux* *win32 *i686 cp38-macosx_arm64"
+skip = "cp38-* cp39-* *musllinux* *win32 *i686"
 test-skip = "*win32 *linux_i686"
 test-command = "cp -r {project}/test . && QISKIT_PARALLEL=FALSE stestr --test-path test/python run --abbreviate"
 # We need to use pre-built versions of Numpy and Scipy in the tests; they have a
@@ -245,7 +244,7 @@ extension-pkg-allow-list = [
     "rustworkx",
 ]
 load-plugins = ["pylint.extensions.docparams", "pylint.extensions.docstyle", "pylint.extensions.bad_builtin"]
-py-version = "3.9"  # update it when bumping minimum supported python version
+py-version = "3.10"  # update it when bumping minimum supported python version
 
 [tool.pylint.basic]
 good-names = ["a", "b", "i", "j", "k", "d", "n", "m", "ex", "v", "w", "x", "y", "z", "Run", "_", "logger", "q", "c", "r", "qr", "cr", "qc", "nd", "pi", "op", "b", "ar", "br", "p", "cp", "ax", "dt", "__unittest", "iSwapGate", "mu"]

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -44,15 +44,6 @@ else:
             " See https://qisk.it/packaging-1-0 for more detail."
         )
 
-if sys.version_info < (3, 10):
-    warnings.warn(
-        "Using Qiskit with Python 3.9 is deprecated as of the 2.1.0 release. "
-        "Support for running Qiskit with Python 3.9 will be removed in the "
-        "2.3.0 release, which coincides with when Python 3.9 goes end of life.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
 from . import _accelerate
 import qiskit._numpy_compat
 

--- a/releasenotes/notes/drop-python3.9-6aedf82b4aa9ad54.yaml
+++ b/releasenotes/notes/drop-python3.9-6aedf82b4aa9ad54.yaml
@@ -1,0 +1,5 @@
+---
+upgrade_misc:
+  - |
+    The minimum supported version of Python is now 3.10, following the end of life of Python 3.9
+    and deprecation warnings in Qiskit since version 2.1.

--- a/setup.py
+++ b/setup.py
@@ -51,5 +51,5 @@ setup(
             features=features,
         )
     ],
-    options={"bdist_wheel": {"py_limited_api": "cp39"}},
+    options={"bdist_wheel": {"py_limited_api": "cp310"}},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.0
-envlist = py39, py310, py311, py312, py313, lint-incr
+envlist = py310, py311, py312, py313, lint-incr
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Python 3.9 is end of life.  This marks all the metadata as dropping support for Python 3.9, and updates the targeted API version of CPython to abi3-3.10 in the wheel builds.

### Details and comments

Blocked by #15264.
Close #15139.