### PR TITLE
Fix plot_histogram distribution detection with leading int zeros

### DIFF
--- a/qiskit/visualization/counts_visualization.py
+++ b/qiskit/visualization/counts_visualization.py
@@ -49,8 +49,8 @@ def _is_deprecated_data_format(data) -> bool:
     if not isinstance(data, list):
         data = [data]
     for dat in data:
-        if isinstance(dat, (QuasiDistribution, ProbDistribution)) or isinstance(
-            next(iter(dat.values())), float
+        if isinstance(dat, (QuasiDistribution, ProbDistribution)) or any(
+            isinstance(v, float) for v in dat.values()
         ):
             return True
     return False
@@ -143,8 +143,8 @@ def plot_histogram(
 
     kind = "counts"
     for dat in data:
-        if isinstance(dat, (QuasiDistribution, ProbDistribution)) or isinstance(
-            next(iter(dat.values())), float
+        if isinstance(dat, (QuasiDistribution, ProbDistribution)) or any(
+            isinstance(v, float) for v in dat.values()
         ):
             kind = "distribution"
     return _plotting_core(

--- a/releasenotes/notes/fix-plot-histogram-distribution-detection-4fe8db6fa77d54e1.yaml
+++ b/releasenotes/notes/fix-plot-histogram-distribution-detection-4fe8db6fa77d54e1.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixed an issue where :func:`~qiskit.visualization.plot_histogram` would
+    incorrectly detect probability distributions as counts when the dictionary
+    contained integer zeros before float probability values. The function now
+    checks all values in the dictionary to determine if any are floats, rather
+    than only checking the first value. This fixes cases where distributions
+    like ``{0: 0, 1: 0, 2: 0.5, 3: 0.5}`` were incorrectly treated as counts
+    and had their values coerced to integers, resulting in an empty plot.
+    Fixes `#11949 <https://github.com/Qiskit/qiskit/issues/11949>`__.


### PR DESCRIPTION
## Summary

Fixes #11949

When a probability distribution dictionary has integer zeros before float values (e.g., `{0: 0, 1: 0, 2: 0.5, 3: 0.5}`), `plot_histogram` incorrectly detected it as "counts" mode because it only checked the type of the first value. This caused float probabilities to be coerced to integers, resulting in empty or incorrect plots.

Changed the detection logic to check if **any** value is a float, rather than only the first value. This is the approach suggested by @jakelishman in the issue comments.

## Changes

- Fixed detection logic in `plot_histogram()` 
- Fixed the same bug in `_is_deprecated_data_format()` (which the previous PR #11979 missed)
- Added 3 regression tests
- Added release note

## Test plan

- [x] All existing `test_plot_histogram.py` tests pass
- [x] New tests verify:
  - Distributions with leading/trailing int zeros are detected correctly
  - Mixed int 0 and float 0.0 values are handled
  - Pure integer counts are still detected as counts mode

---

*Note: This is a fresh implementation of the fix from stale PR #11979, with the additional fix for `_is_deprecated_data_format()`, tests, and release note that were requested but never added.*