### PR TITLE
Fix typos in `qiskit.compiler`

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -89,7 +89,7 @@ def transpile(
             device. If any other option is explicitly set (e.g., ``coupling_map``), it
             will override the backend's.
         basis_gates: List of basis gate names to unroll to
-            (e.g: ``['u1', 'u2', 'u3', 'cx']``). If ``None``, do not unroll.
+            (e.g.: ``['u1', 'u2', 'u3', 'cx']``). If ``None``, do not unroll.
         coupling_map: Directed coupling map (perhaps custom) to target in mapping. If
             the coupling map is symmetric, both directions need to be specified.
 
@@ -98,7 +98,7 @@ def transpile(
             #. ``CouplingMap`` instance
             #. List, must be given as an adjacency matrix, where each entry
                specifies all directed two-qubit interactions supported by backend,
-               e.g: ``[[0, 1], [0, 3], [1, 2], [1, 5], [2, 5], [4, 1], [5, 3]]``
+               e.g.: ``[[0, 1], [0, 3], [1, 2], [1, 5], [2, 5], [4, 1], [5, 3]]``
         initial_layout: Initial position of virtual qubits on physical qubits.
             If this layout makes the circuit compatible with the coupling_map
             constraints, it will be used. The final layout is not guaranteed to be the same,
@@ -134,7 +134,7 @@ def transpile(
             You can see a list of installed plugins by using :func:`~.list_stage_plugins` with
             ``"layout"`` for the ``stage_name`` argument.
         routing_method: Name of routing pass
-            ('basic', 'lookahead', 'stochastic', 'sabre', 'none'). Note
+            ('basic', 'lookahead', 'stochastic', 'sabre', 'none').
             This can also be the external plugin name to use for the ``routing`` stage.
             You can see a list of installed plugins by using :func:`~.list_stage_plugins` with
             ``"routing"`` for the ``stage_name`` argument.
@@ -210,8 +210,8 @@ def transpile(
         hls_config: An optional configuration class
             :class:`~qiskit.transpiler.passes.synthesis.HLSConfig` that will be passed directly
             to :class:`~qiskit.transpiler.passes.synthesis.HighLevelSynthesis` transformation pass.
-            This configuration class allows to specify for various high-level objects the lists of
-            synthesis algorithms and their parameters.
+            This configuration class allows specifying the lists of synthesis algorithms and
+            their parameters for various high-level objects.
         init_method: The plugin name to use for the ``init`` stage. By default an external
             plugin is not used. You can see a list of installed plugins by
             using :func:`~.list_stage_plugins` with ``"init"`` for the stage
@@ -368,7 +368,7 @@ def _parse_output_name(output_name, circuits):
                 )
         else:
             raise TranspilerError(
-                "The parameter output_name should be a string or a"
+                "The parameter output_name should be a string or a "
                 f"list of strings: {type(output_name)} was used."
             )
     else:


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes typos in `qiskit.compiler`, as detected by claude.


### Details and comments

AI tool used: claude opus 4.6

I know using `e.g.` is discouraged by the qiskit style guide. Should that be "fixed" here, or punted?