### PR TITLE
Unify symbol-extraction code in control-flow blocks parameter tracking

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -3414,13 +3414,14 @@ where
     }
 }
 
-/// Perform an action for each `ParameterUse` of a `Symbol` within a control-flow view object.
+/// Perform an action for each `ParameterUse` of a `Symbol` within a control-flow view object from
+/// the given circuit index.
 ///
 /// This encapsulates the logic of both [CircuitData::track_parameters] and
 /// [CircuitData::untrack_parameters].
 fn for_each_symbol_use_in_control_flow<F, E>(
     py: Python,
-    index: usize,
+    instruction_index: usize,
     cf: ControlFlowView<Py<PyAny>>,
     mut action: F,
 ) -> PyResult<()>
@@ -3445,14 +3446,14 @@ where
                 action(
                     symbol,
                     ParameterUse::Index {
-                        instruction: index,
+                        instruction: instruction_index,
                         parameter: 1,
                     },
                 )?;
             }
             // The body is at `params[2]`.
             let usage = ParameterUse::Index {
-                instruction: index,
+                instruction: instruction_index,
                 parameter: 2,
             };
             for symbol in downcast(body)?.borrow().parameters() {
@@ -3468,7 +3469,7 @@ where
         | ControlFlowView::While { .. } => {
             for (idx, body) in cf.blocks().iter().enumerate() {
                 let usage = ParameterUse::Index {
-                    instruction: index,
+                    instruction: instruction_index,
                     parameter: idx as u32,
                 };
                 for symbol in downcast(body)?.borrow().parameters() {


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Previously, the `CircuitData::track_instruction_parameters` and `untrack_instruction_parameters` logic was duplicated for extracting symbols from blocks, which was particularly hard to update because it involves coupled magic numbers.

This factors it out into a single "map" logic, which guarantees that the two will always be in sync with each other.  This wasn't easily possible earlier because of the borrow-check rules on how `CircuitData::try_view_control_flow` worked, but with that factored out to `ControlFlowView::try_from_instruction`, we can now have the finer-grained borrow-check control that lets us do this.

A side effect of `ControlFlowView::try_from_instruction` is that we no longer need to clone blocks in the way the algorithm is written, which is more performant for construction.


### Details and comments

Built on top of #15425.  This is similarly factored out of #15123, so that when we come to that PR, it'll be a much simpler change.
