### PR TITLE
Fix operator precedence bug in std_inverse_pairs

### DIFF
--- a/crates/transpiler/src/passes/inverse_cancellation.rs
+++ b/crates/transpiler/src/passes/inverse_cancellation.rs
@@ -265,10 +265,10 @@ fn std_inverse_pairs(dag: &mut DAGCircuit) {
                     unreachable!("Not an op node");
                 };
                 if inst.qubits == next_inst.qubits
-                    && (inst.op.try_standard_gate() == Some(gate_0)
+                    && ((inst.op.try_standard_gate() == Some(gate_0)
                         && next_inst.op.try_standard_gate() == Some(gate_1))
-                    || (inst.op.try_standard_gate() == Some(gate_1)
-                        && next_inst.op.try_standard_gate() == Some(gate_0))
+                        || (inst.op.try_standard_gate() == Some(gate_1)
+                            && next_inst.op.try_standard_gate() == Some(gate_0)))
                 {
                     dag.remove_op_node(nodes[i]);
                     dag.remove_op_node(nodes[i + 1]);

--- a/test/python/transpiler/test_inverse_cancellation.py
+++ b/test/python/transpiler/test_inverse_cancellation.py
@@ -741,5 +741,33 @@ class TestCXCancellation(QiskitTestCase):
         self.assertEqual(pass_(test), expected)
 
 
+    def test_inverse_pair_different_qubits_not_cancelled(self):
+        """Test that inverse gate pairs on different qubits are not cancelled.
+
+        Regression test for https://github.com/Qiskit/qiskit/issues/15855.
+        The std_inverse_pairs code path had an operator-precedence bug where the
+        qubit-equality check was not applied to the second branch of the
+        gate-matching condition, allowing gates on different qubits to be
+        incorrectly cancelled.
+        """
+        pass_ = InverseCancellation(None)
+        qc = QuantumCircuit(2)
+        qc.t(0)
+        qc.tdg(1)
+        result = pass_(qc)
+        self.assertEqual(result.count_ops().get("t", 0), 1)
+        self.assertEqual(result.count_ops().get("tdg", 0), 1)
+
+    def test_inverse_pair_same_qubits_cancelled(self):
+        """Test that inverse gate pairs on the same qubit are still cancelled."""
+        pass_ = InverseCancellation(None)
+        qc = QuantumCircuit(1)
+        qc.t(0)
+        qc.tdg(0)
+        result = pass_(qc)
+        self.assertNotIn("t", result.count_ops())
+        self.assertNotIn("tdg", result.count_ops())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Fixes incorrect operator precedence in `std_inverse_pairs` in `inverse_cancellation.rs` where `a && b || c` parsed as `(a && b) || c` instead of the intended `a && (b || c)`.
- The second branch of the gate-matching condition skipped the `inst.qubits == next_inst.qubits` check, which could allow inverse gate pairs on different qubits to be incorrectly cancelled.
- The correct pattern already existed in the `inverse_cancellation_pairs` function (line 137–139) in the same file; this fix brings `std_inverse_pairs` in line with it.
- Adds two regression tests: one verifying T/Tdg on different qubits are **not** cancelled, one confirming T/Tdg on the same qubit **are** still cancelled.

Fixes #15855

## AI tool disclosure

This contribution was prepared with assistance from Claude Code (Claude Opus 4.6). All code was reviewed and is understood by the author.

## Test plan

- [x] All 67 existing `test_inverse_cancellation.py` tests pass
- [x] New regression tests pass
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)