### PR TITLE
Fix "`BreakLoopOp' object has no attribute 'blocks" bug (2nd take)

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -3754,7 +3754,12 @@ impl DAGCircuit {
             .node_references()
             .filter_map(|(node_index, node_type)| match node_type {
                 NodeType::Operation(node) => {
-                    if node.op.try_control_flow().is_some() {
+                    if node.op.try_control_flow().is_some_and(|control_flow| {
+                        !matches!(
+                            control_flow.control_flow,
+                            ControlFlow::BreakLoop | ControlFlow::ContinueLoop
+                        )
+                    }) {
                         Some(self.unpack_into(py, node_index, node_type))
                     } else {
                         None

--- a/test/python/circuit/test_control_flow.py
+++ b/test/python/circuit/test_control_flow.py
@@ -18,6 +18,7 @@ import math
 from ddt import ddt, data, unpack, idata
 
 from qiskit.circuit import Clbit, ClassicalRegister, Instruction, Parameter, QuantumCircuit, Qubit
+from qiskit import transpile
 from qiskit.circuit.classical import expr, types
 from qiskit.circuit.controlflow import CASE_DEFAULT, condition_resources, node_resources
 from qiskit.circuit.library import XGate, RXGate
@@ -1281,3 +1282,17 @@ class TestAddingControlFlowOperations(QiskitTestCase):
             )
         with self.assertRaisesRegex(CircuitError, "not in this circuit"):
             outer.append(BoxOp(inner.copy()), [0], [0])
+
+    def test_transpiling_with_control_flow(self):
+        """Test we don't run into compilation errors when transpiling circuits with control flows"""
+        qc = QuantumCircuit(1, 1)
+
+        with qc.for_loop(range(1000)):
+            qc.h(0)
+            qc.measure(0, 0)
+            with qc.if_test((0, False)):
+                qc.continue_loop()
+            qc.break_loop()
+
+        transpiled = transpile(qc)
+        self.assertIsNotNone(transpiled)


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Handles a bug arising in `trivial_recurse` when trying to iterate on the blocks of `BreakLoopOp` or ContinueLoopOp` which has no blocks.

Fixes #15579 


### Details and comments
This problem was first handled in #15581 but I missed another case where it arises, this time in `DagCircuit`. I added a test which attempts transpilation; this test would have caught both cases.

