### PR TITLE
`RCCXGate` is self-inverse

### DIFF
--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -1431,7 +1431,7 @@ impl StandardGate {
             Self::CCX => Some((Self::CCX, smallvec![])),
             Self::CCZ => Some((Self::CCZ, smallvec![])),
             Self::CSwap => Some((Self::CSwap, smallvec![])),
-            Self::RCCX => None, // the inverse in not a StandardGate
+            Self::RCCX => Some((Self::RCCX, smallvec![])),
             Self::C3X => Some((Self::C3X, smallvec![])),
             Self::C3SX => None, // the inverse in not a StandardGate
             Self::RC3X => None, // the inverse in not a StandardGate

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -499,6 +499,20 @@ class RCCXGate(SingletonGate):
     def __eq__(self, other):
         return isinstance(other, RCCXGate)
 
+    def inverse(self, annotated: bool = False):
+        """Invert this gate. The RCCX gate is its own inverse.
+
+        Args:
+            annotated: when set to ``True``, this is typically used to return an
+                :class:`.AnnotatedOperation` with an inverse modifier set instead of a concrete
+                :class:`.Gate`. However, for this class this argument is ignored as this gate
+                is self-inverse.
+
+        Returns:
+            RCCXGate: inverse gate (self-inverse).
+        """
+        return RCCXGate()
+
 
 @with_controlled_gate_array(_SX_ARRAY, num_ctrl_qubits=3, cached_states=(7,))
 class C3SXGate(SingletonControlledGate):

--- a/releasenotes/notes/rccx-gate-is-self-inverse-bb4df23d603e3310.yaml
+++ b/releasenotes/notes/rccx-gate-is-self-inverse-bb4df23d603e3310.yaml
@@ -1,4 +1,5 @@
 ---
 features_circuits:
-  - The :class:`.RCCXGate` is self-inverse so now when calling the ``inverse`` function 
-    for :class:`.RCCXGate` provides an :class:`.RCCXGate`.
+- |
+  The :class:`.RCCXGate` is self-inverse. The :meth:`.RCCXGate.inverse` now returns a new
+  :class:`.RCCXGate` instance instead of an instance of :class:`.Gate` with a custom definition.

--- a/releasenotes/notes/rccx-gate-is-self-inverse-bb4df23d603e3310.yaml
+++ b/releasenotes/notes/rccx-gate-is-self-inverse-bb4df23d603e3310.yaml
@@ -1,0 +1,4 @@
+---
+features_circuits:
+  - The :class:`.RCCXGate` is self-inverse so now when calling the ``inverse`` function 
+    for :class:`.RCCXGate` provides an :class:`.RCCXGate`.


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The `RCCXGate` (as defined in qiskit) is self-inverse.
However, it didn't have an `inverse` method in Python, and hence also not in Rust (https://github.com/Qiskit/qiskit/pull/13168).
This PR adds an inverse method in Python and Rust to `RCCXGate`, that returns the same `RCCXGate`.


### Details and comments

```
qc = QuantumCircuit(3)
qc.rccx(0,1,2)
qc.rccx(0,1,2)
print (Operator(qc) == Operator(np.identity(8))) // = True
```