### PR TITLE
[WIP] switch SabreDAG's control flow representation from cloned DAGCircuits to Block IDs.

### DIFF
--- a/crates/transpiler/src/passes/sabre/dag.rs
+++ b/crates/transpiler/src/passes/sabre/dag.rs
@@ -19,7 +19,7 @@ use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType, Wire};
 use qiskit_circuit::operations::ControlFlowView;
 use qiskit_circuit::operations::Operation;
 use qiskit_circuit::packed_instruction::PackedOperation;
-use qiskit_circuit::{Qubit, VirtualQubit};
+use qiskit_circuit::{Block, Qubit, VirtualQubit};
 
 /// The type of a node in the Sabre interactions graph.
 #[derive(Clone, Debug)]
@@ -33,18 +33,21 @@ pub enum InteractionKind {
     /// A two-qubit interaction.  This is the principal component that we're concerned with.
     TwoQ([VirtualQubit; 2]),
     /// A control-flow operation on more than two qubits.  If it's only on a single qubit, it'll be
-    /// handled by `Synchronize`.  If it's on 2q, it'll be handled by `TwoQ`.  We need to store both
-    /// the Sabre version and the DAG representation of the block, so we can reconstruct things
-    /// later.  When control-flow ops are represented with native DAGs, we won't need to store the
-    /// temporary.
-    ControlFlow(Box<[(SabreDAG, DAGCircuit)]>),
+    /// handled by `Synchronize`.  If it's on 2q, it'll be handled by `TwoQ`.  We store the
+    /// Sabre version and the ID of the block, so we can retrieve the inner DAG and reconstruct things
+    /// later.
+    ControlFlow(Box<[(SabreDAG, Block)]>),
 }
 impl InteractionKind {
-    fn from_control_flow(cf: ControlFlowView<DAGCircuit>) -> Result<Self, SabreDAGError> {
+    fn from_control_flow(
+        cf: ControlFlowView<DAGCircuit>,
+        block_ids: impl Iterator<Item = Block>,
+    ) -> Result<Self, SabreDAGError> {
         let blocks: Box<[_]> = cf
             .blocks()
             .into_iter()
-            .map(|dag| Ok((SabreDAG::from_dag(dag)?, dag.clone())))
+            .zip(block_ids)
+            .map(|(dag, id)| Ok((SabreDAG::from_dag(dag)?, id)))
             .collect::<Result<_, SabreDAGError>>()?;
         Ok(Self::ControlFlow(blocks))
     }
@@ -162,7 +165,7 @@ impl SabreDAG {
                 panic!("op nodes should always be of type `Operation`");
             };
             let kind = if let Some(cf) = dag.try_view_control_flow(inst) {
-                InteractionKind::from_control_flow(cf)?
+                InteractionKind::from_control_flow(cf, inst.blocks_view().iter().copied())?
             } else {
                 InteractionKind::from_op(&inst.op, dag.get_qargs(inst.qubits))?
             };

--- a/crates/transpiler/src/passes/sabre/route.rs
+++ b/crates/transpiler/src/passes/sabre/route.rs
@@ -496,7 +496,8 @@ impl<'a> RoutingState<'a> {
                         let actual = VirtualQubit::new(outer.index() as u32).to_phys(&self.layout);
                         layout.swap_physical(dummy, actual);
                     }
-                    for (sabre, dag) in blocks.iter() {
+                    for (sabre, block_id) in blocks.iter() {
+                        let dag = &self.dag.blocks()[*block_id];
                         let block_result = self.route_control_flow_block(&layout, sabre, dag);
                         self.control_flow.push(block_result);
                     }


### PR DESCRIPTION


<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes #15378.
This PR refactors SabreDAG’s control-flow handling to avoid cloning DAGCircuit instances. Control-flow blocks now reference lightweight Block IDs instead of owning full circuit copies.

### Details and comments

**Changes**

InteractionKind::ControlFlow stores Block IDs rather than DAGCircuit clones

from_control_flow links to existing parent blocks instead of creating new circuits

Routing resolves Block IDs from the parent block collection during recursion

**Impact**

This removes redundant circuit cloning, reduces memory usage, and improves Sabre swap mapping performance—especially for deeply nested control-flow circuits.

AI tool used: Google's Antigravity with Gemini 3
