### PR TITLE
Fix phase for `[-1, 0]` `Isometry`.

### DIFF
--- a/qiskit/circuit/library/generalized_gates/isometry.py
+++ b/qiskit/circuit/library/generalized_gates/isometry.py
@@ -233,7 +233,10 @@ class Isometry(Instruction):
         # UCGate to disentangle a qubit:
         # Find the UCGate, decompose it and apply it to the remaining isometry
         single_qubit_gates = self._find_squs_for_disentangling(v, k, s)
-        if not isometry_rs.ucg_is_identity_up_to_global_phase(single_qubit_gates, self._epsilon):
+        if (
+            not isometry_rs.ucg_is_identity_up_to_global_phase(single_qubit_gates, self._epsilon)
+            or len(single_qubit_gates) == 1
+        ):
             control_labels = list(range(target_label))
             diagonal_ucg = self._append_ucg_up_to_diagonal(
                 circuit, q, single_qubit_gates, control_labels, target_label


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Addresses #15465

Adds a extra condition to _disentangle function in `isometry.py` that prevents the code from ignoring the pi phase of [-1, 0] Isometry.


### Details and comments
The problem only occurs for when the `UCGate` (given as list of single-qubit gates), which is used to disentangle a qubit while encoding the Isometry, is just a single diagonal gate with real values. This only occurs when this gate is either `identity` or `-1*identity`. Earlier this `-1*identity` was skipped, ignoring the global phase, leading to the phase-incorrect [-1,0]. But with the new check this is fixed. 


