### PR TITLE
Calling LitinskiTransformation with use_ppr=True in asv

### DIFF
--- a/test/benchmarks/passes.py
+++ b/test/benchmarks/passes.py
@@ -224,11 +224,8 @@ class LitinskiTransformationPassBenchmarks:
     params = (circuit_names, num_qubits)
     param_names = ["circuit_name", "n_qubits"]
     slow_tests = {
-        ("qft", 512),
-        ("qaoa", 256),
         ("qaoa", 512),
         ("grover", 512),
-        ("multiplier", 256),
         ("multiplier", 512),
     }
     timeout = 300

--- a/test/benchmarks/passes.py
+++ b/test/benchmarks/passes.py
@@ -253,5 +253,5 @@ class LitinskiTransformationPassBenchmarks:
         self.dag = circuit_to_dag(transpiled)
 
     def time_litinski_transformation(self, _, __):
-        _pass = LitinskiTransformation()
+        _pass = LitinskiTransformation(use_ppr=True)
         _pass.run(self.dag)


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #15753 we have added the option `use_ppr` to `LitinskiTransformation`, which creates `PauliProductRotation` gates instead of `PauliEvolution` gates, making the transformation run significantly faster. This tiny PR updates the ASV benchmarks for `LitinskiTransformation`: setting `use_ppr=True` and updating the set of slow (skipped) tests.

### Details and comments

We could also extend `trotter` and `mcx` benchmarks to `1024` and `2048` qubits, but not the other ones: either the setup (transpiling a circuit to Clifford+RZ basis, before calling `LitinskiTransformation`) or the `LitinskiTransformation` pass itself take more time than desired for ASV runs.