### PR TITLE
[codex] Document pi_check behavior

### DIFF
--- a/qiskit/circuit/tools/pi_check.py
+++ b/qiskit/circuit/tools/pi_check.py
@@ -25,25 +25,32 @@ POW_LIST = np.pi ** np.arange(2, 5)
 
 
 def pi_check(inpt, eps=1e-9, output="text", ndigits=None):
-    """Computes if a number is close to an integer
-    fraction or multiple of PI and returns the
-    corresponding string.
+    """Return a string representation of ``inpt``, using simple ``pi`` forms when possible.
+
+    For numeric inputs, ``pi_check`` formats the real and imaginary parts independently. Within
+    ``eps``, it prefers integer multiples of pi, powers of pi from ``pi**2`` through ``pi**4``
+    (except for ``output="qasm"``), and reduced fractions of the form ``n*pi/d`` or
+    ``n/(d*pi)`` with numerators and denominators up to :data:`MAX_FRAC`.  If none of those
+    patterns match, the value falls back to ordinary numeric formatting; ``ndigits`` only affects
+    this fallback formatting.
+
+    String inputs are returned unchanged.  For :class:`~qiskit.circuit.ParameterExpression`
+    inputs, numeric coefficients are rewritten using the same rules while preserving the symbolic
+    structure of the expression's string form.
 
     Args:
-        inpt (float): Number to check.
-        eps (float): EPS to check against.
-        output (str): Options are 'text' (default),
-                      'latex', 'mpl', and 'qasm'.
-        ndigits (int or None): Number of digits to print
-                               if returning raw inpt.
-                               If `None` (default), Python's
-                               default float formatting is used.
+        inpt (complex | ParameterExpression | str): Value to format.
+        eps (float): Tolerance used to decide whether a numeric value matches a supported pi form.
+        output (str): Output style. Supported values are ``"text"`` (default), ``"latex"``,
+            ``"mpl"``, and ``"qasm"``.
+        ndigits (int | None): Significant digits to use when returning a raw numeric fallback.
+            If ``None`` (default), Python's default float formatting is used.
 
     Returns:
-        str: string representation of output.
+        str: Formatted string representation of ``inpt``.
 
     Raises:
