### PR TITLE
Remove manual `pip install` commands from `tox.ini`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -87,8 +87,9 @@ basepython = python3
 setenv =
   {[testenv]setenv}
   PYTHON=coverage run --source qiskit --parallel-mode
-commands_pre =
-  pip install -c {toxinidir}/constraints.txt --group optionals-all
+dependency_groups =
+  {[testenv]dependency_groups}
+  optionals-all
 commands =
   stestr run {posargs}
   coverage combine
@@ -102,10 +103,9 @@ allowlist_externals =
 setenv =
   {[testenv]setenv}
   QISKIT_BUILD_PROFILE=debug
-commands_pre =
-  pip install -c {toxinidir}/constraints.txt --group optionals-all
 dependency_groups =
   doc
+  optionals-all
 commands =
   make cheader
   doxygen docs/Doxyfile


### PR DESCRIPTION
Having manual calls to `pip` implies that `pip` is available.  This is not universally true; if the current `venv` and/or `tox` installation is managed by a different tool that `tox` knows about (such as `uv`), it will use it to create its own `venv`s, which may not have `pip` available within them (like `uv`'s don't).  Using the `dependency-groups` feature allows us to offload all the install work to `tox`, so it works regardless of `venv` manager.

Technically this causes the dependency groups to install before the version of Qiskit under test, which will have the side effect of installing an _old_ version of Qiskit first.  However, `tox` will then forcibly install the new version of Qiskit into the environment, which is what we really want.

<!--
 * See https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md#pull-request-checklist
 * Write a clear description here.
 * Use "Fix #15919" to close issues.
-->

This affected me locally - I couldn't do `tox -e docs` from my existing `uv`-managed installation of `tox`.

### AI/LLM disclosure

- [x] I didn't use LLM tooling, or only used it privately.
- [ ] I used the following tool to help write this PR description:
- [ ] I used the following tool to generate or modify code:

<!-- Any code generated by LLM or modified from LLM suggestions must commented inline too. -->
