### PR TITLE
Correctly enforce matrix size check in `CommutationChecker`

### DIFF
--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -569,9 +569,9 @@ impl CommutationChecker {
             is_cachable(first_op, first_params) && is_cachable(second_op, second_params);
 
         if !check_cache {
-            // The arguments are sorted, so if qargs1.len() > matrix_max_num_qubits, then
-            // qargs1.len() > matrix_max_num_qubits as well.
-            if qargs2.len() > matrix_max_num_qubits as usize {
+            // The arguments are sorted, so if first_qargs.len() > matrix_max_num_qubits, then
+            // second_qargs.len() > matrix_max_num_qubits as well.
+            if second_qargs.len() > matrix_max_num_qubits as usize {
                 return Ok(false);
             }
 

--- a/releasenotes/notes/fix-cc-size-check-17b1520b60dd756e.yaml
+++ b/releasenotes/notes/fix-cc-size-check-17b1520b60dd756e.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug in :class:`.CommutationChecker` where certain Rust-backed gates, such as
+    the :class:`.UnitaryGate`, could circumvent the matrix size check and cause the
+    calculation of large matrices.

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -501,13 +501,23 @@ class TestCommutationChecker(QiskitTestCase):
             scc.commute(almost_identity, [0], [], other, [0], [], approximation_degree=1 - 1e-4)
         )
 
-    def test_large_custom_gate(self):
-        """Test a large custom gate is caught by the qubit threshold."""
-        big = UnitaryGate(np.eye(2**12))
+    def test_matrix_threshold_noncachable(self):
+        """Test the matrix threshold is obeyed for non-cachable gates."""
+        num_qubits = 2
+        big = UnitaryGate(np.eye(2**num_qubits))
+        qubits = list(range(num_qubits))
         other = HGate()
 
-        self.assertFalse(scc.commute(big, list(range(big.num_qubits)), [], other, [0], []))
-        self.assertFalse(scc.commute(other, [0], [], big, list(range(big.num_qubits)), []))
+        # We check passing args in both orders; [A, B] and [B, A] since the commutation
+        # checking does some sorting which we want to also test here.
+        # Since we should skip the test, the commutation should come out to ``False``,
+        # and only if the matrix check is run (which it shouldn't) this would be ``True``.
+        self.assertFalse(
+            scc.commute(big, qubits, [], other, [0], [], matrix_max_num_qubits=num_qubits - 1)
+        )
+        self.assertFalse(
+            scc.commute(other, [0], [], big, qubits, [], matrix_max_num_qubits=num_qubits - 1)
+        )
 
     @data("pauli", "evolution", "measure")
     def test_pauli_based_gates(self, gate_type):

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -501,6 +501,14 @@ class TestCommutationChecker(QiskitTestCase):
             scc.commute(almost_identity, [0], [], other, [0], [], approximation_degree=1 - 1e-4)
         )
 
+    def test_large_custom_gate(self):
+        """Test a large custom gate is caught by the qubit threshold."""
+        big = UnitaryGate(np.eye(2**12))
+        other = HGate()
+
+        self.assertFalse(scc.commute(big, list(range(big.num_qubits)), [], other, [0], []))
+        self.assertFalse(scc.commute(other, [0], [], big, list(range(big.num_qubits)), []))
+
     @data("pauli", "evolution", "measure")
     def test_pauli_based_gates(self, gate_type):
         """Test Pauli-based gates."""


### PR DESCRIPTION
Fixed the matrix size check for non-cachable gates in the commutation  checker.

A typo in the matrix size check allowed to sneak into a matrix-based check even if the operations exceeded the maximum matrix size. The operations `first_..` and `second_..` are sorted, but `..1` and `..2` are not! The wrong one was used here.