### PR TITLE
say that docs dependencies require Python>=3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,12 +212,12 @@ test-random = [
 # Dependencies to build the documentation.  It's ok if the range of Python versions that can build
 # the docs is more restrictive than Python versions that Qiskit supports.
 doc = [
-    "Sphinx==9.1.0",
-    "docutils==0.22.4",
-    "openqasm-pygments",
-    "reno>=4.1.0",  # duplicated with `lint`
-    "sphinxcontrib-katex==0.9.9",
-    "breathe>=4.35.0",
+    "Sphinx==9.1.0; python_version>='3.12'",
+    "docutils==0.22.4; python_version>='3.12'",
+    "openqasm-pygments; python_version>='3.12'",
+    "reno>=4.1.0; python_version>='3.12'",  # duplicated with `lint`
+    "sphinxcontrib-katex==0.9.9; python_version>='3.12'",
+    "breathe>=4.35.0; python_version>='3.12'",
 ]
 
 


### PR DESCRIPTION
<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->

The docs dependencies require at least Python 3.12. The comment above the dependencies mentions this possibility, but making it explicit allows tools like `uv` to work out of the box. Without it, you get this error:
```bash
% uv sync
  × No solution found when resolving dependencies for split (markers: python_full_version == '3.11.*' and
  │ sys_platform == 'win32'):
  ╰─▶ Because the requested Python version (>=3.10) does not satisfy Python>=3.12 and sphinx==9.1.0 depends on
      Python>=3.12, we can conclude that sphinx==9.1.0 cannot be used.
      And because qiskit:dev depends on sphinx==9.1.0 and your project requires qiskit:dev, we can conclude that
      your project's requirements are unsatisfiable.

      hint: While the active Python version is 3.13, the resolution failed for other Python versions supported
      by your project. Consider limiting your project's supported Python versions using `requires-python`.

      hint: The `requires-python` value (>=3.10) includes Python versions that are not supported by
      your dependencies (e.g., sphinx==9.1.0 only supports >=3.12). Consider using a more restrictive
      `requires-python` value (like >=3.12).
```