### PR TITLE
Fixing Qiskit typos (using Bob and codespell)

### DIFF
--- a/crates/accelerate/README.md
+++ b/crates/accelerate/README.md
@@ -1,6 +1,6 @@
 # `qiskit-accelerate`
 
-This crate provides a bits-and-pieces Rust libary for small, self-contained functions
+This crate provides a bits-and-pieces Rust library for small, self-contained functions
 that are used by the main Python-space components to accelerate certain tasks.  If you're trying to
 speed up one particular Python function by replacing its innards with a Rust one, this is the best
 place to put the code.  This is _usually_ the right place to put new Rust/Python code.

--- a/crates/accelerate/src/uc_gate.rs
+++ b/crates/accelerate/src/uc_gate.rs
@@ -133,7 +133,7 @@ pub fn dec_ucg_help(
     let num_controls = num_qubits - 1;
     for dec_step in 0..num_controls {
         let num_ucgs = 2_usize.pow(dec_step);
-        // The decomposition works recursively and the followign loop goes over the different
+        // The decomposition works recursively and the following loop goes over the different
         // UCGates that arise in the decomposition
         for ucg_index in 0..num_ucgs {
             let len_ucg = 2_usize.pow(num_controls - dec_step);

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -737,7 +737,7 @@ pub unsafe extern "C" fn qk_circuit_unitary(
     num_qubits: u32,
     check_input: bool,
 ) -> ExitCode {
-    // SAFETY: Caller quarantees pointer validation, alignment
+    // SAFETY: Caller guarantees pointer validation, alignment
     let circuit = unsafe { mut_ptr_as_ref(circuit) };
     let mat = unsafe { unitary_from_pointer(matrix, num_qubits, check_input.then_some(1e-12)) };
     let Some(mat) = mat else {

--- a/crates/cext/src/dag.rs
+++ b/crates/cext/src/dag.rs
@@ -1462,7 +1462,7 @@ pub unsafe extern "C" fn qk_dag_topological_op_nodes(dag: *const DAGCircuit, out
 }
 
 /// @ingroup QkDag
-/// Replace a node in a `QkDag` with a subcircuit specfied by another `QkDag`
+/// Replace a node in a `QkDag` with a subcircuit specified by another `QkDag`
 ///
 /// @param dag A pointer to the DAG.
 /// @param node The node index of the operation to replace with the other `QkDag`. This

--- a/crates/cext/src/sparse_observable.rs
+++ b/crates/cext/src/sparse_observable.rs
@@ -527,7 +527,7 @@ pub unsafe extern "C" fn qk_obs_boundaries(obs: *mut SparseObservable) -> *mut u
 /// # Safety
 ///
 /// Behavior is undefined ``obs`` is not a valid, non-null pointer to a ``QkObs``,
-/// or if invalid valus are written into the resulting ``QkBitTerm`` pointer.
+/// or if invalid values are written into the resulting ``QkBitTerm`` pointer.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qk_obs_bit_terms(obs: *mut SparseObservable) -> *mut BitTerm {
     // SAFETY: Per documentation, the pointer is non-null and aligned.

--- a/crates/cext/src/transpiler/passes/basis_translator.rs
+++ b/crates/cext/src/transpiler/passes/basis_translator.rs
@@ -28,7 +28,7 @@ use qiskit_transpiler::target::Target;
 /// in the target basis, in which case the circuit remains unchanged.
 /// @param target The target where we will obtain basis gates from.
 /// @param min_qubits The minimum number of qubits for operations in the input
-/// ciruit to translate.
+/// circuit to translate.
 ///
 /// # Example
 ///

--- a/crates/cext/src/transpiler/passes/vf2.rs
+++ b/crates/cext/src/transpiler/passes/vf2.rs
@@ -304,7 +304,7 @@ pub unsafe extern "C" fn qk_vf2_layout_configuration_set_score_initial(
 ///     pointer is null, the pass defaults are used.
 /// @param strict_direction If ``true``, the pass will consider the edge direction in the
 ///     connectivity described in the ``target``. Typically, setting this to ``false``
-///     is desireable as the error heuristic is already very approximate, and two-qubit gates can
+///     is desirable as the error heuristic is already very approximate, and two-qubit gates can
 ///     almost invariably be synthesised to "flip" direction using only local one-qubit gates and
 ///     the native-direction two-qubit gate.
 ///

--- a/crates/cext/src/transpiler/transpile_layout.rs
+++ b/crates/cext/src/transpiler/transpile_layout.rs
@@ -64,7 +64,7 @@ pub unsafe extern "C" fn qk_transpile_layout_num_output_qubits(
 /// @ingroup QkTranspileLayout
 /// Query the initial layout of a ``QkTranspileLayout``.
 ///
-/// The output array from this function represents the mapping from the virutal qubits in the
+/// The output array from this function represents the mapping from the virtual qubits in the
 /// original input circuit to the physical qubit in the output circuit. The
 /// index in the array is the virtual qubit and the value is the physical qubit. For example an
 /// output array of:

--- a/crates/cext/src/transpiler/transpile_layout.rs
+++ b/crates/cext/src/transpiler/transpile_layout.rs
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn qk_transpile_layout_num_output_qubits(
 /// qubit -> 0, and virtual qubit 2 -> physical qubit 2.
 ///
 /// @param layout A pointer to the ``QkTranspileLayout``.
-/// @param filter_ancillas If set to true the output array will not include any indicies for any
+/// @param filter_ancillas If set to true the output array will not include any indices for any
 /// ancillas added by the transpiler.
 /// @param initial_layout A pointer to the array where this function will write the initial layout
 /// to. This must have sufficient space for the full array which will either be
@@ -188,7 +188,7 @@ pub unsafe extern "C" fn qk_transpile_layout_output_permutation(
 /// physical qubit 2 at the end of the transpiled circuit, 1 -> 0, and 2 -> 1.
 ///
 /// @param layout A pointer to the ``QkTranspileLayout``.
-/// @param filter_ancillas If set to true the output array will not include any indicies for any
+/// @param filter_ancillas If set to true the output array will not include any indices for any
 /// ancillas added by the transpiler.
 /// @param final_layout A pointer to the array where this function will write the final layout to.
 /// This must have sufficient space for the output which will either be the number of input or

--- a/crates/circuit/README.md
+++ b/crates/circuit/README.md
@@ -17,7 +17,7 @@ In the future we'll be able to remove all of that except for label.
 
 At rest a `CircuitInstruction` is compacted into a `PackedInstruction` which caches reused qargs
 in the instructions to reduce the memory overhead of `CircuitData`. The `PackedInstruction` objects
-get unpacked back to `CircuitInstruction` when accessed for a more convienent working form.
+get unpacked back to `CircuitInstruction` when accessed for a more convenient working form.
 
 Additionally the `CircuitData` contains a `param_table` field which is used to track parameterized
 instructions that are using python defined `ParameterExpression` objects for any parameters and also
@@ -62,7 +62,7 @@ The `ParamTable` struct is used to track which circuit instructions are using `P
 objects for any of their parameters. The Python space `ParameterExpression` is comprised of a symengine
 symbolic expression that defines operations using `Parameter` objects. Each `Parameter` is modeled by
 a uuid and a name to uniquely identify it. The parameter table maps the `Parameter` objects to the
-`CircuitInstruction` in the `CircuitData` that are using them. The `ParamTable` comprises 3 `HashMaps` internally that map the uuid (as `u128`, which is accesible in Python by using `uuid.int`) to the `ParamEntry`, the `name` to the uuid, and the uuid to the PyObject for the actual `Parameter`.
+`CircuitInstruction` in the `CircuitData` that are using them. The `ParamTable` comprises 3 `HashMaps` internally that map the uuid (as `u128`, which is accessible in Python by using `uuid.int`) to the `ParamEntry`, the `name` to the uuid, and the uuid to the PyObject for the actual `Parameter`.
 
 The `ParamEntry` is just a `HashSet` of 2-tuples with usize elements. The two usizes represent the instruction index in the `CircuitData` and the index of the `CircuitInstruction.params` field of
 a give instruction where the given `Parameter` is used in the circuit. If the instruction index is

--- a/crates/circuit/src/bit.rs
+++ b/crates/circuit/src/bit.rs
@@ -148,7 +148,7 @@ pub trait ShareableBit: Clone + Eq + Hash + Debug {
     const DESCRIPTION: &'static str;
 }
 // An internal trait to let `RegisterInfo` manifest full `ShareableBit` instances from `BitInfo`
-// structs without leaking that implemntation detail into the public.
+// structs without leaking that implementation detail into the public.
 trait ManifestableBit: ShareableBit {
     fn from_info(val: BitInfo<<Self as ShareableBit>::Subclass>) -> Self;
     fn info(&self) -> &BitInfo<<Self as ShareableBit>::Subclass>;

--- a/crates/circuit/src/bit.rs
+++ b/crates/circuit/src/bit.rs
@@ -350,7 +350,7 @@ macro_rules! create_bit_object {
         /// corresponding bits between two circuits.
         ///
         /// These objects are comparable in a global sense, unlike the lighter [Qubit] or [Clbit]
-        /// index-like objects used only _within_ a cirucit.  We use these objects when comparing
+        /// index-like objects used only _within_ a circuit.  We use these objects when comparing
         /// two circuits to each other, and resolving Python objects, but within the context of a
         /// circuit, we just use the simple indices.
         #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -2924,7 +2924,7 @@ impl CircuitData {
                             // Rust that accept a `Param::ParameterExpression` which aren't standard
                             // gates. Technically `StandardInstruction::Delay` could, but in
                             // practice that's not a common path, and it's only supported for
-                            // backwards compatability from before Stretch was introduced. If we did
+                            // backwards compatibility from before Stretch was introduced. If we did
                             // it in rust without Python that's a mistake and this attach() call
                             // will panic and point out the error of your ways when this comment is
                             // read.

--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -2950,7 +2950,7 @@ impl CircuitData {
                                         // be parametric.
                                         //
                                         // Our `bind_expr` coercion means that a non-parametric
-                                        // `ParameterExperssion` after binding would have been coerced
+                                        // `ParameterExpression` after binding would have been coerced
                                         // to a numeric quantity already, so the match here is
                                         // definitely parameterized.
                                         match &new_param {
@@ -3601,7 +3601,7 @@ mod test {
     #[test]
     fn packed_pointer_types_behave() -> PyResult<()> {
         // This is largely to exercise the packed-pointer logic under debug builds (since the
-        // Python-space tests run with Rust in relaese mode) and Miri.
+        // Python-space tests run with Rust in release mode) and Miri.
         let mut qc = CircuitData::from_packed_operations(4, 1, [], Param::Float(0.0))?;
         qc.push_packed_operation(
             Box::new(PauliProductMeasurement {

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -177,7 +177,7 @@ impl CircuitInstruction {
     pub fn get_operation(&self, py: Python) -> PyResult<Py<PyAny>> {
         // This doesn't use `get_or_init` because a) the initialiser is fallible and
         // `get_or_try_init` isn't stable, and b) the initialiser can yield to the Python
-        // interpreter, which might suspend the thread and allow another to inadvertantly attempt to
+        // interpreter, which might suspend the thread and allow another to inadvertently attempt to
         // re-enter the cache setter, which isn't safe.
 
         #[cfg(feature = "cache_pygates")]
@@ -1036,7 +1036,7 @@ fn warn_on_legacy_circuit_instruction_iteration(py: Python) -> PyResult<()> {
             ),
             py.get_type::<PyDeprecationWarning>(),
             // Stack level.  Compared to Python-space calls to `warn`, this is unusually low
-            // beacuse all our internal call structure is now Rust-space and invisible to Python.
+            // because all our internal call structure is now Rust-space and invisible to Python.
             1,
         ))
         .map(|_| ())

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -3990,7 +3990,7 @@ impl DAGCircuit {
     ///
     /// The descendants are the set of all nodes that can be reached from the target node. In
     /// comparison, :meth:`.DAGCircuit.successors` is an iterator over the immediate successors,
-    /// whereas this method contains all the successors' succesors.
+    /// whereas this method contains all the successors' successors.
     #[pyo3(name = "descendants")]
     fn py_descendants(&self, py: Python, node: &DAGNode) -> PyResult<Py<PySet>> {
         let descendants: PyResult<Vec<Py<PyAny>>> = self
@@ -5640,7 +5640,7 @@ impl DAGCircuit {
         Ok(())
     }
 
-    /// Remove the given clbits in the cirucit
+    /// Remove the given clbits in the circuit
     ///
     /// This will reorder all the bits in the circuit.
     pub fn remove_clbits<T: IntoIterator<Item = Clbit>>(&mut self, clbits: T) -> PyResult<()> {
@@ -8517,7 +8517,7 @@ impl DAGCircuitBuilder {
         self.push_back(instruction)
     }
 
-    /// Pushes a valid [PackedInstruction] to the back ot the circuit.
+    /// Pushes a valid [PackedInstruction] to the back of the circuit.
     pub fn push_back(&mut self, instr: PackedInstruction) -> PyResult<NodeIndex> {
         self.dag.track_instruction(&instr);
         let (all_cbits, vars) = self.dag.get_classical_resources(&instr)?;

--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -841,7 +841,7 @@ impl PackedInstruction {
         }
     }
 
-    /// Extract an `ndarray` matrix from this instruciton, if available.
+    /// Extract an `ndarray` matrix from this instruction, if available.
     ///
     /// The returned value will preferentially be a view, if the matrix already exists (e.g. for
     /// `Unitary`).

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -521,7 +521,7 @@ impl ParameterExpression {
     /// # Returns
     ///
     /// * `Ok(Self)` - A parameter expression with the substituted expressions.
-    /// * `Err(ParameterError)` - An error if the subtitution failed.
+    /// * `Err(ParameterError)` - An error if the substitution failed.
     pub fn subs(
         &self,
         map: &HashMap<Symbol, Self>,

--- a/crates/circuit/src/parameter/symbol_expr.rs
+++ b/crates/circuit/src/parameter/symbol_expr.rs
@@ -3335,7 +3335,7 @@ impl Value {
     // convert sympy compatible format
     pub fn sympify(&self) -> SymbolExpr {
         match self {
-            // imaginary number is comverted to value * symbol 'I'
+            // imaginary number is converted to value * symbol 'I'
             Value::Complex(c) => _add(
                 SymbolExpr::Value(Value::Real(c.re)),
                 _mul(

--- a/crates/circuit/src/parameter/symbol_parser.rs
+++ b/crates/circuit/src/parameter/symbol_parser.rs
@@ -100,7 +100,7 @@ fn parse_unary(s: &str) -> IResult<&str, SymbolExpr, VerboseError<&str>> {
         .parse(s)
 }
 
-// sign is separetely parsed in this function
+// sign is separately parsed in this function
 fn parse_sign(s: &str) -> IResult<&str, SymbolExpr, VerboseError<&str>> {
     (
         delimited(multispace0, alt((char('-'), char('+'))), multispace0),

--- a/crates/circuit/src/parameter_table.rs
+++ b/crates/circuit/src/parameter_table.rs
@@ -65,7 +65,7 @@ pub struct ParameterInfo {
 }
 
 /// Type-safe UUID for a symbolic parameter.  This does not track the name of a [Symbol]; it
-/// can't be used alone to reconstruct one.  That tracking remains only withing the
+/// can't be used alone to reconstruct one.  That tracking remains only within the
 /// [ParameterTable].
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
 pub struct ParameterUuid(u128);

--- a/crates/circuit/src/vf2.rs
+++ b/crates/circuit/src/vf2.rs
@@ -79,7 +79,7 @@ pub mod alias {
     }
 
     /// This is _intended_ to be a metatrait that just defines a bunch of bounds on references to
-    /// implementors of [Vf2Graph].  Unfortunately, I couldn't get a `where &'a Self` bound on
+    /// implementers of [Vf2Graph].  Unfortunately, I couldn't get a `where &'a Self` bound on
     /// [Vf2Graph] itself to work correctly with the blanket implementation, so I got stuck writing
     /// this boilerplate that duplicates the trait into a lifetime-bound one that we can then use in
     /// higher-ranked trait bounds.

--- a/crates/circuit_library/src/pauli_evolution.rs
+++ b/crates/circuit_library/src/pauli_evolution.rs
@@ -85,7 +85,7 @@ fn single_qubit_evolution(
 ) -> Box<dyn Iterator<Item = Instruction>> {
     let qubit = vec![Qubit(index)];
 
-    // We don't need to explictly cover the |1><1| projector case (which is the Phase gate),
+    // We don't need to explicitly cover the |1><1| projector case (which is the Phase gate),
     // which will be handled by the multi-qubit evolution.
     match pauli {
         'x' => Box::new(std::iter::once((
@@ -130,7 +130,7 @@ fn two_qubit_evolution<'a>(
     let qubits = vec![Qubit(indices[0]), Qubit(indices[1])];
     let paulistring: String = pauli.iter().collect();
 
-    // We don't need to explictly cover the |11><11| projector case (which is the CPhase gate),
+    // We don't need to explicitly cover the |11><11| projector case (which is the CPhase gate),
     // which will be handled by the multi-qubit evolution. The Paulis need special treatment here
     // since the generic code would use CX-RZ-CX instead of the two-qubit Pauli standard gates.
     match paulistring.as_str() {

--- a/crates/pyext/README.md
+++ b/crates/pyext/README.md
@@ -4,4 +4,4 @@ This is the Rust crate that actually builds the `qiskit._accelerate` Python exte
 
 See the README at the `crates` top level for more information on the structure.
 Any self-contained submodule crates (e.g. `qasm2`) can define their own `pymodule`, but they should compile only as an rlib, and this crate should then build them into the top-level `qiskit._accelerate`.
-This module is also responsible for rewrapping all of the bits-and-pieces parts of `crates/accerelate` into the `qiskit._accelerate` extension module.
+This module is also responsible for rewrapping all of the bits-and-pieces parts of `crates/accelerate` into the `qiskit._accelerate` extension module.

--- a/crates/qpy/src/bytes.rs
+++ b/crates/qpy/src/bytes.rs
@@ -27,7 +27,7 @@ use std::ops::{Deref, DerefMut};
 pub struct Bytes(pub Vec<u8>);
 
 impl Bytes {
-    /// This method is used for debugging; it displays the data as a string of hexdecimal digits
+    /// This method is used for debugging; it displays the data as a string of hexadecimal digits
     pub fn to_hex_string(&self) -> String {
         self.0
             .iter()

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -1273,7 +1273,7 @@ fn add_registers_and_bits(
             }
         }
     }
-    // now add the bits to the ciruit, and then add the registers
+    // now add the bits to the circuit, and then add the registers
     for qubit in final_qubit_list {
         qpy_data.circuit_data.add_qubit(qubit, true)?;
     }

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -637,7 +637,7 @@ fn unpack_py_instruction(
                 for param in py_params {
                     args.push(param.unbind());
                 }
-                // in the case if IfElseOp with Null else body, retaining it would confuse the heuristic detemining
+                // in the case if IfElseOp with Null else body, retaining it would confuse the heuristic determining
                 // whether parameter are blocks or true params; we can simply dump it.
                 instruction_values.retain(|value| !matches!(value, GenericValue::Null));
                 gate_class.call1(PyTuple::new(py, args)?)?

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -201,7 +201,7 @@ fn pack_instruction_blocks(
                 .iter()
                 .map(|block| -> PyResult<_> {
                     // we explicitly name the block "unnamed" because otherwise it will be assigned a serial number name (e.g. "circuit-45")
-                    // which would result in inconsistant results, e.g. when packing the same circuit twice on the same run
+                    // which would result in inconsistent results, e.g. when packing the same circuit twice on the same run
                     let circuit = imports::QUANTUM_CIRCUIT
                         .get_bound(py)
                         .call_method1("_from_circuit_data", (block.clone(), false, "unnamed"))?;

--- a/crates/qpy/src/formats.rs
+++ b/crates/qpy/src/formats.rs
@@ -35,7 +35,7 @@ use std::marker::PhantomData;
 // 3) Annotation Headers: The annotation-related global data.
 // 4) Custom instructions: List of custom gates used in the circuits, e.g. gate with nonstandard control
 // 5) Instruction: The sequential list of gates in the circuit.
-// 6) Calibrations: Obsolete; this was pulse-related data. Here for backwards compatability.
+// 6) Calibrations: Obsolete; this was pulse-related data. Here for backwards compatibility.
 // 7) Layout: The transpilation layout, if one exists (otherwise a dummy is used).
 #[derive(BinWrite, Debug)]
 #[brw(big)]
@@ -129,7 +129,7 @@ pub struct CircuitInstructionV2Pack {
     pub annotations: Option<InstructionsAnnotationPack>,
 }
 
-// To save space, the extras key encoded data about the existance of annotations
+// To save space, the extras key encoded data about the existence of annotations
 // in its msb, and about the type of condition (Two-tuple, Expression or None) in the two lsbs.
 pub mod extras_key_parts {
     pub const ANNOTATIONS: u8 = 0b1000_0000;

--- a/crates/qpy/src/formats.rs
+++ b/crates/qpy/src/formats.rs
@@ -230,7 +230,7 @@ pub struct RegisterV4Pack {
 // 2) Two-tuple: a tuple of the form (register, target) where the register value should be compared with the target.
 // In this case the target is a python int, represented in rust as BigUInt, but in python qpy it was saved using i64 so we keep it for now.
 // Note that we also use (clbit, bool_target) as two tuple, where the clbit is encoded using the "\x00" hack that can be seen in ParamRegisterValue
-// 3) Expresssion
+// 3) Expression
 // In the two-tuple representation, the target value is stored in the `value` field and the number of bytes in the serialized registered are stored in the
 // `register_size` fields. Both are unused in the other cases, making the packing and decoding of this struct rather non-uniform.
 
@@ -377,7 +377,7 @@ pub struct InitialLayoutItemV2Pack {
 // This can be a wide variety of values, mostly used in instruction parameters.
 // Some (not all) examples:
 // integers (e.g. for switch statements and loops),
-// floats, compelx numbers (e.g. for rx gates),
+// floats, complex numbers (e.g. for rx gates),
 // Parameters (and parameter expressions and vectors) (e.g. for rx gates),
 // Expressions (e.g. for complex conditions in control flow statements),
 // Circuits (e.g. for control flow statements having a body)
@@ -597,7 +597,7 @@ pub struct ParameterExpressionSubsOpPack {
 /// A Parameter Expression is stored in two chunks (along with length data)
 /// 1) The parameter expression data itself, already serialized
 /// 2) The symbol table for the parameter expression (to save space when using the same symbol more than once in the expression)
-/// It's not completely clear to me why the symbol table was originally structrued as it was, since not all the data is used
+/// It's not completely clear to me why the symbol table was originally structured as it was, since not all the data is used
 #[binrw]
 #[brw(big)]
 #[derive(Debug)]
@@ -753,7 +753,7 @@ pub enum ExpressionElementPack {
     Index(ExpressionTypePack),
 }
 
-// An expression's var data - either a clbit, a registe, or given by a uuid (for a standalone var)
+// An expression's var data - either a clbit, a register, or given by a uuid (for a standalone var)
 #[derive(BinWrite, BinRead, Debug)]
 #[brw(big)]
 pub enum ExpressionVarElementPack {
@@ -843,7 +843,7 @@ pub struct ModifierPack {
     pub power: f64,
 }
 
-// This is a declaration of a variable that may appear iniside various
+// This is a declaration of a variable that may appear inside various
 // Expressions in the circuit. It contains its uuid, name,
 // usage type (input/capture/local/etc) and type (bool, int, float etc.)
 // This data is not used directly in any expression; rather, its written to the "standalone vars"

--- a/crates/qpy/src/params.rs
+++ b/crates/qpy/src/params.rs
@@ -173,7 +173,7 @@ fn parameter_value_type_from_generic_value(value: &GenericValue) -> PyResult<Par
 // 2) The **symbol_table_data** where the symbols appearing anywhere in the expression are stored; only their uuid values
 // are referred to in the expression data
 // in older QPY versions, parameter expressions could have substitute commands, which made packing more complex
-// this is no longer used in the rust-based paramter expressions, so we do not fully utilize the formats
+// this is no longer used in the rust-based parameter expressions, so we do not fully utilize the formats
 pub(crate) fn pack_parameter_expression(
     exp: &ParameterExpression,
 ) -> PyResult<formats::ParameterExpressionPack> {

--- a/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -192,7 +192,7 @@ impl PauliLindbladMap {
     /// Clear all the generator terms from this map, making it equal to the identity map again.
     ///
     /// This does not change the capacity of the internal allocations, so subsequent addition or
-    /// substraction of generator terms may not need to reallocate.
+    /// subtraction of generator terms may not need to reallocate.
     pub fn clear(&mut self) {
         self.rates.clear();
         self.gamma = 1.0;
@@ -752,7 +752,7 @@ impl PyGeneratorTerm {
 /// :math:`\lambda_P` are real numbers. When all the rates :math:`\lambda_P` are non-negative, this
 /// corresponds to a completely positive and trace preserving map. The sum in the exponential is
 /// called the generator, and each individual term the generators. To simplify notation in the rest
-/// of the documention, we denote :math:`L(P)\bigl[\circ\bigr] = P \circ P - \circ`.
+/// of the documentation, we denote :math:`L(P)\bigl[\circ\bigr] = P \circ P - \circ`.
 ///
 /// Quasi-probability representation
 /// ================================
@@ -1089,7 +1089,7 @@ impl PyPauliLindbladMap {
     /// Clear all the generator terms from this map, making it equal to the identity map again.
     ///
     /// This does not change the capacity of the internal allocations, so subsequent addition or
-    /// substraction operations resulting from composition may not need to reallocate.
+    /// subtraction operations resulting from composition may not need to reallocate.
     ///
     /// Examples:
     ///
@@ -1684,7 +1684,7 @@ impl PyPauliLindbladMap {
 
     /// Sum any like terms in the generator, removing them if the resulting rate has an absolute
     /// value within tolerance of zero. This also removes terms whose Pauli operator is proportional
-    /// to the identity, as the correponding generator is actually the zero map.
+    /// to the identity, as the corresponding generator is actually the zero map.
     ///
     /// As a side effect, this sorts the generators into a fixed canonical order.
     ///

--- a/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -1691,7 +1691,7 @@ impl PyPauliLindbladMap {
     /// .. note::
     ///
     ///     When using this for equality comparisons, note that floating-point rounding and the
-    ///     non-associativity fo floating-point addition may cause non-zero coefficients of summed
+    ///     non-associativity of floating-point addition may cause non-zero coefficients of summed
     ///     terms to compare unequal.  To compare two observables up to a tolerance, it is safest to
     ///     compare the canonicalized difference of the two observables to zero.
     ///

--- a/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/phased_qubit_sparse_pauli.rs
@@ -122,7 +122,7 @@ impl PhasedQubitSparsePauliList {
     /// Clear all the elements of the list.
     ///
     /// This does not change the capacity of the internal allocations, so subsequent addition or
-    /// substraction of elements in the list may not need to reallocate.
+    /// subtraction of elements in the list may not need to reallocate.
     pub fn clear(&mut self) {
         self.qubit_sparse_pauli_list.clear();
         self.phases.clear();
@@ -1288,7 +1288,7 @@ impl PyPhasedQubitSparsePauliList {
     /// Clear all the elements from the list, making it equal to the empty list again.
     ///
     /// This does not change the capacity of the internal allocations, so subsequent addition or
-    /// substraction operations resulting from composition may not need to reallocate.
+    /// subtraction operations resulting from composition may not need to reallocate.
     ///
     /// Examples:
     ///

--- a/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/quantum_info/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -372,7 +372,7 @@ impl QubitSparsePauliList {
     /// Clear all the elements of the list.
     ///
     /// This does not change the capacity of the internal allocations, so subsequent addition or
-    /// substraction of elements in the list may not need to reallocate.
+    /// subtraction of elements in the list may not need to reallocate.
     pub fn clear(&mut self) {
         self.paulis.clear();
         self.indices.clear();
@@ -1974,7 +1974,7 @@ impl PyQubitSparsePauliList {
     /// Clear all the elements from the list, making it equal to the empty list again.
     ///
     /// This does not change the capacity of the internal allocations, so subsequent addition or
-    /// substraction operations resulting from composition may not need to reallocate.
+    /// subtraction operations resulting from composition may not need to reallocate.
     ///
     /// Examples:
     ///

--- a/crates/quantum_info/src/sparse_observable/mod.rs
+++ b/crates/quantum_info/src/sparse_observable/mod.rs
@@ -600,7 +600,7 @@ impl SparseObservable {
     /// Clear all the terms from this operator, making it equal to the zero operator again.
     ///
     /// This does not change the capacity of the internal allocations, so subsequent addition or
-    /// substraction operations may not need to reallocate.
+    /// subtraction operations may not need to reallocate.
     pub fn clear(&mut self) {
         self.coeffs.clear();
         self.bit_terms.clear();
@@ -1322,7 +1322,7 @@ mod compose {
         /// Stack of the coefficients to this point.  We could recalculate by a full
         /// multiplication on each go, but most steps will be in the low indices, where we can
         /// re-use all the multiplications that came before.  This is one longer than the length
-        /// of `multliples`, because it starts off populated with the product of the
+        /// of `multiples`, because it starts off populated with the product of the
         /// non-multiple coefficients (or 1).
         coeffs: Vec<Complex64>,
         /// The full set of indices (including ones that don't correspond to multiples).  Within
@@ -2287,7 +2287,7 @@ impl PySparseTerm {
 /// associative, :class:`SparseObservable` makes no guarantees about the summation order).
 ///
 /// These two categories of representation degeneracy can cause the ``==`` operator to claim that
-/// two observables are not equal, despite representating the same object.  In these cases, it can
+/// two observables are not equal, despite representing the same object.  In these cases, it can
 /// be convenient to define some *canonical form*, which allows observables to be compared
 /// structurally.
 ///
@@ -3210,7 +3210,7 @@ impl PySparseObservable {
     /// Clear all the terms from this operator, making it equal to the zero operator again.
     ///
     /// This does not change the capacity of the internal allocations, so subsequent addition or
-    /// substraction operations may not need to reallocate.
+    /// subtraction operations may not need to reallocate.
     ///
     /// Examples:
     ///

--- a/crates/quantum_info/src/sparse_observable/mod.rs
+++ b/crates/quantum_info/src/sparse_observable/mod.rs
@@ -694,7 +694,7 @@ impl SparseObservable {
 
     /// Calculate the transpose.
     ///
-    /// This operation transposes the individual bit terms but does directly act
+    /// This operation transposes the individual bit terms but does not directly act
     /// on the coefficients.
     pub fn transpose(&self) -> SparseObservable {
         let mut out = self.clone();
@@ -3234,7 +3234,7 @@ impl PySparseObservable {
     /// .. note::
     ///
     ///     When using this for equality comparisons, note that floating-point rounding and the
-    ///     non-associativity fo floating-point addition may cause non-zero coefficients of summed
+    ///     non-associativity of floating-point addition may cause non-zero coefficients of summed
     ///     terms to compare unequal.  To compare two observables up to a tolerance, it is safest to
     ///     compare the canonicalized difference of the two observables to zero.
     ///

--- a/crates/quantum_info/src/sparse_pauli_op.rs
+++ b/crates/quantum_info/src/sparse_pauli_op.rs
@@ -357,7 +357,7 @@ impl From<DecomposeError> for PyErr {
 /// Implementation
 /// --------------
 ///
-/// The original algorithm was described recurisvely, allocating new matrices for each of the
+/// The original algorithm was described recursively, allocating new matrices for each of the
 /// block-wise sums (e.g. `op[top_left] + op[bottom_right]`).  This implementation differs in two
 /// major ways:
 ///
@@ -1236,7 +1236,7 @@ macro_rules! impl_to_matrix_sparse {
                 .for_each(|(indptr_chunk, start_nnz)| {
                     indptr_chunk.iter_mut().for_each(|nnz| *nnz += start_nnz);
                 });
-            // Concatenate the chunkwise values and indices togther.
+            // Concatenate the chunkwise values and indices together.
             let values = copy_flat_parallel(&values_chunks);
             let indices = copy_flat_parallel(&indices_chunks);
             (values, indices, indptr)

--- a/crates/quantum_info/src/versor_u2.rs
+++ b/crates/quantum_info/src/versor_u2.rs
@@ -115,7 +115,7 @@ impl VersorSU2 {
 /// A versor-based (unit-quaternion) representation of a single-qubit gate.
 ///
 /// In general, a single-qubit gate is a member of the group $U(2)$, and the group $SU(2)$ is
-/// isomoprhic to the versors.  We can keep track of the complex phase separately to the rotation
+/// isomorphic to the versors.  We can keep track of the complex phase separately to the rotation
 /// action, to fully describe a member of $U(2)$.
 ///
 /// See [VersorSU2] for the underlying quaternion representation.

--- a/crates/synthesis/src/discrete_basis/solovay_kitaev.rs
+++ b/crates/synthesis/src/discrete_basis/solovay_kitaev.rs
@@ -194,7 +194,7 @@ impl SolovayKitaevSynthesis {
     ///         determines how fast (and if) the algorithm converges and should be chosen
     ///         sufficiently high. Defaults to 12,
     ///     tol (float | None): A tolerance determining the granularity of the basic approximations.
-    ///         Any sequence whose SO(3) representation is withing :math:`\sqrt{\texttt{tol}}` of
+    ///         Any sequence whose SO(3) representation is within :math:`\sqrt{\texttt{tol}}` of
     ///         an existing point, will be discarded. Defaults to ``1e-12``.
     #[new]
     #[pyo3 (signature = (basis_gates=None, depth=12, tol=None, do_checks=false))]

--- a/crates/synthesis/src/linear_phase/cx_cz_depth_lnn.rs
+++ b/crates/synthesis/src/linear_phase/cx_cz_depth_lnn.rs
@@ -174,7 +174,7 @@ fn _update_phase_schedule(
 /// - Width of the circuit (int `n`)
 /// - A CZ circuit, represented by the `n*n` phase schedule phase_schedule
 /// - A CX circuit, represented by box-labels (seq) and whether the box is SWAP+ (swap_plus)
-///   - This circuit corresponds to the CX tranformation that tranforms a matrix to
+///   - This circuit corresponds to the CX transformation that transforms a matrix to
 ///     a NW matrix (c.f. Prop.7.4, [1])
 ///   - SWAP+ is defined in section 3.A. of [2].
 ///   - As previously noted, the northwest diagonalization procedure of [1] consists

--- a/crates/synthesis/src/multi_controlled/mcx.rs
+++ b/crates/synthesis/src/multi_controlled/mcx.rs
@@ -662,8 +662,8 @@ fn synth_relative_mcx(num_controls: usize) -> Result<CircuitData, CircuitDataErr
 fn synth_relative_mcx_n_dirty(num_controls: usize) -> Result<CircuitData, CircuitDataError> {
     // For small values of num_controls, it is more efficient to use a relative MCX
     // gate that does not require any auxiliary qubits, while for large values it is
-    // mot efficient to construct the true MCX gate that uses num_controls ancillas.
-    // An interesting question is whether there are relative-MCX implmentations that
+    // not efficient to construct the true MCX gate that uses num_controls ancillas.
+    // An interesting question is whether there are relative-MCX implementations that
     // use ancilla qubits.
     if num_controls < 11 {
         synth_relative_mcx(num_controls)

--- a/crates/synthesis/src/two_qubit_decompose.rs
+++ b/crates/synthesis/src/two_qubit_decompose.rs
@@ -1279,7 +1279,7 @@ impl TwoQubitGateSequence {
             global_phase: 0.,
         }
     }
-    /// Create this sequence from the consituent parts.
+    /// Create this sequence from the constituent parts.
     pub fn from_sequence(gates: TwoQubitSequenceVec, global_phase: f64) -> Self {
         Self {
             gates,

--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -642,7 +642,7 @@ impl CommutationChecker {
         tol: f64,
     ) -> Result<bool, CommutationError> {
         // Compute relative positioning of qargs of the second gate to the first gate.
-        // Since the qargs come out the same BitData, we already know there are no accidential
+        // Since the qargs come out the same BitData, we already know there are no accidental
         // bit-duplications, but this code additionally maps first_qargs to [0..n] and then
         // computes second_qargs relative to that. For example, it performs the mappings
         //  (first_qargs, second_qargs) = ( [1, 2], [0, 2] ) --> ( [0, 1], [2, 1] )

--- a/crates/transpiler/src/neighbors.rs
+++ b/crates/transpiler/src/neighbors.rs
@@ -134,7 +134,7 @@ impl Neighbors {
                 neighbors.push(neighbor);
             }
             partition.push(neighbors.len());
-            // Sort per neighbour in the vague hope that branch predicition later will be more
+            // Sort per neighbour in the vague hope that branch prediction later will be more
             // reliable, or memory access patterns will be more predictable.
             neighbors[partition[partition.len() - 2]..partition[partition.len() - 1]].sort();
         }
@@ -473,7 +473,7 @@ mod test {
     #[test]
     fn from_parts_catches_errors() {
         let lift = |idx: Vec<u32>| idx.into_iter().map(PhysicalQubit).collect::<Vec<_>>();
-        // Parition doesn't start from zero.
+        // Partition doesn't start from zero.
         assert_eq!(
             Neighbors::from_parts(lift(vec![1, 0]), vec![1, 2, 2]),
             Err(ConstructionError::PartitionInconsistent)

--- a/crates/transpiler/src/passes/apply_layout.rs
+++ b/crates/transpiler/src/passes/apply_layout.rs
@@ -205,7 +205,7 @@ fn py_apply_layout<'py>(
     }
 
     // TODO: while Rust-space and Python-space `TranspileLayout` are two different objects, Python
-    // gets the short end of the "unnecessary conversion" stick, and we have to make a new object ot
+    // gets the short end of the "unnecessary conversion" stick, and we have to make a new object to
     // return to Python.  We don't accept the Python-space object into this function because it
     // can't represent the state of "initial layout is not yet applied", so we may as well just make
     // it ourselves.

--- a/crates/transpiler/src/passes/basis_translator/errors.rs
+++ b/crates/transpiler/src/passes/basis_translator/errors.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 
 use crate::TranspilerError;
 
-/// A collection of the Errrors possible in the [run_basis_translator] function
+/// A collection of the Errors possible in the [run_basis_translator] function
 #[derive(Debug, Error)]
 pub enum BasisTranslatorError {
     #[error[

--- a/crates/transpiler/src/passes/commutation_analysis.rs
+++ b/crates/transpiler/src/passes/commutation_analysis.rs
@@ -155,7 +155,7 @@ pub fn py_analyze_commutations(
     // First set the {wire: [commuting_nodes_1, ...]} bit
     for (wire, commutations) in commutation_set {
         // we know all wires are of type Wire::Qubit, since in analyze_commutations_inner
-        // we only iterater over the qubits
+        // we only iterate over the qubits
         let py_wire = match wire {
             Wire::Qubit(q) => dag.qubits().get(q).unwrap().into_pyobject(py),
             _ => return Err(PyValueError::new_err("Unexpected wire type.")),

--- a/crates/transpiler/src/passes/commutative_optimization.rs
+++ b/crates/transpiler/src/passes/commutative_optimization.rs
@@ -283,7 +283,7 @@ fn try_merge(
     if let (OperationRef::StandardGate(gate1), OperationRef::StandardGate(gate2)) =
         (inst1.op.view(), inst2.op.view())
     {
-        // Check wether the two gates are self-inverse.
+        // Check whether the two gates are self-inverse.
         if let Some((gate1inv, params1inv)) = gate1.inverse(params1) {
             if (gate1inv == gate2) && compare_params(&params1inv, params2)? {
                 return Ok((true, None, 0.));

--- a/crates/transpiler/src/passes/high_level_synthesis.rs
+++ b/crates/transpiler/src/passes/high_level_synthesis.rs
@@ -1014,7 +1014,7 @@ pub fn run_high_level_synthesis(
     // done at the top-level since this does not track the qubit states.
 
     // First, we apply a super-fast (but incomplete) check to see if all the operations
-    // present in the circuit are suported by the target / are in the basis.
+    // present in the circuit are supported by the target / are in the basis.
     if all_instructions_supported(py, data, dag)? {
         return Ok(None);
     }

--- a/crates/transpiler/src/passes/litinski_transformation.rs
+++ b/crates/transpiler/src/passes/litinski_transformation.rs
@@ -69,7 +69,7 @@ pub fn run_litinski_transformation(
             .collect();
 
         return Err(TranspilerError::new_err(format!(
-            "Unable to run Litinski tranformation as the circuit contains instructions not supported by the pass: {:?}",
+            "Unable to run Litinski transformation as the circuit contains instructions not supported by the pass: {:?}",
             unsupported
         )));
     }

--- a/crates/transpiler/src/passes/sabre/route.rs
+++ b/crates/transpiler/src/passes/sabre/route.rs
@@ -58,7 +58,7 @@ const SWAP_EPILOGUE_TRIALS: usize = 4;
 /// At the time of writing (2025-06-11), Qiskit's Python-space model doesn't allow constructing any
 /// control-flow operations with zero blocks, so we could use `NonZero<u32>` directly.  Technically,
 /// though, a `switch` on a zero-bit register _could_ be valid and have zero blocks, so doing this
-/// little trick makes us safe against that long-range assumption changing, for zero measureable
+/// little trick makes us safe against that long-range assumption changing, for zero measurable
 /// runtime cost.
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]

--- a/crates/transpiler/src/passes/unitary_synthesis/decomposers.rs
+++ b/crates/transpiler/src/passes/unitary_synthesis/decomposers.rs
@@ -12,7 +12,7 @@
 
 //! Internals of the decomposer creation and caching for unitary synthesis.
 //!
-//! The decomposer cache logic makes very specifc assumptions about how the cache objects and keys
+//! The decomposer cache logic makes very specific assumptions about how the cache objects and keys
 //! are constructed, so we use this module to localise where all these assumptions are being made,
 //! and to enforce a safe API within the rest of the unitary synthesis logic.
 

--- a/crates/transpiler/src/passes/vf2/vf2_layout.rs
+++ b/crates/transpiler/src/passes/vf2/vf2_layout.rs
@@ -136,7 +136,7 @@ impl Vf2PassConfiguration {
             }
             None => (None, None),
         };
-        // In the leagcy API, negative `max_trials` means unbounded (which we represent as 0) and
+        // In the legacy API, negative `max_trials` means unbounded (which we represent as 0) and
         // `None` means "choose some values based on the size of the graph structures".
         let max_trials = max_trials.map(|value| value.try_into().unwrap_or(0));
         let shuffle_seed = match shuffle_seed {

--- a/crates/transpiler/src/standard_equivalence_library.rs
+++ b/crates/transpiler/src/standard_equivalence_library.rs
@@ -118,7 +118,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding H gate equivalence");
+    .expect("Error while adding H gate equivalence");
 
     // HGate
     //
@@ -132,7 +132,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding H gate equivalence");
+    .expect("Error while adding H gate equivalence");
 
     // CHGate
     // q_0: ──■──     q_0: ─────────────────■─────────────────────
@@ -154,7 +154,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CH gate equivalence");
+    .expect("Error while adding CH gate equivalence");
 
     // PhaseGate
     //
@@ -175,7 +175,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding Phase gate equivalence");
+    .expect("Error while adding Phase gate equivalence");
 
     // PhaseGate
     //
@@ -197,7 +197,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding Phase gate equivalence");
+    .expect("Error while adding Phase gate equivalence");
 
     // CPhaseGate
     //                      ┌────────┐
@@ -236,7 +236,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CPhase gate equivalence");
+    .expect("Error while adding CPhase gate equivalence");
 
     // CPhaseGate
     //
@@ -254,7 +254,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CPhase gate equivalence");
+    .expect("Error while adding CPhase gate equivalence");
 
     // CPhaseGate
     //
@@ -288,7 +288,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         Param::ParameterExpression(theta_div_4.clone()),
         &mut equiv,
     )
-    .expect("Error while addding CPhase gate equivalence");
+    .expect("Error while adding CPhase gate equivalence");
 
     // RGate
     //
@@ -322,7 +322,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding R gate equivalence");
+    .expect("Error while adding R gate equivalence");
 
     // IGate
     //    ┌───┐        ┌──────────┐
@@ -339,7 +339,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding I gate equivalence");
+    .expect("Error while adding I gate equivalence");
 
     // IGate
     //    ┌───┐        ┌───────┐
@@ -352,7 +352,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding I gate equivalence");
+    .expect("Error while adding I gate equivalence");
 
     // IGate
     //    ┌───┐        ┌───────┐
@@ -365,7 +365,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding I gate equivalence");
+    .expect("Error while adding I gate equivalence");
 
     // IGate
     //    ┌───┐        ┌───────┐
@@ -378,7 +378,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding I gate equivalence");
+    .expect("Error while adding I gate equivalence");
 
     // RCCXGate
     //
@@ -406,7 +406,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RCCX gate equivalence");
+    .expect("Error while adding RCCX gate equivalence");
 
     // RXGate
     //
@@ -424,7 +424,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RX gate equivalence");
+    .expect("Error while adding RX gate equivalence");
 
     // CRXGate
     //
@@ -461,7 +461,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CRX gate equivalence");
+    .expect("Error while adding CRX gate equivalence");
 
     // CRXGate
     //
@@ -491,7 +491,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CRX gate equivalence");
+    .expect("Error while adding CRX gate equivalence");
 
     // CRX in terms of one RXX
     //                          ┌───┐   ┌────────────┐┌───┐
@@ -519,7 +519,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CRX gate equivalence");
+    .expect("Error while adding CRX gate equivalence");
 
     // CRX to CRZ
     //
@@ -542,7 +542,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CRX gate equivalence");
+    .expect("Error while adding CRX gate equivalence");
 
     // RXXGate
     //
@@ -570,7 +570,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RXX gate equivalence");
+    .expect("Error while adding RXX gate equivalence");
 
     // RXX to RZX
     //      ┌─────────┐        ┌───┐┌─────────┐┌───┐
@@ -593,7 +593,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RXX gate equivalence");
+    .expect("Error while adding RXX gate equivalence");
 
     // RXX to RZX
     //      ┌─────────┐        ┌───┐            ┌───┐
@@ -618,7 +618,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RXX gate equivalence");
+    .expect("Error while adding RXX gate equivalence");
 
     // RZXGate
     //
@@ -644,7 +644,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RZX gate equivalence");
+    .expect("Error while adding RZX gate equivalence");
 
     // RZXGate to RZZGate
     //      ┌─────────┐
@@ -667,7 +667,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RZX gate equivalence");
+    .expect("Error while adding RZX gate equivalence");
 
     // RYGate
     //
@@ -685,7 +685,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RY gate equivalence");
+    .expect("Error while adding RY gate equivalence");
 
     // RYGate
     //
@@ -707,7 +707,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RY gate equivalence");
+    .expect("Error while adding RY gate equivalence");
 
     // CRYGate
     //
@@ -735,7 +735,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CRY gate equivalence");
+    .expect("Error while adding CRY gate equivalence");
 
     // CRY to CRZ
     //
@@ -758,7 +758,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CRY gate equivalence");
+    .expect("Error while adding CRY gate equivalence");
 
     // CRY to CRZ
     //
@@ -783,7 +783,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CRY gate equivalence");
+    .expect("Error while adding CRY gate equivalence");
 
     // CRY to RZZ
     //
@@ -813,7 +813,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CRY gate equivalence");
+    .expect("Error while adding CRY gate equivalence");
 
     // RYYGate
     //
@@ -841,7 +841,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RYY gate equivalence");
+    .expect("Error while adding RYY gate equivalence");
 
     // RYYGate
     //
@@ -869,7 +869,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RYY gate equivalence");
+    .expect("Error while adding RYY gate equivalence");
 
     // RYY to RZZ
     //
@@ -895,7 +895,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RYY gate equivalence");
+    .expect("Error while adding RYY gate equivalence");
 
     // RYY to RXX
     //
@@ -921,7 +921,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RYY gate equivalence");
+    .expect("Error while adding RYY gate equivalence");
 
     // RZGate
     //                  global phase: -ϴ/2
@@ -939,7 +939,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         Param::ParameterExpression(neg_theta_div_2.clone()),
         &mut equiv,
     )
-    .expect("Error while addding RZ gate equivalence");
+    .expect("Error while adding RZ gate equivalence");
 
     // RZGate to RY
     //
@@ -962,7 +962,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RZ gate equivalence");
+    .expect("Error while adding RZ gate equivalence");
 
     // RZGate to RX
     //
@@ -984,7 +984,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RZ gate equivalence");
+    .expect("Error while adding RZ gate equivalence");
 
     // CRZGate
     //
@@ -1012,7 +1012,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CRZ gate equivalence");
+    .expect("Error while adding CRZ gate equivalence");
 
     // CRZ to CRY
     //
@@ -1035,7 +1035,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CRZ gate equivalence");
+    .expect("Error while adding CRZ gate equivalence");
 
     // CRZ to CRX
     //
@@ -1058,7 +1058,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CRZ gate equivalence");
+    .expect("Error while adding CRZ gate equivalence");
 
     // CRZ to RZZ
     //
@@ -1084,7 +1084,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CRZ gate equivalence");
+    .expect("Error while adding CRZ gate equivalence");
 
     // RZZGate
     //
@@ -1107,7 +1107,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RZZ gate equivalence");
+    .expect("Error while adding RZZ gate equivalence");
 
     // RZZ to RXX
     //                      ┌───┐┌─────────────┐┌───┐
@@ -1132,7 +1132,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RZZ gate equivalence");
+    .expect("Error while adding RZZ gate equivalence");
 
     // RZZ to RZX
     //                          ┌─────────┐
@@ -1155,7 +1155,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RZZ gate equivalence");
+    .expect("Error while adding RZZ gate equivalence");
 
     // RZZ to CPhase
     //
@@ -1189,7 +1189,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         Param::ParameterExpression(theta_div_2.clone()),
         &mut equiv,
     )
-    .expect("Error while addding RZZ gate equivalence");
+    .expect("Error while adding RZZ gate equivalence");
 
     // RZZ to RYY
     //
@@ -1215,7 +1215,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RZZ gate equivalence");
+    .expect("Error while adding RZZ gate equivalence");
 
     // RZXGate
     //
@@ -1241,7 +1241,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding RZX gate equivalence");
+    .expect("Error while adding RZX gate equivalence");
 
     // ECRGate
     //
@@ -1269,7 +1269,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding ECR gate equivalence");
+    .expect("Error while adding ECR gate equivalence");
 
     // ECRGate decomposed to Clifford gates (up to a global phase)
     //
@@ -1291,7 +1291,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         -PI / 4.0,
         &mut equiv,
     )
-    .expect("Error while addding ECR gate equivalence");
+    .expect("Error while adding ECR gate equivalence");
 
     // CXGate decomposed using an ECRGate and Clifford 1-qubit gates
     //                global phase: π/4
@@ -1312,7 +1312,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         PI / 4.0,
         &mut equiv,
     )
-    .expect("Error while addding CX gate equivalence");
+    .expect("Error while adding CX gate equivalence");
 
     // SGate
     //
@@ -1326,7 +1326,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding S gate equivalence");
+    .expect("Error while adding S gate equivalence");
 
     // SGate
     //
@@ -1343,7 +1343,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding S gate equivalence");
+    .expect("Error while adding S gate equivalence");
 
     // SdgGate
     //
@@ -1357,7 +1357,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding Sdg gate equivalence");
+    .expect("Error while adding Sdg gate equivalence");
 
     // SdgGate
     //
@@ -1374,7 +1374,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding Sdg gate equivalence");
+    .expect("Error while adding Sdg gate equivalence");
 
     // SdgGate
     //
@@ -1391,7 +1391,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding Sdg gate equivalence");
+    .expect("Error while adding Sdg gate equivalence");
 
     // SdgGate
     //
@@ -1409,7 +1409,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding Sdg gate equivalence");
+    .expect("Error while adding Sdg gate equivalence");
 
     // SdgGate
     //
@@ -1426,7 +1426,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding SDG gate equivalence");
+    .expect("Error while adding SDG gate equivalence");
 
     // CSGate
     //
@@ -1448,7 +1448,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CS gate equivalence");
+    .expect("Error while adding CS gate equivalence");
 
     // CSGate
     //
@@ -1467,7 +1467,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CS gate equivalence");
+    .expect("Error while adding CS gate equivalence");
 
     // CSdgGate
     //
@@ -1489,7 +1489,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CSDG gate equivalence");
+    .expect("Error while adding CSDG gate equivalence");
 
     // CSdgGate
     //
@@ -1509,7 +1509,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CSDG gate equivalence");
+    .expect("Error while adding CSDG gate equivalence");
 
     // SwapGate
     //                        ┌───┐
@@ -1528,7 +1528,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding SWAP gate equivalence");
+    .expect("Error while adding SWAP gate equivalence");
 
     // SwapGate
     //
@@ -1559,7 +1559,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding SWAP gate equivalence");
+    .expect("Error while adding SWAP gate equivalence");
 
     // SwapGate
     //
@@ -1590,7 +1590,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         -PI / 2.0,
         &mut equiv,
     )
-    .expect("Error while addding Swap gate equivalence");
+    .expect("Error while adding Swap gate equivalence");
 
     // iSwapGate
     //
@@ -1613,7 +1613,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding ISWAP gate equivalence");
+    .expect("Error while adding ISWAP gate equivalence");
 
     // SXGate
     //               global phase: π/4
@@ -1631,7 +1631,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         PI / 4.0,
         &mut equiv,
     )
-    .expect("Error while addding SX gate equivalence");
+    .expect("Error while adding SX gate equivalence");
 
     // HGate decomposed into SXGate and SGate
     //              global phase: -π/4
@@ -1649,7 +1649,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         -PI / 4.0,
         &mut equiv,
     )
-    .expect("Error while addding H gate equivalence");
+    .expect("Error while adding H gate equivalence");
 
     // SXGate
     //               global phase: π/4
@@ -1663,7 +1663,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         PI / 4.0,
         &mut equiv,
     )
-    .expect("Error while addding SX gate equivalence");
+    .expect("Error while adding SX gate equivalence");
 
     // SXdgGate
     //                 global phase: 7π/4
@@ -1681,7 +1681,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         -PI / 4.0,
         &mut equiv,
     )
-    .expect("Error while addding SXDG gate equivalence");
+    .expect("Error while adding SXDG gate equivalence");
 
     // HGate decomposed into SXdgGate and SdgGate
     //              global phase: π/4
@@ -1699,7 +1699,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         PI / 4.0,
         &mut equiv,
     )
-    .expect("Error while addding H gate equivalence");
+    .expect("Error while adding H gate equivalence");
 
     // SXdgGate
     //                 global phase: 7π/4
@@ -1713,7 +1713,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         -PI / 4.0,
         &mut equiv,
     )
-    .expect("Error while addding SXDG gate equivalence");
+    .expect("Error while adding SXDG gate equivalence");
 
     // CSXGate
     //
@@ -1732,7 +1732,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CSX gate equivalence");
+    .expect("Error while adding CSX gate equivalence");
 
     // CSXGate
     //                 global phase: π/4
@@ -1758,7 +1758,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         PI / 4.0,
         &mut equiv,
     )
-    .expect("Error while addding CSX gate equivalence");
+    .expect("Error while adding CSX gate equivalence");
 
     // DCXGate
     //
@@ -1777,7 +1777,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding DCX gate equivalence");
+    .expect("Error while adding DCX gate equivalence");
 
     // DCXGate
     //
@@ -1799,7 +1799,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding DCX gate equivalence");
+    .expect("Error while adding DCX gate equivalence");
 
     // CSwapGate
     //
@@ -1820,7 +1820,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CSWAP gate equivalence");
+    .expect("Error while adding CSWAP gate equivalence");
 
     // TGate
     //
@@ -1834,7 +1834,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding T gate equivalence");
+    .expect("Error while adding T gate equivalence");
 
     // TGate
     //
@@ -1856,7 +1856,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding T gate equivalence");
+    .expect("Error while adding T gate equivalence");
 
     // TdgGate
     //
@@ -1870,7 +1870,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding TDG gate equivalence");
+    .expect("Error while adding TDG gate equivalence");
 
     // TdgGate
     //
@@ -1892,7 +1892,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding TDG gate equivalence");
+    .expect("Error while adding TDG gate equivalence");
 
     // UGate
     //
@@ -1921,7 +1921,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding U gate equivalence");
+    .expect("Error while adding U gate equivalence");
 
     // CUGate
     //                                  ┌──────┐    ┌──────────────┐     »
@@ -2003,7 +2003,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CU gate equivalence");
+    .expect("Error while adding CU gate equivalence");
 
     // CUGate
     //                              ┌──────┐
@@ -2038,7 +2038,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CU gate equivalence");
+    .expect("Error while adding CU gate equivalence");
 
     // U1Gate
     //
@@ -2060,7 +2060,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding U1 gate equivalence");
+    .expect("Error while adding U1 gate equivalence");
 
     // U1Gate
     //
@@ -2078,7 +2078,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding U1 gate equivalence");
+    .expect("Error while adding U1 gate equivalence");
 
     // U1Gate
     //                  global phase: θ/2
@@ -2096,7 +2096,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         Param::ParameterExpression(theta_div_2.clone()),
         &mut equiv,
     )
-    .expect("Error while addding U1 gate equivalence");
+    .expect("Error while adding U1 gate equivalence");
 
     // CU1Gate
     //                       ┌────────┐
@@ -2129,7 +2129,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CU1 gate equivalence");
+    .expect("Error while adding CU1 gate equivalence");
 
     // U2Gate
     //
@@ -2154,7 +2154,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding U2 gate equivalence");
+    .expect("Error while adding U2 gate equivalence");
 
     // U2Gate
     //                    global phase: 7π/4
@@ -2185,7 +2185,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         7.0 * PI / 4.0,
         &mut equiv,
     )
-    .expect("Error while addding U2 gate equivalence");
+    .expect("Error while adding U2 gate equivalence");
 
     // U3Gate
     //                         global phase: λ/2 + ϕ/2 - π/2
@@ -2233,7 +2233,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         Param::ParameterExpression(lam_plus_phi_minus_pi_div_2.clone()),
         &mut equiv,
     )
-    .expect("Error while addding U3 gate equivalence");
+    .expect("Error while adding U3 gate equivalence");
 
     // U3Gate
     //
@@ -2259,7 +2259,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding U3 gate equivalence");
+    .expect("Error while adding U3 gate equivalence");
 
     // CU3Gate
     //                             ┌──────────────┐                                  »
@@ -2319,7 +2319,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CU3 gate equivalence");
+    .expect("Error while adding CU3 gate equivalence");
 
     // CU3Gate
     //
@@ -2347,7 +2347,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CU3 gate equivalence");
+    .expect("Error while adding CU3 gate equivalence");
 
     // XGate
     //
@@ -2365,7 +2365,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding X gate equivalence");
+    .expect("Error while adding X gate equivalence");
 
     // XGate
     //
@@ -2384,7 +2384,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding X gate equivalence");
+    .expect("Error while adding X gate equivalence");
 
     // XGate
     //                 global phase: π/2
@@ -2401,7 +2401,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         PI / 2.0,
         &mut equiv,
     )
-    .expect("Error while addding X gate equivalence");
+    .expect("Error while adding X gate equivalence");
 
     // CXGate
     //
@@ -2442,7 +2442,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
             let cx_to_rxx = cnot_rxx_decompose(pos_ry, pos_rxx).unwrap();
             equiv
                 .add_equivalence(&StandardGate::CX.into(), &[], cx_to_rxx)
-                .expect("Error while addding CX gate equivalence")
+                .expect("Error while adding CX gate equivalence")
         }
     }
 
@@ -2463,7 +2463,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CX gate equivalence");
+    .expect("Error while adding CX gate equivalence");
 
     // CXGate
     //                global phase: 3π/4
@@ -2493,7 +2493,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         3.0 * PI / 4.0,
         &mut equiv,
     )
-    .expect("Error while addding CX gate equivalence");
+    .expect("Error while adding CX gate equivalence");
 
     // CXGate
     //                global phase: 7π/4
@@ -2514,7 +2514,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         -PI / 4.0,
         &mut equiv,
     )
-    .expect("Error while addding CX gate equivalence");
+    .expect("Error while adding CX gate equivalence");
 
     // CXGate
     // q_0: ──■──     q_0: ───────────────■───────────────────
@@ -2540,7 +2540,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CX gate equivalence");
+    .expect("Error while adding CX gate equivalence");
 
     // CXGate
     //                     ┌────────────┐
@@ -2572,7 +2572,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CX gate equivalence");
+    .expect("Error while adding CX gate equivalence");
 
     // CXGate
     //                global phase: π/4
@@ -2596,7 +2596,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         PI / 4.0,
         &mut equiv,
     )
-    .expect("Error while addding CX gate equivalence");
+    .expect("Error while adding CX gate equivalence");
 
     // CCXGate
     //                                                                       ┌───┐
@@ -2629,7 +2629,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CCX gate equivalence");
+    .expect("Error while adding CCX gate equivalence");
 
     // CCXGate
     //
@@ -2655,7 +2655,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CCX gate equivalence");
+    .expect("Error while adding CCX gate equivalence");
 
     // YGate
     //
@@ -2673,7 +2673,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding Y gate equivalence");
+    .expect("Error while adding Y gate equivalence");
 
     // YGate
     //              global phase: 3π/2
@@ -2694,7 +2694,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         3.0 * PI / 2.0,
         &mut equiv,
     )
-    .expect("Error while addding Y gate equivalence");
+    .expect("Error while adding Y gate equivalence");
 
     // YGate
     //              global phase: π/2
@@ -2715,7 +2715,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         PI / 2.0,
         &mut equiv,
     )
-    .expect("Error while addding Y gate equivalence");
+    .expect("Error while adding Y gate equivalence");
 
     // YGate
     //                 global phase: π/2
@@ -2732,7 +2732,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         PI / 2.0,
         &mut equiv,
     )
-    .expect("Error while addding Y gate equivalence");
+    .expect("Error while adding Y gate equivalence");
 
     // CYGate
     //
@@ -2751,7 +2751,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CY gate equivalence");
+    .expect("Error while adding CY gate equivalence");
 
     // ZGate
     //
@@ -2765,7 +2765,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding Z gate equivalence");
+    .expect("Error while adding Z gate equivalence");
 
     // ZGate
     //
@@ -2782,7 +2782,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding Z gate equivalence");
+    .expect("Error while adding Z gate equivalence");
 
     // ZGate
     //                 global phase: π/2
@@ -2799,7 +2799,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         PI / 2.0,
         &mut equiv,
     )
-    .expect("Error while addding Z gate equivalence");
+    .expect("Error while adding Z gate equivalence");
 
     // CZGate
     //
@@ -2818,7 +2818,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CZ gate equivalence");
+    .expect("Error while adding CZ gate equivalence");
 
     // CCZGate
     //
@@ -2839,7 +2839,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding CCZ gate equivalence");
+    .expect("Error while adding CCZ gate equivalence");
 
     // XGate
     //              global phase: π/2
@@ -2853,7 +2853,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         PI / 2.0,
         &mut equiv,
     )
-    .expect("Error while addding X gate equivalence");
+    .expect("Error while adding X gate equivalence");
 
     // YGate
     //              global phase: π/2
@@ -2867,7 +2867,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         PI / 2.0,
         &mut equiv,
     )
-    .expect("Error while addding Y gate equivalence");
+    .expect("Error while adding Y gate equivalence");
 
     // HGate
     //              global phase: π/2
@@ -2884,7 +2884,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         PI / 2.0,
         &mut equiv,
     )
-    .expect("Error while addding H gate equivalence");
+    .expect("Error while adding H gate equivalence");
 
     // HGate
     //              global phase: π/2
@@ -2905,7 +2905,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         PI / 2.0,
         &mut equiv,
     )
-    .expect("Error while addding H gate equivalence");
+    .expect("Error while adding H gate equivalence");
 
     // XXPlusYYGate
     // ┌───────────────┐
@@ -2963,7 +2963,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding XX_PLUS_YY gate equivalence");
+    .expect("Error while adding XX_PLUS_YY gate equivalence");
 
     // XXPlusYYGate
     // ┌───────────────┐
@@ -3007,7 +3007,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding XX_PLUS_YY gate equivalence");
+    .expect("Error while adding XX_PLUS_YY gate equivalence");
 
     // XXMinusYYGate
     // ┌───────────────┐
@@ -3061,7 +3061,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding XX_MINUS_YY gate equivalence");
+    .expect("Error while adding XX_MINUS_YY gate equivalence");
 
     // XXMinusYYGate
     // ┌───────────────┐
@@ -3105,7 +3105,7 @@ pub fn generate_standard_equivalence_library() -> EquivalenceLibrary {
         0.0,
         &mut equiv,
     )
-    .expect("Error while addding XX_MINUS_YY gate equivalence");
+    .expect("Error while adding XX_MINUS_YY gate equivalence");
 
     equiv
 }

--- a/crates/transpiler/src/target/mod.rs
+++ b/crates/transpiler/src/target/mod.rs
@@ -1500,7 +1500,7 @@ impl Target {
 
     // IndexMap methods
 
-    /// Retreive all the gate names in the Target
+    /// Retrieve all the gate names in the Target
     // TODO: Remove once `Target` is being consumed.
     #[allow(dead_code)]
     pub fn keys(&self) -> impl Iterator<Item = &str> {

--- a/crates/transpiler/src/transpile_layout.rs
+++ b/crates/transpiler/src/transpile_layout.rs
@@ -30,7 +30,7 @@ use qiskit_circuit::imports::TRANSPILE_LAYOUT;
 /// and routing permutations. The initial layout permutation is caused by
 /// setting and applying the initial layout (the mapping from virtual circuit
 /// qubits to physical qubits on the target) and the routing permtuations are
-/// caused by swap gate insertion or permutation ellision prior to the initial
+/// caused by swap gate insertion or permutation elision prior to the initial
 /// layout. This struct tracks these details and provide an interface to reason
 /// about these permutations.
 pub struct TranspileLayout {
@@ -94,7 +94,7 @@ impl TranspileLayout {
     /// # Panics
     ///
     /// If the two layouts and the number of virtual qubits are not all the same size, or if the
-    /// numebr of input qubits is larger than the sizes of the other objects.
+    /// number of input qubits is larger than the sizes of the other objects.
     pub fn from_layouts(
         initial_layout: NLayout,
         final_layout: &NLayout,
@@ -436,7 +436,7 @@ impl TranspileLayout {
     /// ((initial layout, physical DAG, routing permutation), virtual permutation)
     /// ```
     /// and this [TranspileLayout] corresponds to the inner 3-tuple.  In order to combine the
-    /// previous virtual permutation into this layout, you wuold call this function.
+    /// previous virtual permutation into this layout, you would call this function.
     ///
     /// The function is a "gets set to" permutation, just like as returned by [output_permutation].
     ///

--- a/docs/cdoc/qk-circuit-library.rst
+++ b/docs/cdoc/qk-circuit-library.rst
@@ -1,5 +1,5 @@
 ===============
-Cirucit Library
+Circuit Library
 ===============
 
 The Qiskit circuit library contains functions for building commonly used quantum circuits.

--- a/qiskit/circuit/_add_control.py
+++ b/qiskit/circuit/_add_control.py
@@ -25,7 +25,7 @@ from ._utils import _ctrl_state_to_int
 
 
 # The list of gates whose controlled versions have efficient synthesis algorithms.
-# For example, a controlled version of X is MCX (with many synthesis algorithms avalable),
+# For example, a controlled version of X is MCX (with many synthesis algorithms available),
 # and a controlled version of Z is MCX + two Hadamard gates.
 #
 # Note: when adding a new gate to this list, also add the decomposition of its controlled

--- a/qiskit/circuit/annotated_operation.py
+++ b/qiskit/circuit/annotated_operation.py
@@ -172,7 +172,7 @@ class AnnotatedOperation(Operation):
         ``annotated``.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Ignored.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring
                 (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``.

--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -130,7 +130,7 @@ class Gate(Instruction):
         is ``False``, and as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
                 Ignored if the controlled gate is implemented as an annotated operation.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring

--- a/qiskit/circuit/library/arithmetic/integer_comparator.py
+++ b/qiskit/circuit/library/arithmetic/integer_comparator.py
@@ -187,7 +187,7 @@ class IntegerComparatorGate(Gate):
         r"""
         Args:
             num_state_qubits: The number of qubits in the registers.
-            value: The value :math:`L` to compre to.
+            value: The value :math:`L` to compare to.
             geq: If ``True`` compute :math:`i \geq L`, otherwise compute :math:`i < L`.
             label: An optional label for the gate.
         """

--- a/qiskit/circuit/library/bit_flip_oracle.py
+++ b/qiskit/circuit/library/bit_flip_oracle.py
@@ -62,7 +62,7 @@ class BitFlipOracleGate(Gate):
             var_order: A list with the order in which variables will be created.
                (default: by appearance)
             label: A label for the gate to display in visualizations. Per default, the label is
-                set to display the textual represntation of the boolean expression (truncated if needed)
+                set to display the textual representation of the boolean expression (truncated if needed)
         """
         if label is None:
             if isinstance(expression, str):

--- a/qiskit/circuit/library/generalized_gates/diagonal.py
+++ b/qiskit/circuit/library/generalized_gates/diagonal.py
@@ -128,7 +128,7 @@ class DiagonalGate(Gate):
 
     def validate_parameter(self, parameter):
         """Diagonal Gate parameter should accept complex
-        (in addition to the Gate parameter types) and always return build-in complex."""
+        (in addition to the Gate parameter types) and always return built-in complex."""
         if isinstance(parameter, complex):
             return complex(parameter)
         else:
@@ -156,7 +156,7 @@ class DiagonalGate(Gate):
 def _extract_rz(phi1, phi2):
     """
     Extract a Rz rotation (angle given by first output) such that exp(j*phase)*Rz(z_angle)
-    is equal to the diagonal matrix with entires exp(1j*ph1) and exp(1j*ph2).
+    is equal to the diagonal matrix with entries exp(1j*ph1) and exp(1j*ph2).
     """
     phase = (phi1 + phi2) / 2.0
     z_angle = phi2 - phi1

--- a/qiskit/circuit/library/generalized_gates/isometry.py
+++ b/qiskit/circuit/library/generalized_gates/isometry.py
@@ -153,7 +153,7 @@ class Isometry(Instruction):
         remaining_isometry = self.iso_data.astype(complex)  # note: "astype" does copy the isometry
         diag = []
         m = int(math.log2(self.iso_data.shape[1]))
-        # Decompose the column with index column_index and attache the gate to the circuit object.
+        # Decompose the column with index column_index and attach the gate to the circuit object.
         # Return the isometry that is left to decompose, where the columns up to index column_index
         # correspond to the firstfew columns of the identity matrix up to diag, and hence we only
         # have to save a list containing them.

--- a/qiskit/circuit/library/generalized_gates/mcg_up_to_diagonal.py
+++ b/qiskit/circuit/library/generalized_gates/mcg_up_to_diagonal.py
@@ -14,7 +14,7 @@
 
 """Multi controlled single-qubit unitary up to diagonal."""
 
-# ToDo: This code should be merged wth the implementation of MCGs
+# ToDo: This code should be merged with the implementation of MCGs
 # ToDo: (introducing a decomposition mode "up_to_diagonal").
 
 import numpy as np

--- a/qiskit/circuit/library/generalized_gates/mcmt.py
+++ b/qiskit/circuit/library/generalized_gates/mcmt.py
@@ -305,7 +305,7 @@ class MCMTGate(ControlledGate):
         value of ``annotated``.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring
                 (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``

--- a/qiskit/circuit/library/generalized_gates/unitary.py
+++ b/qiskit/circuit/library/generalized_gates/unitary.py
@@ -183,7 +183,7 @@ class UnitaryGate(Gate):
         is ``False``, and as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``. Ignored if the controlled gate
                 is implemented as an annotated operation.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring

--- a/qiskit/circuit/library/n_local/n_local.py
+++ b/qiskit/circuit/library/n_local/n_local.py
@@ -189,7 +189,7 @@ def n_local(
         circuit = n_local(3, "x", "crx", entangler_map, reps=2)
         circuit.draw("mpl")
 
-    We can set different entanglements per layer, by specifing a callable that takes
+    We can set different entanglements per layer, by specifying a callable that takes
     as input the current layer index, and returns the entanglement structure. For example,
     the following uses different entanglements for odd and even layers:
 
@@ -1273,7 +1273,7 @@ def get_entangler_map(
         qubits on ``num_circuit_qubits`` qubits.
 
     Raises:
-        ValueError: If the entanglement mode ist not supported.
+        ValueError: If the entanglement mode is not supported.
     """
     try:
         return fast_entangler_map(num_circuit_qubits, num_block_qubits, entanglement, offset)

--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -266,7 +266,7 @@ class PauliEvolutionGate(Gate):
         regardless of the value of ``annotated``.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: A label for the resulting Pauli evolution gate, to display in visualizations.
                 Per default, the label is set to ``exp(-it <operators>)`` where ``<operators>``
                 is the sum of the Paulis. Note that the label does not include any coefficients

--- a/qiskit/circuit/library/phase_oracle.py
+++ b/qiskit/circuit/library/phase_oracle.py
@@ -180,7 +180,7 @@ class PhaseOracleGate(Gate):
             var_order: A list with the order in which variables will be created.
                (default: by appearance)
             label: A label for the gate to display in visualizations. Per default, the label is
-                set to display the textual represntation of the boolean expression (truncated if needed)
+                set to display the textual representation of the boolean expression (truncated if needed)
         """
         if label is None:
             if isinstance(expression, str):

--- a/qiskit/circuit/library/quantum_volume.py
+++ b/qiskit/circuit/library/quantum_volume.py
@@ -160,7 +160,7 @@ def quantum_volume(
             is not specified it will default to ``num_qubits`` layers.
         seed: An optional RNG seed used for generating the random SU(4)
             matrices used in the output circuit. This can be either an
-            integer or a numpy generator. If an integer is specfied it must
+            integer or a numpy generator. If an integer is specified it must
             be an value between 0 and 2**64 - 1.
 
     Reference Circuit:

--- a/qiskit/circuit/library/standard_gates/h.py
+++ b/qiskit/circuit/library/standard_gates/h.py
@@ -95,7 +95,7 @@ class HGate(SingletonGate):
         is ``False``, and as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
                 Ignored if the controlled gate is implemented as an annotated operation.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring

--- a/qiskit/circuit/library/standard_gates/i.py
+++ b/qiskit/circuit/library/standard_gates/i.py
@@ -59,7 +59,7 @@ class IGate(SingletonGate):
     _singleton_lookup_key = stdlib_singleton_key()
 
     def inverse(self, annotated: bool = False):
-        """Returne the inverse gate (itself).
+        """Returns the inverse gate (itself).
 
         Args:
             annotated: when set to ``True``, this is typically used to return an

--- a/qiskit/circuit/library/standard_gates/p.py
+++ b/qiskit/circuit/library/standard_gates/p.py
@@ -113,7 +113,7 @@ class PhaseGate(Gate):
         In each case, the value of ``annotated`` is ignored.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring
                 (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
@@ -256,7 +256,7 @@ class CPhaseGate(ControlledGate):
         the value of ``annotated``.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring
                 (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
@@ -390,7 +390,7 @@ class MCPhaseGate(ControlledGate):
         the value of ``annotated``.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring
                 (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -94,7 +94,7 @@ class RXGate(Gate):
         and as ``False`` otherwise.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring
                 (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``

--- a/qiskit/circuit/library/standard_gates/ry.py
+++ b/qiskit/circuit/library/standard_gates/ry.py
@@ -93,7 +93,7 @@ class RYGate(Gate):
         and as ``False`` otherwise.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring
                 (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``

--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -106,7 +106,7 @@ class RZGate(Gate):
         and as ``False`` otherwise.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring
                 (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``

--- a/qiskit/circuit/library/standard_gates/s.py
+++ b/qiskit/circuit/library/standard_gates/s.py
@@ -99,7 +99,7 @@ class SGate(SingletonGate):
         is ``False``, and as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
                 Ignored if the controlled gate is implemented as an annotated operation.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring
@@ -217,7 +217,7 @@ class SdgGate(SingletonGate):
         is ``False``, and as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
                 Ignored if the controlled gate is implemented as an annotated operation.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring

--- a/qiskit/circuit/library/standard_gates/swap.py
+++ b/qiskit/circuit/library/standard_gates/swap.py
@@ -103,7 +103,7 @@ class SwapGate(SingletonGate):
         is ``False``, and as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
                 Ignored if the controlled gate is implemented as an annotated operation.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring

--- a/qiskit/circuit/library/standard_gates/sx.py
+++ b/qiskit/circuit/library/standard_gates/sx.py
@@ -120,7 +120,7 @@ class SXGate(SingletonGate):
 
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
                 Ignored if the controlled gate is implemented as an annotated operation.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -132,7 +132,7 @@ class UGate(Gate):
         and as ``False`` otherwise.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Ignored if the controlled gate is implemented as an
                 annotated operation.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring

--- a/qiskit/circuit/library/standard_gates/u1.py
+++ b/qiskit/circuit/library/standard_gates/u1.py
@@ -127,7 +127,7 @@ class U1Gate(Gate):
 
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring
                 (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
@@ -272,7 +272,7 @@ class CU1Gate(ControlledGate):
         the value of ``annotated``.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring
                 (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
@@ -418,7 +418,7 @@ class MCU1Gate(ControlledGate):
         the value of ``annotated``.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring
                 (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -137,7 +137,7 @@ class U3Gate(Gate):
         and as ``False`` otherwise.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
                 Ignored if the controlled gate is implemented as an annotated operation.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -111,7 +111,7 @@ class XGate(SingletonGate):
         is ignored.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring
                 (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
@@ -248,7 +248,7 @@ class CXGate(SingletonControlledGate):
         The value of ``annotated`` is ignored.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring
                 (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
@@ -406,7 +406,7 @@ class CCXGate(SingletonControlledGate):
         The value of `annotated` is ignored.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring
                 (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
@@ -605,7 +605,7 @@ class C3XGate(SingletonControlledGate):
         The value of ``annotated`` is ignored.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring
                 (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
@@ -769,7 +769,7 @@ class C4XGate(SingletonControlledGate):
         The value of ``annotated`` is ignored.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring
                 (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``
@@ -950,7 +950,7 @@ class MCXGate(ControlledGate):
         The value of ``annotated`` is ignored.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring
                 (e.g. ``"110"``). If ``None``, defaults to the all-ones state ``2**num_ctrl_qubits - 1``

--- a/qiskit/circuit/library/standard_gates/y.py
+++ b/qiskit/circuit/library/standard_gates/y.py
@@ -112,7 +112,7 @@ class YGate(SingletonGate):
         is ``False``, and as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
                 Ignored if the controlled gate is implemented as an annotated operation.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring

--- a/qiskit/circuit/library/standard_gates/z.py
+++ b/qiskit/circuit/library/standard_gates/z.py
@@ -116,7 +116,7 @@ class ZGate(SingletonGate):
         as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
                 Ignored if the controlled gate is implemented as an annotated operation.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring
@@ -262,7 +262,7 @@ class CZGate(SingletonControlledGate):
         as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: Optional gate label. Defaults to ``None``.
                 Ignored if the controlled gate is implemented as an annotated operation.
             ctrl_state: The control state of the gate, specified either as an integer or a bitstring

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -629,7 +629,7 @@ class QuantumCircuit:
 
     The :class:`QuantumCircuit` class has helper methods to add many of the Qiskit standard-library
     instructions and gates onto a circuit.  These are generally equivalent to manually constructing
-    an instance of the relevent :mod:`qiskit.circuit.library` object, then passing that to
+    an instance of the relevant :mod:`qiskit.circuit.library` object, then passing that to
     :meth:`append` with the remaining arguments placed into the ``qargs`` and ``cargs`` fields as
     appropriate.
 
@@ -7739,7 +7739,7 @@ class _OuterCircuitScopeInterface(CircuitScopeInterface):
         if isinstance(specifier, ClassicalRegister):
             # This is linear complexity for something that should be constant, but QuantumCircuit
             # does not currently keep a hashmap of registers, and requires non-trivial changes to
-            # how it exposes its registers publically before such a map can be safely stored so it
+            # how it exposes its registers publicly before such a map can be safely stored so it
             # doesn't miss updates. (Jake, 2021-11-10).
             if specifier not in self.circuit.cregs:
                 raise CircuitError(f"Register {specifier} is not present in this circuit.")

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1072,7 +1072,7 @@ class QuantumCircuit:
         Default constructor of :class:`QuantumCircuit`.
 
         ..
-            `QuantumCirucit` documents its `__init__` method explicitly, unlike most classes where
+            `QuantumCircuit` documents its `__init__` method explicitly, unlike most classes where
             it's implicitly appended to the class-level documentation, just because the class is so
             huge and has a lot of introductory material to its class docstring.
 
@@ -1997,7 +1997,7 @@ class QuantumCircuit:
         is ``False``, and as :class:`.AnnotatedOperation` when ``annotated`` is ``True``.
 
         Args:
-            num_ctrl_qubits: Number of controls to add. Defauls to ``1``.
+            num_ctrl_qubits: Number of controls to add. Defaults to ``1``.
             label: An optional label to give the controlled gate for visualization.
                 Defaults to ``None``. Ignored if the controlled gate is implemented as an annotated
                 operation.
@@ -2996,7 +2996,7 @@ class QuantumCircuit:
         # instruction param the inner rust append method will raise a runtime error.
         # When this happens we need to handle the parameters separately.
         # This shouldn't happen in practice but 2 tests were doing this and it's not
-        # explicitly prohibted by the API.
+        # explicitly prohibited by the API.
         try:
             self._data.append(instruction)
         except RuntimeError:
@@ -4315,7 +4315,7 @@ class QuantumCircuit:
           QuantumCircuit: a deepcopy of the current circuit, with the specified name
         """
 
-        # vars_mode is "drop" since ``cpy._data`` is overriden anyway with the call to copy,
+        # vars_mode is "drop" since ``cpy._data`` is overridden anyway with the call to copy,
         # so no need to copy variables in this call.
         cpy = self.copy_empty_like(name, vars_mode="drop")
         cpy._data = self._data.copy()
@@ -5013,7 +5013,7 @@ class QuantumCircuit:
             target = self
         else:
             if not isinstance(parameters, dict):
-                # We're going to need to access the sorted order wihin the inner Rust method on
+                # We're going to need to access the sorted order within the inner Rust method on
                 # `target`, so warm up our own cache first so that subsequent calls to
                 # `assign_parameters` on `self` benefit as well.
                 _ = self._data.parameters

--- a/qiskit/primitives/backend_sampler_v2.py
+++ b/qiskit/primitives/backend_sampler_v2.py
@@ -292,7 +292,7 @@ def _analyze_circuit(circuit: QuantumCircuit) -> tuple[list[_MeasureInfo], int]:
 
 
 def _prepare_memory(results: list[Result]) -> list[ResultMemory]:
-    """Joins splitted results if exceeding max_experiments"""
+    """Joins split results if exceeding max_experiments"""
     lst = []
     for res in results:
         for exp in res.results:

--- a/qiskit/primitives/base/base_estimator.py
+++ b/qiskit/primitives/base/base_estimator.py
@@ -61,7 +61,7 @@ class BaseEstimatorV2(ABC):
 
         * Optionally, the estimation precision.
 
-     * precision: the estimation precision. This specification is optional and will be overriden by
+     * precision: the estimation precision. This specification is optional and will be overridden by
         the pub-wise shots if provided.
 
     All estimator implementations must implement default value for the ``precision`` in the

--- a/qiskit/primitives/base/base_sampler.py
+++ b/qiskit/primitives/base/base_sampler.py
@@ -48,7 +48,7 @@ class BaseSamplerV2(ABC):
 
             * Optionally, the number of shots to sample.
 
-     * shots: the number of shots to sample. This specification is optional and will be overriden by
+     * shots: the number of shots to sample. This specification is optional and will be overridden by
         the pub-wise shots if provided.
 
     All sampler implementations must implement default value for the ``shots`` in the

--- a/qiskit/providers/backend.py
+++ b/qiskit/providers/backend.py
@@ -70,7 +70,7 @@ class BackendV2(Backend, ABC):
     provider to implement a stage plugin for ``translation`` or ``scheduling``
     that contains the custom compilation passes and then for the hook methods on
     the backend object to return the plugin name so that :func:`~.transpile` will
-    use it by default when targetting the backend.
+    use it by default when targeting the backend.
 
     Subclasses of this should override the public method :meth:`run` and the internal
     :meth:`_default_options`:

--- a/qiskit/qasm3/__init__.py
+++ b/qiskit/qasm3/__init__.py
@@ -321,7 +321,7 @@ def load(
         filename: the filename to load the program from.
         num_qubits: keyword argument which provides number of physical/virtual qubits.
         annotation_handlers: a mapping whose keys are (parent) namespaces and values are serializers
-            that can handle children of those namesapces.  Requires ``qiskit_qasm3_import>=0.6.0``.
+            that can handle children of those namespaces.  Requires ``qiskit_qasm3_import>=0.6.0``.
     Returns:
         QuantumCircuit: a circuit representation of the OpenQASM 3 program.
 
@@ -373,7 +373,7 @@ def loads(
         program: the OpenQASM 3 program.
         num_qubits: provides number of physical/virtual qubits.
         annotation_handlers: a mapping whose keys are (parent) namespaces and values are serializers
-            that can handle children of those namesapces.  Requires ``qiskit_qasm3_import>=0.6.0``.
+            that can handle children of those namespaces.  Requires ``qiskit_qasm3_import>=0.6.0``.
     Returns:
         QuantumCircuit: a circuit representation of the OpenQASM 3 program.
 

--- a/qiskit/qasm3/exporter.py
+++ b/qiskit/qasm3/exporter.py
@@ -734,7 +734,7 @@ class QASM3Builder:
         #   handling, so they get the lowest priority; they get defined as they are encountered.
         #
         # An alternative approach would be to defer naming decisions until we are outputting the
-        # AST, and using some UUID for each symbol we're going to define in the interrim.  This
+        # AST, and using some UUID for each symbol we're going to define in the interim.  This
         # would require relatively large changes to the symbol-table and AST handling, however.
 
         for builtin, gate in _BUILTIN_GATES.items():
@@ -752,7 +752,7 @@ class QASM3Builder:
             self.symbols.register_defcal(defcal)
         for builtin in self.basis_gates:
             if builtin in _BUILTIN_GATES:
-                # It's built into the langauge; we don't need to re-add it.
+                # It's built into the language; we don't need to re-add it.
                 continue
             try:
                 self.symbols.register_gate_without_definition(builtin, None)

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -1771,7 +1771,7 @@ a struct format to represent a :class:`~qiskit.circuit.library.PauliEvolutionGat
 natively in QPY. To accomplish this the :ref:`qpy_custom_definition` struct now supports
 a new type value ``'p'`` to represent a :class:`~qiskit.circuit.library.PauliEvolutionGate`.
 Enties in the custom instructions tables have unique name generated that start with the
-string ``"###PauliEvolutionGate_"`` followed by a uuid string. This gate name is reservered
+string ``"###PauliEvolutionGate_"`` followed by a uuid string. This gate name is reserved
 in QPY and if you have a custom :class:`~qiskit.circuit.Instruction` object with a definition
 set and that name prefix it will error. If it's of type ``'p'`` the data payload is defined
 as follows:
@@ -1892,7 +1892,7 @@ and if it's ``v`` it represents a :class:`~qiskit.circuit.ParameterVectorElement
 The map element struct is immediately followed by the symbol map key payload, if
 ``symbol_type`` is ``p`` then it is followed immediately by a :ref:`qpy_param_struct`
 object (both the struct and utf8 name bytes) and if ``symbol_type`` is ``v``
-then the struct is imediately followed by :ref:`qpy_param_vector` (both the struct
+then the struct is immediately followed by :ref:`qpy_param_vector` (both the struct
 and utf8 name bytes). That is followed by ``size`` bytes for the
 data of the symbol. The data format is dependent on the value of ``type``. If
 ``type`` is ``p`` then it represents a :class:`~qiskit.circuit.Parameter` and
@@ -2178,7 +2178,7 @@ The PARAMETER_EXPR data starts with a header:
 
 Immediately following the header is ``expr_size`` bytes of utf8 data containing
 the expression string, which is the sympy srepr of the expression for the
-parameter expression. Follwing that is a symbol map which contains
+parameter expression. Following that is a symbol map which contains
 ``map_elements`` elements with the format
 
 .. code-block:: c

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -126,7 +126,7 @@ class Stinespring(QuantumChannel):
                 # convert it to a SuperOp
                 data = SuperOp._init_instruction(data)
             else:
-                # We use the QuantumChannel init transform to intialize
+                # We use the QuantumChannel init transform to initialize
                 # other objects into a QuantumChannel or Operator object.
                 data = self._init_transformer(data)
             op_shape = data._op_shape

--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -263,7 +263,7 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
 
     @phase.setter
     def phase(self, value):
-        # Convert group phase convetion to internal ZX-phase convention
+        # Convert group phase convention to internal ZX-phase convention
         self._phase[:] = np.mod(value + self._count_y(dtype=self._phase.dtype), 4)
 
     @property

--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -154,13 +154,13 @@ class QuantumState:
         raise NotImplementedError(f"{type(self)} does not support addition")
 
     def _multiply(self, other):
-        """Return the scalar multipled state other * self.
+        """Return the scalar multiplied state other * self.
 
         Args:
             other (complex): a complex number.
 
         Returns:
-            QuantumState: the scalar multipled state other * self.
+            QuantumState: the scalar multiplied state other * self.
 
         Raises:
             NotImplementedError: if subclass does not support scala

--- a/qiskit/synthesis/boolean/boolean_expression.py
+++ b/qiskit/synthesis/boolean/boolean_expression.py
@@ -72,7 +72,7 @@ class TruthTable:
     def __str__(self) -> str:
         if self.explicit_storage:
             return "".join(
-                "1" if self[assignemnt] else "0" for assignemnt in self.all_assignments()
+                "1" if self[assignment] else "0" for assignment in self.all_assignments()
             )
         else:
             return f"Truth table on {self.num_bits} bits (implicit representation)"
@@ -168,7 +168,7 @@ class BooleanExpression:
             EsopGenerator,
         )  # import here to avoid cyclic import
 
-        # generating the esop currntly requires generating the full truth table
+        # generating the esop currently requires generating the full truth table
         # there are many optimizations that can be done to improve this step
         esop = EsopGenerator(self.truth_table).esop
         if circuit_type == "bit":

--- a/qiskit/synthesis/boolean/boolean_expression_synth.py
+++ b/qiskit/synthesis/boolean/boolean_expression_synth.py
@@ -17,7 +17,7 @@ from qiskit.circuit.library import ZGate, XGate
 
 
 class EsopGenerator:
-    """Generates an ESOP (Exlusive-sum-of-products) representation
+    """Generates an ESOP (Exclusive-sum-of-products) representation
     for a boolean function given by its truth table"""
 
     def __init__(self, truth_table):
@@ -76,7 +76,7 @@ class EsopGenerator:
 
 def synth_phase_oracle_from_esop(esop, num_qubits):
     """
-    Generates a phase oracle for the boolean function f given in ESOP (Exlusive sum of products) form
+    Generates a phase oracle for the boolean function f given in ESOP (Exclusive sum of products) form
     esop is of the form ('01-1', '11-0', ...) etc
     where 1 is the variable, 0 is negated variable and - is don't care
     """
@@ -108,7 +108,7 @@ def synth_phase_oracle_from_esop(esop, num_qubits):
 
 def synth_bit_oracle_from_esop(esop, num_qubits):
     """
-    Generates a bit-flip oracle for the boolean function f given in ESOP (Exlusive sum of products) form
+    Generates a bit-flip oracle for the boolean function f given in ESOP (Exclusive sum of products) form
     esop is of the form ('01-1', '11-0', ...) etc
     where 1 is the variable, 0 is negated variable and - is don't care
     """

--- a/qiskit/synthesis/linear_phase/cnot_phase_synth.py
+++ b/qiskit/synthesis/linear_phase/cnot_phase_synth.py
@@ -32,7 +32,7 @@ def synth_cnot_phase_aam(
 
     GraySynth is a heuristic algorithm from [1] for synthesizing small parity networks.
     It is inspired by Gray codes. Given a set of binary strings :math:`S`
-    (called ``cnots`` bellow), the algorithm synthesizes a parity network for :math:`S` by
+    (called ``cnots`` below), the algorithm synthesizes a parity network for :math:`S` by
     repeatedly choosing an index :math:`i` to expand and then effectively recursing on
     the co-factors :math:`S_0` and :math:`S_1`, consisting of the strings :math:`y \in S`,
     with :math:`y_i = 0` or :math:`1` respectively. As a subset :math:`S` is recursively expanded,

--- a/qiskit/synthesis/linear_phase/cz_depth_lnn.py
+++ b/qiskit/synthesis/linear_phase/cz_depth_lnn.py
@@ -52,7 +52,7 @@ def synth_cz_depth_line_mr(mat: np.ndarray) -> QuantumCircuit:
            `arXiv:1705.09176 <https://arxiv.org/abs/1705.09176>`_.
     """
 
-    # Call Rust implementaton
+    # Call Rust implementation
     return QuantumCircuit._from_circuit_data(
         synth_cz_depth_line_mr_inner(mat.astype(bool)), legacy_qubits=True
     )

--- a/qiskit/synthesis/multi_controlled/mcx_synthesis.py
+++ b/qiskit/synthesis/multi_controlled/mcx_synthesis.py
@@ -92,7 +92,9 @@ def _synth_mcx_special_cases(num_ctrl_qubits: int) -> QuantumCircuit:
         return qc
 
     else:
-        raise QiskitError("_synth_mcx_special_cases should be called with only 0, 1, or 2 cotrols.")
+        raise QiskitError(
+            "_synth_mcx_special_cases should be called with only 0, 1, or 2 controls."
+        )
 
 
 def synth_mcx_n_clean_m15(num_ctrl_qubits: int) -> QuantumCircuit:
@@ -196,7 +198,7 @@ def synth_mcx_1_clean_b95(num_ctrl_qubits: int) -> QuantumCircuit:
     q_target = q[-2]
     middle = ceil(num_ctrl_qubits / 2)
 
-    # The contruction involving 4 MCX gates is described in Lemma 7.3 of [1], and also
+    # The construction involving 4 MCX gates is described in Lemma 7.3 of [1], and also
     # appears as Lemma 9 in [2]. The optimization that the first and third MCX gates
     # can be synthesized up to relative phase follows from Lemma 7 in [2], as a diagonal
     # gate following the first MCX gate commutes with the second MCX gate, and

--- a/qiskit/synthesis/qft/qft_decompose_full.py
+++ b/qiskit/synthesis/qft/qft_decompose_full.py
@@ -77,7 +77,7 @@ def synth_qft_full(
     if inverse:
         circuit = circuit.inverse()
 
-    # It is important to set the name afte the circuit's generic "inverse" is called,
+    # It is important to set the name after the circuit's generic "inverse" is called,
     # since that will add ``_dg`` to the name.
     if name is not None:
         circuit.name = name

--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -202,7 +202,7 @@ compilation can be repeated later.  There are limits on this:
 In general, a consumer of the :class:`.DAGCircuit` should be able to assume, after any combination
 of built-in, seeded if appropriate, Qiskit passes have run with fixed inputs, that the exact output
 of all :meth:`.DAGCircuit` methods is deterministic.  This includes the order of output even of
-methods that do not make any promise about the order; while the semantics and precide order cannot
+methods that do not make any promise about the order; while the semantics and precise order cannot
 be relied on, the determinism of it for fixed inputs can.
 
 Transpiler-pass authors should consult :ref:`transpiler-custom-passes-determinism` for a discussion

--- a/qiskit/transpiler/layout.py
+++ b/qiskit/transpiler/layout.py
@@ -837,7 +837,7 @@ class TranspileLayout:
         #
         #    qubit `permutation[i]` goes to new index `i`
         #
-        # or in alternative langauge,
+        # or in alternative language,
         #
         #   after the permutation, qubit `i` contains qubit `permutation[i]`.
         #

--- a/qiskit/transpiler/passes/basis/translate_parameterized.py
+++ b/qiskit/transpiler/passes/basis/translate_parameterized.py
@@ -84,7 +84,7 @@ class TranslateParameterizedGates(TransformationPass):
     ) -> None:
         """
         Args:
-            supported_gates: A list of suppported basis gates specified as string. If ``None``,
+            supported_gates: A list of supported basis gates specified as string. If ``None``,
                 a ``target`` must be provided.
             equivalence_library: The equivalence library to translate the gates. Defaults
                 to the equivalence library of all Qiskit standard gates.

--- a/qiskit/transpiler/passes/optimization/contract_idle_wires_in_control_flow.py
+++ b/qiskit/transpiler/passes/optimization/contract_idle_wires_in_control_flow.py
@@ -30,7 +30,7 @@ class ContractIdleWiresInControlFlow(TransformationPass):
                 continue
             replacement = DAGCircuit()
             # Dictionaries to retain insertion order for reproducibility, and because we can
-            # then re-use them as mapping dictionaries.
+            # then reuse them as mapping dictionaries.
             qubits, clbits, vars_ = {}, {}, {}
             for _, _, wire in dag.edges(node):
                 if isinstance(wire, Qubit):

--- a/qiskit/transpiler/passes/scheduling/padding/context_aware_dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/padding/context_aware_dynamical_decoupling.py
@@ -149,7 +149,7 @@ class ContextAwareDynamicalDecoupling(TransformationPass):
         self._skip_reset_qubits = skip_reset_qubits
         self._skip_dd_threshold = skip_dd_threshold
         self._target = target
-        self._coupling_map = target.build_coupling_map()  # build once and re-use for performance
+        self._coupling_map = target.build_coupling_map()  # build once and reuse for performance
         self._pulse_alignment = (
             target.pulse_alignment if pulse_alignment is None else pulse_alignment
         )

--- a/qiskit/transpiler/passes/scheduling/time_unit_conversion.py
+++ b/qiskit/transpiler/passes/scheduling/time_unit_conversion.py
@@ -94,7 +94,7 @@ class TimeUnitConversion(TransformationPass):
                     # If any of the delays use a stretch expression, we can't run scheduling
                     # passes anyway, so we bail out. In theory, we _could_ still traverse
                     # through the stretch expression and replace any Duration value nodes it may
-                    # contain with ones of the same units, but it'd be complex and probably unuseful.
+                    # contain with ones of the same units, but it'd be complex and probably useless.
                     self.property_set["time_unit"] = "stretch"
                     return dag
 

--- a/qiskit/transpiler/passes/synthesis/clifford_unitary_synth_plugin.py
+++ b/qiskit/transpiler/passes/synthesis/clifford_unitary_synth_plugin.py
@@ -46,7 +46,7 @@ class CliffordUnitarySynthesis(UnitarySynthesisPlugin):
     In addition, the parameter ``plugin_config`` of :class:`.UnitarySynthesis`
     can be used to pass the following plugin-specific parameters:
 
-    * min_qubits: the minumum number of qubits to consider (the default value is 1).
+    * min_qubits: the minimum number of qubits to consider (the default value is 1).
 
     * max_qubits: the maximum number of qubits to consider (the default value is 3).
 

--- a/qiskit/transpiler/passes/synthesis/hls_plugins.py
+++ b/qiskit/transpiler/passes/synthesis/hls_plugins.py
@@ -2286,7 +2286,7 @@ class AnnotatedSynthesisDefault(HighLevelSynthesisPlugin):
         # Note that synthesize_operation also returns the output qubits on which the
         # operation is defined, however currently the plugin mechanism has no way
         # to return these (and instead the upstream code greedily grabs some ancilla
-        # qubits from the circuit). We should refactor the plugin "run" iterface to
+        # qubits from the circuit). We should refactor the plugin "run" interface to
         # return the actual ancilla qubits used.
         synthesized_base_op_result = synthesize_operation(
             operation.base_op, base_qubits, base_synthesis_data, annotated_tracker

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -319,7 +319,7 @@ class UnitarySynthesis(TransformationPass):
                 )
 
                 # In the case that a non-default method was used and the option fallback_on_default
-                # is set, check whether the unitary was successfull synthesized: the returned
+                # is set, check whether the unitary was successfully synthesized: the returned
                 # circuit is not ``None``. If not, we fall back on running the default plugin.
                 if (not use_default_method) and self._fallback_on_default and (synth_dag is None):
                     synth_dag = self._run_plugin_synthesis(

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -271,7 +271,7 @@ class StagedPassManager(PassManager):
         will not change between releases.
 
     These stages will be executed in order and any stage set to ``None`` will be skipped.
-    If a stage is provided multiple times (i.e. at diferent relative positions), the
+    If a stage is provided multiple times (i.e. at different relative positions), the
     associated passes, including pre and post, will run once per declaration.
     If a :class:`~qiskit.transpiler.PassManager` input is being used for more than 1 stage here
     (for example in the case of a :class:`~.Pass` that covers both Layout and Routing) you will
@@ -290,7 +290,7 @@ class StagedPassManager(PassManager):
                 instance. If this is not specified the default stages list
                 ``['init', 'layout', 'routing', 'translation', 'optimization', 'scheduling']`` is
                 used. After instantiation, the final list will be immutable and stored as tuple.
-                If a stage is provided multiple times (i.e. at diferent relative positions), the
+                If a stage is provided multiple times (i.e. at different relative positions), the
                 associated passes, including pre and post, will run once per declaration.
             kwargs: The initial :class:`~.PassManager` values for any stages
                 defined in ``stages``. If a argument is not defined the

--- a/qiskit/utils/classtools.py
+++ b/qiskit/utils/classtools.py
@@ -141,6 +141,6 @@ def wrap_method(cls: Type, name: str, *, before: Callable = None, after: Callabl
     # The best time to apply decorators to methods is before they are bound (e.g. by using function
     # decorators during the class definition), but if we're making a class decorator, we can't do
     # that.  We need the actual definition of the method, so we have to dodge the normal output of
-    # `type.__getattribute__`, which evalutes descriptors if it finds them.
+    # `type.__getattribute__`, which evaluates descriptors if it finds them.
     method = inspect.getattr_static(cls, name)
     setattr(cls, name, _WrappedMethod(method, before, after))

--- a/qiskit/utils/lazy_tester.py
+++ b/qiskit/utils/lazy_tester.py
@@ -42,7 +42,7 @@ class _RequireNow:
 
 
 class LazyDependencyManager(abc.ABC):
-    """A mananger for some optional features that are expensive to import, or to verify the
+    """A manager for some optional features that are expensive to import, or to verify the
     existence of.
 
     These objects can be used as Booleans, such as ``if x``, and will evaluate ``True`` if the

--- a/qiskit/utils/optionals.py
+++ b/qiskit/utils/optionals.py
@@ -58,7 +58,7 @@ External Python Libraries
 
     The `IBM CPLEX Optimizer <https://www.ibm.com/analytics/cplex-optimizer>`__ is a
     high-performance mathematical programming solver for linear, mixed-integer and quadratic
-    programming. This is no longer by Qiskit, but it weas historically and the optional
+    programming. This is no longer by Qiskit, but it was historically and the optional
     remains for backwards compatibility.
 
 .. py:data:: HAS_CVXPY
@@ -71,7 +71,7 @@ External Python Libraries
 
     `IBM Decision Optimization CPLEX Modelling
     <https://ibmdecisionoptimization.github.io/docplex-doc/>`__ is a library for prescriptive
-    analysis.  Like CPLEX, this is no longer by Qiskit, but it weas historically and the
+    analysis.  Like CPLEX, this is no longer by Qiskit, but it was historically and the
     optional remains for backwards compatibility.
 
 .. py:data:: HAS_FIXTURES

--- a/qiskit/visualization/array.py
+++ b/qiskit/visualization/array.py
@@ -123,7 +123,7 @@ def _matrix_to_latex(matrix, decimals=10, prefix="", max_size=(8, 8)):
 
     elif len(matrix) > max_height:
         # We need to truncate vertically, so we process the rows at the beginning
-        # and end, and add a line of vertical elipse (dots) characters between them
+        # and end, and add a line of vertical ellipse (dots) characters between them
         out_string += _rows_to_latex(matrix[: max_height // 2], max_width)
 
         if max_width >= matrix.shape[1]:

--- a/qiskit/visualization/state_visualization.py
+++ b/qiskit/visualization/state_visualization.py
@@ -126,7 +126,7 @@ def plot_state_hinton(state, title="", figsize=None, ax_real=None, ax_imag=None,
         ax1.yaxis.set_major_locator(plt.NullLocator())
 
         for (x, y), w in np.ndenumerate(datareal):
-            # Convert from matrix co-ordinates to plot co-ordinates.
+            # Convert from matrix coordinates to plot coordinates.
             plot_x, plot_y = y, lx - x - 1
             color = "white" if w > 0 else "black"
             size = np.sqrt(np.abs(w) / max_weight)
@@ -154,7 +154,7 @@ def plot_state_hinton(state, title="", figsize=None, ax_real=None, ax_imag=None,
         ax2.yaxis.set_major_locator(plt.NullLocator())
 
         for (x, y), w in np.ndenumerate(dataimag):
-            # Convert from matrix co-ordinates to plot co-ordinates.
+            # Convert from matrix coordinates to plot coordinates.
             plot_x, plot_y = y, lx - x - 1
             color = "white" if w > 0 else "black"
             size = np.sqrt(np.abs(w) / max_weight)
@@ -1297,8 +1297,8 @@ def state_to_latex(
         suffix = f"\\\\\n\\text{{dims={dims_str}}}\n\\end{{align}}"
 
     operator_shape = state._op_shape
-    # we only use the ket convetion for qubit statevectors
-    # this means the operator shape should hve no input dimensions and all output dimensions equal to 2
+    # we only use the ket convention for qubit statevectors
+    # this means the operator shape should have no input dimensions and all output dimensions equal to 2
     is_qubit_statevector = len(operator_shape.dims_r()) == 0 and set(operator_shape.dims_l()) == {2}
     if convention == "ket" and is_qubit_statevector:
         latex_str = _state_to_latex_ket(state._data, **args)

--- a/qiskit/visualization/timeline/interface.py
+++ b/qiskit/visualization/timeline/interface.py
@@ -119,7 +119,7 @@ def draw(
         formatter.margin.top: Margin from the top boundary of the figure canvas to
             the zero line of the first time slot (default `0.5`).
         formatter.margin.bottom: Margin from the bottom boundary of the figure canvas to
-            the zero lien of the last time slot (default `0.5`).
+            the zero line of the last time slot (default `0.5`).
         formatter.margin.left_percent:  Margin from the left boundary of the figure canvas to
             the left limit of the horizontal axis. The value is in units of percentage of
             the whole program duration. If the duration is 100 and the value of 0.5 is set,

--- a/test/benchmarks/circuit_construction.py
+++ b/test/benchmarks/circuit_construction.py
@@ -113,7 +113,7 @@ class ParamaterizedDifferentCircuit:
 
     def time_QV100_build(self, circuit_size, num_qubits):
         """Measures an SDKs ability to build a 100Q
-        QV circit from scratch.
+        QV circuit from scratch.
         """
         return quantum_volume(circuit_size, num_qubits, seed=SEED)
 

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -42,7 +42,7 @@ file (
 
 # The following creates a test driver program which gathers all discovered test
 # files into a single executable. This has the benefit that a single test
-# executable is built and run rather than invididual ones for every individual
+# executable is built and run rather than individual ones for every individual
 # test file.
 create_test_sourcelist (source_files test_driver.c ${discovered_tests})
 

--- a/test/python/circuit/library/test_evolution_gate.py
+++ b/test/python/circuit/library/test_evolution_gate.py
@@ -602,7 +602,7 @@ class TestEvolutionGate(QiskitTestCase):
         """Test converting the parameters to sympy is real.
 
         Regression test of #13642, where the parameters in the Pauli evolution had a spurious
-        zero complex part. Even though this is not noticable upon binding or printing the parameter,
+        zero complex part. Even though this is not noticeable upon binding or printing the parameter,
         it does affect the output of Parameter.sympify.
         """
         time = Parameter("t")

--- a/test/python/circuit/test_circuit_data.py
+++ b/test/python/circuit/test_circuit_data.py
@@ -468,7 +468,7 @@ class TestQuantumCircuitInstructionData(QiskitTestCase):
     """QuantumCircuit.data operation tests."""
 
     # N.B. Most of the cases here are not expected use cases of circuit.data
-    # but are included as tests to maintain compatability with the previous
+    # but are included as tests to maintain compatibility with the previous
     # list interface of circuit.data.
 
     def test_iteration_of_data_entry(self):

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -1606,7 +1606,7 @@ class TestOpenControlledToMatrix(QiskitTestCase):
     def test_open_controlled_to_matrix(self, gate_class, ctrl_state):
         """Test open controlled to_matrix."""
         if gate_class in {SingletonControlledGate, _SingletonControlledGateOverrides}:
-            self.skipTest("SingletonGateClass isn't intended for direct initalization")
+            self.skipTest("SingletonGateClass isn't intended for direct initialization")
 
         if gate_class is MCMTGate:
             # parameters are (base_gate, num_controls, num_targets)

--- a/test/python/circuit/test_extensions_standard.py
+++ b/test/python/circuit/test_extensions_standard.py
@@ -1408,7 +1408,7 @@ class TestStandardMethods(QiskitTestCase):
                 continue
             sig = signature(gate_class)
             if gate_class == MSGate:
-                # due to the signature (num_qubits, theta, *, n_qubits=Noe) the signature detects
+                # due to the signature (num_qubits, theta, *, n_qubits=None) the signature detects
                 # 3 arguments but really its only 2. This if can be removed once the deprecated
                 # n_qubits argument is no longer supported.
                 free_params = 2

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -2153,7 +2153,7 @@ class TestParameterExpressions(QiskitTestCase):
 
         t_param = Parameter("t")
 
-        # Create a quantum circuit with 2 paramterized gates.
+        # Create a quantum circuit with 2 parameterized gates.
         circuit = QuantumCircuit(5)
         circuit.append(PauliEvolutionGate(Pauli("XZXZX"), time=t_param), [0, 1, 2, 3, 4])
         circuit.append(PauliEvolutionGate(Pauli("IIIXX"), time=t_param / 2), [0, 1, 2, 3, 4])

--- a/test/python/circuit/test_random_circuit.py
+++ b/test/python/circuit/test_random_circuit.py
@@ -190,7 +190,7 @@ test_cases = (
     (rx.generators.directed_heavy_hex_graph(3), 458),
     # Sparse connected graph
     (rx.generators.directed_path_graph(10), 458),
-    # A graph with no edges, should yeild a circuit with no edges,
+    # A graph with no edges, should yield a circuit with no edges,
     # this means there would be no 2Q gates on that circuit.
     (digraph_with_no_edges(10), 0),
     # A list of tuples of control qubit, target qubit, and edge probability
@@ -254,7 +254,7 @@ class TestRandomCircuitFromGraph(QiskitTestCase):
         """the `min_2q_gate_per_edge` parameter specifies how often each qubit-pair must at
         least be used in a two-qubit gate before the circuit is returned"""
 
-        freq = 8  # Some arbitrary repetations, don't put 1.
+        freq = 8  # Some arbitrary repetitions, don't put 1.
         qc = random_circuit_from_graph(
             interaction_graph=inter_graph, min_2q_gate_per_edge=freq, seed=seed
         )

--- a/test/python/circuit/test_registerless_circuit.py
+++ b/test/python/circuit/test_registerless_circuit.py
@@ -82,7 +82,7 @@ class TestAddingBitsWithoutRegisters(QiskitTestCase):
         with self.assertRaisesRegex(CircuitError, "bits found already"):
             qc.add_bits(qr[:])
 
-    def test_addding_individual_bit(self):
+    def test_adding_individual_bit(self):
         """Verify we can add a single bit to a circuit."""
         qr = QuantumRegister(3, "qr")
         qc = QuantumCircuit(qr)

--- a/test/python/circuit/test_singleton.py
+++ b/test/python/circuit/test_singleton.py
@@ -394,7 +394,7 @@ class TestSingleton(QiskitTestCase):
         mutable = Discrete(3)
 
         with unittest.mock.patch.dict(sys.modules, {dummy_module.__name__: dummy_module}):
-            # The singletons in `additional_singletons` are statics; their lifetimes should be tied
+            # The singletons in `additional_singletons` are static; their lifetimes should be tied
             # to the type object itself, so if we don't delete it, it should be eligible to be
             # reloaded from and produce the exact instances.
             self.assertIs(default, pickle.loads(pickle.dumps(default)))

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -2100,7 +2100,7 @@ class TestTranspile(QiskitTestCase):
         self.assertNotIn("barrier", tqc.count_ops())
 
     @data(0, 1, 2, 3)
-    def test_barrier_not_output_input_preservered(self, opt_level):
+    def test_barrier_not_output_input_preserved(self, opt_level):
         """Test that barriers added as part internal transpiler operations do not leak out."""
         qc = QuantumCircuit(2, 2)
         qc.cx(0, 1)
@@ -2193,7 +2193,7 @@ class TestTranspile(QiskitTestCase):
     @data(0, 1, 2, 3)
     def test_no_cancelling_around_box(self, level):
         """Test that operations aren't cancelled through the walls of a 'box'."""
-        # In linear opeartion, we do cz(0,1) - cz(0,1) - cx(1,2) - cx(1,2), so without the `box`,
+        # In linear operation, we do cz(0,1) - cz(0,1) - cx(1,2) - cx(1,2), so without the `box`,
         # the circuit would optimise to the identity.  We want to be sure that the box itself is
         # treated as atomic, though.
         qc = QuantumCircuit(3)

--- a/test/python/converters/test_circuit_to_dagdependency.py
+++ b/test/python/converters/test_circuit_to_dagdependency.py
@@ -58,7 +58,7 @@ class TestCircuitToDagCanonical(QiskitTestCase):
         self.assertEqual(circuit_out, circuit_in)
 
     def test_metadata(self):
-        """Test circuit metadata is preservered through conversion."""
+        """Test circuit metadata is preserved through conversion."""
         meta_dict = {"experiment_id": "1234", "execution_number": 4}
         qr = QuantumRegister(2)
         circuit_in = QuantumCircuit(qr, metadata=meta_dict)

--- a/test/python/converters/test_circuit_to_dagdependency_v2.py
+++ b/test/python/converters/test_circuit_to_dagdependency_v2.py
@@ -41,7 +41,7 @@ class TestCircuitToDAGDependencyV2(QiskitTestCase):
         self.assertEqual(circuit_out, circuit_in)
 
     def test_metadata(self):
-        """Test circuit metadata is preservered through conversion."""
+        """Test circuit metadata is preserved through conversion."""
         meta_dict = {"experiment_id": "1234", "execution_number": 4}
         qr = QuantumRegister(2)
         circuit_in = QuantumCircuit(qr, metadata=meta_dict)

--- a/test/python/converters/test_dag_to_dagdependency.py
+++ b/test/python/converters/test_dag_to_dagdependency.py
@@ -65,7 +65,7 @@ class TestCircuitToDagDependency(QiskitTestCase):
         self.assertEqual(dag_out, dag_in)
 
     def test_metadata(self):
-        """Test circuit metadata is preservered through conversion."""
+        """Test circuit metadata is preserved through conversion."""
         meta_dict = {"experiment_id": "1234", "execution_number": 4}
         qr = QuantumRegister(2)
         circuit_in = QuantumCircuit(qr, metadata=meta_dict)

--- a/test/python/converters/test_dag_to_dagdependency_v2.py
+++ b/test/python/converters/test_dag_to_dagdependency_v2.py
@@ -45,7 +45,7 @@ class TestCircuitToDagDependencyV2(QiskitTestCase):
         self.assertEqual(dag_out, dag_in)
 
     def test_metadata(self):
-        """Test circuit metadata is preservered through conversion."""
+        """Test circuit metadata is preserved through conversion."""
         meta_dict = {"experiment_id": "1234", "execution_number": 4}
         qr = QuantumRegister(2)
         circuit_in = QuantumCircuit(qr, metadata=meta_dict)

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -92,7 +92,7 @@ def raise_if_dagcircuit_invalid(dag):
         assert len(node.qargs) == node.op.num_qubits
         assert len(node.cargs) == node.op.num_clbits
 
-    # Every edge should be labled with a known wire.
+    # Every edge should be labeled with a known wire.
     edges_outside_wires = [edge_data for edge_data in dag._edges() if edge_data not in dag.wires]
     if edges_outside_wires:
         raise DAGCircuitError(
@@ -1674,7 +1674,7 @@ class TestCircuitControlFlowProperties(QiskitTestCase):
                 # This for loop contributes 3x to size and depth.
                 with qc.for_loop((4, 0, 1)):
                     qc.z(2)
-        # While loops contribute 1x to both size and depth, so thsi
+        # While loops contribute 1x to both size and depth, so this
         with qc.while_loop((qc.clbits[0], True)):
             qc.h(0)
             qc.measure(0, 0)
@@ -3200,7 +3200,7 @@ class TestSwapNodes(QiskitTestCase):
         self.assertEqual(dag, expected)
 
     def test_2q_swap_fully_connected(self):
-        """test swaping full connected 2q gates"""
+        """test swapping full connected 2q gates"""
         dag = DAGCircuit()
         qreg = QuantumRegister(2)
         dag.add_qreg(qreg)

--- a/test/python/qasm3/test_export.py
+++ b/test/python/qasm3/test_export.py
@@ -1455,7 +1455,7 @@ box[a] {
         self.assertEqual(dumps(qc), expected_qasm)
 
     def test_custom_gate_with_hw_qubit_name(self):
-        """Test that the name of a custom gate that is an OQ3 hardware qubit identifer is properly
+        """Test that the name of a custom gate that is an OQ3 hardware qubit identifier is properly
         escaped when translated to OQ3."""
         mygate_circ = QuantumCircuit(1, name="$1")
         mygate_circ.x(0)

--- a/test/python/quantum_info/test_sparse_observable.py
+++ b/test/python/quantum_info/test_sparse_observable.py
@@ -62,7 +62,7 @@ def lnn_target(num_qubits):
 
 
 class AllowRightArithmetic:
-    """Some type that implements only the right-hand-sided arithmatic operations, and allows
+    """Some type that implements only the right-hand-sided arithmetic operations, and allows
     `SparseObservable` to pass through them.
 
     The purpose of this is to detect that `SparseObservable` is correctly delegating binary

--- a/test/python/synthesis/test_boolean.py
+++ b/test/python/synthesis/test_boolean.py
@@ -181,7 +181,7 @@ class TestBooleanExpressionDIMACS(QiskitTestCase):
 
 
 class TestBooleanParse(QiskitTestCase):
-    """Tests the boolean experssion parsers"""
+    """Tests the boolean expression parsers"""
 
     def test_args_collection(self):
         """Tests that args are collected based of appearance in the string"""

--- a/test/python/synthesis/test_multi_controlled_synthesis.py
+++ b/test/python/synthesis/test_multi_controlled_synthesis.py
@@ -372,7 +372,7 @@ class TestMCSynthesisCounts(QiskitTestCase):
         synthesized_circuit = synth_c4x()
         transpiled_circuit = self.pm.run(synthesized_circuit)
         cx_count = transpiled_circuit.count_ops()["cx"]
-        # The bound from the default constuction for C4X
+        # The bound from the default construction for C4X
         self.assertLessEqual(cx_count, 36)
 
     @combine(

--- a/test/python/transpiler/test_basis_translator.py
+++ b/test/python/transpiler/test_basis_translator.py
@@ -533,7 +533,7 @@ class TestBasisTranslator(QiskitTestCase):
 
 
 class TestUnrollerCompatability(QiskitTestCase):
-    """Tests backward compatability with the Unroller pass.
+    """Tests backward compatibility with the Unroller pass.
 
     Duplicate of TestUnroller from test.python.transpiler.test_unroller with
     Unroller replaced by UnrollCustomDefinitions -> BasisTranslator.

--- a/test/python/transpiler/test_commutative_optimization.py
+++ b/test/python/transpiler/test_commutative_optimization.py
@@ -1152,7 +1152,7 @@ measure q0[1] -> c0[1];
         self.assertEqual(qc, qct)
 
     def test_circuit_with_clbits(self):
-        """Test optimization for circuit wih classical bits."""
+        """Test optimization for circuit with classical bits."""
         qc = QuantumCircuit(2, 2)
         qc.cx(0, 1)
         qc.z(0)

--- a/test/python/transpiler/test_dynamical_decoupling.py
+++ b/test/python/transpiler/test_dynamical_decoupling.py
@@ -857,8 +857,8 @@ class TestPadDynamicalDecoupling(QiskitTestCase):
         expected.delay(200, [0])
         self.assertEqual(expected, scheduled)
 
-    def test_paramaterized_global_phase(self):
-        """Test paramaterized global phase in DD circuit.
+    def test_parameterized_global_phase(self):
+        """Test parameterized global phase in DD circuit.
         See:https://github.com/Qiskit/qiskit-terra/issues/10569
         """
         dd_sequence = [XGate(), YGate()] * 2

--- a/test/python/transpiler/test_minimum_point.py
+++ b/test/python/transpiler/test_minimum_point.py
@@ -206,7 +206,7 @@ class TestMinimumPointtPass(QiskitTestCase):
         min_pass.property_set["depth"] = 36
         min_pass.property_set["size"] = 40
         min_pass.run(dag)
-        # Fourth iteration the score is also worse than minmum although depth
+        # Fourth iteration the score is also worse than minimum although depth
         # is better than iteration three it's still higher than the minimum point
         # Also size has increased:. Do not update minimum point and since is increased
         state = min_pass.property_set["test_minimum_point_state"]
@@ -219,7 +219,7 @@ class TestMinimumPointtPass(QiskitTestCase):
         min_pass.property_set["depth"] = 36
         min_pass.property_set["size"] = 40
         min_pass.run(dag)
-        # Fifth iteration the score is also worse than minmum although the same
+        # Fifth iteration the score is also worse than minimum although the same
         # with previous iteration. This means do not update minimum point and bump since
         # value
         state = min_pass.property_set["test_minimum_point_state"]
@@ -268,7 +268,7 @@ class TestMinimumPointtPass(QiskitTestCase):
         min_pass.property_set["depth"] = 36
         min_pass.property_set["size"] = 40
         min_pass.run(dag)
-        # Iteration nine the score is worse than the minium point. Do not update minimum point
+        # Iteration nine the score is worse than the minimum point. Do not update minimum point
         # and since is bumped
         state = min_pass.property_set["test_minimum_point_state"]
         self.assertEqual(state.since, 4)

--- a/test/python/transpiler/test_scheduling_padding_pass.py
+++ b/test/python/transpiler/test_scheduling_padding_pass.py
@@ -129,7 +129,7 @@ class TestSchedulingAndPaddingPass(QiskitTestCase):
 
     @data(ALAPScheduleAnalysis, ASAPScheduleAnalysis)
     def test_empty_circuit(self, schedule_pass):
-        """An empty cirucit is trivially scheduled, so we should succeed without error."""
+        """An empty circuit is trivially scheduled, so we should succeed without error."""
         target = Target(num_qubits=4)
         target.add_instruction(
             CXGate(), {(i, i + 1): InstructionProperties(duration=1e-3) for i in range(3)}

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -1192,7 +1192,7 @@ Instructions:
         self.assertTrue(deserialized_target.instruction_supported("u_var", (0, 1)))
 
     def test_target_no_num_qubits_qubit_properties(self):
-        """Checks that a Target can be initialized with no qubits but a list of Qubit Properities"""
+        """Checks that a Target can be initialized with no qubits but a list of Qubit Properties"""
 
         # Initialize target qubit properties
         qubit_properties = [QubitProperties()]

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -238,7 +238,7 @@ class TestUnitarySynthesisBasisGates(QiskitTestCase):
 
     def test_two_qubit_natural_direction_true_gate_length_raises(self):
         """Verify that error is raised if preferred direction cannot be inferred
-        from gate lenghts/errors.
+        from gate lengths/errors.
         """
         qr = QuantumRegister(2)
         coupling_map = CouplingMap([[0, 1], [1, 0], [1, 2], [1, 3], [3, 4]])

--- a/test/python/utils/test_classtools.py
+++ b/test/python/utils/test_classtools.py
@@ -246,7 +246,7 @@ class TestWrapMethod(QiskitTestCase):
 
     def test_can_wrap_with_builtin(self):
         """Test that builtin functions can be used a callback.  Many CPython builtins don't
-        implement the desriptor protocol that all functions defined with ``def`` or ``lambda`` do,
+        implement the descriptor protocol that all functions defined with ``def`` or ``lambda`` do,
         which means we need to take special care that they work.  This is most relevant for
         C-extension functions created via pybind11, Cython or similar, rather than actual Python
         builtins."""

--- a/test/qpy_compat/process_version.sh
+++ b/test/qpy_compat/process_version.sh
@@ -37,7 +37,7 @@ fi
 
 # `package` is the name of the Python distribution to install (qiskit or qiskit-terra). `version` is
 # the source version: the release with which to generate qpy files with to load with the version
-# under test. 'python_version' is the (compatbile) python version with which to run qiskit within the docker image,
+# under test. 'python_version' is the (compatible) python version with which to run qiskit within the docker image,
 # in the case where docker is used.
 
 package="$1"

--- a/test/utils/base.py
+++ b/test/utils/base.py
@@ -14,7 +14,7 @@
 
 """Base TestCases for the unit tests.
 
-Implementors of unit tests for Qiskit should subclass
+Implementers of unit tests for Qiskit should subclass
 ``QiskitTestCase`` in order to take advantage of utility functions (for example,
 the environment variables for customizing different options), and the
 decorators in the ``decorators`` package.

--- a/test/visual/mpl/graph/test_graph_matplotlib_drawer.py
+++ b/test/visual/mpl/graph/test_graph_matplotlib_drawer.py
@@ -220,7 +220,7 @@ class TestGraphMatplotlibDrawer(QiskitTestCase):
 
     def test_plot_histogram(self):
         """for testing the plot_histogram"""
-        # specifing counts because we do not want oscillation of
+        # specifying counts because we do not want oscillation of
         # result until a changes is made to plot_histogram
 
         counts = {"11": 500, "00": 500}


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

When looking at our C API docs, I spotted a typo: it said "Cirucit Library" instead of "Circuit Library". Out of curiosity, I have asked our new friend Bob to look for other typos, and it found a few more, though not the original one. Apparently Bob uses regex patterns to search for common misspellings, and these apparently include "isomoprhic" but not "cirucit".

AI/LLM used: Bob.

Update: as suggested by both Eli and Julien, I tried `codespell` as well, and the number of additional typos found by codespell shows that Bob is simply not useful for the task.
