### PR TITLE
Fix typos in `qiskit.quantum_info`

### DIFF
--- a/qiskit/quantum_info/analysis/average.py
+++ b/qiskit/quantum_info/analysis/average.py
@@ -20,7 +20,7 @@ from .make_observable import make_dict_observable
 
 
 def average_data(counts: dict, observable: dict | np.ndarray | list) -> float:
-    """Compute the mean value of an diagonal observable.
+    """Compute the mean value of a diagonal observable.
 
     Takes in a diagonal observable in dictionary, list or matrix format and then
     calculates the sum_i value(i) P(i) where value(i) is the value of the

--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -47,7 +47,7 @@ class BaseOperator(GroupMixin, ABC):
 
         .. note::
 
-            If `op_shape`` is specified it will take precedence over other
+            If ``op_shape`` is specified it will take precedence over other
             kwargs.
         """
         self._qargs = None

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -48,7 +48,7 @@ class Kraus(QuantumChannel):
 
     A general operator map :math:`\mathcal{G}` can also be written using the
     generalized Kraus representation which is given by two sets of matrices
-    :math:`[A_0,...,A_{K-1}]`, :math:`[B_0,...,A_{B-1}]` such that
+    :math:`[A_0,...,A_{K-1}]`, :math:`[B_0,...,B_{K-1}]` such that
 
     .. math::
 

--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -121,7 +121,7 @@ class QuantumChannel(LinearOp):
             :class:`~qiskit.quantum_info.SuperOp` representation,
             ie. for a channel :math:`\mathcal{E}`, the SuperOp of
             the transpose channel :math:`\mathcal{{E}}^T` is
-            :math:`S_{mathcal{E}^T} = S_{\mathcal{E}}^T`.
+            :math:`S_{\mathcal{E}^T} = S_{\mathcal{E}}^T`.
         """
 
     def adjoint(self) -> Self:

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -81,7 +81,7 @@ class Stinespring(QuantumChannel):
             output_dims: the output subsystem dimensions.
 
         Raises:
-            QiskitError: if input data cannot be initialized as a
+            QiskitError: if input data cannot be initialized as
                          a list of Kraus matrices.
 
         Additional Information:

--- a/qiskit/quantum_info/operators/dihedral/dihedral.py
+++ b/qiskit/quantum_info/operators/dihedral/dihedral.py
@@ -85,7 +85,7 @@ class CNOTDihedral(BaseOperator, AdjointMixin):
      :class:`~qiskit.circuit.library.SwapGate`, :class:`~qiskit.circuit.library.CCZGate`.
      They can be converted back into a :class:`~qiskit.circuit.QuantumCircuit`,
      or :class:`~qiskit.circuit.Gate` object using the :meth:`~CNOTDihedral.to_circuit`
-     or :meth:`~CNOTDihderal.to_instruction` methods respectively. Note that this
+     or :meth:`~CNOTDihedral.to_instruction` methods respectively. Note that this
      decomposition is not necessarily optimal in terms of number of gates
      if the number of qubits is more than two.
 

--- a/qiskit/quantum_info/operators/mixins/group.py
+++ b/qiskit/quantum_info/operators/mixins/group.py
@@ -41,7 +41,7 @@ class GroupMixin(ABC):
 
         - ``&``, ``__and__`` -> :meth:`compose`
         - ``@``, ``__matmul__`` -> :meth:`dot`
-        - ``^``, ``__xor__`` -> `:meth:`tensor`
+        - ``^``, ``__xor__`` -> :meth:`tensor`
         - ``**``, ``__pow__`` -> :meth:`power`
 
     The following abstract methods must be implemented by subclasses
@@ -152,7 +152,7 @@ class GroupMixin(ABC):
         return self.compose(other, qargs=qargs, front=True)
 
     def power(self, n) -> Self:
-        """Return the compose of a operator with itself n times.
+        """Return the compose of an operator with itself n times.
 
         Args:
             n (int): the number of times to compose with self (n>0).

--- a/qiskit/quantum_info/operators/mixins/group.py
+++ b/qiskit/quantum_info/operators/mixins/group.py
@@ -152,7 +152,7 @@ class GroupMixin(ABC):
         return self.compose(other, qargs=qargs, front=True)
 
     def power(self, n) -> Self:
-        """Return the compose of an operator with itself n times.
+        """Return the composition of an operator with itself n times.
 
         Args:
             n (int): the number of times to compose with self (n>0).

