### PR TITLE
Gpu acceleration

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -42,7 +42,12 @@ from qiskit.quantum_info.operators.operator import Operator
 from qiskit.quantum_info.operators.symplectic.pauli import BasePauli
 from qiskit.quantum_info.operators.symplectic.pauli_list import PauliList
 from qiskit.quantum_info.operators.symplectic.pauli import Pauli
+from qiskit.utils import optionals as _optionals
 
+# Minimum number of elements (self.size * other.size * num_qubits) in the compose()
+# intermediate tensor before the GPU path is used.  Below this threshold the PCIe
+# transfer overhead exceeds the compute saving.
+_GPU_COMPOSE_THRESHOLD = 5_000_000
 
 if TYPE_CHECKING:
     from qiskit.transpiler.layout import TranspileLayout
@@ -349,21 +354,46 @@ class SparsePauliOp(LinearOp):
         # This method is the outer version of `BasePauli.compose`.
         # `x1` and `z1` have shape `(self.size, num_qubits)`.
         # `x2` and `z2` have shape `(other.size, num_qubits)`.
-        # `x1[:, no.newaxis]` results in shape `(self.size, 1, num_qubits)`.
-        # `ar = ufunc(x1[:, np.newaxis], x2)` will be in shape `(self.size, other.size, num_qubits)`.
+        # `x1[:, None]` results in shape `(self.size, 1, num_qubits)`.
+        # `ar = ufunc(x1[:, None], x2)` will be in shape `(self.size, other.size, num_qubits)`.
         # So, `ar.reshape((-1, num_qubits))` will be in shape `(self.size * other.size, num_qubits)`.
         # Ref: https://numpy.org/doc/stable/user/theory.broadcasting.html
 
-        phase = np.add.outer(self.paulis._phase, other.paulis._phase).reshape(-1)
-        if front:
-            q = np.logical_and(x1[:, np.newaxis], z2).reshape((-1, num_qubits))
+        # Use GPU (CuPy) when the intermediate tensor is large enough to amortise PCIe
+        # transfer overhead.  Falls back silently to NumPy when CuPy is not installed.
+        _use_gpu = (
+            bool(_optionals.HAS_CUPY)
+            and self.size * other.size * num_qubits > _GPU_COMPOSE_THRESHOLD
+        )
+        if _use_gpu:
+            import cupy as cp  # pylint: disable=import-outside-toplevel
+
+            xp = cp
         else:
-            q = np.logical_and(z1[:, np.newaxis], x2).reshape((-1, num_qubits))
+            xp = np
+
+        _x1 = xp.asarray(x1)
+        _z1 = xp.asarray(z1)
+        _x2 = xp.asarray(x2)
+        _z2 = xp.asarray(z2)
+
+        phase = xp.add.outer(
+            xp.asarray(self.paulis._phase), xp.asarray(other.paulis._phase)
+        ).reshape(-1)
+        if front:
+            q = xp.logical_and(_x1[:, None], _z2).reshape((-1, num_qubits))
+        else:
+            q = xp.logical_and(_z1[:, None], _x2).reshape((-1, num_qubits))
         # `np.mod` will be applied to `phase` in `SparsePauliOp.__init__`
         phase = phase + 2 * q.sum(axis=1, dtype=np.uint8)
 
-        x3 = np.logical_xor(x1[:, np.newaxis], x2).reshape((-1, num_qubits))
-        z3 = np.logical_xor(z1[:, np.newaxis], z2).reshape((-1, num_qubits))
+        x3 = xp.logical_xor(_x1[:, None], _x2).reshape((-1, num_qubits))
+        z3 = xp.logical_xor(_z1[:, None], _z2).reshape((-1, num_qubits))
+
+        if _use_gpu:
+            x3 = cp.asnumpy(x3)
+            z3 = cp.asnumpy(z3)
+            phase = cp.asnumpy(phase)
 
         if qargs is None:
             pauli_list = PauliList(BasePauli(z3, x3, phase))
