### PR TITLE
Remove phase from `CircuitData::with_capacity`

### DIFF
--- a/crates/circuit/src/bit.rs
+++ b/crates/circuit/src/bit.rs
@@ -366,10 +366,27 @@ macro_rules! create_bit_object {
             }
 
             /// Create a new anonymous bit.
+            #[inline]
             pub fn new_anonymous() -> Self {
                 Self(BitInfo::Anonymous {
                     uid: Self::anonymous_instance_count().fetch_add(1, Ordering::Relaxed),
                     subclass: Default::default(),
+                })
+            }
+
+            /// Create `count` new anonymous bits, returned as an iterator.
+            ///
+            /// This is a bit more efficient than creating the bits individually, since we only have
+            /// to update the underlying atomic instance count once.
+            #[inline]
+            pub fn iter_anonymous(count: u32) -> impl ExactSizeIterator<Item = Self> {
+                let base = Self::anonymous_instance_count()
+                    .fetch_add(count as u64, Ordering::Relaxed);
+                (0..count).map(move |offset| {
+                    Self(BitInfo::Anonymous {
+                        uid: base + offset as u64,
+                        subclass: Default::default(),
+                    })
                 })
             }
         }

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -24,8 +24,9 @@ use crate::circuit_instruction::{CircuitInstruction, OperationFromPython};
 use crate::classical::expr;
 use crate::dag_circuit::{DAGStretchType, DAGVarType, add_global_phase};
 use crate::imports::{ANNOTATED_OPERATION, QUANTUM_CIRCUIT};
+use crate::instruction::Parameters;
 use crate::interner::{Interned, InternedMap, Interner};
-use crate::object_registry::{ObjectRegistry, ObjectRegistryError};
+use crate::object_registry::{self, ObjectRegistry};
 use crate::operations::{
     ControlFlow, ControlFlowView, Operation, OperationRef, Param, PythonOperation, StandardGate,
 };
@@ -36,7 +37,8 @@ use crate::parameter_table::{ParameterTable, ParameterTableError, ParameterUse, 
 use crate::register_data::RegisterData;
 use crate::slice::{PySequenceIndex, SequenceIndex};
 use crate::{
-    Block, BlocksMode, Clbit, ControlFlowBlocks, Qubit, Stretch, Var, VarsMode, instruction,
+    Block, BlocksMode, CapacityError, Clbit, ControlFlowBlocks, Qubit, Stretch, Var, VarsMode,
+    instruction,
 };
 
 use num_complex::Complex64;
@@ -47,7 +49,6 @@ use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyDict, PyList, PySet, PyTuple, PyType};
 use pyo3::{PyTraverseError, PyVisit, import_exception, intern};
 
-use crate::instruction::Parameters;
 use hashbrown::{HashMap, HashSet};
 use indexmap::IndexMap;
 use smallvec::SmallVec;
@@ -66,10 +67,14 @@ import_exception!(qiskit.circuit.exceptions, CircuitError);
 #[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum CircuitDataError {
