### PR TITLE
Update GitHub Releases / qiskit-bot label configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,15 +288,8 @@ message summary line from the git log for the release to the changelog.
 If there are multiple `Changelog:` tags on a PR the git commit message summary
 line from the git log will be used for each changelog category tagged.
 
-The current categories for each label are as follows:
-
-| PR Label               | Changelog Category |
-| -----------------------|--------------------|
-| Changelog: Deprecation | Deprecated         |
-| Changelog: New Feature | Added              |
-| Changelog: API Change  | Changed            |
-| Changelog: Removal     | Removed            |
-| Changelog: Bugfix      | Fixed              |
+The current categories for each label are configured in `qiskit_bot.yaml` in
+the repository root.
 
 ## Release notes
 

--- a/qiskit_bot.yaml
+++ b/qiskit_bot.yaml
@@ -22,3 +22,13 @@ notifications:
         - "@abbycross"
         - "@beckykd"
 always_notify: true
+
+# Set the headings in the GitHub Releases release notes.
+categories:
+  "Changelog: Added": "Added"
+  "Changelog: Fixed": "Fixed"
+  "Changelog: Changed": "Changed"
+  "Changelog: Deprecated": "Deprecated"
+  "Changelog: Removed": "Removed"
+  "Changelog: Build": "Build System"
+  "Changelog: None": null


### PR DESCRIPTION
We recently changed the names of the labels we use in GitHub to generate the changelog through qiskit-bot.  Previously, we used the default qiskit-bot configuration (or, perhaps more precisely, qiskit-bot had Terra's configuration encoded as its default).

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


I've marked this for backport because we'll need it in the `stable/2.3` branch to ensure that new releases in that branch get the correct titles.