### PR TITLE
Reduce size of increment synthesis test

### DIFF
--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -961,7 +961,7 @@ mod test {
     fn test_increment_n_dirty() {
         // Check that both methods to implement the :math:`n`-qubit increment gate using
         // :math:`n` dirty ancilla qubits produce the same matrix (for small number of qubits).
-        for nq in 1..6 {
+        for nq in 1..4 {
             let circuit1 = increment_n_dirty_small(nq).unwrap();
             let mat1 = sim_unitary_circuit(&circuit1).unwrap();
 


### PR DESCRIPTION
The previous test involved synthesising huge matrices in a Rust debug-mode build, which took nearly 5 minutes even on a rather powerful Macbook Pro.  This is disproportionate to the value the test was providing.

If this causes a significant coverage loss, we can look at either testing it only with release builds, or add a slow-test marker for Rust space as well.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


