### PR TITLE
Fix synth_clifford_depth_lnn for single-qubit Cliffords

### DIFF
--- a/crates/synthesis/src/clifford/bm_synthesis.rs
+++ b/crates/synthesis/src/clifford/bm_synthesis.rs
@@ -304,6 +304,10 @@ pub fn synth_clifford_bm_inner(
     let tableau_shape = tableau.shape();
     let num_qubits = tableau_shape[0] / 2;
 
+    if num_qubits == 0 {
+        return Ok((0, CliffordGatesVec::new()));
+    }
+
     if num_qubits > 3 {
         return Err("Can only decompose Cliffords up to 3-qubits.".to_string());
     }

--- a/crates/synthesis/src/linear/lnn.rs
+++ b/crates/synthesis/src/linear/lnn.rs
@@ -133,7 +133,7 @@ fn _matrix_to_north_west(
     while !done {
         // At each iteration the values of i switch between even and odd
         let mut at_least_one_needed = false;
-        for i in (first_qubit..n - 1).step_by(2) {
+        for i in (first_qubit..n.saturating_sub(1)).step_by(2) {
             // "If j < k, we do nothing" (see [1])
             // "If j > k, we swap the two labels, and we also perform a box" (see [1])
             if label_arr[i] > label_arr[i + 1] {
@@ -208,7 +208,7 @@ fn _north_west_to_identity(n: usize, mut mat: ArrayViewMut2<bool>) -> Instructio
     let mut cx_instructions_rows: InstructionList = Vec::new();
     while !done {
         let mut at_least_one_needed = false;
-        for i in (first_qubit..n - 1).step_by(2) {
+        for i in (first_qubit..n.saturating_sub(1)).step_by(2) {
             // Exchange the labels if needed
             if label_arr[i] > label_arr[i + 1] {
                 at_least_one_needed = true;

--- a/crates/synthesis/src/linear_phase/cx_cz_depth_lnn.rs
+++ b/crates/synthesis/src/linear_phase/cx_cz_depth_lnn.rs
@@ -118,6 +118,9 @@ fn _update_phase_schedule(
     phase_schedule: &mut Array2<usize>,
     swap_plus: &HashSet<(usize, usize)>,
 ) {
+    if n <= 1 {
+        return;
+    }
     let mut layer_order: Vec<usize> = ((1 - (n % 2))..n - 2).step_by(2).rev().collect();
     layer_order.extend((n % 2..n - 2).step_by(2));
     if n > 1 {
@@ -187,15 +190,15 @@ fn _apply_phase_to_nw_circuit(
     seq: &[(usize, usize)],
     swap_plus: &HashSet<(usize, usize)>,
 ) -> Vec<CircuitInstructions> {
-    let wires: Vec<_> = (0..n - 1)
+    let wires: Vec<_> = (0..n.saturating_sub(1))
         .step_by(2)
         .zip((1..n).step_by(2))
-        .chain((1..n - 1).step_by(2).zip((2..n).step_by(2)))
+        .chain((1..n.saturating_sub(1)).step_by(2).zip((2..n).step_by(2)))
         .collect();
 
     let mut cir: Vec<CircuitInstructions> = Vec::new();
     for (i, &(j, k)) in (0..seq.len()).rev().zip(seq.iter().rev()) {
-        let (w1, w2) = wires[i % (n - 1)];
+        let (w1, w2) = wires[i % (n.saturating_sub(1))];
         if !swap_plus.contains(&(j, k)) {
             cir.push(CircuitInstructions::CX(w1 as u32, w2 as u32));
         }

--- a/crates/synthesis/src/linear_phase/cz_depth_lnn.rs
+++ b/crates/synthesis/src/linear_phase/cz_depth_lnn.rs
@@ -31,6 +31,7 @@ pub(crate) type LnnGatesVec = Vec<(StandardGate, SmallVec<[Param; 3]>, SmallVec<
 /// A pattern denoted by Pj in [1] for odd number of qubits:
 /// [n-2, n-4, n-4, ..., 3, 3, 1, 1, 0, 0, 2, 2, ..., n-3, n-3]
 fn _odd_pattern1(n: usize) -> Vec<usize> {
+    debug_assert!(n >= 3);
     once(n - 2)
         .chain((0..((n - 3) / 2)).flat_map(|i| [(n - 2 * i - 4); 2]))
         .chain((0..((n - 1) / 2)).flat_map(|i| [2 * i; 2]))
@@ -40,6 +41,7 @@ fn _odd_pattern1(n: usize) -> Vec<usize> {
 /// A pattern denoted by Pk in [1] for odd number of qubits:
 /// [2, 2, 4, 4, ..., n-1, n-1, n-2, n-2, n-4, n-4, ..., 5, 5, 3, 3, 1]
 fn _odd_pattern2(n: usize) -> Vec<usize> {
+    debug_assert!(n >= 3);
     (0..((n - 1) / 2))
         .flat_map(|i| [(2 * i + 2); 2])
         .chain((0..((n - 3) / 2)).flat_map(|i| [n - 2 * i - 2; 2]))
@@ -50,6 +52,7 @@ fn _odd_pattern2(n: usize) -> Vec<usize> {
 /// A pattern denoted by Pj in [1] for even number of qubits:
 /// [n-1, n-3, n-3, n-5, n-5, ..., 1, 1, 0, 0, 2, 2, ..., n-4, n-4, n-2]
 fn _even_pattern1(n: usize) -> Vec<usize> {
+    debug_assert!(n >= 2);
     once(n - 1)
         .chain((0..((n - 2) / 2)).flat_map(|i| [n - 2 * i - 3; 2]))
         .chain((0..((n - 2) / 2)).flat_map(|i| [2 * i; 2]))
@@ -60,6 +63,7 @@ fn _even_pattern1(n: usize) -> Vec<usize> {
 /// A pattern denoted by Pk in [1] for even number of qubits:
 /// [2, 2, 4, 4, ..., n-2, n-2, n-1, n-1, ..., 3, 3, 1, 1]
 fn _even_pattern2(n: usize) -> Vec<usize> {
+    debug_assert!(n >= 2);
     (0..((n - 2) / 2))
         .flat_map(|i| [2 * (i + 1); 2])
         .chain((0..(n / 2)).flat_map(|i| [(n - 2 * i - 1); 2]))
@@ -68,6 +72,10 @@ fn _even_pattern2(n: usize) -> Vec<usize> {
 
 /// Creating the patterns for the phase layers.
 fn _create_patterns(n: usize) -> HashMap<(usize, usize), (usize, usize)> {
+    if n <= 1 {
+        return HashMap::from_iter((0..n).map(|i| ((0, i), (i, i))));
+    }
+
     let (pat1, pat2) = if n % 2 == 0 {
         (_even_pattern1(n), _even_pattern2(n))
     } else {

--- a/releasenotes/notes/fix-clifford-lnn-synthesis-eaa91ea86b9a5f9e.yaml
+++ b/releasenotes/notes/fix-clifford-lnn-synthesis-eaa91ea86b9a5f9e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed :func:`.synth_clifford_depth_lnn` for single-qubit Cliffords.
+    See `#15780 <https://github.com/Qiskit/qiskit/issues/15780>`__.

--- a/test/python/synthesis/test_clifford_decompose_layers.py
+++ b/test/python/synthesis/test_clifford_decompose_layers.py
@@ -30,7 +30,7 @@ from test import QiskitTestCase
 class TestCliffordDecomposeLayers(QiskitTestCase):
     """Tests for clifford advanced decomposition functions."""
 
-    @combine(num_qubits=[4, 5, 6, 7])
+    @combine(num_qubits=[0, 1, 2, 3, 4, 5, 6, 7])
     def test_decompose_clifford(self, num_qubits):
         """Create layer decomposition for a Clifford U, and check that it
         results in an equivalent Clifford."""

--- a/test/python/synthesis/test_clifford_decompose_layers.py
+++ b/test/python/synthesis/test_clifford_decompose_layers.py
@@ -51,7 +51,7 @@ class TestCliffordDecomposeLayers(QiskitTestCase):
             self.assertEqual(circ.data[6].operation.name, "H1")
             self.assertEqual(circ.data[7].operation.name, "Pauli")
 
-    @combine(num_qubits=[4, 5, 6, 7])
+    @combine(num_qubits=[0, 1, 2, 3, 4, 5, 6, 7])
     def test_decompose_lnn_depth(self, num_qubits):
         """Test layered decomposition for linear-nearest-neighbor (LNN) connectivity."""
         rng = np.random.default_rng(1234)

--- a/test/python/synthesis/test_clifford_sythesis.py
+++ b/test/python/synthesis/test_clifford_sythesis.py
@@ -77,7 +77,7 @@ class TestCliffordSynthesis(QiskitTestCase):
             value = Clifford(synth_circ)
             self.assertEqual(value, target)
 
-    @combine(num_qubits=[1, 2, 3, 4, 5])
+    @combine(num_qubits=[0, 1, 2, 3, 4, 5])
     def test_synth_ag(self, num_qubits):
         """Test A&G synthesis for set of {num_qubits}-qubit Cliffords"""
         samples = 50
@@ -87,7 +87,7 @@ class TestCliffordSynthesis(QiskitTestCase):
             value = Clifford(synth_circ)
             self.assertEqual(value, target)
 
-    @combine(num_qubits=[1, 2, 3, 4, 5])
+    @combine(num_qubits=[0, 1, 2, 3, 4, 5])
     def test_synth_greedy(self, num_qubits):
         """Test greedy synthesis for set of {num_qubits}-qubit Cliffords"""
         samples = 50
@@ -97,7 +97,7 @@ class TestCliffordSynthesis(QiskitTestCase):
             value = Clifford(synth_circ)
             self.assertEqual(value, target)
 
-    @combine(num_qubits=[1, 2, 3, 4, 5])
+    @combine(num_qubits=[0, 1, 2, 3, 4, 5])
     def test_synth_full(self, num_qubits):
         """Test synthesis for set of {num_qubits}-qubit Cliffords"""
         samples = 50

--- a/test/python/synthesis/test_clifford_sythesis.py
+++ b/test/python/synthesis/test_clifford_sythesis.py
@@ -67,7 +67,7 @@ class TestCliffordSynthesis(QiskitTestCase):
                 value = Clifford(cliff.to_circuit())
                 self.assertEqual(target, value)
 
-    @combine(num_qubits=[1, 2, 3])
+    @combine(num_qubits=[0, 1, 2, 3])
     def test_synth_bm(self, num_qubits):
         """Test B&M synthesis for set of {num_qubits}-qubit Cliffords"""
         samples = 50

--- a/test/python/synthesis/test_stabilizer_synthesis.py
+++ b/test/python/synthesis/test_stabilizer_synthesis.py
@@ -52,7 +52,7 @@ class TestStabDecomposeLayers(QiskitTestCase):
             self.assertEqual(circ.data[3].operation.name, "H1")
             self.assertEqual(circ.data[4].operation.name, "Pauli")
 
-    @combine(num_qubits=[4, 5, 6, 7])
+    @combine(num_qubits=[0, 1, 2, 3, 4, 5, 6, 7])
     def test_decompose_lnn_depth(self, num_qubits):
         """Test stabilizer state decomposition for linear-nearest-neighbor (LNN) connectivity."""
         rng = np.random.default_rng(1234)
@@ -65,7 +65,7 @@ class TestStabDecomposeLayers(QiskitTestCase):
             depth2q = (circ.decompose()).depth(
                 filter_function=lambda x: x.operation.num_qubits == 2
             )
-            self.assertTrue(depth2q == 2 * num_qubits + 2)
+            self.assertTrue(depth2q <= 2 * num_qubits + 2)
             # Check that the stabilizer state circuit has linear nearest neighbor connectivity
             self.assertTrue(check_lnn_connectivity(circ.decompose()))
             stab_target = StabilizerState(circ)

--- a/test/python/synthesis/test_stabilizer_synthesis.py
+++ b/test/python/synthesis/test_stabilizer_synthesis.py
@@ -30,7 +30,7 @@ from test import QiskitTestCase
 class TestStabDecomposeLayers(QiskitTestCase):
     """Tests for stabilizer state decomposition functions."""
 
-    @combine(num_qubits=[4, 5, 6, 7])
+    @combine(num_qubits=[0, 1, 2, 3, 4, 5, 6, 7])
     def test_decompose_stab(self, num_qubits):
         """Create layer decomposition for a stabilizer state, and check that it
         results in an equivalent stabilizer state."""
@@ -74,7 +74,7 @@ class TestStabDecomposeLayers(QiskitTestCase):
             # Verify that the two stabilizers produce the same probabilities
             self.assertEqual(stab.probabilities_dict(), stab_target.probabilities_dict())
 
-    @combine(num_qubits=[4, 5], method_lnn=[True, False])
+    @combine(num_qubits=[0, 1, 2, 3, 4, 5], method_lnn=[True, False])
     def test_reduced_inverse_clifford(self, num_qubits, method_lnn):
         """Test that one can use this stabilizer state synthesis method to calculate an inverse Clifford
         that preserves the ground state |0...0>, with a reduced circuit depth.


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #15780.

### Details and comments

The function `synth_clifford_depth_lnn` now properly handles LNN synthesis of single-qubit Cliffords (and also a very-very special edge-case of zero-qubit Cliffords, which now returns a 0-qubit empty circuit). 