### PR TITLE
Fix typos in qiskit.synthesis

### DIFF
--- a/qiskit/synthesis/arithmetic/adders/__init__.py
+++ b/qiskit/synthesis/arithmetic/adders/__init__.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Module containing multi-controlled circuits synthesis"""
+"""Module containing adder circuits synthesis"""
 
 from .cdkm_ripple_carry_adder import adder_ripple_c04
 from .vbe_ripple_carry_adder import adder_ripple_v95

--- a/qiskit/synthesis/arithmetic/weighted_sum.py
+++ b/qiskit/synthesis/arithmetic/weighted_sum.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Implement a integer-weighted sum over a set of qubits."""
+"""Implement an integer-weighted sum over a set of qubits."""
 
 from __future__ import annotations
 

--- a/qiskit/synthesis/boolean/boolean_expression.py
+++ b/qiskit/synthesis/boolean/boolean_expression.py
@@ -226,7 +226,7 @@ class BooleanExpression:
             FileNotFoundError: If filename is not found.
         """
         if not isfile(filename):
-            raise FileNotFoundError(f"The file {filename} does not exists.")
+            raise FileNotFoundError(f"The file {filename} does not exist.")
         with open(filename, "r") as dimacs_file:
             dimacs = dimacs_file.read()
         return BooleanExpression.from_dimacs(dimacs)

--- a/qiskit/synthesis/clifford/clifford_decompose_greedy.py
+++ b/qiskit/synthesis/clifford/clifford_decompose_greedy.py
@@ -14,7 +14,7 @@ Circuit synthesis for the Clifford class.
 """
 
 # ---------------------------------------------------------------------
-# Synthesis based on Bravyi et. al. greedy clifford compiler
+# Synthesis based on Bravyi et al. greedy clifford compiler
 # ---------------------------------------------------------------------
 
 from qiskit.circuit import QuantumCircuit

--- a/qiskit/synthesis/clifford/clifford_decompose_layers.py
+++ b/qiskit/synthesis/clifford/clifford_decompose_layers.py
@@ -229,7 +229,7 @@ def _create_graph_state(cliff, validate=False):
             for i in range(rank, num_qubits):
                 if stab[i, 0:num_qubits].any():
                     raise QiskitError(
-                        "After Gauss elimination, the final num_qubits - rank rows"
+                        "After Gauss elimination, the final num_qubits - rank rows "
                         "contain non-zero elements"
                     )
 
