### PR TITLE
Fix approximate-by-default behaviour of `UnitarySynthesis`

### DIFF
--- a/crates/cext/src/transpiler/passes/unitary_synthesis.rs
+++ b/crates/cext/src/transpiler/passes/unitary_synthesis.rs
@@ -17,6 +17,7 @@ use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_transpiler::passes::{
     UnitarySynthesisConfig, UnitarySynthesisState, run_unitary_synthesis,
+    unitary_synthesis::Approximation,
 };
 use qiskit_transpiler::target::Target;
 
@@ -78,16 +79,17 @@ pub unsafe extern "C" fn qk_transpiler_pass_standalone_unitary_synthesis(
         Ok(dag) => dag,
         Err(e) => panic!("{}", e),
     };
-    let approximation_degree = if approximation_degree.is_nan() {
-        None
-    } else {
-        Some(approximation_degree)
-    };
+    let approximation =
+        Approximation::from_py_approximation_degree(if approximation_degree.is_nan() {
+            None
+        } else {
+            Some(approximation_degree)
+        });
     let physical_qubits = (0..dag.num_qubits() as u32)
         .map(PhysicalQubit::new)
         .collect::<Vec<_>>();
     let mut synthesis_state = UnitarySynthesisState::new(UnitarySynthesisConfig {
-        approximation_degree,
+        approximation,
         run_python_decomposers: false,
         ..Default::default()
     });

--- a/crates/cext/src/transpiler/transpile_function.rs
+++ b/crates/cext/src/transpiler/transpile_function.rs
@@ -15,7 +15,7 @@ use std::ffi::c_char;
 use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::dag_circuit::DAGCircuit;
 use qiskit_transpiler::commutation_checker::get_standard_commutation_checker;
-use qiskit_transpiler::passes::{UnitarySynthesisConfig, UnitarySynthesisState};
+use qiskit_transpiler::passes::{UnitarySynthesisConfig, UnitarySynthesisState, unitary_synthesis};
 use qiskit_transpiler::standard_equivalence_library::generate_standard_equivalence_library;
 use qiskit_transpiler::target::Target;
 use qiskit_transpiler::transpile;
@@ -164,7 +164,9 @@ pub unsafe extern "C" fn qk_transpile_stage_init(
         Some(options.approximation_degree)
     };
     let mut synthesis_state = UnitarySynthesisState::new(UnitarySynthesisConfig {
-        approximation_degree,
+        approximation: unitary_synthesis::Approximation::from_py_approximation_degree(
+            approximation_degree,
+        ),
         run_python_decomposers: false,
         ..Default::default()
     });
@@ -411,7 +413,9 @@ pub unsafe extern "C" fn qk_transpile_stage_optimization(
         Some(options.approximation_degree)
     };
     let mut synthesis_state = UnitarySynthesisState::new(UnitarySynthesisConfig {
-        approximation_degree,
+        approximation: unitary_synthesis::Approximation::from_py_approximation_degree(
+            approximation_degree,
+        ),
         run_python_decomposers: false,
         ..Default::default()
     });
@@ -518,7 +522,9 @@ pub unsafe extern "C" fn qk_transpile_stage_translation(
         Some(options.approximation_degree)
     };
     let mut synthesis_state = UnitarySynthesisState::new(UnitarySynthesisConfig {
-        approximation_degree,
+        approximation: unitary_synthesis::Approximation::from_py_approximation_degree(
+            approximation_degree,
+        ),
         run_python_decomposers: false,
         ..Default::default()
     });

--- a/crates/transpiler/src/passes/mod.rs
+++ b/crates/transpiler/src/passes/mod.rs
@@ -49,7 +49,7 @@ mod remove_identity_equiv;
 pub mod sabre;
 mod split_2q_unitaries;
 mod substitute_pi4_rotations;
-mod unitary_synthesis;
+pub mod unitary_synthesis;
 mod unroll_3q_or_more;
 pub mod vf2;
 mod wrap_angles;

--- a/crates/transpiler/src/passes/unitary_synthesis/decomposers.rs
+++ b/crates/transpiler/src/passes/unitary_synthesis/decomposers.rs
@@ -35,8 +35,8 @@ use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyDict};
 
 use super::{
-    DecompositionDirection2q, QpuConstraint, QpuConstraintKind, UnitarySynthesisConfig,
-    UsePulseOptimizer,
+    Approximation, DecompositionDirection2q, NormalizedFidelity, QpuConstraint, QpuConstraintKind,
+    UnitarySynthesisConfig, UsePulseOptimizer,
 };
 use crate::QiskitError;
 use crate::passes::optimize_clifford_t::CLIFFORD_T_GATE_NAMES;
