### PR TITLE
Fix typos in `qiskit.transpiler` and `qiskit.passmanager`

### DIFF
--- a/qiskit/passmanager/__init__.py
+++ b/qiskit/passmanager/__init__.py
@@ -82,8 +82,8 @@ Examples
 ========
 
 We look into a toy optimization task, namely, preparing a row of numbers
-and remove a digit if the number is five.
-Such task might be easily done by converting the input numbers into string.
+and removing a digit if the number is five.
+Such a task might be easily done by converting the input numbers into string.
 We use the pass manager framework here, putting the efficiency aside for
 a moment to learn how to build a custom Qiskit compiler.
 
@@ -127,7 +127,7 @@ Next, we implement a pass that removes a digit when the number is five.
     task = RemoveFive()
 
 Finally, we instantiate a pass manager and schedule the task with it.
-Running the pass manager with random row of numbers returns
+Running the pass manager with a random row of numbers returns
 new numbers that don't contain five.
 
 .. plot::
@@ -205,7 +205,7 @@ values, which have more than six digits.
 
 With the pass manager framework, a developer can flexibly customize
 the optimization task by combining multiple passes and flow controllers.
-See details for following class API documentations.
+See details in the following class API documentation.
 
 
 Interface

--- a/qiskit/passmanager/base_tasks.py
+++ b/qiskit/passmanager/base_tasks.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Baseclasses for the Qiskit passmanager optimization tasks."""
+"""Base classes for the Qiskit passmanager optimization tasks."""
 from __future__ import annotations
 
 import logging
@@ -46,7 +46,7 @@ class Task(ABC):
         Args:
             passmanager_ir: Qiskit IR to optimize.
             state: State associated with workflow execution by the pass manager itself.
-            callback: A callback function which is caller per execution of optimization task.
+            callback: A callback function which is called per execution of optimization task.
 
         Returns:
             Optimized Qiskit IR and state of the workflow.

--- a/qiskit/passmanager/compilation_status.py
+++ b/qiskit/passmanager/compilation_status.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""A property set dictionary that shared among optimization passes."""
+"""A property set dictionary that is shared among optimization passes."""
 
 
 from dataclasses import dataclass, field

--- a/qiskit/passmanager/passmanager.py
+++ b/qiskit/passmanager/passmanager.py
@@ -91,7 +91,7 @@ class BasePassManager(ABC):
         try:
             self._tasks[index] = tasks
         except IndexError as ex:
-            raise PassManagerError(f"Index to replace {index} does not exists") from ex
+            raise PassManagerError(f"Index to replace {index} does not exist") from ex
 
     def remove(self, index: int) -> None:
         """Removes a particular pass in the scheduler.
@@ -105,7 +105,7 @@ class BasePassManager(ABC):
         try:
             del self._tasks[index]
         except IndexError as ex:
-            raise PassManagerError(f"Index to replace {index} does not exists") from ex
+            raise PassManagerError(f"Index to replace {index} does not exist") from ex
 
     def __setitem__(self, index, item):
         self.replace(index, item)
@@ -191,7 +191,7 @@ class BasePassManager(ABC):
                     running_time (float): the time to execute the pass
                     count (int): the index for the pass execution
 
-                The exact arguments pass expose the internals of the pass
+                The exact arguments passed expose the internals of the pass
                 manager and are subject to change as the pass manager internals
                 change. If you intend to reuse a callback function over
                 multiple releases be sure to check that the arguments being

--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -145,7 +145,7 @@ this can be overridden by passing explicit ``<stage>_method="<choice>"`` argumen
 Reproducibility of the preset pipelines
 ---------------------------------------
 
-Quantum compilation often involves solving problems that are knownn to be non-polynomial in
+Quantum compilation often involves solving problems that are known to be non-polynomial in
 complexity, and so are intractable to globally optimize.  In these cases, stochastic and heuristic
 algorithms are often more appropriate.  This leads to problems of reproducibility, however.
 
@@ -154,7 +154,7 @@ to ensure reproducibility of a compilation, pass a known integer to the ``seed_t
 argument of the generator functions.
 
 All built-in plugins to Qiskit are required to produce their analyses and modify the
-:class:`.DAGCircuit` in deterministic ways if they randomization (if any) is seeded, so that a
+:class:`.DAGCircuit` in deterministic ways if their randomization (if any) is seeded, so that a
 compilation can be repeated later.  There are limits on this:
 
 * All built-in passes with stochastic components must provide a way to seed the randomization, and
@@ -1038,7 +1038,7 @@ Some tips for ensuring this include:
   ``HashMap`` and ``HashSet``, respectively; they have similar deterministic-iteration properties to
   Python's :class:`dict`.
 
-* If your pass as stochastic components, ensure that you accept a ``seed`` input, and make your
+* If your pass has stochastic components, ensure that you accept a ``seed`` input, and make your
   output pure if this is supplied as an integer.  Typically this means storing the seed, and
   instantiating a new pRNG from this seed at the start of each call to :meth:`.BasePass.run`.
 

--- a/qiskit/transpiler/basepasses.py
+++ b/qiskit/transpiler/basepasses.py
@@ -129,7 +129,7 @@ class BasePass(GenericPass, metaclass=MetaPass):
                 be used (if set).
 
         Returns:
-            If on transformation pass, the resulting QuantumCircuit.
+            If a transformation pass, the resulting QuantumCircuit.
             If analysis pass, the input circuit.
         """
         from qiskit.transpiler import PassManager

