### PR TITLE
Add `QkCircuit` C/Python interoperation via `QuantumCircuit._data`

### DIFF
--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -1370,40 +1370,171 @@ pub unsafe extern "C" fn qk_opcounts_clear(op_counts: *mut OpCounts) {
     op_counts.data = std::ptr::null_mut();
 }
 
-/// @ingroup QkCircuit
-/// Convert to a Python-space ``QuantumCircuit``.
-///
-/// This function takes ownership of the pointer and gives it to Python. Using
-/// the input ``circuit`` pointer after it's passed to this function is
-/// undefined behavior. In particular, ``qk_circuit_free`` should not be called
-/// on this pointer anymore.
-///
-/// @param circuit The C-space ``QkCircuit`` pointer.
-///
-/// @return A Python ``QuantumCircuit`` object.
-///
-/// # Safety
-///
-/// Behavior is undefined if ``circuit`` is not a valid, non-null pointer to
-/// a ``QkCircuit``
-///
-/// It is assumed that the thread currently executing this function holds the
-/// Python GIL. This is required to create the Python object returned by this
-/// function.
-#[unsafe(no_mangle)]
 #[cfg(feature = "python_binding")]
-pub unsafe extern "C" fn qk_circuit_to_python(
-    circuit: *mut CircuitData,
-) -> *mut ::pyo3::ffi::PyObject {
-    // SAFETY: per documentation, `circuit` is a valid and owned `CircuitData`.
-    let circuit = unsafe { Box::from_raw(mut_ptr_as_ref(circuit)) };
-    // SAFETY: per documentation, we are attached to an interpreter.
-    let py = unsafe { ::pyo3::Python::assume_attached() };
-    circuit
-        .into_py_quantum_circuit(py)
-        .expect("Unable to create a Python circuit")
-        .into_ptr()
+mod py {
+    use crate::circuit::mut_ptr_as_ref;
+    use pyo3::prelude::*;
+    use qiskit_circuit::circuit_data::{CircuitData, PyCircuitData};
+
+    /// @ingroup QkCircuit
+    /// Pass ownership of a `QkCircuit` object to Python.
+    ///
+    /// The resulting Python object is *not* `QuantumCircuit`, it is the inner `CircuitData`, which
+    /// is typically accessed as `QuantumCircuit._data`.  You can use `qk_circuit_to_python_full` to
+    /// produce a complete `QuantumCircuit` object.
+    ///
+    /// It is not safe to use the `QkCircuit` pointer after calling this function.  In particular,
+    /// you should not attempt to clear or free it.  The caller must own the `QkCircuit`, not hold a
+    /// borrowed reference (for example, a `QkCircuit *` retrieved from
+    /// `qk_circuit_borrow_from_python` is not owned).
+    ///
+    /// @param qc The owned object.
+    /// @return An owned Python reference to the object.
+    ///
+    /// # Safety
+    ///
+    /// The caller must be attached to a Python interpreter.  Behavior is undefined if `circuit` is not
+    /// a valid non-null pointer to an initialized and owned `QkCircuit`.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn qk_circuit_to_python(
+        qc: *mut CircuitData,
+    ) -> *mut ::pyo3::ffi::PyObject {
+        // SAFETY: per documentation, we are attached to a Python interpreter.
+        let py = unsafe { Python::assume_attached() };
+        // SAFETY: per documentation, `dag` points to owned and valid data.
+        let qc = unsafe { Box::from_raw(mut_ptr_as_ref(qc)) };
+        match Bound::new(py, PyCircuitData::from(*qc)) {
+            Ok(ob) => ob.into_ptr(),
+            Err(e) => {
+                e.restore(py);
+                ::std::ptr::null_mut()
+            }
+        }
+    }
+
+    /// @ingroup QkCircuit
+    /// Pass ownership of a `QkCircuit` object to Python and create a complete `QuantumCircuit`.
+    ///
+    /// This includes additional Python-space logic to produce the complete `QuantumCircuit`, since
+    /// `QkCircuit` corresponds only to the internal `QuantumCircuit._data` field.
+    ///
+    /// It is not safe to use the `QkCircuit` pointer after calling this function.  In particular,
+    /// you should not attempt to clear or free it.  The caller must own the `QkCircuit`, not hold a
+    /// borrowed reference (for example, a `QkCircuit *` retrieved from
+    /// `qk_circuit_borrow_from_python` is not owned).
+    ///
+    /// @param qc The owned object.
+    /// @return An owned Python reference to the object.
+    ///
+    /// # Safety
+    ///
+    /// The caller must be attached to a Python interpreter.  Behavior is undefined if `circuit` is not
+    /// a valid non-null pointer to an initialized and owned `QkCircuit`.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn qk_circuit_to_python_full(
+        qc: *mut CircuitData,
+    ) -> *mut ::pyo3::ffi::PyObject {
+        // SAFETY: per documentation, we are attached to a Python interpreter.
+        let py = unsafe { Python::assume_attached() };
+        // SAFETY: per documentation, `dag` points to owned and valid data.
+        let qc = unsafe { Box::from_raw(mut_ptr_as_ref(qc)) };
+        match PyCircuitData::from(*qc).into_py_quantum_circuit(py) {
+            Ok(ob) => ob.into_ptr(),
+            Err(e) => {
+                e.restore(py);
+                ::std::ptr::null_mut()
+            }
+        }
+    }
+
+    /// @ingroup QkCircuit
+    /// Retrieve a `QkCircuit` pointer from a Python object.
+    ///
+    /// Note that the input to this function should _not_ be `QuantumCircuit`, but the output of
+    /// `QuantumCircuit._data`.  This is necessary to enforce correct reference-counting semantics.
+    ///
+    /// This borrows a Python reference and extracts the `QkCircuit` pointer for it, if it is of
+    /// the correct type.  The returned pointer is borrowed from the `ob` pointer.  If the
+    /// ``PyObject`` is not the correct type, the return value is ``NULL`` and the exception
+    /// state of the Python interpreter is set.
+    ///
+    /// You must be attached to a Python interpreter to call this function.
+    ///
+    /// You can also use `qk_circuit_convert_from_python`, which is logically the exact same as this
+    /// function, but can be directly used as a "converter" function for the `PyArg_Parse*`
+    /// family of Python converter functions.
+    ///
+    /// @param ob A borrowed Python object.
+    /// @return A pointer to the native object, or `NULL` if the Python object is the wrong type.
+    ///
+    /// # Safety
+    ///
+    /// The caller must be attached to a Python interpreter.  Behavior is undefined if `ob` is
+    /// not a valid non-null pointer to a Python object.
+    #[unsafe(no_mangle)]
+    #[cfg(feature = "python_binding")]
+    pub unsafe extern "C" fn qk_circuit_borrow_from_python(
+        ob: *mut pyo3::ffi::PyObject,
+    ) -> *mut CircuitData {
+        // SAFETY: per documentation, we are attached to a Python interpreter, and `ob` points to a
+        // valid PyObject.
+        unsafe {
+            crate::py::borrow_map::<PyCircuitData, CircuitData>(
+                Python::assume_attached(),
+                ob,
+                // If in the future we change `PyCircuitData` to store an `Arc<RwLock>`, look at
+                // `QkObs`/`SparseObservable` for how to change this Python-space function and the
+                // new ones to be added.
+                |_py, qc| Ok(&mut qc.inner),
+            )
+        }
+    }
+
+    /// @ingroup QkDag
+    /// Retrieve a `QkCircuit` pointer from a Python object.
+    ///
+    /// Note that the input to this function should _not_ be `QuantumCircuit`, but the output of
+    /// `QuantumCircuit._data`.  This is necessary to enforce correct reference-counting semantics.
+    ///
+    /// This borrows a Python reference and extracts the `QkCircuit` pointer for it into
+    /// ``address``, if it is of the correct type.  The returned pointer is borrowed from the
+    /// `object` pointer.  If the ``PyObject`` is not the correct type, the return value is 1, the
+    /// exception state of the Python interpreter is set, and ``address`` is unchanged.
+    ///
+    /// You must be attached to a Python interpreter to call this function.
+    ///
+    /// You can also use `qk_circuit_borrow_from_python`, which is logically the exact same as this,
+    /// but with a more natural signature for direct usage.
+    ///
+    /// @param object A borrowed Python object.
+    /// @param address The location to write the output to.
+    /// @return 0 on success, 1 on failure.
+    ///
+    /// # Safety
+    ///
+    /// The caller must be attached to a Python interpreter.  Behavior is undefined if `object`
+    /// is not a valid non-null pointer to a Python object, or if `address` is not a pointer to
+    /// writeable data of the correct type.
+    #[unsafe(no_mangle)]
+    #[cfg(feature = "python_binding")]
+    pub unsafe extern "C" fn qk_circuit_convert_from_python(
+        object: *mut ::pyo3::ffi::PyObject,
+        address: *mut ::std::ffi::c_void,
+    ) -> ::std::ffi::c_int {
+        // SAFETY: per documentation, we are attached to a Python interpreter, `object` is a valid
+        // pointer to a PyObject, and `address` points to enough space to write a pointer.
+        unsafe {
+            crate::py::convert_map::<PyCircuitData, CircuitData>(
+                Python::assume_attached(),
+                object,
+                address,
+                |_py, qc| Ok(&mut qc.inner),
+            )
+        }
+    }
 }
