### PR TITLE
Add internal evolve methods by Clifford gates

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -707,7 +707,7 @@ def _evolve_cy(base_pauli, qctrl, qtrgt):
 
 
 def _evolve_dcx(base_pauli, qctrl, qtrgt):
-    """Update P -> DCX.P.DCX"""
+    """Update P -> DCX.P.DCXdg"""
     base_pauli._x[:, qtrgt] ^= base_pauli._x[:, qctrl]
     base_pauli._z[:, qctrl] ^= base_pauli._z[:, qtrgt]
     base_pauli._x[:, qctrl] ^= base_pauli._x[:, qtrgt]
@@ -728,12 +728,24 @@ def _evolve_swap(base_pauli, q1, q2):
 
 def _evolve_iswap(base_pauli, q1, q2):
     """Update P -> iSWAP.P.iSWAP"""
-    base_pauli = _evolve_s(base_pauli, q1)
-    base_pauli = _evolve_h(base_pauli, q1)
-    base_pauli = _evolve_s(base_pauli, q2)
-    base_pauli = _evolve_cx(base_pauli, q1, q2)
-    base_pauli = _evolve_cx(base_pauli, q2, q1)
-    base_pauli = _evolve_h(base_pauli, q2)
+    x1 = base_pauli._x[:, q1].copy()
+    z1 = base_pauli._z[:, q1].copy()
+    x2 = base_pauli._x[:, q2].copy()
+    z2 = base_pauli._z[:, q2].copy()
+
+    base_pauli._x[:, q1] = x2
+    base_pauli._x[:, q2] = x1
+    base_pauli._z[:, q1] = x1 ^ x2 ^ z2
+    base_pauli._z[:, q2] = x1 ^ x2 ^ z1
+
+    base_pauli._phase += np.logical_xor(x1, x2) + np.logical_xor(
+        np.logical_and(z1, np.logical_xor(x1, x2).T.astype(base_pauli._phase.dtype)).T.astype(
+            base_pauli._phase.dtype
+        ),
+        np.logical_and(z2, np.logical_xor(x1, x2).T.astype(base_pauli._phase.dtype)).T.astype(
+            base_pauli._phase.dtype
+        ),
+    )
     return base_pauli
 
 

--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -738,14 +738,7 @@ def _evolve_iswap(base_pauli, q1, q2):
     base_pauli._z[:, q1] = x1 ^ x2 ^ z2
     base_pauli._z[:, q2] = x1 ^ x2 ^ z1
 
-    base_pauli._phase += np.logical_xor(x1, x2) + np.logical_xor(
-        np.logical_and(z1, np.logical_xor(x1, x2).T.astype(base_pauli._phase.dtype)).T.astype(
-            base_pauli._phase.dtype
-        ),
-        np.logical_and(z2, np.logical_xor(x1, x2).T.astype(base_pauli._phase.dtype)).T.astype(
-            base_pauli._phase.dtype
-        ),
-    )
+    base_pauli._phase += np.logical_xor(x1, x2).T.astype(base_pauli._phase.dtype)
     return base_pauli
 
 

--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -636,6 +636,22 @@ def _evolve_sdg(base_pauli, qubit):
     return base_pauli
 
 
+def _evolve_sx(base_pauli, qubit):
+    """Update P -> SX.P.SXdg"""
+    z = base_pauli._z[:, qubit]
+    base_pauli._x[:, qubit] ^= z
+    base_pauli._phase -= z.T.astype(base_pauli._phase.dtype)
+    return base_pauli
+
+
+def _evolve_sxdg(base_pauli, qubit):
+    """Update P -> SXdg.P.SX"""
+    z = base_pauli._z[:, qubit]
+    base_pauli._x[:, qubit] ^= z
+    base_pauli._phase += z.T.astype(base_pauli._phase.dtype)
+    return base_pauli
+
+
 def _evolve_i(base_pauli, qubit):
     """Update P -> P"""
     return base_pauli
