### PR TITLE
Use nalgebra::Matrix4 as output for instructions_to_matrix

### DIFF
--- a/crates/quantum_info/src/convert_2q_block_matrix.rs
+++ b/crates/quantum_info/src/convert_2q_block_matrix.rs
@@ -16,12 +16,12 @@ use pyo3::prelude::*;
 
 use num_complex::Complex64;
 use numpy::PyReadonlyArray2;
-use numpy::ndarray::{Array2, ArrayView2, ArrayViewMut2, arr2, aview2};
+use numpy::nalgebra::{Matrix4, MatrixViewMut4};
+use numpy::ndarray::{Array2, ArrayView2};
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
 use qiskit_circuit::Qubit;
 use qiskit_circuit::dag_circuit::DAGCircuit;
-use qiskit_circuit::gate_matrix::TWO_QUBIT_IDENTITY;
 use qiskit_circuit::imports::QI_OPERATOR;
 use qiskit_circuit::interner::Interner;
 use qiskit_circuit::operations::{ArrayType, OperationRef};
@@ -29,6 +29,28 @@ use qiskit_circuit::packed_instruction::PackedInstruction;
 
 use crate::QiskitError;
 use crate::versor_u2::{VersorSU2, VersorU2, VersorU2Error};
+
+#[inline]
+fn matrix4_from_pyreadonly(array: &PyReadonlyArray2<Complex64>) -> Matrix4<Complex64> {
+    Matrix4::new(
+        *array.get((0, 0)).unwrap(),
+        *array.get((0, 1)).unwrap(),
+        *array.get((0, 2)).unwrap(),
+        *array.get((0, 3)).unwrap(),
+        *array.get((1, 0)).unwrap(),
+        *array.get((1, 1)).unwrap(),
+        *array.get((1, 2)).unwrap(),
+        *array.get((1, 3)).unwrap(),
+        *array.get((2, 0)).unwrap(),
+        *array.get((2, 1)).unwrap(),
+        *array.get((2, 2)).unwrap(),
+        *array.get((2, 3)).unwrap(),
+        *array.get((3, 0)).unwrap(),
+        *array.get((3, 1)).unwrap(),
+        *array.get((3, 2)).unwrap(),
+        *array.get((3, 3)).unwrap(),
+    )
+}
 
 #[inline]
 pub fn get_matrix_from_inst(inst: &PackedInstruction) -> PyResult<Array2<Complex64>> {
@@ -59,6 +81,34 @@ pub fn get_matrix_from_inst(inst: &PackedInstruction) -> PyResult<Array2<Complex
     })
 }
 