+#[cfg(feature = "python_binding")]
+pub use py::*;
 
 /// @ingroup QkCircuit
 ///

--- a/crates/cext/src/py.rs
+++ b/crates/cext/src/py.rs
@@ -26,21 +26,51 @@ use pyo3::pyclass::boolean_struct::False;
 ///
 /// # Safety
 ///
-/// `ob` must point to a valid PyObject.
+/// `ob` must point to a valid `PyObject`.
 pub unsafe fn borrow<T>(py: Python, ob: *mut ::pyo3::ffi::PyObject) -> *mut T
 where
     T: PyClass<Frozen = False>,
 {
-    // SAFETY: per documentation, `ob` points to a valid PyObject.  The lifetime of the
-    // `Borrowed` is valid because we immediately consume it back into a pointer, whose
-    // lifetime is thus tied to the incoming `ob`.
-    match unsafe { Borrowed::from_ptr(py, ob) }.cast::<T>() {
-        Ok(ob) => &mut *ob.borrow_mut(),
-        Err(e) => {
-            PyErr::from(e).restore(py);
-            ::std::ptr::null_mut()
-        }
-    }
+    // SAFETY: per documentation, `ob` satisfies the same requirements as it does in `borrow_map_mut`.
+    unsafe { borrow_map::<T, T>(py, ob, |_py, x| Ok(x)) }
+}
+
+/// Borrow a pointer to a Rust-native object extracted from a Python object.
+///
+/// The `map_fn` projects the desired reference from a temporary one.  This is useful in cases where
+/// the object exposed to Python contains the raw Rust type (for example, `PySparseObservable`
+/// contains `SparseObservable`).  We do this with a `map_fn` so we can control the safety of the
+/// lifetime of the temporary reference.
+///
+/// The returned pointer derives its lifetime from the lifetime of `ob`.  The reference `ob` is only
+/// borrowed by the function.
+///
+/// If the `PyObject` is not of the correct type or the `map_fn` returns an error variant, the null
+/// pointer is returned and the Python exception state is set.
+///
+/// # Safety
+///
+/// `ob` must point to a valid `PyObject`.
+pub unsafe fn borrow_map<'py, T, S>(
+    py: Python<'py>,
+    ob: *mut ::pyo3::ffi::PyObject,
+    map_fn: impl for<'a> FnOnce(Python<'py>, &'a mut T) -> PyResult<&'a mut S>,
+) -> *mut S
+where
+    T: PyClass<Frozen = False>,
+{
+    let borrow_map = || -> PyResult<*mut S> {
+        // SAFETY: per documentation, `ob` points to a valid PyObject.  The lifetime of the
+        // `Borrowed` is valid because we either drop it or consume it back into a pointer before
+        // the function returns.
+        let ob = unsafe { Borrowed::from_ptr(py, ob) }.cast::<T>()?;
+        let handle = &mut *ob.borrow_mut();
+        map_fn(py, handle).map(::std::ptr::from_mut)
+    };
+    borrow_map().unwrap_or_else(|e| {
+        e.restore(py);
+        ::std::ptr::null_mut()
+    })
 }
 
 /// Extract a pointer to a Rust-native object from a PyObject representing a PyClass, storing the
