### PR TITLE
Fix defining and appending multi-controlled gates with 0 control qubits.

### DIFF
--- a/qiskit/circuit/annotated_operation.py
+++ b/qiskit/circuit/annotated_operation.py
@@ -46,6 +46,9 @@ class ControlModifier(Modifier):
     ctrl_state: int | str | None = None
 
     def __init__(self, num_ctrl_qubits: int = 0, ctrl_state: int | str | None = None):
+        if num_ctrl_qubits < 0:
+            raise CircuitError("The number of control qubits must be non-negative.")
+
         self.num_ctrl_qubits = num_ctrl_qubits
         self.ctrl_state = _ctrl_state_to_int(ctrl_state, num_ctrl_qubits)
 

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -180,7 +180,7 @@ class ControlledGate(Gate):
             num_ctrl_qubits (int): The number of control qubits.
 
         Raises:
-            CircuitError: ``num_ctrl_qubits`` is not an integer in ``[1, num_qubits]``.
+            CircuitError: ``num_ctrl_qubits`` is not an integer in ``[0, num_qubits]``.
         """
         if num_ctrl_qubits != int(num_ctrl_qubits):
             raise CircuitError("The number of control qubits must be an integer.")
@@ -188,9 +188,11 @@ class ControlledGate(Gate):
         # This is a range rather than an equality limit because some controlled gates represent a
         # controlled version of the base gate whose definition also uses auxiliary qubits.
         upper_limit = self.num_qubits - getattr(self.base_gate, "num_qubits", 0)
-        if num_ctrl_qubits < 1 or num_ctrl_qubits > upper_limit:
+        if num_ctrl_qubits < 0:
+            raise CircuitError("The number of control qubits must be non-negative.")
+        if num_ctrl_qubits > upper_limit:
             limit = "num_qubits" if self.base_gate is None else "num_qubits - base_gate.num_qubits"
-            raise CircuitError(f"The number of control qubits must be in `[1, {limit}]`.")
+            raise CircuitError(f"The number of control qubits must be in `[0, {limit}]`.")
         self._num_ctrl_qubits = num_ctrl_qubits
 
     @property

--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -142,8 +142,15 @@ class Gate(Instruction):
             A controlled version of this gate.
 
         Raises:
-            QiskitError: invalid ``ctrl_state``.
+            QiskitError: invalid ``num_ctrl_qubits`` or ``ctrl_state``.
         """
+        if num_ctrl_qubits < 0:
+            raise CircuitError("The number of control qubits must be non-negative.")
+
+        # In the special case that we have 0 control qubits, we return the copy of the gate itself.
+        if num_ctrl_qubits == 0:
+            return self.copy()
+
         if not annotated:  # captures both None and False
             # pylint: disable=cyclic-import
             from ._add_control import add_control

--- a/qiskit/circuit/library/standard_gates/p.py
+++ b/qiskit/circuit/library/standard_gates/p.py
@@ -360,7 +360,7 @@ class MCPhaseGate(ControlledGate):
 
         if self.num_ctrl_qubits == 0:
             qc.p(self.params[0], 0)
-        if self.num_ctrl_qubits == 1:
+        elif self.num_ctrl_qubits == 1:
             qc.cp(self.params[0], 0, 1)
         else:
             lam = self.params[0]

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -5319,7 +5319,9 @@ class QuantumCircuit:
         self._check_dups(all_qubits)
 
         n_c = len(control_qubits)
