### PR TITLE
Generate docs for all tag pushes

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -4,8 +4,8 @@ on:
     branches:
       - main
     tags:
-      # Only match non-prerelease tags.
-      - "[0-9]+.[0-9]+.[0-9]"
+      # Run on all tags.
+      - "*"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Summary

The docs team needs to generate the docs for 2.4.0rc2, but there was no Sphinx artifact created. In the past, I would manually trigger a workflow, but that isn't sustainable and the team taking over API release docs generation does not have write permission to Qiskit/qiskit. 

### Details and comments

This simply runs on all tags. This workflow only uploads the asset to GH Artifacts, whereas it used to update qiskit.org directly. So, running this workflow more than strictly necessary is extremely low risk.

(Technically, we need `**` if we want to run on tags that include `/`.)
