### PR TITLE
Add refcounting and free-list in control-flow blocks

### DIFF
--- a/crates/accelerate/src/twirling.rs
+++ b/crates/accelerate/src/twirling.rs
@@ -254,7 +254,7 @@ fn generate_twirled_circuit(
                         custom_gate_map,
                         optimizer_target,
                     )?;
-                    Ok(out_circ.add_block(&new_block.into_py_quantum_circuit(py)?))
+                    Ok(out_circ.add_block(new_block.into_py_quantum_circuit(py)?.unbind()))
                 })
                 .collect::<PyResult<_>>()?;
             out_circ.push(PackedInstruction::from_control_flow(

--- a/crates/circuit/src/blocks.rs
+++ b/crates/circuit/src/blocks.rs
@@ -1,0 +1,323 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2025
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use crate::Block;
+
+/// Internal entry in the block list.
+#[derive(Clone, Debug)]
+pub enum Entry<T> {
+    Occupied {
+        block: T,
+        refcount: u32,
+    },
+    /// The index of the next free entry in the stack, if any.
+    Vacant(Option<Block>),
+}
+impl<T> Entry<T> {
+    #[inline]
+    pub fn block(&self) -> Option<&T> {
+        match self {
+            Self::Occupied { block, refcount: _ } => Some(block),
+            Self::Vacant(_) => None,
+        }
+    }
+    #[inline]
+    pub fn block_mut(&mut self) -> Option<&mut T> {
+        match self {
+            Self::Occupied { block, refcount: _ } => Some(block),
+            Self::Vacant(_) => None,
+        }
+    }
+    #[inline]
+    pub fn refcount(&self) -> Option<u32> {
+        match self {
+            Self::Occupied { block: _, refcount } => Some(*refcount),
+            Self::Vacant(_) => None,
+        }
+    }
+
+    #[inline]
+    pub fn refcount_mut(&mut self) -> Option<&mut u32> {
+        match self {
+            Self::Occupied { block: _, refcount } => Some(refcount),
+            Self::Vacant(_) => None,
+        }
+    }
+    #[inline]
+    pub fn clone_without_references(&self) -> Self
+    where
+        T: Clone,
+    {
+        match self {
+            Self::Occupied { block, refcount: _ } => Self::Occupied {
+                block: block.clone(),
+                refcount: 0,
+            },
+            Self::Vacant(next) => Self::Vacant(*next),
+        }
+    }
+    pub fn try_map_without_reference<B, E>(
+        &self,
+        map_fn: impl FnOnce(&T) -> Result<B, E>,
+    ) -> Result<Entry<B>, E> {
+        match self {
+            Self::Occupied { block, refcount: _ } => {
+                map_fn(block).map(|block| Entry::Occupied { block, refcount: 0 })
+            }
+            Self::Vacant(free) => Ok(Entry::Vacant(*free)),
+        }
+    }
+}
+
+/// Storage for the blocks used by control-flow objects in a circuit representation.
+///
+/// Blocks are stored and associated with indices (a [Block]) that is stable with respect to removal
+/// of blocks and usable as an index.  The [Block] indices are _not_ guaranteed to be contiguous for
+/// a given storage, since removal of blocks may leave holes.
+///
+/// The structure tracks the holes in its distributed [Block] values using a free list, so adding
+/// more blocks after removals will re-use previous [Block] values.
+#[derive(Clone, Debug)]
+pub struct ControlFlowBlocks<T> {
+    /// The backing storage for the blocks.
+    entries: Vec<Entry<T>>,
+    /// The top of the free-list stack.
+    free: Option<Block>,
+    /// How many of the `entries` are vacant.
+    num_free: usize,
+}
+
+impl<T> ControlFlowBlocks<T> {
+    #[inline]
+    pub fn new() -> Self {
+        Self::with_capacity(0)
+    }
+    #[inline]
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            entries: Vec::with_capacity(cap),
+            free: None,
+            num_free: 0,
+        }
+    }
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.free = None;
+        self.num_free = 0;
+    }
+
+    /// Clone this tracker, retaining the exact structure of it including the block ids and free
+    /// list, but set the refcount of every block to 0.
+    pub fn clone_without_references(&self) -> Self
+    where
+        T: Clone,
+    {
+        Self {
+            entries: self
+                .entries
+                .iter()
+                .map(Entry::clone_without_references)
+                .collect(),
+            free: self.free,
+            num_free: self.num_free,
+        }
+    }
+    /// Create a new tracker that has the same keys and free list, but with the blocks mapped to
+    /// another type.
+    ///
+    /// The converter function can be fallible.
+    pub fn try_map_without_references<B, E>(
+        &self,
+        mut map_fn: impl FnMut(&T) -> Result<B, E>,
+    ) -> Result<ControlFlowBlocks<B>, E> {
+        let entries = self
+            .entries
+            .iter()
+            .map(|entry| entry.try_map_without_reference(&mut map_fn))
+            .collect::<Result<_, _>>()?;
+        Ok(ControlFlowBlocks {
+            entries,
+            free: self.free,
+            num_free: self.num_free,
+        })
+    }
+    /// Create a new tracker that has the same keys and free list, but with the blocks mapped to
+    /// another type.
+    pub fn map_without_references<B>(
+        &self,
+        mut map_fn: impl FnMut(&T) -> B,
+    ) -> ControlFlowBlocks<B> {
+        let Ok(entries) = self
+            .entries
+            .iter()
+            .map(|entry| entry.try_map_without_reference(|b| Ok(map_fn(b))))
+            .collect::<Result<_, ::std::convert::Infallible>>();
+        ControlFlowBlocks {
+            entries,
+            free: self.free,
+            num_free: self.num_free,
+        }
+    }
+
+    /// How many blocks are present (whether or not they have references).
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.entries.len() - self.num_free
+    }
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.entries.len() == self.num_free
+    }
+
+    /// Get a block, if it exists.  For the (more usual) panicking variant, use the `Index` or
+    /// `IndexMut` implementations like `blocks[block]`.
+    pub fn get(&self, block: Block) -> Option<&T> {
+        self.entries
+            .get(block.index())
+            .and_then(|entry| entry.block())
+    }
+    /// Get a block, if it exists.  For the (more usual) panicking variant, use the `Index` or
+    /// `IndexMut` implementations like `blocks[block]`.
+    pub fn get_mut(&mut self, block: Block) -> Option<&mut T> {
+        self.entries
+            .get_mut(block.index())
+            .and_then(|entry| entry.block_mut())
+    }
+
+    fn push_with_refcount(&mut self, block: T, refcount: u32) -> Block {
+        let entry = Entry::Occupied { block, refcount };
+        match self.free {
+            Some(out) => {
+                let Entry::Vacant(slot) =
+                    ::std::mem::replace(&mut self.entries[out.index()], entry)
+                else {
+                    panic!("only empty slots should be in the free list");
+                };
+                self.free = slot;
+                self.num_free -= 1;
+                out
+            }
+            None => {
+                debug_assert_eq!(self.num_free, 0);
+                let out = Block::new(self.entries.len());
+                self.entries.push(entry);
+                out
+            }
+        }
+    }
+    /// Add a new block with a reference already set.  Returns the new id.
+    ///
+    /// Use [push] if you want to push a block to the system without adding a reference to it.
+    #[inline]
+    pub fn push_with_reference(&mut self, block: T) -> Block {
+        self.push_with_refcount(block, 1)
+    }
+    /// Add a new block, but leave its refcount at 0.  Returns the new id.
+    ///
+    /// Use [push_with_reference] if your intention is to immediately reference the block.
+    #[inline]
+    pub fn push(&mut self, block: T) -> Block {
+        self.push_with_refcount(block, 0)
+    }
+
+    /// Decrement the refcount of a block, removing and returning if it this was the last reference.
+    ///
+    /// Panics if the block is not present, or already had no references.
+    pub fn decrement(&mut self, block: Block) -> Option<T> {
+        match &mut self.entries[block.index()] {
+            Entry::Occupied {
+                block: _,
+                refcount: 0,
+            }
+            | Entry::Vacant(_) => panic!("should not attempt decrement of unreferenced block"),
+            node @ Entry::Occupied {
+                block: _,
+                refcount: 1,
+            } => {
+                self.num_free += 1;
+                let Entry::Occupied { block, refcount: 1 } =
+                    ::std::mem::replace(node, Entry::Vacant(self.free.replace(block)))
+                else {
+                    unreachable!("pattern is the same as in the 'match' arm, but owned");
+                };
+                Some(block)
+            }
+            Entry::Occupied { block: _, refcount } => {
+                *refcount -= 1;
+                None
+            }
+        }
+    }
+
+    /// Increment the refcount of a block.
+    ///
+    /// Panics if the block is not present.
+    pub fn increment(&mut self, block: Block) {
+        let refcount = self.entries[block.index()]
+            .refcount_mut()
+            .expect("should not attempt increment of absent block");
+        *refcount += 1;
+    }
+
+    /// Iterator over the blocks in the tracker.
+    pub fn blocks(&self) -> impl Iterator<Item = &T> {
+        self.entries.iter().filter_map(Entry::block)
+    }
+    /// Iterator over mutable blocks in the tracker.
+    pub fn blocks_mut(&mut self) -> impl Iterator<Item = &mut T> {
+        self.entries.iter_mut().filter_map(Entry::block_mut)
+    }
+
+    /// Iterator over the blocks and their indices.
+    pub fn items(&self) -> impl Iterator<Item = (Block, &T)> {
+        self.entries
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, entry)| entry.block().map(|block| (Block::new(idx), block)))
+    }
+    /// Iterator over mutable blocks and their indices.
+    pub fn items_mut(&mut self) -> impl Iterator<Item = (Block, &mut T)> {
+        self.entries
+            .iter_mut()
+            .enumerate()
+            .filter_map(|(idx, entry)| entry.block_mut().map(|block| (Block::new(idx), block)))
+    }
+
+    pub fn iter_raw(&self) -> impl ExactSizeIterator<Item = (Block, &Entry<T>)> {
+        self.entries
+            .iter()
+            .enumerate()
+            .map(|(i, entry)| (Block::new(i), entry))
+    }
+}
+
+impl<T> ::std::ops::Index<Block> for ControlFlowBlocks<T> {
+    type Output = T;
+    fn index(&self, index: Block) -> &T {
+        self.get(index)
+            .expect("caller should only use live block references")
+    }
+}
+impl<T> ::std::ops::IndexMut<Block> for ControlFlowBlocks<T> {
+    fn index_mut(&mut self, index: Block) -> &mut T {
+        self.get_mut(index)
+            .expect("caller should only use live block references")
+    }
+}
+
+// We can't derive `Default` because the derivation logic only triggers if `T: Default`, even though
+// that's not actually required.
+impl<T> Default for ControlFlowBlocks<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/circuit/src/converters.rs
+++ b/crates/circuit/src/converters.rs
@@ -17,9 +17,8 @@ use crate::bit::{ShareableClbit, ShareableQubit};
 use crate::circuit_data::{CircuitData, CircuitVar};
 use crate::dag_circuit::DAGIdentifierInfo;
 use crate::dag_circuit::{DAGCircuit, NodeType};
