### PR TITLE
Fix clippy warning in qpy module

### DIFF
--- a/crates/qpy/src/bytes.rs
+++ b/crates/qpy/src/bytes.rs
@@ -32,7 +32,7 @@ impl Bytes {
         self.0
             .iter()
             .fold(String::with_capacity(self.0.len() * 2), |mut acc, b| {
-                write!(&mut acc, "{:02x}", b).unwrap();
+                let _ = write!(&mut acc, "{:02x}", b);
                 acc
             })
     }


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes a clippy error in the qpy module when running clippy with the latest stable rust release. In #15698 we denied the use of unwrap() or expect() to minimize the chance of the qpy module panicking. We shouldn't ever panic in the qpy module because anything that causes an error condition was caused by malformed input and should be reported to the user and be handleable and not cause a hard crash. However, the clippy check apparently isn't as exhaustive on our MSRV of 1.85 and it didn't catch the usage of unwrap() in one place. This is causing a failure when you do run clippy with a newer version of Rust.

This commit fixes this error by throwing away the error condition. In this case the call to the `write!()` macro is infallible since it's just the string format which is infallible unless the underlying write fails [1]. But since we're writing to a `String` object that we just allocated in this case there is never a way or this to fail short of a hardware failure. So to solve the clippy error and prevent it from becoming a CI failure in the future this commit opts to just discard the error without using it.


### Details and comments

[1] https://doc.rust-lang.org/std/fmt/struct.Error.html