### PR TITLE
Clarify inverse gate pairs in InverseCancellation docs

### DIFF
--- a/qiskit/transpiler/passes/optimization/inverse_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/inverse_cancellation.py
@@ -43,7 +43,9 @@ class InverseCancellation(TransformationPass):
             gates_to_cancel: List describing the gates to cancel. Each element of the
                 list is either a single gate or a pair of gates. If a single gate, then
                 it should be self-inverse. If a pair of gates, then the gates in the
-                pair should be inverses of each other. If ``None`` a default list of
+                pair should be inverses of each other. Gates such as :class:`.SGate` and
+                :class:`.SdgGate` must therefore be passed as a tuple pair, for example
+                ``[(SGate(), SdgGate())]``. If ``None`` a default list of
                 self-inverse gates and a default list of inverse gate pairs will be used.
                 The current default list of self-inverse gates is:
 


### PR DESCRIPTION
## Summary
- clarify that non-self-inverse gates such as `SGate` and `SdgGate` must be passed as a tuple pair in `InverseCancellation`
- keep the change scoped to the existing pass docstring

## Testing
- `source .venv-codex/bin/activate && python -m unittest test.python.transpiler.test_inverse_cancellation`

fixes #7413

### AI/LLM disclosure

- [ ] I didn't use LLM tooling, or only used it privately.
- [x] I used the following tool to help write this PR description: OpenAI Codex (GPT-5)
- [x] I used the following tool to generate or modify code: OpenAI Codex (GPT-5)
