### PR TITLE
Fix typos in StatevectorEstimator docstring

### DIFF
--- a/qiskit/primitives/statevector_estimator.py
+++ b/qiskit/primitives/statevector_estimator.py
@@ -38,7 +38,7 @@ class StatevectorEstimator(BaseEstimatorV2):
     observables.
 
     Each tuple of ``(circuit, observables, <optional> parameter values, <optional> precision)``,
-    called an estimator primitive unified block (PUB), produces its own array-based result. The
+    called an estimator primitive unified bloc (PUB), produces its own array-based result. The
     :meth:`~.StatevectorEstimator.run` method can be given a sequence of pubs to run in one call.
 
 

--- a/qiskit/primitives/statevector_estimator.py
+++ b/qiskit/primitives/statevector_estimator.py
@@ -38,13 +38,14 @@ class StatevectorEstimator(BaseEstimatorV2):
     observables.
 
     Each tuple of ``(circuit, observables, <optional> parameter values, <optional> precision)``,
-    called an estimator primitive unified bloc (PUB), produces its own array-based result. The
-    :meth:`~.EstimatorV2.run` method can be given a sequence of pubs to run in one call.
+    called an estimator primitive unified block (PUB), produces its own array-based result. The
+    :meth:`~.StatevectorEstimator.run` method can be given a sequence of pubs to run in one call.
+
 
     .. note::
         The result of this class is exact if the circuit contains only unitary operations.
         On the other hand, the result could be stochastic if the circuit contains a non-unitary
-        operation such as a reset for a some subsystems.
+        operation such as a reset for some subsystems.
         The stochastic result can be made reproducible by setting ``seed``, e.g.,
         ``StatevectorEstimator(seed=123)``.
 


### PR DESCRIPTION
This PR fixes several typos in the `StatevectorEstimator` docstring:

* `bloc` → `block` in the definition of the Primitive Unified Block (PUB).
* Fixes the grammatical error `for a some subsystems` → `for some subsystems`.
* Updates the method reference from `EstimatorV2.run` to `StatevectorEstimator.run` for clarity.

No functional changes.