--- a/qiskit/transpiler/coupling.py
+++ b/qiskit/transpiler/coupling.py
@@ -432,7 +432,7 @@ class CouplingMap:
         This method will return a list of :class:`~.CouplingMap` objects, one for each connected
         component in this :class:`~.CouplingMap`. The data payload of each node in the
         :attr:`~.CouplingMap.graph` attribute will contain the qubit number in the original
-        graph. This will enables mapping the qubit index in a component subgraph to
+        graph. This will enable mapping the qubit index in a component subgraph to
         the original qubit in the combined :class:`~.CouplingMap`. For example::
 
             from qiskit.transpiler import CouplingMap

--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -38,7 +38,7 @@ class BasisTranslator(TransformationPass):
       is not already in the target_basis.
 
     If the target keyword argument is specified and that
-    :class:`~qiskit.transpiler.Target` objects contains operations
+    :class:`~qiskit.transpiler.Target` object contains operations
     which are non-global (i.e. they are defined only for a subset of qubits),
     as calculated by :meth:`~qiskit.transpiler.Target.get_non_global_operation_names`,
     this pass will attempt to match the output translation to those constraints.

--- a/qiskit/transpiler/passes/layout/csp_layout.py
+++ b/qiskit/transpiler/passes/layout/csp_layout.py
@@ -12,7 +12,7 @@
 
 """A pass for choosing a Layout of a circuit onto a Coupling graph, as a
 Constraint Satisfaction Problem. It tries to find a solution that fully
-satisfy the circuit, i.e. no further swap is needed. If no solution is
+satisfies the circuit, i.e. no further swap is needed. If no solution is
 found, no ``property_set['layout']`` is set.
 """
 import numpy as np

--- a/qiskit/transpiler/passes/layout/dense_layout.py
+++ b/qiskit/transpiler/passes/layout/dense_layout.py
@@ -169,7 +169,7 @@ def _build_error_matrix(num_qubits, qubit_map, target=None):
     use_error = False
     if target is not None and target.qargs is not None:
         for qargs in target.qargs:
-            # Ignore gates over 2q DenseLayout only works with 2q
+            # Ignore gates over 2q. DenseLayout only works with 2q
             if len(qargs) > 2:
                 continue
             error = 0.0

--- a/qiskit/transpiler/passes/layout/full_ancilla_allocation.py
+++ b/qiskit/transpiler/passes/layout/full_ancilla_allocation.py
@@ -64,7 +64,7 @@ class FullAncillaAllocation(AnalysisPass):
             DAGCircuit: returns the same dag circuit, unmodified
 
         Raises:
