### PR TITLE
Remove deprecated `QISKIT_VERSION_NUMERIC` symbol

### DIFF
--- a/crates/cext/include/qiskit/version.h
+++ b/crates/cext/include/qiskit/version.h
@@ -36,7 +36,4 @@
     QISKIT_GET_VERSION_HEX(QISKIT_VERSION_MAJOR, QISKIT_VERSION_MINOR, QISKIT_VERSION_PATCH,       \
                            QISKIT_RELEASE_LEVEL, QISKIT_RELEASE_SERIAL)
 
-// DEPRECATED, to be removed in Qiskit v2.3.
-#define QISKIT_VERSION_NUMERIC(M, m, p) ((M) << 16 | (m) << 8 | (p))
-
 #endif // QISKIT_VERSION_H

--- a/releasenotes/notes/remove-old-c-version-b44a21055da7d293.yaml
+++ b/releasenotes/notes/remove-old-c-version-b44a21055da7d293.yaml
@@ -1,0 +1,6 @@
+---
+upgrade_c:
+  - |
+    The `QISKIT_VERSION_NUMERIC` symbol was removed from the header file, after being
+    marked deprecated in Qiskit 2.2.  Use `QISKIT_VERSION_HEX` instead, which correctly
+    includes information about the pre-release status.

--- a/test/c/test_version_info.c
+++ b/test/c/test_version_info.c
@@ -71,7 +71,7 @@ static int test_version_macros(void) {
     }
     if (QISKIT_GET_VERSION_HEX(QISKIT_VERSION_MAJOR, QISKIT_VERSION_MINOR, QISKIT_VERSION_PATCH,
                                QISKIT_RELEASE_LEVEL, QISKIT_RELEASE_SERIAL) != QISKIT_VERSION_HEX) {
-        fprintf(stderr, "QISKIT_VERSION_NUMERIC does not match QISKIT_VERSION\n");
+        fprintf(stderr, "QISKIT_VERSION_HEX does not match QISKIT_GET_VERSION_HEX\n");
         return EqualityError;
     }
     return Ok;


### PR DESCRIPTION
This was deprecated in 2.2 since it was originally noticed after the 2.2.0rc1 release that there was a better way.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


Not eligible for backport for the same reason we didn't remove the symbol in #14576 when we put the notice in - we've already released rc1!