### PR TITLE
Fix typos in `qiskit.circuit`

### DIFF
--- a/qiskit/circuit/annotated_operation.py
+++ b/qiskit/circuit/annotated_operation.py
@@ -101,7 +101,7 @@ class AnnotatedOperation(Operation):
         inverted and then controlled by 2 qubits.
         """
         self.base_op = base_op
-        """The base operation that the modifiers in this annotated operation applies to."""
+        """The base operation that the modifiers in this annotated operation apply to."""
         self.modifiers = modifiers if isinstance(modifiers, List) else [modifiers]
         """Ordered sequence of the modifiers to apply to :attr:`base_op`.  The modifiers are applied
         in order from lowest index to highest index."""

--- a/qiskit/circuit/annotation.py
+++ b/qiskit/circuit/annotation.py
@@ -49,7 +49,7 @@ handler to invoke.  This includes in QPY and OpenQASM 3 serialization contexts, 
 transpiler passes will also look at annotations' namespaces to determine if they are relevant, and
 so on.
 
-This can be standard Python identifier (e.g. ``my_namespace``), or a dot-separated list of
+This can be a standard Python identifier (e.g. ``my_namespace``), or a dot-separated list of
 identifiers (e.g. ``my_namespace.subnamespace``).  The namespace is used by all consumers of
 annotations to determine what handler should be invoked.
 
@@ -378,7 +378,7 @@ class OpenQASM3Serializer(abc.ABC):
 
     @abc.abstractmethod
     def dump(self, annotation: Annotation) -> str | Literal[NotImplemented]:
-        """Serialize the paylaod of an annotation to a single line of UTF-8 text.
+        """Serialize the payload of an annotation to a single line of UTF-8 text.
 
         The output of this method should not include the annotation's
         :attr:`~.Annotation.namespace` attribute; this is handled automatically by the OpenQASM 3

--- a/qiskit/circuit/classical/expr/constructors.py
+++ b/qiskit/circuit/classical/expr/constructors.py
@@ -100,7 +100,7 @@ def lift(value: typing.Any, /, type: types.Type | None = None) -> Expr:
 
         The type of the return value can be influenced, if the given value could be interpreted
         losslessly as the given type (use :func:`cast` to perform a full set of casting
-        operations, include lossy ones)::
+        operations, including lossy ones)::
 
             >>> from qiskit.circuit import ClassicalRegister
             >>> from qiskit.circuit.classical import expr, types
@@ -334,7 +334,7 @@ def logic_and(left: typing.Any, right: typing.Any, /) -> Expr:
 
             >>> from qiskit.circuit import Clbit
             >>> from qiskit.circuit.classical import expr
-            >>> expr.logical_and(Clbit(), Clbit())
+            >>> expr.logic_and(Clbit(), Clbit())
             Binary(Binary.Op.LOGIC_AND, Var(<clbit 0>, Bool()), Var(<clbit 1>, Bool()), Bool())
     """
     return _binary_logical(Binary.Op.LOGIC_AND, left, right)
@@ -349,7 +349,7 @@ def logic_or(left: typing.Any, right: typing.Any, /) -> Expr:
 
             >>> from qiskit.circuit import Clbit
             >>> from qiskit.circuit.classical import expr
-            >>> expr.logical_and(Clbit(), Clbit())
+            >>> expr.logic_or(Clbit(), Clbit())
             Binary(Binary.Op.LOGIC_OR, Var(<clbit 0>, Bool()), Var(<clbit 1>, Bool()), Bool())
     """
     return _binary_logical(Binary.Op.LOGIC_OR, left, right)
@@ -438,7 +438,7 @@ def less_equal(left: typing.Any, right: typing.Any, /) -> Expr:
 
             >>> from qiskit.circuit import ClassicalRegister
             >>> from qiskit.circuit.classical import expr
-            >>> expr.less(ClassicalRegister(3, "a"), ClassicalRegister(3, "b"))
+            >>> expr.less_equal(ClassicalRegister(3, "a"), ClassicalRegister(3, "b"))
             Binary(Binary.Op.LESS_EQUAL, \
 Var(ClassicalRegister(3, "a"), Uint(3)), \
 Var(ClassicalRegister(3, "b"), Uint(3)), \
@@ -456,7 +456,7 @@ def greater(left: typing.Any, right: typing.Any, /) -> Expr:
 
             >>> from qiskit.circuit import ClassicalRegister
             >>> from qiskit.circuit.classical import expr
-            >>> expr.less(ClassicalRegister(3, "c"), 5)
+            >>> expr.greater(ClassicalRegister(3, "c"), 5)
             Binary(Binary.Op.GREATER, \
 Var(ClassicalRegister(3, "c"), Uint(3)), \
 Value(5, Uint(3)), \
@@ -474,7 +474,7 @@ def greater_equal(left: typing.Any, right: typing.Any, /) -> Expr:
 
             >>> from qiskit.circuit import ClassicalRegister
             >>> from qiskit.circuit.classical import expr
-            >>> expr.less(ClassicalRegister(3, "a"), ClassicalRegister(3, "b"))
+            >>> expr.greater_equal(ClassicalRegister(3, "a"), ClassicalRegister(3, "b"))
             Binary(Binary.Op.GREATER_EQUAL, \
 Var(ClassicalRegister(3, "a"), Uint(3)), \
 Var(ClassicalRegister(3, "b"), Uint(3)), \

--- a/qiskit/circuit/classical/expr/expr.py
+++ b/qiskit/circuit/classical/expr/expr.py
@@ -92,7 +92,7 @@ class _BinaryOp(enum.Enum):
     right-hand operand.  In all cases, the output bit width is the same as the input, and zeros
     fill in the "exposed" spaces.
 
-    The binary arithmetic operators :data:`ADD`, :data:`SUB:, :data:`MUL`, and :data:`DIV`
+    The binary arithmetic operators :data:`ADD`, :data:`SUB`, :data:`MUL`, and :data:`DIV`
     can be applied to two floats or two unsigned integers, which should be made to be of
     the same width during construction via a cast.
     The :data:`ADD`, :data:`SUB`, and :data:`DIV` operators can be applied on two durations

--- a/qiskit/circuit/classical/expr/visitors.py
+++ b/qiskit/circuit/classical/expr/visitors.py
@@ -342,7 +342,7 @@ def is_lvalue(node: expr.Expr, /) -> bool:
     """Return whether this expression can be used in l-value positions, that is, whether it has a
     well-defined location in memory, such as one that might be writeable.
 
