### PR TITLE
Fix typos in `qiskit.converters`, `qiskit.dagcircuit`, and `qiskit.exceptions`

### DIFF
--- a/qiskit/converters/dagdependency_to_dag.py
+++ b/qiskit/converters/dagdependency_to_dag.py
@@ -18,7 +18,7 @@ def dagdependency_to_dag(dagdependency):
     """Build a ``DAGCircuit`` object from a ``DAGDependency``.
 
     Args:
-        dag dependency (DAGDependency): the input dag.
+        dagdependency (DAGDependency): the input dag.
 
     Return:
         DAGCircuit: the DAG representing the input circuit.

--- a/qiskit/dagcircuit/collect_blocks.py
+++ b/qiskit/dagcircuit/collect_blocks.py
@@ -31,7 +31,7 @@ class BlockCollector:
     into blocks of nodes that satisfy certain criteria. It works both with the
     :class:`~qiskit.dagcircuit.DAGCircuit` and
     :class:`~qiskit.dagcircuit.DAGDependency` representations of a DAG, where
-    DagDependency takes into account commutativity between nodes.
+    the latter takes into account commutativity between nodes.
 
     Collecting nodes from DAGDependency generally leads to more optimal results, but is
     slower, as it requires to construct a DAGDependency beforehand. Thus, DAGCircuit should
@@ -333,7 +333,7 @@ def split_block_into_layers(block: list[DAGOpNode | DAGDepNode]):
 
 class BlockCollapser:
     """This class implements various strategies of consolidating blocks of nodes
-    in a DAG (direct acyclic graph). It works both with
+    in a DAG (directed acyclic graph). It works both with
     the :class:`~qiskit.dagcircuit.DAGCircuit`
     and :class:`~qiskit.dagcircuit.DAGDependency` DAG representations.
     """

--- a/qiskit/dagcircuit/dagdependency.py
+++ b/qiskit/dagcircuit/dagdependency.py
@@ -505,8 +505,8 @@ class DAGDependency:
         """
         Draws the DAGDependency graph.
 
-        This function needs `pydot <https://github.com/erocarrera/pydot>`, which in turn needs
-        Graphviz <https://www.graphviz.org/>` to be installed.
+        This function needs `pydot <https://github.com/erocarrera/pydot>`_, which in turn needs
+        `Graphviz <https://www.graphviz.org/>`_ to be installed.
 
         Args:
             scale (float): scaling factor
@@ -515,7 +515,7 @@ class DAGDependency:
                          'color' (default): color input/output/op nodes
 
         Returns:
-            Ipython.display.Image: if in Jupyter notebook and not saving to file, otherwise None.
+            IPython.display.Image: if in Jupyter notebook and not saving to file, otherwise None.
         """
         from qiskit.visualization.dag_visualization import dag_drawer
 

--- a/qiskit/exceptions.py
+++ b/qiskit/exceptions.py
@@ -77,7 +77,7 @@ Filtering warnings
 Python has built-in mechanisms to filter warnings, described in the documentation of the
 :mod:`warnings` module.  You can use these subclasses in your warning filters from within Python to
 silence warnings you are not interested in.  For example, if you are knowingly using experimental
-features and are comfortable that they make break in later versions, you can silence
+features and are comfortable that they may break in later versions, you can silence
 :exc:`ExperimentalWarning` like this::
 
     import warnings


### PR DESCRIPTION
### Summary

Fixes typos in the three locations in the title of this PR, as found by claude.

### Details and comments


AI tools used: claude opus 4.6