### PR TITLE
Fix `QuantumCircuit.compose` for `front=True` and individual qargs

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2412,9 +2412,7 @@ class QuantumCircuit:
             new_clbits=mapped_clbits,
         )
         if append_existing:
-            dest._current_scope().extend(
-                append_existing, qubits=mapped_qubits, clbits=mapped_clbits
-            )
+            dest._current_scope().extend(append_existing)
 
         return None if inplace else dest
 

--- a/releasenotes/notes/fix-unwanted-remapping-in-circuits-compose-fb2e4dd2d082b93d.yaml
+++ b/releasenotes/notes/fix-unwanted-remapping-in-circuits-compose-fb2e4dd2d082b93d.yaml
@@ -1,0 +1,7 @@
+fixes:
+  - |
+    Fixed :meth:`.QuantumCircuit.compose` raising :exc:`ValueError` (``'qubits'
+    argument is the wrong length``) when ``front=True`` is used with an explicit
+    ``qubits`` mapping.
+
+    See `#15834 <https://github.com/Qiskit/qiskit/issues/15834>`__.

--- a/test/python/circuit/test_compose.py
+++ b/test/python/circuit/test_compose.py
@@ -550,6 +550,23 @@ class TestCircuitCompose(QiskitTestCase):
 
         self.assertEqual(output, expected)
 
+    def test_compose_front_smaller_circuit(self):
+        """Test composing a smaller circuit at the front with explicit qubits mapping."""
+
+        qc_base = QuantumCircuit(2)
+        qc_base.h(0)
+
+        qc_x = QuantumCircuit(1)
+        qc_x.x(0)
+
+        output = qc_base.compose(qc_x, qubits=[0], front=True)
+
+        expected = QuantumCircuit(2)
+        expected.x(0)
+        expected.h(0)
+
+        self.assertEqual(output, expected)
+
     def test_compose_adds_parameters(self):
         """Test the composed circuit contains all parameters."""
         a, b = Parameter("a"), Parameter("b")


### PR DESCRIPTION
When compose() is called with both front=True and a qubits mapping, the original instructions were incorrectly re-appended with the **incoming circuit's qubit remap table**, causing the error when the circuits had different widths. The fix removes the spurious qubits/clbits arguments from that append, and adds a regression test.

Fix https://github.com/Qiskit/qiskit/issues/15834