### PR TITLE
Change type of `CircuitData` blocks from `Py<PyAny>` to `CircuitData`

### DIFF
--- a/crates/accelerate/src/twirling.rs
+++ b/crates/accelerate/src/twirling.rs
@@ -18,8 +18,6 @@ use ndarray::ArrayView2;
 use ndarray::linalg::kron;
 use ndarray::prelude::*;
 use num_complex::Complex64;
-use pyo3::Python;
-use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use qiskit_circuit::circuit_data::CircuitData;
@@ -220,7 +218,6 @@ fn twirl_gate(
 type CustomGateTwirlingMap = HashMap<String, Vec<([StandardGate; 4], f64)>>;
 
 fn generate_twirled_circuit(
-    py: Python,
     circ: &CircuitData,
     rng: &mut Pcg64Mcg,
     twirling_mask: u8,
@@ -241,20 +238,14 @@ fn generate_twirled_circuit(
                 .blocks()
                 .into_iter()
                 .map(|block| {
-                    // TODO: remove this once PackedInstruction's block type is CircuitData.
-                    let block = block
-                        .bind(py)
-                        .getattr(intern!(py, "_data"))?
-                        .extract::<CircuitData>()?;
                     let new_block = generate_twirled_circuit(
-                        py,
-                        &block,
+                        block,
                         rng,
                         twirling_mask,
                         custom_gate_map,
                         optimizer_target,
                     )?;
-                    Ok(out_circ.add_block(new_block.into_py_quantum_circuit(py)?.unbind()))
+                    Ok(out_circ.add_block(new_block))
                 })
                 .collect::<PyResult<_>>()?;
             out_circ.push(PackedInstruction::from_control_flow(
@@ -315,7 +306,6 @@ fn generate_twirled_circuit(
 #[pyfunction]
 #[pyo3(signature=(circ, twirled_gate=None, custom_twirled_gates=None, seed=None, num_twirls=1, optimizer_target=None))]
 pub(crate) fn twirl_circuit(
-    py: Python,
     circ: &CircuitData,
     twirled_gate: Option<Vec<StandardGate>>,
     custom_twirled_gates: Option<Vec<OperationFromPython>>,
@@ -396,7 +386,6 @@ pub(crate) fn twirl_circuit(
     (0..num_twirls)
         .map(|_| {
             generate_twirled_circuit(
-                py,
                 circ,
                 &mut rng,
                 twirling_mask,

--- a/crates/cext/src/transpiler/passes/unitary_synthesis.rs
+++ b/crates/cext/src/transpiler/passes/unitary_synthesis.rs
@@ -111,7 +111,6 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_unitary_synthesis(
 #[cfg(all(test, not(miri)))]
 mod tests {
     use super::*;
-    use pyo3::prelude::*;
 
     use qiskit_circuit::Qubit;
     use qiskit_circuit::bit::ShareableQubit;
@@ -182,7 +181,7 @@ mod tests {
             None,    // concurrent_measurements
         )
         .unwrap();
-        let params: Option<Parameters<Py<PyAny>>> = Some(Parameters::Params(smallvec![
+        let params = Some(Parameters::Params(smallvec![
             Param::ParameterExpression(Arc::new(ParameterExpression::from_symbol(Symbol::new(
                 "ϴ", None, None,
             )))),

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -2489,7 +2489,7 @@ impl CircuitData {
     ///
     /// This is not generally efficient, and mostly just a convenience for the recursive case of
     /// control flow.
-    pub fn assign_single_parameter(&mut self, symbol: Symbol, value: &Param) -> PyResult<()> {
+    fn assign_single_parameter(&mut self, symbol: Symbol, value: &Param) -> PyResult<()> {
         let Ok(uses) = self.param_table.pop(ParameterUuid::from_symbol(&symbol)) else {
             return Ok(());
         };

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -23,7 +23,7 @@ use crate::bit_locator::BitLocator;
 use crate::circuit_instruction::{CircuitInstruction, OperationFromPython};
 use crate::classical::expr;
 use crate::dag_circuit::{DAGStretchType, DAGVarType, add_global_phase};
-use crate::imports::{ANNOTATED_OPERATION, DEEPCOPY, QUANTUM_CIRCUIT};
+use crate::imports::{ANNOTATED_OPERATION, QUANTUM_CIRCUIT};
 use crate::interner::{Interned, InternedMap, Interner};
 use crate::object_registry::ObjectRegistry;
 use crate::operations::{
@@ -131,7 +131,7 @@ pub struct CircuitData {
     /// Clbits registered in the circuit.
     clbits: ObjectRegistry<Clbit, ShareableClbit>,
     /// Basic blocks registered in the circuit.
-    blocks: ControlFlowBlocks<Py<PyAny>>,
+    blocks: ControlFlowBlocks<CircuitData>,
     /// QuantumRegisters stored in the circuit
     qregs: RegisterData<QuantumRegister>,
     /// ClassicalRegisters stored in the circuit
@@ -1185,7 +1185,6 @@ impl CircuitData {
     }
 
     pub fn extend(&mut self, itr: &Bound<PyAny>) -> PyResult<()> {
-        let py = itr.py();
         if let Ok(other) = itr.cast::<CircuitData>() {
             let other = other.borrow();
             // Fast path to avoid unnecessary construction of CircuitInstruction instances.
@@ -1206,9 +1205,7 @@ impl CircuitData {
                 let qubits_id = self.qargs_interner.insert_owned(qubits);
                 let clbits_id = self.cargs_interner.insert_owned(clbits);
                 let params = inst.params.as_ref().map(|params| {
-                    Box::new(
-                        params.map_blocks(|b| self.blocks.push(other.blocks[*b].clone_ref(py))),
-                    )
+                    Box::new(params.map_blocks(|b| self.blocks.push(other.blocks[*b].clone())))
                 });
                 self.push(PackedInstruction {
                     op: inst.op.clone(),
@@ -1425,9 +1422,6 @@ impl CircuitData {
         if let Some(locations) = self.clbit_indices.cached_raw() {
             visit.call(locations)?;
         }
-        for block in self.blocks.blocks() {
-            visit.call(block)?;
-        }
         Ok(())
     }
 
@@ -1440,7 +1434,6 @@ impl CircuitData {
         self.cregs.dispose();
         self.clbit_indices.dispose();
         self.qubit_indices.dispose();
-        self.blocks.clear();
         self.param_table.clear();
     }
 
@@ -1790,7 +1783,7 @@ impl CircuitData {
 
 impl CircuitData {
     #[inline]
-    pub fn blocks(&self) -> &ControlFlowBlocks<Py<PyAny>> {
+    pub fn blocks(&self) -> &ControlFlowBlocks<CircuitData> {
         &self.blocks
     }
 
@@ -1843,7 +1836,7 @@ impl CircuitData {
     /// No attempt is made to deduplicate the given block.
     /// No validation is performed to ensure that the given block is valid
     /// within the circuit.
-    pub fn add_block(&mut self, block: Py<PyAny>) -> Block {
+    pub fn add_block(&mut self, block: CircuitData) -> Block {
         self.blocks.push(block)
     }
 
@@ -1854,12 +1847,10 @@ impl CircuitData {
     /// The inverse of this method is [unpack_blocks_to_circuit_parameters].
     fn extract_blocks_from_circuit_parameters(
         &mut self,
-        params: Option<&Parameters<Py<PyAny>>>,
+        params: Option<&Parameters<CircuitData>>,
     ) -> Option<Box<Parameters<Block>>> {
         params
-            .map(|params| {
-                params.map_blocks(|block| Python::attach(|py| self.add_block(block.clone_ref(py))))
-            })
+            .map(|params| params.map_blocks(|block| self.add_block(block.clone())))
             .map(Box::new)
     }
 
@@ -1871,10 +1862,8 @@ impl CircuitData {
     fn unpack_blocks_to_circuit_parameters(
         &self,
         params: Option<&Parameters<Block>>,
-    ) -> Option<Parameters<Py<PyAny>>> {
-        params.map(|params| {
-            params.map_blocks(|block| Python::attach(|py| self.blocks[*block].clone_ref(py)))
-        })
+    ) -> Option<Parameters<CircuitData>> {
+        params.map(|params| params.map_blocks(|block| self.blocks[*block].clone()))
     }
 
     /// Gets an immutable view of a control flow operation.
@@ -1884,7 +1873,7 @@ impl CircuitData {
     pub fn try_view_control_flow<'a>(
         &'a self,
         instr: &'a PackedInstruction,
-    ) -> Option<ControlFlowView<'a, Py<PyAny>>> {
+    ) -> Option<ControlFlowView<'a, CircuitData>> {
         ControlFlowView::try_from_instruction(instr, &self.blocks)
     }
 
@@ -1901,15 +1890,7 @@ impl CircuitData {
         res.cargs_interner = self.cargs_interner.clone();
 
         if blocks_mode == BlocksMode::Keep && !self.blocks.is_empty() {
-            Python::attach(|py| -> PyResult<()> {
-                // We deepcopy the blocks because QuantumCircuit.copy
-                // promises a deepcopy of all instruction params.
-                let deepcopy = DEEPCOPY.get_bound(py);
-                res.blocks = self.blocks.try_map_without_references(|block| {
-                    deepcopy.call1((block,)).map(|ob| ob.unbind())
-                })?;
-                Ok(())
-            })?;
+            res.blocks = self.blocks.map_without_references(|block| block.clone());
         }
 
         // After initialization, copy register info.
@@ -2065,7 +2046,7 @@ impl CircuitData {
     pub fn from_packed_instructions<I>(
         qubits: ObjectRegistry<Qubit, ShareableQubit>,
         clbits: ObjectRegistry<Clbit, ShareableClbit>,
-        blocks: ControlFlowBlocks<Py<PyAny>>,
+        blocks: ControlFlowBlocks<CircuitData>,
         qargs_interner: Interner<[Qubit]>,
         cargs_interner: Interner<[Clbit]>,
         qregs: RegisterData<QuantumRegister>,
@@ -2333,13 +2314,13 @@ impl CircuitData {
                     }
                 }
             }
-            Parameters::Blocks(_) => Python::attach(|py| {
+            Parameters::Blocks(_) => {
                 let view = ControlFlowView::try_from_instruction(instr, &self.blocks)
                     .expect("all instructions with blocks should be control flow");
-                for_each_symbol_use_in_control_flow(py, instruction_index, view, |symbol, usage| {
+                for_each_symbol_use_in_control_flow(instruction_index, view, |symbol, usage| {
                     self.param_table.track(symbol, Some(usage)).map(|_| ())
-                })
-            })?,
+                })?
+            }
         }
         Ok(())
     }
@@ -2366,13 +2347,13 @@ impl CircuitData {
                     }
                 }
             }
-            Parameters::Blocks(_) => Python::attach(|py| {
+            Parameters::Blocks(_) => {
                 let view = ControlFlowView::try_from_instruction(instr, &self.blocks)
                     .expect("all instructions with blocks should be control flow");
-                for_each_symbol_use_in_control_flow(py, instruction_index, view, |symbol, usage| {
+                for_each_symbol_use_in_control_flow(instruction_index, view, |symbol, usage| {
                     self.param_table.untrack(symbol, usage)
-                })
-            })?,
+                })?
+            }
         }
         Ok(())
     }
@@ -2495,6 +2476,17 @@ impl CircuitData {
             }
         }
         self.assign_parameters_inner(items)
+    }
+
+    /// Assign a single parameter to a value.
+    ///
+    /// This is not generally efficient, and mostly just a convenience for the recursive case of
+    /// control flow.
+    pub fn assign_single_parameter(&mut self, symbol: Symbol, value: &Param) -> PyResult<()> {
+        let Ok(uses) = self.param_table.pop(ParameterUuid::from_symbol(&symbol)) else {
+            return Ok(());
+        };
+        self.assign_parameters_inner(Some((symbol, value, uses)))
     }
 
     /// Returns an immutable view of the Interner used for Qargs
@@ -2668,6 +2660,7 @@ impl CircuitData {
         let mut seen_blocks = HashSet::new();
         for (symbol, value, uses) in iter {
             debug_assert!(!uses.is_empty());
+            seen_blocks.clear();
             uuids.clear();
             for inner_symbol in value.as_ref().iter_parameters()? {
                 uuids.push(self.param_table.track(&inner_symbol, None)?)
@@ -2717,47 +2710,27 @@ impl CircuitData {
                                 previous.py_op.take();
                             }
                         } else if let OperationRef::ControlFlow(op) = previous_op.view() {
-                            Python::attach(|py| -> PyResult<()> {
-                                let assign_parameters_attr = intern!(py, "assign_parameters");
-                                let map_block = |obj: &Py<PyAny>| -> PyResult<Py<PyAny>> {
-                                    obj.call_method(
-                                        py,
-                                        assign_parameters_attr,
-                                        ([(symbol.clone(), value.as_ref().clone_ref(py))]
-                                            .into_py_dict(py)?,),
-                                        Some(
-                                            &[("inplace", false), ("flat_input", true)]
-                                                .into_py_dict(py)?,
-                                        ),
-                                    )
-                                };
-                                let blocks = self.data[instruction].blocks_view();
-                                let block_to_edit = match &op.control_flow {
-                                    ControlFlow::BreakLoop => Err(inconsistent()),
-                                    ControlFlow::ContinueLoop => Err(inconsistent()),
-                                    ControlFlow::ForLoop { .. } => {
-                                        match parameter {
-                                            2 => {
-                                                // In Python land, the loop body exists at parameter
-                                                // position 2.
-                                                Ok(blocks[0])
-                                            }
-                                            _ => Err(inconsistent()),
-                                        }
+                            let blocks = self.data[instruction].blocks_view();
+                            let block_to_edit = match &op.control_flow {
+                                ControlFlow::BreakLoop => Err(inconsistent()),
+                                ControlFlow::ContinueLoop => Err(inconsistent()),
+                                ControlFlow::ForLoop { .. } => {
+                                    match parameter {
+                                        // In Python land, the loop body exists at parameter
+                                        // position 2.
+                                        2 => Ok(blocks[0]),
+                                        _ => Err(inconsistent()),
                                     }
-                                    _ => {
-                                        // Most control flow instructions use the parameters for
-                                        // *just* their blocks.
-                                        Ok(blocks[parameter])
-                                    }
-                                }?;
-                                if !seen_blocks.contains(&block_to_edit) {
-                                    let mapped_block = map_block(&self.blocks[block_to_edit])?;
-                                    self.blocks[block_to_edit] = mapped_block;
-                                    seen_blocks.insert(block_to_edit);
                                 }
-                                Ok(())
-                            })?;
+                                // Most control flow instructions use the parameters for
+                                // *just* their blocks.
+                                _ => Ok(blocks[parameter]),
+                            }?;
+                            if !seen_blocks.contains(&block_to_edit) {
+                                self.blocks[block_to_edit]
+                                    .assign_single_parameter(symbol.clone(), value.as_ref())?;
+                                seen_blocks.insert(block_to_edit);
+                            }
                             for uuid in uuids.iter() {
                                 self.param_table.add_use(*uuid, usage)?
                             }
@@ -3410,21 +3383,13 @@ where
 /// This encapsulates the logic of both [CircuitData::track_parameters] and
 /// [CircuitData::untrack_parameters].
 fn for_each_symbol_use_in_control_flow<F, E>(
-    py: Python,
     instruction_index: usize,
-    cf: ControlFlowView<Py<PyAny>>,
+    cf: ControlFlowView<CircuitData>,
     mut action: F,
-) -> PyResult<()>
+) -> Result<(), E>
 where
     F: FnMut(&Symbol, ParameterUse) -> Result<(), E>,
-    PyErr: From<E>,
 {
-    let downcast = |ob: &Py<PyAny>| -> PyResult<Bound<CircuitData>> {
-        Ok(ob
-            .bind(py)
-            .getattr(intern!(py, "_data"))?
-            .cast_into::<CircuitData>()?)
-    };
     match cf {
         ControlFlowView::ForLoop {
             loop_param,
@@ -3446,7 +3411,7 @@ where
                 instruction: instruction_index,
                 parameter: 2,
             };
-            for symbol in downcast(body)?.borrow().parameters() {
+            for symbol in body.parameters() {
                 action(symbol, usage)?;
             }
         }
@@ -3462,7 +3427,7 @@ where
                     instruction: instruction_index,
                     parameter: idx as u32,
                 };
-                for symbol in downcast(body)?.borrow().parameters() {
+                for symbol in body.parameters() {
                     action(symbol, usage)?;
                 }
             }

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -22,6 +22,7 @@ use pyo3::IntoPyObjectExt;
 use pyo3::types::{PyBool, PyList, PyTuple, PyType};
 use pyo3::{PyResult, intern};
 
+use crate::circuit_data::CircuitData;
 use crate::duration::Duration;
 use crate::imports::{CONTROLLED_GATE, GATE, INSTRUCTION, OPERATION, WARNINGS_WARN};
 use crate::instruction::{Instruction, Parameters, create_py_op};
@@ -78,7 +79,7 @@ pub struct CircuitInstruction {
     /// A sequence of the classical bits that this operation reads from or writes to.
     #[pyo3(get)]
     pub clbits: Py<PyTuple>,
-    pub params: Option<Parameters<Py<PyAny>>>,
+    pub params: Option<Parameters<CircuitData>>,
     pub label: Option<Box<String>>,
     #[cfg(feature = "cache_pygates")]
     pub py_op: OnceLock<Py<PyAny>>,
@@ -108,7 +109,7 @@ impl Instruction for CircuitInstruction {
         self.operation.view()
     }
 
-    fn parameters(&self) -> Option<&Parameters<Py<PyAny>>> {
+    fn parameters(&self) -> Option<&Parameters<CircuitData>> {
         self.params.as_ref()
     }
 
@@ -213,10 +214,18 @@ impl CircuitInstruction {
                 } => [
                     collection.into_py_any(py)?,
                     loop_param.clone().into_py_any(py)?,
-                    self.blocks_view()[0].clone_ref(py),
+                    self.blocks_view()[0]
+                        .clone()
+                        .into_py_quantum_circuit(py)?
+                        .unbind(),
                 ]
                 .into_py_any(py),
-                _ => self.blocks_view().into_py_any(py),
+                _ => self
+                    .blocks_view()
+                    .iter()
+                    .map(|block| block.clone().into_py_quantum_circuit(py))
+                    .collect::<PyResult<Vec<_>>>()?
+                    .into_py_any(py),
             },
             _ => self.params_view().into_py_any(py),
         }
@@ -397,8 +406,8 @@ impl CircuitInstruction {
     ) -> PyResult<Py<PyAny>> {
         fn params_eq(
             py: Python,
-            left: Option<&Parameters<Py<PyAny>>>,
-            right: Option<&Parameters<Py<PyAny>>>,
+            left: Option<&Parameters<CircuitData>>,
+            right: Option<&Parameters<CircuitData>>,
         ) -> PyResult<bool> {
             if left.is_none() && right.is_none() {
                 return Ok(true);
@@ -440,8 +449,14 @@ impl CircuitInstruction {
                     if blocks_a.len() != blocks_b.len() {
                         return Ok(false);
                     }
+                    // TODO: we should be able to do the semantic-equality comparison from Rust
+                    // space in the future, without going via Python.  See gh-15267.
                     for (a, b) in blocks_a.iter().zip(blocks_b) {
-                        if !a.bind(py).eq(b)? {
+                        if !a
+                            .clone()
+                            .into_py_quantum_circuit(py)?
+                            .eq(b.clone().into_py_quantum_circuit(py)?)?
+                        {
                             return Ok(false);
                         }
                     }
@@ -513,7 +528,7 @@ impl CircuitInstruction {
 #[derive(Debug)]
 pub struct OperationFromPython {
     pub operation: PackedOperation,
-    pub params: Option<Parameters<Py<PyAny>>>,
+    pub params: Option<Parameters<CircuitData>>,
     pub label: Option<Box<String>>,
 }
 
@@ -528,7 +543,7 @@ impl OperationFromPython {
     /// Takes the blocks out of [OperationFromPython::params].
     ///
     /// Panics if params is not a block list.
-    pub fn take_blocks(&mut self) -> Option<Vec<Py<PyAny>>> {
+    pub fn take_blocks(&mut self) -> Option<Vec<CircuitData>> {
         self.params.take().map(|p| p.unwrap_blocks())
     }
 }
@@ -538,7 +553,7 @@ impl Instruction for OperationFromPython {
         self.operation.view()
     }
 
-    fn parameters(&self) -> Option<&Parameters<Py<PyAny>>> {
+    fn parameters(&self) -> Option<&Parameters<CircuitData>> {
         self.params.as_ref()
     }
 
@@ -861,7 +876,8 @@ impl<'a, 'py> FromPyObject<'a, 'py> for OperationFromPython {
 pub fn extract_params(
     op: OperationRef,
     params: &Bound<PyAny>,
-) -> PyResult<Option<Parameters<Py<PyAny>>>> {
+) -> PyResult<Option<Parameters<CircuitData>>> {
+    let data_attr = intern!(params.py(), "_data");
     Ok(match op {
         OperationRef::ControlFlow(cf) => match &cf.control_flow {
             ControlFlow::BreakLoop => None,
@@ -870,19 +886,31 @@ pub fn extract_params(
                 // We skip the first two parameters (collection and loop_param) since we
                 // store those directly on the operation in Rust.
                 let mut params = params.try_iter()?.skip(2);
-                Some(Parameters::Blocks(vec![params.next().unwrap()?.unbind()]))
+                Some(Parameters::Blocks(vec![
+                    params
+                        .next()
+                        .ok_or_else(|| {
+                            PyValueError::new_err("not enough values to unpack (expected 3)")
+                        })??
+                        .getattr(data_attr)?
+                        .extract()?,
+                ]))
             }
             _ => {
                 // For all other control flow operations with blocks, the 'params' in Python land
                 // are exactly the blocks.
-                let blocks: Vec<Py<PyAny>> = params
+                let blocks = params
                     .try_iter()?
                     .take_while(|p| match p {
                         // In the case of IfElse, the "false" body might be None.
                         Ok(block) if !block.is_none() => true,
                         _ => false,
                     })
-                    .map(|p| p.map(|p| p.unbind()))
+                    .map(|p| -> PyResult<_> {
+                        p?.getattr(data_attr)?
+                            .extract::<CircuitData>()
+                            .map_err(PyErr::from)
+                    })
                     .collect::<PyResult<_>>()?;
                 Some(Parameters::Blocks(blocks))
             }

--- a/crates/circuit/src/dag_node.rs
+++ b/crates/circuit/src/dag_node.rs
@@ -209,8 +209,14 @@ impl DAGOpNode {
                 let slf_blocks = slf.instruction.blocks_view();
                 let other_blocks = borrowed_other.instruction.blocks_view();
                 let mut params_eq = true;
+                // TODO: we should be able to do the semantic-equality comparison from Rust
+                // space in the future, without going via Python.  See gh-15267.
                 for (a, b) in slf_blocks.iter().zip(other_blocks) {
-                    if !a.bind(py).eq(b)? {
+                    if !a
+                        .clone()
+                        .into_py_quantum_circuit(py)?
+                        .eq(b.clone().into_py_quantum_circuit(py)?)?
+                    {
                         params_eq = false;
                         break;
                     }

--- a/crates/circuit/src/instruction.rs
+++ b/crates/circuit/src/instruction.rs
@@ -10,6 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use crate::circuit_data::CircuitData;
 use crate::operations::{OperationRef, Param};
 use ndarray::Array2;
 use num_complex::Complex64;
@@ -102,7 +103,7 @@ pub trait Instruction {
     ///
     /// For standard gates without parameters this may be [None] or a
     /// `Some(Parameters::Param(smallvec![]))`.
-    fn parameters(&self) -> Option<&Parameters<Py<PyAny>>>;
+    fn parameters(&self) -> Option<&Parameters<CircuitData>>;
 
     /// Get the label for this instruction.
     fn label(&self) -> Option<&str>;
@@ -120,7 +121,7 @@ pub trait Instruction {
 
     /// Get a slice view onto the contained blocks.
     #[inline]
-    fn blocks_view(&self) -> &[Py<PyAny>] {
+    fn blocks_view(&self) -> &[CircuitData] {
         self.parameters()
             .and_then(|p| match p {
                 Parameters::Blocks(b) => Some(b.as_slice()),
@@ -143,7 +144,7 @@ pub trait Instruction {
 pub fn create_py_op(
     py: Python,
     op: OperationRef,
-    params: Option<Parameters<Py<PyAny>>>,
+    params: Option<Parameters<CircuitData>>,
     label: Option<&str>,
 ) -> PyResult<Py<PyAny>> {
     match op {

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -571,7 +571,7 @@ impl ControlFlowInstruction {
     pub fn create_py_op(
         &self,
         py: Python,
-        blocks: Option<Vec<Py<PyAny>>>,
+        blocks: Option<Vec<CircuitData>>,
         label: Option<&str>,
     ) -> PyResult<Py<PyAny>> {
         let mut blocks = blocks.into_iter().flatten();
@@ -597,7 +597,10 @@ impl ControlFlowInstruction {
                 imports::BOX_OP.get(py).call1(
                     py,
                     (
-                        blocks.next().unwrap(),
+                        blocks
+                            .next()
+                            .expect("box should have a body")
+                            .into_py_quantum_circuit(py)?,
                         duration,
                         unit,
                         label,
@@ -620,19 +623,43 @@ impl ControlFlowInstruction {
                 loop_param,
             } => imports::FOR_LOOP_OP.get(py).call(
                 py,
-                (collection, loop_param.clone(), blocks.next()),
+                (
+                    collection,
+                    loop_param.clone(),
+                    blocks
+                        .next()
+                        .expect("for loop should have a body")
+                        .into_py_quantum_circuit(py)?,
+                ),
                 kwargs.as_ref(),
             ),
             ControlFlow::IfElse { condition } => imports::IF_ELSE_OP.get(py).call(
                 py,
-                (condition.clone(), blocks.next().unwrap(), blocks.next()),
+                (
+                    condition.clone(),
+                    blocks
+                        .next()
+                        .expect("if should have a true body")
+                        .into_py_quantum_circuit(py)?,
+                    blocks
+                        .next()
+                        .map(|circuit| circuit.into_py_quantum_circuit(py))
+                        .transpose()?,
+                ),
                 kwargs.as_ref(),
             ),
             ControlFlow::Switch {
                 target, label_spec, ..
             } => {
-                let cases_specifier: Vec<(Vec<CaseSpecifier>, Py<PyAny>)> =
-                    label_spec.iter().cloned().zip(blocks).collect();
+                let cases_specifier: Vec<(Vec<CaseSpecifier>, Py<PyAny>)> = label_spec
+                    .iter()
+                    .cloned()
+                    .zip(blocks)
+                    .map(|(cases, body)| {
+                        body.into_py_quantum_circuit(py)
+                            .map(|ob| (cases, ob.unbind()))
+                    })
+                    .collect::<PyResult<_>>()?;
                 imports::SWITCH_CASE_OP.get(py).call(
                     py,
                     (target.clone(), cases_specifier),
@@ -641,7 +668,13 @@ impl ControlFlowInstruction {
             }
             ControlFlow::While { condition, .. } => imports::WHILE_LOOP_OP.get(py).call(
                 py,
-                (condition.clone(), blocks.next()),
+                (
+                    condition.clone(),
+                    blocks
+                        .next()
+                        .expect("while should have a body")
+                        .into_py_quantum_circuit(py)?,
+                ),
                 kwargs.as_ref(),
             ),
         }

--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -16,7 +16,6 @@ use nalgebra::DMatrix;
 use ndarray::prelude::*;
 use pyo3::Bound;
 use pyo3::IntoPyObjectExt;
-use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyAny;
 use qiskit_circuit::bit::ShareableQubit;
@@ -26,7 +25,7 @@ use qiskit_circuit::converters::QuantumCircuitData;
 use qiskit_circuit::converters::dag_to_circuit;
 use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_circuit::gate_matrix::CX_GATE;
-use qiskit_circuit::imports::{HLS_SYNTHESIZE_OP_USING_PLUGINS, QUANTUM_CIRCUIT};
+use qiskit_circuit::imports::HLS_SYNTHESIZE_OP_USING_PLUGINS;
 use qiskit_circuit::operations::{
     Operation, OperationRef, Param, StandardGate, StandardInstruction, radd_param,
 };
@@ -575,12 +574,11 @@ fn run_on_circuitdata(
         // Check if synthesis for this operation can be skipped
         if definitely_skip_op(py, data, &inst.op, &op_qubits) {
             if let Some(cf) = input_circuit.try_view_control_flow(inst) {
-                let blocks: Vec<_> = Python::attach(|py| {
-                    cf.blocks()
-                        .into_iter()
-                        .map(|b| output_circuit.add_block(b.clone_ref(py)))
-                        .collect()
-                });
+                let blocks: Vec<_> = cf
+                    .blocks()
+                    .into_iter()
+                    .map(|b| output_circuit.add_block(b.clone()))
+                    .collect();
                 output_circuit.push(PackedInstruction {
                     params: (!blocks.is_empty()).then(|| Box::new(Parameters::Blocks(blocks))),
                     ..inst.clone()
@@ -599,17 +597,6 @@ fn run_on_circuitdata(
         // avoid complications related to tracking qubit status for while- loops.
         // In the future, this handling can potentially be improved.
         if let Some(control_flow) = input_circuit.try_view_control_flow(inst) {
-            let quantum_circuit_cls = QUANTUM_CIRCUIT.get_bound(py);
-
-            // old_blocks_py keeps the original QuantumCircuit's appearing within control-flow ops
-            // new_blocks_py keeps the recursively synthesized circuits
-            let old_blocks_py: Vec<Bound<PyAny>> = control_flow
-                .blocks()
-                .into_iter()
-                .map(|b| b.bind(py).clone())
-                .collect();
-            let mut new_blocks_py: Vec<Bound<PyAny>> = Vec::with_capacity(old_blocks_py.len());
-
             // We do not allow using any additional qubits outside of the block.
             let mut block_tracker = tracker.clone();
             let to_disable = (0..tracker.num_qubits())
@@ -618,31 +605,15 @@ fn run_on_circuitdata(
             block_tracker.disable(to_disable);
             block_tracker.set_dirty(&op_qubits);
 
-            for block_py in old_blocks_py {
-                let old_block_py: QuantumCircuitData = block_py.extract()?;
-                let (new_block, _) = run_on_circuitdata(
-                    py,
-                    &old_block_py.data,
-                    &op_qubits,
-                    data,
-                    &mut block_tracker,
-                )?;
-                let new_block = new_block.into_bound_py_any(py)?;
-
-                // We create the new quantum circuit by calling copy_empty_like on the old quantum circuit
-                // and manually set the circuit data to the (recursively synthesized) data.
-                // This makes sure that all the python-space information (qregs, cregs, input variables)
-                // get copied correctly.
-                let new_block_py: Bound<'_, PyAny> = quantum_circuit_cls
-                    .call_method1(intern!(py, "copy_empty_like"), (block_py,))?;
-                new_block_py.setattr(intern!(py, "_data"), &new_block)?;
-                new_blocks_py.push(new_block_py);
-            }
-
-            let blocks = new_blocks_py
+            let blocks = control_flow
+                .blocks()
                 .into_iter()
-                .map(|b| output_circuit.add_block(b.unbind()))
-                .collect();
+                .map(|block| -> PyResult<_> {
+                    let (new_block, _) =
+                        run_on_circuitdata(py, block, &op_qubits, data, &mut block_tracker)?;
+                    Ok(output_circuit.add_block(new_block))
+                })
+                .collect::<PyResult<_>>()?;
             let packed_instruction = PackedInstruction::from_control_flow(
                 inst.op.control_flow().clone(),
                 blocks,

--- a/crates/transpiler/src/target/mod.rs
+++ b/crates/transpiler/src/target/mod.rs
@@ -42,6 +42,7 @@ use smallvec::SmallVec;
 use thiserror::Error;
 
 use qiskit_circuit::PhysicalQubit;
+use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
 use qiskit_circuit::instruction::{Instruction, Parameters, create_py_op};
 use qiskit_circuit::operations::{Operation, OperationRef, Param};
@@ -76,7 +77,7 @@ impl TargetOperation {
     /// Creates a [TargetOperation] from an instance of [PackedOperation]
     pub fn from_packed_operation(
         operation: PackedOperation,
-        params: Option<Parameters<Py<PyAny>>>,
+        params: Option<Parameters<CircuitData>>,
     ) -> Self {
         NormalOperation::from_packed_operation(operation, params).into()
     }
@@ -93,7 +94,7 @@ impl From<NormalOperation> for TargetOperation {
 #[derive(Debug)]
 pub struct NormalOperation {
     pub operation: PackedOperation,
-    pub params: Option<Parameters<Py<PyAny>>>,
+    pub params: Option<Parameters<CircuitData>>,
     op_object: OnceLock<PyResult<Py<PyAny>>>,
 }
 
@@ -101,7 +102,7 @@ impl NormalOperation {
     /// Creates a of [TargetOperation] from an instance of [PackedOperation]
     pub fn from_packed_operation(
         operation: PackedOperation,
-        params: Option<Parameters<Py<PyAny>>>,
+        params: Option<Parameters<CircuitData>>,
     ) -> Self {
         Self {
             operation,
@@ -116,7 +117,7 @@ impl Instruction for NormalOperation {
         self.operation.view()
     }
 
-    fn parameters(&self) -> Option<&Parameters<Py<PyAny>>> {
+    fn parameters(&self) -> Option<&Parameters<CircuitData>> {
         self.params.as_ref()
     }
 
@@ -946,7 +947,7 @@ impl Target {
     pub fn add_instruction(
         &mut self,
         operation: PackedOperation,
-        params: Option<Parameters<Py<PyAny>>>,
+        params: Option<Parameters<CircuitData>>,
         name: Option<&str>,
         props_map: Option<PropsMap>,
     ) -> Result<(), TargetError> {

--- a/crates/transpiler/src/transpiler.rs
+++ b/crates/transpiler/src/transpiler.rs
@@ -537,7 +537,6 @@ mod tests {
     use super::*;
     use crate::target::InstructionProperties;
     use crate::target::Target;
-    use pyo3::prelude::*;
     use qiskit_circuit::circuit_data::CircuitData;
     use qiskit_circuit::instruction::Parameters;
     use qiskit_circuit::operations::{Operation, Param, StandardGate, StandardInstruction};
@@ -549,7 +548,7 @@ mod tests {
 
     fn build_universal_star_target() -> Target {
         let mut target = Target::default();
-        let u_params: Option<Parameters<Py<PyAny>>> = Some(Parameters::Params(smallvec![
+        let u_params = Some(Parameters::Params(smallvec![
             Param::ParameterExpression(Arc::new(ParameterExpression::from_symbol(Symbol::new(
                 "a", None, None,
             )))),

--- a/releasenotes/notes/control-flow-rs-639506776f571c86.yaml
+++ b/releasenotes/notes/control-flow-rs-639506776f571c86.yaml
@@ -7,26 +7,38 @@ upgrade_circuits:
     to the circuit. This was never guaranteed to be the case and mutating control
     flow operation objects directly or by reference was unsound and always
     likely to corrupt the circuit.
-    If you need to mutate an element in the circuit (which is **not** recommended
-    as it’s inefficient and error prone) you should ensure that you do something
-    like::
 
-      from qiskit.circuit import QuantumCircuit
+    As with all in-place mutations to Python objects stored within a :class:`.QuantumCircuit` or
+    :class:`.DAGCircuit`, you must re-assign the instruction to the circuit in order for Rust space
+    to pick up the modifications.  For example, when adding annotations to a :class:`.BoxOp` that is
+    already on a circuit, a transpiler pass should make sure to use :meth:`.DAGCircuit.substitute_node`
+    to update the Rust-space object::
+
+      from qiskit.circuit import QuantumCircuit, Annotation
+
+      class MyAnnotation(Annotation):
+          namespace = "my"
 
       qc = QuantumCircuit(2)
-
-      # original box and body
       with qc.box():
-        qc.cx(0, 1)
+          qc.cx(0, 1)
+      dag = qc.to_dag()
 
-      # create new box op using old one as template
-      new_box_body = QuantumCircuit(2)
-      new_box_body.cx(0, 1)
-      new_box_body.h(0)
-      new_box_op = qc.data[0].operation.replace_blocks((new_box_body,))
+      # Modifications to the box's annotations in-place require
+      # writing back the information to Rust space.
+      box_node = next(dag.topological_op_nodes())
+      box_node.op.annotations.append(MyAnnotation())
 
-      # replace the original operation
-      qc.data[0] = qc.data[0].replace(operation=new_box_op)
-
-    This also applies to :class:`.DAGCircuit` too, but you can use
-    :meth:`.DAGCircuit.substitute_node` instead.
+      # Write back the operation.
+      dag.substitute_node(box_node, box_node.op)
+  - |
+    Transpiler performance in the presence of :class:`.ControlFlowOp` instructions, including
+    :class:`.BoxOp`, is expected to be temporarily worse in Qiskit 2.3, as we transition the internal
+    representation of control flow from its previously Python-centred version to a Rust-native one.
+    We expect the performance to improve again in Qiskit 2.4, and to enable us to resolve
+    long-standing API deficiencies in transpiler passes acting on control-flow operations.
+  - |
+    The blocks of :class:`.ControlFlowOp` instances will no longer track :attr:`~.QuantumCircuit.name`
+    or :attr:`~.QuantumCircuit.metadata` fields.  These were already unsettable with the control-flow
+    builder interface, and their existence was an unintended implementation detail rather than an
+    intentional API.


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This removes one of the largest requirements for Python interaction in the core data model.  However, it currently comes at a major cost of cloning both on extraction from Python space and on producing view objects back _to_ Python space.  We are choosing to make this trade-off as a temporary measure, to prioritise separation of the core data model from Python, given that transpiler performance in the presence of control flow is already poor.

While `CircuitData` and `DAGCircuit` are both directly `pyclass`, we either have to encode the Python interaction deep into the data structures (deeply undesirable) to handle the blocks, or we have this current problematic cloning.  The way around this will be to separate off `PyCircuitData(Ptr<CircuitData>)` and similar for `DAGCircuit`, where `Ptr<T>` is some smart-pointer type that may represent either ownership of an underlying object or a (maybe fallible) reference to an owned object.  The exact mechanism of this (perhaps something `Arc`/`Weak`-based) is not yet decided, but will likely motivate a further change of the `blocks` structure.

This commit is now a completely remade version of a previous PR (gh-15123), but much of the set up work, investigation and planning of what became this was originally done by Kevin Hartman.


### Details and comments

Close #15123 (replaces it)

Based on:
- #15420 
- #15425
- #15428 
- #15430

The hit to performance _is_ huge, though.  In a benchmark script:
```python
from qiskit.circuit import QuantumCircuit
from qiskit.converters import circuit_to_dag

qc = QuantumCircuit(2)
with qc.for_loop(range(1)):
    for _ in range(10_000):
        qc.cx(0, 1)

def main(reps):
    dag = circuit_to_dag(qc, copy_operations=False)
    node = dag.op_nodes()[0]

    for _ in range(reps):
        node = dag.substitute_node(node, node.op)

```

I find `main(1_000)` to go from 2ms with Qiskit 2.2.3 to 700ms with this branch.  Admittedly this is the worst-case scenario, but it's indicative of _quite_ how much cloning now goes on in simple scripts accessing control-flow, and the `dag.substitute_node(node, node.op)` pattern is one that is required for re-extracting from Python space.

It's worth pointing out that the state of `main` before even #15420 (11801be6ba1fadb88c5045d6f7dbd0dd266f75ff) has a memory leak and some _huge_ polynomial scaling in `reps` - the options available to us are to fix `main` in place (such as with this PR and potentially a follow-on if there's something reasonable we can do to rescue performance), or to attempt a major reversion in some form.  Such a reversion would likely not of the actual PRs, but potentially a new PR that puts the block types back to `Py<PyAny>` (`QuantumCircuit`) temporarily, while leaving all the new on-the-side `Block` tracking.