### PR TITLE
Add less fallible method for adding anonymous qubits to circuits

### DIFF
--- a/crates/circuit/src/bit.rs
+++ b/crates/circuit/src/bit.rs
@@ -375,6 +375,7 @@ macro_rules! create_bit_object {
             }
 
             /// Create a new anonymous bit.
+            #[inline]
             pub fn new_anonymous() -> Self {
                 Self(BitInfo::Anonymous {
                     uid: Self::anonymous_instance_count().fetch_add(1, Ordering::Relaxed),
@@ -398,6 +399,22 @@ macro_rules! create_bit_object {
                     BitInfo::Owned { index, .. } => Some(*index),
                     BitInfo::Anonymous { .. } => None,
                 }
+            }
+
+            /// Create `count` new anonymous bits, returned as an iterator.
+            ///
+            /// This is a bit more efficient than creating the bits individually, since we only have
+            /// to update the underlying atomic instance count once.
+            #[inline]
+            pub fn iter_anonymous(count: u32) -> impl ExactSizeIterator<Item = Self> {
+                let base = Self::anonymous_instance_count()
+                    .fetch_add(count as u64, Ordering::Relaxed);
+                (0..count).map(move |offset| {
+                    Self(BitInfo::Anonymous {
+                        uid: base + offset as u64,
+                        subclass: Default::default(),
+                    })
+                })
             }
         }
 

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -984,20 +984,43 @@ impl CircuitData {
         // use the global phase setter to ensure parameters are registered
         // in the parameter table
         res.set_global_phase_param(global_phase)?;
-
-        if num_qubits > 0 {
-            for _i in 0..num_qubits {
-                let bit = ShareableQubit::new_anonymous();
-                res.add_qubit(bit, true)?;
-            }
-        }
-        if num_clbits > 0 {
-            for _i in 0..num_clbits {
-                let bit = ShareableClbit::new_anonymous();
-                res.add_clbit(bit, true)?;
-            }
-        }
+        res.add_anonymous_qubits(num_qubits)
+            .expect("cannot represent a too-large count");
+        res.add_anonymous_clbits(num_clbits)
+            .expect("cannot represent a too-large count");
         Ok(res)
+    }
+
+    /// Add multiple new anonymous qubits.
+    ///
+    /// This can only fail due to circuit capacity issues, since new anonymous qubits are guaranteed
+    /// to be unique.
+    pub fn add_anonymous_qubits(&mut self, num: u32) -> Result<(), CapacityError> {
+        if self.qubits.len() > (u32::MAX - num) as usize {
+            return Err(CapacityError);
+        }
+        for bit in ShareableQubit::iter_anonymous(num) {
+            let index = self.qubits.add_unique_within_capacity(bit.clone());
+            self.qubit_indices
+                .insert(bit, BitLocations::new(index.0, []));
+        }
+        Ok(())
+    }
+
+    /// Add multiple new anonymous clbits.
+    ///
+    /// This can only fail due to circuit capacity issues, since new anonymous qubits are guaranteed
+    /// to be unique.
+    pub fn add_anonymous_clbits(&mut self, num: u32) -> Result<(), CapacityError> {
+        if self.clbits.len() > (u32::MAX - num) as usize {
+            return Err(CapacityError);
+        }
+        for bit in ShareableClbit::iter_anonymous(num) {
+            let index = self.clbits.add_unique_within_capacity(bit.clone());
+            self.clbit_indices
+                .insert(bit, BitLocations::new(index.0, []));
+        }
+        Ok(())
     }
 
     /// Modify `self` to mark its qubits as physical.

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -739,20 +739,43 @@ impl CircuitData {
         // use the global phase setter to ensure parameters are registered
         // in the parameter table
         res.set_global_phase_param(global_phase)?;
-
-        if num_qubits > 0 {
-            for _i in 0..num_qubits {
-                let bit = ShareableQubit::new_anonymous();
-                res.add_qubit(bit, true)?;
-            }
-        }
-        if num_clbits > 0 {
-            for _i in 0..num_clbits {
-                let bit = ShareableClbit::new_anonymous();
-                res.add_clbit(bit, true)?;
-            }
-        }
+        res.add_anonymous_qubits(num_qubits)
+            .expect("cannot represent a too-large count");
+        res.add_anonymous_clbits(num_clbits)
+            .expect("cannot represent a too-large count");
         Ok(res)
+    }
+
+    /// Add multiple new anonymous qubits.
+    ///
+    /// This can only fail due to circuit capacity issues, since new anonymous qubits are guaranteed
+    /// to be unique.
+    pub fn add_anonymous_qubits(&mut self, num: u32) -> Result<(), CapacityError> {
+        if self.qubits.len() > (u32::MAX - num) as usize {
+            return Err(CapacityError);
+        }
+        for bit in ShareableQubit::iter_anonymous(num) {
+            let index = self.qubits.add_unique_within_capacity(bit.clone());
+            self.qubit_indices
+                .insert(bit, BitLocations::new(index.0, []));
+        }
+        Ok(())
+    }
+
+    /// Add multiple new anonymous clbits.
+    ///
+    /// This can only fail due to circuit capacity issues, since new anonymous qubits are guaranteed
+    /// to be unique.
+    pub fn add_anonymous_clbits(&mut self, num: u32) -> Result<(), CapacityError> {
+        if self.clbits.len() > (u32::MAX - num) as usize {
+            return Err(CapacityError);
+        }
+        for bit in ShareableClbit::iter_anonymous(num) {
+            let index = self.clbits.add_unique_within_capacity(bit.clone());
+            self.clbit_indices
+                .insert(bit, BitLocations::new(index.0, []));
+        }
+        Ok(())
     }
 
     /// Modify `self` to mark its qubits as physical.


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

When we can statically state that the qubits we're adding are new anonymous qubits, the only way the qubit-adding functions can fail is by going over capacity.  This commit exposes a way to do this safely, reducing one of the failure modes of `CircuitData::with_capacity`, which can provably not error during bit expansion because the maximums of the `num_qubits` and `num_clbits` arguments are within the capacity.


### Details and comments

Built on #15564
