### PR TITLE
Add helper method for measuring single-qubit in Pauli basis

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -119,7 +119,7 @@ ClbitSpecifier = Union[
 # which operate on either type of bit, but not both at the same time.
 BitType = TypeVar("BitType", Qubit, Clbit)
 
-
+# Enum types for pauli basis
 class PauliBasis(Enum):
     X = "X"
     Y = "Y"

--- a/releasenotes/notes/Pauli-Basis-measurement-function-7101af4963241905.yaml
+++ b/releasenotes/notes/Pauli-Basis-measurement-function-7101af4963241905.yaml
@@ -1,0 +1,14 @@
+---
+title: Pauli Basis measurement helper function
+---
+features_circuits:
+  - |
+    Added a new method :meth:`.QuantumCircuit.measure_pauli_basis` to measure a qubit
+    in any Pauli basis (X, Y, or Z).  
+
+    - Measurements always occur physically in the Z basis.  
+    - X-basis measurement applies a Hadamard before measurement.  
+    - Y-basis measurement applies S† followed by Hadamard before measurement.  
+    - Z-basis measurement is performed directly.  
+
+    Introduced the :class:`.PauliBasis` enum (`X`, `Y`, `Z`) to specify the measurement basis.

--- a/releasenotes/notes/Pauli-Basis-measurement-function-7101af4963241905.yaml
+++ b/releasenotes/notes/Pauli-Basis-measurement-function-7101af4963241905.yaml
@@ -3,7 +3,7 @@ title: Pauli Basis measurement helper function
 ---
 features_circuits:
   - |
-    Added a new method :meth:`.QuantumCircuit.measure_pauli_basis` to measure a qubit
+    Added a new method :meth: QuantumCircuit.measure_pauli_basis to measure a qubit
     in any Pauli basis (X, Y, or Z).  
 
     - Measurements always occur physically in the Z basis.  
@@ -11,4 +11,4 @@ features_circuits:
     - Y-basis measurement applies S† followed by Hadamard before measurement.  
     - Z-basis measurement is performed directly.  
 
-    Introduced the :class:`.PauliBasis` enum (`X`, `Y`, `Z`) to specify the measurement basis.
+    Introduced the :class: "PauliBasis" enum (X, Y, Z) to specify the measurement basis.

--- a/releasenotes/notes/Pauli-Basis-measurement-function-7101af4963241905.yaml
+++ b/releasenotes/notes/Pauli-Basis-measurement-function-7101af4963241905.yaml
@@ -3,7 +3,7 @@ title: Pauli Basis measurement helper function
 ---
 features_circuits:
   - |
-    Added a new method :meth: QuantumCircuit.measure_pauli_basis to measure a qubit
+    Added a new method :meth:`.QuantumCircuit.measure_pauli_basis` to measure a qubit
     in any Pauli basis (X, Y, or Z).  
 
     - Measurements always occur physically in the Z basis.  
@@ -11,4 +11,4 @@ features_circuits:
     - Y-basis measurement applies S† followed by Hadamard before measurement.  
     - Z-basis measurement is performed directly.  
 
-    Introduced the :class: "PauliBasis" enum (X, Y, Z) to specify the measurement basis.
+    Introduced the :class:`.PauliBasis` enum (`X`, `Y`, `Z`) to specify the measurement basis.


### PR DESCRIPTION
### Summary

- Add a new helper method called "measure_pauli_basis", inside the QuantumCircuit class, for measuring a qubit in any Pauli basis (X, Y, or Z)

### Details and comments

- Measurements always occur physically in the Z basis.
- X basis measurement applies a Hadamard gate before measurement.
- Y basis measurement applies S† followed by Hadamard.
- Z basis measurement is performed directly.
- Introduced PauliBasis enum (X, Y, Z) to specify the measurement basis.
- This method returns an "InstructionSet".
- Raises "CircuitError" if an invalid basis is provided.


