### PR TITLE
Unify `ControlFlowView::try_from_instruction`

### DIFF
--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -17,12 +17,16 @@ use std::num::NonZero;
 use std::sync::Arc;
 use std::{fmt, vec};
 
+use crate::bit::{ClassicalRegister, ShareableClbit};
 use crate::circuit_data::CircuitData;
+use crate::classical::expr;
+use crate::duration::Duration;
+use crate::packed_instruction::PackedInstruction;
 use crate::parameter::parameter_expression::{
     ParameterExpression, PyParameter, PyParameterExpression,
 };
 use crate::parameter::symbol_expr::{Symbol, Value};
-use crate::{Qubit, gate_matrix, impl_intopyobject_for_copy_pyclass, imports};
+use crate::{ControlFlowBlocks, Qubit, gate_matrix, impl_intopyobject_for_copy_pyclass, imports};
 
 use nalgebra::{Matrix2, Matrix4};
 use ndarray::{Array2, ArrayView2, Dim, ShapeBuilder, array, aview2};
@@ -30,9 +34,6 @@ use num_bigint::BigUint;
 use num_complex::Complex64;
 use smallvec::{SmallVec, smallvec};
 
-use crate::bit::{ClassicalRegister, ShareableClbit};
-use crate::classical::expr;
-use crate::duration::Duration;
 use numpy::{IntoPyArray, PyArray2, PyReadonlyArray2, ToPyArray};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -688,7 +689,10 @@ impl Operation for ControlFlowInstruction {
 /// An ergonomic view of a control flow operation and its blocks.
 #[derive(Clone, Debug)]
 pub enum ControlFlowView<'a, T> {
-    Box(Option<&'a BoxDuration>, &'a T),
+    Box {
+        duration: Option<&'a BoxDuration>,
+        body: &'a T,
+    },
     BreakLoop,
     ContinueLoop,
     ForLoop {
@@ -703,7 +707,7 @@ pub enum ControlFlowView<'a, T> {
     },
     Switch {
         target: &'a SwitchTarget,
-        cases_specifier: Vec<(&'a Vec<CaseSpecifier>, &'a T)>,
+        cases_specifier: Vec<(&'a [CaseSpecifier], &'a T)>,
     },
     While {
         condition: &'a Condition,
@@ -712,9 +716,69 @@ pub enum ControlFlowView<'a, T> {
 }
 
 impl<'a, T> ControlFlowView<'a, T> {
+    /// Produce a complete control-flow view object from the given instruction.
+    ///
+    /// While [CircuitData] and [DAGCircuit] both provide `try_view_control_flow` methods which just
+    /// delegate to this internally, this function is useful for a) code de-duplication and b)
+    /// finer-grained borrow-check control from within the `impl` blocks of [CircuitData] and
+    /// [DAGCircuit].
+    ///
+    /// Panics or produces invalid results if `inst` and `blocks` aren't from compatible sources
+    /// (e.g. the same [CircuitData]).
+    pub fn try_from_instruction(
+        inst: &'a PackedInstruction,
+        blocks: &'a ControlFlowBlocks<T>,
+    ) -> Option<Self> {
+        let OperationRef::ControlFlow(cf) = inst.op.view() else {
+            return None;
+        };
+        let block_ids = inst.blocks_view();
+        let view = match &cf.control_flow {
+            ControlFlow::Box {
+                duration,
+                annotations: _,
+            } => Self::Box {
+                duration: duration.as_ref(),
+                body: &blocks[block_ids[0]],
+            },
+            ControlFlow::BreakLoop => Self::BreakLoop,
+            ControlFlow::ContinueLoop => Self::ContinueLoop,
+            ControlFlow::ForLoop {
+                collection,
+                loop_param,
+            } => Self::ForLoop {
+                collection,
+                loop_param: loop_param.as_ref(),
+                body: &blocks[block_ids[0]],
+            },
+            ControlFlow::IfElse { condition } => Self::IfElse {
+                condition,
+                true_body: &blocks[block_ids[0]],
+                false_body: block_ids.get(1).map(|bid| &blocks[*bid]),
+            },
+            ControlFlow::Switch {
+                target,
+                label_spec,
+                cases: _,
+            } => Self::Switch {
+                target,
+                cases_specifier: label_spec
+                    .iter()
+                    .zip(block_ids)
+                    .map(|(cases, bid)| (cases.as_slice(), &blocks[*bid]))
+                    .collect(),
+            },
+            ControlFlow::While { condition } => Self::While {
+                condition,
+                body: &blocks[block_ids[0]],
+            },
+        };
+        Some(view)
+    }
+
     pub fn blocks(&self) -> Vec<&'a T> {
         match self {
-            ControlFlowView::Box(_, body) => vec![*body],
+            ControlFlowView::Box { body, .. } => vec![*body],
             ControlFlowView::BreakLoop => vec![],
             ControlFlowView::ContinueLoop => vec![],
             ControlFlowView::ForLoop { body, .. } => vec![*body],


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

`CircuitData` and `DAGCircuit` had two independent implementations of this logic.  This originally stemmed from `CircuitData` using a different internal storage mechanism for the control-flow blocks, but since these were unified into the `ControlFlowBlocks` ref-counted storage, it becomes easily possible to unify the control-flow viewing logic.

This has a knock-on advantage of exposing a finer-grained borrow-check model for the construction of the control-flow views, which is useful for logic _within_ `CircuitData` (such as the `track_parameters` logic) which wants to mutate part of the `CircuitData` state while still producing these immutable control-flow borrows.


### Details and comments

Built on #15420