### PR TITLE
Forbid duplicate `cargs` in `QuantumCircuit.append`

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -3627,16 +3627,6 @@ impl PyCircuitData {
         )
     }
 
-    /// Raise exception if list of qubits contains duplicates.
-    #[staticmethod]
-    fn _check_dups(qubits: Vec<ShareableQubit>) -> PyResult<()> {
-        let qubit_set: HashSet<&ShareableQubit> = qubits.iter().collect();
-        if qubits.len() != qubit_set.len() {
-            return Err(CircuitError::new_err("duplicate qubit arguments"));
-        }
-        Ok(())
-    }
-
     /// Add an input variable to the circuit.
     ///
     /// Args:

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2903,6 +2903,7 @@ class QuantumCircuit:
         base_instruction = CircuitInstruction(operation, (), ())
         for qarg, carg in broadcast_iter:
             self._check_dups(qarg)
+            self._check_dups(carg)
             instruction = base_instruction.replace(qubits=qarg, clbits=carg)
             circuit_scope.append(instruction)
             instructions._add_ref(circuit_scope.instructions, len(circuit_scope.instructions) - 1)
@@ -3728,9 +3729,17 @@ class QuantumCircuit:
                 f"Could not locate provided bit: {bit}. Has it been added to the QuantumCircuit?"
             ) from err
 
-    def _check_dups(self, qubits: Sequence[Qubit]) -> None:
-        """Raise exception if list of qubits contains duplicates."""
-        CircuitData._check_dups(qubits)
+    def _check_dups(self, bits: Sequence[Bit]) -> None:
+        """Raise exception if list of bits contains duplicates."""
+        match bits:
+            case () | (_,):
+                pass
+            case (a, b):
+                if a == b:
+                    raise CircuitError("duplicate bit arguments")
+            case bits:
+                if len(bits) != len(set(bits)):
+                    raise CircuitError("duplicate bit arguments")
 
     def to_instruction(
         self,

--- a/releasenotes/notes/append-check-duplicate-clbits-940015f06af5f3b6.yaml
+++ b/releasenotes/notes/append-check-duplicate-clbits-940015f06af5f3b6.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - :meth:`.QuantumCircuit.append` now correctly rejects duplicate classical bits in the ``cargs``
+    argument, matching the behavior of ``qargs``.  While classical bits *can* in theory be copied,
+    unlike quantum bits, the internal data model of Qiskit cannot represent multiple use of the same
+    bit, and circuits using this would typically experience internal library panics or nonsensical
+    downstream simulator behavior due to the data-model assumption violation.

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -112,6 +112,29 @@ class TestCircuitOperations(QiskitTestCase):
             opaque = Instruction("opaque", 1, len(specifier), [])
             test.append(opaque, [0], specifier)
 
+    def test_append_rejects_duplicates(self):
+        test = QuantumCircuit(3, 3)
+
+        qargs = Instruction("qargs", 2, 0, [])
+        with self.subTest("qubit-int"), self.assertRaisesRegex(CircuitError, "duplicate"):
+            test.append(qargs, [0, 0], [])
+        with self.subTest("qubit-bit"), self.assertRaisesRegex(CircuitError, "duplicate"):
+            test.append(qargs, [test.qubits[0]] * 2, [])
+        with self.subTest("qubit-mixed"), self.assertRaisesRegex(CircuitError, "duplicate"):
+            test.append(qargs, [0, test.qubits[0]], [])
+        with self.subTest("qubit-many"), self.assertRaisesRegex(CircuitError, "duplicate"):
+            test.append(Instruction("many", 3, 0, []), [0, 1, 0], [])
+
+        cargs = Instruction("cargs", 0, 2, [])
+        with self.subTest("clbit-int"), self.assertRaisesRegex(CircuitError, "duplicate"):
+            test.append(cargs, [], [0, 0])
+        with self.subTest("clbit-bit"), self.assertRaisesRegex(CircuitError, "duplicate"):
+            test.append(cargs, [], [test.clbits[0]] * 2)
+        with self.subTest("clbit-mixed"), self.assertRaisesRegex(CircuitError, "duplicate"):
+            test.append(cargs, [], [0, test.clbits[0]])
+        with self.subTest("clbit-many"), self.assertRaisesRegex(CircuitError, "duplicate"):
+            test.append(Instruction("many", 0, 3, []), [], [0, 1, -2])
+
     def test_append_rejects_bits_not_in_circuit(self):
         """Test that append rejects bits that are not in the circuit."""
         test = QuantumCircuit(2, 2)


### PR DESCRIPTION
There's no physical reason that this _must_ be forbidden (unlike with qubits), but in practice Qiskit's data model doesn't currently permit this; the `DAGCircuit` structure in the transpiler will be invalid, causing undefined behaviour following transpilation.  This typically (and ideally) manifests itself as a Rust `panic` somewhere, but in the worst case can make it out the compiler with a circuit that has lost its semantics.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Fix #15747
Fix #15748

Imo this isn't stable for backport because it's a major new error mode in `QuantumCircuit.append`, and the only case we know of it being it is during code fuzzing.