### PR TITLE
Add qk_dag_substitute_node_with_unitary to the C API

### DIFF
--- a/crates/cext/src/dag.rs
+++ b/crates/cext/src/dag.rs
@@ -1026,7 +1026,6 @@ pub unsafe extern "C" fn qk_dag_op_node_kind(dag: *const DAGCircuit, node: u32) 
         }
     }
 }
-
 /// A struct for storing successors and predecessors information
 /// retrieved from `qk_dag_successors` and `qk_dag_predecessors`, respectively.
 ///
@@ -1708,4 +1707,69 @@ pub unsafe extern "C" fn qk_dag_replace_block_with_unitary(
         Ok(new_index) => new_index.index() as u32,
         Err(_) => u32::MAX,
     }
+}
+
+/// @ingroup QkDag
+/// Substitute an operation in a node in a ``QkDag`` with a unitary gate
+/// corresponding to the specified unitary matrix.
+///
+/// The new operation should match the shape of the replaced operation.
+/// The qargs and cargs for the node will remain the same.
+///
+/// @param dag Pointer to the DAG.
+/// @param node The node whose operation is substituted. The number of qubits
+///     in the substituted operation should equal to ``num_qubits`` and the
+///     number of clbits should be ``0``.
+/// @param matrix Pointer to an initialized row-major unitary matrix of size
+///     ``4**num_qubits``.
+/// @param num_qubits The number of qubits the resulting unitary gate acts on.
+///
+/// # Example
+/// ```c
+/// // Create a DAG with H, CX, Z, S gates
+/// QkDag *dag = qk_dag_new();
+/// QkQuantumRegister *qr = qk_quantum_register_new(2, "qr");
+/// qk_dag_add_quantum_register(dag, qr);
+/// qk_dag_apply_gate(dag, QkGate_H, (uint32_t[]){0}, NULL, false);
+/// qk_dag_apply_gate(dag, QkGate_CX, (uint32_t[]){0, 1}, NULL, false);
+/// uint32_t idx_z = qk_dag_apply_gate(dag, QkGate_Z, (uint32_t[]){1}, NULL, false);
+/// qk_dag_apply_gate(dag, QkGate_S, (uint32_t[]){1}, NULL, false);
+///
+/// static const QkComplex64 mat[4] = {{1, 0}, {0, 0}, {0, 0}, {-1, 0}};
+///
+/// // Replace the Z-gate by a unitary matrix
+/// qk_dag_substitute_op_with_unitary(dag, idx_z, mat, 1);
+///
+/// // free the register and dag pointer when done
+/// qk_quantum_register_free(qr);
+/// qk_dag_free(dag);
+/// ```
+///
+/// # Safety
+///
+/// Behavior is undefined if any of:
+/// * `dag` is not an aligned, non-null pointer to a valid ``QkDag``,
+/// * `matrix` is not an aligned pointer to `4**num_qubits` initialized values,
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn qk_dag_substitute_op_with_unitary(
+    dag: *mut DAGCircuit,
+    node: u32,
+    matrix: *const Complex64,
+    num_qubits: u32,
+) {
+    // SAFETY: per documentation, `dag` points to valid data.
+    let dag = unsafe { mut_ptr_as_ref(dag) };
+
+    // SAFETY: per documentation, `matrix` is aligned and valid for `4**num_qubits` reads of
+    // initialized data.
+    let array = unsafe { unitary_from_pointer(matrix, num_qubits, None) }
+        .expect("infallible without tolerance checking");
+
+    dag.substitute_op(
+        NodeIndex::new(node as usize),
+        Box::new(UnitaryGate { array }).into(),
+        None,
+        None,
+    )
+    .expect("Failed to substitute op.")
 }

--- a/crates/cext/src/dag.rs
+++ b/crates/cext/src/dag.rs
@@ -1026,6 +1026,7 @@ pub unsafe extern "C" fn qk_dag_op_node_kind(dag: *const DAGCircuit, node: u32) 
         }
     }
 }
+
 /// A struct for storing successors and predecessors information
 /// retrieved from `qk_dag_successors` and `qk_dag_predecessors`, respectively.
 ///
