### PR TITLE
Remove `cbinding` optional feature from `cext`

### DIFF
--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -300,6 +300,5 @@ As an example:
 /// \qk_deprecated{2.3.0|use :c:func:`qk_ty_new_function` instead.}
 #[deprecated = "use `qk_ty_new_function` instead"]
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub extern "C" fn qk_ty_old_function() {}
 ```

--- a/crates/cext/Cargo.toml
+++ b/crates/cext/Cargo.toml
@@ -36,7 +36,5 @@ anyhow.workspace = true
 cbindgen = "0.29"
 
 [features]
-default = ["cbinding"]
 python_binding = ["dep:pyo3"]
-cbinding = []
 cache_pygates = ["qiskit-circuit/cache_pygates", "qiskit-transpiler/cache_pygates"]

--- a/crates/cext/cbindgen.toml
+++ b/crates/cext/cbindgen.toml
@@ -14,16 +14,11 @@ after_includes = """
 #include "qiskit/attributes.h"
 #include "qiskit/complex.h"
 
-// Always expose [cfg(feature = "cbinding")] -- workaround for
-// https://github.com/mozilla/cbindgen/issues/995
-#define QISKIT_WITH_CBINDINGS
-
 typedef struct QkQuantumRegister QkQuantumRegister;
 typedef struct QkClassicalRegister QkClassicalRegister;
 """
 
 [defines]
-"feature = cbinding" = "QISKIT_WITH_CBINDINGS"
 "feature = python_binding" = "QISKIT_C_PYTHON_INTERFACE"
 
 [parse]

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -46,7 +46,6 @@ use smallvec::smallvec;
 ///     QkCircuit *empty = qk_circuit_new(100, 100);
 ///
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub extern "C" fn qk_circuit_new(num_qubits: u32, num_clbits: u32) -> *mut CircuitData {
     let qubits = if num_qubits > 0 {
         Some(
@@ -91,7 +90,6 @@ pub extern "C" fn qk_circuit_new(num_qubits: u32, num_clbits: u32) -> *mut Circu
 /// nul terminator at the end of the string. It also must be valid for reads of
 /// bytes up to and including the nul terminator.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_quantum_register_new(
     num_qubits: u32,
     name: *const c_char,
@@ -123,7 +121,6 @@ pub unsafe extern "C" fn qk_quantum_register_new(
 /// Behavior is undefined if ``reg`` is not either null or a valid pointer to a
 /// ``QkQuantumRegister``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_quantum_register_free(reg: *mut QuantumRegister) {
     if !reg.is_null() {
         if !reg.is_aligned() {
@@ -154,7 +151,6 @@ pub unsafe extern "C" fn qk_quantum_register_free(reg: *mut QuantumRegister) {
 /// Behavior is undefined if ``reg`` is not either null or a valid pointer to a
 /// ``QkClassicalRegister``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_classical_register_free(reg: *mut ClassicalRegister) {
     if !reg.is_null() {
         if !reg.is_aligned() {
@@ -189,7 +185,6 @@ pub unsafe extern "C" fn qk_classical_register_free(reg: *mut ClassicalRegister)
 /// nul terminator at the end of the string. It also must be valid for reads of
 /// bytes up to and including the nul terminator.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_classical_register_new(
     num_clbits: u32,
     name: *const c_char,
@@ -225,7 +220,6 @@ pub unsafe extern "C" fn qk_classical_register_new(
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit`` and
 /// if ``reg`` is not a valid, non-null pointer to a ``QkQuantumRegister``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_add_quantum_register(
     circuit: *mut CircuitData,
     reg: *const QuantumRegister,
@@ -259,7 +253,6 @@ pub unsafe extern "C" fn qk_circuit_add_quantum_register(
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit`` and
 /// if ``reg`` is not a valid, non-null pointer to a ``QkClassicalRegister``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_add_classical_register(
     circuit: *mut CircuitData,
     reg: *const ClassicalRegister,
@@ -290,7 +283,6 @@ pub unsafe extern "C" fn qk_circuit_add_classical_register(
 ///
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_copy(circuit: *const CircuitData) -> *mut CircuitData {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { const_ptr_as_ref(circuit) };
@@ -314,7 +306,6 @@ pub unsafe extern "C" fn qk_circuit_copy(circuit: *const CircuitData) -> *mut Ci
 ///
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_num_qubits(circuit: *const CircuitData) -> u32 {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { const_ptr_as_ref(circuit) };
@@ -339,7 +330,6 @@ pub unsafe extern "C" fn qk_circuit_num_qubits(circuit: *const CircuitData) -> u
 ///
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_num_clbits(circuit: *const CircuitData) -> u32 {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { const_ptr_as_ref(circuit) };
@@ -363,7 +353,6 @@ pub unsafe extern "C" fn qk_circuit_num_clbits(circuit: *const CircuitData) -> u
 /// Behavior is undefined if ``circuit`` is not either null or a valid pointer to a
 /// ``QkCircuit``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_free(circuit: *mut CircuitData) {
     if !circuit.is_null() {
         if !circuit.is_aligned() {
@@ -408,7 +397,6 @@ pub unsafe extern "C" fn qk_circuit_free(circuit: *mut CircuitData) {
 ///
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_gate(
     circuit: *mut CircuitData,
     gate: StandardGate,
@@ -480,7 +468,6 @@ pub unsafe extern "C" fn qk_circuit_gate(
 /// ```
 ///
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub extern "C" fn qk_gate_num_qubits(gate: StandardGate) -> u32 {
     gate.num_qubits()
 }
