### PR TITLE
Add `Target.build_clifford_t`

### DIFF
--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -962,6 +962,35 @@ class Target(BaseTarget):
     def build_clifford_t(
         cls, num_qubits: int | None, coupling_map: CouplingMap | None = None
     ) -> Target:
+        """Build a :class:`.Target` with a Clifford+T basis.
+
+        This will contain all Clifford standard gates, the :class:`.TGate`, and the
+        :class:`.TdgGate`. If only the number of qubits is provided, an all-to-all
+        connectivity is assumed.
+
+        This can be used to compile to Clifford+T targets, for example::
+
+            from qiskit.circuit import QuantumCircuit, transpile
+            from qiskit.transpiler import Target
+
+            circuit = QuantumCircuit(2)
+            circuit.rx(0.2, 0)
+            circuit.rzz(1.3, 0, 1)
+
+            target = Target.build_clifford_t(num_qubits=2)
+            cliff_t = transpile(circuit, target=target)
+
+        More specific :class:`.Target` objects can also be build with
+        :meth:`.Target.from_configuration` or manually via :meth:`.Target.add_instruction`.
+
+        Args:
+            num_qubits: The number of qubits. Ignored if the ``coupling_map`` is provided.
+            coupling_map: The :class:`.CouplingMap` for the 2-qubit Cliffords. Takes precedence
+                over ``num_qubits``. If ``None``, an all-to-all connectivity is assumed.
+
+        Returns:
+            A Clifford+T target.
+        """
         basis_gates = get_clifford_gate_names() + ["t", "tdg"]
         return Target.from_configuration(basis_gates, num_qubits, coupling_map)
 

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -42,6 +42,7 @@ from qiskit.transpiler.coupling import CouplingMap
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.instruction_durations import InstructionDurations
 from qiskit.transpiler.timing_constraints import TimingConstraints
+from qiskit.quantum_info import get_clifford_gate_names
 
 # import QubitProperties here to provide convenience alias for building a
 # full target
@@ -956,6 +957,13 @@ class Target(BaseTarget):
             for gate in global_ideal_variable_width_gates:
                 target.add_instruction(name_mapping[gate], name=gate)
         return target
+
+    @classmethod
+    def build_clifford_t(
+        cls, num_qubits: int | None, coupling_map: CouplingMap | None = None
+    ) -> Target:
+        basis_gates = get_clifford_gate_names() + ["t", "tdg"]
+        return Target.from_configuration(basis_gates, num_qubits, coupling_map)
 
 
 Mapping.register(Target)

--- a/releasenotes/notes/clifford-t-target-python-1f0d4b579b2d9acb.yaml
+++ b/releasenotes/notes/clifford-t-target-python-1f0d4b579b2d9acb.yaml
@@ -7,7 +7,9 @@ features_transpiler:
     two-qubit Cliffords is assumed, but you can specify a specific
     ``coupling_map``.
 
-    Example::
+    For example:
+
+    .. code-block:: python
 
       from qiskit import QuantumCircuit, transpile
       from qiskit.transpiler import Target

--- a/releasenotes/notes/clifford-t-target-python-1f0d4b579b2d9acb.yaml
+++ b/releasenotes/notes/clifford-t-target-python-1f0d4b579b2d9acb.yaml
@@ -1,0 +1,20 @@
+---
+features_transpiler:
+  - Added :meth:`.Target.build_clifford_t` to conveniently build a
+    :class:`.Target` for Clifford+T transpilation. This target includes
+    all standard Clifford gates, the :class:`.TGate` and the
+    :class:`.TdgGate`. Per default, an all-to-all connectivity for all
+    two-qubit Cliffords is assumed, but you can specify a specific
+    ``coupling_map``.
+
+    Example::
+
+      from qiskit.circuit import QuantumCircuit
+      from qiskit.transpiler import Target, transpile
+
+      circuit = QuantumCircuit(2)
+      circuit.rx(0.2, 0)
+      circuit.rzz(1.3, 0, 1)
+
+      target = Target.build_clifford_t(num_qubits=2)
+      cliff_t = transpile(circuit, target=target)

--- a/releasenotes/notes/clifford-t-target-python-1f0d4b579b2d9acb.yaml
+++ b/releasenotes/notes/clifford-t-target-python-1f0d4b579b2d9acb.yaml
@@ -7,7 +7,7 @@ features_transpiler:
     two-qubit Cliffords is assumed, but you can specify a specific
     ``coupling_map``.
 