@@ -64,14 +94,41 @@ pub unsafe fn convert<T>(
 where
     T: PyClass<Frozen = False>,
 {
-    // SAFETY: per documentation, `object` points to a valid PyObject.
-    let native = unsafe { borrow::<T>(py, object) };
+    // SAFETY: per documentation, `object` and `address` satisfy the same requirements as
+    // `convert_map`.
+    unsafe { convert_map::<T, T>(py, object, address, |_py, x| Ok(x)) }
+}
+
+/// Extract a pointer to a Rust-native object from a `PyObject`, storing the result in `address`.
+///
+/// The exact object stored can be extracted from a `PyClass` by projecting a reference out of some
+/// outer Python-exposed type using `map_fn`.  For example, the `object` might be a
+/// `PySparseObservable`, but the `map_fn` extracts a reference to the inne
+///
+/// This is used to define Python-space "converter" functions for use with the `PyArg_Parse*` family
+/// of functions.
+///
+/// On success, returns 1 and writes out the pointer in `address`.  On failure, returns 0, sets the
+/// Python exception state and leaves `address` untouched.
+///
+/// # Safety
+///
+/// `object` must point to a valid PyObject.  `address` must point to enough space to write a
+/// pointer to.
+pub unsafe fn convert_map<'py, T, S>(
+    py: Python<'py>,
+    object: *mut ::pyo3::ffi::PyObject,
+    address: *mut ::std::ffi::c_void,
+    map_fn: impl for<'a> FnOnce(Python<'py>, &'a mut T) -> PyResult<&'a mut S>,
+) -> ::std::ffi::c_int
+where
+    T: PyClass<Frozen = False>,
+{
+    let native = unsafe { borrow_map(py, object, map_fn) };
     if native.is_null() {
         0
     } else {
-        // SAFETY: per documentation, `address` is a pointer to a valid storage location of
-        // the correct type.
-        unsafe { address.cast::<*mut T>().write(native) };
+        unsafe { address.cast::<*mut S>().write(native) };
         1
     }
 }

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -172,6 +172,7 @@ class QuantumCircuit:
     :attr:`clbits`                 List of :class:`Clbit`\\ s tracked by the circuit.
     :attr:`data`                   List of individual :class:`CircuitInstruction`\\ s that make up
                                    the circuit.