@@ -348,7 +348,7 @@ def _decompose_hadamard_free(
     if validate:
         if (destabz_update != destabz_update.T).any():
             raise QiskitError(
-                "The multiplication of the inverse of destabx and"
+                "The multiplication of the inverse of destabx and "
                 "destabz is not a symmetric matrix."
             )
 

--- a/qiskit/synthesis/clifford/clifford_decompose_layers.py
+++ b/qiskit/synthesis/clifford/clifford_decompose_layers.py
@@ -348,8 +348,8 @@ def _decompose_hadamard_free(
     if validate:
         if (destabz_update != destabz_update.T).any():
             raise QiskitError(
-                "The multiplication of the inverse of destabx and "
-                "destabz is not a symmetric matrix."
+                "The matrix product inv(destabx) * destabz "
+                "for the given Clifford is not a symmetric matrix."
             )
 
     S2_circ = QuantumCircuit(num_qubits, name="S2")

--- a/qiskit/synthesis/cnotdihedral/cnotdihedral_decompose_general.py
+++ b/qiskit/synthesis/cnotdihedral/cnotdihedral_decompose_general.py
@@ -84,7 +84,7 @@ def synth_cnotdihedral_general(elem: CNOTDihedral) -> QuantumCircuit:
     ):
         raise QiskitError("Cannot do Gauss elimination on linear part.")
 
-    # Initialize new_elem to an identity CNOTDihderal element
+    # Initialize new_elem to an identity CNOTDihedral element
     new_elem = elem_cpy.copy()
     new_elem.poly.weight_0 = 0
     new_elem.poly.weight_1 = np.zeros(num_qubits, dtype=np.int8)

--- a/qiskit/synthesis/cnotdihedral/cnotdihedral_decompose_two_qubits.py
+++ b/qiskit/synthesis/cnotdihedral/cnotdihedral_decompose_two_qubits.py
@@ -31,7 +31,7 @@ def synth_cnotdihedral_two_qubits(elem: CNOTDihedral) -> QuantumCircuit:
         A circuit implementation of the :class:`.CNOTDihedral` element.
 
     Raises:
-        QiskitError: if the element in not 1-qubit or 2-qubit :class:`.CNOTDihedral`.
+        QiskitError: if the element is not 1-qubit or 2-qubit :class:`.CNOTDihedral`.
 
     References:
         1. Shelly Garion and Andrew W. Cross, *On the structure of the CNOT-Dihedral group*,
@@ -48,7 +48,7 @@ def synth_cnotdihedral_two_qubits(elem: CNOTDihedral) -> QuantumCircuit:
 
     if elem.num_qubits == 1:
         if elem.poly.weight_0 != 0 or elem.linear != [[1]]:
-            raise QiskitError("1-qubit element in not CNOT-Dihedral .")
+            raise QiskitError("1-qubit element is not CNOT-Dihedral.")
         tpow0 = elem.poly.weight_1[0]
         xpow0 = elem.shift[0]
         if tpow0 > 0:
@@ -61,7 +61,7 @@ def synth_cnotdihedral_two_qubits(elem: CNOTDihedral) -> QuantumCircuit:
 
     # case elem.num_qubits == 2:
     if elem.poly.weight_0 != 0:
-        raise QiskitError("2-qubit element in not CNOT-Dihedral .")
+        raise QiskitError("2-qubit element is not CNOT-Dihedral.")
     weight_1 = elem.poly.weight_1
     weight_2 = elem.poly.weight_2
     linear = elem.linear

--- a/qiskit/synthesis/discrete_basis/solovay_kitaev.py
+++ b/qiskit/synthesis/discrete_basis/solovay_kitaev.py
@@ -55,7 +55,7 @@ class SolovayKitaevDecomposition:
 
         Args:
             basic_approximations: A specification of the basic SO(3) approximations in terms
-                of discrete gates. At each iteration this algorithm, the remaining error is
+                of discrete gates. At each iteration of this algorithm, the remaining error is
                 approximated with the closest sequence of gates in this set.
                 If a ``str``, this specifies a filename from which to load the
                 approximation. If a ``dict``, then this contains

--- a/qiskit/synthesis/evolution/evolution_synthesis.py
+++ b/qiskit/synthesis/evolution/evolution_synthesis.py
@@ -23,7 +23,7 @@ class EvolutionSynthesis(ABC):
 
     @abstractmethod
     def synthesize(self, evolution):
-        """Synthesize an ``qiskit.circuit.library.PauliEvolutionGate``.
+        """Synthesize a ``qiskit.circuit.library.PauliEvolutionGate``.
 
         Args:
             evolution (PauliEvolutionGate): The evolution gate to synthesize.

--- a/qiskit/synthesis/evolution/matrix_synthesis.py
+++ b/qiskit/synthesis/evolution/matrix_synthesis.py
@@ -20,7 +20,7 @@ from .evolution_synthesis import EvolutionSynthesis
 class MatrixExponential(EvolutionSynthesis):
     r"""Exact operator evolution via matrix exponentiation and unitary synthesis.
 
-    This class synthesis the exponential of operators by calculating their exponentially-sized
+    This class synthesizes the exponential of operators by calculating their exponentially-sized
     matrix representation and using exact matrix exponentiation followed by unitary synthesis
     to obtain a circuit. This process is not scalable and serves as comparison or benchmark
     for small systems.

--- a/qiskit/synthesis/evolution/suzuki_trotter.py
+++ b/qiskit/synthesis/evolution/suzuki_trotter.py
@@ -132,7 +132,7 @@ class SuzukiTrotter(ProductFormula):
 
             ("X", [0], t), ("ZZ", [0, 1], 2t), ("X", [0], t)
 
-        Note that the rotation angle contains a factor of 2, such that that evolution
+        Note that the rotation angle contains a factor of 2, such that the evolution
         of a Pauli :math:`P` over time :math:`t`, which is :math:`e^{itP}`, is represented
         by ``(P, indices, 2 * t)``.
 

--- a/qiskit/synthesis/linear/__init__.py
+++ b/qiskit/synthesis/linear/__init__.py
@@ -21,6 +21,6 @@ from .linear_matrix_utils import (
     binary_matmul,
 )
 
-# This is re-import is kept for compatibility with Terra 0.23. Eligible for deprecation in 0.25+.
+# This re-import is kept for compatibility with Terra 0.23. Eligible for deprecation in 0.25+.
 # pylint: disable=cyclic-import,wrong-import-order
 from qiskit.synthesis.linear_phase import synth_cnot_phase_aam as graysynth

--- a/qiskit/synthesis/linear/linear_circuits_utils.py
+++ b/qiskit/synthesis/linear/linear_circuits_utils.py
@@ -50,7 +50,7 @@ def optimize_cx_4_options(function: Callable, mat: np.ndarray, optimize_count: b
     Args:
         function: the synthesis function.
         mat: a binary invertible matrix.
-        optimize_count: True if the number of CX gates in optimize, False if the depth is optimized.
+        optimize_count: True if the number of CX gates is optimized, False if the depth is optimized.
 
     Returns:
         QuantumCircuit: an optimized :class:`.QuantumCircuit`, has the best depth or CX count of

--- a/qiskit/synthesis/linear/linear_depth_lnn.py
+++ b/qiskit/synthesis/linear/linear_depth_lnn.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 
 """
-Optimize the synthesis of an n-qubit circuit contains only CX gates for
+Optimize the synthesis of an n-qubit circuit containing only CX gates for
 linear nearest neighbor (LNN) connectivity.
 The depth of the circuit is bounded by 5*n, while the gate count is approximately 2.5*n^2
 

--- a/qiskit/synthesis/linear_phase/cx_cz_depth_lnn.py
+++ b/qiskit/synthesis/linear_phase/cx_cz_depth_lnn.py
@@ -17,7 +17,7 @@ Return a depth-5n circuit implementation of the -CZ-CX- transformation over LNN.
 
 Args:
     mat_z: n*n symmetric binary matrix representing a -CZ- circuit
-    mat_x: n*n invertable binary matrix representing a -CX- transformation
+    mat_x: n*n invertible binary matrix representing a -CX- transformation
 
 Output:
     QuantumCircuit: :class:`.QuantumCircuit` object containing a depth-5n circuit to implement -CZ-CX-

--- a/qiskit/synthesis/multi_controlled/mcx_synthesis.py
+++ b/qiskit/synthesis/multi_controlled/mcx_synthesis.py
@@ -331,7 +331,7 @@ def synth_mcx_noaux_hp24(num_ctrl_qubits: int) -> QuantumCircuit:
 
 def _n_parallel_ccx_x(n: int, apply_x: bool = True) -> QuantumCircuit:
     r"""
-    Construct a quantum circuit for creating n-condionally clean ancillae using 3n qubits. This
+    Construct a quantum circuit for creating n-conditionally clean ancillae using 3n qubits. This
     implements Fig. 4a of [1]. The circuit applies n relative CCX (RCCX) gates . If apply_x is True,
     each RCCX gate is preceded by an X gate on the target qubit. The order of returned qubits is
     qr_a, qr_b, qr_target.
@@ -537,7 +537,7 @@ def _build_logn_depth_ccx_ladder(
     ancilla_idx: int, ctrls: list[int], skip_cond_clean: bool = False
 ) -> tuple[QuantumCircuit, list[int]]:
     r"""
-    Helper function to build a log-depth ladder compose of CCX and X gates as shown in Fig. 4b of [1].
+    Helper function to build a log-depth ladder composed of CCX and X gates as shown in Fig. 4b of [1].
 
     Args:
         ancilla_idx: Index of the ancillary qubit.

--- a/qiskit/synthesis/multi_controlled/multi_control_rotation_gates.py
+++ b/qiskit/synthesis/multi_controlled/multi_control_rotation_gates.py
@@ -130,7 +130,9 @@ def _mcsu2_real_diagonal(
             raise QiskitError(f"The unitary must be a 2x2 matrix, but has shape {unitary.shape}.")
 
         if not is_unitary_matrix(unitary):
-            raise QiskitError(f"The unitary must be a unitary matrix, but is {unitary}.")
+            raise QiskitError(
+                f"The unitary for the input gate must be a unitary matrix, but is {unitary}."
+            )
 
         if not np.isclose(1.0, np.linalg.det(unitary)):
             raise QiskitError(

--- a/qiskit/synthesis/multi_controlled/multi_control_rotation_gates.py
+++ b/qiskit/synthesis/multi_controlled/multi_control_rotation_gates.py
@@ -130,7 +130,7 @@ def _mcsu2_real_diagonal(
             raise QiskitError(f"The unitary must be a 2x2 matrix, but has shape {unitary.shape}.")
 
         if not is_unitary_matrix(unitary):
-            raise QiskitError(f"The unitary in must be an unitary matrix, but is {unitary}.")
+            raise QiskitError(f"The unitary must be a unitary matrix, but is {unitary}.")
 
         if not np.isclose(1.0, np.linalg.det(unitary)):
             raise QiskitError(

--- a/qiskit/synthesis/one_qubit/one_qubit_decompose.py
+++ b/qiskit/synthesis/one_qubit/one_qubit_decompose.py
@@ -207,7 +207,7 @@ class OneQubitEulerDecomposer:
         # Convert to numpy array in case not already an array
         unitary = np.asarray(unitary, dtype=complex)
 
-        # Check input is a 2-qubit unitary
+        # Check input is a 1-qubit unitary
         if unitary.shape != (2, 2):
             raise QiskitError("OneQubitEulerDecomposer: expected 2x2 input matrix")
         if not is_unitary_matrix(unitary):

--- a/qiskit/synthesis/permutation/permutation_lnn.py
+++ b/qiskit/synthesis/permutation/permutation_lnn.py
@@ -47,7 +47,7 @@ def synth_permutation_depth_lnn_kms(pattern: list[int] | np.ndarray[int]) -> Qua
     # In Qiskit, the permutation pattern [2, 4, 3, 0, 1] means that
     # the permutation that maps qubit 2 to position 0, 4 to 1, 3 to 2, 0 to 3, and 1 to 4.
     # In the permutation synthesis code below the notation is opposite:
-    # [2, 4, 3, 0, 1] means that 0 maps to 2, 1 to 3, 2 to 3, 3 to 0, and 4 to 1.
+    # [2, 4, 3, 0, 1] means that 0 maps to 2, 1 to 4, 2 to 3, 3 to 0, and 4 to 1.
     # This is why we invert the pattern.
     return QuantumCircuit._from_circuit_data(
         _synth_permutation_depth_lnn_kms(pattern), legacy_qubits=True

--- a/qiskit/synthesis/qft/__init__.py
+++ b/qiskit/synthesis/qft/__init__.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Module containing stabilizer QFT circuit synthesis."""
+"""Module containing QFT circuit synthesis."""
 
 from .qft_decompose_lnn import synth_qft_line
 from .qft_decompose_full import synth_qft_full

--- a/qiskit/synthesis/stabilizer/stabilizer_decompose.py
+++ b/qiskit/synthesis/stabilizer/stabilizer_decompose.py
@@ -42,7 +42,7 @@ def synth_stabilizer_layers(
     """Synthesis of a stabilizer state into layers.
 
     It provides a similar decomposition to the synthesis described in Lemma 8 of reference [1],
-    without the initial Hadamard-free sub-circuit which do not affect the stabilizer state.
+    without the initial Hadamard-free sub-circuit which does not affect the stabilizer state.
 
     For example, a 5-qubit stabilizer state is decomposed into the following layers:
 

--- a/qiskit/synthesis/two_qubit/xx_decompose/decomposer.py
+++ b/qiskit/synthesis/two_qubit/xx_decompose/decomposer.py
@@ -55,7 +55,7 @@ def _average_infidelity(p, q):
 class XXDecomposer:
     r"""
     A class for optimal decomposition of 2-qubit unitaries into 2-qubit basis gates of ``XX`` type
-    (i.e., each locally equivalent to :math:`CAN(\alpha, 0, 0)` for a possibly varying :math:`alpha`).
+    (i.e., each locally equivalent to :math:`CAN(\alpha, 0, 0)` for a possibly varying :math:`\alpha`).
 
     Args:
         basis_fidelity: available strengths and fidelity of each.

--- a/qiskit/synthesis/two_qubit/xx_decompose/polytopes.py
+++ b/qiskit/synthesis/two_qubit/xx_decompose/polytopes.py
@@ -57,7 +57,7 @@ class PolytopeData:
 
 def polytope_has_element(polytope, point):
     """
-    Tests whether `polytope` contains `point.
+    Tests whether `polytope` contains `point`.
     """
     return all(
         -EPSILON <= inequality[0] + sum(x * y for x, y in zip(point, inequality[1:]))

--- a/qiskit/synthesis/unitary/aqc/__init__.py
+++ b/qiskit/synthesis/unitary/aqc/__init__.py
@@ -55,7 +55,7 @@ To properly define what we mean by best circuit representation, we define the me
 as the Frobenius norm between the unitary matrix of the compiled circuit :math:`V` and
 the target unitary matrix :math:`U`, i.e., :math:`\|V - U\|_{\mathrm{F}}`. This choice
 is motivated by mathematical programming considerations, and it is related to other
-formulations that appear in the literature. Let's take a look at the problem in more details.
+formulations that appear in the literature. Let's take a look at the problem in more detail.
 
 Let :math:`n` be the number of qubits and :math:`d=2^n`. Given a CNOT structure :math:`ct`
 and a vector of rotation angles :math:`\theta`, the parametric circuit forms a matrix

--- a/qiskit/synthesis/unitary/aqc/approximate.py
+++ b/qiskit/synthesis/unitary/aqc/approximate.py
@@ -24,7 +24,7 @@ class ApproximateCircuit(QuantumCircuit, ABC):
     def __init__(self, num_qubits: int, name: Optional[str] = None) -> None:
         """
         Args:
-            num_qubits: number of qubit this circuit will span.
+            num_qubits: number of qubits this circuit will span.
             name: a name of the circuit.
         """
         super().__init__(num_qubits, name=name)
@@ -33,7 +33,7 @@ class ApproximateCircuit(QuantumCircuit, ABC):
     @abstractmethod
     def thetas(self) -> np.ndarray:
         """
-        The property is not implemented and raises a ``NotImplementedException`` exception.
+        The property is not implemented and raises a ``NotImplementedError`` exception.
 
         Returns:
             a vector of parameters of this circuit.
@@ -56,7 +56,7 @@ class ApproximatingObjective(ABC):
     """
     A base class for an optimization problem definition. An implementing class must provide at least
     an implementation of the ``objective`` method. In such case only gradient free optimizers can
-    be used. Both method, ``objective`` and ``gradient``, preferable to have in an implementation.
+    be used. Both methods, ``objective`` and ``gradient``, are preferable to have in an implementation.
     """
 
     def __init__(self) -> None:

--- a/qiskit/synthesis/unitary/aqc/fast_gradient/layer.py
+++ b/qiskit/synthesis/unitary/aqc/fast_gradient/layer.py
@@ -139,13 +139,13 @@ class Layer2Q(LayerBase):
 
 def init_layer1q_matrices(thetas: np.ndarray, dst: np.ndarray) -> np.ndarray:
     """
-    Initializes 4x4 matrices of 2-qubit gates defined in the paper.
+    Initializes 2x2 matrices of 1-qubit gates defined in the paper.
 
     Args:
-        thetas: depth x 4 matrix of gate parameters for every layer, where
-                "depth" is the number of layers.
-        dst: destination array of size depth x 4 x 4 that will receive gate
-             matrices of each layer.
+        thetas: n x 3 matrix of gate parameters for every qubit, where
+                "n" is the number of qubits.
+        dst: destination array of size n x 2 x 2 that will receive gate
+             matrices of each qubit.
 
     Returns:
         Returns the "dst" array.
@@ -163,14 +163,14 @@ def init_layer1q_matrices(thetas: np.ndarray, dst: np.ndarray) -> np.ndarray:
 
 def init_layer1q_deriv_matrices(thetas: np.ndarray, dst: np.ndarray) -> np.ndarray:
     """
-    Initializes 4x4 derivative matrices of 2-qubit gates defined in the paper.
+    Initializes 2x2 derivative matrices of 1-qubit gates defined in the paper.
 
     Args:
-        thetas: depth x 4 matrix of gate parameters for every layer, where
-                "depth" is the number of layers.
-        dst: destination array of size depth x 4 x 4 x 4 that will receive gate
-             derivative matrices of each layer; there are 4 parameters per gate,
-             hence, 4 derivative matrices per layer.
+        thetas: n x 3 matrix of gate parameters for every qubit, where
+                "n" is the number of qubits.
+        dst: destination array of size n x 3 x 2 x 2 that will receive gate
+             derivative matrices of each qubit; there are 3 parameters per gate,
+             hence, 3 derivative matrices per qubit.
 
     Returns:
         Returns the "dst" array.

--- a/qiskit/synthesis/unitary/aqc/fast_gradient/pmatrix.py
+++ b/qiskit/synthesis/unitary/aqc/fast_gradient/pmatrix.py
@@ -87,7 +87,7 @@ class PMatrix:
     def mul_right_q1(self, layer: Layer1Q, temp_mat: np.ndarray, dagger: bool):
         """
         Multiplies ``NxN`` matrix, wrapped by this object, by a 1-qubit layer
-        matrix of the right, where ``N`` is the actual size of matrices involved,
+        matrix on the right, where ``N`` is the actual size of matrices involved,
         ``N = 2^{num. of qubits}``.
 
         Args:
@@ -151,7 +151,7 @@ class PMatrix:
     def mul_left_q1(self, layer: Layer1Q, temp_mat: np.ndarray):
         """
         Multiplies ``NxN`` matrix, wrapped by this object, by a 1-qubit layer
-        matrix of the left, where ``dim`` is the actual size of matrices involved,
+        matrix on the left, where ``dim`` is the actual size of matrices involved,
         ``dim = 2^{num. of qubits}``.
 
         Args:


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Following in the footsteps of #15697 (and using the prompt from that PR), I used claude 4-6 to fix typos in qiskit/synthesis.

### Details and comments

LLM used: claude 4-6.

From this brief experiment: claude 4-6 is immensely better than clause 4-5 (which spent a lot of time doing something and that then threw the timeout message).
