### PR TITLE
Improve docs for the `fold` field in `CircuitDrawerConfig`

### DIFF
--- a/crates/cext/src/circuit.rs
+++ b/crates/cext/src/circuit.rs
@@ -1978,7 +1978,8 @@ pub struct CircuitDrawerConfig {
     /// If `true`, merges the bottom and top lines of adjacent wires.
     merge_wires: bool,
     /// Sets the line length for wrapping the rendered text. Use 0
-    /// to auto-detect console width.
+    /// to auto-detect console width. Use `SIZE_MAX` to effectively skip
+    /// wrapping altogether.
     fold: usize,
 }
 


### PR DESCRIPTION
This PR addresses the comment https://github.com/Qiskit/qiskit/pull/15361#discussion_r2961311245:

>Do we not have an option for no folding in the api? In python we set this to -1 to not fold. I guess usize::max is fine as an equivalent. But maybe we should document that.

This is labeled for backporting to the 2.4 branch since it's just a documentation update. 