+    :attr:`_data`                  Python-space handle to the C API :c:struct:`QkCircuit` object.
     :attr:`duration`               Total duration of the circuit, added by scheduling transpiler
                                    passes.
                                    This attribute is deprecated and :meth:`.estimate_duration`
@@ -208,9 +209,22 @@ class QuantumCircuit:
     :class:`CircuitInstruction`\\ s contained in an ordered form.  You generally should not mutate
     this object directly; :class:`QuantumCircuit` is only designed for append-only operations (which
     should use :meth:`append`).  Most operations that mutate circuits in place should be written as
-    transpiler passes (:mod:`qiskit.transpiler`).
+    transpiler passes (:mod:`qiskit.transpiler`).  The C API interacts with an internal object,
+    called :attr:`_data`, which is not part of the public Python API, other than as a handle to pass
+    to C-API calls.
 
     .. autoattribute:: data
+
+    .. py::attribute:: _data
+        An opaque handle to the C API object ``QkCircuit``.
+
+        .. warning::
+            No part of this object other than its existence is part of the public API.
+
+        The only valid use of this object from within the public Python API is as part of the
+        extraction of a :c:struct:`QkCircuit` using :c:func:`qk_circuit_borrow_from_python` or
+        similar methods.  The Python-space type of the object is not specified in the public API,
+        and none of its methods, regardless of name, should be considered public.
 
     Alongside the :attr:`data`, the :attr:`global_phase` of a circuit can have some impact on its
     output, if the circuit is used to describe a :class:`.Gate` that may be controlled.  This is

