### PR TITLE
Fix `synth_qft_line` with 32 or more qubits

### DIFF
--- a/crates/synthesis/src/qft/qft_decompose_lnn.rs
+++ b/crates/synthesis/src/qft/qft_decompose_lnn.rs
@@ -74,7 +74,7 @@ pub fn synth_qft_line(
         for j in i..num_qubits - 1 {
             let q0 = num_qubits - j + i - 1;
             let q1 = num_qubits - j + i - 2;
-            let phase = PI / (2_u32.pow((j - i + 2) as u32) as f64);
+            let phase = PI / 2.0_f64.powi((j - i + 2) as i32);
 
             if j - i + 2 < num_qubits - approximation_degree + 1 {
                 append_phase(&mut instructions, q0, phase);

--- a/releasenotes/notes/fix-qft-lnn-9d01e4ecc4995953.yaml
+++ b/releasenotes/notes/fix-qft-lnn-9d01e4ecc4995953.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed :func:`.synth_qft_line` to correctly synthesize circuits with
+    32 or more qubits.

--- a/test/python/synthesis/test_qft_synthesis.py
+++ b/test/python/synthesis/test_qft_synthesis.py
@@ -58,6 +58,12 @@ class TestQFTLNN(QiskitTestCase):
         with self.subTest(msg="synthesized QFT circuit do not have LNN connectivity"):
             self.assertTrue(check_lnn_connectivity(qft_lnn))
 
+    @data(50, 100, 1000)
+    def test_create_large_circuit(self, num_qubits):
+        """Test creating large QFT circuits."""
+        qft = synth_qft_line(num_qubits)
+        self.assertEqual(set(qft.count_ops()), {"p", "cx", "h"})
+
 
 @ddt
 class TestQFTFull(QiskitTestCase):
@@ -110,6 +116,12 @@ class TestQFTFull(QiskitTestCase):
             original = QFT(num_qubits, name="SomeRandomName")
         synthesized = synth_qft_full(num_qubits, name="SomeRandomName")
         self.assertEqual(original.name, synthesized.name)
+
+    @data(50, 100, 1000)
+    def test_create_large_circuit(self, num_qubits):
+        """Test creating large QFT circuits."""
+        qft = synth_qft_full(num_qubits)
+        self.assertEqual(set(qft.count_ops()), {"cp", "h", "swap"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

Discovered the bug when experimenting with Jake's script for running Sabre experiments.

In the debug more, the previous code panicked (attempting to multiply with overflow) when raising 2_u32 to power 32 or more. And in the release mode, I believe, the multiplication silently wrapped around, so we just obtained incorrect circuits.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