-            TranspilerError: If there is not layout in the property set or not set at init time.
+            TranspilerError: If there is no layout in the property set or not set at init time.
         """
         layout = self.property_set.get("layout")
 

--- a/qiskit/transpiler/passes/layout/layout_2q_distance.py
+++ b/qiskit/transpiler/passes/layout/layout_2q_distance.py
@@ -35,7 +35,7 @@ class Layout2qDistance(AnalysisPass):
         """Layout2qDistance initializer.
 
         Args:
-            coupling_map (Union[CouplingMap, Target]): Directed graph represented a coupling map.
+            coupling_map (Union[CouplingMap, Target]): Directed graph representing a coupling map.
             property_name (str): The property name to save the score. Default: layout_score
         """
         super().__init__()

--- a/qiskit/transpiler/passes/layout/sabre_pre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_pre_layout.py
@@ -116,7 +116,7 @@ class SabrePreLayout(AnalysisPass):
 
         if self.coupling_map is None:
             raise TranspilerError(
-                "SabrePreLayout requires coupling_map to be used with either"
+                "SabrePreLayout requires coupling_map to be used with either "
                 "CouplingMap or a Target."
             )
 

--- a/qiskit/transpiler/passes/optimization/_gate_extension.py
+++ b/qiskit/transpiler/passes/optimization/_gate_extension.py
@@ -15,8 +15,8 @@ Dynamically extend Gate classes with functions required for the Hoare
 optimizer, namely triviality-conditions and post-conditions.
 If `_trivial_if` returns `True` and the qubit is in a classical state
 then the gate is trivial.
-If a gate has no `_trivial_if`, then is assumed to be non-trivial.
-If a gate has no `_postconditions`, then is assumed to have unknown post-conditions.
+If a gate has no `_trivial_if`, then it is assumed to be non-trivial.
+If a gate has no `_postconditions`, then it is assumed to have unknown post-conditions.
 """
 from qiskit.circuit.library.standard_gates import IGate, XGate, YGate, ZGate
 from qiskit.circuit.library.standard_gates import CXGate, CCXGate, CYGate, CZGate

--- a/qiskit/transpiler/passes/optimization/collect_multiqubit_blocks.py
+++ b/qiskit/transpiler/passes/optimization/collect_multiqubit_blocks.py
@@ -48,7 +48,7 @@ class CollectMultiQBlocks(AnalysisPass):
         super().__init__()
         self.parent = {}  # parent array for the union
 
-        # the dicts belowed are keyed by a qubit signifying the root of a
+        # the dicts below are keyed by a qubit signifying the root of a
         #    set in the DSU data structure
         self.bit_groups = {}  # current groups of bits stored at top of trees
         self.gate_groups = {}  # current gate lists for the groups
@@ -75,7 +75,7 @@ class CollectMultiQBlocks(AnalysisPass):
     def union_set(self, set1, set2):
         """DSU function for unioning two sets together
         Find the roots of each set. Then assign one to have the other
-        as its parent, thus liking the sets.
+        as its parent, thus linking the sets.
         Merges smaller set into larger set in order to have better runtime
         """
 
@@ -118,7 +118,7 @@ class CollectMultiQBlocks(AnalysisPass):
             blocks to end). After that, we process gates in order of lowest
             number of qubits acted on to largest number of qubits acted on
             because these have less chance of increasing the size of blocks
-            The key also processes all the non operation notes first so that
+            The key also processes all the non operation nodes first so that
             input nodes do not mess with the top sort of op nodes
             """
             if isinstance(x, DAGInNode):

--- a/qiskit/transpiler/passes/optimization/commutative_optimization.py
+++ b/qiskit/transpiler/passes/optimization/commutative_optimization.py
@@ -41,7 +41,7 @@ class CommutativeOptimization(TransformationPass):
     def __init__(self, approximation_degree: float = 1.0, matrix_max_num_qubits: int = 0):
         """
         Args:
