### PR TITLE
fix: typos in comments

### DIFF
--- a/crates/cext/src/pointers.rs
+++ b/crates/cext/src/pointers.rs
@@ -56,7 +56,7 @@ pub(crate) unsafe fn slice_from_ptr<'a, T>(ptr: *const T, len: usize) -> &'a [T]
     unsafe { try_slice_from_ptr(ptr, len) }.expect("caller should ensure a valid pointer")
 }
 
-/// Casts a const pointer to a reference. Panics is the pointer is null or not aligned.
+/// Casts a const pointer to a reference. Panics if the pointer is null or not aligned.
 ///
 /// # Safety
 ///
@@ -68,7 +68,7 @@ pub(crate) unsafe fn const_ptr_as_ref<'a, T>(ptr: *const T) -> &'a T {
     as_ref.unwrap() // we know the pointer is not null, hence we can safely unwrap
 }
 
-/// Casts a mut pointer to a mut reference. Panics is the pointer is null or not aligned.
+/// Casts a mut pointer to a mut reference. Panics if the pointer is null or not aligned.
 ///
 /// # Safety
 ///


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Super unnecessary I know, but I found these typos and wanted to avoid the similar file in `qiskit-fermions` to diverge from this one...

### Details and comments


