### PR TITLE
Fix `PauliEvolutionGate` trace and dim calculation

### DIFF
--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -447,7 +447,7 @@ def _pauli_rotation_trace_and_dim(gate: PauliEvolutionGate) -> tuple[complex, in
             label = operator[0].bit_labels()
             if any(c in label for c in ["+", "-", "0", "1", "l", "r"]):
                 return None
-            dim = len(label)
+            num_qubits = len(label)
             angle = operator.coeffs[0].real * gate.time
         else:
             return None
@@ -455,13 +455,13 @@ def _pauli_rotation_trace_and_dim(gate: PauliEvolutionGate) -> tuple[complex, in
     elif len(operator.paulis) == 1:
         label = operator.paulis.to_labels()[0]
         label = label.replace("I", "")
-        dim = len(label)
+        num_qubits = len(label)
         angle = operator.coeffs[0].real * gate.time
     else:
         return None
 
-    if dim == 0:
+    if num_qubits == 0:
         # This is an identity Pauli rotation.
-        return (np.exp(-1j * angle), dim)
+        return (np.exp(-1j * angle), 1)
 
-    return (np.cos(angle), dim)
+    return (np.cos(angle), 2**num_qubits)

--- a/releasenotes/notes/fix-paulievo-avg-gate-fidelity-507b88c27fa7c9bf.yaml
+++ b/releasenotes/notes/fix-paulievo-avg-gate-fidelity-507b88c27fa7c9bf.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed a bug around :class:`.PauliEvolutionGate`, where the average gate
+    fidelity was slightly larger than the actual fidelity.  This had knock-on effects
+    in passes such as :class:`.RemoveIdentityEquivalent`, which would remove
+    gates at slightly larger angles than it should have.  This has now been fixed
+    and the :class:`.PauliEvolutionGate` is guaranteed to handle cutoffs the same way as
+    other standard rotation gates.

--- a/test/python/transpiler/test_remove_identity_equivalent.py
+++ b/test/python/transpiler/test_remove_identity_equivalent.py
@@ -227,8 +227,10 @@ class TestRemoveIdentityEquivalent(QiskitTestCase):
 
         pass_ = RemoveIdentityEquivalent()
 
-        # it is important to cover a small enough grid around the threshold where we
-        # start removing gates, to ensure all cases are handled consistently
+        # It is important to cover a small enough grid around the threshold where we
+        # start removing gates, to ensure all cases are handled consistently. That
+        # threshold can be calculated by inverting the avg. gate fidelity with the
+        # default tol of 1e-12, coming out at an angle of roughly 3.5e-06.
         for angle in np.linspace(1e-5, 1e-6, num=25):
             # number of expected instructions
             rz = get_rz(angle)

--- a/test/python/transpiler/test_remove_identity_equivalent.py
+++ b/test/python/transpiler/test_remove_identity_equivalent.py
@@ -28,8 +28,9 @@ from qiskit.circuit.library import (
     XXPlusYYGate,
     GlobalPhaseGate,
     UnitaryGate,
+    PauliEvolutionGate,
 )
-from qiskit.quantum_info import Operator
+from qiskit.quantum_info import Operator, Pauli
 from qiskit.transpiler.passes import RemoveIdentityEquivalent
 from qiskit.transpiler.target import Target, InstructionProperties
 
@@ -209,3 +210,33 @@ class TestRemoveIdentityEquivalent(QiskitTestCase):
         qc.append(GlobalPhaseGate(theta), [])
         transpiled = RemoveIdentityEquivalent()(qc)
         self.assertEqual(qc, transpiled)
+
+    def test_pauli_evo_equals_stdgate(self):
+        """Test the Pauli evolution gate is consistent with std gates."""
+
+        def get_rz(angle):
+            qc = QuantumCircuit(1)
+            qc.rz(angle, 0)
+            return qc
+
+        def get_paulievo(angle, n):
+            evo = PauliEvolutionGate(Pauli("Z" + (n - 1) * "I"), time=angle / 2)
+            qc = QuantumCircuit(evo.num_qubits)
+            qc.append(evo, qc.qubits)
+            return qc
+
+        pass_ = RemoveIdentityEquivalent()
+
+        # it is important to cover a small enough grid around the threshold where we
+        # start removing gates, to ensure all cases are handled consistently
+        for angle in np.linspace(1e-5, 1e-6, num=25):
+            # number of expected instructions
+            rz = get_rz(angle)
+            expected = pass_(rz).count_ops().get("rz", 0)
+
+            # check the number matches for different `n`
+            for n in [1, 10]:
+                with self.subTest(n=n):
+                    evo = get_paulievo(angle, n)
+                    num_inst = pass_(evo).count_ops().get("PauliEvolution", 0)
+                    self.assertEqual(expected, num_inst)


### PR DESCRIPTION

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The dimension for the average gate fidelity in `PauliEvolutionGate` was returned as `num_qubits` instead of `2^num_qubits`. This slightly shifted at which fidelities the gate was cut off, e.g. in `RemoveIdentityEquivalent`. This commit fixes this and ensures we treat the cutoff the same as for standard gates that represent the same rotations.

