### PR TITLE
Replace `bincode` with `binrw` in `basic_approximations serialization`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,15 +141,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "binrw"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,7 +2074,7 @@ version = "2.4.0-dev"
 dependencies = [
  "ahash 0.8.12",
  "approx",
- "bincode",
+ "binrw",
  "bytemuck",
  "faer",
  "faer-ext",
@@ -2107,7 +2098,6 @@ dependencies = [
  "rstar",
  "rustiq-core",
  "rustworkx-core",
- "serde",
  "smallvec",
  "thiserror 2.0.18",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ rand_distr = "0.5"
 num-traits = "0.2"
 uuid = { version = "1.21", features = ["v4", "fast-rng"], default-features = false }
 anyhow = "1.0"
+binrw = "0.15"
 
 # Most of the crates don't need the feature `extension-module`, since only `qiskit-pyext` builds an
 # actual C extension (the feature disables linking in `libpython`, which is forbidden in Python

--- a/crates/qpy/Cargo.toml
+++ b/crates/qpy/Cargo.toml
@@ -22,7 +22,7 @@ qiskit-quantum-info.workspace = true
 num-bigint.workspace = true
 num-complex.workspace = true
 bytemuck.workspace = true
-binrw = "0.15"
+binrw.workspace = true
 uuid = {version = "1", features = ["v4"]}
 
 [dependencies.smallvec]

--- a/crates/synthesis/Cargo.toml
+++ b/crates/synthesis/Cargo.toml
@@ -31,16 +31,9 @@ rustworkx-core.workspace = true
 rustiq-core = "0.0.11"
 rsgridsynth =  "0.2.0"
 rstar = "0.12.2"
-serde = { version = "1.0", features = ["derive"] }
 thiserror.workspace = true
 fixedbitset.workspace = true
-
-# `bincode` is a dead project and needs replacement.  The development
-# process ended acrimoniously with the developer rewriting git history
-# and releasing poisoned versions to crates.io.  This is an increased
-# risk of further broken/malicious releases, so we hard-pin to a known
-# good version.
-bincode = "=1.3.3"
+binrw = "0.15"
 
 [dependencies.faer-ext]
 version = "0.7.1"

--- a/crates/synthesis/Cargo.toml
+++ b/crates/synthesis/Cargo.toml
@@ -33,7 +33,7 @@ rsgridsynth =  "0.2.0"
 rstar = "0.12.2"
 thiserror.workspace = true
 fixedbitset.workspace = true
-binrw = "0.15"
+binrw.workspace = true
 
 [dependencies.faer-ext]
 version = "0.7.1"

--- a/qiskit/synthesis/discrete_basis/solovay_kitaev.py
+++ b/qiskit/synthesis/discrete_basis/solovay_kitaev.py
@@ -195,7 +195,7 @@ class SolovayKitaevDecomposition:
                 and storing as such can cause errors when loading the file again.
         """
         # Safety guard: previously, we serialized via npy, but this format is incompatible
-        # with the current serialization, using Rust's serde + bincode. While we can still load
+        # with the current serialization, using Rust's binrw. While we can still load
         # .npy files in legacy format, the new format should not be stored as .npy.
         if filename[~3:] == ".npy":
             raise ValueError(

--- a/releasenotes/notes/upgrade_solovay_kitaev_serialization-8435ea81163255fa.yaml
+++ b/releasenotes/notes/upgrade_solovay_kitaev_serialization-8435ea81163255fa.yaml
@@ -1,0 +1,8 @@
+---
+upgrade_synthesis:
+  - |
+    The serialization format used by
+    :meth:`.SolovayKitaevDecomposition.save_basic_approximations` and
+    :meth:`.SolovayKitaevDecomposition.load_basic_approximations` has been
+    upgraded. Files saved with Qiskit 2.3 or earlier will not be compatible
+    with Qiskit 2.4 or later.


### PR DESCRIPTION
### Summary
Replaces the use of the `bincode` library with `binrw`.

Fixes #15520 


### Details and comments
The `bincode` serialization library is obsolete and needs to be removed from the project. This PR replaces with with the `binrw` library currently used in the `qpy` component of Qiskit. The actual required changes to the code are minimal.