@@ -52,42 +52,6 @@ use qiskit_synthesis::two_qubit_decompose::{
     RXXEquivalent, TwoQubitBasisDecomposer, TwoQubitControlledUDecomposer, TwoQubitGateSequence,
     TwoQubitWeylDecomposition,
 };
-
-/// The fidelity of the 2q basis gate used in a decomposer.
-///
-/// This is necessarily between 0.0 and 1.0 and we normalise away negative zero, which together are
-/// why it's safe to use with total equality and hashing.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct ApproximationDegree(f64);
-impl ApproximationDegree {
-    pub const EXACT: Self = Self(1.0);
-
-    #[inline]
-    pub fn new(val: f64) -> Option<Self> {
-        // The `abs` is normalising signed zero.
-        (0.0..=1.0).contains(&val).then(|| Self(val.abs()))
-    }
-    /// Get the value.  This is guaranteed to be finite, sign positive and in `[0.0, 1.0]`.
-    #[inline]
-    pub fn get(&self) -> f64 {
-        self.0
-    }
-
-    /// Does this represent approximate synthesis?
-    #[inline]
-    pub fn is_approximate(&self) -> bool {
-        *self != Self::EXACT
-    }
-}
-// `impl Eq` is safe for this float-derived quantity because we only permit the range `[0.0, 1.0]`
-// and forbid negative zero.
-impl Eq for ApproximationDegree {}
-impl hash::Hash for ApproximationDegree {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        // This is safe because we're in the range `[0.0, 1.0]` and normalised out negative zero.
-        self.0.to_le_bytes().hash(state)
-    }
-}
 
 /// Constructor for a 2q Ising-like decomposer.  This corresponds to
 /// [TwoQubitControlledUDecomposer], and requires gates that are locally equivalent to RXX (and
@@ -215,7 +179,7 @@ impl StaticKakSource {
 struct StaticKakConstructor {
     source: StaticKakSource,
     euler: EulerBasis,
-    approximation: ApproximationDegree,
+    fidelity: NormalizedFidelity,
     use_pulse_optimizer: UsePulseOptimizer,
 }
 impl StaticKakConstructor {
@@ -238,7 +202,7 @@ impl StaticKakConstructor {
             self.source.gate.clone(),
             self.source.params.clone(),
             matrix.view(),
-            self.approximation.get(),
+            self.fidelity.get(),
             self.euler.as_str(),
             self.use_pulse_optimizer.to_py_pulse_optimize(),
         )
@@ -294,7 +258,7 @@ impl Decomposer2qConstructor {
                     .try_build()
                     .map(|decomposer| Decomposer2q::StaticKak {
                         decomposer: Box::new(decomposer),
-                        approximation: constructor.approximation,
+                        fidelity: constructor.fidelity,
                     })
             }
         }
@@ -314,7 +278,7 @@ pub enum Decomposer2q {
     },
     StaticKak {
         decomposer: Box<TwoQubitBasisDecomposer>,
-        approximation: ApproximationDegree,
+        fidelity: NormalizedFidelity,
     },
 }
 impl Decomposer2q {
@@ -331,8 +295,8 @@ impl Decomposer2q {
             }),
             Self::StaticKak {
                 decomposer,
-                approximation,
-            } => decomposer.call_inner(matrix, None, approximation.is_approximate(), None),
+                fidelity,
+            } => decomposer.call_inner(matrix, None, fidelity.get() < 1.0, None),
         }
     }
 }
@@ -630,13 +594,15 @@ fn get_2q_decomposers(
                     gate: kak_gate.into(),
                     params: smallvec![],
                 };
-                let approximation =
-                    ApproximationDegree::new(config.approximation_degree.unwrap_or(1.0))
-                        .unwrap_or(ApproximationDegree::EXACT);
+                let fidelity = config.approximation.synthesis_fidelity(0.0).map_err(|e| {
+                    PyValueError::new_err(format!(
+                        "requested synthesis fidelity is out of range: {e}"
+                    ))
+                })?;
                 let constructor = Decomposer2qConstructor::StaticKak(StaticKakConstructor {
                     source,
                     euler,
-                    approximation,
+                    fidelity,
                     use_pulse_optimizer: config.use_pulse_optimizer,
                 });
                 let flip = choose_flip(direction, &constructor);
