### PR TITLE
Fix OpenQASM 3 exporter to properly escape invalid identifiers

### DIFF
--- a/releasenotes/notes/fix-qasm3-identifier-escaping-7398f77c219203b6.yaml
+++ b/releasenotes/notes/fix-qasm3-identifier-escaping-7398f77c219203b6.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed an issue where the OpenQASM 3 exporter would produce invalid
+    identifiers when register names started with ASCII digits (e.g., ``3qr``)
+    or contained Unicode number characters (e.g., ``²``). These invalid
+    characters are now properly escaped to underscores.
+    Fixes `#15304 <https://github.com/Qiskit/qiskit/issues/15304>`__ and
+    `#15303 <https://github.com/Qiskit/qiskit/issues/15303>`__.


### PR DESCRIPTION
## Summary

Fixes #15304 and #15303

The OpenQASM 3 exporter was producing invalid identifiers in two cases:
1. Register names starting with ASCII digits (e.g., `3qr` → should be escaped)
2. Names containing Unicode number characters (e.g., `j²` → should be escaped)

The root cause was the regex `[\w]` which matches digits, so names like `3qr` were incorrectly considered valid.

## Solution

Replaced the regex-based validation with proper Unicode-aware functions using `unicodedata.category()` to correctly identify valid identifier characters per the OpenQASM 3 spec:
- First character: Unicode letter (category `L*`) or underscore
- Subsequent: Unicode letters, underscores, or ASCII digits 0-9

This also simplifies the escaping by only replacing invalid characters rather than always prepending an underscore.

## Examples

| Input | Before (invalid) | After (valid) |
|-------|------------------|---------------|
| `3qr` | `3qr` | `_qr` |
| `j²` | `j²` | `j_` |
| `t[0]` | `_t_0_` | `t_0_` |

## Test plan

- [x] Added 4 new tests for identifier escaping
- [x] All 119 existing QASM3 export tests pass
- [x] Manual verification of escaping behavior