### PR TITLE
Allow control-flow block extraction to correct type

### DIFF
--- a/crates/accelerate/src/twirling.rs
+++ b/crates/accelerate/src/twirling.rs
@@ -29,7 +29,7 @@ use qiskit_circuit::instruction::Instruction;
 use qiskit_circuit::operations::StandardGate::{I, X, Y, Z};
 use qiskit_circuit::operations::{Operation, OperationRef, Param, StandardGate};
 use qiskit_circuit::packed_instruction::PackedInstruction;
-use qiskit_circuit::{BlocksMode, VarsMode};
+use qiskit_circuit::{BlocksMode, NoBlocks, VarsMode};
 use qiskit_transpiler::passes::run_optimize_1q_gates_decomposition;
 use qiskit_transpiler::target::Target;
 use rand::prelude::*;
@@ -308,7 +308,7 @@ fn generate_twirled_circuit(
 pub(crate) fn twirl_circuit(
     circ: &CircuitData,
     twirled_gate: Option<Vec<StandardGate>>,
-    custom_twirled_gates: Option<Vec<OperationFromPython>>,
+    custom_twirled_gates: Option<Vec<OperationFromPython<NoBlocks>>>,
     seed: Option<u64>,
     num_twirls: usize,
     optimizer_target: Option<&Target>,

--- a/crates/circuit/src/dag_node.rs
+++ b/crates/circuit/src/dag_node.rs
@@ -15,6 +15,7 @@ use std::hash::Hasher;
 use std::sync::OnceLock;
 
 use crate::TupleLikeArg;
+use crate::circuit_data::CircuitData;
 use crate::circuit_instruction::{CircuitInstruction, OperationFromPython, extract_params};
 use crate::operations::{Operation, OperationRef, Param, PythonOperation};
 
@@ -126,7 +127,7 @@ impl DAGOpNode {
         qargs: Option<TupleLikeArg>,
         cargs: Option<TupleLikeArg>,
     ) -> PyResult<Py<Self>> {
-        let py_op = op.extract::<OperationFromPython>()?;
+        let py_op = op.extract::<OperationFromPython<CircuitData>>()?;
         let qargs = qargs.map_or_else(|| PyTuple::empty(py), |q| q.value);
         let cargs = cargs.map_or_else(|| PyTuple::empty(py), |c| c.value);
         let instruction = CircuitInstruction {
@@ -330,7 +331,7 @@ impl DAGOpNode {
 
     #[setter]
     fn set_op(&mut self, op: &Bound<PyAny>) -> PyResult<()> {
-        let res = op.extract::<OperationFromPython>()?;
+        let res = op.extract::<OperationFromPython<CircuitData>>()?;
         self.instruction.operation = res.operation;
         self.instruction.params = res.params;
         self.instruction.label = res.label;
@@ -448,7 +449,7 @@ impl DAGOpNode {
     fn set_name(&mut self, py: Python, new_name: Py<PyAny>) -> PyResult<()> {
         let op = self.instruction.get_operation_mut(py)?;
         op.setattr(intern!(py, "name"), new_name)?;
-        self.instruction.operation = op.extract::<OperationFromPython>()?.operation;
+        self.instruction.operation = op.extract::<OperationFromPython<CircuitData>>()?.operation;
         Ok(())
     }
 

--- a/crates/circuit/src/instruction.rs
+++ b/crates/circuit/src/instruction.rs
@@ -64,7 +64,7 @@ impl<T> Parameters<T> {
 
     /// Get a cloned version of these parameters, using a fallible mapping function to map any
     /// contained blocks into a new type.
-    pub fn try_map_blocks<S, E>(
+    pub fn try_map_blocks_ref<S, E>(
         &self,
         block_map_fn: impl FnMut(&T) -> Result<S, E>,
     ) -> Result<Parameters<S>, E> {
@@ -78,10 +78,36 @@ impl<T> Parameters<T> {
         }
     }
 
+    /// Get a mapped version of these parameters, using a fallible mapping function to map any
+    /// contained blocks into a new type.
+    pub fn try_map_blocks<S, E>(
+        self,
+        block_map_fn: impl FnMut(T) -> Result<S, E>,
+    ) -> Result<Parameters<S>, E> {
+        match self {
+            Self::Params(params) => Ok(Parameters::Params(params)),
+            Self::Blocks(blocks) => blocks
+                .into_iter()
+                .map(block_map_fn)
+                .collect::<Result<_, _>>()
+                .map(Parameters::Blocks),
+        }
+    }
+
     /// Get a cloned version of these parameters, using an infallible mapping function to map any
     /// contained blocks into a new type.
     #[inline]
-    pub fn map_blocks<S>(&self, mut block_map_fn: impl FnMut(&T) -> S) -> Parameters<S> {
+    pub fn map_blocks_ref<S>(&self, mut block_map_fn: impl FnMut(&T) -> S) -> Parameters<S> {
+        let Ok(out) = self.try_map_blocks_ref(|block| -> Result<S, ::std::convert::Infallible> {
+            Ok(block_map_fn(block))
+        });
+        out
+    }
+
+    /// Get a mapped version of these parameters, using an infallible mapping function to map any
+    /// contained blocks into a new type.
+    #[inline]
+    pub fn map_blocks<S>(self, mut block_map_fn: impl FnMut(T) -> S) -> Parameters<S> {
         let Ok(out) = self.try_map_blocks(|block| -> Result<S, ::std::convert::Infallible> {
             Ok(block_map_fn(block))
         });
@@ -96,6 +122,8 @@ impl<T> Parameters<T> {
 /// [CircuitInstruction] and [OperationFromPython] which own all the data they
 /// need to be converted back to a Python instance.
 pub trait Instruction {
+    type Block;
+
     /// Gets a reference to this instruction's operation.
     fn op(&self) -> OperationRef<'_>;
 
@@ -103,7 +131,7 @@ pub trait Instruction {
     ///
     /// For standard gates without parameters this may be [None] or a
     /// `Some(Parameters::Param(smallvec![]))`.
-    fn parameters(&self) -> Option<&Parameters<CircuitData>>;
+    fn parameters(&self) -> Option<&Parameters<Self::Block>>;
 
     /// Get the label for this instruction.
     fn label(&self) -> Option<&str>;
@@ -121,7 +149,7 @@ pub trait Instruction {
 
     /// Get a slice view onto the contained blocks.
     #[inline]
-    fn blocks_view(&self) -> &[CircuitData] {
+    fn blocks_view(&self) -> &[Self::Block] {
         self.parameters()
             .and_then(|p| match p {
                 Parameters::Blocks(b) => Some(b.as_slice()),
@@ -148,33 +176,16 @@ pub fn create_py_op(
     label: Option<&str>,
 ) -> PyResult<Py<PyAny>> {
     match op {
-        OperationRef::ControlFlow(cf) => cf.create_py_op(
-            py,
-            params.map(|p| match p {
-                Parameters::Blocks(blocks) => blocks,
-                Parameters::Params(_) => {
-                    panic!("control flow operation should not have params")
-                }
-            }),
-            label,
-        ),
+        OperationRef::ControlFlow(cf) => {
+            cf.create_py_op(py, params.map(|p| p.unwrap_blocks()), label)
+        }
         OperationRef::PauliProductMeasurement(ppm) => ppm.create_py_op(py, label),
-        OperationRef::StandardGate(gate) => gate.create_py_op(
-            py,
-            params.map(|p| match p {
-                Parameters::Params(params) => params,
-                Parameters::Blocks(_) => panic!("standard gate should not have blocks"),
-            }),
-            label,
-        ),
-        OperationRef::StandardInstruction(instruction) => instruction.create_py_op(
-            py,
-            params.map(|p| match p {
-                Parameters::Params(params) => params,
-                Parameters::Blocks(_) => panic!("standard instruction should not have blocks"),
-            }),
-            label,
-        ),
+        OperationRef::StandardGate(gate) => {
+            gate.create_py_op(py, params.map(|p| p.unwrap_params()), label)
+        }
+        OperationRef::StandardInstruction(instruction) => {
+            instruction.create_py_op(py, params.map(|p| p.unwrap_params()), label)
+        }
         OperationRef::Gate(gate) => Ok(gate.gate.clone_ref(py)),
         OperationRef::Instruction(instruction) => Ok(instruction.instruction.clone_ref(py)),
         OperationRef::Operation(operation) => Ok(operation.operation.clone_ref(py)),

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -65,6 +65,7 @@ pub struct Stretch(u32);
 pub struct Block(u32);
 
 pub use blocks::ControlFlowBlocks;
+pub use circuit_instruction::NoBlocks;
 pub use nlayout::PhysicalQubit;
 pub use nlayout::VirtualQubit;
 pub use packed_instruction::BlockMapper;

--- a/crates/circuit_library/src/blocks.rs
+++ b/crates/circuit_library/src/blocks.rs
@@ -15,6 +15,7 @@ use pyo3::{
     types::{PyList, PyTuple},
 };
 use qiskit_circuit::{
+    NoBlocks,
     circuit_instruction::OperationFromPython,
     operations::{Operation, Param, StandardGate},
     packed_instruction::PackedOperation,
@@ -47,7 +48,7 @@ impl BlockOperation {
                 let job = builder.call1(py, (py_params,))?;
                 let result = job.cast_bound::<PyTuple>(py)?;
 
-                let operation: OperationFromPython = result.get_item(0)?.extract()?;
+                let operation: OperationFromPython<NoBlocks> = result.get_item(0)?.extract()?;
                 let bound_params = result
                     .get_item(1)?
                     .try_iter()?

--- a/crates/circuit_library/src/pauli_evolution.rs
+++ b/crates/circuit_library/src/pauli_evolution.rs
@@ -17,7 +17,7 @@ use qiskit_circuit::circuit_instruction::OperationFromPython;
 use qiskit_circuit::operations;
 use qiskit_circuit::operations::{Param, StandardGate, multiply_param, radd_param};
 use qiskit_circuit::packed_instruction::PackedOperation;
-use qiskit_circuit::{Clbit, Qubit};
+use qiskit_circuit::{Clbit, NoBlocks, Qubit};
 use smallvec::{SmallVec, smallvec};
 
 // custom type for a more readable code
@@ -493,7 +493,7 @@ fn add_control(gate: StandardGate, params: &[Param], control_state: &[bool]) -> 
                 (num_controls, label, py_control_state, false),
             )
             .expect("Failed to call .control()")
-            .extract::<OperationFromPython>(py)
+            .extract::<OperationFromPython<NoBlocks>>(py)
             .expect("The control state should be valid and match the number of controls.");
 
         controlled_gate.operation

--- a/crates/synthesis/src/discrete_basis/basic_approximations.rs
+++ b/crates/synthesis/src/discrete_basis/basic_approximations.rs
@@ -17,7 +17,7 @@ use num_traits::FloatConst;
 use numpy::{Complex64, PyReadonlyArray2};
 use pyo3::{exceptions::PyValueError, prelude::*};
 use qiskit_circuit::{
-    Qubit,
+    NoBlocks, Qubit,
     circuit_data::CircuitData,
     circuit_instruction::OperationFromPython,
     operations::{Operation, OperationRef, Param, StandardGate},
@@ -283,7 +283,7 @@ impl GateSequence {
     /// Legacy method for backward compatibility with Python SK.
     #[staticmethod]
     fn from_gates_and_matrix(
-        gates: Vec<OperationFromPython>,
+        gates: Vec<OperationFromPython<NoBlocks>>,
         matrix_so3: PyReadonlyArray2<f64>,
         phase: f64,
     ) -> PyResult<Self> {

--- a/crates/synthesis/src/discrete_basis/solovay_kitaev.rs
+++ b/crates/synthesis/src/discrete_basis/solovay_kitaev.rs
@@ -15,6 +15,7 @@ use numpy::{Complex64, PyReadonlyArray2};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::types::PyString;
 use pyo3::{prelude::*, types::PyList};
+use qiskit_circuit::NoBlocks;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
 use qiskit_circuit::instruction::Instruction;
@@ -208,7 +209,7 @@ impl SolovayKitaevSynthesis {
             Some(py_gates) => py_gates
                 .iter()
                 .map(|el| {
-                    let py_op = el.extract::<OperationFromPython>()?;
+                    let py_op = el.extract::<OperationFromPython<NoBlocks>>()?;
                     match py_op.operation.view() {
                         OperationRef::StandardGate(gate) => Ok(gate),
                         _ => Err(PyValueError::new_err("Only standard gates accepted.")),
@@ -268,7 +269,7 @@ impl SolovayKitaevSynthesis {
     ///     CircuitData: The ``CircuitData`` implementing the approximation.
     fn synthesize(
         &self,
-        gate: OperationFromPython,
+        gate: OperationFromPython<NoBlocks>,
         recursion_degree: usize,
     ) -> PyResult<CircuitData> {
         self.synthesize_operation(&gate.operation.view(), gate.params_view(), recursion_degree)
@@ -294,7 +295,10 @@ impl SolovayKitaevSynthesis {
     ///
     /// Returns:
     ///     CircuitData: The sequence in the set of basic approximations closest to the input.
-    fn query_basic_approximation(&self, gate: OperationFromPython) -> PyResult<CircuitData> {
+    fn query_basic_approximation(
+        &self,
+        gate: OperationFromPython<NoBlocks>,
+    ) -> PyResult<CircuitData> {
         let matrix_u2 = match gate.try_matrix() {
             Some(matrix) => Matrix2::new(
                 matrix[(0, 0)],

--- a/crates/synthesis/src/multi_controlled/mcmt.rs
+++ b/crates/synthesis/src/multi_controlled/mcmt.rs
@@ -16,7 +16,7 @@ use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
 use qiskit_circuit::operations::{Param, StandardGate};
 use qiskit_circuit::packed_instruction::PackedOperation;
-use qiskit_circuit::{Clbit, Qubit};
+use qiskit_circuit::{Clbit, NoBlocks, Qubit};
 use smallvec::{SmallVec, smallvec};
 
 type CCXChainItem = PyResult<(
@@ -92,7 +92,7 @@ fn ccx_chain<'a>(
 #[pyfunction]
 #[pyo3(signature = (controlled_gate, num_ctrl_qubits, num_target_qubits, control_state=None))]
 pub fn mcmt_v_chain(
-    mut controlled_gate: OperationFromPython,
+    mut controlled_gate: OperationFromPython<NoBlocks>,
     num_ctrl_qubits: usize,
     num_target_qubits: usize,
     control_state: Option<usize>,

--- a/crates/synthesis/src/pauli_product_measurement.rs
+++ b/crates/synthesis/src/pauli_product_measurement.rs
@@ -22,7 +22,7 @@ use qiskit_circuit::operations::PauliProductMeasurement;
 use qiskit_circuit::operations::StandardGate;
 use qiskit_circuit::operations::StandardInstruction;
 use qiskit_circuit::packed_instruction::PackedOperation;
-use qiskit_circuit::{Clbit, Qubit};
+use qiskit_circuit::{Clbit, NoBlocks, Qubit};
 
 /// Synthesizes a PauliProductMeasurement instruction.
 /// This function is used in HighLevelSynthesis and is exposed to Python's class definition method.
@@ -117,7 +117,7 @@ pub fn synthesize_ppm(ppm: &PauliProductMeasurement) -> PyResult<CircuitData> {
 
 #[pyfunction]
 fn synth_pauli_product_measurement(operation: &Bound<PyAny>) -> PyResult<CircuitData> {
-    let op_from_python = operation.extract::<OperationFromPython>()?;
+    let op_from_python = operation.extract::<OperationFromPython<NoBlocks>>()?;
 
     if let OperationRef::PauliProductMeasurement(ppm) = op_from_python.operation.view() {
         synthesize_ppm(ppm)

--- a/crates/synthesis/src/two_qubit_decompose.rs
+++ b/crates/synthesis/src/two_qubit_decompose.rs
@@ -61,7 +61,7 @@ use qiskit_circuit::instruction::{Instruction, Parameters};
 use qiskit_circuit::operations::{Operation, OperationRef, Param, StandardGate};
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::util::{C_M_ONE, C_ONE, C_ZERO, GateArray1Q, GateArray2Q, IM, M_IM, c64};
-use qiskit_circuit::{Qubit, impl_intopyobject_for_copy_pyclass};
+use qiskit_circuit::{NoBlocks, Qubit, impl_intopyobject_for_copy_pyclass};
 
 const PI2: f64 = PI / 2.;
 const PI4: f64 = PI / 4.;
@@ -2076,7 +2076,7 @@ impl TwoQubitBasisDecomposer {
     #[new]
     #[pyo3(signature=(gate, gate_matrix, basis_fidelity=1.0, euler_basis="U", pulse_optimize=None))]
     fn new(
-        gate: OperationFromPython,
+        gate: OperationFromPython<NoBlocks>,
         gate_matrix: PyReadonlyArray2<Complex64>,
         basis_fidelity: f64,
         euler_basis: &str,
@@ -2555,7 +2555,7 @@ impl TwoQubitControlledUDecomposer {
             OperationRef::Gate(gate) => {
                 Python::attach(|py: Python| -> PyResult<(PackedOperation, SmallVec<_>)> {
                     let raw_inverse = gate.gate.call_method0(py, intern!(py, "inverse"))?;
-                    let mut inverse: OperationFromPython = raw_inverse.extract(py)?;
+                    let mut inverse: OperationFromPython<NoBlocks> = raw_inverse.extract(py)?;
                     let params = inverse.take_params().unwrap_or_default();
                     Ok((inverse.operation, params))
                 })?
@@ -2635,7 +2635,7 @@ impl TwoQubitControlledUDecomposer {
             RXXEquivalent::Standard(gate) => PackedOperation::from_standard_gate(*gate),
             RXXEquivalent::CustomPython(gate_cls) => {
                 Python::attach(|py| -> PyResult<PackedOperation> {
-                    let op: OperationFromPython =
+                    let op: OperationFromPython<NoBlocks> =
                         gate_cls.bind(py).call1((self.scale * angle,))?.extract()?;
                     Ok(op.operation)
                 })?

--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -322,10 +322,10 @@ impl CommutationChecker {
     #[allow(clippy::too_many_arguments)]
     fn py_commute(
         &mut self,
-        op1: OperationFromPython,
+        op1: OperationFromPython<Py<PyAny>>,
         qargs1: &Bound<'_, PyTuple>,
         cargs1: &Bound<'_, PyTuple>,
-        op2: OperationFromPython,
+        op2: OperationFromPython<Py<PyAny>>,
         qargs2: &Bound<'_, PyTuple>,
         cargs2: &Bound<'_, PyTuple>,
         max_num_qubits: Option<u32>,

--- a/crates/transpiler/src/equivalence.rs
+++ b/crates/transpiler/src/equivalence.rs
@@ -37,6 +37,7 @@ use rustworkx_core::petgraph::{
     visit::EdgeRef,
 };
 
+use qiskit_circuit::NoBlocks;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
 use qiskit_circuit::imports::{ImportOnceCell, QUANTUM_CIRCUIT};
@@ -298,7 +299,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for GateOper {
     type Error = PyErr;
 
     fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
-        let op_struct: OperationFromPython = ob.extract()?;
+        let op_struct: OperationFromPython<NoBlocks> = ob.extract()?;
         Ok(Self {
             operation: op_struct.operation,
             params: match op_struct.params {

--- a/crates/transpiler/src/passes/basis_translator/compose_transforms.rs
+++ b/crates/transpiler/src/passes/basis_translator/compose_transforms.rs
@@ -14,7 +14,6 @@ use super::errors::BasisTranslatorError;
 use hashbrown::HashMap;
 use indexmap::{IndexMap, IndexSet};
 use pyo3::prelude::*;
-use qiskit_circuit::Qubit;
 use qiskit_circuit::bit::QuantumRegister;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
@@ -25,6 +24,7 @@ use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::parameter::parameter_expression::ParameterExpression;
 use qiskit_circuit::parameter::symbol_expr::Symbol;
 use qiskit_circuit::parameter_table::ParameterUuid;
+use qiskit_circuit::{NoBlocks, Qubit};
 use qiskit_circuit::{
     dag_circuit::DAGCircuit,
     operations::{Operation, Param},
@@ -73,7 +73,7 @@ pub(super) fn compose_transforms<'a>(
         let gate = if let Some(op) = name_to_packed_operation(&gate_name, gate_num_qubits) {
             op
         } else {
-            let extract_py = Python::attach(|py| -> PyResult<OperationFromPython> {
+            let extract_py = Python::attach(|py| -> PyResult<OperationFromPython<NoBlocks>> {
                 GATE.get_bound(py)
                     .call1((&gate_name, gate_num_qubits, placeholder_params.as_ref()))?
                     .extract()

--- a/crates/transpiler/src/passes/commutative_optimization.rs
+++ b/crates/transpiler/src/passes/commutative_optimization.rs
@@ -25,7 +25,7 @@ use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_circuit::operations::{
     Operation, OperationRef, Param, StandardGate, multiply_param, radd_param,
 };
-use qiskit_circuit::{BlocksMode, Clbit, Qubit, imports};
+use qiskit_circuit::{BlocksMode, Clbit, NoBlocks, Qubit, imports};
 
 use qiskit_circuit::VarsMode;
 use qiskit_circuit::packed_instruction::PackedInstruction;
@@ -322,7 +322,7 @@ fn try_merge(
                 if merge_result.is_none() {
                     Ok(None)
                 } else {
-                    let instr: OperationFromPython = merge_result.extract()?;
+                    let instr: OperationFromPython<NoBlocks> = merge_result.extract()?;
                     let merged_param = instr
                         .params
                         .expect("PauliEvolution gate contains a parameter")

--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -977,7 +977,7 @@ fn py_synthesize_operation(
     data: &Bound<HighLevelSynthesisData>,
     tracker: &mut QubitTracker,
 ) -> PyResult<Option<(CircuitData, Vec<usize>)>> {
-    let op: OperationFromPython = py_op.extract()?;
+    let op: OperationFromPython<Py<PyAny>> = py_op.extract()?;
 
     // Check if the operation can be skipped.
     if definitely_skip_op(py, data, &op.operation, &input_qubits) {

--- a/crates/transpiler/src/passes/inverse_cancellation.rs
+++ b/crates/transpiler/src/passes/inverse_cancellation.rs
@@ -16,13 +16,14 @@ use indexmap::IndexMap;
 use pyo3::prelude::*;
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
+use qiskit_circuit::NoBlocks;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
 use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType};
 use qiskit_circuit::instruction::Instruction;
 use qiskit_circuit::operations::{Operation, OperationRef, StandardGate};
 use qiskit_circuit::packed_instruction::PackedInstruction;
 
-fn gate_eq(gate_a: &PackedInstruction, gate_b: &OperationFromPython) -> PyResult<bool> {
+fn gate_eq(gate_a: &PackedInstruction, gate_b: &OperationFromPython<NoBlocks>) -> PyResult<bool> {
     if gate_a.op.name() != gate_b.operation.name() {
         return Ok(false);
     }
@@ -45,7 +46,7 @@ fn run_on_self_inverse(
     dag: &mut DAGCircuit,
     op_counts: &IndexMap<String, usize, RandomState>,
     self_inverse_gate_names: HashSet<String>,
-    self_inverse_gates: Vec<OperationFromPython>,
+    self_inverse_gates: Vec<OperationFromPython<NoBlocks>>,
 ) -> PyResult<()> {
     if !self_inverse_gate_names
         .iter()
@@ -109,7 +110,7 @@ fn run_on_inverse_pairs(
     dag: &mut DAGCircuit,
     op_counts: &IndexMap<String, usize, RandomState>,
     inverse_gate_names: HashSet<String>,
-    inverse_gates: Vec<[OperationFromPython; 2]>,
+    inverse_gates: Vec<[OperationFromPython<NoBlocks>; 2]>,
 ) -> PyResult<()> {
     if !inverse_gate_names
         .iter()
@@ -290,8 +291,8 @@ pub fn run_inverse_cancellation_standard_gates(dag: &mut DAGCircuit) {
 #[pyo3(name = "inverse_cancellation")]
 pub fn py_run_inverse_cancellation(
     dag: &mut DAGCircuit,
-    inverse_gates: Vec<[OperationFromPython; 2]>,
-    self_inverse_gates: Vec<OperationFromPython>,
+    inverse_gates: Vec<[OperationFromPython<NoBlocks>; 2]>,
+    self_inverse_gates: Vec<OperationFromPython<NoBlocks>>,
     inverse_gate_names: HashSet<String>,
     self_inverse_gate_names: HashSet<String>,
     run_defaults: bool,

--- a/crates/transpiler/src/target/mod.rs
+++ b/crates/transpiler/src/target/mod.rs
@@ -113,6 +113,8 @@ impl NormalOperation {
 }
 
 impl Instruction for NormalOperation {
+    type Block = CircuitData;
+
     fn op(&self) -> OperationRef<'_> {
         self.operation.view()
     }
@@ -156,10 +158,10 @@ impl<'a, 'py> IntoPyObject<'py> for &'a NormalOperation {
 }
 
 impl<'a, 'py> FromPyObject<'a, 'py> for NormalOperation {
-    type Error = <OperationFromPython as FromPyObject<'a, 'py>>::Error;
+    type Error = <OperationFromPython<CircuitData> as FromPyObject<'a, 'py>>::Error;
 
     fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
-        let operation: OperationFromPython = ob.extract()?;
+        let operation: OperationFromPython<CircuitData> = ob.extract()?;
         Ok(Self {
             operation: operation.operation,
             params: operation.params,


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Previously, the `OperationFromPython` extraction helper automatically chose `CircuitData` for the control-flow blocks.  Since this extraction automatically required a clone anyway, the assumed type came at a cost.

This allows `DAGCircuit` to directly extract blocks to the correct type without the intermediate step.  As a side effect, we also allow extraction to fail with a type error if blocks are not expected, and add a way to leave blocks unextracted.



### Details and comments

Built on top of #15432.  It's good for a ~10% improvement in the benchmark in that PR, which probably isn't worth worrying about too much.