### PR TITLE
Reducing the number of Clifford gates in `OptimizeCliffordT`

### DIFF
--- a/crates/transpiler/src/passes/optimize_clifford_t.rs
+++ b/crates/transpiler/src/passes/optimize_clifford_t.rs
@@ -306,7 +306,11 @@ fn optimize_clifford_t_1q(
     }
     global_phase += phase_update;
 
-    is_reduced.then_some((optimized_sequence, global_phase))
+    // Either we have fewer T-gates, or the number of T-gates remains the same
+    // but we have fewer Clifford gates (as the total number of gates is the number
+    // of T-gates + the number of Clifford gates).
+    (is_reduced || optimized_sequence.len() < raw_run.len())
+        .then_some((optimized_sequence, global_phase))
 }
 
 #[pyfunction]

--- a/qiskit/transpiler/passes/optimization/optimize_clifford_t.py
+++ b/qiskit/transpiler/passes/optimization/optimize_clifford_t.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Combine consecutive T/Tdg gates in a Clifford+T circuit."""
+"""Optimize sequences of single-qubit Clifford+T gates."""
 
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import TransformationPass
@@ -18,18 +18,20 @@ from qiskit._accelerate.optimize_clifford_t import optimize_clifford_t
 
 
 class OptimizeCliffordT(TransformationPass):
-    """An optimization pass for Clifford+T circuits.
+    """
+    Optimize sequences of consecutive Clifford+T gates.
 
-    Currently all the pass does is merging pairs of consecutive T-gates into
-    S-gates, and pair of consecutive Tdg-gates into Sdg-gates.
+    This pass rewrites maximal chains of consecutive single-qubit
+    Clifford+T gates, reducing each chain to an equivalent sequence
+    that uses the minimum possible number of T gates.
+
+    For a chain of length :math:`m`, the pass runs in linear time,
+    :math:`O(m)`.
     """
 
     def run(self, dag: DAGCircuit):
         """
         Run the OptimizeCliffordT pass on `dag`.
-
-        The pass applies to a Clifford + T/Tdg circuit, and outputs an optimized
-        Clifford + T/Tdg circuit.
 
         Args:
             dag: The directed acyclic graph to run on.

--- a/releasenotes/notes/tune-optimize-clifford-t-e53dfc81a594ad37.yaml
+++ b/releasenotes/notes/tune-optimize-clifford-t-e53dfc81a594ad37.yaml
@@ -1,0 +1,5 @@
+features_transpiler:
+  - |
+    The :class:`.OptimizeCliffordT` transpiler optimization pass now also
+    replaces chains of consecutive Clifford+T gates when the T-count stays
+    the same but the Clifford count is reduced.

--- a/test/python/transpiler/test_optimize_clifford_t.py
+++ b/test/python/transpiler/test_optimize_clifford_t.py
@@ -173,3 +173,47 @@ class TestOptimizeCliffordT(QiskitTestCase):
 
         self.assertEqual(optimized, expected)
         self.assertEqual(Operator(qc), Operator(expected))
+
+    def test_reduces_clifford_gates(self):
+        """A simple test that the pass reduces the number
+        of Clifford gates even when the number of T-gates
+        remains the same.
+        """
+        qc = QuantumCircuit(1)
+        qc.s(0)
+        qc.t(0)
+        qc.s(0)
+
+        optimized = OptimizeCliffordT()(qc)
+
+        expected = QuantumCircuit(1)
+        expected.t(0)
+        expected.z(0)
+
+        self.assertEqual(optimized, expected)
+        self.assertEqual(Operator(qc), Operator(expected))
+
+    def test_reduces_clifford_gates_2(self):
+        """A simple test that the pass reduces the number
+        of Clifford gates even when the number of T-gates
+        remains the same.
+        """
+        qc = QuantumCircuit(1)
+        qc.s(0)
+        qc.h(0)
+        qc.sx(0)
+        qc.t(0)
+        qc.h(0)
+        qc.z(0)
+        qc.x(0)
+
+        optimized = OptimizeCliffordT()(qc)
+
+        expected = QuantumCircuit(1, global_phase=np.pi / 4)
+        expected.h(0)
+        expected.tdg(0)
+        expected.h(0)
+        expected.x(0)
+
+        self.assertEqual(optimized, expected)
+        self.assertEqual(Operator(qc), Operator(expected))

--- a/test/python/transpiler/test_ross_selinger.py
+++ b/test/python/transpiler/test_ross_selinger.py
@@ -193,7 +193,7 @@ class TestRossSelingerPlugin(QiskitTestCase):
             with self.subTest(eps=eps, t_expect=t_expect):
                 transpiled = transpile(
                     qc,
-                    basis_gates=["cx", "h", "s", "t"],
+                    basis_gates=get_clifford_gate_names() + ["t", "tdg"],
                     unitary_synthesis_method="gridsynth",
                     unitary_synthesis_plugin_config={"epsilon": eps},
                 )


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This is a minor improvement to the `OptimizeCliffordT` optimization pass. Recall that the pass collects sequences of consecutive 1-qubit Clifford+T gates and rewrites them using the minimum number of T-gates. Previously, sequences were not rewritten if the number of T-gates is not decreased. Now the sequences are also rewritten in the case that the number of T-gates remains the same but the number of Clifford gates is reduced.

Update: I also just realized that I forgot to update the class docstring in #14996, this is also done now.