### PR TITLE
Update QPY format version history table

### DIFF
--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -199,6 +199,12 @@ of QPY in qiskit-terra 0.18.0.
    * - Qiskit (qiskit-terra for < 1.0.0) version
      - :func:`.dump` format(s) output versions
      - :func:`.load` maximum supported version (older format versions can always be read)
+   * - 2.4.0
+     - 13, 14, 15, 16, 17
+     - 17
+   * - 2.3.1
+     - 13, 14, 15, 16, 17
+     - 17
    * - 2.3.0
      - 13, 14, 15, 16, 17
      - 17


### PR DESCRIPTION
With the 2.4.0 release pending this commit updates the version history table to include the missing 2.3.1 and the future 2.4.0. Right now the table only shows up to 2.3.0 which is not the current release. We should add this to the release process checklist so we don't forget in future release to update this table.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

### AI/LLM disclosure

- [X] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
