### PR TITLE
Use quantum_volume() function in the PGO script

### DIFF
--- a/tools/pgo_scripts/test_utility_scale.py
+++ b/tools/pgo_scripts/test_utility_scale.py
@@ -82,7 +82,7 @@ def _main():
     qaoa_circ.name = "qaoa_barabasi_albert_N100_3reps"
     qv_circ = quantum_volume(cmap.size(), seed=123456789)
     qv_circ.measure_all()
-    qv_circ.name = "QV1267650600228229401496703205376"
+    qv_circ.name = "QV12554203470773361527671578846415332832204710888928069025792"
     hwb_circ = qasm2.load(
         os.path.join(QASM_DIR, "hwb12.qasm"),
         include_path=qasm2.LEGACY_INCLUDE_PATH,

--- a/tools/pgo_scripts/test_utility_scale.py
+++ b/tools/pgo_scripts/test_utility_scale.py
@@ -19,7 +19,7 @@ import os
 from qiskit import qasm2
 from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.transpiler import CouplingMap
-from qiskit.circuit.library import QuantumVolume
+from qiskit.circuit.library import quantum_volume
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 
 QASM_DIR = os.path.join(
@@ -80,7 +80,7 @@ def _main():
         strict=False,
     )
     qaoa_circ.name = "qaoa_barabasi_albert_N100_3reps"
-    qv_circ = QuantumVolume(100, seed=123456789)
+    qv_circ = quantum_volume(cmap.size(), seed=123456789)
     qv_circ.measure_all()
     qv_circ.name = "QV1267650600228229401496703205376"
     hwb_circ = qasm2.load(


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the pgo utility scale script to use the quantum_volume generator function instead of the legacy QuantumVolume class. When the script was originally written the generator function didn't exist yet so using the class made sense. But the QuantumVolume class has since been superseded by the rust generator function and also the class has also been deprecated pending removal in a future 3.0 release. Using the generator function now will avoid the deprecation warning during the pgo script run. It will also generate the circuits faster as the function is much faster and also provide profiling data for pgo about the quantum_volume function since it is written in rust.

### Details and comments


