### PR TITLE
Represent non-fixed params as `NaN` for `QkTargetOp`

### DIFF
--- a/crates/cext/src/transpiler/target.rs
+++ b/crates/cext/src/transpiler/target.rs
@@ -1343,8 +1343,9 @@ pub struct CTargetOp {
     /// `(uint32_t)-1` in the case of a variadic.
     pub num_qubits: u32,
     /// The parameters tied to this operation if fixed, as an array
-    /// of `double`. If the operation doesn't posess any fixed parameters
-    /// or is variadic, this attribute will be a ``NULL`` pointer.
+    /// of `double`. If any of the parameters represented are not fixed angles
+    /// it will be represented as with the `NaN` value. If there are no parameters
+    /// then this value will be represented with a `NULL` pointer.
     pub params: *mut f64,
     /// The number of parameters supported by this operation. Will default to
     /// `(uint32_t)-1` in the case of a variadic.
@@ -1426,9 +1427,9 @@ pub unsafe extern "C" fn qk_target_op_get(
                 operation
                     .params_view()
                     .iter()
-                    .filter_map(|param| match param {
-                        Param::Float(number) => Some(*number),
-                        _ => None,
+                    .map(|param| match param {
+                        Param::Float(number) => *number,
+                        _ => f64::NAN,
                     })
                     .collect(),
             );

--- a/releasenotes/notes/c-api-target-params-6a54fcfcbe14de7e.yaml
+++ b/releasenotes/notes/c-api-target-params-6a54fcfcbe14de7e.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a mismatch in :c:struct:`QkTargetOp` in which the length of the array
+    stored in :c:member:`QkTargetOp.params` did not match the number exposed by
+    :c:member:`QkTargetOp.num_params`. The following PR fixes it by exposing any
+    placeholder parameters as ``NAN`` so the length of the array always matches
+    that of :c:member:`QkTargetOp.num_params`.

--- a/releasenotes/notes/c-api-target-params-6a54fcfcbe14de7e.yaml
+++ b/releasenotes/notes/c-api-target-params-6a54fcfcbe14de7e.yaml
@@ -3,6 +3,6 @@ fixes:
   - |
     Fixed a mismatch in :c:struct:`QkTargetOp` in which the length of the array
     stored in :c:member:`QkTargetOp.params` did not match the number exposed by
-    :c:member:`QkTargetOp.num_params`. The following PR fixes it by exposing any
-    placeholder parameters as ``NAN`` so the length of the array always matches
-    that of :c:member:`QkTargetOp.num_params`.
+    :c:member:`QkTargetOp.num_params`. Wildcard parameters are now represented
+    by ``NAN``, and the length of the array will always be :c:member:`QkTargetOp.num_params`.
+    This bug was only present in 2.3.0rc1.


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Fixes #15438 
Due to our decision of provisionally exposing parameters in `QkTargetOp` as `double[]` we mistakenly filtered out any non-fixed parameters instead of showing a placeholder value. This PR provisionally exposes any non-fixed parameter instance as `NaN` until we work out a much cleaner way of exposing the parameters to C.

### Details and comments
- [x] Add release note.
