### PR TITLE
Fix numbering in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ Running this will give an outcome similar to `{'000': 497, '111': 503}` which is
 To illustrate the power of the Estimator, we now use the quantum information toolbox to create the operator $XXY+XYX+YXX-YYY$ and pass it to the `run()` function, along with our quantum circuit. Note that the Estimator requires a circuit _**without**_ measurements, so we use the `qc` circuit we created earlier.
 
 ```python
-# 2. Define the observable to be measured 
+# 4. Define the observable to be measured 
 from qiskit.quantum_info import SparsePauliOp
 operator = SparsePauliOp.from_list([("XXY", 1), ("XYX", 1), ("YXX", 1), ("YYY", -1)])
 
-# 3. Execute using the Estimator primitive
+# 5. Execute using the Estimator primitive
 from qiskit.primitives import StatevectorEstimator
 estimator = StatevectorEstimator()
 job = estimator.run([(qc, operator)], precision=1e-3)

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Once you've made your first quantum circuit, choose which primitive you will use
 we use `measure_all(inplace=False)` to get a copy of the circuit in which all the qubits are measured:
 
 ```python
-# 2. Add the classical output in the form of measurement of all qubits
+# 2a. Add the classical output in the form of measurement of all qubits
 qc_measured = qc.measure_all(inplace=False)
 
-# 3. Execute using the Sampler primitive
+# 3a. Execute using the Sampler primitive
 from qiskit.primitives import StatevectorSampler
 sampler = StatevectorSampler()
 job = sampler.run([qc_measured], shots=1000)
@@ -73,11 +73,11 @@ Running this will give an outcome similar to `{'000': 497, '111': 503}` which is
 To illustrate the power of the Estimator, we now use the quantum information toolbox to create the operator $XXY+XYX+YXX-YYY$ and pass it to the `run()` function, along with our quantum circuit. Note that the Estimator requires a circuit _**without**_ measurements, so we use the `qc` circuit we created earlier.
 
 ```python
-# 4. Define the observable to be measured 
+# 2b. Define the observable to be measured 
 from qiskit.quantum_info import SparsePauliOp
 operator = SparsePauliOp.from_list([("XXY", 1), ("XYX", 1), ("YXX", 1), ("YYY", -1)])
 
-# 5. Execute using the Estimator primitive
+# 3b. Execute using the Estimator primitive
 from qiskit.primitives import StatevectorEstimator
 estimator = StatevectorEstimator()
 job = estimator.run([(qc, operator)], precision=1e-3)


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the README example, the numbered steps are incorrect. The comments in the python code snippets were ordered 1. 2. 3. 2. 3. instead of 1. 2. 3. 4. 5. so I fixed this. 


### Details and comments


