### PR TITLE
Remove useless sleep from parallel test

### DIFF
--- a/test/python/utils/test_parallel.py
+++ b/test/python/utils/test_parallel.py
@@ -15,7 +15,6 @@ import os
 import subprocess
 import sys
 import tempfile
-import time
 from unittest import mock
 
 from qiskit.utils import local_hardware_info, should_run_in_parallel, parallel_map
@@ -25,7 +24,6 @@ from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
 def _parfunc(x):
     """Function for testing parallel_map"""
-    time.sleep(1)
     return x
 
 


### PR DESCRIPTION
Most of our platforms no longer parallelise by default, at least without some deliberate setup on the user side.  Having this in the test effectively makes it a go-slow loop.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


