### PR TITLE
Allow passing Target as backend argument in transpile()

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -35,7 +35,7 @@ _CircuitT = TypeVar("_CircuitT", bound=QuantumCircuit | list[QuantumCircuit])
 
 def transpile(
     circuits: _CircuitT,
-    backend: Backend | None = None,
+    backend: Backend | Target| None = None,
     basis_gates: list[str] | None = None,
     coupling_map: CouplingMap | list[list[int]] | None = None,
     initial_layout: Layout | dict | list | None = None,
@@ -248,6 +248,16 @@ def transpile(
             or errors in passes
     """
     arg_circuits_list = isinstance(circuits, list)
+
+    # Allow passing a Target as the second positional argument (backend position)
+    if isinstance(backend, Target):
+        if target is not None:
+            raise TypeError(
+                "Cannot pass a Target as the backend argument and also specify a target argument."
+            )
+        target = backend
+        backend = None
+
     circuits = circuits if arg_circuits_list else [circuits]
 
     if not circuits:


### PR DESCRIPTION
Fixes #15066

When a Target is passed as the second positional argument to transpile(), it is now automatically treated as the target argument instead of backend. A TypeError is raised if both are specified simultaneously.

This makes transpile() consistent with generate_preset_pass_manager() which already supports this behavior.