-        if n_c == 1:  # cu
+        if n_c == 0:
+            self.rx(theta, target_qubit)
+        elif n_c == 1:  # cu
             _apply_cu(
                 self,
                 theta,
@@ -5384,6 +5386,10 @@ class QuantumCircuit:
         all_qubits = control_qubits + target_qubit + ancillary_qubits
         target_qubit = target_qubit[0]
         self._check_dups(all_qubits)
+
+        if len(control_qubits) == 0:
+            self.ry(theta, target_qubit)
+            return
 
         # auto-select the best mode
         if mode is None:
@@ -5477,7 +5483,11 @@ class QuantumCircuit:
         self._check_dups(all_qubits)
 
         n_c = len(control_qubits)
-        if n_c == 1:
+
+        if n_c == 0:
+            self.append(RZGate(lam), [target_qubit])
+
+        elif n_c == 1:
             if use_basis_gates:
                 self.u(0, 0, lam / 2, target_qubit)
                 self.cx(control_qubits[0], target_qubit)

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -5485,7 +5485,7 @@ class QuantumCircuit:
         n_c = len(control_qubits)
 
         if n_c == 0:
-            self.append(RZGate(lam), [target_qubit])
+            self.rz(lam, target_qubit)
 
         elif n_c == 1:
             if use_basis_gates:

--- a/releasenotes/notes/fix-zero-controlled-gates-5084ea5ac5d39a1e.yaml
+++ b/releasenotes/notes/fix-zero-controlled-gates-5084ea5ac5d39a1e.yaml
@@ -1,0 +1,23 @@
+---
+fixes:
+  - |
+    Fixed the :meth:`.Gate.control` method to correctly handle the edge case where 
+    ``num_ctrl_qubits`` is 0. Previously, this could raise an error or cause a core
+    dump. Now it returns a copy of the original gate.
+
+    Fixed `#15666 <https://github.com/Qiskit/qiskit-terra/issues/15666>`__.
+
+  - |
+    Fixed the :meth:`.QuantumCircuit.mcrx`, :meth:`.QuantumCircuit.mcry`,
+    :meth:`.QuantumCircuit.mcrz`, :meth:`.QuantumCircuit.mcp`, and
+    :meth:`.QuantumCircuit.mcx` methods when appending multi-controlled
+    gates with no control qubits. Previously, this could lead to memory overflows.
+    This case is now handled correctly.
+
+    Fixed `#15664 <https://github.com/Qiskit/qiskit-terra/issues/15664>`__.
+
+  - |
+    Fixed the definition of :class:`MCPhaseGate` for the case of 0 controls
+    qubits. 
+
+

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -1403,7 +1403,7 @@ class TestControlledGate(QiskitTestCase):
         # is just some high number to make sure we unwrap any controlled and custom gates.
         self.assertEqual(set(assigned.decompose(reps=3).parameters), set())
 
-    @data(-1, 0, 1.4, "1", 4, 10)
+    @data(-1, 1.4, "1", 4, 10)
     def test_improper_num_ctrl_qubits(self, num_ctrl_qubits):
         """
         Test improperly specified num_ctrl_qubits.
@@ -1411,8 +1411,22 @@ class TestControlledGate(QiskitTestCase):
         num_qubits = 4
         with self.assertRaises(CircuitError):
             ControlledGate(
-                name="cgate", num_qubits=num_qubits, params=[], num_ctrl_qubits=num_ctrl_qubits
+                name="cgate",
+                num_qubits=num_qubits,
+                params=[],
+                num_ctrl_qubits=num_ctrl_qubits,
+                base_gate=XGate(),
             )
+
+    @data((-1, CircuitError), (1.4, CircuitError), ("1", TypeError))
+    @unpack
+    def test_improper_num_ctrl_qubits_in_control(self, num_ctrl_qubits, error):
+        """
+        Test improperly specified num_ctrl_qubits.
+        """
+
+        with self.assertRaises(error):
+            _ = XGate().control(num_ctrl_qubits=num_ctrl_qubits)
 
     def test_improper_num_ctrl_qubits_base_gate(self):
         """Test that the allowed number of control qubits takes the base gate into account."""

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -650,6 +650,36 @@ class TestControlledGate(QiskitTestCase):
             with self.subTest(msg=f"control state = {ctrl_state}"):
                 self.assertTrue(matrix_equal(simulated, expected))
 
+    def test_append_mcrx_with_0_controls(self):
+        """Test appending mcrx with 0 controls."""
+        qc = QuantumCircuit(1)
+        qc.mcrx(0.1, [], 0)
+        self.assertEqual(Operator(qc), Operator(RXGate(0.1)))
+
+    def test_append_mcry_with_0_controls(self):
+        """Test appending mcry with 0 controls."""
+        qc = QuantumCircuit(1)
+        qc.mcry(0.1, [], 0)
+        self.assertEqual(Operator(qc), Operator(RYGate(0.1)))
+
+    def test_append_mcrz_with_0_controls(self):
+        """Test appending mcrz with 0 controls."""
+        qc = QuantumCircuit(1)
+        qc.mcrz(0.1, [], 0)
+        self.assertEqual(Operator(qc), Operator(RZGate(0.1)))
+
+    def test_append_mcp_with_0_controls(self):
+        """Test appending mcp with 0 controls."""
+        qc = QuantumCircuit(1)
+        qc.mcp(0.1, [], 0)
+        self.assertEqual(Operator(qc), Operator(PhaseGate(0.1)))
+
+    def test_append_mcx_with_0_controls(self):
+        """Test appending mcx with 0 controls."""
+        qc = QuantumCircuit(1)
+        qc.mcx([], 0)
+        self.assertEqual(Operator(qc), Operator(XGate()))
+
     @combine(num_controls=[1, 2, 4], use_basis_gates=[True, False])
     def test_multi_controlled_y_rotation_matrix_basic_mode(self, num_controls, use_basis_gates):
         """Test the multi controlled Y rotation using the mode 'basic'.

--- a/test/python/synthesis/test_multi_controlled_synthesis.py
+++ b/test/python/synthesis/test_multi_controlled_synthesis.py
@@ -217,7 +217,7 @@ class TestMCSynthesisCorrectness(QiskitTestCase):
         self.assertSynthesisCorrect(XGate(), 4, synthesized_circuit, clean_ancillas=False)
 
     @combine(
-        num_ctrl_qubits=[1, 2, 3, 4, 5, 6, 7],
+        num_ctrl_qubits=[0, 1, 2, 3, 4, 5, 6, 7],
         base_gate=[
             XGate(),
             YGate(),


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #15664 and #15666. 

### Details and comments

Previously, calling `gate.control(num_ctrl_qubits=0)` for various gates could sometimes raise an error, sometimes cause a core dump, and sometimes work without problems. Similarly, calling `QuantumCircuit` appending method for multi-controlled gates with no controls could sometimes work correctly but produce inefficient circuits, sometimes raise an error, and sometimes cause a memory overflow. 

While controlling gates with 0 controlled qubits is somewhat of an edge case, it could be nice to support this. 

Now, `gate.control(num_ctrl_qubits)=0` returns a copy of the gate and `qc.mcrz` and friends specially handle the case when there are no control qubits.

I have also improved error messages when a negative number of control qubits is specified. 

In addition, testing discovered a very old bug in the definition of the MCPhase gate with zero controls: the definition consisted of two phase gates instead of one.