+#[inline]
+pub fn get_2q_matrix_from_inst(inst: &PackedInstruction) -> PyResult<Matrix4<Complex64>> {
+    if let Some(mat) = inst.try_matrix_as_nalgebra_2q() {
+        return Ok(mat);
+    }
+    if inst.op.try_standard_gate().is_some() {
+        return Err(QiskitError::new_err(
+            "Parameterized gates can't be consolidated",
+        ));
+    }
+    let OperationRef::Gate(gate) = inst.op.view() else {
+        return Err(QiskitError::new_err(
+            "Can't compute matrix of non-unitary op",
+        ));
+    };
+    // If the operation is a custom python gate, we will acquire the gil and use an
+    // Operator. Otherwise, using op.matrix() should work.  A user should not be
+    // able to reach this condition in Rust standalone mode.
+    Python::attach(|py| {
+        let res = QI_OPERATOR
+            .get_bound(py)
+            .call1((gate.instruction.clone_ref(py),))?
+            .getattr(intern!(py, "data"))?
+            .extract()?;
+        Ok(matrix4_from_pyreadonly(&res))
+    })
+}
+
 /// Quaternion-based collect of two parallel runs of 1q gates.
 #[derive(Clone, Debug)]
 struct Separable1q {
@@ -86,7 +136,7 @@ impl Separable1q {
 
     /// Construct the two-qubit gate matrix implied by these two runs.
     #[inline]
-    fn matrix_into<'a>(&self, target: &'a mut [[Complex64; 4]; 4]) -> ArrayView2<'a, Complex64> {
+    fn matrix_into(&self, mut target: MatrixViewMut4<Complex64>) {
         let q0 = VersorU2 {
             phase: self.phase,
             su2: self.qubits[0],
@@ -98,17 +148,16 @@ impl Separable1q {
         let q1_row = [Complex64::new(scalar, iz), Complex64::new(iy, ix)];
         for out_row in 0..2 {
             for out_col in 0..4 {
-                target[out_row][out_col] = q1_row[(out_col & 2) >> 1] * q0[out_row][out_col & 1];
+                target[(out_row, out_col)] = q1_row[(out_col & 2) >> 1] * q0[out_row][out_col & 1];
             }
         }
         let q1_row = [Complex64::new(-iy, ix), Complex64::new(scalar, -iz)];
         for out_row in 0..2 {
             for out_col in 0..4 {
-                target[out_row + 2][out_col] =
+                target[(out_row + 2, out_col)] =
                     q1_row[(out_col & 2) >> 1] * q0[out_row][out_col & 1];
             }
         }
-        aview2(target)
     }
 }
 
@@ -136,7 +185,7 @@ pub fn blocks_to_matrix(
     dag: &DAGCircuit,
     op_list: &[NodeIndex],
     block_index_map: [Qubit; 2],
-) -> PyResult<Array2<Complex64>> {
+) -> PyResult<Matrix4<Complex64>> {
     let inst_iter = op_list.iter().map(|node| dag[*node].unwrap_operation());
     instructions_to_matrix(inst_iter, block_index_map, dag.qargs_interner())
 }
@@ -145,7 +194,7 @@ pub fn instructions_to_matrix<'a>(
     op_list: impl Iterator<Item = &'a PackedInstruction>,
     block_index_map: [Qubit; 2],
     qargs_interner: &'a Interner<[Qubit]>,
-) -> PyResult<Array2<Complex64>> {
+) -> PyResult<Matrix4<Complex64>> {
     #[derive(Clone, Copy, PartialEq, Eq)]
     enum Qarg {
         Q0 = 0,
@@ -169,9 +218,9 @@ pub fn instructions_to_matrix<'a>(
             .expect("not a 1q or 2q gate in the qargs block")]
     };
 
-    let mut work: [[Complex64; 4]; 4] = Default::default();
+    let mut work: Matrix4<Complex64> = Matrix4::zeros();
     let mut qubits_1q: Option<Separable1q> = None;
-    let mut output_matrix: Option<Array2<Complex64>> = None;
+    let mut output_matrix: Option<Matrix4<Complex64>> = None;
     for inst in op_list {
         let qarg = qarg_lookup(inst.qubits);
         match qarg {
@@ -183,31 +232,36 @@ pub fn instructions_to_matrix<'a>(
                 };
             }
             Qarg::Q01 | Qarg::Q10 => {
-                let mut matrix = get_matrix_from_inst(inst)?;
+                let mut matrix = get_2q_matrix_from_inst(inst)?;
                 if qarg == Qarg::Q10 {
-                    change_basis_inplace(matrix.view_mut());
+                    change_basis_inplace(matrix.as_view_mut());
                 }
                 if let Some(sep) = qubits_1q.take() {
-                    matrix = matrix.dot(&sep.matrix_into(&mut work));
+                    sep.matrix_into(work.as_view_mut());
+                    matrix *= work;
                 }
                 output_matrix = if let Some(state) = output_matrix {
-                    Some(matrix.dot(&state))
+                    Some(matrix * state)
                 } else {
                     Some(matrix)
                 };
             }
         }
     }
+
     match (
-        qubits_1q.map(|sep| sep.matrix_into(&mut work)),
+        qubits_1q.map(|sep| {
+            sep.matrix_into(work.as_view_mut());
+            work
+        }),
         output_matrix,
     ) {
-        (Some(sep), Some(state)) => Ok(sep.dot(&state)),
+        (Some(sep), Some(state)) => Ok(sep * state),
         (None, Some(state)) => Ok(state),
-        (Some(sep), None) => Ok(sep.to_owned()),
+        (Some(sep), None) => Ok(sep),
         // This shouldn't actually ever trigger, because we expect blocks to be non-empty, but it's
         // trivial to handle anyway.
-        (None, None) => Ok(arr2(&TWO_QUBIT_IDENTITY)),
+        (None, None) => Ok(Matrix4::identity()),
     }
 }
 
