### PR TITLE
Refactor default optimisation plugin to linearise logic

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -468,6 +468,22 @@ class NoneRoutingPassManager(PassManagerStagePlugin):
         )
 
 
+def _optimization_check_fixed_point():
+    def check(property_set):
+        return not (property_set["depth_fixed_point"] and property_set["size_fixed_point"])
+
+    setup = [Size(recurse=True), Depth(recurse=True), FixedPoint("size"), FixedPoint("depth")]
+    return (setup, check)
+
+
+def _optimization_check_minimum_point(prefix: str):
+    def check(property_set):
+        return not property_set[f"{prefix}_minimum_point"]
+
+    setup = [Size(recurse=True), Depth(recurse=True), MinimumPoint(["depth", "size"], prefix)]
+    return (setup, check)
+
+
 class OptimizationPassManager(PassManagerStagePlugin):
     """Plugin class for optimization stage"""
 
@@ -480,51 +496,37 @@ class OptimizationPassManager(PassManagerStagePlugin):
                 pass_manager_config, optimization_level
             )
 
-        # Obtain the translation method required for this pass to work
-        translation_method = pass_manager_config.translation_method or "default"
-        optimization = PassManager()
-        if optimization_level != 0:
-            plugin_manager = PassManagerStagePluginManager()
-            _depth_check = [Depth(recurse=True), FixedPoint("depth")]
-            _size_check = [Size(recurse=True), FixedPoint("size")]
-            # Minimum point check for optimization level 3.
-            _minimum_point_check = [
-                Depth(recurse=True),
-                Size(recurse=True),
-                MinimumPoint(["depth", "size"], "optimization_loop"),
-            ]
-
-            def _opt_control(property_set):
-                return (not property_set["depth_fixed_point"]) or (
-                    not property_set["size_fixed_point"]
-                )
-
-            translation = plugin_manager.get_passmanager_stage(
-                "translation",
-                translation_method,
-                pass_manager_config,
-                optimization_level=optimization_level,
-            )
-
-            # Basic steps for optimization level 1:
-            # 1. Optimize1qGatesDecomposition
-            # 2. InverseCancellation
-            if optimization_level == 1:
-
-                _opt = [
+        match optimization_level:
+            case 0:
+                return None
+            case 1:
+                pre_loop = []
+                loop = [
                     Optimize1qGatesDecomposition(
                         basis=pass_manager_config.basis_gates, target=pass_manager_config.target
                     ),
                     InverseCancellation(),
                     ContractIdleWiresInControlFlow(),
                 ]
-
-            # Basic steps for optimization level 2:
-            # 1. RemoveIdentityEquivalent
-            # 2. Optimize1qGatesDecomposition
-            # 3. CommutativeCancellation
-            elif optimization_level == 2:
-                _opt = [
+                post_loop = []
+                loop_check, continue_loop = _optimization_check_fixed_point()
+            case 2:
+                pre_loop = [
+                    ConsolidateBlocks(
+                        basis_gates=pass_manager_config.basis_gates,
+                        target=pass_manager_config.target,
+                        approximation_degree=pass_manager_config.approximation_degree,
+                    ),
+                    UnitarySynthesis(
+                        pass_manager_config.basis_gates,
+                        approximation_degree=pass_manager_config.approximation_degree,
+                        coupling_map=pass_manager_config.coupling_map,
+                        method=pass_manager_config.unitary_synthesis_method,
+                        plugin_config=pass_manager_config.unitary_synthesis_plugin_config,
+                        target=pass_manager_config.target,
+                    ),
+                ]
+                loop = [
                     RemoveIdentityEquivalent(
                         approximation_degree=pass_manager_config.approximation_degree,
                         target=pass_manager_config.target,
@@ -535,15 +537,11 @@ class OptimizationPassManager(PassManagerStagePlugin):
                     CommutativeCancellation(target=pass_manager_config.target),
                     ContractIdleWiresInControlFlow(),
                 ]
-
-            # Basic steps for optimization level 3:
-            # 1. ConsolidateBlocks
-            # 2. UnitarySynthesis
-            # 3. RemoveIdentityEquivalent
-            # 4. Optimize1qGatesDecomposition
-            # 5. CommutativeCancellation
-            elif optimization_level == 3:
-                _opt = [
+                post_loop = []
+                loop_check, continue_loop = _optimization_check_fixed_point()
+            case 3:
+                pre_loop = []
+                loop = [
                     ConsolidateBlocks(
                         basis_gates=pass_manager_config.basis_gates,
                         target=pass_manager_config.target,
@@ -567,82 +565,52 @@ class OptimizationPassManager(PassManagerStagePlugin):
                     CommutativeCancellation(target=pass_manager_config.target),
                     ContractIdleWiresInControlFlow(),
                 ]
-
-                def _opt_control(property_set):
-                    return not property_set["optimization_loop_minimum_point"]
-
-            else:
-                raise TranspilerError(f"Invalid optimization_level: {optimization_level}")
-
-            unroll = translation.to_flow_controller()
-
-            # Build nested flow controllers
-            def _unroll_condition(property_set):
-                return not property_set["all_gates_in_basis"]
-
-            # Check if any gate is not in the basis, and if so, run unroll/translation passes
-            _unroll_if_out_of_basis = [
-                GatesInBasis(pass_manager_config.basis_gates, target=pass_manager_config.target),
-                ConditionalController(unroll, condition=_unroll_condition),
-            ]
-
-            if optimization_level == 3:
-                optimization.append(_minimum_point_check)
-            elif optimization_level == 2:
-                optimization.append(
-                    [
-                        ConsolidateBlocks(
-                            basis_gates=pass_manager_config.basis_gates,
-                            target=pass_manager_config.target,
-                            approximation_degree=pass_manager_config.approximation_degree,
-                        ),
-                        UnitarySynthesis(
-                            pass_manager_config.basis_gates,
-                            approximation_degree=pass_manager_config.approximation_degree,
-                            coupling_map=pass_manager_config.coupling_map,
-                            method=pass_manager_config.unitary_synthesis_method,
-                            plugin_config=pass_manager_config.unitary_synthesis_plugin_config,
-                            target=pass_manager_config.target,
-                        ),
-                    ]
-                )
-                optimization.append(_depth_check + _size_check)
-            else:
-                optimization.append(_depth_check + _size_check)
-            opt_loop = (
-                _opt + _unroll_if_out_of_basis + _minimum_point_check
-                if optimization_level == 3
-                else _opt + _unroll_if_out_of_basis + _depth_check + _size_check
-            )
-            optimization.append(DoWhileController(opt_loop, do_while=_opt_control))
-
-            if optimization_level == 3 and pass_manager_config.coupling_map:
-                vf2_call_limit, vf2_max_trials = common.get_vf2_limits(
-                    optimization_level,
-                    pass_manager_config.layout_method,
-                    pass_manager_config.initial_layout,
-                    exact_match=True,
-                )
-                is_vf2_fully_bounded = vf2_call_limit and vf2_max_trials
-                if pass_manager_config.target is not None and is_vf2_fully_bounded:
-                    optimization.append(
-                        VF2PostLayout(
-                            target=pass_manager_config.target,
-                            seed=-1,
-                            call_limit=vf2_call_limit,
-                            max_trials=vf2_max_trials,
-                            strict_direction=True,
-                        )
+                post_loop = []
+                if pass_manager_config.coupling_map and pass_manager_config.target is not None:
+                    vf2_call_limit, vf2_max_trials = common.get_vf2_limits(
+                        optimization_level,
+                        pass_manager_config.layout_method,
+                        pass_manager_config.initial_layout,
+                        exact_match=True,
                     )
-                    optimization.append(
-                        ConditionalController(
-                            ApplyLayout(), condition=common._apply_post_layout_condition
-                        )
-                    )
+                    if vf2_call_limit and vf2_max_trials:
+                        post_loop += [
+                            VF2PostLayout(
+                                target=pass_manager_config.target,
+                                seed=-1,
+                                call_limit=vf2_call_limit,
+                                max_trials=vf2_max_trials,
+                                strict_direction=True,
+                            ),
+                            ConditionalController(
+                                ApplyLayout(), condition=common._apply_post_layout_condition
+                            ),
+                        ]
+                loop_check, continue_loop = _optimization_check_minimum_point("optimization_loop")
+            case bad:
+                raise TranspilerError(f"Invalid optimization_level: {bad}")
 
-            return optimization
-        else:
-            return None
+        # Obtain the translation method required for this pass to work
+        translation = PassManagerStagePluginManager().get_passmanager_stage(
+            "translation",
+            pass_manager_config.translation_method or "default",
+            pass_manager_config,
+            optimization_level=optimization_level,
+        )
+
+        def should_unroll(property_set):
+            return not property_set["all_gates_in_basis"]
+
+        unroll = [
+            GatesInBasis(pass_manager_config.basis_gates, target=pass_manager_config.target),
+            ConditionalController(translation.to_flow_controller(), condition=should_unroll),
+        ]
+
+        optimization = PassManager()
+        optimization.append(pre_loop + loop_check)
+        optimization.append(DoWhileController(loop + unroll + loop_check, do_while=continue_loop))
+        optimization.append(post_loop)
+        return optimization
 
 
 class AlapSchedulingPassManager(PassManagerStagePlugin):
@@ -1001,51 +969,36 @@ class CliffordTOptimizationPassManager(PassManagerStagePlugin):
 
     def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
         """Build pass manager for optimization stage."""
-
-        # Obtain the translation method required for this pass to work
-        optimization = PassManager()
-        if optimization_level != 0:
-            _depth_check = [Depth(recurse=True), FixedPoint("depth")]
-            _size_check = [Size(recurse=True), FixedPoint("size")]
-
-            def _opt_control(property_set):
-                return (not property_set["depth_fixed_point"]) or (
-                    not property_set["size_fixed_point"]
-                )
-
-            if optimization_level == 1:
-                _opt = [
-                    InverseCancellation(),
-                    ContractIdleWiresInControlFlow(),
-                ]
-            elif optimization_level in [2, 3]:
-                # The optimization loop runs OptimizeCliffordT + CommutativeCancellation
-                # until fixpoint.
-                _opt = [
-                    RemoveIdentityEquivalent(
-                        approximation_degree=pass_manager_config.approximation_degree,
-                        target=pass_manager_config.target,
-                    ),
-                    OptimizeCliffordT(),
-                    CommutativeCancellation(target=pass_manager_config.target),
-                    ContractIdleWiresInControlFlow(),
-                ]
-
-            else:
-                raise TranspilerError(f"Invalid optimization_level: {optimization_level}")
-
-            # Build nested flow controllers
-            optimization.append(_depth_check + _size_check)
-
-            opt_loop = _opt + _depth_check + _size_check
-            optimization.append(DoWhileController(opt_loop, do_while=_opt_control))
-            # We need to run BasisTranslator because OptimizeCliffordT does not consider the basis set.
-            if optimization_level in [2, 3]:
-                optimization.append(
-                    BasisTranslator(
-                        sel, pass_manager_config.basis_gates, pass_manager_config.target
-                    )
-                )
-            return optimization
-        else:
+        if optimization_level == 0:
             return None
+        if optimization_level == 1:
+            loop = [
+                InverseCancellation(),
+                ContractIdleWiresInControlFlow(),
+            ]
+            post_loop = []
+        elif optimization_level in (2, 3):
+            # The optimization loop runs OptimizeCliffordT + CommutativeCancellation
+            # until fixpoint.
+            loop = [
+                RemoveIdentityEquivalent(
+                    approximation_degree=pass_manager_config.approximation_degree,
+                    target=pass_manager_config.target,
+                ),
+                OptimizeCliffordT(),
+                CommutativeCancellation(target=pass_manager_config.target),
+                ContractIdleWiresInControlFlow(),
+            ]
+            # We need to run BasisTranslator because OptimizeCliffordT does not consider the basis.
+            post_loop = [
+                BasisTranslator(sel, pass_manager_config.basis_gates, pass_manager_config.target)
+            ]
+        else:
+            raise TranspilerError(f"Invalid optimization_level: {optimization_level}")
+        loop_check, continue_loop = _optimization_check_fixed_point()
+
+        optimization = PassManager()
+        optimization.append(loop_check)
+        optimization.append(DoWhileController(loop + loop_check, do_while=continue_loop))
+        optimization.append(post_loop)
+        return optimization


### PR DESCRIPTION
This keeps the logic exactly the same, but linearises the construction of the pass manager so it's clearer what's going on.  I did this for two reasons:

1. we want to revisit what we're running in the optimisation loop in the default pass managers, since it doesn't feel like we're using our resources as efficiently as we could.  I found it very hard to actually see in the code what was happening before, so this makes it much easier to see what's changing and running.

2. I was trying to update the version of pylint we use, and it was complaining about how we overwrote functions; it was just indicative that the logic was hard to follow.

I used a Python 3.10 `match/case` statement just to see how it feels, now we're able to!

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


