### PR TITLE
Avoid triggering register/layout warning in `remove_final_measurements`

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -4719,16 +4719,18 @@ class QuantumCircuit:
             qubits=circ._data.qubits, reserve=len(circ._data), global_phase=circ.global_phase
         )
 
-        # Re-add old registers
+        # Re-add old registers.  We avoid `add_register` since we already know the registers are
+        # valid, the bits exist, and we don't want to trigger the "modified the quantum registers
+        # with a set layout" warning.
         for qreg in old_qregs:
-            circ.add_register(qreg)
+            circ._data.add_qreg(qreg)
 
         # We must add the clbits first to preserve the original circuit
         # order. This way, add_register never adds clbits and just
         # creates registers that point to them.
         circ.add_bits(clbits_to_add)
         for creg in cregs_to_add:
-            circ.add_register(creg)
+            circ._data.add_creg(creg)
 
         # Set circ instructions to match the new DAG
         for node in new_dag.topological_op_nodes():

--- a/releasenotes/notes/remove-final-measurements-layout-6d0f87de07a6fdd6.yaml
+++ b/releasenotes/notes/remove-final-measurements-layout-6d0f87de07a6fdd6.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    :meth:`.QuantumCircuit.remove_final_measurements` will no longer emit a spurious warning about
+    trying to add registers when called on a circuit with a set layout.

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -14,6 +14,7 @@
 """Test Qiskit's QuantumCircuit class."""
 import copy
 import pickle
+import warnings
 from itertools import combinations
 
 import numpy as np
@@ -37,7 +38,7 @@ from qiskit.circuit import AncillaQubit, AncillaRegister, Qubit
 from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.providers.basic_provider import BasicSimulator
 from qiskit.quantum_info import Operator
-from qiskit.transpiler import Layout, CouplingMap
+from qiskit.transpiler import Layout, CouplingMap, passes
 from test import QiskitTestCase
 
 
@@ -1057,6 +1058,28 @@ class TestCircuitOperations(QiskitTestCase):
         )
         qc.remove_final_measurements(inplace=True)
         self.assertEqual(qc.assign_parameters({a: 1}), expected)
+
+    def test_remove_final_measurement_with_layout(self):
+        def apply_layout(qc):
+            layout = Layout(dict(zip(qc.qubits, [1, 0])))
+            return passes.ApplyLayout()(qc, property_set={"layout": layout})
+
+        qc = QuantumCircuit(2, 2)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.measure([0, 1], [0, 1])
+        qc = apply_layout(qc)
+
+        expected = QuantumCircuit(2)
+        expected.h(0)
+        expected.cx(0, 1)
+        expected = apply_layout(expected)
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error", module=r"(qiskit|test)")
+            self.assertEqual(qc.remove_final_measurements(inplace=False), expected)
+            qc.remove_final_measurements(inplace=True)
+            self.assertEqual(qc, expected)
 
     def test_reverse(self):
         """Test reverse method reverses but does not invert."""


### PR DESCRIPTION
`QuantumCircuit.remove_final_measurements` has always been a bit fragile because it attempts to do effectively in-place deletions of bits of metadata while leaving others intact.  Since the "layout" warning is only about modifying the `qregs`, and those are untouched by `remove_final_measurements`, we know that the register modifications are at least safe here and can avoid the warning.

Fix #16025

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