-        QiskitError: if output is not a valid option.
+        QiskitError: If ``output`` is not a valid option.
     """
     if isinstance(inpt, ParameterExpression):
         param_str = str(inpt)

--- a/qiskit/circuit/tools/pi_check.py
+++ b/qiskit/circuit/tools/pi_check.py
@@ -13,6 +13,8 @@
 
 """Check if number close to values of PI"""
 
+from typing import Literal
+
 import numpy as np
 from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.exceptions import QiskitError
@@ -24,25 +26,21 @@ RECIP_MESH = N / D / np.pi
 POW_LIST = np.pi ** np.arange(2, 5)
 
 
-def pi_check(inpt, eps=1e-9, output="text", ndigits=None):
-    """Return a string representation of ``inpt``, using simple ``pi`` forms when possible.
+def pi_check(
+    inpt: complex | ParameterExpression | str,
+    eps: float = 1e-9,
+    output: Literal["text", "latex", "mpl", "qasm"] = "text",
+    ndigits: int | None = None,
+):
+    """Return ``inpt`` as a string, preferring simple fractions of pi where possible.
 
-    For numeric inputs, ``pi_check`` formats the real and imaginary parts independently. Within
-    ``eps``, it prefers integer multiples of pi, powers of pi from ``pi**2`` through ``pi**4``
-    (except for ``output="qasm"``), and reduced fractions of the form ``n*pi/d`` or
-    ``n/(d*pi)`` with numerators and denominators up to :data:`MAX_FRAC`.  If none of those
-    patterns match, the value falls back to ordinary numeric formatting; ``ndigits`` only affects
-    this fallback formatting.
-
-    String inputs are returned unchanged.  For :class:`~qiskit.circuit.ParameterExpression`
-    inputs, numeric coefficients are rewritten using the same rules while preserving the symbolic
-    structure of the expression's string form.
+    String inputs are returned unchanged. :class:`~qiskit.circuit.ParameterExpression` inputs have
+    their numeric coefficients formatted using the same rules.
 
     Args:
         inpt (complex | ParameterExpression | str): Value to format.
-        eps (float): Tolerance used to decide whether a numeric value matches a supported pi form.
-        output (str): Output style. Supported values are ``"text"`` (default), ``"latex"``,
-            ``"mpl"``, and ``"qasm"``.
+        eps (float): Tolerance used to decide whether a numeric value matches a simple pi form.
+        output: Output style.
         ndigits (int | None): Significant digits to use when returning a raw numeric fallback.
             If ``None`` (default), Python's default float formatting is used.
 

--- a/test/python/circuit/test_tools.py
+++ b/test/python/circuit/test_tools.py
@@ -19,6 +19,7 @@ from numpy import pi
 
 from qiskit.circuit.tools.pi_check import pi_check
 from qiskit.circuit import Parameter
+from qiskit.exceptions import QiskitError
 from test import QiskitTestCase
 
 
@@ -94,6 +95,30 @@ class TestPiCheck(QiskitTestCase):
         expected_string = "π/2 + x"
         result = pi_check(input_number)
         self.assertEqual(result, expected_string)
+
+    def test_output_modes(self):
+        """Test supported output styles."""
+        self.assertEqual(pi_check(pi / 2, output="text"), "π/2")
+        self.assertEqual(pi_check(pi / 2, output="qasm"), "pi/2")
+        self.assertEqual(pi_check(pi / 2, output="latex"), r"\frac{\pi}{2}")
+        self.assertEqual(pi_check(pi / 2, output="mpl"), "$\\pi$/2")
+        self.assertEqual(pi_check(pi**2, output="qasm"), str(pi**2))
+
+    def test_ndigits_applies_to_numeric_fallback(self):
+        """Test ndigits only affects fallback numeric formatting."""
+        self.assertEqual(pi_check(0.3333333333333, ndigits=3), "0.333")
+        self.assertEqual(pi_check(pi / 2, ndigits=3), "π/2")
+
+    def test_string_passthrough(self):
+        """Test string inputs are returned unchanged."""
+        self.assertEqual(pi_check("already formatted"), "already formatted")
+
+    def test_invalid_output_raises(self):
+        """Test invalid output styles raise."""
+        with self.assertRaisesRegex(
+            QiskitError, "pi_check parameter output should be text, latex, mpl, or qasm."
+        ):
+            pi_check(pi, output="invalid")
 
 
 if __name__ == "__main__":

--- a/test/python/circuit/test_tools.py
+++ b/test/python/circuit/test_tools.py
@@ -19,7 +19,6 @@ from numpy import pi
 
 from qiskit.circuit.tools.pi_check import pi_check
 from qiskit.circuit import Parameter
-from qiskit.exceptions import QiskitError
 from test import QiskitTestCase
 
 
@@ -95,30 +94,6 @@ class TestPiCheck(QiskitTestCase):
         expected_string = "π/2 + x"
         result = pi_check(input_number)
         self.assertEqual(result, expected_string)
-
-    def test_output_modes(self):
-        """Test supported output styles."""
-        self.assertEqual(pi_check(pi / 2, output="text"), "π/2")
-        self.assertEqual(pi_check(pi / 2, output="qasm"), "pi/2")
-        self.assertEqual(pi_check(pi / 2, output="latex"), r"\frac{\pi}{2}")
-        self.assertEqual(pi_check(pi / 2, output="mpl"), "$\\pi$/2")
-        self.assertEqual(pi_check(pi**2, output="qasm"), str(pi**2))
-
-    def test_ndigits_applies_to_numeric_fallback(self):
-        """Test ndigits only affects fallback numeric formatting."""
-        self.assertEqual(pi_check(0.3333333333333, ndigits=3), "0.333")
-        self.assertEqual(pi_check(pi / 2, ndigits=3), "π/2")
-
-    def test_string_passthrough(self):
-        """Test string inputs are returned unchanged."""
-        self.assertEqual(pi_check("already formatted"), "already formatted")
-
-    def test_invalid_output_raises(self):
-        """Test invalid output styles raise."""
-        with self.assertRaisesRegex(
-            QiskitError, "pi_check parameter output should be text, latex, mpl, or qasm."
-        ):
-            pi_check(pi, output="invalid")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- trim the `pi_check` docstring back to the high-level intent
- annotate the `output` argument with `Literal[...]` instead of repeating the supported values in prose
- keep the change scoped to documentation rather than expanding the test coverage

## Testing
- `source .venv-codex/bin/activate && python -m unittest test.python.circuit.test_tools`

fixes #10391

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description: OpenAI Codex (GPT-5)
- [x] I used the following tool to generate or modify code: OpenAI Codex (GPT-5)
