### PR TITLE
Correctly handle Blocks in `DAGCircuit::copy_empty_like`

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -42,8 +42,8 @@ use crate::register_data::RegisterData;
 use crate::slice::PySequenceIndex;
 use crate::variable_mapper::VariableMapper;
 use crate::{
-    Block, BlocksMode, Clbit, Qubit, Stretch, TupleLikeArg, Var, VarsMode, converters, imports,
-    instruction, vf2,
+    Block, BlockMapper, BlocksMode, Clbit, Qubit, Stretch, TupleLikeArg, Var, VarsMode, converters,
+    imports, instruction, vf2,
 };
 
 use hashbrown::{HashMap, HashSet};
@@ -1380,8 +1380,13 @@ impl DAGCircuit {
     ///
     /// Returns:
     ///     DAGCircuit: An empty copy of self.
-    #[pyo3(signature = (*, vars_mode=VarsMode::Alike))]
-    pub fn copy_empty_like(&self, vars_mode: VarsMode) -> PyResult<Self> {
+    // NOTE: this is typically not want you want from Rust, because you should be making decisions
+    // about the `BlocksMode`.  Python always wants `Drop` (because you can't reproduce references
+    // to existing blocks from Python space), but in Rust you should decide.
+    //
+    // You likely want `copy_empty_like_with_same_capacity`.
+    #[pyo3(name = "copy_empty_like", signature = (*, vars_mode=VarsMode::Alike))]
+    pub fn py_copy_empty_like(&self, vars_mode: VarsMode) -> PyResult<Self> {
         self.copy_empty_like_with_capacity(0, 0, vars_mode, BlocksMode::Drop)
     }
 
@@ -3449,12 +3454,13 @@ impl DAGCircuit {
         let dags = PyList::empty(py);
 
         for comp_nodes in connected_components.iter() {
-            let mut new_dag = self.copy_empty_like(vars_mode)?;
+            let mut new_dag = self.copy_empty_like(vars_mode, BlocksMode::Drop)?;
             new_dag.global_phase = Param::Float(0.);
 
             // A map from nodes in the this DAGCircuit to nodes in the new dag. Used for adding edges
             let mut node_map: HashMap<NodeIndex, NodeIndex> =
                 HashMap::with_capacity(comp_nodes.len());
+            let mut block_map = BlockMapper::new();
 
             // Adding the nodes to the new dag
             let mut non_classical = false;
@@ -3488,8 +3494,11 @@ impl DAGCircuit {
                             node_map.insert(*node, var_out);
                         }
                         NodeType::Operation(pi) => {
-                            let new_node = new_dag.dag.add_node(NodeType::Operation(pi.clone()));
+                            let pi = block_map.map_instruction(pi, |b| {
+                                new_dag.add_block(self.blocks[b.index()].clone())
+                            });
                             new_dag.increment_op(pi.op.name());
+                            let new_node = new_dag.dag.add_node(NodeType::Operation(pi));
                             node_map.insert(*node, new_node);
                             non_classical = true;
                         }
@@ -4214,28 +4223,14 @@ impl DAGCircuit {
                 return Ok(PyIterator::from_object(&layer_list)?.into());
             }
 
-            let mut new_layer = self.copy_empty_like(vars_mode)?;
-            let mut block_map = HashMap::new();
+            let mut new_layer = self.copy_empty_like(vars_mode, BlocksMode::Drop)?;
+            let mut block_map = BlockMapper::new();
             let data: Vec<_> = op_nodes
                 .iter()
                 .map(|(inst, _)| {
-                    if let Some(Parameters::Blocks(blocks)) = inst.params.as_deref() {
-                        let mapped_blocks = blocks
-                            .iter()
-                            .map(|b| {
-                                *block_map.entry(*b).or_insert_with(|| {
-                                    let block = self.blocks.get(b.index()).unwrap().clone();
-                                    new_layer.add_block(block)
-                                })
-                            })
-                            .collect();
-                        PackedInstruction {
-                            params: Some(Box::new(Parameters::Blocks(mapped_blocks))),
-                            ..(*inst).clone()
-                        }
-                    } else {
-                        (*inst).clone()
-                    }
+                    block_map.map_instruction(inst, |b| {
+                        new_layer.add_block(self.blocks[b.index()].clone())
+                    })
                 })
                 .collect();
             new_layer.extend(data)?;
@@ -4272,7 +4267,8 @@ impl DAGCircuit {
                 Some(NodeType::Operation(node)) => node,
                 _ => unreachable!("A non-operation node was obtained from topological_op_nodes."),
             };
-            let mut new_layer = self.copy_empty_like(vars_mode)?;
+            let mut new_layer = self.copy_empty_like(vars_mode, BlocksMode::Drop)?;
+            let mut block_map = BlockMapper::new();
 
             // Save the support of the operation we add to the layer
             let support_list = PyList::empty(py);
@@ -4284,7 +4280,10 @@ impl DAGCircuit {
                     .map(|qubit| self.qubits.get(*qubit)),
             )?
             .unbind();
-            new_layer.push_back(retrieved_node.clone())?;
+            let inst = block_map.map_instruction(retrieved_node, |b| {
+                new_layer.add_block(self.blocks[b.index()].clone())
+            });
+            new_layer.push_back(inst)?;
 
             if !retrieved_node.op.directive() {
                 support_list.append(qubits)?;
@@ -5208,6 +5207,16 @@ impl DAGCircuit {
             stretches_capture: HashSet::new(),
             stretches_declare: Vec::new(),
         }
+    }
+    /// Create an empty DAG, but with all the same qubit data, classical data and metadata
+    /// (including global phase).
+    ///
+    /// This method clones both the `qargs_interner` and `cargs_interner` of `self`;
+    /// `Interned<[Qubit]>` and `Interned<[Clbit]>` keys from `self` are valid in the output DAG.
+    ///
+    /// This does not include any pre-allocated capacity.
+    pub fn copy_empty_like(&self, vars_mode: VarsMode, blocks_mode: BlocksMode) -> PyResult<Self> {
+        self.copy_empty_like_with_capacity(0, 0, vars_mode, blocks_mode)
     }
 
     /// Create an empty DAG, but with all the same qubit data, classical data and metadata

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -65,6 +65,7 @@ pub struct Block(u32);
 
 pub use nlayout::PhysicalQubit;
 pub use nlayout::VirtualQubit;
+pub use packed_instruction::BlockMapper;
 
 macro_rules! impl_circuit_identifier {
     ($type:ident) => {

--- a/crates/transpiler/src/passes/basis_translator/mod.rs
+++ b/crates/transpiler/src/passes/basis_translator/mod.rs
@@ -34,7 +34,7 @@ use qiskit_circuit::parameter::parameter_expression::ParameterExpression;
 use qiskit_circuit::parameter::symbol_expr::Symbol;
 use qiskit_circuit::parameter::symbol_expr::SymbolExpr;
 use qiskit_circuit::parameter::symbol_expr::Value;
-use qiskit_circuit::{Clbit, PhysicalQubit, Qubit, VarsMode};
+use qiskit_circuit::{BlocksMode, Clbit, PhysicalQubit, Qubit, VarsMode};
 use qiskit_circuit::{
     dag_circuit::DAGCircuit,
     operations::{Operation, OperationRef, PythonOperation},
@@ -336,9 +336,13 @@ fn apply_translation(
     qarg_mapping: Option<&HashMap<Qubit, Qubit>>,
 ) -> Result<(DAGCircuit, bool), BasisTranslatorError> {
     let mut is_updated = false;
-    let out_dag = dag.copy_empty_like(VarsMode::Alike).map_err(|_| {
-        BasisTranslatorError::BasisDAGCircuitError("Error copying DAGCircuit instance".to_string())
-    })?;
+    let out_dag = dag
+        .copy_empty_like(VarsMode::Alike, BlocksMode::Keep)
+        .map_err(|_| {
+            BasisTranslatorError::BasisDAGCircuitError(
+                "Error copying DAGCircuit instance".to_string(),
+            )
+        })?;
     let mut out_dag_builder = out_dag.into_builder();
     for node in dag.topological_op_nodes().map_err(|_| {
         BasisTranslatorError::BasisDAGCircuitError("Error retrieving Op nodes from DAG".to_string())

--- a/crates/transpiler/src/passes/litinski_transformation.rs
+++ b/crates/transpiler/src/passes/litinski_transformation.rs
@@ -19,7 +19,7 @@ use qiskit_circuit::operations::{
     Operation, OperationRef, Param, PauliProductMeasurement, PyGate, StandardGate, multiply_param,
 };
 use qiskit_circuit::packed_instruction::PackedInstruction;
-use qiskit_circuit::{Clbit, Qubit, VarsMode};
+use qiskit_circuit::{BlocksMode, Clbit, Qubit, VarsMode};
 
 use qiskit_quantum_info::clifford::Clifford;
 use qiskit_quantum_info::sparse_observable::PySparseObservable;
@@ -78,7 +78,7 @@ pub fn run_litinski_transformation(
         )));
     }
 
-    let mut new_dag = dag.copy_empty_like(VarsMode::Alike)?;
+    let mut new_dag = dag.copy_empty_like(VarsMode::Alike, BlocksMode::Keep)?;
 
     let py_evo_cls = PAULI_EVOLUTION_GATE.get_bound(py);
     let no_clbits: Vec<Clbit> = Vec::new();

--- a/crates/transpiler/src/passes/split_2q_unitaries.rs
+++ b/crates/transpiler/src/passes/split_2q_unitaries.rs
@@ -21,7 +21,7 @@ use smallvec::{SmallVec, smallvec};
 use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType, Wire};
 use qiskit_circuit::operations::{ArrayType, Operation, OperationRef, Param, UnitaryGate};
 use qiskit_circuit::packed_instruction::PackedOperation;
-use qiskit_circuit::{Qubit, VarsMode};
+use qiskit_circuit::{BlocksMode, Qubit, VarsMode};
 
 use qiskit_synthesis::two_qubit_decompose::{Specialization, TwoQubitWeylDecomposition};
 
@@ -99,7 +99,7 @@ pub fn run_split_2q_unitaries(
     // We have swap-like unitaries, so we create a new DAG in a manner similar to
     // The Elide Permutations pass, while also splitting the unitaries to 1-qubit gates
     let mut mapping: Vec<usize> = (0..dag.num_qubits()).collect();
-    let new_dag = dag.copy_empty_like(VarsMode::Alike)?;
+    let new_dag = dag.copy_empty_like(VarsMode::Alike, BlocksMode::Keep)?;
     let mut new_dag = new_dag.into_builder();
     for node in dag.topological_op_nodes()? {
         let NodeType::Operation(inst) = &dag.dag()[node] else {

--- a/crates/transpiler/src/passes/unitary_synthesis.rs
+++ b/crates/transpiler/src/passes/unitary_synthesis.rs
@@ -35,7 +35,7 @@ use qiskit_circuit::dag_circuit::{DAGCircuit, DAGCircuitBuilder, NodeType};
 use qiskit_circuit::instruction::{Instruction, Parameters};
 use qiskit_circuit::operations::{Operation, OperationRef, Param, PythonOperation, StandardGate};
 use qiskit_circuit::packed_instruction::{PackedInstruction, PackedOperation};
-use qiskit_circuit::{Qubit, VarsMode, imports};
+use qiskit_circuit::{BlocksMode, Qubit, VarsMode, imports};
 
 use crate::QiskitError;
 use crate::target::{NormalOperation, Target, TargetOperation};
@@ -392,7 +392,7 @@ pub fn run_unitary_synthesis(
     pulse_optimize: Option<bool>,
     run_python_decomposers: bool,
 ) -> PyResult<DAGCircuit> {
-    let out_dag = dag.copy_empty_like(VarsMode::Alike)?;
+    let out_dag = dag.copy_empty_like(VarsMode::Alike, BlocksMode::Keep)?;
     let mut out_dag = out_dag.into_builder();
 
     // Iterate over dag nodes and determine unitary synthesis approach
@@ -1157,7 +1157,7 @@ fn reversed_synth_su4_dag(
         unreachable!("reversed_synth_su4_dag should only be called for XXDecomposer")
     };
 
-    let target_dag = synth_dag.copy_empty_like(VarsMode::Alike)?;
+    let target_dag = synth_dag.copy_empty_like(VarsMode::Alike, BlocksMode::Keep)?;
     let flip_bits: [Qubit; 2] = [Qubit(1), Qubit(0)];
     let mut target_dag_builder = target_dag.into_builder();
     for node in synth_dag.topological_op_nodes()? {


### PR DESCRIPTION
For the Python-space function, we always want to "drop" blocks, because there's no way to trigger block re-use from Python space, and we'd always be appending them on afterwards. Rust, on the other hand, needs to decide in each case how it wants to handle the blocks.  Using the Python-space `copy_empty_like` was silently breaking things by using the `BlocksMode::Drop` assumption.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