@@ -227,11 +281,14 @@ pub fn change_basis(matrix: ArrayView2<Complex64>) -> Array2<Complex64> {
 
 /// Change the qubit order of a 2q matrix in place.
 #[inline]
-pub fn change_basis_inplace(mut matrix: ArrayViewMut2<Complex64>) {
-    matrix.swap((0, 1), (0, 2));
-    matrix.swap((3, 1), (3, 2));
-    matrix.swap((1, 0), (2, 0));
-    matrix.swap((1, 3), (2, 3));
-    matrix.swap((1, 1), (2, 2));
-    matrix.swap((1, 2), (2, 1));
+pub fn change_basis_inplace(mut matrix: MatrixViewMut4<Complex64>) {
+    // SAFETY: The bounds are all valid for a 4x4 matrix
+    unsafe {
+        matrix.swap_unchecked((0, 1), (0, 2));
+        matrix.swap_unchecked((3, 1), (3, 2));
+        matrix.swap_unchecked((1, 0), (2, 0));
+        matrix.swap_unchecked((1, 3), (2, 3));
+        matrix.swap_unchecked((1, 1), (2, 2));
+        matrix.swap_unchecked((1, 2), (2, 1));
+    }
 }

--- a/crates/synthesis/src/linalg/mod.rs
+++ b/crates/synthesis/src/linalg/mod.rs
@@ -26,8 +26,9 @@ const RTOL_DEFAULT: f64 = 1e-5;
 pub fn nalgebra_array_view<T: Scalar, R: Dim, C: Dim>(mat: MatrixView<T, R, C>) -> ArrayView2<T> {
     let dim = ndarray::Dim(mat.shape());
     let strides = ndarray::Dim(mat.strides());
-    // SAFETY: We know the array is a 4x4 and contiguous block so   we don't need to
-    // check for invalid format
+    // SAFETY: We know the array is a 2d array from nalgebra and we get the pointer and memory
+    // layout description from nalgebra so we don't need to check for invalid format as nalgebra
+    // has already validated this
     unsafe { ArrayView2::from_shape_ptr(dim.strides(strides), mat.get_unchecked(0)) }
 }
 

--- a/crates/synthesis/src/linalg/mod.rs
+++ b/crates/synthesis/src/linalg/mod.rs
@@ -12,7 +12,7 @@
 
 use approx::{abs_diff_eq, relative_ne};
 use faer::MatRef;
-use nalgebra::{DMatrix, DMatrixView, Dim, Dyn, MatrixView, ViewStorage};
+use nalgebra::{DMatrix, DMatrixView, Dim, Dyn, MatrixView, Scalar, ViewStorage};
 use ndarray::ArrayView2;
 use ndarray::ShapeBuilder;
 use num_complex::Complex64;
@@ -21,6 +21,15 @@ pub mod cos_sin_decomp;
 
 const ATOL_DEFAULT: f64 = 1e-8;
 const RTOL_DEFAULT: f64 = 1e-5;
+
+#[inline]
+pub fn nalgebra_array_view<T: Scalar, R: Dim, C: Dim>(mat: MatrixView<T, R, C>) -> ArrayView2<T> {
+    let dim = ndarray::Dim(mat.shape());
+    let strides = ndarray::Dim(mat.strides());
+    // SAFETY: We know the array is a 4x4 and contiguous block so   we don't need to
+    // check for invalid format
+    unsafe { ArrayView2::from_shape_ptr(dim.strides(strides), mat.get_unchecked(0)) }
+}
 
 #[inline]
 pub fn ndarray_to_faer<T>(array: ArrayView2<'_, T>) -> MatRef<'_, T> {

--- a/crates/synthesis/src/qsd.rs
+++ b/crates/synthesis/src/qsd.rs
@@ -15,7 +15,7 @@ use std::sync::OnceLock;
 
 use approx::abs_diff_eq;
 use hashbrown::HashMap;
-use nalgebra::{DMatrix, DMatrixView, DVector, Matrix4, QR, stack};
+use nalgebra::{DMatrix, DMatrixView, DVector, Matrix4, QR, U4, stack};
 use ndarray::prelude::*;
 use num_complex::Complex64;
 use numpy::PyReadonlyArray2;
@@ -28,7 +28,9 @@ use thiserror::Error;
 use crate::euler_one_qubit_decomposer::{
     EulerBasis, EulerBasisSet, unitary_to_gate_sequence_inner,
 };
-use crate::linalg::{closest_unitary, is_hermitian_matrix, svd_decomposition, verify_unitary};
+use crate::linalg::{
+    closest_unitary, is_hermitian_matrix, nalgebra_array_view, svd_decomposition, verify_unitary,
+};
 use crate::two_qubit_decompose::{TwoQubitBasisDecomposer, two_qubit_decompose_up_to_diagonal};
 use qiskit_circuit::bit::ShareableQubit;
 use qiskit_circuit::circuit_data::{CircuitData, CircuitDataError, PyCircuitData};
@@ -716,19 +718,26 @@ fn apply_a2(
         .collect();
     for ind in ind2q.windows(2) {
         let mat1 = match diagonal_rollover.get(&ind[0]) {
-            Some(circ) => instructions_to_matrix(
-                circ.data().iter(),
-                [Qubit(0), Qubit(1)],
-                circ.qargs_interner(),
-            )?,
+            Some(circ) => {
+                let mat: Matrix4<Complex64> = instructions_to_matrix(
+                    circ.data().iter(),
+                    [Qubit(0), Qubit(1)],
+                    circ.qargs_interner(),
+                )?;
+                nalgebra_array_view::<Complex64, U4, U4>(mat.as_view()).to_owned()
+            }
             None => new_matrices[&ind[0]].to_owned(),
         };
         let mat2 = match diagonal_rollover.get(&ind[1]) {
-            Some(circ) => instructions_to_matrix(
-                circ.data().iter(),
-                [Qubit(0), Qubit(1)],
-                circ.qargs_interner(),
-            )?,
+            Some(circ) => nalgebra_array_view::<Complex64, U4, U4>(
+                instructions_to_matrix(
+                    circ.data().iter(),
+                    [Qubit(0), Qubit(1)],
+                    circ.qargs_interner(),
+                )?
+                .as_view(),
+            )
+            .to_owned(),
             None => new_matrices[&ind[1]].to_owned(),
         };
         let (diagonal_mat, qc2cx) = two_qubit_decompose_up_to_diagonal(mat1.view()).unwrap();

--- a/crates/transpiler/src/passes/consolidate_blocks.rs
+++ b/crates/transpiler/src/passes/consolidate_blocks.rs
@@ -12,7 +12,7 @@
 
 use super::optimize_1q_gates_decomposition::matmul_1q;
 use hashbrown::{HashMap, HashSet};
-use nalgebra::Matrix2;
+use nalgebra::{Matrix2, Matrix4, U4};
 use ndarray::ArrayView2;
 use ndarray::{Array2, aview2};
 use num_complex::Complex64;
@@ -25,7 +25,6 @@ use qiskit_circuit::circuit_data::CircuitData;
 use qiskit_circuit::dag_circuit::{DAGCircuit, NodeType};
 use qiskit_circuit::gate_matrix::{
     CH_GATE, CX_GATE, CY_GATE, CZ_GATE, DCX_GATE, ECR_GATE, ISWAP_GATE, ONE_QUBIT_IDENTITY,
-    TWO_QUBIT_IDENTITY,
 };
 use qiskit_circuit::imports::QI_OPERATOR;
 use qiskit_circuit::interner::Interned;
@@ -33,6 +32,7 @@ use qiskit_circuit::operations::StandardGate;
 use qiskit_circuit::operations::{ArrayType, Operation, Param, UnitaryGate};
 use qiskit_circuit::packed_instruction::PackedOperation;
 use qiskit_quantum_info::convert_2q_block_matrix::{blocks_to_matrix, get_matrix_from_inst};
+use qiskit_synthesis::linalg::nalgebra_array_view;
 use qiskit_synthesis::two_qubit_decompose::RXXEquivalent;
 use qiskit_synthesis::two_qubit_decompose::{
     TwoQubitBasisDecomposer, TwoQubitControlledUDecomposer,
@@ -43,6 +43,29 @@ use smallvec::SmallVec;
 use crate::passes::unitary_synthesis::{PARAM_SET, TWO_QUBIT_BASIS_SET};
 use crate::target::{Qargs, Target};
 use qiskit_circuit::PhysicalQubit;
+
+static IDENTITY_2Q: Matrix4<Complex64> = Matrix4::new(
+    // Row 1
+    Complex64::ONE,
+    Complex64::ZERO,
+    Complex64::ZERO,
+    Complex64::ZERO,
+    // Row 2
+    Complex64::ZERO,
+    Complex64::ONE,
+    Complex64::ZERO,
+    Complex64::ZERO,
+    // Row 3
+    Complex64::ZERO,
+    Complex64::ZERO,
+    Complex64::ONE,
+    Complex64::ZERO,
+    // Row 4
+    Complex64::ZERO,
+    Complex64::ZERO,
+    Complex64::ZERO,
+    Complex64::ONE,
+);
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
@@ -367,12 +390,13 @@ fn py_run_consolidate_blocks(
             let matrix = blocks_to_matrix(dag, &block, block_index_map).ok();
             if let Some(matrix) = matrix {
                 let num_basis_gates = match decomposer {
-                    DecomposerType::TwoQubitBasis(ref decomp) => {
-                        decomp.num_basis_gates_inner(matrix.view())?
-                    }
-                    DecomposerType::TwoQubitControlledU(ref decomp) => {
-                        decomp.num_basis_gates_inner(matrix.view())?
-                    }
+                    DecomposerType::TwoQubitBasis(ref decomp) => decomp.num_basis_gates_inner(
+                        nalgebra_array_view::<Complex64, U4, U4>(matrix.as_view()),
+                    )?,
+                    DecomposerType::TwoQubitControlledU(ref decomp) => decomp
+                        .num_basis_gates_inner(nalgebra_array_view::<Complex64, U4, U4>(
+                            matrix.as_view(),
+                        ))?,
                 };
 
                 if force_consolidate
@@ -381,15 +405,13 @@ fn py_run_consolidate_blocks(
                     || (basis_gates.is_some() && outside_basis)
                     || (target.is_some() && outside_basis)
                 {
-                    if approx::abs_diff_eq!(aview2(&TWO_QUBIT_IDENTITY), matrix) {
+                    if approx::abs_diff_eq!(IDENTITY_2Q, matrix) {
                         for node in block {
                             dag.remove_op_node(node);
                         }
                     } else {
-                        // TODO: Use Matrix4/ArrayType::TwoQ when we're using nalgebra
-                        // for consolidation
                         let unitary_gate = UnitaryGate {
-                            array: ArrayType::NDArray(matrix),
+                            array: ArrayType::TwoQ(matrix),
                         };
                         let qubit_pos_map = block_index_map
                             .into_iter()


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit switches the return type of
convert_2q_block_matrix::instructions_to_matrix() to return a nalgebra
Matrix4 rather than a dynamicly allocated ndarray Array2. The function
explicitly returns a 4x4 Complex64 matrix. Using an nalgebra fixed size
array is stack allocated and we avoid needing a dynamic allocation. This
should also speedup matrix multiplication since nalgebra can leverage
simd better (either directly or implicitly via the compiler) because it
knows the fixed operations needed. We were already setup towards doing
since #13649 which moved to using nalgebra internally for the 1q
component, but it didn't update the whole path in that PR to use an
nalgebra array for everything.

Ideally we'd be using nalgebra data types throughout the two qubit
decomposers too. We should still use faer for the more involved linear
algebra operations in the module but we should be using Matrix4 and
Matrix2 for fixed sized matrices where we know the size of the matrices
in that module and generate faer MatRefs using
qiskit_synthesis::linalg::nalgebra_to_faer() to do linear algebra with
the matrix. This PR is an incremental step towards doing that.

### Details and comments

~This PR is based on top of #15858 and will need to be rebased after that merges. In the meantime you can view the contents of just this PR by looking at the HEAD commit: https://github.com/Qiskit/qiskit/commit/29a718d86a343a679ef7d43e89b1810a1993a39e~ Rebased now