### PR TITLE
Organize C API pass functions documentation into dag-based and circuit-based sections. 

### DIFF
--- a/crates/cext/src/transpiler/passes/basis_translator.rs
+++ b/crates/cext/src/transpiler/passes/basis_translator.rs
@@ -17,7 +17,7 @@ use qiskit_transpiler::passes::run_basis_translator;
 use qiskit_transpiler::standard_equivalence_library::generate_standard_equivalence_library;
 use qiskit_transpiler::target::Target;
 
-/// @ingroup QkTranspilerPasses
+/// @ingroup QkTranspilerPassesStandalone
 /// Run the BasisTranslator transpiler pass on a circuit.
 ///
 /// The BasisTranslator transpiler pass translates gates to a target basis by

--- a/crates/cext/src/transpiler/passes/commutative_cancellation.rs
+++ b/crates/cext/src/transpiler/passes/commutative_cancellation.rs
@@ -19,7 +19,7 @@ use qiskit_transpiler::commutation_checker::get_standard_commutation_checker;
 use qiskit_transpiler::passes::cancel_commutations;
 use qiskit_transpiler::target::Target;
 
-/// @ingroup QkTranspilerPasses
+/// @ingroup QkTranspilerPassesStandalone
 /// Run the CommutativeCancellation transpiler pass on a circuit.
 ///
 /// This pass cancels the redundant (self-adjoint) gates through commutation relations.

--- a/crates/cext/src/transpiler/passes/consolidate_blocks.rs
+++ b/crates/cext/src/transpiler/passes/consolidate_blocks.rs
@@ -15,7 +15,7 @@ use qiskit_transpiler::{passes::run_consolidate_blocks, target::Target};
 
 use crate::pointers::{const_ptr_as_ref, mut_ptr_as_ref};
 
-/// @ingroup QkTranspilerPasses
+/// @ingroup QkTranspilerPassesStandalone
 /// Run the ConsolidateBlocks pass on a circuit.
 ///
 /// ConsolidateBlocks is a transpiler pass that consolidates consecutive blocks of

--- a/crates/cext/src/transpiler/passes/elide_permutations.rs
+++ b/crates/cext/src/transpiler/passes/elide_permutations.rs
@@ -18,7 +18,7 @@ use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_transpiler::passes::run_elide_permutations;
 use qiskit_transpiler::transpile_layout::TranspileLayout;
 
-/// @ingroup QkTranspilerPasses
+/// @ingroup QkTranspilerPassesStandalone
 /// Run the ElidePermutations transpiler pass on a circuit.
 ///
 /// Refer to the ``qk_transpiler_pass_elide_permutations`` function for more details about the pass.

--- a/crates/cext/src/transpiler/passes/gate_direction.rs
+++ b/crates/cext/src/transpiler/passes/gate_direction.rs
@@ -17,7 +17,7 @@ use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_transpiler::passes::{check_direction_target, fix_direction_target};
 use qiskit_transpiler::target::Target;
 
-/// @ingroup QkTranspilerPasses
+/// @ingroup QkTranspilerPassesStandalone
 /// Run the ``CheckGateDirection`` pass on a circuit.
 ///
 /// Refer to the ``qk_transpiler_pass_check_gate_direction`` function for more details about the pass.
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_check_gate_direction(
     check_direction_target(&dag, target).expect("Unexpected error occurred in CheckGateDirection")
 }
 
-/// @ingroup QkTranspilerPasses
+/// @ingroup QkTranspilerPassesStandalone
 /// Run the ``GateDirection`` pass on a circuit.
 ///
 /// Refer to the ``qk_transpiler_pass_gate_direction`` function for more details about the pass.

--- a/crates/cext/src/transpiler/passes/inverse_cancellation.rs
+++ b/crates/cext/src/transpiler/passes/inverse_cancellation.rs
@@ -16,7 +16,7 @@ use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_transpiler::passes::run_inverse_cancellation_standard_gates;
 
-/// @ingroup QkTranspilerPasses
+/// @ingroup QkTranspilerPassesStandalone
 /// Run the InverseCancellation transpiler pass on a circuit.
 ///
 /// Cancels pairs of consecutive gates that are inverses of each other.

--- a/crates/cext/src/transpiler/passes/optimize_1q_sequences.rs
+++ b/crates/cext/src/transpiler/passes/optimize_1q_sequences.rs
@@ -14,7 +14,7 @@ use crate::pointers::{const_ptr_as_ref, mut_ptr_as_ref};
 use qiskit_circuit::{circuit_data::CircuitData, dag_circuit::DAGCircuit};
 use qiskit_transpiler::{passes::run_optimize_1q_gates_decomposition, target::Target};
 
