### PR TITLE
Simplify Sabre release-valve calculation

### DIFF
--- a/crates/transpiler/src/passes/sabre/route.rs
+++ b/crates/transpiler/src/passes/sabre/route.rs
@@ -703,27 +703,12 @@ impl State {
         // If we apply a single swap it could be that we route 2 nodes; that is a setup like
         //  A - B - A - B
         // and we swap the middle two qubits. This cannot happen if we apply 2 or more swaps.
-        if current_swaps.len() > 1 {
-            smallvec![closest_node]
-        } else {
-            // check if the closest node has neighbors that are now routable -- for that we get
-            // the other physical qubit that was swapped and check whether the node on it
-            // is now routable
-            let mut possible_other_qubit = current_swaps[0]
+        match current_swaps.as_slice() {
+            [swap] => swap
                 .iter()
-                // check if other nodes are in the front layer that are connected by this swap
-                .filter_map(|&swap_qubit| self.front_layer.qubits()[swap_qubit.index()])
-                // remove the closest_node, which we know we already routed
-                .filter(|(node_index, _other_qubit)| *node_index != closest_node)
-                .map(|(_node_index, other_qubit)| other_qubit);
-
-            // if there is indeed another candidate, check if that gate is routable
-            if let Some(other_qubit) = possible_other_qubit.next() {
-                if let Some(also_routed) = self.routable_node_on_qubit(problem, other_qubit) {
-                    return smallvec![closest_node, also_routed];
-                }
-            }
-            smallvec![closest_node]
+                .filter_map(|q| self.routable_node_on_qubit(problem, *q))
+                .collect(),
+            _ => smallvec![closest_node],
         }
     }
 


### PR DESCRIPTION
There is an edge case in release-valve handling where, if the shortest path is a single swap (but the heuristics have been chosen such that it is unselectable normally), it is possible for the release valve to cause _two_ gates to be routed.  The previous handling of this path was written in quite a complicated manner, likely to be able to use `closest_node` by name from its discovery earlier in the release-valve process.

Instead, it is easier to recognise that, given a single swap:

* the two qubits cannot be part of the same gate, or the gate would have been routable _without_ the swap;
* the `closest_node` must touch one of these qubits because of the the Dijkstra search;
* therefore we can simply add any routable gate that touches _either_ qubit without risk of duplication or forgetting `closest_swap`.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

This was separated out from #14909 owing to https://github.com/Qiskit/qiskit/pull/14909#discussion_r2991568511.