### PR TITLE
Coercing integer types to floats when appending a PPR to a circuit

### DIFF
--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -894,7 +894,11 @@ impl<'a, 'py, T: CircuitBlock> FromPyObject<'a, 'py> for OperationFromPython<T> 
 
             let py_angle = get_params()?.get_item(0)?;
             let angle = Param::extract(py_angle.as_borrowed())?;
-            debug_assert!(!matches!(angle, Param::Obj(_)));
+            if matches!(angle, Param::Obj(_)) {
+                return Err(PyTypeError::new_err(
+                    "invalid type for angle in PauliProductRotation",
+                ));
+            }
 
             let pauli_rotation = PauliProductRotation {
                 z: z.to_owned(),

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -893,7 +893,8 @@ impl<'a, 'py, T: CircuitBlock> FromPyObject<'a, 'py> for OperationFromPython<T> 
                 .to_vec();
 
             let py_angle = get_params()?.get_item(0)?;
-            let angle = Param::extract_no_coerce(py_angle.as_borrowed())?;
+            let angle = Param::extract(py_angle.as_borrowed())?;
+            debug_assert!(!matches!(angle, Param::Obj(_)));
 
             let pauli_rotation = PauliProductRotation {
                 z: z.to_owned(),

--- a/test/python/circuit/library/test_pauli_product_rotation.py
+++ b/test/python/circuit/library/test_pauli_product_rotation.py
@@ -59,6 +59,14 @@ class TestPauliProductRotationGate(QiskitTestCase):
         with self.subTest(msg="matrix"):
             np.testing.assert_allclose(rotation.to_matrix(), Operator(rotation.definition).data)
 
+    @data(1.2, np.pi / 4, 1, -1, 0)
+    def test_append_to_circuit(self, angle):
+        """Test that appending a Pauli product rotation to a circuit does not panic."""
+        pauli = Pauli("XIZZY")
+        rotation = PauliProductRotationGate(pauli, angle)
+        qc = QuantumCircuit(5)
+        qc.append(rotation, [0, 1, 2, 3, 4])
+
     def test_equality(self):
         """Test some equalities."""
         x = Parameter("x")

--- a/test/python/circuit/library/test_pauli_product_rotation.py
+++ b/test/python/circuit/library/test_pauli_product_rotation.py
@@ -59,7 +59,7 @@ class TestPauliProductRotationGate(QiskitTestCase):
         with self.subTest(msg="matrix"):
             np.testing.assert_allclose(rotation.to_matrix(), Operator(rotation.definition).data)
 
-    @data(1.2, np.pi / 4, 1, -1, 0)
+    @data(1.2, np.pi / 4, 1, -1, 0, Parameter("a"), Parameter("a") + Parameter("b"))
     def test_append_to_circuit(self, angle):
         """Test that appending a Pauli product rotation to a circuit does not panic."""
         pauli = Pauli("XIZZY")


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

When extracting a Rust-space `PauliProductRotation` from a Python-space `PauliProductRotationGate`, we should call `Param::extract` instead of `Param::extract_no_coerce` on the angle. This allows to specify integer types for the angle in the Python-space (e.g., `PauliProductRotationGate(Pauli("XIZ"), 2)`), which then would be automatically converted to `Param::Float(f64)` in the Rust-space. Without this fix, an integer angle is converted `Param::Obj`, which is obviously not what we want.

### Details and comments

No release note because it's an internal fix and PPR has not been released yet.

The only test I could think of was adding a debug assertion in the Rust-space and adding Python tests that would be triggered if the angles were not converted into floats.
