### PR TITLE
Additional check for ResetAfterMeasureSimplification to account for MidCircuitMeasure

### DIFF
--- a/qiskit/transpiler/passes/optimization/reset_after_measure_simplification.py
+++ b/qiskit/transpiler/passes/optimization/reset_after_measure_simplification.py
@@ -34,17 +34,18 @@ class ResetAfterMeasureSimplification(TransformationPass):
     @control_flow.trivial_recurse
     def run(self, dag):
         """Run the pass on a dag."""
-        for node in dag.op_nodes(Measure):
-            succ = next(dag.quantum_successors(node))
-            if isinstance(succ, DAGOpNode) and isinstance(succ.op, Reset):
-                x_body = QuantumCircuit(1)
-                x_body.x(0)
-                new_x = IfElseOp((node.cargs[0], 1), x_body)
-                new_dag = DAGCircuit()
-                new_dag.add_qubits(node.qargs)
-                new_dag.add_clbits(node.cargs)
-                new_dag.apply_operation_back(node.op, node.qargs, node.cargs)
-                new_dag.apply_operation_back(new_x, node.qargs)
-                dag.remove_op_node(succ)
-                dag.substitute_node_with_dag(node, new_dag)
+        for node in dag.op_nodes():
+            if isinstance(node.op, Measure)  or node.op.name.startswith("measure_"):
+                succ = next(dag.quantum_successors(node))
+                if isinstance(succ, DAGOpNode) and isinstance(succ.op, Reset):
+                    x_body = QuantumCircuit(1)
+                    x_body.x(0)
+                    new_x = IfElseOp((node.cargs[0], 1), x_body)
+                    new_dag = DAGCircuit()
+                    new_dag.add_qubits(node.qargs)
+                    new_dag.add_clbits(node.cargs)
+                    new_dag.apply_operation_back(node.op, node.qargs, node.cargs)
+                    new_dag.apply_operation_back(new_x, node.qargs)
+                    dag.remove_op_node(succ)
+                    dag.substitute_node_with_dag(node, new_dag)
         return dag


### PR DESCRIPTION
<!--
⚠️  If you do not respect this template, your pull request will be closed.
⚠️  Your pull request title should be short detailed and understandable for all.
⚠️  Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️  If your pull request fixes an open issue, please link to the issue. Use "Fixes #XXXX" if this PR *fully* closes the issue XXXX.  
☢️  If you used an AI tool to code this PR, add "AI tool used: <Name and version of the tool>". For example, "AI tool used: Microsoft Copilot Chat with GPT-5". Failing to disclose the use of AI tools may result in the PR being closed without further review.  


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
fixes https://github.com/Qiskit/qiskit/issues/15935


### Details and comments
Added an additional check in ResetAfterMeasureSimplification to account for MidCircuitMeasure instructions in the circuit rather than just Measure instructions.