### PR TITLE
Improve error message when composing incompatible circuits

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -1436,10 +1436,19 @@ impl DAGCircuit {
             ));
         }
 
-        if other.qubits.len() > self.qubits.len() || other.clbits.len() > self.clbits.len() {
-            return Err(DAGCircuitError::new_err(
-                "Trying to compose with another DAGCircuit which has more 'in' edges.",
-            ));
+        if other.qubits.len() > self.qubits.len() {
+            return Err(DAGCircuitError::new_err(format!(
+                "The circuit being composed ({} qubits) is larger than the destination circuit ({} qubits).",
+                other.qubits.len(),
+                self.qubits.len()
+            )));
+        }
+        if other.clbits.len() > self.clbits.len() {
+            return Err(DAGCircuitError::new_err(format!(
+                "The circuit being composed ({} clbits) is larger than the destination circuit ({} clbits).",
+                other.clbits.len(),
+                self.clbits.len()
+            )));
         }
 
         let qubits = qubits
@@ -7695,10 +7704,19 @@ impl DAGCircuit {
         block_map: HashMap<Block, Block>,
         inline_captures: bool,
     ) -> PyResult<()> {
-        if other.qubits.len() > self.qubits.len() || other.clbits.len() > self.clbits.len() {
-            return Err(DAGCircuitError::new_err(
-                "Trying to compose with another DAGCircuit which has more 'in' edges.",
-            ));
+        if other.qubits.len() > self.qubits.len() {
+            return Err(DAGCircuitError::new_err(format!(
+                "The circuit being composed ({} qubits) is larger than the destination circuit ({} qubits).",
+                other.qubits.len(),
+                self.qubits.len()
+            )));
+        }
+        if other.clbits.len() > self.clbits.len() {
+            return Err(DAGCircuitError::new_err(format!(
+                "The circuit being composed ({} clbits) is larger than the destination circuit ({} clbits).",
+                other.clbits.len(),
+                self.clbits.len()
+            )));
         }
 
         let qubit_map = match qubits {

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2280,9 +2280,15 @@ class QuantumCircuit:
                 dest.append(other, qargs=qubits, cargs=clbits, copy=copy)
             return None if inplace else dest
 
-        if other.num_qubits > dest.num_qubits or other.num_clbits > dest.num_clbits:
+        if other.num_qubits > dest.num_qubits:
             raise CircuitError(
-                "Trying to compose with another QuantumCircuit which has more 'in' edges."
+                f"The circuit being composed ({other.num_qubits} qubits) is larger than "
+                f"the destination circuit ({dest.num_qubits} qubits)."
+            )
+        if other.num_clbits > dest.num_clbits:
+            raise CircuitError(
+                f"The circuit being composed ({other.num_clbits} clbits) is larger than "
+                f"the destination circuit ({dest.num_clbits} clbits)."
             )
 
         # Maps bits in 'other' to bits in 'dest'.

--- a/test/python/circuit/test_issue_13935.py
+++ b/test/python/circuit/test_issue_13935.py
@@ -1,0 +1,40 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test for issue 13935: obscure error message when composing incompatible circuits."""
+
+from qiskit.circuit import QuantumCircuit
+from qiskit.circuit.exceptions import CircuitError
+from qiskit.test import QiskitTestCase
+
+class TestIssue13935(QiskitTestCase):
+    """Test for issue 13935."""
+
+    def test_compose_more_qubits_error_message(self):
+        """Test that compose raises a descriptive error when 'other' has more qubits."""
+        qc1 = QuantumCircuit(1)
+        qc2 = QuantumCircuit(2)
+        with self.assertRaisesRegex(
+            CircuitError, 
+            r"The circuit being composed \(2 qubits\) is larger than the destination circuit \(1 qubits\)\."
+        ):
+            qc1.compose(qc2)
+
+    def test_compose_more_clbits_error_message(self):
+        """Test that compose raises a descriptive error when 'other' has more clbits."""
+        qc1 = QuantumCircuit(1, 1)
+        qc2 = QuantumCircuit(1, 2)
+        with self.assertRaisesRegex(
+            CircuitError, 
+            r"The circuit being composed \(2 clbits\) is larger than the destination circuit \(1 clbits\)\."
+        ):
+            qc1.compose(qc2)


### PR DESCRIPTION
Fixes #13935. 

### Description
The current error message when composing incompatible circuits (e.g., more qubits in the source than the destination) is quite technical, mentioning "'in' edges" from the underlying DAG structure. This PR improves the user experience by providing a descriptive message that specifies the actual qubit and classical bit counts for both the source and destination circuits.

### Changes
- **Python**: Updated `qiskit/circuit/quantumcircuit.py` to check qubit and clbit counts separately and provide detailed error messages.
- **Rust**: Updated `crates/circuit/src/dag_circuit.rs` (two occurrences) to maintain consistency with the Python layer, using clear formatted strings.
- **Tests**: Added a new regression test in `test/python/circuit/test_issue_13935.py` to verify the new error messages.

This change helps developers quickly identify the cause of composition failures without needing to understand the internal DAG implementation details.
