### PR TITLE
Remove unnecessary `tearDown` code

### DIFF
--- a/test/utils/base.py
+++ b/test/utils/base.py
@@ -154,12 +154,6 @@ class QiskitTestCase(BaseTestCase):
             )
         self.__teardown_called = True
 
-        # Reset the default providers, as in practice they acts as a singleton
-        # due to importing the instances from the top-level qiskit namespace.
-        from qiskit.providers.basic_provider import BasicProvider
-
-        BasicProvider()._backends = BasicProvider()._verify_backends()
-
     def assertQuantumCircuitEqual(self, qc1, qc2, msg=None):
         """Extra assertion method to give a better error message when two circuits are unequal."""
         if qc1 == qc2:


### PR DESCRIPTION
The `_backends` instance value on `BasicProvider()` is an instance value, so re-calculating it on each test return no longer has any effect.  The corresponding value _used_ to be a class attribute on `BasicAer`, but this was changed in #11422.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


