### PR TITLE
Refactor layout writing to avoid slice creation

### DIFF
--- a/crates/cext/src/transpiler/transpile_layout.rs
+++ b/crates/cext/src/transpiler/transpile_layout.rs
@@ -106,14 +106,12 @@ pub unsafe extern "C" fn qk_transpile_layout_initial_layout(
     if let Some(out_initial_layout) = out_initial_layout {
         // SAFETY: Per the documentation initial_layout must be a valid pointer with a sufficient
         // allocation for the output array
-        unsafe {
-            let out_slice =
-                std::slice::from_raw_parts_mut(initial_layout, out_initial_layout.len());
-            out_slice
-                .iter_mut()
-                .zip(out_initial_layout.iter())
-                .for_each(|(dest, src)| *dest = src.0);
-        };
+        // Write directly to avoid creating references to uninitialized memory.
+        for (i, src) in out_initial_layout.iter().enumerate() {
+            unsafe {
+                initial_layout.add(i).write(src.0);
+            }
+        }
         true
     } else {
         false
@@ -160,13 +158,12 @@ pub unsafe extern "C" fn qk_transpile_layout_output_permutation(
     if let Some(permutation) = permutation {
         // SAFETY: Per the documentation output_permutation must be a valid pointer with a sufficient
         // allocation for the output array
-        unsafe {
-            let out_slice = std::slice::from_raw_parts_mut(output_permutation, permutation.len());
-            out_slice
-                .iter_mut()
-                .zip(permutation.iter())
-                .for_each(|(dest, src)| *dest = src.0);
-        };
+        // Write directly to avoid creating references to uninitialized memory.
+        for (i, src) in permutation.iter().enumerate() {
+            unsafe {
+                output_permutation.add(i).write(src.0);
+            }
+        }
         true
     } else {
         false
@@ -214,12 +211,10 @@ pub unsafe extern "C" fn qk_transpile_layout_final_layout(
     let result = layout.final_index_layout(filter_ancillas);
     // SAFETY: Per the documentation final_layout must be a valid pointer with a sufficient
     // allocation for the output array
-    unsafe {
-        let out_slice = std::slice::from_raw_parts_mut(final_layout, result.len());
-        out_slice
-            .iter_mut()
-            .zip(result.iter())
-            .for_each(|(dest, src)| *dest = src.0);
+    for (i, src) in result.iter().enumerate() {
+        unsafe {
+            final_layout.add(i).write(src.0);
+        }
     }
 }
 


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the CONTRIBUTING document.
-->

### Summary

This PR refactors FFI functions (qk_transpile_layout_initial_layout, qk_transpile_layout_output_permutation and qk_transpile_layout_final_layout) in `transpile_layout.rs` to avoid creating mutable references from raw pointers. The previous implementation used `from_raw_parts_mut`, which is not sound when the pointed memory may be uninitialized. This PR switches to `ptr.add(i).write(...)` loops.

### Details and comments

Fixes #15370