### PR TITLE
Bugfix in qsd's `extract_multiplex_blocks`

### DIFF
--- a/crates/synthesis/src/qsd.rs
+++ b/crates/synthesis/src/qsd.rs
@@ -635,7 +635,7 @@ fn extract_multiplex_blocks(umat: &DMatrix<Complex64>, k: usize) -> [DMatrix<Com
         DMatrix::from_fn(um00.shape()[0], um00.shape()[1], |i, j| um00[[i, j]]),
         DMatrix::from_fn(um11.shape()[0], um11.shape()[1], |i, j| um11[[i, j]]),
         DMatrix::from_fn(um01.shape()[0], um01.shape()[1], |i, j| um01[[i, j]]),
-        DMatrix::from_fn(um10.shape()[0], um10.shape()[1], |i, j| um01[[i, j]]),
+        DMatrix::from_fn(um10.shape()[0], um10.shape()[1], |i, j| um10[[i, j]]),
     ]
 }
 


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes a typo bug in `extract_multiplex_blocks` in the qsd code.

### Details and comments
In `extract_multiplex_blocks`, a block matrix is obtained as four slices that are then converted to `DMatrix`. In copying the `u10` part of the matrix, I accidently used `DMatrix::from_fn(um10.shape()[0], um10.shape()[1], |i, j| um01[[i, j]]),` where the last `um01` should have been `um10`.

@alexanderivrii noticed the bug and also explained why it had no effect; we currently only use `extract_multiplex_blocks` when trying to check whether both `um01` and `um10` are zero (so we have a block diagonal matrix). Since we use this in the context of a unitary matrix, one being zero implies the other being zero, so the bug has no observable effect at this stage.

