### PR TITLE
MCMT gates with zero control qubits

### DIFF
--- a/qiskit/circuit/library/generalized_gates/mcmt.py
+++ b/qiskit/circuit/library/generalized_gates/mcmt.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 from qiskit import circuit
 from qiskit.circuit import ControlledGate, Gate, QuantumCircuit
 from qiskit.circuit._utils import _ctrl_state_to_int
+from qiskit.circuit.exceptions import CircuitError
 from qiskit.utils.deprecation import deprecate_func
 from ..standard_gates import get_standard_gate_name_mapping
 
@@ -227,9 +228,9 @@ class MCMTGate(ControlledGate):
             label: The gate label.
         """
         if num_target_qubits < 1:
-            raise ValueError("Need at least one target qubit.")
+            raise CircuitError("The number of control qubits must be non-negative.")
 
-        if num_ctrl_qubits < 1:
+        if num_ctrl_qubits < 0:
             raise ValueError("Need at least one control qubit.")
 
         self.num_target_qubits = num_target_qubits

--- a/releasenotes/notes/add-mcmt-with-zero-control-f0378db25403636d.yaml
+++ b/releasenotes/notes/add-mcmt-with-zero-control-f0378db25403636d.yaml
@@ -1,0 +1,5 @@
+---
+features_circuits:
+  - |
+    The multi-controlled multi-target :class:`.MCMTGate` can now
+    be instantiated with ``num_ctrl_qubits=0``. 

--- a/test/python/circuit/library/test_mcmt.py
+++ b/test/python/circuit/library/test_mcmt.py
@@ -269,12 +269,26 @@ class TestMCMT(QiskitTestCase):
             )
         )
 
-    @combine(num_ctrl=range(1, 3), num_targ=range(2, 4))
+    @combine(num_ctrl=range(0, 3), num_targ=range(2, 4))
     def test_mcmt_x_gate(self, num_ctrl, num_targ):
         """Test the MCMT X gate synthesis."""
         ctrl_state = None
 
         synthesized = synth_mcmt_xgate(num_ctrl, num_targ, ctrl_state)
+        result = Operator(synthesized).data
+
+        x_gate_matrix = XGate().to_matrix()
+        target_gate_matrix = reduce(np.kron, repeat(x_gate_matrix, num_targ))
+
+        expected = _compute_control_matrix(target_gate_matrix, num_ctrl, ctrl_state)
+        self.assertTrue(np.allclose(result, expected))
+
+    @data(2, 3, 4)
+    def test_mcmt_vchain_0_controls(self, num_targ):
+        """Test the MCMT vchain synthesis with 0 control qubits."""
+        ctrl_state = None
+        num_ctrl = 0
+        synthesized = synth_mcmt_vchain(XGate(), num_ctrl, num_targ, ctrl_state)
         result = Operator(synthesized).data
 
         x_gate_matrix = XGate().to_matrix()


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Mostly for consistency with recent changes for other multi-controlled gates, this PR allows to define and synthesize MCMT gates with 0 controls. 

However, if the consensus is that 0-controlled MCMT gates make no sense, I will be happy to close this. After all, a zero-controlled multi-target (single-qubit) gate is equivalent to applying the target gate on every target qubit, without a clever synthesis method that we have in the case ``num_ctrl_qubits >= 1``. The number of target qubits is still required to be at least 1, and if the consensus is that 0-target MCMT gate also make sense, I will be happy to add them (though, these would be no different from identity gates).




### Details and comments