-    Being an l-value is a necessary but not sufficient for this location to be writeable; it is
+    Being an l-value is necessary but not sufficient for this location to be writeable; it is
     permissible that a larger object containing this memory location may not allow writing from
     the scope that attempts to write to it.  This would be an access property of the containing
     program, however, and not an inherent property of the expression system.

--- a/qiskit/circuit/classical/types/ordering.py
+++ b/qiskit/circuit/classical/types/ordering.py
@@ -173,7 +173,7 @@ class CastKind(enum.Enum):
     ``implicit==True`` is the minimum required to specify this."""
     LOSSLESS = enum.auto()
     """The 'from' type can be cast to the 'to' type explicitly, and the cast will be lossless.  This
-    requires a :class:`~.expr.Cast`` node with ``implicit=False``, but there's no danger from
+    requires a :class:`~.expr.Cast` node with ``implicit=False``, but there's no danger from
     inserting one."""
     DANGEROUS = enum.auto()
     """The 'from' type has a defined cast to the 'to' type, but depending on the value, it may lose

--- a/qiskit/circuit/commutation_checker.py
+++ b/qiskit/circuit/commutation_checker.py
@@ -100,7 +100,7 @@ class CommutationChecker:
             approximation_degree: If the average gate fidelity in between the two operations
                 is above this number (up to ``1e-12``) they are assumed to commute.
             matrix_max_num_qubits: the maximum number of qubits for which it is allowed to compute
-                the matrix representation. This is needed if there is no efficient heck readily
+                the matrix representation. This is needed if there is no efficient check readily
                 available, e.g. for custom gates.
 
         Returns:

--- a/qiskit/circuit/controlflow/box.py
+++ b/qiskit/circuit/controlflow/box.py
@@ -57,7 +57,7 @@ class BoxOp(ControlFlowOp):
         Args:
             body: the circuit to use as the body of the box.  This should explicitly close over any
                 :class:`.expr.Var` variables that must be incident from the outer circuit.  The
-                required number of qubit and clbits for the resulting instruction are inferred from
+                required number of qubits and clbits for the resulting instruction are inferred from
                 the number in the circuit, even if they are idle.
             duration: an optional duration for the box as a whole.
             unit: the unit of the ``duration``.

--- a/qiskit/circuit/controlflow/break_loop.py
+++ b/qiskit/circuit/controlflow/break_loop.py
@@ -30,7 +30,7 @@ class BreakLoopOp(Instruction):
         """
         Args:
             num_qubits: the number of qubits this affects.
-            num_clbits: the number of qubits this affects.
+            num_clbits: the number of clbits this affects.
             label: an optional string label for the instruction.
         """
         super().__init__("break_loop", num_qubits, num_clbits, [], label=label)

--- a/qiskit/circuit/controlflow/builder.py
+++ b/qiskit/circuit/controlflow/builder.py
@@ -623,7 +623,7 @@ class ControlFlowBuilderBlock(CircuitScopeInterface):
         This will build a circuit which contains all of the necessary qubits and clbits and no
         others.
 
-        The ``qubits`` and ``clbits`` arguments should be sets that contains all the resources in
+        The ``qubits`` and ``clbits`` arguments should be sets that contain all the resources in
         the outer scope; these will be passed down to inner placeholder instructions, so they can
         apply themselves across the whole scope should they need to.  The resulting
         :obj:`.QuantumCircuit` will be defined over a (nonstrict) subset of these resources.  This

--- a/qiskit/circuit/controlflow/continue_loop.py
+++ b/qiskit/circuit/controlflow/continue_loop.py
@@ -30,7 +30,7 @@ class ContinueLoopOp(Instruction):
         """
         Args:
             num_qubits: the number of qubits this affects.
-            num_clbits: the number of qubits this affects.
+            num_clbits: the number of clbits this affects.
             label: an optional string label for the instruction.
         """
         super().__init__("continue_loop", num_qubits, num_clbits, [], label=label)

--- a/qiskit/circuit/controlflow/if_else.py
+++ b/qiskit/circuit/controlflow/if_else.py
@@ -70,7 +70,7 @@ class IfElseOp(ControlFlowOp):
                 ``Clbit`` to be compared to either a ``bool`` or an ``int``.
             true_body: A program to be executed if ``condition`` evaluates
                 to true.
-            false_body: A optional program to be executed if ``condition``
+            false_body: An optional program to be executed if ``condition``
                 evaluates to false.
             label: An optional label for identifying the instruction.
         """

--- a/qiskit/circuit/delay.py
+++ b/qiskit/circuit/delay.py
@@ -77,7 +77,7 @@ class Delay(Instruction):
 
     @property
     def unit(self):
-        """The unit for the duration of the delay in :attr`.params`"""
+        """The unit for the duration of the delay in :attr:`.params`"""
         return self._unit
 
     @unit.setter

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -491,7 +491,7 @@ class Instruction(Operation):
         )
 
     def repeat(self, n):
-        """Creates an instruction with ``self`` repeated :math`n` times.
+        """Creates an instruction with ``self`` repeated :math:`n` times.
 
         Args:
             n (int): Number of times to repeat the instruction

--- a/qiskit/circuit/library/arithmetic/adders/draper_qft_adder.py
+++ b/qiskit/circuit/library/arithmetic/adders/draper_qft_adder.py
@@ -25,7 +25,7 @@ class DraperQFTAdder(Adder):
     r"""A circuit that uses QFT to perform in-place addition on two qubit registers.
 
     For registers with :math:`n` qubits, the QFT adder can perform addition modulo
-    :math:`2^n` (with ``kind="fixed"``) or ordinary addition by adding a carry qubits (with
+    :math:`2^n` (with ``kind="fixed"``) or ordinary addition by adding a carry qubit (with
     ``kind="half"``).
 
     As an example, a non-fixed_point QFT adder circuit that performs addition on two 2-qubit sized

--- a/qiskit/circuit/library/arithmetic/adders/vbe_ripple_carry_adder.py
+++ b/qiskit/circuit/library/arithmetic/adders/vbe_ripple_carry_adder.py
@@ -47,7 +47,7 @@ class VBERippleCarryAdder(Adder):
     *Carry_dg* correspond to the inverse of the *Carry* gate. Note that
     in this implementation the input register qubits are ordered as all qubits from
     the first input register, followed by all qubits from the second input register.
-    This is different ordering as compared to Figure 2 in [1], which leads to a different
+    This is a different ordering as compared to Figure 2 in [1], which leads to a different
     drawing of the circuit.
 
     .. seealso::

--- a/qiskit/circuit/library/arithmetic/functional_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/functional_pauli_rotations.py
@@ -60,7 +60,7 @@ class FunctionalPauliRotations(BlueprintCircuit, ABC):
             basis: The Pauli rotation to be used.
 
         Raises:
-            ValueError: The provided basis in not X, Y or Z.
+            ValueError: The provided basis is not X, Y or Z.
         """
         basis = basis.lower()
         if self._basis is None or basis != self._basis:

--- a/qiskit/circuit/library/arithmetic/linear_amplitude_function.py
+++ b/qiskit/circuit/library/arithmetic/linear_amplitude_function.py
@@ -63,7 +63,7 @@ class LinearAmplitudeFunction(QuantumCircuit):
 
         f(x) = \sum_{i=1}^m 1_{[p_{i-1}, p_i]}(x) (\alpha_i x + \beta_i)
 
-    where :math:`1_{[a, b]}` is an indication function that is 1 if the argument is in the interval
+    where :math:`1_{[a, b]}` is an indicator function that is 1 if the argument is in the interval
     :math:`[a, b]` and otherwise 0. The breakpoints :math:`p_i` can be specified by the
     ``breakpoints`` argument.
 
@@ -221,7 +221,7 @@ class LinearAmplitudeFunctionGate(Gate):
 
         f(x) = \sum_{i=1}^m 1_{[p_{i-1}, p_i]}(x) (\alpha_i x + \beta_i)
 
-    where :math:`1_{[a, b]}` is an indication function that is 1 if the argument is in the interval
+    where :math:`1_{[a, b]}` is an indicator function that is 1 if the argument is in the interval
     :math:`[a, b]` and otherwise 0. The breakpoints :math:`p_i` can be specified by the
     ``breakpoints`` argument.
 

--- a/qiskit/circuit/library/arithmetic/multipliers/hrs_cumulative_multiplier.py
+++ b/qiskit/circuit/library/arithmetic/multipliers/hrs_cumulative_multiplier.py
@@ -61,7 +61,7 @@ class HRSCumulativeMultiplier(Multiplier):
 
     .. seealso::
 
-        The :class:`.MultiplierGate` objects represents a multiplication, like this circuit class,
+        The :class:`.MultiplierGate` object represents a multiplication, like this circuit class,
         but allows the compiler to select the optimal decomposition based on the context.
         Specific implementations can be set via the :class:`.HLSConfig`, e.g. this circuit
         can be chosen via ``Multiplier=["cumulative_h18"]``.

--- a/qiskit/circuit/library/arithmetic/multipliers/rg_qft_multiplier.py
+++ b/qiskit/circuit/library/arithmetic/multipliers/rg_qft_multiplier.py
@@ -26,10 +26,11 @@ class RGQFTMultiplier(Multiplier):
     r"""A QFT multiplication circuit to store product of two input registers out-of-place.
 
     Multiplication in this circuit is implemented using the procedure of Fig. 3 in [1], where
-    weighted sum rotations are implemented as given in Fig. 5 in [1]. QFT is used on the output
-    register and is followed by rotations controlled by input registers. The rotations
-    transform the state into the product of two input registers in QFT base, which is
-    reverted from QFT base using inverse QFT.
+    weighted sum rotations are implemented as given in Fig. 5 in [1]. The QFT is used on the
+    output register and is followed by rotations controlled by input registers. The rotations
+    transform the state into the product of two input registers in the QFT basis, which is
+    reverted from the QFT basis using the inverse QFT.
+
     As an example, a circuit that performs a modular QFT multiplication on two 2-qubit
     sized input registers with an output register of 2 qubits, is as follows:
 
@@ -50,7 +51,7 @@ class RGQFTMultiplier(Multiplier):
 
     .. seealso::
 
-        The :class:`.MultiplierGate` objects represents a multiplication, like this circuit class,
+        The :class:`.MultiplierGate` object represents a multiplication, like this circuit class,
         but allows the compiler to select the optimal decomposition based on the context.
         Specific implementations can be set via the :class:`.HLSConfig`, e.g. this circuit
         can be chosen via ``Multiplier=["qft_r17"]``.

--- a/qiskit/circuit/library/arithmetic/piecewise_chebyshev.py
+++ b/qiskit/circuit/library/arithmetic/piecewise_chebyshev.py
@@ -192,7 +192,7 @@ class PiecewiseChebyshev(BlueprintCircuit):
         """
         breakpoints = self._breakpoints
 
-        # it the state qubits are set ensure that the breakpoints match beginning and end
+        # if the state qubits are set ensure that the breakpoints match beginning and end
         if self.num_state_qubits is not None:
             num_states = 2**self.num_state_qubits
 
@@ -288,7 +288,7 @@ class PiecewiseChebyshev(BlueprintCircuit):
         changes.
 
         Args:
-            polynomials: The new breakpoints for the piecewise approximation.
+            polynomials: The new polynomials for the piecewise approximation.
         """
         if self._polynomials is None or polynomials != self._polynomials:
             self._invalidate()
@@ -340,7 +340,7 @@ class PiecewiseChebyshev(BlueprintCircuit):
                 self.add_register(qr_ancilla)
 
     def _build(self):
-        """Build the circuit if not already build. The operation is considered successful
+        """Build the circuit if not already built. The operation is considered successful
         when q_objective is :math:`|1>`"""
         if self._is_built:
             return

--- a/qiskit/circuit/library/arithmetic/piecewise_linear_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/piecewise_linear_pauli_rotations.py
@@ -98,7 +98,7 @@ class PiecewiseLinearPauliRotations(FunctionalPauliRotations):
 
     @property
     def slopes(self) -> list[float] | np.ndarray:
-        """The breakpoints of the piecewise linear function.
+        """The slopes of the piecewise linear function.
 
         The function is linear in the intervals ``[point_i, point_{i+1}]`` where the last
         point implicitly is ``2**(num_state_qubits + 1)``.
@@ -117,7 +117,7 @@ class PiecewiseLinearPauliRotations(FunctionalPauliRotations):
 
     @property
     def offsets(self) -> list[float] | np.ndarray:
-        """The breakpoints of the piecewise linear function.
+        """The offsets of the piecewise linear function.
 
         The function is linear in the intervals ``[point_i, point_{i+1}]`` where the last
         point implicitly is ``2**(num_state_qubits + 1)``.

--- a/qiskit/circuit/library/data_preparation/pauli_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/pauli_feature_map.py
@@ -274,8 +274,9 @@ def zz_feature_map(
         ┤ H ├┤ P(2.0*φ(x[2])) ├─────────────────────────────────┤ X ├┤ P(2.0*φ(x[1],x[2])) ├┤ X ├
         └───┘└────────────────┘                                 └───┘└─────────────────────┘└───┘
 
-    where :math:`\varphi` is a classical non-linear function, which defaults to :math:`\varphi(x) = x`
-    if and :math:`\varphi(x,y) = (\pi - x)(\pi - y)`.
+    where :math:`\varphi` is a classical non-linear function, which defaults to
+    :math:`\varphi(x) = x` for single-qubit terms and :math:`\varphi(x,y) = (\pi - x)(\pi - y)`
+    for two-qubit terms.
 
     Examples:
 

--- a/qiskit/circuit/library/generalized_gates/gr.py
+++ b/qiskit/circuit/library/generalized_gates/gr.py
@@ -88,7 +88,7 @@ class GRX(GR):
     The global RX gate is native to atomic systems (ion traps, cold neutrals). The global RX
     can be applied to multiple qubits simultaneously.
 
-    In the one-qubit case, this is equivalent to an RX(theta) operations,
+    In the one-qubit case, this is equivalent to an RX(theta) operation,
     and is thus reduced to the RXGate. The global RX gate is a direct sum of RX
     operations on all individual qubits.
 

--- a/qiskit/circuit/library/generalized_gates/mcmt.py
+++ b/qiskit/circuit/library/generalized_gates/mcmt.py
@@ -27,7 +27,7 @@ from ..standard_gates import get_standard_gate_name_mapping
 class MCMT(QuantumCircuit):
     """The multi-controlled multi-target gate, for an arbitrary singly controlled target gate.
 
-    For example, the H gate controlled on 3 qubits and acting on 2 target qubit is represented as:
+    For example, the H gate controlled on 3 qubits and acting on 2 target qubits is represented as:
 
     .. code-block:: text
 
@@ -42,7 +42,7 @@ class MCMT(QuantumCircuit):
         ┤1     ├
         └──────┘
 
-    This default implementations requires no ancilla qubits, by broadcasting the target gate
+    This default implementation requires no ancilla qubits, by broadcasting the target gate
     to the number of target qubits and using Qiskit's generic control routine to control the
     broadcasted target on the control qubits. If ancilla qubits are available, a more efficient
     variant using the so-called V-chain decomposition can be used. This is implemented in
@@ -61,12 +61,12 @@ class MCMT(QuantumCircuit):
         Args:
             gate: The gate to be applied controlled on the control qubits and applied to the target
                 qubits. Can be either a Gate or a circuit method.
-                If it is a callable, it will be casted to a Gate.
+                If it is a callable, it will be cast to a Gate.
             num_ctrl_qubits: The number of control qubits.
             num_target_qubits: The number of target qubits.
 
         Raises:
-            AttributeError: If the gate cannot be casted to a controlled gate.
+            AttributeError: If the gate cannot be cast to a controlled gate.
             AttributeError: If the number of controls or targets is 0.
         """
         if num_ctrl_qubits == 0 or num_target_qubits == 0:
@@ -188,7 +188,7 @@ class MCMTVChain(MCMT):
 class MCMTGate(ControlledGate):
     """The multi-controlled multi-target gate, for an arbitrary singly controlled target gate.
 
-    For example, the H gate controlled on 3 qubits and acting on 2 target qubit is represented as:
+    For example, the H gate controlled on 3 qubits and acting on 2 target qubits is represented as:
 
     .. parsed-literal::
 

--- a/qiskit/circuit/library/generalized_gates/unitary.py
+++ b/qiskit/circuit/library/generalized_gates/unitary.py
@@ -37,7 +37,7 @@ if typing.TYPE_CHECKING:
 
 
 class UnitaryGate(Gate):
-    """Class quantum gates specified by a unitary matrix.
+    """Class for quantum gates specified by a unitary matrix.
 
     Example:
 

--- a/qiskit/circuit/library/grover_operator.py
+++ b/qiskit/circuit/library/grover_operator.py
@@ -56,7 +56,7 @@ def grover_operator(
 
     This class allows setting a different state preparation, as in quantum amplitude
     amplification (a generalization of Grover's algorithm), :math:`\mathcal{A}` might not be
-    a layer of Hardamard gates [3].
+    a layer of Hadamard gates [3].
 
     The action of the phase oracle :math:`\mathcal{S}_f` is defined as
 
@@ -310,7 +310,7 @@ class GroverOperator(QuantumCircuit):
 
     This class allows setting a different state preparation, as in quantum amplitude
     amplification (a generalization of Grover's algorithm), :math:`\mathcal{A}` might not be
-    a layer of Hardamard gates [3].
+    a layer of Hadamard gates [3].
 
     The action of the phase oracle :math:`\mathcal{S}_f` is defined as
 

--- a/qiskit/circuit/library/iqp.py
+++ b/qiskit/circuit/library/iqp.py
@@ -76,7 +76,7 @@ class IQP(QuantumCircuit):
             interactions: input n-by-n symmetric matrix.
 
         Raises:
-            CircuitError: if the inputs is not as symmetric matrix.
+            CircuitError: if the input is not a symmetric matrix.
         """
         circuit = iqp(interactions)
         super().__init__(*circuit.qregs, name=circuit.name)

--- a/qiskit/circuit/library/n_local/efficient_su2.py
+++ b/qiskit/circuit/library/n_local/efficient_su2.py
@@ -52,7 +52,7 @@ def efficient_su2(
     :math:`SU(2)` is the special unitary group of degree 2, its elements are :math:`2 \times 2`
     unitary matrices with determinant 1, such as the Pauli rotation gates.
 
-    On 3 qubits and using the Pauli :math:`Y` and :math:`Z` rotations as single qubit gates, the
+    On 3 qubits and using the Pauli :math:`Y` and :math:`Z` rotations as single qubit gates,
     this circuit is represented by:
 
     .. parsed-literal::
@@ -158,7 +158,7 @@ class EfficientSU2(TwoLocal):
         └──────────┘└──────────┘ ░ └───┘      ░       ░ └───────────┘└───────────┘
 
     See :class:`~qiskit.circuit.library.RealAmplitudes` for more detail on the possible arguments
-    and options such as skipping unentanglement qubits, which apply here too.
+    and options such as skipping unentangled qubits, which apply here too.
 
     Examples:
 

--- a/qiskit/circuit/library/n_local/evolved_operator_ansatz.py
+++ b/qiskit/circuit/library/n_local/evolved_operator_ansatz.py
@@ -82,7 +82,7 @@ def evolved_operator_ansatz(
         insert_barriers: Whether to insert barriers in between each evolution.
         name: The name of the circuit.
         parameter_prefix: Set the names of the circuit parameters. If a string, the same prefix
-            will be used for each parameters. Can also be a list to specify a prefix per
+            will be used for each parameter. Can also be a list to specify a prefix per
             operator.
         remove_identities: If ``True``, ignore identity operators (note that we do not check
             :class:`.Operator` inputs). This will also remove parameters associated with identities.
@@ -255,7 +255,7 @@ def hamiltonian_variational_ansatz(
         insert_barriers: Whether to insert barriers in between each evolution.
         name: The name of the circuit.
         parameter_prefix: Set the names of the circuit parameters. If a string, the same prefix
-            will be used for each parameters. Can also be a list to specify a prefix per
+            will be used for each parameter. Can also be a list to specify a prefix per
             operator.
 
     References:
@@ -311,7 +311,7 @@ class EvolvedOperatorAnsatz(NLocal):
             insert_barriers: Whether to insert barriers in between each evolution.
             name: The name of the circuit.
             parameter_prefix: Set the names of the circuit parameters. If a string, the same prefix
-                will be used for each parameters. Can also be a list to specify a prefix per
+                will be used for each parameter. Can also be a list to specify a prefix per
                 operator.
             initial_state: A :class:`.QuantumCircuit` object to prepend to the circuit.
             flatten: Set this to ``True`` to output a flat circuit instead of nesting it inside multiple

--- a/qiskit/circuit/library/n_local/excitation_preserving.py
+++ b/qiskit/circuit/library/n_local/excitation_preserving.py
@@ -62,7 +62,7 @@ def excitation_preserving(
     a simpler pattern.
 
     This trial wave function consists of layers of :math:`Z` rotations with 2-qubit entanglements.
-    The entangling is created using :math:`XX+YY` rotations and optionally a controlled-phase
+    The entanglement is created using :math:`XX+YY` rotations and optionally a controlled-phase
     gate for the mode ``"fsim"``.
 
     Examples:
@@ -164,7 +164,7 @@ class ExcitationPreserving(TwoLocal):
     a simpler pattern.
 
     This trial wave function consists of layers of :math:`Z` rotations with 2-qubit entanglements.
-    The entangling is created using :math:`XX+YY` rotations and optionally a controlled-phase
+    The entanglement is created using :math:`XX+YY` rotations and optionally a controlled-phase
     gate for the mode ``'fsim'``.
 
     See :class:`~qiskit.circuit.library.RealAmplitudes` for more detail on the possible arguments

--- a/qiskit/circuit/library/n_local/excitation_preserving.py
+++ b/qiskit/circuit/library/n_local/excitation_preserving.py
@@ -62,7 +62,7 @@ def excitation_preserving(
     a simpler pattern.
 
     This trial wave function consists of layers of :math:`Z` rotations with 2-qubit entanglements.
-    The entangling is creating using :math:`XX+YY` rotations and optionally a controlled-phase
+    The entangling is created using :math:`XX+YY` rotations and optionally a controlled-phase
     gate for the mode ``"fsim"``.
 
     Examples:
@@ -164,11 +164,11 @@ class ExcitationPreserving(TwoLocal):
     a simpler pattern.
 
     This trial wave function consists of layers of :math:`Z` rotations with 2-qubit entanglements.
-    The entangling is creating using :math:`XX+YY` rotations and optionally a controlled-phase
+    The entangling is created using :math:`XX+YY` rotations and optionally a controlled-phase
     gate for the mode ``'fsim'``.
 
     See :class:`~qiskit.circuit.library.RealAmplitudes` for more detail on the possible arguments
-    and options such as skipping unentanglement qubits, which apply here too.
+    and options such as skipping unentangled qubits, which apply here too.
 
     The rotations of the ExcitationPreserving ansatz can be written as
 

--- a/qiskit/circuit/library/n_local/n_local.py
+++ b/qiskit/circuit/library/n_local/n_local.py
@@ -108,7 +108,7 @@ def n_local(
     gate should acts, e.g. ``[[ctrl0, target0], [ctrl1, target1], ...]``.
     A set of default entanglement strategies is provided and can be selected by name:
 
-    * ``"full"`` entanglement is each qubit is entangled with all the others.
+    * ``"full"`` entanglement is where each qubit is entangled with all the others.
     * ``"linear"`` entanglement is qubit :math:`i` entangled with qubit :math:`i + 1`,
         for all :math:`i \in \{0, 1, ... , n - 2\}`, where :math:`n` is the total number of qubits.
     * ``"reverse_linear"`` entanglement is qubit :math:`i` entangled with qubit :math:`i + 1`,

--- a/qiskit/circuit/library/n_local/pauli_two_design.py
+++ b/qiskit/circuit/library/n_local/pauli_two_design.py
@@ -39,7 +39,7 @@ def pauli_two_design(
     The circuit consists of alternating rotation and entanglement layers with
     an initial layer of :math:`\sqrt{H} = RY(\pi/4)` gates.
     The rotation layers contain single qubit Pauli rotations, where the axis is chosen uniformly
-    at random to be X, Y or Z. The entanglement layer is comprised of pairwise CZ gates
+    at random to be X, Y or Z. The entanglement layers are comprised of pairwise CZ gates
     with a total depth of 2.
 
     For instance, the circuit could look like this:
@@ -122,13 +122,13 @@ class PauliTwoDesign(TwoLocal):
     r"""The Pauli Two-Design ansatz.
 
     This class implements a particular form of a 2-design circuit [1], which is frequently studied
-    in quantum machine learning literature, such as the investigation of Barren plateaus in
+    in quantum machine learning literature, such as the investigation of barren plateaus in
     variational algorithms [2].
 
     The circuit consists of alternating rotation and entanglement layers with
     an initial layer of :math:`\sqrt{H} = RY(\pi/4)` gates.
     The rotation layers contain single qubit Pauli rotations, where the axis is chosen uniformly
-    at random to be X, Y or Z. The entanglement layer is comprised of pairwise CZ gates
+    at random to be X, Y or Z. The entanglement layers are comprised of pairwise CZ gates
     with a total depth of 2.
 
     For instance, the circuit could look like this (but note that choosing a different seed

--- a/qiskit/circuit/library/n_local/pauli_two_design.py
+++ b/qiskit/circuit/library/n_local/pauli_two_design.py
@@ -39,7 +39,7 @@ def pauli_two_design(
     The circuit consists of alternating rotation and entanglement layers with
     an initial layer of :math:`\sqrt{H} = RY(\pi/4)` gates.
     The rotation layers contain single qubit Pauli rotations, where the axis is chosen uniformly
-    at random to be X, Y or Z. The entanglement layers is compromised of pairwise CZ gates
+    at random to be X, Y or Z. The entanglement layer is comprised of pairwise CZ gates
     with a total depth of 2.
 
     For instance, the circuit could look like this:
@@ -122,13 +122,13 @@ class PauliTwoDesign(TwoLocal):
     r"""The Pauli Two-Design ansatz.
 
     This class implements a particular form of a 2-design circuit [1], which is frequently studied
-    in quantum machine learning literature, such as e.g. the investigating of Barren plateaus in
+    in quantum machine learning literature, such as the investigation of Barren plateaus in
     variational algorithms [2].
 
     The circuit consists of alternating rotation and entanglement layers with
     an initial layer of :math:`\sqrt{H} = RY(\pi/4)` gates.
     The rotation layers contain single qubit Pauli rotations, where the axis is chosen uniformly
-    at random to be X, Y or Z. The entanglement layers is compromised of pairwise CZ gates
+    at random to be X, Y or Z. The entanglement layer is comprised of pairwise CZ gates
     with a total depth of 2.
 
     For instance, the circuit could look like this (but note that choosing a different seed

--- a/qiskit/circuit/library/n_local/real_amplitudes.py
+++ b/qiskit/circuit/library/n_local/real_amplitudes.py
@@ -261,7 +261,7 @@ class RealAmplitudes(TwoLocal):
             reps: Specifies how often the structure of a rotation layer followed by an entanglement
                 layer is repeated.
             entanglement: Specifies the entanglement structure. Can be a string ('full', 'linear'
-                'reverse_linear, 'circular' or 'sca'), a list of integer-pairs specifying the indices
+                'reverse_linear', 'circular' or 'sca'), a list of integer-pairs specifying the indices
                 of qubits entangled with one another, or a callable returning such a list provided with
                 the index of the entanglement layer.
                 Default to 'reverse_linear' entanglement.

--- a/qiskit/circuit/library/n_local/two_local.py
+++ b/qiskit/circuit/library/n_local/two_local.py
@@ -39,7 +39,7 @@ class TwoLocal(NLocal):
 
     A set of default entanglement strategies is provided:
 
-    * ``'full'`` entanglement is each qubit is entangled with all the others.
+    * ``'full'`` entanglement is where each qubit is entangled with all the others.
     * ``'linear'`` entanglement is qubit :math:`i` entangled with qubit :math:`i + 1`,
       for all :math:`i \in \{0, 1, ... , n - 2\}`, where :math:`n` is the total number of qubits.
     * ``'reverse_linear'`` entanglement is qubit :math:`i` entangled with qubit :math:`i + 1`,
@@ -176,7 +176,7 @@ class TwoLocal(NLocal):
             num_qubits: The number of qubits of the two-local circuit.
             rotation_blocks: The gates used in the rotation layer. Can be specified via the name of
                 a gate (e.g. ``'ry'``) or the gate type itself (e.g. :class:`.RYGate`).
-                If only one gate is provided, the gate same gate is applied to each qubit.
+                If only one gate is provided, the same gate is applied to each qubit.
                 If a list of gates is provided, all gates are applied to each qubit in the provided
                 order.
                 See the Examples section for more detail.

--- a/qiskit/circuit/library/phase_estimation.py
+++ b/qiskit/circuit/library/phase_estimation.py
@@ -65,7 +65,7 @@ class PhaseEstimation(QuantumCircuit):
         Args:
             num_evaluation_qubits: The number of evaluation qubits.
             unitary: The unitary operation :math:`U` which will be repeated and controlled.
-            iqft: A inverse Quantum Fourier Transform, per default the inverse of
+            iqft: An inverse Quantum Fourier Transform, per default the inverse of
                 :class:`~qiskit.circuit.library.QFT` is used. Note that the QFT should not include
                 the usual swaps!
             name: The name of the circuit.

--- a/qiskit/circuit/library/phase_oracle.py
+++ b/qiskit/circuit/library/phase_oracle.py
@@ -116,9 +116,9 @@ class PhaseOracle(QuantumCircuit):
         the CNF is over three boolean variables --- let us call them  :math:`x_1, x_2, x_3`, and
         contains five clauses.  The five clauses, listed afterwards, are implicitly joined by the
         logical `AND` operator, :math:`\land`, while the variables in each clause, represented by
-        their indices, are implicitly disjoined by the logical `OR` operator, :math:`lor`. The
+        their indices, are implicitly disjoined by the logical `OR` operator, :math:`\lor`. The
         :math:`-` symbol preceding a boolean variable index corresponds to the logical `NOT`
-        operator, :math:`lnot`. Character `0` (zero) marks the end of each clause.  Essentially,
+        operator, :math:`\lnot`. Character `0` (zero) marks the end of each clause.  Essentially,
         the code above corresponds to the following CNF:
 
         :math:`(\lnot x_1 \lor \lnot x_2 \lor \lnot x_3)

