### PR TITLE
Performance improvement `BitArray.bitcount`

### DIFF
--- a/qiskit/primitives/containers/bit_array.py
+++ b/qiskit/primitives/containers/bit_array.py
@@ -31,9 +31,6 @@ from qiskit.result import Counts, sampled_expectation_value
 from .observables_array import ObservablesArray, ObservablesArrayLike
 from .shape import ShapedMixin, ShapeInput, shape_tuple
 
-# this lookup table tells you how many bits are 1 in each uint8 value
-_WEIGHT_LOOKUP = np.unpackbits(np.arange(256, dtype=np.uint8).reshape(-1, 1), axis=1).sum(axis=1)
-
 
 def _min_num_bytes(num_bits: int) -> int:
     """Return the minimum number of bytes needed to store ``num_bits``."""
@@ -207,7 +204,7 @@ class BitArray(ShapedMixin):
         Returns:
             A ``numpy.uint64``-array with shape ``(*shape, num_shots)``.
         """
-        return _WEIGHT_LOOKUP[self._array].sum(axis=-1)
+        return np.bitwise_count(self._array).sum(axis=-1, dtype=np.uint64)
 
     @staticmethod
     def from_bool_array(


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This PR modifies `BitArray.bitcount` so it is more performant for large `BitArray`s. It also removes the lookup table in the existing implementation. I encountered this since this method is the current bottleneck of the exp vals function in the [`qiskit-addon-utils` repo](https://github.com/Qiskit/qiskit-addon-utils/blob/main/qiskit_addon_utils/exp_vals/expectation_values.py#L385-L386).

### Details and comments

I did the profiling, Claude Sonnet 4.6 pointed me to `np.bitwise_count`, which I wasn't aware of.