### PR TITLE
Document the root `qiskit` namespace

### DIFF
--- a/docs/apidoc/index.rst
+++ b/docs/apidoc/index.rst
@@ -77,4 +77,5 @@ Other:
 
    compiler
    exceptions
+   root
    utils

--- a/docs/apidoc/root.rst
+++ b/docs/apidoc/root.rst
@@ -1,0 +1,47 @@
+.. _qiskit-root:
+
+==============================
+Root namespace (:mod:`qiskit`)
+==============================
+
+.. currentmodule:: qiskit
+
+Most Qiskit functionality is accessed through specific submodules.
+You can consult the top-level documentation of :mod:`qiskit` to find the list of modules, such as
+:mod:`qiskit.circuit` or :mod:`qiskit.transpiler.passes`.
+
+Several names are re-exported from the repository root, whose canonical public locations are in
+submodules.  The re-exports in the root namespace are part of Qiskit's public API.
+
+..
+   Unlike other `autosummary` directives in Qiskit, we _don't_ set `:toctree:` because we don't want
+   the stub files generated for this table.  This is just a cross-referencing table to other
+   modules, which own the data.
+
+Names re-exported from :mod:`qiskit.circuit`:
+
+.. autosummary::
+   
+   ~circuit.AncillaRegister
+   ~circuit.ClassicalRegister
+   ~circuit.QuantumCircuit
+   ~circuit.QuantumRegister
+
+Names re-exported from :mod:`qiskit.compiler`:
+
+.. autosummary::
+
+   ~compiler.transpile
+
+Names re-exported from :mod:`qiskit.exceptions`:
+
+.. autosummary::
+
+   ~exceptions.MissingOptionalLibraryError
+   ~exceptions.QiskitError
+
+Names re-exported from :mod:`qiskit.transpiler`:
+
+.. autosummary::
+
+   ~transpiler.generate_preset_pass_manager

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -12,6 +12,9 @@
 
 # pylint: disable=wrong-import-position,wrong-import-order
 
+# The documentation of the root namespace is manual in `docs/apidoc/root.rst`, so that the
+# :mod:`qiskit` Sphinx cross-reference can more easily point to the top-level API table in our
+# documentation build.
 """Main Qiskit public functionality."""
 
 import importlib.metadata
@@ -137,6 +140,7 @@ sys.modules["qiskit._accelerate.litinski_transformation"] = _accelerate.litinski
 sys.modules["qiskit._accelerate.unroll_3q_or_more"] = _accelerate.unroll_3q_or_more
 sys.modules["qiskit._accelerate.substitute_pi4_rotations"] = _accelerate.substitute_pi4_rotations
 
+
 from qiskit.exceptions import QiskitError, MissingOptionalLibraryError
 
 # The main qiskit operators
@@ -158,6 +162,9 @@ from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from .version import __version__
 
 
+# The Qiskit repo root is documented manually in `docs/apidoc/root.rst`.  Make sure that all
+# re-exports in `__all__` and any functions/objects defined in-line in this file and intended to be
+# exported to users at the `qiskit.` root are documented in that file.
 __all__ = [
     "AncillaRegister",
     "ClassicalRegister",


### PR DESCRIPTION
We document that there are names exported from `qiskit` root namespace, but previously didn't comment on what they are, other than implicitly via `qiskit.__all__`.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

### Details and comments

Originally I thought of this because I was going to put the `get_include` in the root namespace (like `numpy.get_include`) for #15609, but on second thoughts, maybe we should have a qiskit.capi` module or something like that, in anticipation of exposing the entire C API directly to Python space.