### PR TITLE
Remove link to pulse schedule guide

### DIFF
--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -1366,11 +1366,11 @@ and changing two payloads the INSTRUCTION metadata payload and the CUSTOM_INSTRU
 These now have new fields to better account for :class:`~.ControlledGate` objects in a circuit.
 In addition, new payload MAP_ITEM is defined to implement the :ref:`qpy_mapping` block.
 
-With the support of ``ScheduleBlock``, now :class:`~.QuantumCircuit` can be
-serialized together with :attr:`~.QuantumCircuit.calibrations`, or
-`Pulse Gates <https://quantum.cloud.ibm.com/docs/guides/pulse>`_.
-In QPY version 5 and above, :ref:`qpy_circuit_calibrations` payload is
-packed after the :ref:`qpy_instructions` block.
+.. note::
+
+    Support for representing pulse schedules and custom calibrations was removed in Qiskit v2.0.
+    When loading QPY payloads, these data fields are now ignored or raise an error when using
+    Qiskit for deserialization.
 
 In QPY version 5 and above,
 


### PR DESCRIPTION
Closes #15591. 

Associated with https://github.com/Qiskit/documentation/issues/4359.

We could reroute to the [migration guide](https://quantum.cloud.ibm.com/docs/en/guides/pulse-migration) - but will need to re-edit once the migration guide has been removed, some time in the future. Worth linking out to it anyway?