### PR TITLE
Fix QPY bug with user-defined register named 'ancilla'

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1708,9 +1708,11 @@ class QuantumCircuit:
             if num_qubits is not None and num_qubits > original_num_qubits:
 
                 ancilla_register_name = "ancilla"
+                ancilla_suffix = 0
                 reg_names = [reg.name for reg in self.qregs]
                 while ancilla_register_name in reg_names:
-                    ancilla_register_name = ancilla_register_name + "_"
+                    ancilla_register_name = f"{ancilla_register_name}{ancilla_suffix}"
+                    ancilla_suffix += 1
                 virtuals.extend(
                     QuantumRegister(num_qubits - original_num_qubits, ancilla_register_name)
                 )
@@ -3632,10 +3634,10 @@ class QuantumCircuit:
                 )
 
         for register in regs:
-            # if isinstance(register, Register) and any(
-            #     register.name == reg.name for reg in self.qregs + self.cregs
-            # ):
-            #     raise CircuitError(f'register name "{register.name}" already exists')
+            if isinstance(register, Register) and any(
+                register.name == reg.name for reg in self.qregs + self.cregs
+            ):
+                raise CircuitError(f'register name "{register.name}" already exists')
 
             if isinstance(register, AncillaRegister):
                 for bit in register:

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1706,7 +1706,14 @@ class QuantumCircuit:
 
             virtuals = self.qubits.copy()
             if num_qubits is not None and num_qubits > original_num_qubits:
-                virtuals.extend(QuantumRegister(num_qubits - original_num_qubits, "ancilla"))
+
+                ancilla_register_name = "ancilla"
+                reg_names = [reg.name for reg in self.qregs]
+                while ancilla_register_name in reg_names:
+                    ancilla_register_name = ancilla_register_name + "_"
+                virtuals.extend(
+                    QuantumRegister(num_qubits - original_num_qubits, ancilla_register_name)
+                )
             initial_layout = Layout(dict(enumerate(virtuals)))
         else:
             initial_layout = None
@@ -3625,10 +3632,10 @@ class QuantumCircuit:
                 )
 
         for register in regs:
-            if isinstance(register, Register) and any(
-                register.name == reg.name for reg in self.qregs + self.cregs
-            ):
-                raise CircuitError(f'register name "{register.name}" already exists')
+            # if isinstance(register, Register) and any(
+            #     register.name == reg.name for reg in self.qregs + self.cregs
+            # ):
+            #     raise CircuitError(f'register name "{register.name}" already exists')
 
             if isinstance(register, AncillaRegister):
                 for bit in register:

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1709,9 +1709,9 @@ class QuantumCircuit:
 
                 ancilla_register_name = "ancilla"
                 ancilla_suffix = 0
-                reg_names = [reg.name for reg in self.qregs]
+                reg_names = {reg.name for reg in self.qregs}
                 while ancilla_register_name in reg_names:
-                    ancilla_register_name = f"{ancilla_register_name}{ancilla_suffix}"
+                    ancilla_register_name = f"ancilla{ancilla_suffix}"
                     ancilla_suffix += 1
                 virtuals.extend(
                     QuantumRegister(num_qubits - original_num_qubits, ancilla_register_name)

--- a/qiskit/transpiler/passes/layout/sabre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_layout.py
@@ -302,7 +302,13 @@ class SabreLayout(TransformationPass):
             }
             return dag
 
-        ancillas = QuantumRegister(self.target.num_qubits - dag.num_qubits(), "ancilla")
+        ancilla_register_name = "ancilla"
+        ancilla_suffix = 0
+        while ancilla_register_name in dag.qregs:
+            ancilla_register_name = f"{ancilla_register_name}{ancilla_suffix}"
+            ancilla_suffix += 1
+
+        ancillas = QuantumRegister(self.target.num_qubits - dag.num_qubits(), ancilla_register_name)
         virtuals = list(dag.qubits) + list(ancillas)
         initial_layout = Layout({p: virtuals[v] for v, p in initial.layout_mapping()})
         for register in dag.qregs.values():

--- a/releasenotes/notes/fix_ensure_physical-b1e697146f155e63.yaml
+++ b/releasenotes/notes/fix_ensure_physical-b1e697146f155e63.yaml
@@ -1,8 +1,8 @@
 ---
 fixes:
   - |
-    Fixes a bug that caused :func:`~qiskit.qpy.load` to crash on circuits
-    created using :func:`~qiskit.circuit.QuantumCircuit.ensure_physical` when
+    Fixes a bug that caused :func:`.qpy.load` to crash on circuits
+    created using :func:`.QuantumCircuit.ensure_physical` when
     a user-created register named 'ancilla' is present.
     
 

--- a/releasenotes/notes/fix_ensure_physical-b1e697146f155e63.yaml
+++ b/releasenotes/notes/fix_ensure_physical-b1e697146f155e63.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixes a bug that caused :func:`~qiskit.qpy.load` to crash on circuits
+    created using :func:`~qiskit.circuit.QuantumCircuit.ensure_physical` when
+    a user-created register named 'ancilla' is present.
+    
+