--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -67,7 +67,7 @@ class RZGate(Gate):
     def __init__(self, phi: ParameterValueType, label: Optional[str] = None):
         """
         Args:
-            theta: The rotation angle.
+            phi: The rotation angle.
             label: An optional label for the gate.
         """
         super().__init__("rz", 1, [phi], label=label)

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -89,7 +89,7 @@ class UGate(Gate):
     ):
         r"""
         Args:
-            theta: The angle :math:`\theta corresponding to the :math:`R_Y(\theta)` rotation.
+            theta: The angle :math:`\theta` corresponding to the :math:`R_Y(\theta)` rotation.
             phi: The angle :math:`\phi` corresponding to the :math:`R_Z(\phi)` rotation.
             lam: The angle :math:`\lambda` corresponding to the :math:`R_Z(\lambda)` rotation.
             label: An optional label for the gate.

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -918,7 +918,7 @@ class MCXGate(ControlledGate):
             "Instead, it is recommended to use MCXGate and let HighLevelSynthesis choose "
             "the best synthesis method depending on the number of ancilla qubits available. "
             "However, if a specific synthesis method using a specific number of ancilla "
-            "qubits is require, one can create a custom gate by calling the corresponding "
+            "qubits is required, one can create a custom gate by calling the corresponding "
             "synthesis function directly."
         ),
         since="2.1",

--- a/qiskit/circuit/library/standard_gates/z.py
+++ b/qiskit/circuit/library/standard_gates/z.py
@@ -109,7 +109,7 @@ class ZGate(SingletonGate):
 
         For a single control qubit, the controlled gate is implemented as a
         :class:`.CZGate`. For two control qubits, the controlled gate is implemented
-        as a :class:`.CCZGate`. In these cases, the the value of ``annotated`` is ignored.
+        as a :class:`.CCZGate`. In these cases, the value of ``annotated`` is ignored.
 
         For three or more control qubits, the controlled gate is implemented
         as either :class:`.ControlledGate` when ``annotated`` is ``False``, and

--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -61,7 +61,7 @@ def sympify(expression):
     .. note::
 
         This is for interoperability only.  Qiskit will not accept or work with raw Sympy or
-        Symegine expressions in its parameters, because they do not contain the tracking
+        Symengine expressions in its parameters, because they do not contain the tracking
         information used in circuit-parameter binding and assignment.
     """
     import sympy

