### PR TITLE
Fix timeline drawer for gates without unitary in target

### DIFF
--- a/qiskit/visualization/timeline/generators.py
+++ b/qiskit/visualization/timeline/generators.py
@@ -106,7 +106,6 @@ import warnings
 from typing import List, Union, Dict, Any, Optional
 
 from qiskit.circuit import Qubit, QuantumCircuit
-from qiskit.circuit.exceptions import CircuitError
 from qiskit.visualization.timeline import types, drawings
 
 
@@ -132,11 +131,6 @@ def gen_sched_gate(
         List of `TextData` or `BoxData` drawings.
     """
     try:
-        unitary = str(gate.operand.to_matrix())
-    except (AttributeError, CircuitError):
-        unitary = "n/a"
-
-    try:
         label = gate.operand.label or "n/a"
     except AttributeError:
         label = "n/a"
@@ -147,7 +141,6 @@ def gen_sched_gate(
         "bits": gate.bits,
         "t0": gate.t0,
         "duration": gate.duration,
-        "unitary": unitary,
         "parameters": ", ".join(map(str, gate.operand.params)),
     }
 

--- a/releasenotes/notes/fix_unitary_timeline_drawer-97f111b040574bf8.yaml
+++ b/releasenotes/notes/fix_unitary_timeline_drawer-97f111b040574bf8.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :func:`.timeline_drawer` visualization function
+    where it would error when visualizing a scheduled circuit from a target
+    that had parameterized gates in the target with a duration set.

--- a/test/python/visualization/timeline/test_generators.py
+++ b/test/python/visualization/timeline/test_generators.py
@@ -61,7 +61,6 @@ class TestGates(QiskitTestCase):
             "bits": [self.qubit],
             "t0": 100,
             "duration": 20,
-            "unitary": "[[1.+0.j 0.-0.j]\n [0.+0.j 1.+0.j]]",
             "parameters": "0, 0, 0",
         }
         self.assertDictEqual(ref_meta, drawing_obj.meta)


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The timeline drawer was storing the unitary of a gate from the target in the metadata collected around drawing properties for some reason. This field was never used by anything but was in the metadata dictionary used for visualization. However, if there is a gate without a unitary in the target (such as a parameterized gate like `RGate(theta, phi)` which has a duration then this would error. Since we don't use the unitary for anything there is no reason to collect. This commit fixes the issue by removing the unitary from this internal metadata dictionary.

### Details and comments


