### PR TITLE
Add RXX/RYY-based equivalence for XXMinusYYGate

### DIFF
--- a/crates/transpiler/src/standard_equivalence_library.rs
+++ b/crates/transpiler/src/standard_equivalence_library.rs
@@ -3063,5 +3063,49 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
     )
     .expect("Error while addding XX_MINUS_YY gate equivalence");
 
+    // XXMinusYYGate
+    // ┌───────────────┐
+    // ┤0              ├
+    // │  {XX-YY}(θ,β) │
+    // ┤1              ├
+    // └───────────────┘
+    //   ┌────────┐┌─────────────┐┌──────────────┐┌───────┐
+    //   ┤ Rz(-β) ├┤0            ├┤0             ├┤ Rz(β) ├
+    // ≡ └────────┘│  Rxx(0.5*θ) ││  Ryy(-0.5*θ) │└───────┘
+    //   ──────────┤1            ├┤1             ├─────────
+    //             └─────────────┘└──────────────┘
+    create_standard_equivalence(
+        StandardGate::XXMinusYY,
+        &[
+            Param::ParameterExpression(theta.clone()),
+            Param::ParameterExpression(beta.clone()),
+        ],
+        &[
+            (
+                StandardGate::RZ,
+                &[Qubit(0)],
+                &[Param::ParameterExpression(neg_beta.clone())],
+            ),
+            (
+                StandardGate::RXX,
+                &[Qubit(0), Qubit(1)],
+                &[Param::ParameterExpression(theta_div_2.clone())],
+            ),
+            (
+                StandardGate::RYY,
+                &[Qubit(0), Qubit(1)],
+                &[Param::ParameterExpression(neg_theta_div_2.clone())],
+            ),
+            (
+                StandardGate::RZ,
+                &[Qubit(0)],
+                &[Param::ParameterExpression(beta.clone())],
+            ),
+        ],
+        0.0,
+        &mut equiv,
+    )
+    .expect("Error while addding XX_MINUS_YY gate equivalence");
+
     equiv
 }

--- a/releasenotes/notes/add-xxminusyy-rxx-ryy-equivalence-9f32755f6b587c54.yaml
+++ b/releasenotes/notes/add-xxminusyy-rxx-ryy-equivalence-9f32755f6b587c54.yaml
@@ -1,0 +1,6 @@
+---
+features_synthesis:
+  - |
+    The standard equivalence library now includes an :class:`.RXXGate`/:class:`.RYYGate`-based
+    equivalence for :class:`.XXMinusYYGate`, matching the one that already existed for
+    :class:`.XXPlusYYGate`.


### PR DESCRIPTION
### Summary

Add an RXX/RYY-based equivalence for `XXMinusYYGate` to the standard equivalence library, matching the one that already exists for `XXPlusYYGate`.

The decomposition is: `RZ(-β) → RXX(θ/2) → RYY(-θ/2) → RZ(β)`.

Fixes #15602

### Details and comments

The equivalence library already had two decompositions for `XXPlusYYGate` (a CX-based one and an RXX/RYY-based one) but only a CX-based one for `XXMinusYYGate`. This adds the missing compact form.