### PR TITLE
Use abbreviated output for stestr run in CI

### DIFF
--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           QISKIT_BUILD_PROFILE: release
       - name: Run all tests including slow
-        run: stestr run --slowest
+        run: stestr run --slowest --abbreviate
         env:
           RUST_BACKTRACE: 1
           QISKIT_TESTS: "run_slow"

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -102,7 +102,7 @@ jobs:
           python tools/report_numpy_state.py
           export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))")
           echo "PYTHONHASHSEED=$PYTHONHASHSEED"
-          stestr run --slowest
+          stestr run --slowest --abbreviate
         env:
           QISKIT_PARALLEL: FALSE
           QISKIT_IGNORE_USER_SETTINGS: TRUE
@@ -127,7 +127,7 @@ jobs:
           pushd /tmp/terra-tests
           export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))")
           echo "PYTHONHASHSEED=$PYTHONHASHSEED"
-          stestr run --slowest
+          stestr run --slowest --abbreviate
           popd
         env:
           QISKIT_PARALLEL: FALSE

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -66,7 +66,7 @@ jobs:
           python tools/report_numpy_state.py
           export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))")
           echo "PYTHONHASHSEED=$PYTHONHASHSEED"
-          stestr run --slowest
+          stestr run --slowest --abbreviate
         env:
           QISKIT_PARALLEL: FALSE
           QISKIT_IGNORE_USER_SETTINGS: TRUE

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -65,7 +65,7 @@ jobs:
           python tools/report_numpy_state.py
           $Env:PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 1024))")
           echo "PYTHONHASHSEED=$PYTHONHASHSEED"
-          stestr run --slowest
+          stestr run --slowest --abbreviate
       - name: Filter stestr history
         run: |
           pushd .stestr


### PR DESCRIPTION

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates how we use stestr in CI to enable abbreviated output instead of the full output. Our test suite has grown to the point that printing each individual test case as a new line when it completes will overflow the github actions line limit for CI job logs. This makes it very inconvenient to identify the cause of a failure when a test fails because unless it's in the tests that get displayed before github stops displaying it you have to download the full log file (which you can view in the browser still but without the highlighting or direct link support). stestr has a less verbose output mode where it prints a single character for each test. `.` if a test succeeds, `F` for failure, etc. Test failures are still printed in full as is the summary footer. It's just the output of tests as they execute which is different. While this doesn't give the same level of diagnostic detail that the full output normally does it will not exceed github's limit. As a small side benefit from the benchmarking I did many years ago stestr actually executes slightly faster in this mode because it doesn't have to write nearly as much to stdout.



### Details and comments


