### PR TITLE
Fix inverse() on circuits containing initialize() to raise CircuitError early

### DIFF
--- a/qiskit/circuit/library/data_preparation/initializer.py
+++ b/qiskit/circuit/library/data_preparation/initializer.py
@@ -21,6 +21,7 @@ import typing
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit import QuantumRegister
 from qiskit.circuit.instruction import Instruction
+from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.library.generalized_gates import Isometry
 from .state_preparation import StatePreparation
 
@@ -83,6 +84,25 @@ class Initialize(Instruction):
         initialize_circuit.reset(q)
         initialize_circuit.append(self._stateprep, q)
         self.definition = initialize_circuit
+
+    def inverse(self, annotated: bool = False):
+        """Invert this instruction.
+
+        Args:
+            annotated: if set to ``True`` the output inverse gate will be returned
+                as :class:`.AnnotatedOperation`.
+
+        Returns:
+            The inverse operation.
+
+        Raises:
+            CircuitError: if the instruction is not composite
+                and an inverse has not been implemented for it.
+        """
+        raise CircuitError(
+            f"inverse() not implemented for {self.name}. "
+            f"{self.name} is a non-unitary instruction and cannot be inverted."
+        )
 
     def gates_to_uncompute(self) -> QuantumCircuit:
         """Call to create a circuit with gates that take the desired vector to zero.

--- a/qiskit/circuit/library/data_preparation/initializer.py
+++ b/qiskit/circuit/library/data_preparation/initializer.py
@@ -86,18 +86,16 @@ class Initialize(Instruction):
         self.definition = initialize_circuit
 
     def inverse(self, annotated: bool = False):
-        """Invert this instruction.
+        """Raises an error as :class:`.Initialize` cannot be inverted.
 
         Args:
-            annotated: if set to ``True`` the output inverse gate will be returned
-                as :class:`.AnnotatedOperation`.
+            annotated: Not applicable.
 
         Returns:
-            The inverse operation.
+            Not applicable.
 
         Raises:
-            CircuitError: if the instruction is not composite
-                and an inverse has not been implemented for it.
+            CircuitError: ``Initialize.inverse`` always raises this error.
         """
         raise CircuitError(
             f"inverse() not implemented for {self.name}. "

--- a/releasenotes/notes/fix-initialize-inverse-error-15595-c421b82051229d74.yaml
+++ b/releasenotes/notes/fix-initialize-inverse-error-15595-c421b82051229d74.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed a bug where calling :meth:`.QuantumCircuit.inverse` on a circuit containing
+    :meth:`.QuantumCircuit.initialize` would raise a misleading internal error about invalid
+    parameter types instead of a clear :class:`.CircuitError`. The :class:`.Initialize`
+    instruction is now properly detected as non-invertible and raises :class:`.CircuitError`
+    with an informative error message early, similar to how :class:`.Reset` behaves.
+    Fixed `#15595 <https://github.com/Qiskit/qiskit/issues/15595>`__.
+

--- a/test/python/circuit/test_initializer.py
+++ b/test/python/circuit/test_initializer.py
@@ -514,6 +514,24 @@ class TestInitialize(QiskitTestCase):
         statevector = Statevector(qc)
         self.assertTrue(np.allclose(statevector, desired_vector))
 
+    def test_inverse_raises_circuit_error(self):
+        """Test that inverse() on Initialize raises CircuitError early."""
+        from qiskit.circuit.exceptions import CircuitError
+
+        qc = QuantumCircuit(4)
+        qc.initialize(0, qc.qubits)
+        qc.h(0)
+        qc.h(1)
+        qc.h(2)
+        qc.h(3)
+
+        with self.assertRaises(CircuitError) as context:
+            qc.inverse()
+
+        error_msg = str(context.exception)
+        self.assertIn("inverse() not implemented for initialize", error_msg)
+        self.assertIn("non-unitary instruction", error_msg)
+
 
 class TestInstructionParam(QiskitTestCase):
     """Test conversion of numpy type parameters."""


### PR DESCRIPTION
Fixes #15595

Previously, calling `inverse()` on a circuit containing `initialize()` would crash with a misleading internal error about invalid param types when trying to construct the inverse gate. This happened because `Initialize` has a definition (via `_define()`), so it passed the base `Instruction.inverse()` check, but then failed later during gate construction.

Now, `Initialize.inverse()` explicitly raises `CircuitError` early with a clear message, similar to how `reset()` behaves. This provides a better user experience with an informative error message instead of an internal error.

The fix adds an `inverse()` method to the `Initialize` class that immediately raises `CircuitError`, explaining that `initialize` is a non-unitary instruction and cannot be inverted.

### Changes
- Added `inverse()` method to `Initialize` class that raises `CircuitError` early
- Added import for `CircuitError` exception
- Error message follows the same pattern as other non-invertible instructions (e.g., `PauliProductMeasurement`)

### Testing
The fix prevents the following error:
```
CircuitError: "Invalid param type <class 'complex'> for gate initialize_dg."
```

And instead raises:
```
CircuitError: "inverse() not implemented for initialize. initialize is a non-unitary instruction and cannot be inverted."
```