### PR TITLE
Add precise-error versions of `ObjectRegistry` methods

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -27,8 +27,9 @@ use crate::dag_circuit::{
     DAGCircuit, DAGIdentifierInfo, DAGStretchType, DAGVarType, add_global_phase,
 };
 use crate::imports::{ANNOTATED_OPERATION, QUANTUM_CIRCUIT};
+use crate::instruction::Parameters;
 use crate::interner::{Interned, InternedMap, Interner};
-use crate::object_registry::{ObjectRegistry, ObjectRegistryError};
+use crate::object_registry::{self, ObjectRegistry};
 use crate::operations::{
     ControlFlow, ControlFlowView, Operation, OperationRef, Param, PauliBased, PyOperationTypes,
     PythonOperation, StandardGate,
@@ -40,7 +41,8 @@ use crate::parameter_table::{ParameterTable, ParameterTableError, ParameterUse, 
 use crate::register_data::RegisterData;
 use crate::slice::{PySequenceIndex, SequenceIndex};
 use crate::{
-    Block, BlocksMode, Clbit, ControlFlowBlocks, Qubit, Stretch, Var, VarsMode, instruction,
+    Block, BlocksMode, CapacityError, Clbit, ControlFlowBlocks, Qubit, Stretch, Var, VarsMode,
+    instruction,
 };
 
 use ndarray::ArrayView1;
@@ -52,7 +54,6 @@ use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyDict, PyList, PySet, PyTuple, PyType};
 use pyo3::{PyTraverseError, PyVisit, import_exception, intern};
 
-use crate::instruction::Parameters;
 use hashbrown::{HashMap, HashSet};
 use indexmap::IndexMap;
 use smallvec::SmallVec;
@@ -71,10 +72,14 @@ import_exception!(qiskit.circuit.exceptions, CircuitError);
 #[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum CircuitDataError {
+    #[error(transparent)]
+    Capacity(#[from] CapacityError),
     #[error("invalid type for global phase")]
     InvalidGlobalPhaseType,
     #[error(transparent)]
-    ObjectRegistryError(#[from] ObjectRegistryError),
+    AbsentObject(object_registry::AbsentObject),
+    #[error(transparent)]
+    AddObjectRegistry(object_registry::AddError),
     // Explicitly an error returned from calling Python
     #[error(transparent)]
     ErrorFromPython(#[from] PyErr),
@@ -105,14 +110,26 @@ pub enum CircuitDataError {
     #[error("bad type after binding for gate '{0}': '{1}'")]
     StandardGateParameterIsComplex(String, String),
 }
+impl<T: Debug> From<object_registry::AbsentObject<T>> for CircuitDataError {
+    fn from(val: object_registry::AbsentObject<T>) -> Self {
+        Self::AbsentObject(val.erase_type())
+    }
+}
+impl<T: Debug, B: Debug> From<object_registry::AddError<T, B>> for CircuitDataError {
+    fn from(val: object_registry::AddError<T, B>) -> Self {
+        Self::AddObjectRegistry(val.erase_type())
+    }
+}
 
 impl From<CircuitDataError> for PyErr {
     fn from(error: CircuitDataError) -> Self {
         match error {
+            CircuitDataError::Capacity(c) => c.into(),
             CircuitDataError::InvalidGlobalPhaseType => {
                 PyTypeError::new_err("invalid type for global phase")
             }
-            CircuitDataError::ObjectRegistryError(e) => e.into(),
+            CircuitDataError::AbsentObject(e) => e.into(),
+            CircuitDataError::AddObjectRegistry(e) => e.into(),
             CircuitDataError::ErrorFromPython(e) => e,
             CircuitDataError::ParameterTableError(e) => e.into(),
             CircuitDataError::DuplicateStretch => {
@@ -501,7 +518,11 @@ impl CircuitData {
         bit: ShareableQubit,
         strict: bool,
     ) -> Result<Qubit, CircuitDataError> {
-        let index = self.qubits.add(bit.clone(), strict)?;
+        let index = if strict {
+            self.qubits.add(bit.clone())?
+        } else {
+            self.qubits.add_allow_existing(bit.clone())?
+        };
         self.qubit_indices
             .insert(bit, BitLocations::new(index.0, []));
         Ok(index)
@@ -512,7 +533,11 @@ impl CircuitData {
         bit: ShareableClbit,
         strict: bool,
     ) -> Result<Clbit, CircuitDataError> {
-        let index = self.clbits.add(bit.clone(), strict)?;
+        let index = if strict {
+            self.clbits.add(bit.clone())?
+        } else {
+            self.clbits.add_allow_existing(bit.clone())?
+        };
         self.clbit_indices
             .insert(bit, BitLocations::new(index.0, []));
         Ok(index)
@@ -1000,9 +1025,7 @@ impl CircuitData {
         let mut registry = ObjectRegistry::with_capacity(num_qubits as usize);
         let mut locator = BitLocator::with_capacity(num_qubits as usize);
         for (index, bit) in register.iter().enumerate() {
-            registry
-                .add(bit.clone(), false)
-                .expect("no duplicates, and in-bounds check already performed");
+            registry.add_unique_within_capacity(bit.clone());
             locator.insert(
                 bit,
                 BitLocations::new(index as u32, [(register.clone(), index)]),
@@ -1902,7 +1925,7 @@ impl CircuitData {
             _ => {}
         }
 
-        let var_idx = self.vars.add(var, true)?;
+        let var_idx = self.vars.add(var)?;
         match var_type {
             CircuitVarType::Input => &mut self.vars_input,
             CircuitVarType::Capture => &mut self.vars_capture,
@@ -1976,7 +1999,7 @@ impl CircuitData {
             }
         }
 
-        let stretch_idx = self.stretches.add(stretch, true)?;
+        let stretch_idx = self.stretches.add(stretch)?;
         match stretch_type {
             CircuitStretchType::Capture => &mut self.stretches_capture,
             CircuitStretchType::Declare => &mut self.stretches_declare,
@@ -2623,13 +2646,13 @@ impl PyCircuitData {
 
         borrowed_mut.inner.vars = ObjectRegistry::<Var, expr::Var>::with_capacity(state.5.len());
         for var in state.5 {
-            borrowed_mut.inner.vars.add(var, false)?;
+            borrowed_mut.inner.vars.add(var)?;
         }
 
         borrowed_mut.inner.stretches =
             ObjectRegistry::<Stretch, expr::Stretch>::with_capacity(state.6.len());
         for stretch in state.6 {
-            borrowed_mut.inner.stretches.add(stretch, false)?;
+            borrowed_mut.inner.stretches.add(stretch)?;
         }
 
         Ok(())

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -854,22 +854,22 @@ impl DAGCircuit {
         let binding = dict_state.get_item("qubits")?.unwrap();
         let qubits_raw = binding.extract::<Vec<ShareableQubit>>()?;
         for bit in qubits_raw.into_iter() {
-            self.qubits.add(bit, false)?;
+            self.qubits.add(bit)?;
         }
         let binding = dict_state.get_item("clbits")?.unwrap();
         let clbits_raw = binding.extract::<Vec<ShareableClbit>>()?;
         for bit in clbits_raw.into_iter() {
-            self.clbits.add(bit, false)?;
+            self.clbits.add(bit)?;
         }
         let binding = dict_state.get_item("vars")?.unwrap();
         let vars_raw = binding.cast::<PyList>()?;
         for v in vars_raw.iter() {
-            self.vars.add(v.extract()?, false)?;
+            self.vars.add(v.extract()?)?;
         }
         let binding = dict_state.get_item("stretches")?.unwrap();
         let stretches_raw = binding.cast::<PyList>()?;
         for s in stretches_raw.iter() {
-            self.stretches.add(s.extract()?, false)?;
+            self.stretches.add(s.extract()?)?;
         }
         let binding = dict_state.get_item("qubit_io_map")?.unwrap();
         let qubit_index_map_raw = binding.cast::<PyDict>().unwrap();
@@ -5371,9 +5371,7 @@ impl DAGCircuit {
         let mut registry = ObjectRegistry::with_capacity(num_qubits as usize);
         let mut locator = BitLocator::with_capacity(num_qubits as usize);
         for (index, bit) in register.iter().enumerate() {
-            registry
-                .add(bit.clone(), false)
-                .expect("no duplicates, and in-bounds check already performed");
+            registry.add_unique_within_capacity(bit.clone());
             locator.insert(
                 bit,
                 BitLocations::new(index as u32, [(register.clone(), index)]),
@@ -6549,7 +6547,7 @@ impl DAGCircuit {
     }
 
     pub fn add_qubit_unchecked(&mut self, bit: ShareableQubit) -> PyResult<Qubit> {
-        let qubit = self.qubits.add(bit.clone(), false)?;
+        let qubit = self.qubits.add_unique_within_capacity(bit.clone());
         self.qubit_locations
             .insert(bit, BitLocations::new((self.qubits.len() - 1) as u32, []));
         self.add_wire(Wire::Qubit(qubit))?;
@@ -6557,7 +6555,7 @@ impl DAGCircuit {
     }
 
     pub fn add_clbit_unchecked(&mut self, bit: ShareableClbit) -> PyResult<Clbit> {
-        let clbit = self.clbits.add(bit.clone(), false)?;
+        let clbit = self.clbits.add_unique_within_capacity(bit.clone());
         self.clbit_locations
             .insert(bit, BitLocations::new((self.clbits.len() - 1) as u32, []));
         self.add_wire(Wire::Clbit(clbit))?;
@@ -7309,7 +7307,7 @@ impl DAGCircuit {
             _ => {}
         }
 
-        let var_idx = self.vars.add(var, true)?;
+        let var_idx = self.vars.add(var)?;
         let (in_index, out_index) = self.add_wire(Wire::Var(var_idx))?;
         match type_ {
             DAGVarType::Input => &mut self.vars_input,
@@ -7355,7 +7353,7 @@ impl DAGCircuit {
             _ => {}
         }
 
-        let stretch_idx = self.stretches.add(stretch, true)?;
+        let stretch_idx = self.stretches.add(stretch)?;
         match type_ {
             DAGStretchType::Capture => {
                 self.stretches_capture.insert(stretch_idx);

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -42,7 +42,7 @@ pub mod vf2;
 
 mod variable_mapper;
 
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PySequence, PyString, PyTuple};
 
@@ -203,6 +203,16 @@ impl<'a, 'py> FromPyObject<'a, 'py> for VarsMode {
 pub enum BlocksMode {
     Drop,
     Keep,
+}
+
+/// Simple error type for objects with built-in hard-coded capacity limits.
+#[derive(Clone, Copy, Debug, thiserror::Error)]
+#[error("exceeded allowed runtime capacity")]
+pub struct CapacityError;
+impl From<CapacityError> for PyErr {
+    fn from(val: CapacityError) -> PyErr {
+        PyRuntimeError::new_err(val.to_string())
+    }
 }
 
 #[inline]

--- a/crates/circuit/src/object_registry.rs
+++ b/crates/circuit/src/object_registry.rs
@@ -10,50 +10,15 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use crate::CapacityError;
 use hashbrown::HashMap;
 use hashbrown::hash_map::OccupiedError;
-use pyo3::exceptions::{PyKeyError, PyRuntimeError, PyValueError};
+use pyo3::exceptions::{PyKeyError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyList;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::sync::OnceLock;
-use thiserror::Error;
-
-/// This struct models the error conditions that can be raised from the
-/// rust methods of the [ObjectRegistry] struct. The goal is to explicitly
-/// enumerate all the error types that are returned by these functions and
-/// make it clear that the return type is part of the interface.
-///
-/// In the the future it is expected this single enum will be replaced by per
-/// method error types to make it even more obvious, but this is a step
-/// towards that as we migrate from Python -> Rust.
-#[non_exhaustive]
-#[derive(Error, Debug)]
-pub enum ObjectRegistryError {
-    #[error("Object {0} has not been added to this circuit.")]
-    ObjectMissing(String),
-    #[error("Cannot add object {0}, which would exceed circuit capacity for its kind.")]
-    ExceedsCapacity(String),
-    #[error("Existing object {0} cannot be re-added in strict mode.")]
-    DuplicateObject(String),
-}
-
-impl From<ObjectRegistryError> for PyErr {
-    fn from(error: ObjectRegistryError) -> Self {
-        match error {
-            ObjectRegistryError::ObjectMissing(b) => {
-                PyKeyError::new_err(format!("Object {b} has not been added to this circuit."))
-            }
-            ObjectRegistryError::ExceedsCapacity(b) => PyRuntimeError::new_err(format!(
-                "Cannot add object {b}, which would exceed circuit capacity for its kind.",
-            )),
-            ObjectRegistryError::DuplicateObject(b) => PyValueError::new_err(format!(
-                "Existing object {b} cannot be re-added in strict mode."
-            )),
-        }
-    }
-}
 
 /// Wrapper for Python-side objects that implements [Hash] and [Eq], allowing them to be
 /// used in Rust hash-based sets and maps.
@@ -148,6 +113,50 @@ impl PartialEq for PyObjectAsKey {
 }
 impl Eq for PyObjectAsKey {}
 
+/// Error types for attempts to add unique objects.
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum AddError<T: Debug = String, B: Debug = String> {
+    #[error("cannot add object {ob:?} as it is already mapped to {key:?}")]
+    Duplicate { key: T, ob: B },
+    #[error(transparent)]
+    Capacity(#[from] CapacityError),
+}
+impl<T: Debug, B: Debug> AddError<T, B> {
+    pub fn erase_type(self) -> AddError {
+        match self {
+            Self::Duplicate { key, ob } => AddError::Duplicate {
+                key: format!("{key:?}"),
+                ob: format!("{ob:?}"),
+            },
+            Self::Capacity(c) => AddError::Capacity(c),
+        }
+    }
+}
+impl<T: Debug, B: Debug> From<AddError<T, B>> for PyErr {
+    fn from(val: AddError<T, B>) -> PyErr {
+        match val {
+            AddError::Duplicate { .. } => PyValueError::new_err(val.to_string()),
+            AddError::Capacity(c) => c.into(),
+        }
+    }
+}
+
+/// Error return from functions that look up an object in the registry.
+#[derive(Clone, Debug, thiserror::Error)]
+#[error("object {0:?} is not present")]
+pub struct AbsentObject<T: Debug = String>(T);
+impl<T: Debug> AbsentObject<T> {
+    /// Erase the internal type of the object by evaluating the debug formatting.
+    pub fn erase_type(self) -> AbsentObject {
+        AbsentObject(format!("{:?}", self.0))
+    }
+}
+impl<T: Debug> From<AbsentObject<T>> for PyErr {
+    fn from(val: AbsentObject<T>) -> Self {
+        PyKeyError::new_err(val.to_string())
+    }
+}
+
 /// A registry of unique objects, each mapped to a unique index.
 ///
 /// This is used to associate sharable bits and other globally unique
@@ -168,7 +177,7 @@ pub struct ObjectRegistry<T, B> {
 
 impl<T, B> Default for ObjectRegistry<T, B>
 where
-    T: From<u32> + Copy,
+    T: From<u32> + Copy + Debug,
     u32: From<T>,
     B: Clone + Eq + Hash + Debug,
 {
@@ -187,7 +196,7 @@ impl<T: Eq, B: Eq + Hash> Eq for ObjectRegistry<T, B> {}
 
 impl<T, B> ObjectRegistry<T, B>
 where
-    T: From<u32> + Copy,
+    T: From<u32> + Copy + Debug,
     u32: From<T>,
     B: Clone + Eq + Hash + Debug,
 {
@@ -229,15 +238,10 @@ where
     pub fn map_objects<U: IntoIterator<Item = B>>(
         &self,
         objects: U,
-    ) -> Result<impl Iterator<Item = T> + use<T, B, U>, ObjectRegistryError> {
+    ) -> Result<impl Iterator<Item = T> + use<T, B, U>, AbsentObject<B>> {
         let v: Result<Vec<_>, _> = objects
             .into_iter()
-            .map(|b| {
-                self.indices
-                    .get(&b)
-                    .copied()
-                    .ok_or_else(|| ObjectRegistryError::ObjectMissing(format!("{b:?}")))
-            })
+            .map(|b| self.indices.get(&b).copied().ok_or(AbsentObject(b)))
             .collect();
         v.map(|x| x.into_iter())
     }
@@ -262,12 +266,11 @@ where
     }
 
     /// Registers a new object, automatically creating a unique index within the registry.
-    pub fn add(&mut self, object: B, strict: bool) -> Result<T, ObjectRegistryError> {
-        let idx: u32 = self
-            .objects
-            .len()
-            .try_into()
-            .map_err(|_| ObjectRegistryError::ExceedsCapacity(format!("{object:?}")))?;
+    ///
+    /// Errors if the object is already in the registry.  To ignore duplicates, use
+    /// [add_allow_existing].
+    pub fn add(&mut self, object: B) -> Result<T, AddError<T, B>> {
+        let idx: u32 = self.objects.len().try_into().map_err(|_| CapacityError)?;
         // Dump the cache
         self.cached.take();
         match self.indices.try_insert(object.clone(), idx.into()) {
@@ -275,24 +278,34 @@ where
                 self.objects.push(object);
                 Ok(idx.into())
             }
-            Err(OccupiedError { entry, .. }) if !strict => Ok(*entry.get()),
-            _ => Err(ObjectRegistryError::DuplicateObject(format!("{object:?}"))),
+            Err(OccupiedError { value: _, entry }) => Err(AddError::Duplicate {
+                key: *entry.get(),
+                ob: object,
+            }),
         }
     }
+    /// Add an object to the registry, returning the existing key in the case of duplication.
+    pub fn add_allow_existing(&mut self, object: B) -> Result<T, CapacityError> {
+        match self.add(object) {
+            Ok(key) | Err(AddError::Duplicate { key, ob: _ }) => Ok(key),
+            Err(AddError::Capacity(c)) => Err(c),
+        }
+    }
+    // Add an object to the registry, panicking if it is a duplicate or out of capacity.
+    pub fn add_unique_within_capacity(&mut self, object: B) -> T {
+        self.add(object)
+            .expect("caller should ensure uniqueness and capacity bounds")
+    }
 
-    pub fn replace(&mut self, index: T, replacement: B) -> PyResult<()> {
+    pub fn replace(&mut self, index: T, replacement: B) {
         self.cached.take();
         let to_replace = &mut self.objects[<u32 as From<T>>::from(index) as usize];
         self.indices.remove(to_replace);
         *to_replace = replacement.clone();
         self.indices.insert(replacement, index);
-        Ok(())
     }
 
-    pub fn remove_indices<I>(&mut self, indices: I)
-    where
-        I: IntoIterator<Item = T>,
-    {
+    pub fn remove_indices(&mut self, indices: impl IntoIterator<Item = T>) {
         let mut indices_sorted: Vec<usize> = indices
             .into_iter()
             .map(|i| <u32 as From<T>>::from(i) as usize)

--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -253,7 +253,7 @@ fn get_bits_from_py<T>(
     py_bits2: &Bound<'_, PyTuple>,
 ) -> PyResult<(Vec<T>, Vec<T>)>
 where
-    T: From<u32> + Copy,
+    T: From<u32> + Copy + Debug,
     u32: From<T>,
 {
     // Using `PyObjectAsKey` here is a total hack, but this is a short-term workaround before a
@@ -261,7 +261,7 @@ where
     let mut registry: ObjectRegistry<T, PyObjectAsKey> = ObjectRegistry::new();
 
     for bit in py_bits1.iter().chain(py_bits2.iter()) {
-        registry.add(bit.into(), false)?;
+        registry.add_allow_existing(bit.into())?;
     }
 
     Ok((

--- a/test/python/circuit/test_circuit_data.py
+++ b/test/python/circuit/test_circuit_data.py
@@ -46,7 +46,7 @@ class TestQuantumCircuitData(QiskitTestCase):
         self.assertEqual(data.qubits, list(qr))
 
         # Test re-adding is disallowed by default.
-        with self.assertRaisesRegex(ValueError, "Existing object"):
+        with self.assertRaisesRegex(ValueError, "cannot add object"):
             data.add_qubit(qr[0])
 
         # Make sure re-adding is allowed in non-strict mode
@@ -62,7 +62,7 @@ class TestQuantumCircuitData(QiskitTestCase):
         self.assertEqual(data.qubits, qubits)
 
         # Test re-adding is disallowed by default.
-        with self.assertRaisesRegex(ValueError, "Existing object"):
+        with self.assertRaisesRegex(ValueError, "cannot add object"):
             data.add_qubit(qubits[0])
 
         # Make sure re-adding is allowed in non-strict mode
@@ -111,7 +111,7 @@ class TestQuantumCircuitData(QiskitTestCase):
         self.assertEqual(data.clbits, list(cr))
 
         # Test re-adding is disallowed by default.
-        with self.assertRaisesRegex(ValueError, "Existing object"):
+        with self.assertRaisesRegex(ValueError, "cannot add object"):
             data.add_clbit(cr[0])
 
         # Make sure re-adding is allowed in non-strict mode
@@ -127,7 +127,7 @@ class TestQuantumCircuitData(QiskitTestCase):
         self.assertEqual(data.clbits, clbits)
 
         # Test re-adding is disallowed by default.
-        with self.assertRaisesRegex(ValueError, "Existing object"):
+        with self.assertRaisesRegex(ValueError, "cannot add object"):
             data.add_clbit(clbits[0])
 
         # Make sure re-adding is allowed in non-strict mode
@@ -441,7 +441,7 @@ class TestQuantumCircuitData(QiskitTestCase):
         """Test using foreign bits is not allowed."""
         qr = QuantumRegister(1)
         cr = ClassicalRegister(1)
-        with self.assertRaisesRegex(KeyError, "not been added to this circuit"):
+        with self.assertRaisesRegex(KeyError, "is not present"):
             CircuitData(qr, cr, [CircuitInstruction(XGate(), [Qubit()], [])])
 
     def test_unregistered_bit_error_append(self):
@@ -449,7 +449,7 @@ class TestQuantumCircuitData(QiskitTestCase):
         qr = QuantumRegister(1)
         cr = ClassicalRegister(1)
         data = CircuitData(qr, cr)
-        with self.assertRaisesRegex(KeyError, "not been added to this circuit"):
+        with self.assertRaisesRegex(KeyError, "is not present"):
             qr_foreign = QuantumRegister(1)
             data.append(CircuitInstruction(XGate(), [qr_foreign[0]], []))
 
@@ -458,7 +458,7 @@ class TestQuantumCircuitData(QiskitTestCase):
         qr = QuantumRegister(1)
         cr = ClassicalRegister(1)
         data = CircuitData(qr, cr, [CircuitInstruction(XGate(), [qr[0]], [])])
-        with self.assertRaisesRegex(KeyError, "not been added to this circuit"):
+        with self.assertRaisesRegex(KeyError, "is not present"):
             qr_foreign = QuantumRegister(1)
             data[0] = CircuitInstruction(XGate(), [qr_foreign[0]], [])
 


### PR DESCRIPTION
This modifies the error handling in `ObjectRegistry` to make the error returns from the functions more explicit, and to add methods that allow short-hand assertions about the allowed failure modes.  This is a stepping stone to making more circuit functions infallible when called from Rust space.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


