### PR TITLE
Bump faer to the latest release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,12 +557,19 @@ checksum = "9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1"
 
 [[package]]
 name = "dyn-stack"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490bd48eb68fffcfed519b4edbfd82c69cbe741d175b84f0e0cbe8c57cbe0bdd"
+checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
 dependencies = [
  "bytemuck",
+ "dyn-stack-macros",
 ]
+
+[[package]]
+name = "dyn-stack-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "either"
@@ -624,6 +631,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02da895aab06bbebefb6b2595f6d637b18c9ff629b4cd840965bb3164e4194b0"
+dependencies = [
+ "equator-macro 0.6.0",
+]
+
+[[package]]
 name = "equator-macro"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator-macro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b14b339eb76d07f052cdbad76ca7c1310e56173a138095d3bf42a23c06ef5d8"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,14 +685,13 @@ dependencies = [
 
 [[package]]
 name = "faer"
-version = "0.23.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb922206162d9405f9fc059052b3f997bdc92745da7bfd620645f5092df20d1"
+checksum = "02d2ecfb80b6f8b0c569e36988a052e64b14d8def9d372390b014e8bf79f299a"
 dependencies = [
  "bytemuck",
  "dyn-stack",
- "equator 0.4.2",
- "faer-macros",
+ "equator 0.6.0",
  "faer-traits",
  "gemm",
  "generativity",
@@ -680,7 +701,7 @@ dependencies = [
  "num-complex",
  "num-traits",
  "private-gemm-x86",
- "pulp 0.21.5",
+ "pulp",
  "rand 0.9.2",
  "rand_distr",
  "rayon",
@@ -689,41 +710,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "faer-ext"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4d037166f25435671ecc6054ae76b964f17da513353f1617690470680efdf0"
-dependencies = [
- "faer",
- "ndarray",
- "num-complex",
-]
-
-[[package]]
-name = "faer-macros"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc4b8cd876795d3b19ddfd59b03faa303c0b8adb9af6e188e81fc647c485bb9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "faer-traits"
-version = "0.23.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b69235b5f54416286c485fb047f2f499fc935a4eee2caadf4757f3c94c7b62"
+checksum = "b87d23ed7ab1f26c0cba0e5b9e061a796fbb7dc170fa8bee6970055a1308bb0f"
 dependencies = [
  "bytemuck",
  "dyn-stack",
- "faer-macros",
  "generativity",
  "libm",
  "num-complex",
  "num-traits",
- "pulp 0.21.5",
+ "pulp",
  "qd",
  "reborrow",
 ]
@@ -760,9 +758,9 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "gemm"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab96b703d31950f1aeddded248bc95543c9efc7ac9c4a21fda8703a83ee35451"
+checksum = "aa0673db364b12263d103b68337a68fbecc541d6f6b61ba72fe438654709eacb"
 dependencies = [
  "dyn-stack",
  "gemm-c32",
@@ -780,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "gemm-c32"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6db9fd9f40421d00eea9dd0770045a5603b8d684654816637732463f4073847"
+checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
 dependencies = [
  "dyn-stack",
  "gemm-common",
@@ -795,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "gemm-c64"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfcad8a3d35a43758330b635d02edad980c1e143dc2f21e6fd25f9e4eada8edf"
+checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
 dependencies = [
  "dyn-stack",
  "gemm-common",
@@ -810,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "gemm-common"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a352d4a69cbe938b9e2a9cb7a3a63b7e72f9349174a2752a558a8a563510d0f3"
+checksum = "88027625910cc9b1085aaaa1c4bc46bb3a36aad323452b33c25b5e4e7c8e2a3e"
 dependencies = [
  "bytemuck",
  "dyn-stack",
@@ -822,7 +820,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "paste",
- "pulp 0.21.5",
+ "pulp",
  "raw-cpuid",
  "rayon",
  "seq-macro",
@@ -831,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "gemm-f16"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff95ae3259432f3c3410eaa919033cd03791d81cebd18018393dc147952e109"
+checksum = "e3df7a55202e6cd6739d82ae3399c8e0c7e1402859b30e4cb780e61525d9486e"
 dependencies = [
  "dyn-stack",
  "gemm-common",
@@ -849,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "gemm-f32"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8d3d4385393304f407392f754cd2dc4b315d05063f62cf09f47b58de276864"
+checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
 dependencies = [
  "dyn-stack",
  "gemm-common",
@@ -864,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "gemm-f64"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35b2a4f76ce4b8b16eadc11ccf2e083252d8237c1b589558a49b0183545015bd"
+checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
 dependencies = [
  "dyn-stack",
  "gemm-common",
@@ -1238,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "nano-gemm"
-version = "0.1.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb5ba2bea1c00e53de11f6ab5bd0761ba87dc0045d63b0c87ee471d2d3061376"
+checksum = "9e04345dc84b498ff89fe0d38543d1f170da9e43a2c2bcee73a0f9069f72d081"
 dependencies = [
  "equator 0.2.2",
  "nano-gemm-c32",
@@ -1254,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "nano-gemm-c32"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40449e57a5713464c3a1208c4c3301c8d29ee1344711822cf022bc91373a91b"
+checksum = "0775b1e2520e64deee8fc78b7732e3091fb7585017c0b0f9f4b451757bbbc562"
 dependencies = [
  "nano-gemm-codegen",
  "nano-gemm-core",
@@ -1265,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "nano-gemm-c64"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743a6e6211358fba85d1009616751e4107da86f4c95b24e684ce85f25c25b3bf"
+checksum = "9af49a20d58816e6b5ee65f64142e50edb5eba152678d4bb7377fcbf63f8437a"
 dependencies = [
  "nano-gemm-codegen",
  "nano-gemm-core",
@@ -1276,21 +1274,21 @@ dependencies = [
 
 [[package]]
 name = "nano-gemm-codegen"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963bf7c7110d55430169dc74c67096375491ed580cd2ef84842550ac72e781fa"
+checksum = "6cc8d495c791627779477a2cf5df60049f5b165342610eb0d76bee5ff5c5d74c"
 
 [[package]]
 name = "nano-gemm-core"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3fc4f83ae8861bad79dc3c016bd6b0220da5f9de302e07d3112d16efc24aa6"
+checksum = "d998dfa644de87a0f8660e5ea511d7cb5c33b5a2d9847b7af57a2565105089f0"
 
 [[package]]
 name = "nano-gemm-f32"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3681b7ce35658f79da94b7f62c60a005e29c373c7111ed070e3bf64546a8bb"
+checksum = "879d962e79bc8952e4ad21ca4845a21132540ed3f5e01184b2ff7f720e666523"
 dependencies = [
  "nano-gemm-codegen",
  "nano-gemm-core",
@@ -1298,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "nano-gemm-f64"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1e619ed04d801809e1f63e61b669d380c4119e8b0cdd6ed184c6b111f046d8"
+checksum = "b9a513473dce7dc00c7e7c318481ca4494034e76997218d8dad51bd9f007a815"
 dependencies = [
  "nano-gemm-codegen",
  "nano-gemm-core",
@@ -1709,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "private-gemm-x86"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8138b380908e85071bdd6b2841a38b0858ef09848b754a15219d0b9ca90928"
+checksum = "0af8c3e5087969c323f667ccb4b789fa0954f5aa650550e38e81cf9108be21b5"
 dependencies = [
  "crossbeam",
  "defer",
@@ -1754,20 +1752,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "pulp"
-version = "0.21.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b86df24f0a7ddd5e4b95c94fc9ed8a98f1ca94d3b01bdce2824097e7835907"
-dependencies = [
- "bytemuck",
- "cfg-if",
- "libm",
- "num-complex",
- "reborrow",
- "version_check",
 ]
 
 [[package]]
@@ -1884,14 +1868,14 @@ dependencies = [
 
 [[package]]
 name = "qd"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73940173cf92cd24f3650f5f388946524026712a6ca170762340acf5fb3fde0f"
+checksum = "15f1304a5aecdcfe9ee72fbba90aa37b3aa067a69d14cb7f3d9deada0be7c07c"
 dependencies = [
  "bytemuck",
  "libm",
  "num-traits",
- "pulp 0.21.5",
+ "pulp",
 ]
 
 [[package]]
@@ -1906,7 +1890,7 @@ dependencies = [
  "num-bigint",
  "num-complex",
  "numpy",
- "pulp 0.22.2",
+ "pulp",
  "pyo3",
  "qiskit-circuit",
  "qiskit-quantum-info",
@@ -2110,7 +2094,6 @@ dependencies = [
  "binrw",
  "bytemuck",
  "faer",
- "faer-ext",
  "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
  "indexmap",

--- a/crates/synthesis/Cargo.toml
+++ b/crates/synthesis/Cargo.toml
@@ -26,7 +26,7 @@ num-traits.workspace = true
 rand.workspace = true
 rand_pcg.workspace = true
 rand_distr.workspace = true
-faer = "0.23.2"
+faer = "0.24"
 rustworkx-core.workspace = true
 rustiq-core = "0.0.11"
 rsgridsynth = "0.2.0"
@@ -34,10 +34,6 @@ rstar = "0.12.2"
 thiserror.workspace = true
 fixedbitset.workspace = true
 binrw.workspace = true
-
-[dependencies.faer-ext]
-version = "0.7.1"
-features = ["ndarray"]
 
 [dependencies.smallvec]
 workspace = true

--- a/crates/synthesis/src/linalg/cos_sin_decomp.rs
+++ b/crates/synthesis/src/linalg/cos_sin_decomp.rs
@@ -18,9 +18,10 @@ use numpy::PyReadonlyArray2;
 use numpy::ToPyArray;
 use pyo3::prelude::*;
 
+use crate::linalg::faer_to_ndarray;
 use faer::{Mat, MatRef};
-use faer_ext::IntoNdarray;
 use num_complex::{Complex64, ComplexFloat};
+
 const EPS: f64 = 1e-11;
 
 pub struct CosSinDecompReturn {
@@ -188,10 +189,10 @@ pub fn cossin<'py>(py: Python<'py>, u: PyReadonlyArray2<Complex64>) -> PyResult<
     let mat: Mat<Complex64> = Mat::from_fn(shape[0], shape[1], |i, j| array[[i, j]]);
     let res = cos_sin_decomposition(mat.as_ref());
 
-    let arr0 = res.l0.as_ref().into_ndarray().to_pyarray(py);
-    let arr1 = res.l1.as_ref().into_ndarray().to_pyarray(py);
-    let arr2 = res.r0.as_ref().into_ndarray().to_pyarray(py);
-    let arr3 = res.r1.as_ref().into_ndarray().to_pyarray(py);
+    let arr0 = faer_to_ndarray(res.l0.as_ref()).to_pyarray(py);
+    let arr1 = faer_to_ndarray(res.l1.as_ref()).to_pyarray(py);
+    let arr2 = faer_to_ndarray(res.r0.as_ref()).to_pyarray(py);
+    let arr3 = faer_to_ndarray(res.r1.as_ref()).to_pyarray(py);
 
     Ok(((arr0, arr1), res.thetas, (arr2, arr3))
         .into_pyobject(py)?

--- a/crates/synthesis/src/linalg/mod.rs
+++ b/crates/synthesis/src/linalg/mod.rs
@@ -12,7 +12,6 @@
 
 use approx::{abs_diff_eq, relative_ne};
 use faer::MatRef;
-use faer_ext::IntoFaer;
 use nalgebra::{DMatrix, DMatrixView, Dim, Dyn, MatrixView, ViewStorage};
 use ndarray::ArrayView2;
 use ndarray::ShapeBuilder;
@@ -22,6 +21,36 @@ pub mod cos_sin_decomp;
 
 const ATOL_DEFAULT: f64 = 1e-8;
 const RTOL_DEFAULT: f64 = 1e-5;
+
+#[inline]
+pub fn ndarray_to_faer<T>(array: ArrayView2<'_, T>) -> MatRef<'_, T> {
+    // This function's code is based on faer-ext's IntoFaer::into_faer implementation for ArrayView2:
+    // https://codeberg.org/sarah-quinones/faer-ext/src/commit/0f055b39529c94d1a000982df745cb9ce170f994/src/lib.rs#L108-L114
+    let nrows = array.nrows();
+    let ncols = array.ncols();
+    let strides: [isize; 2] = array.strides().try_into().unwrap();
+    let ptr = array.as_ptr();
+    // SAFETY: We know the array is a 2d array from ndarray and we get the pointer and memory layout
+    // description from ndarray and can be assumed to be valid.
+    unsafe { faer::MatRef::from_raw_parts(ptr, nrows, ncols, strides[0], strides[1]) }
+}
+
+#[inline]
+pub fn faer_to_ndarray<T>(mat: MatRef<'_, T>) -> ArrayView2<'_, T> {
+    // This function's code is based on faer-ext's IntoNdarray::into_ndarray implementation at:
+    // https://codeberg.org/sarah-quinones/faer-ext/src/commit/0f055b39529c94d1a000982df745cb9ce170f994/src/lib.rs#L134-L141
+    let nrows = mat.nrows();
+    let ncols = mat.ncols();
+    let row_stride: usize = mat.row_stride().try_into().unwrap();
+    let col_stride: usize = mat.col_stride().try_into().unwrap();
+    let ptr = mat.as_ptr();
+    // SAFETY: We know the array is a 2d array from nalgebra and we get the pointer and memory layout
+    // description from faer and can be assumed to be valid since the constraints on
+    // `ArrayView2::from_shape_ptr()`
+    // (https://docs.rs/ndarray/latest/ndarray/type.ArrayView.html#method.from_shape_ptr)
+    // should be be met for a faer Mat.
+    unsafe { ArrayView2::from_shape_ptr((nrows, ncols).strides((row_stride, col_stride)), ptr) }
+}
 
 fn nalgebra_to_faer<R: Dim, C: Dim, RStride: Dim, CStride: Dim>(
     mat: MatrixView<'_, Complex64, R, C, RStride, CStride>,
@@ -35,7 +64,7 @@ fn nalgebra_to_faer<R: Dim, C: Dim, RStride: Dim, CStride: Dim>(
     // (https://docs.rs/ndarray/latest/ndarray/type.ArrayView.html#method.from_shape_ptr)
     // should be be met for a valid nalgebra matrix.
     let array = unsafe { ArrayView2::from_shape_ptr(dim.strides(strides), mat.get_unchecked(0)) };
-    array.into_faer()
+    ndarray_to_faer(array)
 }
 
 /// Convert a faer MatRef into a nalgebra MatrixView without copying

--- a/crates/synthesis/src/two_qubit_decompose.rs
+++ b/crates/synthesis/src/two_qubit_decompose.rs
@@ -27,7 +27,6 @@ use std::ops::Deref;
 
 use faer::Side::Lower;
 use faer::{Mat, MatRef, Scale, prelude::*};
-use faer_ext::{IntoFaer, IntoNdarray};
 use ndarray::Zip;
 use ndarray::linalg::kron;
 use ndarray::prelude::*;
@@ -46,6 +45,7 @@ use crate::euler_one_qubit_decomposer::{
     ANGLE_ZERO_EPSILON, EulerBasis, EulerBasisSet, OneQubitGateSequence, angles_from_unitary,
     det_one_qubit, unitary_to_gate_sequence_inner,
 };
+use crate::linalg::{faer_to_ndarray, ndarray_to_faer};
 use qiskit_quantum_info::convert_2q_block_matrix::change_basis;
 
 use rand::prelude::*;
@@ -108,11 +108,8 @@ fn magic_basis_transform(
 }
 
 fn transform_from_magic_basis(u: Mat<c64>) -> Mat<c64> {
-    let unitary: ArrayView2<Complex64> = u.as_ref().into_ndarray();
-    magic_basis_transform(unitary, MagicBasisTransform::OutOf)
-        .view()
-        .into_faer()
-        .to_owned()
+    let unitary: ArrayView2<Complex64> = faer_to_ndarray(u.as_ref());
+    ndarray_to_faer(magic_basis_transform(unitary, MagicBasisTransform::OutOf).view()).to_owned()
 }
 
 // faer::c64 and num_complex::Complex<f64> are both structs
@@ -218,7 +215,7 @@ fn py_decompose_two_qubit_product_gate(
 #[pyfunction]
 fn weyl_coordinates(py: Python, unitary: PyReadonlyArray2<Complex64>) -> PyResult<Py<PyAny>> {
     let array = unitary.as_array();
-    Ok(__weyl_coordinates(array.into_faer())?
+    Ok(__weyl_coordinates(ndarray_to_faer(array))?
         .to_vec()
         .into_pyarray(py)
         .into_any()
@@ -282,7 +279,7 @@ pub fn _num_basis_gates(
     basis_fidelity: f64,
     unitary: PyReadonlyArray2<Complex<f64>>,
 ) -> PyResult<usize> {
-    let u = unitary.as_array().into_faer();
+    let u = ndarray_to_faer(unitary.as_array());
     __num_basis_gates(basis_b, basis_fidelity, u)
 }
 
@@ -596,7 +593,7 @@ impl TwoQubitWeylDecomposition {
 
         let mut u = unitary_matrix.to_owned();
         let unitary_matrix = unitary_matrix.to_owned();
-        let det_u = u.view().into_faer().determinant();
+        let det_u = ndarray_to_faer(u.view()).determinant();
         let det_pow = det_u.powf(-0.25);
         u.mapv_inplace(|x| x * det_pow);
         let mut global_phase = det_u.arg() / 4.;
@@ -636,14 +633,13 @@ impl TwoQubitWeylDecomposition {
                 rand_b = state.sample(StandardNormal);
             }
             let m2_real = m2.mapv(|val| rand_a * val.re + rand_b * val.im);
-            let p_inner = m2_real
-                .view()
-                .into_faer()
-                .self_adjoint_eigen(Lower)
-                .map_err(|e| QiskitError::new_err(format!("{e:?}")))?
-                .U()
-                .into_ndarray()
-                .mapv(Complex64::from);
+            let p_inner = faer_to_ndarray(
+                ndarray_to_faer(m2_real.view())
+                    .self_adjoint_eigen(Lower)
+                    .map_err(|e| QiskitError::new_err(format!("{e:?}")))?
+                    .U(),
+            )
+            .mapv(Complex64::from);
             let d_inner = p_inner.t().dot(&m2).dot(&p_inner).diag().to_owned();
             let mut diag_d: Array2<Complex64> = Array2::zeros((4, 4));
             diag_d
@@ -685,7 +681,7 @@ impl TwoQubitWeylDecomposition {
             let slice_b = p_orig.slice_mut(s![.., *item]);
             Zip::from(slice_a).and(slice_b).for_each(::std::mem::swap);
         }
-        if p.view().into_faer().determinant().re < 0. {
+        if ndarray_to_faer(p.view()).determinant().re < 0. {
             p.slice_mut(s![.., -1]).mapv_inplace(|x| -x);
         }
         let mut temp: Array2<Complex64> = Array2::zeros((4, 4));
@@ -1342,7 +1338,7 @@ impl TwoQubitBasisDecomposer {
 
     /// Compute the number of basis gates needed for a given unitary
     pub fn num_basis_gates_inner(&self, unitary: ArrayView2<Complex64>) -> PyResult<usize> {
-        let u = unitary.into_faer();
+        let u = ndarray_to_faer(unitary);
         __num_basis_gates(self.basis_decomposer.b, self.basis_fidelity, u)
     }
 
@@ -2302,7 +2298,7 @@ impl TwoQubitBasisDecomposer {
 }
 
 fn u4_to_su4(u4: ArrayView2<Complex64>) -> (Array2<Complex64>, f64) {
-    let det_u = u4.into_faer().determinant();
+    let det_u = ndarray_to_faer(u4).determinant();
     let phase_factor = det_u.powf(-0.25).conj();
     let su4 = u4.mapv(|x| x / phase_factor);
     (su4, phase_factor.arg())
@@ -2438,7 +2434,7 @@ pub fn two_qubit_local_invariants(unitary: PyReadonlyArray2<Complex64>) -> [f64;
     // Transform to bell basis
     let bell_basis_unitary = aview2(&MAGIC_DAGGER).dot(&mat.dot(&aview2(&MAGIC)));
     // Get determinate since +- one is allowed.
-    let det_bell_basis = bell_basis_unitary.view().into_faer().determinant();
+    let det_bell_basis = ndarray_to_faer(bell_basis_unitary.view()).determinant();
     let m = bell_basis_unitary.t().dot(&bell_basis_unitary);
     let mut m_tr2 = m.diag().sum();
     m_tr2 *= m_tr2;


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the version of faer we use in qiskit to the latest release 0.24.0 which was released in late January. One thing to note on this version is that the current release of the faer-ext crate is not compatible with this release. So we have to inline the conversions between faer and ndarray and stop using faer-ext. This isn't a terrible loss as it's not that much code and it also simplifies the dependency tree. This is actually probably a better way to handle the conversions because we were already doing the conversions ourselves for nalgebra to workaround the current faer-ext release depending on an incompatible version of nalgebra for our needs.

### Details and comments