### PR TITLE
Fix stable clippy warnings

### DIFF
--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -1568,7 +1568,7 @@ pub fn wrap_conditional_gate(
 
     // Create GenericValue::CircuitData from the CircuitData
     // The instruction_values_to_params function will handle converting this to a Block
-    let if_params = vec![GenericValue::CircuitData(body_data)];
+    let if_params = vec![GenericValue::CircuitData(Box::new(body_data))];
     let if_params_converted = instruction_values_to_params(if_params, qpy_data)?;
 
     Ok((if_else_op, if_params_converted))

--- a/crates/qpy/src/value.rs
+++ b/crates/qpy/src/value.rs
@@ -307,7 +307,7 @@ pub enum GenericValue {
     Expression(Expr),
     Modifier(Py<PyAny>),
     Circuit(Py<PyAny>), // currently we have no rust class corresponding to a circuit, only to the inner CircuitData
-    CircuitData(CircuitData),
+    CircuitData(Box<CircuitData>),
 }
 
 // we want to be able to extract the value relatively painlessly;
@@ -341,7 +341,7 @@ impl GenericValue {
                 Ok(py_circuit.extract::<QuantumCircuitData>(py)?.data)
             })
             .ok(),
-            GenericValue::CircuitData(circuit_data) => Some(circuit_data.clone()),
+            GenericValue::CircuitData(circuit_data) => Some(circuit_data.as_ref().clone()),
             _ => None,
         }
     }

--- a/crates/transpiler/src/passes/convert_to_pauli_rotations.rs
+++ b/crates/transpiler/src/passes/convert_to_pauli_rotations.rs
@@ -65,8 +65,8 @@ static STANDARD_GATE_SUBSTITUTIONS: [Option<GateToPauliRotType>; 52] = [
     None, // U3
     Some((
         &[
-            (&[BitTerm::X], -1.0 * FRAC_PI_4, &[1]),
-            (&[BitTerm::Z], -1.0 * FRAC_PI_8, &[1]),
+            (&[BitTerm::X], -FRAC_PI_4, &[1]),
+            (&[BitTerm::Z], -FRAC_PI_8, &[1]),
             (&[BitTerm::Z, BitTerm::X], FRAC_PI_4, &[0, 1]),
             (&[BitTerm::Z], -FRAC_PI_4, &[0]),
             (&[BitTerm::Y], -FRAC_PI_8, &[1]),
@@ -110,7 +110,7 @@ static STANDARD_GATE_SUBSTITUTIONS: [Option<GateToPauliRotType>; 52] = [
     )), // DCX
     Some((
         &[
-            (&[BitTerm::Z, BitTerm::X], -1.0 * FRAC_PI_4, &[0, 1]),
+            (&[BitTerm::Z, BitTerm::X], -FRAC_PI_4, &[0, 1]),
             (&[BitTerm::Y], -FRAC_PI_2, &[0]),
             (&[BitTerm::Z], FRAC_PI_2, &[1]),
             (&[BitTerm::Y], FRAC_PI_2, &[1]),


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes clippy warnings that appear when running clippy from the latest stable rust release 1.94.0. Fixing this pre-emptively will avoid errors when we try to bump our MSRV in the future and also fix the error for those of use that insist on testing with the latest stable release of Rust and are seeing clippy complain about this.

### Details and comments

I was planning to ignore the warnings when it was just the unnecessary multiplication operator. But the recently introduced warning on: "large size difference between variants" was more important to fix asap. This warning slipped in as part of #15663 where a CircuitData was added as an enum variant which is significantly larger than the other enum variants. This solves that by just boxing the circuit data and then adjusting it's usage in the qpy module.
