### PR TITLE
Fixed commutation checking between two Pauli product measurements

### DIFF
--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -16,6 +16,7 @@ use ndarray::linalg::kron;
 use num_complex::Complex64;
 use num_complex::ComplexFloat;
 use qiskit_circuit::object_registry::PyObjectAsKey;
+use qiskit_circuit::operations::PauliProductMeasurement;
 use qiskit_circuit::standard_gate::standard_generators::standard_gate_exponent;
 use qiskit_quantum_info::sparse_observable::{PySparseObservable, SparseObservable};
 use smallvec::SmallVec;
@@ -224,6 +225,18 @@ fn try_extract_op_from_ppm(
     let local = xz_to_observable(&ppm.x, &ppm.z);
     let out = SparseObservable::identity(num_qubits);
     Some(out.compose_map(&local, |i| qubits[i as usize].0))
+}
+
+/// Given a pauli product measurement, returns its generator (represented as a sparse observable)
+/// and the sign (representing the pauli phase).
+fn observable_generator_from_ppm(
+    ppm: &PauliProductMeasurement,
+    qubits: &[Qubit],
+    num_qubits: u32,
+) -> (SparseObservable, bool) {
+    let local = xz_to_observable(&ppm.x, &ppm.z);
+    let out = SparseObservable::identity(num_qubits);
+    (out.compose_map(&local, |i| qubits[i as usize].0), ppm.neg)
 }
 
 fn try_extract_op_from_ppr(
@@ -496,24 +509,22 @@ impl CommutationChecker {
             _ => (),
         };
 
-        // Special handling for commutativity of two pauli product measurements
+        // Special handling for commutativity of two pauli product measurements in the case they write to
+        // the same classical bit. In this case, it's generally incorrect to interchange them, so we only
+        // do this if they have the same generators (represented as sparse observables + signs).
         if let (
             OperationRef::PauliProductMeasurement(ppm1),
             OperationRef::PauliProductMeasurement(ppm2),
         ) = (op1, op2)
         {
             if cargs1 == cargs2 {
-                // If both PPMs write to the same classical bit, it's generally incorrect to interchange them.
-                // So we return true only if both PPMs are identical.
-                return Ok(qargs1 == qargs2 && ppm1 == ppm2);
-            } else {
-                // PPMs write to different classical bits, and they commute if and only if their pauli generators do.
                 let size = qargs1.iter().chain(qargs2.iter()).max().unwrap().0 + 1;
-                let pauli1 =  try_pauli_generator(op1, qargs1, size).expect("extracting sparse observable generator from pauli product measurement in infallible");
-                let pauli2 =  try_pauli_generator(op2, qargs2, size).expect("extracting sparse observable generator from pauli product measurement in infallible");
-                return Ok(pauli1.commutes(&pauli2, tol));
+                let pauli1 = observable_generator_from_ppm(ppm1, qargs1, size);
+                let pauli2 = observable_generator_from_ppm(ppm2, qargs2, size);
+                return Ok(pauli1 == pauli2);
             }
         }
+
         // Handle commutations between Pauli-based gates among themselves, and with standard gates
         // TODO Support trivial commutations of standard gates with identities in the Paulis
         let size = qargs1.iter().chain(qargs2.iter()).max().unwrap().0 + 1;

--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -505,7 +505,7 @@ impl CommutationChecker {
             if cargs1 == cargs2 {
                 // If both PPMs write to the same classical bit, it's generally incorrect to interchange them.
                 // So we return true only if both PPMs are identical.
-                return Ok(ppm1 == ppm2);
+                return Ok(qargs1 == qargs2 && ppm1 == ppm2);
             } else {
                 // PPMs write to different classical bits, and they commute if and only if their pauli generators do.
                 let size = qargs1.iter().chain(qargs2.iter()).max().unwrap().0 + 1;

--- a/crates/transpiler/src/commutation_checker.rs
+++ b/crates/transpiler/src/commutation_checker.rs
@@ -496,6 +496,24 @@ impl CommutationChecker {
             _ => (),
         };
 
+        // Special handling for commutativity of two pauli product measurements
+        if let (
+            OperationRef::PauliProductMeasurement(ppm1),
+            OperationRef::PauliProductMeasurement(ppm2),
+        ) = (op1, op2)
+        {
+            if cargs1 == cargs2 {
+                // If both PPMs write to the same classical bit, it's generally incorrect to interchange them.
+                // So we return true only if both PPMs are identical.
+                return Ok(ppm1 == ppm2);
+            } else {
+                // PPMs write to different classical bits, and they commute if and only if their pauli generators do.
+                let size = qargs1.iter().chain(qargs2.iter()).max().unwrap().0 + 1;
+                let pauli1 =  try_pauli_generator(op1, qargs1, size).expect("extracting sparse observable generator from pauli product measurement in infallible");
+                let pauli2 =  try_pauli_generator(op2, qargs2, size).expect("extracting sparse observable generator from pauli product measurement in infallible");
+                return Ok(pauli1.commutes(&pauli2, tol));
+            }
+        }
         // Handle commutations between Pauli-based gates among themselves, and with standard gates
         // TODO Support trivial commutations of standard gates with identities in the Paulis
         let size = qargs1.iter().chain(qargs2.iter()).max().unwrap().0 + 1;

--- a/releasenotes/notes/fix-ppm-commutation-ddcde0bf8b20a9f8.yaml
+++ b/releasenotes/notes/fix-ppm-commutation-ddcde0bf8b20a9f8.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed commutativity check between two :class:`.PauliProductMeasurement` instructions
+    in the case that both instructions measure to the same classical bit. In this case,
+    the later measurement overwrites the result of the earlier measurement, and consequently,
+    interchanging the two measurement instructions inside the quantum circuit is generally
+    invalid.

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -556,15 +556,50 @@ class TestCommutationChecker(QiskitTestCase):
 
     def test_ppms_with_same_clbit(self):
         """Test commutativity of two Pauli product measurements with the same clbit."""
-        ppm1 = build_pauli_gate("XXII", "measure")
-        ppm2 = build_pauli_gate("IIZZ", "measure")
 
-        with self.subTest("different paulis"):
-            self.assertFalse(scc.commute(ppm1, [0, 1, 2, 3], [0], ppm2, [0, 1, 2, 3], [0]))
-        with self.subTest("same paulis, different qubits"):
-            self.assertFalse(scc.commute(ppm1, [0, 1, 2, 3], [0], ppm1, [1, 0, 2, 3], [0]))
-        with self.subTest("same paulis and qubits"):
-            self.assertTrue(scc.commute(ppm1, [0, 1, 2, 3], [0], ppm1, [0, 1, 2, 3], [0]))
+        # Each case represents (pauli1, qubits1, pauli2, qubits2, expected result).
+        # Recall that the convention is that pauli strings are read right-to-left, i.e.
+        # pauli strings and qubits are in reverse order relative to each other.
+        cases = [
+            ("XXII", [1, 0, 2, 3], "IIZZ", [1, 0, 2, 3], False),  # different Paulis
+            ("XYIZ", [1, 0, 2, 3], "XYIZ", [1, 0, 4, 3], False),  # different qubits
+            (
+                "ZXII",
+                [1, 0, 2, 3],
+                "-ZXII",
+                [1, 0, 2, 3],
+                False,
+            ),  # different Paulis (including sign)
+            ("XYIZ", [1, 0, 2, 3], "XYIZ", [1, 0, 2, 3], True),  # same Paulis and qubits
+            ("-XYIZ", [1, 0, 2, 3], "-XYIZ", [1, 0, 2, 3], True),  # same Paulis and qubits
+            (
+                "XXIY",
+                [0, 1, 2, 3],
+                "YIXX",
+                [3, 2, 1, 0],
+                True,
+            ),  # same Paulis and qubits up to reordering
+            (
+                "XXIY",
+                [0, 1, 2, 3],
+                "XXIY",
+                [0, 1, 3, 2],
+                True,
+            ),  # same Paulis and qubits up to reordering
+            (
+                "-XXIY",
+                [0, 1, 2, 3],
+                "-YIXX",
+                [2, 3, 1, 0],
+                True,
+            ),  # same Paulis and qubits up to reordering
+        ]
+
+        for pauli1, qubits1, pauli2, qubits2, expected in cases:
+            with self.subTest(pauli1=pauli1, qubits1=qubits1, pauli2=pauli2, qubits2=qubits2):
+                ppm1 = build_pauli_gate(pauli1, "measure")
+                ppm2 = build_pauli_gate(pauli2, "measure")
+                self.assertEqual(scc.commute(ppm1, qubits1, [0], ppm2, qubits2, [0]), expected)
 
     def test_pauli_evolution_sums(self):
         """Test PauliEvolutionGate commutations for operators that are sums of Paulis."""

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -525,10 +525,11 @@ class TestCommutationChecker(QiskitTestCase):
         for p1, q1, p2, q2, expected in cases:
             if p1 == "I" and gate_type == "measure":
                 continue  # PPM doesn't support all-identity gates
+            c1, c2 = ([0], [1]) if gate_type == "measure" else ([], [])
 
             gate1 = build_pauli_gate(p1, gate_type)
             gate2 = build_pauli_gate(p2, gate_type)
-            self.assertEqual(expected, scc.commute(gate1, q1, [], gate2, q2, []))
+            self.assertEqual(expected, scc.commute(gate1, q1, c1, gate2, q2, c2))
 
     @data(
         ("pauli", "measure"),
@@ -544,10 +545,24 @@ class TestCommutationChecker(QiskitTestCase):
         ]
 
         for p1, q1, p2, q2, expected in cases:
+            c1 = [0] if gate_type1 == "measure" else []
+            c2 = [1] if gate_type2 == "measure" else []
+
             gate1 = build_pauli_gate(p1, gate_type1)
             gate2 = build_pauli_gate(p2, gate_type2)
+
             with self.subTest(p1=p1, p2=p2):
-                self.assertEqual(expected, scc.commute(gate1, q1, [], gate2, q2, []))
+                self.assertEqual(expected, scc.commute(gate1, q1, c1, gate2, q2, c2))
+
+    def test_ppms_with_same_clbit(self):
+        """Test commutativity of two Pauli product measurements with the same clbit."""
+        ppm1 = build_pauli_gate("XXII", "measure")
+        ppm2 = build_pauli_gate("IIZZ", "measure")
+
+        with self.subTest("different paulis"):
+            self.assertFalse(scc.commute(ppm1, [0, 1, 2, 3], [0], ppm2, [0, 1, 2, 3], [0]))
+        with self.subTest("same paulis"):
+            self.assertTrue(scc.commute(ppm1, [0, 1, 2, 3], [0], ppm1, [0, 1, 2, 3], [0]))
 
     def test_pauli_evolution_sums(self):
         """Test PauliEvolutionGate commutations for operators that are sums of Paulis."""
@@ -585,7 +600,8 @@ class TestCommutationChecker(QiskitTestCase):
         """Test Pauli-based gates and standard gate commutations are efficiently supported."""
         # 40-qubit Pauli gate with following terms: X: 0-9, Y: 10-19, Z: 20-29, I: 30-39
         pauli = 10 * "I" + 10 * "Z" + 10 * "Y" + 10 * "X"
-        pauli_indices = list(range(len(pauli)))
+        pauli_qubits = list(range(len(pauli)))
+        pauli_clbits = [0] if pauli_type == "measure" else []
         pauli_gate = build_pauli_gate(pauli, pauli_type)
 
         # Test cases in the format: (gate, indices, commutes)
@@ -607,7 +623,9 @@ class TestCommutationChecker(QiskitTestCase):
 
         for std_gate, indices, expected in cases:
             with self.subTest(std_gate=std_gate, indices=indices):
-                commutes = scc.commute(pauli_gate, pauli_indices, [], std_gate, indices, [])
+                commutes = scc.commute(
+                    pauli_gate, pauli_qubits, pauli_clbits, std_gate, indices, []
+                )
                 self.assertEqual(expected, commutes)
 
 

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -566,41 +566,17 @@ class TestCommutationChecker(QiskitTestCase):
             # different qubits
             ("XYIZ", [1, 0, 2, 3], "XYIZ", [1, 0, 4, 3], False),
             # different Paulis (including sign)
-            (
-                "ZXII",
-                [1, 0, 2, 3],
-                "-ZXII",
-                [1, 0, 2, 3],
-                False,
-            ),
+            ("ZXII", [1, 0, 2, 3], "-ZXII", [1, 0, 2, 3], False),
             # same Paulis and qubits
             ("XYIZ", [1, 0, 2, 3], "XYIZ", [1, 0, 2, 3], True),
             # same Paulis and qubits
             ("-XYIZ", [1, 0, 2, 3], "-XYIZ", [1, 0, 2, 3], True),
             # same Paulis and qubits up to reordering
-            (
-                "XXIY",
-                [0, 1, 2, 3],
-                "YIXX",
-                [3, 2, 1, 0],
-                True,
-            ),
+            ("XXIY", [0, 1, 2, 3], "YIXX", [3, 2, 1, 0], True),
             # same Paulis and qubits up to reordering
-            (
-                "XXIY",
-                [0, 1, 2, 3],
-                "XXIY",
-                [0, 1, 3, 2],
-                True,
-            ),
+            ("XXIY", [0, 1, 2, 3], "XXIY", [0, 1, 3, 2], True),
             # same Paulis and qubits up to reordering
-            (
-                "-XXIY",
-                [0, 1, 2, 3],
-                "-YIXX",
-                [2, 3, 1, 0],
-                True,
-            ),
+            ("-XXIY", [0, 1, 2, 3], "-YIXX", [2, 3, 1, 0], True),
         ]
 
         for pauli1, qubits1, pauli2, qubits2, expected in cases:

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -561,38 +561,46 @@ class TestCommutationChecker(QiskitTestCase):
         # Recall that the convention is that pauli strings are read right-to-left, i.e.
         # pauli strings and qubits are in reverse order relative to each other.
         cases = [
-            ("XXII", [1, 0, 2, 3], "IIZZ", [1, 0, 2, 3], False),  # different Paulis
-            ("XYIZ", [1, 0, 2, 3], "XYIZ", [1, 0, 4, 3], False),  # different qubits
+            # different Paulis
+            ("XXII", [1, 0, 2, 3], "IIZZ", [1, 0, 2, 3], False),
+            # different qubits
+            ("XYIZ", [1, 0, 2, 3], "XYIZ", [1, 0, 4, 3], False),
+            # different Paulis (including sign)
             (
                 "ZXII",
                 [1, 0, 2, 3],
                 "-ZXII",
                 [1, 0, 2, 3],
                 False,
-            ),  # different Paulis (including sign)
-            ("XYIZ", [1, 0, 2, 3], "XYIZ", [1, 0, 2, 3], True),  # same Paulis and qubits
-            ("-XYIZ", [1, 0, 2, 3], "-XYIZ", [1, 0, 2, 3], True),  # same Paulis and qubits
+            ),
+            # same Paulis and qubits
+            ("XYIZ", [1, 0, 2, 3], "XYIZ", [1, 0, 2, 3], True),
+            # same Paulis and qubits
+            ("-XYIZ", [1, 0, 2, 3], "-XYIZ", [1, 0, 2, 3], True),
+            # same Paulis and qubits up to reordering
             (
                 "XXIY",
                 [0, 1, 2, 3],
                 "YIXX",
                 [3, 2, 1, 0],
                 True,
-            ),  # same Paulis and qubits up to reordering
+            ),
+            # same Paulis and qubits up to reordering
             (
                 "XXIY",
                 [0, 1, 2, 3],
                 "XXIY",
                 [0, 1, 3, 2],
                 True,
-            ),  # same Paulis and qubits up to reordering
+            ),
+            # same Paulis and qubits up to reordering
             (
                 "-XXIY",
                 [0, 1, 2, 3],
                 "-YIXX",
                 [2, 3, 1, 0],
                 True,
-            ),  # same Paulis and qubits up to reordering
+            ),
         ]
 
         for pauli1, qubits1, pauli2, qubits2, expected in cases:

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -561,7 +561,9 @@ class TestCommutationChecker(QiskitTestCase):
 
         with self.subTest("different paulis"):
             self.assertFalse(scc.commute(ppm1, [0, 1, 2, 3], [0], ppm2, [0, 1, 2, 3], [0]))
