### PR TITLE
Add C/Python interop for `QuantumRegister` and `ClassicalRegister`

### DIFF
--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -1374,6 +1374,9 @@ pub unsafe extern "C" fn qk_opcounts_clear(op_counts: *mut OpCounts) {
 mod py {
     use crate::circuit::mut_ptr_as_ref;
     use pyo3::prelude::*;
+    use qiskit_circuit::bit::{
+        ClassicalRegister, PyClassicalRegister, PyQuantumRegister, QuantumRegister,
+    };
     use qiskit_circuit::circuit_data::{CircuitData, PyCircuitData};
 
     /// @ingroup QkCircuit
@@ -1479,7 +1482,7 @@ mod py {
         // SAFETY: per documentation, we are attached to a Python interpreter, and `ob` points to a
         // valid PyObject.
         unsafe {
-            crate::py::borrow_map::<PyCircuitData, CircuitData>(
+            crate::py::borrow_map_mut::<PyCircuitData, CircuitData>(
                 Python::assume_attached(),
                 ob,
                 // If in the future we change `PyCircuitData` to store an `Arc<RwLock>`, look at
@@ -1508,7 +1511,7 @@ mod py {
     ///
     /// @param object A borrowed Python object.
     /// @param address The location to write the output to.
-    /// @return 0 on success, 1 on failure.
+    /// @return 1 on success, 0 on failure.
     ///
     /// # Safety
     ///
@@ -1524,11 +1527,235 @@ mod py {
         // SAFETY: per documentation, we are attached to a Python interpreter, `object` is a valid
         // pointer to a PyObject, and `address` points to enough space to write a pointer.
         unsafe {
-            crate::py::convert_map::<PyCircuitData, CircuitData>(
+            crate::py::convert_map_mut::<PyCircuitData, CircuitData>(
                 Python::assume_attached(),
                 object,
                 address,
                 |_py, qc| Ok(&mut qc.inner),
+            )
+        }
+    }
+
+    /// @ingroup QkCircuit
+    /// Pass ownership of a `QkQuantumRegister` object to Python.
+    ///
+    /// It is not safe to use the `QkQuantumRegister` pointer after calling this function.  In
+    /// particular, you should not attempt to clear or free it.  The caller must own the
+    /// `QkQuantumRegister`, not hold a borrowed reference (for example, a `QkQuantumRegister *`
+    /// retrieved from `qk_quantum_register_borrow_from_python` is not owned).
+    ///
+    /// @param qr The owned object.
+    /// @return An owned Python reference to the object.
+    ///
+    /// # Safety
+    ///
+    /// The caller must be attached to a Python interpreter.  Behavior is undefined if `circuit` is not
+    /// a valid non-null pointer to an initialized and owned `QkQuantumRegister`.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn qk_quantum_register_to_python(
+        qr: *mut QuantumRegister,
+    ) -> *mut ::pyo3::ffi::PyObject {
+        // SAFETY: per documentation, we are attached to a Python interpreter.
+        let py = unsafe { Python::assume_attached() };
+        // SAFETY: per documentation, `dag` points to owned and valid data.
+        let qreg = unsafe { Box::from_raw(mut_ptr_as_ref(qr)) };
+        match qreg.into_pyobject(py) {
+            Ok(ob) => ob.into_ptr(),
+            Err(e) => {
+                e.restore(py);
+                ::std::ptr::null_mut()
+            }
+        }
+    }
+
+    /// @ingroup QkCircuit
+    /// Retrieve a `QkQuantumRegister` pointer from a Python object.
+    ///
+    /// This borrows a Python reference and extracts the `QkQuantumRegister` pointer for it, if it
+    /// is of the correct type.  The returned pointer is borrowed from the `ob` pointer.  If the
+    /// ``PyObject`` is not the correct type, the return value is ``NULL`` and the exception
+    /// state of the Python interpreter is set.
+    ///
+    /// You must be attached to a Python interpreter to call this function.
+    ///
+    /// You can also use `qk_quantum_register_convert_from_python`, which is logically the exact
+    /// same as this function, but can be directly used as a "converter" function for the
+    /// `PyArg_Parse*` family of Python converter functions.
+    ///
+    /// @param ob A borrowed Python object.
+    /// @return A pointer to the native object, or `NULL` if the Python object is the wrong type.
+    ///
+    /// # Safety
+    ///
+    /// The caller must be attached to a Python interpreter.  Behavior is undefined if `ob` is
+    /// not a valid non-null pointer to a Python object.
+    #[unsafe(no_mangle)]
+    #[cfg(feature = "python_binding")]
+    pub unsafe extern "C" fn qk_quantum_register_borrow_from_python(
+        ob: *mut pyo3::ffi::PyObject,
+    ) -> *const QuantumRegister {
+        // SAFETY: per documentation, we are attached to a Python interpreter, and `ob` points to a
+        // valid PyObject.
+        unsafe {
+            crate::py::borrow_map::<PyQuantumRegister, QuantumRegister>(
+                Python::assume_attached(),
+                ob,
+                |_py, qr| Ok(qr),
+            )
+        }
+    }
+
+    /// @ingroup QkDag
+    /// Retrieve a `QkCircuit` pointer from a Python object.
+    ///
+    /// Note that the input to this function should _not_ be `QuantumCircuit`, but the output of
+    /// `QuantumCircuit._data`.  This is necessary to enforce correct reference-counting semantics.
+    ///
+    /// This borrows a Python reference and extracts the `QkCircuit` pointer for it into
+    /// ``address``, if it is of the correct type.  The returned pointer is borrowed from the
+    /// `object` pointer.  If the ``PyObject`` is not the correct type, the return value is 1, the
+    /// exception state of the Python interpreter is set, and ``address`` is unchanged.
+    ///
+    /// You must be attached to a Python interpreter to call this function.
+    ///
+    /// You can also use `qk_circuit_borrow_from_python`, which is logically the exact same as this,
+    /// but with a more natural signature for direct usage.
+    ///
+    /// @param object A borrowed Python object.
+    /// @param address The location to write the output to.
+    /// @return 1 on success, 0 on failure.
+    ///
+    /// # Safety
+    ///
+    /// The caller must be attached to a Python interpreter.  Behavior is undefined if `object`
+    /// is not a valid non-null pointer to a Python object, or if `address` is not a pointer to
+    /// writeable data of the correct type.
+    #[unsafe(no_mangle)]
+    #[cfg(feature = "python_binding")]
+    pub unsafe extern "C" fn qk_quantum_register_convert_from_python(
+        object: *mut ::pyo3::ffi::PyObject,
+        address: *mut ::std::ffi::c_void,
+    ) -> ::std::ffi::c_int {
+        // SAFETY: per documentation, we are attached to a Python interpreter, `object` is a valid
+        // pointer to a PyObject, and `address` points to enough space to write a pointer.
+        unsafe {
+            crate::py::convert_map::<PyQuantumRegister, QuantumRegister>(
+                Python::assume_attached(),
+                object,
+                address,
+                |_py, qr| Ok(qr),
+            )
+        }
+    }
+
+    /// @ingroup QkCircuit
+    /// Pass ownership of a `QkClassicalRegister` object to Python.
+    ///
+    /// It is not safe to use the `QkClassicalRegister` pointer after calling this function.  In
+    /// particular, you should not attempt to clear or free it.  The caller must own the
+    /// `QkClassicalRegister`, not hold a borrowed reference (for example, a `QkClassicalRegister *`
+    /// retrieved from `qk_classical_register_borrow_from_python` is not owned).
+    ///
+    /// @param cr The owned object.
+    /// @return An owned Python reference to the object.
+    ///
+    /// # Safety
+    ///
+    /// The caller must be attached to a Python interpreter.  Behavior is undefined if `circuit` is not
+    /// a valid non-null pointer to an initialized and owned `QkClassicalRegister`.
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn qk_classical_register_to_python(
+        cr: *mut ClassicalRegister,
+    ) -> *mut ::pyo3::ffi::PyObject {
+        // SAFETY: per documentation, we are attached to a Python interpreter.
+        let py = unsafe { Python::assume_attached() };
+        // SAFETY: per documentation, `dag` points to owned and valid data.
+        let cr = unsafe { Box::from_raw(mut_ptr_as_ref(cr)) };
+        match cr.into_pyobject(py) {
+            Ok(ob) => ob.into_ptr(),
+            Err(e) => {
+                e.restore(py);
+                ::std::ptr::null_mut()
+            }
+        }
+    }
+
+    /// @ingroup QkCircuit
+    /// Retrieve a `QkClassicalRegister` pointer from a Python object.
+    ///
+    /// This borrows a Python reference and extracts the `QkClassicalRegister` pointer for it, if it
+    /// is of the correct type.  The returned pointer is borrowed from the `ob` pointer.  If the
+    /// ``PyObject`` is not the correct type, the return value is ``NULL`` and the exception
+    /// state of the Python interpreter is set.
+    ///
+    /// You must be attached to a Python interpreter to call this function.
+    ///
+    /// You can also use `qk_classical_register_convert_from_python`, which is logically the exact
+    /// same as this function, but can be directly used as a "converter" function for the
+    /// `PyArg_Parse*` family of Python converter functions.
+    ///
+    /// @param ob A borrowed Python object.
+    /// @return A pointer to the native object, or `NULL` if the Python object is the wrong type.
+    ///
+    /// # Safety
+    ///
+    /// The caller must be attached to a Python interpreter.  Behavior is undefined if `ob` is
+    /// not a valid non-null pointer to a Python object.
+    #[unsafe(no_mangle)]
+    #[cfg(feature = "python_binding")]
+    pub unsafe extern "C" fn qk_classical_register_borrow_from_python(
+        ob: *mut pyo3::ffi::PyObject,
+    ) -> *const ClassicalRegister {
+        // SAFETY: per documentation, we are attached to a Python interpreter, and `ob` points to a
+        // valid PyObject.
+        unsafe {
+            crate::py::borrow_map::<PyClassicalRegister, ClassicalRegister>(
+                Python::assume_attached(),
+                ob,
+                |_py, cr| Ok(cr),
+            )
+        }
+    }
+
+    /// @ingroup QkDag
+    /// Retrieve a `QkCircuit` pointer from a Python object.
+    ///
+    /// Note that the input to this function should _not_ be `QuantumCircuit`, but the output of
+    /// `QuantumCircuit._data`.  This is necessary to enforce correct reference-counting semantics.
+    ///
+    /// This borrows a Python reference and extracts the `QkCircuit` pointer for it into
+    /// ``address``, if it is of the correct type.  The returned pointer is borrowed from the
+    /// `object` pointer.  If the ``PyObject`` is not the correct type, the return value is 1, the
+    /// exception state of the Python interpreter is set, and ``address`` is unchanged.
+    ///
+    /// You must be attached to a Python interpreter to call this function.
+    ///
+    /// You can also use `qk_circuit_borrow_from_python`, which is logically the exact same as this,
+    /// but with a more natural signature for direct usage.
+    ///
+    /// @param object A borrowed Python object.
+    /// @param address The location to write the output to.
+    /// @return 1 on success, 0 on failure.
+    ///
+    /// # Safety
+    ///
+    /// The caller must be attached to a Python interpreter.  Behavior is undefined if `object`
+    /// is not a valid non-null pointer to a Python object, or if `address` is not a pointer to
+    /// writeable data of the correct type.
+    #[unsafe(no_mangle)]
+    #[cfg(feature = "python_binding")]
+    pub unsafe extern "C" fn qk_classical_register_convert_from_python(
+        object: *mut ::pyo3::ffi::PyObject,
+        address: *mut ::std::ffi::c_void,
+    ) -> ::std::ffi::c_int {
+        // SAFETY: per documentation, we are attached to a Python interpreter, `object` is a valid
+        // pointer to a PyObject, and `address` points to enough space to write a pointer.
+        unsafe {
+            crate::py::convert_map::<PyClassicalRegister, ClassicalRegister>(
+                Python::assume_attached(),
+                object,
+                address,
+                |_py, cr| Ok(cr),
             )
         }
     }

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -1682,7 +1682,7 @@ mod py {
     ///
     /// This borrows a Python reference and extracts the `QkClassicalRegister` pointer for it, if it
     /// is of the correct type.  The returned pointer is borrowed from the `ob` pointer.  If the
-    /// ``PyObject`` is not the correct type, the return value is ``NULL`` and the exception
+    /// `PyObject` is not the correct type, the return value is `NULL` and the exception
     /// state of the Python interpreter is set.
     ///
     /// You must be attached to a Python interpreter to call this function.

--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -1493,7 +1493,7 @@ mod py {
         }
     }
 
-    /// @ingroup QkDag
+    /// @ingroup QkCircuit
     /// Retrieve a `QkCircuit` pointer from a Python object.
     ///
     /// Note that the input to this function should _not_ be `QuantumCircuit`, but the output of
@@ -1501,8 +1501,8 @@ mod py {
     ///
     /// This borrows a Python reference and extracts the `QkCircuit` pointer for it into
     /// ``address``, if it is of the correct type.  The returned pointer is borrowed from the
-    /// `object` pointer.  If the ``PyObject`` is not the correct type, the return value is 1, the
-    /// exception state of the Python interpreter is set, and ``address`` is unchanged.
+    /// `object` pointer.  If the `PyObject` is not the correct type, the return value is 0, the
+    /// exception state of the Python interpreter is set, and `address` is unchanged.
     ///
     /// You must be attached to a Python interpreter to call this function.
     ///
@@ -1549,7 +1549,7 @@ mod py {
     ///
     /// # Safety
     ///
-    /// The caller must be attached to a Python interpreter.  Behavior is undefined if `circuit` is not
+    /// The caller must be attached to a Python interpreter.  Behavior is undefined if `qr` is not
     /// a valid non-null pointer to an initialized and owned `QkQuantumRegister`.
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn qk_quantum_register_to_python(
@@ -1573,8 +1573,8 @@ mod py {
     ///
     /// This borrows a Python reference and extracts the `QkQuantumRegister` pointer for it, if it
     /// is of the correct type.  The returned pointer is borrowed from the `ob` pointer.  If the
-    /// ``PyObject`` is not the correct type, the return value is ``NULL`` and the exception
-    /// state of the Python interpreter is set.
+    /// `PyObject` is not the correct type, the return value is `NULL` and the exception state of
+    /// the Python interpreter is set.
     ///
     /// You must be attached to a Python interpreter to call this function.
     ///
@@ -1605,21 +1605,18 @@ mod py {
         }
     }
 
-    /// @ingroup QkDag
-    /// Retrieve a `QkCircuit` pointer from a Python object.
+    /// @ingroup QkCircuit
+    /// Retrieve a `QkQuantumRegister` pointer from a Python object.
     ///
-    /// Note that the input to this function should _not_ be `QuantumCircuit`, but the output of
-    /// `QuantumCircuit._data`.  This is necessary to enforce correct reference-counting semantics.
-    ///
-    /// This borrows a Python reference and extracts the `QkCircuit` pointer for it into
-    /// ``address``, if it is of the correct type.  The returned pointer is borrowed from the
-    /// `object` pointer.  If the ``PyObject`` is not the correct type, the return value is 1, the
-    /// exception state of the Python interpreter is set, and ``address`` is unchanged.
+    /// This borrows a Python reference and extracts the `QkQuantumRegister` pointer for it into
+    /// `address`, if it is of the correct type.  The returned pointer is borrowed from the
+    /// `object` pointer.  If the `PyObject` is not the correct type, the return value is 0, the
+    /// exception state of the Python interpreter is set, and `address` is unchanged.
     ///
     /// You must be attached to a Python interpreter to call this function.
     ///
-    /// You can also use `qk_circuit_borrow_from_python`, which is logically the exact same as this,
-    /// but with a more natural signature for direct usage.
+    /// You can also use `qk_quantum_register_borrow_from_python`, which is logically the exact same
+    /// as this, but with a more natural signature for direct usage.
     ///
     /// @param object A borrowed Python object.
     /// @param address The location to write the output to.
@@ -1661,7 +1658,7 @@ mod py {
     ///
     /// # Safety
     ///
-    /// The caller must be attached to a Python interpreter.  Behavior is undefined if `circuit` is not
+    /// The caller must be attached to a Python interpreter.  Behavior is undefined if `cr` is not
     /// a valid non-null pointer to an initialized and owned `QkClassicalRegister`.
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn qk_classical_register_to_python(
@@ -1717,20 +1714,17 @@ mod py {
         }
     }
 
-    /// @ingroup QkDag
-    /// Retrieve a `QkCircuit` pointer from a Python object.
+    /// @ingroup QkCircuit
+    /// Retrieve a `QkClassicalRegister` pointer from a Python object.
     ///
-    /// Note that the input to this function should _not_ be `QuantumCircuit`, but the output of
-    /// `QuantumCircuit._data`.  This is necessary to enforce correct reference-counting semantics.
-    ///
-    /// This borrows a Python reference and extracts the `QkCircuit` pointer for it into
-    /// ``address``, if it is of the correct type.  The returned pointer is borrowed from the
-    /// `object` pointer.  If the ``PyObject`` is not the correct type, the return value is 1, the
-    /// exception state of the Python interpreter is set, and ``address`` is unchanged.
+    /// This borrows a Python reference and extracts the `QkClassicalRegister` pointer for it into
+    /// `address`, if it is of the correct type.  The returned pointer is borrowed from the
+    /// `object` pointer.  If the `PyObject` is not the correct type, the return value is 0, the
+    /// exception state of the Python interpreter is set, and `address` is unchanged.
     ///
     /// You must be attached to a Python interpreter to call this function.
     ///
-    /// You can also use `qk_circuit_borrow_from_python`, which is logically the exact same as this,
+    /// You can also use `qk_classical_register_borrow_from_python`, which is logically the exact same as this,
     /// but with a more natural signature for direct usage.
     ///
     /// @param object A borrowed Python object.

--- a/crates/cext/src/dag.rs
+++ b/crates/cext/src/dag.rs
@@ -1830,7 +1830,7 @@ pub unsafe extern "C" fn qk_dag_borrow_from_python(
 ) -> *mut DAGCircuit {
     // SAFETY: per documentation, we are attached to a Python interpreter, and `ob` points to a
     // valid PyObject.
-    unsafe { crate::py::borrow(::pyo3::Python::assume_attached(), ob) }
+    unsafe { crate::py::borrow_mut(::pyo3::Python::assume_attached(), ob) }
 }
 
 /// @ingroup QkDag
@@ -1863,5 +1863,7 @@ pub unsafe extern "C" fn qk_dag_convert_from_python(
 ) -> ::std::ffi::c_int {
     // SAFETY: per documentation, we are attached to a Python interpreter, `object` is a valid
     // pointer to a PyObject, and `address` points to enough space to write a pointer.
-    unsafe { crate::py::convert::<DAGCircuit>(::pyo3::Python::assume_attached(), object, address) }
+    unsafe {
+        crate::py::convert_mut::<DAGCircuit>(::pyo3::Python::assume_attached(), object, address)
+    }
 }

--- a/crates/cext/src/py.rs
+++ b/crates/cext/src/py.rs
@@ -16,25 +16,6 @@ use pyo3::PyClass;
 use pyo3::prelude::*;
 use pyo3::pyclass::boolean_struct::False;
 
-/// Borrow a pointer to a Rust-native object from a Python object.
-///
-/// The returned pointer derives its lifetime from the lifetime of `ob`.  The reference `ob` is only
-/// borrowed by the function.
-///
-/// If the `PyObject` is not of the correct type, the null pointer is returned and the Python
-/// exception state is set.
-///
-/// # Safety
-///
-/// `ob` must point to a valid `PyObject`.
-pub unsafe fn borrow<T>(py: Python, ob: *mut ::pyo3::ffi::PyObject) -> *mut T
-where
-    T: PyClass<Frozen = False>,
-{
-    // SAFETY: per documentation, `ob` satisfies the same requirements as it does in `borrow_map_mut`.
-    unsafe { borrow_map::<T, T>(py, ob, |_py, x| Ok(x)) }
-}
-
 /// Borrow a pointer to a Rust-native object extracted from a Python object.
 ///
 /// The `map_fn` projects the desired reference from a temporary one.  This is useful in cases where
@@ -54,6 +35,63 @@ where
 pub unsafe fn borrow_map<'py, T, S>(
     py: Python<'py>,
     ob: *mut ::pyo3::ffi::PyObject,
+    map_fn: impl for<'a> FnOnce(Python<'py>, &'a T) -> PyResult<&'a S>,
+) -> *const S
+where
+    T: PyClass,
+{
+    let borrow_map = || -> PyResult<*const S> {
+        // SAFETY: per documentation, `ob` points to a valid PyObject.  The lifetime of the
+        // `Borrowed` is valid because we either drop it or consume it back into a pointer before
+        // the function returns.
+        let ob = unsafe { Borrowed::from_ptr(py, ob) }.cast::<T>()?;
+        let handle = &*ob.borrow();
+        map_fn(py, handle).map(::std::ptr::from_ref)
+    };
+    borrow_map().unwrap_or_else(|e| {
+        e.restore(py);
+        ::std::ptr::null()
+    })
+}
+
+/// Borrow a pointer to a Rust-native object from a Python object.
+///
+/// The returned pointer derives its lifetime from the lifetime of `ob`.  The reference `ob` is only
+/// borrowed by the function.
+///
+/// If the `PyObject` is not of the correct type, the null pointer is returned and the Python
+/// exception state is set.
+///
+/// # Safety
+///
+/// `ob` must point to a valid `PyObject`.
+pub unsafe fn borrow_mut<T>(py: Python, ob: *mut ::pyo3::ffi::PyObject) -> *mut T
+where
+    T: PyClass<Frozen = False>,
+{
+    // SAFETY: per documentation, `ob` satisfies the same requirements as it does in `borrow_map_mut`.
+    unsafe { borrow_map_mut::<T, T>(py, ob, |_py, x| Ok(x)) }
+}
+
+/// Borrow a pointer to a Rust-native object extracted from a Python object.
+///
+/// The `map_fn` projects the desired reference from a temporary one.  This is useful in cases where
+/// the object exposed to Python contains the raw Rust type (for example, `PySparseObservable`
+/// contains `SparseObservable`).  We do this with a `map_fn` so we can control the safety of the
+/// lifetime of the temporary reference.
+///
+/// The returned pointer derives its lifetime from the lifetime of `ob`.  The reference `ob` is only
+/// borrowed by the function.
+///
+/// If the `PyObject` is not of the correct type or the `map_fn` returns an error variant, the null
+/// pointer is returned and the Python exception state is set.
+///
+/// # Safety
+///
+/// `ob` must point to a valid `PyObject`.
+pub unsafe fn borrow_map_mut<'py, T, S>(
+    py: Python<'py>,
+    ob: *mut ::pyo3::ffi::PyObject,
     map_fn: impl for<'a> FnOnce(Python<'py>, &'a mut T) -> PyResult<&'a mut S>,
 ) -> *mut S
 where
@@ -71,32 +109,6 @@ where
         e.restore(py);
         ::std::ptr::null_mut()
     })
-}
-
-/// Extract a pointer to a Rust-native object from a PyObject representing a PyClass, storing the
-/// result in `address`.
-///
-/// This is used to define Python-space "converter" functions for use with the `PyArg_Parse*` family
-/// of functions.
-///
-/// On success, returns 1 and writes out the pointer in `address`.  On failure, returns 0, sets the
-/// Python exception state and leaves `address` untouched.
-///
-/// # Safety
-///
-/// `object` must point to a valid PyObject.  `address` must point to enough space to write a
-/// pointer to.
-pub unsafe fn convert<T>(
-    py: Python,
-    object: *mut ::pyo3::ffi::PyObject,
-    address: *mut ::std::ffi::c_void,
-) -> ::std::ffi::c_int
-where
-    T: PyClass<Frozen = False>,
-{
-    // SAFETY: per documentation, `object` and `address` satisfy the same requirements as
-    // `convert_map`.
-    unsafe { convert_map::<T, T>(py, object, address, |_py, x| Ok(x)) }
 }
 
 /// Extract a pointer to a Rust-native object from a `PyObject`, storing the result in `address`.
@@ -119,12 +131,72 @@ pub unsafe fn convert_map<'py, T, S>(
     py: Python<'py>,
     object: *mut ::pyo3::ffi::PyObject,
     address: *mut ::std::ffi::c_void,
+    map_fn: impl for<'a> FnOnce(Python<'py>, &'a T) -> PyResult<&'a S>,
+) -> ::std::ffi::c_int
+where
+    T: PyClass,
+{
+    let native = unsafe { borrow_map(py, object, map_fn) };
+    if native.is_null() {
+        0
+    } else {
+        unsafe { address.cast::<*const S>().write(native) };
+        1
+    }
+}
+
+/// Extract a pointer to a Rust-native object from a PyObject representing a PyClass, storing the
+/// result in `address`.
+///
+/// This is used to define Python-space "converter" functions for use with the `PyArg_Parse*` family
+/// of functions.
+///
+/// On success, returns 1 and writes out the pointer in `address`.  On failure, returns 0, sets the
+/// Python exception state and leaves `address` untouched.
+///
+/// # Safety
+///
+/// `object` must point to a valid PyObject.  `address` must point to enough space to write a
+/// pointer to.
+pub unsafe fn convert_mut<T>(
+    py: Python,
+    object: *mut ::pyo3::ffi::PyObject,
+    address: *mut ::std::ffi::c_void,
+) -> ::std::ffi::c_int
+where
+    T: PyClass<Frozen = False>,
+{
+    // SAFETY: per documentation, `object` and `address` satisfy the same requirements as
+    // `convert_map`.
+    unsafe { convert_map_mut::<T, T>(py, object, address, |_py, x| Ok(x)) }
+}
+
+/// Extract a pointer to a Rust-native object from a `PyObject`, storing the result in `address`.
+///
+/// The exact object stored can be extracted from a `PyClass` by projecting a reference out of some
+/// outer Python-exposed type using `map_fn`.  For example, the `object` might be a
+/// `PySparseObservable`, but the `map_fn` extracts a reference to the inne
+///
+/// This is used to define Python-space "converter" functions for use with the `PyArg_Parse*` family
+/// of functions.
+///
+/// On success, returns 1 and writes out the pointer in `address`.  On failure, returns 0, sets the
+/// Python exception state and leaves `address` untouched.
+///
+/// # Safety
+///
+/// `object` must point to a valid PyObject.  `address` must point to enough space to write a
+/// pointer to.
+pub unsafe fn convert_map_mut<'py, T, S>(
+    py: Python<'py>,
+    object: *mut ::pyo3::ffi::PyObject,
+    address: *mut ::std::ffi::c_void,
     map_fn: impl for<'a> FnOnce(Python<'py>, &'a mut T) -> PyResult<&'a mut S>,
 ) -> ::std::ffi::c_int
 where
     T: PyClass<Frozen = False>,
 {
-    let native = unsafe { borrow_map(py, object, map_fn) };
+    let native = unsafe { borrow_map_mut(py, object, map_fn) };
     if native.is_null() {
         0
     } else {

--- a/crates/cext/src/py.rs
+++ b/crates/cext/src/py.rs
@@ -23,6 +23,8 @@ use pyo3::pyclass::boolean_struct::False;
 /// contains `SparseObservable`).  We do this with a `map_fn` so we can control the safety of the
 /// lifetime of the temporary reference.
 ///
+/// You can use [`borrow_map_mut`] if you need mutable access to the underlying Rust struct.
+///
 /// The returned pointer derives its lifetime from the lifetime of `ob`.  The reference `ob` is only
 /// borrowed by the function.
 ///
@@ -79,6 +81,9 @@ where
 /// the object exposed to Python contains the raw Rust type (for example, `PySparseObservable`
 /// contains `SparseObservable`).  We do this with a `map_fn` so we can control the safety of the
 /// lifetime of the temporary reference.
+///
+/// You can use [`borrow_map`] if you don't need mutable access, which makes it possible to use this
+/// with structs marked `pyclass(frozen)`.
 ///
 /// The returned pointer derives its lifetime from the lifetime of `ob`.  The reference `ob` is only
 /// borrowed by the function.

--- a/crates/cext/src/py.rs
+++ b/crates/cext/src/py.rs
@@ -180,7 +180,7 @@ where
 ///
 /// The exact object stored can be extracted from a `PyClass` by projecting a reference out of some
 /// outer Python-exposed type using `map_fn`.  For example, the `object` might be a
-/// `PySparseObservable`, but the `map_fn` extracts a reference to the inne
+/// `PySparseObservable`, but the `map_fn` extracts a reference to the inner `SparseObservable`.
 ///
 /// This is used to define Python-space "converter" functions for use with the `PyArg_Parse*` family
 /// of functions.
@@ -190,7 +190,7 @@ where
 ///
 /// # Safety
 ///
-/// `object` must point to a valid PyObject.  `address` must point to enough space to write a
+/// `object` must point to a valid `PyObject`.  `address` must point to enough space to write a
 /// pointer to.
 pub unsafe fn convert_map_mut<'py, T, S>(
     py: Python<'py>,

--- a/crates/cext/src/sparse_observable.rs
+++ b/crates/cext/src/sparse_observable.rs
@@ -1185,7 +1185,7 @@ mod py {
         // SAFETY: per documentation, we are attached to a Python interpreter, and `ob` is a valid
         // pointer to a PyObject.
         unsafe {
-            crate::py::borrow_map(Python::assume_attached(), ob, try_project_inner_observable)
+            crate::py::borrow_map_mut(Python::assume_attached(), ob, try_project_inner_observable)
         }
     }
 
@@ -1219,7 +1219,7 @@ mod py {
         // SAFETY: per documentation, we are attached to a Python interpreter, `object` is a valid
         // pointer to a PyObject, and `address` points to enough space to write a pointer.
         unsafe {
-            crate::py::convert_map(
+            crate::py::convert_map_mut(
                 Python::assume_attached(),
                 object,
                 address,

--- a/crates/cext/src/transpiler/target.rs
+++ b/crates/cext/src/transpiler/target.rs
@@ -86,7 +86,7 @@ pub extern "C" fn qk_target_new(num_qubits: u32) -> *mut Target {
 pub unsafe extern "C" fn qk_target_borrow_from_python(ob: *mut pyo3::ffi::PyObject) -> *mut Target {
     // SAFETY: per documentation, we are attached to a Python interpreter and `ob` points to a valid
     // Python object.
-    unsafe { crate::py::borrow(::pyo3::Python::assume_attached(), ob) }
+    unsafe { crate::py::borrow_mut(::pyo3::Python::assume_attached(), ob) }
 }
 
 /// @ingroup QkTarget
@@ -119,7 +119,7 @@ pub unsafe extern "C" fn qk_target_convert_from_python(
 ) -> ::std::ffi::c_int {
     // SAFETY: per documentation, we are attached to a Python interpreter, `ob` points to a valid
     // Python object and `address` points to anough space to write a pointer.
-    unsafe { crate::py::convert::<Target>(::pyo3::Python::assume_attached(), object, address) }
+    unsafe { crate::py::convert_mut::<Target>(::pyo3::Python::assume_attached(), object, address) }
 }
 
 /// @ingroup QkTarget

--- a/crates/circuit/src/bit.rs
+++ b/crates/circuit/src/bit.rs
@@ -867,6 +867,13 @@ macro_rules! create_bit_object {
                 $reg_struct::anonymous_instance_count().load(Ordering::Relaxed)
             }
         }
+
+        impl ::std::ops::Deref for $pyreg_struct {
+            type Target = $reg_struct;
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
     };
 }
 

--- a/releasenotes/notes/c-python-registers-b8fd83e3dbad7c0c.yaml
+++ b/releasenotes/notes/c-python-registers-b8fd83e3dbad7c0c.yaml
@@ -1,0 +1,12 @@
+---
+features_c:
+  - |
+    :c:struct:`QkQuantumRegister` and :c:struct:`QkClassicalRegister` now have conversions to and
+    from Python space.  These use the functions:
+
+    * :c:func:`qk_quantum_register_to_python`
+    * :c:func:`qk_quantum_register_borrow_from_python`
+    * :c:func:`qk_quantum_register_convert_from_python`
+    * :c:func:`qk_classical_register_to_python`
+    * :c:func:`qk_classical_register_borrow_from_python`
+    * :c:func:`qk_classical_register_convert_from_python`


### PR DESCRIPTION
This is largely very straightforwards, since the types are clearly separated between Rust and Python space.  The only additional trickery needed was to allow the internal `QuantumRegister` to be borrowed from the `PyQuantumRegister` instead of cloning an additional reference to it.  While the runtime savings are incredibly minor, the important detail is that the register does not need to be freed by the C caller, which matches the assumptions of all the other Python-space interoperation methods.

---

Depends on:

- [ ] #15767 (but only in a minor way), and its chain.