### PR TITLE
Add `efficient_su2` with non-perfect match to ASV benchmark

### DIFF
--- a/test/benchmarks/utility_scale.py
+++ b/test/benchmarks/utility_scale.py
@@ -49,6 +49,7 @@ class UtilityScaleBenchmarks:
         self.qaoa_qc = QuantumCircuit.from_qasm_file(self.qaoa_qasm)
         self.qv_qc = build_qv_model_circuit(50, 50, SEED)
         self.circSU2 = efficient_su2(100, reps=3, entanglement="circular")
+        self.circSU2_89 = efficient_su2(89, reps=3, entanglement="circular")
         self.bv_100 = bv_all_ones(100)
         self.bv_like_100 = trivial_bvlike_circuit(100)
 
@@ -112,6 +113,13 @@ class UtilityScaleBenchmarks:
 
     def track_circSU2_depth(self, basis_gate):
         res = self.pm.run(self.circSU2)
+        return res.depth(filter_function=lambda x: x.operation.name == basis_gate)
+
+    def time_circSU2_89(self, _):
+        self.pm.run(self.circSU2_89)
+
+    def track_circSU2_89_depth(self, basis_gate):
+        res = self.pm.run(self.circSU2_89)
         return res.depth(filter_function=lambda x: x.operation.name == basis_gate)
 
     def time_bv_100(self, _):


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Adds a new ASV benchmark for transpiling the `efficient_su2(num_qubits=89)` circuit into the heavy-hex graph. We already have a similar `efficient_su2(num_qubits=100)` benchmark, but for that VF2 can find a perfect mapping. For `89` the perfect mapping does not exist. Note that Benchpress has benchmarks for both `89` and `100` variants.

This benchmark is historically quite bad for sabre due to randomness when selecting the initial mapping, and can be used to track improvements to initial layout selection. In particular, it may be used to show value of `SabrePreLayout` pass (but note that this is off by default).