--- a/qiskit/quantum_info/operators/op_shape.py
+++ b/qiskit/quantum_info/operators/op_shape.py
@@ -170,7 +170,7 @@ class OpShape:
 
     @property
     def _dim_l(self):
-        """Return the total input dimension."""
+        """Return the total output dimension."""
         if self._dims_l:
             return reduce(mul, self._dims_l)
         return 2**self._num_qargs_l
@@ -503,23 +503,23 @@ class OpShape:
                 )
             if self.dims_l(qargs) != other.dims_l():
                 raise QiskitError(
-                    "Cannot add shapes width different left "
+                    "Cannot add shapes with different left "
                     f"dimension on specified qargs {self.dims_l(qargs)} != {other.dims_l()}"
                 )
             if self.dims_r(qargs) != other.dims_r():
                 raise QiskitError(
-                    "Cannot add shapes width different total right "
+                    "Cannot add shapes with different total right "
                     f"dimension on specified qargs{self.dims_r(qargs)} != {other.dims_r()}"
                 )
         elif self != other:
             if self._dim_l != other._dim_l:
                 raise QiskitError(
-                    "Cannot add shapes width different total left "
+                    "Cannot add shapes with different total left "
                     f"dimension {self._dim_l} != {other._dim_l}"
                 )
             if self._dim_r != other._dim_r:
                 raise QiskitError(
-                    "Cannot add shapes width different total right "
+                    "Cannot add shapes with different total right "
                     f"dimension {self._dim_r} != {other._dim_r}"
                 )
         return self

