### PR TITLE
Avoid potential code injection in backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,11 +23,12 @@ jobs:
       - name: Copy metadata
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -e
           # Split Mergify's ref name (e.g. 'mergify/bp/stable/0.25/pr-10828') on the final '-' to
           # get the number of the PR that triggered Mergify.
-          IFS='-' read -ra split <<< "${{ github.event.pull_request.head.ref }}"
+          IFS='-' read -ra split <<< "$BRANCH_REF"
           base_pr=${split[-1]}
 
           gh pr --repo "${{ github.repository }}" view "$base_pr" --json labels,milestone > base_pr.json


### PR DESCRIPTION
In theory, if the Mergify bot were to go rogue, it could use a branch name with arbitrary command execution in it and hijack our action.  In practice, this isn't a security threat because a) the action is already limited to running on Mergify's branches only and b) Mergify can push entirely arbitrary code to its branches anyway, so it can do whatever arbitrary code execution it likes without needing to go via an injection.

Still though, this makes static-analysis tools happier.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

cc @1ucian0: this should actually make that OSPS score you were looking at go up