### PR TITLE
Keep ``LitinskiTransformation`` backward compatible

### DIFF
--- a/crates/transpiler/src/passes/litinski_transformation.rs
+++ b/crates/transpiler/src/passes/litinski_transformation.rs
@@ -42,12 +42,12 @@ static SUPPORTED_INSTRUCTION_NAMES: [&str; 20] = [
 static HANDLED_INSTRUCTION_NAMES: [&str; 4] = ["t", "tdg", "rz", "measure"];
 
 #[pyfunction]
-#[pyo3(signature = (dag, fix_clifford=true, insert_barrier=false, legacy_pauli_evolution=false))]
+#[pyo3(signature = (dag, fix_clifford=true, insert_barrier=false, use_ppr=false))]
 pub fn run_litinski_transformation(
     dag: &DAGCircuit,
     fix_clifford: bool,
     insert_barrier: bool,
-    legacy_pauli_evolution: bool,
+    use_ppr: bool,
 ) -> PyResult<Option<DAGCircuit>> {
     let op_counts = dag.get_op_counts();
 
@@ -246,7 +246,19 @@ pub fn run_litinski_transformation(
                     // In the legacy path, we add PauliEvolutionGate as rotation gates, otherwise
                     // we add PauliProductRotation. The new path should not call Python at any
                     // point.
-                    let (packed_op, param) = if legacy_pauli_evolution {
+                    let (packed_op, param) = if use_ppr {
+                        let angle = if sign {
+                            multiply_param(&angle, -1.0)
+                        } else {
+                            angle
+                        };
+                        let ppr = PauliProductRotation {
+                            z,
+                            x,
+                            angle: angle.clone(),
+                        };
+                        (PauliBased::PauliProductRotation(ppr).into(), angle)
+                    } else {
                         let time = if sign {
                             multiply_param(&angle, -0.5)
                         } else {
@@ -266,18 +278,6 @@ pub fn run_litinski_transformation(
                             }))
                         })?;
                         (py_gate.into(), time)
-                    } else {
-                        let angle = if sign {
-                            multiply_param(&angle, -1.0)
-                        } else {
-                            angle
-                        };
-                        let ppr = PauliProductRotation {
-                            z,
-                            x,
-                            angle: angle.clone(),
-                        };
-                        (PauliBased::PauliProductRotation(ppr).into(), angle)
                     };
 
                     new_dag.apply_operation_back(

--- a/qiskit/transpiler/passes/optimization/litinski_transformation.py
+++ b/qiskit/transpiler/passes/optimization/litinski_transformation.py
@@ -19,7 +19,7 @@ from qiskit._accelerate.litinski_transformation import run_litinski_transformati
 
 
 class LitinskiTransformation(TransformationPass):
-    """Applies Litinski transform to a circuit.
+    r"""Applies Litinski transform to a circuit.
 
     The transform applies to a circuit containing Clifford, single-qubit :math:`R_Z`-rotation gates
     (including :math:`T` and :math:`T^\dagger`), and standard :math:`Z`-measurements, and moves
@@ -86,7 +86,7 @@ class LitinskiTransformation(TransformationPass):
                 ``fix_clifford=False``.
             use_ppr: If ``True``, use :class:`.PauliProductRotationGate` to represent
                 the Pauli rotation gates. This is encouraged to improve performance using a fully
-                Rust-backed path. If ``False`` or unset, use :class:`.PauliEvolutionGate`.
+                Rust-backed path. If ``False`` or ``None``, use :class:`.PauliEvolutionGate`.
         """
         super().__init__()
         self.fix_clifford = fix_clifford

--- a/qiskit/transpiler/passes/optimization/litinski_transformation.py
+++ b/qiskit/transpiler/passes/optimization/litinski_transformation.py
@@ -19,15 +19,12 @@ from qiskit._accelerate.litinski_transformation import run_litinski_transformati
 
 
 class LitinskiTransformation(TransformationPass):
-    """
-    Applies Litinski transform to a circuit.
+    """Applies Litinski transform to a circuit.
 
-    The transform applies to a circuit containing Clifford, single-qubit RZ-rotation gates
-    (including T and Tdg), and standard Z-measurements, and moves Clifford gates to the end
-    of the circuit. In the process, it changes RZ-rotations to product pauli rotations
-    (implemented as :class:`.PauliEvolutionGate` gates), and changes Z-measurements
-    to product pauli measurements (implemented using :class:`.PauliProductMeasurement`
-    instructions).
+    The transform applies to a circuit containing Clifford, single-qubit :math:`R_Z`-rotation gates
+    (including :math:`T` and :math:`T^\dagger`), and standard :math:`Z`-measurements, and moves
+    Clifford gates to the end of the circuit. In the process, it transforms :math:`R_Z`-rotations to
+    Pauli product rotations, and :math:`Z`-measurements to Pauli product measurements.
 
     The pass supports all of the Clifford gates in the list returned by
     :func:`.get_clifford_gate_names`:
@@ -35,9 +32,35 @@ class LitinskiTransformation(TransformationPass):
     ``["id", "x", "y", "z", "h", "s", "sdg", "sx", "sxdg", "cx", "cz", "cy",
     "swap","iswap", "ecr", "dcx"]``
 
-    The list of supported RZ-rotations is:
+    The list of supported :math:`R_Z`-rotations is:
 
     ``["t", "tdg", "rz"]``
+
+    Example:
+
+    .. plot::
+        :include-source:
+        :nofigs:
+
+        from qiskit import generate_preset_pass_manager
+        from qiskit.circuit import QuantumCircuit
+        from qiskit.transpiler.passes import LitinskiTransformation
+
+        litinski = LitinskiTransformation(fix_clifford=False, use_ppr=True)
+
+        rz_basis = ["rz", "h", "x", "cx"]
+        pm = generate_preset_pass_manager(basis_gates=rz_basis)
+        pm.optimization.append(litinski)
+
+        qc = QuantumCircuit(3, 1)
+        qc.h(0)
+        qc.rz(1.23, 0)
+        qc.cx(0, 1)
+        qc.t(1)
+        qc.cx(1, 2)
+        qc.measure(2, 0)
+
+        pbc = pm.run(qc)
 
     References:
 
@@ -50,10 +73,9 @@ class LitinskiTransformation(TransformationPass):
         self,
         fix_clifford: bool = True,
         insert_barrier: bool = False,
-        legacy_pauli_evolution: bool = False,
+        use_ppr: bool = False,
     ):
         """
-
         Args:
             fix_clifford: If ``False`` (non-default), the returned circuit contains
                 only :class:`.PauliEvolution` gates, with the final Clifford gates omitted.
@@ -62,14 +84,14 @@ class LitinskiTransformation(TransformationPass):
             insert_barrier: If ``True`` and ``fix_clifford=True``, insert a barrier between the
                 circuit and the final cliffords. This argument has no effect if
                 ``fix_clifford=False``.
-            legacy_pauli_evolution: If ``True``, use :class:`.PauliEvolutionGate` to represent
-                the Pauli rotation gates. Otherwise, use :class:`.PauliProductRotationGate`
-                (the default), which uses a more efficient, fully Rust-backed path.
+            use_ppr: If ``True``, use :class:`.PauliProductRotationGate` to represent
+                the Pauli rotation gates. This is encouraged to improve performance using a fully
+                Rust-backed path. If ``False``, use :class:`.PauliEvolutionGate`.
         """
         super().__init__()
         self.fix_clifford = fix_clifford
         self.insert_barrier = insert_barrier
-        self.legacy_pauli_evolution = legacy_pauli_evolution
+        self.use_ppr = use_ppr
 
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         """Run the LitinskiTransformation pass on ``dag``.
@@ -84,7 +106,7 @@ class LitinskiTransformation(TransformationPass):
             TranspilerError: If the circuit contains gates not supported by the pass.
         """
         new_dag = run_litinski_transformation(
-            dag, self.fix_clifford, self.insert_barrier, self.legacy_pauli_evolution
+            dag, self.fix_clifford, self.insert_barrier, self.use_ppr
         )
 
         # If the pass did not do anything, the result is None

--- a/qiskit/transpiler/passes/optimization/litinski_transformation.py
+++ b/qiskit/transpiler/passes/optimization/litinski_transformation.py
@@ -73,7 +73,7 @@ class LitinskiTransformation(TransformationPass):
         self,
         fix_clifford: bool = True,
         insert_barrier: bool = False,
-        use_ppr: bool = False,
+        use_ppr: bool | None = None,
     ):
         """
         Args:
@@ -86,11 +86,17 @@ class LitinskiTransformation(TransformationPass):
                 ``fix_clifford=False``.
             use_ppr: If ``True``, use :class:`.PauliProductRotationGate` to represent
                 the Pauli rotation gates. This is encouraged to improve performance using a fully
-                Rust-backed path. If ``False``, use :class:`.PauliEvolutionGate`.
+                Rust-backed path. If ``False`` or unset, use :class:`.PauliEvolutionGate`.
         """
         super().__init__()
         self.fix_clifford = fix_clifford
         self.insert_barrier = insert_barrier
+
+        # In Qiskit v2.4 the default is to keep using PauliEvolutionGate as rotation gates, but
+        # come v2.5 we can start to warn that in v3.0 the default will be changed to PPR gates
+        # (i.e. we will set ``use_ppr=True`` per default).
+        if use_ppr is None:
+            use_ppr = False
         self.use_ppr = use_ppr
 
     def run(self, dag: DAGCircuit) -> DAGCircuit:

--- a/releasenotes/notes/litinski-pbc-da1f25fda250979c.yaml
+++ b/releasenotes/notes/litinski-pbc-da1f25fda250979c.yaml
@@ -1,6 +1,6 @@
 ---
 features_transpiler:
-  - Added a argument ``use_ppr`` to the :class:`.LitinskiTransformation` pass, which, if ``True``  
+  - Added an argument ``use_ppr`` to the :class:`.LitinskiTransformation` pass, which, if ``True``,  
     uses the Rust-native :class:`.PauliProductRotationGate` to represent Pauli product 
     rotations. This improves performance and ergonomics, since the :class:`.PauliProductRotationGate`
     directly represents single Pauli products instead of generic sums of Paulis. 

--- a/releasenotes/notes/litinski-pbc-da1f25fda250979c.yaml
+++ b/releasenotes/notes/litinski-pbc-da1f25fda250979c.yaml
@@ -1,8 +1,8 @@
 ---
-upgrade_transpiler:
-  - The :class:`.LitinskiTransformation` pass now uses :class:`.PauliProductRotationGate`
-    objects to represent Pauli rotations instead of :class:`.PauliEvolutionGate`.  This
-    improves performance and ergonomics, since the :class:`.PauliProductRotationGate`
-    directly represents single Pauli products instead of generic sums of Paulis.
-    The legacy behavior can still be invoked by passing ``legacy_pauli_evolution=True``
-    as argument to :class:`.LitinskiTransformation`.
+features_transpiler:
+  - Added a argument ``use_ppr`` to the :class:`.LitinskiTransformation` pass, which, if ``True``  
+    uses the Rust-native :class:`.PauliProductRotationGate` to represent Pauli product 
+    rotations. This improves performance and ergonomics, since the :class:`.PauliProductRotationGate`
+    directly represents single Pauli products instead of generic sums of Paulis. 
+    If ``use_ppr=False`` (the default), the pass keeps using :class:`.PauliEvolutionGate` objects
+    to represent the rotations.

--- a/test/python/transpiler/test_litinski_transformation.py
+++ b/test/python/transpiler/test_litinski_transformation.py
@@ -35,7 +35,24 @@ from test import QiskitTestCase
 class TestLitinskiTransformation(QiskitTestCase):
     """Test the Litinski Transformation pass."""
 
-    def test_t_tdg_gates(self):
+    def test_default(self):
+        """Test the default behavior for backward compat."""
+        angle = 0.1
+        qc = QuantumCircuit(1)
+        qc.h(0)
+        qc.rz(angle, 0)
+
+        default = LitinskiTransformation()
+        qct = default(qc)
+
+        expected = QuantumCircuit(1)
+        expected.append(PauliEvolutionGate(Pauli("X"), angle / 2), [0])
+        expected.h(0)
+
+        self.assertEqual(expected, qct)
+
+    @data(True, False)
+    def test_t_tdg_gates(self, use_ppr):
         """Test circuit with T/Tdg gates."""
         qc = QuantumCircuit(4)
         qc.h(0)
@@ -47,12 +64,14 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc.s(2)
         qc.t(2)
 
-        qct = LitinskiTransformation()(qc)
+        qct = LitinskiTransformation(use_ppr=use_ppr)(qc)
+        ppr_name = "pauli_product_rotation" if use_ppr else "PauliEvolution"
 
-        self.assertEqual(qct.count_ops(), {"pauli_product_rotation": 4, "cx": 2, "h": 1, "s": 1})
+        self.assertEqual(qct.count_ops(), {ppr_name: 4, "cx": 2, "h": 1, "s": 1})
         self.assertEqual(Operator(qct), Operator(qc))
 
-    def test_rz_gates(self):
+    @data(True, False)
+    def test_rz_gates(self, use_ppr):
         """Test circuit with RZ-rotation gates."""
         qc = QuantumCircuit(4)
         qc.h(0)
@@ -63,12 +82,14 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc.s(2)
         qc.rz(0.1, 1)
 
-        qct = LitinskiTransformation()(qc)
+        qct = LitinskiTransformation(use_ppr=use_ppr)(qc)
+        ppr_name = "pauli_product_rotation" if use_ppr else "PauliEvolution"
 
-        self.assertEqual(qct.count_ops(), {"pauli_product_rotation": 3, "cx": 2, "h": 1, "s": 1})
+        self.assertEqual(qct.count_ops(), {ppr_name: 3, "cx": 2, "h": 1, "s": 1})
         self.assertEqual(Operator(qct), Operator(qc))
 
-    def test_omit_clifford_gates(self):
+    @data(True, False)
+    def test_omit_clifford_gates(self, use_ppr):
         """Test fix_clifford."""
         qc = QuantumCircuit(4)
         qc.h(0)
@@ -79,11 +100,13 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc.s(2)
         qc.rz(0.1, 1)
 
-        qct = LitinskiTransformation(fix_clifford=False)(qc)
+        qct = LitinskiTransformation(fix_clifford=False, use_ppr=use_ppr)(qc)
+        ppr_name = "pauli_product_rotation" if use_ppr else "PauliEvolution"
 
-        self.assertEqual(qct.count_ops(), {"pauli_product_rotation": 3})
+        self.assertEqual(qct.count_ops(), {ppr_name: 3})
 
-    def test_parametric_rz_gates(self):
+    @data(True, False)
+    def test_parametric_rz_gates(self, use_ppr):
         """Test circuit with parameterized RZ-rotation gates."""
         alpha = Parameter("alpha")
         beta = Parameter("beta")
@@ -97,8 +120,9 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc.s(2)
         qc.rz(0.1, 1)
 
-        qct = LitinskiTransformation()(qc)
-        self.assertEqual(qct.count_ops(), {"pauli_product_rotation": 3, "cx": 2, "h": 1, "s": 1})
+        qct = LitinskiTransformation(use_ppr=use_ppr)(qc)
+        ppr_name = "pauli_product_rotation" if use_ppr else "PauliEvolution"
+        self.assertEqual(qct.count_ops(), {ppr_name: 3, "cx": 2, "h": 1, "s": 1})
 
         qc_bound = qc.assign_parameters([0.123, -1.234])
         qct_bound = qct.assign_parameters([0.123, -1.234])
@@ -211,7 +235,7 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc = QuantumCircuit(2)
         qc.t(0)
 
-        qct = LitinskiTransformation()(qc)
+        qct = LitinskiTransformation(use_ppr=True)(qc)
 
         expected = QuantumCircuit(2, global_phase=np.pi / 8)
         expected.append(PauliProductRotationGate(Pauli("Z"), np.pi / 4), [0])
@@ -223,7 +247,7 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc = QuantumCircuit(2)
         qc.tdg(0)
 
-        qct = LitinskiTransformation()(qc)
+        qct = LitinskiTransformation(use_ppr=True)(qc)
 
         expected = QuantumCircuit(2, global_phase=-np.pi / 8)
         expected.append(PauliProductRotationGate(Pauli("Z"), -np.pi / 4), [0])
@@ -236,7 +260,7 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc.h(0)
         qc.t(0)
 
-        qct = LitinskiTransformation()(qc)
+        qct = LitinskiTransformation(use_ppr=True)(qc)
 
         expected = QuantumCircuit(2, global_phase=np.pi / 8)
         expected.append(PauliProductRotationGate(Pauli("X"), np.pi / 4), [0])
@@ -250,7 +274,7 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc.h(0)
         qc.tdg(0)
 
-        qct = LitinskiTransformation()(qc)
+        qct = LitinskiTransformation(use_ppr=True)(qc)
 
         expected = QuantumCircuit(2, global_phase=-np.pi / 8)
         expected.append(PauliProductRotationGate(Pauli("X"), -np.pi / 4), [0])
@@ -264,7 +288,7 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc.sx(0)
         qc.t(0)
 
-        qct = LitinskiTransformation()(qc)
+        qct = LitinskiTransformation(use_ppr=True)(qc)
 
         expected = QuantumCircuit(2, global_phase=np.pi / 8)
         expected.append(PauliProductRotationGate(Pauli("Y"), np.pi / 4), [0])
@@ -278,7 +302,7 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc.sx(0)
         qc.tdg(0)
 
-        qct = LitinskiTransformation()(qc)
+        qct = LitinskiTransformation(use_ppr=True)(qc)
 
         expected = QuantumCircuit(2, global_phase=-np.pi / 8)
         expected.append(PauliProductRotationGate(Pauli("Y"), -np.pi / 4), [0])
@@ -292,7 +316,7 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc.cx(0, 1)
         qc.t(1)
 
-        qct = LitinskiTransformation()(qc)
+        qct = LitinskiTransformation(use_ppr=True)(qc)
 
         expected = QuantumCircuit(2, global_phase=np.pi / 8)
         expected.append(PauliProductRotationGate(Pauli("ZZ"), np.pi / 4), [0, 1])
@@ -306,7 +330,7 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc.cx(0, 1)
         qc.tdg(1)
 
-        qct = LitinskiTransformation()(qc)
+        qct = LitinskiTransformation(use_ppr=True)(qc)
 
         expected = QuantumCircuit(2, global_phase=-np.pi / 8)
         expected.append(PauliProductRotationGate(Pauli("ZZ"), -np.pi / 4), [0, 1])
@@ -319,7 +343,7 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc = QuantumCircuit(2, 2)
         qc.measure(0, 0)
 
-        qct = LitinskiTransformation()(qc)
+        qct = LitinskiTransformation(use_ppr=True)(qc)
 
         expected = QuantumCircuit(2, 2)
         expected.append(PauliProductMeasurement(Pauli("Z")), [0], [0])
@@ -332,7 +356,7 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc.h(0)
         qc.measure(0, 0)
 
-        qct = LitinskiTransformation()(qc)
+        qct = LitinskiTransformation(use_ppr=True)(qc)
 
         expected = QuantumCircuit(2, 2)
         expected.append(PauliProductMeasurement(Pauli("X")), [0], [0])
@@ -346,7 +370,7 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc.sx(0)
         qc.measure(0, 0)
 
-        qct = LitinskiTransformation()(qc)
+        qct = LitinskiTransformation(use_ppr=True)(qc)
 
         expected = QuantumCircuit(2, 2)
         expected.append(PauliProductMeasurement(Pauli("Y")), [0], [0])
@@ -360,7 +384,7 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc.cx(0, 1)
         qc.measure(1, 1)
 
-        qct = LitinskiTransformation()(qc)
+        qct = LitinskiTransformation(use_ppr=True)(qc)
 
         expected = QuantumCircuit(2, 2)
         expected.append(PauliProductMeasurement(Pauli("ZZ")), [0, 1], [1])
@@ -374,7 +398,7 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc.x(0)
         qc.measure(0, 0)
 
-        qct = LitinskiTransformation()(qc)
+        qct = LitinskiTransformation(use_ppr=True)(qc)
 
         expected = QuantumCircuit(2, 2)
         expected.append(PauliProductMeasurement(Pauli("-Z")), [0], [0])
@@ -389,7 +413,7 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc.x(0)
         qc.measure(0, 0)
 
-        qct = LitinskiTransformation()(qc)
+        qct = LitinskiTransformation(use_ppr=True)(qc)
 
         expected = QuantumCircuit(2, 2)
         expected.append(PauliProductMeasurement(Pauli("-X")), [0], [0])
@@ -405,7 +429,7 @@ class TestLitinskiTransformation(QiskitTestCase):
         qc.x(0)
         qc.measure(0, 0)
 
-        qct = LitinskiTransformation()(qc)
+        qct = LitinskiTransformation(use_ppr=True)(qc)
 
         expected = QuantumCircuit(2, 2)
         expected.append(PauliProductMeasurement(Pauli("-Y")), [0], [0])
@@ -444,7 +468,7 @@ class TestLitinskiTransformation(QiskitTestCase):
 
         # Apply the Litinski transform with fix_cliffords=False (ignoring the Clifford gates
         # at the end of the transformed circuit, and clearing the global phase).
-        qct = LitinskiTransformation(fix_clifford=False)(qc)
+        qct = LitinskiTransformation(fix_clifford=False, use_ppr=True)(qc)
         qct.global_phase = 0
 
         # The transformed circuit (as shown at the bottom-right of the figure).
@@ -468,7 +492,9 @@ class TestLitinskiTransformation(QiskitTestCase):
         circuit.rz(1.0, 0)
         circuit.measure(0, 0)
 
-        transform = LitinskiTransformation(fix_clifford=fix_clifford, insert_barrier=True)
+        transform = LitinskiTransformation(
+            fix_clifford=fix_clifford, insert_barrier=True, use_ppr=True
+        )
         out = transform(circuit)
 
         if fix_clifford:
@@ -478,21 +504,3 @@ class TestLitinskiTransformation(QiskitTestCase):
 
         ops = [op.name for op in out.data]
         self.assertListEqual(expected_ops, ops)
-
-    def test_legacy_pauli_evolution(self):
-        """Test the legacy behavior of using PauliEvolutionGate for rotations."""
-        x = Parameter("x")
-        circuit = QuantumCircuit(2)
-        circuit.cx(0, 1)
-        circuit.h(0)
-        circuit.rz(x, 0)
-        circuit.t(1)
-
-        transform = LitinskiTransformation(fix_clifford=False, legacy_pauli_evolution=True)
-        out = transform(circuit)
-
-        expected = QuantumCircuit(2, global_phase=np.pi / 8)
-        expected.append(PauliEvolutionGate(Pauli("XX"), x / 2), [0, 1])
-        expected.append(PauliEvolutionGate(Pauli("ZZ"), np.pi / 8), [0, 1])
-
-        self.assertEqual(expected, out)


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

A recent commit changes the default behavior of the Litinski transformation to emit `PauliProductRotationGate` for the Pauli rotations instead of the `PauliEvolutionGate`. To remain backward compatible, this commit changes the default behavior and instead requires opt-in for the new, fast, Rust-backed path.

### Details and comments

Also fixes the reno to call this a "new feature".