### PR TITLE
Docs: Standardize C API documentation pages for QkBitTerm, QkExitCode, and QkNeighbors

### DIFF
--- a/docs/cdoc/qk-bit-term.rst
+++ b/docs/cdoc/qk-bit-term.rst
@@ -10,7 +10,7 @@ QkBitTerm
 
    enum QkBitTerm
 
-An enum that to represent each of the single-qubit alphabet terms enumerated below.
+An enum that represents each of the single-qubit alphabet terms enumerated below.
 
 Values
 ------

--- a/docs/cdoc/qk-exit-code.rst
+++ b/docs/cdoc/qk-exit-code.rst
@@ -45,3 +45,6 @@ Values
     Mismatching number of qubits.
 
     Value: 201
+
+Functions
+---------

--- a/docs/cdoc/qk-neighbors.rst
+++ b/docs/cdoc/qk-neighbors.rst
@@ -6,7 +6,7 @@ QkNeighbors
    :members:
 
 Functions
-=========
+---------
 
 .. doxygengroup:: QkNeighbors
    :members:


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Standardize and improve formatting in C API documentation pages under `docs/cdoc/`:
- Fix grammar in `qk-bit-term.rst` (“An enum that to represent…” → “An enum that represents…”)
- Make "Functions" heading level consistent in `qk-neighbors.rst`
- Add missing "Functions" section to `qk-exit-code.rst`

### Details and comments

- Only documentation files were changed.
- All changes follow the guidelines for documentation consistency and accessibility.
- No behavioral changes to code or API.
- AI tool used: Microsoft Copilot Chat with GPT-4
