### PR TITLE
Seed randomness in `UCR` tests

### DIFF
--- a/test/python/circuit/test_ucx_y_z.py
+++ b/test/python/circuit/test_ucx_y_z.py
@@ -62,7 +62,7 @@ class TestUCRXYZ(QiskitTestCase):
                 # Simulate the decomposed gate
                 unitary = Operator(qc)
                 unitary_desired = _get_ucr_matrix(angles, rot_axis)
-                self.assertTrue(matrix_equal(unitary_desired, unitary, ignore_phase=True))
+                self.assertTrue(matrix_equal(unitary_desired, unitary))
 
 
 def _get_ucr_matrix(angles, rot_axis):

--- a/test/python/circuit/test_ucx_y_z.py
+++ b/test/python/circuit/test_ucx_y_z.py
@@ -24,6 +24,7 @@ from qiskit.compiler import transpile
 from qiskit.circuit.library import UCRXGate, UCRYGate, UCRZGate
 from test import QiskitTestCase  # pylint: disable=wrong-import-order
 
+rng = np.random.default_rng(2026_02_05)
 angles_list = [
     [0],
     [0.4],
@@ -31,9 +32,9 @@ angles_list = [
     [0, 0.8],
     [0, 0, 1, 1],
     [0, 1, 0.5, 1],
-    (2 * np.pi * np.random.rand(2**3)).tolist(),
-    (2 * np.pi * np.random.rand(2**4)).tolist(),
-    (2 * np.pi * np.random.rand(2**5)).tolist(),
+    (2 * np.pi * rng.random(2**3)).tolist(),
+    (2 * np.pi * rng.random(2**4)).tolist(),
+    (2 * np.pi * rng.random(2**5)).tolist(),
 ]
 
 rot_axis_list = ["X", "Y", "Z"]
@@ -55,7 +56,9 @@ class TestUCRXYZ(QiskitTestCase):
                 qc.append(gate, q)
 
                 # Decompose the gate
-                qc = transpile(qc, basis_gates=["u1", "u3", "u2", "cx", "id"])
+                qc = transpile(
+                    qc, basis_gates=["u1", "u3", "u2", "cx", "id"], seed_transpiler=2026_02_05
+                )
                 # Simulate the decomposed gate
                 unitary = Operator(qc)
                 unitary_desired = _get_ucr_matrix(angles, rot_axis)


### PR DESCRIPTION
These tests depend on Numpy random inputs that are unseeded, so can potentially introduce non-determinism in the numerical comparisons.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


Close #15605

This is the only true non-determinism identified there with a detectable failure rate.  The test isn't wrong, and it doesn't appear to be indicative of unreasonable rounding error in the decomposition, so the fix is just to set the seeds.