### PR TITLE
[codex] Fix LightCone mid-circuit measurements

### DIFF
--- a/qiskit/transpiler/passes/optimization/light_cone.py
+++ b/qiskit/transpiler/passes/optimization/light_cone.py
@@ -12,13 +12,11 @@
 
 """Cancel the redundant (self-adjoint) gates through commutation relations."""
 from __future__ import annotations
-import warnings
-from qiskit.circuit import Gate, Qubit
+from qiskit.circuit import Gate, Measure, Qubit
 from qiskit.circuit.commutation_library import SessionCommutationChecker as scc
-from qiskit.circuit.library import PauliGate, ZGate
+from qiskit.circuit.library import PauliGate, PauliProductMeasurement, ZGate
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import TransformationPass
-from qiskit.transpiler.passes.utils.remove_final_measurements import calc_final_ops
 
 translation_table = str.maketrans({"+": "X", "-": "X", "l": "Y", "r": "Y", "0": "Z", "1": "Z"})
 
@@ -54,12 +52,13 @@ class LightCone(TransformationPass):
         self.indices = indices
 
     @staticmethod
-    def _find_measurement_qubits(dag: DAGCircuit) -> set[Qubit]:
-        final_nodes = calc_final_ops(dag, {"measure"})
-        qubits_measured = set()
-        for node in final_nodes:
-            qubits_measured |= set(node.qargs)
-        return qubits_measured
+    def _measurement_observable(node) -> tuple[Gate, list[Qubit]] | None:
+        if isinstance(node.op, Measure):
+            return ZGate(), list(node.qargs)
+        if isinstance(node.op, PauliProductMeasurement):
+            pauli_label = node.op.pauli().to_label().lstrip("-")
+            return PauliGate(pauli_label), list(node.qargs)
+        return None
 
     def _get_initial_lightcone(
         self, dag: DAGCircuit
@@ -69,18 +68,18 @@ class LightCone(TransformationPass):
         If a `bit_terms` is provided, the qubits corresponding to the
         non-trivial Paulis define the light-cone.
         """
-        lightcone_qubits = self._find_measurement_qubits(dag)
         if self.bit_terms is None:
-            lightcone_operations = [(ZGate(), [qubit_index]) for qubit_index in lightcone_qubits]
+            lightcone_qubits = set()
+            lightcone_operations = []
         else:
             # Having both measurements and an observable is not allowed
-            if len(dag.qubits) < max(self.indices) + 1:
-                raise ValueError("`indices` contains values outside the qubit range.")
-            if lightcone_qubits:
+            if any(self._measurement_observable(node) is not None for node in dag.op_nodes()):
                 raise ValueError(
                     "The circuit contains measurements and an observable has been given: "
                     "remove the observable or the measurements."
                 )
+            if len(dag.qubits) < max(self.indices) + 1:
+                raise ValueError("`indices` contains values outside the qubit range.")
             lightcone_qubits = [dag.qubits[i] for i in self.indices]
             # `lightcone_operations` is a list of tuples, each containing (operation, list_of_qubits)
             lightcone_operations = [(PauliGate(self.bit_terms), lightcone_qubits)]
@@ -105,6 +104,14 @@ class LightCone(TransformationPass):
 
         # Iterate over the nodes in reverse topological order
         for node in dag.topological_op_nodes(reverse=True):
+            if self.bit_terms is None:
+                measurement = self._measurement_observable(node)
+                if measurement is not None:
+                    lightcone_qubits.update(node.qargs)
+                    lightcone_operations.append(measurement)
+                    new_dag.apply_operation_front(node.op, node.qargs, node.cargs)
+                    continue
+
             # Check if the node belongs to the light-cone
             if lightcone_qubits.intersection(node.qargs):
                 # Check commutation with all previous operations

--- a/releasenotes/notes/light-cone-midcircuit-measurements-4be8bca1e7d6c3f0.yaml
+++ b/releasenotes/notes/light-cone-midcircuit-measurements-4be8bca1e7d6c3f0.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed :class:`.LightCone` so it correctly handles mid-circuit measurements,
+    including :class:`.PauliProductMeasurement` instructions, instead of only
+    seeding the light cone from final measurements. Circuits that mix an
+    observable with any measurement instructions now consistently raise
+    :exc:`ValueError`.
+
+    See `#15937 <https://github.com/Qiskit/qiskit/issues/15937>`__.

--- a/test/python/transpiler/test_light_cone.py
+++ b/test/python/transpiler/test_light_cone.py
@@ -21,10 +21,10 @@ from qiskit.circuit import (
     Parameter,
     QuantumCircuit,
 )
-from qiskit.circuit.library import real_amplitudes
+from qiskit.circuit.library import PauliProductMeasurement, real_amplitudes
 from qiskit.circuit.library.n_local.efficient_su2 import efficient_su2
 from qiskit.converters import circuit_to_dag
-from qiskit.quantum_info import SparsePauliOp, SparseObservable
+from qiskit.quantum_info import Pauli, SparsePauliOp, SparseObservable
 from qiskit.transpiler.passes.optimization.light_cone import LightCone
 from qiskit.transpiler.passmanager import PassManager
 
@@ -230,6 +230,54 @@ class TestLightConePass(QiskitTestCase):
         expected.measure(0, 0)
 
         self.assertEqual(expected, new_circuit)
+
+    def test_mid_circuit_measurement(self):
+        """Test for a mid-circuit standard measurement."""
+        light_cone = LightCone()
+        pm = PassManager([light_cone])
+
+        qc = QuantumCircuit(2, 1)
+        qc.cx(0, 1)
+        qc.z(0)
+        qc.measure(0, 0)
+        qc.h(0)
+
+        new_circuit = pm.run(qc)
+
+        expected = QuantumCircuit(2, 1)
+        expected.measure(0, 0)
+
+        self.assertEqual(expected, new_circuit)
+
+    def test_mid_circuit_pauli_product_measurement(self):
+        """Test for a mid-circuit Pauli product measurement."""
+        light_cone = LightCone()
+        pm = PassManager([light_cone])
+
+        qc = QuantumCircuit(1, 1)
+        qc.h(0)
+        qc.append(PauliProductMeasurement(Pauli("X")), [0], [0])
+        qc.z(0)
+
+        new_circuit = pm.run(qc)
+
+        expected = QuantumCircuit(1, 1)
+        expected.h(0)
+        expected.append(PauliProductMeasurement(Pauli("X")), [0], [0])
+
+        self.assertEqual(expected, new_circuit)
+
+    def test_observable_rejects_mid_circuit_measurement(self):
+        """Test that observables reject non-final measurements as well."""
+        light_cone = LightCone(bit_terms="X", indices=[0])
+        pm = PassManager([light_cone])
+
+        qc = QuantumCircuit(1, 1)
+        qc.measure(0, 0)
+        qc.h(0)
+
+        with self.assertRaises(ValueError):
+            pm.run(qc)
 
     @ddt.data(SparsePauliOp("IX"), SparseObservable("I+"))
     def test_parameter_expression(self, sparse_object):


### PR DESCRIPTION
## Summary
- fix `LightCone` so it seeds the light cone while reverse-walking any measurement instruction, not only final measurements
- support both standard `Measure` operations and `PauliProductMeasurement` instructions
- reject observable-mode `LightCone` runs when the circuit contains any measurement, including non-final ones
- add focused regression tests and a release-note fragment

## Root cause
`LightCone` initialized its measured qubits from final measurements only. For circuits with mid-circuit measurements, that left the initial light cone empty, so the pass could incorrectly remove the measurement itself and return an empty circuit.

## Validation
- `./.tox/py313/bin/stestr run test.python.transpiler.test_light_cone`

## References
- Fixes #15937