### PR TITLE
Use bytemuck to cast `u32` to `Qubit`.

### DIFF
--- a/crates/circuit/Cargo.toml
+++ b/crates/circuit/Cargo.toml
@@ -18,7 +18,7 @@ qiskit-quantum-info.workspace = true
 rayon.workspace = true
 ahash.workspace = true
 rustworkx-core.workspace = true
-bytemuck.workspace = true
+bytemuck = {workspace = true, features = ["derive"]}
 bitfield-struct.workspace = true
 num-complex.workspace = true
 num-bigint.workspace = true

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -40,15 +40,16 @@ pub mod var_stretch_container;
 mod variable_mapper;
 pub mod vf2;
 
+use bytemuck::AnyBitPattern;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PySequence, PyString, PyTuple};
 
-#[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq, FromPyObject)]
+#[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq, FromPyObject, AnyBitPattern)]
 #[repr(transparent)]
 pub struct Qubit(pub u32);
 
-#[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq, FromPyObject)]
+#[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq, FromPyObject, AnyBitPattern)]
 #[repr(transparent)]
 pub struct Clbit(pub u32);
 

--- a/crates/quantum_info/src/clifford.rs
+++ b/crates/quantum_info/src/clifford.rs
@@ -290,7 +290,7 @@ impl Clifford {
 
     /// Evolving the single-qubit Pauli-Z with Z on qubit qbit.
     /// Returns the evolved Pauli in the a sparse ZX format: (sign, z, x, indices).
-    pub fn get_inverse_z(&self, qbit: usize) -> (bool, Vec<bool>, Vec<bool>, Vec<usize>) {
+    pub fn get_inverse_z(&self, qbit: usize) -> (bool, Vec<bool>, Vec<bool>, Vec<u32>) {
         let mut z = Vec::with_capacity(self.num_qubits);
         let mut x = Vec::with_capacity(self.num_qubits);
         let mut indices = Vec::with_capacity(self.num_qubits);
@@ -303,7 +303,7 @@ impl Clifford {
             if z_bit || x_bit {
                 z.push(z_bit);
                 x.push(x_bit);
-                indices.push(i);
+                indices.push(i as u32);
                 if x_bit {
                     pauli_indices.push(i);
                 }

--- a/crates/transpiler/src/passes/litinski_transformation.rs
+++ b/crates/transpiler/src/passes/litinski_transformation.rs
@@ -254,7 +254,7 @@ pub fn run_litinski_transformation(
                     let (sign, z, x, indices) =
                         clifford.get_inverse_z(dag.get_qargs(inst.qubits)[0].index());
                     qargs.clear();
-                    qargs.extend(indices.iter().map(|i| Qubit::new(*i)));
+                    qargs.extend(bytemuck::cast_slice(&indices));
 
                     // In the legacy path, we add PauliEvolutionGate as rotation gates, otherwise
                     // we add PauliProductRotation. The new path should not call Python at any
@@ -309,7 +309,7 @@ pub fn run_litinski_transformation(
                     let (sign, z, x, indices) =
                         clifford.get_inverse_z(dag.get_qargs(inst.qubits)[0].index());
                     qargs.clear();
-                    qargs.extend(indices.iter().map(|i| Qubit::new(*i)));
+                    qargs.extend(bytemuck::cast_slice(&indices));
 
                     let ppm = PauliProductMeasurement { z, x, neg: sign };
 


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->
Fixes #15932
- Derive the `AnyBitPattern` trait for `Qubit` and `Clbit` to allow bytemuck to easily cast from `u32` which also enables us to cast from and to their respective slice types.
- Implemented said cases in the `ListinskiTransformation` pass.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
