### PR TITLE
Use `QkParam` as parameters for `QkTargetOp`.

### DIFF
--- a/crates/cext/src/transpiler/target.rs
+++ b/crates/cext/src/transpiler/target.rs
@@ -1342,7 +1342,7 @@ pub struct CTargetOp {
     /// The number of qubits this operation supports. Will default to
     /// `(uint32_t)-1` in the case of a variadic.
     pub num_qubits: u32,
-    /// The parameters tied to this operation if fixed, as `QkParam`.
+    /// The parameters tied to this operation, as `QkParam`.
     /// If there are no parameters then this value will be represented
     /// with a `NULL` pointer.
     pub params: *mut *const Param,
@@ -1427,8 +1427,10 @@ pub unsafe extern "C" fn qk_target_op_get(
                     .params_view()
                     .iter()
                     .map(|param| match param {
+                        Param::Float(_) | Param::ParameterExpression(_) => {
+                            std::ptr::from_ref(param)
+                        }
                         Param::Obj(_) => panic!("Objects are not supported in the C API."),
-                        _ => std::ptr::from_ref(param),
                     })
                     .collect(),
             );

--- a/releasenotes/notes/target-c-api-qkparams-12c6c57e99582b2b.yaml
+++ b/releasenotes/notes/target-c-api-qkparams-12c6c57e99582b2b.yaml
@@ -1,0 +1,5 @@
+---
+upgrade_c:
+  - Modified :c:struct:`QkTargetOp` to use :c:struct:`QkParam` as the type for its
+    :c:member:`QkTargetOp.params` attribute. Allowing users to access any free or fixed
+    parameter in an operation.

--- a/test/c/test_target.c
+++ b/test/c/test_target.c
@@ -1025,14 +1025,17 @@ static int test_target_operation(void) {
             if (inst_idx == 1) {
                 double param_val = qk_param_as_real(op.params[0]);
                 if (param_val != 3.14) {
-                    printf("The param value for instruction '%s' did not match. Expected %f, got %f\n", op.name, param_val,
-                           3.14);
+                    printf(
+                        "The param value for instruction '%s' did not match. Expected %f, got %f\n",
+                        op.name, param_val, 3.14);
                     result = EqualityError;
                     goto cleanup;
                 }
             } else {
                 if (op.params == NULL && op.num_params != 0) {
-                    printf("The param values for instruction '%s' did not match. Got length %u for NULL params.\n", op.name, op.num_params);
+                    printf("The param values for instruction '%s' did not match. Got length %u for "
+                           "NULL params.\n",
+                           op.name, op.num_params);
                     result = EqualityError;
                     goto cleanup;
                 }

--- a/test/c/test_target.c
+++ b/test/c/test_target.c
@@ -1022,6 +1022,21 @@ static int test_target_operation(void) {
                 result = EqualityError;
                 goto cleanup;
             }
+            if (inst_idx == 1) {
+                double param_val = qk_param_as_real(op.params[0]);
+                if (param_val != 3.14) {
+                    printf("The param value for instruction '%s' did not match. Expected %f, got %f\n", op.name, param_val,
+                           3.14);
+                    result = EqualityError;
+                    goto cleanup;
+                }
+            } else {
+                if (op.params == NULL && op.num_params != 0) {
+                    printf("The param values for instruction '%s' did not match. Got length %u for NULL params.\n", op.name, op.num_params);
+                    result = EqualityError;
+                    goto cleanup;
+                }
+            }
         } else if (inst_idx == 7) {
             if (op.op_type != QkOperationKind_Measure) {
                 printf("The operation's type did not match, expected Measure, got %s",

--- a/test/c/test_target.c
+++ b/test/c/test_target.c
@@ -1001,7 +1001,7 @@ static int test_target_operation(void) {
         qk_target_op_get(target, inst_idx, &op);
 
         if (strcmp(op.name, names[inst_idx]) != 0) {
-            printf("The operation names did not match. Expected %s, got %s", names[inst_idx],
+            printf("The operation names did not match. Expected %s, got %s\n", names[inst_idx],
                    op.name);
             result = EqualityError;
             break;
@@ -1010,14 +1010,14 @@ static int test_target_operation(void) {
         char *op_types[6] = {"Gate", "Barrier", "Delay", "Measure", "Reset", "Unitary"};
         if (inst_idx < 7) {
             if (op.op_type != QkOperationKind_Gate) {
-                printf("The operation's type did not match, expected Gate, got %s",
+                printf("The operation's type did not match, expected Gate, got %s\n",
                        op_types[(size_t)op.op_type]);
                 result = EqualityError;
                 break;
             }
             QkGate gate = qk_target_op_gate(target, inst_idx);
             if (gate != std_gates[inst_idx]) {
-                printf("The gate type did not match. Expected %i, got %i", std_gates[inst_idx],
+                printf("The gate type did not match. Expected %i, got %i\n", std_gates[inst_idx],
                        gate);
                 result = EqualityError;
                 break;
@@ -1042,14 +1042,14 @@ static int test_target_operation(void) {
             }
         } else if (inst_idx == 7) {
             if (op.op_type != QkOperationKind_Measure) {
-                printf("The operation's type did not match, expected Measure, got %s",
+                printf("The operation's type did not match, expected Measure, got %s\n",
                        op_types[(size_t)op.op_type]);
                 result = EqualityError;
                 break;
             }
         } else {
             if (op.op_type != QkOperationKind_Reset) {
-                printf("The operation's type did not match, expected Reset, got %s",
+                printf("The operation's type did not match, expected Reset, got %s\n",
                        op_types[(size_t)op.op_type]);
                 result = EqualityError;
                 break;


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Since #15106 will enable the usage of symbols and `ParameterExpression` objects as parameters for the C API, we should be able to retrieve both real value parameters and `Symbol` types from placeholder parameters from any parametric operation in  the `Target` through the C API. The following commits add this capability by replacing the `QkTargetOp.params` attribute's type of `*mut f64` with *mut *mut QkParam`.

### Details and comments
- [x] Add release note.

