### PR TITLE
Clarify test assertion for `UnitarySynthesis`

### DIFF
--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -357,12 +357,12 @@ class TestUnitarySynthesisBasisGates(QiskitTestCase):
 
         qv64_1 = pm1.run(qv64.decompose())
         qv64_2 = pm2.run(qv64.decompose())
-        edges = [list(edge) for edge in coupling_map.get_edges()]
-        self.assertTrue(
-            all(
-                [qv64_1.qubits.index(qubit) for qubit in instr.qubits] in edges
+        self.assertLessEqual(
+            {
+                tuple(qv64_1.qubits.index(qubit) for qubit in instr.qubits)
                 for instr in qv64_1.get_instructions("cx")
-            )
+            },
+            {tuple(edge) for edge in coupling_map.get_edges()},
         )
         self.assertEqual(Operator(qv64_1), Operator(qv64_2))
 
@@ -1039,13 +1039,11 @@ class TestUnitarySynthesisTarget(QiskitTestCase):
     def test_two_qubit_natural_direction_true_duration_fallback_target(self):
         """Verify fallback path when pulse_optimize==True."""
         basis_gates = ["id", "rz", "sx", "x", "cx", "reset"]
-        qr = QuantumRegister(2)
+        qr = QuantumRegister(5)
         coupling_map = CouplingMap([[0, 1], [1, 0], [1, 2], [1, 3], [3, 4]])
         backend = GenericBackendV2(
             num_qubits=5, basis_gates=basis_gates, coupling_map=coupling_map, seed=1
         )
-
-        triv_layout_pass = TrivialLayout(coupling_map)
         qc = QuantumCircuit(qr)
         qc.unitary(random_unitary(4, seed=12), [0, 1])
         unisynth_pass = UnitarySynthesis(
@@ -1053,10 +1051,13 @@ class TestUnitarySynthesisTarget(QiskitTestCase):
             pulse_optimize=True,
             natural_direction=True,
         )
-        pm = PassManager([triv_layout_pass, unisynth_pass])
-        qc_out = pm.run(qc)
-        self.assertTrue(
-            all(((qr[0], qr[1]) == instr.qubits for instr in qc_out.get_instructions("cx")))
+        qc_out = unisynth_pass(qc)
+        self.assertEqual(
+            {
+                tuple(qc_out.find_bit(q).index for q in instr.qubits)
+                for instr in qc_out.get_instructions("cx")
+            },
+            {(0, 1)},
         )
 
 


### PR DESCRIPTION
In a rework of `UnitarySynthesis` I'm working on, I was (temporarily) failing this test, but didn't have much to go on because the failure message was just "False is not true".  This commit changes the assertion to something more useful, so that the failing edges all appear in the output.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