-            approximation_degree: the threshold used in the the average gate fidelity
+            approximation_degree: the threshold used in the average gate fidelity
                 computation to decide whether pairs of gates can be considered as
                 canceling or commuting.
             matrix_max_num_qubits: Upper-bound on the number of qubits for the matrix-based

--- a/qiskit/transpiler/passes/optimization/light_cone.py
+++ b/qiskit/transpiler/passes/optimization/light_cone.py
@@ -113,8 +113,8 @@ class LightCone(TransformationPass):
                     max_num_qubits = max(len(op[1]), len(node.qargs))
                     if max_num_qubits > 10:
                         warnings.warn(
-                            "LightCone pass is checking commutation of"
-                            f"operators of size {max_num_qubits}."
+                            "LightCone pass is checking commutation of "
+                            f"operators of size {max_num_qubits}. "
                             "This operation can be slow.",
                             category=RuntimeWarning,
                         )

--- a/qiskit/transpiler/passes/optimization/litinski_transformation.py
+++ b/qiskit/transpiler/passes/optimization/litinski_transformation.py
@@ -59,7 +59,7 @@ class LitinskiTransformation(TransformationPass):
         self.fix_clifford = fix_clifford
 
     def run(self, dag: DAGCircuit) -> DAGCircuit:
-        """Run the LitiskiTransformation pass on ``dag``.
+        """Run the LitinskiTransformation pass on ``dag``.
 
         Args:
             dag: the input DAG.

--- a/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
@@ -40,7 +40,7 @@ from qiskit.dagcircuit.dagcircuit import DAGCircuit
 
 logger = logging.getLogger(__name__)
 
