### PR TITLE
Bump version of `cibuildwheel` to 3.4

### DIFF
--- a/.github/workflows/wheels-build.yml
+++ b/.github/workflows/wheels-build.yml
@@ -80,8 +80,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          # Used for the ARM builds.
-          - macos-14
+          - macos-15
           - windows-latest
           - ubuntu-24.04-arm
     steps:
@@ -116,7 +115,7 @@ jobs:
         env:
           PGO_WORK_DIR: ${{ github.workspace }}/pgo-data
           PGO_OUT_PATH: ${{ github.workspace }}/merged.profdata
-      - uses: pypa/cibuildwheel@v3.0.1
+      - uses: pypa/cibuildwheel@v3.4.0
       - uses: actions/upload-artifact@v5
         with:
           path: ./wheelhouse/*.whl
@@ -132,7 +131,7 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
       - uses: dtolnay/rust-toolchain@stable
-      - uses: pypa/cibuildwheel@v3.0.1
+      - uses: pypa/cibuildwheel@v3.4.0
       - uses: actions/upload-artifact@v5
         with:
           path: ./wheelhouse/*.whl
@@ -153,7 +152,7 @@ jobs:
       - uses: docker/setup-qemu-action@v3
         with:
           platforms: all
-      - uses: pypa/cibuildwheel@v3.0.1
+      - uses: pypa/cibuildwheel@v3.4.0
         env:
           CIBW_ARCHS_LINUX: s390x
           CIBW_TEST_SKIP: "cp*"
@@ -176,7 +175,7 @@ jobs:
       - uses: docker/setup-qemu-action@v3
         with:
           platforms: all
-      - uses: pypa/cibuildwheel@v3.0.1
+      - uses: pypa/cibuildwheel@v3.4.0
         env:
           CIBW_ARCHS_LINUX: ppc64le
           CIBW_TEST_SKIP: "cp*"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,9 +2461,9 @@ dependencies = [
 
 [[package]]
 name = "spindle"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f794dedb367e82477aa6bbf83ea9bbce9bc074b3caacaa82fc4ba398ec9b701d"
+checksum = "673aaca3d8aa5387a6eba861fbf984af5348d9df5d940c25c6366b19556fdf64"
 dependencies = [
  "atomic-wait",
  "crossbeam",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,8 +193,13 @@ manylinux-x86_64-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux2014"
 manylinux-ppc64le-image = "manylinux2014"
 manylinux-s390x-image = "manylinux2014"
-skip = "cp38-* cp39-* *musllinux* *win32 *i686"
-test-skip = "*win32 *linux_i686"
+build = ["cp3??-*"]
+skip = ["*-win32", "*_i686", "*_universal2", "*-musllinux_*"]
+# We actually support CPython 3.14 via the stable API, but we can't test it for
+# the release because there's no available versions of Numpy with support for
+# both glibc 2.17 (from our manylinux image) and Python 3.14.  On `main` the
+# glibc version is higher and we do test this.
+test-skip = ["cp314-*"]
 test-command = "cp -r {project}/test . && QISKIT_PARALLEL=FALSE stestr --test-path test/python run --abbreviate"
 # We need to use pre-built versions of Numpy and Scipy in the tests; they have a
 # tendency to crash if they're installed from source by `pip install`, and since


### PR DESCRIPTION
We are using quite an old version of `cibuildwheel`, and we're about to do a release.  This updates the action to take advantage to bugfixes in handling of the GitHub images since our last bump, and (slightly) modernises the `build`/`skip` syntax to use the list form and a more explicit "allowlist" rather than the awkward blocklist we had before.

To avoid bumping the manylinux image for the 2.3 series, as was done in gh-15791[^1], we simply skip the CPython 3.14 tests, which would fail due to an inability to install Numpy.

[^1]: 228f50c95d: Update Linux build image to `manylinux_2_28`

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


