### PR TITLE
Hard pin `bincode` due to project death

### DIFF
--- a/crates/synthesis/Cargo.toml
+++ b/crates/synthesis/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 [dependencies]
 qiskit-circuit.workspace = true
 qiskit-quantum-info.workspace = true
-bincode = "1.3"
 bytemuck.workspace = true
 num-complex.workspace = true
 nalgebra.workspace = true
@@ -34,6 +33,13 @@ rsgridsynth =  "0.2.0"
 rstar = "0.12.2"
 serde = { version = "1.0", features = ["derive"] }
 thiserror.workspace = true
+
+# `bincode` is a dead project and needs replacement.  The development
+# process ended acrimoniously with the developer rewriting git history
+# and releasing poisoned versions to crates.io.  This is an increased
+# risk of further broken/malicious releases, so we hard-pin to a known
+# good version.
+bincode = "=1.3.3"
 
 [dependencies.faer-ext]
 version = "0.7.1"


### PR DESCRIPTION
The developer has stated that the project is dead, and made several strongly negative moves in the development process such as rewriting git history and pushing poisoned versions to crates.io.  This raises an increased possibility of the supply chain of the package being compromised, so we can hard-pin it to a known-good version for now, and investigate removing the dependency entirely.

See https://www.reddit.com/r/rust/comments/1pnz1iz/bincode_development_has_ceased_permanently/.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Related to #15520