### PR TITLE
Enable `try_matrix` & friends for PPR and PPM

### DIFF
--- a/crates/circuit/src/instruction.rs
+++ b/crates/circuit/src/instruction.rs
@@ -164,6 +164,7 @@ pub trait Instruction {
             OperationRef::StandardGate(g) => g.matrix(self.params_view()),
             OperationRef::Gate(g) => g.matrix(),
             OperationRef::Unitary(u) => u.matrix(),
+            OperationRef::PauliProductRotation(ppr) => ppr.matrix(),
             _ => None,
         }
     }

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -1740,6 +1740,29 @@ impl PauliProductRotation {
         }
         Some(out)
     }
+
+    pub fn matrix_as_static_1q(&self) -> Option<[[Complex64; 2]; 2]> {
+        if self.num_qubits() == 1 {
+            let arr = self.matrix()?;
+            Some([[arr[(0, 0)], arr[(0, 1)]], [arr[(1, 0)], arr[(1, 1)]]])
+        } else {
+            None
+        }
+    }
+
+    pub fn matrix_as_static_2q(&self) -> Option<[[Complex64; 4]; 4]> {
+        if self.num_qubits() == 2 {
+            let arr = self.matrix()?;
+            Some([
+                [arr[[0, 0]], arr[[0, 1]], arr[[0, 2]], arr[[0, 3]]],
+                [arr[[1, 0]], arr[[1, 1]], arr[[1, 2]], arr[[1, 3]]],
+                [arr[[2, 0]], arr[[2, 1]], arr[[2, 2]], arr[[2, 3]]],
+                [arr[[3, 0]], arr[[3, 1]], arr[[3, 2]], arr[[3, 3]]],
+            ])
+        } else {
+            None
+        }
+    }
 }
 
 impl PartialEq for PauliProductRotation {

--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -954,6 +954,7 @@ impl PackedInstruction {
             OperationRef::StandardGate(g) => g.matrix(self.params_view()),
             OperationRef::Gate(g) => g.matrix(),
             OperationRef::Unitary(u) => u.matrix(),
+            OperationRef::PauliProductRotation(ppr) => ppr.matrix(),
             _ => None,
         }
     }
@@ -966,6 +967,7 @@ impl PackedInstruction {
         match self.op.view() {
             OperationRef::StandardGate(g) => g.matrix(self.params_view()).map(CowArray::from),
             OperationRef::Gate(g) => g.matrix().map(CowArray::from),
+            OperationRef::PauliProductRotation(ppr) => ppr.matrix().map(CowArray::from),
             OperationRef::Unitary(u) => Some(CowArray::from(u.matrix_view())),
             _ => None,
         }

--- a/crates/circuit/src/packed_instruction.rs
+++ b/crates/circuit/src/packed_instruction.rs
@@ -981,6 +981,7 @@ impl PackedInstruction {
                 standard.matrix_as_static_1q(self.params_view())
             }
             OperationRef::Gate(gate) => gate.matrix_as_static_1q(),
+            OperationRef::PauliProductRotation(ppr) => ppr.matrix_as_static_1q(),
             OperationRef::Unitary(unitary) => unitary.matrix_as_static_1q(),
             _ => None,
         }
@@ -1005,6 +1006,7 @@ impl PackedInstruction {
                 standard.matrix_as_static_2q(self.params_view())
             }
             OperationRef::Gate(gate) => gate.matrix_as_static_2q(),
+            OperationRef::PauliProductRotation(ppr) => ppr.matrix_as_static_2q(),
             OperationRef::Unitary(unitary) => unitary.matrix_as_static_2q(),
             _ => None,
         }

--- a/crates/synthesis/src/discrete_basis/solovay_kitaev.rs
+++ b/crates/synthesis/src/discrete_basis/solovay_kitaev.rs
@@ -119,6 +119,11 @@ impl SolovayKitaevSynthesis {
                 let matrix_nalgebra: Matrix2<Complex64> = Matrix2::from_fn(|i, j| matrix[(i, j)]);
                 self.synthesize_matrix(&matrix_nalgebra, recursion_degree)
             }
