### PR TITLE
Fix OptimizeCliffordT to avoid throwing an error

### DIFF
--- a/crates/transpiler/src/passes/optimize_clifford_t.rs
+++ b/crates/transpiler/src/passes/optimize_clifford_t.rs
@@ -10,13 +10,13 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-use hashbrown::HashSet;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use std::f64::consts::PI;
 
 use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType};
 use qiskit_circuit::operations::{OperationRef, Param, StandardGate};
+use qiskit_circuit::packed_instruction::PackedInstruction;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
 // The Clifford+T optimization pass only applies to circuits with Clifford+T/Tdg gates.
@@ -99,7 +99,7 @@ impl Clifford1q {
                 self.append_clifford_gate(StandardGate::Z);
                 self.w = (self.w + 6) % 8;
             }
-            _ => unreachable!("should not be here"),
+            _ => unreachable!("should not be here, gate = {:?}", gate),
         }
     }
 
@@ -146,7 +146,7 @@ impl Clifford1q {
                 self.prepend_clifford_gate(StandardGate::X);
                 self.w = (self.w + 6) % 8;
             }
-            _ => unreachable!("should not be here"),
+            _ => unreachable!("should not be here, gate = {:?}", gate),
         }
     }
 
@@ -312,12 +312,26 @@ fn optimize_clifford_t_1q(
 #[pyfunction]
 #[pyo3(name = "optimize_clifford_t")]
 pub fn run_optimize_clifford_t(dag: &mut DAGCircuit) -> PyResult<()> {
-    let namelist: HashSet<String> = CLIFFORD_T_GATE_NAMES
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
+    let filter = |inst: &PackedInstruction| -> bool {
+        matches!(
+            inst.op.view(),
+            OperationRef::StandardGate(
+                StandardGate::I
+                    | StandardGate::X
+                    | StandardGate::Y
+                    | StandardGate::Z
+                    | StandardGate::H
+                    | StandardGate::S
+                    | StandardGate::Sdg
+                    | StandardGate::SX
+                    | StandardGate::SXdg
+                    | StandardGate::T
+                    | StandardGate::Tdg
+            )
+        )
+    };
 
-    let runs: Vec<Vec<NodeIndex>> = dag.collect_runs(namelist).collect();
+    let runs: Vec<Vec<NodeIndex>> = dag.collect_runs_by(filter).collect();
 
     for raw_run in runs {
         let optimized_sequence = optimize_clifford_t_1q(dag, &raw_run);


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

In #14433 we added a simple Clifford+T optimization pass to optimize sequences of consecutive 1-qubit Clifford+T gates in a circuit, and in #14996 we have significantly improved the pass. However, in #14996 we have also made a change to raise an error when the circuit contains non- Clifford+T gates. Probably the (faulty) intuition was that the pass should be only called for pure Clifford+T circuits, but technically this is a breaking change to the pass behavior and in fact we do want to run the pass even with other instructions in the circuit (e.g. measures). This PR fixes this oversight.


### Details and comments

There is no bugfix release note since the faulty behavior was added for 2.3. Also the release note in #14996 is already worded correctly with respect to the expected behavior of the pass.

