### PR TITLE
Don't track loop_param 

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -2001,22 +2001,16 @@ fn for_each_symbol_use_in_control_flow(
             body,
             collection: _,
         } => {
-            // The loop param is technically a parameter in Python land at `params[1]`.
-            if let Some(symbol) = loop_param {
-                action(
-                    symbol,
-                    ParameterUse::Index {
-                        instruction: instruction_index,
-                        parameter: 1,
-                    },
-                )?;
-            }
             // The body is at `params[2]`.
             let usage = ParameterUse::Index {
                 instruction: instruction_index,
                 parameter: 2,
             };
             for symbol in body.parameters() {
+                // Skip the loop variable itself — it is runtime-bound.
+                if loop_param.as_ref() == Some(&symbol) {
+                    continue;
+                }
                 action(symbol, usage)?;
             }
         }

--- a/releasenotes/notes/fix-for-loop-loop-param-in-outer-parameters-e0f2b653308aaadc.yaml
+++ b/releasenotes/notes/fix-for-loop-loop-param-in-outer-parameters-e0f2b653308aaadc.yaml
@@ -2,7 +2,7 @@ fixes:
   - |
     Fixed a bug where the loop variable of a :class:`.ForLoopOp` was incorrectly
     tracked in the outer circuit's parameter table, causing it to appear in
-    ``QuantumCircuit.parameters`` and making ``assign_parameters`` raise an internal
-    ``RuntimeError``.
+    :attr:`.QuantumCircuit.parameters` and making :meth:`~.QuantumCircuit.assign_parameters` raise an internal
+    :exc:`RuntimeError`.
     
     See `#15657 <https://github.com/Qiskit/qiskit/issues/15657>`__ for details.

--- a/releasenotes/notes/fix-for-loop-loop-param-in-outer-parameters-e0f2b653308aaadc.yaml
+++ b/releasenotes/notes/fix-for-loop-loop-param-in-outer-parameters-e0f2b653308aaadc.yaml
@@ -1,0 +1,8 @@
+fixes:
+  - |
+    Fixed a bug where the loop variable of a :class:`.ForLoopOp` was incorrectly
+    tracked in the outer circuit's parameter table, causing it to appear in
+    ``QuantumCircuit.parameters`` and making ``assign_parameters`` raise an internal
+    ``RuntimeError``.
+    
+    See `#15657 <https://github.com/Qiskit/qiskit/issues/15657>`__ for details.

--- a/test/python/circuit/test_control_flow.py
+++ b/test/python/circuit/test_control_flow.py
@@ -813,6 +813,19 @@ class TestAddingControlFlowOperations(QiskitTestCase):
         self.assertEqual(qc.data[0].qubits, tuple(qc.qubits[1:4]))
         self.assertEqual(qc.data[0].clbits, (qc.clbits[1],))
 
+    def test_for_loop_loop_parameter_not_in_outer_parameters(self):
+        """A ForLoopOp's loop_parameter must NOT appear in the outer circuit's parameters."""
+        theta = Parameter("θ")
+        body = QuantumCircuit(1)
+        body.rx(theta, 0)
+
+        qc = QuantumCircuit(1)
+        qc.append(ForLoopOp(range(3), theta, body), [0])
+
+        self.assertNotIn(theta, qc.parameters)
+        with self.assertRaisesRegex(CircuitError, r"not present in the circuit"):
+            qc.assign_parameters({theta: math.pi / 2}, inplace=False)
+
     @idata(CONDITION_PARAMETRISATION)
     def test_appending_if_else_op(self, condition):
         """Verify we can append a IfElseOp to a QuantumCircuit."""


### PR DESCRIPTION
When a ForLoopOp is appended to an outer circuit, the loop parameter is currently being tracked in the outer circuit's parameter table. This makes it visible in `qc.parameters`, allowing users to call `assign_parameters` on it — which we did not intend to allow.

The parameter was being tracked from two sources in `for_each_symbol_use_in_control_flow` in `circuit_data.rs`:

1. Via the `params[1]` (`loop_param`) slot directly
2. Via `body.parameters()`, if the loop variable is a free parameter of the body circuit as it happened in the issue [https://github.com/Qiskit/qiskit/issues/15657]

This PR removes both tracking sources so that the loop parameter is never registered in the outer circuit's `param_table` and therefore never appears in `qc.parameters`.

Fix https://github.com/Qiskit/qiskit/issues/15657