### PR TITLE
Upgrade to PyO3 0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,12 +1029,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
-
-[[package]]
 name = "interpol"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,9 +1474,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aac2e6a6e4468ffa092ad43c39b81c79196c2bb773b8db4085f695efe3bba17"
+checksum = "778da78c64ddc928ebf5ad9df5edf0789410ff3bdbf3619aed51cd789a6af1e2"
 dependencies = [
  "libc",
  "nalgebra",
@@ -1814,15 +1808,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
+checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
 dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
- "indoc",
  "libc",
- "memoffset",
  "num-bigint",
  "num-complex",
  "num-traits",
@@ -1832,23 +1824,22 @@ dependencies = [
  "pyo3-ffi",
  "pyo3-macros",
  "smallvec",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
+checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
+checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1856,9 +1847,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
+checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1868,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
+checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2847,12 +2838,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ hashbrown.version = "0.15.5"
 num-bigint = "0.4"
 num-complex = "0.4"
 nalgebra = "0.33"
-numpy = "0.27"
+numpy = "0.28"
 ndarray = "0.16"
 smallvec = "1.15"
 thiserror = "2.0"
@@ -46,7 +46,7 @@ anyhow = "1.0"
 # distributions).  We only activate that feature when building the C extension module; we still need
 # it disabled for Rust-only tests to avoid linker errors with it not being loaded.  See
 # https://pyo3.rs/main/features#extension-module for more.
-pyo3 = { version = "0.27", features = ["abi3-py310"] }
+pyo3 = { version = "0.28.1", features = ["abi3-py310"] }
 
 # These are our own crates.
 qiskit-accelerate = { path = "crates/accelerate" }

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -213,7 +213,7 @@ type CircuitDataState<'py> = (
 /// Raises:
 ///     KeyError: if ``data`` contains a reference to a bit that is not present
 ///         in ``qubits`` or ``clbits``.
-#[pyclass(sequence, module = "qiskit._accelerate.circuit")]
+#[pyclass(sequence, module = "qiskit._accelerate.circuit", from_py_object)]
 #[derive(Clone, Debug)]
 pub struct CircuitData {
     /// The packed instruction listing.

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -70,7 +70,12 @@ use smallvec::SmallVec;
 ///     mutations of the object do not invalidate the types, nor the restrictions placed on it by
 ///     its context.  Typically this will mean, for example, that :attr:`qubits` must be a sequence
 ///     of distinct items, with no duplicates.
-#[pyclass(freelist = 20, sequence, module = "qiskit._accelerate.circuit")]
+#[pyclass(
+    freelist = 20,
+    sequence,
+    module = "qiskit._accelerate.circuit",
+    from_py_object
+)]
 #[derive(Clone, Debug)]
 pub struct CircuitInstruction {
     pub operation: PackedOperation,

--- a/crates/circuit/src/classical/expr/binary.rs
+++ b/crates/circuit/src/classical/expr/binary.rs
@@ -129,7 +129,13 @@ impl PyBinaryOp {
 ///     left: The left-hand operand.
 ///     right: The right-hand operand.
 ///     type: The resolved type of the result.
-#[pyclass(eq, extends = PyExpr, name = "Binary", module = "qiskit._accelerate.circuit.classical.expr")]
+#[pyclass(
+    eq,
+    extends = PyExpr,
+    name = "Binary",
+    module = "qiskit._accelerate.circuit.classical.expr",
+    from_py_object
+)]
 #[derive(PartialEq, Clone, Debug)]
 pub struct PyBinary(Binary);
 

--- a/crates/circuit/src/classical/expr/cast.rs
+++ b/crates/circuit/src/classical/expr/cast.rs
@@ -47,7 +47,13 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Cast {
 
 /// A cast from one type to another, implied by the use of an expression in a different
 /// context.
-#[pyclass(eq, extends = PyExpr, name = "Cast", module = "qiskit._accelerate.circuit.classical.expr")]
+#[pyclass(
+    eq,
+    extends = PyExpr,
+    name = "Cast",
+    module = "qiskit._accelerate.circuit.classical.expr",
+    from_py_object
+)]
 #[derive(PartialEq, Clone, Debug)]
 pub struct PyCast(Cast);
 

--- a/crates/circuit/src/classical/expr/expr.rs
+++ b/crates/circuit/src/classical/expr/expr.rs
@@ -395,7 +395,8 @@ impl From<Box<Index>> for Expr {
     subclass,
     frozen,
     name = "Expr",
-    module = "qiskit._accelerate.circuit.classical.expr"
+    module = "qiskit._accelerate.circuit.classical.expr",
+    skip_from_py_object
 )]
 #[derive(PartialEq, Clone, Copy, Debug, Hash)]
 pub struct PyExpr(pub ExprKind); // ExprKind is used for fast extraction from Python

--- a/crates/circuit/src/classical/expr/index.rs
+++ b/crates/circuit/src/classical/expr/index.rs
@@ -50,7 +50,13 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Index {
 ///     target: The object being indexed.
 ///     index: The expression doing the indexing.
 ///     type: The resolved type of the result.
-#[pyclass(eq, extends = PyExpr, name = "Index", module = "qiskit._accelerate.circuit.classical.expr")]
+#[pyclass(
+    eq,
+    extends = PyExpr,
+    name = "Index",
+    module = "qiskit._accelerate.circuit.classical.expr",
+    from_py_object,
+)]
 #[derive(PartialEq, Clone, Debug)]
 pub struct PyIndex(Index);
 

--- a/crates/circuit/src/classical/expr/stretch.rs
+++ b/crates/circuit/src/classical/expr/stretch.rs
@@ -48,7 +48,15 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Stretch {
 ///
 /// In general, construction of stretch variables for use in programs should use :meth:`Stretch.new`
 /// or :meth:`.QuantumCircuit.add_stretch`
-#[pyclass(eq, hash, frozen, extends = PyExpr, name = "Stretch", module = "qiskit._accelerate.circuit.classical.expr")]
+#[pyclass(
+    eq,
+    hash,
+    frozen,
+    extends = PyExpr,
+    name = "Stretch",
+    module = "qiskit._accelerate.circuit.classical.expr",
+    from_py_object
+)]
 #[derive(PartialEq, Clone, Debug, Hash)]
 pub struct PyStretch(Stretch);
 

