### PR TITLE
Fix parameter handling in PPR

### DIFF
--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -36,7 +36,7 @@ use crate::packed_instruction::PackedOperation;
 use crate::parameter::parameter_expression::ParameterExpression;
 use nalgebra::{Dyn, MatrixView2, MatrixView4};
 use num_complex::Complex64;
-use smallvec::SmallVec;
+use smallvec::{SmallVec, smallvec};
 
 /// A single instruction in a :class:`.QuantumCircuit`, comprised of the :attr:`operation` and
 /// various operands.
@@ -898,13 +898,13 @@ impl<'a, 'py, T: CircuitBlock> FromPyObject<'a, 'py> for OperationFromPython<T> 
             let pauli_rotation = PauliProductRotation {
                 z: z.to_owned(),
                 x: x.to_owned(),
-                angle,
+                angle: angle.clone(),
             };
             let pbc = Box::new(PauliBased::PauliProductRotation(pauli_rotation));
 
             return Ok(OperationFromPython {
                 operation: PackedOperation::from_pauli_based(pbc),
-                params: None,
+                params: Some(Parameters::Params(smallvec![angle])),
                 label: extract_label()?,
             });
         }

--- a/test/python/circuit/library/test_pauli_product_rotation.py
+++ b/test/python/circuit/library/test_pauli_product_rotation.py
@@ -251,6 +251,10 @@ class TestPauliProductRotationGate(QiskitTestCase):
         bound = circuit.assign_parameters({angle: value})
         self.assertEqual(bound.num_parameters, 0)
 
+        params = bound.data[0].operation.params
+        self.assertEqual(len(params), 1)
+        self.assertAlmostEqual(value, params[0])
+
         expected = QuantumCircuit(pauli.num_qubits)
         expected.append(PauliProductRotationGate(pauli, value), expected.qubits)
         self.assertEqual(expected, bound)

--- a/test/python/circuit/library/test_pauli_product_rotation.py
+++ b/test/python/circuit/library/test_pauli_product_rotation.py
@@ -236,3 +236,21 @@ class TestPauliProductRotationGate(QiskitTestCase):
 
             counts = {"sx": 1, "sxdg": 1, "h": 2, "cx": 4, num_ctrl_qubits * "c" + "rz": 1}
             self.assertDictEqual(counts, ctrl.definition.count_ops())
+
+    def test_parameter_assignment(self):
+        """Test parameter assignment."""
+        angle = Parameter("x")
+        pauli = Pauli("XYZ")
+        ppr = PauliProductRotationGate(pauli, angle)
+
+        value = 5.4321
+        circuit = QuantumCircuit(pauli.num_qubits)
+        circuit.append(ppr, circuit.qubits)
+        self.assertEqual(circuit.num_parameters, 1)
+
+        bound = circuit.assign_parameters({angle: value})
+        self.assertEqual(bound.num_parameters, 0)
+
+        expected = QuantumCircuit(pauli.num_qubits)
+        expected.append(PauliProductRotationGate(pauli, value), expected.qubits)
+        self.assertEqual(expected, bound)


### PR DESCRIPTION


<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The Python `PauliProductRotationGate` didn't keep track of the parameters when converted into a Rust-space `PackedInstruction`. This led to the circuit not knowing about the parameter values in the circuit.

### Details and comments

No reno since PPR has not yet been released.