### PR TITLE
Fix docstring grammar and formatting in test_sparse_pauli_op.py

### DIFF
--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -39,7 +39,7 @@ from qiskit.utils import optionals
 
 
 def pauli_mat(label):
-    """Return Pauli matrix from a Pauli label"""
+    """Return Pauli matrix from a Pauli label."""
     mat = np.eye(1, dtype=complex)
     for i in label:
         if i == "I":
@@ -413,7 +413,7 @@ class TestSparsePauliOpConversions(QiskitTestCase):
         self.assertEqual(op.to_list(), target)
 
     def test_to_list_parameters(self):
-        """Test to_operator method with paramters."""
+        """Test to_operator method with parameters."""
         labels = ["XI", "YZ", "YY", "ZZ"]
         coeffs = np.array(ParameterVector("a", 4))
         op = SparsePauliOp(labels, coeffs)
@@ -582,7 +582,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
         self.parameter_names = (f"param_{x}" for x in it.count())
 
     def random_spp_op(self, num_qubits, num_terms, use_parameters=False):
-        """Generate a pseudo-random SparsePauliOp"""
+        """Generate a pseudo-random SparsePauliOp."""
         if use_parameters:
             coeffs = np.array(ParameterVector(next(self.parameter_names), num_terms))
         else:
@@ -1140,9 +1140,9 @@ class TestSparsePauliOpMethods(QiskitTestCase):
             self.assertNotEqual(spp_op1, spp_op2)
             self.assertTrue(spp_op1.equiv(spp_op2))
 
-    @combine(parameterized=[True, False], qubit_wise=[True, False])
+   @combine(parameterized=[True, False], qubit_wise=[True, False])
     def test_noncommutation_graph(self, parameterized, qubit_wise):
-        """Test noncommutation graph"""
+        """Test noncommutation graph."""
 
         def commutes(left: Pauli, right: Pauli, qubit_wise: bool) -> bool:
             if len(left) != len(right):
@@ -1178,7 +1178,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
 
     @combine(parameterized=[True, False], qubit_wise=[True, False])
     def test_group_commuting(self, parameterized, qubit_wise):
-        """Test general grouping commuting operators"""
+        """Test general grouping of commuting operators."""
 
         def commutes(left: Pauli, right: Pauli, qubit_wise: bool) -> bool:
             if len(left) != len(right):
@@ -1358,7 +1358,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
         self.assertEqual(op, res)
 
     def test_apply_layout_null_layout_and_num_qubits(self):
-        """Test apply_layout with a null layout a num_qubits provided"""
+        """Test apply_layout with a null layout and num_qubits provided."""
         op = SparsePauliOp.from_list([("II", 1), ("IZ", 2), ("XI", 3)])
         res = op.apply_layout(layout=None, num_qubits=5)
         # this should expand the operator

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -1140,7 +1140,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
             self.assertNotEqual(spp_op1, spp_op2)
             self.assertTrue(spp_op1.equiv(spp_op2))
 
-   @combine(parameterized=[True, False], qubit_wise=[True, False])
+    @combine(parameterized=[True, False], qubit_wise=[True, False])
     def test_noncommutation_graph(self, parameterized, qubit_wise):
         """Test noncommutation graph."""
 


### PR DESCRIPTION
Fixed a grammatical error in test_apply_layout_null_layout_and_num_qubits (missing "and") and added missing periods to several docstrings to comply with style guidelines.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