--- a/crates/circuit/src/classical/expr/unary.rs
+++ b/crates/circuit/src/classical/expr/unary.rs
@@ -112,7 +112,13 @@ impl PyUnaryOp {
 ///     op: The opcode describing which operation is being done.
 ///     operand: The operand of the operation.
 ///     type: The resolved type of the result.
-#[pyclass(eq, extends = PyExpr, name = "Unary", module = "qiskit._accelerate.circuit.classical.expr")]
+#[pyclass(
+    eq,
+    extends = PyExpr,
+    name = "Unary",
+    module = "qiskit._accelerate.circuit.classical.expr",
+    from_py_object
+)]
 #[derive(PartialEq, Clone, Debug)]
 pub struct PyUnary(Unary);
 

--- a/crates/circuit/src/classical/expr/value.rs
+++ b/crates/circuit/src/classical/expr/value.rs
@@ -46,7 +46,13 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Value {
 }
 
 /// A single scalar value.
-#[pyclass(eq, extends = PyExpr, name = "Value", module = "qiskit._accelerate.circuit.classical.expr")]
+#[pyclass(
+    eq,
+    extends = PyExpr,
+    name = "Value",
+    module = "qiskit._accelerate.circuit.classical.expr",
+    from_py_object
+)]
 #[derive(PartialEq, Clone, Debug)]
 pub struct PyValue(Value);
 

--- a/crates/circuit/src/classical/expr/var.rs
+++ b/crates/circuit/src/classical/expr/var.rs
@@ -77,7 +77,15 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Var {
 /// :meth:`.QuantumCircuit.add_var`.
 ///
 /// Variables are immutable after construction, so they can be used as dictionary keys."""
-#[pyclass(eq, hash, frozen, extends = PyExpr, name = "Var", module = "qiskit._accelerate.circuit.classical.expr")]
+#[pyclass(
+    eq,
+    hash,
+    frozen,
+    extends = PyExpr,
+    name = "Var",
+    module = "qiskit._accelerate.circuit.classical.expr",
+    from_py_object
+)]
 #[derive(PartialEq, Clone, Debug, Hash)]
 pub struct PyVar(Var);
 

--- a/crates/circuit/src/classical/types.rs
+++ b/crates/circuit/src/classical/types.rs
@@ -76,7 +76,8 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Type {
     subclass,
     frozen,
     name = "Type",
-    module = "qiskit._accelerate.circuit.classical.types"
+    module = "qiskit._accelerate.circuit.classical.types",
+    from_py_object
 )]
 #[derive(PartialEq, Clone, Copy, Debug, Hash)]
 struct PyType(TypeKind);
@@ -124,7 +125,15 @@ enum TypeKind {
 }
 
 /// The Boolean type.  This has exactly two values: ``True`` and ``False``.
-#[pyclass(eq, hash, extends = PyType, frozen, name = "Bool", module = "qiskit._accelerate.circuit.classical.types")]
+#[pyclass(
+    eq,
+    hash,
+    extends = PyType,
+    frozen,
+    name = "Bool",
+    module = "qiskit._accelerate.circuit.classical.types",
+    from_py_object
+)]
 #[derive(PartialEq, Clone, Copy, Debug, Hash)]
 struct PyBool;
 
@@ -149,7 +158,15 @@ impl PyBool {
 }
 
 /// A length of time, possibly negative.
-#[pyclass(eq, hash, extends = PyType, frozen, name = "Duration", module = "qiskit._accelerate.circuit.classical.types")]
+#[pyclass(
+    eq,
+    hash,
+    extends = PyType,
+    frozen,
+    name = "Duration",
+    module = "qiskit._accelerate.circuit.classical.types",
+    from_py_object
+)]
 #[derive(PartialEq, Clone, Copy, Debug, Hash)]
 struct PyDuration;
 
@@ -176,7 +193,15 @@ impl PyDuration {
 /// An IEEE-754 double-precision floating point number.
 ///
 /// In the future, this may also be used to represent other fixed-width floats.
-#[pyclass(eq, hash, extends = PyType, frozen, name = "Float", module = "qiskit._accelerate.circuit.classical.types")]
+#[pyclass(
+    eq,
+    hash,
+    extends = PyType,
+    frozen,
+    name = "Float",
+    module = "qiskit._accelerate.circuit.classical.types",
+    from_py_object
+)]
 #[derive(PartialEq, Clone, Copy, Debug, Hash)]
 struct PyFloat;
 
@@ -201,7 +226,15 @@ impl PyFloat {
 }
 
 /// An unsigned integer of fixed bit width.
-#[pyclass(eq, hash, extends = PyType, frozen, name = "Uint", module = "qiskit._accelerate.circuit.classical.types")]
+#[pyclass(
+    eq,
+    hash,
+    extends = PyType,
+    frozen,
+    name = "Uint",
+    module = "qiskit._accelerate.circuit.classical.types",
+    from_py_object
+)]
 #[derive(PartialEq, Clone, Copy, Debug, Hash)]
 struct PyUint(u16);
 

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -188,7 +188,7 @@ impl Wire {
 /// There are 3 types of nodes in the graph: inputs, outputs, and operations.
 /// The nodes are connected by directed edges that correspond to qubits and
 /// bits.
-#[pyclass(module = "qiskit._accelerate.circuit")]
+#[pyclass(module = "qiskit._accelerate.circuit", from_py_object)]
 #[derive(Clone, Debug)]
 pub struct DAGCircuit {
     /// Circuit name.  Generally, this corresponds to the name
@@ -280,7 +280,12 @@ fn reject_new_register(reg: &ClassicalRegister) -> PyResult<()> {
     )))
 }
 
