### PR TITLE
Fix elided lifetime clippy warning

### DIFF
--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -845,7 +845,7 @@ impl PackedInstruction {
     ///
     /// The returned value will preferentially be a view, if the matrix already exists (e.g. for
     /// `Unitary`).
-    pub fn try_cow_array(&self) -> Option<CowArray<Complex64, Ix2>> {
+    pub fn try_cow_array(&self) -> Option<CowArray<'_, Complex64, Ix2>> {
         match self.op.view() {
             OperationRef::StandardGate(g) => g.matrix(self.params_view()).map(CowArray::from),
             OperationRef::Gate(g) => g.matrix().map(CowArray::from),


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes a clippy warning around hiding an elided lifetime which clippy asserts can be confusing. This is flagged as a warning in newer versions of clippy so fixing this pre-emptively will avoid errors when we try to bump our MSRV in the future and also fix the error for those of use that insist on testing with the latest stable release of rust and are seeing clippy complain about this.

### Details and comments


