### PR TITLE
Add dense matrix support for PauliProductRotation

### DIFF
--- a/crates/circuit/src/gate_matrix.rs
+++ b/crates/circuit/src/gate_matrix.rs
@@ -10,6 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use ndarray::{Array2, array};
 use num_complex::Complex64;
 use std::f64::consts::FRAC_1_SQRT_2;
 
@@ -513,4 +514,58 @@ pub fn xx_plus_yy_gate(theta: f64, beta: f64) -> GateArray2Q {
         ],
         [C_ZERO, C_ZERO, C_ZERO, C_ONE],
     ]
+}
+
+pub fn pauli_zx_to_matrix(z: &[bool], x: &[bool]) -> Array2<Complex64> {
+    debug_assert_eq!(z.len(), x.len());
+
+    let i = array![
+        [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+        [Complex64::new(0.0, 0.0), Complex64::new(1.0, 0.0)],
+    ];
+    let x_mat = array![
+        [Complex64::new(0.0, 0.0), Complex64::new(1.0, 0.0)],
+        [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+    ];
+    let z_mat = array![
+        [Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+        [Complex64::new(0.0, 0.0), Complex64::new(-1.0, 0.0)],
+    ];
+    let y_mat = array![
+        [Complex64::new(0.0, 0.0), Complex64::new(0.0, -1.0)],
+        [Complex64::new(0.0, 1.0), Complex64::new(0.0, 0.0)],
+    ];
+
+    fn kron(a: &Array2<Complex64>, b: &Array2<Complex64>) -> Array2<Complex64> {
+        let (ar, ac) = a.dim();
+        let (br, bc) = b.dim();
+        let mut out = Array2::<Complex64>::zeros((ar * br, ac * bc));
+
+        for i in 0..ar {
+            for j in 0..ac {
+                let coeff = a[(i, j)];
+                for k in 0..br {
+                    for l in 0..bc {
+                        out[(i * br + k, j * bc + l)] = coeff * b[(k, l)];
+                    }
+                }
+            }
+        }
+
+        out
+    }
+
+    let mut result = array![[Complex64::new(1.0, 0.0)]];
+
+    for (&z_bit, &x_bit) in z.iter().zip(x.iter()) {
+        let factor = match (z_bit, x_bit) {
+            (false, false) => &i,
+            (false, true) => &x_mat,
+            (true, false) => &z_mat,
+            (true, true) => &y_mat,
+        };
+        result = kron(&result, factor);
+    }
+
+    result
 }


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

AI tool used: ChatGPT (OpenAI GPT-5.4 Thinking) for understanding the issue clearly and not relying on it completely.

Fixes #15869.

### Summary

This PR adds the missing dense Pauli-matrix helper required by the existing `PauliProductRotation::matrix()` implementation.

### Details and comments

This PR is intentionally minimal and limited to:
- `crates/circuit/src/gate_matrix.rs`

It adds `pauli_zx_to_matrix(z, x)` so the existing `PauliProductRotation::matrix()` path in `operations.rs` can construct the dense Pauli-product matrix and return the dense rotation matrix correctly.

The resulting matrix follows:

`cos(theta / 2) * I - i * sin(theta / 2) * P`

Validation run locally:
- `cargo fmt --all`
- `cargo check -p qiskit-circuit --lib --all-features`
- `cargo clippy -p qiskit-circuit --lib --all-features -- -D warnings`

