### PR TITLE
Fix linear dependency on base bit count in `QuantumCircuit.compose`

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -395,9 +395,9 @@ impl CircuitData {
         global_phase: Param,
     ) -> PyResult<Self> {
         let mut self_ = Self::new(qubits, clbits, global_phase)?;
+        self_.reserve(reserve);
         if let Some(data) = data {
-            self_.reserve(reserve);
-            self_.extend(data)?;
+            self_.py_extend(data)?;
         }
         Ok(self_)
     }
@@ -692,8 +692,8 @@ impl CircuitData {
     ///     ValueError: The specified ``bit`` is already present and flag ``strict``
     ///         was provided.
     #[pyo3(name="add_qubit", signature = (bit, *, strict=true))]
-    pub fn py_add_qubit(&mut self, bit: ShareableQubit, strict: bool) -> PyResult<()> {
-        Ok(self.add_qubit(bit, strict)?)
+    pub fn py_add_qubit(&mut self, bit: ShareableQubit, strict: bool) -> PyResult<u32> {
+        Ok(self.add_qubit(bit, strict)?.0)
     }
 
     /// Registers a :class:`.QuantumRegister` instance.
@@ -741,8 +741,8 @@ impl CircuitData {
     ///     ValueError: The specified ``bit`` is already present and flag ``strict``
     ///         was provided.
     #[pyo3(name="add_clbit", signature = (bit, *, strict=true))]
-    pub fn py_add_clbit(&mut self, bit: ShareableClbit, strict: bool) -> PyResult<()> {
-        Ok(self.add_clbit(bit, strict)?)
+    pub fn py_add_clbit(&mut self, bit: ShareableClbit, strict: bool) -> PyResult<u32> {
+        Ok(self.add_clbit(bit, strict)?.0)
     }
 
     /// Registers a :class:`.QuantumRegister` instance.
@@ -1236,43 +1236,83 @@ impl CircuitData {
         Ok(())
     }
 
-    pub fn extend(&mut self, itr: &Bound<PyAny>) -> PyResult<()> {
-        if let Ok(other) = itr.cast::<CircuitData>() {
-            let other = other.borrow();
-            // Fast path to avoid unnecessary construction of CircuitInstruction instances.
-            self.data.reserve(other.data.len());
-            for inst in other.data.iter() {
-                let qubits = other
-                    .qargs_interner
-                    .get(inst.qubits)
-                    .iter()
-                    .map(|b| Ok(self.qubits.find(other.qubits.get(*b).unwrap()).unwrap()))
-                    .collect::<PyResult<Vec<Qubit>>>()?;
-                let clbits = other
-                    .cargs_interner
-                    .get(inst.clbits)
-                    .iter()
-                    .map(|b| Ok(self.clbits.find(other.clbits.get(*b).unwrap()).unwrap()))
-                    .collect::<PyResult<Vec<Clbit>>>()?;
-                let qubits_id = self.qargs_interner.insert_owned(qubits);
-                let clbits_id = self.cargs_interner.insert_owned(clbits);
-                let params = inst.params.as_ref().map(|params| {
-                    Box::new(params.map_blocks_ref(|b| self.blocks.push(other.blocks[*b].clone())))
-                });
-                self.push(PackedInstruction {
-                    op: inst.op.clone(),
-                    qubits: qubits_id,
-                    clbits: clbits_id,
-                    params,
-                    label: inst.label.clone(),
-                    #[cfg(feature = "cache_pygates")]
-                    py_op: inst.py_op.clone(),
-                })?;
-            }
-            return Ok(());
+    /// Copy `CircuitInstruction` instances from a Python iterator into this object.
+    ///
+    /// This method (with this magic name) forms part of the Python "sequence" API.
+    #[pyo3(name = "extend")]
+    pub fn py_extend(&mut self, other: &Bound<PyAny>) -> PyResult<()> {
+        for inst in other.try_iter()? {
+            self.append(inst?.cast()?)?;
         }
-        for v in itr.try_iter()? {
-            self.append(v?.cast()?)?;
+        Ok(())
+    }
+
+    /// Copy instructions from one `CircuitData`  onto this one, optionally remapping the qubits and
+    /// clbits by index.
+    ///
+    /// This assumes that all the variables and registers used in `other` have been set up
+    /// correctly, but will copy across control-flow blocks as required.
+    #[pyo3(name = "native_extend", signature = (other, *, qubits=None, clbits=None))]
+    pub fn py_native_extend(
+        &mut self,
+        other: &CircuitData,
+        qubits: Option<Vec<Qubit>>,
+        clbits: Option<Vec<Clbit>>,
+    ) -> PyResult<()> {
+        if qubits
+            .as_ref()
+            .is_some_and(|q| q.len() != other.num_qubits())
+        {
+            return Err(PyValueError::new_err(
+                "'qubits' argument is the wrong length",
+            ));
+        } else if other.num_qubits() > self.num_qubits() {
+            return Err(PyValueError::new_err(format!(
+                "too many input qubits ({}) for circuit ({})",
+                other.num_qubits(),
+                self.num_qubits(),
+            )));
+        }
+        if clbits
+            .as_ref()
+            .is_some_and(|q| q.len() != other.num_clbits())
+        {
+            return Err(PyValueError::new_err(
+                "'clbits' argument is the wrong length",
+            ));
+        } else if other.num_clbits() > self.num_clbits() {
+            return Err(PyValueError::new_err(format!(
+                "too many input clbits ({}) for circuit ({})",
+                other.num_clbits(),
+                self.num_clbits(),
+            )));
+        }
+        let qargs_map = self
+            .qargs_interner
+            .merge_map_slice(&other.qargs_interner, |q| {
+                Some(qubits.as_ref().map_or(*q, |qubits| qubits[q.index()]))
+            });
+        let cargs_map = self
+            .cargs_interner
+            .merge_map_slice(&other.cargs_interner, |c| {
+                Some(clbits.as_ref().map_or(*c, |clbits| clbits[c.index()]))
+            });
+        let block_map = other
+            .blocks
+            .items()
+            .map(|(bid, block)| (bid, self.add_block(block.clone())))
+            .collect::<HashMap<_, _>>();
+        self.data.reserve(other.data.len());
+        for inst in other.iter() {
+            self.push(PackedInstruction {
+                qubits: qargs_map[inst.qubits],
+                clbits: cargs_map[inst.clbits],
+                params: inst
+                    .params
+                    .as_ref()
+                    .map(|params| Box::new(params.map_blocks_ref(|bid| block_map[bid]))),
+                ..inst.clone()
+            })?;
         }
         Ok(())
     }
@@ -1879,18 +1919,26 @@ impl CircuitData {
         Ok(self_)
     }
 
-    pub fn add_qubit(&mut self, bit: ShareableQubit, strict: bool) -> Result<(), CircuitDataError> {
+    pub fn add_qubit(
+        &mut self,
+        bit: ShareableQubit,
+        strict: bool,
+    ) -> Result<Qubit, CircuitDataError> {
         let index = self.qubits.add(bit.clone(), strict)?;
         self.qubit_indices
             .insert(bit, BitLocations::new(index.0, []));
-        Ok(())
+        Ok(index)
     }
 
-    pub fn add_clbit(&mut self, bit: ShareableClbit, strict: bool) -> Result<(), CircuitDataError> {
+    pub fn add_clbit(
+        &mut self,
+        bit: ShareableClbit,
+        strict: bool,
+    ) -> Result<Clbit, CircuitDataError> {
         let index = self.clbits.add(bit.clone(), strict)?;
         self.clbit_indices
             .insert(bit, BitLocations::new(index.0, []));
-        Ok(())
+        Ok(index)
     }
 
     #[inline]

--- a/qiskit/circuit/controlflow/builder.py
+++ b/qiskit/circuit/controlflow/builder.py
@@ -74,11 +74,18 @@ class CircuitScopeInterface(abc.ABC):
         """
 
     @abc.abstractmethod
-    def extend(self, data: CircuitData):
+    def extend(
+        self,
+        data: CircuitData,
+        qubits: list[Qubit] | None = None,
+        clbits: list[Clbit] | None = None,
+    ):
         """Appends all instructions from ``data`` to the scope.
 
         Args:
             data: The instruction listing.
+            qubits: an optional qubit remapping to apply
+            clbits: an optional clbit remapping to apply
         """
 
     @abc.abstractmethod
@@ -443,20 +450,25 @@ class ControlFlowBuilderBlock(CircuitScopeInterface):
         self._instructions.append(instruction)
         return instruction
 
-    def extend(self, data: CircuitData):
+    def extend(
+        self,
+        data: CircuitData,
+        qubits: list[Qubit] | None = None,
+        clbits: list[Clbit] | None = None,
+    ):
         if self._forbidden_message is not None:
             raise CircuitError(self._forbidden_message)
         if not self._allow_jumps:
             data.foreach_op(self._raise_on_jump)
-        active_qubits, active_clbits = data.active_bits()
-        # Add bits in deterministic order.
-        for b in data.qubits:
-            if b in active_qubits:
-                self.instructions.add_qubit(b, strict=False)
-        for b in data.clbits:
-            if b in active_clbits:
-                self.instructions.add_clbit(b, strict=False)
-        self.instructions.extend(data)
+        mapped_qubits = [
+            self.instructions.add_qubit(b, strict=False)
+            for b in (data.qubits if qubits is None else qubits)
+        ]
+        mapped_clbits = [
+            self.instructions.add_clbit(b, strict=False)
+            for b in (data.clbits if clbits is None else clbits)
+        ]
+        self.instructions.native_extend(data, qubits=mapped_qubits, clbits=mapped_clbits)
 
     def resolve_classical_resource(self, specifier):
         if self._built:

--- a/releasenotes/notes/compose-performance-c689ec71cb469226.yaml
+++ b/releasenotes/notes/compose-performance-c689ec71cb469226.yaml
@@ -1,0 +1,8 @@
+---
+features_circuits:
+  - :meth:`.QuantumCircuit.compose` can be up to approximately two times faster when composing
+    very long circuits onto another.
+fixes:
+  - Fixed a runtime cost linear in the number of bits of the base circuit in :meth:`.QuantumCircuit.compose`.
+    This could cause performance problems when repeatedly composing small circuits with no clbits onto a base
+    with a very large number of clbits.


### PR DESCRIPTION
Up to Qiskit 2.3, the bit-remapping mechanism of
`QuantumCircuit.compose` was to produce a temporary `CircuitData` instance with its Python-space bit-tracker fields expanded to that of remapping values, using the list of the full circuit base if no remapping was to be done.  It then would run through the data of the source, re-interning the `qubits` and `clbits` keys of each instruction by re-indexing from the `ShareableQubit` and `ShareableClbit` trackers. This was a spiritual successor to how the remapping would originally have been done in Python space.

However, this has the downside that for each call to `compose`, if `qubits=None` or `clbits=None`, there was a cost linear in the number of bits just to set up temporary bit tracking information that would never be used.  This is illustrated below in the simple exploratory QEC script:

```python
from qiskit import QuantumCircuit, transpile

def build_quadratic(qubits: list[int], cycles: int, backend):
    data_qubits = qubits[::2]
    meas_qubits = qubits[1::2]
    num_meas_qubits = len(meas_qubits)

    unit_cell = QuantumCircuit(backend.num_qubits)
    for q_i in range(num_meas_qubits):
        unit_cell.cx(data_qubits[q_i], meas_qubits[q_i])
    for q_i in range(num_meas_qubits):
        unit_cell.cx(data_qubits[q_i + 1], meas_qubits[q_i])
    isa_unit_cell = transpile(unit_cell, backend, optimization_level=1)

    qc = QuantumCircuit(backend.num_qubits, num_meas_qubits * cycles)
    for i in range(cycles):
        # As of Qiskit 2.3, this `compose` call has a cost linear in the
        # number of clbits of `qc`, _not_ `isa_unit_cell`, which makes
        # the total cost of the build quadratic in cycle count.
        qc.compose(isa_unit_cell, inplace=True)
        qc.measure(
            meas_qubits,
            [i*num_meas_qubits + j for j in range(num_meas_qubits)],
        )
    return qc

def build_linear(qubits: list[int], cycles: int, backend):
    data_qubits = qubits[::2]
    meas_qubits = qubits[1::2]
    num_meas_qubits = len(meas_qubits)

    unit_cell = QuantumCircuit(backend.num_qubits, num_meas_qubits)
    for q_i in range(num_meas_qubits):
        unit_cell.cx(data_qubits[q_i], meas_qubits[q_i])
    for q_i in range(num_meas_qubits):
        unit_cell.cx(data_qubits[q_i + 1], meas_qubits[q_i])
    unit_cell.measure(meas_qubits, unit_cell.clbits)
    isa_unit_cell = transpile(unit_cell, backend, optimization_level=1)

    qc = QuantumCircuit(backend.num_qubits, num_meas_qubits * cycles)
    for i in range(cycles):
        # Even on Qiskit 2.3, giving the `compose` call a restricted
        # number of clbits to remap solves the problem.
        clbits = [i*num_meas_qubits + j for j in range(num_meas_qubits)]
        qc.compose(isa_unit_cell, inplace=True, clbits=clbits)
    return qc
```

Given the above, the runtime scaling of the two methods can be illustrated with a timing script such as:

```python
from qiskit_ibm_runtime.fake_provider import FakeTorino

used_qubits = [21, 36, 41, 42, 43]
backend = FakeTorino()

print("Linear:")
for cycles in [100, 1_000, 10_000]:
    print(f"{cycles: 6}: ", end="")
    %timeit build_linear(used_qubits, cycles, backend)

print("Quadratic:")
for cycles in [100, 1_000, 10_000]:
    print(f"{cycles: 6}: ", end="")
    %timeit build_quadratic(used_qubits, cycles, backend)
```

Using commit 07346d174230 as a proxy for Qiskit 2.3 (the numbers would not be substantially different), the output on my laptop is:

```
Linear:
   100: 5.75 ms ± 169 μs
  1000: 29.1 ms ± 138 μs
 10000: 264 ms ± 551 μs
Quadratic:
   100: 6.67 ms ± 23.6 μs
  1000: 105 ms ± 608 μs
 10000: 8.26 s ± 37.6 ms
```

Using this commit, the new runtimes are:

```
Linear:
   100: 4.89 ms ± 70.9 μs
  1000: 23 ms ± 151 μs
 10000: 203 ms ± 2.28 ms
Quadratic:
   100: 5.13 ms ± 38 μs
  1000: 24.4 ms ± 121 μs
 10000: 217 ms ± 1.55 ms
```

The improvements here could likely have been realised by a much simpler patch that simply passed `clbits=base.clbits[:source.num_clbits]` (and similar for qubits) to the bit-remapping calls in the existing `compose` structure, but I didn't fully discover the underlying reason for the slowdown until I had already prepared this patch, which fixes it more completely.

---

The rework of the inners of `CircuitData::extend` to use interner merging to manage the bit remapping have a knock-on effect of up to approximately a 2x speedup in large-scale `compose calls`.  For example, the timing script:

```python
from qiskit.circuit import QuantumCircuit
qc = QuantumCircuit(1)
for _ in range(10_000_000):
    qc.x(0)
%timeit QuantumCircuit(1).compose(qc, inplace=True)
```

went from 337ms with commit 07346d174230 to 171ms with this one.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


