### PR TITLE
QPY Rust and Python compatibility fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2203,6 +2203,7 @@ dependencies = [
  "indexmap",
  "num-bigint",
  "num-complex",
+ "num-traits",
  "numpy",
  "oq3_semantics",
  "pyo3",

--- a/crates/qpy/Cargo.toml
+++ b/crates/qpy/Cargo.toml
@@ -21,6 +21,7 @@ qiskit-circuit.workspace = true
 qiskit-quantum-info.workspace = true
 num-bigint.workspace = true
 num-complex.workspace = true
+num-traits.workspace = true
 bytemuck.workspace = true
 binrw.workspace = true
 uuid = {version = "1", features = ["v4"]}

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -187,8 +187,12 @@ fn recognize_instruction_type(
     } else if ControlFlowType::from_str(name).is_ok()
         || matches!(
             name,
-            // We don't handle old style SwitchCaseOp in rust yet
-            "IfElseOp" | "WhileLoopOp" | "ForLoopOp" | "BreakLoopOp" | "ContinueLoopOp"
+            "IfElseOp"
+                | "WhileLoopOp"
+                | "ForLoopOp"
+                | "BreakLoopOp"
+                | "ContinueLoopOp"
+                | "SwitchCaseOp"
         )
     {
         InstructionType::ControlFlow
@@ -596,25 +600,20 @@ fn unpack_control_flow(
             ControlFlow::While { condition }
         }
         ControlFlowType::SwitchCase => {
-            let mut instruction_values = get_instruction_values(instruction, qpy_data)?;
-            if instruction_values.len() < 3 {
-                return Err(QpyError::MissingData(format!(
-                    "Switch case instruction has {} parameters, expected at least 3 (target, label_spec, cases)",
-                    instruction_values.len()
-                )));
-            }
-            param_values = instruction_values.split_off(3);
-            let mut iter = instruction_values.into_iter();
-            let ((target_value, label_spec_value), cases_value) = iter
-                .next()
-                .zip(iter.next())
-                .zip(iter.next())
-                .ok_or_else(|| {
-                    QpyError::MissingData(
-                        "Switch case instruction missing some of its parameters".to_string(),
-                    )
-                })?;
-            let target = match target_value {
+            // we follow the python way of storing switch params
+            // the first param is the target, the next param is the cases specificer
+            // the cases specifier is a list of pairs (tuples)
+            // the second element in each pair is the subcircuit for this case
+            // the first element is the list of the case labels, or a single case label
+            // or the special default case label
+            let instruction_values = get_instruction_values(instruction, qpy_data)?;
+            let [target_value, cases, ..] = &instruction_values[..] else {
+                return Err(QpyError::MissingData(
+                    "Switch case requires at least 2 parameters".to_string(),
+                ));
+            };
+
+            let target = match target_value.clone() {
                 GenericValue::Expression(exp) => Ok(SwitchTarget::Expr(exp)),
                 GenericValue::Register(ParamRegisterValue::Register(reg)) => {
                     Ok(SwitchTarget::Register(reg))
@@ -627,45 +626,44 @@ fn unpack_control_flow(
                 )),
             }?;
 
-            let GenericValue::Tuple(label_spec_tuple_tuple) = label_spec_value else {
-                return Err(QpyError::InvalidInstruction(
-                    "could not identify switch case label spec".to_string(),
-                ));
-            };
-            let label_spec = label_spec_tuple_tuple
-                .iter()
-                .map(|label_spec_tuple_tuple_element| -> Result<_, QpyError> {
-                    let GenericValue::Tuple(label_spec_tuple) = label_spec_tuple_tuple_element
-                    else {
-                        return Err(QpyError::InvalidInstruction(
+            // now split the zipped cases: move the circuits to params, keep the labels for further processing
+            let mut label_spec = Vec::new();
+            for case in cases.as_vec().ok_or(QpyError::InvalidInstruction(
+                "bad parameters for switch statement".to_string(),
+            ))? {
+                let [case_labels, case_circuit, ..] = &case.as_vec().ok_or(
+                    QpyError::InvalidInstruction("bad parameters for switch statement".to_string()),
+                )?[..] else {
+                    return Err(QpyError::InvalidInstruction(
+                        "bad parameters for switch statement".to_string(),
+                    ));
+                };
+                param_values.push(case_circuit.clone());
+                // label spec handling
+                let GenericValue::Tuple(label_spec_element_tuple) = case_labels else {
+                    return Err(QpyError::InvalidInstruction(
+                        "could not identify switch case label spec".to_string(),
+                    ));
+                };
+                let label_spec_element = label_spec_element_tuple
+                    .iter()
+                    .map(|label_spec_element| match label_spec_element.as_le() {
+                        GenericValue::CaseDefault => Ok(CaseSpecifier::Default),
+                        GenericValue::BigInt(value) => Ok(CaseSpecifier::Uint(value.clone())),
+                        GenericValue::Int64(value) => {
+                            Ok(CaseSpecifier::Uint(BigUint::from(value as u64)))
+                        }
+                        _ => Err(QpyError::InvalidInstruction(
                             "could not identify switch case label spec".to_string(),
-                        ));
-                    };
-                    label_spec_tuple
-                        .iter()
-                        .map(|label_spec_element| match label_spec_element {
-                            GenericValue::CaseDefault => Ok(CaseSpecifier::Default),
-                            GenericValue::BigInt(value) => Ok(CaseSpecifier::Uint(value.clone())),
-                            GenericValue::Int64(value) => {
-                                Ok(CaseSpecifier::Uint(BigUint::from(*value as u64)))
-                            }
-                            _ => Err(QpyError::InvalidInstruction(
-                                "could not identify switch case label spec".to_string(),
-                            )),
-                        })
-                        .collect::<Result<_, QpyError>>()
-                })
-                .collect::<Result<_, QpyError>>()?;
-            let cases = match cases_value {
-                GenericValue::Int64(value) => Ok(value as u32),
-                _ => Err(QpyError::InvalidInstruction(
-                    "could not identify switch cases".to_string(),
-                )),
-            }?;
+                        )),
+                    })
+                    .collect::<Result<_, QpyError>>()?;
+                label_spec.push(label_spec_element);
+            }
             ControlFlow::Switch {
                 target,
                 label_spec,
-                cases,
+                cases: param_values.len() as u32,
             }
         }
     };
@@ -811,24 +809,6 @@ fn unpack_py_instruction(
                 if name.as_str() == "ForLoopOp" {
                     // we used the params to construct the loop; they should not be retained as params except the subcircuit
                     instruction_values.retain(|value| matches!(value, GenericValue::Circuit(_)));
-                }
-                if name.as_str() == "SwitchCaseOp" {
-                    // switch cases are as the second component of the second parameter
-                    // we keep only the circuits and remove everything else from the params
-                    if let GenericValue::Tuple(cases) = &instruction_values[1] {
-                        instruction_values = cases
-                            .iter()
-                            .map(|case| -> Result<_, QpyError> {
-                                if let GenericValue::Tuple(case_elements) = case {
-                                    Ok(case_elements[1].clone())
-                                } else {
-                                    Err(QpyError::InvalidInstruction(
-                                        "Unable to read switch case op".to_string(),
-                                    ))
-                                }
-                            })
-                            .collect::<Result<_, QpyError>>()?;
-                    }
                 }
                 gate_class.call1(args)?
             }

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -600,19 +600,52 @@ fn unpack_control_flow(
             ControlFlow::While { condition }
         }
         ControlFlowType::SwitchCase => {
-            // we follow the python way of storing switch params
-            // the first param is the target, the next param is the cases specificer
-            // the cases specifier is a list of pairs (tuples)
-            // the second element in each pair is the subcircuit for this case
-            // the first element is the list of the case labels, or a single case label
-            // or the special default case label
-            let instruction_values = get_instruction_values(instruction, qpy_data)?;
-            let [target_value, cases, ..] = &instruction_values[..] else {
-                return Err(QpyError::MissingData(
-                    "Switch case requires at least 2 parameters".to_string(),
-                ));
+            let mut instruction_values = get_instruction_values(instruction, qpy_data)?;
+            let (target_value, case_label_list) = if instruction_values.len() < 3 {
+                // we follow the python way of storing switch params
+                // the first param is the target, the next param is the cases specificer
+                // the cases specifier is a list of pairs (tuples)
+                // the second element in each pair is the subcircuit for this case
+                // the first element is the list of the case labels, or a single case label
+                // or the special default case label
+                let [target_value, cases, ..] = &instruction_values[..] else {
+                    return Err(QpyError::MissingData(
+                        "Switch case requires at least 2 parameters".to_string(),
+                    ));
+                };
+                let mut case_label_list = Vec::new();
+                for case in cases.as_vec().ok_or(QpyError::InvalidInstruction(
+                    "bad parameters for switch statement".to_string(),
+                ))? {
+                    let [case_labels, case_circuit, ..] =
+                        &case.as_vec().ok_or(QpyError::InvalidInstruction(
+                            "bad parameters for switch statement".to_string(),
+                        ))?[..]
+                    else {
+                        return Err(QpyError::InvalidInstruction(
+                            "bad parameters for switch statement".to_string(),
+                        ));
+                    };
+                    param_values.push(case_circuit.clone());
+                    case_label_list.push(case_labels.clone());
+                }
+                (target_value, case_label_list)
+            } else {
+                param_values = instruction_values.split_off(3);
+                let [target_value, label_spec_value, ..] = &instruction_values[..] else {
+                    return Err(QpyError::MissingData(
+                        "Switch case requires at least 3 parameters".to_string(),
+                    ));
+                };
+                (
+                    target_value,
+                    label_spec_value.to_vec().ok_or_else(|| {
+                        QpyError::InvalidInstruction(
+                            "bad parameters for switch statement".to_string(),
+                        )
+                    })?,
+                )
             };
-
             let target = match target_value.clone() {
                 GenericValue::Expression(exp) => Ok(SwitchTarget::Expr(exp)),
                 GenericValue::Register(ParamRegisterValue::Register(reg)) => {
@@ -628,17 +661,7 @@ fn unpack_control_flow(
 
             // now split the zipped cases: move the circuits to params, keep the labels for further processing
             let mut label_spec = Vec::new();
-            for case in cases.as_vec().ok_or(QpyError::InvalidInstruction(
-                "bad parameters for switch statement".to_string(),
-            ))? {
-                let [case_labels, case_circuit, ..] = &case.as_vec().ok_or(
-                    QpyError::InvalidInstruction("bad parameters for switch statement".to_string()),
-                )?[..] else {
-                    return Err(QpyError::InvalidInstruction(
-                        "bad parameters for switch statement".to_string(),
-                    ));
-                };
-                param_values.push(case_circuit.clone());
+            for case_labels in case_label_list {
                 // label spec handling
                 let GenericValue::Tuple(label_spec_element_tuple) = case_labels else {
                     return Err(QpyError::InvalidInstruction(

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -614,13 +614,13 @@ fn unpack_control_flow(
                     ));
                 };
                 let mut case_label_list = Vec::new();
-                for case in cases.as_vec().ok_or(QpyError::InvalidInstruction(
+                for case in cases.as_slice().ok_or(QpyError::InvalidInstruction(
                     "bad parameters for switch statement".to_string(),
                 ))? {
                     let [case_labels, case_circuit, ..] =
-                        &case.as_vec().ok_or(QpyError::InvalidInstruction(
+                        &case.as_slice().ok_or(QpyError::InvalidInstruction(
                             "bad parameters for switch statement".to_string(),
-                        ))?[..]
+                        ))?
                     else {
                         return Err(QpyError::InvalidInstruction(
                             "bad parameters for switch statement".to_string(),

--- a/crates/qpy/src/circuit_reader.rs
+++ b/crates/qpy/src/circuit_reader.rs
@@ -603,7 +603,7 @@ fn unpack_control_flow(
             let mut instruction_values = get_instruction_values(instruction, qpy_data)?;
             let (target_value, case_label_list) = if instruction_values.len() < 3 {
                 // we follow the python way of storing switch params
-                // the first param is the target, the next param is the cases specificer
+                // the first param is the target, the next param is the cases specifier
                 // the cases specifier is a list of pairs (tuples)
                 // the second element in each pair is the subcircuit for this case
                 // the first element is the list of the case labels, or a single case label

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -373,12 +373,9 @@ fn pack_pauli_product_rotation(
     })
 }
 
-/// Convert snake_case name (e.g., "if_else") to Python class names (e.g., "IfElseOp") 
+/// Convert snake_case name (e.g., "if_else") to Python class names (e.g., "IfElseOp")
 /// for backwards compatibility with old QPY versions
-
-fn control_flow_class_name(
-    name: &str,
-) -> Result<String, QpyError> {
+fn control_flow_class_name(name: &str) -> Result<String, QpyError> {
     match name {
         "if_else" => Ok("IfElseOp".to_string()),
         "while_loop" => Ok("WhileLoopOp".to_string()),
@@ -411,8 +408,26 @@ fn pack_control_flow_inst(
                 },
             };
             let mut params = Vec::new();
-            params.push(pack_generic_value(&duration_param, qpy_data)?);
+            // ideally, we'd do params.push(pack_generic_value(&duration_param, qpy_data)?);
+            // however, Python expects the BoxOp params to be handled differentely, so this is code for backwards compatibility:
             params.extend(pack_instruction_blocks(instruction, qpy_data)?);
+            match duration_param {
+                GenericValue::Duration(duration) => {
+                    let duration_value_pack = Python::attach(|py| {
+                        py_pack_param(&duration.py_value(py), qpy_data, Endian::Little)
+                    })?;
+                    let duration_unit_string = GenericValue::String(duration.unit().to_string());
+                    params.push(duration_value_pack);
+                    params.push(pack_generic_value(&duration_unit_string, qpy_data)?);
+                }
+                GenericValue::Expression(_) => {
+                    let duration_value_pack = pack_generic_value(&duration_param, qpy_data)?;
+                    let duration_unit_string = GenericValue::String("expr".to_string());
+                    params.push(duration_value_pack);
+                    params.push(pack_generic_value(&duration_unit_string, qpy_data)?);
+                }
+                _ => (),
+            }
             params
         }
         ControlFlow::BreakLoop | ControlFlow::ContinueLoop => Vec::new(),
@@ -1290,4 +1305,3 @@ pub(crate) fn py_write_circuit(
     )?;
     Ok(serialized_circuit.len())
 }
-

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -399,16 +399,15 @@ fn pack_pauli_product_rotation(
 
 /// Convert snake_case name (e.g., "if_else") to Python class names (e.g., "IfElseOp")
 /// for backwards compatibility with old QPY versions
-fn control_flow_class_name(name: &str) -> Result<String, QpyError> {
-    match name {
-        "if_else" => Ok("IfElseOp".to_string()),
-        "while_loop" => Ok("WhileLoopOp".to_string()),
-        "for_loop" => Ok("ForLoopOp".to_string()),
-        "switch_case" => Ok("SwitchCaseOp".to_string()),
-        "break_loop" => Ok("BreakLoopOp".to_string()),
-        "continue_loop" => Ok("ContinueLoopOp".to_string()),
-        "box" => Ok("BoxOp".to_string()),
-        _ => Err(QpyError::InvalidInstruction(name.to_string())),
+fn control_flow_class_name(control_flow: &ControlFlow) -> String {
+    match control_flow {
+        ControlFlow::Box { .. } => "BoxOp".to_string(),
+        ControlFlow::BreakLoop => "BreakLoopOp".to_string(),
+        ControlFlow::ContinueLoop => "ContinueLoopOp".to_string(),
+        ControlFlow::IfElse { .. } => "IfElseOp".to_string(),
+        ControlFlow::While { .. } => "WhileLoopOp".to_string(),
+        ControlFlow::ForLoop { .. } => "ForLoopOp".to_string(),
+        ControlFlow::Switch { .. } => "SwitchCaseOp".to_string(),
     }
 }
 fn pack_control_flow_inst(
@@ -556,7 +555,7 @@ fn pack_control_flow_inst(
         extras_key: condition_key | annotations_key,
         num_ctrl_qubits: 0, // standard instructions have no control qubits
         ctrl_state: 0,
-        gate_class_name: control_flow_class_name(control_flow_inst.name())?, // need to use the Python class names for backward compatability
+        gate_class_name: control_flow_class_name(&control_flow_inst.control_flow), // need to use the Python class names for backward compatibility
         label: Default::default(),
         condition: packed_condition,
         bit_data: Default::default(),

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -394,8 +394,9 @@ fn pack_pauli_product_rotation(
     })
 }
 
-/// Convert snake_case name (e.g., "if_else") to Python class names (e.g., "IfElseOp")
-/// for backwards compatibility with old QPY versions
+/// Get Python class names (e.g., "IfElseOp") for a control flow op.
+/// This is for backwards compatibility with old QPY versions, since the
+/// Rust name uses snake_case.
 fn control_flow_class_name(control_flow: &ControlFlow) -> String {
     String::from(match control_flow {
         ControlFlow::Box { .. } => "BoxOp",
@@ -499,35 +500,34 @@ fn pack_control_flow_inst(
                 }
             };
             let case_circuits = extract_instruction_blocks(instruction, qpy_data);
-            let case_labels = label_spec
-                .iter()
-                .map(|label_vec| -> Result<GenericValue, QpyError> {
-                    Ok(GenericValue::Tuple(
-                        label_vec
-                            .iter()
-                            .map(|label_element| -> Result<GenericValue, QpyError> {
-                                match label_element {
-                                    CaseSpecifier::Default => Ok(GenericValue::CaseDefault),
-                                    CaseSpecifier::Uint(val) => {
-                                        Ok(GenericValue::Int64(val.to_i64().ok_or_else(|| {
-                                            QpyError::ConversionError(
-                                                "Case specifier too large".to_string(),
-                                            )
-                                        })?)
-                                        .as_le())
-                                    }
-                                }
-                            })
-                            .collect::<Result<Vec<GenericValue>, _>>()?,
-                    ))
-                })
-                .collect::<Result<Vec<GenericValue>, _>>()?;
             let cases = GenericValue::Tuple(
-                case_labels
-                    .into_iter()
+                label_spec
+                    .iter()
+                    .map(|label_vec| -> Result<GenericValue, QpyError> {
+                        Ok(GenericValue::Tuple(
+                            label_vec
+                                .iter()
+                                .map(|label_element| -> Result<GenericValue, QpyError> {
+                                    match label_element {
+                                        CaseSpecifier::Default => Ok(GenericValue::CaseDefault),
+                                        CaseSpecifier::Uint(val) => Ok(GenericValue::Int64(
+                                            val.to_i64().ok_or_else(|| {
+                                                QpyError::ConversionError(
+                                                    "Case specifier too large".to_string(),
+                                                )
+                                            })?,
+                                        )
+                                        .as_le()),
+                                    }
+                                })
+                                .collect::<Result<Vec<GenericValue>, _>>()?,
+                        ))
+                    })
                     .zip(case_circuits)
-                    .map(|(label, circuit)| GenericValue::Tuple(vec![label, circuit]))
-                    .collect(),
+                    .map(|(label, circuit)| -> Result<GenericValue, QpyError> {
+                        Ok(GenericValue::Tuple(vec![label?, circuit]))
+                    })
+                    .collect::<Result<Vec<GenericValue>, _>>()?,
             );
             vec![
                 pack_generic_value(&target_value, qpy_data)?,

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -22,6 +22,7 @@ use binrw::Endian;
 use hashbrown::{HashMap, HashSet};
 use indexmap::IndexSet;
 use numpy::ToPyArray;
+use num_traits::ToPrimitive;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyDict, PyTuple};
@@ -215,6 +216,31 @@ fn pack_instruction_blocks(
         }),
     }
 }
+
+/// extracts instruction blocks from an instruction into a vector of GenericValues
+fn extract_instruction_blocks(
+    inst: &PackedInstruction,
+    qpy_data: &mut QPYWriteData,
+) -> Result<Vec<GenericValue>, QpyError> {
+    let blocks = qpy_data
+        .circuit_data
+        .unpack_blocks_to_circuit_parameters(inst.params.as_deref())
+        .ok_or_else(|| {
+            QpyError::ConversionError("Could not extract blocks from instruction".to_string())
+        })?;
+    match blocks {
+        Parameters::Params(_) => Err(QpyError::ConversionError(
+            "Instruction has params but expected blocks".to_string(),
+        )),
+        Parameters::Blocks(blocks) => {
+            Ok(blocks
+                .iter()
+                .map(|block: &CircuitData| GenericValue::CircuitData(Box::new(block.clone())))
+                .collect())
+        }
+    }
+}
+
 /// packs one specific instruction into CircuitInstructionV2Pack, creating a new custom operation if needed
 fn pack_instruction(
     instruction: &PackedInstruction,
@@ -457,8 +483,14 @@ fn pack_control_flow_inst(
         ControlFlow::Switch {
             target,
             label_spec,
-            cases,
+            ..
         } => {
+            // we follor the python way of storing switch params
+            // the first param is the target, the next param is the cases specificer
+            // the cases specifier is a list of pairs (tuples)
+            // the second element in each pair is the subcircuit for this case
+            // the first element is the list of the case labels, or a single case label 
+            // or the special default case label
             let target_value = match target {
                 SwitchTarget::Bit(clbit) => {
                     GenericValue::Register(ParamRegisterValue::ShareableClbit(clbit))
@@ -468,28 +500,34 @@ fn pack_control_flow_inst(
                     GenericValue::Register(ParamRegisterValue::Register(reg))
                 }
             };
-            let label_spec_value = GenericValue::Tuple(
+            let case_circuits = extract_instruction_blocks(instruction, qpy_data)?;
+            let case_labels = 
                 label_spec
                     .iter()
-                    .map(|label_vec| {
-                        GenericValue::Tuple(
+                    .map(|label_vec| -> Result<GenericValue, QpyError> {
+                        Ok(GenericValue::Tuple(
                             label_vec
                                 .iter()
-                                .map(|label_element| match label_element {
-                                    CaseSpecifier::Default => GenericValue::CaseDefault,
-                                    CaseSpecifier::Uint(val) => GenericValue::BigInt(val.clone()),
+                                .map(|label_element| -> Result<GenericValue, QpyError> {
+                                    match label_element {
+                                        CaseSpecifier::Default => Ok(GenericValue::CaseDefault),
+                                        CaseSpecifier::Uint(val) => Ok(GenericValue::Int64(val.to_i64().ok_or_else(|| QpyError::ConversionError("Case specifier too large".to_string()))?).as_le()),
+                                    }
                                 })
-                                .collect(),
-                        )
+                                .collect::<Result<Vec<GenericValue>, _>>()?
+                        ))
                     })
-                    .collect::<Vec<_>>(),
-            );
-            let cases_value = GenericValue::Int64(cases as i64);
+                    .collect::<Result<Vec<GenericValue>, _>>()?;
+            let cases = GenericValue::Tuple(case_labels
+            .into_iter()
+            .zip(case_circuits)
+            .map(|(label, circuit)| {
+                GenericValue::Tuple(vec![label, circuit])
+            })
+            .collect());
             let mut params = Vec::new();
             params.push(pack_generic_value(&target_value, qpy_data)?);
-            params.push(pack_generic_value(&label_spec_value, qpy_data)?);
-            params.push(pack_generic_value(&cases_value, qpy_data)?);
-            params.extend(pack_instruction_blocks(instruction, qpy_data)?);
+            params.push(pack_generic_value(&cases, qpy_data)?);            
             params
         }
     };

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -450,7 +450,18 @@ fn pack_control_flow_inst(
                     params.push(duration_value_pack);
                     params.push(pack_generic_value(&duration_unit_string, qpy_data)?);
                 }
-                _ => (),
+                GenericValue::Null => {
+                    // we follow the python default
+                    let duration_value_pack = pack_generic_value(&GenericValue::Null, qpy_data)?;
+                    let duration_unit_string = GenericValue::String("dt".to_string());
+                    params.push(duration_value_pack);
+                    params.push(pack_generic_value(&duration_unit_string, qpy_data)?);
+                }
+                _ => {
+                    return Err(QpyError::InvalidInstruction(
+                        "Box instruction with unknown duration data".to_string(),
+                    ));
+                }
             }
             params
         }

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -21,6 +21,7 @@
 use binrw::Endian;
 use hashbrown::{HashMap, HashSet};
 use indexmap::IndexSet;
+use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 use numpy::ToPyArray;
 
@@ -163,7 +164,12 @@ fn pack_condition(
                 serialize_param_register_value(&ParamRegisterValue::Register(reg), qpy_data)?;
             let register_size = bytes.len() as u16;
             let data = formats::ConditionData::Register(bytes);
-            // TODO: this may cause loss of data, but we are constrained by the current qpy format
+            if target_value > BigUint::from(i64::MAX as u64) {
+                return Err(QpyError::InvalidInstruction(format!(
+                    "Register condition value {} exceeds i64::MAX and cannot be serialized in QPY format",
+                    target_value
+                )));
+            }
             // Handle zero case: iter_u64_digits() returns empty iterator for 0
             let low_digits = target_value.iter_u64_digits().next().unwrap_or(0) as i64;
             Ok(formats::ConditionPack {

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -442,7 +442,7 @@ fn pack_control_flow_inst(
                         };
                         let duration_unit_string =
                             GenericValue::String(duration.unit().to_string());
-                        params.push(pack_generic_value(&duration_value, qpy_data)?);
+                        params.push(pack_generic_value(&duration_value.as_le(), qpy_data)?);
                         params.push(pack_generic_value(&duration_unit_string, qpy_data)?);
                     }
                     BoxDuration::Expr(exp) => {

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -21,8 +21,8 @@
 use binrw::Endian;
 use hashbrown::{HashMap, HashSet};
 use indexmap::IndexSet;
-use numpy::ToPyArray;
 use num_traits::ToPrimitive;
+use numpy::ToPyArray;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyDict, PyTuple};
@@ -232,12 +232,10 @@ fn extract_instruction_blocks(
         Parameters::Params(_) => Err(QpyError::ConversionError(
             "Instruction has params but expected blocks".to_string(),
         )),
-        Parameters::Blocks(blocks) => {
-            Ok(blocks
-                .iter()
-                .map(|block: &CircuitData| GenericValue::CircuitData(Box::new(block.clone())))
-                .collect())
-        }
+        Parameters::Blocks(blocks) => Ok(blocks
+            .iter()
+            .map(|block: &CircuitData| GenericValue::CircuitData(Box::new(block.clone())))
+            .collect()),
     }
 }
 
@@ -481,15 +479,13 @@ fn pack_control_flow_inst(
             pack_instruction_blocks(instruction, qpy_data)?
         }
         ControlFlow::Switch {
-            target,
-            label_spec,
-            ..
+            target, label_spec, ..
         } => {
-            // we follor the python way of storing switch params
+            // we follow the python way of storing switch params
             // the first param is the target, the next param is the cases specificer
             // the cases specifier is a list of pairs (tuples)
             // the second element in each pair is the subcircuit for this case
-            // the first element is the list of the case labels, or a single case label 
+            // the first element is the list of the case labels, or a single case label
             // or the special default case label
             let target_value = match target {
                 SwitchTarget::Bit(clbit) => {
@@ -501,34 +497,40 @@ fn pack_control_flow_inst(
                 }
             };
             let case_circuits = extract_instruction_blocks(instruction, qpy_data)?;
-            let case_labels = 
-                label_spec
-                    .iter()
-                    .map(|label_vec| -> Result<GenericValue, QpyError> {
-                        Ok(GenericValue::Tuple(
-                            label_vec
-                                .iter()
-                                .map(|label_element| -> Result<GenericValue, QpyError> {
-                                    match label_element {
-                                        CaseSpecifier::Default => Ok(GenericValue::CaseDefault),
-                                        CaseSpecifier::Uint(val) => Ok(GenericValue::Int64(val.to_i64().ok_or_else(|| QpyError::ConversionError("Case specifier too large".to_string()))?).as_le()),
+            let case_labels = label_spec
+                .iter()
+                .map(|label_vec| -> Result<GenericValue, QpyError> {
+                    Ok(GenericValue::Tuple(
+                        label_vec
+                            .iter()
+                            .map(|label_element| -> Result<GenericValue, QpyError> {
+                                match label_element {
+                                    CaseSpecifier::Default => Ok(GenericValue::CaseDefault),
+                                    CaseSpecifier::Uint(val) => {
+                                        Ok(GenericValue::Int64(val.to_i64().ok_or_else(|| {
+                                            QpyError::ConversionError(
+                                                "Case specifier too large".to_string(),
+                                            )
+                                        })?)
+                                        .as_le())
                                     }
-                                })
-                                .collect::<Result<Vec<GenericValue>, _>>()?
-                        ))
-                    })
-                    .collect::<Result<Vec<GenericValue>, _>>()?;
-            let cases = GenericValue::Tuple(case_labels
-            .into_iter()
-            .zip(case_circuits)
-            .map(|(label, circuit)| {
-                GenericValue::Tuple(vec![label, circuit])
-            })
-            .collect());
-            let mut params = Vec::new();
-            params.push(pack_generic_value(&target_value, qpy_data)?);
-            params.push(pack_generic_value(&cases, qpy_data)?);            
-            params
+                                }
+                            })
+                            .collect::<Result<Vec<GenericValue>, _>>()?,
+                    ))
+                })
+                .collect::<Result<Vec<GenericValue>, _>>()?;
+            let cases = GenericValue::Tuple(
+                case_labels
+                    .into_iter()
+                    .zip(case_circuits)
+                    .map(|(label, circuit)| GenericValue::Tuple(vec![label, circuit]))
+                    .collect(),
+            );
+            vec![
+                pack_generic_value(&target_value, qpy_data)?,
+                pack_generic_value(&cases, qpy_data)?,
+            ]
         }
     };
     let annotations_key = if packed_annotations.is_some() {

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -33,6 +33,7 @@ use qiskit_circuit::bit::{
 use qiskit_circuit::circuit_data::{CircuitData, PyCircuitData};
 use qiskit_circuit::circuit_instruction::{CircuitInstruction, OperationFromPython};
 use qiskit_circuit::converters::QuantumCircuitData;
+use qiskit_circuit::duration::Duration;
 use qiskit_circuit::imports;
 use qiskit_circuit::instruction::Parameters;
 use qiskit_circuit::operations::{
@@ -227,22 +228,12 @@ fn pack_instruction_blocks(
 fn extract_instruction_blocks(
     inst: &PackedInstruction,
     qpy_data: &mut QPYWriteData,
-) -> Result<Vec<GenericValue>, QpyError> {
-    let blocks = qpy_data
-        .circuit_data
-        .unpack_blocks_to_circuit_parameters(inst.params.as_deref())
-        .ok_or_else(|| {
-            QpyError::ConversionError("Could not extract blocks from instruction".to_string())
-        })?;
-    match blocks {
-        Parameters::Params(_) => Err(QpyError::ConversionError(
-            "Instruction has params but expected blocks".to_string(),
-        )),
-        Parameters::Blocks(blocks) => Ok(blocks
-            .iter()
-            .map(|block: &CircuitData| GenericValue::CircuitData(Box::new(block.clone())))
-            .collect()),
-    }
+) -> Vec<GenericValue> {
+    inst.blocks_view()
+        .iter()
+        .filter_map(|&block_id| qpy_data.circuit_data.blocks().get(block_id))
+        .map(|block| GenericValue::CircuitData(Box::new(block.clone())))
+        .collect()
 }
 
 /// packs one specific instruction into CircuitInstructionV2Pack, creating a new custom operation if needed
@@ -406,15 +397,15 @@ fn pack_pauli_product_rotation(
 /// Convert snake_case name (e.g., "if_else") to Python class names (e.g., "IfElseOp")
 /// for backwards compatibility with old QPY versions
 fn control_flow_class_name(control_flow: &ControlFlow) -> String {
-    match control_flow {
-        ControlFlow::Box { .. } => "BoxOp".to_string(),
-        ControlFlow::BreakLoop => "BreakLoopOp".to_string(),
-        ControlFlow::ContinueLoop => "ContinueLoopOp".to_string(),
-        ControlFlow::IfElse { .. } => "IfElseOp".to_string(),
-        ControlFlow::While { .. } => "WhileLoopOp".to_string(),
-        ControlFlow::ForLoop { .. } => "ForLoopOp".to_string(),
-        ControlFlow::Switch { .. } => "SwitchCaseOp".to_string(),
-    }
+    String::from(match control_flow {
+        ControlFlow::Box { .. } => "BoxOp",
+        ControlFlow::BreakLoop => "BreakLoopOp",
+        ControlFlow::ContinueLoop => "ContinueLoopOp",
+        ControlFlow::IfElse { .. } => "IfElseOp",
+        ControlFlow::While { .. } => "WhileLoopOp",
+        ControlFlow::ForLoop { .. } => "ForLoopOp",
+        ControlFlow::Switch { .. } => "SwitchCaseOp",
+    })
 }
 fn pack_control_flow_inst(
     control_flow_inst: &ControlFlowInstruction,
@@ -429,44 +420,39 @@ fn pack_control_flow_inst(
             annotations,
         } => {
             packed_annotations = pack_annotations(&annotations, qpy_data)?;
-            let duration_param = match duration {
-                None => GenericValue::Null,
-                Some(box_duration) => match box_duration {
-                    BoxDuration::Duration(duration) => GenericValue::Duration(duration),
-                    BoxDuration::Expr(exp) => GenericValue::Expression(exp),
-                },
-            };
             let mut params = Vec::new();
-            // ideally, we'd do params.push(pack_generic_value(&duration_param, qpy_data)?);
-            // however, Python expects the BoxOp params to be handled differentely, so this is code for backwards compatibility:
             params.extend(pack_instruction_blocks(instruction, qpy_data)?);
-            match duration_param {
-                GenericValue::Duration(duration) => {
-                    let duration_value_pack = Python::attach(|py| {
-                        py_pack_param(&duration.py_value(py), qpy_data, Endian::Little)
-                    })?;
-                    let duration_unit_string = GenericValue::String(duration.unit().to_string());
-                    params.push(duration_value_pack);
-                    params.push(pack_generic_value(&duration_unit_string, qpy_data)?);
-                }
-                GenericValue::Expression(_) => {
-                    let duration_value_pack = pack_generic_value(&duration_param, qpy_data)?;
-                    let duration_unit_string = GenericValue::String("expr".to_string());
-                    params.push(duration_value_pack);
-                    params.push(pack_generic_value(&duration_unit_string, qpy_data)?);
-                }
-                GenericValue::Null => {
+            match duration {
+                None => {
                     // we follow the python default
                     let duration_value_pack = pack_generic_value(&GenericValue::Null, qpy_data)?;
                     let duration_unit_string = GenericValue::String("dt".to_string());
                     params.push(duration_value_pack);
                     params.push(pack_generic_value(&duration_unit_string, qpy_data)?);
                 }
-                _ => {
-                    return Err(QpyError::InvalidInstruction(
-                        "Box instruction with unknown duration data".to_string(),
-                    ));
-                }
+                Some(box_duration) => match box_duration {
+                    BoxDuration::Duration(duration) => {
+                        let duration_value = match duration {
+                            Duration::dt(v) => GenericValue::Int64(v),
+                            Duration::ps(v)
+                            | Duration::us(v)
+                            | Duration::ns(v)
+                            | Duration::ms(v)
+                            | Duration::s(v) => GenericValue::Float64(v),
+                        };
+                        let duration_unit_string =
+                            GenericValue::String(duration.unit().to_string());
+                        params.push(pack_generic_value(&duration_value, qpy_data)?);
+                        params.push(pack_generic_value(&duration_unit_string, qpy_data)?);
+                    }
+                    BoxDuration::Expr(exp) => {
+                        let duration_value_pack =
+                            pack_generic_value(&GenericValue::Expression(exp), qpy_data)?;
+                        let duration_unit_string = GenericValue::String("expr".to_string());
+                        params.push(duration_value_pack);
+                        params.push(pack_generic_value(&duration_unit_string, qpy_data)?);
+                    }
+                },
             }
             params
         }
@@ -512,7 +498,7 @@ fn pack_control_flow_inst(
                     GenericValue::Register(ParamRegisterValue::Register(reg))
                 }
             };
-            let case_circuits = extract_instruction_blocks(instruction, qpy_data)?;
+            let case_circuits = extract_instruction_blocks(instruction, qpy_data);
             let case_labels = label_spec
                 .iter()
                 .map(|label_vec| -> Result<GenericValue, QpyError> {

--- a/crates/qpy/src/circuit_writer.rs
+++ b/crates/qpy/src/circuit_writer.rs
@@ -163,9 +163,8 @@ fn pack_condition(
             let register_size = bytes.len() as u16;
             let data = formats::ConditionData::Register(bytes);
             // TODO: this may cause loss of data, but we are constrained by the current qpy format
-            let low_digits = target_value.iter_u64_digits().next().ok_or_else(|| {
-                QpyError::MissingData("Register condition value is missing".to_string())
-            })? as i64;
+            // Handle zero case: iter_u64_digits() returns empty iterator for 0
+            let low_digits = target_value.iter_u64_digits().next().unwrap_or(0) as i64;
             Ok(formats::ConditionPack {
                 register_size,
                 value: low_digits,
@@ -374,6 +373,23 @@ fn pack_pauli_product_rotation(
     })
 }
 
+/// Convert snake_case name (e.g., "if_else") to Python class names (e.g., "IfElseOp") 
+/// for backwards compatibility with old QPY versions
+
+fn control_flow_class_name(
+    name: &str,
+) -> Result<String, QpyError> {
+    match name {
+        "if_else" => Ok("IfElseOp".to_string()),
+        "while_loop" => Ok("WhileLoopOp".to_string()),
+        "for_loop" => Ok("ForLoopOp".to_string()),
+        "switch_case" => Ok("SwitchCaseOp".to_string()),
+        "break_loop" => Ok("BreakLoopOp".to_string()),
+        "continue_loop" => Ok("ContinueLoopOp".to_string()),
+        "box" => Ok("BoxOp".to_string()),
+        _ => Err(QpyError::InvalidInstruction(name.to_string())),
+    }
+}
 fn pack_control_flow_inst(
     control_flow_inst: &ControlFlowInstruction,
     instruction: &PackedInstruction,
@@ -474,7 +490,7 @@ fn pack_control_flow_inst(
         extras_key: condition_key | annotations_key,
         num_ctrl_qubits: 0, // standard instructions have no control qubits
         ctrl_state: 0,
-        gate_class_name: control_flow_inst.name().to_string(), // this name is NOT a proper python class name, but we don't instantiate from the python class anymore
+        gate_class_name: control_flow_class_name(control_flow_inst.name())?, // need to use the Python class names for backward compatability
         label: Default::default(),
         condition: packed_condition,
         bit_data: Default::default(),
@@ -1274,3 +1290,4 @@ pub(crate) fn py_write_circuit(
     )?;
     Ok(serialized_circuit.len())
 }
+

--- a/crates/qpy/src/params.rs
+++ b/crates/qpy/src/params.rs
@@ -284,7 +284,7 @@ fn pack_parameter_replay_entry(
             (ParameterType::Parameter, *parameter.symbol.uuid.as_bytes())
         }
         ParameterValueType::VectorElement(element) => (
-            ParameterType::Parameter, // Python QPY expects Parameter, not ParameterVector here
+            ParameterType::Parameter, // Python QPY expects Parameter, not ParameterVector
             *element.symbol.uuid.as_bytes(),
         ),
     })

--- a/crates/qpy/src/params.rs
+++ b/crates/qpy/src/params.rs
@@ -284,7 +284,7 @@ fn pack_parameter_replay_entry(
             (ParameterType::Parameter, *parameter.symbol.uuid.as_bytes())
         }
         ParameterValueType::VectorElement(element) => (
-            ParameterType::ParameterVector,
+            ParameterType::Parameter, // Python QPY expects Parameter, not ParameterVector here
             *element.symbol.uuid.as_bytes(),
         ),
     })

--- a/crates/qpy/src/params.rs
+++ b/crates/qpy/src/params.rs
@@ -301,7 +301,6 @@ pub(crate) fn unpack_parameter_expression(
     } else {
         HashMap::with_capacity(0)
     };
-
     for item in &parameter_expression_pack.symbol_table_data {
         let (symbol_uuid, value, symbol_name) = match item {
             formats::ParameterExpressionSymbolPack::ParameterExpression(_) => {
@@ -328,11 +327,7 @@ pub(crate) fn unpack_parameter_expression(
                     }
                     _ => load_value(symbol_pack.value_key, &symbol_pack.value_data, qpy_data)?,
                 };
-                (
-                    symbol_pack.symbol_data.uuid,
-                    value,
-                    symbol_pack.symbol_data.name.clone(),
-                )
+                (symbol_pack.symbol_data.uuid, value, symbol.repr(false))
             }
         };
         param_uuid_map.insert(symbol_uuid, value.clone());

--- a/crates/qpy/src/value.rs
+++ b/crates/qpy/src/value.rs
@@ -362,6 +362,12 @@ impl GenericValue {
             _ => None,
         }
     }
+    pub(crate) fn to_vec(&self) -> Option<Vec<GenericValue>> {
+        match self {
+            GenericValue::Tuple(elements) => Some(elements.clone()),
+            _ => None,
+        }
+    }
 }
 
 macro_rules! impl_from_generic {

--- a/crates/qpy/src/value.rs
+++ b/crates/qpy/src/value.rs
@@ -638,7 +638,7 @@ pub(crate) fn pack_for_collection(value: &ForCollection) -> GenericValue {
     match value {
         ForCollection::List(vec) => GenericValue::Tuple(
             vec.iter()
-                .map(|&val| GenericValue::Int64(val as i64))
+                .map(|&val| GenericValue::Int64(val as i64).as_le())
                 .collect(),
         ),
         ForCollection::PyRange(py_range) => GenericValue::Range(*py_range),

--- a/crates/qpy/src/value.rs
+++ b/crates/qpy/src/value.rs
@@ -355,8 +355,8 @@ impl GenericValue {
             _ => None,
         }
     }
-    // return the inner Vec when the GenericData is a Tuple
-    pub(crate) fn as_vec(&self) -> Option<&Vec<GenericValue>> {
+    // return the inner GenericValue slice when the GenericData is a Tuple
+    pub(crate) fn as_slice(&self) -> Option<&[GenericValue]> {
         match self {
             GenericValue::Tuple(elements) => Some(elements),
             _ => None,

--- a/crates/qpy/src/value.rs
+++ b/crates/qpy/src/value.rs
@@ -355,6 +355,13 @@ impl GenericValue {
             _ => None,
         }
     }
+    // return the inner Vec when the GenericData is a Tuple
+    pub(crate) fn as_vec(&self) -> Option<&Vec<GenericValue>> {
+        match self {
+            GenericValue::Tuple(elements) => Some(elements),
+            _ => None,
+        }
+    }
 }
 
 macro_rules! impl_from_generic {

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -77,6 +77,7 @@ from qiskit.qpy import (
     UnsupportedFeatureForVersion,
     QPY_COMPATIBILITY_VERSION,
     QPY_VERSION,
+    QpyError,
 )
 from qiskit.quantum_info import Pauli, SparsePauliOp, Clifford
 from qiskit.quantum_info.random import random_unitary
@@ -2100,6 +2101,34 @@ class TestLoadFromQPY(QiskitTestCase):
         for old, new in zip(old_if_else.blocks, new_if_else.blocks):
             self.assertMinimalVarEqual(old, new)
             self.assertDeprecatedBitProperties(old, new)
+
+    def test_register_condition(self):
+        """Test that using register condition passes as long as the register index is not too large"""
+        n_qubits = 2
+        cr0 = ClassicalRegister(n_qubits)
+        cr1 = ClassicalRegister(n_qubits)
+        qr = QuantumRegister(n_qubits)
+        qc = QuantumCircuit(qr, cr0, cr1)
+        qc.x(qr)
+        qc.measure(qr, cr0)
+        with qc.if_test((cr0, 0)):
+            qc.x(qr)
+        qc.measure(qr, cr1)
+        with io.BytesIO() as fptr:
+            dump(qc, fptr)
+            fptr.seek(0)
+            new_qc = load(fptr)[0]
+            self.assertEqual(qc, new_qc)
+
+        qc = QuantumCircuit(qr, cr0, cr1)
+        qc.x(qr)
+        qc.measure(qr, cr0)
+        with qc.if_test((cr0, 7342574385754343653453453453533935345)):
+            qc.x(qr)
+        qc.measure(qr, cr1)
+        with self.assertRaisesRegex(QpyError, "exceeds i64::MAX"):
+            with io.BytesIO() as fptr:
+                dump(qc, fptr)
 
     def test_load_empty_vars_while(self):
         """Test loading circuit with vars in while closures."""

--- a/test/python/qpy/test_roundtrip.py
+++ b/test/python/qpy/test_roundtrip.py
@@ -126,7 +126,7 @@ class TestQPYRoundtrip(QiskitTestCase):
         qr = QuantumRegister(2, "q1")
         cr = ClassicalRegister(2, "c1")
         qc = QuantumCircuit(qr, cr)
-        qc.switch(expr.bit_and(cr, 3), [(1, body.copy())], [0], [])
+        qc.switch(expr.bit_and(cr, 3), [(1, body.copy()), (2, body.copy())], [0], [])
         qc.switch(expr.logic_not(qc.clbits[0]), [(False, body.copy())], [0], [])
         self.assert_roundtrip_equal(qc, version=version)
         if version >= QPY_RUST_WRITE_MIN_VERSION:

--- a/test/python/qpy/test_roundtrip.py
+++ b/test/python/qpy/test_roundtrip.py
@@ -20,10 +20,11 @@ from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit.circuit.library import PauliEvolutionGate
 from qiskit.circuit.random import random_circuit
 from qiskit.circuit.parameter import Parameter
+from qiskit.circuit.parametervector import ParameterVector
 from qiskit.quantum_info import SparsePauliOp
 from qiskit.circuit.classical import expr
 from qiskit.synthesis import LieTrotter
-from qiskit.qpy.common import QPY_RUST_READ_MIN_VERSION, QPY_VERSION
+from qiskit.qpy.common import QPY_RUST_READ_MIN_VERSION, QPY_RUST_WRITE_MIN_VERSION, QPY_VERSION
 from qiskit.qpy.binary_io import write_circuit, read_circuit
 from test import QiskitTestCase
 
@@ -70,6 +71,8 @@ class TestQPYRoundtrip(QiskitTestCase):
         qc.cx(1, 2)
         qc.measure_all()
         self.assert_roundtrip_equal(qc, version=version)
+        if version >= QPY_RUST_WRITE_MIN_VERSION:
+            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
 
     @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
     def test_ifelse(self, version):
@@ -80,6 +83,8 @@ class TestQPYRoundtrip(QiskitTestCase):
         body.x(0)
         qc.if_else(condition, body, None, [qc.qubits[0]], [])
         self.assert_roundtrip_equal(qc, version=version)
+        if version >= QPY_RUST_WRITE_MIN_VERSION:
+            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
 
     @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
     def test_box(self, version):
@@ -88,6 +93,8 @@ class TestQPYRoundtrip(QiskitTestCase):
         with qc.box(duration=13):
             qc.cx(0, 1)
         self.assert_roundtrip_equal(qc, version=version)
+        if version >= QPY_RUST_WRITE_MIN_VERSION:
+            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
 
     @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
     def test_forloop(self, version):
@@ -100,6 +107,8 @@ class TestQPYRoundtrip(QiskitTestCase):
             with qc.if_test((0, True)):
                 qc.break_loop()
         self.assert_roundtrip_equal(qc, version=version)
+        if version >= QPY_RUST_WRITE_MIN_VERSION:
+            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
 
     @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
     def test_switch(self, version):
@@ -111,6 +120,8 @@ class TestQPYRoundtrip(QiskitTestCase):
         qc.switch(expr.bit_and(cr, 3), [(1, body.copy())], [0], [])
         qc.switch(expr.logic_not(qc.clbits[0]), [(False, body.copy())], [0], [])
         self.assert_roundtrip_equal(qc, version=version)
+        if version >= QPY_RUST_WRITE_MIN_VERSION:
+            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
 
     @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
     def test_evolutiongate(self, version):
@@ -123,6 +134,8 @@ class TestQPYRoundtrip(QiskitTestCase):
         qc = QuantumCircuit(2)
         qc.append(evo, range(2))
         self.assert_roundtrip_equal(qc, version=version)
+        if version >= QPY_RUST_WRITE_MIN_VERSION:
+            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
 
     @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
     def test_parameter_expression(self, version):
@@ -145,6 +158,20 @@ class TestQPYRoundtrip(QiskitTestCase):
         qc.h(0)
         qc.measure(0, 0)
         self.assert_roundtrip_equal(qc, version=version)
+        if version >= QPY_RUST_WRITE_MIN_VERSION:
+            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
+    
+    @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
+    def test_parameter_expression_with_vectors(self, version):
+        """Test loading a circuit with parameter expression works"""
+        theta = ParameterVector("θ", 3)
+        beta = Parameter("β")
+        qr = QuantumRegister(1)
+        qc = QuantumCircuit(qr)
+        qc.rx(beta+theta[1], qr)
+        self.assert_roundtrip_equal(qc, version=version)
+        if version >= QPY_RUST_WRITE_MIN_VERSION:
+            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
 
     @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
     def test_parameter_expression_subs(self, version):
@@ -156,6 +183,8 @@ class TestQPYRoundtrip(QiskitTestCase):
         exp = exp.subs({b: a})
         qc.ry(exp, 0)
         self.assert_roundtrip_equal(qc, version=version)
+        if version >= QPY_RUST_WRITE_MIN_VERSION:
+            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
 
     @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
     def test_random_circuits(self, version):

--- a/test/python/qpy/test_roundtrip.py
+++ b/test/python/qpy/test_roundtrip.py
@@ -160,7 +160,7 @@ class TestQPYRoundtrip(QiskitTestCase):
         self.assert_roundtrip_equal(qc, version=version)
         if version >= QPY_RUST_WRITE_MIN_VERSION:
             self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
-    
+
     @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
     def test_parameter_expression_with_vectors(self, version):
         """Test loading a circuit with parameter expression works"""
@@ -168,7 +168,7 @@ class TestQPYRoundtrip(QiskitTestCase):
         beta = Parameter("β")
         qr = QuantumRegister(1)
         qc = QuantumCircuit(qr)
-        qc.rx(beta+theta[1], qr)
+        qc.rx(beta + theta[1], qr)
         self.assert_roundtrip_equal(qc, version=version)
         if version >= QPY_RUST_WRITE_MIN_VERSION:
             self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")

--- a/test/python/qpy/test_roundtrip.py
+++ b/test/python/qpy/test_roundtrip.py
@@ -14,7 +14,7 @@
 
 import io
 
-from ddt import ddt, idata
+from ddt import ddt, idata, unpack
 
 from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit.circuit.library import PauliEvolutionGate
@@ -26,7 +26,24 @@ from qiskit.circuit.classical import expr
 from qiskit.synthesis import LieTrotter
 from qiskit.qpy.common import QPY_RUST_READ_MIN_VERSION, QPY_RUST_WRITE_MIN_VERSION, QPY_VERSION
 from qiskit.qpy.binary_io import write_circuit, read_circuit
+from qiskit.qpy import UnsupportedFeatureForVersion
 from test import QiskitTestCase
+
+
+def all_qpy_combinations(min_version):
+    def wrapper(func):
+        return idata(
+            (version, write_with, read_with)
+            for version in range(min_version, QPY_VERSION + 1)
+            for write_with in (
+                ("Python", "Rust") if version >= QPY_RUST_WRITE_MIN_VERSION else ("Python",)
+            )
+            for read_with in (
+                ("Python", "Rust") if version >= QPY_RUST_READ_MIN_VERSION else ("Python",)
+            )
+        )(unpack(func))
+
+    return wrapper
 
 
 @ddt
@@ -36,10 +53,10 @@ class TestQPYRoundtrip(QiskitTestCase):
     def assert_roundtrip_equal(
         self,
         circuit,
-        version=None,
+        version,
+        write_with,
+        read_with,
         annotation_factories=None,
-        write_with="Python",
-        read_with="Rust",
     ):
         """QPY roundtrip equal test."""
         qpy_file = io.BytesIO()
@@ -62,20 +79,18 @@ class TestQPYRoundtrip(QiskitTestCase):
         self.assertEqual(circuit, new_circuit)
         self.assertEqual(circuit.layout, new_circuit.layout)
 
-    @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
-    def test_simple(self, version):
+    @all_qpy_combinations(QPY_RUST_READ_MIN_VERSION)
+    def test_simple(self, version, write_with, read_with):
         """Basic roundtrip test"""
         qc = QuantumCircuit(3)
         qc.h(0)
         qc.cx(0, 1)
         qc.cx(1, 2)
         qc.measure_all()
-        self.assert_roundtrip_equal(qc, version=version)
-        if version >= QPY_RUST_WRITE_MIN_VERSION:
-            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
+        self.assert_roundtrip_equal(qc, version=version, read_with=read_with, write_with=write_with)
 
-    @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
-    def test_ifelse(self, version):
+    @all_qpy_combinations(QPY_RUST_READ_MIN_VERSION)
+    def test_ifelse(self, version, write_with, read_with):
         """Check the IfElse control flow gate passes roundtrip"""
         qc = QuantumCircuit(2, 1)
         condition = (qc.cregs[0], 0)
@@ -84,31 +99,31 @@ class TestQPYRoundtrip(QiskitTestCase):
         false_body = QuantumCircuit([qc.qubits[1]])
         false_body.y(0)
         qc.if_else(condition, body, false_body, [qc.qubits[0]], [])
-        self.assert_roundtrip_equal(qc, version=version)
-        if version >= QPY_RUST_WRITE_MIN_VERSION:
-            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
+        self.assert_roundtrip_equal(qc, version=version, read_with=read_with, write_with=write_with)
 
-    @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
-    def test_box(self, version):
+    @all_qpy_combinations(QPY_RUST_READ_MIN_VERSION)
+    def test_box(self, version, write_with, read_with):
         """Check the BoxOp control flow gate passes roundtrip"""
         qc = QuantumCircuit(2)
         with qc.box(duration=13):
             qc.cx(0, 1)
-        self.assert_roundtrip_equal(qc, version=version)
-        if version >= QPY_RUST_WRITE_MIN_VERSION:
-            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
+        self.assert_roundtrip_equal(qc, version=version, read_with=read_with, write_with=write_with)
 
         # test with Expression duration
         qc = QuantumCircuit(2)
         a = qc.add_stretch("a")
         with qc.box(duration=expr.mul(2, a)):
             qc.cx(0, 1)
-            # self.assert_roundtrip_equal(qc, version=version)
-        if version >= QPY_RUST_WRITE_MIN_VERSION:
-            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
+        if version < 14:
+            with io.BytesIO() as fptr, self.assertRaises(UnsupportedFeatureForVersion):
+                write_circuit(fptr, qc, version=version, use_rust=write_with == "Rust")
+        else:
+            self.assert_roundtrip_equal(
+                qc, version=version, read_with=read_with, write_with=write_with
+            )
 
-    @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
-    def test_forloop(self, version):
+    @all_qpy_combinations(QPY_RUST_READ_MIN_VERSION)
+    def test_forloop(self, version, write_with, read_with):
         """Check the ForLoop control flow gate passes roundtrip"""
         qc = QuantumCircuit(2, 1)
         with qc.for_loop(range(5)):
@@ -117,9 +132,7 @@ class TestQPYRoundtrip(QiskitTestCase):
             qc.measure(0, 0)
             with qc.if_test((0, True)):
                 qc.break_loop()
-        self.assert_roundtrip_equal(qc, version=version)
-        if version >= QPY_RUST_WRITE_MIN_VERSION:
-            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
+        self.assert_roundtrip_equal(qc, version=version, read_with=read_with, write_with=write_with)
 
         qc = QuantumCircuit(2, 1)
         with qc.for_loop((1, 4)):
@@ -128,13 +141,10 @@ class TestQPYRoundtrip(QiskitTestCase):
             qc.measure(0, 0)
             with qc.if_test((0, True)):
                 qc.break_loop()
-        self.assert_roundtrip_equal(qc, version=version)
-        if version >= QPY_RUST_WRITE_MIN_VERSION:
-            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
-            self.assert_roundtrip_equal(qc, version=version, read_with="Rust", write_with="Rust")
+        self.assert_roundtrip_equal(qc, version=version, read_with=read_with, write_with=write_with)
 
-    @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
-    def test_nested_for_loop(self, version):
+    @all_qpy_combinations(QPY_RUST_READ_MIN_VERSION)
+    def test_nested_for_loop(self, version, write_with, read_with):
         """Check the nested ForLoop control flow gate passes roundtrip"""
         qc = QuantumCircuit(6, 6)
         with qc.if_test(expr.equal(qc.cregs[0], 1)) as else_:
@@ -145,12 +155,10 @@ class TestQPYRoundtrip(QiskitTestCase):
             qc.cz(1, 4)
             with qc.for_loop((1, 2)):
                 qc.cx(1, 5)
-        self.assert_roundtrip_equal(qc, version=version)
-        if version >= QPY_RUST_WRITE_MIN_VERSION:
-            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
+        self.assert_roundtrip_equal(qc, version=version, read_with=read_with, write_with=write_with)
 
-    @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
-    def test_switch(self, version):
+    @all_qpy_combinations(QPY_RUST_READ_MIN_VERSION)
+    def test_switch(self, version, write_with, read_with):
         """Check the SwitchOp control flow gate passes roundtrip"""
         body = QuantumCircuit(1)
         qr = QuantumRegister(2, "q1")
@@ -158,12 +166,10 @@ class TestQPYRoundtrip(QiskitTestCase):
         qc = QuantumCircuit(qr, cr)
         qc.switch(expr.bit_and(cr, 3), [(1, body.copy()), (2, body.copy())], [0], [])
         qc.switch(expr.logic_not(qc.clbits[0]), [(False, body.copy())], [0], [])
-        self.assert_roundtrip_equal(qc, version=version)
-        if version >= QPY_RUST_WRITE_MIN_VERSION:
-            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
+        self.assert_roundtrip_equal(qc, version=version, read_with=read_with, write_with=write_with)
 
-    @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
-    def test_evolutiongate(self, version):
+    @all_qpy_combinations(QPY_RUST_READ_MIN_VERSION)
+    def test_evolutiongate(self, version, write_with, read_with):
         """Test loading a circuit with evolution gate works."""
         synthesis = LieTrotter(reps=2)
         evo = PauliEvolutionGate(
@@ -172,12 +178,10 @@ class TestQPYRoundtrip(QiskitTestCase):
 
         qc = QuantumCircuit(2)
         qc.append(evo, range(2))
-        self.assert_roundtrip_equal(qc, version=version)
-        if version >= QPY_RUST_WRITE_MIN_VERSION:
-            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
+        self.assert_roundtrip_equal(qc, version=version, read_with=read_with, write_with=write_with)
 
-    @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
-    def test_parameter_expression(self, version):
+    @all_qpy_combinations(QPY_RUST_READ_MIN_VERSION)
+    def test_parameter_expression(self, version, write_with, read_with):
         """Test loading a circuit with parameter expression works"""
         theta = Parameter("theta")
         phi = Parameter("phi")
@@ -196,24 +200,20 @@ class TestQPYRoundtrip(QiskitTestCase):
             qc.cx(i, i + 1)
         qc.h(0)
         qc.measure(0, 0)
-        self.assert_roundtrip_equal(qc, version=version)
-        if version >= QPY_RUST_WRITE_MIN_VERSION:
-            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
+        self.assert_roundtrip_equal(qc, version=version, read_with=read_with, write_with=write_with)
 
-    @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
-    def test_parameter_expression_with_vectors(self, version):
+    @all_qpy_combinations(QPY_RUST_READ_MIN_VERSION)
+    def test_parameter_expression_with_vectors(self, version, write_with, read_with):
         """Test loading a circuit with parameter expression works"""
         theta = ParameterVector("θ", 3)
         beta = Parameter("β")
         qr = QuantumRegister(1)
         qc = QuantumCircuit(qr)
         qc.rx(beta + theta[1], qr)
-        self.assert_roundtrip_equal(qc, version=version)
-        if version >= QPY_RUST_WRITE_MIN_VERSION:
-            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
+        self.assert_roundtrip_equal(qc, version=version, read_with=read_with, write_with=write_with)
 
-    @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
-    def test_parameter_expression_subs(self, version):
+    @all_qpy_combinations(QPY_RUST_READ_MIN_VERSION)
+    def test_parameter_expression_subs(self, version, write_with, read_with):
         """Test loading a circuit with parameter substitution works"""
         qc = QuantumCircuit(1)
         a = Parameter("a")
@@ -221,14 +221,14 @@ class TestQPYRoundtrip(QiskitTestCase):
         exp = a + b
         exp = exp.subs({b: a})
         qc.ry(exp, 0)
-        self.assert_roundtrip_equal(qc, version=version)
-        if version >= QPY_RUST_WRITE_MIN_VERSION:
-            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
+        self.assert_roundtrip_equal(qc, version=version, read_with=read_with, write_with=write_with)
 
-    @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
-    def test_random_circuits(self, version):
+    @all_qpy_combinations(QPY_RUST_READ_MIN_VERSION)
+    def test_random_circuits(self, version, write_with, read_with):
         """Test loading a random circuit works"""
         for i in range(10):
             qc = random_circuit(10, 10, measure=True, conditional=True, reset=True, seed=42 + i)
             # Make sure the circuits round-trip as a sanity check
-            self.assert_roundtrip_equal(qc, version=version)
+            self.assert_roundtrip_equal(
+                qc, version=version, read_with=read_with, write_with=write_with
+            )

--- a/test/python/qpy/test_roundtrip.py
+++ b/test/python/qpy/test_roundtrip.py
@@ -77,11 +77,13 @@ class TestQPYRoundtrip(QiskitTestCase):
     @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
     def test_ifelse(self, version):
         """Check the IfElse control flow gate passes roundtrip"""
-        qc = QuantumCircuit(1, 1)
+        qc = QuantumCircuit(2, 1)
         condition = (qc.cregs[0], 0)
         body = QuantumCircuit([qc.qubits[0]])
         body.x(0)
-        qc.if_else(condition, body, None, [qc.qubits[0]], [])
+        false_body = QuantumCircuit([qc.qubits[1]])
+        false_body.y(0)
+        qc.if_else(condition, body, false_body, [qc.qubits[0]], [])
         self.assert_roundtrip_equal(qc, version=version)
         if version >= QPY_RUST_WRITE_MIN_VERSION:
             self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
@@ -115,6 +117,34 @@ class TestQPYRoundtrip(QiskitTestCase):
             qc.measure(0, 0)
             with qc.if_test((0, True)):
                 qc.break_loop()
+        self.assert_roundtrip_equal(qc, version=version)
+        if version >= QPY_RUST_WRITE_MIN_VERSION:
+            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
+
+        qc = QuantumCircuit(2, 1)
+        with qc.for_loop((1, 4)):
+            qc.h(0)
+            qc.cx(0, 1)
+            qc.measure(0, 0)
+            with qc.if_test((0, True)):
+                qc.break_loop()
+        self.assert_roundtrip_equal(qc, version=version)
+        if version >= QPY_RUST_WRITE_MIN_VERSION:
+            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
+            self.assert_roundtrip_equal(qc, version=version, read_with="Rust", write_with="Rust")
+
+    @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
+    def test_nested_for_loop(self, version):
+        """Check the nested ForLoop control flow gate passes roundtrip"""
+        qc = QuantumCircuit(6, 6)
+        with qc.if_test(expr.equal(qc.cregs[0], 1)) as else_:
+            qc.cx(0, 1)
+            qc.cz(0, 2)
+            qc.cz(0, 3)
+        with else_:
+            qc.cz(1, 4)
+            with qc.for_loop((1, 2)):
+                qc.cx(1, 5)
         self.assert_roundtrip_equal(qc, version=version)
         if version >= QPY_RUST_WRITE_MIN_VERSION:
             self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")

--- a/test/python/qpy/test_roundtrip.py
+++ b/test/python/qpy/test_roundtrip.py
@@ -96,6 +96,15 @@ class TestQPYRoundtrip(QiskitTestCase):
         if version >= QPY_RUST_WRITE_MIN_VERSION:
             self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
 
+        # test with Expression duration
+        qc = QuantumCircuit(2)
+        a = qc.add_stretch("a")
+        with qc.box(duration=expr.mul(2, a)):
+            qc.cx(0, 1)
+            # self.assert_roundtrip_equal(qc, version=version)
+        if version >= QPY_RUST_WRITE_MIN_VERSION:
+            self.assert_roundtrip_equal(qc, version=version, read_with="Python", write_with="Rust")
+
     @idata(range(QPY_RUST_READ_MIN_VERSION, QPY_VERSION + 1))
     def test_forloop(self, version):
         """Check the ForLoop control flow gate passes roundtrip"""


### PR DESCRIPTION
### Summary
Fixes several incompatibilities between the Python and Rust file formats; in all cases, the Rust code was changed to conform to the Python expected standard

### Details and comments
This PR handles several problems detected with the Rust QPY component, most related to problems arising when an older, Python-based version of the QPY module attempts to read files generated with the Rust module. New tests were added to cover all these cases.

#### ParameterVector in qpy_reply
In Python, the data type of a `ParameterVector` inside the qpy_replay object is stored as Parameter (`b'p'`) and not ParameterVector (`b'v'`). Rust saved them with separate types, resulting in Python failing to load QPY files generated with Rust when the circuits contained parameter expressions involving ParameterVectors.

The fix makes Rust save the data type as `Parameter` as well. This should not cause problems, as parameters and parameter vectors are treated exactly the same when unpacking a parameter expression:

```
let lhs: Option<ParameterValueType> = match op.lhs_type {
                ParameterType::Parameter | ParameterType::ParameterVector => {
                    if let Some(value) = param_uuid_map.get(&op.lhs) {
                        Some(parameter_value_type_from_generic_value(value)?)
                    } else {
```

Note that writing `b'v' here breaks the QPY17 format, meaning that version 2.4.0rc1 does not fully conform to QPY17.

#### BoxOp duration parameter
In Rust, the `BoxOp` duration parameter was stored as `GenericData` which is either duration or expression. This should be the implementation going forward to QPY18 and beyond, but in Python support for duration in instruction parameters was nonexistant, so a hack was used instead, where `BoxOp` had two parameters, one for the numerical value and the other for the **string** of the duration's units - as well as "expr" when storing an expression. The current Rust code now conforms to this hack.

#### Control flow names
Previously, Rust stored the "new style" control flow names, e.g. `if_else`. This makes Python unable to correctly create those gates as it expects the actual class name. A conversion method from the new to the old style was added.

#### SwitchCaseOp handling
The way in which `SwitchCaseOp` parameters are stored in Python QPY is obsolete since the introduction of Rust based control flow ops. However, for now we still need to conform to the old method and the code was changed to reflect this. This allows us to dispose of the specialized treatment for this case in `unpack_py_instruction` since now we won't read switch instructions via this path.

Since the qpy write code of 2.4.0rc1 already used the new (now reverted) style that does not conform to QPY17 (although control flows are not defined in the spec), but we'll probably transition to it on QPY18, the read code now supports both approaches.

#### Additional bugfixes
As part of the new testing, another bug was discovered in the way condition register is handled - if its value is 0, the program would raise an error. This was fixed.

Another problem discovered was related to parameter vector name lookup in the old style using name-hashing (which was dumped in QPY15). For a parameter vector element e.g. `rz[0]` the name used was `rz` while the lookup tried to find `rz`. This was fixed and the correct name is now stored. However, I did not manage to reproduce the error even with the QPY which led to it being reported. The user that raised the issue confirmed this PR solved it for him.