-/// @ingroup QkTranspilerPasses
+/// @ingroup QkTranspilerPassesStandalone
 /// Runs the Optimize1qGatesDecomposition pass in standalone mode on a circuit.
 ///
 /// \qk_deprecated{2.4.0|use :c:func:`qk_transpiler_pass_standalone_optimize_1q_sequences` instead.}
@@ -24,7 +24,6 @@ use qiskit_transpiler::{passes::run_optimize_1q_gates_decomposition, target::Tar
 /// In the case a null pointer is provided and gate errors are unknown
 /// the pass will choose the sequence with the least amount of gates,
 /// and will support all basis gates on its Euler basis set.
-///
 ///
 /// # Safety
 ///
@@ -42,7 +41,7 @@ pub unsafe extern "C" fn qk_transpiler_standalone_optimize_1q_sequences(
     unsafe { qk_transpiler_pass_standalone_optimize_1q_sequences(circuit, target) };
 }
 
-/// @ingroup QkTranspilerPasses
+/// @ingroup QkTranspilerPassesStandalone
 /// Runs the Optimize1qGatesDecomposition pass in standalone mode on a circuit.
 ///
 /// Refer to the ``qk_transpiler_pass_optimize_1q_sequences`` function for more details about the pass.

--- a/crates/cext/src/transpiler/passes/remove_diagonal_gates_before_measure.rs
+++ b/crates/cext/src/transpiler/passes/remove_diagonal_gates_before_measure.rs
@@ -15,7 +15,7 @@ use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_transpiler::passes::run_remove_diagonal_before_measure;
 
-/// @ingroup QkTranspilerPasses
+/// @ingroup QkTranspilerPassesStandalone
 /// Run the ``RemoveDiagonalGatesBeforeMeasure`` pass on a circuit.
 ///
 /// Refer to the ``qk_transpiler_pass_remove_diagonal_gates_before_measure`` function for more details about the pass.

--- a/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
+++ b/crates/cext/src/transpiler/passes/remove_identity_equiv.rs
@@ -17,7 +17,7 @@ use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_transpiler::passes::run_remove_identity_equiv;
 use qiskit_transpiler::target::Target;
 
-/// @ingroup QkTranspilerPasses
+/// @ingroup QkTranspilerPassesStandalone
 /// Run the RemoveIdentityEquivalent transpiler pass on a circuit.
 ///
 /// Refer to the ``qk_transpiler_pass_remove_identity_equivalent`` function for more details about the pass.

--- a/crates/cext/src/transpiler/passes/sabre_layout.rs
+++ b/crates/cext/src/transpiler/passes/sabre_layout.rs
@@ -56,7 +56,7 @@ pub extern "C" fn qk_sabre_layout_options_default() -> SabreLayoutOptions {
     }
 }
 
-/// @ingroup QkTranspilerPasses
+/// @ingroup QkTranspilerPassesStandalone
 /// Run the SabreLayout transpiler pass on a circuit.
 ///
 /// The SabreLayout pass chooses a layout via an iterative bidirectional routing of the input

--- a/crates/cext/src/transpiler/passes/split_2q_unitaries.rs
+++ b/crates/cext/src/transpiler/passes/split_2q_unitaries.rs
@@ -18,7 +18,7 @@ use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_transpiler::passes::run_split_2q_unitaries;
 use qiskit_transpiler::transpile_layout::TranspileLayout;
 
-/// @ingroup QkTranspilerPasses
+/// @ingroup QkTranspilerPassesStandalone
 /// Run the Split2QUnitaries transpiler pass on a circuit.
 ///
 /// Refer to the ``qk_transpiler_pass_split_2q_unitaries`` function for more details about the pass.

--- a/crates/cext/src/transpiler/passes/unitary_synthesis.rs
+++ b/crates/cext/src/transpiler/passes/unitary_synthesis.rs
@@ -20,7 +20,7 @@ use qiskit_transpiler::passes::{
 };
 use qiskit_transpiler::target::Target;
 
-/// @ingroup QkTranspilerPasses
+/// @ingroup QkTranspilerPassesStandalone
 /// Run the UnitarySynthesis transpiler pass.
 ///
 /// The UnitarySynthesis transpiler pass will synthesize any UnitaryGates in the circuit into gates

--- a/crates/cext/src/transpiler/passes/vf2.rs
+++ b/crates/cext/src/transpiler/passes/vf2.rs
@@ -281,7 +281,7 @@ pub unsafe extern "C" fn qk_vf2_layout_configuration_set_score_initial(
     unsafe { (*config).0.score_initial_layout = score_initial };
 }
 
