### PR TITLE
Follow through on MCMT deprecations

### DIFF
--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -335,8 +335,6 @@ of the following, which derive :class:`.QuantumCircuit` and are eagerly construc
    :template: autosummary/class_no_inherited_members.rst
 
    Diagonal
-   MCMT
-   MCMTVChain
    MCXGrayCode
    MCXRecursive
    MCXVChain
@@ -883,8 +881,6 @@ from .blueprintcircuit import BlueprintCircuit
 from .generalized_gates import (
     Diagonal,
     DiagonalGate,
-    MCMT,
-    MCMTVChain,
     Permutation,
     PermutationGate,
     GMS,

--- a/qiskit/circuit/library/generalized_gates/__init__.py
+++ b/qiskit/circuit/library/generalized_gates/__init__.py
@@ -14,7 +14,7 @@
 
 from .diagonal import Diagonal, DiagonalGate
 from .permutation import Permutation, PermutationGate
-from .mcmt import MCMT, MCMTVChain, MCMTGate
+from .mcmt import MCMTGate
 from .gms import GMS, MSGate
 from .gr import GR, GRX, GRY, GRZ
 from .pauli import PauliGate

--- a/qiskit/circuit/library/generalized_gates/mcmt.py
+++ b/qiskit/circuit/library/generalized_gates/mcmt.py
@@ -14,175 +14,9 @@
 
 from __future__ import annotations
 
-import warnings
-from collections.abc import Callable
-
-from qiskit import circuit
-from qiskit.circuit import ControlledGate, Gate, QuantumCircuit
+from qiskit.circuit import ControlledGate, Gate
 from qiskit.circuit._utils import _ctrl_state_to_int
-from qiskit.utils.deprecation import deprecate_func
 from ..standard_gates import get_standard_gate_name_mapping
-
-
-class MCMT(QuantumCircuit):
-    """The multi-controlled multi-target gate, for an arbitrary singly controlled target gate.
-
-    For example, the H gate controlled on 3 qubits and acting on 2 target qubit is represented as:
-
-    .. code-block:: text
-
-        ───■────
-           │
-        ───■────
-           │
-        ───■────
-        ┌──┴───┐
-        ┤0     ├
-        │  2-H │
-        ┤1     ├
-        └──────┘
-
-    This default implementations requires no ancilla qubits, by broadcasting the target gate
-    to the number of target qubits and using Qiskit's generic control routine to control the
-    broadcasted target on the control qubits. If ancilla qubits are available, a more efficient
-    variant using the so-called V-chain decomposition can be used. This is implemented in
-    :class:`~qiskit.circuit.library.MCMTVChain`.
-    """
-
-    @deprecate_func(since="1.4", additional_msg="Use MCMTGate instead.")
-    def __init__(
-        self,
-        gate: Gate | Callable[[QuantumCircuit, circuit.Qubit, circuit.Qubit], circuit.Instruction],
-        num_ctrl_qubits: int,
-        num_target_qubits: int,
-    ) -> None:
-        """Create a new multi-control multi-target gate.
-
-        Args:
-            gate: The gate to be applied controlled on the control qubits and applied to the target
-                qubits. Can be either a Gate or a circuit method.
-                If it is a callable, it will be casted to a Gate.
-            num_ctrl_qubits: The number of control qubits.
-            num_target_qubits: The number of target qubits.
-
-        Raises:
-            AttributeError: If the gate cannot be casted to a controlled gate.
-            AttributeError: If the number of controls or targets is 0.
-        """
-        if num_ctrl_qubits == 0 or num_target_qubits == 0:
-            raise AttributeError("Need at least one control and one target qubit.")
-
-        if callable(gate):
-            warnings.warn(
-                "Passing a callable to MCMT is pending deprecation since Qiskit 1.3. Pass a "
-                "gate instance or the gate name instead, e.g. pass 'h' instead of QuantumCircuit.h.",
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
-            gate = gate.__name__
-        elif isinstance(gate, QuantumCircuit):
-            warnings.warn(
-                "Passing a QuantumCircuit is pending deprecation since Qiskit 1.3. Pass a gate "
-                "or turn the circuit into a gate using the ``to_gate`` method, instead.",
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
-            gate = gate.to_gate()
-
-        self.gate = MCMTGate._identify_base_gate(gate)
-        self.num_ctrl_qubits = num_ctrl_qubits
-        self.num_target_qubits = num_target_qubits
-
-        # initialize the circuit object
-        num_qubits = num_ctrl_qubits + num_target_qubits + self.num_ancilla_qubits
-        super().__init__(num_qubits, name="mcmt")
-        self._build()
-
-    def _build(self):
-        gate = MCMTGate(self.gate, self.num_ctrl_qubits, self.num_target_qubits)
-        self.append(gate, self.qubits)
-
-    @property
-    def num_ancilla_qubits(self):
-        """Return the number of ancillas."""
-        return 0
-
-    def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None, annotated=False):
-        """Return the controlled version of the MCMT circuit."""
-        if not annotated and ctrl_state is None:
-            gate = MCMT(self.gate, self.num_ctrl_qubits + num_ctrl_qubits, self.num_target_qubits)
-        else:
-            gate = super().control(num_ctrl_qubits, label, ctrl_state, annotated=annotated)
-        return gate
-
-    def inverse(self, annotated: bool = False):
-        """Return the inverse MCMT circuit, which is itself."""
-        return MCMT(self.gate, self.num_ctrl_qubits, self.num_target_qubits)
-
-
-class MCMTVChain(MCMT):
-    """The MCMT implementation using the CCX V-chain.
-
-    This implementation requires ancillas but is decomposed into a much shallower circuit
-    than the default implementation in :class:`~qiskit.circuit.library.MCMT`.
-
-    Expanded circuit:
-
-    .. plot::
-       :alt: Diagram illustrating the previously described circuit.
-
-       from qiskit.circuit.library import MCMTVChain, ZGate
-       from qiskit.visualization.library import _generate_circuit_library_visualization
-       circuit = MCMTVChain(ZGate(), 2, 2)
-       _generate_circuit_library_visualization(circuit.decompose())
-
-    Examples:
-
-        >>> from qiskit.circuit.library import HGate
-        >>> MCMTVChain(HGate(), 3, 2).draw()
-
-        q_0: ──■────────────────────────■──
-               │                        │
-        q_1: ──■────────────────────────■──
-               │                        │
-        q_2: ──┼────■──────────────■────┼──
-               │    │  ┌───┐       │    │
-        q_3: ──┼────┼──┤ H ├───────┼────┼──
-               │    │  └─┬─┘┌───┐  │    │
-        q_4: ──┼────┼────┼──┤ H ├──┼────┼──
-             ┌─┴─┐  │    │  └─┬─┘  │  ┌─┴─┐
-        q_5: ┤ X ├──■────┼────┼────■──┤ X ├
-             └───┘┌─┴─┐  │    │  ┌─┴─┐└───┘
-        q_6: ─────┤ X ├──■────■──┤ X ├─────
-                  └───┘          └───┘
-    """
-
-    @deprecate_func(
-        since="1.4",
-        additional_msg="Use MCMTGate with the V-chain synthesis plugin instead.",
-    )
-    def __init__(
-        self,
-        gate: Gate | Callable[[QuantumCircuit, circuit.Qubit, circuit.Qubit], circuit.Instruction],
-        num_ctrl_qubits: int,
-        num_target_qubits: int,
-    ) -> None:
-        super().__init__(gate, num_ctrl_qubits, num_target_qubits)
-
-    def _build(self):
-        # pylint: disable=cyclic-import
-        from qiskit.synthesis.multi_controlled import synth_mcmt_vchain
-
-        synthesized = synth_mcmt_vchain(self.gate, self.num_ctrl_qubits, self.num_target_qubits)
-        self.compose(synthesized, inplace=True, copy=False)
-
-    @property
-    def num_ancilla_qubits(self):
-        """Return the number of ancilla qubits required."""
-        return max(0, self.num_ctrl_qubits - 1)
-
-    def inverse(self, annotated: bool = False):
-        return MCMTVChain(self.gate, self.num_ctrl_qubits, self.num_target_qubits)
 
 
 class MCMTGate(ControlledGate):
@@ -271,26 +105,12 @@ class MCMTGate(ControlledGate):
                     f"Unknown gate {gate}. Available: {list(get_standard_gate_name_mapping.keys())}"
                 )
 
-        # extract the base gate
-        if isinstance(gate, ControlledGate):
-            warnings.warn(
-                "Passing a controlled gate to MCMT is pending deprecation since Qiskit 1.3. Pass a "
-                "single-qubit gate instance or the gate name instead, e.g. pass 'h' instead of 'ch'.",
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
-            base_gate = gate.base_gate
-        elif isinstance(gate, Gate):
-            base_gate = gate
-        else:
-            raise TypeError(f"Invalid gate type {type(gate)}.")
-
-        if base_gate.num_qubits != 1:
+        if gate.num_qubits != 1:
             raise ValueError(
-                f"MCMTGate requires a base gate with a single qubit, but got {base_gate.num_qubits}."
+                f"MCMTGate requires a base gate with a single qubit, but got {gate.num_qubits}."
             )
 
-        return base_gate
+        return gate
 
     def control(
         self,

--- a/releasenotes/notes/mcmt-remove-deprecations-6e906dcbb3e43046.yaml
+++ b/releasenotes/notes/mcmt-remove-deprecations-6e906dcbb3e43046.yaml
@@ -1,0 +1,6 @@
+upgrade_circuits:
+  - Removed ``MCMT`` and ``MCMTVChain``, which have been deprecated since Qiskit v1.3.
+    The :class:`.MCMTGate` can be used instead.
+  - Removed support for passing single-qubit single-controlled gates to :class:`.MCMTGate`,
+    which has been deprecated since Qiskit v1.3. Instead, pass the single-qubit gate without
+    control. For example, instead of ``MCMTGate(CXGate())`` use ``MCMTGate(XGate())``.

--- a/test/python/circuit/library/test_mcmt.py
+++ b/test/python/circuit/library/test_mcmt.py
@@ -18,18 +18,13 @@ from itertools import repeat
 from ddt import ddt, data, unpack
 import numpy as np
 
-from qiskit.exceptions import QiskitError
 from qiskit.compiler import transpile
 from qiskit.circuit import QuantumCircuit, QuantumRegister, Parameter
 from qiskit.circuit.library import (
-    MCMT,
-    MCMTVChain,
-    CHGate,
     XGate,
     ZGate,
+    HGate,
     RYGate,
-    CXGate,
-    CZGate,
     MCMTGate,
     GlobalPhaseGate,
     SwapGate,
@@ -49,13 +44,12 @@ from test import QiskitTestCase, combine  # pylint: disable=wrong-import-order
 class TestMCMT(QiskitTestCase):
     """Test the multi-controlled multi-target circuit."""
 
-    @data(MCMT, MCMTVChain)
-    def test_mcmt_as_normal_control(self, mcmt_class):
+    def test_mcmt_as_normal_control(self):
         """Test that the MCMT can act as normal control gate."""
+        mcmt = MCMTGate(gate=HGate(), num_ctrl_qubits=1, num_target_qubits=1)
+
         qc = QuantumCircuit(2)
-        with self.assertWarns(DeprecationWarning):
-            mcmt = mcmt_class(gate=CHGate(), num_ctrl_qubits=1, num_target_qubits=1)
-        qc = qc.compose(mcmt, [0, 1])
+        qc.append(mcmt, [0, 1])
 
         ref = QuantumCircuit(2)
         ref.ch(0, 1)
@@ -68,54 +62,22 @@ class TestMCMT(QiskitTestCase):
     def test_missing_qubits(self):
         """Test that an error is raised if qubits are missing."""
         with self.subTest(msg="no control qubits"):
-            with self.assertWarns(DeprecationWarning):
-                with self.assertRaises(AttributeError):
-                    _ = MCMT(XGate(), num_ctrl_qubits=0, num_target_qubits=1)
+            with self.assertRaises(ValueError):
+                _ = MCMTGate(XGate(), num_ctrl_qubits=0, num_target_qubits=1)
 
         with self.subTest(msg="no target qubits"):
-            with self.assertWarns(DeprecationWarning):
-                with self.assertRaises(AttributeError):
-                    _ = MCMT(ZGate(), num_ctrl_qubits=4, num_target_qubits=0)
-
-    def test_different_gate_types(self):
-        """Test the different supported input types for the target gate."""
-        x_circ = QuantumCircuit(1)
-        x_circ.x(0)
-        for input_gate in [x_circ, QuantumCircuit.cx, QuantumCircuit.x, "cx", "x", CXGate()]:
-            with self.subTest(input_gate=input_gate):
-                with self.assertWarns(DeprecationWarning):
-                    mcmt = MCMT(input_gate, 2, 2)
-                if isinstance(input_gate, QuantumCircuit):
-                    self.assertEqual(mcmt.gate.definition[0].operation, XGate())
-                    self.assertEqual(len(mcmt.gate.definition), 1)
-                else:
-                    self.assertEqual(mcmt.gate, XGate())
-
-    def test_mcmt_v_chain_ancilla_test(self):
-        """Test too few and too many ancillas for the MCMT V-chain mode."""
-        with self.subTest(msg="insufficient number of auxiliary qubits on gate"):
-            qc = QuantumCircuit(5)
-            with self.assertWarns(DeprecationWarning):
-                mcmt = MCMTVChain(ZGate(), 3, 1)
-            with self.assertRaises(QiskitError):
-                qc.append(mcmt, range(5))
-
-        with self.subTest(msg="too many auxiliary qubits on gate"):
-            qc = QuantumCircuit(9)
-            with self.assertWarns(DeprecationWarning):
-                mcmt = MCMTVChain(ZGate(), 3, 1)
-            with self.assertRaises(QiskitError):
-                qc.append(mcmt, range(9))
+            with self.assertRaises(ValueError):
+                _ = MCMTGate(ZGate(), num_ctrl_qubits=4, num_target_qubits=0)
 
     @data(
-        [CZGate(), 1, 1],
-        [CHGate(), 1, 1],
-        [CZGate(), 3, 3],
-        [CHGate(), 3, 3],
-        [CZGate(), 1, 5],
-        [CHGate(), 1, 5],
-        [CZGate(), 5, 1],
-        [CHGate(), 5, 1],
+        [ZGate(), 1, 1],
+        [HGate(), 1, 1],
+        [ZGate(), 3, 3],
+        [HGate(), 3, 3],
+        [ZGate(), 1, 5],
+        [HGate(), 1, 5],
+        [ZGate(), 5, 1],
+        [HGate(), 5, 1],
     )
     @unpack
     def test_mcmt_v_chain_simulation(self, cgate, num_controls, num_targets):
@@ -131,21 +93,17 @@ class TestMCMT(QiskitTestCase):
             # on a 0 state)
             qc.x(targets)
 
+            # Ensure the circuit has enough ancillas for the V-chain decomposition
             num_ancillas = max(0, num_controls - 1)
-
             if num_ancillas > 0:
                 ancillas = QuantumRegister(num_ancillas)
                 qc.add_register(ancillas)
-                qubits = controls[:] + targets[:] + ancillas[:]
-            else:
-                qubits = controls[:] + targets[:]
 
             for i in subset:
                 qc.x(controls[i])
 
-            with self.assertWarns(DeprecationWarning):
-                mcmt = MCMTVChain(cgate, num_controls, num_targets)
-            qc.compose(mcmt, qubits, inplace=True)
+            mcmt = MCMTGate(cgate, num_controls, num_targets)
+            qc.append(mcmt, controls[:] + targets[:])
 
             for i in subset:
                 qc.x(controls[i])
@@ -155,11 +113,11 @@ class TestMCMT(QiskitTestCase):
             # target register is initially |11...1>, with length equal to 2**(n_targets)
             vec_exp = np.array([0] * (2 ** (num_targets) - 1) + [1])
 
-            if isinstance(cgate, CZGate):
+            if isinstance(cgate, ZGate):
                 # Z gate flips the last qubit only if it's applied an odd number of times
                 if len(subset) == num_controls and (num_controls % 2) == 1:
                     vec_exp[-1] = -1
-            elif isinstance(cgate, CHGate):
+            elif isinstance(cgate, HGate):
                 # if all the control qubits have been activated,
                 # we repeatedly apply the kronecker product of the Hadamard
                 # with itself and then multiply the results for the original
@@ -318,20 +276,6 @@ class TestMCMT(QiskitTestCase):
         self.assertEqual(circuit.count_ops().get("cry", 0), num_target)
         self.assertEqual(circuit.num_parameters, 1)
         self.assertEqual(circuit.parameters[0], theta)
-
-    def test_mcmt_circuit_as_gate(self):
-        """Test the MCMT plugin is only triggered for the gate, not the same-named circuit.
-
-        Regression test of #13563.
-        """
-        circuit = QuantumCircuit(2)
-        gate = RYGate(0.1)
-        with self.assertWarns(DeprecationWarning):
-            mcmt = MCMT(gate=gate, num_ctrl_qubits=1, num_target_qubits=1)
-        circuit.append(mcmt, circuit.qubits)  # append the MCMT circuit as gate called "MCMT"
-
-        transpiled = transpile(circuit, basis_gates=["u", "cx"])
-        self.assertEqual(Operator(transpiled), Operator(gate.control(1, annotated=False)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

-  Removed ``MCMT`` and ``MCMTVChain``, which have been deprecated since Qiskit v1.3.
    The `MCMTGate` can be used instead.
  - Removed support for passing single-qubit single-controlled gates to :class:`.MCMTGate`,
    which has been deprecated since Qiskit v1.3. Instead, pass the single-qubit gate without
    control. For example, instead of ``MCMTGate(CXGate())`` use ``MCMTGate(XGate())``.