--- a/qiskit/circuit/parametervector.py
+++ b/qiskit/circuit/parametervector.py
@@ -28,7 +28,7 @@ class ParameterVector:
     The elements of a vector are sorted by the name of the vector, then the numeric value of their
     index.
 
-    This class fulfill the :class:`collections.abc.Sequence` interface.
+    This class fulfills the :class:`collections.abc.Sequence` interface.
     """
 
     __slots__ = ("_name", "_params", "_root_uuid")
@@ -99,8 +99,8 @@ class ParameterVector:
         >>> from qiskit.circuit import ParameterVector
         >>> pv = ParameterVector("theta", 20)
         >>> elt_19 = pv[19]
-        >>> rv.resize(10)
-        >>> rv.resize(20)
+        >>> pv.resize(10)
+        >>> pv.resize(20)
         >>> pv[19] == elt_19
         True
         """

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -332,7 +332,7 @@ class QuantumCircuit:
 
     Similarly, if you want a circuit that contains all the same data objects (bits, registers,
     variables, etc) but with none of the instructions, you can use :meth:`copy_empty_like`.  This is
-    quite common when you want to build up a new layer of a circuit to then use apply onto the back
+    quite common when you want to build up a new layer of a circuit to then apply onto the back
     with :meth:`compose`, or to do a full rewrite of a circuit's instructions.
 
     .. automethod:: copy_empty_like
