### PR TITLE
Small fixes to ``QkObs`` docs

### DIFF
--- a/crates/cext/src/sparse_observable.rs
+++ b/crates/cext/src/sparse_observable.rs
@@ -230,15 +230,15 @@ pub unsafe extern "C" fn qk_obs_free(obs: *mut SparseObservable) {
 ///
 /// # Example
 /// ```c
-///     uint32_t num_qubits = 100;
-///     QkObs *obs = qk_obs_zero(num_qubits);
+/// uint32_t num_qubits = 100;
+/// QkObs *obs = qk_obs_zero(num_qubits);
 ///
-///     QkComplex64 coeff = {1, 0};
-///     QkBitTerm bit_terms[3] = {QkBitTerm_X, QkBitTerm_Y, QkBitTerm_Z};
-///     uint32_t indices[3] = {0, 1, 2};
-///     QkObsTerm term = {coeff, 3, bit_terms, indices, num_qubits};
+/// QkComplex64 coeff = {1, 0};
+/// QkBitTerm bit_terms[3] = {QkBitTerm_X, QkBitTerm_Y, QkBitTerm_Z};
+/// uint32_t indices[3] = {0, 1, 2};
+/// QkObsTerm term = {coeff, 3, bit_terms, indices, num_qubits};
 ///
-///     int exit_code = qk_obs_add_term(obs, &term);
+/// QkExitCode exit_code = qk_obs_add_term(obs, &term);
 /// ```
 ///
 /// # Safety
@@ -286,9 +286,9 @@ pub unsafe extern "C" fn qk_obs_add_term(
 /// ```c
 ///     QkObs *obs = qk_obs_identity(100);
 ///     QkObsTerm term;
-///     int exit_code = qk_obs_term(obs, 0, &term);
+///     QkExitCode exit_code = qk_obs_term(obs, 0, &term);
 ///     // out-of-bounds indices return an error code
-///     // int error = qk_obs_term(obs, 12, &term);
+///     // QkExitCode error = qk_obs_term(obs, 12, &term);
 /// ```
 ///
 /// # Safety
@@ -444,24 +444,24 @@ pub unsafe extern "C" fn qk_obs_coeffs(obs: *mut SparseObservable) -> *mut Compl
 ///
 /// # Example
 /// ```c
-///     uint32_t num_qubits = 100;
-///     QkObs *obs = qk_obs_zero(num_qubits);
+/// uint32_t num_qubits = 100;
+/// QkObs *obs = qk_obs_zero(num_qubits);
 ///
-///     QkComplex64 coeff = {1, 0};
-///     QkBitTerm bit_terms[3] = {QkBitTerm_X, QkBitTerm_Y, QkBitTerm_Z};
-///     uint32_t term_indices[3] = {0, 1, 2};
-///     QkObsTerm term = {coeff, 3, bit_terms, term_indices, num_qubits};
-///     qk_obs_add_term(obs, &term);
+/// QkComplex64 coeff = {1, 0};
+/// QkBitTerm bit_terms[3] = {QkBitTerm_X, QkBitTerm_Y, QkBitTerm_Z};
+/// uint32_t term_indices[3] = {0, 1, 2};
+/// QkObsTerm term = {coeff, 3, bit_terms, term_indices, num_qubits};
+/// qk_obs_add_term(obs, &term);
 ///
-///     size_t len = qk_obs_len(obs);
-///     uint32_t *indices = qk_obs_indices(obs);
+/// size_t len = qk_obs_len(obs);
+/// uint32_t *indices = qk_obs_indices(obs);
 ///
-///     for (size_t i = 0; i < len; i++) {
-///         printf("index %i: %i\n", i, indices[i]);
-///     }
+/// for (size_t i = 0; i < len; i++) {
+///     printf("index %i: %i\n", i, indices[i]);
+/// }
+///
+/// qk_obs_free(obs);
 /// ```
-///
-///     qk_obs_free(obs);
 ///
 /// # Safety
 ///
@@ -759,7 +759,7 @@ pub unsafe extern "C" fn qk_obs_compose_map(
 ///
 /// uint32_t layout[3] = {0, 10, 9};  // qubit mapping is: 0->0, 1->10, 2->9
 /// uint32_t num_output_qubits = 11;
-/// int exit = qk_obs_apply_layout(obs, layout, num_output_qubits);
+/// QkExitCode exit = qk_obs_apply_layout(obs, layout, num_output_qubits);
 /// ```
 ///
 /// In a compiler workflow, this function can conveniently be used to apply a
@@ -775,7 +775,7 @@ pub unsafe extern "C" fn qk_obs_compose_map(
 /// qk_transpile_layout_final_layout(transpile_layout, false, layout);
 ///
 /// // apply the layout
-/// int exit = qk_obs_apply_layout(obs, layout, num_output_qubits);
+/// QkExitCode exit = qk_obs_apply_layout(obs, layout, num_output_qubits);
 ///
 /// // free the layout array
 /// free(layout);


### PR DESCRIPTION

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

- A code block didn't include last statement
- prefer `QkExitCode` over plain `int`

### Details and comments

Can be post RC1 too since it's just docs. At some point we should also ensure a consistent indentation of C code snippets but here I'm just fixing the ones where the code actually changed.


