### PR TITLE
Document explicitly that visualisers are insecure

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -4577,6 +4577,9 @@ impl DAGCircuit {
     /// `the Graphviz documentation <https://www.graphviz.org/download/>`__ on
     /// how to install it.
     ///
+    /// .. warning::
+    ///     This deliberately involves calling the system Graphviz binary on untrusted user data.
+    ///
     /// Args:
     ///     scale (float): scaling factor
     ///     filename (str): file path to save image to (format inferred from name)

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -4578,7 +4578,9 @@ impl DAGCircuit {
     /// how to install it.
     ///
     /// .. warning::
-    ///     This deliberately involves calling the system Graphviz binary on untrusted user data.
+    ///     This function will call the system Graphviz tool on a file involving user-controllable
+    ///     strings (such as gate labels or register names).  It is recommended to only call this
+    ///     function on trusted input.
     ///
     /// Args:
     ///     scale (float): scaling factor

--- a/qiskit/circuit/equivalence.py
+++ b/qiskit/circuit/equivalence.py
@@ -34,7 +34,9 @@ class EquivalenceLibrary(BaseEquivalenceLibrary):
         """Draws the equivalence relations available in the library.
 
         .. warning::
-            This deliberately involves calling the system Graphviz binary on untrusted user data.
+            This function will call the system Graphviz tool on a file involving user-controllable
+            strings (such as gate names).  It is recommended to only call this function on trusted
+            input.
 
         Args:
             filename (str): An optional path to write the output image to.  If unspecified, the

--- a/qiskit/circuit/equivalence.py
+++ b/qiskit/circuit/equivalence.py
@@ -33,13 +33,15 @@ class EquivalenceLibrary(BaseEquivalenceLibrary):
     def draw(self, filename=None):
         """Draws the equivalence relations available in the library.
 
+        .. warning::
+            This deliberately involves calling the system Graphviz binary on untrusted user data.
+
         Args:
-            filename (str): An optional path to write the output image to
-                if specified this method will return None.
+            filename (str): An optional path to write the output image to.  If unspecified, the
+                image will instead be returned.
 
         Returns:
-            PIL.Image or IPython.display.SVG: Drawn equivalence library as an
-                IPython SVG if in a jupyter notebook, or as a PIL.Image otherwise.
+            PIL.Image: If ``filename`` is ``None``, then the rendered image.
 
         Raises:
             InvalidFileError: if filename is not valid.

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3863,13 +3863,23 @@ class QuantumCircuit:
     ):
         r"""Draw the quantum circuit. Use the output parameter to choose the drawing format:
 
-        **text**: ASCII art TextDrawing that can be printed in the console.
+        ``text``
+            ASCII art TextDrawing that can be printed in the console.
 
-        **mpl**: images with color rendered purely in Python using matplotlib.
+        ``mpl``
+            Images with color rendered purely in Python using matplotlib.
 
-        **latex**: high-quality images compiled via latex.
+        ``latex``
+            High-quality images compiled via LaTeX.
 
-        **latex_source**: raw uncompiled latex output.
+            .. warning::
+                This will call an installed system version of ``pdflatex`` on arbitrary user input
+                by design (such as to render custom code in :attr:`.Instruction.label`), and should
+                not be used in a secure setting.
+
+        ``latex_source``
+            Raw uncompiled LaTeX output.  This is the source of what would be rendered by the
+            ``latex`` drawer.
 
         .. warning::
 

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3874,8 +3874,8 @@ class QuantumCircuit:
 
             .. warning::
                 This will call an installed system version of ``pdflatex`` on arbitrary user input
-                by design (such as to render custom code in :attr:`.Instruction.label`), and should
-                not be used in a secure setting.
+                by design (such as to render custom code in :attr:`.Instruction.label`), so should
+                only be used on trusted input.
 
         ``latex_source``
             Raw uncompiled LaTeX output.  This is the source of what would be rendered by the

--- a/qiskit/dagcircuit/dagdependency.py
+++ b/qiskit/dagcircuit/dagdependency.py
@@ -508,6 +508,9 @@ class DAGDependency:
         This function needs `pydot <https://github.com/erocarrera/pydot>`_, which in turn needs
         `Graphviz <https://www.graphviz.org/>`_ to be installed.
 
+        .. warning::
+            This deliberately involves calling the system Graphviz binary on untrusted user data.
+
         Args:
             scale (float): scaling factor
             filename (str): file path to save image to (format inferred from name)

--- a/qiskit/dagcircuit/dagdependency.py
+++ b/qiskit/dagcircuit/dagdependency.py
@@ -509,7 +509,9 @@ class DAGDependency:
         `Graphviz <https://www.graphviz.org/>`_ to be installed.
 
         .. warning::
-            This deliberately involves calling the system Graphviz binary on untrusted user data.
+            This function will call the system Graphviz tool on a file involving user-controllable
+            strings (such as gate labels or register names).  It is recommended to only call this
+            function on trusted input.
 
         Args:
             scale (float): scaling factor

--- a/qiskit/dagcircuit/dagdependency_v2.py
+++ b/qiskit/dagcircuit/dagdependency_v2.py
@@ -471,6 +471,9 @@ class _DAGDependencyV2:
         This function needs `pydot <https://github.com/erocarrera/pydot>`, which in turn needs
         Graphviz <https://www.graphviz.org/>` to be installed.
 
+        .. warning::
+            This deliberately involves calling the system Graphviz binary on untrusted user data.
+
         Args:
             scale (float): scaling factor
             filename (str): file path to save image to (format inferred from name)

--- a/qiskit/dagcircuit/dagdependency_v2.py
+++ b/qiskit/dagcircuit/dagdependency_v2.py
@@ -472,7 +472,9 @@ class _DAGDependencyV2:
         Graphviz <https://www.graphviz.org/>` to be installed.
 
         .. warning::
-            This deliberately involves calling the system Graphviz binary on untrusted user data.
+            This function will call the system Graphviz tool on a file involving user-controllable
+            strings (such as gate labels or register names).  It is recommended to only call this
+            function on trusted input.
 
         Args:
             scale (float): scaling factor

--- a/qiskit/transpiler/coupling.py
+++ b/qiskit/transpiler/coupling.py
@@ -492,7 +492,9 @@ class CouplingMap:
         ``rustworkx`` package to draw the :class:`CouplingMap` object.
 
         .. warning::
-            This deliberately involves calling the system Graphviz binary on untrusted user data.
+            This function will call the system Graphviz tool on a file involving user-controllable
+            strings (such as qubit objects).  It is recommended to only call this function on
+            trusted input.
 
         Args:
             method (str): The layout method to use. See the documentation for

--- a/qiskit/transpiler/coupling.py
+++ b/qiskit/transpiler/coupling.py
@@ -491,6 +491,9 @@ class CouplingMap:
         This function calls the :func:`~rustworkx.visualization.graphviz_draw` function from the
         ``rustworkx`` package to draw the :class:`CouplingMap` object.
 
+        .. warning::
+            This deliberately involves calling the system Graphviz binary on untrusted user data.
+
         Args:
             method (str): The layout method to use. See the documentation for
                 :func:`~rustworkx.visualization.graphviz_draw` for the list of supported methods

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -207,6 +207,9 @@ class PassManager(BasePassManager):
         This function needs `pydot <https://github.com/erocarrera/pydot>`__, which in turn needs
         `Graphviz <https://www.graphviz.org/>`__ to be installed.
 
+        .. warning::
+            This deliberately involves calling the system Graphviz binary on untrusted user data.
+
         Args:
             filename (str): file path to save image to.
             style (dict): keys are the pass classes and the values are the colors to make them. An
@@ -418,7 +421,19 @@ class StagedPassManager(PassManager):
         return super().to_flow_controller()
 
     def draw(self, filename=None, style=None, raw=False):
-        """Draw the staged pass manager."""
+        """Draw the staged pass manager.
+
+        .. warning::
+            This deliberately involves calling the system Graphviz binary on untrusted user data.
+
+        Args:
+            filename (str): file path to save image to.
+            style (dict): keys are the pass classes and the values are the colors to make them. An
+                example can be seen in the DEFAULT_STYLE. An ordered dict can be used to ensure
+                a priority coloring when pass falls into multiple categories. Any values not
+                included in the provided dict will be filled in from the default dict.
+            raw (bool): If ``True``, save the raw Dot output instead of the image.
+        """
         from qiskit.visualization import staged_pass_manager_drawer
 
         return staged_pass_manager_drawer(self, filename=filename, style=style, raw=raw)

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -208,7 +208,9 @@ class PassManager(BasePassManager):
         `Graphviz <https://www.graphviz.org/>`__ to be installed.
 
         .. warning::
-            This deliberately involves calling the system Graphviz binary on untrusted user data.
+            This function will call the system Graphviz tool on a file involving user-controllable
+            strings (such as pass names).  It is recommended to only call this function on trusted
+            input.
 
         Args:
             filename (str): file path to save image to.
@@ -424,7 +426,9 @@ class StagedPassManager(PassManager):
         """Draw the staged pass manager.
 
         .. warning::
-            This deliberately involves calling the system Graphviz binary on untrusted user data.
+            This function will call the system Graphviz tool on a file involving user-controllable
+            strings (such as pass names).  It is recommended to only call this function on trusted
+            input.
 
         Args:
             filename (str): file path to save image to.

--- a/qiskit/visualization/__init__.py
+++ b/qiskit/visualization/__init__.py
@@ -27,6 +27,13 @@ development environment:
 
    pip install 'qiskit[visualization]'
 
+.. warning::
+
+    In general, the visualization tooling in Qiskit may call system programs on arbitrary user
+    input, and should not be used in secure settings.  The visualization tooling provided in Qiskit
+    is mostly intended for local visualization, and deliberately allows user injection of their own
+    custom code inside attributes, such as :attr:`.Instruction.label` in the circuit drawers.
+
 Common Keyword Arguments
 ========================
 

--- a/qiskit/visualization/__init__.py
+++ b/qiskit/visualization/__init__.py
@@ -30,9 +30,11 @@ development environment:
 .. warning::
 
     In general, the visualization tooling in Qiskit may call system programs on arbitrary user
-    input, and should not be used in secure settings.  The visualization tooling provided in Qiskit
-    is mostly intended for local visualization, and deliberately allows user injection of their own
-    custom code inside attributes, such as :attr:`.Instruction.label` in the circuit drawers.
+    input, and should only be used on trusted inputs.  The visualization tooling provided in Qiskit
+    is mostly intended for local visualization, and deliberately allows user code injection in
+    several places, such as Graphviz node labels like register names in :meth:`.DAGCircuit.draw`, or
+    LaTeX instruction labels from :attr:`.Instruction.label` in the ``latex`` mode of
+    :meth:`.QuantumCircuit.draw`.
 
 Common Keyword Arguments
 ========================

--- a/qiskit/visualization/circuit/circuit_visualization.py
+++ b/qiskit/visualization/circuit/circuit_visualization.py
@@ -78,13 +78,23 @@ def circuit_drawer(
 ):
     r"""Draw the quantum circuit. Use the output parameter to choose the drawing format:
 
-    **text**: ASCII art TextDrawing that can be printed in the console.
+    ``text``
+        ASCII art TextDrawing that can be printed in the console.
 
-    **mpl**: images with color rendered purely in Python using matplotlib.
+    ``mpl``
+        Images with color rendered purely in Python using matplotlib.
 
-    **latex**: high-quality images compiled via latex.
+    ``latex``
+        High-quality images compiled via LaTeX.
 
-    **latex_source**: raw uncompiled latex output.
+        .. warning::
+            This will call an installed system version of ``pdflatex`` on arbitrary user input by
+            design (such as to render custom code in :attr:`.Instruction.label`), and should not be
+            used in a secure setting.
+
+    ``latex_source``
+        Raw uncompiled LaTeX output.  This is the source of what would be rendered by the
+        ``latex`` drawer.
 
     .. warning::
 

--- a/qiskit/visualization/circuit/circuit_visualization.py
+++ b/qiskit/visualization/circuit/circuit_visualization.py
@@ -89,8 +89,8 @@ def circuit_drawer(
 
         .. warning::
             This will call an installed system version of ``pdflatex`` on arbitrary user input by
-            design (such as to render custom code in :attr:`.Instruction.label`), and should not be
-            used in a secure setting.
+            design (such as to render custom code in :attr:`.Instruction.label`), so should only be
+            used on trusted data.
 
     ``latex_source``
         Raw uncompiled LaTeX output.  This is the source of what would be rendered by the

--- a/qiskit/visualization/dag_visualization.py
+++ b/qiskit/visualization/dag_visualization.py
@@ -88,7 +88,9 @@ def dag_drawer(
     ``rustworkx`` package to draw the DAG.
 
     .. warning::
-        This deliberately involves calling the system Graphviz binary on untrusted user data.
+        This function will call the system Graphviz tool on a file involving user-controllable
+        strings (such as operation labels).  It is recommended to only call this function on trusted
+        input.
 
     Args:
         dag (DAGCircuit or DAGDependency): The dag to draw.

--- a/qiskit/visualization/dag_visualization.py
+++ b/qiskit/visualization/dag_visualization.py
@@ -87,6 +87,9 @@ def dag_drawer(
     This function calls the :func:`~rustworkx.visualization.graphviz_draw` function from the
     ``rustworkx`` package to draw the DAG.
 
+    .. warning::
+        This deliberately involves calling the system Graphviz binary on untrusted user data.
+
     Args:
         dag (DAGCircuit or DAGDependency): The dag to draw.
         scale (float): scaling factor

--- a/qiskit/visualization/gate_map.py
+++ b/qiskit/visualization/gate_map.py
@@ -958,7 +958,9 @@ def plot_coupling_map(
     """Plots an arbitrary coupling map of qubits (embedded in a plane).
 
     .. warning::
-        This deliberately involves calling the system Graphviz binary on untrusted user data.
+        This function will call the system Graphviz tool on a file involving user-controllable
+        strings (such as qubit labels).  It is recommended to only call this function on trusted
+        input.
 
     Args:
         num_qubits (int): The number of qubits defined and plotted.

--- a/qiskit/visualization/gate_map.py
+++ b/qiskit/visualization/gate_map.py
@@ -957,6 +957,9 @@ def plot_coupling_map(
 ):
     """Plots an arbitrary coupling map of qubits (embedded in a plane).
 
+    .. warning::
+        This deliberately involves calling the system Graphviz binary on untrusted user data.
+
     Args:
         num_qubits (int): The number of qubits defined and plotted.
         qubit_coordinates (List[List[int]]): A list of two-element lists, with entries of each nested

--- a/qiskit/visualization/pass_manager_visualization.py
+++ b/qiskit/visualization/pass_manager_visualization.py
@@ -38,6 +38,9 @@ def pass_manager_drawer(pass_manager, filename=None, style=None, raw=False):
     This function needs `pydot <https://github.com/pydot/pydot>`__, which in turn needs
     `Graphviz <https://www.graphviz.org/>`__ to be installed.
 
+    .. warning::
+        This function involves calling the system Graphviz binary on untrusted user data.
+
     Args:
         pass_manager (PassManager): the pass manager to be drawn
         filename (str): file path to save image to
@@ -114,6 +117,9 @@ def staged_pass_manager_drawer(pass_manager, filename=None, style=None, raw=Fals
 
         This function needs `pydot <https://github.com/erocarrera/pydot>`__, which in turn needs
     `Graphviz <https://www.graphviz.org/>`__ to be installed.
+
+    .. warning::
+        This function involves calling the system Graphviz binary on untrusted user data.
 
     Args:
         pass_manager (StagedPassManager): the staged pass manager to be drawn

--- a/qiskit/visualization/pass_manager_visualization.py
+++ b/qiskit/visualization/pass_manager_visualization.py
@@ -39,7 +39,9 @@ def pass_manager_drawer(pass_manager, filename=None, style=None, raw=False):
     `Graphviz <https://www.graphviz.org/>`__ to be installed.
 
     .. warning::
-        This function involves calling the system Graphviz binary on untrusted user data.
+        This function will call the system Graphviz tool on a file involving user-controllable
+        strings (such as pass names).  It is recommended to only call this function on trusted
+        input.
 
     Args:
         pass_manager (PassManager): the pass manager to be drawn

--- a/qiskit/visualization/pass_manager_visualization.py
+++ b/qiskit/visualization/pass_manager_visualization.py
@@ -121,7 +121,9 @@ def staged_pass_manager_drawer(pass_manager, filename=None, style=None, raw=Fals
     `Graphviz <https://www.graphviz.org/>`__ to be installed.
 
     .. warning::
-        This function involves calling the system Graphviz binary on untrusted user data.
+        This function will call the system Graphviz tool on a file involving user-controllable
+        strings (such as pass names).  It is recommended to only call this function on trusted
+        input.
 
     Args:
         pass_manager (StagedPassManager): the staged pass manager to be drawn


### PR DESCRIPTION
It is by design that the visualisation tooling allows injection of arbitrary user code, especially with regard to the LaTeX and Graphviz drawers, which then subprocess out system binaries.  This documents the system-call behaviour more explicitly in the relevant functions.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