@@ -498,7 +485,6 @@ pub extern "C" fn qk_gate_num_qubits(gate: StandardGate) -> u32 {
 /// ```
 ///
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub extern "C" fn qk_gate_num_params(gate: StandardGate) -> u32 {
     gate.num_params()
 }
@@ -522,7 +508,6 @@ pub extern "C" fn qk_gate_num_params(gate: StandardGate) -> u32 {
 ///
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_measure(
     circuit: *mut CircuitData,
     qubit: u32,
@@ -559,7 +544,6 @@ pub unsafe extern "C" fn qk_circuit_measure(
 ///
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_reset(circuit: *mut CircuitData, qubit: u32) -> ExitCode {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { mut_ptr_as_ref(circuit) };
@@ -597,7 +581,6 @@ pub unsafe extern "C" fn qk_circuit_reset(circuit: *mut CircuitData, qubit: u32)
 ///
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_barrier(
     circuit: *mut CircuitData,
     qubits: *const u32,
@@ -746,7 +729,6 @@ pub(crate) unsafe fn unitary_from_pointer(
 /// * ``matrix`` is an aligned pointer to ``4**num_qubits`` initialized ``QkComplex64`` values
 /// * ``qubits`` is an aligned pointer to ``num_qubits`` initialized ``uint32_t`` values
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_unitary(
     circuit: *mut CircuitData,
     matrix: *const Complex64,
@@ -805,7 +787,6 @@ pub unsafe extern "C" fn qk_circuit_unitary(
 ///
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_count_ops(circuit: *const CircuitData) -> OpCounts {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { const_ptr_as_ref(circuit) };
@@ -844,7 +825,6 @@ pub unsafe extern "C" fn qk_circuit_count_ops(circuit: *const CircuitData) -> Op
 ///
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_num_instructions(circuit: *const CircuitData) -> usize {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { const_ptr_as_ref(circuit) };
@@ -944,7 +924,6 @@ impl CInstruction {
 /// otherwise this function will panic. Behavior is undefined if ``instruction`` is not a valid,
 /// non-null pointer to a memory allocation with sufficient space for a ``QkCircuitInstruction``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_get_instruction(
     circuit: *const CircuitData,
     index: usize,
@@ -987,7 +966,6 @@ pub unsafe extern "C" fn qk_circuit_get_instruction(
 ///
 /// Behavior is undefined if ``inst`` is not a valid, non-null pointer to a ``QkCircuitInstruction``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_instruction_clear(inst: *mut CInstruction) {
     // SAFETY: Loading the data from pointers contained in a CInstruction. These should only be
     // created by rust code and are constructed from Vecs internally or CStrings.
@@ -1027,7 +1005,6 @@ pub unsafe extern "C" fn qk_circuit_instruction_clear(inst: *mut CInstruction) {
 ///
 /// Behavior is undefined if ``op_counts`` is not the object returned by ``qk_circuit_count_ops``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_opcounts_clear(op_counts: *mut OpCounts) {
     // SAFETY: The user guarantees the input is a valid OpCounts pointer.
     let op_counts = unsafe { mut_ptr_as_ref(op_counts) };
@@ -1075,7 +1052,6 @@ pub unsafe extern "C" fn qk_opcounts_clear(op_counts: *mut OpCounts) {
 /// function.
 #[unsafe(no_mangle)]
 #[cfg(feature = "python_binding")]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_to_python(
     circuit: *mut CircuitData,
 ) -> *mut ::pyo3::ffi::PyObject {
@@ -1138,7 +1114,6 @@ impl From<CDelayUnit> for DelayUnit {
 ///
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_delay(
     circuit: *mut CircuitData,
     qubit: u32,
@@ -1194,7 +1169,6 @@ pub unsafe extern "C" fn qk_circuit_delay(
 ///
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.  
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_to_dag(circuit: *const CircuitData) -> *mut DAGCircuit {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let circuit = unsafe { const_ptr_as_ref(circuit) };
@@ -1288,7 +1262,6 @@ impl From<CBlocksMode> for BlocksMode {
 ///
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_copy_empty_like(
     circuit: *const CircuitData,
     vars_mode: CVarsMode,

--- a/crates/cext/src/circuit_library/iqp.rs
+++ b/crates/cext/src/circuit_library/iqp.rs
@@ -44,7 +44,6 @@ use qiskit_circuit_library::iqp::{check_symmetric, iqp, py_random_iqp};
 /// invalid pointer or a buffer that is too small results in undefined
 /// behaviour.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_circuit_library_iqp(
     num_qubits: u32,
     interactions: *const i64, // row-major n×n
@@ -103,7 +102,6 @@ pub unsafe extern "C" fn qk_circuit_library_iqp(
 ///
 /// @return A newly allocated `QkCircuit*` (caller must free with `qk_circuit_free`).
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub extern "C" fn qk_circuit_library_random_iqp(num_qubits: u32, seed: i64) -> *mut CircuitData {
     let seed = if seed < 0 { None } else { Some(seed as u64) };
     let circuit_data = py_random_iqp(num_qubits, seed)

--- a/crates/cext/src/circuit_library/quantum_volume.rs
+++ b/crates/cext/src/circuit_library/quantum_volume.rs
@@ -42,7 +42,6 @@ use qiskit_circuit_library::quantum_volume::quantum_volume;
 /// QkCircuit *qc = qk_circuit_library_quantum_volume(10, 10, -1)
 /// ```
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub extern "C" fn qk_circuit_library_quantum_volume(
     num_qubits: u32,
     depth: usize,

--- a/crates/cext/src/dag.rs
+++ b/crates/cext/src/dag.rs
@@ -42,7 +42,6 @@ use crate::pointers::{check_ptr, const_ptr_as_ref, mut_ptr_as_ref};
 /// QkDag *empty = qk_dag_new();
 /// ```
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub extern "C" fn qk_dag_new() -> *mut DAGCircuit {
     let dag = DAGCircuit::new();
     Box::into_raw(Box::new(dag))
@@ -68,7 +67,6 @@ pub extern "C" fn qk_dag_new() -> *mut DAGCircuit {
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag`` and
 /// if ``reg`` is not a valid, non-null pointer to a ``QkQuantumRegister``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_add_quantum_register(
     dag: *mut DAGCircuit,
     reg: *const QuantumRegister,
@@ -102,7 +100,6 @@ pub unsafe extern "C" fn qk_dag_add_quantum_register(
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag`` and
 /// if ``reg`` is not a valid, non-null pointer to a ``QkClassicalRegister``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_add_classical_register(
     dag: *mut DAGCircuit,
     reg: *const ClassicalRegister,
@@ -137,7 +134,6 @@ pub unsafe extern "C" fn qk_dag_add_classical_register(
 ///
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_num_qubits(dag: *const DAGCircuit) -> u32 {
     // SAFETY: Per documentation, the pointer is to valid data.
     let dag = unsafe { const_ptr_as_ref(dag) };
@@ -165,7 +161,6 @@ pub unsafe extern "C" fn qk_dag_num_qubits(dag: *const DAGCircuit) -> u32 {
 ///
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_num_clbits(dag: *const DAGCircuit) -> u32 {
     // SAFETY: Per documentation, the pointer is to valid data.
     let dag = unsafe { const_ptr_as_ref(dag) };
@@ -197,7 +192,6 @@ pub unsafe extern "C" fn qk_dag_num_clbits(dag: *const DAGCircuit) -> u32 {
 ///
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_num_op_nodes(dag: *const DAGCircuit) -> usize {
     // SAFETY: Per documentation, the pointer is to valid data.
     let dag = unsafe { const_ptr_as_ref(dag) };
@@ -243,7 +237,6 @@ pub enum CDagNodeType {
 ///
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_node_type(dag: *const DAGCircuit, node: u32) -> CDagNodeType {
     // SAFETY: Per documentation, the pointer is to valid data.
     let dag = unsafe { const_ptr_as_ref(dag) };
@@ -270,7 +263,6 @@ pub unsafe extern "C" fn qk_dag_node_type(dag: *const DAGCircuit, node: u32) -> 
 ///
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_qubit_in_node(dag: *const DAGCircuit, qubit: u32) -> u32 {
     // SAFETY: Per documentation, the pointer is to valid data.
     let dag = unsafe { const_ptr_as_ref(dag) };
@@ -289,7 +281,6 @@ pub unsafe extern "C" fn qk_dag_qubit_in_node(dag: *const DAGCircuit, qubit: u32
 ///
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_qubit_out_node(dag: *const DAGCircuit, qubit: u32) -> u32 {
     // SAFETY: Per documentation, the pointer is to valid data.
     let dag = unsafe { const_ptr_as_ref(dag) };
@@ -308,7 +299,6 @@ pub unsafe extern "C" fn qk_dag_qubit_out_node(dag: *const DAGCircuit, qubit: u3
 ///
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_clbit_in_node(dag: *const DAGCircuit, clbit: u32) -> u32 {
     // SAFETY: Per documentation, the pointer is to valid data.
     let dag = unsafe { const_ptr_as_ref(dag) };
@@ -327,7 +317,6 @@ pub unsafe extern "C" fn qk_dag_clbit_in_node(dag: *const DAGCircuit, clbit: u32
 ///
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_clbit_out_node(dag: *const DAGCircuit, clbit: u32) -> u32 {
     // SAFETY: Per documentation, the pointer is to valid data.
     let dag = unsafe { const_ptr_as_ref(dag) };
@@ -346,7 +335,6 @@ pub unsafe extern "C" fn qk_dag_clbit_out_node(dag: *const DAGCircuit, clbit: u3
 ///
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_wire_node_value(dag: *const DAGCircuit, node: u32) -> u32 {
     // SAFETY: Per documentation, the pointer is to valid data.
     let dag = unsafe { const_ptr_as_ref(dag) };
@@ -375,7 +363,6 @@ pub unsafe extern "C" fn qk_dag_wire_node_value(dag: *const DAGCircuit, node: u3
 ///
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_op_node_num_qubits(dag: *const DAGCircuit, node: u32) -> u32 {
     // SAFETY: Per documentation, the pointer is to valid data.
     let dag = unsafe { const_ptr_as_ref(dag) };
@@ -397,7 +384,6 @@ pub unsafe extern "C" fn qk_dag_op_node_num_qubits(dag: *const DAGCircuit, node:
 ///
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_op_node_num_clbits(dag: *const DAGCircuit, node: u32) -> u32 {
     // SAFETY: Per documentation, the pointer is to valid data.
     let dag = unsafe { const_ptr_as_ref(dag) };
@@ -419,7 +405,6 @@ pub unsafe extern "C" fn qk_dag_op_node_num_clbits(dag: *const DAGCircuit, node:
 ///
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_op_node_num_params(dag: *const DAGCircuit, node: u32) -> u32 {
     // SAFETY: Per documentation, the pointer is to valid data.
     let dag = unsafe { const_ptr_as_ref(dag) };
@@ -442,7 +427,6 @@ pub unsafe extern "C" fn qk_dag_op_node_num_params(dag: *const DAGCircuit, node:
 ///
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_op_node_qubits(dag: *const DAGCircuit, node: u32) -> *const u32 {
     // SAFETY: Per documentation, the pointer is to valid data.
     let dag = unsafe { const_ptr_as_ref(dag) };
@@ -465,7 +449,6 @@ pub unsafe extern "C" fn qk_dag_op_node_qubits(dag: *const DAGCircuit, node: u32
 ///
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_op_node_clbits(dag: *const DAGCircuit, node: u32) -> *const u32 {
     // SAFETY: Per documentation, the pointer is to valid data.
     let dag = unsafe { const_ptr_as_ref(dag) };
@@ -511,7 +494,6 @@ pub unsafe extern "C" fn qk_dag_op_node_clbits(dag: *const DAGCircuit, node: u32
 ///
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_apply_gate(
     dag: *mut DAGCircuit,
     gate: StandardGate,
@@ -619,7 +601,6 @@ pub unsafe extern "C" fn qk_dag_apply_gate(
 /// Behavior is undefined if `dag` is not an aligned, non-null pointer to a valid ``QkDag``,
 /// or if `qubit` or `clbit` are out of range.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_apply_measure(
     dag: *mut DAGCircuit,
     qubit: u32,
@@ -680,7 +661,6 @@ pub unsafe extern "C" fn qk_dag_apply_measure(
 /// Behavior is undefined if `dag` is not an aligned, non-null pointer to a valid ``QkDag``,
 /// or if `qubit` is out of range.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_apply_reset(dag: *mut DAGCircuit, qubit: u32, front: bool) -> u32 {
     // SAFETY: per documentation, `dag` points to valid data.
     let dag = unsafe { mut_ptr_as_ref(dag) };
@@ -746,7 +726,6 @@ pub unsafe extern "C" fn qk_dag_apply_reset(dag: *mut DAGCircuit, qubit: u32, fr
 /// * `qubits` is not aligned or is not valid for `num_qubits` reads of initialized, in-bounds and
 ///   unduplicated indices, unless `qubits` is null.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_apply_barrier(
     dag: *mut DAGCircuit,
     qubits: *const u32,
@@ -817,7 +796,6 @@ pub unsafe extern "C" fn qk_dag_apply_barrier(
 /// * `matrix` is not an aligned pointer to `4**num_qubits` initialized values,
 /// * `qubits` is not an aligned pointer to `num_qubits` initialized values.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_apply_unitary(
     dag: *mut DAGCircuit,
     matrix: *const Complex64,
@@ -904,7 +882,6 @@ pub unsafe extern "C" fn qk_dag_apply_unitary(
 /// You can check ``qk_dag_op_node_num_params`` to determine how many params
 /// are required for any given operation node.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_op_node_gate_op(
     dag: *const DAGCircuit,
     node: u32,
@@ -947,7 +924,6 @@ pub unsafe extern "C" fn qk_dag_op_node_gate_op(
 /// Behavior is undefined if `dag` is not a non-null pointer to a valid `QkDag`, if `out` is
 /// unaligned, or if `out` is not valid for `4**num_qubits` writes of `QkComplex64`.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_op_node_unitary(
     dag: *const DAGCircuit,
     node: u32,
@@ -1025,7 +1001,6 @@ pub enum COperationKind {
 ///
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_op_node_kind(dag: *const DAGCircuit, node: u32) -> COperationKind {
     // SAFETY: Per documentation, the pointer is to valid data.
     let dag = unsafe { const_ptr_as_ref(dag) };
@@ -1095,7 +1070,6 @@ pub struct CDagNeighbors {
 ///
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_successors(dag: *const DAGCircuit, node: u32) -> CDagNeighbors {
     // SAFETY: Per documentation, the pointers are to valid data.
     let dag = unsafe { const_ptr_as_ref(dag) };
@@ -1142,7 +1116,6 @@ pub unsafe extern "C" fn qk_dag_successors(dag: *const DAGCircuit, node: u32) ->
 ///
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_predecessors(dag: *const DAGCircuit, node: u32) -> CDagNeighbors {
     // SAFETY: Per documentation, the pointers are to valid data.
     let dag = unsafe { const_ptr_as_ref(dag) };
@@ -1170,7 +1143,6 @@ pub unsafe extern "C" fn qk_dag_predecessors(dag: *const DAGCircuit, node: u32) 
 /// Behavior is undefined if ``neighbors`` is not a valid, non-null pointer to a QkDagNeighbors
 /// object populated with either ``qk_dag_successors`` or ``qk_dag_predecessors``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_neighbors_clear(neighbors: *mut CDagNeighbors) {
     // SAFETY: Per documentation, the pointer is to a valid data.
     let neighbors = unsafe { mut_ptr_as_ref(neighbors) };
@@ -1230,7 +1202,6 @@ pub unsafe extern "C" fn qk_dag_neighbors_clear(neighbors: *mut CDagNeighbors) {
 /// Behavior is undefined if either `dag` or `instruction` are not valid, aligned, non-null pointers
 /// to the relevant data type.  The fields of `instruction` need not be initialized.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_get_instruction(
     dag: *const DAGCircuit,
     index: u32,
@@ -1317,7 +1288,6 @@ pub unsafe extern "C" fn qk_dag_get_instruction(
 /// If ``qubit`` nor ``clbit`` are NULL, it must contains a less or equal amount
 /// than what the circuit owns.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_compose(
     dag: *mut DAGCircuit,
     other: *const DAGCircuit,
@@ -1383,7 +1353,6 @@ pub unsafe extern "C" fn qk_dag_compose(
 /// Behavior is undefined if ``dag`` is not either null or a valid pointer to a
 /// ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_free(dag: *mut DAGCircuit) {
     if !dag.is_null() {
         if !dag.is_aligned() {
@@ -1427,7 +1396,6 @@ pub unsafe extern "C" fn qk_dag_free(dag: *mut DAGCircuit) {
 ///
 /// Behavior is undefined if ``dag`` is not a valid, non-null pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_to_circuit(dag: *const DAGCircuit) -> *mut CircuitData {
     // SAFETY: Per documentation, the pointer is to valid data.
     let dag = unsafe { const_ptr_as_ref(dag) };
@@ -1480,7 +1448,6 @@ pub unsafe extern "C" fn qk_dag_to_circuit(dag: *const DAGCircuit) -> *mut Circu
 /// or if ``out_order`` is not a valid, non-null pointer to a sequence of ``qk_dag_num_op_nodes(dag)``
 /// consecutive elements of ``uint32_t``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_topological_op_nodes(dag: *const DAGCircuit, out_order: *mut u32) {
     // SAFETY: Per documentation, ``dag`` is non-null and valid.
     let dag = unsafe { const_ptr_as_ref(dag) };
@@ -1542,7 +1509,6 @@ pub unsafe extern "C" fn qk_dag_topological_op_nodes(dag: *const DAGCircuit, out
 /// Behavior is undefined if ``dag`` and ``replacement`` are not a valid, non-null pointer to a
 /// ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_substitute_node_with_dag(
     dag: *mut DAGCircuit,
     node: u32,
@@ -1606,7 +1572,6 @@ pub unsafe extern "C" fn qk_dag_substitute_node_with_dag(
 ///
 /// Behavior is undefined if ``dag`` is not a valid pointer to a ``QkDag``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_dag_copy_empty_like(
     dag: *const DAGCircuit,
     vars_mode: CVarsMode,

--- a/crates/cext/src/param.rs
+++ b/crates/cext/src/param.rs
@@ -40,7 +40,6 @@ use qiskit_circuit::parameter::symbol_expr::{Symbol, SymbolExpr, Value};
 /// nul terminator at the end of the string. It also must be valid for reads of
 /// bytes up to and including the nul terminator.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_new_symbol(name: *const c_char) -> *mut Param {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let name = unsafe { CStr::from_ptr(name).to_str().unwrap() };
@@ -73,7 +72,6 @@ pub unsafe extern "C" fn qk_param_new_symbol(name: *const c_char) -> *mut Param 
 /// ```
 ///
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub extern "C" fn qk_param_zero() -> *mut Param {
     Box::into_raw(Box::new(Param::Float(0.)))
 }
@@ -94,7 +92,6 @@ pub extern "C" fn qk_param_zero() -> *mut Param {
 ///
 /// Behavior is undefined if ``param`` is not either null or a valid pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_free(param: *mut Param) {
     if !param.is_null() {
         if !param.is_aligned() {
@@ -123,7 +120,6 @@ pub unsafe extern "C" fn qk_param_free(param: *mut Param) {
 /// ```
 ///
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub extern "C" fn qk_param_from_double(value: f64) -> *mut Param {
     let value = Param::Float(value);
     Box::into_raw(Box::new(value))
@@ -144,7 +140,6 @@ pub extern "C" fn qk_param_from_double(value: f64) -> *mut Param {
 /// ```
 ///
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub extern "C" fn qk_param_from_complex(value: Complex64) -> *mut Param {
     let value = SymbolExpr::Value(Value::Complex(value));
     let expr = ParameterExpression::from_symbol_expr(value);
@@ -170,7 +165,6 @@ pub extern "C" fn qk_param_from_complex(value: Complex64) -> *mut Param {
 ///
 /// The behavior is undefined if ``param`` is not a valid pointer to a non-null ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_copy(param: *const Param) -> *mut Param {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let expr = unsafe { const_ptr_as_ref(param) };
@@ -205,7 +199,6 @@ pub unsafe extern "C" fn qk_param_copy(param: *const Param) -> *mut Param {
 /// Do not change the length of the string after it's returned (by writing a nul byte somewhere
 /// inside the string or removing the final one), although values can be mutated.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_str(param: *const Param) -> *mut c_char {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let expr = unsafe { const_ptr_as_ref(param) };
@@ -241,7 +234,6 @@ pub unsafe extern "C" fn qk_param_str(param: *const Param) -> *mut c_char {
 /// The behavior is undefined if any of ``out``, ``lhs`` or ``rhs`` is not a valid, non-null
 /// pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_add(
     out: *mut Param,
     lhs: *const Param,
@@ -298,7 +290,6 @@ pub unsafe extern "C" fn qk_param_add(
 /// The behavior is undefined if any of ``out``, ``lhs`` or ``rhs`` is not a valid, non-null
 /// pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_sub(
     out: *mut Param,
     lhs: *const Param,
@@ -354,7 +345,6 @@ pub unsafe extern "C" fn qk_param_sub(
 /// The behavior is undefined if any of ``out``, ``lhs`` or ``rhs`` is not a valid, non-null
 /// pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_mul(
     out: *mut Param,
     lhs: *const Param,
@@ -410,7 +400,6 @@ pub unsafe extern "C" fn qk_param_mul(
 /// The behavior is undefined if any of ``out``, ``num`` or ``den`` is not a valid, non-null
 /// pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_div(
     out: *mut Param,
     num: *const Param,
@@ -466,7 +455,6 @@ pub unsafe extern "C" fn qk_param_div(
 /// The behavior is undefined if any of ``out``, ``base`` or ``pow`` is not a valid, non-null
 /// pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_pow(
     out: *mut Param,
     base: *const Param,
@@ -522,7 +510,6 @@ pub unsafe extern "C" fn qk_param_pow(
 /// The behavior is undefined if any of ``out`` or ``src`` is not a valid, non-null
 /// pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_sin(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
@@ -562,7 +549,6 @@ pub unsafe extern "C" fn qk_param_sin(out: *mut Param, src: *const Param) -> Exi
 /// The behavior is undefined if any of ``out`` or ``src`` is not a valid, non-null
 /// pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_cos(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
@@ -602,7 +588,6 @@ pub unsafe extern "C" fn qk_param_cos(out: *mut Param, src: *const Param) -> Exi
 /// The behavior is undefined if any of ``out`` or ``src`` is not a valid, non-null
 /// pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_tan(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
@@ -642,7 +627,6 @@ pub unsafe extern "C" fn qk_param_tan(out: *mut Param, src: *const Param) -> Exi
 /// The behavior is undefined if any of ``out`` or ``src`` is not a valid, non-null
 /// pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_asin(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
@@ -682,7 +666,6 @@ pub unsafe extern "C" fn qk_param_asin(out: *mut Param, src: *const Param) -> Ex
 /// The behavior is undefined if any of ``out`` or ``src`` is not a valid, non-null
 /// pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_acos(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
@@ -722,7 +705,6 @@ pub unsafe extern "C" fn qk_param_acos(out: *mut Param, src: *const Param) -> Ex
 /// The behavior is undefined if any of ``out`` or ``src`` is not a valid, non-null
 /// pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_atan(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
@@ -762,7 +744,6 @@ pub unsafe extern "C" fn qk_param_atan(out: *mut Param, src: *const Param) -> Ex
 /// The behavior is undefined if any of ``out`` or ``src`` is not a valid, non-null
 /// pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_log(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
@@ -802,7 +783,6 @@ pub unsafe extern "C" fn qk_param_log(out: *mut Param, src: *const Param) -> Exi
 /// The behavior is undefined if any of ``out`` or ``src`` is not a valid, non-null
 /// pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_exp(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
@@ -842,7 +822,6 @@ pub unsafe extern "C" fn qk_param_exp(out: *mut Param, src: *const Param) -> Exi
 /// The behavior is undefined if any of ``out`` or ``src`` is not a valid, non-null
 /// pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_abs(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
@@ -882,7 +861,6 @@ pub unsafe extern "C" fn qk_param_abs(out: *mut Param, src: *const Param) -> Exi
 /// The behavior is undefined if any of ``out`` or ``src`` is not a valid, non-null
 /// pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_sign(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
@@ -922,7 +900,6 @@ pub unsafe extern "C" fn qk_param_sign(out: *mut Param, src: *const Param) -> Ex
 /// The behavior is undefined if any of ``out`` or ``src`` is not a valid, non-null
 /// pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_neg(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
@@ -962,7 +939,6 @@ pub unsafe extern "C" fn qk_param_neg(out: *mut Param, src: *const Param) -> Exi
 /// The behavior is undefined if any of ``out`` or ``src`` is not a valid, non-null
 /// pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_conjugate(out: *mut Param, src: *const Param) -> ExitCode {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let out = unsafe { mut_ptr_as_ref(out) };
@@ -1007,7 +983,6 @@ pub unsafe extern "C" fn qk_param_conjugate(out: *mut Param, src: *const Param) 
 /// The behavior is undefined if any of ``lhs`` or ``rhs`` is not a valid, non-null
 /// pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_equal(lhs: *const Param, rhs: *const Param) -> bool {
     // SAFETY: Per documentation, the pointers are non-null and aligned.
     let lhs = unsafe { const_ptr_as_ref(lhs) };
@@ -1046,7 +1021,6 @@ pub unsafe extern "C" fn qk_param_equal(lhs: *const Param, rhs: *const Param) ->
 ///
 /// The behavior is undefined if ``param`` is not a valid, non-null pointer to a ``QkParam``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_param_as_real(param: *const Param) -> f64 {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let param = unsafe { const_ptr_as_ref(param) };

--- a/crates/cext/src/sparse_observable.rs
+++ b/crates/cext/src/sparse_observable.rs
@@ -82,7 +82,6 @@ impl TryFrom<&CSparseTerm> for SparseTermView<'_> {
 /// ```
 ///
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub extern "C" fn qk_obs_zero(num_qubits: u32) -> *mut SparseObservable {
     let obs = SparseObservable::zero(num_qubits);
     Box::into_raw(Box::new(obs))
@@ -101,7 +100,6 @@ pub extern "C" fn qk_obs_zero(num_qubits: u32) -> *mut SparseObservable {
 /// ```
 ///
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub extern "C" fn qk_obs_identity(num_qubits: u32) -> *mut SparseObservable {
     let obs = SparseObservable::identity(num_qubits);
     Box::into_raw(Box::new(obs))
@@ -155,7 +153,6 @@ pub extern "C" fn qk_obs_identity(num_qubits: u32) -> *mut SparseObservable {
 ///     sorted in ascending order, the first element is 0 and the last element is
 ///     smaller than ``num_terms``
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_new(
     num_qubits: u32,
     num_terms: u64,
@@ -194,7 +191,6 @@ pub unsafe extern "C" fn qk_obs_new(
 ///
 /// Behavior is undefined if ``obs`` is not either null or a valid pointer to a ``QkObs``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_free(obs: *mut SparseObservable) {
     if !obs.is_null() {
         if !obs.is_aligned() {
@@ -234,7 +230,6 @@ pub unsafe extern "C" fn qk_obs_free(obs: *mut SparseObservable) {
 ///   * ``obs`` is a valid, non-null pointer to a ``QkObs``
 ///   * ``cterm`` is a valid, non-null pointer to a ``QkObsTerm``
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_add_term(
     obs: *mut SparseObservable,
     cterm: *const CSparseTerm,
@@ -283,7 +278,6 @@ pub unsafe extern "C" fn qk_obs_add_term(
 /// * ``obs`` is a valid, non-null pointer to a ``QkObs``
 /// * ``out`` is a valid, non-null pointer to a ``QkObsTerm``
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_term(
     obs: *mut SparseObservable,
     index: u64,
@@ -327,7 +321,6 @@ pub unsafe extern "C" fn qk_obs_term(
 ///
 /// Behavior is undefined ``obs`` is not a valid, non-null pointer to a ``QkObs``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_num_terms(obs: *const SparseObservable) -> usize {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let obs = unsafe { const_ptr_as_ref(obs) };
@@ -352,7 +345,6 @@ pub unsafe extern "C" fn qk_obs_num_terms(obs: *const SparseObservable) -> usize
 ///
 /// Behavior is undefined ``obs`` is not a valid, non-null pointer to a ``QkObs``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_num_qubits(obs: *const SparseObservable) -> u32 {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let obs = unsafe { const_ptr_as_ref(obs) };
@@ -377,7 +369,6 @@ pub unsafe extern "C" fn qk_obs_num_qubits(obs: *const SparseObservable) -> u32 
 ///
 /// Behavior is undefined ``obs`` is not a valid, non-null pointer to a ``QkObs``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_len(obs: *const SparseObservable) -> usize {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let obs = unsafe { const_ptr_as_ref(obs) };
@@ -410,7 +401,6 @@ pub unsafe extern "C" fn qk_obs_len(obs: *const SparseObservable) -> usize {
 ///
 /// Behavior is undefined ``obs`` is not a valid, non-null pointer to a ``QkObs``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_coeffs(obs: *mut SparseObservable) -> *mut Complex64 {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let obs = unsafe { mut_ptr_as_ref(obs) };
@@ -453,7 +443,6 @@ pub unsafe extern "C" fn qk_obs_coeffs(obs: *mut SparseObservable) -> *mut Compl
 ///
 /// Behavior is undefined ``obs`` is not a valid, non-null pointer to a ``QkObs``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_indices(obs: *mut SparseObservable) -> *mut u32 {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let obs = unsafe { mut_ptr_as_ref(obs) };
@@ -495,7 +484,6 @@ pub unsafe extern "C" fn qk_obs_indices(obs: *mut SparseObservable) -> *mut u32 
 ///
 /// Behavior is undefined ``obs`` is not a valid, non-null pointer to a ``QkObs``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_boundaries(obs: *mut SparseObservable) -> *mut usize {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let obs = unsafe { mut_ptr_as_ref(obs) };
@@ -541,7 +529,6 @@ pub unsafe extern "C" fn qk_obs_boundaries(obs: *mut SparseObservable) -> *mut u
 /// Behavior is undefined ``obs`` is not a valid, non-null pointer to a ``QkObs``,
 /// or if invalid valus are written into the resulting ``QkBitTerm`` pointer.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_bit_terms(obs: *mut SparseObservable) -> *mut BitTerm {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let obs = unsafe { mut_ptr_as_ref(obs) };
@@ -570,7 +557,6 @@ pub unsafe extern "C" fn qk_obs_bit_terms(obs: *mut SparseObservable) -> *mut Bi
 /// * ``obs`` is a valid, non-null pointer to a ``QkObs``
 /// * ``coeff`` is a valid, non-null pointer to a ``QkComplex64``
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_multiply(
     obs: *const SparseObservable,
     coeff: *const Complex64,
@@ -603,7 +589,6 @@ pub unsafe extern "C" fn qk_obs_multiply(
 /// Behavior is undefined if ``left`` or ``right`` are not valid, non-null pointers to
 /// ``QkObs``\ s.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_add(
     left: *const SparseObservable,
     right: *const SparseObservable,
@@ -637,7 +622,6 @@ pub unsafe extern "C" fn qk_obs_add(
 /// Behavior is undefined if ``first`` or ``second`` are not valid, non-null pointers to
 /// ``QkObs``\ s.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_compose(
     first: *const SparseObservable,
     second: *const SparseObservable,
@@ -678,7 +662,6 @@ pub unsafe extern "C" fn qk_obs_compose(
 ///   * ``qargs`` must point to an array of ``uint32_t``, readable for ``qk_obs_num_qubits(second)``
 ///     elements (meaning the number of qubits in ``second``)
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_compose_map(
     first: *const SparseObservable,
     second: *const SparseObservable,
@@ -761,7 +744,6 @@ pub unsafe extern "C" fn qk_obs_compose_map(
 /// is not a valid, non-null pointer to a sequence of ``qk_obs_num_qubits(obs)`` consecutive
 /// elements of ``uint32_t``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_apply_layout(
     obs: *mut SparseObservable,
     layout: *const u32,
@@ -815,7 +797,6 @@ pub unsafe extern "C" fn qk_obs_apply_layout(
 ///
 /// Behavior is undefined ``obs`` is not a valid, non-null pointer to a ``QkObs``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_canonicalize(
     obs: *const SparseObservable,
     tol: f64,
@@ -844,7 +825,6 @@ pub unsafe extern "C" fn qk_obs_canonicalize(
 ///
 /// Behavior is undefined ``obs`` is not a valid, non-null pointer to a ``QkObs``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_copy(obs: *const SparseObservable) -> *mut SparseObservable {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let obs = unsafe { const_ptr_as_ref(obs) };
@@ -876,7 +856,6 @@ pub unsafe extern "C" fn qk_obs_copy(obs: *const SparseObservable) -> *mut Spars
 /// Behavior is undefined if ``obs`` or ``other`` are not valid, non-null pointers to
 /// ``QkObs``\ s.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_equal(
     obs: *const SparseObservable,
     other: *const SparseObservable,
@@ -913,7 +892,6 @@ pub unsafe extern "C" fn qk_obs_equal(
 /// Do not change the length of the string after it's returned (by writing a nul byte somewhere
 /// inside the string or removing the final one), although values can be mutated.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_str(obs: *const SparseObservable) -> *mut c_char {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let obs = unsafe { const_ptr_as_ref(obs) };
@@ -932,7 +910,6 @@ pub unsafe extern "C" fn qk_obs_str(obs: *const SparseObservable) -> *mut c_char
 /// Behavior is undefined if ``str`` is not a pointer returned by ``qk_obs_str`` or
 /// ``qk_obsterm_str``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_str_free(string: *mut c_char) {
     if !string.is_null() {
         if !string.is_aligned() {
@@ -972,7 +949,6 @@ pub unsafe extern "C" fn qk_str_free(string: *mut c_char) {
 ///
 /// Do not change the length of the string after it's returned, although values can be mutated.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obsterm_str(term: *const CSparseTerm) -> *mut c_char {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let term = unsafe { const_ptr_as_ref(term) };
@@ -1000,7 +976,6 @@ pub unsafe extern "C" fn qk_obsterm_str(term: *const CSparseTerm) -> *mut c_char
 ///
 /// The behavior is undefined if ``bit_term`` is not a valid ``uint8_t`` value of a ``QkBitTerm``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub extern "C" fn qk_bitterm_label(bit_term: BitTerm) -> u8 {
     // BitTerm is implemented as u8, which is calling convention compatible with C,
     // hence we can pass ``bit_term`` by value
@@ -1027,7 +1002,6 @@ pub extern "C" fn qk_bitterm_label(bit_term: BitTerm) -> u8 {
 /// function.
 #[unsafe(no_mangle)]
 #[cfg(feature = "python_binding")]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_obs_to_python(obs: *const SparseObservable) -> *mut PyObject {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let obs = unsafe { const_ptr_as_ref(obs) };

--- a/crates/cext/src/transpiler/neighbors.rs
+++ b/crates/cext/src/transpiler/neighbors.rs
@@ -67,7 +67,6 @@ pub struct CNeighbors {
 ///
 /// `neighbors` must point to a valid, initialized `QkNeighbors` object.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_neighbors_is_all_to_all(neighbors: *const CNeighbors) -> bool {
     // SAFETY: per documentation, `neighbors` points to a valid initialized `CNeighbors`.
     unsafe { (*neighbors).neighbors.is_null() && (*neighbors).partition.is_null() }
@@ -111,7 +110,6 @@ pub unsafe extern "C" fn qk_neighbors_is_all_to_all(neighbors: *const CNeighbors
 /// `target` must point to a valid `QkTarget` object.  `neighbors` must be aligned and safe to write
 /// to, but need not be initialized.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_neighbors_from_target(
     target: *const Target,
     neighbors: *mut CNeighbors,
@@ -168,7 +166,6 @@ pub unsafe extern "C" fn qk_neighbors_from_target(
 /// `neighbors` must point to a valid, initialized `QkNeighbors` object, which must have been
 /// initialized by a call to `qk_neighbors_from_target` and unaltered since then.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_neighbors_clear(neighbors: *mut CNeighbors) {
     // SAFETY: per documentation, `neighbors` points to a valid initialised `CNeighbors`.
     let neighbors = unsafe { mut_ptr_as_ref(neighbors) };

--- a/crates/cext/src/transpiler/passes/basis_translator.rs
+++ b/crates/cext/src/transpiler/passes/basis_translator.rs
@@ -59,7 +59,6 @@ use qiskit_transpiler::target::Target;
 /// Behavior is undefined if ``circuit`` and/or ``target`` are not valid, non-null
 /// pointers to a ``QkCircuit`` or ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpiler_pass_standalone_basis_translator(
     circuit: *mut CircuitData,
     target: *const Target,

--- a/crates/cext/src/transpiler/passes/commutative_cancellation.rs
+++ b/crates/cext/src/transpiler/passes/commutative_cancellation.rs
@@ -53,7 +53,6 @@ use qiskit_transpiler::target::Target;
 /// Behavior is undefined if ``circuit`` or ``target`` is not a valid, ``QkCircuit`` and ``QkTarget``.
 /// ``QkCircuit`` is not expected to be null and behavior is undefined if it is.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpiler_pass_standalone_commutative_cancellation(
     circuit: *mut CircuitData,
     target: *const Target,

--- a/crates/cext/src/transpiler/passes/consolidate_blocks.rs
+++ b/crates/cext/src/transpiler/passes/consolidate_blocks.rs
@@ -35,7 +35,6 @@ use crate::pointers::{const_ptr_as_ref, mut_ptr_as_ref};
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit`` and
 /// if ``target`` is not a valid pointer to a ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpiler_pass_standalone_consolidate_blocks(
     circuit: *mut CircuitData,
     target: *const Target,

--- a/crates/cext/src/transpiler/passes/elide_permutations.rs
+++ b/crates/cext/src/transpiler/passes/elide_permutations.rs
@@ -57,7 +57,6 @@ use qiskit_transpiler::transpile_layout::TranspileLayout;
 ///
 /// Behavior is undefined if ``circuit``  is not a valid, non-null pointer to a ``QkCircuit``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpiler_pass_standalone_elide_permutations(
     circuit: *mut CircuitData,
 ) -> *mut TranspileLayout {

--- a/crates/cext/src/transpiler/passes/gate_direction.rs
+++ b/crates/cext/src/transpiler/passes/gate_direction.rs
@@ -47,7 +47,6 @@ use qiskit_transpiler::target::Target;
 ///
 /// Behavior is undefined if ``circuit`` or ``target`` are not valid, non-null pointers to ``QkCircuit`` and ``QkTarget`` objects, respectively.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpiler_pass_standalone_check_gate_direction(
     circuit: *const CircuitData,
     target: *const Target,
@@ -93,7 +92,6 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_check_gate_direction(
 ///
 /// Behavior is undefined if ``circuit`` or ``target`` are not valid, non-null pointers to ``QkCircuit`` and ``QkTarget`` objects, respectively.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpiler_pass_standalone_gate_direction(
     circuit: *mut CircuitData,
     target: *const Target,

--- a/crates/cext/src/transpiler/passes/inverse_cancellation.rs
+++ b/crates/cext/src/transpiler/passes/inverse_cancellation.rs
@@ -63,7 +63,6 @@ use qiskit_transpiler::passes::run_inverse_cancellation_standard_gates;
 ///
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpiler_pass_standalone_inverse_cancellation(
     circuit: *mut CircuitData,
 ) {

--- a/crates/cext/src/transpiler/passes/optimize_1q_sequences.rs
+++ b/crates/cext/src/transpiler/passes/optimize_1q_sequences.rs
@@ -68,7 +68,6 @@ use qiskit_transpiler::{passes::run_optimize_1q_gates_decomposition, target::Tar
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit`` and
 /// if ``target`` is not a valid pointer to a ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpiler_standalone_optimize_1q_sequences(
     circuit: *mut CircuitData,
     target: *const Target,

--- a/crates/cext/src/transpiler/passes/remove_diagonal_gates_before_measure.rs
+++ b/crates/cext/src/transpiler/passes/remove_diagonal_gates_before_measure.rs
@@ -39,7 +39,6 @@ use qiskit_transpiler::passes::run_remove_diagonal_before_measure;
 ///
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpiler_pass_standalone_remove_diagonal_gates_before_measure(
     circuit: *mut CircuitData,
 ) {

--- a/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
+++ b/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
@@ -78,7 +78,6 @@ use qiskit_transpiler::target::Target;
 ///
 /// Behavior is undefined if ``circuit`` or ``target`` is not a valid, non-null pointer to a ``QkCircuit`` and ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpiler_pass_standalone_remove_identity_equivalent(
     circuit: *mut CircuitData,
     target: *const Target,

--- a/crates/cext/src/transpiler/passes/sabre_layout.rs
+++ b/crates/cext/src/transpiler/passes/sabre_layout.rs
@@ -105,7 +105,6 @@ pub extern "C" fn qk_sabre_layout_options_default() -> SabreLayoutOptions {
 ///
 /// Behavior is undefined if ``circuit`` or ``target`` is not a valid, non-null pointer to a ``QkCircuit`` and ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpiler_pass_standalone_sabre_layout(
     circuit: *mut CircuitData,
     target: *const Target,

--- a/crates/cext/src/transpiler/passes/split_2q_unitaries.rs
+++ b/crates/cext/src/transpiler/passes/split_2q_unitaries.rs
@@ -48,7 +48,6 @@ use qiskit_transpiler::transpile_layout::TranspileLayout;
 ///
 /// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to a ``QkCircuit``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpiler_pass_standalone_split_2q_unitaries(
     circuit: *mut CircuitData,
     requested_fidelity: f64,

--- a/crates/cext/src/transpiler/passes/unitary_synthesis.rs
+++ b/crates/cext/src/transpiler/passes/unitary_synthesis.rs
@@ -66,7 +66,6 @@ use qiskit_transpiler::target::Target;
 ///
 /// Behavior is undefined if ``circuit`` or ``target`` is not a valid, non-null pointer to a ``QkCircuit`` and ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpiler_pass_standalone_unitary_synthesis(
     circuit: *mut CircuitData,
     target: *const Target,

--- a/crates/cext/src/transpiler/passes/vf2.rs
+++ b/crates/cext/src/transpiler/passes/vf2.rs
@@ -41,7 +41,6 @@ pub struct VF2LayoutResult(Vf2PassReturn);
 /// Behavior is undefined if ``layout`` is not a valid, non-null pointer to a
 /// ``QkVF2LayoutResult``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_vf2_layout_result_has_match(layout: *const VF2LayoutResult) -> bool {
     // SAFETY: per documentation this is a valid pointer to a layout.
     let layout = unsafe { const_ptr_as_ref(layout) };
@@ -60,7 +59,6 @@ pub unsafe extern "C" fn qk_vf2_layout_result_has_match(layout: *const VF2Layout
 /// Behavior is undefined if ``layout`` is not a valid, non-null pointer to a
 /// ``QkVF2LayoutResult``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_vf2_layout_result_has_improvement(
     layout: *const VF2LayoutResult,
 ) -> bool {
@@ -83,7 +81,6 @@ pub unsafe extern "C" fn qk_vf2_layout_result_has_improvement(
 /// ``QkVF2LayoutResult`` containing a result, or if the qubit is out of range for the initial
 /// circuit.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_vf2_layout_result_map_virtual_qubit(
     layout: *const VF2LayoutResult,
     qubit: u32,
@@ -112,7 +109,6 @@ pub unsafe extern "C" fn qk_vf2_layout_result_map_virtual_qubit(
 ///
 /// Behavior is undefined if ``layout`` is not a valid, non-null pointer to a ``QkVF2Layout``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_vf2_layout_result_free(layout: *mut VF2LayoutResult) {
     if !layout.is_null() {
         if !layout.is_aligned() {
@@ -137,7 +133,6 @@ pub struct VF2LayoutConfiguration(Vf2PassConfiguration);
 ///
 /// @return A pointer to the configuration.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub extern "C" fn qk_vf2_layout_configuration_new() -> *mut VF2LayoutConfiguration {
     Box::into_raw(Box::new(VF2LayoutConfiguration(
         Vf2PassConfiguration::default_unbounded(),
@@ -153,7 +148,6 @@ pub extern "C" fn qk_vf2_layout_configuration_new() -> *mut VF2LayoutConfigurati
 /// Behavior is undefined if ``config`` is a non-null pointer, but does not point to a valid,
 /// aligned `QkVF2LayoutConfiguration` object.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_vf2_layout_configuration_free(config: *mut VF2LayoutConfiguration) {
     if !config.is_null() {
         if !config.is_aligned() {
@@ -183,7 +177,6 @@ pub unsafe extern "C" fn qk_vf2_layout_configuration_free(config: *mut VF2Layout
 /// Behavior is undefined if `config` is not a valid, aligned, non-null pointer to a
 /// `QkVF2LayoutConfiguration`.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_vf2_layout_configuration_set_call_limit(
     config: *mut VF2LayoutConfiguration,
     before: i64,
@@ -208,7 +201,6 @@ pub unsafe extern "C" fn qk_vf2_layout_configuration_set_call_limit(
 /// Behavior is undefined if `config` is not a valid, aligned, non-null pointer to a
 /// `QkVF2LayoutConfiguration`.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_vf2_layout_configuration_set_time_limit(
     config: *mut VF2LayoutConfiguration,
     limit: f64,
@@ -232,7 +224,6 @@ pub unsafe extern "C" fn qk_vf2_layout_configuration_set_time_limit(
 /// Behavior is undefined if `config` is not a valid, aligned, non-null pointer to a
 /// `QkVF2LayoutConfiguration`.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_vf2_layout_configuration_set_max_trials(
     config: *mut VF2LayoutConfiguration,
     limit: u64,
@@ -260,7 +251,6 @@ pub unsafe extern "C" fn qk_vf2_layout_configuration_set_max_trials(
 /// Behavior is undefined if `config` is not a valid, aligned, non-null pointer to a
 /// `QkVF2LayoutConfiguration`.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_vf2_layout_configuration_set_shuffle_seed(
     config: *mut VF2LayoutConfiguration,
     seed: u64,
@@ -284,7 +274,6 @@ pub unsafe extern "C" fn qk_vf2_layout_configuration_set_shuffle_seed(
 /// Behavior is undefined if `config` is not a valid, aligned, non-null pointer to a
 /// `VF2LayoutConfiguration`.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_vf2_layout_configuration_set_score_initial(
     config: *mut VF2LayoutConfiguration,
     score_initial: bool,
@@ -355,7 +344,6 @@ pub unsafe extern "C" fn qk_vf2_layout_configuration_set_score_initial(
 /// `QkCircuit` and `QkTarget`.  Behavior is undefined if ``config`` is a non-null pointer that
 /// does not point to a valid `QkVF2LayoutConfiguration` object (but a null pointer is fine).
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpiler_pass_standalone_vf2_layout_average(
     circuit: *const CircuitData,
     target: *const Target,
@@ -447,7 +435,6 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_vf2_layout_average(
 /// `QkCircuit` and `QkTarget`.  Behavior is undefined if ``config`` is a non-null pointer that
 /// does not point to a valid `QkVF2LayoutConfiguration` object (but a null pointer is fine).
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpiler_pass_standalone_vf2_layout_exact(
     circuit: *const CircuitData,
     target: *const Target,
@@ -499,7 +486,6 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_vf2_layout_exact(
     note = "use `qk_transpiler_pass_standalone_vf2_layout_average` instead"
 )]
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpiler_pass_standalone_vf2_layout(
     circuit: *const CircuitData,
     target: *const Target,

--- a/crates/cext/src/transpiler/target.rs
+++ b/crates/cext/src/transpiler/target.rs
@@ -10,7 +10,6 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-#[cfg(feature = "cbinding")]
 use std::ffi::{CStr, CString, c_char};
 use std::ptr::null_mut;
 use std::sync::Arc;
@@ -45,7 +44,6 @@ use smallvec::{SmallVec, smallvec};
 /// ```
 ///
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub extern "C" fn qk_target_new(num_qubits: u32) -> *mut Target {
     let target = Target::new(
         None,
@@ -79,7 +77,6 @@ pub extern "C" fn qk_target_new(num_qubits: u32) -> *mut Target {
 ///
 /// Behavior is undefined if ``QkTarget`` is not a valid, non-null pointer to a ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_num_qubits(target: *const Target) -> u32 {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let target = unsafe { const_ptr_as_ref(target) };
@@ -104,7 +101,6 @@ pub unsafe extern "C" fn qk_target_num_qubits(target: *const Target) -> u32 {
 ///
 /// Behavior is undefined if ``QkTarget`` is not a valid, non-null pointer to a ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_dt(target: *const Target) -> f64 {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let target = unsafe { const_ptr_as_ref(target) };
@@ -129,7 +125,6 @@ pub unsafe extern "C" fn qk_target_dt(target: *const Target) -> f64 {
 ///
 /// Behavior is undefined if ``QkTarget`` is not a valid, non-null pointer to a ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_granularity(target: *const Target) -> u32 {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let target = unsafe { const_ptr_as_ref(target) };
@@ -154,7 +149,6 @@ pub unsafe extern "C" fn qk_target_granularity(target: *const Target) -> u32 {
 ///
 /// Behavior is undefined if ``QkTarget`` is not a valid, non-null pointer to a ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_min_length(target: *const Target) -> u32 {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let target = unsafe { const_ptr_as_ref(target) };
@@ -179,7 +173,6 @@ pub unsafe extern "C" fn qk_target_min_length(target: *const Target) -> u32 {
 ///
 /// Behavior is undefined if ``QkTarget`` is not a valid, non-null pointer to a ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_pulse_alignment(target: *const Target) -> u32 {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let target = unsafe { const_ptr_as_ref(target) };
@@ -204,7 +197,6 @@ pub unsafe extern "C" fn qk_target_pulse_alignment(target: *const Target) -> u32
 ///
 /// Behavior is undefined if ``QkTarget`` is not a valid, non-null pointer to a ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_acquire_alignment(target: *const Target) -> u32 {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let target = unsafe { const_ptr_as_ref(target) };
@@ -230,7 +222,6 @@ pub unsafe extern "C" fn qk_target_acquire_alignment(target: *const Target) -> u
 ///
 /// Behavior is undefined if ``QkTarget`` is not a valid, non-null pointer to a ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_set_dt(target: *mut Target, dt: f64) -> ExitCode {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let target = unsafe { mut_ptr_as_ref(target) };
@@ -258,7 +249,6 @@ pub unsafe extern "C" fn qk_target_set_dt(target: *mut Target, dt: f64) -> ExitC
 ///
 /// Behavior is undefined if ``QkTarget`` is not a valid, non-null pointer to a ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_set_granularity(
     target: *mut Target,
     granularity: u32,
@@ -289,7 +279,6 @@ pub unsafe extern "C" fn qk_target_set_granularity(
 ///
 /// Behavior is undefined if ``QkTarget`` is not a valid, non-null pointer to a ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_set_min_length(
     target: *mut Target,
     min_length: u32,
@@ -319,7 +308,6 @@ pub unsafe extern "C" fn qk_target_set_min_length(
 ///
 /// Behavior is undefined if ``QkTarget`` is not a valid, non-null pointer to a ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_set_pulse_alignment(
     target: *mut Target,
     pulse_alignment: u32,
@@ -350,7 +338,6 @@ pub unsafe extern "C" fn qk_target_set_pulse_alignment(
 ///
 /// Behavior is undefined if ``QkTarget`` is not a valid, non-null pointer to a ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_set_acquire_alignment(
     target: *mut Target,
     acquire_alignment: u32,
@@ -383,7 +370,6 @@ pub unsafe extern "C" fn qk_target_set_acquire_alignment(
 ///
 /// Behavior is undefined if ``QkTarget`` is not a valid, non-null pointer to a ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_copy(target: *mut Target) -> *mut Target {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let target = unsafe { const_ptr_as_ref(target) };
@@ -406,7 +392,6 @@ pub unsafe extern "C" fn qk_target_copy(target: *mut Target) -> *mut Target {
 ///
 /// Behavior is undefined if ``QkTarget`` is not a valid, non-null pointer to a ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_free(target: *mut Target) {
     if !target.is_null() {
         if !target.is_aligned() {
@@ -516,7 +501,6 @@ impl TargetEntry {
 ///     QkTargetEntry *had_entry = qk_target_entry_new(QkGate_H);
 /// ```
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub extern "C" fn qk_target_entry_new(operation: StandardGate) -> *mut TargetEntry {
     Box::into_raw(Box::new(TargetEntry::new(operation)))
 }
@@ -541,7 +525,6 @@ pub extern "C" fn qk_target_entry_new(operation: StandardGate) -> *mut TargetEnt
 ///     qk_target_add_instruction(measure_target, entry);
 /// ```
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub extern "C" fn qk_target_entry_new_measure() -> *mut TargetEntry {
     Box::into_raw(Box::new(TargetEntry::new_instruction(
         StandardInstruction::Measure,
@@ -568,7 +551,6 @@ pub extern "C" fn qk_target_entry_new_measure() -> *mut TargetEntry {
 ///     qk_target_add_instruction(reset_target, entry);
 /// ```
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub extern "C" fn qk_target_entry_new_reset() -> *mut TargetEntry {
     Box::into_raw(Box::new(TargetEntry::new_instruction(
         StandardInstruction::Reset,
@@ -605,7 +587,6 @@ pub extern "C" fn qk_target_entry_new_reset() -> *mut TargetEntry {
 /// The ``name`` pointer is expected to be either a C string comprising of valid UTF-8 characters
 /// or a null pointer.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_entry_new_fixed(
     operation: StandardGate,
     params: *mut f64,
@@ -650,7 +631,6 @@ pub unsafe extern "C" fn qk_target_entry_new_fixed(
 /// The behavior is undefined if ``entry`` is not a valid,
 /// non-null pointer to a ``QkTargetEntry`` object.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_entry_num_properties(entry: *const TargetEntry) -> usize {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let prop_map = unsafe { const_ptr_as_ref(entry) };
@@ -677,7 +657,6 @@ pub unsafe extern "C" fn qk_target_entry_num_properties(entry: *const TargetEntr
 /// The behavior is undefined if ``entry`` is not a valid,
 /// non-null pointer to a ``QkTargetEntry`` object.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_entry_free(entry: *mut TargetEntry) {
     if !entry.is_null() {
         if !entry.is_aligned() {
@@ -717,7 +696,6 @@ pub unsafe extern "C" fn qk_target_entry_free(entry: *mut TargetEntry) {
 /// The behavior is undefined if ``entry`` is not a valid, non-null pointer
 /// to a ``QkTargetEntry`` object.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_entry_add_property(
     entry: *mut TargetEntry,
     qargs: *mut u32,
@@ -766,7 +744,6 @@ pub unsafe extern "C" fn qk_target_entry_add_property(
 /// The ``name`` pointer is expected to be either a C string comprising
 /// of valid UTF-8 characters or a null pointer.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_entry_set_name(
     entry: *mut TargetEntry,
     name: *const c_char,
@@ -812,7 +789,6 @@ pub unsafe extern "C" fn qk_target_entry_set_name(
 ///
 /// Behavior is undefined if ``entry`` is not a valid, non-null pointer to a ``QkTargetEntry``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_add_instruction(
     target: *mut Target,
     target_entry: *mut TargetEntry,
@@ -886,7 +862,6 @@ pub unsafe extern "C" fn qk_target_add_instruction(
 /// a given gate. You can check ``qk_gate_num_qubits`` to determine how many qubits are required
 /// for a given gate.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_update_property(
     target: *mut Target,
     instruction: StandardGate,
@@ -937,7 +912,6 @@ pub unsafe extern "C" fn qk_target_update_property(
 ///
 /// Behavior is undefined if ``QkTarget`` is not a valid, non-null pointer to a ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_num_instructions(target: *const Target) -> usize {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let target = unsafe { const_ptr_as_ref(target) };
@@ -992,7 +966,6 @@ pub unsafe extern "C" fn qk_target_num_instructions(target: *const Target) -> us
 /// be undefined just as mentioned above for the ``qargs`` argument. You can always check ``qk_gate_num_params``
 /// in the case of a ``QkGate``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_instruction_supported(
     target: *const Target,
     operation_name: *const c_char,
@@ -1055,7 +1028,6 @@ pub unsafe extern "C" fn qk_target_instruction_supported(
 /// Behavior is undefined if ``QkTarget`` is not a valid, non-null pointer to a ``QkTarget``.
 /// Behavior is undefined if ``name`` is not a pointer to a valid null-terminated string.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_op_index(target: *const Target, name: *const c_char) -> usize {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
 
@@ -1093,7 +1065,6 @@ pub unsafe extern "C" fn qk_target_op_index(target: *const Target, name: *const 
 ///
 /// Behavior is undefined if ``QkTarget`` is not a valid, non-null pointer to a ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_op_name(target: *const Target, index: usize) -> *mut c_char {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let target_borrowed = unsafe { const_ptr_as_ref(target) };
@@ -1129,7 +1100,6 @@ pub unsafe extern "C" fn qk_target_op_name(target: *const Target, index: usize) 
 ///
 /// Behavior is undefined if ``QkTarget`` is not a valid, non-null pointer to a ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_op_num_properties(target: *const Target, index: usize) -> usize {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let target_borrowed = unsafe { const_ptr_as_ref(target) };
@@ -1167,7 +1137,6 @@ pub unsafe extern "C" fn qk_target_op_num_properties(target: *const Target, inde
 ///
 /// Behavior is undefined if ``QkTarget`` is not a valid, non-null pointer to a ``QkTarget``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_op_qargs_index(
     target: *const Target,
     op_idx: usize,
@@ -1226,7 +1195,6 @@ pub unsafe extern "C" fn qk_target_op_qargs_index(
 /// Behavior is undefined if each `qargs_out` or `qargs_len` are not aligned and writeable for a
 /// single value of the correct type.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_op_qargs(
     target: *const Target,
     op_idx: usize,
@@ -1281,7 +1249,6 @@ pub unsafe extern "C" fn qk_target_op_qargs(
 /// Behavior is undefined if ``inst_props`` does not point to an address of the correct size to
 /// store ``QkInstructionProperties`` in.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_op_props(
     target: *const Target,
     op_idx: usize,
@@ -1384,7 +1351,6 @@ pub struct CTargetOp {
 /// Behavior is undefined if ``out_op`` does not point to an address of the correct size to
 /// store ``QkTargetOp`` in.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_op_get(
     target: *const Target,
     index: usize,
@@ -1508,7 +1474,6 @@ pub unsafe extern "C" fn qk_target_op_get(
 ///
 /// Behavior is undefined if the ``target`` pointer is null or not aligned.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_op_gate(target: *const Target, index: usize) -> StandardGate {
     // SAFETY: Per documentation, the pointer is non-null and aligned.
     let target_borrowed = unsafe { const_ptr_as_ref(target) };
@@ -1536,7 +1501,6 @@ pub unsafe extern "C" fn qk_target_op_gate(target: *const Target, index: usize) 
 /// The data belonging to a ``QkTargetOp`` originates in Rust and
 /// can only be freed using this function.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_target_op_clear(op: *mut CTargetOp) {
     // We need to consume both the name and the parameters
 

--- a/crates/cext/src/transpiler/transpile_function.rs
+++ b/crates/cext/src/transpiler/transpile_function.rs
@@ -78,7 +78,6 @@ impl Default for TranspileOptions {
 ///
 /// @return A ``QkTranspileOptions`` object with default settings.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub extern "C" fn qk_transpiler_default_options() -> TranspileOptions {
     TranspileOptions::default()
 }
@@ -129,7 +128,6 @@ pub extern "C" fn qk_transpiler_default_options() -> TranspileOptions {
 /// pointer for ``layout`` will be overwritten by this function. If the value pointed to needs to
 /// be freed this must be done outside of this function as it will not be freed by this function.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpile_stage_init(
     dag: *mut DAGCircuit,
     target: *const Target,
@@ -261,7 +259,6 @@ pub unsafe extern "C" fn qk_transpile_stage_init(
 /// respectively. ``options`` must be a valid pointer a to a ``QkTranspileOptions`` or ``NULL``.
 /// ``error`` must be a valid pointer to a ``char`` pointer or ``NULL``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpile_stage_routing(
     dag: *mut DAGCircuit,
     target: *const Target,
@@ -378,7 +375,6 @@ pub unsafe extern "C" fn qk_transpile_stage_routing(
 /// be a valid pointer a to a ``QkTranspileOptions`` or ``NULL``. ``error`` must
 /// be a valid pointer to a ``char`` pointer or ``NULL``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpile_stage_optimization(
     dag: *mut DAGCircuit,
     target: *const Target,
@@ -485,7 +481,6 @@ pub unsafe extern "C" fn qk_transpile_stage_optimization(
 /// a ``QkTranspileOptions`` or ``NULL``. ``error`` must be a valid pointer to a ``char`` pointer
 /// or ``NULL``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpile_stage_translation(
     dag: *mut DAGCircuit,
     target: *const Target,
@@ -592,7 +587,6 @@ pub unsafe extern "C" fn qk_transpile_stage_translation(
 /// ``NULL`` pointer. ``options`` must be a valid pointer a to a ``QkTranspileOptions`` or ``NULL``.
 /// ``error`` must be a valid pointer to a ``char`` pointer or ``NULL``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpile_stage_layout(
     dag: *mut DAGCircuit,
     target: *const Target,
@@ -755,7 +749,6 @@ pub unsafe extern "C" fn qk_transpile_stage_layout(
 /// ``options`` must be a valid pointer a to a ``QkTranspileOptions`` or ``NULL``.
 /// ``error`` must be a valid pointer to a ``char`` pointer or ``NULL``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpile(
     qc: *const CircuitData,
     target: *const Target,

--- a/crates/cext/src/transpiler/transpile_layout.rs
+++ b/crates/cext/src/transpiler/transpile_layout.rs
@@ -35,7 +35,6 @@ use qiskit_circuit::circuit_data::CircuitData;
 /// Behavior is undefined if ``layout`` is not a valid, non-null pointer to a
 /// ``QkTranspileLayout``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpile_layout_num_input_qubits(
     layout: *const TranspileLayout,
 ) -> u32 {
@@ -55,7 +54,6 @@ pub unsafe extern "C" fn qk_transpile_layout_num_input_qubits(
 /// Behavior is undefined if ``layout`` is not a valid, non-null pointer to a
 /// ``QkTranspileLayout``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpile_layout_num_output_qubits(
     layout: *const TranspileLayout,
 ) -> u32 {
@@ -97,7 +95,6 @@ pub unsafe extern "C" fn qk_transpile_layout_num_output_qubits(
 /// ``qk_transpile_layout_num_input_qubits()``) or the number of output qubits if ``filter_ancillas``
 /// is false (which can be queried with ``qk_transpile_layout_num_output_qubits()``).
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpile_layout_initial_layout(
     layout: *const TranspileLayout,
     filter_ancillas: bool,
@@ -152,7 +149,6 @@ pub unsafe extern "C" fn qk_transpile_layout_initial_layout(
 /// of output qubits in the ``QkTranspileLayout`` which can be queried with
 /// ``qk_transpile_layout_num_output_qubits()``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpile_layout_output_permutation(
     layout: *const TranspileLayout,
     output_permutation: *mut u32,
@@ -206,7 +202,6 @@ pub unsafe extern "C" fn qk_transpile_layout_output_permutation(
 /// ``qk_transpile_layout_num_input_qubits()``) or the number of output qubits if ``filter_ancillas``
 /// is false (which can be queried with ``qk_transpile_layout_num_output_qubits()``).
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpile_layout_final_layout(
     layout: *const TranspileLayout,
     filter_ancillas: bool,
@@ -258,7 +253,6 @@ pub unsafe extern "C" fn qk_transpile_layout_final_layout(
 /// valid pointer to a contiguous array of ``uint32_t`` with enough space for the number of qubits
 /// indicated in ``target``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpile_layout_generate_from_mapping(
     original_dag: *const DAGCircuit,
     target: *const Target,
@@ -296,7 +290,6 @@ pub unsafe extern "C" fn qk_transpile_layout_generate_from_mapping(
 ///
 /// Behavior is undefined if ``layout`` is not a valid, non-null pointer to a ``QkTranspileLayout``.
 #[unsafe(no_mangle)]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpile_layout_free(layout: *mut TranspileLayout) {
     if !layout.is_null() {
         if !layout.is_aligned() {
@@ -329,7 +322,6 @@ pub unsafe extern "C" fn qk_transpile_layout_free(layout: *mut TranspileLayout) 
 /// returned by this function.
 #[unsafe(no_mangle)]
 #[cfg(feature = "python_binding")]
-#[cfg(feature = "cbinding")]
 pub unsafe extern "C" fn qk_transpile_layout_to_python(
     layout: *const TranspileLayout,
     circuit: *const CircuitData,


### PR DESCRIPTION
The purpose of the Rust-space feature is to allow definition of functions conditionally.  We then had a workaround in the `cbindgen` configuration that inserted an extra always-on C preprocessor symbol definition to enforce that these were always available to C users.

However, since these functions are all in `cext` whose sole purpose is to define and export these functions, there's no reason to consider them optional at all; there's no usage of `cext` that _doesn't_ involve exporting these functions.  The optional feature made sense if/when the exported C FFI functions were embedded in a different Rust crate, but this is no longer the case.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

I don't actually understand why we ever had the `cbinding` feature.  The history in #13694 doesn't have an out-of-band explanation, and it seems like we didn't talk about it during the review.  I'm guessing that a very early prototype had the `QkObs` C FFI functions defined within `accelerate` itself, much like the Python bindings were/are, and so in that case it made sense to make the bindings optional.

If I'm wrong about that, and there still _is_ a reason to have this, then we can close the PR.

cc: @Cryoris @mrossinek 