--- a/qiskit/quantum_info/operators/predicates.py
+++ b/qiskit/quantum_info/operators/predicates.py
@@ -44,7 +44,7 @@ def matrix_equal(mat1, mat2, ignore_phase=False, rtol=RTOL_DEFAULT, atol=ATOL_DE
     documentation for additional information on tolerance parameters.
 
     If ignore_phase is True both matrices will be multiplied by
-    exp(-1j * theta) where `theta` is the first nphase for a
+    exp(-1j * theta) where `theta` is the phase of the
     first non-zero matrix element `|a| * exp(1j * theta)`.
 
     Args:

--- a/qiskit/quantum_info/operators/random.py
+++ b/qiskit/quantum_info/operators/random.py
@@ -115,7 +115,7 @@ def random_quantum_channel(
 
     Args:
         input_dims (int or tuple): the input dimension of the channel.
-        output_dims (int or tuple): the input dimension of the channel.
+        output_dims (int or tuple): the output dimension of the channel.
         rank (int): Optional. The rank of the quantum channel Choi-matrix.
         seed (int or np.random.Generator): Optional. Set a fixed seed or
                                            generator for RNG.

--- a/qiskit/quantum_info/operators/scalar_op.py
+++ b/qiskit/quantum_info/operators/scalar_op.py
@@ -29,7 +29,7 @@ from qiskit.quantum_info.operators.mixins import generate_apidocs
 class ScalarOp(LinearOp):
     """Scalar identity operator class.
 
-    This is a symbolic representation of an scalar identity operator on
+    This is a symbolic representation of a scalar identity operator on
     multiple subsystems. It may be used to initialize a symbolic scalar
     multiplication of an identity and then be implicitly converted to other
     kinds of operator subclasses by using the :meth:`compose`, :meth:`dot`,

--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -354,7 +354,7 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return ret
 
     def _count_y(self, dtype=None):
-        """Count the number of I Paulis"""
+        """Count the number of Y Paulis"""
         return _count_y(self._x, self._z, dtype=dtype)
 
     @staticmethod
@@ -422,7 +422,7 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
             group_phase (bool): Optional. If ``True`` use group-phase convention
                                 instead of BasePauli ZX-phase convention.
                                 (default: ``False``).
-            sparse (bool): Optional. Of ``True`` return a sparse CSR matrix,
+            sparse (bool): Optional. If ``True`` return a sparse CSR matrix,
                            otherwise return a dense Numpy array
                            (default: ``False``).
 
@@ -727,7 +727,7 @@ def _evolve_rz(base_pauli, qubit, multiple):
 
 
 def _count_y(x, z, dtype=None):
-    """Count the number of I Paulis"""
+    """Count the number of Y Paulis"""
     return (x & z).sum(axis=1, dtype=dtype)
 
 

--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -634,7 +634,7 @@ class Clifford(BaseOperator, AdjointMixin, Operation):
 
     @classmethod
     def from_operator(cls, operator: Operator) -> Clifford:
-        """Create a Clifford from a operator.
+        """Create a Clifford from an operator.
 
         Note that this function takes exponentially long time w.r.t. the number of qubits.
 

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -484,7 +484,7 @@ def _prepend_y(clifford, qubit):
 
 
 def _append_z(clifford, qubit):
-    """Apply an Z gate to a Clifford.
+    """Apply a Z gate to a Clifford.
 
     Args:
         clifford (Clifford): a Clifford.

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -236,7 +236,7 @@ class Pauli(BasePauli):
 
     @classmethod
     def set_truncation(cls, val: int):
-        """Set the max number of Pauli characters to display before truncation/
+        """Set the max number of Pauli characters to display before truncation.
 
         Args:
             val (int): the number of characters.
@@ -412,7 +412,7 @@ class Pauli(BasePauli):
         .. note::
 
             The difference between `to_label` and :meth:`__str__` is that
-            the later will truncate the output for large numbers of qubits.
+            the latter will truncate the output for large numbers of qubits.
 
         Returns:
             str: the Pauli string label.

--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -854,7 +854,7 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         return super().commutes(other, qargs=qargs)
 
     def anticommutes(self, other: BasePauli, qargs: list | None = None) -> bool:
-        """Return ``True`` if other Pauli that anticommutes with other.
+        """Return ``True`` if other Pauli anticommutes with self.
 
         Args:
             other (PauliList): another PauliList operator.
@@ -881,7 +881,7 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         return self._commutes_with_all(other)
 
     def anticommutes_with_all(self, other: PauliList) -> np.ndarray:
-        """Return indexes of rows that commute other.
+        """Return indexes of rows that anti-commute with other.
 
         If ``other`` is a multi-row Pauli list the returned vector indexes rows
         of the current PauliList that anti-commute with *all* Paulis in other.
@@ -1039,7 +1039,7 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
                           return a list of Numpy arrays (Default: ``False``).
 
         Returns:
-            list: A list of dense Pauli matrices if ``array=False` and ``sparse=False`.
+            list: A list of dense Pauli matrices if ``array=False`` and ``sparse=False``.
             list: A list of sparse Pauli matrices if ``array=False`` and ``sparse=True``.
             array: A dense rank-3 array of Pauli matrices if ``array=True``.
         """

--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -854,7 +854,7 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         return super().commutes(other, qargs=qargs)
 
     def anticommutes(self, other: BasePauli, qargs: list | None = None) -> bool:
-        """Return ``True`` if other Pauli anticommutes with self.
+        """Return ``True`` if the other Pauli anticommutes with this one.
 
         Args:
             other (PauliList): another PauliList operator.
@@ -881,7 +881,7 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         return self._commutes_with_all(other)
 
     def anticommutes_with_all(self, other: PauliList) -> np.ndarray:
-        """Return indexes of rows that anti-commute with other.
+        """Return indexes of rows that anticommute with the other Pauli list.
 
         If ``other`` is a multi-row Pauli list the returned vector indexes rows
         of the current PauliList that anti-commute with *all* Paulis in other.

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -680,7 +680,7 @@ class SparsePauliOp(LinearOp):
         than ``1e-17`` will be reduced to ``1 X`` whereas :meth:`.SparsePauliOp.simplify` would
         return ``1+1e-17j X``.
 
-        If a both the real and imaginary part of a coefficient is 0 after chopping, the
+        If both the real and imaginary part of a coefficient is 0 after chopping, the
         corresponding Pauli is removed from the operator.
 
         Args:
@@ -753,7 +753,7 @@ class SparsePauliOp(LinearOp):
     def from_operator(
         obj: Operator, atol: float | None = None, rtol: float | None = None
     ) -> SparsePauliOp:
-        """Construct from an Operator objector.
+        """Construct from an Operator object.
 
         Note that the cost of this construction is exponential in general because the number of
         possible Pauli terms in the decomposition is exponential in the number of qubits.

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -136,7 +136,7 @@ class DensityMatrix(QuantumState, TolerancesMixin):
         return {"data": self.data, "dims": self._op_shape.dims_l()}
 
     def draw(self, output: str | None = None, **drawer_args):
-        """Return a visualization of the Statevector.
+        """Return a visualization of the DensityMatrix.
 
         **repr**: ASCII TextMatrix of the state's ``__repr__``.
 
@@ -167,7 +167,7 @@ class DensityMatrix(QuantumState, TolerancesMixin):
         Returns:
             :class:`matplotlib.Figure` or :class:`str` or
             :class:`TextMatrix` or :class:`IPython.display.Latex`:
-            Drawing of the Statevector.
+            Drawing of the DensityMatrix.
 
         Raises:
             ValueError: when an invalid output method is selected.
@@ -519,7 +519,7 @@ class DensityMatrix(QuantumState, TolerancesMixin):
 
         Additional Information:
             If all subsystems are reset this will return the ground state
-            on all subsystems. If only a some subsystems are reset this
+            on all subsystems. If only some subsystems are reset this
             function will perform evolution by the reset
             :class:`~qiskit.quantum_info.SuperOp` of the reset subsystems.
         """
@@ -560,7 +560,7 @@ class DensityMatrix(QuantumState, TolerancesMixin):
              - :math:`\frac{1}{2}\begin{pmatrix} 1 & i \\ -i & 1 \end{pmatrix}`
 
         Args:
-            label (string): a eigenstate string ket label (see table for
+            label (string): an eigenstate string ket label (see table for
                             allowed values).
 
         Returns:
@@ -593,7 +593,7 @@ class DensityMatrix(QuantumState, TolerancesMixin):
 
             * ``Int`` -- the integer specifies the total dimension of the
               state. If it is a power of two the state will be initialized
-              as an N-qubit state. If it is not a power of  two the state
+              as an N-qubit state. If it is not a power of two the state
               will have a single d-dimensional subsystem.
         """
         size = np.prod(dims)

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -136,7 +136,7 @@ class DensityMatrix(QuantumState, TolerancesMixin):
         return {"data": self.data, "dims": self._op_shape.dims_l()}
 
     def draw(self, output: str | None = None, **drawer_args):
-        """Return a visualization of the DensityMatrix.
+        """Return a visualization of the density matrix.
 
         **repr**: ASCII TextMatrix of the state's ``__repr__``.
 
@@ -167,7 +167,7 @@ class DensityMatrix(QuantumState, TolerancesMixin):
         Returns:
             :class:`matplotlib.Figure` or :class:`str` or
             :class:`TextMatrix` or :class:`IPython.display.Latex`:
-            Drawing of the DensityMatrix.
+            Drawing of the density matrix.
 
         Raises:
             ValueError: when an invalid output method is selected.

--- a/qiskit/quantum_info/states/measures.py
+++ b/qiskit/quantum_info/states/measures.py
@@ -174,7 +174,7 @@ def concurrence(state: Statevector | DensityMatrix) -> float:
         C(|\psi\rangle) = \sqrt{2(1 - Tr[\rho_0^2])}
 
     where :math:`\rho_0 = Tr_1[|\psi\rangle\!\langle\psi|]` is the
-    reduced state from by taking the
+    reduced state by taking the
     :func:`~qiskit.quantum_info.partial_trace` of the input state.
 
     For density matrices the concurrence is only defined for

--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -38,7 +38,7 @@ class QuantumState:
 
         .. note::
 
-            If `op_shape`` is specified it will take precedence over other
+            If ``op_shape`` is specified it will take precedence over other
             kwargs.
         """
         self._op_shape = op_shape
@@ -163,7 +163,7 @@ class QuantumState:
             QuantumState: the scalar multiplied state other * self.
 
         Raises:
-            NotImplementedError: if subclass does not support scala
+            NotImplementedError: if subclass does not support scalar
                                  multiplication.
         """
         raise NotImplementedError(f"{type(self)} does not support scalar multiplication")
@@ -253,7 +253,7 @@ class QuantumState:
                                 subsystems (Default: None).
 
         Returns:
-            np.array: list of sampled counts if the order sampled.
+            np.array: list of sampled counts in the order sampled.
 
         Additional Information:
 
@@ -263,7 +263,7 @@ class QuantumState:
             not modified.
 
             The seed for random number generator used for sampling can be
-            set to a fixed value by using the stats :meth:`seed` method.
+            set to a fixed value by using the state's :meth:`seed` method.
         """
         # Get measurement probabilities for measured qubits
         probs = self.probabilities(qargs)
@@ -294,7 +294,7 @@ class QuantumState:
             not modified.
 
             The seed for random number generator used for sampling can be
-            set to a fixed value by using the stats :meth:`seed` method.
+            set to a fixed value by using the state's :meth:`seed` method.
         """
         # Sample list of outcomes
         samples = self.sample_memory(shots, qargs=qargs)

--- a/qiskit/quantum_info/states/random.py
+++ b/qiskit/quantum_info/states/random.py
@@ -66,7 +66,7 @@ def random_density_matrix(
     method: Literal["Hilbert-Schmidt", "Bures"] = "Hilbert-Schmidt",
     seed: int | np.random.Generator | None = None,
 ) -> DensityMatrix:
-    """Generate a random DensityMatrix.
+    """Generate a random density matrix.
 
     Args:
         dims (int or tuple): the dimensions of the DensityMatrix.

--- a/qiskit/quantum_info/states/random.py
+++ b/qiskit/quantum_info/states/random.py
@@ -29,7 +29,7 @@ from .densitymatrix import DensityMatrix
 def random_statevector(
     dims: int | tuple, seed: int | np.random.Generator | None = None
 ) -> Statevector:
-    """Generator a random Statevector.
+    """Generate a random Statevector.
 
     The statevector is sampled from the uniform distribution. This is the measure
     induced by the Haar measure on unitary matrices.
@@ -66,7 +66,7 @@ def random_density_matrix(
     method: Literal["Hilbert-Schmidt", "Bures"] = "Hilbert-Schmidt",
     seed: int | np.random.Generator | None = None,
 ) -> DensityMatrix:
-    """Generator a random DensityMatrix.
+    """Generate a random DensityMatrix.
 
     Args:
         dims (int or tuple): the dimensions of the DensityMatrix.

--- a/qiskit/quantum_info/states/stabilizerstate.py
+++ b/qiskit/quantum_info/states/stabilizerstate.py
@@ -555,14 +555,14 @@ class StabilizerState(QuantumState):
                                 subsystems (Default: None).
 
         Returns:
-            np.array: list of sampled counts if the order sampled.
+            np.array: list of sampled counts in the order sampled.
 
         Additional Information:
 
             This function implements the measurement :meth:`measure` method.
 
             The seed for random number generator used for sampling can be
-            set to a fixed value by using the stats :meth:`seed` method.
+            set to a fixed value by using the state's :meth:`seed` method.
         """
         memory = []
         for _ in range(shots):

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -78,7 +78,7 @@ class Statevector(QuantumState, TolerancesMixin):
               with the total number of subsystems given by the length of the list.
 
             * ``Int`` or ``None`` -- the length of the input vector
-              specifies the total dimension of the density matrix. If it is a
+              specifies the total dimension of the state. If it is a
               power of two the state will be initialized as an N-qubit state.
               If it is not a power of two the state will have a single
               d-dimensional subsystem.
@@ -688,7 +688,7 @@ class Statevector(QuantumState, TolerancesMixin):
 
         Additional Information:
             If all subsystems are reset this will return the ground state
-            on all subsystems. If only a some subsystems are reset this
+            on all subsystems. If only some subsystems are reset this
             function will perform a measurement on those subsystems and
             evolve the subsystems so that the collapsed post-measurement
             states are rotated to the 0-state. The RNG seed for this
@@ -744,11 +744,11 @@ class Statevector(QuantumState, TolerancesMixin):
              - :math:`[1 / \\sqrt{2},  -i / \\sqrt{2}]`
 
         Args:
-            label (string): a eigenstate string ket label (see table for
+            label (string): an eigenstate string ket label (see table for
                             allowed values).
 
         Returns:
-            Statevector: The N-qubit basis state density matrix.
+            Statevector: The N-qubit basis state statevector.
 
         Raises:
             QiskitError: if the label contains invalid characters, or the
@@ -810,7 +810,7 @@ class Statevector(QuantumState, TolerancesMixin):
 
             * ``Int`` -- the integer specifies the total dimension of the
               state. If it is a power of two the state will be initialized
-              as an N-qubit state. If it is not a power of  two the state
+              as an N-qubit state. If it is not a power of two the state
               will have a single d-dimensional subsystem.
         """
         size = np.prod(dims)


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes some typos in `quantum_info`, as recommended by claude.

### Details and comments


AI tool used: claude opus 4.6