### PR TITLE
Refactor DAGCircuit to use Qubit/Clbit instead of ShareableQubit/ShareableClbit

### DIFF
--- a/crates/cext/src/dag.rs
+++ b/crates/cext/src/dag.rs
@@ -1382,16 +1382,22 @@ pub unsafe extern "C" fn qk_dag_compose(
     let local_qubits = qubits.as_ref().map(|qubits_vec| {
         qubits_vec
             .iter()
-            .enumerate()
-            .map(|(index, _)| Qubit::new(index))
+            .map(|shareable_qubit| {
+                dag.qubits()
+                    .find(shareable_qubit)
+                    .expect("Qubit not found in dag")
+            })
             .collect::<Vec<_>>()
     });
 
     let local_clbits = clbits.as_ref().map(|clbits_vec| {
         clbits_vec
             .iter()
-            .enumerate()
-            .map(|(index, _)| Clbit::new(index))
+            .map(|shareable_clbit| {
+                dag.clbits()
+                    .find(shareable_clbit)
+                    .expect("Clbit not found in dag")
+            })
             .collect::<Vec<_>>()
     });
 

--- a/crates/cext/src/dag.rs
+++ b/crates/cext/src/dag.rs
@@ -1378,15 +1378,32 @@ pub unsafe extern "C" fn qk_dag_compose(
         .items()
         .map(|(index, block)| (index, dag.add_block(block.clone())))
         .collect();
+
+    let local_qubits = qubits.as_ref().map(|qubits_vec| {
+        qubits_vec
+            .iter()
+            .enumerate()
+            .map(|(index, _)| Qubit::new(index))
+            .collect::<Vec<_>>()
+    });
+
+    let local_clbits = clbits.as_ref().map(|clbits_vec| {
+        clbits_vec
+            .iter()
+            .enumerate()
+            .map(|(index, _)| Clbit::new(index))
+            .collect::<Vec<_>>()
+    });
+
     // Since we don't yet support vars in C, we can skip the inline_captures check.
     dag.compose(
         other_dag,
-        qubits.as_deref(),
-        clbits.as_deref(),
+        local_qubits.as_deref(),
+        local_clbits.as_deref(),
         block_map,
         false,
     )
-    .expect("Error during circuit composition.");
+        .expect("Error during circuit composition.");
     ExitCode::Success
 }
 

--- a/crates/cext/src/dag.rs
+++ b/crates/cext/src/dag.rs
@@ -15,7 +15,7 @@ use num_complex::Complex64;
 use smallvec::smallvec;
 
 use crate::exit_codes::ExitCode;
-use qiskit_circuit::bit::{ClassicalRegister, QuantumRegister, ShareableClbit, ShareableQubit};
+use qiskit_circuit::bit::{ClassicalRegister, QuantumRegister};
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::converters::dag_to_circuit;
 use qiskit_circuit::dag_circuit::{DAGCircuit, NodeIndex, NodeType};
@@ -28,7 +28,6 @@ use qiskit_circuit::{Clbit, Qubit};
 use crate::circuit::{CBlocksMode, CInstruction, CVarsMode};
 
 use crate::circuit::unitary_from_pointer;
-use crate::dag::CDagNodeType::ClbitIn;
 use crate::pointers::{check_ptr, const_ptr_as_ref, mut_ptr_as_ref};
 
 /// @ingroup QkDag

--- a/crates/cext/src/dag.rs
+++ b/crates/cext/src/dag.rs
@@ -1345,14 +1345,14 @@ pub unsafe extern "C" fn qk_dag_compose(
     let local_qubits: Option<Vec<Qubit>> = if check_ptr(qubits).is_ok() {
         let qubit_slice = unsafe { std::slice::from_raw_parts(qubits, other_dag.num_qubits()) };
         Some(qubit_slice.iter().map(|&bit| Qubit(bit)).collect())
-    }  else {
+    } else {
         None
     };
 
     let local_clbits: Option<Vec<Clbit>> = if check_ptr(clbits).is_ok() {
         let clbit_slice = unsafe { std::slice::from_raw_parts(clbits, other_dag.num_clbits()) };
         Some(clbit_slice.iter().map(|&bit| Clbit(bit)).collect())
-    }  else {
+    } else {
         None
     };
 
@@ -1364,7 +1364,7 @@ pub unsafe extern "C" fn qk_dag_compose(
         block_map,
         false,
     )
-        .expect("Error during circuit composition.");
+    .expect("Error during circuit composition.");
     ExitCode::Success
 }
 

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -8013,7 +8013,7 @@ impl DAGCircuit {
             .collect();
 
         let qubit_map = match qubits {
-            None => self
+            None => other
                 .qubits
                 .objects()
                 .iter()
@@ -8045,7 +8045,13 @@ impl DAGCircuit {
         };
 
         let clbit_map = match clbits {
-            None => identity_clbit_map.clone(),
+            None => other
+                .clbits
+                .objects()
+                .iter()
+                .cloned()
+                .zip(self.clbits.objects().iter().cloned())
+                .collect(),
             Some(clbits) => {
                 if clbits.len() != other.clbits.len() {
                     return Err(DAGCircuitError::new_err(concat!(
@@ -8125,16 +8131,10 @@ impl DAGCircuit {
         }
         let build_var_mapper = |cregs: &RegisterData<ClassicalRegister>| -> VariableMapper {
             let mut edge_map = HashMap::new();
-            if clbit_map.is_empty() {
-                // try to ido a 1-1 mapping in order
-                for (a, b) in identity_clbit_map.iter() {
-                    edge_map.insert(a.clone(), b.clone());
-                }
-            } else {
-                for (a, b) in clbit_map.iter() {
-                    edge_map.insert(a.clone(), b.clone());
-                }
-            };
+            for (a, b) in clbit_map.iter() {
+                edge_map.insert(a.clone(), b.clone());
+            }
+
             VariableMapper::new(
                 cregs.registers().to_vec(),
                 edge_map,

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -8004,14 +8004,6 @@ impl DAGCircuit {
             ));
         }
 
-        let identity_clbit_map: HashMap<ShareableClbit, ShareableClbit> = other
-            .clbits
-            .objects()
-            .iter()
-            .cloned()
-            .zip(self.clbits.objects().iter().cloned())
-            .collect();
-
         let qubit_map = match qubits {
             None => other
                 .qubits

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -1624,10 +1624,12 @@ impl DAGCircuit {
                             Ok(Qubit::new(index))
                         } else {
                             let shareable_qubit = q.extract::<ShareableQubit>()?;
-                            self.qubits.find(&shareable_qubit)
-                                .ok_or_else(|| DAGCircuitError::new_err(
-                                    format!("Qubit {:?} not found in DAG", shareable_qubit)
+                            self.qubits.find(&shareable_qubit).ok_or_else(|| {
+                                DAGCircuitError::new_err(format!(
+                                    "Qubit {:?} not found in DAG",
+                                    shareable_qubit
                                 ))
+                            })
                         }
                     })
                     .collect::<PyResult<Vec<Qubit>>>()
@@ -1644,10 +1646,12 @@ impl DAGCircuit {
                             Ok(Clbit::new(index))
                         } else {
                             let shareable_clbit = c.extract::<ShareableClbit>()?;
-                            self.clbits.find(&shareable_clbit)
-                                .ok_or_else(|| DAGCircuitError::new_err(
-                                    format!("Clbit {:?} not found in DAG", shareable_clbit)
+                            self.clbits.find(&shareable_clbit).ok_or_else(|| {
+                                DAGCircuitError::new_err(format!(
+                                    "Clbit {:?} not found in DAG",
+                                    shareable_clbit
                                 ))
+                            })
                         }
                     })
                     .collect::<PyResult<Vec<Clbit>>>()
@@ -7751,7 +7755,8 @@ impl DAGCircuit {
                         )));
                     }
                     let qubit_index = qc_data.qubits().find(shareable_qubit).unwrap();
-                    ordered_vec[qubit_index.index()] = new_dag.add_qubit_unchecked(shareable_qubit.clone())?;
+                    ordered_vec[qubit_index.index()] =
+                        new_dag.add_qubit_unchecked(shareable_qubit.clone())?;
                     Ok(())
                 })?;
             // The `Vec::get` use is because an arbitrary interner might contain old references to
@@ -7788,7 +7793,8 @@ impl DAGCircuit {
                         )));
                     };
                     let clbit_index = qc_data.clbits().find(shareable_clbit).unwrap();
-                    ordered_vec[clbit_index.index()] = new_dag.add_clbit_unchecked(shareable_clbit.clone())?;
+                    ordered_vec[clbit_index.index()] =
+                        new_dag.add_clbit_unchecked(shareable_clbit.clone())?;
                     Ok(())
                 })?;
             // The `Vec::get` use is because an arbitrary interner might contain old references to
