### PR TITLE
Handle zero-length permutation synthesis

### DIFF
--- a/crates/synthesis/src/permutation/mod.rs
+++ b/crates/synthesis/src/permutation/mod.rs
@@ -120,7 +120,7 @@ pub(crate) fn _append_cx_stage1(gates: &mut LnnGatesVec, n: usize) {
         ))
     }
 
-    for i in 0..(n.div_ceil(2) - 1) {
+    for i in 0..(n.div_ceil(2).saturating_sub(1)) {
         gates.push((
             StandardGate::CX,
             smallvec![],

--- a/releasenotes/notes/fix-0q-permutation-synthesis-e98a6e8909faf279.yaml
+++ b/releasenotes/notes/fix-0q-permutation-synthesis-e98a6e8909faf279.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    The builtin permutation synthesis plugins in :mod:`qiskit.synthesis` will now
-    correctly handle zero-length permutations.
+    The builtin ``permutation.kms`` synthesis plugin in :mod:`qiskit.synthesis` will now
+    correctly handle zero-length permutations.  Fixed `#15550 <https://github.com/Qiskit/qiskit/issues/15550>`__.

--- a/releasenotes/notes/fix-0q-permutation-synthesis-e98a6e8909faf279.yaml
+++ b/releasenotes/notes/fix-0q-permutation-synthesis-e98a6e8909faf279.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The builtin permutation synthesis plugins in :mod:`qiskit.synthesis` will now
+    correctly handle zero-length permutations.

--- a/test/python/synthesis/test_permutation_synthesis.py
+++ b/test/python/synthesis/test_permutation_synthesis.py
@@ -36,7 +36,7 @@ from test import QiskitTestCase  # pylint: disable=wrong-import-order
 class TestPermutationSynthesis(QiskitTestCase):
     """Test the permutation synthesis functions."""
 
-    @data(4, 5, 10, 15, 20)
+    @data(0, 4, 5, 10, 15, 20)
     def test_inverse_pattern(self, width):
         """Test _inverse_pattern function produces correct index map."""
         np.random.seed(1)
@@ -72,7 +72,7 @@ class TestPermutationSynthesis(QiskitTestCase):
                 _validate_permutation(pattern_duplicate)
                 self.assertIn(f"input contains {pattern[0]} more than once", str(exc.exception))
 
-    @data(4, 5, 10, 15, 20)
+    @data(0, 4, 5, 10, 15, 20)
     def test_synth_permutation_basic(self, width):
         """Test synth_permutation_basic function produces the correct
         circuit."""
@@ -90,7 +90,7 @@ class TestPermutationSynthesis(QiskitTestCase):
             synthesized_pattern = LinearFunction(qc).permutation_pattern()
             self.assertTrue(np.array_equal(synthesized_pattern, pattern))
 
-    @data(4, 5, 10, 15, 20)
+    @data(0, 4, 5, 10, 15, 20)
     def test_synth_permutation_acg(self, width):
         """Test synth_permutation_acg function produces the correct
         circuit."""
@@ -111,7 +111,7 @@ class TestPermutationSynthesis(QiskitTestCase):
             synthesized_pattern = LinearFunction(qc).permutation_pattern()
             self.assertTrue(np.array_equal(synthesized_pattern, pattern))
 
-    @data(4, 5, 10, 15, 20)
+    @data(0, 4, 5, 10, 15, 20)
     def test_synth_permutation_depth_lnn_kms(self, width):
         """Test synth_permutation_depth_lnn_kms function produces the correct
         circuit."""
@@ -138,7 +138,7 @@ class TestPermutationSynthesis(QiskitTestCase):
             synthesized_pattern = LinearFunction(qc).permutation_pattern()
             self.assertTrue(np.array_equal(synthesized_pattern, pattern))
 
-    @data(1, 2, 3, 4, 5, 10, 15, 20)
+    @data(0, 1, 2, 3, 4, 5, 10, 15, 20)
     def test_synth_permutation_reverse_lnn_kms(self, num_qubits):
         """Test synth_permutation_reverse_lnn_kms function produces the correct
         circuit."""


### PR DESCRIPTION
This _mostly_ already worked, we just needed to correct an oversight where we'd overflow via subtraction.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


Fix #15550