### PR TITLE
Restore `QISKIT_NO_CACHE_GATES=1` test in CI

### DIFF
--- a/.github/workflows/on-merge-queue.yml
+++ b/.github/workflows/on-merge-queue.yml
@@ -31,6 +31,7 @@ jobs:
       python-version: "3.10"
       install-optionals: true
       runner: ${{ matrix.runner }}
+      qiskit-pycache: false
   test-linux-3-13:
     name: Python Unit Tests
     if: github.repository_owner == 'Qiskit'

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -42,6 +42,7 @@ jobs:
       python-version: "3.10"
       install-optionals: true
       runner: ${{ matrix.runner }}
+      qiskit-pycache: false
   main-tests-ubuntu-3-13:
     if: github.repository_owner == 'Qiskit'
     name: Python Unit Tests

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -23,6 +23,12 @@ on:
           Decides whether we perform rust tests
         type: boolean
         default: false
+      qiskit-pycache:
+        description: >
+          Whether to include the Python operation cache fields in the Rust
+          structures when building Qiskit.
+        type: boolean
+        default: true
 
 jobs:
   unit-tests:
@@ -54,6 +60,9 @@ jobs:
           set -e
           python -m pip install --upgrade pip setuptools wheel
           python -m venv test-job
+      - name: Set gate-caching settings for build
+        if: ${{ !inputs.qiskit-pycache }}
+        run: 'echo "QISKIT_NO_CACHE_GATES=1" >> $GITHUB_ENV'
       - name: Install Qiskit from sdist
         if: ${{ inputs.install-from-sdist }}
         run: |

--- a/test/python/circuit/test_control_flow_builders.py
+++ b/test/python/circuit/test_control_flow_builders.py
@@ -2107,7 +2107,7 @@ class TestControlFlowBuilders(QiskitTestCase):
             instruction = circuit.data[-1].operation
             self.assertIsInstance(instruction, ForLoopOp)
             _, bound_parameter, _ = instruction.params
-            self.assertIs(bound_parameter, parameter)
+            self.assertEqual(bound_parameter, parameter)
 
         with self.subTest("passed and unused"):
             circuit = QuantumCircuit(1, 1)
@@ -2117,7 +2117,7 @@ class TestControlFlowBuilders(QiskitTestCase):
             instruction = circuit.data[-1].operation
             self.assertIsInstance(instruction, ForLoopOp)
             _, bound_parameter, _ = instruction.params
-            self.assertIs(parameter, received_parameter)
+            self.assertEqual(parameter, received_parameter)
 
         with self.subTest("generated and used"):
             circuit = QuantumCircuit(1, 1)
@@ -2127,7 +2127,7 @@ class TestControlFlowBuilders(QiskitTestCase):
             instruction = circuit.data[-1].operation
             self.assertIsInstance(instruction, ForLoopOp)
             _, bound_parameter, _ = instruction.params
-            self.assertIs(bound_parameter, received_parameter)
+            self.assertEqual(bound_parameter, received_parameter)
 
         with self.subTest("generated and used in deferred-build if"):
             circuit = QuantumCircuit(1, 1)
@@ -2139,7 +2139,7 @@ class TestControlFlowBuilders(QiskitTestCase):
             instruction = circuit.data[-1].operation
             self.assertIsInstance(instruction, ForLoopOp)
             _, bound_parameter, _ = instruction.params
-            self.assertIs(bound_parameter, received_parameter)
+            self.assertEqual(bound_parameter, received_parameter)
 
         with self.subTest("generated and used in deferred-build else"):
             circuit = QuantumCircuit(1, 1)
@@ -2153,7 +2153,7 @@ class TestControlFlowBuilders(QiskitTestCase):
             instruction = circuit.data[-1].operation
             self.assertIsInstance(instruction, ForLoopOp)
             _, bound_parameter, _ = instruction.params
-            self.assertIs(bound_parameter, received_parameter)
+            self.assertEqual(bound_parameter, received_parameter)
 
     def test_for_does_not_bind_generated_parameter_if_unused(self):
         """Test that the ``for`` manager does not bind a generated parameter into the resulting


### PR DESCRIPTION
This restores the CI test with disabled gate caching, which was
accidentally deleted in the move to GitHub Actions (gh-13474).   The
missing test coverage meant we merged some changes around control flow
that still unexpectedly relied on the Python-object cache.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


This _should_ need #15413 to merge before the test suite will pass; I'm just pushing this separately to verify that the configuration is correct.

Close #15402