### PR TITLE
Fixing `QuantumCircuit.repeat` with parameterized gates

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1905,7 +1905,7 @@ class QuantumCircuit:
             except QiskitError:
                 inst = self.to_instruction()
             for i in range(reps):
-                repeated_circ._append(inst, self.qubits, self.clbits)
+                repeated_circ.append(inst, self.qubits, self.clbits)
                 if insert_barriers and i != reps - 1:
                     repeated_circ.barrier()
 

--- a/releasenotes/notes/fix-repeat-with-parameterized-gates-f1da5eea4de71251.yaml
+++ b/releasenotes/notes/fix-repeat-with-parameterized-gates-f1da5eea4de71251.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Fixed :meth:`.QuantumCircuit.repeat` for circuits with parameterized gates.
+
+    See `#15645 <https://github.com/Qiskit/qiskit/issues/15645>`__.

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -2145,7 +2145,7 @@ class TestParameterExpressions(QiskitTestCase):
             (a + b).numeric()
 
     def test_repeat_with_parameterized_gates(self):
-        """Tests that repeating a circuit with paramerized gates
+        """Tests that repeating a circuit with parameterized gates
         handles parameters correctly.
 
         See https://github.com/Qiskit/qiskit/issues/15645.

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -22,13 +22,13 @@ from ddt import data, ddt, named_data
 
 import qiskit
 import qiskit.circuit.library as circlib
-from qiskit.circuit.library.standard_gates.rz import RZGate
+from qiskit.circuit.library import RZGate, PauliEvolutionGate
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.circuit import Gate, Instruction, Parameter, ParameterExpression, ParameterVector
 from qiskit.circuit.parametertable import ParameterView
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.compiler import transpile
-from qiskit.quantum_info import Operator
+from qiskit.quantum_info import Operator, Pauli
 from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.providers.basic_provider import BasicSimulator
 from qiskit.utils import parallel_map
@@ -2143,6 +2143,36 @@ class TestParameterExpressions(QiskitTestCase):
 
         with self.assertRaisesRegex(TypeError, "unbound parameters"):
             (a + b).numeric()
+
+    def test_repeat_with_parameterized_gates(self):
+        """Tests that repeating a circuit with paramerized gates
+        handles parameters correctly.
+
+        See https://github.com/Qiskit/qiskit/issues/15645.
+        """
+
+        t_param = Parameter("t")
+
+        # Create a quantum circuit with 2 paramterized gates.
+        circuit = QuantumCircuit(5)
+        circuit.append(PauliEvolutionGate(Pauli("XZXZX"), time=t_param), [0, 1, 2, 3, 4])
+        circuit.append(PauliEvolutionGate(Pauli("IIIXX"), time=t_param / 2), [0, 1, 2, 3, 4])
+
+        # Repeat the circuit 10 times.
+        repeated_circuit = circuit.repeat(10)
+
+        # Divide each parameter by num_steps.
+        num_steps = 5
+        repeated_circuit.assign_parameters({t_param: t_param / num_steps}, inplace=True)
+
+        # Decompose the repeated circuit. The decomposed circuit has the two operations
+        # from the circuit repeated 10 times.
+        decomposed_circuit = repeated_circuit.decompose()
+
+        for idx in [0, 1]:
+            expected_param = circuit[idx].operation.params[0] / num_steps
+            actual_param = decomposed_circuit[idx].operation.params[0]
+            self.assertEqual(expected_param, actual_param)
 
 
 class TestParameterEquality(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #15645.

The PR implements Jake's suggestion to replace `_append` by `append` in `QuantumCircuit.repeat`.

### Details and comments

Previously, `QuantumCircuit.repeat` called `_append`, and in particular did not copy parameterized gates. As the result, calling `assign_parameters` mutated each parameter multiple times, leading to incorrect results. In contrast, `append` copies parameterized gates, and this solves the problem.

See the issue for additional information.