+    #[error(transparent)]
+    Capacity(#[from] CapacityError),
     #[error("invalid type for global phase")]
     InvalidGlobalPhaseType,
     #[error(transparent)]
-    ObjectRegistryError(#[from] ObjectRegistryError),
+    AbsentObject(object_registry::AbsentObject),
+    #[error(transparent)]
+    AddObjectRegistry(object_registry::AddError),
     // Explicitly an error returned from calling Python
     #[error(transparent)]
     ErrorFromPython(#[from] PyErr),
@@ -100,14 +105,26 @@ pub enum CircuitDataError {
     #[error("bad type after binding for gate '{0}': '{1}'")]
     StandardGateParameterIsComplex(String, String),
 }
+impl<T: Debug> From<object_registry::AbsentObject<T>> for CircuitDataError {
+    fn from(val: object_registry::AbsentObject<T>) -> Self {
+        Self::AbsentObject(val.erase_type())
+    }
+}
+impl<T: Debug, B: Debug> From<object_registry::AddError<T, B>> for CircuitDataError {
+    fn from(val: object_registry::AddError<T, B>) -> Self {
+        Self::AddObjectRegistry(val.erase_type())
+    }
+}
 
 impl From<CircuitDataError> for PyErr {
     fn from(error: CircuitDataError) -> Self {
         match error {
+            CircuitDataError::Capacity(c) => c.into(),
             CircuitDataError::InvalidGlobalPhaseType => {
                 PyTypeError::new_err("invalid type for global phase")
             }
-            CircuitDataError::ObjectRegistryError(e) => e.into(),
+            CircuitDataError::AbsentObject(e) => e.into(),
+            CircuitDataError::AddObjectRegistry(e) => e.into(),
             CircuitDataError::ErrorFromPython(e) => e,
             CircuitDataError::ParameterTableError(e) => e.into(),
             CircuitDataError::DuplicateStretch => {
@@ -515,13 +532,13 @@ impl CircuitData {
 
         borrowed_mut.vars = ObjectRegistry::<Var, expr::Var>::with_capacity(state.5.len());
         for var in state.5 {
-            borrowed_mut.vars.add(var, false)?;
+            borrowed_mut.vars.add(var)?;
         }
 
         borrowed_mut.stretches =
             ObjectRegistry::<Stretch, expr::Stretch>::with_capacity(state.6.len());
         for stretch in state.6 {
-            borrowed_mut.stretches.add(stretch, false)?;
+            borrowed_mut.stretches.add(stretch)?;
         }
 
         Ok(())
@@ -694,9 +711,16 @@ impl CircuitData {
     /// Raises:
     ///     ValueError: The specified ``bit`` is already present and flag ``strict``
     ///         was provided.
-    #[pyo3(name="add_qubit", signature = (bit, *, strict=true))]
-    pub fn py_add_qubit(&mut self, bit: ShareableQubit, strict: bool) -> PyResult<()> {
-        Ok(self.add_qubit(bit, strict)?)
+    #[pyo3(signature = (bit, *, strict=true))]
+    pub fn add_qubit(&mut self, bit: ShareableQubit, strict: bool) -> Result<(), CircuitDataError> {
+        let index = if strict {
+            self.qubits.add(bit.clone())?
+        } else {
+            self.qubits.add_allow_existing(bit.clone())?
+        };
+        self.qubit_indices
+            .insert(bit, BitLocations::new(index.0, []));
+        Ok(())
     }
 
     /// Registers a :class:`.QuantumRegister` instance.
@@ -743,9 +767,16 @@ impl CircuitData {
     /// Raises:
     ///     ValueError: The specified ``bit`` is already present and flag ``strict``
     ///         was provided.
-    #[pyo3(name="add_clbit", signature = (bit, *, strict=true))]
-    pub fn py_add_clbit(&mut self, bit: ShareableClbit, strict: bool) -> PyResult<()> {
-        Ok(self.add_clbit(bit, strict)?)
+    #[pyo3(signature = (bit, *, strict=true))]
+    pub fn add_clbit(&mut self, bit: ShareableClbit, strict: bool) -> Result<(), CircuitDataError> {
+        let index = if strict {
+            self.clbits.add(bit.clone())?
+        } else {
+            self.clbits.add_allow_existing(bit.clone())?
+        };
+        self.clbit_indices
+            .insert(bit, BitLocations::new(index.0, []));
+        Ok(())
     }
 
     /// Registers a :class:`.QuantumRegister` instance.
@@ -1851,20 +1882,6 @@ impl CircuitData {
         Ok(self_)
     }
 
-    pub fn add_qubit(&mut self, bit: ShareableQubit, strict: bool) -> Result<(), CircuitDataError> {
-        let index = self.qubits.add(bit.clone(), strict)?;
-        self.qubit_indices
-            .insert(bit, BitLocations::new(index.0, []));
-        Ok(())
-    }
-
-    pub fn add_clbit(&mut self, bit: ShareableClbit, strict: bool) -> Result<(), CircuitDataError> {
-        let index = self.clbits.add(bit.clone(), strict)?;
-        self.clbit_indices
-            .insert(bit, BitLocations::new(index.0, []));
-        Ok(())
-    }
-
     pub fn set_global_phase(&mut self, angle: Param) -> Result<(), CircuitDataError> {
         if let Param::ParameterExpression(expr) = &self.global_phase {
             for symbol in expr.iter_symbols() {
@@ -2357,9 +2374,7 @@ impl CircuitData {
         let mut registry = ObjectRegistry::with_capacity(num_qubits as usize);
         let mut locator = BitLocator::with_capacity(num_qubits as usize);
         for (index, bit) in register.iter().enumerate() {
-            registry
-                .add(bit.clone(), false)
-                .expect("no duplicates, and in-bounds check already performed");
+            registry.add_unique_within_capacity(bit.clone());
             locator.insert(
                 bit,
                 BitLocations::new(index as u32, [(register.clone(), index)]),
@@ -3232,7 +3247,7 @@ impl CircuitData {
             _ => {}
         }
 
-        let var_idx = self.vars.add(var, true)?;
+        let var_idx = self.vars.add(var)?;
         match var_type {
             CircuitVarType::Input => &mut self.vars_input,
             CircuitVarType::Capture => &mut self.vars_capture,
@@ -3306,7 +3321,7 @@ impl CircuitData {
             }
         }
 
-        let stretch_idx = self.stretches.add(stretch, true)?;
+        let stretch_idx = self.stretches.add(stretch)?;
         match stretch_type {
             CircuitStretchType::Capture => &mut self.stretches_capture,
             CircuitStretchType::Declare => &mut self.stretches_declare,

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -2117,12 +2117,8 @@ impl CircuitData {
         >,
     {
         let instruction_iter = instructions.into_iter();
-        let mut res = Self::with_capacity(
-            num_qubits,
-            num_clbits,
-            instruction_iter.size_hint().0,
-            global_phase,
-        )?;
+        let mut res = Self::with_capacity(num_qubits, num_clbits, instruction_iter.size_hint().0);
+        res.set_global_phase_param(global_phase)?;
 
         for item in instruction_iter {
             let (operation, params, qargs, cargs) = item?;
@@ -2271,8 +2267,8 @@ impl CircuitData {
         I: IntoIterator<Item = (StandardGate, SmallVec<[Param; 3]>, SmallVec<[Qubit; 2]>)>,
     {
         let instruction_iter = instructions.into_iter();
-        let mut res =
-            Self::with_capacity(num_qubits, 0, instruction_iter.size_hint().0, global_phase)?;
+        let mut res = Self::with_capacity(num_qubits, 0, instruction_iter.size_hint().0);
+        res.set_global_phase_param(global_phase)?;
 
         for (operation, params, qargs) in instruction_iter {
             let qubits = res.qargs_interner.insert(&qargs);
@@ -2285,12 +2281,7 @@ impl CircuitData {
     }
 
     /// Build an empty CircuitData object with an initially allocated instruction capacity
-    pub fn with_capacity(
-        num_qubits: u32,
-        num_clbits: u32,
-        instruction_capacity: usize,
-        global_phase: Param,
-    ) -> Result<Self, CircuitDataError> {
+    pub fn with_capacity(num_qubits: u32, num_clbits: u32, instruction_capacity: usize) -> Self {
         let mut res = CircuitData {
             data: Vec::with_capacity(instruction_capacity),
             qargs_interner: Interner::new(),
@@ -2313,14 +2304,11 @@ impl CircuitData {
             stretches_capture: Vec::new(),
             stretches_declare: Vec::new(),
         };
-
-        // use the global phase setter to ensure parameters are registered in the parameter table
-        res.set_global_phase_param(global_phase)?;
         res.add_anonymous_qubits(num_qubits)
             .expect("cannot represent a too-large count");
         res.add_anonymous_clbits(num_clbits)
             .expect("cannot represent a too-large count");
-        Ok(res)
+        res
     }
 
     /// Add multiple new anonymous qubits.

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -1076,12 +1076,10 @@ impl DAGCircuit {
     ///
     /// Args:
     ///     angle (float, :class:`.ParameterExpression`): The phase angle.
-    #[setter]
-    pub fn set_global_phase(&mut self, angle: Param) -> PyResult<()> {
+    #[setter(global_phase)]
+    pub fn set_global_phase_param(&mut self, angle: Param) -> PyResult<()> {
         match angle {
-            Param::Float(angle) => {
-                self.global_phase = Param::Float(angle.rem_euclid(2. * PI));
-            }
+            Param::Float(angle) => self.set_global_phase_f64(angle),
             Param::ParameterExpression(angle) => {
                 self.global_phase = Param::ParameterExpression(angle);
             }
@@ -6478,6 +6476,14 @@ impl DAGCircuit {
         Ok((in_node, out_node))
     }
 
+    /// Set the global phase to a float value.
+    ///
+    /// Unlike the general [set_global_phase_param], this is infallible.
+    #[inline]
+    pub fn set_global_phase_f64(&mut self, angle: f64) {
+        self.global_phase = Param::Float(angle.rem_euclid(::std::f64::consts::TAU));
+    }
+
     /// Get the nodes on the given wire.
     ///
     /// Note: result is empty if the wire is not in the DAG.
@@ -7584,7 +7590,7 @@ impl DAGCircuit {
                     "Invalid parameter type, only float and parameter expression are supported",
                 ));
             }
-            _ => self.set_global_phase(add_global_phase(&self.global_phase, value))?,
+            _ => self.set_global_phase_param(add_global_phase(&self.global_phase, value))?,
         }
         Ok(())
     }

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -849,22 +849,22 @@ impl DAGCircuit {
         let binding = dict_state.get_item("qubits")?.unwrap();
         let qubits_raw = binding.extract::<Vec<ShareableQubit>>()?;
         for bit in qubits_raw.into_iter() {
-            self.qubits.add(bit, false)?;
+            self.qubits.add(bit)?;
         }
         let binding = dict_state.get_item("clbits")?.unwrap();
         let clbits_raw = binding.extract::<Vec<ShareableClbit>>()?;
         for bit in clbits_raw.into_iter() {
-            self.clbits.add(bit, false)?;
+            self.clbits.add(bit)?;
         }
         let binding = dict_state.get_item("vars")?.unwrap();
         let vars_raw = binding.cast::<PyList>()?;
         for v in vars_raw.iter() {
-            self.vars.add(v.extract()?, false)?;
+            self.vars.add(v.extract()?)?;
         }
         let binding = dict_state.get_item("stretches")?.unwrap();
         let stretches_raw = binding.cast::<PyList>()?;
         for s in stretches_raw.iter() {
-            self.stretches.add(s.extract()?, false)?;
+            self.stretches.add(s.extract()?)?;
         }
         let binding = dict_state.get_item("qubit_io_map")?.unwrap();
         let qubit_index_map_raw = binding.cast::<PyDict>().unwrap();
@@ -5339,9 +5339,7 @@ impl DAGCircuit {
         let mut registry = ObjectRegistry::with_capacity(num_qubits as usize);
         let mut locator = BitLocator::with_capacity(num_qubits as usize);
         for (index, bit) in register.iter().enumerate() {
-            registry
-                .add(bit.clone(), false)
-                .expect("no duplicates, and in-bounds check already performed");
+            registry.add_unique_within_capacity(bit.clone());
             locator.insert(
                 bit,
                 BitLocations::new(index as u32, [(register.clone(), index)]),
@@ -6518,7 +6516,7 @@ impl DAGCircuit {
     }
 
     pub fn add_qubit_unchecked(&mut self, bit: ShareableQubit) -> PyResult<Qubit> {
-        let qubit = self.qubits.add(bit.clone(), false)?;
+        let qubit = self.qubits.add_unique_within_capacity(bit.clone());
         self.qubit_locations
             .insert(bit, BitLocations::new((self.qubits.len() - 1) as u32, []));
         self.add_wire(Wire::Qubit(qubit))?;
@@ -6526,7 +6524,7 @@ impl DAGCircuit {
     }
 
     pub fn add_clbit_unchecked(&mut self, bit: ShareableClbit) -> PyResult<Clbit> {
-        let clbit = self.clbits.add(bit.clone(), false)?;
+        let clbit = self.clbits.add_unique_within_capacity(bit.clone());
         self.clbit_locations
             .insert(bit, BitLocations::new((self.clbits.len() - 1) as u32, []));
         self.add_wire(Wire::Clbit(clbit))?;
@@ -7278,7 +7276,7 @@ impl DAGCircuit {
             _ => {}
         }
 
-        let var_idx = self.vars.add(var, true)?;
+        let var_idx = self.vars.add(var)?;
         let (in_index, out_index) = self.add_wire(Wire::Var(var_idx))?;
         match type_ {
             DAGVarType::Input => &mut self.vars_input,
@@ -7324,7 +7322,7 @@ impl DAGCircuit {
             _ => {}
         }
 
-        let stretch_idx = self.stretches.add(stretch, true)?;
+        let stretch_idx = self.stretches.add(stretch)?;
         match type_ {
             DAGStretchType::Capture => {
                 self.stretches_capture.insert(stretch_idx);

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -43,7 +43,7 @@ pub mod vf2;
 mod variable_mapper;
 
 use pyo3::PyTypeInfo;
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PySequence, PyString, PyTuple};
 
@@ -204,6 +204,16 @@ impl<'a, 'py> FromPyObject<'a, 'py> for VarsMode {
 pub enum BlocksMode {
     Drop,
     Keep,
+}
+
+/// Simple error type for objects with built-in hard-coded capacity limits.
+#[derive(Clone, Copy, Debug, thiserror::Error)]
+#[error("exceeded allowed runtime capacity")]
+pub struct CapacityError;
+impl From<CapacityError> for PyErr {
+    fn from(val: CapacityError) -> PyErr {
+        PyRuntimeError::new_err(val.to_string())
+    }
 }
 
 #[inline]

--- a/crates/synthesis/src/discrete_basis/basic_approximations.rs
+++ b/crates/synthesis/src/discrete_basis/basic_approximations.rs
@@ -20,7 +20,7 @@ use qiskit_circuit::{
     NoBlocks, Qubit,
     circuit_data::CircuitData,
     circuit_instruction::OperationFromPython,
-    operations::{Operation, OperationRef, Param, StandardGate},
+    operations::{Operation, OperationRef, StandardGate},
 };
 use rstar::{Point, RTree};
 use serde::{Deserialize, Serialize};
@@ -237,13 +237,12 @@ impl GateSequence {
         target: Option<(&Matrix2<Complex64>, f64)>,
     ) -> Result<CircuitData, DiscreteBasisError> {
         let global_phase = match target {
-            Some((target_u2, target_phase)) => {
-                Param::Float(self.compute_phase(target_u2, target_phase)?)
-            }
-            None => Param::Float(self.phase),
+            Some((target_u2, target_phase)) => self.compute_phase(target_u2, target_phase)?,
+            None => self.phase,
         };
 
-        let mut circuit = CircuitData::with_capacity(1, 0, self.gates.len(), global_phase).unwrap();
+        let mut circuit = CircuitData::with_capacity(1, 0, self.gates.len());
+        circuit.set_global_phase_f64(global_phase);
         for gate in &self.gates {
             circuit.push_standard_gate(*gate, &[], &[Qubit(0)]).unwrap();
         }

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -254,7 +254,7 @@ impl CircuitDataForSynthesis for CircuitData {
 /// Efficient synthesis for 4-controlled X-gate.
 #[pyfunction]
 pub fn c4x() -> Result<CircuitData, CircuitDataError> {
-    let mut circuit = CircuitData::with_capacity(5, 0, 0, Param::Float(0.0))?;
+    let mut circuit = CircuitData::with_capacity(5, 0, 0);
     circuit.h(4)?;
     circuit.cp(PI2, 3, 4)?;
     circuit.h(4)?;
@@ -323,7 +323,7 @@ pub fn synth_mcx_n_dirty_i15(
     action_only: bool,
 ) -> Result<CircuitData, CircuitDataError> {
     if num_controls == 1 {
-        let mut circuit = CircuitData::with_capacity(2, 0, 1, Param::Float(0.0))?;
+        let mut circuit = CircuitData::with_capacity(2, 0, 1);
         circuit.cx(0, 1)?;
         Ok(circuit)
     } else if num_controls == 2 {
@@ -333,7 +333,7 @@ pub fn synth_mcx_n_dirty_i15(
     } else {
         let num_ancillas = num_controls - 2;
         let num_qubits = num_controls + 1 + num_ancillas;
-        let mut circuit = CircuitData::with_capacity(num_qubits as u32, 0, 0, Param::Float(0.0))?;
+        let mut circuit = CircuitData::with_capacity(num_qubits as u32, 0, 0);
 
         let controls: Vec<u32> = (0..num_controls).map(|q| q as u32).collect();
         let target = num_controls as u32;
@@ -418,7 +418,7 @@ pub fn synth_mcx_noaux_v24(
         let num_qubits = (num_controls + 1) as u32;
         let target = num_controls as u32;
 
-        let mut circuit = CircuitData::with_capacity(num_qubits, 0, 0, Param::Float(0.0))?;
+        let mut circuit = CircuitData::with_capacity(num_qubits, 0, 0);
         circuit.h(target)?;
 
         let mcphase_cls = imports::MCPHASE_GATE.get_bound(py);
@@ -478,7 +478,7 @@ fn increment_n_dirty_large(n: u32) -> PyResult<CircuitData> {
         Ok(())
     }
 
-    let mut circuit = CircuitData::with_capacity(2 * n, 0, 0, Param::Float(0.0))?;
+    let mut circuit = CircuitData::with_capacity(2 * n, 0, 0);
     let qubits: Vec<u32> = (0..n).collect();
     let ancillas: Vec<u32> = (n..2 * n).collect();
 
@@ -550,7 +550,7 @@ fn increment_n_dirty_large(n: u32) -> PyResult<CircuitData> {
 ///
 /// Best suitable for when n is small.
 fn increment_n_dirty_small(n: u32) -> PyResult<CircuitData> {
-    let mut circuit = CircuitData::with_capacity(2 * n, 0, 0, Param::Float(0.0))?;
+    let mut circuit = CircuitData::with_capacity(2 * n, 0, 0);
 
     for k in (1..n).rev() {
         let k_mcx = synth_mcx_n_dirty_i15(k as usize, false, false)?;
@@ -586,7 +586,7 @@ fn increment_n_dirty(n: u32) -> PyResult<CircuitData> {
 fn synth_relative_mcx(num_controls: usize) -> Result<CircuitData, CircuitDataError> {
     let num_qubits = (num_controls + 1) as u32;
     let target = num_controls as u32;
-    let mut circuit = CircuitData::with_capacity(num_qubits, 0, 0, Param::Float(0.0))?;
+    let mut circuit = CircuitData::with_capacity(num_qubits, 0, 0);
 
     match num_controls {
         0 => {
@@ -688,7 +688,7 @@ fn increment_1_dirty(n: u32, flag_add: bool) -> PyResult<CircuitData> {
     // We say that qubits 0..k are "first half" qubits, qubits k+1..n are "second-half" qubits.
     let ancilla = n;
 
-    let mut circuit = CircuitData::with_capacity(n + 1, 0, 0, Param::Float(0.0))?;
+    let mut circuit = CircuitData::with_capacity(n + 1, 0, 0);
 
     if !flag_add {
         for i in 0..n {
@@ -787,7 +787,7 @@ fn increment_2_dirty(n: u32, flag_add: bool) -> PyResult<CircuitData> {
     let ancilla1 = n;
     let ancilla2 = n + 1;
 
-    let mut circuit = CircuitData::with_capacity(n + 2, 0, 0, Param::Float(0.0))?;
+    let mut circuit = CircuitData::with_capacity(n + 2, 0, 0);
 
     if !flag_add {
         for i in 0..n {
@@ -877,7 +877,7 @@ fn increment_2_dirty(n: u32, flag_add: bool) -> PyResult<CircuitData> {
 pub fn synth_mcx_noaux_hp24(num_controls: usize) -> PyResult<CircuitData> {
     let n = num_controls + 1;
 
-    let mut circuit = CircuitData::with_capacity(n as u32, 0, 0, Param::Float(0.0))?;
+    let mut circuit = CircuitData::with_capacity(n as u32, 0, 0);
 
     // Handle small cases explicitly
     if n == 2 {

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -219,7 +219,7 @@ impl CircuitDataForSynthesis for CircuitData {
 
         let mut inverse_circuit =
             CircuitData::copy_empty_like(self, VarsMode::Alike, BlocksMode::Keep)?;
-        inverse_circuit.set_global_phase(inverse_global_phase)?;
+        inverse_circuit.set_global_phase_param(inverse_global_phase)?;
 
         let data = self.data();
 

--- a/crates/synthesis/src/pauli_product_measurement.rs
+++ b/crates/synthesis/src/pauli_product_measurement.rs
@@ -17,7 +17,6 @@ use qiskit_circuit::circuit_data::CircuitError;
 use qiskit_circuit::circuit_instruction::OperationFromPython;
 use qiskit_circuit::operations::Operation;
 use qiskit_circuit::operations::OperationRef;
-use qiskit_circuit::operations::Param;
 use qiskit_circuit::operations::PauliProductMeasurement;
 use qiskit_circuit::operations::StandardGate;
 use qiskit_circuit::operations::StandardInstruction;
@@ -31,7 +30,7 @@ pub fn synthesize_ppm(ppm: &PauliProductMeasurement) -> PyResult<CircuitData> {
     // is tricky.
     let num_qubits = ppm.num_qubits();
 
-    let mut circuit = CircuitData::with_capacity(num_qubits, 1, 0, Param::Float(0.0))?;
+    let mut circuit = CircuitData::with_capacity(num_qubits, 1, 0);
 
     // Filtering 'I's
     let pauli_qubits = ppm

--- a/crates/synthesis/src/qsd.rs
+++ b/crates/synthesis/src/qsd.rs
@@ -219,7 +219,7 @@ fn qsd_inner(
     let numerator = 63 * x * x - 168 * x;
     let gates_bound = numerator.div_ceil(16);
 
-    let mut out = CircuitData::with_capacity(num_qubits as u32, 0, gates_bound, Param::Float(0.))?;
+    let mut out = CircuitData::with_capacity(num_qubits as u32, 0, gates_bound);
     // perform block ZXZ decomposition from [2]
     let (a1, a2, b, c) = block_zxz_decomp(mat);
 

--- a/crates/synthesis/src/ross_selinger.rs
+++ b/crates/synthesis/src/ross_selinger.rs
@@ -34,8 +34,8 @@ where
     S: IntoIterator<Item = char>,
 {
     let qubit = [Qubit(0)];
-    let mut circuit =
-        CircuitData::with_capacity(1u32, 0, instruction_capacity, Param::Float(phase))?;
+    let mut circuit = CircuitData::with_capacity(1u32, 0, instruction_capacity);
+    circuit.set_global_phase_f64(phase);
     for c in s {
         match c {
             'I' => {}

--- a/crates/synthesis/src/two_qubit_decompose.rs
+++ b/crates/synthesis/src/two_qubit_decompose.rs
@@ -1166,7 +1166,7 @@ impl TwoQubitWeylDecomposition {
         let mut target_1q_basis_list = EulerBasisSet::new();
         target_1q_basis_list.add_basis(euler_basis);
 
-        let mut gate_sequence = CircuitData::with_capacity(2, 0, 21, Param::Float(0.))?;
+        let mut gate_sequence = CircuitData::with_capacity(2, 0, 21);
         let mut global_phase: f64 = self.global_phase;
 
         let c2r = unitary_to_gate_sequence_inner(

--- a/crates/synthesis/src/two_qubit_decompose.rs
+++ b/crates/synthesis/src/two_qubit_decompose.rs
@@ -1242,7 +1242,7 @@ impl TwoQubitWeylDecomposition {
                 &[Qubit(1)],
             )?;
         }
-        gate_sequence.set_global_phase(Param::Float(global_phase))?;
+        gate_sequence.set_global_phase_f64(global_phase);
         Ok(gate_sequence)
     }
 }
@@ -2223,7 +2223,7 @@ impl TwoQubitBasisDecomposer {
         let sequence =
             self.generate_sequence(unitary, basis_fidelity, approximate, _num_basis_uses)?;
         let mut dag = DAGCircuit::with_capacity(2, 0, None, Some(sequence.gates.len()), None, None);
-        dag.set_global_phase(Param::Float(sequence.global_phase))?;
+        dag.set_global_phase_f64(sequence.global_phase);
         dag.add_qubit_unchecked(ShareableQubit::new_anonymous())?;
         dag.add_qubit_unchecked(ShareableQubit::new_anonymous())?;
         let mut builder = dag.into_builder();

--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -236,7 +236,7 @@ fn get_bits_from_py<T>(
     py_bits2: &Bound<'_, PyTuple>,
 ) -> PyResult<(Vec<T>, Vec<T>)>
 where
-    T: From<u32> + Copy,
+    T: From<u32> + Copy + Debug,
     u32: From<T>,
 {
     // Using `PyObjectAsKey` here is a total hack, but this is a short-term workaround before a
@@ -244,7 +244,7 @@ where
     let mut registry: ObjectRegistry<T, PyObjectAsKey> = ObjectRegistry::new();
 
     for bit in py_bits1.iter().chain(py_bits2.iter()) {
-        registry.add(bit.into(), false)?;
+        registry.add_allow_existing(bit.into())?;
     }
 
     Ok((

--- a/crates/transpiler/src/passes/commutative_optimization.rs
+++ b/crates/transpiler/src/passes/commutative_optimization.rs
@@ -506,7 +506,7 @@ pub fn run_commutative_optimization(
         return Ok(None);
     }
 
-    new_dag.set_global_phase(new_global_phase)?;
+    new_dag.set_global_phase_param(new_global_phase)?;
 
     for idx in 0..num_nodes {
         match &node_actions[idx] {

--- a/crates/transpiler/src/passes/disjoint_layout.rs
+++ b/crates/transpiler/src/passes/disjoint_layout.rs
@@ -29,7 +29,7 @@ use crate::target::{Qargs, Target};
 use qiskit_circuit::bit::ShareableQubit;
 use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_circuit::imports::ImportOnceCell;
-use qiskit_circuit::operations::{Operation, OperationRef, Param, StandardInstruction};
+use qiskit_circuit::operations::{Operation, OperationRef, StandardInstruction};
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_circuit::{
     BlockMapper, BlocksMode, Clbit, PhysicalQubit, Qubit, VarsMode, VirtualQubit,
@@ -447,7 +447,7 @@ fn separate_dag(dag: &mut DAGCircuit) -> PyResult<Vec<DAGCircuit>> {
             let qubits_to_revmove: Vec<Qubit> = qubits.difference(&dag_qubits).copied().collect();
 
             new_dag.remove_qubits(qubits_to_revmove)?;
-            new_dag.set_global_phase(Param::Float(0.))?;
+            new_dag.set_global_phase_f64(0.);
             let old_qubits = dag.qubits();
             let mut block_map = BlockMapper::new();
             for index in dag.topological_op_nodes(false)? {

--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -708,7 +708,7 @@ fn run_on_circuitdata(
                     output_circuit.global_phase().clone(),
                     synthesized_circuit.global_phase().clone(),
                 );
-                output_circuit.set_global_phase(updated_global_phase)?;
+                output_circuit.set_global_phase_param(updated_global_phase)?;
             }
         }
     }

--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -740,8 +740,8 @@ fn extract_definition(op: &PackedOperation, params: &[Param]) -> PyResult<Option
                 [2, 2] => {
                     let [theta, phi, lam, phase] =
                         angles_from_unitary(unitary.view(), EulerBasis::U);
-                    let mut circuit_data: CircuitData =
-                        CircuitData::with_capacity(1, 0, 1, Param::Float(phase))?;
+                    let mut circuit_data = CircuitData::with_capacity(1, 0, 1);
+                    circuit_data.set_global_phase_f64(phase);
                     circuit_data.push_standard_gate(
                         StandardGate::U,
                         &[Param::Float(theta), Param::Float(phi), Param::Float(lam)],

--- a/crates/transpiler/src/standard_equivalence_library.rs
+++ b/crates/transpiler/src/standard_equivalence_library.rs
@@ -44,8 +44,8 @@ fn cnot_rxx_decompose(plus_ry: bool, plus_rxx: bool) -> PyResult<CircuitData> {
         true => 1.0,
         false => -1.0,
     };
-    let mut circuit =
-        CircuitData::with_capacity(2, 0, 5, (-sgn_ry * sgn_rxx * PI / 4.0).into()).unwrap();
+    let mut circuit = CircuitData::with_capacity(2, 0, 5);
+    circuit.set_global_phase_f64(-sgn_ry * sgn_rxx * PI / 4.0);
 
     circuit.push_standard_gate(
         StandardGate::RY,
@@ -85,8 +85,10 @@ fn create_standard_equivalence<P>(
 where
     P: Into<Param>,
 {
-    let mut circuit =
-        CircuitData::with_capacity(0, 0, eq_instructions.len(), eq_global_phase.into()).unwrap();
+    let mut circuit = CircuitData::with_capacity(0, 0, eq_instructions.len());
+    circuit
+        .set_global_phase_param(eq_global_phase.into())
+        .expect("phase should be valid type, and cannot cause name conflict with an empty circuit");
     let qreg = QuantumRegister::new_owning("q", gate.num_qubits());
     circuit.add_qreg(qreg, true).unwrap();
     for (operation, qargs, eq_params) in eq_instructions {

--- a/test/python/circuit/test_circuit_data.py
+++ b/test/python/circuit/test_circuit_data.py
@@ -46,7 +46,7 @@ class TestQuantumCircuitData(QiskitTestCase):
         self.assertEqual(data.qubits, list(qr))
 
         # Test re-adding is disallowed by default.
-        with self.assertRaisesRegex(ValueError, "Existing object"):
+        with self.assertRaisesRegex(ValueError, "cannot add object"):
             data.add_qubit(qr[0])
 
         # Make sure re-adding is allowed in non-strict mode
@@ -62,7 +62,7 @@ class TestQuantumCircuitData(QiskitTestCase):
         self.assertEqual(data.qubits, qubits)
 
         # Test re-adding is disallowed by default.
-        with self.assertRaisesRegex(ValueError, "Existing object"):
+        with self.assertRaisesRegex(ValueError, "cannot add object"):
             data.add_qubit(qubits[0])
 
         # Make sure re-adding is allowed in non-strict mode
@@ -111,7 +111,7 @@ class TestQuantumCircuitData(QiskitTestCase):
         self.assertEqual(data.clbits, list(cr))
 
         # Test re-adding is disallowed by default.
-        with self.assertRaisesRegex(ValueError, "Existing object"):
+        with self.assertRaisesRegex(ValueError, "cannot add object"):
             data.add_clbit(cr[0])
 
         # Make sure re-adding is allowed in non-strict mode
@@ -127,7 +127,7 @@ class TestQuantumCircuitData(QiskitTestCase):
         self.assertEqual(data.clbits, clbits)
 
         # Test re-adding is disallowed by default.
-        with self.assertRaisesRegex(ValueError, "Existing object"):
+        with self.assertRaisesRegex(ValueError, "cannot add object"):
             data.add_clbit(clbits[0])
 
         # Make sure re-adding is allowed in non-strict mode
@@ -441,7 +441,7 @@ class TestQuantumCircuitData(QiskitTestCase):
         """Test using foreign bits is not allowed."""
         qr = QuantumRegister(1)
         cr = ClassicalRegister(1)
-        with self.assertRaisesRegex(KeyError, "not been added to this circuit"):
+        with self.assertRaisesRegex(KeyError, "is not present"):
             CircuitData(qr, cr, [CircuitInstruction(XGate(), [Qubit()], [])])
 
     def test_unregistered_bit_error_append(self):
@@ -449,7 +449,7 @@ class TestQuantumCircuitData(QiskitTestCase):
         qr = QuantumRegister(1)
         cr = ClassicalRegister(1)
         data = CircuitData(qr, cr)
-        with self.assertRaisesRegex(KeyError, "not been added to this circuit"):
+        with self.assertRaisesRegex(KeyError, "is not present"):
             qr_foreign = QuantumRegister(1)
             data.append(CircuitInstruction(XGate(), [qr_foreign[0]], []))
 
@@ -458,7 +458,7 @@ class TestQuantumCircuitData(QiskitTestCase):
         qr = QuantumRegister(1)
         cr = ClassicalRegister(1)
         data = CircuitData(qr, cr, [CircuitInstruction(XGate(), [qr[0]], [])])
-        with self.assertRaisesRegex(KeyError, "not been added to this circuit"):
+        with self.assertRaisesRegex(KeyError, "is not present"):
             qr_foreign = QuantumRegister(1)
             data[0] = CircuitInstruction(XGate(), [qr_foreign[0]], [])
 


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This makes the function infallible (as it _should_ be!).  The only real failure mechanism of the function is by passing a global-phase parameter of an incorrect `Param` variant.  When the global-phase is known to be either a symbol expression or a float, setting the global phase on an empty circuit is guaranteed to be infallible; setting the global phase to a float is _always_ infallible, while setting the global phase to a symbolic expression can only fail if there are duplicated symbol names.  This cannot happen for empty circuits, since `ParameterExpression` enforces name uniqueness in the same way that `CircuitData` does.


### Details and comments

Built on #15570 and #15562.  This is where I've been going with the infallibility - it was seriously annoying me that we were forcing awkward `unwrap` or fallibility checks on basic circuit construction.