@@ -690,6 +706,13 @@ def _evolve_cy(base_pauli, qctrl, qtrgt):
     return base_pauli
 
 
+def _evolve_dcx(base_pauli, qctrl, qtrgt):
+    """Update P -> DCX.P.DCX"""
+    base_pauli = _evolve_cx(base_pauli, qctrl, qtrgt)
+    base_pauli = _evolve_cx(base_pauli, qtrgt, qctrl)
+    return base_pauli
+
+
 def _evolve_swap(base_pauli, q1, q2):
     """Update P -> SWAP.P.SWAP"""
     x1 = base_pauli._x[:, q1].copy()
@@ -698,6 +721,17 @@ def _evolve_swap(base_pauli, q1, q2):
     base_pauli._z[:, q1] = base_pauli._z[:, q2]
     base_pauli._x[:, q2] = x1
     base_pauli._z[:, q2] = z1
+    return base_pauli
+
+
+def _evolve_iswap(base_pauli, q1, q2):
+    """Update P -> iSWAP.P.iSWAP"""
+    base_pauli = _evolve_s(base_pauli, q1)
+    base_pauli = _evolve_h(base_pauli, q1)
+    base_pauli = _evolve_s(base_pauli, q2)
+    base_pauli = _evolve_cx(base_pauli, q1, q2)
+    base_pauli = _evolve_cx(base_pauli, q2, q1)
+    base_pauli = _evolve_h(base_pauli, q2)
     return base_pauli
 
 
@@ -740,13 +774,17 @@ _basis_1q = {
     "s": _evolve_s,
     "sdg": _evolve_sdg,
     "sinv": _evolve_sdg,
+    "sx": _evolve_sx,
+    "sxdg": _evolve_sxdg,
 }
 _basis_2q = {
     "cx": _evolve_cx,
     "cz": _evolve_cz,
     "cy": _evolve_cy,
     "swap": _evolve_swap,
+    "iswap": _evolve_iswap,
     "ecr": _evolve_ecr,
+    "dcx": _evolve_dcx,
 }
 
 # Non-Clifford gates

--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -708,8 +708,10 @@ def _evolve_cy(base_pauli, qctrl, qtrgt):
 
 def _evolve_dcx(base_pauli, qctrl, qtrgt):
     """Update P -> DCX.P.DCX"""
-    base_pauli = _evolve_cx(base_pauli, qctrl, qtrgt)
-    base_pauli = _evolve_cx(base_pauli, qtrgt, qctrl)
+    base_pauli._x[:, qtrgt] ^= base_pauli._x[:, qctrl]
+    base_pauli._z[:, qctrl] ^= base_pauli._z[:, qtrgt]
+    base_pauli._x[:, qctrl] ^= base_pauli._x[:, qtrgt]
+    base_pauli._z[:, qtrgt] ^= base_pauli._z[:, qctrl]
     return base_pauli
 
 

--- a/test/python/quantum_info/operators/symplectic/test_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli.py
@@ -582,9 +582,12 @@ class TestPauli(QiskitTestCase):
         qc = random_clifford_circuit(num_qubits, 20, seed=1234)
         op = Operator(qc)
         pauli = random_pauli(num_qubits, seed=5678)
+        pauli_cpy = pauli.copy()
         target = Operator(pauli).compose(op).dot(op.adjoint())
         value = Operator(pauli._append_circuit(qc))
+        value_evolve = Operator(pauli_cpy.evolve(qc, frame="s"))
         self.assertEqual(value, target)
+        self.assertEqual(value_evolve, target)
 
     @data("s", "h")
     def test_evolve_with_misleading_name(self, frame):

--- a/test/python/quantum_info/operators/symplectic/test_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli.py
@@ -24,6 +24,7 @@ from ddt import data, ddt, unpack
 
 from qiskit import QuantumCircuit
 from qiskit.circuit import Qubit