@@ -419,7 +419,7 @@ class QuantumCircuit:
     -------------------------------
 
     A :class:`.Bit` instance is, on its own, just a unique handle for circuits to use in their own
-    contexts.  If you have got a :class:`.Bit` instance and a circuit, just can find the contexts
+    contexts.  If you have got a :class:`.Bit` instance and a circuit, you can find the contexts
     that the bit exists in using :meth:`find_bit`, such as its integer index in the circuit and any
     registers it is contained in.
 
@@ -812,7 +812,7 @@ class QuantumCircuit:
 
     :class:`QuantumCircuit` has corresponding methods for all of the control-flow operations that
     are supported by Qiskit.  These have two forms for calling them.  The first is a very
-    straightfowards convenience wrapper that takes in the block bodies of the instructions as
+    straightforward convenience wrapper that takes in the block bodies of the instructions as
     :class:`QuantumCircuit` arguments, and simply constructs and appends the corresponding
     :class:`.ControlFlowOp`.
 
@@ -978,7 +978,7 @@ class QuantumCircuit:
     ==============================
 
     Circuits are a fairly low-level abstraction of quantum algorithms.  However, even within this,
-    there are distinctions. Quantum programmers often want to use a wide arrange of gates and
+    there are distinctions. Quantum programmers often want to use a wide array of gates and
     instructions, and work in a regime where all qubits and interact with all others.  Quantum
     hardware, however, typically has a restrictive set of native gates, and only certain pairs of
     hardware qubits can interact.  We term these two regimes "abstract circuits" and "physical
