### PR TITLE
Fix ParameterExpression.sympify() for RPOW operations

### DIFF
--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -2129,7 +2129,7 @@ pub fn qpy_replay(
                         symbol_expr::BinaryOp::Mul => OpCode::MUL,
                         symbol_expr::BinaryOp::Div => OpCode::DIV,
                         symbol_expr::BinaryOp::Pow => {
-                            // If RHS is None (an expression), use RPOW and swap operands
+                            // If RHS is None (an expression), use RPOW
                             if rhs_value.is_none() {
                                 OpCode::RPOW
                             } else {
@@ -2138,7 +2138,7 @@ pub fn qpy_replay(
                         }
                     };
                     if op == OpCode::RPOW {
-                        // For RPOW, swap lhs and rhs
+                        // For RPOW, swap lhs and rhs (Python's sympify will swap again to get correct order)
                         replay.push(OPReplay {
                             op,
                             lhs: rhs_value,

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -2141,7 +2141,7 @@ pub fn qpy_replay(
                             lhs: lhs_value,
                             rhs: rhs_value,
                         });
-                    }   
+                    }
                 }
                 _ => {
                     let op = match op {

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -2119,17 +2119,26 @@ pub fn qpy_replay(
 
             // add the expression to the replay
             match lhs_value {
-                None
-                | Some(ParameterValueType::Parameter(_))
+                Some(ParameterValueType::Parameter(_))
                 | Some(ParameterValueType::VectorElement(_)) => {
+                    // For POW operations: if LHS is a Parameter and RHS is an expression (None),
+                    // we need to use RPOW instead of POW
                     let op = match op {
                         symbol_expr::BinaryOp::Add => OpCode::ADD,
                         symbol_expr::BinaryOp::Sub => OpCode::SUB,
                         symbol_expr::BinaryOp::Mul => OpCode::MUL,
                         symbol_expr::BinaryOp::Div => OpCode::DIV,
-                        symbol_expr::BinaryOp::Pow => OpCode::RPOW,
+                        symbol_expr::BinaryOp::Pow => {
+                            // If RHS is None (an expression), use RPOW
+                            if rhs_value.is_none() {
+                                OpCode::RPOW
+                            } else {
+                                OpCode::POW
+                            }
+                        }
                     };
                     if op == OpCode::RPOW {
+                        // For RPOW, swap lhs and rhs (Python's sympify will swap again to get correct order)
                         replay.push(OPReplay {
                             op,
                             lhs: rhs_value,
@@ -2142,6 +2151,21 @@ pub fn qpy_replay(
                             rhs: rhs_value,
                         });
                     }
+                }
+                None => {
+                    // When LHS is an expression (None), use normal operations
+                    let op = match op {
+                        symbol_expr::BinaryOp::Add => OpCode::ADD,
+                        symbol_expr::BinaryOp::Sub => OpCode::SUB,
+                        symbol_expr::BinaryOp::Mul => OpCode::MUL,
+                        symbol_expr::BinaryOp::Div => OpCode::DIV,
+                        symbol_expr::BinaryOp::Pow => OpCode::POW,
+                    };
+                    replay.push(OPReplay {
+                        op,
+                        lhs: lhs_value,
+                        rhs: rhs_value,
+                    });
                 }
                 _ => {
                     let op = match op {

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -2119,26 +2119,17 @@ pub fn qpy_replay(
 
             // add the expression to the replay
             match lhs_value {
-                Some(ParameterValueType::Parameter(_))
+                None
+                | Some(ParameterValueType::Parameter(_))
                 | Some(ParameterValueType::VectorElement(_)) => {
-                    // For POW operations: if LHS is a Parameter and RHS is an expression (None),
-                    // we need to use RPOW instead of POW
                     let op = match op {
                         symbol_expr::BinaryOp::Add => OpCode::ADD,
                         symbol_expr::BinaryOp::Sub => OpCode::SUB,
                         symbol_expr::BinaryOp::Mul => OpCode::MUL,
                         symbol_expr::BinaryOp::Div => OpCode::DIV,
-                        symbol_expr::BinaryOp::Pow => {
-                            // If RHS is None (an expression), use RPOW
-                            if rhs_value.is_none() {
-                                OpCode::RPOW
-                            } else {
-                                OpCode::POW
-                            }
-                        }
+                        symbol_expr::BinaryOp::Pow => OpCode::RPOW,
                     };
                     if op == OpCode::RPOW {
-                        // For RPOW, swap lhs and rhs (Python's sympify will swap again to get correct order)
                         replay.push(OPReplay {
                             op,
                             lhs: rhs_value,
@@ -2150,22 +2141,7 @@ pub fn qpy_replay(
                             lhs: lhs_value,
                             rhs: rhs_value,
                         });
-                    }
-                }
-                None => {
-                    // When LHS is an expression (None), use normal operations
-                    let op = match op {
-                        symbol_expr::BinaryOp::Add => OpCode::ADD,
-                        symbol_expr::BinaryOp::Sub => OpCode::SUB,
-                        symbol_expr::BinaryOp::Mul => OpCode::MUL,
-                        symbol_expr::BinaryOp::Div => OpCode::DIV,
-                        symbol_expr::BinaryOp::Pow => OpCode::POW,
-                    };
-                    replay.push(OPReplay {
-                        op,
-                        lhs: lhs_value,
-                        rhs: rhs_value,
-                    });
+                    }   
                 }
                 _ => {
                     let op = match op {

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -2119,8 +2119,7 @@ pub fn qpy_replay(
 
             // add the expression to the replay
             match lhs_value {
-                None
-                | Some(ParameterValueType::Parameter(_))
+                Some(ParameterValueType::Parameter(_))
                 | Some(ParameterValueType::VectorElement(_)) => {
                     // For POW operations: if LHS is a Parameter and RHS is an expression (None),
                     // we need to use RPOW instead of POW
@@ -2152,6 +2151,21 @@ pub fn qpy_replay(
                             rhs: rhs_value,
                         });
                     }
+                }
+                None => {
+                    // When LHS is an expression (None), use normal operations
+                    let op = match op {
+                        symbol_expr::BinaryOp::Add => OpCode::ADD,
+                        symbol_expr::BinaryOp::Sub => OpCode::SUB,
+                        symbol_expr::BinaryOp::Mul => OpCode::MUL,
+                        symbol_expr::BinaryOp::Div => OpCode::DIV,
+                        symbol_expr::BinaryOp::Pow => OpCode::POW,
+                    };
+                    replay.push(OPReplay {
+                        op,
+                        lhs: lhs_value,
+                        rhs: rhs_value,
+                    });
                 }
                 _ => {
                     let op = match op {

--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -117,11 +117,13 @@ def sympify(expression):
                     stack.append(getattr(rhs, "__pow__")(lhs))
                 elif inst.op == OpCode.RDIV:
                     # Construct division directly: rhs / lhs (e.g., 2 / a)
-                    # Use sympy's division operator to handle the case where __rtruediv__ returns NotImplemented
+                    # Use sympy's division operator to handle the case where
+                    # __rtruediv__ returns NotImplemented
                     stack.append(rhs / lhs)
                 elif inst.op == OpCode.RSUB:
                     # Construct subtraction directly: rhs - lhs (e.g., 2 - a)
-                    # Use sympy's subtraction operator to handle the case where __rsub__ returns NotImplemented
+                    # Use sympy's subtraction operator to handle the case where
+                    # __rsub__ returns NotImplemented
                     stack.append(rhs - lhs)
             elif (
                 not isinstance(lhs, sympy.Basic)

--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -110,15 +110,19 @@ def sympify(expression):
                 # For reverse operations, the Rust code already swapped operands in the replay,
                 # so we need to apply the operation with rhs op lhs to get the correct result.
                 # For RPOW: rhs ** lhs (Rust already swapped, so we use __pow__ directly)
-                # For RDIV: rhs / lhs (use __rtruediv__ to get correct order: 2 / a)
-                # For RSUB: rhs - lhs (use __rsub__ to get correct order: 2 - a)
+                # For RDIV: rhs / lhs (construct division directly: 2 / a)
+                # For RSUB: rhs - lhs (construct subtraction directly: 2 - a)
                 if inst.op == OpCode.RPOW:
                     # Rust already swapped operands, so we use __pow__ directly: rhs ** lhs
                     stack.append(getattr(rhs, "__pow__")(lhs))
                 elif inst.op == OpCode.RDIV:
-                    stack.append(getattr(rhs, "__rtruediv__")(lhs))
+                    # Construct division directly: rhs / lhs (e.g., 2 / a)
+                    # Use sympy's division operator to handle the case where __rtruediv__ returns NotImplemented
+                    stack.append(rhs / lhs)
                 elif inst.op == OpCode.RSUB:
-                    stack.append(getattr(rhs, "__rsub__")(lhs))
+                    # Construct subtraction directly: rhs - lhs (e.g., 2 - a)
+                    # Use sympy's subtraction operator to handle the case where __rsub__ returns NotImplemented
+                    stack.append(rhs - lhs)
             elif (
                 not isinstance(lhs, sympy.Basic)
                 and isinstance(rhs, sympy.Basic)

--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -105,7 +105,17 @@ def sympify(expression):
             rhs = stack.pop()
             lhs = stack.pop()
 
-            if (
+            # Handle reverse operations (RSUB, RDIV, RPOW) by swapping operands
+            if inst.op in {OpCode.RSUB, OpCode.RDIV, OpCode.RPOW}:
+                # For reverse operations, we need rhs op lhs instead of lhs op rhs
+                # For RPOW: rhs ** lhs, for RDIV: rhs / lhs, for RSUB: rhs - lhs
+                if inst.op == OpCode.RPOW:
+                    stack.append(getattr(rhs, "__pow__")(lhs))
+                elif inst.op == OpCode.RDIV:
+                    stack.append(getattr(rhs, "__truediv__")(lhs))
+                elif inst.op == OpCode.RSUB:
+                    stack.append(getattr(rhs, "__sub__")(lhs))
+            elif (
                 not isinstance(lhs, sympy.Basic)
                 and isinstance(rhs, sympy.Basic)
                 and inst.op in [OpCode.ADD, OpCode.MUL]

--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -107,15 +107,14 @@ def sympify(expression):
 
             # Handle reverse operations (RSUB, RDIV, RPOW) by swapping operands
             if inst.op in {OpCode.RSUB, OpCode.RDIV, OpCode.RPOW}:
-                # For reverse operations, we need rhs op lhs instead of lhs op rhs
-                # For RPOW: rhs ** lhs, for RDIV: rhs / lhs, for RSUB: rhs - lhs
-                # We use reverse methods (__rsub__, __rtruediv__, __rpow__) to get the correct order
+                # For reverse operations, the Rust code already swapped operands in the replay,
+                # so we need to apply the operation with rhs op lhs to get the correct result.
+                # For RPOW: rhs ** lhs (Rust already swapped, so we use __pow__ directly)
+                # For RDIV: rhs / lhs (use __rtruediv__ to get correct order: 2 / a)
+                # For RSUB: rhs - lhs (use __rsub__ to get correct order: 2 - a)
                 if inst.op == OpCode.RPOW:
-                    # Try __rpow__ first (Python 3.11+), fallback to __pow__ if not available
-                    if hasattr(rhs, "__rpow__"):
-                        stack.append(getattr(rhs, "__rpow__")(lhs))
-                    else:
-                        stack.append(getattr(rhs, "__pow__")(lhs))
+                    # Rust already swapped operands, so we use __pow__ directly: rhs ** lhs
+                    stack.append(getattr(rhs, "__pow__")(lhs))
                 elif inst.op == OpCode.RDIV:
                     stack.append(getattr(rhs, "__rtruediv__")(lhs))
                 elif inst.op == OpCode.RSUB:

--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -109,12 +109,17 @@ def sympify(expression):
             if inst.op in {OpCode.RSUB, OpCode.RDIV, OpCode.RPOW}:
                 # For reverse operations, we need rhs op lhs instead of lhs op rhs
                 # For RPOW: rhs ** lhs, for RDIV: rhs / lhs, for RSUB: rhs - lhs
+                # We use reverse methods (__rsub__, __rtruediv__, __rpow__) to get the correct order
                 if inst.op == OpCode.RPOW:
-                    stack.append(getattr(rhs, "__pow__")(lhs))
+                    # Try __rpow__ first (Python 3.11+), fallback to __pow__ if not available
+                    if hasattr(rhs, "__rpow__"):
+                        stack.append(getattr(rhs, "__rpow__")(lhs))
+                    else:
+                        stack.append(getattr(rhs, "__pow__")(lhs))
                 elif inst.op == OpCode.RDIV:
-                    stack.append(getattr(rhs, "__truediv__")(lhs))
+                    stack.append(getattr(rhs, "__rtruediv__")(lhs))
                 elif inst.op == OpCode.RSUB:
-                    stack.append(getattr(rhs, "__sub__")(lhs))
+                    stack.append(getattr(rhs, "__rsub__")(lhs))
             elif (
                 not isinstance(lhs, sympy.Basic)
                 and isinstance(rhs, sympy.Basic)

--- a/releasenotes/notes/fix-parameter-expression-rpow-sympify-15583.yaml
+++ b/releasenotes/notes/fix-parameter-expression-rpow-sympify-15583.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed a bug in :meth:`~qiskit.circuit.ParameterExpression.sympify()` where reverse power
+    operations (RPOW) were incorrectly converting to sympy expressions with swapped operands.
+    Previously, expressions like ``a ** (b - 2)`` would incorrectly convert to ``(b - 2)**a``
+    instead of ``a ** (b - 2)``. The fix adds proper handling for reverse operations (RPOW,
+    RDIV, RSUB) to correctly swap operands before applying the operation, matching the Rust
+    implementation behavior.
+

--- a/test/python/circuit/test_parameter_expression.py
+++ b/test/python/circuit/test_parameter_expression.py
@@ -575,3 +575,36 @@ class TestParameterExpression(QiskitTestCase):
         sympy_result2 = res2.sympify()
         expected2 = sympy.Symbol("a") ** (2 * sympy.Symbol("b"))
         self.assertEqual(sympy_result2, expected2)
+
+    @unittest.skipUnless(HAS_SYMPY, "Sympy is required for this test")
+    def test_sympify_reverse_operations(self):
+        """Test that sympify correctly handles all reverse operations (RPOW, RDIV, RSUB).
+
+        This test ensures that reverse operations correctly swap operands when converting
+        to sympy expressions. Reverse operations are used when the left operand is numeric
+        and the right operand is a ParameterExpression.
+        """
+        import sympy
+
+        a, b = Parameter("a"), Parameter("b")
+
+        # Test RPOW: a ** (b - 2) should convert to a ** (b - 2)
+        # This uses RPOW internally when the exponent is a ParameterExpression
+        res_pow = a ** (b - 2)
+        sympy_pow = res_pow.sympify()
+        expected_pow = sympy.Symbol("a") ** (sympy.Symbol("b") - 2)
+        self.assertEqual(sympy_pow, expected_pow)
+
+        # Test RDIV: 2 / a should convert to 2 / a
+        # RDIV is used when left operand is numeric and right is ParameterExpression
+        res_div = 2 / a
+        sympy_div = res_div.sympify()
+        expected_div = 2 / sympy.Symbol("a")
+        self.assertEqual(sympy_div, expected_div)
+
+        # Test RSUB: 2 - a should convert to 2 - a
+        # RSUB is used when left operand is numeric and right is ParameterExpression
+        res_sub = 2 - a
+        sympy_sub = res_sub.sympify()
+        expected_sub = 2 - sympy.Symbol("a")
+        self.assertEqual(sympy_sub, expected_sub)


### PR DESCRIPTION
Fixes #15583

### Summary

The `sympify()` method was not correctly handling reverse power operations (RPOW). When converting `ParameterExpression` to sympy, RPOW operations need to swap operands (rhs ** lhs instead of lhs ** rhs) to match the Rust implementation.

### Details

This fix adds special handling for RPOW, RDIV, and RSUB operations to correctly swap operands before applying the operation. The issue was that when converting expressions like `a ** (b - 2)` to sympy, the operands were being swapped incorrectly, resulting in `(b - 2)**a` instead of `a ** (b - 2)`.

### Testing

This fixes the reproduction case from issue #15583:
```python
from qiskit.circuit import Parameter

a, b = Parameter("a"), Parameter("b")
res = a ** (b - 2)
print(res)  # CORRECT: a**(-2 + b)
print(res.sympify())  # Now CORRECT: a**(-2 + b) instead of (b - 2)**a
```