### PR TITLE
Fix typos in `qiskit.primitives` docstrings

### DIFF
--- a/qiskit/primitives/__init__.py
+++ b/qiskit/primitives/__init__.py
@@ -47,14 +47,14 @@ Following construction, an estimator is used by calling its :meth:`~.BaseEstimat
 with a list of pubs (Primitive Unified Blocs). Each pub contains three values that, together,
 define a computation unit of work for the estimator to complete:
 
-* a single :class:`~qiskit.circuit.QuantumCircuit`, possibly parametrized, whose final state we
+* a single :class:`~qiskit.circuit.QuantumCircuit`, possibly parameterized, whose final state we
   define as :math:`\psi(\theta)`,
 
 * one or more observables (specified as any ``ObservablesArrayLike``, including
   :class:`~.quantum_info.Pauli`, :class:`~.SparsePauliOp`, ``str``) that specify which expectation
   values to estimate, denoted :math:`H_j`, and
 
-* a collection parameter value sets to bind the circuit against, :math:`\theta_k`.
+* a collection of parameter value sets to bind the circuit against, :math:`\theta_k`.
 
 Running an estimator returns a :class:`~qiskit.primitives.BasePrimitiveJob` object, where calling
 the method :meth:`~qiskit.primitives.BasePrimitiveJob.result` results in expectation value estimates
@@ -127,7 +127,7 @@ define a computational unit of work for the sampler to complete:
 
 * Optionally, the number of shots to sample, determined in the run method if not set.
 
-Running an estimator returns a :class:`~qiskit.primitives.BasePrimitiveJob` object, where calling
+Running a sampler returns a :class:`~qiskit.primitives.BasePrimitiveJob` object, where calling
 the method :meth:`~qiskit.primitives.BasePrimitiveJob.result` results in output samples and metadata
 for each pub.
 
@@ -192,7 +192,7 @@ An ``EstimatorV1`` implementation is initialized with an empty parameter set.
   (list of list of float).
 
 The method should return a :class:`~qiskit.providers.JobV1` object. Calling
-:meth:`qiskit.providers.JobV1.result()` yields the
+:meth:`qiskit.providers.JobV1.result()` yields
 a list of expectation values plus optional metadata like confidence intervals for
 the estimation.
 
@@ -317,7 +317,7 @@ Migration from Primitives V1 to V2
 
 The formal distinction between the Primitives V1 and V2 APIs are the base classes from which
 primitives implementations inherit, which are all listed at the bottom of the page. At a conceptual
-level, however, here are some notable differences keep in mind when migrating from V1 to V2:
+level, however, here are some notable differences to keep in mind when migrating from V1 to V2:
 
 1. The V2 primitives favour vectorized inputs, where single circuits can be grouped with
    vector-valued (or more generally, array-valued) specifications. Each group is called a
@@ -384,9 +384,9 @@ level, however, here are some notable differences keep in mind when migrating fr
    via their inherent probabilistic nature, out of the options and into the API itself. For the
    sampler, this means that the ``shots`` argument is now part of the :meth:`~.BaseSamplerV2.run`
    signature, and moreover that each pub is able to specify its own value for ``shots``, which takes
-   precedence over any value given to the method. The sampler has an analogous ``precision``
+   precedence over any value given to the method. The estimator has an analogous ``precision``
    argument that specifies the error bars that the primitive implementation should target for
-   expectation values estimates.
+   expectation value estimates.
 
    This concept is not present in the API of the V1 primitives, though all implementations of the
    V1 primitives have related settings somewhere in their options.

--- a/qiskit/primitives/backend_estimator_v2.py
+++ b/qiskit/primitives/backend_estimator_v2.py
@@ -86,7 +86,7 @@ def _prepare_counts(results: list[Result]):
 
 def _pauli_expval_with_variance(counts: Counts, paulis: PauliList) -> tuple[np.ndarray, np.ndarray]:
     """Return array of expval and variance pairs for input Paulis.
-    Note: All non-identity Pauli's are treated as Z-paulis, assuming
+    Note: All non-identity Paulis are treated as Z-Paulis, assuming
     that basis rotations have been applied to convert them to the
     diagonal basis.
     """
@@ -250,7 +250,7 @@ class BackendEstimatorV2(BaseEstimatorV2):
 
     @property
     def backend(self) -> BackendV2:
-        """Returns the backend which this sampler object based on."""
+        """Returns the backend which this estimator object is based on."""
         return self._backend
 
     def run(

--- a/qiskit/primitives/backend_sampler_v2.py
+++ b/qiskit/primitives/backend_sampler_v2.py
@@ -72,7 +72,7 @@ ResultMemory = Union[list[str], list[list[float]], list[list[list[float]]]]
 """Type alias for possible level 2 and level 1 result memory formats. For level
 2, the format is a list of bit strings. For level 1, format can be either a
 list of I/Q pairs (list with two floats) for each memory slot if using
-``meas_return=avg`` or a list of of lists of I/Q pairs if using
+``meas_return=avg`` or a list of lists of I/Q pairs if using
 ``meas_return=single`` with the outer list indexing shot number and the inner
 list indexing memory slot.
 """
@@ -133,7 +133,7 @@ class BackendSamplerV2(BaseSamplerV2):
 
     @property
     def backend(self) -> BackendV2:
-        """Returns the backend which this sampler object based on."""
+        """Returns the backend which this sampler object is based on."""
         return self._backend
 
     @property

--- a/qiskit/primitives/base/base_estimator.py
+++ b/qiskit/primitives/base/base_estimator.py
@@ -50,7 +50,7 @@ class BaseEstimatorV2(ABC):
         or tuple of two to four elements that define the unit of work for the
         estimator. These are:
 
-        * A single :class:`~qiskit.circuit.QuantumCircuit`, possibly parametrized,
+        * A single :class:`~qiskit.circuit.QuantumCircuit`, possibly parameterized,
             whose final state we define as :math:`\psi(\theta)`.
 
         * One or more observables (specified as any :class:`~.ObservablesArrayLike`, including
@@ -62,7 +62,7 @@ class BaseEstimatorV2(ABC):
         * Optionally, the estimation precision.
 
      * precision: the estimation precision. This specification is optional and will be overridden by
-        the pub-wise shots if provided.
+        the pub-wise precision if provided.
 
     All estimator implementations must implement default value for the ``precision`` in the
     :meth:`.run` method. This default value will be used any time ``precision=None`` is specified, which
@@ -118,7 +118,7 @@ class BaseEstimatorV1(BasePrimitiveV1, Generic[T]):
       (list of list of float).
 
     The method returns a :class:`~qiskit.providers.JobV1` object. Calling
-    :meth:`qiskit.providers.JobV1.result()` yields the
+    :meth:`qiskit.providers.JobV1.result()` yields
     a list of expectation values plus optional metadata like confidence intervals for
     the estimation.
 

--- a/qiskit/primitives/base/base_sampler.py
+++ b/qiskit/primitives/base/base_sampler.py
@@ -162,7 +162,7 @@ class BaseSamplerV1(BasePrimitiveV1, Generic[T]):
         """Run the job of the sampling of bitstrings.
 
         Args:
-            circuits: One of more circuit objects.
+            circuits: One or more circuit objects.
             parameter_values: Parameters to be bound to the circuit.
             run_options: Backend runtime options used for circuit execution.
 

--- a/qiskit/primitives/containers/bindings_array.py
+++ b/qiskit/primitives/containers/bindings_array.py
@@ -219,7 +219,7 @@ class BindingsArray(ShapedMixin):
 
         Args:
             circuit: The circuit to bind.
-            loc: A tuple of indices, on for each dimension of this array.
+            loc: A tuple of indices, one for each dimension of this array.
 
         Returns:
             The bound circuit.

--- a/qiskit/primitives/containers/bit_array.py
+++ b/qiskit/primitives/containers/bit_array.py
@@ -87,7 +87,7 @@ class BitArray(ShapedMixin):
         """
         Args:
             array: The ``uint8`` data array.
-            num_bits: How many bit are in each outcome.
+            num_bits: How many bits are in each outcome.
 
         Raises:
             TypeError: If the input is not a NumPy array with type ``numpy.uint8``.
@@ -620,7 +620,7 @@ class BitArray(ShapedMixin):
 
         Args:
             observables: The observable(s) to take the expectation value of.
-                Must have a shape broadcastable with with this bit array and
+                Must have a shape broadcastable with this bit array and
                 the same number of qubits as the number of bits of this bit array.
                 The observables must be diagonal (I, Z, 0 or 1) too.
 

--- a/qiskit/primitives/containers/pub_result.py
+++ b/qiskit/primitives/containers/pub_result.py
@@ -35,7 +35,7 @@ class PubResult:
     about the entire submission).
 
     You typically get instances of this class by iterating over or indexing into a
-    :class:`.PrimitiveResult`, which is what you get from ``MyPritimive().run().result()``.
+    :class:`.PrimitiveResult`, which is what you get from ``MyPrimitive().run().result()``.
     """
 
     __slots__ = ("_data", "_metadata")

--- a/qiskit/primitives/containers/sampler_pub.py
+++ b/qiskit/primitives/containers/sampler_pub.py
@@ -76,7 +76,7 @@ class SamplerPub(ShapedMixin):
 
     @property
     def shots(self) -> int | None:
-        """An specific number of shots to run with (optional).
+        """A specific number of shots to run with (optional).
 
         This value takes precedence over any value owed by or supplied to a sampler.
         """

--- a/qiskit/primitives/statevector_sampler.py
+++ b/qiskit/primitives/statevector_sampler.py
@@ -94,7 +94,7 @@ class StatevectorSampler(BaseSamplerV2):
         circuit.measure([0, 1], alpha)
         circuit.measure([2], beta)
 
-        # Define a sweep over parameter values, where the second axis is over.
+        # Define a sweep over parameter values, where the second axis is over
         # the two parameters in the circuit.
         params = np.vstack([
             np.linspace(-np.pi, np.pi, 100),

--- a/qiskit/primitives/utils.py
+++ b/qiskit/primitives/utils.py
@@ -25,7 +25,7 @@ def _statevector_from_circuit(
 ) -> Statevector:
     """Generate a statevector from a circuit. Used in StatevectorEstimator class.
 
-    If the input circuit includes any resets for a some subsystem,
+    If the input circuit includes any resets for some subsystem,
     :meth:`.Statevector.reset` behaves in a stochastic way in :meth:`.Statevector.evolve`.
     This function sets a random number generator to be reproducible.
 
@@ -33,7 +33,7 @@ def _statevector_from_circuit(
 
     Args:
         circuit: The quantum circuit.
-        seed: The random number generator or None.
+        rng: The random number generator or None.
     """
     sv = Statevector.from_int(0, 2**circuit.num_qubits)
     sv.seed(rng)


### PR DESCRIPTION
### Summary

Inspired by #15683, largely out of curiosity, I asked claude 4.6 to fix typos in just the primitives. I feared it would run out of context if i gave it the whole library. It seems to have done a good job, on the whole.

### Details and comments


My prompt was as follows, with no subsequent intervention.

> Fix typos in the primitives subpackage of qiskit (qiskit/primitives/**/*.py). Don't bother fixing broken variable names, just docstrings and maybe comments.
