### PR TITLE
Fixed grammar mistakes in qiskit/circuit

### DIFF
--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -539,7 +539,7 @@ The available modifiers for :class:`AnnotatedOperation` are:
 .. autoclass:: PowerModifier
 
 For information on how to create custom gates and instructions, including how to build one-off
-objects, and re-usable parametric gates via subclassing, see :ref:`circuit-custom-gates` below.
+objects, and reusable parametric gates via subclassing, see :ref:`circuit-custom-gates` below.
 The Qiskit circuit library in :mod:`qiskit.circuit.library` contains many predefined gates and
 circuits for you to use.
 

--- a/qiskit/circuit/_add_control.py
+++ b/qiskit/circuit/_add_control.py
@@ -74,7 +74,7 @@ def add_control(
         num_ctrl_qubits: The number of controls to add to gate.
         label: An optional gate label.
         ctrl_state: The control state in decimal or as a bitstring
-            (e.g. '111'). If specified as a bitstring the length
+            (e.g. '111'). If specified as a bitstring, the length
             must equal num_ctrl_qubits, MSB on left. If None, use
             2**num_ctrl_qubits-1.
 
@@ -116,7 +116,7 @@ def control(
         num_ctrl_qubits: The number of controls to add to gate (default=1).
         label: An optional gate label.
         ctrl_state: The control state in decimal or as
-            a bitstring (e.g. '111'). If specified as a bitstring the length
+            a bitstring (e.g. '111'). If specified as a bitstring, the length
             must equal num_ctrl_qubits, MSB on left. If None, use
             2**num_ctrl_qubits-1.
 

--- a/qiskit/circuit/_classical_resource_map.py
+++ b/qiskit/circuit/_classical_resource_map.py
@@ -80,7 +80,7 @@ class VariableMapper(expr.ExprVisitor[expr.Expr]):
         If ``allow_reorder`` is ``True``, then when a legacy condition (the two-tuple form) is made
         on a register that has a counterpart in the destination with all the same (mapped) bits but
         in a different order, then that register will be used and the value suitably modified to
-        make the equality condition work.  This is maintaining legacy (tested) behavior of
+        make the equality condition work.  This is maintaining the legacy (tested) behavior of
         :meth:`.DAGCircuit.compose`; nowhere else does this, and in general this would require *far*
         more complex classical rewriting than Terra needs to worry about in the full expression era.
         """

--- a/qiskit/circuit/_standard_gates_commutations.py
+++ b/qiskit/circuit/_standard_gates_commutations.py
@@ -43,7 +43,7 @@ commutation. The relative placement is defined by the gate qubit arrangements as
 q1[i] is the ith qubit of the first gate and q2^{-1}[q] returns the qubit index of qubit q in the second
 gate (possibly 'None'). In the second example, the zeroth qubit of cy overlaps with qubit 1 of cx. Non-
 overlapping qubits are specified as 'None' in the dictionary key, e.g. example 3, there is no overlap
-on the zeroth qubit of the first cx but the zeroth qubit of the second gate overlaps with qubit 1 of the
+on the zeroth qubit of the first cx, but the zeroth qubit of the second gate overlaps with qubit 1 of the
 first cx.
 """
 

--- a/qiskit/circuit/_utils.py
+++ b/qiskit/circuit/_utils.py
@@ -36,7 +36,7 @@ def _compute_control_matrix(base_mat, num_ctrl_qubits, ctrl_state=None):
 
     Args:
         base_mat (ndarray): unitary to be controlled
-        num_ctrl_qubits (int): number of controls for new unitary
+        num_ctrl_qubits (int): number of controls for the new unitary
         ctrl_state (int or str or None): The control state in decimal or as
             a bitstring (e.g. '111'). If None, use 2**num_ctrl_qubits-1.
 

--- a/qiskit/circuit/controlflow/if_else.py
+++ b/qiskit/circuit/controlflow/if_else.py
@@ -449,7 +449,7 @@ class ElseContext:
 
     def __enter__(self):
         if self._used:
-            raise CircuitError("Cannot re-use an 'else' context.")
+            raise CircuitError("Cannot reuse an 'else' context.")
         self._used = True
         circuit = self._if_context.circuit
         if not self._if_context.appended:
@@ -489,7 +489,7 @@ class ElseContext:
         circuit = self._if_context.circuit
         if exc_type is not None:
             # If we're leaving the context manager because an exception was raised, we need to
-            # restore the "if" block we popped off.  At that point, it's safe to re-use this context
+            # restore the "if" block we popped off.  At that point, it's safe to reuse this context
             # manager, assuming nothing else untoward happened to the circuit, but that's checked by
             # the __enter__ method.
             circuit._pop_scope()

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -536,7 +536,7 @@ class QuantumCircuit:
     A :class:`QuantumCircuit` alone is not a single :class:`~.circuit.Instruction`; it is rather
     more complicated, since it can, in general, represent a complete program with typed classical
     memory inputs and outputs, and control flow.  Qiskit's (and most hardware's) data model does not
-    yet have the concept of re-usable callable subroutines with virtual quantum operands.  You can
+    yet have the concept of reusable callable subroutines with virtual quantum operands.  You can
     convert simple circuits that act only on qubits with unitary operations into a :class:`.Gate`
     using :meth:`to_gate`, and simple circuits acting only on qubits and clbits into a
     :class:`~.circuit.Instruction` with :meth:`to_instruction`.


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

I noticed some grammar issues in underscore files of the `qiskit/circuit` folder. So, I fixed them.

### Details and comments


