### PR TITLE
Change StatevectorEstimator to always estimate in [-1,+1]

### DIFF
--- a/qiskit/primitives/statevector_estimator.py
+++ b/qiskit/primitives/statevector_estimator.py
@@ -29,86 +29,126 @@ from .utils import _statevector_from_circuit
 
 
 class StatevectorEstimator(BaseEstimatorV2):
-    """
-    Simple implementation of :class:`BaseEstimatorV2` with full state vector simulation.
+    r"""
+        Simple implementation of :class:`BaseEstimatorV2` with full state vector simulation.
 
-    This class is implemented via :class:`~.Statevector` which turns provided circuits into
-    pure state vectors. These states are subsequently acted on by :class:`~.SparsePauliOp`,
-    which implies that, at present, this implementation is only compatible with Pauli-based
-    observables.
+        This class is implemented via :class:`~.Statevector` which turns provided circuits into
+        pure state vectors. These states are subsequently acted on by :class:`~.SparsePauliOp`,
+        which implies that, at present, this implementation is only compatible with Pauli-based
+        observables.
 
-    Each tuple of ``(circuit, observables, <optional> parameter values, <optional> precision)``,
-    called an estimator primitive unified bloc (PUB), produces its own array-based result. The
-    :meth:`~.StatevectorEstimator.run` method can be given a sequence of pubs to run in one call.
+        Each tuple of ``(circuit, observables, <optional> parameter values, <optional> precision)``,
+        called an estimator primitive unified bloc (PUB), produces its own array-based result. The
+        :meth:`~.StatevectorEstimator.run` method can be given a sequence of pubs to run in one call.
 
+        The default precision value used by this estimator, ``default_precision=0.0``, results in exact
+        expecation value estimates for unitary circuits, up to numerical precision. If a positive value
+        is provided, then it is used to add artificial noise to the exact estimates by drawing a random
+        variates whose mean values are equal to the exact values, and whose standard deviations are equal to
+        ``precision`` clipped to the largest value consistent with the expectation value's space of
+        support. The method of doing so is described below.
 
-    .. note::
-        The result of this class is exact if the circuit contains only unitary operations.
-        On the other hand, the result could be stochastic if the circuit contains a non-unitary
-        operation such as a reset for some subsystems.
-        The stochastic result can be made reproducible by setting ``seed``, e.g.,
-        ``StatevectorEstimator(seed=123)``.
+        When an observable is an n-qubit Pauli, its expectation value must live in the interval
+        :math:`[-1, 1]`, so that it is natural for this estimator implementation to always report estimates
+        in :math:`[-1,1]` even when the precision is set to a positive value. More generally, for a
+        multi-term observable :math:`A=\sum_k b_k P_k` expanded in the Pauli basis and a quantum state :math:`\rho`,
+        using Hölder's inequality and the triangle inequality, the expectation value is bounded by
+        
+        .. math::
 
-    .. plot::
-        :alt: Output from the previous code.
-        :include-source:
+            |\mathrm{Tr}(\rho A)|
+            \leq \left\lVert \rho \right\rVert_1 \left\lVert B \right\rVert_\infty
+            \leq \sum_k |b_k|.
 
-        from qiskit.circuit import Parameter, QuantumCircuit
-        from qiskit.primitives import StatevectorEstimator
-        from qiskit.quantum_info import Pauli, SparsePauliOp
+        While this inequality is loose, in the sense that for a particular observable :math:`A` one can generally not find a state :math:`\rho` for
+        which the inequality is saturated, it is still useful, because, in practical experiments,
+        expectation values are often estimated term-by-term such that the right-hand-side naturally
+        represents a typical bound seen experimentally.
 
-        import matplotlib.pyplot as plt
-        import numpy as np
+        This class chooses to use the Beta distribution to bound returned estimates to the 
+        interval :math:`[-b, b]` when non-zero precision is present, where :math:`b=\sum_k |b_k|`.
+        Since the Beta distribution has support on the interval :math:`[0, 1]`, it is used in conjunction 
+        with an affine transformation between :math:`[-b, b]` and :math:`[0, 1]`. In particular, given an
+        exact expecation value :math:`a`, setting
 