+            OperationRef::PauliProductRotation(ppr) => {
+                let matrix = ppr.matrix().expect("PPR should have a matrix defined");
+                let matrix_nalgebra: Matrix2<Complex64> = Matrix2::from_fn(|i, j| matrix[(i, j)]);
+                self.synthesize_matrix(&matrix_nalgebra, recursion_degree)
+            }
             OperationRef::Gate(gate) => {
                 let matrix = gate.matrix();
                 match matrix {

--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -862,6 +862,7 @@ pub fn try_matrix_with_definition(
 ) -> Option<Array2<Complex64>> {
     match operation {
         OperationRef::StandardGate(gate) => gate.matrix(params),
+        OperationRef::PauliProductRotation(ppr) => ppr.matrix(),
         OperationRef::Unitary(unitary) => unitary.matrix(),
         OperationRef::Gate(gate) => Python::attach(|py| -> Option<_> {
             if let Some(matrix) = gate.matrix() {

--- a/releasenotes/notes/fix-ppr-commutation-checking-3d0c0c9397da4570.yaml
+++ b/releasenotes/notes/fix-ppr-commutation-checking-3d0c0c9397da4570.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed matrix-based checks for :class:`.PauliProductRotationGate` in the
+    :class:`.CommutationChecker`.  Previously, these checks always returned
+    ``False``.

--- a/releasenotes/notes/fix-ppr-commutation-checking-3d0c0c9397da4570.yaml
+++ b/releasenotes/notes/fix-ppr-commutation-checking-3d0c0c9397da4570.yaml
@@ -1,6 +1,6 @@
 ---
-fixes:
+features_transpiler:
   - |
-    Fixed matrix-based checks for :class:`.PauliProductRotationGate` in the
+    Enable matrix-based checks for :class:`.PauliProductRotationGate` in the
     :class:`.CommutationChecker`.  Previously, these checks always returned
     ``False``.

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -627,17 +627,20 @@ class TestCommutationChecker(QiskitTestCase):
                 commutes = scc.commute(pauli_gate, pauli_indices, [], std_gate, indices, [])
                 self.assertEqual(expected, commutes)
 
-    @data("evolution", "pauli", "rotation")
+    @data("evolution", "pauli", "rotation", "measure")
     def test_pauli_based_with_matrix(self, pauli_type):
         """Test commutation with a matrix-based gate."""
         z_pauli = build_pauli_gate("Z", pauli_type)
+        clbit = [0] if pauli_type == "measure" else []
         z_unitary = UnitaryGate(ZGate().to_matrix())
         x_unitary = UnitaryGate(XGate().to_matrix())
 
         with self.subTest(other="x_unitary"):
-            self.assertFalse(scc.commute(z_pauli, [0], [], x_unitary, [0], []))
+            self.assertFalse(scc.commute(z_pauli, [0], clbit, x_unitary, [0], []))
+
+        expect = pauli_type != "measure"  # False for measure, else True
         with self.subTest(other="z_unitary"):
-            self.assertTrue(scc.commute(z_pauli, [0], [], z_unitary, [0], []))
+            self.assertEqual(expect, scc.commute(z_pauli, [0], clbit, z_unitary, [0], []))
 
 
 def build_pauli_gate(pauli_string: str, gate_type: str) -> Gate:

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -627,6 +627,18 @@ class TestCommutationChecker(QiskitTestCase):
                 commutes = scc.commute(pauli_gate, pauli_indices, [], std_gate, indices, [])
                 self.assertEqual(expected, commutes)
 
+    @data("evolution", "pauli", "rotation")
+    def test_pauli_based_with_matrix(self, pauli_type):
+        """Test commutation with a matrix-based gate."""
+        z_pauli = build_pauli_gate("Z", pauli_type)
+        z_unitary = UnitaryGate(ZGate().to_matrix())
+        x_unitary = UnitaryGate(XGate().to_matrix())
+
+        with self.subTest(other="x_unitary"):
+            self.assertFalse(scc.commute(z_pauli, [0], [], x_unitary, [0], []))
+        with self.subTest(other="z_unitary"):
+            self.assertTrue(scc.commute(z_pauli, [0], [], z_unitary, [0], []))
+
 
 def build_pauli_gate(pauli_string: str, gate_type: str) -> Gate:
     """Build a Pauli-based gate off a Pauli string.

--- a/test/python/transpiler/test_solovay_kitaev.py
+++ b/test/python/transpiler/test_solovay_kitaev.py
@@ -33,10 +33,11 @@ from qiskit.circuit.library import (
     RXGate,
     RYGate,
     RZGate,
+    PauliProductRotationGate,
 )
 from qiskit.circuit import QuantumRegister
 from qiskit.converters import circuit_to_dag, dag_to_circuit
-from qiskit.quantum_info import Operator
+from qiskit.quantum_info import Operator, Pauli
 from qiskit.synthesis.discrete_basis.generate_basis_approximations import (
     generate_basic_approximations,
 )
@@ -382,6 +383,20 @@ class TestSolovayKitaev(QiskitTestCase):
         transpiled = self.default_sk(circuit)
         diff = _trace_distance(circuit, transpiled)
         self.assertLess(diff, 1e-6)
+
+    def test_ppr(self):
+        """Test a circuit with a Pauli-product rotation."""
+        ppr = PauliProductRotationGate(Pauli("X"), 0.2)
+        circuit = QuantumCircuit(1)
+        circuit.append(ppr, [0])
+
+        transpiled = self.default_sk(circuit)
+        with self.subTest(msg="test gate set"):
+            self.assertEqual(set(transpiled.count_ops()), {"h", "t", "tdg"})
+
+        with self.subTest(msg="test approximation"):
+            diff = _trace_distance(circuit, transpiled)
+            self.assertLess(diff, 1e-5)
 
     @data(["unitary"], ["rz"])
     def test_sk_synth_gates_to_basis(self, synth_gates):


### PR DESCRIPTION
Previously, the `matrix` method was added but not actually used in the codebase. This commit also fixes the commutation checker for PPR with another matrix-based gate, which previously failed since it couldn't extract a matrix from PPR.

It would be good to backport this to 2.4, though we have to backport #15975 first.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
