### PR TITLE
Add pauli() accessor to PauliProductMeasurement

### DIFF
--- a/qiskit/circuit/library/pauli_product_measurement.py
+++ b/qiskit/circuit/library/pauli_product_measurement.py
@@ -145,7 +145,7 @@ class PauliProductMeasurement(Instruction):
         including its global phase of ``+1`` or ``-1``.
 
         Returns:
-            Pauli: The Pauli product measured by this instruction.
+            The Pauli product measured by this instruction.
         """
         return Pauli((self._pauli_z, self._pauli_x, self._pauli_phase))
 

--- a/qiskit/circuit/library/pauli_product_measurement.py
+++ b/qiskit/circuit/library/pauli_product_measurement.py
@@ -136,6 +136,19 @@ class PauliProductMeasurement(Instruction):
         """
         return [self._pauli_z, self._pauli_x, self._pauli_phase]
 
+    def pauli(self) -> Pauli:
+        """Return the Pauli product implemented by this measurement.
+
+        This is a public accessor that reconstructs and returns the
+        :class:`~qiskit.quantum_info.Pauli` corresponding to this
+        instruction's underlying tensor product of Pauli operators,
+        including its global phase of ``+1`` or ``-1``.
+
+        Returns:
+            Pauli: The Pauli product measured by this instruction.
+        """
+        return Pauli((self._pauli_z, self._pauli_x, self._pauli_phase))
+
 
 def _get_default_label(pauli: Pauli):
     """Creates the default label for PauliProductMeasurement instruction,

--- a/releasenotes/notes/allow-pauli-accessor-15468.yaml
+++ b/releasenotes/notes/allow-pauli-accessor-15468.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Added a public accessor ``pauli()`` to
+    :class:`qiskit.circuit.library.PauliProductMeasurement` to return the
+    underlying :class:`qiskit.quantum_info.Pauli` measured by the instruction,
+    including its global phase of ``+1`` or ``-1``.
+    (See `#15468 <https://github.com/Qiskit/qiskit/issues/15468>`__.)

--- a/releasenotes/notes/allow-pauli-accessor-15468.yaml
+++ b/releasenotes/notes/allow-pauli-accessor-15468.yaml
@@ -1,8 +1,6 @@
 ---
 features:
   - |
-    Added a public accessor ``pauli()`` to
-    :class:`qiskit.circuit.library.PauliProductMeasurement` to return the
-    underlying :class:`qiskit.quantum_info.Pauli` measured by the instruction,
-    including its global phase of ``+1`` or ``-1``.
-    (See `#15468 <https://github.com/Qiskit/qiskit/issues/15468>`__.)
+    Added a :meth:`.PauliProductMeasurement.pauli` method to
+    return the underlying :class:`~qiskit.quantum_info.Pauli` measured 
+    by the instruction, including its global phase of ``+1`` or ``-1``.

--- a/test/python/circuit/library/test_ppm.py
+++ b/test/python/circuit/library/test_ppm.py
@@ -183,6 +183,12 @@ class TestPauliProductMeasurement(QiskitTestCase):
 
         self.assertEqual(ppm_from_circuit.label, custom_label)
 
+    def test_pauli_accessor(self):
+        """Check that ``pauli()`` returns the original Pauli."""
+        original = Pauli("-XZ")
+        ppm = PauliProductMeasurement(original)
+        self.assertEqual(ppm.pauli(), original)
+
     @data(0, 1, 2, 3)
     def test_transpile(self, optimization_level):
         """Check that transpiling circuits with PauliProductMeasurement instructions


### PR DESCRIPTION
## Summary
Add a public accessor method `pauli()` to `PauliProductMeasurement` to expose the underlying Pauli object measured by the instruction.

## Details and comments

This PR implements the feature requested in #15468 by adding a public `pauli()` method to the `PauliProductMeasurement` class.

**Implementation:**
- Added `pauli() -> Pauli` method that reconstructs the Pauli product from internal z/x/phase components
- Returns the full Pauli including global phase (+1 or -1)
- Leverages existing internal storage (`_pauli_z`, `_pauli_x`, `_pauli_phase`)

**Testing:**
- Added `test_pauli_accessor()` unit test in `test/python/circuit/library/test_ppm.py`
- Verifies that `PauliProductMeasurement(Pauli("-XZ")).pauli() == Pauli("-XZ")`

**Documentation:**
- Added release note via `reno` in `releasenotes/notes/allow-pauli-accessor-15468.yaml`

**Verification:**
- Tested locally: 31/31 PauliProductMeasurement tests pass

Fixes #15468

