### PR TITLE
Disable implicit cloning `FromPyObject` impl of `PyCircuitData`

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -286,10 +286,9 @@ pub struct CircuitData {
 ///         in ``qubits`` or ``clbits``.
 #[pyclass(
     name = "CircuitData",
-    freelist = 20,
     sequence,
     module = "qiskit._accelerate.circuit",
-    from_py_object
+    skip_from_py_object
 )]
 #[derive(Clone, Debug)]
 pub struct PyCircuitData {

--- a/crates/circuit/src/converters.rs
+++ b/crates/circuit/src/converters.rs
@@ -36,9 +36,9 @@ impl<'a, 'py> FromPyObject<'a, 'py> for QuantumCircuitData<'py> {
         let py = ob.py();
         ob.getattr("data")?; // in case _data is lazily generated in python
         let circuit_data = ob.getattr("_data")?;
-        let data_borrowed = circuit_data.extract::<PyCircuitData>()?.into();
+        let data_borrowed = circuit_data.cast::<PyCircuitData>()?;
         Ok(QuantumCircuitData {
-            data: data_borrowed,
+            data: data_borrowed.borrow().inner.clone(),
             name: ob.getattr(intern!(py, "name"))?.extract()?,
             metadata: ob.getattr(intern!(py, "metadata")).ok(),
             transpile_layout: ob.getattr(intern!(py, "layout")).ok(),

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -3144,10 +3144,11 @@ impl PyInstruction {
         Python::attach(|py| -> Option<CircuitData> {
             match self.instruction.getattr(py, intern!(py, "definition")) {
                 Ok(definition) => definition
-                    .getattr(py, intern!(py, "_data"))
+                    .bind(py)
+                    .getattr(intern!(py, "_data"))
                     .ok()?
-                    .extract::<PyCircuitData>(py)
-                    .map(Into::into)
+                    .cast::<PyCircuitData>()
+                    .map(|data| data.borrow().inner.clone())
                     .ok(),
                 Err(_) => None,
             }

--- a/crates/transpiler/src/equivalence.rs
+++ b/crates/transpiler/src/equivalence.rs
@@ -358,10 +358,8 @@ impl<'a, 'py> FromPyObject<'a, 'py> for CircuitFromPython {
 
     fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         if ob.is_instance(QUANTUM_CIRCUIT.get_bound(ob.py()))? {
-            let data: Bound<PyAny> = ob.getattr("_data")?;
-            let data_downcast: Bound<PyCircuitData> = data.cast_into()?;
-            let data_extract: PyCircuitData = data_downcast.extract()?;
-            Ok(Self(data_extract.into()))
+            let data = ob.getattr("_data")?.cast_into::<PyCircuitData>()?;
+            Ok(Self(data.borrow().inner.clone()))
         } else {
             Err(PyTypeError::new_err(
                 "Provided object was not an instance of QuantumCircuit",


### PR DESCRIPTION
`CircuitData` is _in general_ a heavy type to extract, and in general it _shouldn't_ be too easy to accidentally extract it instead of borrowing it.  This will become more important for correctness (not just performance) in the future when the `inner` type becomes `Arc<RwLock<CircuitData>>`, so we don't end up with spurious clones of the `Arc`, which would be far harder to detect, because there won't be a performance hit that goes with it; we'd only be able to detect subsequent problems in runtime threaded code that attempted to do things like `Arc::get_mut` on Python instances that _should_ have been unique.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