+from qiskit.circuit.random import random_clifford_circuit
 from qiskit.circuit.library import (
     CXGate,
     CYGate,
@@ -36,6 +37,7 @@ from qiskit.circuit.library import (
     SGate,
     SwapGate,
     iSwapGate,
+    DCXGate,
     XGate,
     YGate,
     ZGate,
@@ -440,6 +442,30 @@ class TestPauli(QiskitTestCase):
         self.assertEqual(value, value_h)
         self.assertEqual(value_inv, value_s)
 
+    @combine(
+        gate=[
+            IGate(),
+            XGate(),
+            YGate(),
+            ZGate(),
+            HGate(),
+            SGate(),
+            SdgGate(),
+            SXGate(),
+            SXdgGate(),
+        ],
+        label=pauli_group_labels(1, False),
+    )
+    def test_append_circuit_1_qubit(self, gate, label):
+        """Test _append_circuit method for 1-qubit clifford gates"""
+        qc = QuantumCircuit(1)
+        qc.append(gate, [0])
+        op = Operator(gate)
+        pauli = Pauli(label)
+        target = op.dot(pauli).dot(op.adjoint())
+        value = Operator(pauli._append_circuit(qc))
+        self.assertEqual(value, target)
+
     @data(
         *it.product(
             (
@@ -449,6 +475,7 @@ class TestPauli(QiskitTestCase):
                 SwapGate(),
                 iSwapGate(),
                 ECRGate(),
+                DCXGate(),
                 CPhaseGate(theta=np.pi),
                 CRXGate(theta=np.pi),
                 CRYGate(theta=np.pi),
@@ -479,6 +506,28 @@ class TestPauli(QiskitTestCase):
         self.assertEqual(value, value_h)
         self.assertEqual(value_inv, value_s)
 
+    @combine(
+        gate=[
+            CXGate(),
+            CYGate(),
+            CZGate(),
+            SwapGate(),
+            iSwapGate(),
+            ECRGate(),
+            DCXGate(),
+        ],
+        label=pauli_group_labels(2, False),
+    )
+    def test_append_circuit_2_qubit(self, gate, label):
+        """Test _append_circuit method for 2-qubit clifford gates"""
+        qc = QuantumCircuit(2)
+        qc.append(gate, [0, 1])
+        op = Operator(gate)
+        pauli = Pauli(label)
+        target = op.dot(pauli).dot(op.adjoint())
+        value = Operator(pauli._append_circuit(qc))
+        self.assertEqual(value, target)
+
     @data(
         *it.product(
             (
@@ -489,11 +538,15 @@ class TestPauli(QiskitTestCase):
                 HGate(),
                 SGate(),
                 SdgGate(),
+                SXGate(),
+                SXdgGate(),
                 CXGate(),
                 CYGate(),
                 CZGate(),
                 SwapGate(),
+                iSwapGate(),
                 ECRGate(),
+                DCXGate(),
             ),
             [int, np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.int64, np.uint64],
         )
@@ -522,6 +575,16 @@ class TestPauli(QiskitTestCase):
         self.assertEqual(value, target)
         self.assertEqual(value, value_h)
         self.assertEqual(value_inv, value_s)
+
+    def test_evolve_clifford_circuit(self):
+        """Test evolve method for random Clifford circuit"""
+        num_qubits = 5
+        qc = random_clifford_circuit(num_qubits, 20, seed=1234)
+        op = Operator(qc)
+        pauli = random_pauli(num_qubits, seed=5678)
+        target = Operator(pauli).compose(op).dot(op.adjoint())
+        value = Operator(pauli._append_circuit(qc))
+        self.assertEqual(value, target)
 
     @data("s", "h")
     def test_evolve_with_misleading_name(self, frame):

--- a/test/python/quantum_info/operators/symplectic/test_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli.py
@@ -431,9 +431,13 @@ class TestPauli(QiskitTestCase):
     @unpack
     def test_evolve_clifford1(self, gate, label):
         """Test evolve method for 1-qubit Clifford gates."""
+        qc = QuantumCircuit(1)
+        qc.append(gate, [0])
         op = Operator(gate)
         pauli = Pauli(label)
+        pauli_cpy = pauli.copy()
         value = Operator(pauli.evolve(gate))
+        value_qc = Operator(pauli_cpy._append_circuit(qc))
         value_h = Operator(pauli.evolve(gate, frame="h"))
         value_s = Operator(pauli.evolve(gate, frame="s"))
         value_inv = Operator(pauli.evolve(gate.inverse()))
@@ -441,30 +445,7 @@ class TestPauli(QiskitTestCase):
         self.assertEqual(value, target)
         self.assertEqual(value, value_h)
         self.assertEqual(value_inv, value_s)
-
-    @combine(
-        gate=[
-            IGate(),
-            XGate(),
-            YGate(),
-            ZGate(),
-            HGate(),
-            SGate(),
-            SdgGate(),
-            SXGate(),
-            SXdgGate(),
-        ],
-        label=pauli_group_labels(1, False),
-    )
-    def test_append_circuit_1_qubit(self, gate, label):
-        """Test _append_circuit method for 1-qubit clifford gates"""
-        qc = QuantumCircuit(1)
-        qc.append(gate, [0])
-        op = Operator(gate)
-        pauli = Pauli(label)
-        target = op.dot(pauli).dot(op.adjoint())
-        value = Operator(pauli._append_circuit(qc))
-        self.assertEqual(value, target)
+        self.assertEqual(value_s, value_qc)
 
     @data(
         *it.product(
@@ -495,9 +476,13 @@ class TestPauli(QiskitTestCase):
     @unpack
     def test_evolve_clifford2(self, gate, label):
         """Test evolve method for 2-qubit Clifford gates."""
+        qc = QuantumCircuit(2)
+        qc.append(gate, [0, 1])
         op = Operator(gate)
         pauli = Pauli(label)
+        pauli_cpy = pauli.copy()
         value = Operator(pauli.evolve(gate))
+        value_qc = Operator(pauli_cpy._append_circuit(qc))
         value_h = Operator(pauli.evolve(gate, frame="h"))
         value_s = Operator(pauli.evolve(gate, frame="s"))
         value_inv = Operator(pauli.evolve(gate.inverse()))
@@ -505,28 +490,7 @@ class TestPauli(QiskitTestCase):
         self.assertEqual(value, target)
         self.assertEqual(value, value_h)
         self.assertEqual(value_inv, value_s)
-
-    @combine(
-        gate=[
-            CXGate(),
-            CYGate(),
-            CZGate(),
-            SwapGate(),
-            iSwapGate(),
-            ECRGate(),
-            DCXGate(),
-        ],
-        label=pauli_group_labels(2, False),
-    )
-    def test_append_circuit_2_qubit(self, gate, label):
-        """Test _append_circuit method for 2-qubit clifford gates"""
-        qc = QuantumCircuit(2)
-        qc.append(gate, [0, 1])
-        op = Operator(gate)
-        pauli = Pauli(label)
-        target = op.dot(pauli).dot(op.adjoint())
-        value = Operator(pauli._append_circuit(qc))
-        self.assertEqual(value, target)
+        self.assertEqual(value_qc, value_s)
 
     @data(
         *it.product(

--- a/test/python/quantum_info/operators/symplectic/test_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli.py
@@ -431,12 +431,9 @@ class TestPauli(QiskitTestCase):
     @unpack
     def test_evolve_clifford1(self, gate, label):
         """Test evolve method for 1-qubit Clifford gates."""
-        qc = QuantumCircuit(1)
-        qc.append(gate, [0])
         op = Operator(gate)
         pauli = Pauli(label)
         value = Operator(pauli.evolve(gate))
-        value_qc = Operator(pauli.evolve(qc))
         value_h = Operator(pauli.evolve(gate, frame="h"))
         value_s = Operator(pauli.evolve(gate, frame="s"))
         value_inv = Operator(pauli.evolve(gate.inverse()))
@@ -444,7 +441,6 @@ class TestPauli(QiskitTestCase):
         self.assertEqual(value, target)
         self.assertEqual(value, value_h)
         self.assertEqual(value_inv, value_s)
-        self.assertEqual(value, value_qc)
 
     @data(
         *it.product(
@@ -475,12 +471,9 @@ class TestPauli(QiskitTestCase):
     @unpack
     def test_evolve_clifford2(self, gate, label):
         """Test evolve method for 2-qubit Clifford gates."""
-        qc = QuantumCircuit(2)
-        qc.append(gate, [0, 1])
         op = Operator(gate)
         pauli = Pauli(label)
         value = Operator(pauli.evolve(gate))
-        value_qc = Operator(pauli.evolve(qc))
         value_h = Operator(pauli.evolve(gate, frame="h"))
         value_s = Operator(pauli.evolve(gate, frame="s"))
         value_inv = Operator(pauli.evolve(gate.inverse()))
@@ -488,7 +481,6 @@ class TestPauli(QiskitTestCase):
         self.assertEqual(value, target)
         self.assertEqual(value, value_h)
         self.assertEqual(value_inv, value_s)
-        self.assertEqual(value, value_qc)
 
     @data(
         *it.product(

--- a/test/python/quantum_info/operators/symplectic/test_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli.py
@@ -547,11 +547,14 @@ class TestPauli(QiskitTestCase):
         op = Operator(qc)
         pauli = random_pauli(5, seed=5678)
         pauli_cpy = pauli.copy()
-        target = Operator(pauli).compose(op, qargs=qargs).dot(op.adjoint(), qargs=qargs)
+        target_s = Operator(pauli).compose(op, qargs=qargs).dot(op.adjoint(), qargs=qargs)
+        target_h = Operator(pauli).compose(op.adjoint(), qargs=qargs).dot(op, qargs=qargs)
         value = Operator(pauli._append_circuit(qc, qargs=qargs))
-        value_evolve = Operator(pauli_cpy.evolve(qc, frame="s", qargs=qargs))
-        self.assertEqual(value, target)
-        self.assertEqual(value_evolve, target)
+        value_evolve_s = Operator(pauli_cpy.evolve(qc, frame="s", qargs=qargs))
+        value_evolve_h = Operator(pauli_cpy.evolve(qc, frame="h", qargs=qargs))
+        self.assertEqual(value, target_s)
+        self.assertEqual(value_evolve_s, target_s)
+        self.assertEqual(value_evolve_h, target_h)
 
     @data("s", "h")
     def test_evolve_with_misleading_name(self, frame):

--- a/test/python/quantum_info/operators/symplectic/test_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli.py
@@ -435,9 +435,8 @@ class TestPauli(QiskitTestCase):
         qc.append(gate, [0])
         op = Operator(gate)
         pauli = Pauli(label)
-        pauli_cpy = pauli.copy()
         value = Operator(pauli.evolve(gate))
-        value_qc = Operator(pauli_cpy._append_circuit(qc))
+        value_qc = Operator(pauli.evolve(qc))
         value_h = Operator(pauli.evolve(gate, frame="h"))
         value_s = Operator(pauli.evolve(gate, frame="s"))
         value_inv = Operator(pauli.evolve(gate.inverse()))
@@ -445,7 +444,7 @@ class TestPauli(QiskitTestCase):
         self.assertEqual(value, target)
         self.assertEqual(value, value_h)
         self.assertEqual(value_inv, value_s)
-        self.assertEqual(value_s, value_qc)
+        self.assertEqual(value, value_qc)
 
     @data(
         *it.product(
@@ -480,9 +479,8 @@ class TestPauli(QiskitTestCase):
         qc.append(gate, [0, 1])
         op = Operator(gate)
         pauli = Pauli(label)
-        pauli_cpy = pauli.copy()
         value = Operator(pauli.evolve(gate))
-        value_qc = Operator(pauli_cpy._append_circuit(qc))
+        value_qc = Operator(pauli.evolve(qc))
         value_h = Operator(pauli.evolve(gate, frame="h"))
         value_s = Operator(pauli.evolve(gate, frame="s"))
         value_inv = Operator(pauli.evolve(gate.inverse()))
@@ -490,7 +488,7 @@ class TestPauli(QiskitTestCase):
         self.assertEqual(value, target)
         self.assertEqual(value, value_h)
         self.assertEqual(value_inv, value_s)
-        self.assertEqual(value_qc, value_s)
+        self.assertEqual(value, value_qc)
 
     @data(
         *it.product(
@@ -542,17 +540,14 @@ class TestPauli(QiskitTestCase):
 
     def test_evolve_clifford_circuit_qargs(self):
         """Test evolve method for random Clifford circuit"""
-        qargs = [2, 4, 1]
-        qc = random_clifford_circuit(3, 20, seed=123)
+        qargs = [2, 4, 1, 0]
+        qc = random_clifford_circuit(4, 100, seed=123)
         op = Operator(qc)
         pauli = random_pauli(5, seed=5678)
-        pauli_cpy = pauli.copy()
         target_s = Operator(pauli).compose(op, qargs=qargs).dot(op.adjoint(), qargs=qargs)
         target_h = Operator(pauli).compose(op.adjoint(), qargs=qargs).dot(op, qargs=qargs)
-        value = Operator(pauli._append_circuit(qc, qargs=qargs))
-        value_evolve_s = Operator(pauli_cpy.evolve(qc, frame="s", qargs=qargs))
-        value_evolve_h = Operator(pauli_cpy.evolve(qc, frame="h", qargs=qargs))
-        self.assertEqual(value, target_s)
+        value_evolve_s = Operator(pauli.evolve(qc, frame="s", qargs=qargs))
+        value_evolve_h = Operator(pauli.evolve(qc, frame="h", qargs=qargs))
         self.assertEqual(value_evolve_s, target_s)
         self.assertEqual(value_evolve_h, target_h)
 

--- a/test/python/quantum_info/operators/symplectic/test_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli.py
@@ -540,16 +540,16 @@ class TestPauli(QiskitTestCase):
         self.assertEqual(value, value_h)
         self.assertEqual(value_inv, value_s)
 
-    def test_evolve_clifford_circuit(self):
+    def test_evolve_clifford_circuit_qargs(self):
         """Test evolve method for random Clifford circuit"""
-        num_qubits = 5
-        qc = random_clifford_circuit(num_qubits, 20, seed=1234)
+        qargs = [2, 4, 1]
+        qc = random_clifford_circuit(3, 20, seed=123)
         op = Operator(qc)
-        pauli = random_pauli(num_qubits, seed=5678)
+        pauli = random_pauli(5, seed=5678)
         pauli_cpy = pauli.copy()
-        target = Operator(pauli).compose(op).dot(op.adjoint())
-        value = Operator(pauli._append_circuit(qc))
-        value_evolve = Operator(pauli_cpy.evolve(qc, frame="s"))
+        target = Operator(pauli).compose(op, qargs=qargs).dot(op.adjoint(), qargs=qargs)
+        value = Operator(pauli._append_circuit(qc, qargs=qargs))
+        value_evolve = Operator(pauli_cpy.evolve(qc, frame="s", qargs=qargs))
         self.assertEqual(value, target)
         self.assertEqual(value_evolve, target)
 


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Add internal `evolve` methods by gate for some Clifford gates that were missing:
`_evolve_sx, _evolve_sxdg, _evolve_dcx, _evolve_iswap`.

### Details and comments
see also: https://github.com/Qiskit/qiskit/issues/15798#issuecomment-4062650447