@@ -3920,7 +3920,7 @@ class QuantumCircuit:
                   the location specified in ``~/.qiskit/settings.conf``.
                 * If a dictionary, every entry overrides the default configuration. If the
                   ``"name"`` key is given, the default configuration is given by that style.
-                  For example, ``{"name": "textbook", "subfontsize": 5}`` loads the ``"texbook"``
+                  For example, ``{"name": "textbook", "subfontsize": 5}`` loads the ``"textbook"``
                   style and sets the subfontsize (e.g. the gate angles) to ``5``.
                 * If ``None`` the default style ``"iqp"`` is used or, if given, the default style
                   specified in ``~/.qiskit/settings.conf``.
@@ -3947,7 +3947,7 @@ class QuantumCircuit:
                 the ``text`` output, will be silently ignored otherwise.
             idle_wires: Include (or not) idle wires (wires with no circuit elements)
                 in output visualization. The string ``"auto"`` is also possible, in which
-                case idle wires are show except that the circuit has a layout attached.
+                case idle wires are shown except when the circuit has a layout attached.
                 Default is ``"auto"`` unless the
                 user config file (usually ``~/.qiskit/settings.conf``) has an
                 alternative value set. For example, ``circuit_idle_wires = False``.
@@ -3975,7 +3975,7 @@ class QuantumCircuit:
             expr_len: The number of characters to display if an :class:`~.expr.Expr`
                 is used for the condition in a :class:`.ControlFlowOp`. If this number is exceeded,
                 the string will be truncated at that number and '...' added to the end.