@@ -377,7 +407,11 @@ class SparsePauliOp(LinearOp):
         # note: the following is a faster code equivalent to
         # `coeffs = np.kron(self.coeffs, other.coeffs)`
         # since `self.coeffs` and `other.coeffs` are both 1d arrays.
-        coeffs = np.multiply.outer(self.coeffs, other.coeffs).ravel()
+        _c1 = xp.asarray(self.coeffs)
+        _c2 = xp.asarray(other.coeffs)
+        coeffs = xp.multiply.outer(_c1, _c2).ravel()
+        if _use_gpu:
+            coeffs = cp.asnumpy(coeffs)
         return SparsePauliOp(pauli_list, coeffs, copy=False)
 
     def tensor(self, other: SparsePauliOp) -> SparsePauliOp:

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -390,18 +390,21 @@ class SparsePauliOp(LinearOp):
         x3 = xp.logical_xor(_x1[:, None], _x2).reshape((-1, num_qubits))
         z3 = xp.logical_xor(_z1[:, None], _z2).reshape((-1, num_qubits))
 
-        if _use_gpu:
-            x3 = cp.asnumpy(x3)
-            z3 = cp.asnumpy(z3)
-            phase = cp.asnumpy(phase)
-
         if qargs is None:
+            if _use_gpu:
+                x3 = cp.asnumpy(x3)
+                z3 = cp.asnumpy(z3)
+                phase = cp.asnumpy(phase)
             pauli_list = PauliList(BasePauli(z3, x3, phase))
         else:
-            x4 = np.repeat(self.paulis.x, other.size, axis=0)
-            z4 = np.repeat(self.paulis.z, other.size, axis=0)
+            x4 = xp.repeat(xp.asarray(self.paulis.x), other.size, axis=0)
+            z4 = xp.repeat(xp.asarray(self.paulis.z), other.size, axis=0)
             x4[:, qargs] = x3
             z4[:, qargs] = z3
+            if _use_gpu:
+                x4 = cp.asnumpy(x4)
+                z4 = cp.asnumpy(z4)
+                phase = cp.asnumpy(phase)
             pauli_list = PauliList(BasePauli(z4, x4, phase))
 
         # note: the following is a faster code equivalent to

--- a/qiskit/utils/optionals.py
+++ b/qiskit/utils/optionals.py
@@ -61,6 +61,12 @@ External Python Libraries
     programming. This is no longer used by Qiskit, but it was historically and the optional
     remains for backwards compatibility.
 
+.. py:data:: HAS_CUPY
+
+    `CuPy <https://cupy.dev/>`__ is a NumPy-compatible array library that runs on NVIDIA GPUs.
+    When available, certain hot-path operations in :class:`.SparsePauliOp` (such as
+    :meth:`~.SparsePauliOp.compose`) will offload large intermediate tensors to the GPU.
+
 .. py:data:: HAS_CVXPY
 
     `CVXPY <https://www.cvxpy.org/>`__ is a Python package for solving convex optimization
@@ -281,6 +287,7 @@ HAS_CPLEX = _LazyImportTester(
     install="pip install cplex",
     msg="This may not be possible for all Python versions and OSes",
 )
