### PR TITLE
Move most inline C header into structured `cbindgen` inputs

### DIFF
--- a/crates/cext/cbindgen.toml
+++ b/crates/cext/cbindgen.toml
@@ -5,18 +5,20 @@ style = "type"
 cpp_compat = true
 usize_is_size_t = true
 
-after_includes = """
+# The `Python.h` file is documented as wanting to be the first file included, because it reserves
+# the right to define macros that impact the system-header includes.  Putting it here means it comes
+# before our include guard, but `Python.h` has its own, so it shouldn't be harmful.
+header = """
 #ifdef QISKIT_C_PYTHON_INTERFACE
     #include <Python.h>
 #endif
-
-#include "qiskit/version.h"
-#include "qiskit/attributes.h"
-#include "qiskit/complex.h"
-
-typedef struct QkQuantumRegister QkQuantumRegister;
-typedef struct QkClassicalRegister QkClassicalRegister;
 """
+# Manually written include files.
+includes = [
+    "qiskit/version.h",
+    "qiskit/attributes.h",
+    "qiskit/complex.h",
+]
 
 [defines]
 "feature = python_binding" = "QISKIT_C_PYTHON_INTERFACE"

--- a/crates/cext/src/extras.rs
+++ b/crates/cext/src/extras.rs
@@ -1,6 +1,6 @@
 // This code is part of Qiskit.
 //
-// (C) Copyright IBM 2024
+// (C) Copyright IBM 2026
 //
 // This code is licensed under the Apache License, Version 2.0. You may
 // obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -10,13 +10,10 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-mod extras;
-mod pointers;
+//! The purpose of this module is to have "dummy" definitions of objects that Qiskit and `cext` use,
+//! but aren't otherwise visible to `cbindgen.`  This is principally types that are macro-generated.
 
-pub mod circuit;
-pub mod circuit_library;
-pub mod dag;
-pub mod exit_codes;
-pub mod param;
-pub mod sparse_observable;
-pub mod transpiler;
+#[allow(dead_code)] // used by cbindgen
+pub struct QuantumRegister;
+#[allow(dead_code)] // used by cbindgen
+pub struct ClassicalRegister;


### PR DESCRIPTION
We used to have a lot more include-file logic specified in the `after_includes` string literal.  This moves out (almost) all the rest of it into structured locations.  The components are:

* the extra type definitions
* the manual header-file includes
* the guarded `#include <Python.h>`

`ClassicalRegister` and `QuantumRegister` are macro-generated in `qiskit-circuit`, which prevents `cbindgen` from seeing them (at least without using a nightly toolchain to do macro expansion).  This switches the hard-coded `typedef` statements in the `cbindgen.toml` file out for actual `struct` definitions, abusing the fact that `cbindgen` has no concept of namespaces.  This form means we don't have to manually match the output of `cbindgen` ourselves, and if we get a better strategy for typedef/opaque-struct documentation, we'll be able to apply it to these types too.

The manual header-file includes are handled by a regular structured field in `cbindgen`'s config.

The guarded include of `Python.h` has to remain in a free-form field, but it's now moved to be at the top of the file, before the system includes, because `Python.h` is documented as requiring that.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

This is just a small tidy up I realised was possible while seeing what it would look like to generate the `cbindgen::Config` object directly in Rust code as part of turning the C bindings generation into a library reusable by several different parts of the build process.  (Answer: it looks fine, but unless we need the configuration to be influenced dynamically, it's probably still easiest to read as a `toml` file.)