-    For example:
+    For example
 
     .. code-block:: python
 

--- a/releasenotes/notes/clifford-t-target-python-1f0d4b579b2d9acb.yaml
+++ b/releasenotes/notes/clifford-t-target-python-1f0d4b579b2d9acb.yaml
@@ -9,8 +9,8 @@ features_transpiler:
 
     Example::
 
-      from qiskit.circuit import QuantumCircuit
-      from qiskit.transpiler import Target, transpile
+      from qiskit import QuantumCircuit, transpile
+      from qiskit.transpiler import Target
 
       circuit = QuantumCircuit(2)
       circuit.rx(0.2, 0)

--- a/test/python/transpiler/test_clifford_t_passmanager.py
+++ b/test/python/transpiler/test_clifford_t_passmanager.py
@@ -406,11 +406,11 @@ class TestCliffordTTarget(QiskitTestCase):
         """Test the coupling map is respected."""
 
         num_qubits = 3
-        cmap = CouplingMap([(0, 1), (1, 2), (2, 0)])
-        target = Target.build_clifford_t(num_qubits, cmap)
+        target_cmap = CouplingMap([(0, 1), (1, 2), (2, 0)])
+        target = Target.build_clifford_t(num_qubits, target_cmap)
 
-        edges = set(target.build_coupling_map().get_edges())
-        self.assertEqual(set(cmap.get_edges()), edges)
+        cmap = target.build_coupling_map()
+        self.assertEqual(target_cmap, cmap)
 
 
 def _get_t_count(qc):

--- a/test/python/transpiler/test_clifford_t_passmanager.py
+++ b/test/python/transpiler/test_clifford_t_passmanager.py
@@ -25,6 +25,7 @@ from qiskit.circuit.library import (
     MultiplierGate,
     ModularAdderGate,
 )
+from qiskit.transpiler import Target
 from qiskit.transpiler.passes.utils import CheckGateDirection
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit.transpiler import CouplingMap
@@ -150,13 +151,13 @@ class TestCliffordTPassManager(QiskitTestCase):
         qc.append(gate, qc.qubits)
 
         # Transpile to a Clifford+T basis set
-        basis_gates = get_clifford_gate_names() + ["t", "tdg"]
+        target = Target.build_clifford_t(qc.num_qubits)
         pm = generate_preset_pass_manager(
-            basis_gates=basis_gates, optimization_level=optimization_level, seed_transpiler=0
+            target=target, optimization_level=optimization_level, seed_transpiler=0
         )
         transpiled = pm.run(qc)
 
-        self.assertLessEqual(set(transpiled.count_ops()), set(basis_gates))
+        self.assertLessEqual(set(transpiled.count_ops()), set(target.operation_names))
         t_count = _get_t_count(transpiled)
 
         # This is the T-count with optimization level 0.
@@ -306,10 +307,10 @@ class TestCliffordTPassManager(QiskitTestCase):
         qc.append(gate, qc.qubits[0:nq])
 
         # Transpile to a Clifford+T basis set
-        basis_gates = get_clifford_gate_names() + ["t", "tdg"]
-        pm = generate_preset_pass_manager(basis_gates=basis_gates, optimization_level=0)
+        target = Target.build_clifford_t(qc.num_qubits)
+        pm = generate_preset_pass_manager(target=target, optimization_level=0)
         transpiled = pm.run(qc)
-        self.assertLessEqual(set(transpiled.count_ops()), set(basis_gates))
+        self.assertLessEqual(set(transpiled.count_ops()), set(target.operation_names))
 
         # The resulting decomposition should be efficient in terms of T-count
         # provided 1 ancilla qubit is available
@@ -330,10 +331,10 @@ class TestCliffordTPassManager(QiskitTestCase):
         qc.append(gate, qc.qubits[0:nq])
 
         # Transpile to a Clifford+T basis set
-        basis_gates = get_clifford_gate_names() + ["t", "tdg"]
-        pm = generate_preset_pass_manager(basis_gates=basis_gates, optimization_level=0)
+        target = Target.build_clifford_t(qc.num_qubits)
+        pm = generate_preset_pass_manager(target=target, optimization_level=0)
         transpiled = pm.run(qc)
