### PR TITLE
Automatically determine `coeffs` type in `SparsePauliOp.from_sparse_list`

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -798,7 +798,7 @@ class SparsePauliOp(LinearOp):
 
     @staticmethod
     def from_list(
-        obj: Iterable[tuple[str, complex]], dtype: type = complex, *, num_qubits: int = None
+        obj: Iterable[tuple[str, complex]], dtype: type | None = None, *, num_qubits: int = None
     ) -> SparsePauliOp:
         """Construct from a list of Pauli strings and coefficients.
 
@@ -821,7 +821,8 @@ class SparsePauliOp(LinearOp):
 
         Args:
             obj (Iterable[Tuple[str, complex]]): The list of 2-tuples specifying the Pauli terms.
-            dtype (type): The dtype of coeffs (Default: complex).
+            dtype (type | None): Data type for the coefficients. If None, the dtype is automatically
+            inferred. Default is None.
             num_qubits (int): The number of qubits of the operator (Default: None).
 
         Returns:
@@ -848,6 +849,12 @@ class SparsePauliOp(LinearOp):
         if size == 0:
             obj = [("I" * num_qubits, 0)]
             size = len(obj)
+
+        if dtype is None:
+            if any(isinstance(coeff, ParameterExpression) for (_, coeff) in obj):
+                dtype = object
+            else:
+                dtype = complex
 
         coeffs = np.zeros(size, dtype=dtype)
         labels = np.zeros(size, dtype=f"<U{num_qubits}")

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -863,7 +863,6 @@ class SparsePauliOp(LinearOp):
         obj: Iterable[tuple[str, list[int], complex]],
         num_qubits: int,
         do_checks: bool = True,
-        #dtype: type = complex,
         dtype: type | None = None,
     ) -> SparsePauliOp:
         """Construct from a list of local Pauli strings and coefficients.
@@ -896,7 +895,9 @@ class SparsePauliOp(LinearOp):
             num_qubits (int): The number of qubits of the operator.
             do_checks (bool): The flag of checking if the input indices are not duplicated
             (Default: True).
-            dtype (type): The dtype of coeffs (Default: complex).
+            dtype (type | None): Data type for the coefficients. If None, the dtype is automatically 
+            inferred. Default is None.
+
 
         Returns:
             SparsePauliOp: The SparsePauliOp representation of the Pauli terms.
@@ -913,8 +914,7 @@ class SparsePauliOp(LinearOp):
             size = len(obj)
 
         if dtype is None:
-            coeffs_list = [coeff for (_, _, coeff) in obj]
-            if any(isinstance(coeff, ParameterExpression) for coeff in coeffs_list):
+            if any(isinstance(coeff, ParameterExpression) for (_, _, coeff) in obj):
                 dtype = object
             else:
                 dtype = complex

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -863,7 +863,8 @@ class SparsePauliOp(LinearOp):
         obj: Iterable[tuple[str, list[int], complex]],
         num_qubits: int,
         do_checks: bool = True,