-        # Define a circuit with two parameters.
-        circuit = QuantumCircuit(2)
-        circuit.h(0)
-        circuit.cx(0, 1)
-        circuit.ry(Parameter("a"), 0)
-        circuit.rz(Parameter("b"), 0)
-        circuit.cx(0, 1)
-        circuit.h(0)
+        .. math::
 
-        # Define a sweep over parameter values, where the second axis is over
-        # the two parameters in the circuit.
-        params = np.vstack([
-            np.linspace(-np.pi, np.pi, 100),
-            np.linspace(-4 * np.pi, 4 * np.pi, 100)
-        ]).T
+            \mu &= \frac{a + b}{2b} \\
+            \sigma^2 &= \frac{\mathrm{min}(\mu(1-\mu), \mathrm{precision}^2)}{4b^2} \\
+            \alpha &= \frac{\mu^2(1-\mu)}{\sigma^2} - \mu \\
+            \beta &= \frac{\mu(1-\mu)^2}{\sigma^2} - (1-\mu)
 
-        # Define three observables. Many formats are supported here including
-        # classes such as qiskit.quantum_info.SparsePauliOp. The inner length-1
-        # lists cause this array of observables to have shape (3, 1), rather
-        # than shape (3,) if they were omitted.
-        observables = [
-            [SparsePauliOp(["XX", "IY"], [0.5, 0.5])],
-            [Pauli("XX")],
-            [Pauli("IY")]
-        ]
+        and drawing :math:`\hat{a} \sim \mathrm{Beta}(\alpha, \beta)` leads to 
+        :math:`\mathbb{E}[\hat{a}]=a`, :math:`\mathbb{V}[\hat{a}]=\mathrm{precision}^2`, and 
+        :math:`-b\leq \hat{a} \leq b`.
 
-        # Instantiate a new statevector simulation based estimator object.
-        estimator = StatevectorEstimator()
+        .. note::
+            Assuming the precision is set to zero, the result of this class is exact if the circuit 
+            contains only unitary operations. On the other hand, the result could be stochastic if 
+            the circuit contains a non-unitary operation such as a reset for some subsystems.
+            The stochastic result can be made reproducible by setting ``seed``, e.g.,
+            ``StatevectorEstimator(seed=123)``.
 
-        # Estimate the expectation value for all 300 combinations of
-        # observables and parameter values, where the pub result will have
-        # shape (3, 100). This shape is due to our array of parameter
-        # bindings having shape (100,), combined with our array of observables
-        # having shape (3, 1)
-        pub = (circuit, observables, params)
-        job = estimator.run([pub])
+        .. plot::
+            :alt: Output from the previous code.
+            :include-source:
 
-        # Extract the result for the 0th pub (this example only has one pub).
-        result = job.result()[0]
+            from qiskit.circuit import Parameter, QuantumCircuit
+            from qiskit.primitives import StatevectorEstimator
+            from qiskit.quantum_info import Pauli, SparsePauliOp
 
-        # Error-bar information is also available, but the error is 0
-        # for this StatevectorEstimator.
-        result.data.stds
+            import matplotlib.pyplot as plt
+            import numpy as np
 
