### PR TITLE
Check if cregbundle is None to avoid warning statement

### DIFF
--- a/qiskit/visualization/circuit/circuit_visualization.py
+++ b/qiskit/visualization/circuit/circuit_visualization.py
@@ -301,6 +301,8 @@ def circuit_drawer(
                     if check_clbit_in_inst(block, cregbundle) is False:
                         return False
             elif inst.clbits and not isinstance(inst.operation, Measure):
+                if cregbundle is None:
+                    return False
                 if cregbundle is not False:
                     warn(
                         "Cregbundle set to False since an instruction needs to refer"

--- a/releasenotes/notes/avoid-unset-cregbundle-warning-a42589f84b124c06.yaml
+++ b/releasenotes/notes/avoid-unset-cregbundle-warning-a42589f84b124c06.yaml
@@ -1,0 +1,8 @@
+---
+
+
+fixes:
+  - |
+    Avoid throwing warning when drawing circuit without setting cregbundle.
+
+    See `#15949 <https://github.com/Qiskit/qiskit/issues/15949>`__.

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -21,6 +21,7 @@ import tempfile
 import unittest.mock
 from codecs import encode
 from math import pi
+import warnings
 
 import numpy
 
@@ -4754,6 +4755,26 @@ class TestCircuitAnnotatedOperations(QiskitVisualizationTestCase):
             str(circuit_drawer(circuit, output="text", initial_state=False)),
             expected,
         )
+
+    def test_warning_for_none_cregbundle(self):
+        with warnings.catch_warnings(record=True, category=RuntimeWarning) as w:
+            warnings.filterwarnings(
+                "always",
+                category=RuntimeWarning,
+                message=".*Cregbundle.*",
+                )
+            qr = QuantumRegister(1, 'q')
+            cr = ClassicalRegister(1, 'c')
+            qc = QuantumCircuit(qr, cr)
+            with qc.while_loop((cr, 0)):
+                qc.h(qr[0])
+                qc.measure(qr[0], cr[0])
+                with qc.if_test((cr[0], 1)):
+                    qc.break_loop()
+            qc.draw('text')
+            self.assertEqual(w, [])
+
+        
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
fixes https://github.com/Qiskit/qiskit/issues/15949


### Details and comments
Added check to see if cregbundle is set to None to avoid warning output

Tested by running the same code as the issue and didn't see the warning with the change.

- Without change
```
(qiskit-dev) amruthpremjith@Amruths-MacBook-Pro qiskit % python3 test.py
/Users/amruthpremjith/qiskit/fork/qiskit/qiskit/visualization/circuit/circuit_visualization.py:301: RuntimeWarning: Cregbundle set to False since an instruction needs to refer to individual classical wire
  if check_clbit_in_inst(block, cregbundle) is False:
```
- With change
```
(qiskit-dev) amruthpremjith@Amruths-MacBook-Pro qiskit % python3 test.py
(qiskit-dev) amruthpremjith@Amruths-MacBook-Pro qiskit % 
```

