### PR TITLE
Enable ruff T20 group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -340,6 +340,8 @@ select = [
     "PIE",
     # flake8-no-pep420
     "INP",
+    # flake8-print
+    "T20",
 ]
 ignore = [
     "E402",  # module-import-not-at-top-of-file false positives with module docs
@@ -372,6 +374,8 @@ ignore = [
 "*.ipynb" = ["F821"]
 # Security rules from bandit don't apply to tests and utils
 "tools/*" = [
+# Tools can print to stdout
+    "T201",
     "S603",
 # Docstring rules don't apply to tools as they're not documented
     "D100",

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -240,7 +240,7 @@ class Operator(LinearOp):
     def _ipython_display_(self):
         out = self.draw()
         if isinstance(out, str):
-            print(out)
+            print(out)  # noqa: T201
         else:
             from IPython.display import display
 

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -180,7 +180,7 @@ class DensityMatrix(QuantumState, TolerancesMixin):
     def _ipython_display_(self):
         out = self.draw()
         if isinstance(out, str):
-            print(out)
+            print(out)  # noqa: T201
         else:
             from IPython.display import display
 

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -267,7 +267,7 @@ class Statevector(QuantumState, TolerancesMixin):
     def _ipython_display_(self):
         out = self.draw()
         if isinstance(out, str):
-            print(out)
+            print(out)  # noqa: T201
         else:
             from IPython.display import display
 

--- a/qiskit/visualization/circuit/matplotlib.py
+++ b/qiskit/visualization/circuit/matplotlib.py
@@ -252,7 +252,7 @@ class MatplotlibDrawer:
             "}": (0.1896, 0.1188),
         }
 
-    def draw(self, filename=None, verbose=False):
+    def draw(self, filename=None):
         """Main entry point to 'matplotlib' ('mpl') drawer. Called from
         ``visualization.circuit_drawer`` and from ``QuantumCircuit.draw`` through circuit_drawer.
         """
@@ -390,7 +390,6 @@ class MatplotlibDrawer:
             qubits_dict,
             clbits_dict,
             glob_data,
-            verbose,
         )
         if filename:
             mpl_figure.savefig(
@@ -1080,7 +1079,6 @@ class MatplotlibDrawer:
         qubits_dict,
         clbits_dict,
         glob_data,
-        verbose=False,
     ):
         """Draw the gates in the circuit"""
 
@@ -1105,9 +1103,6 @@ class MatplotlibDrawer:
                 op = node.op
 
                 self._get_colors(node, node_data)
-
-                if verbose:
-                    print(op)
 
                 # add conditional
                 if getattr(op, "condition", None) or isinstance(op, SwitchCaseOp):

--- a/test/qpy_compat/get_versions.py
+++ b/test/qpy_compat/get_versions.py
@@ -75,7 +75,7 @@ def available_versions():
                     if release["packagetype"] == "bdist_wheel" and not release["yanked"]
                     for tag in tags_from_wheel_name(release["filename"])
                 ):
-                    print(
+                    print(  # noqa: T201
                         f"skipping '{other_version}', which has no installable binary artifacts",
                         file=sys.stderr,
                     )
@@ -96,7 +96,7 @@ def available_versions():
                         python_versions, key=lambda s: tuple(map(int, s.split(".")))
                     )
                 except ValueError:
-                    print(
+                    print(  # noqa: T201
                         f"skipping '{other_version}', which has no installable binary artifacts",
                         file=sys.stderr,
                     )
@@ -118,7 +118,7 @@ def available_versions():
 def main():
     """main"""
     for package, version, python_version in available_versions():
-        print(package, version, python_version)
+        print(package, version, python_version)  # noqa: T201
 
 
 if __name__ == "__main__":

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -1102,7 +1102,7 @@ def load_qpy(qpy_files, version_parts):
             # so not loading and comparing these payloads.
             # See https://github.com/Qiskit/qiskit/pull/13814
             continue
-        print(f"Loading qpy file: {path}")
+        print(f"Loading qpy file: {path}")  # noqa: T201
         with open(path, "rb") as fd:
             qpy_circuits = load(fd)
         equivalent = path in {"open_controlled_gates.qpy", "controlled_gates.qpy"}

--- a/test/randomized/test_transpiler_equivalence.py
+++ b/test/randomized/test_transpiler_equivalence.py
@@ -285,7 +285,7 @@ class QCircuitMachine(RuleBasedStateMachine):
             + ", ".join(f"{key:s}={value!r}" for key, value in kwargs.items() if value is not None)
             + ")"
         )
-        print(f"Evaluating {call} for:\n{qasm2.dumps(self.qc)}")
+        print(f"Evaluating {call} for:\n{qasm2.dumps(self.qc)}")  # noqa: T201
 
         shots = 4096
 


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

One of the lints we previously had enabled in pylint was disallowing prints. This was added in #13796 to prevent us from accidentally committing print debug statements which was happening fairly frequently. However, in the recently merged #15603 we migrated from pylint to use ruff and during that migration this lint was dropped. This commit corrects this oversight by enabling the ruff rule group T20 which is used to disable using print or pprint in code.

One small change that this enabled was the discovery there was an unused `verbose` flag in the internal matplotlib circuit drawer APIs that was used to print every op node as it drew them. This has no real value and wasn't exposed via any public API so this commit just opts to remove the option along with the print statement.

### Details and comments