@@ -1722,23 +1723,20 @@ pub unsafe extern "C" fn qk_dag_replace_block_with_unitary(
 ///     number of clbits should be ``0``.
 /// @param matrix Pointer to an initialized row-major unitary matrix of size
 ///     ``4**num_qubits``.
-/// @param num_qubits The number of qubits the resulting unitary gate acts on.
+/// @param num_qubits The number of qubits the unitary acts on.
 ///
 /// # Example
 /// ```c
-/// // Create a DAG with H, CX, Z, S gates
+/// // Create a DAG with a Z-gate
 /// QkDag *dag = qk_dag_new();
 /// QkQuantumRegister *qr = qk_quantum_register_new(2, "qr");
 /// qk_dag_add_quantum_register(dag, qr);
-/// qk_dag_apply_gate(dag, QkGate_H, (uint32_t[]){0}, NULL, false);
-/// qk_dag_apply_gate(dag, QkGate_CX, (uint32_t[]){0, 1}, NULL, false);
 /// uint32_t idx_z = qk_dag_apply_gate(dag, QkGate_Z, (uint32_t[]){1}, NULL, false);
-/// qk_dag_apply_gate(dag, QkGate_S, (uint32_t[]){1}, NULL, false);
 ///
 /// static const QkComplex64 mat[4] = {{1, 0}, {0, 0}, {0, 0}, {-1, 0}};
 ///
 /// // Replace the Z-gate by a unitary matrix
-/// qk_dag_substitute_op_with_unitary(dag, idx_z, mat, 1);
+/// qk_dag_substitute_node_with_unitary(dag, idx_z, mat, 1);
 ///
 /// // free the register and dag pointer when done
 /// qk_quantum_register_free(qr);
@@ -1751,7 +1749,7 @@ pub unsafe extern "C" fn qk_dag_replace_block_with_unitary(
 /// * `dag` is not an aligned, non-null pointer to a valid ``QkDag``,
 /// * `matrix` is not an aligned pointer to `4**num_qubits` initialized values,
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn qk_dag_substitute_op_with_unitary(
+pub unsafe extern "C" fn qk_dag_substitute_node_with_unitary(
     dag: *mut DAGCircuit,
     node: u32,
     matrix: *const Complex64,
@@ -1767,7 +1765,7 @@ pub unsafe extern "C" fn qk_dag_substitute_op_with_unitary(
 
     dag.substitute_op(
         NodeIndex::new(node as usize),
-        Box::new(UnitaryGate { array }).into(),
+        UnitaryGate { array }.into(),
         None,
         None,
     )

--- a/releasenotes/notes/c-api-dag-substitute-node-d68e9e70a31f33d4.yaml
+++ b/releasenotes/notes/c-api-dag-substitute-node-d68e9e70a31f33d4.yaml
@@ -1,0 +1,5 @@
+---
+features_c:
+  - |
+    Added the C API function :c:func:`qk_dag_substitute_op_with_unitary`, which
+    substitutes an operation in a node in a DAG circuit by a unitary gate.

--- a/releasenotes/notes/c-api-dag-substitute-node-d68e9e70a31f33d4.yaml
+++ b/releasenotes/notes/c-api-dag-substitute-node-d68e9e70a31f33d4.yaml
@@ -1,5 +1,5 @@
 ---
 features_c:
   - |
-    Added the C API function :c:func:`qk_dag_substitute_op_with_unitary`, which
+    Added the C API function :c:func:`qk_dag_substitute_node_with_unitary`, which
     substitutes an operation in a node in a DAG circuit by a unitary gate.

--- a/test/c/test_dag.c
+++ b/test/c/test_dag.c
@@ -1280,7 +1280,7 @@ cleanup:
     return result;
 }
 
-static int test_dag_substitute_op_with_unitary(void) {
+static int test_dag_substitute_node_with_unitary(void) {
     int result = Ok;
 
     // Create a DAG with H, CX, Z, S gates
@@ -1296,7 +1296,7 @@ static int test_dag_substitute_op_with_unitary(void) {
     static const QkComplex64 mat[4] = {{1, 0}, {0, 0}, {0, 0}, {-1, 0}};
 
     // Replace the Z-gate by a unitary matrix
-    qk_dag_substitute_op_with_unitary(dag, idx_z, mat, 1);
+    qk_dag_substitute_node_with_unitary(dag, idx_z, mat, 1);
 
     // The resulting DAG should still have 4 operations
     size_t num_ops_z = qk_dag_num_op_nodes(dag);
@@ -1342,7 +1342,7 @@ int test_dag(void) {
     num_failed += RUN_TEST(test_dag_replace_block_with_unitary);
     num_failed += RUN_TEST(test_dag_replace_qubitless_block_with_unitary);
     num_failed += RUN_TEST(test_dag_replace_illegal_block_with_unitary);
-    num_failed += RUN_TEST(test_dag_substitute_op_with_unitary);
+    num_failed += RUN_TEST(test_dag_substitute_node_with_unitary);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);

--- a/test/c/test_dag.c
+++ b/test/c/test_dag.c
@@ -1280,6 +1280,47 @@ cleanup:
     return result;
 }
 
+static int test_dag_substitute_op_with_unitary(void) {
+    int result = Ok;
+
+    // Create a DAG with H, CX, Z, S gates
+    QkDag *dag = qk_dag_new();
+    QkQuantumRegister *qr = qk_quantum_register_new(2, "qr");
+    qk_dag_add_quantum_register(dag, qr);
+
+    qk_dag_apply_gate(dag, QkGate_H, (uint32_t[]){0}, NULL, false);
+    qk_dag_apply_gate(dag, QkGate_CX, (uint32_t[]){0, 1}, NULL, false);
+    uint32_t idx_z = qk_dag_apply_gate(dag, QkGate_Z, (uint32_t[]){1}, NULL, false);
+    qk_dag_apply_gate(dag, QkGate_S, (uint32_t[]){1}, NULL, false);
+
+    static const QkComplex64 mat[4] = {{1, 0}, {0, 0}, {0, 0}, {-1, 0}};
+
+    // Replace the Z-gate by a unitary matrix
+    qk_dag_substitute_op_with_unitary(dag, idx_z, mat, 1);
+
+    // The resulting DAG should still have 4 operations
+    size_t num_ops_z = qk_dag_num_op_nodes(dag);
+    if (num_ops_z != 4) {
+        result = EqualityError;
+        printf("Number of instructions is %zu but expected 4\n", num_ops_z);
+        goto cleanup;
+    }
+
+    // And the new operation must be unitary
+    QkOperationKind new_node_kind_z = qk_dag_op_node_kind(dag, idx_z);
+    if (new_node_kind_z != QkOperationKind_Unitary) {
+        result = EqualityError;
+        printf("The node with index %u has incorrect operation type: expected: %d but got %d.\n",
+               idx_z, QkOperationKind_Unitary, new_node_kind_z);
+    }
+
+cleanup:
+    qk_quantum_register_free(qr);
+    qk_dag_free(dag);
+
+    return result;
+}
+
 int test_dag(void) {
     int num_failed = 0;
     num_failed += RUN_TEST(test_empty);
@@ -1301,6 +1342,7 @@ int test_dag(void) {
     num_failed += RUN_TEST(test_dag_replace_block_with_unitary);
     num_failed += RUN_TEST(test_dag_replace_qubitless_block_with_unitary);
     num_failed += RUN_TEST(test_dag_replace_illegal_block_with_unitary);
+    num_failed += RUN_TEST(test_dag_substitute_op_with_unitary);
 
     fflush(stderr);
     fprintf(stderr, "=== Number of failed subtests: %i\n", num_failed);


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Adding `qk_dag_substitute_op_with_unitary` to the C API. Addresses the "unitary" part of #15192. This complements other existing functions that deal with unitary gates in a DAG.

### Details and comments

The suggested API is
```rust
pub unsafe extern "C" fn qk_dag_substitute_op_with_unitary(
    dag: *mut DAGCircuit,
    node: u32,
    matrix: *const Complex64,
    num_qubits: u32,
)
```
where `num_qubits` is the number of qubits over which `matrix` is defined. The users are responsible for making sure that the number of qubits and clbits in the replaced operation is the same as in the new operation, that is `num_qubits` and `0` respectively. The function panics otherwise.

We could also avoid specifying `num_qubits`, deriving it from the node being replaced.

