### PR TITLE
Revert "Follow through on MCMT deprecations (#15606)"

### DIFF
--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -335,6 +335,8 @@ of the following, which derive :class:`.QuantumCircuit` and are eagerly construc
    :template: autosummary/class_no_inherited_members.rst
 
    Diagonal
+   MCMT
+   MCMTVChain
    MCXGrayCode
    MCXRecursive
    MCXVChain
@@ -881,6 +883,8 @@ from .blueprintcircuit import BlueprintCircuit
 from .generalized_gates import (
     Diagonal,
     DiagonalGate,
+    MCMT,
+    MCMTVChain,
     Permutation,
     PermutationGate,
     GMS,

--- a/qiskit/circuit/library/generalized_gates/__init__.py
+++ b/qiskit/circuit/library/generalized_gates/__init__.py
@@ -14,7 +14,7 @@
 
 from .diagonal import Diagonal, DiagonalGate
 from .permutation import Permutation, PermutationGate
-from .mcmt import MCMTGate
+from .mcmt import MCMT, MCMTVChain, MCMTGate
 from .gms import GMS, MSGate
 from .gr import GR, GRX, GRY, GRZ
 from .pauli import PauliGate

--- a/qiskit/circuit/library/generalized_gates/mcmt.py
+++ b/qiskit/circuit/library/generalized_gates/mcmt.py
@@ -14,9 +14,175 @@
 
 from __future__ import annotations
 
-from qiskit.circuit import ControlledGate, Gate
+import warnings
+from collections.abc import Callable
+
+from qiskit import circuit
+from qiskit.circuit import ControlledGate, Gate, QuantumCircuit
 from qiskit.circuit._utils import _ctrl_state_to_int
+from qiskit.utils.deprecation import deprecate_func
 from ..standard_gates import get_standard_gate_name_mapping
+
+
+class MCMT(QuantumCircuit):
+    """The multi-controlled multi-target gate, for an arbitrary singly controlled target gate.
+
+    For example, the H gate controlled on 3 qubits and acting on 2 target qubit is represented as:
+
+    .. code-block:: text
+
+        ───■────
+           │
+        ───■────
+           │
+        ───■────
+        ┌──┴───┐
+        ┤0     ├
+        │  2-H │
+        ┤1     ├
+        └──────┘
+
+    This default implementations requires no ancilla qubits, by broadcasting the target gate
+    to the number of target qubits and using Qiskit's generic control routine to control the
+    broadcasted target on the control qubits. If ancilla qubits are available, a more efficient
+    variant using the so-called V-chain decomposition can be used. This is implemented in
+    :class:`~qiskit.circuit.library.MCMTVChain`.
+    """
+
+    @deprecate_func(since="1.4", additional_msg="Use MCMTGate instead.")
+    def __init__(
+        self,
+        gate: Gate | Callable[[QuantumCircuit, circuit.Qubit, circuit.Qubit], circuit.Instruction],
+        num_ctrl_qubits: int,
+        num_target_qubits: int,
+    ) -> None:
+        """Create a new multi-control multi-target gate.
+
+        Args:
+            gate: The gate to be applied controlled on the control qubits and applied to the target
+                qubits. Can be either a Gate or a circuit method.
+                If it is a callable, it will be casted to a Gate.
+            num_ctrl_qubits: The number of control qubits.
+            num_target_qubits: The number of target qubits.
+
+        Raises:
+            AttributeError: If the gate cannot be casted to a controlled gate.
+            AttributeError: If the number of controls or targets is 0.
+        """
+        if num_ctrl_qubits == 0 or num_target_qubits == 0:
+            raise AttributeError("Need at least one control and one target qubit.")
+
+        if callable(gate):
+            warnings.warn(
+                "Passing a callable to MCMT is pending deprecation since Qiskit 1.3. Pass a "
+                "gate instance or the gate name instead, e.g. pass 'h' instead of QuantumCircuit.h.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            gate = gate.__name__
+        elif isinstance(gate, QuantumCircuit):
+            warnings.warn(
+                "Passing a QuantumCircuit is pending deprecation since Qiskit 1.3. Pass a gate "
+                "or turn the circuit into a gate using the ``to_gate`` method, instead.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            gate = gate.to_gate()
+
+        self.gate = MCMTGate._identify_base_gate(gate)
+        self.num_ctrl_qubits = num_ctrl_qubits
+        self.num_target_qubits = num_target_qubits
+
+        # initialize the circuit object
+        num_qubits = num_ctrl_qubits + num_target_qubits + self.num_ancilla_qubits
+        super().__init__(num_qubits, name="mcmt")
+        self._build()
+
+    def _build(self):
+        gate = MCMTGate(self.gate, self.num_ctrl_qubits, self.num_target_qubits)
+        self.append(gate, self.qubits)
+
+    @property
+    def num_ancilla_qubits(self):
+        """Return the number of ancillas."""
+        return 0
+
+    def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None, annotated=False):
+        """Return the controlled version of the MCMT circuit."""
+        if not annotated and ctrl_state is None:
+            gate = MCMT(self.gate, self.num_ctrl_qubits + num_ctrl_qubits, self.num_target_qubits)
+        else:
+            gate = super().control(num_ctrl_qubits, label, ctrl_state, annotated=annotated)
+        return gate
+
+    def inverse(self, annotated: bool = False):
+        """Return the inverse MCMT circuit, which is itself."""
+        return MCMT(self.gate, self.num_ctrl_qubits, self.num_target_qubits)
+
+
+class MCMTVChain(MCMT):
+    """The MCMT implementation using the CCX V-chain.
+
+    This implementation requires ancillas but is decomposed into a much shallower circuit
+    than the default implementation in :class:`~qiskit.circuit.library.MCMT`.
+
+    Expanded circuit:
+
+    .. plot::
+       :alt: Diagram illustrating the previously described circuit.
+
+       from qiskit.circuit.library import MCMTVChain, ZGate
+       from qiskit.visualization.library import _generate_circuit_library_visualization
+       circuit = MCMTVChain(ZGate(), 2, 2)
+       _generate_circuit_library_visualization(circuit.decompose())
+
+    Examples:
+
+        >>> from qiskit.circuit.library import HGate
+        >>> MCMTVChain(HGate(), 3, 2).draw()
+
+        q_0: ──■────────────────────────■──
+               │                        │
+        q_1: ──■────────────────────────■──
+               │                        │
+        q_2: ──┼────■──────────────■────┼──
+               │    │  ┌───┐       │    │
+        q_3: ──┼────┼──┤ H ├───────┼────┼──
+               │    │  └─┬─┘┌───┐  │    │
+        q_4: ──┼────┼────┼──┤ H ├──┼────┼──
+             ┌─┴─┐  │    │  └─┬─┘  │  ┌─┴─┐
+        q_5: ┤ X ├──■────┼────┼────■──┤ X ├
+             └───┘┌─┴─┐  │    │  ┌─┴─┐└───┘
+        q_6: ─────┤ X ├──■────■──┤ X ├─────
+                  └───┘          └───┘
+    """
+
+    @deprecate_func(
+        since="1.4",
+        additional_msg="Use MCMTGate with the V-chain synthesis plugin instead.",
+    )
+    def __init__(
+        self,
+        gate: Gate | Callable[[QuantumCircuit, circuit.Qubit, circuit.Qubit], circuit.Instruction],
+        num_ctrl_qubits: int,
+        num_target_qubits: int,
+    ) -> None:
+        super().__init__(gate, num_ctrl_qubits, num_target_qubits)
+
+    def _build(self):
+        # pylint: disable=cyclic-import
+        from qiskit.synthesis.multi_controlled import synth_mcmt_vchain
+
+        synthesized = synth_mcmt_vchain(self.gate, self.num_ctrl_qubits, self.num_target_qubits)
+        self.compose(synthesized, inplace=True, copy=False)
+
+    @property
+    def num_ancilla_qubits(self):
+        """Return the number of ancilla qubits required."""
+        return max(0, self.num_ctrl_qubits - 1)
+
+    def inverse(self, annotated: bool = False):
+        return MCMTVChain(self.gate, self.num_ctrl_qubits, self.num_target_qubits)
 
 
 class MCMTGate(ControlledGate):
@@ -105,12 +271,26 @@ class MCMTGate(ControlledGate):
                     f"Unknown gate {gate}. Available: {list(get_standard_gate_name_mapping.keys())}"
                 )
 
-        if gate.num_qubits != 1:
+        # extract the base gate
+        if isinstance(gate, ControlledGate):
+            warnings.warn(
+                "Passing a controlled gate to MCMT is pending deprecation since Qiskit 1.3. Pass a "
+                "single-qubit gate instance or the gate name instead, e.g. pass 'h' instead of 'ch'.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            base_gate = gate.base_gate
+        elif isinstance(gate, Gate):
+            base_gate = gate
+        else:
+            raise TypeError(f"Invalid gate type {type(gate)}.")
+
+        if base_gate.num_qubits != 1:
             raise ValueError(
-                f"MCMTGate requires a base gate with a single qubit, but got {gate.num_qubits}."
+                f"MCMTGate requires a base gate with a single qubit, but got {base_gate.num_qubits}."
             )
 
-        return gate
+        return base_gate
 
     def control(
         self,

--- a/releasenotes/notes/mcmt-remove-deprecations-6e906dcbb3e43046.yaml
+++ b/releasenotes/notes/mcmt-remove-deprecations-6e906dcbb3e43046.yaml
@@ -1,6 +1,0 @@
-upgrade_circuits:
-  - Removed ``MCMT`` and ``MCMTVChain``, which have been deprecated since Qiskit v1.3.
-    The :class:`.MCMTGate` can be used instead.
-  - Removed support for passing single-qubit single-controlled gates to :class:`.MCMTGate`,
-    which has been deprecated since Qiskit v1.3. Instead, pass the single-qubit gate without
-    control. For example, instead of ``MCMTGate(CXGate())`` use ``MCMTGate(XGate())``.


### PR DESCRIPTION


<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Revert #15606.

This was not eligible for removal yet, we can only do breaking changes (= changing documented behavior) with major versions. So we'll have to revert this and re-open #15606, and only merge it for 3.0.

Thanks for pointing that out @mtreinish, I misremembered the policy and thought it's not breaking if the alternative path existed for 2 releases -- I should read the policy better 🙂 