-            measure_arrows: If True, draw an arrow from each measure box down the the classical bit
+            measure_arrows: If True, draw an arrow from each measure box down to the classical bit
                 or register where the measure value is placed. If False, do not draw arrow, but
                 instead place the name of the bit or register in the measure box.
                 Default is ``True`` unless the user config file (usually ``~/.qiskit/settings.conf``)
@@ -4218,7 +4218,7 @@ class QuantumCircuit:
         """Get instructions matching name.
 
         Args:
-            name (str): The name of instruction to.
+            name (str): The name of instruction to get.
 
         Returns:
             list(tuple): list of (instruction, qargs, cargs).
@@ -5207,7 +5207,7 @@ class QuantumCircuit:
         For the full matrix form of this gate, see the underlying gate documentation.
 
         Args:
-            theta: THe angle of the rotation.
+            theta: The angle of the rotation.
             qubit: The qubit(s) to apply the gate to.
 
         Returns:
@@ -7025,7 +7025,7 @@ class QuantumCircuit:
                 if given an iterable of :class:`.Annotation` objects, the context-manager form of
                 this method is triggered.
             qubits: the qubits to apply the :class:`.BoxOp` to, in the explicit form.
-            clbits: the qubits to apply the :class:`.BoxOp` to, in the explicit form.
+            clbits: the clbits to apply the :class:`.BoxOp` to, in the explicit form.
             label: an optional string label for the instruction.
             duration: an optional explicit duration for the :class:`.BoxOp`.  Scheduling passes are
                 constrained to schedule the contained scope to match a given duration, including

--- a/qiskit/circuit/singleton.py
+++ b/qiskit/circuit/singleton.py
@@ -132,7 +132,7 @@ If your constructor does not have defaults for all its arguments, you must set
 
 Subclasses of :class:`SingletonInstruction` and the other associated classes can control how their
 constructor's arguments are interpreted, in order to help the singleton machinery return the
-singleton even in the case than an optional argument is explicitly set to its default.
+singleton even in the case that an optional argument is explicitly set to its default.
 
 .. automethod:: SingletonInstruction._singleton_lookup_key
 


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixing typos in `qiskit.circuits`, as found by Claude.

### Details and comments

AI tool used: claude opus 4.6
