### PR TITLE
Use `Symbol` as the loop parameter in `ForLoop`

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -2621,7 +2621,7 @@ impl CircuitData {
 
     /// Does the circuit use this `Symbol` as a parameter?
     pub fn uses_parameter(&self, sym: &Symbol) -> bool {
-        self.param_table.contains(&ParameterUuid::from_symbol(sym))
+        self.param_table.contains(sym)
     }
 
     /// Get the unsorted symbols in this circuit.

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -2389,7 +2389,7 @@ impl CircuitData {
                             // argument position 1.
                             if let Some(loop_param) = loop_param {
                                 self.param_table.track(
-                                    &loop_param.bind(py).extract()?,
+                                    loop_param,
                                     Some(ParameterUse::Index {
                                         instruction: instruction_index,
                                         parameter: 1,
@@ -2484,7 +2484,7 @@ impl CircuitData {
                             // argument position 1.
                             if let Some(loop_param) = loop_param {
                                 self.param_table.untrack(
-                                    &loop_param.bind(py).extract()?,
+                                    loop_param,
                                     ParameterUse::Index {
                                         instruction: instruction_index,
                                         parameter: 1,
@@ -2617,6 +2617,11 @@ impl CircuitData {
     /// Get the sorted symbols in this circuit.
     pub fn parameters(&self) -> &[Symbol] {
         self.param_table.symbols()
+    }
+
+    /// Does the circuit use this `Symbol` as a parameter?
+    pub fn uses_parameter(&self, sym: &Symbol) -> bool {
+        self.param_table.contains(&ParameterUuid::from_symbol(sym))
     }
 
     /// Get the unsorted symbols in this circuit.

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -32,6 +32,7 @@ use crate::operations::{
 };
 use crate::packed_instruction::PackedOperation;
 use crate::parameter::parameter_expression::ParameterExpression;
+use crate::parameter::symbol_expr::Symbol;
 use nalgebra::{Dyn, MatrixView2, MatrixView4};
 use num_complex::Complex64;
 use smallvec::SmallVec;
@@ -212,7 +213,7 @@ impl CircuitInstruction {
                     ..
                 } => [
                     indexset.into_py_any(py)?,
-                    loop_param.into_py_any(py)?,
+                    loop_param.clone().into_py_any(py)?,
                     self.blocks_view()[0].clone_ref(py),
                 ]
                 .into_py_any(py),
@@ -700,11 +701,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for OperationFromPython {
                                 .map(|index| index?.extract())
                                 .collect::<PyResult<_>>()?
                         };
-                        let loop_param = params
-                            .next()
-                            .unwrap()?
-                            .extract::<Option<Bound<PyAny>>>()?
-                            .map(|p| p.unbind());
+                        let loop_param = params.next().unwrap()?.extract::<Option<Symbol>>()?;
                         ControlFlow::ForLoop {
                             indexset,
                             loop_param,

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -2352,15 +2352,10 @@ impl DAGCircuit {
                                                 .call1((Uuid::new_v4().to_string(),))?;
                                             let mut body_a_circuit =
                                                 converters::dag_to_circuit(body_a, false)?;
-                                            if body_a_circuit
-                                                .get_parameters(py)?
-                                                .contains(loop_param_a)?
-                                            {
+                                            if body_a_circuit.uses_parameter(loop_param_a) {
                                                 body_a_circuit.assign_parameters_from_mapping([
                                                     (
-                                                        ParameterUuid::from_parameter(
-                                                            loop_param_a.bind(py),
-                                                        )?,
+                                                        ParameterUuid::from_symbol(loop_param_a),
                                                         Param::ParameterExpression(Arc::new(
                                                             ParameterExpression::from_symbol(
                                                                 sentinel.clone().extract()?,
@@ -2385,15 +2380,10 @@ impl DAGCircuit {
 
                                             let mut body_b_circuit =
                                                 converters::dag_to_circuit(body_b, false)?;
-                                            if body_b_circuit
-                                                .get_parameters(py)?
-                                                .contains(loop_param_b)?
-                                            {
+                                            if body_b_circuit.uses_parameter(loop_param_b) {
                                                 body_b_circuit.assign_parameters_from_mapping([
                                                     (
-                                                        ParameterUuid::from_parameter(
-                                                            loop_param_b.bind(py),
-                                                        )?,
+                                                        ParameterUuid::from_symbol(loop_param_b),
                                                         Param::ParameterExpression(Arc::new(
                                                             ParameterExpression::from_symbol(
                                                                 sentinel.clone().extract()?,

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -383,7 +383,7 @@ pub enum ControlFlow {
     ContinueLoop,
     ForLoop {
         indexset: Vec<usize>,
-        loop_param: Option<Py<PyAny>>,
+        loop_param: Option<Symbol>,
     },
     IfElse {
         condition: Condition,
@@ -445,14 +445,7 @@ impl ControlFlowInstruction {
                 ControlFlow::ForLoop {
                     indexset: other_indexset,
                     loop_param: other_loop_param,
-                } => Ok(self_indexset == other_indexset
-                    && self_loop_param
-                        .as_ref()
-                        .zip(other_loop_param.as_ref())
-                        .map(|(p1, p2)| p1.bind(py).eq(p2))
-                        .unwrap_or_else(|| {
-                            Ok(self_loop_param.is_none() && other_loop_param.is_none())
-                        })?),
+                } => Ok(self_indexset == other_indexset && self_loop_param == other_loop_param),
                 _ => Ok(false),
             },
             ControlFlow::IfElse {
@@ -540,7 +533,7 @@ impl ControlFlowInstruction {
                 loop_param,
             } => imports::FOR_LOOP_OP.get(py).call(
                 py,
-                (indexset, loop_param, blocks.next()),
+                (indexset, loop_param.clone(), blocks.next()),
                 kwargs.as_ref(),
             ),
             ControlFlow::IfElse { condition } => imports::IF_ELSE_OP.get(py).call(
@@ -614,7 +607,7 @@ pub enum ControlFlowView<'a, T> {
     ContinueLoop,
     ForLoop {
         indexset: &'a [usize],
-        loop_param: Option<&'a Py<PyAny>>,
+        loop_param: Option<&'a Symbol>,
         body: &'a T,
     },
     IfElse {

--- a/crates/circuit/src/parameter_table.rs
+++ b/crates/circuit/src/parameter_table.rs
@@ -115,8 +115,9 @@ impl ParameterTable {
     }
 
     /// Does this table track the given parameter?
-    pub fn contains(&self, uuid: &ParameterUuid) -> bool {
-        self.by_uuid.contains_key(uuid)
+    pub fn contains(&self, symbol: &Symbol) -> bool {
+        self.by_uuid
+            .contains_key(&ParameterUuid::from_symbol(symbol))
     }
 
     /// Add a new usage of a parameter coming in, optionally adding a first usage to it.

--- a/crates/circuit/src/parameter_table.rs
+++ b/crates/circuit/src/parameter_table.rs
@@ -114,6 +114,11 @@ impl ParameterTable {
         self.by_uuid.len()
     }
 
+    /// Does this table track the given parameter?
+    pub fn contains(&self, uuid: &ParameterUuid) -> bool {
+        self.by_uuid.contains_key(uuid)
+    }
+
     /// Add a new usage of a parameter coming in, optionally adding a first usage to it.
     ///
     /// The no-use form is useful when doing parameter assignments from Rust space, where the


### PR DESCRIPTION
This is one step to removing the Python dependence from control-flow operations.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


Split out from #15123 in order to unblock #15380.