### PR TITLE
QDrift C API Implementation

### DIFF
--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -958,8 +958,8 @@ pub unsafe extern "C" fn qk_circuit_get_instruction(
 ///
 /// # Example
 /// ```c
-///    QkCircuit *qc = qk_circuit_new(1, 0);
-///   double phase = qk_circuit_get_global_phase(qc);
+///  QkCircuit *qc = qk_circuit_new(1, 0);
+///  double phase = qk_circuit_get_global_phase(qc);
 /// ```
 ///
 /// # Safety

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -950,6 +950,37 @@ pub unsafe extern "C" fn qk_circuit_get_instruction(
 }
 
 /// @ingroup QkCircuit
+/// Get the global phase of the circuit.
+/// 
+/// @param circuit A pointer to the circuit.
+/// 
+/// @return The global phase of the circuit as a float.
+/// 
+/// # Example
+/// ```c
+///    QkCircuit *qc = qk_circuit_new(1, 0);
+///   double phase = qk_circuit_get_global_phase(qc);
+/// ```
+/// 
+/// # Safety
+/// 
+/// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
+#[unsafe(no_mangle)]
+#[cfg(feature = "cbinding")]
+pub unsafe extern "C" fn qk_circuit_get_global_phase(
+    circuit: *const CircuitData,
+) -> f64 {
+    // SAFETY: Per documentation, the pointer is non-null and aligned.
+    let circuit = unsafe { const_ptr_as_ref(circuit) };
+
+    match circuit.global_phase() {
+        Param::Float(v) => *v,
+        // Should never be possible
+        _ => panic!("Global phase is not a float"),
+    }
+}
+
+/// @ingroup QkCircuit
 /// Clear the data in circuit instruction object.
 ///
 /// This function doesn't free the allocation for the provided ``QkCircuitInstruction`` pointer, it

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -951,25 +951,23 @@ pub unsafe extern "C" fn qk_circuit_get_instruction(
 
 /// @ingroup QkCircuit
 /// Get the global phase of the circuit.
-/// 
+///
 /// @param circuit A pointer to the circuit.
-/// 
+///
 /// @return The global phase of the circuit as a float.
-/// 
+///
 /// # Example
 /// ```c
 ///    QkCircuit *qc = qk_circuit_new(1, 0);
 ///   double phase = qk_circuit_get_global_phase(qc);
 /// ```
-/// 
+///
 /// # Safety
-/// 
+///
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
 #[unsafe(no_mangle)]
 #[cfg(feature = "cbinding")]
-pub unsafe extern "C" fn qk_circuit_get_global_phase(
-    circuit: *const CircuitData,
-) -> f64 {
+pub unsafe extern "C" fn qk_circuit_get_global_phase(circuit: *const CircuitData) -> f64 {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { const_ptr_as_ref(circuit) };
 

--- a/crates/cext/src/circuit_library/mod.rs
+++ b/crates/cext/src/circuit_library/mod.rs
@@ -10,5 +10,5 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-pub mod quantum_volume;
 pub mod qdrift;
+pub mod quantum_volume;

--- a/crates/cext/src/circuit_library/mod.rs
+++ b/crates/cext/src/circuit_library/mod.rs
@@ -11,3 +11,4 @@
 // that they have been altered from the originals.
 
 pub mod quantum_volume;
+pub mod qdrift;

--- a/crates/cext/src/circuit_library/qdrift.rs
+++ b/crates/cext/src/circuit_library/qdrift.rs
@@ -1,0 +1,179 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use crate::exit_codes::ExitCode;
+use crate::pointers::{const_ptr_as_ref, mut_ptr_as_ref};
+
+use num_complex::Complex64;
+
+use qiskit_circuit::circuit_data::CircuitData;
+use qiskit_circuit::operations::Param;
+use qiskit_circuit_library::pauli_evolution::Instruction;
+use qiskit_circuit_library::pauli_evolution::sparse_term_evolution;
+use qiskit_quantum_info::sparse_observable::SparseObservable;
+
+use rand::distr::{
+    Distribution,
+    weighted::WeightedIndex
+};
+
+use std::ptr;
+
+
+fn approx_real(z: &Complex64) -> f64 {
+    if z.im.abs() > 1e-12 {
+        panic!("Complex coefficient with imaginary part encountered in QDRIFT.")
+    }
+    z.re
+}
+
+fn qdrift_build_circuit(
+    obs: &SparseObservable,
+    reps: usize,
+    time: f64,
+) -> Result<CircuitData, ExitCode> {
+    let num_qubits = obs.num_qubits();
+    if reps == 0 || num_qubits == 0 || obs.coeffs().is_empty() {
+        return Err(ExitCode::CInputError)
+    }
+
+    // If the observable contains projectors, convert to Paulis
+    let pauli_obs = obs.as_paulis();
+    let obs = &pauli_obs;
+    
+    let bit_terms = obs.bit_terms();
+    let boundaries = obs.boundaries();
+    let indices = obs.indices();
+
+    let n_terms = obs.coeffs().len();
+    let mut mags: Vec<f64> = Vec::with_capacity(n_terms);
+    let mut signs: Vec<f64> = Vec::with_capacity(n_terms);
+    let mut lambda = 0.0f64;
+    
+    for &c in obs.coeffs() {
+        let r = approx_real(&c);
+        // artificially make weights positive
+        let m = r.abs();
+        if m == 0.0 {
+            mags.push(0.0);
+            signs.push(0.0);
+            continue
+        }
+        mags.push(m);
+        signs.push(r.signum());
+        lambda += m;
+    }
+    
+    // Zero hamiltonian
+    if lambda == 0.0 {
+        return Err(ExitCode::Success)
+    }
+
+    let num_gates = (2.0 * lambda.powi(2) * time.powi(2) * reps as f64).ceil() as usize;
+
+    let probs: Vec<f64> = mags.iter().map(|m| m / lambda).collect();
+
+    let dist = WeightedIndex::new(&probs).unwrap();
+    // let mut rng = StdRng::seed_from_u64(seed as u64);
+    let mut rng = rand::rng();
+
+    let rescaled_time = 2.0 * lambda / num_gates as f64 * time;
+
+    // sample term indices (0..n_terms)
+    let sampled_indices: Vec<usize> =
+        (0..num_gates).map(|_| dist.sample(&mut rng)).collect();
+    let mut pauli_strings: Vec<String> = Vec::with_capacity(num_gates);
+    let mut pauli_indices: Vec<Vec<u32>> = Vec::with_capacity(num_gates);
+    let mut pauli_thetas: Vec<Param> = Vec::with_capacity(num_gates);
+    for i in sampled_indices {
+        let start = boundaries[i];
+        let end = boundaries[i + 1];
+
+        let term_bits = &bit_terms[start..end];
+        let term_indices = &indices[start..end];
+        debug_assert_eq!(term_bits.len(), term_indices.len());
+
+        let theta = signs[i] * rescaled_time;
+
+        let mut pauli_chars = vec!["I"; num_qubits as usize];
+        for (bit, &idx) in term_bits.iter().zip(term_indices.iter()) {
+            pauli_chars[idx as usize] = bit.py_label();
+        }
+        let pauli_string: String = pauli_chars.join("");
+        let dense_indices: Vec<u32> = (0..num_qubits).collect();
+
+        pauli_strings.push(pauli_string);
+        pauli_indices.push(dense_indices);
+        pauli_thetas.push(Param::Float(theta));
+    }
+
+    // Construct the evolutions
+    let evos = pauli_strings.iter()
+        .zip(pauli_indices.into_iter())
+        .zip(pauli_thetas.into_iter())
+        .flat_map(move |((pauli_str, idxs), time_param)| {
+            let inner = sparse_term_evolution(
+                pauli_str.as_str(),
+                idxs,
+                time_param,
+                false,  // no phase gate for Paulis
+                false,  // use chain CX structure
+            );
+            // This will never return a PyErr, so we can safely infer the error type
+            // Infallible will not work directly since CircuitData::from_packed_operations expects
+            // the items in the iterator to be PyResult<_>
+            inner.map(|inst: Instruction| Ok::<Instruction, _>(inst))
+        });
+    
+    let global_phase = Param::Float(0.0);
+    
+    // use CircuitData::from_packed_operations(num_qubits as u32, 0, evos, global_phase);
+    // to assemble the circuit
+    CircuitData::from_packed_operations(
+        num_qubits as u32,
+        0,
+        evos,
+        global_phase,
+    ).map_err(|_| ExitCode::ArithmeticError)
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "cbinding")]
+pub extern "C" fn qk_circuit_library_qdrift(
+    obs: *const SparseObservable, // H in e^{-i t H}
+    reps: usize, // n in e^{-it/n H}^n
+    // insert_barriers: bool, // TODO wait for C implementation of barriers
+    // cx_structure: CXStructure, // use chain by default
+    // atomic_evolution: AtomicEvolution, // TODO add later
+    // seed: usize, // TODO use seed or ThreadRng from rand::rng()
+    // wrap: bool,  // TODO wait for C support
+    // preserve_order: bool, // TODO add later
+    // atomic_evolution_sparse_observable: bool // TODO add later
+    time: f64, // evolution time e in e^{-i t H}
+    out: *mut *mut CircuitData, // output pointer to CircuitData
+) -> ExitCode {
+    // Safety: obs must be a valid pointer to a QkObs object created by Rust code.
+    let obs = unsafe { const_ptr_as_ref(obs) };
+    let out_ref = unsafe { mut_ptr_as_ref(out) };
+
+    *out_ref = ptr::null_mut();
+
+    match qdrift_build_circuit(obs, reps, time) {
+        Ok(circuit) => {
+            let boxed = Box::new(circuit);
+            *out_ref = Box::into_raw(boxed);
+        }
+        Err(e) => return e
+    }
+
+    return ExitCode::Success
+}

--- a/crates/cext/src/circuit_library/qdrift.rs
+++ b/crates/cext/src/circuit_library/qdrift.rs
@@ -46,9 +46,11 @@ fn qdrift_build_circuit(
         return Err(ExitCode::CInputError);
     }
 
-    // If the observable contains projectors, convert to Paulis
-    let pauli_obs = obs.as_paulis();
-    let obs = &pauli_obs;
+    // If the observable contains projectors, return an error. 
+    // User should explicitly opt in to Pauli decomposition.
+    if obs.bit_terms().iter().any(|b| b.is_projector()) {
+        return Err(ExitCode::CInputError);
+    }
 
     let bit_terms = obs.bit_terms();
     let boundaries = obs.boundaries();

--- a/crates/cext/src/circuit_library/qdrift.rs
+++ b/crates/cext/src/circuit_library/qdrift.rs
@@ -26,7 +26,7 @@ use rand::distr::{Distribution, weighted::WeightedIndex};
 use std::ptr;
 
 /// Internal helper to extract real part of a complex number,
-/// panicking if imaginary part is non-zero.
+/// returning an error if imaginary part is non-zero.
 fn approx_real(z: &Complex64) -> Result<f64, ExitCode> {
     if z.im.abs() > 1e-12 {
         return Err(ExitCode::CInputError);

--- a/crates/cext/src/circuit_library/qdrift.rs
+++ b/crates/cext/src/circuit_library/qdrift.rs
@@ -174,11 +174,11 @@ fn qdrift_build_circuit(
 ///   - Contain only *real* coefficients `c_j` (imaginary parts must be
 ///     numerically zero).
 ///   - Projectors are computationally inefficient - For example, the decomposition acting on a
-///     term with :math:`n` projectors :math:`|+><+|` will use :math:`2^n` Pauli terms.
+///     term with :math:`n` projectors will use :math:`2^n` Pauli terms.
 /// - `reps`: The number of outer repetitions `n` in the product formula,
 ///   i.e. QDRIFT approximates `exp(-i * time * H)` by a product of
 ///   `reps` independently sampled segments.  Must be strictly positive;
-///   `reps == 0` is rejected with a non-success `ExitCode`. :contentReference[oaicite:2]{index=2}
+///   `reps == 0` is rejected with a non-success `ExitCode`.
 /// - `time`: Evolution time `t` in `exp(-i * t * H)`.  This is a real
 ///   scalar and may be positive, negative, or zero.  The total number of
 ///   gates scales quadratically in `|time|`.

--- a/crates/cext/src/circuit_library/qdrift.rs
+++ b/crates/cext/src/circuit_library/qdrift.rs
@@ -46,7 +46,7 @@ fn qdrift_build_circuit(
         return Err(ExitCode::CInputError);
     }
 
-    // If the observable contains projectors, return an error. 
+    // If the observable contains projectors, return an error.
     // User should explicitly opt in to Pauli decomposition.
     if obs.bit_terms().iter().any(|b| b.is_projector()) {
         return Err(ExitCode::CInputError);
@@ -61,7 +61,6 @@ fn qdrift_build_circuit(
     let mut mags: Vec<f64> = Vec::with_capacity(n_terms);
     let mut signs: Vec<f64> = Vec::with_capacity(n_terms);
     let mut lambda = 0.0f64;
-    let mut kappa = 0.0f64;
 
     for (i, &c) in obs.coeffs().iter().enumerate() {
         let start = boundaries[i];
@@ -69,13 +68,9 @@ fn qdrift_build_circuit(
         let is_identity = start == end;
 
         let r = approx_real(&c);
-        let r = match r {
-            Err(e) => return Err(e),
-            Ok(r) => r,
-        };
+        let r = r?;
 
         if is_identity {
-            kappa += r;
             mags.push(0.0);
             signs.push(0.0);
             continue;
@@ -207,9 +202,11 @@ fn qdrift_build_circuit(
  *   same expected gate count.
  *
  * @warning
+ * # Safety
  * Safety assumptions:
  * - obs must be a valid pointer managed by the Qiskit C API.
  * - out must be a valid writable pointer to a QkCircuit* location.
+ *  
  * Violating these conditions may cause undefined behavior.
  *
  * @par Example

--- a/crates/circuit_library/src/lib.rs
+++ b/crates/circuit_library/src/lib.rs
@@ -18,7 +18,7 @@ mod entanglement;
 mod iqp;
 mod multi_local;
 mod parameter_ledger;
-mod pauli_evolution;
+pub mod pauli_evolution;
 mod pauli_feature_map;
 pub mod quantum_volume;
 

--- a/crates/circuit_library/src/pauli_evolution.rs
+++ b/crates/circuit_library/src/pauli_evolution.rs
@@ -21,7 +21,7 @@ use qiskit_circuit::{Clbit, Qubit};
 use smallvec::{SmallVec, smallvec};
 
 // custom type for a more readable code
-type Instruction = (
+pub type Instruction = (
     PackedOperation,
     SmallVec<[Param; 3]>,
     Vec<Qubit>,

--- a/releasenotes/notes/qdrift-c-api-addition-122bb199ff2dc83b.yaml
+++ b/releasenotes/notes/qdrift-c-api-addition-122bb199ff2dc83b.yaml
@@ -1,20 +1,7 @@
 ---
 prelude: >
-    Replace this text with content to appear at the top of the section for this
-    release. All of the prelude content is merged together and then rendered
-    separately from the items listed in other parts of the file, so the text
-    needs to be worded so that both the prelude and the other items make sense
-    when read independently. This may mean repeating some details. Not every
-    release note requires a prelude. Usually only notes describing major
-    features or adding release theme details should have a prelude.
-features:
-  - |
-    List new features here, or remove this section.  All of the list items in
-    this section are combined when the release notes are rendered, so the text
-    needs to be worded so that it does not depend on any information only
-    available in another section, such as the prelude. This may mean repeating
-    some details. If the feature note is contained within one of the modules
-    listed below you should use the appropriate subsection instead.
+    This release note describes the addition of a new feature in the C API
+    circuit library that enables the synthesis of QDRIFT circuits.
 features_c:
   - |
     Introduced a new feature in the C API circuit library to synthesize QDRIFT

--- a/releasenotes/notes/qdrift-c-api-addition-122bb199ff2dc83b.yaml
+++ b/releasenotes/notes/qdrift-c-api-addition-122bb199ff2dc83b.yaml
@@ -1,13 +1,10 @@
 ---
-prelude: >
-    This release note describes the addition of a new feature in the C API
-    circuit library that enables the synthesis of QDRIFT circuits.
 features_c:
   - |
     Introduced a new feature in the C API circuit library to synthesize QDRIFT
     circuits. The function `qk_circuit_library_qdrift` allows users to create
     quantum circuits that approximate the time evolution under a given sparse
-    observable using the QDRIFT algorithm. For example::
+    observable using the QDRIFT algorithm. For example.. code-block:: c
 
         #include <qiskit.h>
         // Create a sparse observable representing the Hamiltonian

--- a/releasenotes/notes/qdrift-c-api-addition-122bb199ff2dc83b.yaml
+++ b/releasenotes/notes/qdrift-c-api-addition-122bb199ff2dc83b.yaml
@@ -1,0 +1,33 @@
+---
+prelude: >
+    Replace this text with content to appear at the top of the section for this
+    release. All of the prelude content is merged together and then rendered
+    separately from the items listed in other parts of the file, so the text
+    needs to be worded so that both the prelude and the other items make sense
+    when read independently. This may mean repeating some details. Not every
+    release note requires a prelude. Usually only notes describing major
+    features or adding release theme details should have a prelude.
+features:
+  - |
+    List new features here, or remove this section.  All of the list items in
+    this section are combined when the release notes are rendered, so the text
+    needs to be worded so that it does not depend on any information only
+    available in another section, such as the prelude. This may mean repeating
+    some details. If the feature note is contained within one of the modules
+    listed below you should use the appropriate subsection instead.
+features_c:
+  - |
+    Introduced a new feature in the C API circuit library to synthesize QDRIFT
+    circuits. The function `qk_circuit_library_qdrift` allows users to create
+    quantum circuits that approximate the time evolution under a given sparse
+    observable using the QDRIFT algorithm. For example::
+
+        #include <qiskit.h>
+        // Create a sparse observable representing the Hamiltonian
+        QkObs *obs = qk_obs_zero(2); // 2-qubit observable
+        // Add terms to the observable (e.g., Pauli strings with coefficients)
+        QkBitTerm bit_term[2] = {QkBitTerm_Z, QkBitTerm_Z};
+        QkComplex64 coeff = {1, 0};
+        uint32_t indices[2] = {0, 1};
+        QkObsTerm term_2 = {coeff, 2, bit_term, indices, 2};
+        code = qk_obs_add_term(obs, &term_2);

--- a/test/c/test_basis_translator.c
+++ b/test/c/test_basis_translator.c
@@ -38,7 +38,7 @@ static int test_circuit_in_basis(void) {
     if (circuit_len != 2) {
         result = EqualityError;
         printf(
-            "The number of gates resulting from the translation is incorrect. Expected 2, got %lu",
+            "The number of gates resulting from the translation is incorrect. Expected 2, got %zu",
             circuit_len);
         goto cleanup;
     }
@@ -85,7 +85,7 @@ static int test_basic_basis_translator(void) {
     if (result_op_counts.len != 1) {
         result = EqualityError;
         printf(
-            "The number of gates resulting from the translation is incorrect. Expected 1, got %lu",
+            "The number of gates resulting from the translation is incorrect. Expected 1, got %zu",
             result_op_counts.len);
         goto cleanup;
     }
@@ -126,7 +126,7 @@ static int test_toffoli_basis_translator(void) {
     if (result_op_counts.len != 4) {
         result = EqualityError;
         printf(
-            "The number of gates resulting from the translation is incorrect. Expected 1, got %lu",
+            "The number of gates resulting from the translation is incorrect. Expected 1, got %zu",
             result_op_counts.len);
         goto cleanup;
     }

--- a/test/c/test_consolidate_blocks.c
+++ b/test/c/test_consolidate_blocks.c
@@ -258,7 +258,7 @@ static int test_non_cx_target(void) {
     if (counts.len != 1) {
         result = EqualityError;
         printf("The pass run did not result in a circuit with one unitary gate. Expected 1 gate, "
-               "got %li.",
+               "got %zu.",
                counts.len);
         goto cleanup;
     }

--- a/test/c/test_qdrift.c
+++ b/test/c/test_qdrift.c
@@ -45,8 +45,8 @@ static int test_qdrift_single_zz(void) {
 
     size_t instr_count = qk_circuit_num_instructions(circ);
     if (instr_count != 1) {
-        printf("Expected 1 instruction for single ZZ term, got %lu\n",
-               (unsigned long)instr_count);
+        printf("Expected 1 instruction for single ZZ term, got %zu\n",
+               instr_count);
         result = EqualityError;
         goto cleanup_circ;
     }
@@ -120,8 +120,8 @@ static int test_qdrift_xi_plus_zz(void) {
     // For H = XI + ZZ, lambda = 2, t = 0.5, reps = 1:
     // num_gates = ceil(2 * lambda^2 * t^2 * reps) = ceil(2) = 2.
     if (instr_count != 2) {
-        printf("Expected 2 instructions for XI+ZZ, got %lu\n",
-               (unsigned long)instr_count);
+        printf("Expected 2 instructions for XI+ZZ, got %zu\n",
+               instr_count);
         result = EqualityError;
         goto cleanup_circ;
     }
@@ -204,7 +204,7 @@ static int test_qdrift_gate_count_scaling(void) {
 
         size_t n = qk_circuit_num_instructions(circ);
         if (n != 1) {
-            printf("[scaling] Expected 1 gate, got %lu\n", (unsigned long)n);
+            printf("[scaling] Expected 1 gate, got %zu\n", n);
             result = EqualityError;
         }
         qk_circuit_free(circ);
@@ -219,7 +219,7 @@ static int test_qdrift_gate_count_scaling(void) {
 
         size_t n = qk_circuit_num_instructions(circ);
         if (n != 2) {
-            printf("[scaling] Expected 2 gates, got %lu\n", (unsigned long)n);
+            printf("[scaling] Expected 2 gates, got %zu\n", n);
             result = EqualityError;
         }
         qk_circuit_free(circ);
@@ -234,7 +234,7 @@ static int test_qdrift_gate_count_scaling(void) {
 
         size_t n = qk_circuit_num_instructions(circ);
         if (n != 4) {
-            printf("[scaling] Expected 4 gates, got %lu\n", (unsigned long)n);
+            printf("[scaling] Expected 4 gates, got %zu\n", n);
             result = EqualityError;
         }
         qk_circuit_free(circ);
@@ -374,7 +374,7 @@ static int test_qdrift_non_pauli_as_pauli(void) {
     }
 
     size_t instr_count = qk_circuit_num_instructions(circ);
-    printf("[plus] QDRIFT produced %lu instructions\n", (unsigned long)instr_count);
+    printf("[plus] QDRIFT produced %zu instructions\n", instr_count);
 
     for (size_t k = 0; k < instr_count; ++k) {
         QkCircuitInstruction instr;
@@ -382,16 +382,16 @@ static int test_qdrift_non_pauli_as_pauli(void) {
 
         // Single-qubit only
         if (instr.num_qubits != 1) {
-            printf("[plus] Instruction %lu has %u qubits (expected 1)\n",
-                   (unsigned long)k, (unsigned)instr.num_qubits);
+            printf("[plus] Instruction %zu has %u qubits (expected 1)\n",
+                   k, instr.num_qubits);
             result = EqualityError;
             goto cleanup_circ;
         }
 
         // Must be qubit 0
         if (instr.qubits[0] != 0) {
-            printf("[plus] Instruction %lu acts on qubit %u (expected 0)\n",
-                   (unsigned long)k, instr.qubits[0]);
+            printf("[plus] Instruction %zu acts on qubit %u (expected 0)\n",
+                   k, instr.qubits[0]);
             result = EqualityError;
             goto cleanup_circ;
         }
@@ -458,8 +458,8 @@ static int test_qdrift_global_phase(void) {
     // Expect no nontrivial instructions for H = I (pure global phase).
     size_t instr_count = qk_circuit_num_instructions(circ);
     if (instr_count != 0) {
-        printf("[global_phase] Expected 0 instructions for identity Hamiltonian, got %lu\n",
-               (unsigned long)instr_count);
+        printf("[global_phase] Expected 0 instructions for identity Hamiltonian, got %zu\n",
+               instr_count);
         // Not necessarily a hard failure, but this likely indicates a bug.
         result = EqualityError;
         // continue anyway to inspect phase

--- a/test/c/test_qdrift.c
+++ b/test/c/test_qdrift.c
@@ -414,6 +414,12 @@ cleanup_obs:
     return result;
 }
 
+/*
+* Test QDRIFT circuit synthesis correctly accounts for global phase from
+* identity terms in the observable.
+* Note: the 2 pi periodicity of global phase means we check the result
+* modulo 2 pi.
+*/
 static int test_qdrift_global_phase(void) {
     int result = Ok;
     QkExitCode code;

--- a/test/c/test_qdrift.c
+++ b/test/c/test_qdrift.c
@@ -1,0 +1,501 @@
+/**
+* This code is part of Qiskit.
+*
+* (C) Copyright IBM 2025
+*
+* This code is licensed under the Apache License, Version 2.0. You may
+* obtain a copy of this license in the LICENSE.txt file in the root directory
+* of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+*
+* Any modifications or derivative works of this code must retain this
+* copyright notice, and modified files need to carry a notice indicating
+* that they have been altered from the originals.
+**/
+#include "common.h"
+#include <math.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <qiskit.h>
+
+/*
+* Test QDRIFT circuit synthesis for a single ZZ term.
+* All possible valid outcomes: [ZZ]
+*/
+static int test_qdrift_single_zz(void) {
+    int result = Ok;
+    QkExitCode code;
+
+    // Build H = Z0 Z1, 2-qubit system
+    QkObs *obs = qk_obs_zero(2);
+
+    QkBitTerm bit_terms[2] = {QkBitTerm_Z, QkBitTerm_Z};
+    QkComplex64 coeff = {1, 0};
+    uint32_t indices[2] = {0, 1};
+    QkObsTerm term = {coeff, 2, bit_terms, indices, 2};
+    code = qk_obs_add_term(obs, &term);
+
+    QkCircuit *circ = NULL;
+    code = qk_circuit_library_qdrift(obs, 1, 0.5, &circ);
+    if (code != QkExitCode_Success || circ == NULL) {
+        printf("qk_circuit_library_qdrift single ZZ failed with code %u\n", code);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    size_t instr_count = qk_circuit_num_instructions(circ);
+    if (instr_count != 1) {
+        printf("Expected 1 instruction for single ZZ term, got %lu\n",
+               (unsigned long)instr_count);
+        result = EqualityError;
+        goto cleanup_circ;
+    }
+
+    QkCircuitInstruction instr;
+    qk_circuit_get_instruction(circ, 0, &instr);
+
+    if (strcmp(instr.name, "rzz") != 0 && strcmp(instr.name, "zz") != 0) {
+        printf("Expected ZZ-type gate ('rzz' or 'zz'), got '%s'\n", instr.name);
+        result = EqualityError;
+        goto cleanup_circ;
+    }
+
+    if (instr.num_qubits != 2) {
+        printf("Expected ZZ instruction on 2 qubits, got %u\n",
+               (unsigned)instr.num_qubits);
+        result = EqualityError;
+        goto cleanup_circ;
+    }
+
+    uint32_t q0 = instr.qubits[0];
+    uint32_t q1 = instr.qubits[1];
+    if (!((q0 == 0 && q1 == 1) || (q0 == 1 && q1 == 0))) {
+        printf("Expected ZZ gate on qubits {0,1}, got {%u,%u}\n", q0, q1);
+        result = EqualityError;
+        goto cleanup_circ;
+    }
+
+cleanup_circ:
+    qk_circuit_free(circ);
+cleanup:
+    qk_obs_free(obs);
+    return result;
+}
+
+/* 
+* Test QDRIFT circuit synthesis for the observable H = XI + ZZ.
+* All possible valid outcomes: [XI, XI], [ZZ, ZZ], [XI, ZZ] or [ZZ, XI]. 
+*/
+static int test_qdrift_xi_plus_zz(void) {
+    int result = Ok;
+    QkExitCode code;
+
+    // 2-qubit observable H = XI + ZZ
+    QkObs *obs = qk_obs_zero(2);
+
+    // Term 1: X on qubit 1 (XI).
+    QkBitTerm bit_term_1[1] = {QkBitTerm_X};
+    QkComplex64 coeff_1 = {1, 0};
+    uint32_t indices_1[1] = {1};
+    QkObsTerm term_1 = {coeff_1, 1, bit_term_1, indices_1, 2};
+    code = qk_obs_add_term(obs, &term_1);
+
+    // Term 2: ZZ on qubits {0,1}.
+    QkBitTerm bit_term_2[2] = {QkBitTerm_Z, QkBitTerm_Z};
+    QkComplex64 coeff_2 = {1, 0};
+    uint32_t indices_2[2] = {0, 1};
+    QkObsTerm term_2 = {coeff_2, 2, bit_term_2, indices_2, 2};
+    code = qk_obs_add_term(obs, &term_2);
+
+    QkCircuit *circ = NULL;
+    code = qk_circuit_library_qdrift(obs, 1, 0.5, &circ);
+    if (code != QkExitCode_Success || circ == NULL) {
+        printf("qk_circuit_library_qdrift XI+ZZ failed with code %u\n", code);
+        result = EqualityError;
+        goto cleanup;
+    }
+
+    size_t instr_count = qk_circuit_num_instructions(circ);
+
+    // For H = XI + ZZ, lambda = 2, t = 0.5, reps = 1:
+    // num_gates = ceil(2 * lambda^2 * t^2 * reps) = ceil(2) = 2.
+    if (instr_count != 2) {
+        printf("Expected 2 instructions for XI+ZZ, got %lu\n",
+               (unsigned long)instr_count);
+        result = EqualityError;
+        goto cleanup_circ;
+    }
+
+    // Because QDRIFT is stochastic, we don't assert *which* terms appear where.
+    // We just check all instructions are either X-like or ZZ-like and on the
+    // expected qubits.
+
+    for (size_t k = 0; k < instr_count; ++k) {
+        QkCircuitInstruction instr;
+        qk_circuit_get_instruction(circ, k, &instr);
+
+        if (strcmp(instr.name, "rx") == 0 || strcmp(instr.name, "x") == 0) {
+            // X-type
+            if (instr.num_qubits != 1) {
+                printf("X-type instruction expected on 1 qubit, got %u\n",
+                       (unsigned)instr.num_qubits);
+                result = EqualityError;
+                goto cleanup_circ;
+            }
+            // Expect qubit 1 for XI → ("X", [1])
+            if (instr.qubits[0] != 1) {
+                printf("X term expected on qubit 1, got %u\n", instr.qubits[0]);
+                result = EqualityError;
+                goto cleanup_circ;
+            }
+        } else if (strcmp(instr.name, "rzz") == 0 || strcmp(instr.name, "zz") == 0) {
+            // ZZ-type
+            if (instr.num_qubits != 2) {
+                printf("ZZ-type instruction expected on 2 qubits, got %u\n",
+                       (unsigned)instr.num_qubits);
+                result = EqualityError;
+                goto cleanup_circ;
+            }
+            uint32_t q0 = instr.qubits[0];
+            uint32_t q1 = instr.qubits[1];
+            if (!((q0 == 0 && q1 == 1) || (q0 == 1 && q1 == 0))) {
+                printf("ZZ term expected on qubits {0,1}, got {%u,%u}\n", q0, q1);
+                result = EqualityError;
+                goto cleanup_circ;
+            }
+        } else {
+            printf("Unexpected instruction name: %s\n", instr.name);
+            result = EqualityError;
+            goto cleanup_circ;
+        }
+    }
+
+cleanup_circ:
+    qk_circuit_free(circ);
+cleanup:
+    qk_obs_free(obs);
+    return result;
+}
+
+/*
+* Test QDRIFT gate count scaling with time and repetitions.
+* Expected gate counts:
+*   t=0.5, reps=1  -> 1 gate
+*   t=1.0, reps=1  -> 2 gates
+*   t=1.0, reps=2  -> 4 gates
+*/
+static int test_qdrift_gate_count_scaling(void) {
+    int result = Ok;
+    QkExitCode code;
+
+    QkObs *obs = qk_obs_zero(1);
+
+    QkBitTerm bits[1] = {QkBitTerm_X};
+    uint32_t idxs[1] = {0};
+    QkComplex64 coeff = {1, 0};
+    QkObsTerm term = {coeff, 1, bits, idxs, 1};
+    qk_obs_add_term(obs, &term);
+
+    /* Case A: t=0.5 → num_gates = 1 */
+    {
+        QkCircuit *circ = NULL;
+        code = qk_circuit_library_qdrift(obs, 1, 0.5, &circ);
+        if (code != QkExitCode_Success) return EqualityError;
+
+        size_t n = qk_circuit_num_instructions(circ);
+        if (n != 1) {
+            printf("[scaling] Expected 1 gate, got %lu\n", (unsigned long)n);
+            result = EqualityError;
+        }
+        qk_circuit_free(circ);
+        if (result != Ok) goto cleanup;
+    }
+
+    /* Case B: t=1.0 → num_gates = 2 */
+    {
+        QkCircuit *circ = NULL;
+        code = qk_circuit_library_qdrift(obs, 1, 1.0, &circ);
+        if (code != QkExitCode_Success) return EqualityError;
+
+        size_t n = qk_circuit_num_instructions(circ);
+        if (n != 2) {
+            printf("[scaling] Expected 2 gates, got %lu\n", (unsigned long)n);
+            result = EqualityError;
+        }
+        qk_circuit_free(circ);
+        if (result != Ok) goto cleanup;
+    }
+
+    /* Case C: reps=2, t=1.0 → num_gates = 4 */
+    {
+        QkCircuit *circ = NULL;
+        code = qk_circuit_library_qdrift(obs, 2, 1.0, &circ);
+        if (code != QkExitCode_Success) return EqualityError;
+
+        size_t n = qk_circuit_num_instructions(circ);
+        if (n != 4) {
+            printf("[scaling] Expected 4 gates, got %lu\n", (unsigned long)n);
+            result = EqualityError;
+        }
+        qk_circuit_free(circ);
+        if (result != Ok) goto cleanup;
+    }
+
+cleanup:
+    qk_obs_free(obs);
+    return result;
+}
+
+/*
+* Test QDRIFT circuit synthesis produces valid qubit indices.
+*/
+static int test_qdrift_qubit_bounds(void) {
+    int result = Ok;
+    QkExitCode code;
+
+    QkObs *obs = qk_obs_zero(4);
+
+    // Add X on each qubit independently.
+    for (uint32_t q = 0; q < 4; ++q) {
+        QkBitTerm bit[1] = {QkBitTerm_X};
+        uint32_t idx[1] = {q};
+        QkComplex64 coeff = {1, 0};
+        QkObsTerm term = {coeff, 1, bit, idx, 1};
+        code = qk_obs_add_term(obs, &term);
+        if (code != QkExitCode_Success) {
+            printf("[bounds] Failed add term at q=%u\n", q);
+            result = EqualityError;
+            goto cleanup_obs;
+        }
+    }
+
+    QkCircuit *circ = NULL;
+    code = qk_circuit_library_qdrift(obs, 1, 1.0, &circ);
+    if (code != QkExitCode_Success || !circ) {
+        printf("[bounds] QDRIFT failed\n");
+        result = EqualityError;
+        goto cleanup_obs;
+    }
+
+    size_t n = qk_circuit_num_instructions(circ);
+    for (size_t k = 0; k < n; ++k) {
+        QkCircuitInstruction instr;
+        qk_circuit_get_instruction(circ, k, &instr);
+
+        for (size_t i = 0; i < instr.num_qubits; ++i) {
+            if (instr.qubits[i] >= 4) {
+                printf("[bounds] Out-of-range qubit %u\n", instr.qubits[i]);
+                result = EqualityError;
+                goto cleanup_circ;
+            }
+        }
+    }
+
+cleanup_circ:
+    qk_circuit_free(circ);
+cleanup_obs:
+    qk_obs_free(obs);
+    return result;
+}
+
+/*
+* Test QDRIFT rejects invalid repetition counts.
+*/
+static int test_qdrift_invalid_reps(void) {
+    int result = Ok;
+    QkExitCode code;
+
+    QkObs *obs = qk_obs_zero(1);
+
+    QkBitTerm bit_term[1] = {QkBitTerm_X};
+    QkComplex64 coeff = {1, 0};
+    uint32_t indices[1] = {0};
+    QkObsTerm term = {coeff, 1, bit_term, indices, 1};
+
+    code = qk_obs_add_term(obs, &term);
+
+    QkCircuit *circ = NULL;
+    code = qk_circuit_library_qdrift(obs, 0, 0.5, &circ);
+    if (code == QkExitCode_Success) {
+        printf("qk_circuit_library_qdrift unexpectedly succeeded with reps=0\n");
+        result = EqualityError;
+        // still free any circuit if allocated
+        if (circ != NULL) {
+            qk_circuit_free(circ);
+        }
+        goto cleanup;
+    }
+
+cleanup:
+    qk_obs_free(obs);
+    return result;
+}
+
+/*
+* Test QDRIFT circuit synthesis for a non-Pauli observable, in this case the 
+* projector onto the +1 eigenstate of X: |+><+| = (I + X)/2.
+* and the projector onto the +1 eigenstate of Y: |R><R| = (I + Y)/2.
+* All possible valid outcomes: [X, X], [X, Y], [Y, X], [Y, Y], [I, I], [I, X], [X, I], [I, Y], [Y, I]
+* Paulis are chosen with weights I = 0.5, X = 0.25, Y = 0.25 since QDrift samples terms with probability 
+* proportional to their coefficient magnitudes.
+*/
+static int test_qdrift_non_pauli_as_pauli(void) {
+    int result = Ok;
+    QkExitCode code;
+
+    // 1-qubit observable: H = |+><+| = (I + X)/2
+    QkObs *obs = qk_obs_zero(1);
+    if (!obs) {
+        printf("[plus] qk_obs_zero(1) failed\n");
+        return EqualityError;
+    }
+
+    // Non-Pauli operator: Projector onto + eigenstate of X.
+    // QkBitTerm_Plus is the projector.
+    QkBitTerm bits[1] = { QkBitTerm_Plus };
+    uint32_t idxs[1] = { 0 };
+    QkComplex64 coeff = {1, 0};
+    QkObsTerm term = {coeff, 1, bits, idxs, 1};
+
+    QkBitTerm bits2[1] = { QkBitTerm_Right };
+    uint32_t idxs2[1] = { 0 };
+    QkObsTerm term2 = {coeff, 1, bits2, idxs2, 1};
+
+    qk_obs_add_term(obs, &term);
+    qk_obs_add_term(obs, &term2);
+
+    // Run QDRIFT for time t=1.0
+    QkCircuit *circ = NULL;
+    code = qk_circuit_library_qdrift(obs, 1, 1.0, &circ);
+    if (code != QkExitCode_Success || !circ) {
+        printf("[plus] QDRIFT failed: %u\n", code);
+        result = EqualityError;
+        goto cleanup_obs;
+    }
+
+    size_t instr_count = qk_circuit_num_instructions(circ);
+    printf("[plus] QDRIFT produced %lu instructions\n", (unsigned long)instr_count);
+
+    for (size_t k = 0; k < instr_count; ++k) {
+        QkCircuitInstruction instr;
+        qk_circuit_get_instruction(circ, k, &instr);
+
+        // Single-qubit only
+        if (instr.num_qubits != 1) {
+            printf("[plus] Instruction %lu has %u qubits (expected 1)\n",
+                   (unsigned long)k, (unsigned)instr.num_qubits);
+            result = EqualityError;
+            goto cleanup_circ;
+        }
+
+        // Must be qubit 0
+        if (instr.qubits[0] != 0) {
+            printf("[plus] Instruction %lu acts on qubit %u (expected 0)\n",
+                   (unsigned long)k, instr.qubits[0]);
+            result = EqualityError;
+            goto cleanup_circ;
+        }
+
+        // Only allowed gate: rx, x, ry, y
+        if (strcmp(instr.name, "rx") != 0 && strcmp(instr.name, "x") != 0 &&
+            strcmp(instr.name, "ry") != 0 && strcmp(instr.name, "y") != 0) {
+            printf("[plus] Unexpected gate '%s' (expected 'rx' or 'x')\n",
+                   instr.name);
+            result = EqualityError;
+            goto cleanup_circ;
+        }
+    }
+
+cleanup_circ:
+    qk_circuit_free(circ);
+cleanup_obs:
+    qk_obs_free(obs);
+    return result;
+}
+
+static int test_qdrift_global_phase(void) {
+    int result = Ok;
+    QkExitCode code;
+
+    // Build H = 1 * I on 1 qubit.
+    QkObs *obs = qk_obs_zero(1);
+    if (!obs) {
+        printf("[global_phase] qk_obs_zero(1) failed\n");
+        return EqualityError;
+    }
+
+    // Identity term: no bits, no indices.
+    QkComplex64 coeff = {1, 0};
+    // Dummy arrays of length 1, never used because len = 0, but non-null.
+    QkBitTerm dummy_bits[1] = { QkBitTerm_X };   // value doesn’t matter
+    uint32_t  dummy_idxs[1] = { 0 };             // value doesn’t matter
+
+    QkObsTerm term_I = {
+        coeff,
+        1,            // num_qubits in the observable
+        dummy_bits,   // non-null pointer
+        dummy_idxs,   // non-null pointer
+        0             // len = 0  → identity term
+    };
+
+    code = qk_obs_add_term(obs, &term_I);
+    if (code != QkExitCode_Success) {
+        printf("[global_phase] qk_obs_add_term(I) failed: %u\n", code);
+        result = EqualityError;
+        goto cleanup_obs;
+    }
+
+    // Evolve for time t = 1.0, reps = 1.
+    double time = 1.0;
+    QkCircuit *circ = NULL;
+    code = qk_circuit_library_qdrift(obs, 1, time, &circ);
+    if (code != QkExitCode_Success || !circ) {
+        printf("[global_phase] qk_circuit_library_qdrift failed: %u\n", code);
+        result = EqualityError;
+        goto cleanup_obs;
+    }
+
+    // Expect no nontrivial instructions for H = I (pure global phase).
+    size_t instr_count = qk_circuit_num_instructions(circ);
+    if (instr_count != 0) {
+        printf("[global_phase] Expected 0 instructions for identity Hamiltonian, got %lu\n",
+               (unsigned long)instr_count);
+        // Not necessarily a hard failure, but this likely indicates a bug.
+        result = EqualityError;
+        // continue anyway to inspect phase
+    }
+
+    // Global phase check 
+    double phase = qk_circuit_get_global_phase(circ);
+
+    // Mathematically, for H = I, global phase should be ~ -time.
+    double expected = -time;
+
+    if (fabs(phase - expected) > 1e-6) {
+        printf("[global_phase] Expected global phase ~ %g, got %g\n",
+               expected, phase);
+        result = EqualityError;
+    }
+
+    qk_circuit_free(circ);
+cleanup_obs:
+    qk_obs_free(obs);
+    return result;
+}
+
+int test_qdrift(void) {
+    int num_failed = 0;
+
+    num_failed += RUN_TEST(test_qdrift_single_zz);
+    num_failed += RUN_TEST(test_qdrift_xi_plus_zz);
+    num_failed += RUN_TEST(test_qdrift_gate_count_scaling);
+    num_failed += RUN_TEST(test_qdrift_qubit_bounds);
+    num_failed += RUN_TEST(test_qdrift_invalid_reps);
+    num_failed += RUN_TEST(test_qdrift_non_pauli_as_pauli);
+    num_failed += RUN_TEST(test_qdrift_global_phase);
+
+    fflush(stderr);
+    fprintf(stderr, "=== QDRIFT: Number of failed subtests: %i\n", num_failed);
+
+    return num_failed;
+}


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

This pull request implements QDrift Trotterization within the C circuit library.


### Details and comments

As part of the implementation, some things were made public:

`pauli_evolution` module from the Rust `circuit_library` crate, a type alias within that module `Instruction`, and a function `sparse_term_evolution`

The implementation was loosely based on the Python version, but is grounded in the mathematics from the paper: [https://arxiv.org/abs/1811.08017](https://arxiv.org/abs/1811.08017)

Tests were created for valid observables, invalid observables, gate count scaling, invalid repetitions, observables containing projectors, and global phase.