### PR TITLE
Pin testtools version to unblock CI

### DIFF
--- a/.github/workflows/neko.yml
+++ b/.github/workflows/neko.yml
@@ -13,6 +13,12 @@ jobs:
     name: Qiskit Neko Integration Tests
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout base repository
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: |
+            constraints.txt
+          sparse-checkout-cone-mode: false
       - name: preinstall dependencies
         run: |
           pip install -U setuptools pip

--- a/.github/workflows/neko.yml
+++ b/.github/workflows/neko.yml
@@ -13,6 +13,11 @@ jobs:
     name: Qiskit Neko Integration Tests
     runs-on: ubuntu-latest
     steps:
+      - name: preinstall dependencies
+        run: |
+          pip install -U setuptools pip
+          pip install stestr>=3.2.0 -c constraints.txt
+        shell: bash
       - uses: Qiskit/qiskit-neko@main
         with:
           test_selection: terra

--- a/constraints.txt
+++ b/constraints.txt
@@ -19,3 +19,8 @@ pydot>=4.0.0
 # Our Sphinx version is not compatible with snowballstemmer>=3.0.0 (and
 # neither is latest Sphinx at this time). See https://github.com/sphinx-doc/sphinx/issues/13533.
 snowballstemmer<3.0.0
+
+# testtools 2.8.3 broke compatibility with stestr. This pin is temporary
+# until stestr fixes compatibility with the latest "bugfix" release of
+# testtools.
+testtools!=2.8.3

--- a/constraints.txt
+++ b/constraints.txt
@@ -23,4 +23,4 @@ snowballstemmer<3.0.0
 # testtools 2.8.3 broke compatibility with stestr. This pin is temporary
 # until stestr fixes compatibility with the latest "bugfix" release of
 # testtools.
-testtools!=2.8.3
+testtools==2.8.2

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -7,7 +7,7 @@
 
 # Test-runner enhancements.
 fixtures
-testtools!=2.8.3
+testtools
 
 # Interactivity.
 ipython

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -7,7 +7,7 @@
 
 # Test-runner enhancements.
 fixtures
-testtools
+testtools!=2.8.3
 
 # Interactivity.
 ipython


### PR DESCRIPTION


<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The recent release of testtools 2.8.23 breaks stestr in a couple of ways. While we wait for a new stestr or testtools release to fix compatibility this commit temporarily pins the testtools version to unblock CI.

### Details and comments


