### PR TITLE
Enforce `Cargo.lock` is up-to-date in lint CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,5 +31,8 @@ jobs:
       - name: Run lint
         run: |
           set -e
+          # Check that `Cargo.lock` is checked in and up-to-date before attempting to build the
+          # package. The exact command isn't important, it should just be cheap and update the lock.
+          cargo metadata --format-version=1 --locked >/dev/null
           make cformat
           tox -e lint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,7 +617,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.117",
 ]
 
 [[package]]


### PR DESCRIPTION
It is currently possible to merge changes to `main` that leave `Cargo.lock` needing updates.  This enforces, as part of the CI lint job, that `Cargo.lock` is unchanged when running `cargo` compilation commands.  It's hard to do this via `tox` because the package is highly opinionated and doesn't permit running commands before package build.

We may want to go further in the future in CI and enforce that the entire `git` repository is clean after the equivalent local commands, but that would require a bit more work because there are differences in CI where we generate files that are not necessarily covered in `.gitignore` (such as coverage and PGO steps).


<details><summary>Old message</summary>
It is currently possible to merge changes to `main` that leave `Cargo.lock` needing updates.  This enforces, as part of the `tox` lint job (which becomes the CI lint job), that `Cargo.lock` is unchanged when running `cargo` compilation commands.

We may want to go further in the future in CI and enforce that the entire `git` repository is clean after the equivalent local commands, but that would require a bit more work because there are differences in CI where we generate files that are not necessarily covered in `.gitignore` (such as coverage and PGO steps).
</details>

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


This should fail on the first run of the lint job, because there's currently an uncommited update to `syn` pending.