-use crate::object_registry::{ObjectRegistry, PyObjectAsKey};
+use crate::imports;
 use crate::operations::{OperationRef, PythonOperation};
-use crate::{Block, imports};
 
 /// An extractable representation of a QuantumCircuit reserved only for
 /// conversion purposes.
@@ -57,22 +56,14 @@ pub fn circuit_to_dag(
 
 #[pyfunction(signature = (dag, copy_operations = true))]
 pub fn dag_to_circuit(dag: &DAGCircuit, copy_operations: bool) -> PyResult<CircuitData> {
-    let blocks = {
-        let dag_blocks = dag.iter_blocks();
-        let mut registry: ObjectRegistry<Block, PyObjectAsKey> =
-            ObjectRegistry::with_capacity(dag_blocks.len());
-        if dag_blocks.len() > 0 {
-            Python::attach(|py| -> PyResult<()> {
-                let dag_to_circuit = imports::DAG_TO_CIRCUIT.get_bound(py);
-                for dag_block in dag_blocks {
-                    let block = dag_to_circuit.call1((dag_block.clone(),))?;
-                    registry.add(PyObjectAsKey::new(&block), false)?;
-                }
-                Ok(())
-            })?
-        }
-        registry
-    };
+    let blocks = dag.blocks().try_map_without_references(|block| {
+        Python::attach(|py| {
+            imports::DAG_TO_CIRCUIT
+                .get_bound(py)
+                .call1((block.clone(),))
+                .map(|ob| ob.unbind())
+        })
+    })?;
     CircuitData::from_packed_instructions(
         dag.qubits().clone(),
         dag.clbits().clone(),

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -6072,13 +6072,9 @@ impl DAGCircuit {
 
     /// Apply a [PackedInstruction] to the back of the circuit.
     ///
-    /// The provided `instr` MUST be valid for this DAG, e.g. its
-    /// bits, registers, vars, and interner IDs must be valid in
-    /// this DAG.
-    ///
-    /// This is mostly used to apply operations from one DAG to
-    /// another that was created from the first via
-    /// [DAGCircuit::copy_empty_like].
+    /// The caller must already have arranged for any interned tracking fields (such as `qubits`,
+    /// `clbits` and any `Block`s) to have been added to the DAG.  The function may panic, or other
+    /// produce an invalid data structure if not.
     #[inline]
     pub fn push_back(&mut self, instr: PackedInstruction) -> PyResult<NodeIndex> {
         self.push_external(instr, Direction::Outgoing)
@@ -6086,13 +6082,9 @@ impl DAGCircuit {
 
     /// Apply a [PackedInstruction] to the front of the circuit.
     ///
-    /// The provided `instr` MUST be valid for this DAG, e.g. its
-    /// bits, registers, vars, and interner IDs must be valid in
-    /// this DAG.
-    ///
-    /// This is mostly used to apply operations from one DAG to
-    /// another that was created from the first via
-    /// [DAGCircuit::copy_empty_like].
+    /// The caller must already have arranged for any interned tracking fields (such as `qubits`,
+    /// `clbits` and any `Block`s) to have been added to the DAG.  The function may panic, or other
+    /// produce an invalid data structure if not.
     #[inline]
     pub fn push_front(&mut self, instr: PackedInstruction) -> PyResult<NodeIndex> {
         self.push_external(instr, Direction::Incoming)

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -15,6 +15,7 @@ use std::env;
 pub mod annotation;
 pub mod bit;
 pub mod bit_locator;
+mod blocks;
 pub mod circuit_data;
 pub mod circuit_instruction;
 pub mod classical;
@@ -63,6 +64,7 @@ pub struct Stretch(u32);
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct Block(u32);
 
+pub use blocks::ControlFlowBlocks;
 pub use nlayout::PhysicalQubit;
 pub use nlayout::VirtualQubit;
 pub use packed_instruction::BlockMapper;

--- a/crates/transpiler/src/passes/disjoint_layout.rs
+++ b/crates/transpiler/src/passes/disjoint_layout.rs
@@ -32,7 +32,7 @@ use qiskit_circuit::imports::ImportOnceCell;
 use qiskit_circuit::operations::{Operation, OperationRef, Param, StandardInstruction};
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::{
-    Block, BlockMapper, BlocksMode, Clbit, PhysicalQubit, Qubit, VarsMode, VirtualQubit,
+    BlockMapper, BlocksMode, Clbit, PhysicalQubit, Qubit, VarsMode, VirtualQubit,
 };
 
 create_exception!(qiskit, MultiQEncountered, pyo3::exceptions::PyException);
@@ -212,9 +212,9 @@ pub fn distribute_components(dag: &mut DAGCircuit, target: &Target) -> PyResult<
                     out_dag.add_creg(creg.clone())?;
                 }
                 let block_map = dag
-                    .iter_blocks()
-                    .enumerate()
-                    .map(|(index, block)| (Block::new(index), out_dag.add_block(block.clone())))
+                    .blocks()
+                    .items()
+                    .map(|(index, block)| (index, out_dag.add_block(block.clone())))
                     .collect();
                 out_dag.compose(
                     dag,
@@ -461,7 +461,7 @@ fn separate_dag(dag: &mut DAGCircuit) -> PyResult<Vec<DAGCircuit>> {
                     let mapped_clbits: Vec<Clbit> =
                         new_dag.cargs_interner().get(node.clbits).to_vec();
                     let mapped_params = node.params.as_deref().map(|p| {
-                        block_map.map_params(p, |b| new_dag.add_block(dag.view_block(b).clone()))
+                        block_map.map_params(p, |b| new_dag.add_block(dag.blocks()[b].clone()))
                     });
                     new_dag.apply_operation_back(
                         node.op.clone(),

--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -578,7 +578,7 @@ fn run_on_circuitdata(
                 let blocks: Vec<_> = Python::attach(|py| {
                     cf.blocks()
                         .into_iter()
-                        .map(|b| output_circuit.add_block(b.bind(py)))
+                        .map(|b| output_circuit.add_block(b.clone_ref(py)))
                         .collect()
                 });
                 output_circuit.push(PackedInstruction {
@@ -641,7 +641,7 @@ fn run_on_circuitdata(
 
             let blocks = new_blocks_py
                 .into_iter()
-                .map(|b| output_circuit.add_block(&b))
+                .map(|b| output_circuit.add_block(b.unbind()))
                 .collect();
             let packed_instruction = PackedInstruction::from_control_flow(
                 inst.op.control_flow().clone(),

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -2688,6 +2688,7 @@ class TestDagSubstituteNode(QiskitTestCase):
         dag.add_creg(cr1)
         dag.add_creg(cr2)
         node = dag.apply_operation_back(IfElseOp(expr.logic_not(cr1), body.copy(), None), qr, [])
+        self.assertEqual(dag.num_blocks(), 1)  # Sanity check.
         dag.substitute_node(node, IfElseOp(expr.equal(cr1, 0), body.copy(), None), inplace=inplace)
 
         expected = DAGCircuit()
@@ -2697,6 +2698,9 @@ class TestDagSubstituteNode(QiskitTestCase):
         expected.apply_operation_back(IfElseOp(expr.equal(cr1, 0), body.copy(), None), qr, [])
 
         self.assertEqual(dag, expected)
+        # If the below assertion fails, `substitute_node` most likely failed to track the refcounts
+        # correctly / failed to free a block after the substitution.
+        self.assertEqual(dag.num_blocks(), 1)
 
     @data(True, False)
     def test_reject_replace_if_else_op_with_other_resources(self, inplace):


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This replaces the tracking of the control-flow blocks in `CircuitData` and `DAGCircuit` with a custom stable-index list of blocks, imbibed with a free list (implemented as an in-place stack), where each block counts its number of references.  With the current control-flow setup, we do not actually expect any valid circuit to increase the refcount of a given block beyond 1, but since the stable-index and free-list form of the object already required a custom `Entry` type to distinguish the cases: present and referenced; present and not referenced; and absent; the `refcount` field came for free anyway.

This updates `CircuitData` and `DAGCircuit` to keep these refcounts up-to-date as the circuit is modified, and to immediately free blocks whose refcount drops to zero (by default).

Automatic freeing of the blocks is necessary to prevent (effective) memory leaks when calling methods like `DAGCircuit.substitute_node`, which is a necessary call when a control-flow operation (like `BoxOp`) is mutated from Python space to update it.


### Details and comments

The main point here is that we previously effectively had memory leaks in `DAGCircuit` and the control-flow builder interface of `QuantumCircuit`; we wouldn't ever _remove_ blocks from a circuit.  There are two main places we actually expect this to have a huge effect:

- when you enter the `ElseContext` of the `QuantumCircuit.if_test` builder, it pops off the old instruction and then replaces it.  If we didn't free the `true` body, which we didn't before this PR, we'd duplicate its block.
- when calling `DAGCircuit` substitution methods, like `DAGCircuit.substitute_node` to resync Python space to Rust space (as is the solution to #15409), we would keep the old block around, which would mean that many modifications would hugely spike the memory use.

Tracking ref-counts and freeing loose slots has the knock-on effect of `Block` no longer being necessarily contiguous in a circuit.  We _could_ restore that if, instead of refcounts, we kept references to the circuit indices that used each block, kept the blocks in a `Vec` (like before this PR), used `swap_remove` on removal, and updated the instructions that used the now-moved block.  For now, though, we just use the non-contiguous stable indices.