### PR TITLE
Stop using a parallel sort in disjoint utils

### DIFF
--- a/crates/transpiler/src/passes/disjoint_layout.rs
+++ b/crates/transpiler/src/passes/disjoint_layout.rs
@@ -18,7 +18,6 @@ use pyo3::create_exception;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyList;
-use rayon::prelude::*;
 use rustworkx_core::connectivity::connected_components;
 use rustworkx_core::petgraph::EdgeType;
 use rustworkx_core::petgraph::prelude::*;
@@ -273,10 +272,10 @@ fn map_components(
         .enumerate()
         .map(|(idx, dag)| (idx, dag.num_qubits()))
         .collect();
-    dag_qubits.par_sort_unstable_by_key(|x| x.1);
+    dag_qubits.sort_unstable_by_key(|x| x.1);
     dag_qubits.reverse();
     let mut cmap_indices = (0..cmap_components.len()).collect::<Vec<_>>();
-    cmap_indices.par_sort_unstable_by_key(|x| free_qubits[*x]);
+    cmap_indices.sort_unstable_by_key(|x| free_qubits[*x]);
     cmap_indices.reverse();
     for (dag_index, dag_num_qubits) in dag_qubits {
         let mut found = false;

--- a/releasenotes/notes/fix_multiprocessing_with_multithreading_bug-948c7ade10f66c60.yaml
+++ b/releasenotes/notes/fix_multiprocessing_with_multithreading_bug-948c7ade10f66c60.yaml
@@ -1,0 +1,13 @@
+---
+fixes:
+  - |
+    Fixed a potential deadlock issue when running layout passes such as :class:`.SabreLayout`
+    with a disjoint connectivity in the :class:`.Target` and in a multiprocessing
+    context from running :meth:`.PassManager.run` or :func:`.transpile` with more
+    than one circuit. On Linux this is the default behavior when running :meth:`.PassManager.run`
+    or :func:`.transpile` with more than one circuit, on all other platforms
+    multiprocessing context has to be opted into. This was due to an underlying issue
+    in CPython tracked in `python/cpython#84559 <https://github.com/python/cpython/issues/84559>`__
+    when mixing multiprocessing and multithreading, typically Qiskit guards against mixing
+    the two methods of parallelism but in the case of handling disjoint connectivity graphs this
+    guard was missing around multithreaded rust code.


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit switches the use of `par_sort_by_unstable()` to the serial `sort_by_unstable()` implementation in the disjoint layout module. While the parallel sort is faster and has some heuristics to limit the multithreaded usage when the overhead isn't worth the tradeoff, the use of multithreading from Rust is potentially fraught when mixing with multiprocessing in Python. For this reason all of our multithreaded calls are supposed to guard against running in parallel based on env vars that indicate the rust code is being executed in a multiprocessing context. However the parallel sorts were missing this check and in this case the overhead of checking we can run in multiple threads will likely outweigh any speedup from a parallel sort. So this commit just opts to drop the parallel sort and avoid the potential complications.

### Details and comments


