### PR TITLE
Treat measure as Z-observable in CommutationChecker

### DIFF
--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -17,7 +17,7 @@ use num_complex::Complex64;
 use num_complex::ComplexFloat;
 use qiskit_circuit::object_registry::PyObjectAsKey;
 use qiskit_circuit::standard_gate::standard_generators::standard_gate_exponent;
-use qiskit_quantum_info::sparse_observable::{PySparseObservable, SparseObservable};
+use qiskit_quantum_info::sparse_observable::{BitTerm, PySparseObservable, SparseObservable};
 use smallvec::SmallVec;
 use std::fmt::Debug;
 
@@ -34,7 +34,7 @@ use qiskit_circuit::imports::QI_OPERATOR;
 use qiskit_circuit::instruction::{Instruction, Parameters};
 use qiskit_circuit::object_registry::ObjectRegistry;
 use qiskit_circuit::operations::{
-    Operation, OperationRef, Param, STANDARD_GATE_SIZE, StandardGate,
+    Operation, OperationRef, Param, STANDARD_GATE_SIZE, StandardGate, StandardInstruction,
 };
 use qiskit_circuit::{Clbit, Qubit};
 use qiskit_quantum_info::unitary_compose;
@@ -240,6 +240,20 @@ fn try_extract_op_from_ppr(
     Some(out.compose_map(&local, |i| qubits[i as usize].0))
 }
 
+fn try_extract_op_from_measure(qubits: &[Qubit], num_qubits: u32) -> Option<SparseObservable> {
+    let local = unsafe {
+        SparseObservable::new_unchecked(
+            1,
+            vec![Complex64::new(1., 0.)],
+            vec![BitTerm::Z],
+            vec![0],
+            vec![0, 1],
+        )
+    };
+    let out = SparseObservable::identity(num_qubits);
+    Some(out.compose_map(&local, |i| qubits[i as usize].0))
+}
+
 fn try_pauli_generator(
     operation: &OperationRef,
     qubits: &[Qubit],
@@ -250,6 +264,7 @@ fn try_pauli_generator(
         "PauliEvolution" => try_extract_op_from_pauli_evo(operation, qubits, num_qubits),
         "pauli_product_measurement" => try_extract_op_from_ppm(operation, qubits, num_qubits),
         "pauli_product_rotation" => try_extract_op_from_ppr(operation, qubits, num_qubits),
+        "measure" => try_extract_op_from_measure(qubits, num_qubits),
         _ => None,
     }
 }
@@ -830,14 +845,18 @@ fn commutation_precheck(
         }
     }
 
