### PR TITLE
Fix gridsynth plugin config

### DIFF
--- a/qiskit/transpiler/passes/synthesis/ross_selinger_plugin.py
+++ b/qiskit/transpiler/passes/synthesis/ross_selinger_plugin.py
@@ -105,7 +105,10 @@ class RossSelingerSynthesis(UnitarySynthesisPlugin):
         """Run the Ross-Selinger synthesis plugin on the given unitary."""
         # ToDo: possibly we should use the approximation_degree instead,
         # and compute epsilon based on that.
-        epsilon = options.get("epsilon", 1e-10)
+        if (config := options.get("config")) is not None:
+            epsilon = config.get("epsilon", 1e-10)
+        else:
+            epsilon = 1e-10
 
         approximate_circuit = gridsynth_unitary(unitary, epsilon)
         return circuit_to_dag(approximate_circuit)

--- a/test/python/transpiler/test_ross_selinger.py
+++ b/test/python/transpiler/test_ross_selinger.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from ddt import ddt, data
 
+from qiskit import transpile
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library import (
     RZGate,
@@ -179,6 +180,25 @@ class TestRossSelingerPlugin(QiskitTestCase):
         # The approximation should be good enough for the Operator-equality check to pass
         self.assertEqual(Operator(circuit), Operator(compiled))
         self.assertLessEqual(set(compiled.count_ops()), CLIFFORD_T_GATES_SET)
+
+    def test_plugin_config(self):
+        """Test the plugin configs are propagated correctly."""
+        qc = QuantumCircuit(1)
+        qc.rx(1.0, 0)
+
+        epsilons = [1e-6, 1e-8, 1e-10]
+        t_expected = [62, 81, 105]
+
+        for eps, t_expect in zip(epsilons, t_expected):
+            with self.subTest(eps=eps, t_expect=t_expect):
+                transpiled = transpile(
+                    qc,
+                    basis_gates=["cx", "h", "s", "t"],
+                    unitary_synthesis_method="gridsynth",
+                    unitary_synthesis_plugin_config={"epsilon": eps},
+                )
+                t_count = transpiled.count_ops().get("t", 0)
+                self.assertLessEqual(t_count, t_expect)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Setting "epsilon" was not correctly propagated: the unitary synthesis plugins provide the user configuration in `options["config"]`, not in `options` itself.

### Details and comments

The first RC1 bug! No reno since this bug is not yet released.