-        # Pull out the array-based expectation value estimate data from the
-        # result and plot a trace for each observable.
-        for idx, pauli in enumerate(observables):
-            plt.plot(result.data.evs[idx], label=pauli)
-        plt.legend()
+            # Define a circuit with two parameters.
+            circuit = QuantumCircuit(2)
+            circuit.h(0)
+            circuit.cx(0, 1)
+            circuit.ry(Parameter("a"), 0)
+            circuit.rz(Parameter("b"), 0)
+            circuit.cx(0, 1)
+            circuit.h(0)
+
+            # Define a sweep over parameter values, where the second axis is over
+            # the two parameters in the circuit.
+            params = np.vstack([
+                np.linspace(-np.pi, np.pi, 100),
+                np.linspace(-4 * np.pi, 4 * np.pi, 100)
+            ]).T
+
+            # Define three observables. Many formats are supported here including
+            # classes such as qiskit.quantum_info.SparsePauliOp. The inner length-1
+            # lists cause this array of observables to have shape (3, 1), rather
+            # than shape (3,) if they were omitted.
+            observables = [
+                [SparsePauliOp(["XX", "IY"], [0.5, 0.5])],
+                [Pauli("XX")],
+                [Pauli("IY")]
+            ]
+
+            # Instantiate a new statevector simulation based estimator object.
+            estimator = StatevectorEstimator()
+
+            # Estimate the expectation value for all 300 combinations of
+            # observables and parameter values, where the pub result will have
+            # shape (3, 100). This shape is due to our array of parameter
+            # bindings having shape (100,), combined with our array of observables
+            # having shape (3, 1)
+            pub = (circuit, observables, params)
+            job = estimator.run([pub])
+
+            # Extract the result for the 0th pub (this example only has one pub).
+            result = job.result()[0]
+
+            # Error-bar information is also available, but the error is 0
+            # for this StatevectorEstimator.
+            result.data.stds
+
+            # Pull out the array-based expectation value estimate data from the
+            # result and plot a trace for each observable.
+            for idx, pauli in enumerate(observables):
+                plt.plot(result.data.evs[idx], label=pauli)
+            plt.legend()
     """
 
     def __init__(
@@ -167,11 +207,13 @@ class StatevectorEstimator(BaseEstimatorV2):
             if precision != 0:
                 if not np.isreal(expectation_value):
                     raise ValueError("Given operator is not Hermitian and noise cannot be added.")
-                mu = (expectation_value + 1) / 2
-                s2 = min(mu * (1 - mu), precision**2)
-                alpha = 4 * mu**2 * (1 - mu) / s2 - mu
-                beta = 4 * mu * (1 - mu) ** 2 / s2 - (1 - mu)
-                expectation_value = 2 * rng.beta(alpha, beta) - 1
+
+                bound = np.abs(coeffs).sum()
+                mu = (expectation_value + bound) / (2 * bound)
+                s2 = min(mu * (1 - mu), precision**2) / (4 * bound**2)
+                alpha = mu**2 * (1 - mu) / s2 - mu
+                beta = mu * (1 - mu) ** 2 / s2 - (1 - mu)
+                expectation_value = 2 * bound * rng.beta(alpha, beta) - bound
             evs[index] = expectation_value
 
         data = DataBin(evs=evs, stds=stds, shape=evs.shape)

--- a/qiskit/primitives/statevector_estimator.py
+++ b/qiskit/primitives/statevector_estimator.py
@@ -41,18 +41,19 @@ class StatevectorEstimator(BaseEstimatorV2):
         called an estimator primitive unified bloc (PUB), produces its own array-based result. The
         :meth:`~.StatevectorEstimator.run` method can be given a sequence of pubs to run in one call.
 
-        The default precision value used by this estimator, ``default_precision=0.0``, results in exact
-        expecation value estimates for unitary circuits, up to numerical precision. If a positive value
-        is provided, then it is used to add artificial noise to the exact estimates by drawing a random
-        variates whose mean values are equal to the exact values, and whose standard deviations are equal to
-        ``precision`` clipped to the largest value consistent with the expectation value's space of
-        support. The method of doing so is described below.
+        The default precision value used by this estimator, ``default_precision=0.0``, results in
+        exact expecation value estimates for unitary circuits, up to numerical precision. If a
+        positive value is provided, then it is used to add artificial noise to the exact estimates
+        by drawing a random variates whose mean values are equal to the exact values, and whose
+        standard deviations are equal to ``precision`` clipped to the largest value consistent with
+        the expectation value's space of support. The method of doing so is described below.
 
         When an observable is an n-qubit Pauli, its expectation value must live in the interval
-        :math:`[-1, 1]`, so that it is natural for this estimator implementation to always report estimates
-        in :math:`[-1,1]` even when the precision is set to a positive value. More generally, for a
-        multi-term observable :math:`A=\sum_k b_k P_k` expanded in the Pauli basis and a quantum state :math:`\rho`,
-        using Hölder's inequality and the triangle inequality, the expectation value is bounded by
+        :math:`[-1, 1]`, so that it is natural for this estimator implementation to always report
+        estimates in :math:`[-1,1]` even when the precision is set to a positive value. More
+        generally, for a multi-term observable :math:`A=\sum_k b_k P_k` expanded in the Pauli basis
+        and a quantum state :math:`\rho`, using Hölder's inequality and the triangle inequality, the
+        expectation value is bounded by
         
         .. math::
 
@@ -60,15 +61,16 @@ class StatevectorEstimator(BaseEstimatorV2):
             \leq \left\lVert \rho \right\rVert_1 \left\lVert B \right\rVert_\infty
             \leq \sum_k |b_k|.
 
-        While this inequality is loose, in the sense that for a particular observable :math:`A` one can generally not find a state :math:`\rho` for
-        which the inequality is saturated, it is still useful, because, in practical experiments,
-        expectation values are often estimated term-by-term such that the right-hand-side naturally
-        represents a typical bound seen experimentally.
+        While this inequality is loose, in the sense that for a particular observable :math:`A` one
+        can generally not find a state :math:`\rho` for which the inequality is saturated, it is
+        still useful, because, in practical experiments, expectation values are often estimated
+        term-by-term such that the right-hand-side naturally represents a typical bound seen
+        experimentally.
 
-        This class chooses to use the Beta distribution to bound returned estimates to the 
-        interval :math:`[-b, b]` when non-zero precision is present, where :math:`b=\sum_k |b_k|`.
-        Since the Beta distribution has support on the interval :math:`[0, 1]`, it is used in conjunction 
-        with an affine transformation between :math:`[-b, b]` and :math:`[0, 1]`. In particular, given an
+        This class chooses to use the Beta distribution to bound returned estimates to the interval
+        :math:`[-b, b]` when non-zero precision is present, where :math:`b=\sum_k |b_k|`. Since the
+        Beta distribution has support on the interval :math:`[0, 1]`, it is used in conjunction with
+        an affine transformation between :math:`[-b, b]` and :math:`[0, 1]`. In particular, given an
         exact expecation value :math:`a`, setting
 
         .. math::
@@ -80,7 +82,10 @@ class StatevectorEstimator(BaseEstimatorV2):
 
         and drawing :math:`\hat{a} \sim \mathrm{Beta}(\alpha, \beta)` leads to 
         :math:`\mathbb{E}[\hat{a}]=a`, :math:`\mathbb{V}[\hat{a}]=\mathrm{precision}^2`, and 
-        :math:`-b\leq \hat{a} \leq b`.
+        :math:`-b\leq \hat{a} \leq b`. The minimum with $\mu(1-\mu)$ is taken in $\sigma^2$ because
+        no random variable with support on a unit-length interval can have a variance greater 
+        than $\mu(1-\mu)$, where $\mu$ is its mean value; failing to do this would lead to negative
+        values of $\alpha$ or $\beta$.
 
         .. note::
             Assuming the precision is set to zero, the result of this class is exact if the circuit 
@@ -214,6 +219,7 @@ class StatevectorEstimator(BaseEstimatorV2):
                 alpha = mu**2 * (1 - mu) / s2 - mu
                 beta = mu * (1 - mu) ** 2 / s2 - (1 - mu)
                 expectation_value = 2 * bound * rng.beta(alpha, beta) - bound
+
             evs[index] = expectation_value
 
         data = DataBin(evs=evs, stds=stds, shape=evs.shape)

--- a/qiskit/primitives/statevector_estimator.py
+++ b/qiskit/primitives/statevector_estimator.py
@@ -167,7 +167,11 @@ class StatevectorEstimator(BaseEstimatorV2):
             if precision != 0:
                 if not np.isreal(expectation_value):
                     raise ValueError("Given operator is not Hermitian and noise cannot be added.")
-                expectation_value = rng.normal(expectation_value, precision)
+                mu = (expectation_value + 1) / 2
+                s2 = min(mu * (1 - mu), precision**2)
+                alpha = 4 * mu**2 * (1 - mu) / s2 - mu
+                beta = 4 * mu * (1 - mu) ** 2 / s2 - (1 - mu)
+                expectation_value = 2 * rng.beta(alpha, beta) - 1
             evs[index] = expectation_value
 
         data = DataBin(evs=evs, stds=stds, shape=evs.shape)

--- a/qiskit/primitives/statevector_estimator.py
+++ b/qiskit/primitives/statevector_estimator.py
@@ -73,10 +73,10 @@ class StatevectorEstimator(BaseEstimatorV2):
 
         .. math::
 
-            \mu &= \frac{a + b}{2b} \\
-            \sigma^2 &= \frac{\mathrm{min}(\mu(1-\mu), \mathrm{precision}^2)}{4b^2} \\
-            \alpha &= \frac{\mu^2(1-\mu)}{\sigma^2} - \mu \\
-            \beta &= \frac{\mu(1-\mu)^2}{\sigma^2} - (1-\mu)
+            \mu = \frac{a + b}{2b} \\
+            \sigma^2 = \frac{\mathrm{min}(\mu(1-\mu), \mathrm{precision}^2)}{4b^2} \\
+            \alpha = \frac{\mu^2(1-\mu)}{\sigma^2} - \mu \\
+            \beta = \frac{\mu(1-\mu)^2}{\sigma^2} - (1-\mu)
 
         and drawing :math:`\hat{a} \sim \mathrm{Beta}(\alpha, \beta)` leads to 
         :math:`\mathbb{E}[\hat{a}]=a`, :math:`\mathbb{V}[\hat{a}]=\mathrm{precision}^2`, and 

--- a/qiskit/primitives/statevector_estimator.py
+++ b/qiskit/primitives/statevector_estimator.py
@@ -29,131 +29,131 @@ from .utils import _statevector_from_circuit
 
 
 class StatevectorEstimator(BaseEstimatorV2):
-    r"""
-        Simple implementation of :class:`BaseEstimatorV2` with full state vector simulation.
+    r"""Simple implementation of :class:`BaseEstimatorV2` with full state vector simulation.
 
-        This class is implemented via :class:`~.Statevector` which turns provided circuits into
-        pure state vectors. These states are subsequently acted on by :class:`~.SparsePauliOp`,
-        which implies that, at present, this implementation is only compatible with Pauli-based
-        observables.
+    This class is implemented via :class:`~.Statevector` which turns provided circuits into
+    pure state vectors. These states are subsequently acted on by :class:`~.SparsePauliOp`,
+    which implies that, at present, this implementation is only compatible with Pauli-based
+    observables.
 
-        Each tuple of ``(circuit, observables, <optional> parameter values, <optional> precision)``,
-        called an estimator primitive unified bloc (PUB), produces its own array-based result. The
-        :meth:`~.StatevectorEstimator.run` method can be given a sequence of pubs to run in one call.
+    Each tuple of ``(circuit, observables, <optional> parameter values, <optional> precision)``,
+    called an estimator primitive unified bloc (PUB), produces its own array-based result. The
+    :meth:`~.StatevectorEstimator.run` method can be given a sequence of pubs to run in one call.
 
-        The default precision value used by this estimator, ``default_precision=0.0``, results in
-        exact expecation value estimates for unitary circuits, up to numerical precision. If a
-        positive value is provided, then it is used to add artificial noise to the exact estimates
-        by drawing a random variates whose mean values are equal to the exact values, and whose
-        standard deviations are equal to ``precision`` clipped to the largest value consistent with
-        the expectation value's space of support. The method of doing so is described below.
+    The default precision value used by this estimator, ``default_precision=0.0``, results in
+    exact expecation value estimates for unitary circuits, up to numerical precision. If a
+    positive value is provided, then it is used to add artificial noise to the exact estimates
+    by drawing a random variates whose mean values are equal to the exact values, and whose
+    standard deviations are equal to ``precision`` clipped to the largest value consistent with
+    the expectation value's space of support. The method of doing so is described below.
 
-        When an observable is an n-qubit Pauli, its expectation value must live in the interval
-        :math:`[-1, 1]`, so that it is natural for this estimator implementation to always report
-        estimates in :math:`[-1,1]` even when the precision is set to a positive value. More
-        generally, for a multi-term observable :math:`A=\sum_k b_k P_k` expanded in the Pauli basis
-        and a quantum state :math:`\rho`, using Hölder's inequality and the triangle inequality, the
-        expectation value is bounded by
+    When an observable is an n-qubit Pauli, its expectation value must live in the interval
+    :math:`[-1, 1]`, so that it is natural for this estimator implementation to always report
+    estimates in :math:`[-1,1]` even when the precision is set to a positive value. More
+    generally, for a multi-term observable :math:`A=\sum_k b_k P_k` expanded in the Pauli basis
+    and a quantum state :math:`\rho`, using Hölder's inequality and the triangle inequality, the
+    expectation value is bounded by
+    
+    .. math::
+
+        |\mathrm{Tr}(\rho A)|
+        \leq \left\lVert \rho \right\rVert_1 \left\lVert B \right\rVert_\infty
+        \leq \sum_k |b_k|.
+
+    While this inequality is loose, in the sense that for a particular observable :math:`A` one
+    can generally not find a state :math:`\rho` for which the inequality is saturated, it is
+    still useful, because, in practical experiments, expectation values are often estimated
+    term-by-term such that the right-hand-side naturally represents a typical bound seen
+    experimentally.
+
+    This class chooses to use the Beta distribution to bound returned estimates to the interval
+    :math:`[-b, b]` when non-zero precision is present, where :math:`b=\sum_k |b_k|`. Since the
+    Beta distribution has support on the interval :math:`[0, 1]`, it is used in conjunction with
+    an affine transformation between :math:`[-b, b]` and :math:`[0, 1]`. In particular, given an
+    exact expecation value :math:`a`, setting
+
+    .. math::
+
+        \mu = \frac{a + b}{2b} \\
+        \sigma^2 = \frac{\mathrm{min}(\mu(1-\mu), \mathrm{precision}^2)}{4b^2} \\
+        \alpha = \frac{\mu^2(1-\mu)}{\sigma^2} - \mu \\
+        \beta = \frac{\mu(1-\mu)^2}{\sigma^2} - (1-\mu)
+
+    and drawing :math:`\hat{a} \sim \mathrm{Beta}(\alpha, \beta)` leads to 
+    :math:`\mathbb{E}[\hat{a}]=a`, :math:`\mathbb{V}[\hat{a}]=\mathrm{precision}^2`, and 
+    :math:`-b\leq \hat{a} \leq b`. The minimum with $\mu(1-\mu)$ is taken in $\sigma^2$ because
+    no random variable with support on a unit-length interval can have a variance greater 
+    than $\mu(1-\mu)$, where $\mu$ is its mean value; failing to do this would lead to negative
+    values of $\alpha$ or $\beta$.
+
+    .. note::
+        Assuming the precision is set to zero, the result of this class is exact if the circuit 
+        contains only unitary operations. On the other hand, the result could be stochastic if 
+        the circuit contains a non-unitary operation such as a reset for some subsystems.
+        The stochastic result can be made reproducible by setting ``seed``, e.g.,
+        ``StatevectorEstimator(seed=123)``.
+
+    .. plot::
+        :alt: Output from the previous code.
+        :include-source:
+
+        from qiskit.circuit import Parameter, QuantumCircuit
+        from qiskit.primitives import StatevectorEstimator
+        from qiskit.quantum_info import Pauli, SparsePauliOp
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+
+        # Define a circuit with two parameters.
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        circuit.ry(Parameter("a"), 0)
+        circuit.rz(Parameter("b"), 0)
+        circuit.cx(0, 1)
+        circuit.h(0)
+
+        # Define a sweep over parameter values, where the second axis is over
+        # the two parameters in the circuit.
+        params = np.vstack([
+            np.linspace(-np.pi, np.pi, 100),
+            np.linspace(-4 * np.pi, 4 * np.pi, 100)
+        ]).T
+
+        # Define three observables. Many formats are supported here including
+        # classes such as qiskit.quantum_info.SparsePauliOp. The inner length-1
+        # lists cause this array of observables to have shape (3, 1), rather
+        # than shape (3,) if they were omitted.
+        observables = [
+            [SparsePauliOp(["XX", "IY"], [0.5, 0.5])],
+            [Pauli("XX")],
+            [Pauli("IY")]
+        ]
+
+        # Instantiate a new statevector simulation based estimator object.
+        estimator = StatevectorEstimator()
+
+        # Estimate the expectation value for all 300 combinations of
+        # observables and parameter values, where the pub result will have
+        # shape (3, 100). This shape is due to our array of parameter
+        # bindings having shape (100,), combined with our array of observables
+        # having shape (3, 1)
+        pub = (circuit, observables, params)
+        job = estimator.run([pub])
+
+        # Extract the result for the 0th pub (this example only has one pub).
+        result = job.result()[0]
+
+        # Error-bar information is also available, but the error is 0
+        # for this StatevectorEstimator.
+        result.data.stds
+
+        # Pull out the array-based expectation value estimate data from the
+        # result and plot a trace for each observable.
+        for idx, pauli in enumerate(observables):
+            plt.plot(result.data.evs[idx], label=pauli)
+        plt.legend()
         
-        .. math::
-
-            |\mathrm{Tr}(\rho A)|
-            \leq \left\lVert \rho \right\rVert_1 \left\lVert B \right\rVert_\infty
-            \leq \sum_k |b_k|.
-
-        While this inequality is loose, in the sense that for a particular observable :math:`A` one
-        can generally not find a state :math:`\rho` for which the inequality is saturated, it is
-        still useful, because, in practical experiments, expectation values are often estimated
-        term-by-term such that the right-hand-side naturally represents a typical bound seen
-        experimentally.
-
-        This class chooses to use the Beta distribution to bound returned estimates to the interval
-        :math:`[-b, b]` when non-zero precision is present, where :math:`b=\sum_k |b_k|`. Since the
-        Beta distribution has support on the interval :math:`[0, 1]`, it is used in conjunction with
-        an affine transformation between :math:`[-b, b]` and :math:`[0, 1]`. In particular, given an
-        exact expecation value :math:`a`, setting
-
-        .. math::
-
-            \mu = \frac{a + b}{2b} \\
-            \sigma^2 = \frac{\mathrm{min}(\mu(1-\mu), \mathrm{precision}^2)}{4b^2} \\
-            \alpha = \frac{\mu^2(1-\mu)}{\sigma^2} - \mu \\
-            \beta = \frac{\mu(1-\mu)^2}{\sigma^2} - (1-\mu)
-
-        and drawing :math:`\hat{a} \sim \mathrm{Beta}(\alpha, \beta)` leads to 
-        :math:`\mathbb{E}[\hat{a}]=a`, :math:`\mathbb{V}[\hat{a}]=\mathrm{precision}^2`, and 
-        :math:`-b\leq \hat{a} \leq b`. The minimum with $\mu(1-\mu)$ is taken in $\sigma^2$ because
-        no random variable with support on a unit-length interval can have a variance greater 
-        than $\mu(1-\mu)$, where $\mu$ is its mean value; failing to do this would lead to negative
-        values of $\alpha$ or $\beta$.
-
-        .. note::
-            Assuming the precision is set to zero, the result of this class is exact if the circuit 
-            contains only unitary operations. On the other hand, the result could be stochastic if 
-            the circuit contains a non-unitary operation such as a reset for some subsystems.
-            The stochastic result can be made reproducible by setting ``seed``, e.g.,
-            ``StatevectorEstimator(seed=123)``.
-
-        .. plot::
-            :alt: Output from the previous code.
-            :include-source:
-
-            from qiskit.circuit import Parameter, QuantumCircuit
-            from qiskit.primitives import StatevectorEstimator
-            from qiskit.quantum_info import Pauli, SparsePauliOp
-
-            import matplotlib.pyplot as plt
-            import numpy as np
-
-            # Define a circuit with two parameters.
-            circuit = QuantumCircuit(2)
-            circuit.h(0)
-            circuit.cx(0, 1)
-            circuit.ry(Parameter("a"), 0)
-            circuit.rz(Parameter("b"), 0)
-            circuit.cx(0, 1)
-            circuit.h(0)
-
-            # Define a sweep over parameter values, where the second axis is over
-            # the two parameters in the circuit.
-            params = np.vstack([
-                np.linspace(-np.pi, np.pi, 100),
-                np.linspace(-4 * np.pi, 4 * np.pi, 100)
-            ]).T
-
-            # Define three observables. Many formats are supported here including
-            # classes such as qiskit.quantum_info.SparsePauliOp. The inner length-1
-            # lists cause this array of observables to have shape (3, 1), rather
-            # than shape (3,) if they were omitted.
-            observables = [
-                [SparsePauliOp(["XX", "IY"], [0.5, 0.5])],
-                [Pauli("XX")],
-                [Pauli("IY")]
-            ]
-
-            # Instantiate a new statevector simulation based estimator object.
-            estimator = StatevectorEstimator()
-
-            # Estimate the expectation value for all 300 combinations of
-            # observables and parameter values, where the pub result will have
-            # shape (3, 100). This shape is due to our array of parameter
-            # bindings having shape (100,), combined with our array of observables
-            # having shape (3, 1)
-            pub = (circuit, observables, params)
-            job = estimator.run([pub])
-
-            # Extract the result for the 0th pub (this example only has one pub).
-            result = job.result()[0]
-
-            # Error-bar information is also available, but the error is 0
-            # for this StatevectorEstimator.
-            result.data.stds
-
-            # Pull out the array-based expectation value estimate data from the
-            # result and plot a trace for each observable.
-            for idx, pauli in enumerate(observables):
-                plt.plot(result.data.evs[idx], label=pauli)
-            plt.legend()
     """
 
     def __init__(

--- a/test/python/primitives/test_statevector_estimator.py
+++ b/test/python/primitives/test_statevector_estimator.py
@@ -278,12 +278,12 @@ class TestStatevectorEstimator(QiskitTestCase):
         theta1 = self.theta[0]
         job = estimator.run([(psi1, hamiltonian1, [theta1])])
         result = job.result()
-        np.testing.assert_allclose(result[0].data.evs, [1.901141473854881])
+        np.testing.assert_allclose(result[0].data.evs, [1.537818491149677])
         # The result of the second run is the same
         job = estimator.run([(psi1, hamiltonian1, [theta1]), (psi1, hamiltonian1, [theta1])])
         result = job.result()
-        np.testing.assert_allclose(result[0].data.evs, [1.901141473854881])
-        np.testing.assert_allclose(result[1].data.evs, [1.901141473854881])
+        np.testing.assert_allclose(result[0].data.evs, [1.537818491149677])
+        np.testing.assert_allclose(result[1].data.evs, [1.537818491149677])
         # precision=0 implies the exact expectation value
         job = estimator.run([(psi1, hamiltonian1, [theta1])], precision=0)
         result = job.result()


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Closes https://github.com/Qiskit/qiskit/issues/15826 by switching from the normal distribution to the beta distribution when adding artificial precision noise to expectation value estimates.

### Details and comments


