### PR TITLE
[DO NOT MERGE] Add backwards compatibility test for real amplitude circuits

### DIFF
--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -316,7 +316,7 @@ impl ParameterExpression {
             while current_sub_operation > 0 && subs_operations[current_sub_operation - 1].0 == i + 1
             {
                 if let Some(exp) = stack.pop() {
-                    let sub_exp = exp.subs(&subs_operations[current_sub_operation - 1].1, false)?;
+                    let sub_exp = exp.subs(&subs_operations[current_sub_operation - 1].1, true)?;
                     stack.push(sub_exp);
                 }
                 current_sub_operation -= 1;

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -918,6 +918,17 @@ def generate_v14_expr():
     ]
 
 
+def generate_real_amplitude_circuits():
+    """Real-amplitudes 2-local circuit`."""
+    from qiskit.circuit.library import RealAmplitudes
+    from qiskit import transpile
+
+    circuit = RealAmplitudes(num_qubits=2, reps=2)
+    isa_circuit = transpile(circuit.decompose(), optimization_level=0)
+
+    return [circuit, isa_circuit]
+
+
 def generate_box():
     """Circuits that contain `Box`.  Only added in Qiskit 2.0."""
     bare = QuantumCircuit(2, name="box-bare")
@@ -959,6 +970,8 @@ def generate_circuits(version_parts, current_version, load_context=False):
         output_circuits["teleport.qpy"] = [
             generate_single_clbit_condition_teleportation(current_version)
         ]
+
+        output_circuits["real_amplitude.qpy"] = generate_real_amplitude_circuits()
 
     if version_parts >= (0, 19, 0):
         output_circuits["param_phase.qpy"] = generate_param_phase()
@@ -1109,8 +1122,14 @@ def load_qpy(qpy_files, version_parts):
             # See https://github.com/Qiskit/qiskit/pull/13814
             continue
         print(f"Loading qpy file: {path}")  # noqa: T201
-        with open(path, "rb") as fd:
-            qpy_circuits = load(fd)
+        try:
+            with open(path, "rb") as fd:
+                qpy_circuits = load(fd)
+        except Exception as ex:
+            msg = f"****QPY Load error****: Failed to load {path} with the exception: {ex}"
+            sys.stderr.write(msg)
+            sys.exit(1)
+
         equivalent = path in {"open_controlled_gates.qpy", "controlled_gates.qpy"}
         for i, circuit in enumerate(circuits):
             bind = None

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -1152,6 +1152,7 @@ def load_qpy(qpy_files, version_parts):
                 equivalent=equivalent,
                 context=context,
             )
+            print(f"Terminated successfully with qpy file: {path}")
 
     from qiskit.qpy.exceptions import QpyError
 

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -926,7 +926,7 @@ def generate_real_amplitude_circuits():
     circuit = RealAmplitudes(num_qubits=2, reps=2)
     isa_circuit = transpile(circuit.decompose(), optimization_level=0)
 
-    return [circuit, isa_circuit]
+    return [isa_circuit, circuit]
 
 
 def generate_box():

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -861,7 +861,15 @@ def generate_replay_with_expression_substitutions():
     qc = QuantumCircuit(1)
     qc.rz(a2, 0)
 
-    return [qc]
+    qc2 = QuantumCircuit(1)
+    theta = Parameter("θ")
+    rz = Parameter("rz")
+    exp = theta + np.pi
+    exp = exp.subs({theta: rz})
+    exp = exp.subs({rz: theta})
+    qc2.rz(exp, 0)
+
+    return [qc, qc2]
 
 
 def generate_v14_expr():
@@ -918,17 +926,6 @@ def generate_v14_expr():
     ]
 
 
-def generate_real_amplitude_circuits():
-    """Real-amplitudes 2-local circuit`."""
-    from qiskit.circuit.library import RealAmplitudes
-    from qiskit import transpile
-
-    circuit = RealAmplitudes(num_qubits=2, reps=2)
-    isa_circuit = transpile(circuit.decompose(), optimization_level=0)
-
-    return [isa_circuit, circuit]
-
-
 def generate_box():
     """Circuits that contain `Box`.  Only added in Qiskit 2.0."""
     bare = QuantumCircuit(2, name="box-bare")
@@ -970,8 +967,6 @@ def generate_circuits(version_parts, current_version, load_context=False):
         output_circuits["teleport.qpy"] = [
             generate_single_clbit_condition_teleportation(current_version)
         ]
-
-        output_circuits["real_amplitude.qpy"] = generate_real_amplitude_circuits()
 
     if version_parts >= (0, 19, 0):
         output_circuits["param_phase.qpy"] = generate_param_phase()


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR adds new test to the QPY backwards compatibility suite based on `RealAmplitude` circuits, as the 2.4 release candidates encountered errors with such circuits generated by old qiskit implementations which were not locally reproducible.


### Details and comments


