### PR TITLE
Mark `doc` dependency group as Python>=3.12 for `uv`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -503,3 +503,10 @@ exclude_also = [
     "if TYPE_CHECKING:",          # Code that only runs during type checks
     "@abstractmethod",            # Abstract methods are not testable
     ]
+
+# Qiskit doesn't mandate use of `uv`, but we can include this as a convenience for the multitude of
+# devs who do like it.  Without setting the per-group Python versions, `uv sync` (and any other
+# command that attempts to build the lockfile) will fail on some groups, even if you don't attempt
+# to use the group with a bad version of Python.
+[tool.uv.dependency-groups]
+doc = { requires-python = ">=3.12" }


### PR DESCRIPTION
Qiskit does not mandate the use of `uv` to manage the project, but we have enough downstream devs that like it, and `uv` is now established enough that it's not so onerous to mark the extra Python dependency on the group.

Hopefully this concept will standardise for the whole Python ecosystem, rather than remaining `uv`-specific.

See #16022 for the motivation.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