--- a/releasenotes/notes/fix_sabre_layout-e457b0e9630f4d9a.yaml
+++ b/releasenotes/notes/fix_sabre_layout-e457b0e9630f4d9a.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixes a bug that caused :func:`~qiskit.qpy.load` to crash on circuits
+    created using :class:`~qiskit.transpiler.passes.SabreLayout` when
+    a user-created register named 'ancilla' is present.
+    
+

--- a/releasenotes/notes/fix_sabre_layout-e457b0e9630f4d9a.yaml
+++ b/releasenotes/notes/fix_sabre_layout-e457b0e9630f4d9a.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    Fixes a bug that caused :func:`~qiskit.qpy.load` to crash on circuits
+    Fixes a bug that caused :func:`.qpy.load` to crash on circuits
     created using :class:`~qiskit.transpiler.passes.SabreLayout` when
     a user-created register named 'ancilla' is present.
     

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -25,11 +25,11 @@ import re
 import ddt
 import numpy as np
 
-from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
+from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister, transpile
 from qiskit.circuit import CASE_DEFAULT, IfElseOp, WhileLoopOp, SwitchCaseOp
 from qiskit.circuit.classical import expr, types
-from qiskit.circuit import Clbit
-from qiskit.circuit import Qubit
+from qiskit.circuit import Clbit, Qubit
+from qiskit.transpiler import Target, CouplingMap
 from qiskit.circuit.random import random_circuit
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.library import (
@@ -2304,6 +2304,24 @@ class TestLoadFromQPY(QiskitTestCase):
             fptr.seek(0)
             out_circuit = load(fptr)[0]
 
+        self.assertEqual(qc, out_circuit)
+
+        qc = QuantumCircuit(QuantumRegister(2, "qr"), QuantumRegister(2, "ancilla"))
+        qc.cx(0, 1)
+        qc.cx(0, 2)
+        qc.cx(1, 2)
+        qc = transpile(
+            qc,
+            target=Target.from_configuration(
+                basis_gates=["sx", "rz", "cz"], coupling_map=CouplingMap.from_line(5)
+            ),
+            optimization_level=1,
+        )
+
+        with io.BytesIO() as fptr:
+            dump(qc, fptr, version=17)
+            fptr.seek(0)
+            out_circuit = load(fptr)[0]
         self.assertEqual(qc, out_circuit)
 
 

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -71,7 +71,13 @@ from qiskit.circuit.instruction import Instruction
 from qiskit.circuit.parameter import Parameter
 from qiskit.circuit.parametervector import ParameterVector
 from qiskit.synthesis import LieTrotter, SuzukiTrotter
-from qiskit.qpy import dump, load, UnsupportedFeatureForVersion, QPY_COMPATIBILITY_VERSION
+from qiskit.qpy import (
+    dump,
+    load,
+    UnsupportedFeatureForVersion,
+    QPY_COMPATIBILITY_VERSION,
+    QPY_VERSION,
+)
 from qiskit.quantum_info import Pauli, SparsePauliOp, Clifford
 from qiskit.quantum_info.random import random_unitary
 from qiskit.circuit.controlledgate import ControlledGate
@@ -2286,6 +2292,19 @@ class TestLoadFromQPY(QiskitTestCase):
                 out_circuits = load(fptr)
         self.assertEqual(circuits, out_circuits)
         self.assertEqual([qc.name for qc in circuits], [qc.name for qc in out_circuits])
+
+    @ddt.idata(range(max(QPY_COMPATIBILITY_VERSION, 13), QPY_VERSION + 1))
+    def test_ancilla_register_with_physical(self, version):
+        """Test for possible conflicts when naming a register 'ancilla'"""
+        qc = QuantumCircuit(QuantumRegister(2, "qr"), QuantumRegister(2, "ancilla"))
+        qc.ensure_physical(qc.num_qubits + 1)
+
+        with io.BytesIO() as fptr:
+            dump(qc, fptr, version=version)
+            fptr.seek(0)
+            out_circuit = load(fptr)[0]
+
+        self.assertEqual(qc, out_circuit)
 
 
 class TestSymengineLoadFromQPY(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes a bug in QPY resulting from saving and loading a circuit which was generated with a register named `ancilla`.

Fixes #15613 


### Details and comments
This bug arises from trying to save and load a circuit with transpile layout which has two distinct registers with the same name. This results from `ensure_physical` using the hard-coded name `ancilla` [in the code](https://github.com/Qiskit/qiskit/blob/main/qiskit/circuit/quantumcircuit.py#L1709)
```
if num_qubits is not None and num_qubits > original_num_qubits:
         virtuals.extend(QuantumRegister(num_qubits - original_num_qubits, "ancilla"))
```

This is not a QPY-related problem per se; the solution is to avoid the name clash in the first place. This can be done by either renaming the user's register, or using a different name for the new register. Since I did not see that `ensure_physical` guarantees anything about the naming of the added register, I attempt a fix by appending `_` to the name of the added register until there is no clash.

