### PR TITLE
ci: add CI job to test minimum dependency version constraints

### DIFF
--- a/.github/workflows/test_min_deps.yml
+++ b/.github/workflows/test_min_deps.yml
@@ -25,7 +25,7 @@ jobs:
           #needed to ensure dependency versions aren't updated when qiskit is installed
           pip install --no-deps -e .
 
-          pip install --group test
+          pip install --group test --no-deps
 
       - run: |
           source venv/bin/activate

--- a/.github/workflows/test_min_deps.yml
+++ b/.github/workflows/test_min_deps.yml
@@ -19,8 +19,8 @@ jobs:
           source venv/bin/activate
           pip install --upgrade pip
 
-          #install minimum runtime dependencies as defined in the min_requirements.txt
-          pip install -r min_requirements.txt
+          #installs minimum requiered versions of all dependencies from requirements.txt
+          pip install -r <(sed 's/[>~]=/==/g' requirements.txt)
 
           #needed to ensure dependency versions aren't updated when qiskit is installed
           pip install --no-deps -e .

--- a/.github/workflows/test_min_deps.yml
+++ b/.github/workflows/test_min_deps.yml
@@ -1,0 +1,32 @@
+name: Test Minimum Dependencies
+
+on:
+  pull_request:
+
+jobs:
+  test-min-deps:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install --upgrade pip
+
+          #install minimum runtime dependencies as defined in the min_requirements.txt
+          pip install -r min_requirements.txt
+
+          #needed to ensure dependency versions aren't updated when qiskit is installed
+          pip install --no-deps -e .
+
+          pip install --group test
+
+      - run: |
+          source venv/bin/activate
+          stestr run

--- a/min_requirements.txt
+++ b/min_requirements.txt
@@ -1,0 +1,5 @@
+rustworkx==0.15.0
+numpy==1.21
+scipy==1.5
+dill==0.3
+stevedore==3.0.0

--- a/min_requirements.txt
+++ b/min_requirements.txt
@@ -1,5 +1,0 @@
-rustworkx==0.15.0
-numpy==1.21
-scipy==1.5
-dill==0.3
-stevedore==3.0.0


### PR DESCRIPTION
Fixes #15854 

AI tool used: ChatGPT (GPT-5)



* [x]  I have added the tests to cover my changes.
* [x]  I have updated the documentation accordingly.
* [x] I have read the CONTRIBUTING document.

### Summary

Add a CI job to test Qiskit against its minimum declared dependency versions.

### Details and comments

This PR introduces a CI job that installs qiskit using the minimum
versions of its runtime dependencies (as specified in the requirements.txt)
and runs the existing test suite.

The purpose of this job is to ensure that the declared minimum dependency
constraints are actually valid and remain compatible over time.

During local testing, installation fails for scipy==1.5 in a Python 3.10 environment.

This is mainly due to incompatibilities between scipy==1.5 and numpy==1.21.
SciPy 1.5 was built against much older NumPy versions (~1.17), and does not
work reliably with newer versions like 1.21.

Additionally, numpy==1.21 only supports Python 3.10 starting from later patch
releases (>=1.21.3). Since the version constraint does not specify a patch
version, pip may resolve to a version that is not compatible with Python 3.10.

As a result, installing Qiskit with only the declared minimum dependency
versions does not produce a working environment.