@@ -7998,14 +8004,6 @@ impl DAGCircuit {
             ));
         }
 
-        // Number of qubits and clbits must match number in circuit or None
-        let identity_qubit_map: HashMap<ShareableQubit, ShareableQubit> = other
-            .qubits
-            .objects()
-            .iter()
-            .cloned()
-            .zip(self.qubits.objects().iter().cloned())
-            .collect();
         let identity_clbit_map: HashMap<ShareableClbit, ShareableClbit> = other
             .clbits
             .objects()
@@ -8015,7 +8013,13 @@ impl DAGCircuit {
             .collect();
 
         let qubit_map = match qubits {
-            None => identity_qubit_map.clone(),
+            None => self
+                .qubits
+                .objects()
+                .iter()
+                .cloned()
+                .zip(self.qubits.objects().iter().cloned())
+                .collect(),
             Some(qubits) => {
                 if qubits.len() != other.qubits.len() {
                     return Err(DAGCircuitError::new_err(concat!(

--- a/crates/transpiler/src/passes/disjoint_layout.rs
+++ b/crates/transpiler/src/passes/disjoint_layout.rs
@@ -211,6 +211,23 @@ pub fn distribute_components(dag: &mut DAGCircuit, target: &Target) -> PyResult<
                 for creg in dag.cregs() {
                     out_dag.add_creg(creg.clone())?;
                 }
+
+                let qubits_indices: Vec<Qubit> = dag
+                    .qubits()
+                    .objects()
+                    .iter()
+                    .enumerate()
+                    .map(|(index, _)| Qubit::new(index))
+                    .collect();
+
+                let clbits_indices: Vec<Clbit> = dag
+                    .clbits()
+                    .objects()
+                    .iter()
+                    .enumerate()
+                    .map(|(index, _)| Clbit::new(index))
+                    .collect();
+
                 let block_map = dag
                     .blocks()
                     .items()
@@ -218,8 +235,8 @@ pub fn distribute_components(dag: &mut DAGCircuit, target: &Target) -> PyResult<
                     .collect();
                 out_dag.compose(
                     dag,
-                    Some(dag.qubits().objects()),
-                    Some(dag.clbits().objects()),
+                    Some(&qubits_indices),
+                    Some(&clbits_indices),
                     block_map,
                     false,
                 )?;

--- a/crates/transpiler/src/passes/disjoint_layout.rs
+++ b/crates/transpiler/src/passes/disjoint_layout.rs
@@ -216,16 +216,23 @@ pub fn distribute_components(dag: &mut DAGCircuit, target: &Target) -> PyResult<
                     .qubits()
                     .objects()
                     .iter()
-                    .enumerate()
-                    .map(|(index, _)| Qubit::new(index))
+                    .map(|qubit| {
+                        out_dag
+                            .qubits()
+                            .find(qubit)
+                            .expect("Qubit from dag not found in out_dag")
+                    })
                     .collect();
-
                 let clbits_indices: Vec<Clbit> = dag
                     .clbits()
                     .objects()
                     .iter()
-                    .enumerate()
-                    .map(|(index, _)| Clbit::new(index))
+                    .map(|clbit| {
+                        out_dag
+                            .clbits()
+                            .find(clbit)
+                            .expect("Clbit from dag not found in out_dag")
+                    })
                     .collect();
 
                 let block_map = dag


### PR DESCRIPTION
### Summary

Refactors internal DAGCircuit functions to use `Qubit`/`Clbit` indices instead of `ShareableQubit`/`ShareableClbit` for improved efficiency and API simplicity.

### Details and comments

This PR addresses #15316 by refactoring the following functions:
- `DAGCircuit::from_circuit` and `DAGCircuit::from_circuit_data` now accept `Qubit`/`Clbit` indices
- `converters::circuit_to_dag` handles the mapping from shareable bits to local indices  
- `DAGCircuit::compose` uses local bit indices internally
- `DAGCircuit::py_compose` performs bit mapping before calling the internal compose
- Updated C extension (dag.rs) to convert to local bit indices
- Updated disjoint_layout pass to use local bit indices

This separation allows Rust and C callers to work with efficient local indices while Python callers continue to use the shareable bit types.

All existing tests pass without modifications.

Fixes #15316

**Checklist:**
- [x] I have added the tests to cover my changes. _(Existing tests already cover this functionality)_
- [x] I have updated the documentation accordingly. _(No user-facing API changes)_
- [x] I have read the CONTRIBUTING document.

**AI tool used:** Claude 3.7 Sonnet was used to assist with understanding the codebase structure and refactoring approach.