### PR TITLE
Fix standard gate header equations

### DIFF
--- a/qiskit/circuit/library/standard_gates/dcx.py
+++ b/qiskit/circuit/library/standard_gates/dcx.py
@@ -20,7 +20,7 @@ from qiskit._accelerate.circuit import StandardGate
 
 @with_gate_array([[1, 0, 0, 0], [0, 0, 0, 1], [0, 1, 0, 0], [0, 0, 1, 0]])
 class DCXGate(SingletonGate):
-    r"""Double-CNOT gate.
+    r"""Double-CX gate.
 
     A 2-qubit Clifford gate consisting of two back-to-back
     CNOTs with alternate controls.

--- a/qiskit/circuit/library/standard_gates/dcx.py
+++ b/qiskit/circuit/library/standard_gates/dcx.py
@@ -23,7 +23,7 @@ class DCXGate(SingletonGate):
     r"""Double-CX gate.
 
     A 2-qubit Clifford gate consisting of two back-to-back
-    CNOTs with alternate controls.
+    CX gates with alternate controls.
 
     Can be applied to a :class:`~qiskit.circuit.QuantumCircuit`
     with the :meth:`~qiskit.circuit.QuantumCircuit.dcx` method.

--- a/qiskit/circuit/library/standard_gates/s.py
+++ b/qiskit/circuit/library/standard_gates/s.py
@@ -29,7 +29,7 @@ _SDG_ARRAY = numpy.array([[1, 0], [0, -1j]])
 
 @with_gate_array(_S_ARRAY)
 class SGate(SingletonGate):
-    r"""Single qubit S gate (Z**0.5).
+    r"""Single qubit S gate (:math:`\sqrt{Z}`).
 
     It induces a :math:`\pi/2` phase, and is sometimes called the P gate (phase).
 
@@ -123,7 +123,7 @@ class SGate(SingletonGate):
         return gate
 
     def inverse(self, annotated: bool = False):
-        """Return inverse of S (SdgGate).
+        """Return inverse of S (:class:`.SdgGate`).
 
         Args:
             annotated: when set to ``True``, this is typically used to return an
@@ -147,7 +147,7 @@ class SGate(SingletonGate):
 
 @with_gate_array(_SDG_ARRAY)
 class SdgGate(SingletonGate):
-    r"""Single qubit S-adjoint gate (~Z**0.5).
+    r"""Single qubit S-adjoint gate (:math:`S^\dagger`).
 
     It induces a :math:`-\pi/2` phase.
 
@@ -179,7 +179,10 @@ class SdgGate(SingletonGate):
     _standard_gate = StandardGate.Sdg
 
     def __init__(self, label: Optional[str] = None):
-        """Create new Sdg gate."""
+        """
+        Args:
+            label: An optional label for the gate.
+        """
         super().__init__("sdg", 1, [], label=label)
 
     _singleton_lookup_key = stdlib_singleton_key()
@@ -352,7 +355,7 @@ class CSGate(SingletonControlledGate):
 
 @with_controlled_gate_array(_SDG_ARRAY, num_ctrl_qubits=1)
 class CSdgGate(SingletonControlledGate):
-    r"""Controlled-S^\dagger gate.
+    r"""Controlled-:math:`S^\dagger` gate.
 
     Can be applied to a :class:`~qiskit.circuit.QuantumCircuit`
     with the :meth:`~qiskit.circuit.QuantumCircuit.csdg` method.

--- a/qiskit/circuit/library/standard_gates/t.py
+++ b/qiskit/circuit/library/standard_gates/t.py
@@ -24,10 +24,10 @@ from qiskit._accelerate.circuit import StandardGate
 
 @with_gate_array([[1, 0], [0, (1 + 1j) / math.sqrt(2)]])
 class TGate(SingletonGate):
-    r"""Single qubit T gate (Z**0.25).
+    r"""Single qubit T gate (:math:`\sqrt[4]{Z}`).
 
-    It induces a :math:`\pi/4` phase, and is sometimes called the pi/8 gate
-    (because of how the RZ(\pi/4) matrix looks like).
+    It induces a :math:`\pi/4` phase, and is sometimes called the :math:`\pi/8` gate, because
+    it is equivalent to :math:`\exp(i\pi/8 Z)` up to a global phase.
 
     This is a non-Clifford gate and a fourth-root of Pauli-Z.
 
@@ -101,7 +101,7 @@ class TGate(SingletonGate):
 
 @with_gate_array([[1, 0], [0, (1 - 1j) / math.sqrt(2)]])
 class TdgGate(SingletonGate):
-    r"""Single qubit T-adjoint gate (~Z**0.25).
+    r"""Single qubit T-adjoint gate (:math:`T^\dagger`).
 
     It induces a :math:`-\pi/4` phase.
 
@@ -114,7 +114,7 @@ class TdgGate(SingletonGate):
 
     .. math::
 
-        Tdg = \begin{pmatrix}
+        T^\dagger = \begin{pmatrix}
                 1 & 0 \\
                 0 & e^{-i\pi/4}
             \end{pmatrix}
@@ -133,7 +133,10 @@ class TdgGate(SingletonGate):
     _standard_gate = StandardGate.Tdg
 
     def __init__(self, label: Optional[str] = None):
-        """Create new Tdg gate."""
+        """
+        Args:
+            label: An optional label for the gate.
+        """
         super().__init__("tdg", 1, [], label=label)
 
     _singleton_lookup_key = stdlib_singleton_key()

--- a/qiskit/circuit/library/standard_gates/t.py
+++ b/qiskit/circuit/library/standard_gates/t.py
@@ -27,7 +27,7 @@ class TGate(SingletonGate):
     r"""Single qubit T gate (:math:`\sqrt[4]{Z}`).
 
     It induces a :math:`\pi/4` phase, and is sometimes called the :math:`\pi/8` gate, because
-    it is equivalent to :math:`\exp(i\pi/8 Z)` up to a global phase.
+    it is equivalent to :math:`\exp(i\pi/8~Z)` up to a global phase.
 
     This is a non-Clifford gate and a fourth-root of Pauli-Z.
 


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The standard gate headers have math which is not in math mode, this commit fixes that.

<img width="968" height="458" alt="image" src="https://github.com/user-attachments/assets/6519d645-54d2-4247-b163-776366b63cba" />


### Details and comments