@@ -714,11 +680,13 @@ fn get_2q_decomposers(
                     continue;
                 };
                 let fidelity = config
-                    .approximation_degree
-                    .map(|a| a * (1. - candidate.error))
-                    .unwrap_or(1.);
-                let approximation =
-                    ApproximationDegree::new(fidelity).unwrap_or(ApproximationDegree::EXACT);
+                    .approximation
+                    .synthesis_fidelity(candidate.error)
+                    .map_err(|e| {
+                        PyValueError::new_err(format!(
+                            "requested synthesis fidelity is out of range: {e}"
+                        ))
+                    })?;
                 // TODO: the 2q decomposers internally already do everything that's needed to handle
                 // _all_ of the 1q bases simultaneously without further decompositions, but don't
                 // expose that functionality.  This wastes huge amounts of time and needs a fix.
@@ -732,7 +700,7 @@ fn get_2q_decomposers(
                     let constructor = Decomposer2qConstructor::StaticKak(StaticKakConstructor {
                         source,
                         euler,
-                        approximation,
+                        fidelity,
                         use_pulse_optimizer: config.use_pulse_optimizer,
                     });
                     let flip = choose_flip(candidate.direction, &constructor);
@@ -776,8 +744,7 @@ fn get_xx_decomposers(
     // `StandardGate` into a a known strength (or function of strength).
     let embodiments_lookup = imports::XX_EMBODIMENTS.get_bound(py).cast::<PyDict>()?;
     let xx_decomposer_class = imports::XX_DECOMPOSER.get_bound(py);
-    let approximation_degree = config.approximation_degree.unwrap_or(1.);
-    let is_approximate = approximation_degree != 1.;
+    let approximation = config.approximation;
 
     let mut extend_with_flip = |out: &mut Vec<(usize, FlipDirection)>,
                                 candidates: &[Candidate2q],
@@ -805,7 +772,17 @@ fn get_xx_decomposers(
                 embodiment
             };
             embodiments.set_item(strength, embodiment)?;
-            fidelities.set_item(strength, (1.0 - candidate.error) * approximation_degree)?;
+            fidelities.set_item(
+                strength,
+                approximation
+                    .synthesis_fidelity(candidate.error)
+                    .map_err(|e| {
+                        PyValueError::new_err(format!(
+                            "requested synthesis fidelity is out of range: {e}"
+                        ))
+                    })?
+                    .get(),
+            )?;
         }
         if !fidelities.is_truthy()? {
             return Ok(());
@@ -818,7 +795,7 @@ fn get_xx_decomposers(
             ))?;
             let constructor = Decomposer2qConstructor::DiscretePauli(DiscretePauliConstructor {
                 decomposer: ob.unbind(),
-                is_approximate,
+                is_approximate: approximation != Approximation::Exact,
             });
             if let Some(index) = cache.cache(constructor) {
                 out.push((index, flip));

--- a/crates/transpiler/src/passes/unitary_synthesis/mod.rs
+++ b/crates/transpiler/src/passes/unitary_synthesis/mod.rs
@@ -43,8 +43,10 @@ use std::sync::OnceLock;
 
 /// The fidelity of the 2q basis gate used in a decomposer.
 ///
-/// This is necessarily between 0.0 and 1.0 and we normalise away negative zero, which together are
-/// why it's safe to use with total equality and hashing.
+/// This is "normalised" in the sense that the value is guaranteed (when constructed safely) to be
+/// between 0.0 and 1.0 inclusive, and the allowed floating-point values are standardised so we only
+/// use one canonical representation of each (i.e. no negative zero).  These conditions make it safe
+/// to use with total equality and hashing, which lets it be put in a hashmap.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NormalizedFidelity(f64);
 impl NormalizedFidelity {
@@ -69,7 +71,11 @@ impl hash::Hash for NormalizedFidelity {
     }
 }
 
-/// Whether to do approximate synthesis.
+/// The strategy to use for approximate synthesis (or `Exact` for exact synthesis).
+///
+/// This is used internally in the Rust code, because the Python form `float | None` has been
+/// frequently accidentally misinterpreted (there, `None` does not mean exact, and `1.0` has a
+/// very different meaning to `1.0 - 1ULP`).
 #[derive(Clone, Copy, Debug, PartialEq, Default)]
 pub enum Approximation {
     /// Do perfect synthesis, regardless of reported gate errors.

--- a/crates/transpiler/src/passes/unitary_synthesis/mod.rs
+++ b/crates/transpiler/src/passes/unitary_synthesis/mod.rs
@@ -17,6 +17,7 @@ use indexmap::IndexSet;
 use nalgebra::{DMatrix, Matrix2};
 use ndarray::prelude::*;
 use num_complex::Complex64;
+use std::hash;
 
 use numpy::PyReadonlyArray2;
 use pyo3::prelude::*;
@@ -40,7 +41,69 @@ use qiskit_synthesis::two_qubit_decompose::TwoQubitGateSequence;
 #[cfg(feature = "cache_pygates")]
 use std::sync::OnceLock;
 
-/// A borrowed view onto the hardawre constraint.
+/// The fidelity of the 2q basis gate used in a decomposer.
+///
+/// This is necessarily between 0.0 and 1.0 and we normalise away negative zero, which together are
+/// why it's safe to use with total equality and hashing.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct NormalizedFidelity(f64);
+impl NormalizedFidelity {
+    #[inline]
+    pub fn new(val: f64) -> Option<Self> {
+        // The `abs` is normalising signed zero.
+        (0.0..=1.0).contains(&val).then(|| Self(val.abs()))
+    }
+    /// Get the value.  This is guaranteed to be finite, sign positive and in `[0.0, 1.0]`.
+    #[inline]
+    pub fn get(&self) -> f64 {
+        self.0
+    }
+}
+// `impl Eq` is safe for this float-derived quantity because we only permit the range `[0.0, 1.0]`
+// and forbid negative zero.
+impl Eq for NormalizedFidelity {}
+impl hash::Hash for NormalizedFidelity {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        // This is safe because we're in the range `[0.0, 1.0]` and normalised out negative zero.
+        self.0.to_le_bytes().hash(state)
+    }
+}
+
+/// Whether to do approximate synthesis.
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
+pub enum Approximation {
+    /// Do perfect synthesis, regardless of reported gate errors.
+    #[default]
+    Exact,
+    /// Scale the reported gate fidelity by the given amount.
+    ScaleFidelity(f64),
+}
+impl Approximation {
+    /// Convert from the Python-space representation of `approximation_degree`.
+    pub fn from_py_approximation_degree(val: Option<f64>) -> Self {
+        match val {
+            // ... yeah, I don't know why we've historically done this either.
+            None => Self::ScaleFidelity(1.0),
+            Some(1.0) => Self::Exact,
+            Some(val) => Self::ScaleFidelity(val),
+        }
+    }
+
+    /// Get the fidelity target that should be used for a given gate error.
+    ///
+    /// Returns `Err` with the value of an out-of-bounds requested fidelity.
+    pub fn synthesis_fidelity(&self, gate_error: f64) -> Result<NormalizedFidelity, f64> {
+        match self {
+            Self::Exact => Ok(NormalizedFidelity::new(1.0).expect("1.0 should be in bounds")),
+            Self::ScaleFidelity(scale) => {
+                let fidelity = scale * (1.0 - gate_error);
+                NormalizedFidelity::new(fidelity).ok_or(fidelity)
+            }
+        }
+    }
+}
+
+/// A borrowed view onto the hardware constraint.
 #[derive(Clone, Copy, Debug)]
 pub enum QpuConstraint<'a> {
     Target(&'a Target),
@@ -132,12 +195,8 @@ impl DecompositionDirection2q {
 /// This implements `Default`, which is a convenient constructor.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UnitarySynthesisConfig {
-    /// Whether to allow approximations (`Some`) or not (`None`).
-    ///
-    /// If `Some`, the weight is a multiplicative multiplier on fidelity, such that `1.0` means "use
-    /// the gate fidelity exactly" and `0.5` would mean "treat the gate as having half its natural
-    /// fidelity", etc.
-    pub approximation_degree: Option<f64>,
+    /// Whether to do approximate synthesis.
+    pub approximation: Approximation,
     pub use_pulse_optimizer: UsePulseOptimizer,
     pub decomposition_direction_2q: DecompositionDirection2q,
     /// Whether to allow use of Python-space decomposers.
@@ -146,7 +205,7 @@ pub struct UnitarySynthesisConfig {
 impl Default for UnitarySynthesisConfig {
     fn default() -> Self {
         Self {
-            approximation_degree: None,
+            approximation: Approximation::Exact,
             use_pulse_optimizer: UsePulseOptimizer::IfBetter,
             decomposition_direction_2q: DecompositionDirection2q::BestValid,
             run_python_decomposers: false,
@@ -603,7 +662,7 @@ pub fn py_unitary_synthesis(
     pulse_optimize: Option<bool>,
 ) -> PyResult<DAGCircuit> {
     let config = UnitarySynthesisConfig {
-        approximation_degree,
+        approximation: Approximation::from_py_approximation_degree(approximation_degree),
         use_pulse_optimizer: UsePulseOptimizer::from_py_pulse_optimize(pulse_optimize),
         decomposition_direction_2q: DecompositionDirection2q::from_py_natural_direction(
             natural_direction,
@@ -647,7 +706,7 @@ pub fn py_synthesize_unitary_matrix(
     pulse_optimize: Option<bool>,
 ) -> PyResult<DAGCircuit> {
     let config = UnitarySynthesisConfig {
-        approximation_degree,
+        approximation: Approximation::from_py_approximation_degree(approximation_degree),
         use_pulse_optimizer: UsePulseOptimizer::from_py_pulse_optimize(pulse_optimize),
         decomposition_direction_2q: DecompositionDirection2q::from_py_natural_direction(
             natural_direction,

--- a/crates/transpiler/src/transpiler.rs
+++ b/crates/transpiler/src/transpiler.rs
@@ -16,6 +16,7 @@ use crate::commutation_checker::CommutationChecker;
 use crate::commutation_checker::get_standard_commutation_checker;
 use crate::equivalence::EquivalenceLibrary;
 use crate::passes::sabre::route::PyRoutingTarget;
+use crate::passes::unitary_synthesis;
 use crate::passes::*;
 use crate::standard_equivalence_library::generate_standard_equivalence_library;
 use crate::target::Target;
@@ -469,7 +470,9 @@ pub fn transpile(
     let mut equivalence_library = generate_standard_equivalence_library();
     let sabre_heuristic = get_sabre_heuristic(target)?;
     let mut synthesis_state = UnitarySynthesisState::new(UnitarySynthesisConfig {
-        approximation_degree,
+        approximation: unitary_synthesis::Approximation::from_py_approximation_degree(
+            approximation_degree,
+        ),
         run_python_decomposers: false,
         ..Default::default()
     });

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -1084,7 +1084,7 @@ class TestUnitarySynthesisTarget(QiskitTestCase):
         qc.unitary(near_2cx, [0, 1])
 
         # First, a sanity check: the pass defaults should produce an exact synthesis, and it should
-        # have taken 3 cx since it
+        # have taken 3 cx since we know the permutation needs that.
         from_default = UnitarySynthesis(target=target)(qc)
         self.assertLess(
             1 - average_gate_fidelity(Operator(near_2cx), Operator(from_default)), 1e-15

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -62,7 +62,7 @@ from qiskit.circuit.library import (
     PauliEvolutionGate,
     CPhaseGate,
 )
-from qiskit.quantum_info import SparsePauliOp
+from qiskit.quantum_info import SparsePauliOp, average_gate_fidelity
 from qiskit.circuit import Measure
 from qiskit.circuit.controlflow import IfElseOp
 from qiskit.circuit import Parameter, Gate
@@ -1054,6 +1054,69 @@ class TestUnitarySynthesisTarget(QiskitTestCase):
             },
             {(0, 1)},
         )
+
+    def test_approximate_synthesis(self):
+        # Arbitrary Hermitian matrix with a norm known to be sensibly sized (it's about 2.8).
+        herm = np.array(
+            [
+                [-0.742, 0.643 + 0.341j, 0.166 - 0.432j, 0.803 + 0.285j],
+                [0.643 - 0.341j, 1.462, -0.477 + 0.0674j, 0.216 + 0.653j],
+                [0.166 + 0.432j, -0.477 - 0.0674j, 0.007, -0.231 - 0.226j],
+                [0.803 - 0.285j, 0.216 - 0.653j, -0.231 + 0.226j, -0.743],
+            ]
+        )
+        # A unitary perturbation that is a small distance from the identity.  It needs 3 cx to
+        # synthesise.
+        perturbation = scipy.linalg.expm(-1j * herm * 1e-3)
+
+        target = Target(2)
+        target.add_instruction(CXGate(), {(0, 1): InstructionProperties(error=1e-4)})
+        target.add_instruction(RZGate(Parameter("a")))
+        target.add_instruction(SXGate())
+
+        pass_exact = UnitarySynthesis(target=target, approximation_degree=1.0)
+        pass_approximate = UnitarySynthesis(target=target, approximation_degree=None)
+
+        # iSwap can be synthesised with 2 CX.
+        near_2cx = iSwapGate().to_matrix() @ perturbation
+        qc = QuantumCircuit(2)
+        qc.ensure_physical()
+        qc.unitary(near_2cx, [0, 1])
+
+        # First, a sanity check: the pass defaults should produce an exact synthesis, and it should
+        # have taken 3 cx since it
+        from_default = UnitarySynthesis(target=target)(qc)
+        self.assertLess(
+            1 - average_gate_fidelity(Operator(near_2cx), Operator(from_default)), 1e-15
+        )
+        self.assertEqual(from_default.count_ops()["cx"], 3)
+        # These two circuits should be exactly identical, since it's the same decomposition.
+        self.assertEqual(from_default, pass_exact(qc))
+        # ... but now if we allow approximation up to the gate error, we should be able to find the
+        # 2-cx synthesis of iSwap (or something else that's nearby).
+        self.assertEqual(pass_approximate(qc).count_ops()["cx"], 2)
+
+        # The same applies for gates that are near a 1-cx decomposition...
+        near_1cx = CXGate().to_matrix() @ perturbation
+        qc = QuantumCircuit(2)
+        qc.ensure_physical()
+        qc.unitary(near_1cx, [0, 1])
+        from_exact = pass_exact(qc)
+        self.assertLess(1 - average_gate_fidelity(Operator(near_1cx), Operator(from_exact)), 1e-15)
+        self.assertEqual(from_exact.count_ops()["cx"], 3)
+        self.assertEqual(pass_approximate(qc).count_ops()["cx"], 1)
+
+        # ... and near a 0q decomposition.
+        near_separable = np.kron(XGate().to_matrix(), ZGate().to_matrix()) @ perturbation
+        qc = QuantumCircuit(2)
+        qc.ensure_physical()
+        qc.unitary(near_separable, [0, 1])
+        from_exact = pass_exact(qc)
+        self.assertLess(
+            1 - average_gate_fidelity(Operator(near_separable), Operator(from_exact)), 1e-15
+        )
+        self.assertEqual(from_exact.count_ops()["cx"], 3)
+        self.assertNotIn("cx", pass_approximate(qc).count_ops())
 
 
 if __name__ == "__main__":

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -1084,7 +1084,7 @@ class TestUnitarySynthesisTarget(QiskitTestCase):
         qc.unitary(near_2cx, [0, 1])
 
         # First, a sanity check: the pass defaults should produce an exact synthesis, and it should
-        # have taken 3 cx since we know the permutation needs that.
+        # have taken 3 cx since we know the perturbation needs that.
         from_default = UnitarySynthesis(target=target)(qc)
         self.assertLess(
             1 - average_gate_fidelity(Operator(near_2cx), Operator(from_default)), 1e-15


### PR DESCRIPTION
In gh-15492[^1], we accidentally swapped the behaviour of `approximation_degree` such that `None` was treated as "exact" and `1.0` as "up to gate error".  Despite all _other_ explicit float values meaning up-to-gate-fidelity multiplied by the value, `approximation_degree=1.0` has historically _actually_ meant "exact synthesis", and `None` is "up to gate error" instead.

While the oversight is easy to correct (and now encapsulated on entry to `UnitarySynthesis` rather than dealing with two different systems), the more worrying aspect was that our test suite did not catch the swap; we came unfortunately close to releasing Qiskit 2.4 with approximate synthesis turned on by default.

[^1]: 0b8bceb0: Rewrite default `UnitarySynthesis` to cache decomposers

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

No bugfix release note because the bug isn't released.

I didn't put `Approximation` up in the complete top level of `qiskit_transpiler` as of this commit because I haven't actually audited that _all_ our transpiler passes behave the same way with respect to scaling relative to the gate fidelity.  We can/should do that, and move the `Approximation` struct up to a top-level helper if so.