### PR TITLE
Use realistic errors in C API test Target

### DIFF
--- a/test/python/c_api/ffi.py
+++ b/test/python/c_api/ffi.py
@@ -189,7 +189,7 @@ def build_homogenous_target(
             for edge in cmap.get_edges():
                 qubits = into_c_array_ptr(edge, ctypes.c_uint32)
                 if not ideal_gates:
-                    error = rng.uniform(0.0, 1.0)
+                    error = rng.uniform(0.0, 0.1)
                     duration = rng.uniform(0.0, 1.0)
                 else:
                     error = float("nan")
@@ -199,7 +199,7 @@ def build_homogenous_target(
             for qubit in range(cmap.size()):
                 qubits = into_c_array_ptr([qubit], ctypes.c_uint32)
                 if not ideal_gates:
-                    error = rng.uniform(0.0, 1.0)
+                    error = rng.uniform(0.0, 0.01)
                     duration = rng.uniform(0.0, 1.0)
                 else:
                     error = float("nan")
@@ -212,7 +212,7 @@ def build_homogenous_target(
     for qubit in range(cmap.size()):
         qubits = into_c_array_ptr([qubit], ctypes.c_uint32)
         if not ideal_gates:
-            error = rng.uniform(0.0, 1.0)
+            error = rng.uniform(0.0, 0.1)
             duration = rng.uniform(0.0, 1.0)
         else:
             error = float("nan")


### PR DESCRIPTION
Previously, the error rates were ludicrously high, which meant that, in general, `UnitarySynthesis` could synthesise entangling 2q blocks into separable states without any 2q gates at all, while maintaining its configured fidelity target.

For example, the `Target` used in
`test.python.c_api.TestTranspile.test_translate_ecr_basis` has ECR properties of (approximately):

    (0, 1): (duration=0.976, error=0.094)
    (1, 0): (duration=0.786, error=0.786)

The error on the (1, 0) link is ridiculous, and effectively means that any synthesis that depends on that error will create pure noise.  Due to weirdness in the `UnitarySynthesis` "preferred direction" logic as of Qiskit 2.3.0, the "preferred direction" is chosen based first on the duration, meaning that the (1, 0) link is chosen, but the _error_ used in the approximation of this decomposition is not updated to the flipped error, but instead remains as the (0, 1) error.

The actual root compilation bug here is in the heuristic choices of `UnitarySynthesis`, but this can be fixed separately in a follow up. Regardless of those heuristics, the `Target` construction in these C tests is creating crazy situations but testing as if the backend is sane.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


