### PR TITLE
Replace `coverage3` with `coverage`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,8 @@ test_randomized:
 	python3 -m unittest discover -s test/randomized -t . -v
 
 coverage:
-	coverage3 run --source qiskit -m unittest discover -s test/python -q
-	coverage3 report
+	coverage run --source qiskit -m unittest discover -s test/python -q
+	coverage report
 
 coverage_erase:
 	coverage erase

--- a/tox.ini
+++ b/tox.ini
@@ -89,13 +89,13 @@ commands = black {posargs} qiskit test tools setup.py docs/conf.py
 basepython = python3
 setenv =
   {[testenv]setenv}
-  PYTHON=coverage3 run --source qiskit --parallel-mode
+  PYTHON=coverage run --source qiskit --parallel-mode
 commands_pre =
   {[testenv]install_command} -r{toxinidir}/requirements-optional.txt
 commands =
   stestr run {posargs}
-  coverage3 combine
-  coverage3 report
+  coverage combine
+  coverage report
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
As of `coverage>=7.13`, the `coverage3` name is deprecated and emits a warning message.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


