### PR TITLE
Disable incremental compilation in `ccoverage` recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ ctest: cheader build-clib-dev
 	ctest -V -C Debug --test-dir $(C_DIR_TEST_BUILD)
 
 .PHONY: ccoverage
-ccoverage: C_LIB_RUSTC_FLAGS=-Cinstrument-coverage -Cincremental=false
+ccoverage: C_LIB_RUSTC_FLAGS=-Cinstrument-coverage
 ccoverage: ctest
 
 .PHONY: cclean


### PR DESCRIPTION
The `rustc` flag `-Cincremental=false` actually _turns on_ incremental compilation, using the directory `false` as the backing store[^1].  This was set in the original GitHub Action that managed the coverage job, but not noticed until the logic moved to the Makefile where it could also easily be run by users.

[^1]: https://doc.rust-lang.org/rustc/codegen-options/index.html#incremental

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


Found by Max - thanks!