### PR TITLE
Bug fix for Clifford+T transpilation: passing incorrect argument to `generate_unroll_3q`

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -47,6 +47,7 @@ from qiskit.transpiler.passes.optimization import (
     RemoveIdentityEquivalent,
     ContractIdleWiresInControlFlow,
 )
+from qiskit.transpiler.optimization_metric import OptimizationMetric
 from qiskit.transpiler.passes import Depth, Size, FixedPoint, MinimumPoint
 from qiskit.transpiler.passes.utils.gates_basis import GatesInBasis
 from qiskit.transpiler.passes.synthesis.unitary_synthesis import UnitarySynthesis
@@ -74,6 +75,10 @@ class DefaultInitPassManager(PassManagerStagePlugin):
     """Plugin class for default init stage."""
 
     def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
+        if pass_manager_config._is_clifford_t:
+            optimization_metric = OptimizationMetric.COUNT_T
+        else:
+            optimization_metric = OptimizationMetric.COUNT_2Q
 
         if optimization_level == 0:
             init = None
@@ -93,7 +98,7 @@ class DefaultInitPassManager(PassManagerStagePlugin):
                     pass_manager_config.unitary_synthesis_plugin_config,
                     pass_manager_config.hls_config,
                     pass_manager_config.qubits_initially_zero,
-                    pass_manager_config._is_clifford_t,
+                    optimization_metric,
                 )
         elif optimization_level == 1:
             init = PassManager()
@@ -113,7 +118,7 @@ class DefaultInitPassManager(PassManagerStagePlugin):
                     pass_manager_config.unitary_synthesis_plugin_config,
                     pass_manager_config.hls_config,
                     pass_manager_config.qubits_initially_zero,
-                    pass_manager_config._is_clifford_t,
+                    optimization_metric,
                 )
             init.append(
                 [
@@ -131,7 +136,7 @@ class DefaultInitPassManager(PassManagerStagePlugin):
                 pass_manager_config.unitary_synthesis_plugin_config,
                 pass_manager_config.hls_config,
                 pass_manager_config.qubits_initially_zero,
-                pass_manager_config._is_clifford_t,
+                optimization_metric,
             )
             if pass_manager_config.routing_method != "none":
                 init.append(ElidePermutations())

--- a/releasenotes/notes/fix-clifford-t-transpilation-3e5c76eb7f8e11cd.yaml
+++ b/releasenotes/notes/fix-clifford-t-transpilation-3e5c76eb7f8e11cd.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug when transpiling into a Clifford+T basis, where a Clifford+T basis
+    was not interpreted as such, leading to significantly more T-gates in the
+    transpiled circuit.

--- a/test/python/transpiler/test_clifford_t_passmanager.py
+++ b/test/python/transpiler/test_clifford_t_passmanager.py
@@ -143,6 +143,26 @@ class TestCliffordTPassManager(QiskitTestCase):
         self.assertLessEqual(set(transpiled.count_ops()), set(basis_gates))
 
     @data(0, 1, 2, 3)
+    def test_multiplier(self, optimization_level):
+        """Clifford+T transpilation of a multiplier gate, using different optimization levels."""
+        gate = MultiplierGate(4)
+        qc = QuantumCircuit(gate.num_qubits)
+        qc.append(gate, qc.qubits)
+
+        # Transpile to a Clifford+T basis set
+        basis_gates = get_clifford_gate_names() + ["t", "tdg"]
+        pm = generate_preset_pass_manager(
+            basis_gates=basis_gates, optimization_level=optimization_level, seed_transpiler=0
+        )
+        transpiled = pm.run(qc)
+        self.assertLessEqual(set(transpiled.count_ops()), set(basis_gates))
+        t_count = _get_t_count(transpiled)
+
+        # expected T-count based on optimization level
+        expected_t_count = {0: 1085, 1: 1083, 2: 1071, 3: 1071}
+        self.assertEqual(_get_t_count(transpiled), 0)
+
+    @data(0, 1, 2, 3)
     def test_iqp(self, optimization_level):
         """Clifford+T transpilation of IQP circuits."""
         interactions = np.array([[6, 5, 1], [5, 4, 3], [1, 3, 2]])

--- a/test/python/transpiler/test_clifford_t_passmanager.py
+++ b/test/python/transpiler/test_clifford_t_passmanager.py
@@ -155,12 +155,16 @@ class TestCliffordTPassManager(QiskitTestCase):
             basis_gates=basis_gates, optimization_level=optimization_level, seed_transpiler=0
         )
         transpiled = pm.run(qc)
+
         self.assertLessEqual(set(transpiled.count_ops()), set(basis_gates))
         t_count = _get_t_count(transpiled)
 
-        # expected T-count based on optimization level
-        expected_t_count = {0: 1085, 1: 1083, 2: 1071, 3: 1071}
-        self.assertEqual(_get_t_count(transpiled), 0)
+        # This is the T-count with optimization level 0.
+        # We should not expect to see more T-gates with higher optimization levels
+        # (while this is technically possible, it means that Clifford+T transpiler
+        # pipeline is not setup correctly).
+        expected_t_count = 1085
+        self.assertLessEqual(t_count, expected_t_count)
 
     @data(0, 1, 2, 3)
     def test_iqp(self, optimization_level):


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

In #14902 we have added a new argument `optimization_metric` to `generate_unroll_3q`, with the goal of passing this information further down to `HighLevelSynthesis`, allowing it to choose the best decomposition for each (high-level) gate, depending on the optimization metric (currently T-count or CX-count). However, the `DefaultInitPassManager` did not pass this information correctly, and a Clifford+T basis was not interpreted as such when the transpiler optimization level is 2 or 3, leading to significantly more T-gates than expected for multipliers (and other high-level gates with efficient Clifford+T synthesis). This PR fixes this problem and adds a relevant test.

### Details and comments


