### PR TITLE
Support adding a barrier in `LitinskiTransformation`

### DIFF
--- a/crates/transpiler/src/passes/litinski_transformation.rs
+++ b/crates/transpiler/src/passes/litinski_transformation.rs
@@ -326,7 +326,15 @@ pub fn run_litinski_transformation(
         if insert_barrier {
             let barrier = StandardInstruction::Barrier(dag.num_qubits() as u32).into();
             let qubits = (0..dag.num_qubits() as u32).map(Qubit).collect::<Vec<_>>();
-            new_dag.apply_operation_back(barrier, &qubits, &[], None, None, None)?;
+            new_dag.apply_operation_back(
+                barrier,
+                &qubits,
+                &[],
+                None,
+                None,
+                #[cfg(feature = "cache_pygates")]
+                None,
+            )?;
         }
         for inst in clifford_ops.into_iter() {
             new_dag.push_back(inst.clone())?;

--- a/qiskit/transpiler/passes/optimization/litinski_transformation.py
+++ b/qiskit/transpiler/passes/optimization/litinski_transformation.py
@@ -41,37 +41,40 @@ class LitinskiTransformation(TransformationPass):
 
     References:
 
-        [1]: Litinski. A Game of Surface Codes.
-             `Quantum 3, 128 (2019) <https://quantum-journal.org/papers/q-2019-03-05-128>`_
+    [1] Litinski. A Game of Surface Codes.
+    `Quantum 3, 128 (2019) <https://quantum-journal.org/papers/q-2019-03-05-128>`_
 
     """
 
-    def __init__(self, fix_clifford: bool = True):
+    def __init__(self, fix_clifford: bool = True, insert_barrier: bool = False):
         """
 
         Args:
-            fix_clifford: if ``False`` (non-default), the returned circuit contains
-                only PauliEvolution gates, with the final Clifford gates omitted.
+            fix_clifford: If ``False`` (non-default), the returned circuit contains
+                only :class:`.PauliEvolution` gates, with the final Clifford gates omitted.
                 Note that in this case the operators of the original and synthesized
                 circuits will generally not be equivalent.
+            insert_barrier: If ``True`` and ``fix_clifford=True``, insert a barrier between the
+                circuit and the final cliffords. This argument has no effect if
+                ``fix_clifford=False``.
         """
         super().__init__()
         self.fix_clifford = fix_clifford
+        self.insert_barrier = insert_barrier
 
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         """Run the LitiskiTransformation pass on ``dag``.
 
         Args:
-            dag: the input DAG.
+            dag: The input DAG.
 
         Returns:
             The output DAG.
 
         Raises:
-            TranspilerError: if the circuit contains gates
-                not supported by the pass.
+            TranspilerError: If the circuit contains gates not supported by the pass.
         """
-        new_dag = run_litinski_transformation(dag, self.fix_clifford)
+        new_dag = run_litinski_transformation(dag, self.fix_clifford, self.insert_barrier)
 
         # If the pass did not do anything, the result is None
         if new_dag is None:

--- a/releasenotes/notes/litinski-barrier-8fa96fc4ba9b8cae.yaml
+++ b/releasenotes/notes/litinski-barrier-8fa96fc4ba9b8cae.yaml
@@ -1,0 +1,5 @@
+---
+features_transpiler:
+  - Added a new argument called ``insert_barrier`` to the :class:`.LitinskiTransformation` pass.
+    If ``fix_clifford=True`` and ``insert_barrier=True``, a barrier is added in between the
+    Pauli-based computation part of the circuit and the final cliffords.

--- a/test/python/transpiler/test_litinski_transformation.py
+++ b/test/python/transpiler/test_litinski_transformation.py
@@ -458,3 +458,22 @@ class TestLitinskiTransformation(QiskitTestCase):
         expected.append(PauliProductMeasurement(Pauli("XX")), [0, 3], [3])
 
         self.assertEqual(qct, expected)
+
+    @data(True, False)
+    def test_barrier(self, fix_clifford):
+        """Test adding a barrier."""
+        circuit = QuantumCircuit(1, 1)
+        circuit.h(0)
+        circuit.rz(1.0, 0)
+        circuit.measure(0, 0)
+
+        transform = LitinskiTransformation(fix_clifford=fix_clifford, insert_barrier=True)
+        out = transform(circuit)
+
+        if fix_clifford:
+            expected_ops = ["PauliEvolution", "pauli_product_measurement", "barrier", "h"]
+        else:
+            expected_ops = ["PauliEvolution", "pauli_product_measurement"]
+
+        ops = [op.name for op in out.data]
+        self.assertListEqual(expected_ops, ops)


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #15638 by supporting adding a barrier in-between the PBC and the Cliffords in the Litinski transformation. 

