### PR TITLE
Add approximation_degree argument to CommutativeCancellation pass [fix #14115]

### DIFF
--- a/qiskit/transpiler/passes/optimization/commutative_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/commutative_cancellation.py
@@ -34,21 +34,25 @@ class CommutativeCancellation(TransformationPass):
         H, X, Y, Z, CX, CY, CZ
     """
 
-    def __init__(self, basis_gates=None, target=None, approximation_degree=None):
+    def __init__(
+        self,
+        basis_gates: list[str] | None = None,
+        target: "Target" | None = None,
+        approximation_degree: float | None = None,
+    ) -> None:
         """
         CommutativeCancellation initializer.
 
         Args:
-            basis_gates (list[str]): Basis gates to consider, e.g.
-                ``['u3', 'cx']``. For the effects of this pass, the basis is
-                the set intersection between the ``basis_gates`` parameter
-                and the gates in the dag.
-            target (Target): The :class:`~.Target` representing the target backend, if both
-                ``basis_gates`` and ``target`` are specified then this argument will take
-                precedence and ``basis_gates`` will be ignored.
-            approximation_degree (float): Heuristic dial used to manage circuit approximation
-                (0.0 to 1.0, default 1.0). Lower values allow more gate cancellation
-                approximations. If None, defaults to 1.0.
+            basis_gates: Basis gates to consider, e.g. ``['u3', 'cx']``. For the
+                effects of this pass, the basis is the set intersection between
+                the ``basis_gates`` parameter and the gates in the dag.
+            target: The :class:`~.Target` representing the target backend. If both
+                ``basis_gates`` and ``target`` are specified, ``target`` takes
+                precedence and ``basis_gates`` is ignored.
+            approximation_degree: Heuristic dial for circuit approximation (0.0 to
+                1.0, default 1.0). Lower values allow more gate cancellation
+                approximations. If ``None``, defaults to 1.0.
         """
         super().__init__()
         if basis_gates:

--- a/qiskit/transpiler/passes/optimization/commutative_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/commutative_cancellation.py
@@ -34,7 +34,7 @@ class CommutativeCancellation(TransformationPass):
         H, X, Y, Z, CX, CY, CZ
     """
 
-    def __init__(self, basis_gates=None, target=None):
+    def __init__(self, basis_gates=None, target=None, approximation_degree=None):
         """
         CommutativeCancellation initializer.
 
@@ -46,6 +46,9 @@ class CommutativeCancellation(TransformationPass):
             target (Target): The :class:`~.Target` representing the target backend, if both
                 ``basis_gates`` and ``target`` are specified then this argument will take
                 precedence and ``basis_gates`` will be ignored.
+            approximation_degree (float): Heuristic dial used to manage circuit approximation
+                (0.0 to 1.0, default 1.0). Lower values allow more gate cancellation
+                approximations. If None, defaults to 1.0.
         """
         super().__init__()
         if basis_gates:
@@ -55,6 +58,7 @@ class CommutativeCancellation(TransformationPass):
         self.target = target
         if target is not None:
             self.basis = set(target.operation_names)
+        self.approximation_degree = approximation_degree
 
         self._var_z_map = {"rz": RZGate, "p": PhaseGate, "u1": U1Gate}
 
@@ -78,7 +82,8 @@ class CommutativeCancellation(TransformationPass):
         Returns:
             DAGCircuit: the optimized DAG.
         """
+        approximation_degree = 1.0 if self.approximation_degree is None else self.approximation_degree
         commutation_cancellation.cancel_commutations(
-            dag, self._commutation_checker, sorted(self.basis)
+            dag, self._commutation_checker, sorted(self.basis), approximation_degree
         )
         return dag

--- a/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
+++ b/qiskit/transpiler/preset_passmanagers/builtin_plugins.py
@@ -157,7 +157,11 @@ class DefaultInitPassManager(PassManagerStagePlugin):
                     ContractIdleWiresInControlFlow(),
                 ]
             )
-            init.append(CommutativeCancellation())
+            init.append(
+                CommutativeCancellation(
+                    approximation_degree=pass_manager_config.approximation_degree
+                )
+            )
             init.append(ConsolidateBlocks())
 
             # If approximation degree is None that indicates a request to approximate up to the
@@ -526,7 +530,10 @@ class OptimizationPassManager(PassManagerStagePlugin):
                     Optimize1qGatesDecomposition(
                         basis=pass_manager_config.basis_gates, target=pass_manager_config.target
                     ),
-                    CommutativeCancellation(target=pass_manager_config.target),
+                    CommutativeCancellation(
+                        target=pass_manager_config.target,
+                        approximation_degree=pass_manager_config.approximation_degree,
+                    ),
                     ContractIdleWiresInControlFlow(),
                 ]
                 post_loop = []
@@ -554,7 +561,10 @@ class OptimizationPassManager(PassManagerStagePlugin):
                     Optimize1qGatesDecomposition(
                         basis=pass_manager_config.basis_gates, target=pass_manager_config.target
                     ),
-                    CommutativeCancellation(target=pass_manager_config.target),
+                    CommutativeCancellation(
+                        target=pass_manager_config.target,
+                        approximation_degree=pass_manager_config.approximation_degree,
+                    ),
                     ContractIdleWiresInControlFlow(),
                 ]
                 post_loop = []

--- a/test/python/transpiler/test_commutative_cancellation.py
+++ b/test/python/transpiler/test_commutative_cancellation.py
@@ -884,5 +884,32 @@ measure q0[1] -> c0[1];
         self.assertTrue(left.structurally_equal(right))
 
 
+    def test_approximation_degree(self):
+        """Test that approximation_degree parameter is accepted and passed through."""
+        qr = QuantumRegister(2, "q")
+        circuit = QuantumCircuit(qr)
+        circuit.h(qr[0])
+        circuit.h(qr[0])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[0], qr[1])
+
+        # Test with explicit approximation_degree
+        passmanager = PassManager()
+        passmanager.append(CommutativeCancellation(approximation_degree=0.5))
+        result = passmanager.run(circuit)
+
+        # The gates should be cancelled (H cancels H, CX cancels CX)
+        # regardless of approximation_degree setting
+        self.assertEqual(result.count_ops()["h"], 0)
+        self.assertEqual(result.count_ops()["cx"], 0)
+
+        # Also test with None (should default to 1.0)
+        passmanager2 = PassManager()
+        passmanager2.append(CommutativeCancellation(approximation_degree=None))
+        result2 = passmanager2.run(circuit)
+        self.assertEqual(result2.count_ops()["h"], 0)
+        self.assertEqual(result2.count_ops()["cx"], 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/transpiler/test_commutative_cancellation.py
+++ b/test/python/transpiler/test_commutative_cancellation.py
@@ -885,30 +885,26 @@ measure q0[1] -> c0[1];
 
 
     def test_approximation_degree(self):
-        """Test that approximation_degree parameter is accepted and passed through."""
+        """Test that approximation_degree parameter is accepted and correctly wired."""
         qr = QuantumRegister(2, "q")
-        circuit = QuantumCircuit(qr)
-        circuit.h(qr[0])
-        circuit.h(qr[0])
-        circuit.cx(qr[0], qr[1])
-        circuit.cx(qr[0], qr[1])
 
-        # Test with explicit approximation_degree
-        passmanager = PassManager()
-        passmanager.append(CommutativeCancellation(approximation_degree=0.5))
-        result = passmanager.run(circuit)
+        for approx_degree in [None, 0.5, 1.0]:
+            with self.subTest(approximation_degree=approx_degree):
+                circuit = QuantumCircuit(qr)
+                circuit.h(qr[0])
+                circuit.h(qr[0])
+                circuit.cx(qr[0], qr[1])
+                circuit.cx(qr[0], qr[1])
 
-        # The gates should be cancelled (H cancels H, CX cancels CX)
-        # regardless of approximation_degree setting
-        self.assertEqual(result.count_ops()["h"], 0)
-        self.assertEqual(result.count_ops()["cx"], 0)
+                passmanager = PassManager()
+                passmanager.append(
+                    CommutativeCancellation(approximation_degree=approx_degree)
+                )
+                result = passmanager.run(circuit)
 
-        # Also test with None (should default to 1.0)
-        passmanager2 = PassManager()
-        passmanager2.append(CommutativeCancellation(approximation_degree=None))
-        result2 = passmanager2.run(circuit)
-        self.assertEqual(result2.count_ops()["h"], 0)
-        self.assertEqual(result2.count_ops()["cx"], 0)
+                # Gates should be fully cancelled regardless of approximation_degree
+                self.assertEqual(result.count_ops().get("h", 0), 0)
+                self.assertEqual(result.count_ops().get("cx", 0), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes Qiskit/qiskit#14115 - The CommutativeCancellation pass was missing an approximation_degree parameter, which is already supported by the underlying cancel_commutations Rust function and wired through in the C API, but not exposed via the Python class.

## Changes

1. **commutative_cancellation.py**: Added approximation_degree parameter to CommutativeCancellation.__init__ (default None → internally 1.0), and passed it through to cancel_commutations.

2. **builtin_plugins.py**: Updated the three instantiation sites of CommutativeCancellation in the preset pass managers to pass pass_manager_config.approximation_degree.

3. **test_commutative_cancellation.py**: Added test_approximation_degree to verify the new parameter is accepted and doesn't break existing gate cancellation behavior.

## Motivation

Other optimization passes (RemoveIdentityEquivalent, ConsolidateBlocks, UnitarySynthesis) already accept approximation_degree. CommutativeCancellation was inconsistent — the underlying Rust function supports it, but the Python wrapper didn't expose it, and the preset pass managers weren't wiring it through.

## Testing

- test_approximation_degree: Verifies gates are still correctly cancelled with both explicit and None approximation_degree values.
- Full test suite: python -m pytest test/python/transpiler/test_commutative_cancellation.py (requires pip install ddt)