### PR TITLE
Document that pass-manager plugins can return `None`

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -74,7 +74,7 @@ _discrete_skipped_ops = {
 class DefaultInitPassManager(PassManagerStagePlugin):
     """Plugin class for default init stage."""
 
-    def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
+    def pass_manager(self, pass_manager_config, optimization_level=None):
         if pass_manager_config._is_clifford_t:
             optimization_metric = OptimizationMetric.COUNT_T
         else:
@@ -471,7 +471,7 @@ class NoneRoutingPassManager(PassManagerStagePlugin):
 class OptimizationPassManager(PassManagerStagePlugin):
     """Plugin class for optimization stage"""
 
-    def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
+    def pass_manager(self, pass_manager_config, optimization_level=None):
         """Build pass manager for optimization stage."""
 
         # Use the dedicated plugin for the Clifford+T basis when appropriate.
@@ -999,7 +999,7 @@ def _get_trial_count(default_trials=5):
 class CliffordTOptimizationPassManager(PassManagerStagePlugin):
     """Plugin class for optimization stage"""
 
-    def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
+    def pass_manager(self, pass_manager_config, optimization_level=None):
         """Build pass manager for optimization stage."""
 
         # Obtain the translation method required for this pass to work

--- a/qiskit/transpiler/preset_passmanagers/plugin.py
+++ b/qiskit/transpiler/preset_passmanagers/plugin.py
@@ -184,7 +184,7 @@ class PassManagerStagePlugin(abc.ABC):
     @abc.abstractmethod
     def pass_manager(
         self, pass_manager_config: PassManagerConfig, optimization_level: Optional[int] = None
-    ) -> PassManager:
+    ) -> PassManager | None:
         """This method is designed to return a :class:`~.PassManager` for the stage this implements
 
         Args:
@@ -195,8 +195,12 @@ class PassManagerStagePlugin(abc.ABC):
                 should be used to set values for any tunable parameters to trade off runtime
                 for potential optimization. Valid values should be ``0``, ``1``, ``2``, or ``3``
                 and the higher the number the more optimization is expected.
+
+        Returns:
+            the :class:`.PassManager` to run, or ``None`` if nothing is needed for this
+            configuration (for example, an optimization plugin might return ``None`` at
+            ``optimization_level=0``).
         """
-        pass
 
 
 class PassManagerStagePluginManager:
@@ -229,7 +233,7 @@ class PassManagerStagePluginManager:
         plugin_name: str,
         pm_config: PassManagerConfig,
         optimization_level=None,
-    ) -> PassManager:
+    ) -> PassManager | None:
         """Get a stage"""
         if stage_name == "init":
             return self._build_pm(


### PR DESCRIPTION
Qiskit already uses this as part of the builtin optimisation plugin, so it's not new behaviour.

The plugins are updated to only specify `-> PassManager` if they override the base behaviour to infallibly return `PassManager`.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


