### PR TITLE
Fix broken ASV benchmarks

### DIFF
--- a/test/benchmarks/manipulate.py
+++ b/test/benchmarks/manipulate.py
@@ -17,7 +17,11 @@
 import os
 
 from qiskit import QuantumCircuit
+from qiskit.providers.fake_provider import GenericBackendV2
+from qiskit.compiler import transpile
+from qiskit.transpiler import CouplingMap
 from qiskit.circuit import pauli_twirl_2q_gates
+from qiskit.circuit.library import quantum_volume
 from qiskit.passmanager import PropertySet
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from .utils import multi_control_circuit
@@ -28,8 +32,14 @@ class TestCircuitManipulate:
         qasm_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "qasm")
         self.qft_qasm = os.path.join(qasm_dir, "dtc_100_cx_12345.qasm")
         self.qft_qc = QuantumCircuit.from_qasm_file(self.qft_qasm)
-        self.qv_qasm = os.path.join(qasm_dir, "qv_N100_12345.qasm")
-        self.qv_qc = QuantumCircuit.from_qasm_file(self.qv_qasm)
+
+        qv_circuit = quantum_volume(100, seed=2025_12345)
+        qv_circuit.measure_all()
+        backend = GenericBackendV2(100, coupling_map=CouplingMap.from_line(100), seed=2025_12345)
+        self.qv_qc = transpile(
+            qv_circuit, backend, optimization_level=0, seed_transpiler=2025_12345
+        )
+
         self.dtc_qasm = os.path.join(qasm_dir, "dtc_100_cx_12345.qasm")
         self.dtc_qc = QuantumCircuit.from_qasm_file(self.dtc_qasm)
         self.translate = generate_preset_pass_manager(1, basis_gates=["rx", "ry", "rz", "cz"])

--- a/test/benchmarks/mapping_passes.py
+++ b/test/benchmarks/mapping_passes.py
@@ -14,6 +14,8 @@
 # pylint: disable=attribute-defined-outside-init,unsubscriptable-object
 # pylint: disable=unused-wildcard-import,wildcard-import,undefined-variable
 
+from copy import deepcopy
+
 from qiskit.transpiler import CouplingMap
 from qiskit.transpiler.passes import *
 from qiskit.converters import circuit_to_dag
@@ -96,7 +98,7 @@ class PassBenchmarks:
         self.enlarge_dag = enlarge_pass.run(self.full_ancilla_dag)
         apply_pass = ApplyLayout()
         apply_pass.property_set["layout"] = self.layout
-        self.dag = apply_pass.run(self.enlarge_dag)
+        self.dag = apply_pass.run(deepcopy(self.enlarge_dag))
 
     def time_sabre_swap(self, _, __):
         swap = SabreSwap(self.coupling_map, seed=42)
@@ -222,6 +224,7 @@ class RoutedPassBenchmarks:
         apply_pass = ApplyLayout()
         apply_pass.property_set["layout"] = self.layout
         self.dag = apply_pass.run(self.enlarge_dag)
+        self.routed_dag = SabreSwap(self.coupling_map, seed=42).run(self.dag)
 
     def time_gate_direction(self, _, __):
         GateDirection(self.coupling_map).run(self.routed_dag)


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Some of our existing ASV benchmarks were broken. This commit fixes these (though alternatively I could have simply deleted some of the benchmarks as well). 

### Details and Comments

For `TestCircuitManipulate`: #13919 deleted the huge qasm file `qv_N100_12345.qasm` and modified the `circuit_construction` benchmark to construct the relevant quantum circuit instead of loading it from qasm. This PR applies the same fix to the `manipulate` benchmark as well.

For `PassBenchmarks`: the `ApplyLayout` pass is a _transformation_ pass, and in particular changes the DAG from _virtual_ to _physical_ (which also changes the register names). If we want to save the DAG before the `ApplyLayout` pass (so that we can run the `ApplyLayout` to measure its performance), we should `deepcopy`. 

For `RoutedPassBenchmarks`: `self.routed_dag` was not defined. Note that `GateDirection`/`CheckGateDirection` raise an error if the DAG's connectivity does not adhere to the coupling map. At some point in the past, the test included `StochasticSwap` to route the circuit (and define `self.routed_dag` in the first place), however the line got removed with the removal of stochastic swap. As we still need to route the circuit for this benchmark, I have reincluded the removed line with `SabreSwap` instead.
