### PR TITLE
Fix control-flow builders with uncached Python control-flow

### DIFF
--- a/qiskit/circuit/controlflow/if_else.py
+++ b/qiskit/circuit/controlflow/if_else.py
@@ -239,6 +239,13 @@ class IfElsePlaceholder(InstructionPlaceholder):
             return self.__true_block.registers.copy()
         return self.__true_block.registers | self.__false_block.registers
 
+    @property
+    def blocks(self):
+        """Dummy blocks to allow this to be used duck-typed like a `ControlFlowOp`."""
+        if self.__false_block is None:
+            return (self.__true_block,)
+        return (self.__true_block, self.__false_block)
+
     def _calculate_placeholder_resources(self) -> InstructionResources:
         """Get the placeholder resources (see :meth:`.placeholder_resources`).
 
@@ -321,7 +328,7 @@ class IfContext:
         Terra.
     """
 
-    __slots__ = ("_appended_instructions", "_circuit", "_condition", "_in_loop", "_label")
+    __slots__ = ("_circuit", "_condition", "_in_loop", "_label", "_depth", "_appended")
 
     def __init__(
         self,
@@ -334,8 +341,9 @@ class IfContext:
         self._circuit = circuit
         self._condition = validate_condition(condition)
         self._label = label
-        self._appended_instructions = None
         self._in_loop = in_loop
+        self._depth = None
+        self._appended = False
 
     # Only expose the necessary public interface, and make it read-only.  If Python had friend
     # classes, or a "protected" access modifier, that's what we'd use (since these are only
@@ -362,9 +370,20 @@ class IfContext:
         """Whether this context manager is enclosed within a loop."""
         return self._in_loop
 
+    @property
+    def depth(self) -> int | None:
+        """The depth of this scope in the circuit (if the scope is entered)."""
+        return self._depth
+
+    @property
+    def appended(self) -> bool:
+        """Whether this context has appended its instruction to the circuit."""
+        return self._appended
+
     def __enter__(self):
         resources = condition_resources(self._condition)
-        self._circuit._push_scope(
+        self._appended = False
+        self._depth = self._circuit._push_scope(
             clbits=resources.clbits,
             registers=resources.cregs,
             allow_jumps=self._in_loop,
@@ -385,18 +404,17 @@ class IfContext:
             # resources we use until the containing loop concludes, to support ``break``.
             operation = IfElsePlaceholder(self._condition, true_block, label=self._label)
             resources = operation.placeholder_resources()
-            self._appended_instructions = self._circuit.append(
-                operation, resources.qubits, resources.clbits
-            )
+            self._circuit.append(operation, resources.qubits, resources.clbits)
         else:
             # If we're not in a loop, we don't need to be worried about passing in any outer-scope
             # resources because there can't be anything that will consume them.
             true_body = true_block.build(true_block.qubits(), true_block.clbits())
-            self._appended_instructions = self._circuit.append(
+            self._circuit.append(
                 IfElseOp(self._condition, true_body=true_body, false_body=None, label=self._label),
                 tuple(true_body.qubits),
                 tuple(true_body.clbits),
             )
+        self._appended = True
         return False
 
 
@@ -432,19 +450,25 @@ class ElseContext:
         if self._used:
             raise CircuitError("Cannot re-use an 'else' context.")
         self._used = True
-        appended_instructions = self._if_context.appended_instructions
         circuit = self._if_context.circuit
-        if appended_instructions is None:
+        if not self._if_context.appended:
             raise CircuitError("Cannot attach an 'else' branch to an incomplete 'if' block.")
-        if len(appended_instructions) != 1:
-            # I'm not even sure how you'd get this to trigger, but just in case...
-            raise CircuitError("Cannot attach an 'else' to a broadcasted 'if' block.")
-        appended = appended_instructions[0]
         instruction = circuit._peek_previous_instruction_in_scope()
-        if appended.operation is not instruction.operation:
+        cur_depth = len(circuit._control_flow_scopes)
+        # Basic sanity checks.  We used to do circuit-block identity checks (`appended.operation is
+        # instruction.operation`), but Python-space no longer the owner, these are no longer
+        # entirely reliable.
+        if (
+            instruction.name != "if_else"
+            # There should be no "false" body.
+            or len(instruction.operation.blocks) != 1
+            # The `if` is complete, so the current circuit depth should be one less than the
+            # depth that the `if` represented.
+            or self._if_context.depth != cur_depth + 1
+        ):
             raise CircuitError(
                 "The 'if' block is not the most recent instruction in the circuit."
-                f" Expected to find: {appended!r}, but instead found: {instruction!r}."
+                f" Instead found: {instruction!r}."
             )
         self._if_instruction = circuit._pop_previous_instruction_in_scope()
         if isinstance(self._if_instruction.operation, IfElseOp):

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -6859,7 +6859,7 @@ class QuantumCircuit:
         registers: Iterable[Register] = (),
         allow_jumps: bool = True,
         forbidden_message: Optional[str] = None,
-    ):
+    ) -> int:
         """Add a scope for collecting instructions into this circuit.
 
         This should only be done by the control-flow context managers, which will handle cleaning up
@@ -6871,6 +6871,9 @@ class QuantumCircuit:
             allow_jumps: Whether this scope allows jumps to be used within it.
             forbidden_message: If given, all attempts to add instructions to this scope will raise a
                 :exc:`.CircuitError` with this message.
+
+        Returns:
+            the depth of control-flow scopes (after the push)
         """
         self._control_flow_scopes.append(
             ControlFlowBuilderBlock(
@@ -6882,6 +6885,7 @@ class QuantumCircuit:
                 forbidden_message=forbidden_message,
             )
         )
+        return len(self._control_flow_scopes)
 
     def _pop_scope(self) -> ControlFlowBuilderBlock:
         """Finish a scope used in the control-flow builder interface, and return it to the caller.


### PR DESCRIPTION
The `ElseContext` builder previously relied on referential identity of the `IfElseOp`'s true body, which is no longer stable with the move of control-flow operations to Rust space.  This sanity check is simpler and easier to trick if you try, but it should still catch a proper set of reasonable user errors.

It would be possible to add significantly more complex special handling between Rust space and Python space to make the test less foolable, but this commit is a reasonable trade-off for realistic user errors.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


Fix #15403

There's one more change that needs to be made for #15402 to pass, which I'll do in a separate PR.