### PR TITLE
[codex] Document inverse gate pairs

### DIFF
--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -302,6 +302,7 @@ you would do something like the following (building off the previous example):
     inverse_gate_list = [
         lib.CXGate(),
         lib.HGate(),
+        (lib.SGate(), lib.SdgGate()),
         (lib.RXGate(np.pi / 4), lib.RXGate(-np.pi / 4)),
         (lib.PhaseGate(np.pi / 4), lib.PhaseGate(-np.pi / 4)),
         (lib.TGate(), lib.TdgGate()),

--- a/qiskit/transpiler/passes/optimization/inverse_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/inverse_cancellation.py
@@ -29,8 +29,13 @@ from qiskit._accelerate.inverse_cancellation import (
 
 
 class InverseCancellation(TransformationPass):
-    """Cancel specific Gates which are inverses of each other when they occur back-to-
-    back."""
+    """Cancel adjacent gates that are inverses of each other.
+
+    Entries in ``gates_to_cancel`` can be either a single gate or a 2-tuple of gates.
+    Single-gate entries are only valid for self-inverse gates such as :class:`.HGate`
+    or :class:`.CXGate`. Gates whose inverses are represented by a different gate, such
+    as :class:`.SGate` and :class:`.SdgGate`, must be given as a tuple pair.
+    """
 
     def __init__(
         self,
@@ -43,8 +48,10 @@ class InverseCancellation(TransformationPass):
             gates_to_cancel: List describing the gates to cancel. Each element of the
                 list is either a single gate or a pair of gates. If a single gate, then
                 it should be self-inverse. If a pair of gates, then the gates in the
-                pair should be inverses of each other. If ``None`` a default list of
-                self-inverse gates and a default list of inverse gate pairs will be used.
+                pair should be inverses of each other. For example, use
+                ``[(SGate(), SdgGate())]`` instead of ``[SGate(), SdgGate()]``.
+                If ``None`` a default list of self-inverse gates and a default list of
+                inverse gate pairs will be used.
                 The current default list of self-inverse gates is:
 
                   * :class:`.CXGate`

--- a/test/python/transpiler/test_inverse_cancellation.py
+++ b/test/python/transpiler/test_inverse_cancellation.py
@@ -29,6 +29,8 @@ from qiskit.circuit.library import (
     HGate,
     CXGate,
     PhaseGate,
+    SGate,
+    SdgGate,
     XGate,
     TGate,
     TdgGate,
@@ -182,6 +184,11 @@ class TestInverseCancellation(QiskitTestCase):
         qc.rx(np.pi / 4, 0)
         with self.assertRaises(TranspilerError):
             InverseCancellation([RXGate(np.pi / 4)])
+
+    def test_inverse_pair_requires_tuple(self):
+        """Test that non-self-inverse gates must be passed as tuple pairs."""
+        with self.assertRaisesRegex(TranspilerError, "Gate s is not self-inverse"):
+            InverseCancellation([SGate(), SdgGate()])
 
     def test_string_gate_error(self):
         """Test that when gate is passed as a string an error is raised."""
@@ -365,6 +372,15 @@ class TestInverseCancellation(QiskitTestCase):
         inverse_pass = InverseCancellation([(TGate(), TdgGate())])
         new_circ = inverse_pass(qc)
         self.assertEqual(qc, new_circ)
+
+    def test_s_sdg_inverse_pair(self):
+        """Test that a custom SGate/SdgGate pair cancels when given as a tuple."""
+        qc = QuantumCircuit(1)
+        qc.s(0)
+        qc.sdg(0)
+        inverse_pass = InverseCancellation([(SGate(), SdgGate())])
+        new_circ = inverse_pass(qc)
+        self.assertEqual(new_circ, QuantumCircuit(1))
 
     @ddt.data([(TGate(), TdgGate())], None)
     def test_some_inverse_pairs(self, gates_to_cancel):


### PR DESCRIPTION
## Summary
- clarify in `InverseCancellation` docs that single entries are only for self-inverse gates
- document that inverse pairs like `SGate` and `SdgGate` must be passed as tuples
- add tests covering both the error case and the tuple-pair cancellation path

## Testing
- `source .venv-codex/bin/activate && python -m unittest test.python.transpiler.test_inverse_cancellation`

fixes #7413

AI tool used: OpenAI Codex (GPT-5)
