### PR TITLE
Rewrite QPY `ParameterExpression` handling in pure Polish form

### DIFF
--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -135,7 +135,7 @@ impl fmt::Display for ParameterExpression {
 impl ParameterExpression {
     pub fn qpy_replay(&self) -> Vec<OPReplay> {
         let mut replay = Vec::new();
-        let mut unused: IndexSet<_> = self.name_map.values().cloned().collect();
+        let mut unused: IndexSet<_, ahash::RandomState> = self.name_map.values().cloned().collect();
         // The recursive inner `qpy_replay` assumes it starts from a containing operation, so fails
         // to build a complete replay in the case it starts from a single symbol or value.
         match &self.expr {
@@ -2075,7 +2075,7 @@ fn qpy_replay_inner(
     expr: &ParameterExpression,
     name_map: &HashMap<String, Symbol>,
     replay: &mut Vec<OPReplay>,
-    unused: &mut IndexSet<Symbol>,
+    unused: &mut IndexSet<Symbol, ahash::RandomState>,
 ) {
     match &expr.expr {
         // This function is written under the assumption that the top-level expression involves an

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -154,7 +154,10 @@ impl ParameterExpression {
                     Value::Complex(v) => OPReplay {
                         op: OpCode::ADD,
                         lhs: Some(ParameterValueType::Complex(v)),
-                        rhs: Some(ParameterValueType::Float(-0.0)),
+                        rhs: Some(ParameterValueType::Complex(Complex64 {
+                            re: -0.0,
+                            im: -0.0,
+                        })),
                     },
                 };
                 replay.push(item);
@@ -171,15 +174,14 @@ impl ParameterExpression {
                 qpy_replay(self, &self.name_map, &mut replay, &mut unused);
             }
         }
-        // For any unused symbols, we'll add something like `expr + x - x`.  This sort of
-        // cancellation is how unused symbols appear; it doesn't matter if the _actual_ cause was `0
-        // * x` or whatever, because the end observable effect is the same.
+        // For any unused symbols, we'll add something like `(x * 0) + expr`.  This sort of
+        // cancellation is how unused symbols appear; it doesn't matter if the _actual_ cause was
+        // `x - x` or whatever, because the end observable effect is the same.
         for symbol in unused {
-            let operand = ParameterValueType::from_symbol(symbol);
             replay.push(OPReplay {
-                op: OpCode::SUB,
-                lhs: Some(operand.clone()),
-                rhs: Some(operand),
+                op: OpCode::MUL,
+                lhs: Some(ParameterValueType::from_symbol(symbol)),
+                rhs: Some(ParameterValueType::Int(0)),
             });
             replay.push(OPReplay {
                 op: OpCode::ADD,

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -171,7 +171,7 @@ impl ParameterExpression {
                 });
             }
             SymbolExpr::Unary { .. } | SymbolExpr::Binary { .. } => {
-                qpy_replay(self, &self.name_map, &mut replay, &mut unused);
+                qpy_replay_inner(self, &self.name_map, &mut replay, &mut unused);
             }
         }
         // For any unused symbols, we'll add something like `(x * 0) + expr`.  This sort of
@@ -2071,7 +2071,7 @@ fn filter_name_map(
     }
 }
 
-fn qpy_replay(
+fn qpy_replay_inner(
     expr: &ParameterExpression,
     name_map: &HashMap<String, Symbol>,
     replay: &mut Vec<OPReplay>,
@@ -2103,7 +2103,7 @@ fn qpy_replay(
             let lhs = filter_name_map(expr, name_map);
 
             // recurse on the instruction
-            qpy_replay(&lhs, name_map, replay, unused);
+            qpy_replay_inner(&lhs, name_map, replay, unused);
 
             let lhs_value = ParameterValueType::extract_from_expr(expr);
 
@@ -2129,8 +2129,8 @@ fn qpy_replay(
             // recurse on the parameter expressions
             let lhs = filter_name_map(lhs, name_map);
             let rhs = filter_name_map(rhs, name_map);
-            qpy_replay(&lhs, name_map, replay, unused);
-            qpy_replay(&rhs, name_map, replay, unused);
+            qpy_replay_inner(&lhs, name_map, replay, unused);
+            qpy_replay_inner(&rhs, name_map, replay, unused);
 
             // add the expression to the replay
             match lhs_value {

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -136,8 +136,8 @@ impl ParameterExpression {
     pub fn qpy_replay(&self) -> Vec<OPReplay> {
         let mut replay = Vec::new();
         let mut unused: IndexSet<_, ahash::RandomState> = self.name_map.values().cloned().collect();
-        // The recursive inner `qpy_replay` assumes it starts from a containing operation, so fails
-        // to build a complete replay in the case it starts from a single symbol or value.
+        // The recursive inner `qpy_replay_inner` assumes it starts from a containing operation, so
+        // fails to build a complete replay in the case it starts from a single symbol or value.
         match &self.expr {
             SymbolExpr::Value(v) => {
                 let item = match *v {
@@ -149,6 +149,8 @@ impl ParameterExpression {
                     Value::Real(v) => OPReplay {
                         op: OpCode::ADD,
                         lhs: Some(ParameterValueType::Float(v)),
+                        // `-0.0` is technically the identity element of floating-point addition;
+                        // `0.0 + x` is not bit-for-bit equal to `x` solely if `x` is `-0.0`.
                         rhs: Some(ParameterValueType::Float(-0.0)),
                     },
                     Value::Complex(v) => OPReplay {

--- a/crates/circuit/src/parameter/parameter_expression.rs
+++ b/crates/circuit/src/parameter/parameter_expression.rs
@@ -12,6 +12,7 @@
 
 use hashbrown::hash_map::Entry;
 use hashbrown::{HashMap, HashSet};
+use indexmap::IndexSet;
 use num_complex::Complex64;
 use pyo3::exceptions::{PyRuntimeError, PyTypeError, PyValueError, PyZeroDivisionError};
 use pyo3::types::{IntoPyDict, PyComplex, PyFloat, PyInt, PyNotImplemented, PySet, PyString};
@@ -134,7 +135,58 @@ impl fmt::Display for ParameterExpression {
 impl ParameterExpression {
     pub fn qpy_replay(&self) -> Vec<OPReplay> {
         let mut replay = Vec::new();
-        qpy_replay(self, &self.name_map, &mut replay);
+        let mut unused: IndexSet<_> = self.name_map.values().cloned().collect();
+        // The recursive inner `qpy_replay` assumes it starts from a containing operation, so fails
+        // to build a complete replay in the case it starts from a single symbol or value.
+        match &self.expr {
+            SymbolExpr::Value(v) => {
+                let item = match *v {
+                    Value::Int(v) => OPReplay {
+                        op: OpCode::ADD,
+                        lhs: Some(ParameterValueType::Int(v)),
+                        rhs: Some(ParameterValueType::Int(0)),
+                    },
+                    Value::Real(v) => OPReplay {
+                        op: OpCode::ADD,
+                        lhs: Some(ParameterValueType::Float(v)),
+                        rhs: Some(ParameterValueType::Float(-0.0)),
+                    },
+                    Value::Complex(v) => OPReplay {
+                        op: OpCode::ADD,
+                        lhs: Some(ParameterValueType::Complex(v)),
+                        rhs: Some(ParameterValueType::Float(-0.0)),
+                    },
+                };
+                replay.push(item);
+            }
+            SymbolExpr::Symbol(sym) => {
+                unused.swap_remove(sym.as_ref());
+                replay.push(OPReplay {
+                    op: OpCode::ADD,
+                    lhs: ParameterValueType::extract_from_expr(&self.expr),
+                    rhs: Some(ParameterValueType::Int(0)),
+                });
+            }
+            SymbolExpr::Unary { .. } | SymbolExpr::Binary { .. } => {
+                qpy_replay(self, &self.name_map, &mut replay, &mut unused);
+            }
+        }
+        // For any unused symbols, we'll add something like `expr + x - x`.  This sort of
+        // cancellation is how unused symbols appear; it doesn't matter if the _actual_ cause was `0
+        // * x` or whatever, because the end observable effect is the same.
+        for symbol in unused {
+            let operand = ParameterValueType::from_symbol(symbol);
+            replay.push(OPReplay {
+                op: OpCode::SUB,
+                lhs: Some(operand.clone()),
+                rhs: Some(operand),
+            });
+            replay.push(OPReplay {
+                op: OpCode::ADD,
+                lhs: None,
+                rhs: None,
+            });
+        }
         replay
     }
 }
@@ -188,21 +240,16 @@ impl ParameterExpression {
     ///
     /// This only succeeds if the underlying expression is, in fact, only a symbol.
     pub fn try_to_symbol(&self) -> Result<Symbol, ParameterError> {
-        if let SymbolExpr::Symbol(symbol) = &self.expr {
-            Ok(symbol.as_ref().clone())
-        } else {
-            Err(ParameterError::NotASymbol)
-        }
+        self.try_to_symbol_ref().cloned()
     }
 
     /// Try casting to a [Symbol], returning a reference.
     ///
     /// This only succeeds if the underlying expression is, in fact, only a symbol.
     pub fn try_to_symbol_ref(&self) -> Result<&Symbol, ParameterError> {
-        if let SymbolExpr::Symbol(symbol) = &self.expr {
-            Ok(symbol.as_ref())
-        } else {
-            Err(ParameterError::NotASymbol)
+        match &self.expr {
+            SymbolExpr::Symbol(sym) if self.name_map.len() == 1 => Ok(sym.as_ref()),
+            _ => Err(ParameterError::NotASymbol),
         }
     }
 
@@ -257,17 +304,10 @@ impl ParameterExpression {
     }
 
     /// Load from a sequence of [OPReplay]s. Used in serialization.
-    pub fn from_qpy(
-        replay: &[OPReplay],
-        subs_operations: Option<Vec<(usize, HashMap<Symbol, ParameterExpression>)>>,
-    ) -> Result<Self, ParameterError> {
+    pub fn from_qpy(replay: &[OPReplay]) -> Result<Self, ParameterError> {
         // the stack contains the latest lhs and rhs values
         let mut stack: Vec<ParameterExpression> = Vec::new();
-        let subs_operations = subs_operations.unwrap_or_default();
-        let mut current_sub_operation = subs_operations.len(); // we avoid using a queue since we only make one pass anyway
-        for (i, inst) in replay.iter().enumerate() {
-            let OPReplay { op, lhs, rhs } = inst;
-
+        for OPReplay { op, lhs, rhs } in replay {
             // put the values on the stack, if they exist
             if let Some(value) = lhs {
                 stack.push(value.clone().into());
@@ -312,15 +352,6 @@ impl ParameterExpression {
                 }
             };
             stack.push(result);
-            //now check whether any substitutions need to be applied at this stage
-            while current_sub_operation > 0 && subs_operations[current_sub_operation - 1].0 == i + 1
-            {
-                if let Some(exp) = stack.pop() {
-                    let sub_exp = exp.subs(&subs_operations[current_sub_operation - 1].1, false)?;
-                    stack.push(sub_exp);
-                }
-                current_sub_operation -= 1;
-            }
         }
 
         // once we're done, just return the last element in the stack
@@ -1370,49 +1401,18 @@ impl PyParameterExpression {
         }
     }
 
-    fn __getstate__(&self) -> PyResult<(Vec<OPReplay>, Option<ParameterValueType>)> {
-        // We distinguish in two cases:
-        //  (a) This is indeed an expression which can be rebuild from the QPY replay. This means
-        //      the replay is *not empty* and it contains all symbols.
-        //  (b) This expression is in fact only a Value or a Symbol. In this case, the QPY replay
-        //      will be empty and we instead pass a `ParameterValueType` for reconstruction.
-        let qpy = self._qpy_replay()?;
-        if !qpy.is_empty() {
-            Ok((qpy, None))
-        } else {
-            let value = ParameterValueType::extract_from_expr(&self.inner.expr);
-            if value.is_none() {
-                Err(PyValueError::new_err(format!(
-                    "Failed to serialize the parameter expression: {self:?}"
-                )))
-            } else {
-                Ok((qpy, value))
-            }
-        }
+    fn __getstate__(&self) -> Vec<OPReplay> {
+        self._qpy_replay()
     }
 
-    fn __setstate__(&mut self, state: (Vec<OPReplay>, Option<ParameterValueType>)) -> PyResult<()> {
-        // if there a replay, load from the replay
-        if !state.0.is_empty() {
-            let from_qpy = ParameterExpression::from_qpy(&state.0, None)?;
-            self.inner = from_qpy;
-        // otherwise, load from the ParameterValueType
-        } else if let Some(value) = state.1 {
-            let expr = ParameterExpression::from(value);
-            self.inner = expr;
-        } else {
-            return Err(PyValueError::new_err(
-                "Failed to read QPY replay or extract value.",
-            ));
-        }
+    fn __setstate__(&mut self, state: Vec<OPReplay>) -> PyResult<()> {
+        self.inner = ParameterExpression::from_qpy(&state)?;
         Ok(())
     }
 
     #[getter]
-    fn _qpy_replay(&self) -> PyResult<Vec<OPReplay>> {
-        let mut replay = Vec::new();
-        qpy_replay(&self.inner, &self.inner.name_map, &mut replay);
-        Ok(replay)
+    fn _qpy_replay(&self) -> Vec<OPReplay> {
+        self.inner.qpy_replay()
     }
 }
 
@@ -1872,6 +1872,13 @@ pub enum ParameterValueType {
 }
 
 impl ParameterValueType {
+    fn from_symbol(symbol: Symbol) -> Self {
+        if symbol.index.is_some() {
+            Self::VectorElement(PyParameterVectorElement { symbol })
+        } else {
+            Self::Parameter(PyParameter { symbol })
+        }
+    }
     fn extract_from_expr(expr: &SymbolExpr) -> Option<ParameterValueType> {
         if let Some(value) = expr.eval(true) {
             match value {
@@ -1880,20 +1887,7 @@ impl ParameterValueType {
                 Value::Complex(c) => Some(ParameterValueType::Complex(c)),
             }
         } else if let SymbolExpr::Symbol(symbol) = expr {
-            match symbol.index {
-                None => {
-                    let param = PyParameter {
-                        symbol: symbol.as_ref().clone(),
-                    };
-                    Some(ParameterValueType::Parameter(param))
-                }
-                Some(_) => {
-                    let param = PyParameterVectorElement {
-                        symbol: symbol.as_ref().clone(),
-                    };
-                    Some(ParameterValueType::VectorElement(param))
-                }
-            }
+            Some(Self::from_symbol(symbol.as_ref().clone()))
         } else {
             // ParameterExpressions have the value None, as they must be constructed
             None
@@ -2075,14 +2069,18 @@ fn filter_name_map(
     }
 }
 
-pub fn qpy_replay(
+fn qpy_replay(
     expr: &ParameterExpression,
     name_map: &HashMap<String, Symbol>,
     replay: &mut Vec<OPReplay>,
+    unused: &mut IndexSet<Symbol>,
 ) {
     match &expr.expr {
-        SymbolExpr::Value(_) | SymbolExpr::Symbol(_) => {
-            // nothing to do here, we only need to traverse instructions
+        // This function is written under the assumption that the top-level expression involves an
+        // operation, since `OPReplay` items correspond to operations that own their operands.
+        SymbolExpr::Value(_) => (),
+        SymbolExpr::Symbol(sym) => {
+            unused.swap_remove(sym.as_ref());
         }
         SymbolExpr::Unary { op, expr } => {
             let op = match op {
@@ -2103,7 +2101,7 @@ pub fn qpy_replay(
             let lhs = filter_name_map(expr, name_map);
 
             // recurse on the instruction
-            qpy_replay(&lhs, name_map, replay);
+            qpy_replay(&lhs, name_map, replay, unused);
 
             let lhs_value = ParameterValueType::extract_from_expr(expr);
 
@@ -2129,8 +2127,8 @@ pub fn qpy_replay(
             // recurse on the parameter expressions
             let lhs = filter_name_map(lhs, name_map);
             let rhs = filter_name_map(rhs, name_map);
-            qpy_replay(&lhs, name_map, replay);
-            qpy_replay(&rhs, name_map, replay);
+            qpy_replay(&lhs, name_map, replay, unused);
+            qpy_replay(&rhs, name_map, replay, unused);
 
             // add the expression to the replay
             match lhs_value {

--- a/crates/circuit/src/parameter/symbol_expr.rs
+++ b/crates/circuit/src/parameter/symbol_expr.rs
@@ -13,6 +13,7 @@
 use hashbrown::HashMap;
 use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyValueError;
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::cmp::PartialOrd;
 use std::convert::From;
@@ -123,12 +124,17 @@ impl Symbol {
         &self.name
     }
 
+    pub fn fullname(&self) -> Cow<'_, str> {
+        self.index
+            .map(|i| Cow::Owned(format!("{}[{}]", &self.name, i)))
+            .unwrap_or(Cow::Borrowed(&self.name))
+    }
+
     pub fn repr(&self, with_uuid: bool) -> String {
-        match (self.index, with_uuid) {
-            (Some(i), true) => format!("{}[{}]_{}", self.name, i, self.uuid.as_u128()),
-            (Some(i), false) => format!("{}[{}]", self.name, i),
-            (None, true) => format!("{}_{}", self.name, self.uuid.as_u128()),
-            (None, false) => self.name.clone(),
+        if with_uuid {
+            format!("{}_{}", self.fullname(), self.uuid.as_u128())
+        } else {
+            self.fullname().into_owned()
         }
     }
     pub fn is_vector_element(&self) -> bool {

--- a/crates/qpy/src/formats.rs
+++ b/crates/qpy/src/formats.rs
@@ -661,6 +661,11 @@ pub enum ParameterExpressionSymbolPack {
     Parameter(ParameterExpressionParameterSymbolPack),
     #[brw(magic = b'v')]
     ParameterVector(ParameterExpressionParameterVectorSymbolPack),
+    /// This variant _should not_ exist; it is counter to the QPY spec, and has no semantic meaning.
+    /// However, Qiskit 2.0 (with QPY 13 non-symengine serialisation but before Rust-space
+    /// `ParameterExpression` or QPY) would populate the "symbol map" with the raw dictionaries
+    /// given to `ParameterExpression.subs` calls, which include expressions.  The equivalent "read"
+    /// code would load up the entries, then immediately filter them out to make the symbol map.
     #[brw(magic = b'e')]
     ParameterExpression(ParameterExpressionParameterExpressionSymbolPack),
 }

--- a/crates/qpy/src/params.rs
+++ b/crates/qpy/src/params.rs
@@ -10,11 +10,12 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 use binrw::Endian;
+use num_complex::Complex64;
 use pyo3::prelude::*;
 use qiskit_circuit::imports;
 use qiskit_circuit::operations::Param;
 use qiskit_circuit::parameter::parameter_expression::{
-    OPReplay, OpCode, ParameterExpression, ParameterValueType, PyParameter,
+    OPReplay, ParameterExpression, ParameterValueType,
 };
 use qiskit_circuit::parameter::symbol_expr::Symbol;
 use std::sync::Arc;
@@ -43,13 +44,18 @@ use hashbrown::HashMap;
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ParameterType {
     Integer = b'i',
+    /// The payload is an immediate-value float.
     Float = b'f',
+    /// The payload is an immediate-value complex number.
     Complex = b'c',
+    /// The payload is an immediate-value UUID corresponding to a `Symbol` in the expression's map.
     Parameter = b'p',
-    ParameterVector = b'v',
+    /// There is no immediate value; take an expression off the stack instead.
     Null = b'n',
-    LhsExpression = b's',
-    RhsExpression = b'e',
+    /// Should only occur when the "op code" type is "expression". Carries no data.
+    StartExpression = b's',
+    /// Should only occur when the "op code" type is "expression". Carries no data.
+    EndExpression = b'e',
 }
 
 fn parameter_type_name(type_key: &ParameterType) -> String {
@@ -58,10 +64,9 @@ fn parameter_type_name(type_key: &ParameterType) -> String {
         ParameterType::Float => "float",
         ParameterType::Complex => "complex",
         ParameterType::Parameter => "parameter",
-        ParameterType::ParameterVector => "parameter vector",
         ParameterType::Null => "null",
-        ParameterType::LhsExpression => "lhs expression",
-        ParameterType::RhsExpression => "rhs expression",
+        ParameterType::StartExpression => "start expression",
+        ParameterType::EndExpression => "end expression",
     })
 }
 
@@ -79,7 +84,6 @@ impl TryFrom<ParameterType> for ValueType {
             ParameterType::Float => Ok(ValueType::Float),
             ParameterType::Integer => Ok(ValueType::Integer),
             ParameterType::Null => Ok(ValueType::Null),
-            ParameterType::ParameterVector => Ok(ValueType::ParameterVector),
             ParameterType::Parameter => Ok(ValueType::Parameter),
             _ => Err(QpyError::ConversionError(format!(
                 "Cannot convert to value type {}",
@@ -119,56 +123,6 @@ pub(crate) fn pack_parameter_expression_by_op(
             "Invalid opcode: {}",
             opcode
         ))),
-    }
-}
-
-pub(crate) fn unpack_parameter_expression_standard_op(
-    packed_parameter: formats::ParameterExpressionElementPack,
-) -> Result<(u8, formats::ParameterExpressionStandardOpPack), QpyError> {
-    match packed_parameter {
-        formats::ParameterExpressionElementPack::Add(op) => Ok((0, op)),
-        formats::ParameterExpressionElementPack::Sub(op) => Ok((1, op)),
-        formats::ParameterExpressionElementPack::Mul(op) => Ok((2, op)),
-        formats::ParameterExpressionElementPack::Div(op) => Ok((3, op)),
-        formats::ParameterExpressionElementPack::Pow(op) => Ok((4, op)),
-        formats::ParameterExpressionElementPack::Sin(op) => Ok((5, op)),
-        formats::ParameterExpressionElementPack::Cos(op) => Ok((6, op)),
-        formats::ParameterExpressionElementPack::Tan(op) => Ok((7, op)),
-        formats::ParameterExpressionElementPack::Asin(op) => Ok((8, op)),
-        formats::ParameterExpressionElementPack::Acos(op) => Ok((9, op)),
-        formats::ParameterExpressionElementPack::Exp(op) => Ok((10, op)),
-        formats::ParameterExpressionElementPack::Log(op) => Ok((11, op)),
-        formats::ParameterExpressionElementPack::Sign(op) => Ok((12, op)),
-        formats::ParameterExpressionElementPack::Grad(op) => Ok((13, op)),
-        formats::ParameterExpressionElementPack::Conj(op) => Ok((14, op)),
-        formats::ParameterExpressionElementPack::Abs(op) => Ok((16, op)),
-        formats::ParameterExpressionElementPack::Atan(op) => Ok((17, op)),
-        formats::ParameterExpressionElementPack::Rsub(op) => Ok((18, op)),
-        formats::ParameterExpressionElementPack::Rdiv(op) => Ok((19, op)),
-        formats::ParameterExpressionElementPack::Rpow(op) => Ok((20, op)),
-        formats::ParameterExpressionElementPack::Expression(op) => Ok((255, op)),
-        _ => Err(QpyError::ConversionError(format!(
-            "Non standard operation {:?}",
-            packed_parameter
-        ))),
-    }
-}
-
-fn parameter_value_type_from_generic_value(
-    value: &GenericValue,
-) -> Result<ParameterValueType, QpyError> {
-    match value {
-        GenericValue::Complex64(complex) => Ok(ParameterValueType::Complex(*complex)),
-        GenericValue::Int64(int) => Ok(ParameterValueType::Int(*int)),
-        GenericValue::Float64(float) => Ok(ParameterValueType::Float(*float)),
-        GenericValue::ParameterExpressionSymbol(symbol) => {
-            Ok(ParameterValueType::Parameter(PyParameter {
-                symbol: symbol.clone(),
-            }))
-        }
-        _ => Err(QpyError::ConversionError(
-            "Data value that cannot be stored as a parameter value".to_string(),
-        )),
     }
 }
 
@@ -227,18 +181,15 @@ fn pack_symbol_table_element(
 fn pack_parameter_expression_elements(
     exp: &ParameterExpression,
 ) -> Result<Vec<formats::ParameterExpressionElementPack>, QpyError> {
-    let mut result = Vec::new();
-    for replay_obj in exp.qpy_replay().iter() {
-        let packed_parameter = pack_parameter_expression_element(replay_obj)?;
-        result.extend(packed_parameter);
-    }
-    Ok(result)
+    exp.qpy_replay()
+        .iter()
+        .map(pack_parameter_expression_element)
+        .collect()
 }
 
 fn pack_parameter_expression_element(
     replay_obj: &OPReplay,
-) -> Result<Vec<formats::ParameterExpressionElementPack>, QpyError> {
-    let mut result = Vec::new();
+) -> Result<formats::ParameterExpressionElementPack, QpyError> {
     let (lhs_type, lhs) = pack_parameter_replay_entry(&replay_obj.lhs)?;
     let (rhs_type, rhs) = pack_parameter_replay_entry(&replay_obj.rhs)?;
     let op_code = replay_obj.op as u8;
@@ -248,9 +199,7 @@ fn pack_parameter_expression_element(
         rhs_type,
         rhs,
     };
-    let packed_parameter = vec![pack_parameter_expression_by_op(op_code, entry)?];
-    result.extend(packed_parameter);
-    Ok(result)
+    pack_parameter_expression_by_op(op_code, entry)
 }
 
 // this function identifies the data type of the parameter replay entry
@@ -291,171 +240,227 @@ fn pack_parameter_replay_entry(
 }
 
 pub(crate) fn unpack_parameter_expression(
-    parameter_expression_pack: &formats::ParameterExpressionPack,
+    pack: &formats::ParameterExpressionPack,
     qpy_data: &mut QPYReadData,
 ) -> Result<ParameterExpression, QpyError> {
-    // we begin by loading the symbol table data and hashing it according to each symbol's uuid
-    let mut param_uuid_map: HashMap<[u8; 16], GenericValue> = HashMap::new(); // For QPY version >= 15
-    let mut param_name_map: HashMap<String, GenericValue> = if qpy_data.version < 15 {
-        HashMap::with_capacity(parameter_expression_pack.symbol_table_data.len())
-    } else {
-        HashMap::with_capacity(0)
-    };
-    for item in &parameter_expression_pack.symbol_table_data {
-        let (symbol_uuid, value, symbol_name) = match item {
-            formats::ParameterExpressionSymbolPack::ParameterExpression(_) => {
-                continue;
-            }
-            formats::ParameterExpressionSymbolPack::Parameter(symbol_pack) => {
-                let symbol = unpack_symbol(&symbol_pack.symbol_data);
-                let value = match symbol_pack.value_key {
-                    ValueType::Parameter => GenericValue::ParameterExpressionSymbol(symbol.clone()),
-                    _ => load_value(symbol_pack.value_key, &symbol_pack.value_data, qpy_data)?,
-                };
-                (
-                    symbol_pack.symbol_data.uuid,
-                    value,
-                    symbol_pack.symbol_data.name.clone(),
-                )
-            }
-            formats::ParameterExpressionSymbolPack::ParameterVector(symbol_pack) => {
-                // this call will also create the corresponding vector and update qpy_data if needed
-                let symbol = unpack_parameter_vector(&symbol_pack.symbol_data, qpy_data)?;
-                let value = match symbol_pack.value_key {
-                    ValueType::ParameterVector => {
-                        GenericValue::ParameterExpressionSymbol(symbol.clone())
+    let uuid_map = pack.symbol_table_data.iter().try_fold(
+        HashMap::new(),
+        |mut map, item| -> Result<_, QpyError> {
+            let symbol = match item {
+                // The QPY format (ever since V1) says that this mapping can have a value type after
+                // it.  Actually, anything other than a "value" that's the zero-data case (meaning
+                // it's just a `Parameter`/`ParameterVectorElement` definition) is completely
+                // meaningless; all versions of Python-space Qiskit QPY loads would immediately
+                // violate their own data models by constructing a `ParameterExpression` with an
+                // invalid `symbol_map`. No version of Qiskit has ever _written_ a QPY file with
+                // such a mapping, which is likely how it went unnoticed for so long.
+                //
+                // We simply treat a value mapping as an error; the semantics aren't defined.
+                formats::ParameterExpressionSymbolPack::Parameter(p) => {
+                    if p.value_key != ValueType::Parameter {
+                        return Err(QpyError::InvalidValueType {
+                            expected: "parameter".to_owned(),
+                            actual: p.value_key.to_string(),
+                        });
                     }
-                    _ => load_value(symbol_pack.value_key, &symbol_pack.value_data, qpy_data)?,
-                };
-                (symbol_pack.symbol_data.uuid, value, symbol.repr(false))
-            }
-        };
-        param_uuid_map.insert(symbol_uuid, value.clone());
-        if qpy_data.version < 15 {
-            param_name_map.insert(symbol_name, value.clone());
-        }
-    }
-    let parameter_expression_data = deserialize_vec::<formats::ParameterExpressionElementPack>(
-        &parameter_expression_pack.expression_data,
+                    unpack_symbol(&p.symbol_data)
+                }
+                formats::ParameterExpressionSymbolPack::ParameterVector(v) => {
+                    if v.value_key != ValueType::ParameterVector {
+                        return Err(QpyError::InvalidValueType {
+                            expected: "parameter vector element".to_owned(),
+                            actual: v.value_key.to_string(),
+                        });
+                    }
+                    unpack_parameter_vector(&v.symbol_data, qpy_data)?
+                }
+                // This variant should not exist; see its documentation comment.  We have to
+                // silently skip it to handle loading incorrect QPY files from Qiskit 2.0 with
+                // substitutions involving expressions.
+                formats::ParameterExpressionSymbolPack::ParameterExpression(_) => {
+                    return Ok(map);
+                }
+            };
+            map.insert(symbol.uuid, symbol);
+            Ok(map)
+        },
     )?;
+    let name_map = if qpy_data.version < 15 {
+        uuid_map
+            .values()
+            .map(|sym| (sym.name().to_owned(), sym.clone()))
+            .collect::<HashMap<_, _>>()
+    } else {
+        // Not used for QPY >= 15, so no need to bother calculating it.
+        Default::default()
+    };
 
-    // we now convert the parameter_expression_data into Vec<OPReplay> that can be used via ParameterExpression::from_qpy
-    let mut replay: Vec<OPReplay> = Vec::new();
-    // Due to sub operations being different than the other elements of the replay, we store them separately, with an index
-    // indicating when to perform them
-    let mut sub_operations: Vec<(usize, HashMap<Symbol, ParameterExpression>)> = Vec::new();
-    for element in parameter_expression_data {
-        if let formats::ParameterExpressionElementPack::Substitute(subs) = element {
-            let mapping_pack = deserialize::<formats::MappingPack>(&subs.mapping_data)?.0;
-            let mut subs_mapping: HashMap<Symbol, ParameterExpression> = HashMap::new();
-
-            for item in mapping_pack.items {
-                let (value_generic_item, key_generic_item) = if qpy_data.version >= 15 {
-                    // UUID based element hashing used in QPY >= 15
-                    let key_uuid: [u8; 16] = (&item.key_bytes).try_into()?;
-                    let value_generic_item =
-                        load_value(item.item_type, &item.item_bytes, qpy_data)?;
-                    let key_generic_item = param_uuid_map.get(&key_uuid).ok_or_else(|| {
-                        QpyError::ConversionError(format!(
-                            "Parameter UUID not found: {:?}",
-                            &key_uuid
-                        ))
-                    })?;
-                    (value_generic_item, key_generic_item)
-                } else {
-                    // Name based element hashing used in QPY <= 14
-                    let key_name: String = item.key_bytes.try_into()?;
-                    // This line could lead to clashes in the case of duplicate parameter names
-                    // This is indeed the reason QPY15 moved to UUID based hashing
-                    let value_generic_item =
-                        load_value(item.item_type, &item.item_bytes, qpy_data)?;
-                    let key_generic_item = param_name_map.get(&key_name).ok_or_else(|| {
-                        QpyError::ConversionError(format!(
-                            "Parameter name not found: {:?}",
-                            &key_name
-                        ))
-                    })?;
-                    (value_generic_item, key_generic_item)
-                };
-                let key = if let GenericValue::ParameterExpressionSymbol(symbol) = key_generic_item
-                {
-                    symbol
-                } else {
-                    return Err(QpyError::ConversionError(format!(
-                        "Substitution command used left operand {:?} which is not a symbol",
-                        &key_generic_item
-                    )));
-                };
-
-                let value = match value_generic_item {
-                    GenericValue::ParameterExpressionSymbol(symbol) => {
-                        ParameterExpression::from_symbol(symbol)
-                    }
-                    GenericValue::ParameterExpressionVectorSymbol(symbol) => {
-                        ParameterExpression::from_symbol(symbol)
-                    }
-                    GenericValue::ParameterExpression(exp) => exp.as_ref().clone(),
-                    _ => {
-                        return Err(QpyError::ConversionError(format!(
-                            "Substitution command used right operand {:?} which is not a parameter expression",
-                            &value_generic_item
-                        )));
-                    }
-                };
-                subs_mapping.insert(key.clone(), value);
+    let empty_stack = || {
+        QpyError::DeserializationError(
+            "malformed expression: stack was empty before expression completed".to_string(),
+        )
+    };
+    let unknown_parameter = || {
+        QpyError::InvalidParameter(
+            "malformed expression: reference to unknown parameter".to_string(),
+        )
+    };
+    let unexpected_recursion = || {
+        QpyError::DeserializationError(
+            "malformed expression: encountered recursive marker in unexpected location".to_string(),
+        )
+    };
+    let mut stack = Vec::<ParameterExpression>::new();
+    let operand = |stack: &mut Vec<ParameterExpression>, ty, data: [u8; 16]| {
+        let upper = |data: [u8; 16]| bytemuck::cast::<[u8; 16], [[u8; 8]; 2]>(data)[1];
+        let lower = |data: [u8; 16]| bytemuck::cast::<[u8; 16], [[u8; 8]; 2]>(data)[0];
+        match ty {
+            ParameterType::Integer => {
+                let i = i64::from_be_bytes(upper(data));
+                Ok(ParameterValueType::Int(i).into())
             }
-            let _opcode = OpCode::SUBSTITUTE;
-            sub_operations.push((replay.len(), subs_mapping));
-        } else {
-            let (opcode, op) = unpack_parameter_expression_standard_op(element)?;
-            // loading values from replay pack is tricky, since everything is stored using 16-bytes, even 8-byte ints and floats
-            // LHS
-            let lhs: Option<ParameterValueType> = match op.lhs_type {
-                ParameterType::Parameter | ParameterType::ParameterVector => {
-                    if let Some(value) = param_uuid_map.get(&op.lhs) {
-                        Some(parameter_value_type_from_generic_value(value)?)
-                    } else {
-                        return Err(QpyError::ConversionError(format!(
-                            "Parameter UUID not found: {:?}",
-                            op.lhs
-                        )));
-                    }
-                }
-                ParameterType::Float | ParameterType::Integer | ParameterType::Complex => {
-                    let value =
-                        load_value(ValueType::try_from(op.lhs_type)?, &op.lhs.into(), qpy_data)?;
-                    Some(parameter_value_type_from_generic_value(&value)?)
-                }
-                ParameterType::Null => None, // pass
-                ParameterType::LhsExpression | ParameterType::RhsExpression => continue,
-            };
-            // RHS
-            let rhs: Option<ParameterValueType> = match op.rhs_type {
-                ParameterType::Parameter | ParameterType::ParameterVector => {
-                    if let Some(value) = param_uuid_map.get(&op.rhs) {
-                        Some(parameter_value_type_from_generic_value(value)?)
-                    } else {
-                        return Err(QpyError::ConversionError(format!(
-                            "Parameter UUID not found: {:?}",
-                            op.rhs
-                        )));
-                    }
-                }
-                ParameterType::Float | ParameterType::Integer | ParameterType::Complex => {
-                    let value =
-                        load_value(ValueType::try_from(op.rhs_type)?, &op.rhs.into(), qpy_data)?;
-                    Some(parameter_value_type_from_generic_value(&value)?)
-                }
-                ParameterType::Null => None, // pass
-                ParameterType::LhsExpression | ParameterType::RhsExpression => continue,
-            };
-            let op = OpCode::from_u8(opcode)?;
-            replay.push(OPReplay { op, lhs, rhs });
+            ParameterType::Float => {
+                let f = f64::from_be_bytes(upper(data));
+                Ok(ParameterValueType::Float(f).into())
+            }
+            ParameterType::Complex => {
+                let re = f64::from_be_bytes(upper(data));
+                let im = f64::from_be_bytes(lower(data));
+                Ok(ParameterValueType::Complex(Complex64 { re, im }).into())
+            }
+            ParameterType::Parameter => uuid_map
+                .get(&Uuid::from_bytes(data))
+                .map(|sym| ParameterExpression::from_symbol(sym.clone()))
+                .ok_or_else(unknown_parameter),
+            ParameterType::Null => stack.pop().ok_or_else(empty_stack),
+            ParameterType::StartExpression | ParameterType::EndExpression => {
+                Err(unexpected_recursion())
+            }
+        }
+    };
+    let lhs_rhs = |stack: &mut Vec<ParameterExpression>,
+                   pack: &formats::ParameterExpressionStandardOpPack|
+     -> Result<[ParameterExpression; 2], QpyError> {
+        let rhs = operand(stack, pack.rhs_type, pack.rhs)?;
+        let lhs = operand(stack, pack.lhs_type, pack.lhs)?;
+        Ok([lhs, rhs])
+    };
+    let expr_from_value = |value| -> Result<ParameterExpression, QpyError> {
+        match value {
+            GenericValue::ParameterExpressionSymbol(sym)
+            | GenericValue::ParameterExpressionVectorSymbol(sym) => {
+                Ok(ParameterExpression::from_symbol(sym))
+            }
+            GenericValue::ParameterExpression(expr) => Ok((*expr).clone()),
+            GenericValue::Int64(_) | GenericValue::Float64(_) | GenericValue::Complex64(_) => {
+                // These could/should be handled, but Python-space `ParameterExpression` had a split
+                // between `subs`/`bind` (where `bind` was only for numeric values) that
+                // Python-space QPY replays have never correctly generated or handled, so for now we
+                // skip.  The intended semantics from the QPY specification are clear.
+                Err(QpyError::DeserializationError(
+                    "internal error: unhandled numeric value in substitution".to_string(),
+                ))
+            }
+            _ => Err(QpyError::InvalidValueType {
+                expected: "a parameter expression".to_string(),
+                actual: "arbitrary value".to_string(),
+            }),
+        }
+    };
+    let elements =
+        deserialize_vec::<formats::ParameterExpressionElementPack>(&pack.expression_data)?;
+    for element in elements {
+        use formats::ParameterExpressionElementPack::*;
+        let out = match element {
+            Add(vals) => {
+                let [lhs, rhs] = lhs_rhs(&mut stack, &vals)?;
+                lhs.add(&rhs)?
+            }
+            Sub(vals) => {
+                let [lhs, rhs] = lhs_rhs(&mut stack, &vals)?;
+                lhs.sub(&rhs)?
+            }
+            Mul(vals) => {
+                let [lhs, rhs] = lhs_rhs(&mut stack, &vals)?;
+                lhs.mul(&rhs)?
+            }
+            Div(vals) => {
+                let [lhs, rhs] = lhs_rhs(&mut stack, &vals)?;
+                lhs.div(&rhs)?
+            }
+            Pow(vals) => {
+                let [lhs, rhs] = lhs_rhs(&mut stack, &vals)?;
+                lhs.pow(&rhs)?
+            }
+            Sin(vals) => operand(&mut stack, vals.lhs_type, vals.lhs)?.sin(),
+            Cos(vals) => operand(&mut stack, vals.lhs_type, vals.lhs)?.cos(),
+            Tan(vals) => operand(&mut stack, vals.lhs_type, vals.lhs)?.tan(),
+            Asin(vals) => operand(&mut stack, vals.lhs_type, vals.lhs)?.asin(),
+            Acos(vals) => operand(&mut stack, vals.lhs_type, vals.lhs)?.acos(),
+            Exp(vals) => operand(&mut stack, vals.lhs_type, vals.lhs)?.exp(),
+            Log(vals) => operand(&mut stack, vals.lhs_type, vals.lhs)?.log(),
+            Sign(vals) => operand(&mut stack, vals.lhs_type, vals.lhs)?.sign(),
+            Grad(vals) => {
+                let [lhs, rhs] = lhs_rhs(&mut stack, &vals)?;
+                lhs.derivative(&rhs.try_to_symbol()?)?
+            }
+            Conj(vals) => operand(&mut stack, vals.lhs_type, vals.lhs)?.conjugate(),
+            Abs(vals) => operand(&mut stack, vals.lhs_type, vals.lhs)?.abs(),
+            Atan(vals) => operand(&mut stack, vals.lhs_type, vals.lhs)?.atan(),
+            Rsub(vals) => {
+                let [lhs, rhs] = lhs_rhs(&mut stack, &vals)?;
+                rhs.sub(&lhs)?
+            }
+            Rdiv(vals) => {
+                let [lhs, rhs] = lhs_rhs(&mut stack, &vals)?;
+                rhs.div(&lhs)?
+            }
+            Rpow(vals) => {
+                let [lhs, rhs] = lhs_rhs(&mut stack, &vals)?;
+                rhs.pow(&lhs)?
+            }
+            Substitute(payload) => {
+                let pack = deserialize::<formats::MappingPack>(&payload.mapping_data)?.0;
+                let version = qpy_data.version;
+                let mapping = pack
+                    .items
+                    .iter()
+                    .map(|item| -> Result<_, QpyError> {
+                        let sym = if version >= 15 {
+                            let key = Uuid::from_slice(&item.key_bytes).map_err(|_| {
+                                QpyError::DeserializationError(
+                                    "invalid mapping: uuid incorrect length".to_string(),
+                                )
+                            })?;
+                            uuid_map.get(&key).ok_or_else(unknown_parameter)?.clone()
+                        } else {
+                            let key = std::str::from_utf8(&item.key_bytes)?;
+                            name_map.get(key).ok_or_else(unknown_parameter)?.clone()
+                        };
+                        let replacement = expr_from_value(load_value(
+                            item.item_type,
+                            &item.item_bytes,
+                            qpy_data,
+                        )?)?;
+                        Ok((sym, replacement))
+                    })
+                    .collect::<Result<HashMap<_, _>, QpyError>>()?;
+                stack.pop().ok_or_else(empty_stack)?.subs(&mapping, false)?
+            }
+            // The "expression" payload (marking the start or end of a recursive definition) doesn't
+            // actually carry any payload or have any meaning.  If we do nothing in its loop
+            // iteration, we still manipulate the stack in the same way we're supposed to.
+            Expression(_) => continue,
         };
+        stack.push(out);
     }
-    ParameterExpression::from_qpy(&replay, Some(sub_operations)).map_err(|_| {
-        QpyError::ConversionError("Failure while loading parameter expression".to_string())
-    })
+    if stack.len() > 1 {
+        return Err(QpyError::DeserializationError(format!(
+            "malformed expression stack: {} remaining items",
+            stack.len()
+        )));
+    }
+    stack.pop().ok_or_else(empty_stack)
 }
 
 pub(crate) fn pack_symbol(symbol: &Symbol) -> formats::ParameterSymbolPack {

--- a/crates/qpy/src/params.rs
+++ b/crates/qpy/src/params.rs
@@ -43,6 +43,7 @@ use hashbrown::HashMap;
 #[repr(u8)]
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ParameterType {
+    /// The payload is an immediate-value integer.
     Integer = b'i',
     /// The payload is an immediate-value float.
     Float = b'f',

--- a/crates/qpy/src/params.rs
+++ b/crates/qpy/src/params.rs
@@ -288,7 +288,7 @@ pub(crate) fn unpack_parameter_expression(
     let name_map = if qpy_data.version < 15 {
         uuid_map
             .values()
-            .map(|sym| (sym.name().to_owned(), sym.clone()))
+            .map(|sym| (sym.fullname().into_owned(), sym.clone()))
             .collect::<HashMap<_, _>>()
     } else {
         // Not used for QPY >= 15, so no need to bother calculating it.
@@ -300,10 +300,10 @@ pub(crate) fn unpack_parameter_expression(
             "malformed expression: stack was empty before expression completed".to_string(),
         )
     };
-    let unknown_parameter = || {
-        QpyError::InvalidParameter(
-            "malformed expression: reference to unknown parameter".to_string(),
-        )
+    let unknown_parameter = |repr: String| {
+        QpyError::InvalidParameter(format!(
+            "malformed expression: reference to unknown parameter: {repr}"
+        ))
     };
     let unexpected_recursion = || {
         QpyError::DeserializationError(
@@ -328,10 +328,13 @@ pub(crate) fn unpack_parameter_expression(
                 let im = f64::from_be_bytes(lower(data));
                 Ok(ParameterValueType::Complex(Complex64 { re, im }).into())
             }
-            ParameterType::Parameter => uuid_map
-                .get(&Uuid::from_bytes(data))
-                .map(|sym| ParameterExpression::from_symbol(sym.clone()))
-                .ok_or_else(unknown_parameter),
+            ParameterType::Parameter => {
+                let key = Uuid::from_bytes(data);
+                uuid_map
+                    .get(&key)
+                    .map(|sym| ParameterExpression::from_symbol(sym.clone()))
+                    .ok_or_else(|| unknown_parameter(format!("{key:?}")))
+            }
             ParameterType::Null => stack.pop().ok_or_else(empty_stack),
             ParameterType::StartExpression | ParameterType::EndExpression => {
                 Err(unexpected_recursion())
@@ -432,10 +435,16 @@ pub(crate) fn unpack_parameter_expression(
                                     "invalid mapping: uuid incorrect length".to_string(),
                                 )
                             })?;
-                            uuid_map.get(&key).ok_or_else(unknown_parameter)?.clone()
+                            uuid_map
+                                .get(&key)
+                                .ok_or_else(|| unknown_parameter(format!("{key:?}")))?
+                                .clone()
                         } else {
                             let key = std::str::from_utf8(&item.key_bytes)?;
-                            name_map.get(key).ok_or_else(unknown_parameter)?.clone()
+                            name_map
+                                .get(key)
+                                .ok_or_else(|| unknown_parameter(key.to_string()))?
+                                .clone()
                         };
                         let replacement = expr_from_value(load_value(
                             item.item_type,

--- a/qiskit/qpy/binary_io/value.py
+++ b/qiskit/qpy/binary_io/value.py
@@ -680,25 +680,12 @@ def _read_parameter_expr_v13(buf, symbol_map, version, vectors):
         if expression_data.OP_CODE == 255:
             continue
         method_str = op_code_to_method(expression_data.OP_CODE)
-        if expression_data.OP_CODE in {0, 1, 2, 3, 4, 13, 15, 18, 19, 20}:
+        if expression_data.OP_CODE in (0, 1, 2, 3, 4, 13, 15, 18, 19, 20):
             rhs = stack.pop()
             lhs = stack.pop()
-            # Reverse ops for commutative ops, which are add, mul (0 and 2 respectively)
-            # op codes 13 and 15 can never be reversed and 18, 19, 20
-            # are the reversed versions of non-commutative operations
-            # so 1, 3, 4 and 18, 19, 20 handle this explicitly.
-            if (
-                not isinstance(lhs, ParameterExpression)
-                and isinstance(rhs, ParameterExpression)
-                and expression_data.OP_CODE in {0, 2}
-            ):
-                if expression_data.OP_CODE == 0:
-                    method_str = "__radd__"
-                elif expression_data.OP_CODE == 2:
-                    method_str = "__rmul__"
-                stack.append(getattr(rhs, method_str)(lhs))
-            else:
-                stack.append(getattr(lhs, method_str)(rhs))
+            if not isinstance(lhs, ParameterExpression):
+                lhs = ParameterExpression._Value(lhs)
+            stack.append(getattr(lhs, method_str)(rhs))
         else:
             lhs = stack.pop()
             stack.append(getattr(lhs, method_str)())

--- a/releasenotes/notes/fix-parameterexpression-replay-154ba293a5c598ed.yaml
+++ b/releasenotes/notes/fix-parameterexpression-replay-154ba293a5c598ed.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    :class:`.ParameterExpression` instances with cancelled-out variables (like ``x - x``) will now
+    retain the reference to ``x`` after a round-trip through QPY and pickle.
+  - |
+    :class:`.ParameterExpression` instances that evaluated to a bare value (like ``0*x + 2``) will
+    now successfully round-trip through QPY and pickle.

--- a/releasenotes/notes/fix-parameterexpression-replay-154ba293a5c598ed.yaml
+++ b/releasenotes/notes/fix-parameterexpression-replay-154ba293a5c598ed.yaml
@@ -6,3 +6,13 @@ fixes:
   - |
     :class:`.ParameterExpression` instances that evaluated to a bare value (like ``0*x + 2``) will
     now successfully round-trip through QPY and pickle.
+issues:
+  - |
+    Qiskit v2.2 and v2.3 can generate unreadable QPY files for circuits containing a
+    :class:`.ParameterExpression` where all the contained :class:`.Parameter` instances were
+    cancelled out of the final expression.  For example, if the expression ``0*x + 1.5`` appears in
+    a circuit, Qiskit v2.2 and v2.3 will both produce a QPY file that cannot be read by any version
+    of Qiskit, including themselves and v2.4, due to errors in the QPY generation.
+
+    This error will typically appear (in Qiskit v2.4, at least) as a :exc:`.QpyError` with a message
+    such as "malformed expression: stack was empty before expression completed".

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -366,6 +366,23 @@ class TestLoadFromQPY(QiskitTestCase):
         self.assertEqual(qc, new_circuit)
         self.assertDeprecatedBitProperties(qc, new_circuit)
 
+    def test_degenerate_parameter_expression(self):
+        """Test a circuit with a parameter expression that simplifies to 0."""
+        x = Parameter("x")
+        y_vec = ParameterVector("y", 2)
+        z = Parameter("z")
+        cases = [0 * x, 0 * x + 2, 0 * x + z, x - x, 0 * y_vec[0], 0 * (x + y_vec[1])]
+        for case in cases:
+            qc = QuantumCircuit(1)
+            qc.rz(case, 0)
+            qpy_file = io.BytesIO()
+            dump(qc, qpy_file)
+            qpy_file.seek(0)
+            new_circuit = load(qpy_file)[0]
+            self.assertEqual(qc, new_circuit)
+            # should still have the same parameters even if they are not used
+            self.assertEqual(qc.parameters, new_circuit.parameters)
+
     def test_string_parameter(self):
         """Test a PauliGate instruction that has string parameters."""
 

--- a/test/python/circuit/test_parameter_expression.py
+++ b/test/python/circuit/test_parameter_expression.py
@@ -15,6 +15,8 @@
 import cmath
 import math
 import unittest
+import pickle
+import copy
 
 from test import combine
 from test import QiskitTestCase
@@ -491,6 +493,16 @@ class TestParameterExpression(QiskitTestCase):
                 result = expr.gradient(param)
                 self.assertIsInstance(result, (int, float, complex))
                 self.assertEqual(result, expected)
+
+    @ddt.idata(operand for operand in operands if isinstance(operand, ParameterExpression))
+    def test_pickle_roundtrip(self, expr):
+        pickled = pickle.loads(pickle.dumps(expr))
+        copied = copy.copy(expr)
+        deep_copied = copy.deepcopy(expr)
+        self.assertEqual([expr] * 3, [pickled, copied, deep_copied])
+        self.assertEqual(
+            [expr.parameters] * 3, [pickled.parameters, copied.parameters, deep_copied.parameters]
+        )
 
     @unittest.skipUnless(HAS_SYMPY, "Sympy is required for this test")
     def test_sympify_all_ops(self):

--- a/test/python/qpy/test_roundtrip.py
+++ b/test/python/qpy/test_roundtrip.py
@@ -78,6 +78,7 @@ class TestQPYRoundtrip(QiskitTestCase):
         )
         self.assertEqual(circuit, new_circuit)
         self.assertEqual(circuit.layout, new_circuit.layout)
+        self.assertEqual(circuit.parameters, new_circuit.parameters)
 
     @all_qpy_combinations(QPY_RUST_READ_MIN_VERSION)
     def test_simple(self, version, write_with, read_with):
@@ -222,6 +223,20 @@ class TestQPYRoundtrip(QiskitTestCase):
         exp = exp.subs({b: a})
         qc.ry(exp, 0)
         self.assert_roundtrip_equal(qc, version=version, read_with=read_with, write_with=write_with)
+
+    @all_qpy_combinations(QPY_RUST_READ_MIN_VERSION)
+    def test_degenerate_parameter_expression(self, version, write_with, read_with):
+        """Test a circuit with a parameter expression that simplifies to 0."""
+        x = Parameter("x")
+        y_vec = ParameterVector("y", 2)
+        z = Parameter("z")
+        cases = [0 * x, 0 * x + 2, 0 * x + z, x - x, 0 * y_vec[0], 0 * (x + y_vec[1])]
+        for case in cases:
+            qc = QuantumCircuit(1)
+            qc.rz(case, 0)
+            self.assert_roundtrip_equal(
+                qc, version=version, write_with=write_with, read_with=read_with
+            )
 
     @all_qpy_combinations(QPY_RUST_READ_MIN_VERSION)
     def test_random_circuits(self, version, write_with, read_with):

--- a/test/qpy_compat/dockerfile
+++ b/test/qpy_compat/dockerfile
@@ -7,6 +7,6 @@ ARG PACKAGE_VERSION=
 ENV PIP_NO_CACHE_DIR=1 PIP_DISABLE_PIP_VERSION_CHECK=1 PYTHONDONTWRITEBYTECODE=1
 WORKDIR /work
 COPY qpy_test_constraints.txt .
-RUN python -m pip install --upgrade pip && pip install -c qpy_test_constraints.txt "${PACKAGE_NAME}==${PACKAGE_VERSION}"; 
+RUN python -m pip install --upgrade pip && pip install -c qpy_test_constraints.txt packaging "${PACKAGE_NAME}==${PACKAGE_VERSION}";
 
 CMD ["python", "-c", "import qiskit; import sys; print(f'Qiskit version: {qiskit.__version__}'); print(f'Python version: {sys.version}')"]

--- a/test/qpy_compat/process_version_with_venv.sh
+++ b/test/qpy_compat/process_version_with_venv.sh
@@ -49,7 +49,7 @@ venv_dir="$(pwd -P)/venvs/$package-$version"
 if [[ ! -d $cache_dir ]] ; then
     echo "Building venv for $package==$version"
     "$python" -m venv "$venv_dir"
-    "$venv_dir/bin/pip" install -c "${our_dir}/qpy_test_constraints.txt" "${package}==${version}"
+    "$venv_dir/bin/pip" install -c "${our_dir}/qpy_test_constraints.txt" "${package}==${version}" packaging
     mkdir -p "$cache_dir"
     pushd "$cache_dir"
     echo "Generating QPY files with $package==$version"

--- a/test/qpy_compat/run_tests.sh
+++ b/test/qpy_compat/run_tests.sh
@@ -82,7 +82,7 @@ for i in "${!symengine_versions[@]}"; do
     symengine_venv="$symengine_venv_prefix$i"
     files_dir="$symengine_files_prefix$i"
     python -m venv "$symengine_venv"
-    "$symengine_venv/bin/pip" install -c "$repo_root/constraints.txt" "$qiskit_dev_wheel" "symengine$specifier"
+    "$symengine_venv/bin/pip" install -c "$repo_root/constraints.txt" packaging "$qiskit_dev_wheel" "symengine$specifier"
     mkdir -p "$files_dir"
     pushd "$files_dir"
     "$symengine_venv/bin/python" -c 'import symengine; print(symengine.__version__)' > "SYMENGINE_VERSION"

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -15,13 +15,13 @@
 """Test cases to verify qpy backwards compatibility."""
 
 import argparse
-
 import itertools
 import random
 import re
 import sys
 
 import numpy as np
+from packaging.version import Version
 
 import qiskit
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
@@ -38,52 +38,6 @@ try:
     from qiskit.qpy import dump, load
 except ModuleNotFoundError:
     from qiskit.circuit.qpy_serialization import dump, load
-
-
-# This version pattern is taken from the pypa packaging project:
-# https://github.com/pypa/packaging/blob/21.3/packaging/version.py#L223-L254
-# which is dual licensed Apache 2.0 and BSD see the source for the original
-# authors and other details
-VERSION_PATTERN = (
-    "^"
-    + r"""
-    v?
-    (?:
-        (?:(?P<epoch>[0-9]+)!)?                           # epoch
-        (?P<release>[0-9]+(?:\.[0-9]+)*)                  # release segment
-        (?P<pre>                                          # pre-release
-            [-_\.]?
-            (?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))
-            [-_\.]?
-            (?P<pre_n>[0-9]+)?
-        )?
-        (?P<post>                                         # post release
-            (?:-(?P<post_n1>[0-9]+))
-            |
-            (?:
-                [-_\.]?
-                (?P<post_l>post|rev|r)
-                [-_\.]?
-                (?P<post_n2>[0-9]+)?
-            )
-        )?
-        (?P<dev>                                          # dev release
-            [-_\.]?
-            (?P<dev_l>dev)
-            [-_\.]?
-            (?P<dev_n>[0-9]+)?
-        )?
-    )
-    (?:\+(?P<local>[a-z0-9]+(?:[-_\.][a-z0-9]+)*))?       # local version
-"""
-    + "$"
-)
-
-
-def version_release_parts(version: str):
-    """The "release" component of a valid Python version string, as a tuple of integers."""
-    version_match = re.search(VERSION_PATTERN, version, re.VERBOSE | re.IGNORECASE)
-    return tuple(int(x) for x in version_match.group("release").split("."))
 
 
 def generate_full_circuit():
@@ -130,7 +84,7 @@ def generate_random_circuits(version):
         qc.measure_all()
         for j in range(i):
             qc.reset(j)
-            if version >= (2, 0, 0):
+            if version.release >= (2, 0, 0):
                 condition = (qc.cregs[0], i)
                 body = QuantumCircuit([qc.qubits[0]])
                 body.x(0)
@@ -302,7 +256,7 @@ def generate_single_clbit_condition_teleportation(version):
     teleport_qc = QuantumCircuit(qr, cr, name="Reset Test")
     teleport_qc.x(0)
     teleport_qc.measure(0, cr[0])
-    if version >= (2, 0, 0):
+    if version.release >= (2, 0, 0):
         condition = (cr[0], 1)
         body = QuantumCircuit([teleport_qc.qubits[0]])
         body.x(0)
@@ -469,7 +423,7 @@ def generate_schedule_blocks(current_version):
             builder.barrier(channels.DriveChannel(0), channels.DriveChannel(1))
             gaussian_amp = 0.1
             gaussian_angle = 0.7
-            if current_version < (1, 0, 0):
+            if current_version.release < (1, 0, 0):
                 builder.play(
                     library.Gaussian(160, gaussian_amp * np.exp(1j * gaussian_angle), 40),
                     channels.DriveChannel(0),
@@ -564,7 +518,7 @@ def generate_controlled_gates(version):
     """Test QPY serialization with custom ControlledGates."""
     circuits = []
     qc = QuantumCircuit(3, name="custom_controlled_gates")
-    if version >= (2, 3, 0):
+    if version.release >= (2, 3, 0):
         controlled_gate = DCXGate().control(1, annotated=False)
     else:
         controlled_gate = DCXGate().control(1)
@@ -577,7 +531,7 @@ def generate_controlled_gates(version):
     custom_gate.definition = custom_definition
     nested_qc = QuantumCircuit(3, name="nested_qc")
     qc.append(custom_gate, [0])
-    if version >= (2, 3, 0):
+    if version.release >= (2, 3, 0):
         controlled_gate = custom_gate.control(2, annotated=False)
     else:
         controlled_gate = custom_gate.control(2)
@@ -593,7 +547,7 @@ def generate_open_controlled_gates(version):
     """Test QPY serialization with custom ControlledGates with open controls."""
     circuits = []
     qc = QuantumCircuit(3, name="open_controls_simple")
-    if version >= (2, 3, 0):
+    if version.release >= (2, 3, 0):
         controlled_gate = DCXGate().control(1, ctrl_state=0, annotated=False)
     else:
         controlled_gate = DCXGate().control(1, ctrl_state=0)
@@ -607,7 +561,7 @@ def generate_open_controlled_gates(version):
     custom_gate.definition = custom_definition
     nested_qc = QuantumCircuit(3, name="open_controls_nested")
     nested_qc.append(custom_gate, [0])
-    if version >= (2, 3, 0):
+    if version.release >= (2, 3, 0):
         controlled_gate = custom_gate.control(2, ctrl_state=1, annotated=False)
     else:
         controlled_gate = custom_gate.control(2, ctrl_state=1)
@@ -852,8 +806,10 @@ def generate_v12_expr():
     return [index, shift]
 
 
-def generate_replay_with_expressions():
+def generate_replay_with_expressions(version):
     """Circuits with parameters that have expressions in the replay"""
+    out = []
+
     a = Parameter("a")
     b = Parameter("b")
     c = Parameter("c")
@@ -863,6 +819,7 @@ def generate_replay_with_expressions():
     a2 = a1.subs({a: 3 * b})
     qc = QuantumCircuit(1)
     qc.rz(a2, 0)
+    out.append(qc)
 
     qc2 = QuantumCircuit(1)
     theta = Parameter("θ")
@@ -871,14 +828,19 @@ def generate_replay_with_expressions():
     exp = exp.subs({theta: rz})
     exp = exp.subs({rz: theta})
     qc2.rz(exp, 0)
+    out.append(qc2)
 
     pv = ParameterVector("rz", 2)
     qc3 = QuantumCircuit(1, name="subs-vector")
     qc3.rz((pv[0] + 0.5).subs({pv[0]: pv[1]}), 0)
 
-    cancelled = QuantumCircuit(1, name="cancellations")
-    for case in (0 * a, 0 * a + 2, 0 * a + b, a - a, 0 * pv[0], 0 * (pv[0] + pv[1] + a)):
-        cancelled.rz(case, 0)
+    # Qiskit versions between 2.2.0rc1 and 2.4.0rc2 inclusive generate invalid QPY files for
+    # expressions involving cancellations.
+    if not (Version("2.2.0rc1") <= version < Version("2.4.0rc3")):
+        cancelled = QuantumCircuit(1, name="cancellations")
+        for case in (0 * a, 0 * a + 2, 0 * a + b, a - a, 0 * pv[0], 0 * (pv[0] + pv[1] + a)):
+            cancelled.rz(case, 0)
+        out.append(cancelled)
 
     everything = QuantumCircuit(1, name="everything")
     expression = (a + b.sin() * 0.25) * c**2
@@ -892,8 +854,9 @@ def generate_replay_with_expressions():
     final_expr = final_expr.abs()
     final_expr = final_expr.subs({c: a})
     everything.rz(final_expr, 0)
+    out.append(everything)
 
-    return [qc, qc2, qc3, cancelled, everything]
+    return out
 
 
 def generate_v14_expr():
@@ -968,7 +931,7 @@ def generate_box():
     return [bare, nested]
 
 
-def generate_circuits(version_parts, current_version, load_context=False):
+def generate_circuits(generating_version, current_version, load_context=False):
     """Generate reference circuits.
 
     If load_context is True, avoid generating Pulse-based reference
@@ -983,69 +946,75 @@ def generate_circuits(version_parts, current_version, load_context=False):
         "register_edge_cases.qpy": generate_register_edge_cases(),
         "parameterized.qpy": [generate_parameterized_circuit()],
     }
-    if version_parts is None:
-        return output_circuits
 
-    if version_parts >= (0, 18, 1):
+    if generating_version.release >= (0, 18, 1):
         output_circuits["qft_circuit.qpy"] = [generate_qft_circuit()]
         output_circuits["teleport.qpy"] = [
             generate_single_clbit_condition_teleportation(current_version)
         ]
 
-    if version_parts >= (0, 19, 0):
+    if generating_version.release >= (0, 19, 0):
         output_circuits["param_phase.qpy"] = generate_param_phase()
 
-    if version_parts >= (0, 19, 1):
+    if generating_version.release >= (0, 19, 1):
         output_circuits["parameter_vector.qpy"] = [generate_parameter_vector()]
         output_circuits["pauli_evo.qpy"] = [generate_evolution_gate()]
         output_circuits["parameter_vector_expression.qpy"] = [
             generate_parameter_vector_expression()
         ]
-    if version_parts >= (0, 19, 2):
+    if generating_version.release >= (0, 19, 2):
         output_circuits["control_flow.qpy"] = generate_control_flow_circuits()
-    if version_parts >= (0, 21, 0) and version_parts < (2, 0):
+    if (0, 21, 0) <= generating_version.release < (2, 0):
         output_circuits["schedule_blocks.qpy"] = (
             None if load_context else generate_schedule_blocks(current_version)
         )
         output_circuits["pulse_gates.qpy"] = (
             None if load_context else generate_calibrated_circuits()
         )
-    if version_parts >= (0, 24, 0) and version_parts < (2, 0):
+    if (0, 24, 0) <= generating_version.release < (2, 0):
         output_circuits["referenced_schedule_blocks.qpy"] = (
             None if load_context else generate_referenced_schedule()
         )
-    if version_parts >= (0, 24, 0):
+    if generating_version.release >= (0, 24, 0):
         output_circuits["control_flow_switch.qpy"] = generate_control_flow_switch_circuits()
-    if version_parts >= (0, 24, 1):
+    if generating_version.release >= (0, 24, 1):
         output_circuits["open_controlled_gates.qpy"] = generate_open_controlled_gates(
             current_version
         )
         output_circuits["controlled_gates.qpy"] = generate_controlled_gates(current_version)
-    if version_parts >= (0, 24, 2):
+    if generating_version.release >= (0, 24, 2):
         output_circuits["layout.qpy"] = generate_layout_circuits()
-    if version_parts >= (0, 25, 0) and version_parts < (2, 0):
+    if (0, 25, 0) <= generating_version.release < (2, 0):
         output_circuits["acquire_inst_with_kernel_and_disc.qpy"] = (
             None if load_context else generate_acquire_instruction_with_kernel_and_discriminator()
         )
         output_circuits["control_flow_expr.qpy"] = generate_control_flow_expr()
-    if version_parts >= (0, 45, 2):
+    if generating_version.release >= (0, 45, 2):
         output_circuits["clifford.qpy"] = generate_clifford_circuits()
-    if version_parts >= (1, 0, 0):
+    if generating_version.release >= (1, 0, 0):
         output_circuits["annotated.qpy"] = generate_annotated_circuits()
-    if version_parts >= (1, 1, 0):
+    if generating_version.release >= (1, 1, 0):
         output_circuits["standalone_vars.qpy"] = generate_standalone_var()
         output_circuits["v12_expr.qpy"] = generate_v12_expr()
-    if version_parts >= (1, 4, 1):
-        output_circuits["replay_with_expressions.qpy"] = generate_replay_with_expressions()
+    if generating_version.release >= (1, 4, 1):
+        output_circuits["replay_with_expressions.qpy"] = generate_replay_with_expressions(
+            generating_version
+        )
 
-    if version_parts >= (2, 0, 0):
+    if generating_version.release >= (2, 0, 0):
         output_circuits["v14_expr.qpy"] = generate_v14_expr()
         output_circuits["box.qpy"] = generate_box()
     return output_circuits
 
 
 def assert_equal(
-    reference, qpy, count, version_parts, bind=None, equivalent=False, context="Unknown context"
+    reference,
+    qpy,
+    count,
+    generating_version,
+    bind=None,
+    equivalent=False,
+    context="Unknown context",
 ):
     """Compare two circuits."""
     reference_parameter_names = [x.name for x in reference.parameters]
@@ -1081,7 +1050,7 @@ def assert_equal(
 
     # Check deprecated bit properties, if set.  The QPY dumping code before Terra 0.23.2 didn't
     # include enough information for us to fully reconstruct this, so we only test if newer.
-    if version_parts >= (0, 23, 2) and isinstance(reference, QuantumCircuit):
+    if generating_version.release >= (0, 23, 2) and isinstance(reference, QuantumCircuit):
         for ref_bit, qpy_bit in itertools.chain(
             zip(reference.qubits, qpy.qubits), zip(reference.clbits, qpy.clbits)
         ):
@@ -1097,7 +1066,7 @@ def assert_equal(
                 sys.exit(1)
 
     if (
-        version_parts >= (0, 24, 2)
+        generating_version.release >= (0, 24, 2)
         and isinstance(reference, QuantumCircuit)
         and reference.layout != qpy.layout
     ):
@@ -1125,7 +1094,7 @@ def generate_qpy(qpy_files):
             dump(circuits, fd)
 
 
-def load_qpy(qpy_files, version_parts):
+def load_qpy(qpy_files, generating_version):
     """Load qpy circuits from files and compare to reference circuits."""
     pulse_files = {
         "schedule_blocks.qpy": (0, 21, 0),
@@ -1160,12 +1129,12 @@ def load_qpy(qpy_files, version_parts):
             elif path == "replay_with_expressions.qpy":
                 bind = [2.0, 1.5, 0.125, -0.25, 0.75]
 
-            context = f"Version {version_parts}, QPY file {path}, Circuit number {i}"
+            context = f"Version {generating_version}, QPY file {path}, Circuit number {i}"
             assert_equal(
                 circuit,
                 qpy_circuits[i],
                 i,
-                version_parts,
+                generating_version,
                 bind=bind,
                 equivalent=equivalent,
                 context=context,
@@ -1177,7 +1146,7 @@ def load_qpy(qpy_files, version_parts):
 
         # version_parts is the version of Qiskit used to generate the payloads being loaded in this test.
         # min_version is the minimal version of Qiskit this pulse payload was generated with.
-        if version_parts < min_version or version_parts >= (2, 0):
+        if generating_version.release < min_version or generating_version.release >= (2, 0):
             continue
 
         if path == "pulse_gates.qpy":
@@ -1215,19 +1184,17 @@ def _main():
     )
     args = parser.parse_args()
 
-    current_version = version_release_parts(qiskit.__version__)
+    current_version = Version(qiskit.__version__)
 
     # Terra 0.18.0 was the first release with QPY, so that's the default.
-    version_parts = (0, 18, 0)
-    if args.version:
-        version_parts = version_release_parts(args.version)
+    generating_version = Version(args.version or "0.18.0")
 
     if args.command == "generate":
-        qpy_files = generate_circuits(version_parts, current_version)
+        qpy_files = generate_circuits(generating_version, current_version)
         generate_qpy(qpy_files)
     else:
-        qpy_files = generate_circuits(version_parts, current_version, load_context=True)
-        load_qpy(qpy_files, version_parts)
+        qpy_files = generate_circuits(generating_version, current_version, load_context=True)
+        load_qpy(qpy_files, generating_version)
 
 
 if __name__ == "__main__":

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -861,7 +861,15 @@ def generate_replay_with_expression_substitutions():
     qc = QuantumCircuit(1)
     qc.rz(a2, 0)
 
-    return [qc]
+    qc2 = QuantumCircuit(1)
+    theta = Parameter("θ")
+    rz = Parameter("rz")
+    exp = theta + np.pi
+    exp = exp.subs({theta: rz})
+    exp = exp.subs({rz: theta})
+    qc2.rz(exp, 0)
+
+    return [qc, qc2]
 
 
 def generate_v14_expr():

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -852,10 +852,13 @@ def generate_v12_expr():
     return [index, shift]
 
 
-def generate_replay_with_expression_substitutions():
-    """Circuits with parameters that have substituted expressions in the replay"""
+def generate_replay_with_expressions():
+    """Circuits with parameters that have expressions in the replay"""
     a = Parameter("a")
     b = Parameter("b")
+    c = Parameter("c")
+    d = Parameter("d")
+
     a1 = a * 2
     a2 = a1.subs({a: 3 * b})
     qc = QuantumCircuit(1)
@@ -873,7 +876,24 @@ def generate_replay_with_expression_substitutions():
     qc3 = QuantumCircuit(1, name="subs-vector")
     qc3.rz((pv[0] + 0.5).subs({pv[0]: pv[1]}), 0)
 
-    return [qc, qc2, qc3]
+    cancelled = QuantumCircuit(1, name="cancellations")
+    for case in (0 * a, 0 * a + 2, 0 * a + b, a - a, 0 * pv[0], 0 * (pv[0] + pv[1] + a)):
+        cancelled.rz(case, 0)
+
+    everything = QuantumCircuit(1, name="everything")
+    expression = (a + b.sin() * 0.25) * c**2
+    final_expr = (
+        (expression.cos() + d.arccos() - d.arcsin() + d.arctan() + d.tan()) / d.exp()
+        + expression.gradient(a)
+        + expression.log().sign()
+        - a.sin()
+        - b.conjugate()
+    )
+    final_expr = final_expr.abs()
+    final_expr = final_expr.subs({c: a})
+    everything.rz(final_expr, 0)
+
+    return [qc, qc2, qc3, cancelled, everything]
 
 
 def generate_v14_expr():
@@ -1016,9 +1036,7 @@ def generate_circuits(version_parts, current_version, load_context=False):
         output_circuits["standalone_vars.qpy"] = generate_standalone_var()
         output_circuits["v12_expr.qpy"] = generate_v12_expr()
     if version_parts >= (1, 4, 1):
-        output_circuits["replay_with_expressions.qpy"] = (
-            generate_replay_with_expression_substitutions()
-        )
+        output_circuits["replay_with_expressions.qpy"] = generate_replay_with_expressions()
 
     if version_parts >= (2, 0, 0):
         output_circuits["v14_expr.qpy"] = generate_v14_expr()
@@ -1030,18 +1048,11 @@ def assert_equal(
     reference, qpy, count, version_parts, bind=None, equivalent=False, context="Unknown context"
 ):
     """Compare two circuits."""
+    reference_parameter_names = [x.name for x in reference.parameters]
+    qpy_parameter_names = [x.name for x in qpy.parameters]
     if bind is not None:
-        reference_parameter_names = [x.name for x in reference.parameters]
-        qpy_parameter_names = [x.name for x in qpy.parameters]
-        if reference_parameter_names != qpy_parameter_names:
-            msg = (
-                f"Circuit {count} parameter mismatch:"
-                f" {reference_parameter_names} != {qpy_parameter_names}"
-            )
-            sys.stderr.write(msg)
-            sys.exit(4)
-        reference = reference.assign_parameters(bind)
-        qpy = qpy.assign_parameters(bind)
+        reference = reference.assign_parameters(bind[: reference.num_parameters])
+        qpy = qpy.assign_parameters(bind[: qpy.num_parameters])
 
     if equivalent:
         if not Operator.from_circuit(reference).equiv(Operator.from_circuit(qpy)):
@@ -1059,6 +1070,15 @@ def assert_equal(
         )
         sys.stderr.write(msg)
         sys.exit(1)
+
+    if reference_parameter_names != qpy_parameter_names:
+        msg = (
+            f"Circuit {count} parameter mismatch:"
+            f" {reference_parameter_names} != {qpy_parameter_names}"
+        )
+        sys.stderr.write(msg)
+        sys.exit(4)
+
     # Check deprecated bit properties, if set.  The QPY dumping code before Terra 0.23.2 didn't
     # include enough information for us to fully reconstruct this, so we only test if newer.
     if version_parts >= (0, 23, 2) and isinstance(reference, QuantumCircuit):
@@ -1138,7 +1158,7 @@ def load_qpy(qpy_files, version_parts):
             elif path == "parameter_vector_expression.qpy":
                 bind = np.linspace(1.0, 2.0, 15)
             elif path == "replay_with_expressions.qpy":
-                bind = [2.0]
+                bind = [2.0, 1.5, 0.125, -0.25, 0.75]
 
             context = f"Version {version_parts}, QPY file {path}, Circuit number {i}"
             assert_equal(

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -869,7 +869,11 @@ def generate_replay_with_expression_substitutions():
     exp = exp.subs({rz: theta})
     qc2.rz(exp, 0)
 
-    return [qc, qc2]
+    pv = ParameterVector("rz", 2)
+    qc3 = QuantumCircuit(1, name="subs-vector")
+    qc3.rz((pv[0] + 0.5).subs({pv[0]: pv[1]}), 0)
+
+    return [qc, qc2, qc3]
 
 
 def generate_v14_expr():

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -806,7 +806,7 @@ def generate_v12_expr():
     return [index, shift]
 
 
-def generate_replay_with_expressions(version):
+def generate_replay_with_expressions():
     """Circuits with parameters that have expressions in the replay"""
     out = []
 
@@ -834,14 +834,6 @@ def generate_replay_with_expressions(version):
     qc3 = QuantumCircuit(1, name="subs-vector")
     qc3.rz((pv[0] + 0.5).subs({pv[0]: pv[1]}), 0)
 
-    # Qiskit versions between 2.2.0rc1 and 2.4.0rc2 inclusive generate invalid QPY files for
-    # expressions involving cancellations.
-    if not (Version("2.2.0rc1") <= version < Version("2.4.0rc3")):
-        cancelled = QuantumCircuit(1, name="cancellations")
-        for case in (0 * a, 0 * a + 2, 0 * a + b, a - a, 0 * pv[0], 0 * (pv[0] + pv[1] + a)):
-            cancelled.rz(case, 0)
-        out.append(cancelled)
-
     everything = QuantumCircuit(1, name="everything")
     expression = (a + b.sin() * 0.25) * c**2
     final_expr = (
@@ -856,6 +848,29 @@ def generate_replay_with_expressions(version):
     everything.rz(final_expr, 0)
     out.append(everything)
 
+    return out
+
+
+def generate_replay_with_cancellations():
+    # Qiskit versions between 2.2.0rc1 and 2.4.0rc2 inclusive generate invalid QPY files for
+    # expressions involving cancellations.
+    a = Parameter("a")
+    b = Parameter("b")
+    pv = ParameterVector("rz", 2)
+
+    out = []
+    cases = (
+        0 * a,
+        0 * a + 2,
+        0 * a + b,
+        a - a,
+        0 * pv[0],
+        0 * (pv[0] + pv[1] + a),
+    )
+    for i, case in enumerate(cases):
+        cancelled = QuantumCircuit(1, name=f"cancellations-{i}")
+        cancelled.rz(case, 0)
+        out.append(cancelled)
     return out
 
 
@@ -997,9 +1012,11 @@ def generate_circuits(generating_version, current_version, load_context=False):
         output_circuits["standalone_vars.qpy"] = generate_standalone_var()
         output_circuits["v12_expr.qpy"] = generate_v12_expr()
     if generating_version.release >= (1, 4, 1):
-        output_circuits["replay_with_expressions.qpy"] = generate_replay_with_expressions(
-            generating_version
-        )
+        output_circuits["replay_with_expressions.qpy"] = generate_replay_with_expressions()
+        # Qiskit versions between 2.2.0rc1 and 2.4.0rc2 inclusive generate invalid QPY files for
+        # expressions involving cancellations.
+        if not Version("2.2.0rc1") <= generating_version <= Version("2.4.0rc2"):
+            output_circuits["replay_with_cancellations.qpy"] = generate_replay_with_cancellations()
 
     if generating_version.release >= (2, 0, 0):
         output_circuits["v14_expr.qpy"] = generate_v14_expr()
@@ -1126,7 +1143,7 @@ def load_qpy(qpy_files, generating_version):
                 bind = np.linspace(1.0, 2.0, 22)
             elif path == "parameter_vector_expression.qpy":
                 bind = np.linspace(1.0, 2.0, 15)
-            elif path == "replay_with_expressions.qpy":
+            elif path in ("replay_with_expressions.qpy", "replay_with_cancellations.qpy"):
                 bind = [2.0, 1.5, 0.125, -0.25, 0.75]
 
             context = f"Version {generating_version}, QPY file {path}, Circuit number {i}"


### PR DESCRIPTION
This patch is a fairly invasive change, but one that fixes the known edge cases of replay generation from `ParameterExpression` itself.  This fixes several `pickle`, `copy`/`deepcopy` and QPY bugs around `ParameterExpression`.

The Python-space QPY loader is modified in a small way to allow it to handle QPY-format permitted "replay" elements that act between two bare values; this was always allowed by the QPY spec, but couldn't be generated by Python-space QPY/`ParameterExpression`.  Doing so actually significantly simplifies the loading logic, since it no longer needs to reflect certain arithmetic operations.  The new Rust-space `ParameterExpression` uses binary operations with two numeric operands (e.g. `Add(2, 0)`) to safely propagate bare values through the QPY replay.  This was not previously necessary in Python space because there was no public interface to create a bare-numeric `ParameterExpression` without replayable expressions having been tracked.  Similarly, cancelled-out symbols are propagated in the replay with `Sub(x, x)` operations, which already must work across all compliant QPY loaders, and both Rust- and Python-space `ParameterExpression.

History
-------

The QPY replay was _intended_ to be a pure Polish-notation representation of the operations to take to rebuild the expression. This mostly worked fine at the time, but the patch was written under a lot of stress and without full CI tooling, due to it being in response to a security bug.  This led to some less-than-ideal parts of the format specification, such as the start/end recursion opcodes in the QPY format not actually being necessary; they are actually zero-operand no-ops to the stack, but this wasn't noticed during the patch due to time pressure.

Further, as `ParameterExpression` moved to Rust, the tracked internal "replay" list disappeared, since we could now reliably walk the expression tree and issue rebuild commands directly.  This generated replay, however, _only_ examined the expression and not potentially cancelled-out parameters.

All together, there were several problems affecting QPY (both Rust and Python), and `ParameterExpression`'s interaction with `pickle` and the copy module, mostly relating to situations where the resulting expression had cancelled-out parameters or had degraded to be a bare value.  For example, expressions like `x - x` (or `0*x + 3`, or arbitrarily complex extensions of these) are supposed to retain a reference to `x` for binding purposes, but failed to do so after pickle or QPY roundtrips.  Several of these expressions failed during QPY deserialisation, as the replay stack handling failed to cope with bare values.

<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Close #15355 
Close #15900 (obsolete)
