### PR TITLE
Relax required version of CMake

### DIFF
--- a/releasenotes/notes/cmake-version-e91270cf39cd5013.yaml
+++ b/releasenotes/notes/cmake-version-e91270cf39cd5013.yaml
@@ -1,0 +1,6 @@
+---
+build:
+  - The minimum version of CMake required to build and run the C-API test suite has been lowered to
+    3.20 from 3.27.  Qiskit does not commit to any particular policy around the version of CMake
+    required, but will make a best-effort attempt to match the repositories of common and
+    still-supported Linux distributions.

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -1,7 +1,7 @@
 # This file is inspired by the description of handling a larger number of tests
 # provided here:
 # https://cmake.org/cmake/help/book/mastering-cmake/chapter/Testing%20With%20CMake%20and%20CTest.html
-cmake_minimum_required (VERSION 3.27)
+cmake_minimum_required (VERSION 3.20)
 
 # Since we only use CMake to scaffold `ctest`, we just have the whole
 # configuration here.


### PR DESCRIPTION
We are aware of users trying to use the test suite on Ubuntu 22.04 (jammy) systems, which still have LTS support and CMake 3.22 in their repos.  We don't use any recent CMake features, so lowering the barrier to use on those platforms isn't onerous for us.

I tested this by installing `cmake==3.20.5` using the PyPI-packaged versions.  We may well be able to go back earlier even than that, but the 3.20 series was the oldest that I could trivially install to test on my machine.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Follow on from https://github.com/Qiskit/qiskit/pull/14504#discussion_r2758455423.  cc: @mrossinek 