-/// @ingroup QkTranspilerPasses
+/// @ingroup QkTranspilerPassesStandalone
 /// Use the VF2 algorithm to choose a layout (if possible) for the input circuit, using a
 /// noise-aware scoring heuristic based only on hardware error rates, and not the specific gates in
 /// the circuit.
@@ -369,7 +369,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_vf2_layout_average(
         .unwrap()
 }
 
-/// @ingroup QkTranspilerPasses
+/// @ingroup QkTranspilerPassesStandalone
 /// Use the VF2 algorithm to choose a layout (if possible) for the input circuit, using a
 /// noise-aware scoring heuristic that requires the result is already fully compatible with
 /// the hardware.
@@ -458,7 +458,7 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_vf2_layout_exact(
         .unwrap()
 }
 
-/// @ingroup QkTranspilerPasses
+/// @ingroup QkTranspilerPassesStandalone
 /// Deprecated version of `qk_transpiler_pass_standalone_vf2_layout_average`.
 ///
 /// This legacy interface does not use `QkVf2LayoutConfiguration`, and has a name that is not clear

--- a/docs/cdoc/index.h
+++ b/docs/cdoc/index.h
@@ -20,6 +20,7 @@
  * @defgroup QkTranspileLayout QkTranspileLayout
  * @defgroup QkTranspiler QkTranspiler
  * @defgroup QkTranspilerPasses QkTranspilerPasses
+ * @defgroup QkTranspilerPassesStandalone QkTranspilerPassesStandalone
  * @defgroup QkVF2LayoutConfiguration QkVF2LayoutConfiguration
  * @defgroup QkVF2LayoutResult QkVF2LayoutResult
  */

--- a/docs/cdoc/qk-transpiler-passes.rst
+++ b/docs/cdoc/qk-transpiler-passes.rst
@@ -15,18 +15,28 @@ In Qiskit, the transpiler is built up by executing as a series of passes that ea
 to analyze or transform a quantum circuit. The Python :mod:`~qiskit.transpiler` documentation contains a
 more detailed explanation of the transpilation process.
 
-The Qiskit C API provides functions that execute transpiler passes in a standalone mode, where you
-provide the pass with a ``QkCircuit`` and then any necessary configuration for the execution of the
-pass, typically at least a ``QkTarget``. These functions return either a new ``QkCircuit`` pointer
-or the analysis results of running the pass. While this can be used to create a custom workflow, the
-functions following the naming convention ``qk_transpiler_pass_standalone_*`` will have higher overhead
-as internally they're converting from the quantum circuit to the dag circuit IR on the input, and if
-the function returns a new circuit it will convert back before returning. These standalone functions
-are intended to execute single passes in isolation rather than building a custom transpilation pipeline.
+The Qiskit C API provides transpiler pass functions in two forms: ones that operate on a :c:struct:`QkDag` 
+and another set that operate on a :c:struct:`QkCircuit`. The DAG‑based functions, which follow the naming 
+convention ``qk_transpiler_pass_*``, accept a :c:struct:`QkDag` along with a :c:struct:`QkTarget` and any 
+pass‑specific configuration parameters. These functions are the recommended choice when chaining multiple 
+passes, e.g. when creating a custom transpilation pipeline, because they operate directly on the DAG object 
+and allow it to be passed efficiently from one pass to the next within a transpilation session. By contrast, 
+the circuit‑based functions, following the ``qk_transpiler_pass_standalone_*`` naming convention, operate on a 
+:c:struct:`QkCircuit` and are intended for executing individual passes in isolation. While they can also be 
+used to build custom workflows, each call incurs additional overhead because the input circuit must be converted 
+to a DAG internally and, if a transformed circuit is returned, the resulting DAG must then be converted back to 
+a circuit.
 
-Functions
-=========
+DAG-based Functions
+===================
 
 .. doxygengroup:: QkTranspilerPasses
+    :members:
+    :content-only:
+
+Circuit-based Functions
+=======================
+
+.. doxygengroup:: QkTranspilerPassesStandalone
     :members:
     :content-only:


### PR DESCRIPTION
### Summary
This PR refactors the C API documentation page of the tranpsiler passes to organize the passed into two sections: one for the dag-based variants and another one for the circuit-based variants. It also updates the general description text to highlight the main purpose of each variant. 

### Details and comments
~~This PR is based on #15614 and will be rebased once it's merged. The changes of this PR can be viewed in this commit: a7bcb2d94b2a356938e4fec4dea4500beb776b76~~

A new group named `QkTranspilerPassesStandalone` is created for all the `qk_transpiler_pass_standalone_*` functions. The existing one, `QkTranspilerPasses`, will be used for the dag-based pass functions. The dag-based functions are placed in the documentation before the circuit-based ones and in general the message is that the dag-based pass functions are the preferred ones to use in a custom transpilation pipeline. 

