### PR TITLE
Fix MCX synthesis methods when the number of control qubits is 0

### DIFF
--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -322,7 +322,11 @@ pub fn synth_mcx_n_dirty_i15(
     relative_phase: bool,
     action_only: bool,
 ) -> Result<CircuitData, CircuitDataError> {
-    if num_controls == 1 {
+    if num_controls == 0 {
+        let mut circuit = CircuitData::with_capacity(1, 0, 1, Param::Float(0.0))?;
+        circuit.x(0)?;
+        Ok(circuit)
+    } else if num_controls == 1 {
         let mut circuit = CircuitData::with_capacity(2, 0, 1, Param::Float(0.0))?;
         circuit.cx(0, 1)?;
         Ok(circuit)
@@ -410,7 +414,17 @@ pub fn synth_mcx_noaux_v24(
     py: Python,
     num_controls: usize,
 ) -> Result<CircuitData, CircuitDataError> {
-    if num_controls == 3 {
+    if num_controls == 0 {
+        let mut circuit = CircuitData::with_capacity(1, 0, 1, Param::Float(0.0))?;
+        circuit.x(0)?;
+        Ok(circuit)
+    } else if num_controls == 1 {
+        let mut circuit = CircuitData::with_capacity(2, 0, 1, Param::Float(0.0))?;
+        circuit.cx(0, 1)?;
+        Ok(circuit)
+    } else if num_controls == 2 {
+        Ok(ccx())
+    } else if num_controls == 3 {
         Ok(c3x())
     } else if num_controls == 4 {
         c4x()
@@ -880,7 +894,9 @@ pub fn synth_mcx_noaux_hp24(num_controls: usize) -> PyResult<CircuitData> {
     let mut circuit = CircuitData::with_capacity(n as u32, 0, 0, Param::Float(0.0))?;
 
     // Handle small cases explicitly
-    if n == 2 {
+    if n == 1 {
+        circuit.x(0)?;
+    } else if n == 2 {
         circuit.cx(0, 1)?;
     } else {
         circuit.h(num_controls as u32)?;

--- a/qiskit/synthesis/multi_controlled/mcx_synthesis.py
+++ b/qiskit/synthesis/multi_controlled/mcx_synthesis.py
@@ -57,20 +57,50 @@ def synth_mcx_n_dirty_i15(
     Returns:
         The synthesized quantum circuit.
 
+    Raises:
+        QiskitError: if ``num_ctrl_qubits`` is illegal.
+
     References:
         1. Iten et. al., *Quantum Circuits for Isometries*, Phys. Rev. A 93, 032318 (2016),
            `arXiv:1501.06911 <https://arxiv.org/abs/1501.06911>`_
     """
+    if num_ctrl_qubits < 0:
+        raise QiskitError(
+            "The method synth_mcx_n_dirty_i15 cannot be called with a negative number of control qubits."
+        )
+
     return QuantumCircuit._from_circuit_data(
         synth_mcx_n_dirty_i15_rs(num_ctrl_qubits, relative_phase, action_only)
     )
 
 
+def _synth_mcx_special_cases(num_ctrl_qubits: int) -> QuantumCircuit:
+    """Internal function that produces default MCX circuits when num_ctrl_qubits is 0, 1, or 2."""
+    if num_ctrl_qubits == 0:
+        qc = QuantumCircuit(1)
+        qc.x(0)
+        return qc
+
+    elif num_ctrl_qubits == 1:
+        qc = QuantumCircuit(2)
+        qc.cx(0, 1)
+        return qc
+
+    elif num_ctrl_qubits == 2:
+        qc = QuantumCircuit(3)
+        qc.ccx(0, 1, 2)
+        return qc
+
+    else:
+        raise QiskitError("_synth_mcx_special_cases should be called with only 0, 1, or 2 cotrols.")
+
+
 def synth_mcx_n_clean_m15(num_ctrl_qubits: int) -> QuantumCircuit:
     r"""
-    Synthesize a multi-controlled X gate with :math:`k` controls using :math:`k - 2`
+    Synthesize a multi-controlled X gate with :math:`k\ge 3` controls using :math:`k - 2`
     clean ancillary qubits with producing a circuit with :math:`2 * k - 1` qubits
     and at most :math:`6 * k - 6` CX gates, by Maslov [1].
+    For :math:`k\le 2` the returned circuit contains a single X, CX or CCX gate respectively.
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -78,10 +108,20 @@ def synth_mcx_n_clean_m15(num_ctrl_qubits: int) -> QuantumCircuit:
     Returns:
         The synthesized quantum circuit.
 
+    Raises:
+        QiskitError: if ``num_ctrl_qubits`` is illegal.
+
     References:
         1. Maslov., Phys. Rev. A 93, 022311 (2016),
            `arXiv:1508.03273 <https://arxiv.org/pdf/1508.03273>`_
     """
+    if num_ctrl_qubits < 0:
+        raise QiskitError(
+            "The method synth_mcx_n_clean_m15 cannot be called with a negative number of control qubits."
+        )
+
+    if num_ctrl_qubits <= 2:
+        return _synth_mcx_special_cases(num_ctrl_qubits)
 
     num_qubits = 2 * num_ctrl_qubits - 1
     q = QuantumRegister(num_qubits, name="q")
@@ -111,9 +151,10 @@ def synth_mcx_n_clean_m15(num_ctrl_qubits: int) -> QuantumCircuit:
 
 def synth_mcx_1_clean_b95(num_ctrl_qubits: int) -> QuantumCircuit:
     r"""
-    Synthesize a multi-controlled X gate with :math:`k` controls using a single
+    Synthesize a multi-controlled X gate with :math:`k\ge 3` controls using a single
     clean ancillary qubit producing a circuit with :math:`k + 2` qubits and at most
     :math:`16 * k - 24` CX gates, by [1], [2].
+    For :math:`k\le 2` the returned circuit contains a single X, CX or CCX gate respectively.
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -121,12 +162,22 @@ def synth_mcx_1_clean_b95(num_ctrl_qubits: int) -> QuantumCircuit:
     Returns:
         The synthesized quantum circuit.
 
+    Raises:
+        QiskitError: if ``num_ctrl_qubits`` is illegal.
+
     References:
         1. Barenco et. al., *Elementary gates for quantum computation*, Phys.Rev. A52 3457 (1995),
            `arXiv:quant-ph/9503016 <https://arxiv.org/abs/quant-ph/9503016>`_
         2. Iten et. al., *Quantum Circuits for Isometries*, Phys. Rev. A 93, 032318 (2016),
            `arXiv:1501.06911 <https://arxiv.org/abs/1501.06911>`_
     """
+    if num_ctrl_qubits < 0:
+        raise QiskitError(
+            "The method synth_mcx_1_clean_b95 cannot be called with a negative number of control qubits."
+        )
+
+    if num_ctrl_qubits <= 2:
+        return _synth_mcx_special_cases(num_ctrl_qubits)
 
     if num_ctrl_qubits == 3:
         return synth_c3x()
@@ -169,18 +220,30 @@ def synth_mcx_1_clean_b95(num_ctrl_qubits: int) -> QuantumCircuit:
 
 def synth_mcx_gray_code(num_ctrl_qubits: int) -> QuantumCircuit:
     r"""
-    Synthesize a multi-controlled X gate with :math:`k` controls using the Gray code.
+    Synthesize a multi-controlled X gate with :math:`k\ge 3` controls using the Gray code.
 
     Produces a quantum circuit with :math:`k + 1` qubits. This method
     produces exponentially many CX gates and should be used only for small
     values of :math:`k`.
+    For :math:`k\le 2` the returned circuit contains a single X, CX or CCX gate respectively.
 
     Args:
         num_ctrl_qubits: The number of control qubits.
 
+    Raises:
+        QiskitError: if ``num_ctrl_qubits`` is illegal.
+
     Returns:
         The synthesized quantum circuit.
     """
+    if num_ctrl_qubits < 0:
+        raise QiskitError(
+            "The method synth_mcx_gray_code cannot be called with a negative number of control qubits."
+        )
+
+    if num_ctrl_qubits <= 2:
+        return _synth_mcx_special_cases(num_ctrl_qubits)
+
     from qiskit.circuit.library.standard_gates.u3 import _gray_code_chain
 
     num_qubits = num_ctrl_qubits + 1
@@ -213,11 +276,19 @@ def synth_mcx_noaux_v24(num_ctrl_qubits: int) -> QuantumCircuit:
     Returns:
         The synthesized quantum circuit.
 
+    Raises:
+        QiskitError: if ``num_ctrl_qubits`` is illegal.
+
     References:
         1. Vale et. al., *Circuit Decomposition of Multicontrolled Special Unitary
            Single-Qubit Gates*, IEEE TCAD 43(3) (2024),
            `arXiv:2302.06377 <https://arxiv.org/abs/2302.06377>`_
     """
+    if num_ctrl_qubits < 0:
+        raise QiskitError(
+            "The method synth_mcx_noaux_v24 cannot be called with a negative number of control qubits."
+        )
+
     circ = QuantumCircuit._from_circuit_data(synth_mcx_noaux_v24_rs(num_ctrl_qubits))
     return circ
 
@@ -236,11 +307,19 @@ def synth_mcx_noaux_hp24(num_ctrl_qubits: int) -> QuantumCircuit:
     Returns:
         The synthesized quantum circuit.
 
+    Raises:
+        QiskitError: if ``num_ctrl_qubits`` is illegal.
+
     References:
         1. Huang and Palsberg, *Compiling Conditional Quantum Gates without Using
            Helper Qubits*, PLDI (2024),
            <https://dl.acm.org/doi/10.1145/3656436>`_
     """
+    if num_ctrl_qubits < 0:
+        raise QiskitError(
+            "The method synth_mcx_noaux_hp24 cannot be called with a negative number of control qubits."
+        )
+
     circ = QuantumCircuit._from_circuit_data(synth_mcx_noaux_hp24_rs(num_ctrl_qubits))
     return circ
 
@@ -331,8 +410,9 @@ def _linear_depth_ladder_ops(num_ladder_qubits: int) -> tuple[QuantumCircuit, li
 
 def synth_mcx_1_kg24(num_ctrl_qubits: int, clean: bool = True) -> QuantumCircuit:
     r"""
-    Synthesize a multi-controlled X gate with :math:`k` controls using :math:`1` ancillary qubit as
+    Synthesize a multi-controlled X gate with :math:`k\ge 3` controls using :math:`1` ancillary qubit as
     described in Sec. 5 of [1].
+    For :math:`k\le 2` the returned circuit contains a single X, CX or CCX gate respectively.
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -342,15 +422,19 @@ def synth_mcx_1_kg24(num_ctrl_qubits: int, clean: bool = True) -> QuantumCircuit
         The synthesized quantum circuit.
 
     Raises:
-        QiskitError: If num_ctrl_qubits <= 2.
+        QiskitError: if ``num_ctrl_qubits`` is illegal.
 
     References:
         1. Khattar and Gidney, Rise of conditionally clean ancillae for optimizing quantum circuits
         `arXiv:2407.17966 <https://arxiv.org/abs/2407.17966>`__
     """
+    if num_ctrl_qubits < 0:
+        raise QiskitError(
+            "The method synth_mcx_1_kg24 cannot be called with a negative number of control qubits."
+        )
 
     if num_ctrl_qubits <= 2:
-        raise QiskitError("kg24 synthesis requires at least 3 control qubits. Use CCX directly.")
+        return _synth_mcx_special_cases(num_ctrl_qubits)
 
     q_controls = QuantumRegister(num_ctrl_qubits, name="ctrl")
     q_target = QuantumRegister(1, name="targ")
@@ -380,9 +464,9 @@ def synth_mcx_1_kg24(num_ctrl_qubits: int, clean: bool = True) -> QuantumCircuit
 
 def synth_mcx_1_clean_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
     r"""
-    Synthesize a multi-controlled X gate with :math:`k` controls using :math:`1` clean ancillary qubit
-    producing a circuit with :math:`2k-3` Toffoli gates or :math:`6k-6` CX gates and depth
-    :math:`O(k)` as described in Sec. 5.1 of [1].
+    Synthesize a multi-controlled X gate with :math:`k\ge 3` controls using :math:`1` clean
+    ancillary qubit producing a circuit with :math:`2k-3` Toffoli gates or :math:`6k-6`
+    CX gates and depth :math:`O(k)` as described in Sec. 5.1 of [1].
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -391,21 +475,30 @@ def synth_mcx_1_clean_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
         The synthesized quantum circuit.
 
     Raises:
-        QiskitError: If num_ctrl_qubits <= 2.
+        QiskitError: if ``num_ctrl_qubits`` is illegal.
 
     References:
         1. Khattar and Gidney, Rise of conditionally clean ancillae for optimizing quantum circuits
         `arXiv:2407.17966 <https://arxiv.org/abs/2407.17966>`__
     """
+
+    if num_ctrl_qubits < 0:
+        raise QiskitError(
+            "The method synth_mcx_n_dirty_i15 cannot be called with a negative number of control qubits."
+        )
+
+    if num_ctrl_qubits <= 2:
+        return _synth_mcx_special_cases(num_ctrl_qubits)
 
     return synth_mcx_1_kg24(num_ctrl_qubits, clean=True)
 
 
 def synth_mcx_1_dirty_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
     r"""
-    Synthesize a multi-controlled X gate with :math:`k` controls using :math:`1` dirty ancillary qubit
-    producing a circuit with :math:`4k-8` Toffoli gates or :math:`12k-18` CX gates and depth
-    :math:`O(k)` as described in Sec. 5.3 of [1].
+    Synthesize a multi-controlled X gate with :math:`k\ge 3` controls using :math:`1` dirty
+    ancillary qubit producing a circuit with :math:`4k-8` Toffoli gates or :math:`12k-18`
+    CX gates and depth :math:`O(k)` as described in Sec. 5.3 of [1].
+    For :math:`k\le 2` the returned circuit contains a single X, CX or CCX gate respectively.
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -414,12 +507,19 @@ def synth_mcx_1_dirty_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
         The synthesized quantum circuit.
 
     Raises:
-        QiskitError: If num_ctrl_qubits <= 2.
+        QiskitError: if ``num_ctrl_qubits`` is illegal.
 
     References:
         1. Khattar and Gidney, Rise of conditionally clean ancillae for optimizing quantum circuits
         `arXiv:2407.17966 <https://arxiv.org/abs/2407.17966>`__
     """
+    if num_ctrl_qubits < 0:
+        raise QiskitError(
+            "The method synth_mcx_n_dirty_i15 cannot be called with a negative number of control qubits."
+        )
+
+    if num_ctrl_qubits <= 2:
+        return _synth_mcx_special_cases(num_ctrl_qubits)
 
     return synth_mcx_1_kg24(num_ctrl_qubits, clean=False)
 
@@ -488,8 +588,9 @@ def _build_logn_depth_ccx_ladder(
 
 def synth_mcx_2_kg24(num_ctrl_qubits: int, clean: bool = True) -> QuantumCircuit:
     r"""
-    Synthesize a multi-controlled X gate with :math:`k` controls using :math:`2` ancillary qubits.
+    Synthesize a multi-controlled X gate with :math:`k\ge 3` controls using :math:`2` ancillary qubits.
     as described in Sec. 5 of [1].
+    For :math:`k\le 2` the returned circuit contains a single X, CX or CCX gate respectively.
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -499,15 +600,20 @@ def synth_mcx_2_kg24(num_ctrl_qubits: int, clean: bool = True) -> QuantumCircuit
         The synthesized quantum circuit.
 
     Raises:
-        QiskitError: If num_ctrl_qubits <= 2.
+        QiskitError: if ``num_ctrl_qubits`` is illegal.
 
     References:
         1. Khattar and Gidney, Rise of conditionally clean ancillae for optimizing quantum circuits
         `arXiv:2407.17966 <https://arxiv.org/abs/2407.17966>`__
     """
 
+    if num_ctrl_qubits < 0:
+        raise QiskitError(
+            "The method synth_mcx_n_dirty_i15 cannot be called with a negative number of control qubits."
+        )
+
     if num_ctrl_qubits <= 2:
-        raise QiskitError("kg24 synthesis requires at least 3 control qubits. Use CCX directly.")
+        return _synth_mcx_special_cases(num_ctrl_qubits)
 
     q_control = QuantumRegister(num_ctrl_qubits, name="ctrl")
     q_target = QuantumRegister(1, name="targ")
@@ -553,9 +659,10 @@ def synth_mcx_2_kg24(num_ctrl_qubits: int, clean: bool = True) -> QuantumCircuit
 
 def synth_mcx_2_clean_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
     r"""
-    Synthesize a multi-controlled X gate with :math:`k` controls using :math:`2` clean ancillary qubits
-    producing a circuit with :math:`2k-3` Toffoli gates or :math:`6k-6` CX gates and
-    depth :math:`O(\log(k))` as described in Sec. 5.2 of [1].
+    Synthesize a multi-controlled X gate with :math:`k\ge 3` controls using :math:`2` clean
+    ancillary qubits producing a circuit with :math:`2k-3` Toffoli gates or :math:`6k-6`
+    CX gates and depth :math:`O(\log(k))` as described in Sec. 5.2 of [1].
+    For :math:`k\le 2` the returned circuit contains a single X, CX or CCX gate respectively.
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -564,21 +671,30 @@ def synth_mcx_2_clean_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
         The synthesized quantum circuit.
 
     Raises:
-        QiskitError: If num_ctrl_qubits <= 2.
+        QiskitError: if ``num_ctrl_qubits`` is illegal.
 
     References:
         1. Khattar and Gidney, Rise of conditionally clean ancillae for optimizing quantum circuits
         `arXiv:2407.17966 <https://arxiv.org/abs/2407.17966>`__
     """
+
+    if num_ctrl_qubits < 0:
+        raise QiskitError(
+            "The method synth_mcx_n_dirty_i15 cannot be called with a negative number of control qubits."
+        )
+
+    if num_ctrl_qubits <= 2:
+        return _synth_mcx_special_cases(num_ctrl_qubits)
 
     return synth_mcx_2_kg24(num_ctrl_qubits, clean=True)
 
 
 def synth_mcx_2_dirty_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
     r"""
-    Synthesize a multi-controlled X gate with :math:`k` controls using :math:`2` dirty ancillary qubits
-    producing a circuit with :math:`4k-8` Toffoli gates or :math:`12k-18` CX gates and depth
-    :math:`O(\log(k))` as described in Sec. 5.4 of [1].
+    Synthesize a multi-controlled X gate with :math:`k\ge 3` controls using :math:`2` dirty
+    ancillary qubits producing a circuit with :math:`4k-8` Toffoli gates or :math:`12k-18`CX
+    gates and depth :math:`O(\log(k))` as described in Sec. 5.4 of [1].
+    For :math:`k\le 2` the returned circuit contains a single X, CX or CCX gate respectively.
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -587,12 +703,19 @@ def synth_mcx_2_dirty_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
         The synthesized quantum circuit.
 
     Raises:
-        QiskitError: If num_ctrl_qubits <= 2.
+        QiskitError: if ``num_ctrl_qubits`` is illegal.
 
     References:
         1. Khattar and Gidney, Rise of conditionally clean ancillae for optimizing quantum circuits
         `arXiv:2407.17966 <https://arxiv.org/abs/2407.17966>`__
     """
+    if num_ctrl_qubits < 0:
+        raise QiskitError(
+            "The method synth_mcx_n_dirty_i15 cannot be called with a negative number of control qubits."
+        )
+
+    if num_ctrl_qubits <= 2:
+        return _synth_mcx_special_cases(num_ctrl_qubits)
 
     return synth_mcx_2_kg24(num_ctrl_qubits, clean=False)
 

--- a/qiskit/synthesis/multi_controlled/mcx_synthesis.py
+++ b/qiskit/synthesis/multi_controlled/mcx_synthesis.py
@@ -66,7 +66,7 @@ def synth_mcx_n_dirty_i15(
     """
     if num_ctrl_qubits < 0:
         raise QiskitError(
-            "The method synth_mcx_n_dirty_i15 cannot be called with a negative number of control qubits."
+            "synth_mcx_n_dirty_i15 cannot be called with a negative number of control qubits."
         )
 
     return QuantumCircuit._from_circuit_data(
@@ -118,7 +118,7 @@ def synth_mcx_n_clean_m15(num_ctrl_qubits: int) -> QuantumCircuit:
     """
     if num_ctrl_qubits < 0:
         raise QiskitError(
-            "The method synth_mcx_n_clean_m15 cannot be called with a negative number of control qubits."
+            "synth_mcx_n_clean_m15 cannot be called with a negative number of control qubits."
         )
 
     if num_ctrl_qubits <= 2:
@@ -175,7 +175,7 @@ def synth_mcx_1_clean_b95(num_ctrl_qubits: int) -> QuantumCircuit:
     """
     if num_ctrl_qubits < 0:
         raise QiskitError(
-            "The method synth_mcx_1_clean_b95 cannot be called with a negative number of control qubits."
+            "synth_mcx_1_clean_b95 cannot be called with a negative number of control qubits."
         )
 
     if num_ctrl_qubits <= 2:
@@ -241,7 +241,7 @@ def synth_mcx_gray_code(num_ctrl_qubits: int) -> QuantumCircuit:
     """
     if num_ctrl_qubits < 0:
         raise QiskitError(
-            "The method synth_mcx_gray_code cannot be called with a negative number of control qubits."
+            "synth_mcx_gray_code cannot be called with a negative number of control qubits."
         )
 
     if num_ctrl_qubits <= 2:
@@ -289,7 +289,7 @@ def synth_mcx_noaux_v24(num_ctrl_qubits: int) -> QuantumCircuit:
     """
     if num_ctrl_qubits < 0:
         raise QiskitError(
-            "The method synth_mcx_noaux_v24 cannot be called with a negative number of control qubits."
+            "synth_mcx_noaux_v24 cannot be called with a negative number of control qubits."
         )
 
     circ = QuantumCircuit._from_circuit_data(synth_mcx_noaux_v24_rs(num_ctrl_qubits))
@@ -320,7 +320,7 @@ def synth_mcx_noaux_hp24(num_ctrl_qubits: int) -> QuantumCircuit:
     """
     if num_ctrl_qubits < 0:
         raise QiskitError(
-            "The method synth_mcx_noaux_hp24 cannot be called with a negative number of control qubits."
+            "synth_mcx_noaux_hp24 cannot be called with a negative number of control qubits."
         )
 
     circ = QuantumCircuit._from_circuit_data(synth_mcx_noaux_hp24_rs(num_ctrl_qubits))
@@ -434,7 +434,7 @@ def synth_mcx_1_kg24(num_ctrl_qubits: int, clean: bool = True) -> QuantumCircuit
     """
     if num_ctrl_qubits < 0:
         raise QiskitError(
-            "The method synth_mcx_1_kg24 cannot be called with a negative number of control qubits."
+            "synth_mcx_1_kg24 cannot be called with a negative number of control qubits."
         )
 
     if num_ctrl_qubits <= 2:
@@ -490,7 +490,7 @@ def synth_mcx_1_clean_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
 
     if num_ctrl_qubits < 0:
         raise QiskitError(
-            "The method synth_mcx_1_clean_kg24 cannot be called with a negative number of control qubits."
+            "synth_mcx_1_clean_kg24 cannot be called with a negative number of control qubits."
         )
 
     if num_ctrl_qubits <= 2:
@@ -522,7 +522,7 @@ def synth_mcx_1_dirty_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
     """
     if num_ctrl_qubits < 0:
         raise QiskitError(
-            "The method synth_mcx_1_dirty_kg24 cannot be called with a negative number of control qubits."
+            "synth_mcx_1_dirty_kg24 cannot be called with a negative number of control qubits."
         )
 
     if num_ctrl_qubits <= 2:
@@ -617,7 +617,7 @@ def synth_mcx_2_kg24(num_ctrl_qubits: int, clean: bool = True) -> QuantumCircuit
 
     if num_ctrl_qubits < 0:
         raise QiskitError(
-            "The method synth_mcx_2_kg24 cannot be called with a negative number of control qubits."
+            "synth_mcx_2_kg24 cannot be called with a negative number of control qubits."
         )
 
     if num_ctrl_qubits <= 2:
@@ -689,7 +689,7 @@ def synth_mcx_2_clean_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
 
     if num_ctrl_qubits < 0:
         raise QiskitError(
-            "The method synth_mcx_2_clean_kg24 cannot be called with a negative number of control qubits."
+            "synth_mcx_2_clean_kg24 cannot be called with a negative number of control qubits."
         )
 
     if num_ctrl_qubits <= 2:
@@ -721,7 +721,7 @@ def synth_mcx_2_dirty_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
     """
     if num_ctrl_qubits < 0:
         raise QiskitError(
-            "The method synth_mcx_2_dirty_kg24 cannot be called with a negative number of control qubits."
+            "synth_mcx_2_dirty_kg24 cannot be called with a negative number of control qubits."
         )
 
     if num_ctrl_qubits <= 2:

--- a/qiskit/synthesis/multi_controlled/mcx_synthesis.py
+++ b/qiskit/synthesis/multi_controlled/mcx_synthesis.py
@@ -490,7 +490,7 @@ def synth_mcx_1_clean_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
 
     if num_ctrl_qubits < 0:
         raise QiskitError(
-            "The method synth_mcx_n_dirty_i15 cannot be called with a negative number of control qubits."
+            "The method synth_mcx_1_clean_kg24 cannot be called with a negative number of control qubits."
         )
 
     if num_ctrl_qubits <= 2:
@@ -522,7 +522,7 @@ def synth_mcx_1_dirty_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
     """
     if num_ctrl_qubits < 0:
         raise QiskitError(
-            "The method synth_mcx_n_dirty_i15 cannot be called with a negative number of control qubits."
+            "The method synth_mcx_1_dirty_kg24 cannot be called with a negative number of control qubits."
         )
 
     if num_ctrl_qubits <= 2:
@@ -617,7 +617,7 @@ def synth_mcx_2_kg24(num_ctrl_qubits: int, clean: bool = True) -> QuantumCircuit
 
     if num_ctrl_qubits < 0:
         raise QiskitError(
-            "The method synth_mcx_n_dirty_i15 cannot be called with a negative number of control qubits."
+            "The method synth_mcx_2_kg24 cannot be called with a negative number of control qubits."
         )
 
     if num_ctrl_qubits <= 2:
@@ -689,7 +689,7 @@ def synth_mcx_2_clean_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
 
     if num_ctrl_qubits < 0:
         raise QiskitError(
-            "The method synth_mcx_n_dirty_i15 cannot be called with a negative number of control qubits."
+            "The method synth_mcx_2_clean_kg24 cannot be called with a negative number of control qubits."
         )
 
     if num_ctrl_qubits <= 2:
@@ -721,7 +721,7 @@ def synth_mcx_2_dirty_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
     """
     if num_ctrl_qubits < 0:
         raise QiskitError(
-            "The method synth_mcx_n_dirty_i15 cannot be called with a negative number of control qubits."
+            "The method synth_mcx_2_dirty_kg24 cannot be called with a negative number of control qubits."
         )
 
     if num_ctrl_qubits <= 2:

--- a/qiskit/synthesis/multi_controlled/mcx_synthesis.py
+++ b/qiskit/synthesis/multi_controlled/mcx_synthesis.py
@@ -41,9 +41,9 @@ def synth_mcx_n_dirty_i15(
     Synthesize a multi-controlled X gate with :math:`k` controls based on the paper
     by Iten et al. [1].
 
-    For :math:`k\ge 4` the method uses :math:`k - 2` dirty ancillary qubits, producing a circuit
-    with :math:`2 * k - 1` qubits and at most :math:`8 * k - 6` CX gates. For :math:`k\le 3`
-    explicit efficient circuits are used instead.
+    For :math:`k\ge 4`, the method uses :math:`k - 2` dirty ancillary qubits, producing a circuit
+    with :math:`2 * k - 1` qubits and at most :math:`8 * k - 6` CX gates. For :math:`k\le 3`,
+    explicitly constructed efficient circuits that require no ancillary qubits are used instead.
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -100,7 +100,8 @@ def synth_mcx_n_clean_m15(num_ctrl_qubits: int) -> QuantumCircuit:
     Synthesize a multi-controlled X gate with :math:`k\ge 3` controls using :math:`k - 2`
     clean ancillary qubits with producing a circuit with :math:`2 * k - 1` qubits
     and at most :math:`6 * k - 6` CX gates, by Maslov [1].
-    For :math:`k\le 2` the returned circuit contains a single X, CX or CCX gate respectively.
+    For :math:`k\le 2`, the returned circuit consists of a single X, CX or CCX gate
+    (corresponding to :math:`k = 0, 1, 2`, respectively) and uses no ancillary qubits.
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -154,7 +155,8 @@ def synth_mcx_1_clean_b95(num_ctrl_qubits: int) -> QuantumCircuit:
     Synthesize a multi-controlled X gate with :math:`k\ge 3` controls using a single
     clean ancillary qubit producing a circuit with :math:`k + 2` qubits and at most
     :math:`16 * k - 24` CX gates, by [1], [2].
-    For :math:`k\le 2` the returned circuit contains a single X, CX or CCX gate respectively.
+    For :math:`k\le 2`, the returned circuit consists of a single X, CX or CCX gate
+    (corresponding to :math:`k = 0, 1, 2`, respectively) and uses no ancillary qubits.
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -225,7 +227,8 @@ def synth_mcx_gray_code(num_ctrl_qubits: int) -> QuantumCircuit:
     Produces a quantum circuit with :math:`k + 1` qubits. This method
     produces exponentially many CX gates and should be used only for small
     values of :math:`k`.
-    For :math:`k\le 2` the returned circuit contains a single X, CX or CCX gate respectively.
+    For :math:`k\le 2`, the returned circuit consists of a single X, CX or CCX gate
+    (corresponding to :math:`k = 0, 1, 2`, respectively) and uses no ancillary qubits.
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -412,7 +415,8 @@ def synth_mcx_1_kg24(num_ctrl_qubits: int, clean: bool = True) -> QuantumCircuit
     r"""
     Synthesize a multi-controlled X gate with :math:`k\ge 3` controls using :math:`1` ancillary qubit as
     described in Sec. 5 of [1].
-    For :math:`k\le 2` the returned circuit contains a single X, CX or CCX gate respectively.
+    For :math:`k\le 2`, the returned circuit consists of a single X, CX or CCX gate
+    (corresponding to :math:`k = 0, 1, 2`, respectively) and uses no ancillary qubits.
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -467,6 +471,8 @@ def synth_mcx_1_clean_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
     Synthesize a multi-controlled X gate with :math:`k\ge 3` controls using :math:`1` clean
     ancillary qubit producing a circuit with :math:`2k-3` Toffoli gates or :math:`6k-6`
     CX gates and depth :math:`O(k)` as described in Sec. 5.1 of [1].
+    For :math:`k\le 2`, the returned circuit consists of a single X, CX or CCX gate
+    (corresponding to :math:`k = 0, 1, 2`, respectively) and uses no ancillary qubits.
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -498,7 +504,8 @@ def synth_mcx_1_dirty_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
     Synthesize a multi-controlled X gate with :math:`k\ge 3` controls using :math:`1` dirty
     ancillary qubit producing a circuit with :math:`4k-8` Toffoli gates or :math:`12k-18`
     CX gates and depth :math:`O(k)` as described in Sec. 5.3 of [1].
-    For :math:`k\le 2` the returned circuit contains a single X, CX or CCX gate respectively.
+    For :math:`k\le 2`, the returned circuit consists of a single X, CX or CCX gate
+    (corresponding to :math:`k = 0, 1, 2`, respectively) and uses no ancillary qubits.
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -590,7 +597,8 @@ def synth_mcx_2_kg24(num_ctrl_qubits: int, clean: bool = True) -> QuantumCircuit
     r"""
     Synthesize a multi-controlled X gate with :math:`k\ge 3` controls using :math:`2` ancillary qubits.
     as described in Sec. 5 of [1].
-    For :math:`k\le 2` the returned circuit contains a single X, CX or CCX gate respectively.
+    For :math:`k\le 2`, the returned circuit consists of a single X, CX or CCX gate
+    (corresponding to :math:`k = 0, 1, 2`, respectively) and uses no ancillary qubits.
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -662,7 +670,8 @@ def synth_mcx_2_clean_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
     Synthesize a multi-controlled X gate with :math:`k\ge 3` controls using :math:`2` clean
     ancillary qubits producing a circuit with :math:`2k-3` Toffoli gates or :math:`6k-6`
     CX gates and depth :math:`O(\log(k))` as described in Sec. 5.2 of [1].
-    For :math:`k\le 2` the returned circuit contains a single X, CX or CCX gate respectively.
+    For :math:`k\le 2`, the returned circuit consists of a single X, CX or CCX gate
+    (corresponding to :math:`k = 0, 1, 2`, respectively) and uses no ancillary qubits.
 
     Args:
         num_ctrl_qubits: The number of control qubits.
@@ -692,9 +701,10 @@ def synth_mcx_2_clean_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
 def synth_mcx_2_dirty_kg24(num_ctrl_qubits: int) -> QuantumCircuit:
     r"""
     Synthesize a multi-controlled X gate with :math:`k\ge 3` controls using :math:`2` dirty
-    ancillary qubits producing a circuit with :math:`4k-8` Toffoli gates or :math:`12k-18`CX
+    ancillary qubits producing a circuit with :math:`4k-8` Toffoli gates or :math:`12k-18` CX
     gates and depth :math:`O(\log(k))` as described in Sec. 5.4 of [1].
-    For :math:`k\le 2` the returned circuit contains a single X, CX or CCX gate respectively.
+    For :math:`k\le 2`, the returned circuit consists of a single X, CX or CCX gate
+    (corresponding to :math:`k = 0, 1, 2`, respectively) and uses no ancillary qubits.
 
     Args:
         num_ctrl_qubits: The number of control qubits.

--- a/releasenotes/notes/fix-mcx-synthesis-with-0-controls-e3f820aab104f3dc.yaml
+++ b/releasenotes/notes/fix-mcx-synthesis-with-0-controls-e3f820aab104f3dc.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed MCX synthesis methods to handle correctly the edge case where ``num_ctrl_qubits``
+    is 0.
+
+    Fixed `#15665 <https://github.com/Qiskit/qiskit-terra/issues/15665>`__.

--- a/test/python/synthesis/test_multi_controlled_synthesis.py
+++ b/test/python/synthesis/test_multi_controlled_synthesis.py
@@ -119,7 +119,7 @@ class TestMCSynthesisCorrectness(QiskitTestCase):
         )
         self.assertTrue(result)
 
-    @data(1, 2, 3, 4, 5, 6)
+    @data(0, 1, 2, 3, 4, 5, 6)
     def test_mcx_n_dirty_i15(self, num_ctrl_qubits: int):
         """Test synth_mcx_n_dirty_i15 by comparing synthesized and expected matrices."""
         synthesized_circuit = synth_mcx_n_dirty_i15(num_ctrl_qubits)
@@ -127,7 +127,7 @@ class TestMCSynthesisCorrectness(QiskitTestCase):
             XGate(), num_ctrl_qubits, synthesized_circuit, clean_ancillas=False
         )
 
-    @data(3, 4, 5, 6)
+    @data(0, 1, 2, 3, 4, 5, 6)
     def test_mcx_n_clean_m15(self, num_ctrl_qubits: int):
         """Test synth_mcx_n_clean_m15 by comparing synthesized and expected matrices."""
         # Note: the method requires at least 3 control qubits
@@ -136,61 +136,55 @@ class TestMCSynthesisCorrectness(QiskitTestCase):
             XGate(), num_ctrl_qubits, synthesized_circuit, clean_ancillas=True
         )
 
-    @data(3, 4, 5, 6, 7, 8)
+    @data(0, 1, 2, 3, 4, 5, 6, 7, 8)
     def test_mcx_1_clean_b95(self, num_ctrl_qubits: int):
         """Test synth_mcx_1_clean_b95 by comparing synthesized and expected matrices."""
-        # Note: the method requires at least 3 control qubits
         synthesized_circuit = synth_mcx_1_clean_b95(num_ctrl_qubits)
         self.assertSynthesisCorrect(
             XGate(), num_ctrl_qubits, synthesized_circuit, clean_ancillas=True
         )
 
-    @data(3, 4, 5, 6, 7, 8)
+    @data(0, 1, 2, 3, 4, 5, 6, 7, 8)
     def test_mcx_1_clean_kg24(self, num_ctrl_qubits: int):
         """Test synth_mcx_1_clean_kg24 by comparing synthesized and expected matrices."""
-        # Note: the method requires at least 3 control qubits
         synthesized_circuit = synth_mcx_1_clean_kg24(num_ctrl_qubits)
         self.assertSynthesisCorrect(
             XGate(), num_ctrl_qubits, synthesized_circuit, clean_ancillas=True
         )
 
-    @data(3, 4, 5, 6, 7, 8)
+    @data(0, 1, 2, 3, 4, 5, 6, 7, 8)
     def test_mcx_1_dirty_kg24(self, num_ctrl_qubits: int):
         """Test synth_mcx_1_dirty_kg24 by comparing synthesized and expected matrices."""
-        # Note: the method requires at least 3 control qubits
         synthesized_circuit = synth_mcx_1_dirty_kg24(num_ctrl_qubits)
         self.assertSynthesisCorrect(
             XGate(), num_ctrl_qubits, synthesized_circuit, clean_ancillas=False
         )
 
-    @data(3, 4, 5, 6, 7, 8)
+    @data(0, 1, 2, 3, 4, 5, 6, 7, 8)
     def test_mcx_2_clean_kg24(self, num_ctrl_qubits: int):
         """Test synth_mcx_2_clean_kg24 by comparing synthesized and expected matrices."""
-        # Note: the method requires at least 3 control qubits
         synthesized_circuit = synth_mcx_2_clean_kg24(num_ctrl_qubits)
         self.assertSynthesisCorrect(
             XGate(), num_ctrl_qubits, synthesized_circuit, clean_ancillas=True
         )
 
-    @data(3, 4, 5, 6, 7, 8)
+    @data(0, 1, 2, 3, 4, 5, 6, 7, 8)
     def test_mcx_2_dirty_kg24(self, num_ctrl_qubits: int):
         """Test synth_mcx_2_dirty_kg24 by comparing synthesized and expected matrices."""
-        # Note: the method requires at least 3 control qubits
         synthesized_circuit = synth_mcx_2_dirty_kg24(num_ctrl_qubits)
         self.assertSynthesisCorrect(
             XGate(), num_ctrl_qubits, synthesized_circuit, clean_ancillas=False
         )
 
-    @data(3, 4, 5, 6, 7, 8)
+    @data(0, 1, 2, 3, 4, 5, 6, 7, 8)
     def test_mcx_gray_code(self, num_ctrl_qubits: int):
         """Test synth_mcx_gray_code by comparing synthesized and expected matrices."""
-        # Note: the method requires at least 3 control qubits
         synthesized_circuit = synth_mcx_gray_code(num_ctrl_qubits)
         self.assertSynthesisCorrect(
             XGate(), num_ctrl_qubits, synthesized_circuit, clean_ancillas=False
         )
 
-    @data(1, 2, 3, 4, 5, 6, 7, 8)
+    @data(0, 1, 2, 3, 4, 5, 6, 7, 8)
     def test_mcx_noaux_v24(self, num_ctrl_qubits: int):
         """Test synth_mcx_noaux_v24 by comparing synthesized and expected matrices."""
         synthesized_circuit = synth_mcx_noaux_v24(num_ctrl_qubits)
@@ -198,7 +192,7 @@ class TestMCSynthesisCorrectness(QiskitTestCase):
             XGate(), num_ctrl_qubits, synthesized_circuit, clean_ancillas=False
         )
 
-    @data(1, 2, 3, 4, 5, 6, 7, 8)
+    @data(0, 1, 2, 3, 4, 5, 6, 7, 8)
     def test_mcx_noaux_hp24(self, num_ctrl_qubits: int):
         """Test synth_mcx_noaux_hp24 by comparing synthesized and expected matrices."""
         synthesized_circuit = synth_mcx_noaux_hp24(num_ctrl_qubits)


### PR DESCRIPTION

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

The PR extends MCX synthesis methods to correctly handle the edge case where ``num_ctrl_qubits`` is 0. 

Fixes #15665.


### Details and comments

While this is somewhat of an edge case, the synthesis functions (such as `synth_mcx_n_dirty_i15`) appear in our [documentation](https://quantum.cloud.ibm.com/docs/en/api/qiskit/synthesis). As no restrictions on the number of control qubits are stated, it makes sense to support all nonnegative values for ``num_ctrl_qubits`` for all documented synthesis methods.

In fact, some of the documented synthesis methods require at least 3 control qubits, with this PR a default implementation (consisting of an X-gate, CX-gate or CCX-gate respectively) is used for small values of ``num_ctrl_qubits`` (including 0).

In addition, an improved error message is raised when the number of control qubits passed to the synthesis methods is negative. 

Note that I did not change the HLS plugins: some of the plugins still return None when the number of control qubits is low. This is fine, thought, as the default plugin can handle all of the values.


