### PR TITLE
Bump minimal NumPy Version to 1.21

### DIFF
--- a/releasenotes/notes/numpy-minimum-version-bump-909cf30bf392cfe9.yaml
+++ b/releasenotes/notes/numpy-minimum-version-bump-909cf30bf392cfe9.yaml
@@ -1,6 +1,6 @@
 ---
-upgrade:
+fixes:
   - |
-    The minimum required version of NumPy has been increased from 1.17 to 1.21.
-    This bound was already effectively in place because Qiskit uses :class:`numpy.typing.NDArray`,
+    The minimum require version of NumPy is now correctly listed as 1.21 (instead of 1.17).
+    This bound has been effectively in place for several releases due to the use of :class:`numpy.typing.NDArray`,
     which was introduced in NumPy 1.21, so Qiskit would fail to import with older versions of NumPy.

--- a/releasenotes/notes/numpy-minimum-version-bump-909cf30bf392cfe9.yaml
+++ b/releasenotes/notes/numpy-minimum-version-bump-909cf30bf392cfe9.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    The minimum required version of NumPy has been increased from 1.17 to 1.21.
+    This change was necessary because Qiskit uses :class:`numpy.typing.NDArray`,
+    which was introduced in NumPy 1.21. Users should ensure they have NumPy 1.21
+    or later installed.

--- a/releasenotes/notes/numpy-minimum-version-bump-909cf30bf392cfe9.yaml
+++ b/releasenotes/notes/numpy-minimum-version-bump-909cf30bf392cfe9.yaml
@@ -2,6 +2,5 @@
 upgrade:
   - |
     The minimum required version of NumPy has been increased from 1.17 to 1.21.
-    This change was necessary because Qiskit uses :class:`numpy.typing.NDArray`,
-    which was introduced in NumPy 1.21. Users should ensure they have NumPy 1.21
-    or later installed.
+    This bound was already effectively in place because Qiskit uses :class:`numpy.typing.NDArray`,
+    which was introduced in NumPy 1.21, so Qiskit would fail to import with older versions of NumPy.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rustworkx>=0.15.0
-numpy>=1.17,<3
+numpy>=1.21,<3
 scipy>=1.5
 dill>=0.3
 stevedore>=3.0.0


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
The minimum required version of NumPy has been increased from 1.17 to 1.21.
This change was necessary because Qiskit uses :class:`numpy.typing.NDArray`, which was introduced in NumPy 1.21.
Users should ensure they have NumPy 1.21 or later installed.

### Details and comments
I don't think additional tests are necessary. To reproduce run

```bash
pip install --upgrade qiskit "numpy<1.21"
python -c "from qiskit.primitives import StatevectorSampler"
```

which will yield

```python
ImportError: cannot import name 'NDArray' from 'numpy.typing'
```


Running with appropriate python version

```bash
pip install --upgrade qiskit "numpy<1.22"
python -c "from qiskit.primitives import StatevectorSampler"
```

will work and won't yield any error.

Changelog entry & PR summary created using: GitHub Copilot using Claude Sonnet 4.5