+HAS_CUPY = _LazyImportTester("cupy", install="pip install cupy-cuda12x")
 HAS_CVXPY = _LazyImportTester("cvxpy", install="pip install cvxpy")
 HAS_DOCPLEX = _LazyImportTester(
     {"docplex": (), "docplex.mp.model": ("Model",)},

--- a/test/benchmarks/quantum_info.py
+++ b/test/benchmarks/quantum_info.py
@@ -215,8 +215,17 @@ class SparsePauliOpGPUComposeBench:
     ``_GPU_COMPOSE_THRESHOLD`` (5 000 000), ensuring the CuPy branch is taken.
     """
 
-    # (num_qubits, num_terms): product num_terms^2 * num_qubits must be > 5_000_000
-    params = [[10, 800], [20, 520], [30, 420]]
+    # "num_qubits,num_terms": product num_terms^2 * num_qubits must be > 5_000_000
+    # Rows span just-above-threshold (~6M) up to large tensors (~50M) at varying
+    # qubit counts, so we can see how GPU speedup scales with both tensor size and shape.
+    params = [
+        # ~6M elements (just above threshold)
+        "10,800", "20,520", "30,420",
+        # ~20M elements
+        "10,1500", "20,1000", "30,820", "50,640",
+        # ~50M elements
+        "10,2300", "20,1600", "50,1000",
+    ]
     param_names = ["num_qubits,num_terms"]
 
     def setup(self, num_qubits_num_terms):
@@ -225,7 +234,7 @@ class SparsePauliOpGPUComposeBench:
         except ImportError as exc:
             raise NotImplementedError("CuPy not installed") from exc
 
-        num_qubits, num_terms = num_qubits_num_terms
+        num_qubits, num_terms = map(int, num_qubits_num_terms.split(","))
         self.p1 = SparsePauliOp(
             random_pauli_list(num_qubits=num_qubits, size=num_terms, phase=True)
         )
@@ -245,3 +254,48 @@ class SparsePauliOpGPUComposeBench:
 
         with unittest.mock.patch.object(_spo, "_GPU_COMPOSE_THRESHOLD", 10**18):
             self.p1.compose(self.p2)
+
+
+class SparsePauliOpGPUComposeQargsBench:
+    """Benchmark SparsePauliOp.compose with qargs on GPU vs CPU.
+
+    Uses a larger operator composed onto a subset of qubits, exercising the
+    cp.repeat + scatter path added alongside the qargs=None GPU path.
+    """
+
+    # "total_qubits,sub_qubits,num_terms": compose a sub_qubits operator onto
+    # a subset of a total_qubits operator.  num_terms^2 * sub_qubits > 5_000_000.
+    params = [
+        "20,10,800", "30,10,800", "50,10,800",
+        "30,20,520", "50,20,520",
+        "50,30,420",
+    ]
+    param_names = ["total_qubits,sub_qubits,num_terms"]
+
+    def setup(self, params):
+        try:
+            import cupy  # noqa: F401  pylint: disable=import-outside-toplevel
+        except ImportError as exc:
+            raise NotImplementedError("CuPy not installed") from exc
+
+        total_qubits, sub_qubits, num_terms = map(int, params.split(","))
+        self.p1 = SparsePauliOp(
+            random_pauli_list(num_qubits=total_qubits, size=num_terms, phase=True)
+        )
+        self.p2 = SparsePauliOp(
+            random_pauli_list(num_qubits=sub_qubits, size=num_terms, phase=True)
+        )
+        self.qargs = list(range(sub_qubits))
+
+    def time_compose_qargs_gpu(self, _):
+        """GPU path: compose smaller op onto subset of qubits."""
+        self.p1.compose(self.p2, qargs=self.qargs)
+
+    def time_compose_qargs_cpu(self, _):
+        """CPU path on same inputs for direct comparison."""
+        from qiskit.quantum_info.operators.symplectic import (  # pylint: disable=import-outside-toplevel
+            sparse_pauli_op as _spo,
+        )
+
+        with unittest.mock.patch.object(_spo, "_GPU_COMPOSE_THRESHOLD", 10**18):
+            self.p1.compose(self.p2, qargs=self.qargs)

--- a/test/benchmarks/quantum_info.py
+++ b/test/benchmarks/quantum_info.py
@@ -12,6 +12,7 @@
 
 
 import random
+import unittest.mock
 
 import numpy as np
 
@@ -205,3 +206,42 @@ class SparsePauliOpBench:
         self.p1.to_matrix()
 
     time_to_matrix.params = [[2, 4, 6, 8, 10], [50]]
+
+
+class SparsePauliOpGPUComposeBench:
+    """Benchmark SparsePauliOp.compose on the GPU path (requires CuPy).
+
+    Sizes are chosen so that ``self.size * other.size * num_qubits`` exceeds
+    ``_GPU_COMPOSE_THRESHOLD`` (5 000 000), ensuring the CuPy branch is taken.
+    """
+
+    # (num_qubits, num_terms): product num_terms^2 * num_qubits must be > 5_000_000
+    params = [[10, 800], [20, 520], [30, 420]]
+    param_names = ["num_qubits,num_terms"]
+
+    def setup(self, num_qubits_num_terms):
+        try:
+            import cupy  # noqa: F401  pylint: disable=import-outside-toplevel
+        except ImportError as exc:
+            raise NotImplementedError("CuPy not installed") from exc
+
+        num_qubits, num_terms = num_qubits_num_terms
+        self.p1 = SparsePauliOp(
+            random_pauli_list(num_qubits=num_qubits, size=num_terms, phase=True)
+        )
+        self.p2 = SparsePauliOp(
+            random_pauli_list(num_qubits=num_qubits, size=num_terms, phase=True)
+        )
+
+    def time_compose_gpu(self, _):
+        """Force GPU path by using operators already above the threshold."""
+        self.p1.compose(self.p2)
+
+    def time_compose_cpu(self, _):
+        """Force CPU path on the same operator sizes for a direct comparison."""
+        from qiskit.quantum_info.operators.symplectic import (  # pylint: disable=import-outside-toplevel
+            sparse_pauli_op as _spo,
+        )
+
+        with unittest.mock.patch.object(_spo, "_GPU_COMPOSE_THRESHOLD", 10**18):
+            self.p1.compose(self.p2)

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -1448,5 +1448,92 @@ class TestSparsePauliOpMethods(QiskitTestCase):
         )
 
 
+@unittest.skipUnless(optionals.HAS_CUPY, "CuPy required")
+class TestSparsePauliOpGPU(QiskitTestCase):
+    """Tests for GPU-accelerated SparsePauliOp operations (requires CuPy)."""
+
+    RNG = np.random.default_rng(2024)
+
+    def _random_op(self, num_qubits, num_terms):
+        labels = [
+            "".join(self.RNG.choice(["I", "X", "Y", "Z"], size=num_qubits))
+            for _ in range(num_terms)
+        ]
+        coeffs = self.RNG.uniform(-1, 1, num_terms) + 1j * self.RNG.uniform(-1, 1, num_terms)
+        return SparsePauliOp(labels, coeffs)
+
+    def test_compose_gpu_matches_cpu(self):
+        """GPU compose path returns the same result as the CPU path."""
+        import unittest.mock
+
+        from qiskit.quantum_info.operators.symplectic import sparse_pauli_op as _spo_module
+
+        op1 = self._random_op(4, 8)
+        op2 = self._random_op(4, 8)
+        cpu_result = op1.compose(op2)
+
+        # Force the GPU path by temporarily lowering the threshold below the tensor size.
+        with unittest.mock.patch.object(_spo_module, "_GPU_COMPOSE_THRESHOLD", 0):
+            gpu_result = op1.compose(op2)
+
+        np.testing.assert_allclose(
+            cpu_result.to_matrix(), gpu_result.to_matrix(), atol=1e-8
+        )
+
+    def test_compose_gpu_front_matches_cpu(self):
+        """GPU compose with front=True returns the same result as the CPU path."""
+        import unittest.mock
+
+        from qiskit.quantum_info.operators.symplectic import sparse_pauli_op as _spo_module
+
+        op1 = self._random_op(3, 6)
+        op2 = self._random_op(3, 6)
+        cpu_result = op1.compose(op2, front=True)
+
+        with unittest.mock.patch.object(_spo_module, "_GPU_COMPOSE_THRESHOLD", 0):
+            gpu_result = op1.compose(op2, front=True)
+
+        np.testing.assert_allclose(
+            cpu_result.to_matrix(), gpu_result.to_matrix(), atol=1e-8
+        )
+
+    def test_compose_gpu_qargs_matches_cpu(self):
+        """GPU compose with qargs returns the same result as the CPU path."""
+        import unittest.mock
+
+        from qiskit.quantum_info.operators.symplectic import sparse_pauli_op as _spo_module
+
+        op1 = self._random_op(3, 8)
+        op2 = self._random_op(2, 4)
+        qargs = [0, 2]
+        cpu_result = op1.compose(op2, qargs=qargs)
+
+        with unittest.mock.patch.object(_spo_module, "_GPU_COMPOSE_THRESHOLD", 0):
+            gpu_result = op1.compose(op2, qargs=qargs)
+
+        np.testing.assert_allclose(
+            cpu_result.to_matrix(), gpu_result.to_matrix(), atol=1e-8
+        )
+
+    def test_compose_cpu_fallback_matches_gpu(self):
+        """CPU path (above threshold) gives same result as GPU path (threshold=0)."""
+        import unittest.mock
+
+        from qiskit.quantum_info.operators.symplectic import sparse_pauli_op as _spo_module
+
+        op1 = self._random_op(2, 2)
+        op2 = self._random_op(2, 2)
+
+        # Default threshold is well above 2*2*2=8 → CPU path.
+        cpu_result = op1.compose(op2)
+        # Force GPU path.
+        with unittest.mock.patch.object(_spo_module, "_GPU_COMPOSE_THRESHOLD", 0):
+            gpu_result = op1.compose(op2)
+
+        np.testing.assert_allclose(
+            cpu_result.to_matrix(), gpu_result.to_matrix(), atol=1e-8
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ x] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the CONTRIBUTING document.
-->

### Summary

Offloads the boolean tensor operations in `SparsePauliOp.compose()` to the GPU via CuPy when available and the intermediate tensor size exceeds 5,000,000 elements (`self.size × other.size × num_qubits`). Falls back silently to NumPy when CuPy is not installed or the tensor is below the threshold — no behaviour change for existing users.

Closes #15929

### Details and comments

**Changes**

- **`qiskit/utils/optionals.py`** — add `HAS_CUPY` lazy optional tester
- **`SparsePauliOp.compose()`** — select `xp = cupy / numpy` based on tensor size; keep the entire `qargs` branch (including `repeat` + scatter assignment) on GPU, transferring back to CPU only once before constructing `BasePauli`
- **`test/python/.../test_sparse_pauli_op.py`** — add `TestSparsePauliOpGPU` correctness tests (skip when CuPy not installed) covering `qargs=None`, `front=True`, `qargs` set, and CPU/GPU parity
- **`test/benchmarks/quantum_info.py`** — add `SparsePauliOpGPUComposeBench` and `SparsePauliOpGPUComposeQargsBench` with paired `time_compose_cpu` / `time_compose_gpu` methods for direct ASV comparison

**Benchmarks**

Measured on AMD Ryzen 9 7950X + NVIDIA RTX PRO 4500 Blackwell, CUDA 13.2, `cupy-cuda12x`:

*`qargs=None`:*
| Operator size | CPU | GPU | Speedup |
|---|---|---|---|
| 10 qubits, 800 terms | 34ms | 22ms | 1.6x |
| 10 qubits, 1500 terms | 104ms | 59ms | 1.8x |
| 10 qubits, 2300 terms | 238ms | 136ms | 1.8x |
| 50 qubits, 1000 terms | 73ms | 48ms | 1.5x |

*`qargs` set (e.g. `apply_layout`):*
| Operator size | CPU | GPU | Speedup |
|---|---|---|---|
| 50 total / 10 sub, 800 terms | 66ms | 40ms | 1.6x |
| 50 total / 30 sub, 420 terms | 28ms | 16ms | 1.8x |

**Test plan**

- `stestr run quantum_info.operators.symplectic.test_sparse_pauli_op.TestSparsePauliOpGPU` — all 4 pass with CuPy installed
- `stestr run quantum_info.operators.symplectic.test_sparse_pauli_op.TestSparsePauliOpMethods` — 272 pass, 2 skip (pre-existing), 0 fail
- `asv run --python=same --bench SparsePauliOpGPUCompose` — both benchmark classes report GPU speedup


