### PR TITLE
Split `Target::new` into Python and Rust facing methods

### DIFF
--- a/crates/transpiler/src/target/errors.rs
+++ b/crates/transpiler/src/target/errors.rs
@@ -10,6 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use pyo3::exceptions::PyValueError;
 use thiserror::Error;
 
 /// A collection of the Errors possible in the [Target].
@@ -28,6 +29,8 @@ pub enum TargetError {
         instruction: String,
         arguments: String,
     },
+    #[error["The number of qubits ({num_qubits}) does not match the nuber of qubit properties ({num_props})"]]
+    NumQubitsMismatch { num_qubits: u32, num_props: usize },
     #[error(
         "The number of parameters for {instruction}: {instruction_num} does not match the provided number of parameters: {argument_num}."
     )]
@@ -54,6 +57,9 @@ pub enum TargetError {
 
 impl From<TargetError> for ::pyo3::PyErr {
     fn from(val: TargetError) -> Self {
-        crate::TranspilerError::new_err(val.to_string())
+        match val {
+            TargetError::NumQubitsMismatch { .. } => PyValueError::new_err(val.to_string()),
+            _ => crate::TranspilerError::new_err(val.to_string()),
+        }
     }
 }


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Previously, Rust's `Target` only had a `new` constructor defined in the Python methods. This PR moves the constructor to the Rust-native methods and exposes a Python `Target::py_new` constructor to be called on from Python.

This allows (1) for proper error handling when constructing Targets from the C API, since we can match on specific `TargetError`s instead of a generic `PyErr`, and (2) is a tiny step work towards a clean conditional Python-free compilation for C.

