### PR TITLE
Factor out block conversions dependent on foreign types

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -899,16 +899,7 @@ impl CircuitData {
             }
             let py_op = func.call1((self.unpack_py_op(py, instr)?,))?;
             let result = py_op.extract::<OperationFromPython>()?;
-            let params = match result.params {
-                Some(Parameters::Blocks(circuits)) => Some(Box::new(Parameters::Blocks(
-                    circuits
-                        .into_iter()
-                        .map(|circuit| self.blocks.push(circuit))
-                        .collect(),
-                ))),
-                Some(Parameters::Params(params)) => Some(Box::new(Parameters::Params(params))),
-                None => None,
-            };
+            let params = self.extract_blocks_from_circuit_parameters(result.params.as_ref());
             let inst = &mut self.data[index];
             inst.op = result.operation;
             inst.params = params;
@@ -1043,16 +1034,7 @@ impl CircuitData {
             let inst = &self.data[index];
             let qubits = self.qargs_interner.get(inst.qubits);
             let clbits = self.cargs_interner.get(inst.clbits);
-            let params = match inst.params.as_deref() {
-                Some(Parameters::Blocks(blocks)) => Some(Parameters::Blocks(
-                    blocks
-                        .iter()
-                        .map(|block| self.blocks[*block].clone_ref(py))
-                        .collect(),
-                )),
-                Some(Parameters::Params(params)) => Some(Parameters::Params(params.clone())),
-                None => None,
-            };
+            let params = self.unpack_blocks_to_circuit_parameters(inst.params.as_deref());
             CircuitInstruction {
                 operation: inst.op.clone(),
                 qubits: PyTuple::new(py, self.qubits.map_indices(qubits))
@@ -1224,15 +1206,11 @@ impl CircuitData {
                     .collect::<PyResult<Vec<Clbit>>>()?;
                 let qubits_id = self.qargs_interner.insert_owned(qubits);
                 let clbits_id = self.cargs_interner.insert_owned(clbits);
-                let params = match inst.params.as_deref() {
-                    Some(Parameters::Blocks(blocks)) => Some(Box::new(Parameters::Blocks(
-                        blocks
-                            .iter()
-                            .map(|b| self.blocks.push(other.blocks[*b].clone_ref(py)))
-                            .collect(),
-                    ))),
-                    _ => inst.params.clone(),
-                };
+                let params = inst.params.as_ref().map(|params| {
+                    Box::new(
+                        params.map_blocks(|b| self.blocks.push(other.blocks[*b].clone_ref(py))),
+                    )
+                });
                 self.push(PackedInstruction {
                     op: inst.op.clone(),
                     qubits: qubits_id,
@@ -1837,16 +1815,7 @@ impl CircuitData {
                 return Ok(ob.clone_ref(py));
             }
         }
-        let params = match instr.params.as_deref() {
-            Some(Parameters::Blocks(blocks)) => Some(Parameters::Blocks(
-                blocks
-                    .iter()
-                    .map(|b| self.blocks[*b].clone_ref(py))
-                    .collect(),
-            )),
-            Some(Parameters::Params(params)) => Some(Parameters::Params(params.clone())),
-            None => None,
-        };
+        let params = self.unpack_blocks_to_circuit_parameters(instr.params.as_deref());
         let out = instruction::create_py_op(
             py,
             instr.op.view(),
@@ -1877,6 +1846,36 @@ impl CircuitData {
     /// within the circuit.
     pub fn add_block(&mut self, block: Py<PyAny>) -> Block {
         self.blocks.push(block)
+    }
+
+    /// Given a `params` object in terms of owned Python-space circuit objects (such as from an
+    /// `OperationFromPython` extraction), add all the blocks to the circuit and return the `params`
+    /// field suitable for inclusion in a `PackedInstruction`.
+    ///
+    /// The inverse of this method is [unpack_blocks_to_circuit_parameters].
+    fn extract_blocks_from_circuit_parameters(
+        &mut self,
+        params: Option<&Parameters<Py<PyAny>>>,
+    ) -> Option<Box<Parameters<Block>>> {
+        params
+            .map(|params| {
+                params.map_blocks(|block| Python::attach(|py| self.add_block(block.clone_ref(py))))
+            })
+            .map(Box::new)
+    }
+
+    /// Given a `params` object from an instruction packed into this circuit, extract any relevant
+    /// blocks into the owned-object `CircuitData` block type, suitable for passing back to Python
+    /// space.
+    ///
+    /// The inverse of this method is [extract_blocks_from_circuit_parameters].
+    fn unpack_blocks_to_circuit_parameters(
+        &self,
+        params: Option<&Parameters<Block>>,
+    ) -> Option<Parameters<Py<PyAny>>> {
+        params.map(|params| {
+            params.map_blocks(|block| Python::attach(|py| self.blocks[*block].clone_ref(py)))
+        })
     }
 
     /// Gets an immutable view of a control flow operation.
@@ -2587,16 +2586,7 @@ impl CircuitData {
                 .map_objects(inst.clbits.extract::<Vec<ShareableClbit>>(py)?.into_iter())?
                 .collect(),
         );
-        let params = match &inst.params {
-            Some(Parameters::Blocks(circuits)) => Some(Box::new(Parameters::Blocks(
-                circuits
-                    .iter()
-                    .map(|circuit| self.blocks.push(circuit.clone_ref(py)))
-                    .collect(),
-            ))),
-            Some(Parameters::Params(params)) => Some(Box::new(Parameters::Params(params.clone()))),
-            None => None,
-        };
+        let params = self.extract_blocks_from_circuit_parameters(inst.params.as_ref());
         Ok(PackedInstruction {
             op: inst.operation.clone(),
             qubits,

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -5002,7 +5002,7 @@ impl DAGCircuit {
     }
 
     /// Given a `params` object in terms of owned Python-space circuit objects (such as from an
-    /// `OperationFromPython` extraction), add all the blocks to the circuit and return the `params`
+    /// `OperationFromPython` extraction), add all the blocks to the DAG and return the `params`
     /// field suitable for inclusion in a `PackedInstruction`.
     ///
     /// The inverse of this method is [unpack_blocks_to_circuit_parameters].

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -1476,19 +1476,7 @@ impl DAGCircuit {
                     .map_objects(cargs.into_iter().flatten())?
                     .collect(),
             );
-            let params = match py_op.params {
-                Some(Parameters::Blocks(circuits)) => Python::attach(|py| -> PyResult<_> {
-                    let mut blocks = Vec::with_capacity(circuits.len());
-                    for circuit in circuits {
-                        let dag = circuit_to_dag(circuit.extract(py)?, false, None, None)?;
-                        let block = self.blocks.push(dag);
-                        blocks.push(block);
-                    }
-                    Ok(Some(Box::new(Parameters::Blocks(blocks))))
-                })?,
-                Some(Parameters::Params(params)) => Some(Box::new(Parameters::Params(params))),
-                None => None,
-            };
+            let params = self.extract_blocks_from_circuit_parameters(py_op.params.as_ref())?;
             let instr = PackedInstruction {
                 op: py_op.operation,
                 qubits: qubits_id,
@@ -1551,18 +1539,7 @@ impl DAGCircuit {
                     .map_objects(cargs.into_iter().flatten())?
                     .collect(),
             );
-            let params = match py_op.params {
-                Some(Parameters::Blocks(circuits)) => Python::attach(|py| -> PyResult<_> {
-                    let mut blocks = Vec::with_capacity(circuits.len());
-                    for circuit in circuits {
-                        let dag = circuit_to_dag(circuit.extract(py)?, false, None, None)?;
-                        blocks.push(self.blocks.push(dag));
-                    }
-                    Ok(Some(Box::new(Parameters::Blocks(blocks))))
-                })?,
-                Some(Parameters::Params(params)) => Some(Box::new(Parameters::Params(params))),
-                None => None,
-            };
+            let params = self.extract_blocks_from_circuit_parameters(py_op.params.as_ref())?;
             let instr = PackedInstruction {
                 op: py_op.operation,
                 qubits: qubits_id,
@@ -3027,23 +3004,7 @@ impl DAGCircuit {
 
         let block_ids: Vec<_> = node_block.iter().map(|n| n.node.unwrap()).collect();
         let py_op = op.extract::<OperationFromPython>()?;
-        let params = match py_op.params {
-            Some(Parameters::Blocks(circuits)) => Python::attach(|py| -> PyResult<_> {
-                let mut blocks = Vec::with_capacity(circuits.len());
-                for circuit in circuits {
-                    blocks.push(self.add_block(circuit_to_dag(
-                        circuit.extract(py)?,
-                        false,
-                        None,
-                        None,
-                    )?));
-                }
-                Ok(Some(Parameters::Blocks(blocks)))
-            })?,
-            Some(Parameters::Params(params)) => Some(Parameters::Params(params)),
-            None => None,
-        };
-
+        let params = self.extract_blocks_from_circuit_parameters(py_op.params.as_ref())?;
         let new_node = self.replace_block(
             &block_ids,
             py_op.operation,
@@ -3376,7 +3337,6 @@ impl DAGCircuit {
         let node_index = node.as_ref().node.unwrap();
         self.substitute_node_with_py_op(node_index, op)?;
         if inplace {
-            let dag_to_circuit = imports::DAG_TO_CIRCUIT.get_bound(py);
             let PackedInstruction {
                 params,
                 label,
@@ -3386,19 +3346,8 @@ impl DAGCircuit {
             } = self.dag[node_index].unwrap_operation().clone();
             let temp: OperationFromPython = op.extract()?;
             node.instruction.operation = temp.operation;
-            node.instruction.params = match params.as_deref() {
-                Some(Parameters::Blocks(blocks)) => {
-                    let mut unpacked_blocks = Vec::new();
-                    for block in blocks {
-                        let dag = &self.blocks[*block];
-                        let block = dag_to_circuit.call1((dag.clone(),))?.unbind();
-                        unpacked_blocks.push(block);
-                    }
-                    Some(Parameters::Blocks(unpacked_blocks))
-                }
-                Some(Parameters::Params(params)) => Some(Parameters::Params(params.clone())),
-                None => None,
-            };
+            node.instruction.params =
+                self.unpack_blocks_to_circuit_parameters(params.as_deref())?;
             node.instruction.label = label;
             #[cfg(feature = "cache_pygates")]
             {
@@ -5046,6 +4995,53 @@ impl DAGCircuit {
         self.blocks.push(block)
     }
 
+    /// Add a new block to this circuit, extracting it from the equivalent typed block from a
+    /// `CircuitData`.
+    pub fn add_block_from_circuit(&mut self, block: &Bound<PyAny>) -> PyResult<Block> {
+        circuit_to_dag(block.extract()?, false, None, None).map(|dag| self.add_block(dag))
+    }
+
+    /// Given a `params` object in terms of owned Python-space circuit objects (such as from an
+    /// `OperationFromPython` extraction), add all the blocks to the circuit and return the `params`
+    /// field suitable for inclusion in a `PackedInstruction`.
+    ///
+    /// The inverse of this method is [unpack_blocks_to_circuit_parameters].
+    fn extract_blocks_from_circuit_parameters(
+        &mut self,
+        params: Option<&Parameters<Py<PyAny>>>,
+    ) -> PyResult<Option<Box<Parameters<Block>>>> {
+        Ok(params
+            .map(|params| {
+                params.try_map_blocks(|block| {
+                    Python::attach(|py| self.add_block_from_circuit(block.bind(py)))
+                })
+            })
+            .transpose()?
+            .map(Box::new))
+    }
+
+    /// Given a `params` object from an instruction packed into this DAG, extract any relevant
+    /// blocks into the owned-object `CircuitData` block type, suitable for passing back to Python
+    /// space.
+    ///
+    /// The inverse of this method is [extract_blocks_from_circuit_parameters].
+    fn unpack_blocks_to_circuit_parameters(
+        &self,
+        params: Option<&Parameters<Block>>,
+    ) -> PyResult<Option<Parameters<Py<PyAny>>>> {
+        params
+            .map(|params| {
+                params.try_map_blocks(|block| {
+                    Python::attach(|py| {
+                        converters::dag_to_circuit(&self.blocks[*block], false)
+                            .and_then(|circuit| circuit.into_py_quantum_circuit(py))
+                            .map(|ob| ob.unbind())
+                    })
+                })
+            })
+            .transpose()
+    }
+
     /// Gets a mutable reference to the given basic block.
     ///
     /// Panics if the block is not found.
@@ -5120,24 +5116,10 @@ impl DAGCircuit {
                 return Ok(ob.clone_ref(py));
             }
         }
-        let dag_to_circuit = imports::DAG_TO_CIRCUIT.get_bound(py);
-        let params = match instr.params.as_deref() {
-            Some(Parameters::Blocks(blocks)) => {
-                let mut unpacked_blocks = Vec::new();
-                for block in blocks {
-                    let dag = &self.blocks[*block];
-                    let block = dag_to_circuit.call1((dag.clone(),))?.unbind();
-                    unpacked_blocks.push(block);
-                }
-                Some(Parameters::Blocks(unpacked_blocks))
-            }
-            Some(Parameters::Params(params)) => Some(Parameters::Params(params.clone())),
-            None => None,
-        };
         let out = instruction::create_py_op(
             py,
             instr.op.view(),
-            params,
+            self.unpack_blocks_to_circuit_parameters(instr.params.as_deref())?,
             instr.label.as_deref().map(String::as_str),
         )?;
         #[cfg(feature = "cache_pygates")]
@@ -6694,21 +6676,8 @@ impl DAGCircuit {
                     )?
                     .collect(),
             );
-            let params = match &op_node.instruction.params {
-                Some(Parameters::Blocks(circuits)) => Python::attach(|py| -> PyResult<_> {
-                    let mut blocks = Vec::with_capacity(circuits.len());
-                    for circuit in circuits {
-                        let dag = circuit_to_dag(circuit.extract(py)?, false, None, None)?;
-                        blocks.push(Block(self.blocks.len() as u32));
-                        self.blocks.push(dag);
-                    }
-                    Ok(Some(Box::new(Parameters::Blocks(blocks))))
-                })?,
-                Some(Parameters::Params(params)) => {
-                    Some(Box::new(Parameters::Params(params.clone())))
-                }
-                None => None,
-            };
+            let params =
+                self.extract_blocks_from_circuit_parameters(op_node.instruction.params.as_ref())?;
             let inst = PackedInstruction {
                 op: op_node.instruction.operation.clone(),
                 qubits,
@@ -6749,21 +6718,7 @@ impl DAGCircuit {
             NodeType::Operation(packed) => {
                 let qubits = self.qargs_interner.get(packed.qubits);
                 let clbits = self.cargs_interner.get(packed.clbits);
-                let dag_to_circuit = imports::DAG_TO_CIRCUIT.get_bound(py);
-                let params = match packed.params.as_deref() {
-                    Some(Parameters::Blocks(blocks)) => {
-                        let mut circuits = Vec::new();
-                        for block in blocks {
-                            let dag = &self.blocks[*block];
-                            let circuit = dag_to_circuit.call1((dag.clone(),))?.unbind();
-                            circuits.push(circuit);
-                        }
-                        Some(Parameters::Blocks(circuits))
-                    }
-                    Some(Parameters::Params(params)) => Some(Parameters::Params(params.clone())),
-                    None => None,
-                };
-
+                let params = self.unpack_blocks_to_circuit_parameters(packed.params.as_deref())?;
                 Py::new(
                     py,
                     (
@@ -7175,9 +7130,10 @@ impl DAGCircuit {
                     .collect();
                 new_inst.qubits = self.qargs_interner.insert_owned(new_qubit_indices);
                 new_inst.clbits = self.cargs_interner.insert_owned(new_clbit_indices);
-                if let Some(Parameters::Blocks(blocks)) = new_inst.params.as_deref_mut() {
-                    *blocks = blocks.iter().map(|b| block_map[b]).collect();
-                }
+                new_inst.params = new_inst
+                    .params
+                    .as_ref()
+                    .map(|params| Box::new(params.map_blocks(|b| block_map[b])));
                 self.track_instruction(new_inst);
             }
             let new_index = self.dag.add_node(new_node);
@@ -7944,7 +7900,7 @@ impl DAGCircuit {
         &mut self,
         block_ids: &[NodeIndex],
         op: PackedOperation,
-        params: Option<Parameters<Block>>,
+        params: Option<Box<Parameters<Block>>>,
         label: Option<&str>,
         cycle_check: bool,
         qubit_pos_map: &HashMap<Qubit, usize>,
@@ -7997,7 +7953,7 @@ impl DAGCircuit {
             op,
             qubits,
             clbits,
-            params: params.map(Box::new),
+            params,
             label: label.map(|label| Box::new(label.to_string())),
             #[cfg(feature = "cache_pygates")]
             py_op: OnceLock::new(),
@@ -8285,15 +8241,10 @@ impl DAGCircuit {
                             op: new_cf.into(),
                             qubits: self.qargs_interner.insert_owned(mapped_qargs),
                             clbits: self.cargs_interner.insert_owned(mapped_cargs),
-                            params: match inst.params.as_deref() {
-                                Some(Parameters::Blocks(blocks)) => {
-                                    Some(Box::new(Parameters::Blocks(
-                                        blocks.iter().map(|b| block_map[b]).collect(),
-                                    )))
-                                }
-                                None => None,
-                                _ => panic!("expected blocks"),
-                            },
+                            params: inst
+                                .params
+                                .as_ref()
+                                .map(|params| Box::new(params.map_blocks(|b| block_map[b]))),
                             label: inst.label.clone(),
                             #[cfg(feature = "cache_pygates")]
                             py_op: OnceLock::new(),
@@ -8368,10 +8319,11 @@ impl DAGCircuit {
         node_index: NodeIndex,
         op: &Bound<PyAny>,
     ) -> PyResult<()> {
-        // Extract information from node that is going to be replaced
-        let old_packed = self.dag[node_index].unwrap_operation();
         // Extract information from new op
         let new_op = op.extract::<OperationFromPython>()?;
+        let params = self.extract_blocks_from_circuit_parameters(new_op.params.as_ref())?;
+        // Extract information from node that is going to be replaced
+        let old_packed = self.dag[node_index].unwrap_operation();
         let current_wires: HashSet<Wire> =
             self.dag.edges(node_index).map(|e| *e.weight()).collect();
         let mut new_wires: HashSet<Wire> = self
@@ -8398,19 +8350,6 @@ impl DAGCircuit {
                 new_op.operation.num_clbits()
             )));
         }
-
-        let params = match new_op.params {
-            Some(Parameters::Blocks(circuits)) => Python::attach(|py| -> PyResult<_> {
-                let mut blocks = Vec::with_capacity(circuits.len());
-                for circuit in circuits {
-                    let dag = circuit_to_dag(circuit.extract(py)?, false, None, None)?;
-                    blocks.push(self.blocks.push(dag));
-                }
-                Ok(Some(Box::new(Parameters::Blocks(blocks))))
-            })?,
-            Some(Parameters::Params(params)) => Some(Box::new(Parameters::Params(params))),
-            None => None,
-        };
         let label = new_op.label.clone();
 
         #[cfg(feature = "cache_pygates")]


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

There is a lot of code in the `DAGCircuit` that depends on the foreign types of the blocks within `CircuitData`, `OperationFromPython` and `CircuitInstruction`.  This led to a lot of duplication of code, and makes it costly to change the types of the stored blocks.  This is a problem, because we already expect to change from `Py<PyAny>` imminently, and then likely again to some other shareable type that will permit copy-free exposure of the blocks to Python space.


### Details and comments

Built on top of #15420.  Like #15425 and #15428, this is setting things up for #15123 / its successor to modify the type of the blocks in `CircuitData`, but especially because we know we're going to need to do it a second time in the 2.4 series (and for `DAGCircuit`) to avoid cloning cost when exposing these objects to Python.