-# When expanding the list of supported gates this needs to updated in
+# When expanding the list of supported gates this needs to be updated in
 # lockstep with the VALID_BASES constant in src/euler_one_qubit_decomposer.rs
 # and the global variables in one_qubit_decompose.py
 NAME_MAP = {
@@ -219,7 +219,7 @@ class Optimize1qGatesDecomposition(TransformationPass):
     def _error(self, circuit, qubit):
         """
         Calculate a rough error for a `circuit` that runs on a specific
-        `qubit` of `target` (`circuit` is a list of DAGOPNodes).
+        `qubit` of `target` (`circuit` is a list of DAGOpNodes).
 
         Use basis errors from target if available, otherwise use length
         of circuit as a weak proxy for error.

--- a/qiskit/transpiler/passes/optimization/split_2q_unitaries.py
+++ b/qiskit/transpiler/passes/optimization/split_2q_unitaries.py
@@ -19,7 +19,7 @@ from qiskit._accelerate.split_2q_unitaries import split_2q_unitaries
 
 
 class Split2QUnitaries(TransformationPass):
-    """Attempt to splits two-qubit unitaries in a :class:`.DAGCircuit` into two single-qubit gates.
+    """Attempt to split two-qubit unitaries in a :class:`.DAGCircuit` into two single-qubit gates.
 
     This pass will analyze all :class:`.UnitaryGate` instances and determine whether the
     matrix is actually a product of 2 single qubit gates. In these cases the 2q gate can be

--- a/qiskit/transpiler/passes/optimization/substitute_pi4_rotations.py
+++ b/qiskit/transpiler/passes/optimization/substitute_pi4_rotations.py
@@ -44,7 +44,7 @@ class SubstitutePi4Rotations(TransformationPass):
 
       # The following quantum circuit consists of 5 Clifford gates,
       # four rotation gates whose angles are integer multiples of pi/4,
-      # and one controlled rotation gate whose angle is an integer multiple pf pi/2
+      # and one controlled rotation gate whose angle is an integer multiple of pi/2
 
       qc = QuantumCircuit(3)
       qc.cx(0, 1)

--- a/qiskit/transpiler/passes/optimization/template_matching/maximal_matches.py
+++ b/qiskit/transpiler/passes/optimization/template_matching/maximal_matches.py
@@ -18,7 +18,7 @@ matching algorithm.
 
 class Match:
     """
-    Class Match is an object to store a list of match with its qubits and
+    Class Match is an object to store a list of matches with its qubits and
     clbits configuration.
     """
 

--- a/qiskit/transpiler/passes/optimization/template_optimization.py
+++ b/qiskit/transpiler/passes/optimization/template_optimization.py
@@ -73,7 +73,7 @@ class TemplateOptimization(TransformationPass):
                 is not given. The key is the name of the gate and the value its quantum cost.
         """
         super().__init__()
-        # If no template is given; the template are set as x-x, cx-cx, ccx-ccx.
+        # If no template is given; the templates are set as x-x, cx-cx, ccx-ccx.
         if template_list is None:
             template_list = [template_nct_2a_1(), template_nct_2a_2(), template_nct_2a_3()]
         self.template_list = template_list
@@ -101,7 +101,7 @@ class TemplateOptimization(TransformationPass):
 
         for template in self.template_list:
             if not isinstance(template, (QuantumCircuit, DAGDependency)):
-                raise TranspilerError("A template is a Quantumciruit or a DAGDependency.")
+                raise TranspilerError("A template is a QuantumCircuit or a DAGDependency.")
 
             if len(template.qubits) > len(circuit_dag_dep.qubits):
                 continue
@@ -117,7 +117,7 @@ class TemplateOptimization(TransformationPass):
 
                 if not comparison:
                     raise TranspilerError(
-                        "A template is a Quantumciruit() that performs the identity."
+                        "A template is a QuantumCircuit() that performs the identity."
                     )
             except TypeError:
                 pass

--- a/qiskit/transpiler/passes/routing/algorithms/__init__.py
+++ b/qiskit/transpiler/passes/routing/algorithms/__init__.py
@@ -24,7 +24,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""The permutation modules contains some functions for permuting on architectures given a mapping.
+"""The permutation module contains some functions for permuting on architectures given a mapping.
 
 A permutation function takes in a graph and a permutation of graph nodes,
 and returns a sequence of SWAPs that implements that permutation on the graph.

--- a/qiskit/transpiler/passes/routing/algorithms/token_swapper.py
+++ b/qiskit/transpiler/passes/routing/algorithms/token_swapper.py
@@ -50,7 +50,7 @@ class ApproximateTokenSwapper:
         """Construct an ApproximateTokenSwapping object.
 
         Args:
-            graph: Undirected graph represented a coupling map.
+            graph: Undirected graph representing a coupling map.
             seed: Seed to use for random trials.
         """
         self.graph = graph

--- a/qiskit/transpiler/passes/routing/basic_swap.py
+++ b/qiskit/transpiler/passes/routing/basic_swap.py
@@ -33,7 +33,7 @@ class BasicSwap(TransformationPass):
         """BasicSwap initializer.
 
         Args:
-            coupling_map (Union[CouplingMap, Target]): Directed graph represented a coupling map.
+            coupling_map (Union[CouplingMap, Target]): Directed graph representing a coupling map.
             fake_run (bool): if true, it will only pretend to do routing, i.e., no
                 swap is effectively added.
         """

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_gate_router.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_gate_router.py
@@ -49,7 +49,7 @@ class Commuting2qGateRouter(TransformationPass):
              |
              4
 
-    To do this we use a line swap strategy for qubits 0, 1, 3, and 4 defined it in terms
+    To do this we use a line swap strategy for qubits 0, 1, 3, and 4 defined in terms
     of virtual qubits 0, 1, 2, and 3.
 
     .. plot::
@@ -79,7 +79,7 @@ class Commuting2qGateRouter(TransformationPass):
         # Define the swap strategy on qubits before the initial_layout is applied.
         swap_strat = SwapStrategy.from_line([0, 1, 2, 3])
 
-        # Chose qubits 0, 1, 3, and 4 from the backend coupling map shown above.
+        # Choose qubits 0, 1, 3, and 4 from the backend coupling map shown above.
         backend_cmap = CouplingMap(couplinglist=[(0, 1), (1, 2), (1, 3), (3, 4)])
         initial_layout = Layout.from_intlist([0, 1, 3, 4], *circ.qregs)
 

--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -58,7 +58,7 @@ class SabreSwap(TransformationPass):
 
     This transpiler pass adds onto the SABRE algorithm in that it will run
     multiple trials of the algorithm with different seeds. The best output,
-    determined by the trial with the least amount of SWAPed inserted, will
+    determined by the trial with the least amount of SWAPs inserted, will
     be selected from the random trials.
 
     **References:**
@@ -114,7 +114,7 @@ class SabreSwap(TransformationPass):
             Second is the basic cost but now evaluated for the
             extended set as well (i.e. :math:`|E|` number of upcoming successors to gates in
             front_layer F). This is weighted by some amount EXTENDED_SET_WEIGHT (W) to
-            signify that upcoming gates are less important that the front_layer.
+            signify that upcoming gates are less important than the front_layer.
 
             .. math::
 

--- a/qiskit/transpiler/passes/scheduling/alignments/__init__.py
+++ b/qiskit/transpiler/passes/scheduling/alignments/__init__.py
@@ -40,7 +40,7 @@ the underlying pulse instruction should satisfy other two waveform constraints.
 Pulse alignment constraint
 
     This value is reported by ``timing_constraints["pulse_alignment"]`` in the backend
-    configuration in units of dt. The start time of the all pulse instruction should be
+    configuration in units of dt. The start time of all pulse instructions should be
     multiple of this value. Violation of this constraint may result in the
     backend execution failure.
 

--- a/qiskit/transpiler/passes/scheduling/scheduling/set_io_latency.py
+++ b/qiskit/transpiler/passes/scheduling/scheduling/set_io_latency.py
@@ -37,14 +37,14 @@ class SetIOLatency(AnalysisPass):
         """Create pass with latency information.
 
         Args:
-            clbit_write_latency: A control flow constraints. Because standard superconducting
+            clbit_write_latency: A control flow constraint. Because standard superconducting
                 quantum processor implement dispersive QND readout, the actual data transfer
                 to the clbit happens after the round-trip stimulus signal is buffered
                 and discriminated into quantum state.
                 The interval ``[t0, t0 + clbit_write_latency]`` is regarded as idle time
                 for clbits associated with the measure instruction.
                 This defaults to 0 dt which is identical to Qiskit Pulse scheduler.
-            conditional_latency: A control flow constraints. This value represents
+            conditional_latency: A control flow constraint. This value represents
                 a latency of reading a classical register for the conditional operation.
                 The gate operation occurs after this latency. This appears as a delay
                 in front of the DAGOpNode of the gate.

--- a/qiskit/transpiler/passes/synthesis/solovay_kitaev_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/solovay_kitaev_synthesis.py
@@ -194,7 +194,7 @@ class SolovayKitaev(TransformationPass):
             Output dag with 1q gates synthesized in the discrete target basis.
 
         Raises:
-            TranspilerError: if a gates does not have to_matrix
+            TranspilerError: if a gate does not have to_matrix
         """
         for node in dag.op_nodes():
             # ignore operations on which the algorithm cannot run
@@ -304,7 +304,7 @@ class SolovayKitaevSynthesis(UnitarySynthesisPlugin):
 
     @property
     def supports_basis_gates(self):
-        """The plugin does not support basis gates. By default it synthesis to the
+        """The plugin does not support basis gates. By default it synthesizes to the
         ``["h", "t", "tdg"]`` gate basis."""
         return True
 
@@ -323,7 +323,7 @@ class SolovayKitaevSynthesis(UnitarySynthesisPlugin):
         recursion_degree = config.get("recursion_degree", 5)
 
         # Check if we didn't yet construct the Solovay-Kitaev instance (which contains the basic
-        # approximations) or if the basic approximations need need to be recomputed.
+        # approximations) or if the basic approximations need to be recomputed.
         if (SolovayKitaevSynthesis._sk is None) or (
             (basis_gates != SolovayKitaevSynthesis._basis_gates)
             or (depth != SolovayKitaevSynthesis._depth)

--- a/qiskit/transpiler/passes/utils/dag_fixed_point.py
+++ b/qiskit/transpiler/passes/utils/dag_fixed_point.py
@@ -20,7 +20,7 @@ from qiskit.transpiler.basepasses import AnalysisPass
 class DAGFixedPoint(AnalysisPass):
     """Check if the DAG has reached a fixed point.
 
-    A dummy analysis pass that checks if the DAG a fixed point (the DAG is not
+    A dummy analysis pass that checks if the DAG reached a fixed point (the DAG is not
     modified anymore). The result is saved in
     ``property_set['dag_fixed_point']`` as a boolean.
     """

--- a/qiskit/transpiler/passes/utils/remove_final_measurements.py
+++ b/qiskit/transpiler/passes/utils/remove_final_measurements.py
@@ -23,7 +23,7 @@ def calc_final_ops(dag: DAGCircuit, final_op_names: set[str]) -> list[DAGOpNode]
         final_op_names: names of the operations to find at the end of the circuit.
 
     Returns:
-    List of nodes corresponding the the relevant operations at the end of the circuit.
+    List of nodes corresponding to the relevant operations at the end of the circuit.
     """
     final_ops = []
 

--- a/qiskit/transpiler/passes/utils/wrap_angles.py
+++ b/qiskit/transpiler/passes/utils/wrap_angles.py
@@ -31,7 +31,7 @@ class WrapAngles(TransformationPass):
     transformation, but is simple to follow:
 
     .. plot::
-       :alt: Circuit digram of the output from running the WrapAngles pass
+       :alt: Circuit diagram of the output from running the WrapAngles pass
        :include-source:
 
        from qiskit.circuit import Gate, Parameter, Qubit, QuantumCircuit

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -378,7 +378,7 @@ class StagedPassManager(PassManager):
     ) -> None:
         raise NotImplementedError
 
-    # Raise NotImplemntedError on individual pass manipulation
+    # Raise NotImplementedError on individual pass manipulation
     def remove(self, index: int) -> None:
         raise NotImplementedError
 

--- a/qiskit/transpiler/passmanager_config.py
+++ b/qiskit/transpiler/passmanager_config.py
@@ -43,7 +43,7 @@ class PassManagerConfig:
             initial_layout (Layout): Initial position of virtual qubits on
                 physical qubits.
             basis_gates (list): List of basis gate names to unroll to.
-            coupling_map (CouplingMap): Directed graph represented a coupling
+            coupling_map (CouplingMap): Directed graph representing a coupling
                 map.
             layout_method (str): the pass to use for choosing initial qubit
                 placement. This will be the plugin name if an external layout stage

--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -630,7 +630,7 @@ class AlapSchedulingPassManager(PassManagerStagePlugin):
 
 
 class AsapSchedulingPassManager(PassManagerStagePlugin):
-    """Plugin class for alap scheduling stage."""
+    """Plugin class for asap scheduling stage."""
 
     def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
         """Build scheduling stage PassManager"""
@@ -646,7 +646,7 @@ class AsapSchedulingPassManager(PassManagerStagePlugin):
 
 
 class DefaultSchedulingPassManager(PassManagerStagePlugin):
-    """Plugin class for alap scheduling stage."""
+    """Plugin class for default scheduling stage."""
 
     def pass_manager(self, pass_manager_config, optimization_level=None) -> PassManager:
         """Build scheduling stage PassManager"""

--- a/qiskit/transpiler/preset_passmanagers/common.py
+++ b/qiskit/transpiler/preset_passmanagers/common.py
@@ -213,7 +213,7 @@ def generate_unroll_3q(
         qubits_initially_zero (bool): Indicates whether the input circuit is
             zero-initialized.
         optimization_metric (OptimizationMetric): the :class:`~.OptimizationMetric` object
-            that the metric used when optimizing the unrolling.
+            that defines the metric used when optimizing the unrolling.
 
     Returns:
         PassManager: The unroll 3q or more pass manager
@@ -258,7 +258,7 @@ def generate_embed_passmanager(coupling_map):
     that can be used to expand and apply an initial layout to a circuit
 
     Args:
-        coupling_map (Union[CouplingMap, Target): The coupling map for the backend to embed
+        coupling_map (Union[CouplingMap, Target]): The coupling map for the backend to embed
             the circuit to.
     Returns:
         PassManager: The embedding passmanager that assumes the layout property
@@ -737,7 +737,7 @@ def get_vf2_limits(
     """Get the VF2 limits for VF2-based layout passes.
 
     Returns:
-        VF2Limits: An namedtuple with optional elements
+        VF2Limits: A namedtuple with optional elements
         ``call_limit`` and ``max_trials``.
     """
     limits = VF2Limits(None, None)

--- a/qiskit/transpiler/preset_passmanagers/plugin.py
+++ b/qiskit/transpiler/preset_passmanagers/plugin.py
@@ -134,7 +134,7 @@ and falls back to using :class:`~.TrivialLayout` if
 
 The second step is to expose the :class:`~.PassManagerStagePlugin`
 subclass as a setuptools entry point in the package metadata. This can be done
-an ``entry-points`` table in ``pyproject.toml`` for the plugin package with the necessary entry
+in an ``entry-points`` table in ``pyproject.toml`` for the plugin package with the necessary entry
 points under the appropriate namespace for the stage your plugin is for. You can see the list of
 stages, entry points, and expectations from the stage in :ref:`stage_table`.  For example,
 continuing from the example plugin above:

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -99,7 +99,7 @@ class Target(BaseTarget):
     they are made (either through versioning, subclassing, or mixins) to add
     on to the set of information exposed by a target.
 
-    As a basic example, let's assume backend has two qubits, supports
+    As a basic example, let's assume a backend has two qubits, supports
     :class:`~qiskit.circuit.library.UGate` on both qubits and
     :class:`~qiskit.circuit.library.CXGate` in both directions. To model this
     you would create the target like::
@@ -220,7 +220,7 @@ class Target(BaseTarget):
     usual API for constructing a :class:`Target` should be a function that returns a base
     :class:`Target`, not a subclass with a custom initializer.
 
-    You may use subclassing to add *addition* Python-space properties to your :class:`Target`, for
+    You may use subclassing to add *additional* Python-space properties to your :class:`Target`, for
     example to then interpret in custom backend-specific transpiler stages; the :class:`Target` is
     passed to stage-plugin constructors.
 
@@ -401,7 +401,7 @@ class Target(BaseTarget):
                 The operation object to add to the map. If it's parameterized any value
                 of the parameter can be set. Optionally for variable width
                 instructions (such as control flow operations such as :class:`~.ForLoop` or
-                :class:`~MCXGate`) you can specify the class. If the class is specified than the
+                :class:`~MCXGate`) you can specify the class. If the class is specified then the
                 ``name`` argument must be specified. When a class is used the gate is treated as global
                 and not having any properties set.
             properties (dict): A dictionary of qarg entries to an
@@ -620,7 +620,7 @@ class Target(BaseTarget):
 
         If there is a mix of two qubit operations that have a connectivity
         constraint and those that are globally defined this will also return
-        ``None`` because the globally connectivity means there is no constraint
+        ``None`` because the global connectivity means there is no constraint
         on the target. If you wish to see the constraints of the two qubit
         operations that have constraints you should use the ``two_q_gate``
         argument to limit the output to the gates which have a constraint.


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes typos in `qiskit.transpiler` and `qiskit.passmanager`


### Details and comments

AI tools used: claude opus 4.6

(The three things one can look at endlessly: how water flows, how fire burns, and how claude opus 4.6 fixes qiskit errors.)