-        with self.subTest("same paulis"):
+        with self.subTest("same paulis, different qubits"):
+            self.assertFalse(scc.commute(ppm1, [0, 1, 2, 3], [0], ppm1, [1, 0, 2, 3], [0]))
+        with self.subTest("same paulis and qubits"):
             self.assertTrue(scc.commute(ppm1, [0, 1, 2, 3], [0], ppm1, [0, 1, 2, 3], [0]))
 
     def test_pauli_evolution_sums(self):


### PR DESCRIPTION

### Summary

We have recently realized that checking commutativity between two `PauliProductMeasurement` instructions (introduced in #15359) is incorrect in the case that both measurements measure to the same classical bit. In this case, the later measurement overwrites the result of the earlier measurement, and thus the order of these instructions in the quantum circuit matters. This PR applies a simple fix of saying that two Pauli product measurement instruction do not commute unless they are completely identical (including pauli, qubits and clbits).

(Updated) This also handles "canonicalization":  `PPM(XZ, qubits=[0,1], clbits=[0])` is the same as `PPM(ZX, qubits=[1,0], clbits=[0])`, and so they are now also computed to commute.

Note: the current strategy of constructing sparse observable is in the spirit of the existing code, and I am trying to do minimal changes in order to backport a variant of this to 2.4. I have a followup PR #15815 that greatly increases the efficiency of commuting PPRs/PPMs among themselves (including canonicalization, but temporarily having the same problems as being fixed here).

This also updates commutativity checking tests to pass clbits when checking commutativity between two PPMs.

One other question: do we want to backport the fix to 2.4? If so, we would need to adjust this PR to the commutation checker version before #15488.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
