### PR TITLE
Make `DAGCircuit`'s topological iterators infallible

### DIFF
--- a/crates/cext/src/dag.rs
+++ b/crates/cext/src/dag.rs
@@ -1508,7 +1508,7 @@ pub unsafe extern "C" fn qk_dag_topological_op_nodes(dag: *const DAGCircuit, out
     // SAFETY: Per documentation, ``dag`` is non-null and valid.
     let dag = unsafe { const_ptr_as_ref(dag) };
 
-    let out_topological_op_nodes = dag.topological_op_nodes(false).unwrap();
+    let out_topological_op_nodes = dag.topological_op_nodes(false);
 
     for (i, node) in out_topological_op_nodes.enumerate() {
         // SAFETY: per documentation, `out_order` is aligned and points to a valid

--- a/crates/circuit/src/converters.rs
+++ b/crates/circuit/src/converters.rs
@@ -68,7 +68,7 @@ pub fn dag_to_circuit(dag: &DAGCircuit, copy_operations: bool) -> PyResult<Circu
         dag.cregs_data().clone(),
         dag.qubit_locations().clone(),
         dag.clbit_locations().clone(),
-        dag.topological_op_nodes(false)?.map(|node_index| {
+        dag.topological_op_nodes(false).map(|node_index| {
             let NodeType::Operation(ref instr) = dag[node_index] else {
                 unreachable!(
                     "The received node from topological_op_nodes() is not an Operation node."

--- a/crates/transpiler/src/passes/alap_schedule_analysis.rs
+++ b/crates/transpiler/src/passes/alap_schedule_analysis.rs
@@ -72,12 +72,7 @@ pub fn run_alap_schedule_analysis<T: TimeOps>(
     // and nodes are packed from the very end of the circuit.
     // The physical meaning of t0 and t1 is flipped here.
 
-    for node_index in dag
-        .topological_op_nodes(false)?
-        .collect::<Vec<_>>()
-        .into_iter()
-        .rev()
-    {
+    for node_index in dag.topological_op_nodes(true) {
         let op = dag[node_index].unwrap_operation();
 
         let qargs: Vec<Wire> = dag

--- a/crates/transpiler/src/passes/asap_schedule_analysis.rs
+++ b/crates/transpiler/src/passes/asap_schedule_analysis.rs
@@ -45,7 +45,7 @@ pub fn run_asap_schedule_analysis<T: TimeOps>(
         idle_after.insert(Wire::Clbit(Clbit::new(index)), zero);
     }
 
-    for node_index in dag.topological_op_nodes(false)? {
+    for node_index in dag.topological_op_nodes(false) {
         let op = dag[node_index].unwrap_operation();
 
         let qargs: Vec<Wire> = dag

--- a/crates/transpiler/src/passes/basis_translator/mod.rs
+++ b/crates/transpiler/src/passes/basis_translator/mod.rs
@@ -344,9 +344,7 @@ fn apply_translation(
             )
         })?;
     let mut out_dag_builder = out_dag.into_builder();
-    for node in dag.topological_op_nodes(false).map_err(|_| {
-        BasisTranslatorError::BasisDAGCircuitError("Error retrieving Op nodes from DAG".to_string())
-    })? {
+    for node in dag.topological_op_nodes(false) {
         let node_obj = dag[node].unwrap_operation();
         let node_qarg = dag.get_qargs(node_obj.qubits);
         let node_carg = dag.get_cargs(node_obj.clbits);
@@ -505,12 +503,8 @@ fn replace_node(
             target_dag: format!("{:?}", target_dag),
         });
     }
-    if node.params_view().is_empty() {
-        for inner_index in target_dag.topological_op_nodes(false).map_err(|_| {
-            BasisTranslatorError::BasisDAGCircuitError(
-                "Error retrieving Op nodes from DAG".to_string(),
-            )
-        })? {
+    if params_view.is_empty() {
+        for inner_index in target_dag.topological_op_nodes(false) {
             let inner_node = &target_dag[inner_index].unwrap_operation();
             let old_qargs = dag.qargs_interner().get(node.qubits);
             let old_cargs = dag.cargs_interner().get(node.clbits);
@@ -578,11 +572,7 @@ fn replace_node(
                     _ => None,
                 }),
         );
-        for inner_index in target_dag.topological_op_nodes(false).map_err(|_| {
-            BasisTranslatorError::BasisDAGCircuitError(
-                "Error retrieving Op nodes from DAG".to_string(),
-            )
-        })? {
+        for inner_index in target_dag.topological_op_nodes(false) {
             let inner_node = &target_dag[inner_index].unwrap_operation();
             let old_qargs = dag.qargs_interner().get(node.qubits);
             let old_cargs = dag.cargs_interner().get(node.clbits);

--- a/crates/transpiler/src/passes/commutative_optimization.rs
+++ b/crates/transpiler/src/passes/commutative_optimization.rs
@@ -412,7 +412,7 @@ pub fn run_commutative_optimization(
     // this does not happen right now).
     let mut new_dag = dag.copy_empty_like_with_same_capacity(VarsMode::Alike, BlocksMode::Keep)?;
 
-    let node_indices = dag.topological_op_nodes(false)?.collect::<Vec<_>>();
+    let node_indices = dag.topological_op_nodes(false).collect::<Vec<_>>();
     let num_nodes = node_indices.len();
 
     let mut node_actions: Vec<NodeAction> = vec![NodeAction::Keep; num_nodes];

--- a/crates/transpiler/src/passes/disjoint_layout.rs
+++ b/crates/transpiler/src/passes/disjoint_layout.rs
@@ -450,7 +450,7 @@ fn separate_dag(dag: &mut DAGCircuit) -> PyResult<Vec<DAGCircuit>> {
             new_dag.set_global_phase(Param::Float(0.))?;
             let old_qubits = dag.qubits();
             let mut block_map = BlockMapper::new();
-            for index in dag.topological_op_nodes(false)? {
+            for index in dag.topological_op_nodes(false) {
                 let node = dag[index].unwrap_operation();
                 let qargs: HashSet<Qubit> = dag.get_qargs(node.qubits).iter().copied().collect();
                 if dag_qubits.is_superset(&qargs) {

--- a/crates/transpiler/src/passes/elide_permutations.rs
+++ b/crates/transpiler/src/passes/elide_permutations.rs
@@ -40,7 +40,7 @@ pub fn run_elide_permutations(dag: &DAGCircuit) -> PyResult<Option<(DAGCircuit, 
 
     // note that DAGCircuit::copy_empty_like clones the interners
     let mut new_dag = dag.copy_empty_like_with_capacity(0, 0, VarsMode::Alike, BlocksMode::Keep)?;
-    for node_index in dag.topological_op_nodes(false)? {
+    for node_index in dag.topological_op_nodes(false) {
         if let NodeType::Operation(inst) = &dag[node_index] {
             match inst.op.view() {
                 OperationRef::StandardGate(StandardGate::Swap) => {

--- a/crates/transpiler/src/passes/litinski_transformation.rs
+++ b/crates/transpiler/src/passes/litinski_transformation.rs
@@ -101,7 +101,7 @@ pub fn run_litinski_transformation(
     let mut clifford_ops: Vec<&PackedInstruction> = Vec::with_capacity(clifford_count);
     // Apply the Litinski transformation: that is, express a given circuit as a sequence of Pauli
     // product rotations and Pauli product measurements, followed by a final Clifford operator.
-    for node_index in dag.topological_op_nodes(false)? {
+    for node_index in dag.topological_op_nodes(false) {
         // Convert T and Tdg gates to RZ rotations.
         if let NodeType::Operation(inst) = &dag[node_index] {
             let name = inst.op.name();

--- a/crates/transpiler/src/passes/sabre/dag.rs
+++ b/crates/transpiler/src/passes/sabre/dag.rs
@@ -154,10 +154,7 @@ impl SabreDAG {
                 single.map_or(Predecessors::AllUnmapped, Predecessors::Single)
             };
 
-        for dag_node in dag
-            .topological_op_nodes(false)
-            .expect("infallible if DAG is in a valid state")
-        {
+        for dag_node in dag.topological_op_nodes(false) {
             let NodeType::Operation(inst) = &dag[dag_node] else {
                 panic!("op nodes should always be of type `Operation`");
             };

--- a/crates/transpiler/src/passes/split_2q_unitaries.rs
+++ b/crates/transpiler/src/passes/split_2q_unitaries.rs
@@ -101,7 +101,7 @@ pub fn run_split_2q_unitaries(
     let mut mapping: Vec<usize> = (0..dag.num_qubits()).collect();
     let new_dag = dag.copy_empty_like(VarsMode::Alike, BlocksMode::Keep)?;
     let mut new_dag = new_dag.into_builder();
-    for node in dag.topological_op_nodes(false)? {
+    for node in dag.topological_op_nodes(false) {
         let NodeType::Operation(inst) = &dag.dag()[node] else {
             unreachable!("Op nodes contain a non-operation");
         };


### PR DESCRIPTION
Both `topological_nodes` and `topological_op_nodes` are already guaranteed to be infallible by the data-consistency requirements of the `DAGCircuit`. This guarantees it in the interface as well.

The return type of `DAGCircuit::topological_nodes` was needlessly being hidden, where users could make use of it.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

This is just fixing a small annoyance I had when looking at other things to do with the topological sorters.  It's not particularly important.
