### PR TITLE
Fix rustdoc indent in RemoveIdentityEquivalent pass

### DIFF
--- a/crates/transpiler/src/passes/remove_identity_equiv.rs
+++ b/crates/transpiler/src/passes/remove_identity_equiv.rs
@@ -59,7 +59,7 @@ pub fn average_gate_fidelity_below_tol(tr_over_dim: Complex64, dim: f64, tol: f6
 /// * `matrix_from_definition`: if `true`, can call the Python-space `Operator` class to
 ///   construct the matrix.
 /// * `matrix_from_definition_max_qubits`: maximum number of qubits allowed for matrix-based
-///    checks.
+///   checks.
 /// * `error_cutoff_fn`: function to compute the allowed error tolerance.
 ///
 /// # Returns


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an overindentation issue in the docstring of one of the public rust functions in the RemoveIdentityEquivalent transpiler pass's rust module. Besides fixing an incorrect indent this is flagged as a warning in newer versions of clippy so fixing them pre-emptively will avoid errors when we try to bump our MSRV in the future.

### Details and comments