### PR TITLE
minor fixes for `cargo clippy --all-targets`

### DIFF
--- a/crates/circuit/src/circuit_drawer.rs
+++ b/crates/circuit/src/circuit_drawer.rs
@@ -1630,6 +1630,7 @@ q_3: ──────────────────────┤1     
             let qubits = (0..num_qubits)
                 .map(|x| Qubit(x + (i as u32 % (num_wires - num_qubits))))
                 .collect::<Vec<_>>();
+            #[allow(clippy::approx_constant)]
             let params = (0..num_params)
                 .map(|_x| 3.141.into())
                 .collect::<Vec<Param>>();
@@ -1718,6 +1719,7 @@ q_4: ─────────────────────────
 
     #[cfg(not(miri))]
     #[test]
+    #[allow(clippy::approx_constant)]
     fn test_global_phase() {
         let mut circuit = basic_circuit();
         circuit.set_global_phase_param(3.14.into()).unwrap();
@@ -1848,7 +1850,7 @@ q_1: ┤1         ├┤1            ├┤1         ├
             }
         }
         for i in [1, 2, 3, 4] {
-            let qubits = (0..i).map(|x| Qubit::new(x)).collect::<Vec<_>>();
+            let qubits = (0..i).map(Qubit::new).collect::<Vec<_>>();
             let inst = PackedInstruction {
                 op: StandardInstruction::Barrier(i as u32).into(),
                 qubits: circuit.add_qargs(&qubits),

--- a/crates/qpy/src/consts.rs
+++ b/crates/qpy/src/consts.rs
@@ -70,6 +70,7 @@ pub fn standard_gate_from_gate_class_name(name: &str) -> Option<StandardGate> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use qiskit_circuit::imports::get_std_gate_class_name;

--- a/crates/synthesis/src/linalg/mod.rs
+++ b/crates/synthesis/src/linalg/mod.rs
@@ -372,7 +372,6 @@ pub fn is_zero_matrix_faer(mat: MatRef<Complex64>, atol: Option<f64>) -> bool {
 #[cfg(test)]
 mod test {
     use super::*;
-    use faer::prelude::*;
     use nalgebra::DMatrix;
 
     #[test]


### PR DESCRIPTION
This PR fixes clippy warnings and errors when calling `cargo clippy --all-targets` (which also includes code in our rust tests).

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