--- a/releasenotes/notes/c-python-circuit-8134e518a12612af.yaml
+++ b/releasenotes/notes/c-python-circuit-8134e518a12612af.yaml
@@ -1,0 +1,20 @@
+---
+features_c:
+  - |
+    The C API now supports converting :c:struct:`QkCircuit` to and from Python-space objects, using the methods:
+
+    * :c:func:`qk_circuit_borrow_from_python`
+    * :c:func:`qk_circuit_convert_from_python`
+    * :c:func:`qk_circuit_to_python_full`
+    * :c:func:`qk_circuit_to_python`
+
+    Note that :c:func:`qk_circuit_to_python` is not new, but its behavior changed in Qiskit 2.4 to return the
+    Python object that directly corresponds to :c:struct:`QkCircuit` (see :attr:`.QuantumCircuit._data`), instead
+    of :class:`.QuantumCircuit` itself.  :c:func:`qk_circuit_to_python_full` replaces the old method.
+features_circuits:
+  - The formally private attribute :attr:`.QuantumCircuit._data` is now public API, but only as a handle
+    for passing to C-API functions expecting :c:struct:`QkCircuit`.  The type of the object is not specified
+    in the public API, nor are any methods on it.
+upgrade_c:
+  - :c:func:`qk_circuit_to_python` no longer returns a complete :class:`.QuantumCircuit`, but only the type of
+    :attr:`.QuantumCircuit._data`.  The new method :c:func:`qk_circuit_to_python_full` provides the old functionality.

--- a/test/python/capi/ffi.py
+++ b/test/python/capi/ffi.py
@@ -67,10 +67,10 @@ LIB.qk_circuit_gate.argtypes = [
 ]
 LIB.qk_circuit_gate.restype = ctypes.c_uint32
 LIB.qk_circuit_measure.argtypes = [ctypes.POINTER(QkCircuit), ctypes.c_uint32, ctypes.c_uint32]
-LIB.qk_circuit_to_python.argtypes = [
+LIB.qk_circuit_to_python_full.argtypes = [
     ctypes.POINTER(QkCircuit),
 ]
-LIB.qk_circuit_to_python.restype = ctypes.py_object
+LIB.qk_circuit_to_python_full.restype = ctypes.py_object
 LIB.qk_circuit_barrier.argtypes = [
     ctypes.POINTER(QkCircuit),
     ctypes.POINTER(ctypes.c_uint32),
@@ -251,6 +251,6 @@ def transpile_from_c(
         )
     layout = LIB.qk_transpile_layout_to_python(result.layout, result.circuit)
     LIB.qk_transpile_layout_free(result.layout)
-    out = LIB.qk_circuit_to_python(result.circuit)
+    out = LIB.qk_circuit_to_python_full(result.circuit)
     out._layout = layout
     return out


### PR DESCRIPTION
We previously had a `qk_circuit_to_python` method that returned a complete `QuantumCircuit`, though without the stable C extension module mode, this was only practically useful for testing via `ctypes` in our unit tests.

This is a breaking change that explicitly makes the C/Python conversion type the direct Python-space `CircuitData` handle, and documents a path to retrieving this from `QuantumCircuit`, replacing the old method with `qk_circuit_to_python_full` (which in practice is likely to be the only useful call in the near future).

This is necessary because the `qk_circuit_borrow_from_python` method cannot safely take a `QuantumCircuit` in a `PyObject *`, because we would need to extract a _new_ Python reference to `QuantumCircuit._data` internally, and then either _leak_ the refcount of that or risk Python garbage-collecting it out from underneath us if another thread/worker were to reassign the outer `QuantumCircuit._data`.

The documentation of `QuantumCircuit._data` deliberately and explicitly makes _all_ features of the attribute private except for the ability to pass it to C-API functions expecting "Python handle to `QkCircuit`". This specifically does not preclude a hypothetical unification of `PyCircuitData` and `QuantumCircuit` in the future; we will be able to maintain backwards compatibility if that comes to pass by simply having `QuantumCircuit._data` return itself.