### PR TITLE
Fix typos in `qiskit.utils`, `qiskit.synth`, and `qiskit.visualization`

### DIFF
--- a/qiskit/synthesis/two_qubit/two_qubit_decompose.py
+++ b/qiskit/synthesis/two_qubit/two_qubit_decompose.py
@@ -125,7 +125,7 @@ class TwoQubitWeylDecomposition:
 
     This class avoids some problems of numerical instability near high-symmetry loci within the Weyl
     chamber. If there is a high-symmetry gate "nearby" (in terms of the requested average gate fidelity),
-    then it return a canonicalized decomposition of that high-symmetry gate.
+    then it returns a canonicalized decomposition of that high-symmetry gate.
 
     References:
         1. Cross, A. W., Bishop, L. S., Sheldon, S., Nation, P. D. & Gambetta, J. M.,

--- a/qiskit/synthesis/two_qubit/xx_decompose/paths.py
+++ b/qiskit/synthesis/two_qubit/xx_decompose/paths.py
@@ -138,7 +138,7 @@ xx_region_polytope = PolytopeData(
             equalities=[],
             name=(
                 "I ∩ A alcove ∩ "
-                "A unreflected ∩ ah slant ∩ al frustrum ∩ B alcove ∩ B unreflected ∩ AF=B3"
+                "A unreflected ∩ ah slant ∩ al frustum ∩ B alcove ∩ B unreflected ∩ AF=B3"
             ),
         ),
         ConvexPolytopeData(
@@ -162,7 +162,7 @@ xx_region_polytope = PolytopeData(
             equalities=[],
             name=(
                 "I ∩ A alcove ∩ "
-                "A reflected ∩ ah strength ∩ al frustrum ∩ B alcove ∩ B reflected ∩ AF=B3"
+                "A reflected ∩ ah strength ∩ al frustum ∩ B alcove ∩ B reflected ∩ AF=B3"
             ),
         ),
         ConvexPolytopeData(
@@ -187,7 +187,7 @@ xx_region_polytope = PolytopeData(
             equalities=[],
             name=(
                 "I ∩ A alcove ∩ "
-                "A unreflected ∩ af slant ∩ al frustrum ∩ B alcove ∩ B unreflected ∩ AF=B1"
+                "A unreflected ∩ af slant ∩ al frustum ∩ B alcove ∩ B unreflected ∩ AF=B1"
             ),
         ),
         ConvexPolytopeData(
@@ -212,7 +212,7 @@ xx_region_polytope = PolytopeData(
             equalities=[],
             name=(
                 "I ∩ A alcove ∩ "
-                "A reflected ∩ af strength ∩ al frustrum ∩ B alcove ∩ B reflected ∩ AF=B1"
+                "A reflected ∩ af strength ∩ al frustum ∩ B alcove ∩ B reflected ∩ AF=B1"
             ),
         ),
     ]
@@ -267,7 +267,7 @@ xx_lift_polytope = PolytopeData(
             equalities=[[0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0]],
             name=(
                 "I ∩ A alcove ∩ "
-                "A unreflected ∩ ah slant ∩ al frustrum ∩ B alcove ∩ B unreflected ∩ AF=B3"
+                "A unreflected ∩ ah slant ∩ al frustum ∩ B alcove ∩ B unreflected ∩ AF=B3"
             ),
         ),
         ConvexPolytopeData(
@@ -305,7 +305,7 @@ xx_lift_polytope = PolytopeData(
             equalities=[[0, 0, 0, 1, -1, 0, 0, 0, 0, 0, 0]],
             name=(
                 "I ∩ A alcove ∩ "
-                "A unreflected ∩ af slant ∩ al frustrum ∩ B alcove ∩ B unreflected ∩ AF=B1"
+                "A unreflected ∩ af slant ∩ al frustum ∩ B alcove ∩ B unreflected ∩ AF=B1"
             ),
         ),
         ConvexPolytopeData(
@@ -343,7 +343,7 @@ xx_lift_polytope = PolytopeData(
             equalities=[[0, 0, 0, 1, -1, 0, 0, 0, 0, 0, 0]],
             name=(
                 "I ∩ A alcove ∩ "
-                "A reflected ∩ af strength ∩ al frustrum ∩ B alcove ∩ B reflected ∩ AF=B1"
+                "A reflected ∩ af strength ∩ al frustum ∩ B alcove ∩ B reflected ∩ AF=B1"
             ),
         ),
         ConvexPolytopeData(
@@ -381,7 +381,7 @@ xx_lift_polytope = PolytopeData(
             equalities=[[0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0]],
             name=(
                 "I ∩ A alcove ∩ "
-                "A reflected ∩ ah strength ∩ al frustrum ∩ B alcove ∩ B reflected ∩ AF=B3"
+                "A reflected ∩ ah strength ∩ al frustum ∩ B alcove ∩ B reflected ∩ AF=B3"
             ),
         ),
     ]

--- a/qiskit/synthesis/two_qubit/xx_decompose/polytopes.py
+++ b/qiskit/synthesis/two_qubit/xx_decompose/polytopes.py
@@ -245,7 +245,7 @@ A = np.array(
         [-1, -1, 0],  # pi/2 ≥ a + b
         [-1, -1, -1],  # strength
         [1, -1, -1],  # slant
-        [0, 0, -1],  # frustrum
+        [0, 0, -1],  # frustum
     ]
 )
 A1 = A.reshape(-1, 1, 3)  # pylint:disable=too-many-function-args

--- a/qiskit/utils/lazy_tester.py
+++ b/qiskit/utils/lazy_tester.py
@@ -29,7 +29,7 @@ from .classtools import wrap_method
 
 class _RequireNow:
     """Helper callable that accepts all function signatures and simply calls
-    :meth:`.LazyDependencyManager.require_now`.  This helpful when used with :func:`.wrap_method`,
+    :meth:`.LazyDependencyManager.require_now`.  This is helpful when used with :func:`.wrap_method`,
     as the callable needs to be compatible with all signatures and be picklable."""
 
     __slots__ = ("_feature", "_tester")

--- a/qiskit/utils/optionals.py
+++ b/qiskit/utils/optionals.py
@@ -27,7 +27,7 @@ Qiskit Components
 
 .. py:data:: HAS_AER
 
-    `Qiskit Aer <https://qiskit.github.io/qiskit-aer/>` provides high-performance simulators for
+    `Qiskit Aer <https://qiskit.github.io/qiskit-aer/>`__ provides high-performance simulators for
     the quantum circuits constructed within Qiskit.
 
 .. py:data:: HAS_IBMQ
@@ -58,7 +58,7 @@ External Python Libraries
 
     The `IBM CPLEX Optimizer <https://www.ibm.com/analytics/cplex-optimizer>`__ is a
     high-performance mathematical programming solver for linear, mixed-integer and quadratic
-    programming. This is no longer by Qiskit, but it was historically and the optional
+    programming. This is no longer used by Qiskit, but it was historically and the optional
     remains for backwards compatibility.
 
 .. py:data:: HAS_CVXPY
@@ -71,7 +71,7 @@ External Python Libraries
 
     `IBM Decision Optimization CPLEX Modelling
     <https://ibmdecisionoptimization.github.io/docplex-doc/>`__ is a library for prescriptive
-    analysis.  Like CPLEX, this is no longer by Qiskit, but it was historically and the
+    analysis.  Like CPLEX, this is no longer used by Qiskit, but it was historically and the
     optional remains for backwards compatibility.
 
 .. py:data:: HAS_FIXTURES
@@ -179,7 +179,7 @@ External Python Libraries
 
 .. py:data:: HAS_SYMPY
 
-    `SymPy <https://www.sympy.org/en/index.html>`__ is Python library for symbolic mathematics.
+    `SymPy <https://www.sympy.org/en/index.html>`__ is a Python library for symbolic mathematics.
     ``SymPy`` was historically used for the implementation of the :class:`.ParameterExpression`
     class but isn't any longer. However it is needed for some legacy functionality that uses
     :meth:`.ParameterExpression.sympify`. It is also used in some visualization functions

--- a/qiskit/utils/units.py
+++ b/qiskit/utils/units.py
@@ -39,7 +39,7 @@ def apply_prefix(value: float | ParameterExpression, unit: str) -> float | Param
         See https://docs.python.org/3/tutorial/floatingpoint.html for details.
 
     Raises:
-        ValueError: If the ``units`` aren't recognized.
+        ValueError: If the ``unit`` isn't recognized.
     """
     prefactors = {
         "f": -15,

--- a/qiskit/visualization/circuit/circuit_visualization.py
+++ b/qiskit/visualization/circuit/circuit_visualization.py
@@ -110,7 +110,7 @@ def circuit_drawer(
                 the location specified in ``~/.qiskit/settings.conf``.
             * If a dictionary, every entry overrides the default configuration. If the
                 ``"name"`` key is given, the default configuration is given by that style.
-                For example, ``{"name": "textbook", "subfontsize": 5}`` loads the ``"texbook"``
+                For example, ``{"name": "textbook", "subfontsize": 5}`` loads the ``"textbook"``
                 style and sets the subfontsize (e.g. the gate angles) to ``5``.
             * If ``None`` the default style ``"iqp"`` is used or, if given, the default style
                 specified in ``~/.qiskit/settings.conf``.
@@ -172,7 +172,7 @@ def circuit_drawer(
         expr_len: The number of characters to display if an :class:`~.expr.Expr`
             is used for the condition in a :class:`.ControlFlowOp`. If this number is exceeded,
             the string will be truncated at that number and '...' added to the end.
-        measure_arrows: If True, draw an arrow from each measure box down the the classical bit
+        measure_arrows: If True, draw an arrow from each measure box down to the classical bit
             or register where the measure value is placed. If False, do not draw arrow, but
             instead place the name of the bit or register in the measure box.
             Default is ``True`` unless the user config file (usually ``~/.qiskit/settings.conf``)
@@ -428,7 +428,7 @@ def _text_circuit_drawer(
         expr_len (int): Optional. The number of characters to display if an :class:`~.expr.Expr`
             is used for the condition in a :class:`.ControlFlowOp`. If this number is exceeded,
             the string will be truncated at that number and '...' added to the end.
-        measure_arrows: If True, draw an arrow from each measure box down the the classical bit
+        measure_arrows: If True, draw an arrow from each measure box down to the classical bit
             or register where the measure value is placed. If False, do not draw arrow, but
             instead place the name of the bit or register in the measure box.
 
@@ -719,7 +719,7 @@ def _matplotlib_circuit_drawer(
         expr_len (int): Optional. The number of characters to display if an :class:`~.expr.Expr`
             is used for the condition in a :class:`.ControlFlowOp`. If this number is exceeded,
             the string will be truncated at that number and '...' added to the end.
-        measure_arrows: If True, draw an arrow from each measure box down the the classical bit
+        measure_arrows: If True, draw an arrow from each measure box down to the classical bit
             or register where the measure value is placed. If False, do not draw arrow, but
             instead place the name of the bit or register in the measure box.
 

--- a/qiskit/visualization/circuit/text.py
+++ b/qiskit/visualization/circuit/text.py
@@ -238,7 +238,7 @@ class MultiBox(DrawElement):
         """In multi-bit elements, the label is centered vertically.
 
         Args:
-            input_length (int): Rhe amount of wires affected.
+            input_length (int): The amount of wires affected.
             order (int): Which middle element is this one?
         """
         if input_length == order == 0:

--- a/qiskit/visualization/gate_map.py
+++ b/qiskit/visualization/gate_map.py
@@ -60,7 +60,7 @@ def plot_gate_map(
         filename (str): file path to save image to.
         qubit_coordinates (Sequence): An optional sequence input (list or array being the
             most common) of 2d coordinates for each qubit. The length of the
-            sequence much match the number of qubits on the backend. The sequence
+            sequence must match the number of qubits on the backend. The sequence
             should be the planar coordinates in a 0-based square grid where each
             qubit is located.
 
@@ -1237,7 +1237,7 @@ def plot_error_map(backend, figsize=(15, 12), show_title=True, qubit_coordinates
         show_title (bool): Show the title or not.
         qubit_coordinates (Sequence): An optional sequence input (list or array being the
             most common) of 2d coordinates for each qubit. The length of the
-            sequence much mast the number of qubits on the backend. The sequence
+            sequence must match the number of qubits on the backend. The sequence
             should be the planar coordinates in a 0-based square grid where each
             qubit is located.
 

--- a/qiskit/visualization/state_visualization.py
+++ b/qiskit/visualization/state_visualization.py
@@ -786,7 +786,7 @@ def bit_string_index(s):
 
 
 def phase_to_rgb(complex_number):
-    """Map a phase of a complexnumber to a color in (r,g,b).
+    """Map a phase of a complex number to a color in (r,g,b).
 
     complex_number is phase is first mapped to angle in the range
     [0, 2pi] and then to the HSL color wheel


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes typos in the above named locations, as found by Claude. This PR also concludes a series of PRs where all python subpackages have been treated one at a time.

### Details and comments

AI tool used: Claude Opus 4.6