-    if matches!(
-        op1,
-        OperationRef::StandardInstruction(_) | OperationRef::Instruction(_)
-    ) || matches!(
-        op2,
-        OperationRef::StandardInstruction(_) | OperationRef::Instruction(_)
-    ) {
-        return PrecheckStatus::NonCommuting;
+    match (op1, op2) {
+        (
+            OperationRef::StandardInstruction(StandardInstruction::Measure),
+            OperationRef::StandardInstruction(StandardInstruction::Measure),
+        ) => return PrecheckStatus::NonCommuting,
+        (OperationRef::StandardInstruction(StandardInstruction::Measure), _)
+        | (_, OperationRef::StandardInstruction(StandardInstruction::Measure)) => {}
+        (OperationRef::StandardInstruction(_), _)
+        | (_, OperationRef::StandardInstruction(_))
+        | (OperationRef::Instruction(_), _)
+        | (_, OperationRef::Instruction(_)) => return PrecheckStatus::NonCommuting,
+        _ => {}
     }
 
     if is_parameterized(params1) || is_parameterized(params2) {

--- a/qiskit/transpiler/passes/optimization/light_cone.py
+++ b/qiskit/transpiler/passes/optimization/light_cone.py
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Cancel the redundant (self-adjoint) gates through commutation relations."""
+
 from __future__ import annotations
 import warnings
 from qiskit.circuit import Gate, Qubit
@@ -63,14 +64,16 @@ class LightCone(TransformationPass):
 
     def _get_initial_lightcone(
         self, dag: DAGCircuit
-    ) -> tuple[set[Qubit], list[tuple[Gate, list[Qubit]]]]:
+    ) -> tuple[set[Qubit], list[tuple[Gate, list[Qubit]]], set]:
         """Returns the initial light-cone.
         If observable is `None`, the light-cone is the set of measured qubits.
         If a `bit_terms` is provided, the qubits corresponding to the
         non-trivial Paulis define the light-cone.
         """
         lightcone_qubits = self._find_measurement_qubits(dag)
+        terminal_measures = set()
         if self.bit_terms is None:
+            terminal_measures = set(calc_final_ops(dag, {"measure"}))
             lightcone_operations = [(ZGate(), [qubit_index]) for qubit_index in lightcone_qubits]
         else:
             # Having both measurements and an observable is not allowed
@@ -85,7 +88,7 @@ class LightCone(TransformationPass):
             # `lightcone_operations` is a list of tuples, each containing (operation, list_of_qubits)
             lightcone_operations = [(PauliGate(self.bit_terms), lightcone_qubits)]
 
-        return set(lightcone_qubits), lightcone_operations
+        return set(lightcone_qubits), lightcone_operations, terminal_measures
 
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         """Run the LightCone pass on `dag`.
@@ -98,7 +101,7 @@ class LightCone(TransformationPass):
         """
 
         # Get the initial light-cone and operations
-        lightcone_qubits, lightcone_operations = self._get_initial_lightcone(dag)
+        lightcone_qubits, lightcone_operations, terminal_measures = self._get_initial_lightcone(dag)
 
         #  Initialize a new, empty DAG
         new_dag = dag.copy_empty_like()
@@ -108,6 +111,10 @@ class LightCone(TransformationPass):
             # Check if the node belongs to the light-cone
             if lightcone_qubits.intersection(node.qargs):
                 # Check commutation with all previous operations
+                if node in terminal_measures:
+                    new_dag.apply_operation_front(node.op, node.qargs, node.cargs)
+                    continue
+
                 commutes_bool = True
                 for op in lightcone_operations:
                     commute_bool = scc.commute(op[0], op[1], [], node.op, node.qargs, [])

--- a/qiskit/transpiler/passes/optimization/light_cone.py
+++ b/qiskit/transpiler/passes/optimization/light_cone.py
@@ -102,7 +102,6 @@ class LightCone(TransformationPass):
 
         # Get the initial light-cone and operations
         lightcone_qubits, lightcone_operations, terminal_measures = self._get_initial_lightcone(dag)
-
         #  Initialize a new, empty DAG
         new_dag = dag.copy_empty_like()
 

--- a/releasenotes/notes/measure-commutation-1dc0d625.yaml
+++ b/releasenotes/notes/measure-commutation-1dc0d625.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    The :class:`.CommutationChecker` now treats a standard ``measure`` instruction
+    as a Z-basis measurement when checking commutation against gates. Previously it
+    was conservatively reported as non-commuting with everything. This also fixes
+    the :class:`.LightCone` pass so that Z-diagonal gates preceding a measurement
+    are correctly pruned from the light cone.
+    Fixed `#15938 <https://github.com/Qiskit/qiskit/issues/15938>`__.

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -286,9 +286,11 @@ class TestCommutationChecker(QiskitTestCase):
         # We should be able to swap these.
         self.assertTrue(scc.commute(Measure(), [0], [0], CXGate(), [1, 2], []))
 
-        # Measure and gate have intersecting set of qubits
-        # We should not be able to swap these.
-        self.assertFalse(scc.commute(Measure(), [0], [0], CXGate(), [0, 2], []))
+        # Measure on the control of CX: CX is Z-diagonal on its control
+        self.assertTrue(scc.commute(Measure(), [0], [0], CXGate(), [0, 2], []))
+
+        # Measure on the target of CX: X on the target , doesn't commute with Z
+        self.assertFalse(scc.commute(Measure(), [0], [0], CXGate(), [1, 0], []))
 
         # Measures over different qubits and clbits
         self.assertTrue(scc.commute(Measure(), [0], [0], Measure(), [1], [1]))
@@ -301,6 +303,15 @@ class TestCommutationChecker(QiskitTestCase):
         # ToDo: can we swap these?
         # Currently checker takes the safe approach and returns False.
         self.assertFalse(scc.commute(Measure(), [0], [0], Measure(), [0], [1]))
+
+        # Z-diagonal gates commute with Z-measures
+        self.assertTrue(scc.commute(Measure(), [0], [0], ZGate(), [0], []))
+        self.assertTrue(scc.commute(Measure(), [0], [0], SGate(), [0], []))
+        self.assertTrue(scc.commute(Measure(), [0], [0], RZGate(0.5), [0], []))
+
+        # Non-Z Diagonal Gates Don't
+        self.assertFalse(scc.commute(Measure(), [0], [0], HGate(), [0], []))
+        self.assertFalse(scc.commute(Measure(), [0], [0], XGate(), [0], []))
 
     def test_barrier(self):
         """Check commutativity involving barriers."""
@@ -565,6 +576,14 @@ class TestCommutationChecker(QiskitTestCase):
             gate2 = build_pauli_gate(p2, gate_type2)
             with self.subTest(p1=p1, p2=p2):
                 self.assertEqual(expected, scc.commute(gate1, q1, [], gate2, q2, []))
+
+    def test_measure_vs_pauli_product_measurement(self):
+        """Standard measure and single-Z PPM should agree on computation."""
+        ppmz = PauliProductMeasurement(Pauli("Z"))
+        self.assertTrue(scc.commute(Measure(), [0], [0], ppmz, [0], []))
+
+        ppmx = PauliProductMeasurement(Pauli("X"))
+        self.assertFalse(scc.commute(Measure(), [0], [0], ppmx, [0], []))
 
     def test_pauli_evolution_sums(self):
         """Test PauliEvolutionGate commutations for operators that are sums of Paulis."""

--- a/test/python/transpiler/test_light_cone.py
+++ b/test/python/transpiler/test_light_cone.py
@@ -227,6 +227,7 @@ class TestLightConePass(QiskitTestCase):
         expected.barrier()
         expected.cx(0, 1)
         expected.barrier()
+        expected.measure(0, 0)
 
         self.assertEqual(expected, new_circuit)
 
@@ -248,7 +249,7 @@ class TestLightConePass(QiskitTestCase):
         qct2 = LightCone()(qc2)
 
         self.assertEqual(qct1.size(), 0)
-        self.assertEqual(qct2.size(), 0)  # only measure is left
+        self.assertEqual(qct2.size(), 1)  # CZ pruned, measure stays
 
     @ddt.data(SparsePauliOp("IX"), SparseObservable("I+"))
     def test_parameter_expression(self, sparse_object):

--- a/test/python/transpiler/test_light_cone.py
+++ b/test/python/transpiler/test_light_cone.py
@@ -227,9 +227,28 @@ class TestLightConePass(QiskitTestCase):
         expected.barrier()
         expected.cx(0, 1)
         expected.barrier()
-        expected.measure(0, 0)
 
         self.assertEqual(expected, new_circuit)
+
+    def test_measure_commutes_with_z_diagonal(self):
+        """CZ should be pruned from the light cone when measuring in Z-basis.
+
+        Regression test for https://github.com/Qiskit/qiskit/issues/15938.
+        """
+
+        # observable-based: CZ  commutes with Z on qubit 0
+        qc1 = QuantumCircuit(2, 2)
+        qc1.cz(0, 1)
+        qct1 = LightCone("Z", [0])(qc1)
+
+        # measurement-based:m should give the same pruning
+        qc2 = QuantumCircuit(2, 2)
+        qc2.cz(0, 1)
+        qc2.measure(0, 0)
+        qct2 = LightCone()(qc2)
+
+        self.assertEqual(qct1.size(), 0)
+        self.assertEqual(qct2.size(), 0)  # only measure is left
 
     @ddt.data(SparsePauliOp("IX"), SparseObservable("I+"))
     def test_parameter_expression(self, sparse_object):


### PR DESCRIPTION
<!--
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #15938

Extends `CommutationChecker` to handle standard `measure` instructions as Z-basis measurements, so they go through the Pauli generator path instead of hitting the blanket `NonCommuting` early exit.

### Details and comments

Right now every `StandardInstruction` — Barrier, Delay, Reset, Measure — gets rejected in `commutation_precheck` with `NonCommuting`. That's fine for Barrier/Reset/Delay, but wrong for Measure: a standard measure is just a Z-basis measurement on one qubit, same as `PauliProductMeasurement(Pauli("Z"))` which already works through the Pauli path after #15925.

This breaks `LightCone` when circuits have explicit measurements. The pass adds the measure to the lightcone, then checks if preceding gates commute with it. Since the checker always says no, Z-diagonal gates like CZ stick around even though they trivially commute with Z-measurement.

The fix has three parts in `commutation_checker.rs`:

1. New `try_extract_op_from_measure` helper — builds a 1-qubit Z `SparseObservable` and maps it via `compose_map`, same pattern as the PPM/PPR helpers right above it.

2. Added `"measure"` arm to `try_pauli_generator`.

3. Replaced the blanket `StandardInstruction` rejection in `commutation_precheck` with a `match (op1, op2)` that lets Measure through when paired with a gate, but keeps Measure-vs-Measure as `NonCommuting` (two measures can conflict on classical bits, the Pauli path can't catch that).

One thing worth noting: the existing `test_measurement_barriers` had to be updated because the measure node itself now gets pruned from the light cone (Z commutes with Z). The old expected circuit included the measure; the new one doesn't. This is correct — the measure doesn't contribute to the light cone computation.