-        self.assertLessEqual(set(transpiled.count_ops()), set(basis_gates))
+        self.assertLessEqual(set(transpiled.count_ops()), set(target.operation_names))
 
         # The resulting decomposition should be efficient in terms of T-count
         # provided 1 ancilla qubit is available
@@ -350,10 +351,10 @@ class TestCliffordTPassManager(QiskitTestCase):
         qc.append(gate, qc.qubits)
 
         # Transpile to a Clifford+T basis set
-        basis_gates = get_clifford_gate_names() + ["t", "tdg"]
-        pm = generate_preset_pass_manager(basis_gates=basis_gates, optimization_level=0)
+        target = Target.build_clifford_t(qc.num_qubits)
+        pm = generate_preset_pass_manager(target=target, optimization_level=0)
         transpiled = pm.run(qc)
-        self.assertLessEqual(set(transpiled.count_ops()), set(basis_gates))
+        self.assertLessEqual(set(transpiled.count_ops()), set(target.operation_names))
 
         # The resulting decomposition should be efficient in terms of T-count,
         # except surprisingly for the case n=1 (which is why it is not used in this test)
@@ -370,10 +371,10 @@ class TestCliffordTPassManager(QiskitTestCase):
         qc.append(gate, qc.qubits)
 
         # Transpile to a Clifford+T basis set
-        basis_gates = get_clifford_gate_names() + ["t", "tdg"]
-        pm = generate_preset_pass_manager(basis_gates=basis_gates, optimization_level=0)
+        target = Target.build_clifford_t(qc.num_qubits)
+        pm = generate_preset_pass_manager(target=target, optimization_level=0)
         transpiled = pm.run(qc)
-        self.assertLessEqual(set(transpiled.count_ops()), set(basis_gates))
+        self.assertLessEqual(set(transpiled.count_ops()), set(target.operation_names))
 
         # The resulting decomposition should be efficient in terms of T-count,
         t_count = _get_t_count(transpiled)

--- a/test/python/transpiler/test_clifford_t_passmanager.py
+++ b/test/python/transpiler/test_clifford_t_passmanager.py
@@ -382,6 +382,37 @@ class TestCliffordTPassManager(QiskitTestCase):
         self.assertLessEqual(t_count, expected_t_count[n])
 
 
+class TestCliffordTTarget(QiskitTestCase):
+    """Tests for the Clifford+T target."""
+
+    def test_default(self):
+        """Test the default setup."""
+
+        num_qubits = 3
+        target = Target.build_clifford_t(num_qubits)
+
+        with self.subTest(msg="all-to-all connectivity"):
+            # ``None`` means no coupling map constraints
+            cmap = target.build_coupling_map()
+            self.assertIsNone(cmap)
+
+        with self.subTest(msg="check gates"):
+            expected_basis = set(get_clifford_gate_names()) | {"t", "tdg"}
+            basis = set(target.operation_names)
+
+            self.assertEqual(expected_basis, basis)
+
+    def test_coupling_map(self):
+        """Test the coupling map is respected."""
+
+        num_qubits = 3
+        cmap = CouplingMap([(0, 1), (1, 2), (2, 0)])
+        target = Target.build_clifford_t(num_qubits, cmap)
+
+        edges = set(target.build_coupling_map().get_edges())
+        self.assertEqual(set(cmap.get_edges()), edges)
+
+
 def _get_t_count(qc):
     """Returns the number of T/Tdg gates in a circuit."""
     ops = qc.count_ops()


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Added `Target.build_clifford_t` to conveniently build a
Target for Clifford+T transpilation. This target includes
all standard Clifford gates (see `get_clifford_gate_names`)
T and Tdg.

Closes #15632. 

### Details and comments

This internally uses `Target.from_configuration`, and maybe should be called `from_clifford_t` for consistency. 

The initial plan was to build the Target Rust-first and expose the same functionality to C, but the C-exposed Target and the Python one have lots of differences which makes using a single Rust-source complicated. I'll add a second PR to expose this to C too.

For example:

```python
      from qiskit import QuantumCircuit, transpile
      from qiskit.transpiler import Target

      circuit = QuantumCircuit(2)
      circuit.rx(0.2, 0)
      circuit.rzz(1.3, 0, 1)

      target = Target.build_clifford_t(num_qubits=2)
      cliff_t = transpile(circuit, target=target)
```

