### PR TITLE
Update Linux build image to `manylinux_2_28`

### DIFF
--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -80,8 +80,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          # Used for the ARM builds.
-          - macos-14
+          - macos-15
           - windows-latest
           - ubuntu-24.04-arm
     steps:
@@ -116,7 +115,7 @@ jobs:
         env:
           PGO_WORK_DIR: ${{ github.workspace }}/pgo-data
           PGO_OUT_PATH: ${{ github.workspace }}/merged.profdata
-      - uses: pypa/cibuildwheel@v3.0.1
+      - uses: pypa/cibuildwheel@v3.4.0
       - uses: actions/upload-artifact@v7
         with:
           path: ./wheelhouse/*.whl
@@ -132,7 +131,7 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
       - uses: dtolnay/rust-toolchain@stable
-      - uses: pypa/cibuildwheel@v3.0.1
+      - uses: pypa/cibuildwheel@v3.4.0
       - uses: actions/upload-artifact@v7
         with:
           path: ./wheelhouse/*.whl
@@ -153,7 +152,7 @@ jobs:
       - uses: docker/setup-qemu-action@v3
         with:
           platforms: all
-      - uses: pypa/cibuildwheel@v3.0.1
+      - uses: pypa/cibuildwheel@v3.4.0
         env:
           CIBW_ARCHS_LINUX: s390x
           CIBW_TEST_SKIP: "cp*"
@@ -176,7 +175,7 @@ jobs:
       - uses: docker/setup-qemu-action@v3
         with:
           platforms: all
-      - uses: pypa/cibuildwheel@v3.0.1
+      - uses: pypa/cibuildwheel@v3.4.0
         env:
           CIBW_ARCHS_LINUX: ppc64le
           CIBW_TEST_SKIP: "cp*"

--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -106,7 +106,7 @@ jobs:
           set -e
           mkdir -p "$PGO_WORK_DIR"
           cat >>"$GITHUB_ENV" <<EOF
-          CIBW_BEFORE_ALL_LINUX=yum install -y wget && {package}/tools/install_rust.sh
+          CIBW_BEFORE_ALL_LINUX=dnf install -y wget && {package}/tools/install_rust.sh
           CIBW_BEFORE_BUILD=bash ./tools/build_pgo.sh $PGO_WORK_DIR $PGO_OUT_PATH
           CIBW_ENVIRONMENT=RUSTUP_TOOLCHAIN=stable RUSTFLAGS='-Cprofile-use=$PGO_OUT_PATH -Cllvm-args=-pgo-warn-missing-function'
           CIBW_ENVIRONMENT_MACOS=MACOSX_DEPLOYMENT_TARGET='10.12' RUSTUP_TOOLCHAIN=stable RUSTFLAGS='-Cprofile-use=$PGO_OUT_PATH -Cllvm-args=-pgo-warn-missing-function'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,10 +279,10 @@ line-length = 100
 target-version = ['py310', 'py311']
 
 [tool.cibuildwheel]
-manylinux-x86_64-image = "manylinux2014"
-manylinux-aarch64-image = "manylinux2014"
-manylinux-ppc64le-image = "manylinux2014"
-manylinux-s390x-image = "manylinux2014"
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+manylinux-ppc64le-image = "manylinux_2_28"
+manylinux-s390x-image = "manylinux_2_28"
 build = ["cp3??-*"]
 skip = ["*-win32", "*_i686", "*_universal2", "*-musllinux_*"]
 test-command = "cp -r {project}/test . && QISKIT_PARALLEL=FALSE stestr --test-path test/python run --abbreviate"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,8 +283,8 @@ manylinux-x86_64-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux2014"
 manylinux-ppc64le-image = "manylinux2014"
 manylinux-s390x-image = "manylinux2014"
-skip = "cp38-* cp39-* *musllinux* *win32 *i686"
-test-skip = "*win32 *linux_i686"
+build = ["cp3??-*"]
+skip = ["*-win32", "*_i686", "*_universal2", "*-musllinux_*"]
 test-command = "cp -r {project}/test . && QISKIT_PARALLEL=FALSE stestr --test-path test/python run --abbreviate"
 test-groups = ["test"]
 # We need to use pre-built versions of Numpy and Scipy in the tests; we don't configure

--- a/releasenotes/notes/bump-manylinux-1e139c60ca73b7b4.yaml
+++ b/releasenotes/notes/bump-manylinux-1e139c60ca73b7b4.yaml
@@ -1,0 +1,10 @@
+---
+upgrade_build:
+  - |
+    Qiskit now builds on the `manylinux_2_28 image <https://github.com/pypa/manylinux?tab=readme-ov-file#manylinux_2_28-almalinux-8-based>`__,
+    which effectively increases the required version of ``glibc`` on Linux hosts to 2.28, up from 2.17.
+    This should be supported on Debian 10+ (buster), Ubuntu 18.10+ (cosmic), Fedora 29+ and RHEL 8+.
+
+    NumPy on Python 3.14 already requires glibc 2.28, so in practice, Qiskit was not usable on manylinux2014-limited
+    machines already with later Python versions.  The glibc version was updated for all Python versions for consistency
+    in the build.

--- a/releasenotes/notes/bump-manylinux-1e139c60ca73b7b4.yaml
+++ b/releasenotes/notes/bump-manylinux-1e139c60ca73b7b4.yaml
@@ -5,6 +5,8 @@ upgrade_misc:
     which effectively increases the required version of ``glibc`` on Linux hosts to 2.28, up from 2.17.
     This should be supported on Debian 10+ (buster), Ubuntu 18.10+ (cosmic), Fedora 29+ and RHEL 8+.
 
-    NumPy on Python 3.14 already requires glibc 2.28, so in practice, Qiskit was not usable on manylinux2014-limited
-    machines already with later Python versions.  The glibc version was updated for all Python versions for consistency
+    NumPy on Python 3.14 already requires glibc 2.28, so in practice, Qiskit was already not usable on platforms limited to the manylinux2014 dependencies
+    with later Python versions.  The glibc version was updated for all Python versions for consistency
     in the build.
+
+    It may continue to be possible to build Qiskit from source using older versions of ``glibc``, though this will no longer be tested in CI.

--- a/releasenotes/notes/bump-manylinux-1e139c60ca73b7b4.yaml
+++ b/releasenotes/notes/bump-manylinux-1e139c60ca73b7b4.yaml
@@ -1,5 +1,5 @@
 ---
-upgrade_build:
+upgrade_misc:
   - |
     Qiskit now builds on the `manylinux_2_28 image <https://github.com/pypa/manylinux?tab=readme-ov-file#manylinux_2_28-almalinux-8-based>`__,
     which effectively increases the required version of ``glibc`` on Linux hosts to 2.28, up from 2.17.


### PR DESCRIPTION
This is a change we already made on Aer out of necessity, and now are driven to do with Qiskit to formally support Python 3.14 at Tier 1 support (i.e. tested in CI and as part of the wheel-build).  In practice, this should encompass the vast majority of (if not all) hardware still actively running the most recent Qiskit version, and Qiskit remains significantly more conservative in platform and Python-version support than the rest of the scientific-Python ecosystem.

This commit also bumps the version of `cibuildwheel`:

We are using quite an old version of `cibuildwheel`, and we're about to do a release.  This updates the action to take advantage to bugfixes in handling of the GitHub images since our last bump, and (slightly) modernises the `build`/`skip` syntax to use the list form and a more explicit "allowlist" rather than the awkward blocklist we had before.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Mostly I want to see if the spurious HTTP rate limiting responses we're seeing on other PRs have anything to do with the old `cibuildwheel` version.

We will need to backport the `cibuildwheel` bump to stable/2.3, but we can leave that branch using the older `manylinux2014` images and skip the Python 3.14 test on those platforms, to avoid backporting a drop in platform support, even if we weren't fully able to test on Python 3.14 there.