-#[pyclass(name = "BitLocations", module = "qiskit._accelerate.circuit", sequence)]
+#[pyclass(
+    name = "BitLocations",
+    module = "qiskit._accelerate.circuit",
+    sequence,
+    skip_from_py_object
+)]
 #[derive(Clone, Debug)]
 pub struct PyBitLocations {
     #[pyo3(get)]

--- a/crates/circuit/src/dag_node.rs
+++ b/crates/circuit/src/dag_node.rs
@@ -34,7 +34,7 @@ use pyo3::types::PyTuple;
 use pyo3::{PyResult, intern};
 
 /// Parent class for DAGOpNode, DAGInNode, and DAGOutNode.
-#[pyclass(module = "qiskit._accelerate.circuit", subclass)]
+#[pyclass(module = "qiskit._accelerate.circuit", subclass, skip_from_py_object)]
 #[derive(Clone, Debug)]
 pub struct DAGNode {
     pub node: Option<NodeIndex>,

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -42,7 +42,6 @@ pub mod vf2;
 
 mod variable_mapper;
 
-use pyo3::PyTypeInfo;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PySequence, PyString, PyTuple};
@@ -229,35 +228,6 @@ pub fn circuit(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<bit::PyClassicalRegister>()?;
     m.add_class::<bit::PyQuantumRegister>()?;
     m.add_class::<bit::PyAncillaRegister>()?;
-
-    // We need to explicitly add the auto-generated Python subclasses of Duration
-    // to the module so that pickle can find them during deserialization.
-    m.add_class::<duration::Duration>()?;
-    m.add(
-        "Duration_ps",
-        duration::Duration::type_object(m.py()).getattr("ps")?,
-    )?;
-    m.add(
-        "Duration_ns",
-        duration::Duration::type_object(m.py()).getattr("ns")?,
-    )?;
-    m.add(
-        "Duration_us",
-        duration::Duration::type_object(m.py()).getattr("us")?,
-    )?;
-    m.add(
-        "Duration_ms",
-        duration::Duration::type_object(m.py()).getattr("ms")?,
-    )?;
-    m.add(
-        "Duration_s",
-        duration::Duration::type_object(m.py()).getattr("s")?,
-    )?;
-    m.add(
-        "Duration_dt",
-        duration::Duration::type_object(m.py()).getattr("dt")?,
-    )?;
-
     m.add_class::<circuit_data::CircuitData>()?;
     m.add_class::<circuit_instruction::CircuitInstruction>()?;
     m.add_class::<dag_circuit::DAGCircuit>()?;
@@ -266,6 +236,7 @@ pub fn circuit(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<dag_node::DAGOutNode>()?;
     m.add_class::<dag_node::DAGOpNode>()?;
     m.add_class::<dag_circuit::PyBitLocations>()?;
+    m.add_class::<duration::Duration>()?;
     m.add_class::<operations::ControlFlowType>()?;
     m.add_class::<operations::StandardGate>()?;
     m.add_class::<operations::StandardInstructionType>()?;

--- a/crates/circuit/src/nlayout.rs
+++ b/crates/circuit/src/nlayout.rs
@@ -134,7 +134,7 @@ impl VirtualQubit {
 ///         physical qubit index on the coupling graph.
 ///     logical_qubits (int): The number of logical qubits in the layout
 ///     physical_qubits (int): The number of physical qubits in the layout
-#[pyclass(module = "qiskit._accelerate.nlayout")]
+#[pyclass(module = "qiskit._accelerate.nlayout", skip_from_py_object)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NLayout {
     virt_to_phys: Vec<PhysicalQubit>,

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -360,7 +360,7 @@ impl Operation for OperationRef<'_> {
 /// Used to tag control flow instructions via the `_control_flow_type` class
 /// attribute in the corresponding Python class.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[pyclass(module = "qiskit._accelerate.circuit", eq, eq_int)]
+#[pyclass(module = "qiskit._accelerate.circuit", eq, eq_int, from_py_object)]
 #[repr(u8)]
 pub enum ControlFlowType {
     Box = 0,
@@ -628,10 +628,10 @@ impl ControlFlowInstruction {
                 let (duration, unit) = match duration {
                     Some(duration) => match duration {
                         BoxDuration::Duration(duration) => {
-                            (Some(duration.py_value(py)?), Some(duration.unit()))
+                            (Some(duration.py_value(py)), Some(duration.unit()))
                         }
                         BoxDuration::Expr(expr) => {
-                            (Some(expr.clone().into_py_any(py)?), Some("expr"))
+                            (Some(expr.clone().into_bound_py_any(py)?), Some("expr"))
                         }
                     },
                     None => (None, None),
@@ -1020,7 +1020,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for DelayUnit {
 /// This is also used to tag standard instructions via the `_standard_instruction_type` class
 /// attribute in the corresponding Python class.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[pyclass(module = "qiskit._accelerate.circuit", eq, eq_int)]
+#[pyclass(module = "qiskit._accelerate.circuit", eq, eq_int, from_py_object)]
 #[repr(u8)]
 pub enum StandardInstructionType {
     Barrier = 0,
@@ -1153,7 +1153,7 @@ impl StandardInstruction {
 
 #[derive(Clone, Debug, Copy, Eq, PartialEq, Hash)]
 #[repr(u8)]
-#[pyclass(module = "qiskit._accelerate.circuit", eq, eq_int)]
+#[pyclass(module = "qiskit._accelerate.circuit", eq, eq_int, from_py_object)]
 pub enum StandardGate {
     GlobalPhase = 0,
     H = 1,

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -704,7 +704,8 @@ impl ParameterExpression {
 #[pyclass(
     subclass,
     module = "qiskit._accelerate.circuit",
-    name = "ParameterExpression"
+    name = "ParameterExpression",
+    from_py_object
 )]
 #[derive(Clone, Debug)]
 pub struct PyParameterExpression {
@@ -1448,7 +1449,14 @@ impl PyParameterExpression {
 ///         bc = qc.assign_parameters({phi: 3.14})
 ///         bc.measure_all()
 ///         bc.draw("mpl")
-#[pyclass(sequence, subclass, module="qiskit._accelerate.circuit", extends=PyParameterExpression, name="Parameter")]
+#[pyclass(
+    sequence,
+    subclass,
+    module="qiskit._accelerate.circuit",
+    extends=PyParameterExpression,
+    name="Parameter",
+    from_py_object
+)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
 pub struct PyParameter {
     pub symbol: Symbol,
@@ -1675,7 +1683,14 @@ impl PyParameter {
 /// .. note::
 ///     There is very little reason to ever construct this class directly.  Objects of this type are
 ///     automatically constructed efficiently as part of creating a :class:`.ParameterVector`.
-#[pyclass(sequence, subclass, module="qiskit._accelerate.circuit", extends=PyParameter, name="ParameterVectorElement")]
+#[pyclass(
+    sequence,
+    subclass,
+    module="qiskit._accelerate.circuit",
+    extends=PyParameter,
+    name="ParameterVectorElement",
+    from_py_object
+)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd)]
 pub struct PyParameterVectorElement {
     pub symbol: Symbol,
@@ -1913,7 +1928,7 @@ impl From<ParameterValueType> for ParameterExpression {
     }
 }
 
-#[pyclass(module = "qiskit._accelerate.circuit")]
+#[pyclass(module = "qiskit._accelerate.circuit", from_py_object)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 #[repr(u8)]
 pub enum OpCode {
@@ -1990,7 +2005,7 @@ impl OpCode {
 }
 
 // enum for QPY replay
-#[pyclass(sequence, module = "qiskit._accelerate.circuit")]
+#[pyclass(sequence, module = "qiskit._accelerate.circuit", from_py_object)]
 #[derive(Clone, Debug)]
 pub struct OPReplay {
     pub op: OpCode,

--- a/crates/circuit_library/src/blocks.rs
+++ b/crates/circuit_library/src/blocks.rs
@@ -62,7 +62,7 @@ impl BlockOperation {
 }
 
 #[derive(Debug, Clone)]
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 pub struct Block {
     pub operation: BlockOperation,
     pub num_qubits: u32,

--- a/crates/qasm2/src/bytecode.rs
+++ b/crates/qasm2/src/bytecode.rs
@@ -22,7 +22,7 @@ use crate::{CustomClassical, CustomInstruction};
 
 /// The Rust parser produces an iterator of these `Bytecode` instructions, which comprise an opcode
 /// integer for operation distinction, and a free-form tuple containing the operands.
-#[pyclass(module = "qiskit._accelerate.qasm2", frozen)]
+#[pyclass(module = "qiskit._accelerate.qasm2", frozen, skip_from_py_object)]
 #[derive(Clone)]
 pub struct Bytecode {
     #[pyo3(get)]
@@ -32,7 +32,7 @@ pub struct Bytecode {
 }
 
 /// The operations that are represented by the "bytecode" passed to Python.
-#[pyclass(module = "qiskit._accelerate.qasm2", frozen, eq)]
+#[pyclass(module = "qiskit._accelerate.qasm2", frozen, eq, skip_from_py_object)]
 #[derive(Clone, Eq, PartialEq)]
 pub enum OpCode {
     // There is only a `Gate` here, not a `GateInBasis`, because in Python space we don't have the
@@ -61,7 +61,7 @@ pub enum OpCode {
 // that makes things a little fiddlier with PyO3, and there's no real benefit for our uses.
 
 /// A (potentially folded) floating-point constant value as part of an expression.
-#[pyclass(module = "qiskit._accelerate.qasm2", frozen)]
+#[pyclass(module = "qiskit._accelerate.qasm2", frozen, skip_from_py_object)]
 #[derive(Clone)]
 pub struct ExprConstant {
     #[pyo3(get)]
@@ -69,7 +69,7 @@ pub struct ExprConstant {
 }
 
 /// A reference to one of the arguments to the gate.
-#[pyclass(module = "qiskit._accelerate.qasm2", frozen)]
+#[pyclass(module = "qiskit._accelerate.qasm2", frozen, skip_from_py_object)]
 #[derive(Clone)]
 pub struct ExprArgument {
     #[pyo3(get)]
@@ -78,7 +78,7 @@ pub struct ExprArgument {
 
 /// A unary operation acting on some other part of the expression tree.  This includes the `+` and
 /// `-` unary operators, but also any of the built-in scientific-calculator functions.
-#[pyclass(module = "qiskit._accelerate.qasm2", frozen)]
+#[pyclass(module = "qiskit._accelerate.qasm2", frozen, skip_from_py_object)]
 #[derive(Clone)]
 pub struct ExprUnary {
     #[pyo3(get)]
@@ -88,7 +88,7 @@ pub struct ExprUnary {
 }
 
 /// A binary operation acting on two other parts of the expression tree.
-#[pyclass(module = "qiskit._accelerate.qasm2", frozen)]
+#[pyclass(module = "qiskit._accelerate.qasm2", frozen, skip_from_py_object)]
 #[derive(Clone)]
 pub struct ExprBinary {
     #[pyo3(get)]
@@ -100,7 +100,7 @@ pub struct ExprBinary {
 }
 
 /// Some custom callable Python function that the user told us about.
-#[pyclass(module = "qiskit._accelerate.qasm2", frozen)]
+#[pyclass(module = "qiskit._accelerate.qasm2", frozen, skip_from_py_object)]
 #[derive(Clone)]
 pub struct ExprCustom {
     #[pyo3(get)]
@@ -113,7 +113,7 @@ pub struct ExprCustom {
 /// each of these, but this way involves fewer imports in Python, and also serves to split up the
 /// option tree at the top level, so we don't have to test every unary operator before testing
 /// other operations.
-#[pyclass(module = "qiskit._accelerate.qasm2", frozen, eq)]
+#[pyclass(module = "qiskit._accelerate.qasm2", frozen, eq, skip_from_py_object)]
 #[derive(Clone, PartialEq, Eq)]
 pub enum UnaryOpCode {
     Negate,
@@ -129,7 +129,7 @@ pub enum UnaryOpCode {
 /// each of these, but this way involves fewer imports in Python, and also serves to split up the
 /// option tree at the top level, so we don't have to test every binary operator before testing
 /// other operations.
-#[pyclass(module = "qiskit._accelerate.qasm2", frozen, eq)]
+#[pyclass(module = "qiskit._accelerate.qasm2", frozen, eq, skip_from_py_object)]
 #[derive(Clone, PartialEq, Eq)]
 pub enum BinaryOpCode {
     Add,

--- a/crates/qasm2/src/lib.rs
+++ b/crates/qasm2/src/lib.rs
@@ -23,7 +23,7 @@ mod parse;
 
 /// Information about a custom instruction that Python space is able to construct to pass down to
 /// us.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct CustomInstruction {
     pub name: String,
@@ -51,7 +51,7 @@ impl CustomInstruction {
 /// The given `callable` must be a Python function that takes `num_params` floats, and returns a
 /// float.  The `name` is the identifier that refers to it in the OpenQASM 2 program.  This cannot
 /// clash with any defined gates.
-#[pyclass()]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct CustomClassical {
     pub name: String,

--- a/crates/qasm3/src/circuit.rs
+++ b/crates/qasm3/src/circuit.rs
@@ -66,7 +66,8 @@ register_type!(PyClassicalRegister);
     module = "qiskit._accelerate.qasm3",
     frozen,
     name = "CustomGate",
-    get_all
+    get_all,
+    from_py_object
 )]
 #[derive(Clone, Debug)]
 pub struct PyGate {

--- a/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -590,7 +590,12 @@ impl GeneratorTerm {
 /// A single term from a complete :class:`PauliLindbladMap`.
 ///
 /// These are typically created by indexing into or iterating through a :class:`PauliLindbladMap`.
-#[pyclass(name = "GeneratorTerm", frozen, module = "qiskit.quantum_info")]
+#[pyclass(
+    name = "GeneratorTerm",
+    frozen,
+    module = "qiskit.quantum_info",
+    skip_from_py_object
+)]
 #[derive(Clone, Debug)]
 struct PyGeneratorTerm {
     inner: GeneratorTerm,
@@ -1783,7 +1788,7 @@ impl PyPauliLindbladMap {
     ///
     /// Args: qubit_sparse_pauli (QubitSparsePauli): the qubit sparse Pauli to compute the Pauli
     ///     fidelity of.
-    fn pauli_fidelity(&self, qubit_sparse_pauli: PyQubitSparsePauli) -> PyResult<f64> {
+    fn pauli_fidelity(&self, qubit_sparse_pauli: &PyQubitSparsePauli) -> PyResult<f64> {
         let inner = self.inner.read().map_err(|_| InnerReadError)?;
         let result = inner.pauli_fidelity(qubit_sparse_pauli.inner())?;
         Ok(result)

--- a/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
@@ -456,7 +456,8 @@ impl PhasedQubitSparsePauli {
 #[pyclass(
     name = "PhasedQubitSparsePauli",
     frozen,
-    module = "qiskit.quantum_info"
+    module = "qiskit.quantum_info",
+    skip_from_py_object
 )]
 #[derive(Clone, Debug)]
 pub struct PyPhasedQubitSparsePauli {
@@ -777,13 +778,13 @@ impl PyPhasedQubitSparsePauli {
     ///
     /// Args:
     ///     other (PhasedQubitSparsePauli): the qubit sparse Pauli to compose with.
-    fn compose(&self, other: PyPhasedQubitSparsePauli) -> PyResult<Self> {
+    fn compose(&self, other: &PyPhasedQubitSparsePauli) -> PyResult<Self> {
         Ok(PyPhasedQubitSparsePauli {
             inner: self.inner.compose(&other.inner)?,
         })
     }
 
-    fn __matmul__(&self, other: PyPhasedQubitSparsePauli) -> PyResult<Self> {
+    fn __matmul__(&self, other: &PyPhasedQubitSparsePauli) -> PyResult<Self> {
         self.compose(other)
     }
 
@@ -792,7 +793,7 @@ impl PyPhasedQubitSparsePauli {
     /// Args:
     ///     other (PhasedQubitSparsePauli): the phased qubit sparse Pauli to check for commutation
     ///         with.
-    fn commutes(&self, other: PyPhasedQubitSparsePauli) -> PyResult<bool> {
+    fn commutes(&self, other: &PyPhasedQubitSparsePauli) -> PyResult<bool> {
         Ok(self.inner.commutes(&other.inner)?)
     }
 

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -1166,7 +1166,12 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Pauli {
 ///     :param int|None num_qubits: Optional number of qubits for the operator.  For most data
 ///         inputs, this can be inferred and need not be passed.  It is only necessary for the
 ///         sparse-label format.  If given unnecessarily, it must match the data input.
-#[pyclass(name = "QubitSparsePauli", frozen, module = "qiskit.quantum_info")]
+#[pyclass(
+    name = "QubitSparsePauli",
+    frozen,
+    module = "qiskit.quantum_info",
+    skip_from_py_object
+)]
 #[derive(Clone, Debug)]
 pub struct PyQubitSparsePauli {
     inner: QubitSparsePauli,
@@ -1450,13 +1455,13 @@ impl PyQubitSparsePauli {
     ///
     /// Args:
     ///     other (QubitSparsePauli): the qubit sparse Pauli to compose with.
-    fn compose(&self, other: PyQubitSparsePauli) -> PyResult<Self> {
+    fn compose(&self, other: &PyQubitSparsePauli) -> PyResult<Self> {
         Ok(PyQubitSparsePauli {
             inner: self.inner.compose(&other.inner)?,
         })
     }
 
-    fn __matmul__(&self, other: PyQubitSparsePauli) -> PyResult<Self> {
+    fn __matmul__(&self, other: &PyQubitSparsePauli) -> PyResult<Self> {
         self.compose(other)
     }
 
@@ -1464,7 +1469,7 @@ impl PyQubitSparsePauli {
     ///
     /// Args:
     ///     other (QubitSparsePauli): the qubit sparse Pauli to check for commutation with.
-    fn commutes(&self, other: PyQubitSparsePauli) -> PyResult<bool> {
+    fn commutes(&self, other: &PyQubitSparsePauli) -> PyResult<bool> {
         Ok(self.inner.commutes(&other.inner)?)
     }
 

--- a/crates/quantum_info/src/sparse_observable/mod.rs
+++ b/crates/quantum_info/src/sparse_observable/mod.rs
@@ -1829,7 +1829,12 @@ impl<'a, 'py> FromPyObject<'a, 'py> for BitTerm {
 /// A single term from a complete :class:`SparseObservable`.
 ///
 /// These are typically created by indexing into or iterating through a :class:`SparseObservable`.
-#[pyclass(name = "Term", frozen, module = "qiskit.quantum_info")]
+#[pyclass(
+    name = "Term",
+    frozen,
+    module = "qiskit.quantum_info",
+    skip_from_py_object
+)]
 #[derive(Clone, Debug)]
 struct PySparseTerm {
     inner: SparseTerm,
@@ -3172,10 +3177,10 @@ impl PySparseObservable {
     )]
     unsafe fn from_raw_parts<'py>(
         num_qubits: u32,
-        coeffs: PyArrayLike1<'py, Complex64>,
-        bit_terms: PyArrayLike1<'py, u8>,
-        indices: PyArrayLike1<'py, u32>,
-        boundaries: PyArrayLike1<'py, usize>,
+        coeffs: PyArrayLike1<'py, Complex64, numpy::AllowTypeChange>,
+        bit_terms: PyArrayLike1<'py, u8, numpy::AllowTypeChange>,
+        indices: PyArrayLike1<'py, u32, numpy::AllowTypeChange>,
+        boundaries: PyArrayLike1<'py, usize, numpy::AllowTypeChange>,
         check: bool,
     ) -> PyResult<Self> {
         let coeffs = coeffs.as_array().to_vec();
@@ -4200,7 +4205,7 @@ impl ArrayView {
 
 /// Use the Numpy Python API to convert a `PyArray` into a dynamically chosen `dtype`, copying only
 /// if required.
-fn cast_array_type<'py, T>(
+fn cast_array_type<'py, T: numpy::Element>(
     py: Python<'py>,
     array: Bound<'py, PyArray1<T>>,
     dtype: Option<&Bound<'py, PyAny>>,

--- a/crates/synthesis/src/discrete_basis/basic_approximations.rs
+++ b/crates/synthesis/src/discrete_basis/basic_approximations.rs
@@ -49,7 +49,7 @@ impl From<DiscreteBasisError> for PyErr {
 /// Gates are stored in **circuit order**, not in matrix multiplication order. That means that
 /// e.g. [H, T] corresponds to the matrix U = T @ H. The matrix is not stored as U(2), but in
 /// a SO(3) representation, which discards the global phase.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone, Debug)]
 pub struct GateSequence {
     // The sequence of standard gates.

--- a/crates/synthesis/src/discrete_basis/solovay_kitaev.rs
+++ b/crates/synthesis/src/discrete_basis/solovay_kitaev.rs
@@ -32,7 +32,7 @@ use super::math::{self, group_commutator_decomposition};
 ///
 /// This generates the basic approximation set once as R-tree and re-uses it for
 /// each queried decomposition.
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 #[derive(Clone, Debug)]
 pub struct SolovayKitaevSynthesis {
     /// The set of basic approximations.
@@ -280,7 +280,7 @@ impl SolovayKitaevSynthesis {
     /// Query the basic approximation for a [GateSequence].
     ///
     /// Legacy compat.
-    fn find_basic_approximation(&self, sequence: GateSequence) -> GateSequence {
+    fn find_basic_approximation(&self, sequence: &GateSequence) -> GateSequence {
         let approximation = self
             .basic_approximations
             .query(&sequence.matrix_so3)

--- a/crates/synthesis/src/euler_one_qubit_decomposer.rs
+++ b/crates/synthesis/src/euler_one_qubit_decomposer.rs
@@ -687,7 +687,12 @@ impl Default for EulerBasisSet {
 }
 
 #[derive(Clone, Debug, Copy, Eq, Hash, PartialEq)]
-#[pyclass(module = "qiskit._accelerate.euler_one_qubit_decomposer", eq, eq_int)]
+#[pyclass(
+    module = "qiskit._accelerate.euler_one_qubit_decomposer",
+    eq,
+    eq_int,
+    from_py_object
+)]
 pub enum EulerBasis {
     U3 = 0,
     U321 = 1,

--- a/crates/synthesis/src/permutation/mod.rs
+++ b/crates/synthesis/src/permutation/mod.rs
@@ -27,7 +27,10 @@ mod utils;
 /// Checks whether an array of size N is a permutation of 0, 1, ..., N - 1.
 #[pyfunction]
 #[pyo3(signature = (pattern))]
-pub fn _validate_permutation(py: Python, pattern: PyArrayLike1<i64>) -> PyResult<Py<PyAny>> {
+pub fn _validate_permutation(
+    py: Python,
+    pattern: PyArrayLike1<i64, numpy::AllowTypeChange>,
+) -> PyResult<Py<PyAny>> {
     let view = pattern.as_array();
     utils::validate_permutation(&view)?;
     Ok(py.None())
@@ -36,7 +39,10 @@ pub fn _validate_permutation(py: Python, pattern: PyArrayLike1<i64>) -> PyResult
 /// Finds inverse of a permutation pattern.
 #[pyfunction]
 #[pyo3(signature = (pattern))]
-pub fn _inverse_pattern(py: Python, pattern: PyArrayLike1<i64>) -> PyResult<Py<PyAny>> {
+pub fn _inverse_pattern(
+    py: Python,
+    pattern: PyArrayLike1<i64, numpy::AllowTypeChange>,
+) -> PyResult<Py<PyAny>> {
     let view = pattern.as_array();
     let inverse_i64: Vec<i64> = utils::invert(&view).iter().map(|&x| x as i64).collect();
     Ok(inverse_i64.into_pyobject(py)?.unbind())
@@ -44,7 +50,9 @@ pub fn _inverse_pattern(py: Python, pattern: PyArrayLike1<i64>) -> PyResult<Py<P
 
 #[pyfunction]
 #[pyo3(signature = (pattern))]
-pub fn _synth_permutation_basic(pattern: PyArrayLike1<i64>) -> PyResult<CircuitData> {
+pub fn _synth_permutation_basic(
+    pattern: PyArrayLike1<i64, numpy::AllowTypeChange>,
+) -> PyResult<CircuitData> {
     let view = pattern.as_array();
     let num_qubits = view.len();
     Ok(CircuitData::from_standard_gates(
@@ -62,7 +70,9 @@ pub fn _synth_permutation_basic(pattern: PyArrayLike1<i64>) -> PyResult<CircuitD
 
 #[pyfunction]
 #[pyo3(signature = (pattern))]
-fn _synth_permutation_acg(pattern: PyArrayLike1<i64>) -> PyResult<CircuitData> {
+fn _synth_permutation_acg(
+    pattern: PyArrayLike1<i64, numpy::AllowTypeChange>,
+) -> PyResult<CircuitData> {
     let inverted = utils::invert(&pattern.as_array());
     let view = inverted.view();
     let num_qubits = view.len();
@@ -86,7 +96,9 @@ fn _synth_permutation_acg(pattern: PyArrayLike1<i64>) -> PyResult<CircuitData> {
 /// architecture using the Kutin, Moulton, Smithline method.
 #[pyfunction]
 #[pyo3(signature = (pattern))]
-pub fn _synth_permutation_depth_lnn_kms(pattern: PyArrayLike1<i64>) -> PyResult<CircuitData> {
+pub fn _synth_permutation_depth_lnn_kms(
+    pattern: PyArrayLike1<i64, numpy::AllowTypeChange>,
+) -> PyResult<CircuitData> {
     let mut inverted = utils::invert(&pattern.as_array());
     let mut view = inverted.view_mut();
     let num_qubits = view.len();

--- a/crates/synthesis/src/two_qubit_decompose.rs
+++ b/crates/synthesis/src/two_qubit_decompose.rs
@@ -197,7 +197,7 @@ fn decompose_two_qubit_product_gate(
 ///     QiskitError: if decomposition isn't possible.
 fn py_decompose_two_qubit_product_gate(
     py: Python,
-    special_unitary: PyArrayLike2<Complex64>,
+    special_unitary: PyArrayLike2<Complex64, numpy::AllowTypeChange>,
 ) -> PyResult<(Py<PyAny>, Py<PyAny>, f64)> {
     let view = special_unitary.as_array();
     let (l, r, phase) = decompose_two_qubit_product_gate(view)?;
@@ -417,7 +417,7 @@ fn compute_unitary(sequence: &TwoQubitSequenceVec, global_phase: f64) -> Array2<
 const DEFAULT_FIDELITY: f64 = 1.0 - 1.0e-9;
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
-#[pyclass(module = "qiskit._accelerate.two_qubit_decompose", eq)]
+#[pyclass(module = "qiskit._accelerate.two_qubit_decompose", eq, from_py_object)]
 pub enum Specialization {
     General,
     IdEquiv,
@@ -479,7 +479,11 @@ impl Specialization {
 
 #[derive(Clone, Debug)]
 #[allow(non_snake_case)]
-#[pyclass(module = "qiskit._accelerate.two_qubit_decompose", subclass)]
+#[pyclass(
+    module = "qiskit._accelerate.two_qubit_decompose",
+    subclass,
+    skip_from_py_object
+)]
 pub struct TwoQubitWeylDecomposition {
     #[pyo3(get)]
     a: f64,
@@ -1296,7 +1300,11 @@ impl Default for TwoQubitGateSequence {
 
 #[derive(Clone, Debug)]
 #[allow(non_snake_case)]
-#[pyclass(module = "qiskit._accelerate.two_qubit_decompose", subclass)]
+#[pyclass(
+    module = "qiskit._accelerate.two_qubit_decompose",
+    subclass,
+    skip_from_py_object
+)]
 pub struct TwoQubitBasisDecomposer {
     gate: PackedOperation,
     gate_params: SmallVec<[f64; 3]>,
@@ -2521,7 +2529,11 @@ impl<'py> IntoPyObject<'py> for RXXEquivalent {
 }
 
 #[derive(Clone, Debug)]
-#[pyclass(module = "qiskit._accelerate.two_qubit_decompose", subclass)]
+#[pyclass(
+    module = "qiskit._accelerate.two_qubit_decompose",
+    subclass,
+    skip_from_py_object
+)]
 pub struct TwoQubitControlledUDecomposer {
     rxx_equivalent_gate: RXXEquivalent,
     euler_basis: EulerBasis,

--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -926,7 +926,7 @@ fn get_relative_placement(
 }
 
 #[derive(Clone, Debug)]
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 pub struct CommutationLibrary {
     pub library: Option<HashMap<(String, String), CommutationLibraryEntry>>,
 }

--- a/crates/transpiler/src/equivalence.rs
+++ b/crates/transpiler/src/equivalence.rs
@@ -56,7 +56,12 @@ pub static PYDIGRAPH: ImportOnceCell = ImportOnceCell::new("rustworkx", "PyDiGra
 
 // Custom Structs
 
-#[pyclass(frozen, sequence, module = "qiskit._accelerate.equivalence")]
+#[pyclass(
+    frozen,
+    sequence,
+    module = "qiskit._accelerate.equivalence",
+    from_py_object
+)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Key {
     #[pyo3(get)]
@@ -127,7 +132,12 @@ impl Display for Key {
     }
 }
 
-#[pyclass(frozen, sequence, module = "qiskit._accelerate.equivalence")]
+#[pyclass(
+    frozen,
+    sequence,
+    module = "qiskit._accelerate.equivalence",
+    from_py_object
+)]
 #[derive(Debug, Clone)]
 pub struct Equivalence {
     #[pyo3(get)]
@@ -183,7 +193,12 @@ impl Display for Equivalence {
     }
 }
 
-#[pyclass(frozen, sequence, module = "qiskit._accelerate.equivalence")]
+#[pyclass(
+    frozen,
+    sequence,
+    module = "qiskit._accelerate.equivalence",
+    from_py_object
+)]
 #[derive(Debug, Clone)]
 pub struct NodeData {
     #[pyo3(get)]
@@ -227,7 +242,12 @@ impl Display for NodeData {
     }
 }
 
-#[pyclass(frozen, sequence, module = "qiskit._accelerate.equivalence")]
+#[pyclass(
+    frozen,
+    sequence,
+    module = "qiskit._accelerate.equivalence",
+    from_py_object
+)]
 #[derive(Debug, Clone)]
 pub struct EdgeData {
     #[pyo3(get)]
@@ -359,7 +379,8 @@ type KTIType = IndexMap<Key, NodeIndex, RandomState>;
 #[pyclass(
     subclass,
     name = "BaseEquivalenceLibrary",
-    module = "qiskit._accelerate.equivalence"
+    module = "qiskit._accelerate.equivalence",
+    skip_from_py_object
 )]
 #[derive(Debug, Clone)]
 pub struct EquivalenceLibrary {

--- a/crates/transpiler/src/passes/alap_schedule_analysis.rs
+++ b/crates/transpiler/src/passes/alap_schedule_analysis.rs
@@ -195,7 +195,8 @@ pub fn py_run_alap_schedule_analysis(
         for (py_node, py_duration) in node_durations.iter() {
             let node_idx = py_node
                 .cast_into::<DAGOpNode>()?
-                .extract::<DAGNode>()?
+                .cast_into::<DAGNode>()?
+                .borrow()
                 .node
                 .expect("Node index not found.");
             let val = py_duration.extract::<u64>()?;
@@ -213,7 +214,8 @@ pub fn py_run_alap_schedule_analysis(
         for (py_node, py_duration) in node_durations.iter() {
             let node_idx = py_node
                 .cast_into::<DAGOpNode>()?
-                .extract::<DAGNode>()?
+                .cast_into::<DAGNode>()?
+                .borrow()
                 .node
                 .expect("Node index not found.");
             let val = py_duration.extract::<f64>()?;

--- a/crates/transpiler/src/passes/asap_schedule_analysis.rs
+++ b/crates/transpiler/src/passes/asap_schedule_analysis.rs
@@ -177,7 +177,8 @@ pub fn py_run_asap_schedule_analysis(
         for (py_node, py_duration) in node_durations.iter() {
             let node_idx = py_node
                 .cast_into::<DAGOpNode>()?
-                .extract::<DAGNode>()?
+                .cast_into::<DAGNode>()?
+                .borrow()
                 .node
                 .expect("Node index not found.");
             let val = py_duration.extract::<u64>()?;
@@ -195,7 +196,8 @@ pub fn py_run_asap_schedule_analysis(
         for (py_node, py_duration) in node_durations.iter() {
             let node_idx = py_node
                 .cast_into::<DAGOpNode>()?
-                .extract::<DAGNode>()?
+                .cast_into::<DAGNode>()?
+                .borrow()
                 .node
                 .expect("Node index not found.");
             let val = py_duration.extract::<f64>()?;

--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -51,7 +51,7 @@ use qiskit_circuit::instruction::{Instruction, Parameters};
 /// The global qubits are numbered by consecutive integers starting at `0`,
 /// and the states are distinguished into clean (:math:`|0\rangle`)
 /// and dirty (unknown).
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 #[derive(Clone, Debug)]
 struct QubitTracker {
     /// The total number of global qubits
@@ -277,7 +277,10 @@ impl QubitTracker {
 }
 
 /// Internal class that encapsulates immutable data required by the HighLevelSynthesis transpiler pass.
-#[pyclass(module = "qiskit._accelerate.high_level_synthesis")]
+#[pyclass(
+    module = "qiskit._accelerate.high_level_synthesis",
+    skip_from_py_object
+)]
 #[derive(Clone, Debug)]
 pub struct HighLevelSynthesisData {
     // The high-level-synthesis config that specifies the synthesis methods

--- a/crates/transpiler/src/passes/sabre/heuristic.rs
+++ b/crates/transpiler/src/passes/sabre/heuristic.rs
@@ -19,8 +19,7 @@ use pyo3::types::PyString;
 use qiskit_circuit::impl_intopyobject_for_copy_pyclass;
 
 /// Affect the dynamic scaling of the weight of node-set-based heuristics (basic and lookahead).
-#[pyclass]
-#[pyo3(module = "qiskit._accelerate.sabre", frozen, eq)]
+#[pyclass(module = "qiskit._accelerate.sabre", frozen, eq, from_py_object)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum SetScaling {
     /// No dynamic scaling of the weight.
@@ -47,8 +46,7 @@ impl SetScaling {
 
 /// Define the characteristics of the basic heuristic.  This is a simple sum of the physical
 /// distances of every gate in the front layer.
-#[pyclass]
-#[pyo3(module = "qiskit._accelerate.sabre", frozen)]
+#[pyclass(module = "qiskit._accelerate.sabre", frozen, from_py_object)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct BasicHeuristic {
     /// The relative weighting of this heuristic to others.  Typically you should just set this to
@@ -83,8 +81,7 @@ impl BasicHeuristic {
 
 /// Define the characteristics of the lookahead heuristic.  This is a sum of the physical distances
 /// of every gate in the lookahead set, which is gates immediately after the front layer.
-#[pyclass]
-#[pyo3(module = "qiskit._accelerate.sabre", frozen)]
+#[pyclass(module = "qiskit._accelerate.sabre", frozen, from_py_object)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct LookaheadHeuristic {
     /// The relative weight of this heuristic.  Typically this is defined relative to the
@@ -127,7 +124,7 @@ impl LookaheadHeuristic {
 /// multiplier associated with it, beginning at 1.0, and has :attr:`increment` added to it each time
 /// the qubit is involved in a swap.  The final heuristic is calculated by multiplying all other
 /// components by the maximum multiplier involved in a given swap.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(module = "qiskit._accelerate.sabre", frozen)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct DecayHeuristic {
@@ -162,8 +159,7 @@ impl DecayHeuristic {
 
 /// A complete description of the heuristic that Sabre will use.  See the individual elements for a
 /// greater description.
-#[pyclass]
-#[pyo3(module = "qiskit._accelerate.sabre", frozen)]
+#[pyclass(module = "qiskit._accelerate.sabre", frozen, eq, skip_from_py_object)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Heuristic {
     pub basic: Option<BasicHeuristic>,
@@ -251,10 +247,6 @@ impl Heuristic {
                 ..self.clone()
             })
         }
-    }
-
-    pub fn __eq__(&self, py: Python, other: Py<PyAny>) -> bool {
-        other.extract::<Self>(py).is_ok_and(|other| self == &other)
     }
 
     pub fn __repr__(&self, py: Python) -> PyResult<Py<PyAny>> {

--- a/crates/transpiler/src/passes/vf2/error_map.rs
+++ b/crates/transpiler/src/passes/vf2/error_map.rs
@@ -34,7 +34,7 @@ use hashbrown::HashMap;
 /// error rates, you should assign both elements of the key to the same
 /// qubit index. If an edge or qubit is ideal and has no error rate, you can
 /// either set it to ``0.0`` explicitly or as ``NaN``.
-#[pyclass(mapping, module = "qiskit._accelerate.error_map")]
+#[pyclass(mapping, module = "qiskit._accelerate.error_map", skip_from_py_object)]
 #[derive(Clone, Debug)]
 pub struct ErrorMap {
     pub error_map: HashMap<[PhysicalQubit; 2], f64>,

--- a/crates/transpiler/src/target/instruction_properties.rs
+++ b/crates/transpiler/src/target/instruction_properties.rs
@@ -18,7 +18,8 @@ use pyo3::{prelude::*, pyclass};
 #[pyclass(
     subclass,
     name = "BaseInstructionProperties",
-    module = "qiskit._accelerate.target"
+    module = "qiskit._accelerate.target",
+    from_py_object
 )]
 #[derive(Clone, Debug, PartialEq)]
 pub struct InstructionProperties {

--- a/crates/transpiler/src/target/mod.rs
+++ b/crates/transpiler/src/target/mod.rs
@@ -197,7 +197,8 @@ memory.
     mapping,
     subclass,
     name = "BaseTarget",
-    module = "qiskit._accelerate.target"
+    module = "qiskit._accelerate.target",
+    skip_from_py_object
 )]
 #[derive(Clone, Debug)]
 pub struct Target {

--- a/crates/transpiler/src/target/qubit_properties.rs
+++ b/crates/transpiler/src/target/qubit_properties.rs
@@ -14,7 +14,7 @@ use pyo3::{prelude::*, pyclass};
 /**
     A representation of a ``QubitProperties`` object.
 */
-#[pyclass(subclass, module = "qiskit._accelerate.target")]
+#[pyclass(subclass, module = "qiskit._accelerate.target", from_py_object)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct QubitProperties {
     #[pyo3(get, set)]


### PR DESCRIPTION
The major change for us is that `pyclass` on `Clone` types no longer automatically derives a cloning implementation of `FromPyObject`.  We now have to opt-in to having it with an extra derive.  Here I've tried to avoid opting in, except in cases where the underlying `struct` is small and `Copy`; this turned up a few places where we've been lazy with / missed `extract` calls that could just be `cast`s.  I left one place (in `ConsolidateBlocks`) where we _shouldn't_ need to clone out of Python space, but it would be rather involved to refactor the logic to make this work better, since we're unfortunately using the Python-exposed function as the main driver logic, rather than the Rust-native help function that lives next to it.

On the `rust-numpy` side, a change intended to fix a bug in implicit dimension handling in `PyArrayLike` had a knock-on effect of making allocating type conversions fail.  Every current usage within Qiskit _wants_ the automatic conversion by nature of using `PyArrayLike` as an extraction point and not a cast, so we have to change our usage sites to allow the conversion now.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


Close #15669.

I imagine the `skip_from_py_object` attribute on `pyclass` will disappear in the next PyO3 release - I think it's only necessary while the default is in the process of changing; if it's not there, there'd be a trait overlap problem with the current blanket implementation that's being deprecated.