### PR TITLE
fix(transpiler): RemoveFinalMeasurements incorrectly removes measurements feeding control-flow conditions

### DIFF
--- a/qiskit/transpiler/passes/utils/remove_final_measurements.py
+++ b/qiskit/transpiler/passes/utils/remove_final_measurements.py
@@ -48,6 +48,17 @@ def calc_final_ops(dag: DAGCircuit, final_op_names: set[str]) -> list[DAGOpNode]
                 continue
         if node.name in final_op_names:
             # Current node is either a measure, or a barrier with all final op children.
+            # A measure whose classical output is *read* by a successor (e.g. as a
+            # control-flow condition in while_loop, if_else, or switch_case) is not truly
+            # final — removing it would corrupt that condition.
+            # Exception: a successor that is itself a measure merely overwrites the clbit
+            # rather than branching on it, so it is safe to ignore.  For any other classical
+            # successor we err on the side of preservation (conservative but correct).
+            if any(
+                isinstance(s, DAGOpNode) and s.name != "measure"
+                for s in dag.classical_successors(node)
+            ):
+                continue
             final_ops.append(node)
             to_visit.extend(dag.quantum_predecessors(node))
 

--- a/releasenotes/notes/fix-remove-final-measurements-control-flow-14319.yaml
+++ b/releasenotes/notes/fix-remove-final-measurements-control-flow-14319.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed :class:`.RemoveFinalMeasurements` incorrectly removing measurements whose classical
+    output is consumed by a control-flow condition (``while_loop``, ``if_else``, or
+    ``switch_case``).  Such measurements are not truly final and must be preserved; removing
+    them caused the condition register to always read its default value ``0``, making
+    ``while_loop`` circuits run indefinitely.
+    Fixes `#14319 <https://github.com/Qiskit/qiskit/issues/14319>`__.

--- a/test/python/transpiler/test_remove_final_measurements.py
+++ b/test/python/transpiler/test_remove_final_measurements.py
@@ -304,6 +304,74 @@ class TestRemoveFinalMeasurements(QiskitTestCase):
         final_barriers = calc_final_ops(circuit_to_dag(qc), {"barrier"})
         self.assertEqual(final_barriers, [])
 
+    def test_measure_feeding_while_loop_condition_not_removed(self):
+        """Test that measures feeding a while_loop condition are not removed (#14319)."""
+        qreg = QuantumRegister(2)
+        creg = ClassicalRegister(2)
+        qc = QuantumCircuit(qreg, creg)
+        qc.measure(qreg[0], creg[0])
+        qc.measure(qreg[1], creg[1])
+        with qc.while_loop((creg, 0b00)):
+            qc.x(0)
+
+        result = RemoveFinalMeasurements().run(circuit_to_dag(qc))
+        # Both measures feed the while_loop condition and must be preserved.
+        op_names = [n.name for n in result.topological_op_nodes()]
+        self.assertEqual(op_names.count("measure"), 2)
+        self.assertIn("while_loop", op_names)
+
+    def test_measure_feeding_if_else_condition_not_removed(self):
+        """Test that a measure feeding an if_else condition is not removed (#14319)."""
+        qc = QuantumCircuit(2, 1)
+        qc.h(0)
+        qc.measure(0, 0)
+        with qc.if_test((qc.clbits[0], 1)):
+            qc.x(1)
+
+        result = RemoveFinalMeasurements().run(circuit_to_dag(qc))
+        # The measure feeds the if_else condition (if_test compiles to if_else in the DAG)
+        # and must be preserved.
+        op_names = [n.name for n in result.topological_op_nodes()]
+        self.assertEqual(op_names.count("measure"), 1)
+        self.assertIn("if_else", op_names)
+
+    def test_measure_feeding_switch_case_condition_not_removed(self):
+        """Test that a measure feeding a switch_case discriminant is not removed (#14319)."""
+        qc = QuantumCircuit(2, 1)
+        qc.measure(0, 0)
+        with qc.switch(qc.clbits[0]) as case:
+            with case(0):
+                qc.x(1)
+
+        result = RemoveFinalMeasurements().run(circuit_to_dag(qc))
+        # The measure feeds the switch_case discriminant and must be preserved.
+        op_names = [n.name for n in result.topological_op_nodes()]
+        self.assertEqual(op_names.count("measure"), 1)
+        self.assertIn("switch_case", op_names)
+
+    def test_chained_measures_first_is_removed_second_feeds_condition(self):
+        """Test that when two measures share a clbit, the first (overwritten) is removable (#14319).
+
+        measure q[0] -> c[0]; measure q[1] -> c[0]; while_loop(c[0] == 0, body on q[2])
+        The first measure's value is overwritten by the second, so it is truly final and
+        should be removed.  The second feeds the while_loop and must be preserved.
+        q[2] (not q[0]) is used inside the while_loop so that q[0]'s wire ends at the
+        first measure, making it quantum-final and reachable by the reverse traversal.
+        """
+        qreg = QuantumRegister(3)
+        creg = ClassicalRegister(1)
+        qc = QuantumCircuit(qreg, creg)
+        qc.measure(qreg[0], creg[0])  # overwritten by second measure — truly final
+        qc.measure(qreg[1], creg[0])  # feeds while_loop — must be preserved
+        with qc.while_loop((creg, 0b0)):
+            qc.x(qreg[2])  # uses q[2], not q[0], so q[0]'s wire ends at its measure
+
+        result = RemoveFinalMeasurements().run(circuit_to_dag(qc))
+        op_names = [n.name for n in result.topological_op_nodes()]
+        # First measure (overwritten) is removed; second (feeds condition) is preserved.
+        self.assertEqual(op_names.count("measure"), 1)
+        self.assertIn("while_loop", op_names)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`RemoveFinalMeasurements` was incorrectly removing measurements whose classical output feeds a control-flow condition (`while_loop`, `if_else`, `switch_case`). The pass only checked quantum wire successors to determine if a measurement was "final", completely ignoring classical wire successors. Removing such measurements left the condition register at its default value `0`, causing `while_loop` circuits to run indefinitely.

Fixes #14319.

## Root cause

In `calc_final_ops`, the reverse DAG traversal walks backwards through quantum wire predecessors. A `measure` node's classical wire successors were never inspected, so a measurement whose clbit feeds a `while_loop` condition was indistinguishable from a truly final one.

## Fix

Before marking a node as final, check whether any classical successor is a `DAGOpNode` that is not itself a `measure`. A `measure` successor merely overwrites the clbit (safe to remove); any other op means the clbit value is being read and the measurement must be preserved. For all other classical successors we err on the side of preservation (conservative but correct).

```python
if any(
    isinstance(s, DAGOpNode) and s.name != "measure"
    for s in dag.classical_successors(node)
):
    continue
```

## Test plan

- `test_measure_feeding_while_loop_condition_not_removed`
- `test_measure_feeding_if_else_condition_not_removed`
- `test_measure_feeding_switch_case_condition_not_removed`
- `test_chained_measures_first_is_removed_second_feeds_condition` — exercises the `!= "measure"` branch: first measure is overwritten and correctly removed, second feeds the condition and is preserved
- All 9 existing tests continue to pass
- `LightCone` pass (which also uses `calc_final_ops`) tested and unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)