### PR TITLE
Bump spindle to 0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,9 +2461,9 @@ dependencies = [
 
 [[package]]
 name = "spindle"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f794dedb367e82477aa6bbf83ea9bbce9bc074b3caacaa82fc4ba398ec9b701d"
+checksum = "673aaca3d8aa5387a6eba861fbf984af5348d9df5d940c25c6366b19556fdf64"
 dependencies = [
  "atomic-wait",
  "crossbeam",


### PR DESCRIPTION
Version 0.2.5 is broken on Rust 1.94+ nightly because of breaking change in 1.94.  That version is due to become stable on the 5th of March, 2026 at which point Rust stable would fail to build Qiskit.

More importantly right now, bumping Spindle lets me try out using the latest nightly with Miri, which is helpful because the older toolchain has some build trouble on a couple of my systems.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