-        dtype: type = complex,
+        #dtype: type = complex,
+        dtype: type | None = None,
     ) -> SparsePauliOp:
         """Construct from a list of local Pauli strings and coefficients.
 
@@ -910,6 +911,13 @@ class SparsePauliOp(LinearOp):
         if size == 0:
             obj = [("I" * num_qubits, range(num_qubits), 0)]
             size = len(obj)
+
+        if dtype is None:
+            coeffs_list = [coeff for (_, _, coeff) in obj]
+            if any(isinstance(coeff, ParameterExpression) for coeff in coeffs_list):
+                dtype = object
+            else:
+                dtype = complex
 
         coeffs = np.zeros(size, dtype=dtype)
         labels = np.zeros(size, dtype=f"<U{num_qubits}")

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -895,7 +895,7 @@ class SparsePauliOp(LinearOp):
             num_qubits (int): The number of qubits of the operator.
             do_checks (bool): The flag of checking if the input indices are not duplicated
             (Default: True).
-            dtype (type | None): Data type for the coefficients. If None, the dtype is automatically 
+            dtype (type | None): Data type for the coefficients. If None, the dtype is automatically
             inferred. Default is None.
 
 

--- a/releasenotes/notes/sparse-pauli-op-dtype-inference-a68791c5258404e0.yaml
+++ b/releasenotes/notes/sparse-pauli-op-dtype-inference-a68791c5258404e0.yaml
@@ -1,5 +1,5 @@
 ---
-features_quantum_info:
+fixes:
   - |
     The methods :meth:`.SparsePauliOp.from_list` and 
     :meth:`.SparsePauliOp.from_sparse_list` now automatically 

--- a/releasenotes/notes/sparse-pauli-op-dtype-inference-a68791c5258404e0.yaml
+++ b/releasenotes/notes/sparse-pauli-op-dtype-inference-a68791c5258404e0.yaml
@@ -1,0 +1,24 @@
+---
+features_quantum_info:
+  - |
+    Added the ``dtype`` argument to the :meth:`.SparsePauliOp.from_list` and 
+    :meth:`.SparsePauliOp.from_sparse_list` methods. This allows users to 
+    explicitly specify the data type of the coefficients.
+    
+    Additionally, both methods now automatically infer the coefficient data type 
+    if ``dtype`` is set to ``None``. If :class:`.ParameterExpression` objects are 
+    detected in the input list, the methods will automatically use ``dtype=object``, 
+    removing the need for users to manually specify it in parameterized workflows.
+
+    For example::
+
+        from qiskit.quantum_info import SparsePauliOp
+        from qiskit.circuit import Parameter
+
+        theta = Parameter("theta")
+        
+        # Previously raised an error or required dtype=object
+        op_list = SparsePauliOp.from_list([("X", theta)])
+        
+        # Also works for sparse lists
+        op_sparse = SparsePauliOp.from_sparse_list([("X", [0], theta)], num_qubits=1)

--- a/releasenotes/notes/sparse-pauli-op-dtype-inference-a68791c5258404e0.yaml
+++ b/releasenotes/notes/sparse-pauli-op-dtype-inference-a68791c5258404e0.yaml
@@ -1,15 +1,11 @@
 ---
 features_quantum_info:
   - |
-    Added the ``dtype`` argument to the :meth:`.SparsePauliOp.from_list` and 
-    :meth:`.SparsePauliOp.from_sparse_list` methods. This allows users to 
-    explicitly specify the data type of the coefficients.
-    
-    Additionally, both methods now automatically infer the coefficient data type 
-    if ``dtype`` is set to ``None``. If :class:`.ParameterExpression` objects are 
-    detected in the input list, the methods will automatically use ``dtype=object``, 
-    removing the need for users to manually specify it in parameterized workflows.
-
+    The methods :meth:`.SparsePauliOp.from_list` and 
+    :meth:`.SparsePauliOp.from_sparse_list` now automatically 
+    infer the coefficient data type, if the ``dtype`` argument is 
+    not specified.
+  
     For example::
 
         from qiskit.quantum_info import SparsePauliOp
@@ -17,8 +13,6 @@ features_quantum_info:
 
         theta = Parameter("theta")
         
-        # Previously raised an error or required dtype=object
+        # Previously required manually setting dtype=object
         op_list = SparsePauliOp.from_list([("X", theta)])
-        
-        # Also works for sparse lists
         op_sparse = SparsePauliOp.from_sparse_list([("X", [0], theta)], num_qubits=1)

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+    # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2024.
 #
@@ -220,6 +220,7 @@ class TestSparsePauliOpConversions(QiskitTestCase):
         spp_op = SparsePauliOp.from_sparse_list(zip(paulis, indices, coeffs), num_qubits=3)
         np.testing.assert_array_equal(spp_op.coeffs, coeffs)
         self.assertEqual(spp_op.paulis, PauliList(expected_labels))
+        self.assertEqual(sppop.coeffs.dtype, np.complex128)
 
     def test_from_index_list_parameters(self):
         """Test from_list method specifying the Paulis via indices with parameters."""
@@ -232,6 +233,21 @@ class TestSparsePauliOpConversions(QiskitTestCase):
         )
         np.testing.assert_array_equal(spp_op.coeffs, coeffs)
         self.assertEqual(spp_op.paulis, PauliList(expected_labels))
+        self.assertEqual(sppop.coeffs.dtype, object)
+
+
+    def test_from_sparse_list_dtype_inference(self):
+        """Test from_sparse_list auto-infers dtype correctly."""
+        # infer complex128 dtype.
+        sppop = SparsePauliOp.from_sparse_list(
+            [("X", [0], 1.0), ("Z", [1], 2.0j)], num_qubits=2
+        )
+        self.assertEqual(sppop.coeffs.dtype, np.complex128)
+
+        # infer object dtype due to ParameterExpression.
+        param = Parameter("a")
+        sppop = SparsePauliOp.from_sparse_list([("X", [0], param)], num_qubits=1)
+        self.assertEqual(sppop.coeffs.dtype, object)
 
     def test_from_index_list_endianness(self):
         """Test the construction from index list has the right endianness."""
@@ -276,6 +292,7 @@ class TestSparsePauliOpConversions(QiskitTestCase):
         spp_op = SparsePauliOp.from_sparse_list(iterable, num_qubits)
         self.assertEqual(spp_op.paulis, PauliList("I" * num_qubits))
         np.testing.assert_array_equal(spp_op.coeffs, [0])
+        self.assertEqual(sppop.coeffs.dtype, np.complex128)
 
     def test_to_matrix(self):
         """Test to_matrix method."""

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -246,6 +246,18 @@ class TestSparsePauliOpConversions(QiskitTestCase):
         spp_op = SparsePauliOp.from_sparse_list([("X", [0], param)], num_qubits=1)
         self.assertEqual(spp_op.coeffs.dtype, object)
 
+    def test_from_sparse_list_automatically_determine_coeff_type_regression(self):
+        """Regression test for issue where from_sparse_list failed to infer dtype."""
+        param = Parameter("a")
+
+        op1 = SparsePauliOp.from_sparse_list([("IX", [0, 1], 2), ("ZI", [0, 1], 3)], num_qubits=2)
+        op1 *= param
+
+        op2 = SparsePauliOp.from_sparse_list(op1.to_sparse_list(), num_qubits=2)
+
+        self.assertEqual(op2.paulis, op1.paulis)
+        self.assertEqual(op2.coeffs.dtype, object)
+
     def test_from_index_list_endianness(self):
         """Test the construction from index list has the right endianness."""
         spp_op = SparsePauliOp.from_sparse_list([("ZX", [1, 4], 1)], num_qubits=5)

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -202,6 +202,7 @@ class TestSparsePauliOpConversions(QiskitTestCase):
         spp_op = SparsePauliOp.from_list(zip(labels, coeffs))
         np.testing.assert_array_equal(spp_op.coeffs, coeffs)
         self.assertEqual(spp_op.paulis, PauliList(labels))
+        self.assertEqual(spp_op.coeffs.dtype, np.complex128)
 
     def test_from_list_parameters(self):
         """Test from_list method with parameters."""
@@ -210,9 +211,10 @@ class TestSparsePauliOpConversions(QiskitTestCase):
         spp_op = SparsePauliOp.from_list(zip(labels, coeffs), dtype=object)
         np.testing.assert_array_equal(spp_op.coeffs, coeffs)
         self.assertEqual(spp_op.paulis, PauliList(labels))
+        self.assertEqual(spp_op.coeffs.dtype, object)
 
     def test_from_index_list(self):
-        """Test from_list method specifying the Paulis via indices."""
+        """Test from_sparse_list method specifying the Paulis via indices."""
         expected_labels = ["XXZ", "IXI", "YIZ", "III"]
         paulis = ["XXZ", "X", "YZ", ""]
         indices = [[2, 1, 0], [1], [2, 0], []]
@@ -223,7 +225,7 @@ class TestSparsePauliOpConversions(QiskitTestCase):
         self.assertEqual(spp_op.coeffs.dtype, np.complex128)
 
     def test_from_index_list_parameters(self):
-        """Test from_list method specifying the Paulis via indices with parameters."""
+        """Test from_sparse_list method specifying the Paulis via indices with parameters."""
         expected_labels = ["XXZ", "IXI", "YIZ", "III"]
         paulis = ["XXZ", "X", "YZ", ""]
         indices = [[2, 1, 0], [1], [2, 0], []]
@@ -246,6 +248,17 @@ class TestSparsePauliOpConversions(QiskitTestCase):
         spp_op = SparsePauliOp.from_sparse_list([("X", [0], param)], num_qubits=1)
         self.assertEqual(spp_op.coeffs.dtype, object)
 
+    def test_from_list_dtype_inference(self):
+        """Test from_list auto-infers dtype correctly."""
+        # infer complex128 dtype.
+        spp_op = SparsePauliOp.from_list([("XI", 1.0), ("IZ", 2.0j)])
+        self.assertEqual(spp_op.coeffs.dtype, np.complex128)
+
+        # infer object dtype due to ParameterExpression.
+        param = Parameter("a")
+        spp_op = SparsePauliOp.from_list([("X", param)])
+        self.assertEqual(spp_op.coeffs.dtype, object)
+
     def test_from_sparse_list_automatically_determine_coeff_type_regression(self):
         """Regression test for issue where from_sparse_list failed to infer dtype."""
         param = Parameter("a")
@@ -258,6 +271,18 @@ class TestSparsePauliOpConversions(QiskitTestCase):
         self.assertEqual(op2.paulis, op1.paulis)
         self.assertEqual(op2.coeffs.dtype, object)
 
+    def test_from_list_automatically_determine_coeff_type_regression(self):
+        """Regression test for issue where from_list failed to infer dtype."""
+        param = Parameter("a")
+
+        op1 = SparsePauliOp.from_list([("IX", 2), ("ZI", 3)])
+        op1 *= param
+
+        op2 = SparsePauliOp.from_list(op1.to_list())
+
+        self.assertEqual(op2.paulis, op1.paulis)
+        self.assertEqual(op2.coeffs.dtype, object)
+
     def test_from_index_list_endianness(self):
         """Test the construction from index list has the right endianness."""
         spp_op = SparsePauliOp.from_sparse_list([("ZX", [1, 4], 1)], num_qubits=5)
@@ -265,12 +290,12 @@ class TestSparsePauliOpConversions(QiskitTestCase):
         self.assertEqual(spp_op.paulis[0], expected)
 
     def test_from_index_list_raises(self):
-        """Test from_list via Pauli + indices raises correctly, if number of qubits invalid."""
+        """Test from_sparse_list via Pauli + indices raises correctly, if number of qubits invalid."""
         with self.assertRaises(QiskitError):
             _ = SparsePauliOp.from_sparse_list([("Z", [2], 1)], 1)
 
     def test_from_index_list_same_index(self):
-        """Test from_list via Pauli + number of qubits raises correctly, if indices duplicate."""
+        """Test from_sparse_list via Pauli + number of qubits raises correctly, if indices duplicate."""
         with self.assertRaises(QiskitError):
             _ = SparsePauliOp.from_sparse_list([("ZZ", [0, 0], 1)], 2)
         with self.assertRaises(QiskitError):
@@ -285,6 +310,7 @@ class TestSparsePauliOpConversions(QiskitTestCase):
         spp_op = SparsePauliOp.from_list(zip(labels, coeffs))
         np.testing.assert_array_equal(spp_op.coeffs, coeffs)
         self.assertEqual(spp_op.paulis, PauliList(labels))
+        self.assertEqual(spp_op.coeffs.dtype, np.complex128)
 
     @combine(iterable=[[], (), zip()], num_qubits=[1, 2, 3])
     def test_from_empty_iterable(self, iterable, num_qubits):
@@ -294,6 +320,7 @@ class TestSparsePauliOpConversions(QiskitTestCase):
         spp_op = SparsePauliOp.from_list(iterable, num_qubits=num_qubits)
         self.assertEqual(spp_op.paulis, PauliList("I" * num_qubits))
         np.testing.assert_array_equal(spp_op.coeffs, [0])
+        self.assertEqual(spp_op.coeffs.dtype, np.complex128)
 
     @combine(iterable=[[], (), zip()], num_qubits=[1, 2, 3])
     def test_from_sparse_empty_iterable(self, iterable, num_qubits):
@@ -818,6 +845,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
         target_op = SparsePauliOp.from_list(zip(target_labels, target_coeffs))
         self.assertEqual(simplified_op, target_op)
         np.testing.assert_array_equal(simplified_op.paulis.phase, np.zeros(simplified_op.size))
+        self.assertEqual(spp_op.coeffs.dtype, np.complex128)
 
     @combine(num_qubits=[1, 2, 3, 4], num_adds=[0, 1, 2, 3])
     def test_simplify2(self, num_qubits, num_adds):
@@ -1096,6 +1124,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
         op2 = op1 + 1e-7 * SparsePauliOp.from_list([("I", 1)])
         self.assertFalse(op1.equiv(op2))
         self.assertTrue(op1.equiv(op2, atol=1e-7))
+        self.assertEqual(op1.coeffs.dtype, np.complex128)
 
     def test_eq_equiv(self):
         """Test __eq__ and equiv methods with some specific cases."""

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -1,4 +1,4 @@
-    # This code is part of Qiskit.
+# This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2024.
 #
@@ -220,7 +220,7 @@ class TestSparsePauliOpConversions(QiskitTestCase):
         spp_op = SparsePauliOp.from_sparse_list(zip(paulis, indices, coeffs), num_qubits=3)
         np.testing.assert_array_equal(spp_op.coeffs, coeffs)
         self.assertEqual(spp_op.paulis, PauliList(expected_labels))
-        self.assertEqual(sppop.coeffs.dtype, np.complex128)
+        self.assertEqual(spp_op.coeffs.dtype, np.complex128)
 
     def test_from_index_list_parameters(self):
         """Test from_list method specifying the Paulis via indices with parameters."""
@@ -233,21 +233,18 @@ class TestSparsePauliOpConversions(QiskitTestCase):
         )
         np.testing.assert_array_equal(spp_op.coeffs, coeffs)
         self.assertEqual(spp_op.paulis, PauliList(expected_labels))
-        self.assertEqual(sppop.coeffs.dtype, object)
-
+        self.assertEqual(spp_op.coeffs.dtype, object)
 
     def test_from_sparse_list_dtype_inference(self):
         """Test from_sparse_list auto-infers dtype correctly."""
         # infer complex128 dtype.
-        sppop = SparsePauliOp.from_sparse_list(
-            [("X", [0], 1.0), ("Z", [1], 2.0j)], num_qubits=2
-        )
-        self.assertEqual(sppop.coeffs.dtype, np.complex128)
+        spp_op = SparsePauliOp.from_sparse_list([("X", [0], 1.0), ("Z", [1], 2.0j)], num_qubits=2)
+        self.assertEqual(spp_op.coeffs.dtype, np.complex128)
 
         # infer object dtype due to ParameterExpression.
         param = Parameter("a")
-        sppop = SparsePauliOp.from_sparse_list([("X", [0], param)], num_qubits=1)
-        self.assertEqual(sppop.coeffs.dtype, object)
+        spp_op = SparsePauliOp.from_sparse_list([("X", [0], param)], num_qubits=1)
+        self.assertEqual(spp_op.coeffs.dtype, object)
 
     def test_from_index_list_endianness(self):
         """Test the construction from index list has the right endianness."""
@@ -292,7 +289,7 @@ class TestSparsePauliOpConversions(QiskitTestCase):
         spp_op = SparsePauliOp.from_sparse_list(iterable, num_qubits)
         self.assertEqual(spp_op.paulis, PauliList("I" * num_qubits))
         np.testing.assert_array_equal(spp_op.coeffs, [0])
-        self.assertEqual(sppop.coeffs.dtype, np.complex128)
+        self.assertEqual(spp_op.coeffs.dtype, np.complex128)
 
     def test_to_matrix(self):
         """Test to_matrix method."""


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes https://github.com/Qiskit/qiskit/issues/15423

### Details and comments

Detailed write-up and reasoning [here](https://github.com/Qiskit/qiskit/issues/15423#issuecomment-3626985085)


### TODO:

- [x] https://github.com/Qiskit/qiskit/pull/15427#discussion_r2618386766 
- [x] https://github.com/Qiskit/qiskit/pull/15427#pullrequestreview-3576929597
- [x] https://github.com/Qiskit/qiskit/pull/15427#issuecomment-3716350599

