### PR TITLE
Fix status reporting of `Finalize` branch-protection job

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -40,8 +40,6 @@ jobs:
   finalize:
     name: Finalize
     runs-on: 'ubuntu-latest'
-    steps:
-      - run: ':'
     # This list should contain every other job in this file.
     needs:
       - docs
@@ -55,6 +53,19 @@ jobs:
       - miri
       - qpy
       - neko
+    # This job needs to trigger even if its predecessors failed and return the same status.  By
+    # default, GitHub Actions will "skip" the job if a requirement failed, but that counts as a
+    # "success" state, which is not acceptable for a branch-protection rule.  We don't use `always`
+    # because we don't want `cancelled` to trigger this.
+    if: success() || failure()
+    steps:
+      - run: |
+          echo "Successful run."
+        if: ${{ !contains(needs.*.result, 'failure') }}
+      - run: |
+          echo "Predecessor jobs failed.  See GitHub Actions logs." >&2
+          exit 1
+        if: ${{ contains(needs.*.result, 'failure') }}
 
   docs:
     name: Documentation


### PR DESCRIPTION
When we updated the branch-protection rules in gh-15794[^1], we set the "finalize" job to require all the previous runs.  However, if a previous run fails, then this job does not report another failure status, just a "skipped".  "Skipped" counts as a success state for evaluating branch-protection rules, so the previous form was not properly protecting the branch.

[^1]: 913091b5: Unify GitHub Actions branch-protection run logic

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


See #15817 where I'm testing that this PR actually does do the correct thing.

Close #15817