### PR TITLE
Use nalgebra matrices for uncommon paths in consolidate blocks

### DIFF
--- a/crates/quantum_info/src/convert_2q_block_matrix.rs
+++ b/crates/quantum_info/src/convert_2q_block_matrix.rs
@@ -16,7 +16,7 @@ use pyo3::prelude::*;
 
 use num_complex::Complex64;
 use numpy::PyReadonlyArray2;
-use numpy::nalgebra::{Matrix4, MatrixViewMut4};
+use numpy::nalgebra::{Matrix2, Matrix4, MatrixViewMut4};
 use numpy::ndarray::{Array2, ArrayView2};
 use rustworkx_core::petgraph::stable_graph::NodeIndex;
 
@@ -49,6 +49,16 @@ fn matrix4_from_pyreadonly(array: &PyReadonlyArray2<Complex64>) -> Matrix4<Compl
         *array.get((3, 1)).unwrap(),
         *array.get((3, 2)).unwrap(),
         *array.get((3, 3)).unwrap(),
+    )
+}
+
+#[inline]
+fn matrix2_from_pyreadonly(array: &PyReadonlyArray2<Complex64>) -> Matrix2<Complex64> {
+    Matrix2::new(
+        *array.get((0, 0)).unwrap(),
+        *array.get((0, 1)).unwrap(),
+        *array.get((1, 0)).unwrap(),
+        *array.get((1, 1)).unwrap(),
     )
 }
 
@@ -106,6 +116,34 @@ pub fn get_2q_matrix_from_inst(inst: &PackedInstruction) -> PyResult<Matrix4<Com
             .getattr(intern!(py, "data"))?
             .extract()?;
         Ok(matrix4_from_pyreadonly(&res))
+    })
+}
+
+#[inline]
+pub fn get_1q_matrix_from_inst(inst: &PackedInstruction) -> PyResult<Matrix2<Complex64>> {
+    if let Some(mat) = inst.try_matrix_as_nalgebra_1q() {
+        return Ok(mat);
+    }
+    if inst.op.try_standard_gate().is_some() {
+        return Err(QiskitError::new_err(
+            "Parameterized gates can't be consolidated",
+        ));
+    }
+    let OperationRef::Gate(gate) = inst.op.view() else {
+        return Err(QiskitError::new_err(
+            "Can't compute matrix of non-unitary op",
+        ));
+    };
+    // If the operation is a custom python gate, we will acquire the gil and use an
+    // Operator. Otherwise, using op.matrix() should work.  A user should not be
+    // able to reach this condition in Rust standalone mode.
+    Python::attach(|py| {
+        let res = QI_OPERATOR
+            .get_bound(py)
+            .call1((gate.instruction.clone_ref(py),))?
+            .getattr(intern!(py, "data"))?
+            .extract()?;
+        Ok(matrix2_from_pyreadonly(&res))
     })
 }
 

--- a/crates/transpiler/src/passes/consolidate_blocks.rs
+++ b/crates/transpiler/src/passes/consolidate_blocks.rs
@@ -31,7 +31,9 @@ use qiskit_circuit::interner::Interned;
 use qiskit_circuit::operations::StandardGate;
 use qiskit_circuit::operations::{ArrayType, Operation, Param, UnitaryGate};
 use qiskit_circuit::packed_instruction::PackedOperation;
-use qiskit_quantum_info::convert_2q_block_matrix::{blocks_to_matrix, get_matrix_from_inst};
+use qiskit_quantum_info::convert_2q_block_matrix::{
+    blocks_to_matrix, get_1q_matrix_from_inst, get_2q_matrix_from_inst, get_matrix_from_inst,
+};
 use qiskit_synthesis::linalg::nalgebra_array_view;
 use qiskit_synthesis::two_qubit_decompose::RXXEquivalent;
 use qiskit_synthesis::two_qubit_decompose::{
@@ -289,14 +291,31 @@ fn py_run_consolidate_blocks(
                 phys_qargs.get(dag, inst.qubits),
             ) {
                 all_block_gates.insert(inst_node);
-                let matrix = match get_matrix_from_inst(inst) {
-                    Ok(mat) => mat,
-                    Err(_) => continue,
-                };
-                // TODO: Use Matrix2/ArrayType::OneQ when we're using nalgebra
-                // for consolidation
-                let unitary_gate = UnitaryGate {
-                    array: ArrayType::NDArray(matrix),
+                let num_qubits = inst.op.num_qubits();
+                let unitary_gate = if num_qubits == 1 {
+                    let matrix = match get_1q_matrix_from_inst(inst) {
+                        Ok(mat) => mat,
+                        Err(_) => continue,
+                    };
+                    UnitaryGate {
+                        array: ArrayType::OneQ(matrix),
+                    }
+                } else if num_qubits == 2 {
+                    let matrix = match get_2q_matrix_from_inst(inst) {
+                        Ok(mat) => mat,
+                        Err(_) => continue,
+                    };
+                    UnitaryGate {
+                        array: ArrayType::TwoQ(matrix),
+                    }
+                } else {
+                    let matrix = match get_matrix_from_inst(inst) {
+                        Ok(mat) => mat,
+                        Err(_) => continue,
+                    };
+                    UnitaryGate {
+                        array: ArrayType::NDArray(matrix),
+                    }
                 };
                 dag.substitute_op(
                     inst_node,
@@ -450,12 +469,15 @@ fn py_run_consolidate_blocks(
                     first_qubits,
                 )
             {
-                let matrix = match get_matrix_from_inst(first_inst) {
+                // Runs are necessarily single qubit gates so if it has a matrix then it
+                // must have a single qubit matrix or it's not a run and the blocks handling above
+                // would have covered it
+                let matrix = match get_1q_matrix_from_inst(first_inst) {
                     Ok(mat) => mat,
                     Err(_) => continue,
                 };
                 let unitary_gate = UnitaryGate {
-                    array: ArrayType::NDArray(matrix),
+                    array: ArrayType::OneQ(matrix),
                 };
                 dag.substitute_op(
                     first_inst_node,


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the recently merged #15871 we updated the consolidate blocks pass to use Matrix4 in the common path of a 2q block being consolidated. This is like > 90% of what the pass does when run in the preset pass manager. However, there were uncommon cases in the pass around the handling of blocks of a single gate that are outside of the target which were not updated to use nalgebra arrays if it's a fixed size 1q or 2q gate. This commit updates these uncommon paths so that we're always returning an nalgebra matrix in the output UnitaryGate if the block being consolidated is a single qubit or two qubits.

### Details and comments


